### PR TITLE
Fix iOS processing, attachments, and speech onboarding

### DIFF
--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
     
     
 }

--- a/app/android/settings.gradle
+++ b/app/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.10.1' apply false
+    id "com.android.application" version '8.11.1' apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -243,8 +243,12 @@ Future<({ServerConversation? item, bool ok})> getConversationByIdResult(String c
   if (response.statusCode == 200) {
     return (item: ServerConversation.fromJson(jsonDecode(response.body) as Map<String, dynamic>), ok: true);
   } else if (response.statusCode == 402) {
-    Logger.debug('Unlimited Plan Required for conversation: $conversationId');
-    return (item: null, ok: false);
+    // Locked conversations are still returned by the list endpoint as a
+    // redacted completed row, but their detail endpoint intentionally returns
+    // 402. Treat that response as an authoritative terminal result for
+    // lifecycle reconciliation so a stale Processing card is cleared.
+    Logger.debug('Conversation is locked/redacted: $conversationId');
+    return (item: null, ok: true);
   } else if (response.statusCode == 404) {
     return (item: null, ok: true);
   }

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -232,21 +232,27 @@ Future<List<CalendarEventLink>> listGoogleCalendarEvents({
   return [];
 }
 
-Future<ServerConversation?> getConversationById(String conversationId) async {
+Future<({ServerConversation? item, bool ok})> getConversationByIdResult(String conversationId) async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/conversations/$conversationId',
     headers: {},
     method: 'GET',
     body: '',
   );
-  if (response == null) return null;
+  if (response == null) return (item: null, ok: false);
   if (response.statusCode == 200) {
-    return ServerConversation.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    return (item: ServerConversation.fromJson(jsonDecode(response.body) as Map<String, dynamic>), ok: true);
   } else if (response.statusCode == 402) {
     Logger.debug('Unlimited Plan Required for conversation: $conversationId');
-    return null;
+    return (item: null, ok: false);
+  } else if (response.statusCode == 404) {
+    return (item: null, ok: true);
   }
-  return null;
+  return (item: null, ok: false);
+}
+
+Future<ServerConversation?> getConversationById(String conversationId) async {
+  return (await getConversationByIdResult(conversationId)).item;
 }
 
 Future<bool> updateConversationTitle(String conversationId, String title) async {

--- a/app/lib/gen/assets.gen.dart
+++ b/app/lib/gen/assets.gen.dart
@@ -1,3 +1,5 @@
+// dart format width=80
+
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,7 +7,7 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
 import 'package:flutter/widgets.dart';
 
@@ -54,15 +56,15 @@ class $AssetsFontsGen {
 
   /// List of all assets
   List<String> get values => [
-    sfprodisplayblackitalic,
-    sfprodisplaybold,
-    sfprodisplayheavyitalic,
-    sfprodisplaylightitalic,
-    sfprodisplaymedium,
-    sfprodisplayregular,
-    sfprodisplaysemibolditalic,
-    sfprodisplaythinitalic,
-  ];
+        sfprodisplayblackitalic,
+        sfprodisplaybold,
+        sfprodisplayheavyitalic,
+        sfprodisplaylightitalic,
+        sfprodisplaymedium,
+        sfprodisplayregular,
+        sfprodisplaysemibolditalic,
+        sfprodisplaythinitalic
+      ];
 }
 
 class $AssetsImagesGen {
@@ -336,79 +338,79 @@ class $AssetsImagesGen {
 
   /// List of all assets
   List<dynamic> get values => [
-    a1,
-    a2,
-    a3,
-    a4,
-    a5,
-    logoTextWhite,
-    aiMagic,
-    appLauncherIcon,
-    appleRemindersLogo,
-    appleLogo,
-    appleWatch,
-    background,
-    beeDevice,
-    blob,
-    calendarLogo,
-    checkbox,
-    clone,
-    emailLogo,
-    emotionalFeedback1,
-    facebookLogo,
-    fieldy,
-    friendPendant,
-    googleLogo,
-    gradientCard,
-    herologo,
-    icChart,
-    icCloneChat,
-    icClonePlus,
-    icDollar,
-    imessageLogo,
-    instagramLogo,
-    instruction1,
-    instruction2,
-    instruction3,
-    limitless,
-    linkIcon,
-    linkedinLogo,
-    logoTransparent,
-    logoTransparentV2,
-    neoOne,
-    newBackground,
-    notionLogo,
-    omiDevkitWithoutRope,
-    omiGlass,
-    omiWithRopeNoPadding,
-    omiWithRope,
-    omiWithoutRopeGreenCharging,
-    omiWithoutRopeTurnedOff,
-    omiWithoutRope,
-    onboardingBg1,
-    onboardingBg2,
-    onboardingBg3,
-    onboardingBg4,
-    onboardingBg51,
-    onboardingBg52,
-    onboardingBg6,
-    onboarding,
-    plaudNotePin,
-    raybanMeta,
-    recordingGreenCircleIcon,
-    slackLogo,
-    speaker0Icon,
-    speaker1Icon,
-    splash,
-    splashIcon,
-    stars,
-    stripeLogo,
-    telegramLogo,
-    whatsappLogo,
-    xLogo,
-    xLogoMini,
-    youtubeLogo,
-  ];
+        a1,
+        a2,
+        a3,
+        a4,
+        a5,
+        logoTextWhite,
+        aiMagic,
+        appLauncherIcon,
+        appleRemindersLogo,
+        appleLogo,
+        appleWatch,
+        background,
+        beeDevice,
+        blob,
+        calendarLogo,
+        checkbox,
+        clone,
+        emailLogo,
+        emotionalFeedback1,
+        facebookLogo,
+        fieldy,
+        friendPendant,
+        googleLogo,
+        gradientCard,
+        herologo,
+        icChart,
+        icCloneChat,
+        icClonePlus,
+        icDollar,
+        imessageLogo,
+        instagramLogo,
+        instruction1,
+        instruction2,
+        instruction3,
+        limitless,
+        linkIcon,
+        linkedinLogo,
+        logoTransparent,
+        logoTransparentV2,
+        neoOne,
+        newBackground,
+        notionLogo,
+        omiDevkitWithoutRope,
+        omiGlass,
+        omiWithRopeNoPadding,
+        omiWithRope,
+        omiWithoutRopeGreenCharging,
+        omiWithoutRopeTurnedOff,
+        omiWithoutRope,
+        onboardingBg1,
+        onboardingBg2,
+        onboardingBg3,
+        onboardingBg4,
+        onboardingBg51,
+        onboardingBg52,
+        onboardingBg6,
+        onboarding,
+        plaudNotePin,
+        raybanMeta,
+        recordingGreenCircleIcon,
+        slackLogo,
+        speaker0Icon,
+        speaker1Icon,
+        splash,
+        splashIcon,
+        stars,
+        stripeLogo,
+        telegramLogo,
+        whatsappLogo,
+        xLogo,
+        xLogoMini,
+        youtubeLogo
+      ];
 }
 
 class $AssetsIntegrationAppLogosGen {
@@ -467,25 +469,23 @@ class $AssetsIntegrationAppLogosGen {
 
   /// List of all assets
   List<dynamic> get values => [
-    appleHealthLogo,
-    asanaLogo,
-    clickupLogo,
-    githubLogo,
-    gmailLogo,
-    googleCalendar,
-    googleTasksLogo,
-    mondayLogo,
-    notionLogo,
-    todoistLogo,
-    trelloLogo,
-    whoop,
-    xLogo,
-  ];
+        appleHealthLogo,
+        asanaLogo,
+        clickupLogo,
+        githubLogo,
+        gmailLogo,
+        googleCalendar,
+        googleTasksLogo,
+        mondayLogo,
+        notionLogo,
+        todoistLogo,
+        trelloLogo,
+        whoop,
+        xLogo
+      ];
 }
 
-class Assets {
-  const Assets._();
-
+abstract final class Assets {
   static const $AssetsCompetitorLogosGen competitorLogos =
       $AssetsCompetitorLogosGen();
   static const $AssetsFontsGen fonts = $AssetsFontsGen();
@@ -499,12 +499,18 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
+  const AssetGenImage(
+    this._assetName, {
+    this.size,
+    this.flavors = const {},
+    this.animation,
+  });
 
   final String _assetName;
 
   final Size? size;
   final Set<String> flavors;
+  final AssetGenImageAnimation? animation;
 
   Image image({
     Key? key,
@@ -559,11 +565,30 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({AssetBundle? bundle, String? package}) {
-    return AssetImage(_assetName, bundle: bundle, package: package);
+  ImageProvider provider({
+    AssetBundle? bundle,
+    String? package,
+  }) {
+    return AssetImage(
+      _assetName,
+      bundle: bundle,
+      package: package,
+    );
   }
 
   String get path => _assetName;
 
   String get keyName => _assetName;
+}
+
+class AssetGenImageAnimation {
+  const AssetGenImageAnimation({
+    required this.isAnimation,
+    required this.duration,
+    required this.frames,
+  });
+
+  final bool isAnimation;
+  final Duration duration;
+  final int frames;
 }

--- a/app/lib/gen/fonts.gen.dart
+++ b/app/lib/gen/fonts.gen.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 /// GENERATED CODE - DO NOT MODIFY BY HAND
 /// *****************************************************
 ///  FlutterGen
@@ -5,11 +6,9 @@
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
-// ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
+// ignore_for_file: deprecated_member_use,directives_ordering,implicit_dynamic_list_literal,unnecessary_import
 
-class FontFamily {
-  FontFamily._();
-
+abstract final class FontFamily {
   /// Font family: SF Pro Display
   static const String sFProDisplay = 'SF Pro Display';
 }

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -182,7 +182,9 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
     } else if (uploaded > 0) {
       // Uploads finished, reconciler is resolving jobs in the background.
       title = l.syncCardProcessing;
-      progressText = l.syncCardProgressOf(uploaded, uploaded + readyToBackUp);
+      // Uploaded WAL counts are queue state, not server segment progress. A
+      // localized background hint avoids presenting them as a completion meter.
+      progressText = l.syncProcessingBackgroundHint;
     } else if (attention > 0) {
       title = l.syncCardNeedsAttention(attention);
       titleColor = Colors.orangeAccent;

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -315,7 +315,7 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
           Expanded(
             child: Text(
               SyncProvider.isPendingUploadError(syncState.errorMessage)
-                  ? context.l10n.syncStatusRetrying
+                  ? context.l10n.syncStatusFailed
                   : syncState.errorMessage ?? context.l10n.syncFailed,
               style: const TextStyle(color: Colors.redAccent, fontSize: 13),
             ),

--- a/app/lib/pages/conversations/auto_sync_page.dart
+++ b/app/lib/pages/conversations/auto_sync_page.dart
@@ -314,7 +314,9 @@ class _AutoSyncPageState extends State<AutoSyncPage> {
           const SizedBox(width: 12),
           Expanded(
             child: Text(
-              syncState.errorMessage ?? context.l10n.syncFailed,
+              SyncProvider.isPendingUploadError(syncState.errorMessage)
+                  ? context.l10n.syncStatusRetrying
+                  : syncState.errorMessage ?? context.l10n.syncFailed,
               style: const TextStyle(color: Colors.redAccent, fontSize: 13),
             ),
           ),

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -68,6 +68,36 @@ typedef _ConversationPageSnapshot = ({
 
 int _identitySignature(Iterable<Object> values) => Object.hashAll(values.map(identityHashCode));
 
+/// Whether a failed page request should release the scroll request latch so
+/// the same server offset can be retried.
+bool shouldReleaseConversationLoadMoreLatch({
+  required String? currentRequestKey,
+  required String requestKey,
+  required bool succeeded,
+}) =>
+    !succeeded && currentRequestKey == requestKey;
+
+String conversationLoadMoreFilterKey({
+  required String query,
+  required String? folderId,
+  required String? speakerId,
+  required DateTime? date,
+  required bool starredOnly,
+  required bool discarded,
+  required bool shortOnly,
+  required int shortThreshold,
+}) =>
+    [
+      query,
+      folderId ?? '',
+      speakerId ?? '',
+      date?.toIso8601String() ?? '',
+      starredOnly,
+      discarded,
+      shortOnly,
+      shortThreshold,
+    ].join('|');
+
 _ConversationPageSnapshot _conversationPageSnapshot(
   ConversationProvider conversations,
   LocalRecordingsProvider recordings,
@@ -249,13 +279,16 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
   bool _requestMoreIfNeeded(ConversationProvider provider) {
     if (provider.isLoadingConversations) return false;
 
-    final filterKey = [
-      provider.previousQuery,
-      provider.selectedFolderId ?? '',
-      provider.selectedSpeakerId ?? '',
-      provider.selectedDate?.toIso8601String() ?? '',
-      provider.showStarredOnly,
-    ].join('|');
+    final filterKey = conversationLoadMoreFilterKey(
+      query: provider.previousQuery,
+      folderId: provider.selectedFolderId,
+      speakerId: provider.selectedSpeakerId,
+      date: provider.selectedDate,
+      starredOnly: provider.showStarredOnly,
+      discarded: provider.showDiscardedConversations,
+      shortOnly: provider.showShortConversations,
+      shortThreshold: provider.shortConversationThreshold,
+    );
     if (_loadMoreFilterKey != filterKey) {
       _loadMoreFilterKey = filterKey;
       _lastLoadMoreRequestKey = null;
@@ -267,9 +300,8 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
       if (provider.totalSearchPages <= provider.currentSearchPage) return false;
       pageOrCount = 'page:${provider.currentSearchPage}';
     } else {
-      final count = provider.conversations.length + provider.memoriesToDelete.length;
-      if (count == 0 || count % 50 != 0) return false;
-      pageOrCount = 'count:$count';
+      if (!provider.hasMoreConversations) return false;
+      pageOrCount = 'offset:${provider.conversationServerOffset}';
     }
 
     final requestKey = '$filterKey|$pageOrCount';
@@ -279,7 +311,18 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
     if (isSearch) {
       unawaited(provider.searchMoreConversations());
     } else {
-      unawaited(provider.getMoreConversationsFromServer());
+      unawaited(provider.getMoreConversationsFromServer().then((succeeded) {
+        if (mounted &&
+            shouldReleaseConversationLoadMoreLatch(
+              currentRequestKey: _lastLoadMoreRequestKey,
+              requestKey: requestKey,
+              succeeded: succeeded,
+            )) {
+          // A failed page fetch leaves the server cursor unchanged; release
+          // the latch so the next scroll can retry the same offset.
+          _lastLoadMoreRequestKey = null;
+        }
+      }));
     }
     return true;
   }

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -441,7 +441,7 @@ class _SyncPageState extends State<SyncPage> {
 
   String _formatErrorMessage(BuildContext context, String errorMessage) {
     if (SyncProvider.isPendingUploadError(errorMessage)) {
-      return context.l10n.syncStatusRetrying;
+      return context.l10n.syncStatusFailed;
     }
     if (errorMessage.startsWith('Exception: ')) {
       errorMessage = errorMessage.substring('Exception: '.length);

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -541,7 +541,8 @@ class _SyncPageState extends State<SyncPage> {
       titleColor = Colors.orangeAccent;
     } else if (uploaded > 0) {
       title = l.syncCardProcessing;
-      subtitle = '${l.syncCardProgressOf(uploaded, uploaded + readyToSync)} · ${l.syncProcessingBackgroundHint}';
+      // Uploaded WAL counts are queue state, not server segment progress.
+      subtitle = l.syncProcessingBackgroundHint;
     } else if (readyToSync > 0) {
       title = l.syncCardReadyCount(readyToSync);
       action = _statusActionPill(l.sync, Colors.deepPurpleAccent, () {

--- a/app/lib/pages/conversations/sync_page.dart
+++ b/app/lib/pages/conversations/sync_page.dart
@@ -440,6 +440,9 @@ class _SyncPageState extends State<SyncPage> {
   }
 
   String _formatErrorMessage(BuildContext context, String errorMessage) {
+    if (SyncProvider.isPendingUploadError(errorMessage)) {
+      return context.l10n.syncStatusRetrying;
+    }
     if (errorMessage.startsWith('Exception: ')) {
       errorMessage = errorMessage.substring('Exception: '.length);
     }

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -64,6 +64,11 @@ class ConversationProvider extends ChangeNotifier {
 
   List<ServerConversation> processingConversations = [];
 
+  // A websocket transition can arrive while lifecycle probes are in flight.
+  // Reconciliation compares this revision with its start snapshot so stale
+  // page/detail data cannot overwrite newer processing state.
+  int _processingStateRevision = 0;
+
   // Merge functionality state
   Set<String> mergingConversationIds = {};
   bool isSelectionModeActive = false;
@@ -89,6 +94,11 @@ class ConversationProvider extends ChangeNotifier {
   // misleading get-started/"No conversations yet" hero for a user who really
   // does have conversations (just an empty local cache + a slow auth/network).
   static const int _slowFetchRetryIntervalSeconds = 15;
+
+  // Lifecycle probes are best-effort checks for processing cards. Bound both
+  // backend fan-out and the time they can hold the primary conversation fetch.
+  static const int _processingLifecycleMaxConcurrency = 4;
+  static const Duration _processingLifecycleDeadline = Duration(seconds: 2);
 
   // The empty-state widget should defer to a pending auto-retry so the user
   // doesn't see "No conversations yet" in the gap between backoff attempts.
@@ -142,6 +152,7 @@ class ConversationProvider extends ChangeNotifier {
     searchedConversations = [];
     groupedConversations = {};
     processingConversations = [];
+    _processingStateRevision++;
     mergingConversationIds = {};
     selectedConversationIds = {};
     isSelectionModeActive = false;
@@ -254,11 +265,21 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void addProcessingConversation(ServerConversation conversation) {
-    processingConversations.add(conversation);
+    _processingStateRevision++;
+    final existingIndex = processingConversations.indexWhere((item) => item.id == conversation.id);
+    if (existingIndex == -1) {
+      processingConversations.add(conversation);
+    } else {
+      // A replayed processing-start event can arrive while reconciliation is
+      // waiting. Replace the old snapshot so the UI cannot render a stale
+      // duplicate ahead of the live row.
+      processingConversations[existingIndex] = conversation;
+    }
     notifyListeners();
   }
 
   void removeProcessingConversation(String conversationId) {
+    _processingStateRevision++;
     processingConversations.removeWhere((m) => m.id == conversationId);
     notifyListeners();
   }
@@ -430,6 +451,9 @@ class ConversationProvider extends ChangeNotifier {
   Future _fetchNewConversations() async {
     if (!_isSignedIn()) return;
     final generation = _sessionGeneration;
+    final processingRowsAtStart = _realProcessingConversationsById();
+    final processingIdsAtStart = processingRowsAtStart.keys.toSet();
+    final processingRevisionAtStart = _processingStateRevision;
     setLoadingConversations(true);
     final result = await _getConversationsFromServer();
     if (generation != _sessionGeneration) return;
@@ -437,35 +461,30 @@ class ConversationProvider extends ChangeNotifier {
       setLoadingConversations(false);
       return;
     }
-    setLoadingConversations(false);
 
     // A background/debounced refresh failed (transient network error, token
     // expiry, etc.). Don't treat the empty result as "no new conversations" —
     // keep the existing list untouched; the next refresh trigger will retry.
-    if (!result.ok) return;
+    if (!result.ok) {
+      setLoadingConversations(false);
+      return;
+    }
 
     List<ServerConversation> newConversations = result.items;
 
-    final processingIdsAtStart = _realProcessingConversationIds();
     final pageConversationIds = newConversations.map((conversation) => conversation.id).toSet();
     final lifecycleResults = await _loadProcessingLifecycleResults(newConversations, processingIdsAtStart);
     if (generation != _sessionGeneration || !_isSignedIn()) return;
-    _reconcileProcessingConversations(lifecycleResults, processingIdsAtStart, pageConversationIds);
-
-    List<ServerConversation> upsertConvos = [];
-
-    // processing convos
-    upsertConvos = newConversations
-        .where(
-          (c) => _isActiveProcessingStatus(c.status) && processingConversations.indexWhere((cc) => cc.id == c.id) == -1,
-        )
-        .toList();
-    if (upsertConvos.isNotEmpty) {
-      processingConversations.insertAll(0, upsertConvos);
-    }
+    _reconcileProcessingConversations(
+      lifecycleResults,
+      processingIdsAtStart,
+      pageConversationIds,
+      processingRevisionAtStart,
+      processingRowsAtStart,
+    );
 
     // completed convos
-    upsertConvos = newConversations
+    final upsertConvos = newConversations
         .where((c) => c.status == ConversationStatus.completed && conversations.indexWhere((cc) => cc.id == c.id) == -1)
         .toList();
     if (upsertConvos.isNotEmpty) {
@@ -481,6 +500,10 @@ class ConversationProvider extends ChangeNotifier {
     }
 
     _groupConversationsByDateWithoutNotify();
+    // Keep pagination blocked until lifecycle reconciliation and the final
+    // list assignment are complete. [getMoreConversationsFromServer] uses
+    // this loading state as its serialization guard.
+    setLoadingConversations(false);
     notifyListeners();
   }
 
@@ -491,6 +514,12 @@ class ConversationProvider extends ChangeNotifier {
       return false;
     }
     final generation = _sessionGeneration;
+    final conversationsAtStart = <String, ServerConversation>{
+      for (final conversation in conversations) conversation.id: conversation,
+    };
+    final processingRowsAtStart = _realProcessingConversationsById();
+    final processingIdsAtStart = processingRowsAtStart.keys.toSet();
+    final processingRevisionAtStart = _processingStateRevision;
     previousQuery = "";
     currentSearchPage = 0;
     totalSearchPages = 0;
@@ -507,7 +536,6 @@ class ConversationProvider extends ChangeNotifier {
       _cancelInitialFetchRetry();
       return false;
     }
-    setLoadingConversations(false);
 
     if (!result.ok) {
       // The request failed (no response / non-200) — most commonly the auth
@@ -523,6 +551,7 @@ class ConversationProvider extends ChangeNotifier {
         searchedConversations = conversations;
       }
       _groupConversationsByDateWithoutNotify();
+      setLoadingConversations(false);
       notifyListeners();
       _scheduleInitialFetchRetry();
       return false;
@@ -533,14 +562,40 @@ class ConversationProvider extends ChangeNotifier {
     _initialFetchRetryCount = 0;
     final fetchedConversations = _filterPendingDeletes(result.items);
 
-    final processingIdsAtStart = _realProcessingConversationIds();
     final pageConversationIds = fetchedConversations.map((conversation) => conversation.id).toSet();
     final lifecycleResults = await _loadProcessingLifecycleResults(fetchedConversations, processingIdsAtStart);
     if (generation != _sessionGeneration || !_isSignedIn()) return false;
-    _reconcileProcessingConversations(lifecycleResults, processingIdsAtStart, pageConversationIds);
+    _reconcileProcessingConversations(
+      lifecycleResults,
+      processingIdsAtStart,
+      pageConversationIds,
+      processingRevisionAtStart,
+      processingRowsAtStart,
+    );
 
-    // completed convos
-    conversations = fetchedConversations.where((m) => m.status == ConversationStatus.completed).toList();
+    // A ConversationEvent can complete a row while the list/lifecycle awaits
+    // above. The stale page may omit that row, so preserve only completed rows
+    // that were added or replaced live during this fetch. Do not carry forward
+    // an unchanged pre-fetch row (the server page is authoritative for those),
+    // and never resurrect a row in the undo/delete window.
+    final completedById = <String, ServerConversation>{
+      for (final conversation in fetchedConversations)
+        if (conversation.status == ConversationStatus.completed) conversation.id: conversation,
+    };
+    for (final conversation in conversations) {
+      if (conversation.status != ConversationStatus.completed) continue;
+      if (memoriesToDelete.containsKey(conversation.id) || !_matchesActiveConversationFilters(conversation)) {
+        continue;
+      }
+      // A changed live object wins over a stale page object even when the
+      // page contains the same ID with older status/content. Unchanged
+      // pre-fetch rows remain governed by the authoritative page.
+      if (!identical(conversationsAtStart[conversation.id], conversation)) {
+        completedById[conversation.id] = conversation;
+      }
+    }
+    conversations = completedById.values.toList()
+      ..sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
 
     // Only use cache when no folder filter is applied
     if (conversations.isEmpty && selectedFolderId == null) {
@@ -554,6 +609,10 @@ class ConversationProvider extends ChangeNotifier {
     }
     _groupConversationsByDateWithoutNotify();
 
+    // Keep pagination blocked until lifecycle reconciliation and the final
+    // list assignment are complete. [getMoreConversationsFromServer] uses
+    // this loading state as its serialization guard.
+    setLoadingConversations(false);
     notifyListeners();
     return true;
   }
@@ -750,8 +809,10 @@ class ConversationProvider extends ChangeNotifier {
     return status == ConversationStatus.processing || status == ConversationStatus.merging;
   }
 
-  Set<String> _realProcessingConversationIds() =>
-      processingConversations.map((conversation) => conversation.id).where((id) => id != '0').toSet();
+  Map<String, ServerConversation> _realProcessingConversationsById() => {
+        for (final conversation in processingConversations)
+          if (conversation.id != '0') conversation.id: conversation,
+      };
 
   Future<Map<String, ({ServerConversation? item, bool ok})>> _loadProcessingLifecycleResults(
     List<ServerConversation> pageItems,
@@ -760,34 +821,92 @@ class ConversationProvider extends ChangeNotifier {
     final results = <String, ({ServerConversation? item, bool ok})>{
       for (final conversation in pageItems) conversation.id: (item: conversation, ok: true),
     };
-    await Future.wait(
-      processingIdsAtStart.where((id) => !results.containsKey(id)).map((id) async {
+
+    // Probe every card that was already tracked at refresh start, including
+    // IDs present on this page. The page can carry an older status than the
+    // detail endpoint; a failed probe remains inconclusive and preserves the
+    // local card rather than replacing it with stale page data.
+    final ids = processingIdsAtStart.toList();
+    if (ids.isEmpty) return results;
+
+    // Page entries are only a fallback for untracked rows. Tracked IDs must
+    // start inconclusive until their lifecycle probe succeeds, otherwise a
+    // probe that times out would silently retain a stale page status.
+    for (final id in ids) {
+      results[id] = (item: null, ok: false);
+    }
+
+    var nextIndex = 0;
+    var deadlineExpired = false;
+    Future<void> worker() async {
+      while (true) {
+        if (deadlineExpired || nextIndex >= ids.length) return;
+        final id = ids[nextIndex++];
+        ({ServerConversation? item, bool ok}) lifecycleResult;
         try {
-          results[id] = await _conversationLifecycleFetcher(id);
+          lifecycleResult = await _conversationLifecycleFetcher(id);
         } catch (_) {
-          results[id] = (item: null, ok: false);
+          lifecycleResult = (item: null, ok: false);
         }
-      }),
-    );
+        // A timed-out worker may still complete later. Do not mutate the map
+        // after the caller has received the fail-soft result.
+        if (!deadlineExpired) results[id] = lifecycleResult;
+      }
+    }
+
+    final workerCount =
+        ids.length < _processingLifecycleMaxConcurrency ? ids.length : _processingLifecycleMaxConcurrency;
+    final workers = List<Future<void>>.generate(workerCount, (_) => worker());
+    try {
+      await Future.wait(workers).timeout(_processingLifecycleDeadline);
+    } on TimeoutException {
+      deadlineExpired = true;
+      // Mark all unresolved probes inconclusive. Existing cards are retained
+      // by reconciliation, while page-only rows still come from the page.
+      for (final id in ids) {
+        results[id] ??= (item: null, ok: false);
+      }
+    }
     return results;
+  }
+
+  bool _matchesActiveConversationFilters(ServerConversation conversation) {
+    if (!showDiscardedConversations && conversation.discarded) return false;
+    if (showStarredOnly && !conversation.starred) return false;
+    if (selectedDate != null) {
+      final conversationDate = conversationLocalDayKey(conversation.startedAt ?? conversation.createdAt);
+      final filterDate = DateTime(selectedDate!.year, selectedDate!.month, selectedDate!.day);
+      if (conversationDate != filterDate) return false;
+    }
+    if (selectedFolderId != null && conversation.folderId != selectedFolderId) return false;
+    return true;
   }
 
   void _reconcileProcessingConversations(
     Map<String, ({ServerConversation? item, bool ok})> lifecycleResults,
     Set<String> processingIdsAtStart,
     Set<String> pageConversationIds,
+    int processingRevisionAtStart,
+    Map<String, ServerConversation> processingRowsAtStart,
   ) {
     final localPlaceholder = processingConversations.where((conversation) => conversation.id == '0').toList();
     final reconciled = <ServerConversation>[];
 
     for (final existing in processingConversations.where((conversation) => conversation.id != '0')) {
+      // A row added or replaced by websocket after this refresh began is newer
+      // than the page/detail snapshot. Preserve that live object for this pass;
+      // unrelated websocket events must not block reconciliation of this ID.
+      if (!identical(processingRowsAtStart[existing.id], existing)) {
+        if (_matchesActiveConversationFilters(existing)) reconciled.add(existing);
+        continue;
+      }
       final result = lifecycleResults[existing.id];
       if (result == null || !result.ok) {
-        reconciled.add(existing);
+        if (_matchesActiveConversationFilters(existing)) reconciled.add(existing);
         continue;
       }
       final current = result.item;
-      if (current != null && _isActiveProcessingStatus(current.status)) {
+      if (current != null && _isActiveProcessingStatus(current.status) && _matchesActiveConversationFilters(current)) {
         reconciled.add(current);
       }
     }
@@ -799,7 +918,12 @@ class ConversationProvider extends ChangeNotifier {
       // websocket completion removed one while lifecycle GETs were in flight,
       // a stale detail response must not revive it here. This loop only admits
       // newly discovered active rows from the authoritative list page.
-      if (processingIdsAtStart.contains(conversation.id) || !pageConversationIds.contains(conversation.id)) continue;
+      if (_processingStateRevision != processingRevisionAtStart ||
+          processingIdsAtStart.contains(conversation.id) ||
+          !pageConversationIds.contains(conversation.id) ||
+          !_matchesActiveConversationFilters(conversation)) {
+        continue;
+      }
       if (reconciled.every((existing) => existing.id != conversation.id)) {
         reconciled.add(conversation);
       }

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -88,6 +88,8 @@ class ConversationProvider extends ChangeNotifier {
   Timer? _initialFetchRetryTimer;
   int _initialFetchRetryCount = 0;
   int _sessionGeneration = 0;
+  int _conversationFetchRevision = 0;
+  int _conversationLoadingRevision = 0;
   static const int _maxInitialFetchRetries = 4;
   // After the fast backoff budget is spent we keep retrying on a slow fixed
   // interval rather than giving up — otherwise a prolonged outage latches the
@@ -99,11 +101,17 @@ class ConversationProvider extends ChangeNotifier {
   // backend fan-out and the time they can hold the primary conversation fetch.
   static const int _processingLifecycleMaxConcurrency = 4;
   static const Duration _processingLifecycleDeadline = Duration(seconds: 2);
+  static const int _conversationPageSize = 50;
+  int _conversationServerOffset = 0;
+  bool _conversationServerHasMore = false;
+  final Set<String> _conversationServerLoadedIds = {};
 
   // The empty-state widget should defer to a pending auto-retry so the user
   // doesn't see "No conversations yet" in the gap between backoff attempts.
   bool get isAwaitingInitialFetchRetry => _initialFetchRetryTimer?.isActive ?? false;
   bool get hasActiveSearch => previousQuery.isNotEmpty || selectedSpeakerId != null;
+  bool get hasMoreConversations => _conversationServerHasMore;
+  int get conversationServerOffset => _conversationServerOffset;
 
   final ConversationListFetcher? _conversationListFetcher;
   final ConversationLifecycleFetcher _conversationLifecycleFetcher;
@@ -113,6 +121,12 @@ class ConversationProvider extends ChangeNotifier {
 
   @visibleForTesting
   ConversationDetailsFetcher? conversationDetailsFetcherOverride;
+
+  @visibleForTesting
+  ConversationListFetcher? conversationPageFetcherOverride;
+
+  @visibleForTesting
+  Future<bool> Function(String conversationId)? conversationDeleteFetcherOverride;
 
   ConversationProvider({
     ConversationListFetcher? conversationListFetcher,
@@ -148,11 +162,15 @@ class ConversationProvider extends ChangeNotifier {
 
   void clearUserData() {
     _sessionGeneration++;
+    _conversationFetchRevision++;
     conversations = [];
     searchedConversations = [];
     groupedConversations = {};
     processingConversations = [];
     _processingStateRevision++;
+    _conversationServerOffset = 0;
+    _conversationServerHasMore = false;
+    _conversationServerLoadedIds.clear();
     mergingConversationIds = {};
     selectedConversationIds = {};
     isSelectionModeActive = false;
@@ -451,12 +469,20 @@ class ConversationProvider extends ChangeNotifier {
   Future _fetchNewConversations() async {
     if (!_isSignedIn()) return;
     final generation = _sessionGeneration;
+    final fetchRevision = ++_conversationFetchRevision;
+    _conversationLoadingRevision = fetchRevision;
     final processingRowsAtStart = _realProcessingConversationsById();
     final processingIdsAtStart = processingRowsAtStart.keys.toSet();
     final processingRevisionAtStart = _processingStateRevision;
+    final conversationsAtStart = <String, ServerConversation>{
+      for (final conversation in conversations) conversation.id: conversation,
+    };
     setLoadingConversations(true);
     final result = await _getConversationsFromServer();
-    if (generation != _sessionGeneration) return;
+    if (generation != _sessionGeneration || fetchRevision != _conversationFetchRevision) {
+      if (_conversationLoadingRevision == fetchRevision) setLoadingConversations(false);
+      return;
+    }
     if (!_isSignedIn()) {
       setLoadingConversations(false);
       return;
@@ -470,11 +496,14 @@ class ConversationProvider extends ChangeNotifier {
       return;
     }
 
-    List<ServerConversation> newConversations = result.items;
-
+    final rawNewConversations = result.items;
+    final newConversations = _filterPendingDeletes(rawNewConversations);
     final pageConversationIds = newConversations.map((conversation) => conversation.id).toSet();
     final lifecycleResults = await _loadProcessingLifecycleResults(newConversations, processingIdsAtStart);
-    if (generation != _sessionGeneration || !_isSignedIn()) return;
+    if (generation != _sessionGeneration || fetchRevision != _conversationFetchRevision || !_isSignedIn()) {
+      if (_conversationLoadingRevision == fetchRevision) setLoadingConversations(false);
+      return;
+    }
     _reconcileProcessingConversations(
       lifecycleResults,
       processingIdsAtStart,
@@ -482,22 +511,46 @@ class ConversationProvider extends ChangeNotifier {
       processingRevisionAtStart,
       processingRowsAtStart,
     );
+    if (_conversationServerOffset == 0) {
+      _conversationServerOffset = rawNewConversations.length;
+      _conversationServerHasMore = rawNewConversations.length >= _conversationPageSize;
+    }
+    _conversationServerLoadedIds.addAll(rawNewConversations.map((conversation) => conversation.id));
+    final currentlyProcessingIds = processingConversations
+        .where((conversation) => _isActiveProcessingStatus(conversation.status))
+        .map((conversation) => conversation.id)
+        .toSet();
 
-    // completed convos
-    final upsertConvos = newConversations
-        .where((c) => c.status == ConversationStatus.completed && conversations.indexWhere((cc) => cc.id == c.id) == -1)
-        .toList();
-    if (upsertConvos.isNotEmpty) {
-      // Check if this is the first conversation
-      bool wasEmpty = conversations.isEmpty;
-
-      conversations.insertAll(0, upsertConvos);
-
-      // Mark first conversation for app review
-      if (wasEmpty && await _appReviewService.isFirstConversation()) {
-        await _appReviewService.markFirstConversation();
+    // A lifecycle probe can be newer than the stale refresh page (for example,
+    // the page still says processing while the detail endpoint says completed).
+    // Publish those authoritative completed details through the same upsert
+    // path as page completions.
+    final completedById = <String, ServerConversation>{
+      for (final conversation in newConversations)
+        if (conversation.status == ConversationStatus.completed && !currentlyProcessingIds.contains(conversation.id))
+          conversation.id: conversation,
+    };
+    for (final lifecycleResult in lifecycleResults.values) {
+      final conversation = lifecycleResult.item;
+      if (!lifecycleResult.ok ||
+          conversation == null ||
+          conversation.status != ConversationStatus.completed ||
+          currentlyProcessingIds.contains(conversation.id) ||
+          memoriesToDelete.containsKey(conversation.id) ||
+          !_matchesActiveConversationFilters(conversation)) {
+        continue;
+      }
+      completedById[conversation.id] = conversation;
+    }
+    for (final conversation in completedById.values) {
+      final index = conversations.indexWhere((existing) => existing.id == conversation.id);
+      if (index == -1) {
+        conversations.insert(0, conversation);
+      } else if (identical(conversationsAtStart[conversation.id], conversations[index])) {
+        conversations[index] = conversation;
       }
     }
+    conversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
 
     _groupConversationsByDateWithoutNotify();
     // Keep pagination blocked until lifecycle reconciliation and the final
@@ -514,6 +567,8 @@ class ConversationProvider extends ChangeNotifier {
       return false;
     }
     final generation = _sessionGeneration;
+    final fetchRevision = ++_conversationFetchRevision;
+    _conversationLoadingRevision = fetchRevision;
     final conversationsAtStart = <String, ServerConversation>{
       for (final conversation in conversations) conversation.id: conversation,
     };
@@ -527,7 +582,8 @@ class ConversationProvider extends ChangeNotifier {
 
     setLoadingConversations(true);
     final result = await _getConversationsFromServer();
-    if (generation != _sessionGeneration) {
+    if (generation != _sessionGeneration || fetchRevision != _conversationFetchRevision) {
+      if (_conversationLoadingRevision == fetchRevision) setLoadingConversations(false);
       _cancelInitialFetchRetry();
       return false;
     }
@@ -545,7 +601,14 @@ class ConversationProvider extends ChangeNotifier {
       // so the list self-heals without the user having to pull-to-refresh.
       conversationsLoadFailed = true;
       if (conversations.isEmpty && selectedFolderId == null) {
-        conversations = _filterPendingDeletes(SharedPreferencesUtil().cachedConversations);
+        final activeProcessingIds = processingConversations
+            .where((conversation) => _isActiveProcessingStatus(conversation.status))
+            .map((conversation) => conversation.id)
+            .toSet();
+        conversations = _filterPendingDeletes(SharedPreferencesUtil().cachedConversations)
+            .where((conversation) =>
+                !activeProcessingIds.contains(conversation.id) && _matchesActiveConversationFilters(conversation))
+            .toList();
       }
       if (searchedConversations.isEmpty) {
         searchedConversations = conversations;
@@ -561,10 +624,12 @@ class ConversationProvider extends ChangeNotifier {
     _initialFetchRetryTimer?.cancel();
     _initialFetchRetryCount = 0;
     final fetchedConversations = _filterPendingDeletes(result.items);
-
     final pageConversationIds = fetchedConversations.map((conversation) => conversation.id).toSet();
     final lifecycleResults = await _loadProcessingLifecycleResults(fetchedConversations, processingIdsAtStart);
-    if (generation != _sessionGeneration || !_isSignedIn()) return false;
+    if (generation != _sessionGeneration || fetchRevision != _conversationFetchRevision || !_isSignedIn()) {
+      if (_conversationLoadingRevision == fetchRevision) setLoadingConversations(false);
+      return false;
+    }
     _reconcileProcessingConversations(
       lifecycleResults,
       processingIdsAtStart,
@@ -572,16 +637,40 @@ class ConversationProvider extends ChangeNotifier {
       processingRevisionAtStart,
       processingRowsAtStart,
     );
+    _conversationServerOffset = result.items.length;
+    _conversationServerHasMore = result.items.length >= _conversationPageSize;
+    _conversationServerLoadedIds
+      ..clear()
+      ..addAll(result.items.map((conversation) => conversation.id));
 
     // A ConversationEvent can complete a row while the list/lifecycle awaits
     // above. The stale page may omit that row, so preserve only completed rows
     // that were added or replaced live during this fetch. Do not carry forward
     // an unchanged pre-fetch row (the server page is authoritative for those),
     // and never resurrect a row in the undo/delete window.
+    final currentlyProcessingIds = processingConversations
+        .where((conversation) => _isActiveProcessingStatus(conversation.status))
+        .map((conversation) => conversation.id)
+        .toSet();
     final completedById = <String, ServerConversation>{
       for (final conversation in fetchedConversations)
-        if (conversation.status == ConversationStatus.completed) conversation.id: conversation,
+        if (conversation.status == ConversationStatus.completed && !currentlyProcessingIds.contains(conversation.id))
+          conversation.id: conversation,
     };
+    for (final lifecycleResult in lifecycleResults.values) {
+      final conversation = lifecycleResult.item;
+      if (!lifecycleResult.ok ||
+          conversation == null ||
+          conversation.status != ConversationStatus.completed ||
+          currentlyProcessingIds.contains(conversation.id) ||
+          memoriesToDelete.containsKey(conversation.id) ||
+          !_matchesActiveConversationFilters(conversation)) {
+        continue;
+      }
+      // A successful lifecycle probe is authoritative when the page still
+      // reports this row as processing, so publish its completed detail.
+      completedById[conversation.id] = conversation;
+    }
     for (final conversation in conversations) {
       if (conversation.status != ConversationStatus.completed) continue;
       if (memoriesToDelete.containsKey(conversation.id) || !_matchesActiveConversationFilters(conversation)) {
@@ -599,7 +688,14 @@ class ConversationProvider extends ChangeNotifier {
 
     // Only use cache when no folder filter is applied
     if (conversations.isEmpty && selectedFolderId == null) {
-      conversations = _filterPendingDeletes(SharedPreferencesUtil().cachedConversations);
+      final activeProcessingIds = processingConversations
+          .where((conversation) => _isActiveProcessingStatus(conversation.status))
+          .map((conversation) => conversation.id)
+          .toSet();
+      conversations = _filterPendingDeletes(SharedPreferencesUtil().cachedConversations)
+          .where((conversation) =>
+              !activeProcessingIds.contains(conversation.id) && _matchesActiveConversationFilters(conversation))
+          .toList();
     } else if (selectedFolderId == null) {
       // Only cache when viewing all folders
       SharedPreferencesUtil().cachedConversations = conversations;
@@ -939,32 +1035,51 @@ class ConversationProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future getMoreConversationsFromServer() async {
-    // Use server-equivalent length so the load-more gate and offset stay aligned
-    // with what the server has — pending-delete IDs are still present server-side
-    // until the 3-second undo timer fires the actual DELETE. Without this, a
-    // delete leaves the local length non-multiple-of-50 and load-more never fires.
-    final serverEquivalentLength = conversations.length + memoriesToDelete.length;
-    if (serverEquivalentLength % 50 != 0) return;
-    if (isLoadingConversations) return;
+  Future<bool> getMoreConversationsFromServer() async {
+    // Use the server cursor rather than the displayed list length. Live
+    // websocket overlays (and pending-delete filtering) can make the local
+    // list cardinality differ from the server page cardinality.
+    if (!_conversationServerHasMore) return false;
+    if (isLoadingConversations) return false;
+    final operationRevision = ++_conversationFetchRevision;
+    _conversationLoadingRevision = operationRevision;
     setLoadingConversations(true);
 
     // Date filter if selected
     final (startDate, endDate) = _getDateFilterRange();
 
-    var newConversations = await getConversations(
-      offset: serverEquivalentLength,
-      includeDiscarded: showDiscardedConversations,
-      startDate: startDate,
-      endDate: endDate,
-      folderId: selectedFolderId,
-      starred: showStarredOnly ? true : null,
-    );
-    conversations.addAll(_filterPendingDeletes(newConversations));
+    final pageOffset = _conversationServerOffset;
+    final pageResult = conversationPageFetcherOverride != null
+        ? await conversationPageFetcherOverride!.call()
+        : await getConversationsResult(
+            offset: pageOffset,
+            includeDiscarded: showDiscardedConversations,
+            startDate: startDate,
+            endDate: endDate,
+            folderId: selectedFolderId,
+            starred: showStarredOnly ? true : null,
+          );
+    if (operationRevision != _conversationFetchRevision) {
+      if (_conversationLoadingRevision == operationRevision) setLoadingConversations(false);
+      return false;
+    }
+    if (!pageResult.ok) {
+      setLoadingConversations(false);
+      notifyListeners();
+      return false;
+    }
+    final newConversations = pageResult.items;
+    _conversationServerOffset += newConversations.length;
+    _conversationServerHasMore = newConversations.length >= _conversationPageSize;
+    _conversationServerLoadedIds.addAll(newConversations.map((conversation) => conversation.id));
+    final existingIds = conversations.map((conversation) => conversation.id).toSet();
+    conversations.addAll(
+        _filterPendingDeletes(newConversations).where((conversation) => !existingIds.contains(conversation.id)));
     conversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
     _groupConversationsByDateWithoutNotify();
     setLoadingConversations(false);
     notifyListeners();
+    return true;
   }
 
   Future<void> addConversation(ServerConversation conversation) async {
@@ -1121,7 +1236,44 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void deleteConversationOnServer(String conversationId) {
-    deleteConversationServer(conversationId);
+    final wasLoadedFromServer = _conversationServerLoadedIds.contains(conversationId);
+    final deleteFuture =
+        conversationDeleteFetcherOverride?.call(conversationId) ?? deleteConversationServer(conversationId);
+    unawaited(deleteFuture.then((succeeded) {
+      // Only rebase the server cursor after the backend confirms deletion. A
+      // failed DELETE leaves the row in the server sequence and must not make
+      // the next page skip an item.
+      if (succeeded && wasLoadedFromServer && _conversationServerLoadedIds.remove(conversationId)) {
+        if (_conversationServerOffset > 0) _conversationServerOffset--;
+      }
+      if (succeeded) {
+        final invalidatedRevision = _conversationFetchRevision;
+        _conversationFetchRevision++;
+        if (_conversationLoadingRevision == invalidatedRevision) {
+          setLoadingConversations(false);
+        }
+      }
+      // Keep the tombstone in place until the request settles so a concurrent
+      // refresh cannot reinsert the server row before DELETE completes.
+      if (succeeded) {
+        conversations.removeWhere((conversation) => conversation.id == conversationId);
+        searchedConversations.removeWhere((conversation) => conversation.id == conversationId);
+        for (final group in groupedConversations.values) {
+          group.removeWhere((conversation) => conversation.id == conversationId);
+        }
+        groupedConversations.removeWhere((_, group) => group.isEmpty);
+      }
+      _clearDeleteTombstone(conversationId);
+      notifyListeners();
+    }, onError: (Object _, StackTrace __) {
+      // Match the prior behavior on a failed request: release the local
+      // tombstone, but do not rebase the server cursor.
+      _clearDeleteTombstone(conversationId);
+      notifyListeners();
+    }));
+  }
+
+  void _clearDeleteTombstone(String conversationId) {
     memoriesToDelete.remove(conversationId);
     deleteTimestamps.remove(conversationId);
     if (lastDeletedConversationId == conversationId) {
@@ -1148,7 +1300,10 @@ class ConversationProvider extends ChangeNotifier {
   void deleteConversation(ServerConversation conversation) {
     conversations.removeWhere((element) => element.id == conversation.id);
     searchedConversations.removeWhere((element) => element.id == conversation.id);
-    deleteConversationServer(conversation.id);
+    // Keep a tombstone through the in-flight DELETE so a concurrent list
+    // response cannot reinsert the just-removed row before confirmation.
+    memoriesToDelete[conversation.id] = conversation;
+    deleteConversationOnServer(conversation.id);
     groupConversationsByDate();
   }
 

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -64,10 +64,10 @@ class ConversationProvider extends ChangeNotifier {
 
   List<ServerConversation> processingConversations = [];
 
-  // A websocket transition can arrive while lifecycle probes are in flight.
-  // Reconciliation compares this revision with its start snapshot so stale
-  // page/detail data cannot overwrite newer processing state.
-  int _processingStateRevision = 0;
+  // Per-conversation websocket transition versions. Reconciliation snapshots
+  // these before lifecycle probes so a completion/removal for row B cannot
+  // suppress an unrelated newly discovered row A.
+  final Map<String, int> _processingStateRevisionById = {};
 
   // Merge functionality state
   Set<String> mergingConversationIds = {};
@@ -167,7 +167,7 @@ class ConversationProvider extends ChangeNotifier {
     searchedConversations = [];
     groupedConversations = {};
     processingConversations = [];
-    _processingStateRevision++;
+    _processingStateRevisionById.clear();
     _conversationServerOffset = 0;
     _conversationServerHasMore = false;
     _conversationServerLoadedIds.clear();
@@ -283,7 +283,7 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void addProcessingConversation(ServerConversation conversation) {
-    _processingStateRevision++;
+    _bumpProcessingStateRevision(conversation.id);
     final existingIndex = processingConversations.indexWhere((item) => item.id == conversation.id);
     if (existingIndex == -1) {
       processingConversations.add(conversation);
@@ -297,10 +297,16 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void removeProcessingConversation(String conversationId) {
-    _processingStateRevision++;
+    _bumpProcessingStateRevision(conversationId);
     processingConversations.removeWhere((m) => m.id == conversationId);
     notifyListeners();
   }
+
+  void _bumpProcessingStateRevision(String conversationId) {
+    _processingStateRevisionById[conversationId] = (_processingStateRevisionById[conversationId] ?? 0) + 1;
+  }
+
+  Map<String, int> _processingStateRevisionSnapshot() => Map<String, int>.from(_processingStateRevisionById);
 
   void onConversationTap(String conversationId) {
     final idx = conversations.indexWhere((c) => c.id == conversationId);
@@ -473,7 +479,7 @@ class ConversationProvider extends ChangeNotifier {
     _conversationLoadingRevision = fetchRevision;
     final processingRowsAtStart = _realProcessingConversationsById();
     final processingIdsAtStart = processingRowsAtStart.keys.toSet();
-    final processingRevisionAtStart = _processingStateRevision;
+    final processingRevisionsAtStart = _processingStateRevisionSnapshot();
     final conversationsAtStart = <String, ServerConversation>{
       for (final conversation in conversations) conversation.id: conversation,
     };
@@ -508,7 +514,7 @@ class ConversationProvider extends ChangeNotifier {
       lifecycleResults,
       processingIdsAtStart,
       pageConversationIds,
-      processingRevisionAtStart,
+      processingRevisionsAtStart,
       processingRowsAtStart,
     );
     if (_conversationServerOffset == 0) {
@@ -574,7 +580,7 @@ class ConversationProvider extends ChangeNotifier {
     };
     final processingRowsAtStart = _realProcessingConversationsById();
     final processingIdsAtStart = processingRowsAtStart.keys.toSet();
-    final processingRevisionAtStart = _processingStateRevision;
+    final processingRevisionsAtStart = _processingStateRevisionSnapshot();
     previousQuery = "";
     currentSearchPage = 0;
     totalSearchPages = 0;
@@ -634,7 +640,7 @@ class ConversationProvider extends ChangeNotifier {
       lifecycleResults,
       processingIdsAtStart,
       pageConversationIds,
-      processingRevisionAtStart,
+      processingRevisionsAtStart,
       processingRowsAtStart,
     );
     _conversationServerOffset = result.items.length;
@@ -982,7 +988,7 @@ class ConversationProvider extends ChangeNotifier {
     Map<String, ({ServerConversation? item, bool ok})> lifecycleResults,
     Set<String> processingIdsAtStart,
     Set<String> pageConversationIds,
-    int processingRevisionAtStart,
+    Map<String, int> processingRevisionsAtStart,
     Map<String, ServerConversation> processingRowsAtStart,
   ) {
     final localPlaceholder = processingConversations.where((conversation) => conversation.id == '0').toList();
@@ -1014,7 +1020,7 @@ class ConversationProvider extends ChangeNotifier {
       // websocket completion removed one while lifecycle GETs were in flight,
       // a stale detail response must not revive it here. This loop only admits
       // newly discovered active rows from the authoritative list page.
-      if (_processingStateRevision != processingRevisionAtStart ||
+      if (_processingStateRevisionById[conversation.id] != processingRevisionsAtStart[conversation.id] ||
           processingIdsAtStart.contains(conversation.id) ||
           !pageConversationIds.contains(conversation.id) ||
           !_matchesActiveConversationFilters(conversation)) {
@@ -1236,10 +1242,15 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void deleteConversationOnServer(String conversationId) {
+    final generation = _sessionGeneration;
     final wasLoadedFromServer = _conversationServerLoadedIds.contains(conversationId);
     final deleteFuture =
         conversationDeleteFetcherOverride?.call(conversationId) ?? deleteConversationServer(conversationId);
     unawaited(deleteFuture.then((succeeded) {
+      // A DELETE can outlive sign-out/account switching. Its result belongs
+      // to the session that started it; never let an old account mutate the
+      // new provider's tombstones, cursor, revision, or loading state.
+      if (generation != _sessionGeneration) return;
       // Only rebase the server cursor after the backend confirms deletion. A
       // failed DELETE leaves the row in the server sequence and must not make
       // the next page skip an item.

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -14,6 +14,7 @@ import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/utils/logger.dart';
 
 typedef ConversationListFetcher = Future<({List<ServerConversation> items, bool ok})> Function();
+typedef ConversationLifecycleFetcher = Future<({ServerConversation? item, bool ok})> Function(String id);
 typedef DailySummariesChecker = Future<bool> Function();
 typedef ConversationSearchFetcher = Future<(List<ServerConversation>, int, int)> Function(
   String query, {
@@ -95,6 +96,7 @@ class ConversationProvider extends ChangeNotifier {
   bool get hasActiveSearch => previousQuery.isNotEmpty || selectedSpeakerId != null;
 
   final ConversationListFetcher? _conversationListFetcher;
+  final ConversationLifecycleFetcher _conversationLifecycleFetcher;
   final DailySummariesChecker? _dailySummariesChecker;
   final ConversationSearchFetcher _conversationSearchFetcher;
   final bool Function() _isSignedIn;
@@ -104,10 +106,12 @@ class ConversationProvider extends ChangeNotifier {
 
   ConversationProvider({
     ConversationListFetcher? conversationListFetcher,
+    ConversationLifecycleFetcher? conversationLifecycleFetcher,
     DailySummariesChecker? dailySummariesChecker,
     ConversationSearchFetcher? conversationSearchFetcher,
     bool Function()? isSignedIn,
   })  : _conversationListFetcher = conversationListFetcher,
+        _conversationLifecycleFetcher = conversationLifecycleFetcher ?? getConversationByIdResult,
         _dailySummariesChecker = dailySummariesChecker,
         _conversationSearchFetcher = conversationSearchFetcher ?? searchConversationsServer,
         _isSignedIn = isSignedIn ?? AuthService.instance.isSignedIn {
@@ -442,25 +446,18 @@ class ConversationProvider extends ChangeNotifier {
 
     List<ServerConversation> newConversations = result.items;
 
-    // A conversation the server no longer reports as processing must drop its
-    // "Processing" card. The websocket ConversationEvent that normally clears it
-    // can be missed (socket drop, app backgrounded on Android), and unlike
-    // fetchConversations this path never rebuilt processingConversations — so a
-    // stale card stayed pinned at the top of the list indefinitely.
-    final resolvedIds =
-        newConversations.where((c) => c.status != ConversationStatus.processing).map((c) => c.id).toSet();
-    if (resolvedIds.isNotEmpty) {
-      processingConversations.removeWhere((c) => resolvedIds.contains(c.id));
-    }
+    final processingIdsAtStart = _realProcessingConversationIds();
+    final pageConversationIds = newConversations.map((conversation) => conversation.id).toSet();
+    final lifecycleResults = await _loadProcessingLifecycleResults(newConversations, processingIdsAtStart);
+    if (generation != _sessionGeneration || !_isSignedIn()) return;
+    _reconcileProcessingConversations(lifecycleResults, processingIdsAtStart, pageConversationIds);
 
     List<ServerConversation> upsertConvos = [];
 
     // processing convos
     upsertConvos = newConversations
         .where(
-          (c) =>
-              c.status == ConversationStatus.processing &&
-              processingConversations.indexWhere((cc) => cc.id == c.id) == -1,
+          (c) => _isActiveProcessingStatus(c.status) && processingConversations.indexWhere((cc) => cc.id == c.id) == -1,
         )
         .toList();
     if (upsertConvos.isNotEmpty) {
@@ -534,13 +531,16 @@ class ConversationProvider extends ChangeNotifier {
     conversationsLoadFailed = false;
     _initialFetchRetryTimer?.cancel();
     _initialFetchRetryCount = 0;
-    conversations = _filterPendingDeletes(result.items);
+    final fetchedConversations = _filterPendingDeletes(result.items);
 
-    // processing convos
-    processingConversations = conversations.where((m) => m.status == ConversationStatus.processing).toList();
+    final processingIdsAtStart = _realProcessingConversationIds();
+    final pageConversationIds = fetchedConversations.map((conversation) => conversation.id).toSet();
+    final lifecycleResults = await _loadProcessingLifecycleResults(fetchedConversations, processingIdsAtStart);
+    if (generation != _sessionGeneration || !_isSignedIn()) return false;
+    _reconcileProcessingConversations(lifecycleResults, processingIdsAtStart, pageConversationIds);
 
     // completed convos
-    conversations = conversations.where((m) => m.status == ConversationStatus.completed).toList();
+    conversations = fetchedConversations.where((m) => m.status == ConversationStatus.completed).toList();
 
     // Only use cache when no folder filter is applied
     if (conversations.isEmpty && selectedFolderId == null) {
@@ -744,6 +744,68 @@ class ConversationProvider extends ChangeNotifier {
       folderId: selectedFolderId,
       starred: showStarredOnly ? true : null,
     );
+  }
+
+  bool _isActiveProcessingStatus(ConversationStatus status) {
+    return status == ConversationStatus.processing || status == ConversationStatus.merging;
+  }
+
+  Set<String> _realProcessingConversationIds() =>
+      processingConversations.map((conversation) => conversation.id).where((id) => id != '0').toSet();
+
+  Future<Map<String, ({ServerConversation? item, bool ok})>> _loadProcessingLifecycleResults(
+    List<ServerConversation> pageItems,
+    Set<String> processingIdsAtStart,
+  ) async {
+    final results = <String, ({ServerConversation? item, bool ok})>{
+      for (final conversation in pageItems) conversation.id: (item: conversation, ok: true),
+    };
+    await Future.wait(
+      processingIdsAtStart.where((id) => !results.containsKey(id)).map((id) async {
+        try {
+          results[id] = await _conversationLifecycleFetcher(id);
+        } catch (_) {
+          results[id] = (item: null, ok: false);
+        }
+      }),
+    );
+    return results;
+  }
+
+  void _reconcileProcessingConversations(
+    Map<String, ({ServerConversation? item, bool ok})> lifecycleResults,
+    Set<String> processingIdsAtStart,
+    Set<String> pageConversationIds,
+  ) {
+    final localPlaceholder = processingConversations.where((conversation) => conversation.id == '0').toList();
+    final reconciled = <ServerConversation>[];
+
+    for (final existing in processingConversations.where((conversation) => conversation.id != '0')) {
+      final result = lifecycleResults[existing.id];
+      if (result == null || !result.ok) {
+        reconciled.add(existing);
+        continue;
+      }
+      final current = result.item;
+      if (current != null && _isActiveProcessingStatus(current.status)) {
+        reconciled.add(current);
+      }
+    }
+
+    for (final result in lifecycleResults.values) {
+      final conversation = result.item;
+      if (!result.ok || conversation == null || !_isActiveProcessingStatus(conversation.status)) continue;
+      // Previously tracked IDs are owned by the live-list loop above. If a
+      // websocket completion removed one while lifecycle GETs were in flight,
+      // a stale detail response must not revive it here. This loop only admits
+      // newly discovered active rows from the authoritative list page.
+      if (processingIdsAtStart.contains(conversation.id) || !pageConversationIds.contains(conversation.id)) continue;
+      if (reconciled.every((existing) => existing.id != conversation.id)) {
+        reconciled.add(conversation);
+      }
+    }
+
+    processingConversations = [...localPlaceholder, ...reconciled];
   }
 
   void updateActionItemState(String convoId, bool state, int i, DateTime date) {

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -1279,6 +1279,7 @@ class ConversationProvider extends ChangeNotifier {
     }, onError: (Object _, StackTrace __) {
       // Match the prior behavior on a failed request: release the local
       // tombstone, but do not rebase the server cursor.
+      if (generation != _sessionGeneration) return;
       _clearDeleteTombstone(conversationId);
       notifyListeners();
     }));

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -186,6 +186,7 @@ class SpeechProfileProvider extends ChangeNotifier
       throw Exception("Can not create new speech profile socket");
     }
     _socket?.subscribe(this, this);
+    await _socket?.requestFirstOnboardingQuestion();
   }
 
   /// Start phone microphone streaming (alternative to BLE device streaming).

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -31,6 +31,12 @@ List<SyncedConversationPointer> sortSyncedConversationPointers(Iterable<SyncedCo
 }
 
 class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSyncProgressListener {
+  /// Machine-readable error state consumed by sync surfaces, which own the
+  /// localized copy. Providers must not embed user-facing English in state.
+  static const pendingUploadErrorCode = 'sync_pending_upload';
+
+  static bool isPendingUploadError(String? message) => message == pendingUploadErrorCode;
+
   // Services
   final AudioPlayerUtils _audioPlayerUtils = AudioPlayerUtils.instance;
   final IWalService? _walServiceOverride;
@@ -681,7 +687,9 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     } else if (baseMessage.toLowerCase().contains('temporarily unavailable')) {
       baseMessage = 'Server is temporarily unavailable. Try again later';
     } else if (baseMessage.toLowerCase().contains('upload failed')) {
-      baseMessage = 'Omi could not upload or process this recording. It remains pending; try again';
+      // Keep state locale-neutral; the sync pages resolve this code through
+      // AppLocalizations at render time.
+      return pendingUploadErrorCode;
     }
 
     if (wal != null) {

--- a/app/lib/providers/sync_provider.dart
+++ b/app/lib/providers/sync_provider.dart
@@ -625,12 +625,10 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
       if (permanentFailures > 0) {
         final hint = result?.localUploadPermanentError;
         final errorMessage = _formatSyncError(
-          hint != null ? Exception(hint) : Exception('Upload failed. Check your connection and try again'),
+          hint != null ? Exception(hint) : Exception('Upload failed unexpectedly'),
           failedWal,
         );
-        DebugLogManager.logWarning(
-          'SyncProvider: $context had $permanentFailures permanent local upload failure(s)',
-        );
+        DebugLogManager.logWarning('SyncProvider: $context had $permanentFailures permanent local upload failure(s)');
         _updateSyncState(_syncState.toError(message: errorMessage, failedWal: failedWal));
       } else if (localFailures > 0) {
         DebugLogManager.logWarning(
@@ -683,7 +681,7 @@ class SyncProvider extends ChangeNotifier implements IWalServiceListener, IWalSy
     } else if (baseMessage.toLowerCase().contains('temporarily unavailable')) {
       baseMessage = 'Server is temporarily unavailable. Try again later';
     } else if (baseMessage.toLowerCase().contains('upload failed')) {
-      baseMessage = 'Upload failed. Check your connection and try again';
+      baseMessage = 'Omi could not upload or process this recording. It remains pending; try again';
     }
 
     if (wal != null) {

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -115,7 +115,7 @@ class NativeBleTransport extends DeviceTransport {
   @override
   Future<bool> isConnected() async {
     try {
-      return _hostApi.isPeripheralConnected(_peripheralUuid);
+      return await _hostApi.isPeripheralConnected(_peripheralUuid);
     } catch (e) {
       return false;
     }
@@ -124,7 +124,7 @@ class NativeBleTransport extends DeviceTransport {
   @override
   Future<bool> ping() async {
     try {
-      return _hostApi.isPeripheralConnected(_peripheralUuid);
+      return await _hostApi.isPeripheralConnected(_peripheralUuid);
     } catch (e) {
       return false;
     }

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -187,6 +187,10 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
     return;
   }
 
+  Future requestFirstOnboardingQuestion() async {
+    await sendText(jsonEncode({'type': 'start_onboarding'}));
+  }
+
   @override
   void onClosed([int? closeCode]) {
     _listeners.forEach((k, v) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1192,10 +1192,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   intl_country_data:
     dependency: "direct main"
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "93.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "10.0.1"
   ansicolor:
     dependency: transitive
     description:
@@ -149,18 +149,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
@@ -169,30 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.1"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.2"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -357,10 +341,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.7"
   dartx:
     dependency: transitive
     description:
@@ -413,18 +397,18 @@ packages:
     dependency: "direct main"
     description:
       name: envied
-      sha256: a4e2b1d0caa479b5d61332ae516518c175a6d09328a35a0bc0a53894cc5d7e4d
+      sha256: "58e4c620ae2efd25d0a822cf364858e56bdd2767ecafde272cd8b5e7343dcd50"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.8"
   envied_generator:
     dependency: "direct dev"
     description:
       name: envied_generator
-      sha256: "894f6c5eb624c60a1ce6f642b6fd7ec68bc3440aa6f1881837aa9acbbeade0c8"
+      sha256: b8d7552641f81b511b9b69492135801a3c3a945e2af609ad817ff1fc9bd997e2
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.3.8"
   equatable:
     dependency: transitive
     description:
@@ -695,18 +679,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: "3eaa2d3d8be58267ac4cd5e215ac965dd23cae0410dc073de2e82e227be32bfc"
+      sha256: "8ccb1f809642b34eb4857d8d7c4e5b41430a8cba8206177aae2ffe9d72b5eef3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.15.0"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: e74b4ead01df3e8f02e73a26ca856759dbbe8cb3fd60941ba9f4005cd0cd19c9
+      sha256: "2b0fff517a75a14ed2eff749c1da2d6b8b568e542ad2b1c967356669a4c29bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.15.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -850,14 +834,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
-  frontend_server_client:
-    dependency: transitive
-    description:
-      name: frontend_server_client
-      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -1225,18 +1201,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct main"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.14.1"
   just_audio:
     dependency: "direct main"
     description:
@@ -1393,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1700,10 +1676,10 @@ packages:
     dependency: "direct dev"
     description:
       name: pigeon
-      sha256: fe36bc5ad43ab7f4d8a9d974850aef1148f6d88a53bd14b3d87475ec403a3cdb
+      sha256: "04cfefc8add8b47ddf9ccac8b92bb4edeb67c87f185c623ba0db118ac99334ad"
       url: "https://pub.dev"
     source: hosted
-    version: "26.1.0"
+    version: "26.3.4"
   platform:
     dependency: transitive
     description:
@@ -2001,18 +1977,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "4.2.4"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: a447acb083d3a5ef17f983dd36201aeea33fedadb3228fa831f2f0c92f0f3aca
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.7"
+    version: "1.3.13"
   source_span:
     dependency: transitive
     description:
@@ -2153,10 +2129,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   time:
     dependency: transitive
     description:
@@ -2173,14 +2149,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.7.1"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   tuple:
     dependency: "direct main"
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -1192,10 +1192,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   intl_country_data:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -79,14 +79,14 @@ dependencies:
   uuid: ^4.4.0
   tuple: ^2.0.2
   googleapis_auth: 2.0.0
-  envied: 1.1.1
+  envied: 1.3.8
   awesome_notifications_core: ^0.9.3
   awesome_notifications: any
   nordic_dfu: ^6.1.4+hotfix
   mcumgr_flutter: ^0.4.2
   flutter_archive: ^6.0.3
-  json_annotation: ^4.9.0
-  json_serializable: ^6.9.5
+  json_annotation: ^4.12.0
+  json_serializable: ^6.14.1
   package_info_plus: ^8.0.1
   device_info_plus: ^11.5.0
   path_provider: 2.1.5
@@ -160,10 +160,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   fake_async: ^1.3.3
-  envied_generator: 1.1.1
-  build_runner: ^2.4.15
+  envied_generator: 1.3.8
+  build_runner: ^2.15.1
   flutter_flavorizr: ^2.2.3
-  flutter_gen_runner: 5.10.0
+  flutter_gen_runner: 5.15.0
   pigeon: ^26.0.1
 
 flutter_launcher_icons:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -60,7 +60,7 @@ dependencies:
   collection: ^1.19.1
   http: ^1.4.0
   pdf: ^3.11.0
-  intl: ^0.20.3
+  intl: ^0.20.2
   permission_handler: ^12.0.0+1
   flutter_contacts: ^1.1.9+2
   intl_country_data:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -60,7 +60,7 @@ dependencies:
   collection: ^1.19.1
   http: ^1.4.0
   pdf: ^3.11.0
-  intl: 0.20.2
+  intl: ^0.20.3
   permission_handler: ^12.0.0+1
   flutter_contacts: ^1.1.9+2
   intl_country_data:

--- a/app/test/providers/conversation_provider_processing_reconcile_test.dart
+++ b/app/test/providers/conversation_provider_processing_reconcile_test.dart
@@ -7,6 +7,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/pages/conversations/conversations_page.dart';
 
 void main() {
   setUp(() async {
@@ -352,6 +353,490 @@ void main() {
     await fetch;
 
     expect(provider.conversations.single.structured.title, 'Live');
+  });
+
+  test('successful lifecycle completion publishes detail when page still says processing', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.processing, title: 'Stale')], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.completed, title: 'Completed'), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.fetchConversations();
+
+    expect(provider.processingConversations, isEmpty);
+    expect(provider.conversations.single.structured.title, 'Completed');
+  });
+
+  test('background refresh publishes lifecycle completion when page still says processing', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.processing, title: 'Stale')], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.completed, title: 'Completed'), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+    expect(provider.conversations.single.structured.title, 'Completed');
+  });
+
+  test('background refresh replaces stale same-id completed object with lifecycle detail', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.processing, title: 'Page')], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.completed, title: 'Detail'), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.conversations = [_conversation('c1', status: ConversationStatus.completed, title: 'Old')];
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.conversations.single.structured.title, 'Detail');
+  });
+
+  test('background refresh does not publish stale lifecycle completion over newer processing start', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.processing, title: 'Page')], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'Old'));
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'New'));
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.completed), ok: true));
+    await refresh;
+
+    expect(provider.processingConversations.single.structured.title, 'New');
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('full fetch does not publish stale page completion over newer processing start', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.completed, title: 'Page')], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'Old'));
+
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'New'));
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.completed), ok: true));
+    await fetch;
+
+    expect(provider.processingConversations.single.structured.title, 'New');
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('cache fallback does not resurrect a row still marked processing', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.completed, title: 'Page')], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    final cached = _conversation('c1', status: ConversationStatus.completed, title: 'Cached');
+    SharedPreferencesUtil().cachedConversations = [cached];
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'Old'));
+
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'New'));
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.completed), ok: true));
+    await fetch;
+
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('failed fetch cache fallback does not resurrect a row still marked processing', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: false),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    SharedPreferencesUtil().cachedConversations = [
+      _conversation('c1', status: ConversationStatus.completed, title: 'Cached'),
+    ];
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    final fetched = await provider.fetchConversations();
+
+    expect(fetched, isFalse);
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('live completion overlay does not disable the next server page', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final firstPage = List<ServerConversation>.generate(
+      50,
+      (index) => _conversation('page-$index', status: ConversationStatus.completed),
+    );
+    var requestedOffset = -1;
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: firstPage, ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    provider.conversationPageFetcherOverride = () async {
+      requestedOffset = provider.conversationServerOffset;
+      return (items: <ServerConversation>[], ok: true);
+    };
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('off-page', status: ConversationStatus.processing));
+
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+    await provider.addConversation(_conversation('live', status: ConversationStatus.completed, title: 'Live'));
+    lifecycle.complete((item: _conversation('off-page', status: ConversationStatus.processing), ok: true));
+    await fetch;
+
+    expect(provider.conversations, hasLength(51));
+    expect(provider.hasMoreConversations, isTrue);
+    expect(provider.conversationServerOffset, 50);
+    await provider.getMoreConversationsFromServer();
+    expect(requestedOffset, 50);
+  });
+
+  test('failed load-more preserves cursor for a retry and deduplicates boundary rows', () async {
+    var calls = 0;
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (
+        items: List<ServerConversation>.generate(
+          50,
+          (index) => _conversation('page-$index', status: ConversationStatus.completed),
+        ),
+        ok: true
+      ),
+      isSignedIn: () => true,
+    );
+    provider.conversationPageFetcherOverride = () async {
+      calls++;
+      if (calls == 1) return (items: <ServerConversation>[], ok: false);
+      return (
+        items: [
+          _conversation('page-49', status: ConversationStatus.completed),
+          _conversation('page-50', status: ConversationStatus.completed),
+        ],
+        ok: true
+      );
+    };
+    addTearDown(provider.dispose);
+
+    await provider.fetchConversations();
+    await provider.getMoreConversationsFromServer();
+    expect(provider.conversationServerOffset, 50);
+    await provider.getMoreConversationsFromServer();
+
+    expect(calls, 2);
+    expect(provider.conversationServerOffset, 52);
+    expect(provider.conversations.where((conversation) => conversation.id == 'page-49'), hasLength(1));
+    expect(provider.conversations.where((conversation) => conversation.id == 'page-50'), hasLength(1));
+  });
+
+  test('background refresh does not rewind a loaded page cursor', () async {
+    var requestedOffsets = <int>[];
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (
+        items: List<ServerConversation>.generate(
+          50,
+          (index) => _conversation('page-$index', status: ConversationStatus.completed),
+        ),
+        ok: true
+      ),
+      isSignedIn: () => true,
+    );
+    provider.conversationPageFetcherOverride = () async {
+      requestedOffsets.add(provider.conversationServerOffset);
+      return (
+        items: List<ServerConversation>.generate(
+          50,
+          (index) => _conversation('next-$index', status: ConversationStatus.completed),
+        ),
+        ok: true
+      );
+    };
+    addTearDown(provider.dispose);
+
+    await provider.fetchConversations();
+    await provider.getMoreConversationsFromServer();
+    await provider.forceRefreshConversations();
+    await provider.getMoreConversationsFromServer();
+
+    expect(requestedOffsets, [50, 100]);
+  });
+
+  test('successful delete rebases cursor for a loaded row, not an unloaded row', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (
+        items: List<ServerConversation>.generate(
+          50,
+          (index) => _conversation('page-$index', status: ConversationStatus.completed),
+        ),
+        ok: true
+      ),
+      isSignedIn: () => true,
+    );
+    provider.conversationDeleteFetcherOverride = (_) async => true;
+    addTearDown(provider.dispose);
+
+    await provider.fetchConversations();
+    expect(provider.conversationServerOffset, 50);
+    provider.deleteConversationOnServer('page-10');
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.conversationServerOffset, 49);
+    provider.deleteConversationOnServer('never-loaded');
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.conversationServerOffset, 49);
+  });
+
+  test('failed delete does not rebase the server cursor', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (
+        items: List<ServerConversation>.generate(
+          50,
+          (index) => _conversation('page-$index', status: ConversationStatus.completed),
+        ),
+        ok: true
+      ),
+      isSignedIn: () => true,
+    );
+    provider.conversationDeleteFetcherOverride = (_) async => false;
+    addTearDown(provider.dispose);
+
+    await provider.fetchConversations();
+    provider.deleteConversationOnServer('page-10');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.conversationServerOffset, 50);
+  });
+
+  test('pending delete tombstone hides a row until DELETE settles', () async {
+    final delete = Completer<bool>();
+    final conversation = _conversation('page-10', status: ConversationStatus.completed);
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: [conversation], ok: true),
+      isSignedIn: () => true,
+    );
+    provider.conversationDeleteFetcherOverride = (_) => delete.future;
+    addTearDown(provider.dispose);
+
+    provider.conversations = [conversation];
+    provider.memoriesToDelete[conversation.id] = conversation;
+    provider.deleteConversationOnServer(conversation.id);
+
+    await provider.fetchConversations();
+    expect(provider.conversations, isEmpty);
+    expect(provider.memoriesToDelete, contains(conversation.id));
+
+    delete.complete(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.memoriesToDelete, isEmpty);
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('background refresh does not reinsert a row while DELETE is pending', () async {
+    final delete = Completer<bool>();
+    final conversation = _conversation('c1', status: ConversationStatus.completed);
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: [conversation], ok: true),
+      isSignedIn: () => true,
+    );
+    provider.conversationDeleteFetcherOverride = (_) => delete.future;
+    addTearDown(provider.dispose);
+
+    provider.conversations = [conversation];
+    provider.deleteConversationLocally(conversation, conversationLocalDayKey(conversation.createdAt));
+    provider.deleteConversationOnServer(conversation.id);
+
+    await provider.forceRefreshConversations();
+    expect(provider.conversations, isEmpty);
+    expect(provider.memoriesToDelete, contains(conversation.id));
+
+    delete.complete(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.memoriesToDelete, isEmpty);
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('stale full fetch is discarded after a confirmed delete', () async {
+    final page = Completer<({List<ServerConversation> items, bool ok})>();
+    final conversation = _conversation('c1', status: ConversationStatus.completed);
+    final provider = ConversationProvider(
+      conversationListFetcher: () => page.future,
+      isSignedIn: () => true,
+    );
+    final delete = Completer<bool>();
+    provider.conversationDeleteFetcherOverride = (_) => delete.future;
+    addTearDown(provider.dispose);
+    provider.conversations = [conversation];
+    provider.memoriesToDelete[conversation.id] = conversation;
+    final fetch = provider.fetchConversations();
+    provider.deleteConversationOnServer(conversation.id);
+    delete.complete(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.isLoadingConversations, isFalse);
+    page.complete((items: [conversation], ok: true));
+    await fetch;
+    expect(provider.conversations, isEmpty);
+    expect(provider.isLoadingConversations, isFalse);
+  });
+
+  test('stale background fetch is discarded after a confirmed delete', () async {
+    final page = Completer<({List<ServerConversation> items, bool ok})>();
+    final conversation = _conversation('c1', status: ConversationStatus.completed);
+    final provider = ConversationProvider(
+      conversationListFetcher: () => page.future,
+      isSignedIn: () => true,
+    );
+    final delete = Completer<bool>();
+    provider.conversationDeleteFetcherOverride = (_) => delete.future;
+    addTearDown(provider.dispose);
+    provider.conversations = [conversation];
+    provider.memoriesToDelete[conversation.id] = conversation;
+    final refresh = provider.forceRefreshConversations();
+    provider.deleteConversationOnServer(conversation.id);
+    delete.complete(true);
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.isLoadingConversations, isFalse);
+    page.complete((items: [conversation], ok: true));
+    await refresh;
+    expect(provider.conversations, isEmpty);
+  });
+
+  test('older overlapping full fetch cannot overwrite newer fetch', () async {
+    final first = Completer<({List<ServerConversation> items, bool ok})>();
+    final second = Completer<({List<ServerConversation> items, bool ok})>();
+    var calls = 0;
+    final provider = ConversationProvider(
+      conversationListFetcher: () => ++calls == 1 ? first.future : second.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    final older = provider.fetchConversations();
+    final newer = provider.fetchConversations();
+    second.complete((items: [_conversation('new', status: ConversationStatus.completed)], ok: true));
+    await newer;
+    expect(provider.conversations.map((item) => item.id), ['new']);
+    first.complete((items: [_conversation('old', status: ConversationStatus.completed)], ok: true));
+    await older;
+    expect(provider.conversations.map((item) => item.id), ['new']);
+    expect(provider.isLoadingConversations, isFalse);
+  });
+
+  test('full fetch owns loading over an in-flight load-more request', () async {
+    final page = Completer<({List<ServerConversation> items, bool ok})>();
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final firstPage = List<ServerConversation>.generate(
+      50,
+      (index) => _conversation('page-$index', status: ConversationStatus.completed),
+    );
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: firstPage, ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    provider.conversationPageFetcherOverride = () => page.future;
+    addTearDown(provider.dispose);
+    await provider.fetchConversations();
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    final more = provider.getMoreConversationsFromServer();
+    final refresh = provider.fetchConversations();
+    page.complete((items: [_conversation('page-50', status: ConversationStatus.completed)], ok: true));
+    await more;
+    expect(provider.isLoadingConversations, isTrue);
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.processing), ok: true));
+    await refresh;
+    expect(provider.isLoadingConversations, isFalse);
+  });
+
+  test('load-more filter key changes when short or discarded filters change', () {
+    final base = conversationLoadMoreFilterKey(
+      query: '',
+      folderId: null,
+      speakerId: null,
+      date: null,
+      starredOnly: false,
+      discarded: false,
+      shortOnly: false,
+      shortThreshold: 0,
+    );
+    expect(
+      conversationLoadMoreFilterKey(
+        query: '',
+        folderId: null,
+        speakerId: null,
+        date: null,
+        starredOnly: false,
+        discarded: true,
+        shortOnly: false,
+        shortThreshold: 0,
+      ),
+      isNot(base),
+    );
+    expect(
+      conversationLoadMoreFilterKey(
+        query: '',
+        folderId: null,
+        speakerId: null,
+        date: null,
+        starredOnly: false,
+        discarded: false,
+        shortOnly: true,
+        shortThreshold: 30,
+      ),
+      isNot(base),
+    );
+  });
+
+  test('failed page request releases the UI latch for the same offset retry', () {
+    expect(
+      shouldReleaseConversationLoadMoreLatch(
+        currentRequestKey: 'offset:50',
+        requestKey: 'offset:50',
+        succeeded: false,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldReleaseConversationLoadMoreLatch(
+        currentRequestKey: 'offset:50',
+        requestKey: 'offset:50',
+        succeeded: true,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldReleaseConversationLoadMoreLatch(
+        currentRequestKey: 'offset:100',
+        requestKey: 'offset:50',
+        succeeded: false,
+      ),
+      isFalse,
+    );
   });
 
   test('loading stays active until lifecycle reconciliation assigns the page', () async {

--- a/app/test/providers/conversation_provider_processing_reconcile_test.dart
+++ b/app/test/providers/conversation_provider_processing_reconcile_test.dart
@@ -21,6 +21,8 @@ void main() {
     final provider = ConversationProvider(
       conversationListFetcher: () async =>
           (items: [_conversation('c1', status: ConversationStatus.completed)], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.completed), ok: true),
       isSignedIn: () => true,
     );
     addTearDown(provider.dispose);
@@ -66,6 +68,8 @@ void main() {
     final provider = ConversationProvider(
       conversationListFetcher: () async =>
           (items: [_conversation('c1', status: ConversationStatus.processing)], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.processing), ok: true),
       isSignedIn: () => true,
     );
     addTearDown(provider.dispose);
@@ -134,6 +138,53 @@ void main() {
     expect(provider.processingConversations.map((c) => c.id), ['c1']);
   });
 
+  test('timed-out tracked page lookup preserves the local processing card', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.completed)], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(const Duration(seconds: 3));
+    await refresh;
+
+    expect(provider.processingConversations.single.status, ConversationStatus.processing);
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.completed), ok: true));
+  });
+
+  test('lifecycle probes stop dequeuing after the deadline', () async {
+    final pending = <Completer<({ServerConversation? item, bool ok})>>[];
+    var calls = 0;
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) {
+        calls++;
+        final completer = Completer<({ServerConversation? item, bool ok})>();
+        pending.add(completer);
+        return completer.future;
+      },
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    for (var i = 0; i < 8; i++) {
+      provider.addProcessingConversation(_conversation('c$i', status: ConversationStatus.processing));
+    }
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(const Duration(seconds: 3));
+    await refresh;
+
+    expect(calls, 4);
+    for (final completer in pending) {
+      completer.complete((item: null, ok: false));
+    }
+  });
+
   test('authoritative missing lifecycle clears an absent real processing card', () async {
     final provider = ConversationProvider(
       conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
@@ -148,7 +199,97 @@ void main() {
     expect(provider.processingConversations, isEmpty);
   });
 
-  test('websocket completion during lifecycle lookup is not re-added by stale response', () async {
+  test('processingIdsAtStart prevents stale lifecycle data from reviving a completed row', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.completed)], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    // Remove the row as the websocket handler does, but mutate the public list
+    // directly here so this regression isolates the processingIdsAtStart guard
+    // from the separate removal-tombstone guard.
+    provider.processingConversations.removeWhere((conversation) => conversation.id == 'c1');
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.processing), ok: true));
+    await refresh;
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('websocket processing revision blocks a newly discovered stale page row', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('new', status: ConversationStatus.processing)], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('off-page', status: ConversationStatus.processing));
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    // The page row has not been admitted yet, so the websocket removal is a
+    // list no-op but still advances the state revision observed by refresh.
+    provider.removeProcessingConversation('new');
+    lifecycle.complete((item: _conversation('off-page', status: ConversationStatus.completed), ok: true));
+    await refresh;
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('websocket completion during list fetch blocks a stale processing page row', () async {
+    final page = Completer<({List<ServerConversation> items, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () => page.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.removeProcessingConversation('new');
+    page.complete((items: [_conversation('new', status: ConversationStatus.processing)], ok: true));
+    await refresh;
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('websocket processing start during list fetch keeps the newer live row', () async {
+    final page = Completer<({List<ServerConversation> items, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () => page.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.addProcessingConversation(_conversation('new', status: ConversationStatus.processing, title: 'Live'));
+    page.complete((items: [_conversation('new', status: ConversationStatus.processing, title: 'Stale')], ok: true));
+    await refresh;
+
+    expect(provider.processingConversations.single.structured.title, 'Live');
+  });
+
+  test('replayed processing start replaces the existing row instead of duplicating it', () async {
+    final provider = ConversationProvider(isSignedIn: () => true);
+    addTearDown(provider.dispose);
+
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'Old'));
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, title: 'Live'));
+
+    expect(provider.processingConversations, hasLength(1));
+    expect(provider.processingConversations.single.structured.title, 'Live');
+  });
+
+  test('full fetch preserves a websocket-completed row omitted by the stale page', () async {
     final lifecycle = Completer<({ServerConversation? item, bool ok})>();
     final provider = ConversationProvider(
       conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
@@ -158,11 +299,144 @@ void main() {
     addTearDown(provider.dispose);
     provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
 
-    final refresh = provider.forceRefreshConversations();
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+    // This is the websocket completion path: remove the processing card and
+    // publish the completed conversation while the stale fetch is waiting.
+    provider.removeProcessingConversation('c1');
+    await provider.addConversation(_conversation('c1', status: ConversationStatus.completed, title: 'Completed'));
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.completed), ok: true));
+    await fetch;
+
+    expect(provider.conversations.map((conversation) => conversation.id), ['c1']);
+    expect(provider.conversations.single.structured.title, 'Completed');
+  });
+
+  test('full fetch prefers websocket completion when stale page still has processing row', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.processing, title: 'Stale')], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    final fetch = provider.fetchConversations();
     await Future<void>.delayed(Duration.zero);
     provider.removeProcessingConversation('c1');
-    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.processing), ok: true));
-    await refresh;
+    await provider.addConversation(_conversation('c1', status: ConversationStatus.completed, title: 'Completed'));
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.completed), ok: true));
+    await fetch;
+
+    expect(provider.conversations.single.structured.title, 'Completed');
+  });
+
+  test('full fetch prefers changed websocket object over stale completed page row', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.completed, title: 'Stale')], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.conversations = [_conversation('c1', status: ConversationStatus.completed, title: 'Before')];
+    provider.addProcessingConversation(_conversation('off-page', status: ConversationStatus.processing));
+
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.updateConversation(_conversation('c1', status: ConversationStatus.completed, title: 'Live'));
+    lifecycle.complete((item: null, ok: false));
+    await fetch;
+
+    expect(provider.conversations.single.structured.title, 'Live');
+  });
+
+  test('loading stays active until lifecycle reconciliation assigns the page', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('off-page', status: ConversationStatus.processing));
+
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.isLoadingConversations, isTrue);
+    lifecycle.complete((item: _conversation('off-page', status: ConversationStatus.completed), ok: true));
+    await fetch;
+    expect(provider.isLoadingConversations, isFalse);
+  });
+
+  test('processing cards obey the active folder filter', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.processing, folderId: 'other'), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.selectedFolderId = 'selected';
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, folderId: 'other'));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('processing cards obey the active date filter', () async {
+    final selectedDate = DateTime(2026, 1, 2);
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async => (
+        item: _conversation('c1', status: ConversationStatus.processing, createdAt: DateTime.utc(2026, 1, 1)),
+        ok: true
+      ),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.selectedDate = selectedDate;
+    provider.addProcessingConversation(
+      _conversation('c1', status: ConversationStatus.processing, createdAt: DateTime.utc(2026, 1, 1)),
+    );
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('processing cards obey the starred filter', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.processing, starred: false), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.showStarredOnly = true;
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, starred: false));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('processing cards obey the discarded filter', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.processing, discarded: true), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.showDiscardedConversations = false;
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing, discarded: true));
+
+    await provider.forceRefreshConversations();
 
     expect(provider.processingConversations, isEmpty);
   });
@@ -193,9 +467,21 @@ void main() {
   });
 }
 
-ServerConversation _conversation(String id, {required ConversationStatus status}) => ServerConversation(
+ServerConversation _conversation(
+  String id, {
+  required ConversationStatus status,
+  DateTime? createdAt,
+  bool discarded = false,
+  bool starred = false,
+  String? folderId,
+  String title = 'Title',
+}) =>
+    ServerConversation(
       id: id,
-      createdAt: DateTime.utc(2026),
-      structured: Structured('Title', 'Overview'),
+      createdAt: createdAt ?? DateTime.utc(2026),
+      structured: Structured(title, 'Overview'),
       status: status,
+      discarded: discarded,
+      starred: starred,
+      folderId: folderId,
     );

--- a/app/test/providers/conversation_provider_processing_reconcile_test.dart
+++ b/app/test/providers/conversation_provider_processing_reconcile_test.dart
@@ -701,6 +701,28 @@ void main() {
     expect(provider.conversations.single, same(newConversation));
   });
 
+  test('delete failure from a prior session cannot mutate the new session', () async {
+    final delete = Completer<bool>();
+    final provider = ConversationProvider(isSignedIn: () => true);
+    provider.conversationDeleteFetcherOverride = (_) => delete.future;
+    addTearDown(provider.dispose);
+
+    final oldConversation = _conversation('c1', status: ConversationStatus.completed, title: 'Old account');
+    provider.memoriesToDelete[oldConversation.id] = oldConversation;
+    provider.deleteConversationOnServer(oldConversation.id);
+
+    provider.clearUserData();
+    final newConversation = _conversation('c1', status: ConversationStatus.completed, title: 'New account');
+    provider.memoriesToDelete[newConversation.id] = newConversation;
+    provider.conversations = [newConversation];
+
+    delete.completeError(StateError('old session delete failed'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.memoriesToDelete[newConversation.id], same(newConversation));
+    expect(provider.conversations.single, same(newConversation));
+  });
+
   test('pending delete tombstone hides a row until DELETE settles', () async {
     final delete = Completer<bool>();
     final conversation = _conversation('page-10', status: ConversationStatus.completed);

--- a/app/test/providers/conversation_provider_processing_reconcile_test.dart
+++ b/app/test/providers/conversation_provider_processing_reconcile_test.dart
@@ -65,6 +65,26 @@ void main() {
     expect(provider.processingConversations, isEmpty);
   });
 
+  test('locked lifecycle detail is terminal and clears the processing card', () async {
+    // The list endpoint returns a redacted completed row for locked
+    // conversations while the detail endpoint returns 402. The HTTP adapter
+    // maps that 402 to an authoritative null result (ok: true), which must
+    // not leave the Processing card pinned forever.
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('c1', status: ConversationStatus.completed)], ok: true),
+      conversationLifecycleFetcher: (_) async => (item: null, ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+    expect(provider.conversations.map((conversation) => conversation.id), ['c1']);
+  });
+
   test('refresh keeps processing cards the server still reports as processing', () async {
     final provider = ConversationProvider(
       conversationListFetcher: () async =>
@@ -243,6 +263,33 @@ void main() {
     await refresh;
 
     expect(provider.processingConversations, isEmpty);
+  });
+
+  test('unrelated websocket transition does not suppress a newly discovered row', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('new', status: ConversationStatus.processing)], ok: true),
+      conversationLifecycleFetcher: (id) {
+        if (id == 'unrelated') {
+          return Future.value((item: _conversation('unrelated', status: ConversationStatus.completed), ok: true));
+        }
+        return lifecycle.future;
+      },
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('unrelated', status: ConversationStatus.processing));
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    // This unrelated completion must not suppress the newly discovered page
+    // row, which has no websocket mutation of its own.
+    provider.removeProcessingConversation('unrelated');
+    lifecycle.complete((item: _conversation('new', status: ConversationStatus.processing), ok: true));
+    await refresh;
+
+    expect(provider.processingConversations.map((conversation) => conversation.id), ['new']);
   });
 
   test('websocket completion during list fetch blocks a stale processing page row', () async {
@@ -630,6 +677,28 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(provider.conversationServerOffset, 50);
+  });
+
+  test('delete completion from a prior session cannot mutate the new session', () async {
+    final delete = Completer<bool>();
+    final provider = ConversationProvider(isSignedIn: () => true);
+    provider.conversationDeleteFetcherOverride = (_) => delete.future;
+    addTearDown(provider.dispose);
+
+    final oldConversation = _conversation('c1', status: ConversationStatus.completed, title: 'Old account');
+    provider.memoriesToDelete[oldConversation.id] = oldConversation;
+    provider.deleteConversationOnServer(oldConversation.id);
+
+    provider.clearUserData();
+    final newConversation = _conversation('c1', status: ConversationStatus.completed, title: 'New account');
+    provider.memoriesToDelete[newConversation.id] = newConversation;
+    provider.conversations = [newConversation];
+
+    delete.complete(true);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.memoriesToDelete[newConversation.id], same(newConversation));
+    expect(provider.conversations.single, same(newConversation));
   });
 
   test('pending delete tombstone hides a row until DELETE settles', () async {

--- a/app/test/providers/conversation_provider_processing_reconcile_test.dart
+++ b/app/test/providers/conversation_provider_processing_reconcile_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -30,6 +32,36 @@ void main() {
     expect(provider.conversations.map((c) => c.id), contains('c1'));
   });
 
+  test('refresh clears the processing card when lifecycle rolls back to in progress', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.in_progress), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('refresh clears the processing card when lifecycle failed', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.failed), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
   test('refresh keeps processing cards the server still reports as processing', () async {
     final provider = ConversationProvider(
       conversationListFetcher: () async =>
@@ -42,6 +74,21 @@ void main() {
     await provider.forceRefreshConversations();
 
     expect(provider.processingConversations.map((c) => c.id), ['c1']);
+  });
+
+  test('refresh keeps cards the server reports as merging', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async =>
+          (item: _conversation('c1', status: ConversationStatus.merging), ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations.single.status, ConversationStatus.merging);
   });
 
   test('refresh keeps a local placeholder card the server does not know about', () async {
@@ -71,6 +118,78 @@ void main() {
     await provider.forceRefreshConversations();
 
     expect(provider.processingConversations.map((c) => c.id), ['c1']);
+  });
+
+  test('failed lifecycle lookup leaves an absent processing card untouched', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async => (item: null, ok: false),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations.map((c) => c.id), ['c1']);
+  });
+
+  test('authoritative missing lifecycle clears an absent real processing card', () async {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) async => (item: null, ok: true),
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    await provider.forceRefreshConversations();
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('websocket completion during lifecycle lookup is not re-added by stale response', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.addProcessingConversation(_conversation('c1', status: ConversationStatus.processing));
+
+    final refresh = provider.forceRefreshConversations();
+    await Future<void>.delayed(Duration.zero);
+    provider.removeProcessingConversation('c1');
+    lifecycle.complete((item: _conversation('c1', status: ConversationStatus.processing), ok: true));
+    await refresh;
+
+    expect(provider.processingConversations, isEmpty);
+  });
+
+  test('full fetch does not publish processing rows into the completed list while lifecycle lookup waits', () async {
+    final lifecycle = Completer<({ServerConversation? item, bool ok})>();
+    final provider = ConversationProvider(
+      conversationListFetcher: () async =>
+          (items: [_conversation('processing', status: ConversationStatus.processing)], ok: true),
+      conversationLifecycleFetcher: (_) => lifecycle.future,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    provider.conversations = [_conversation('existing', status: ConversationStatus.completed)];
+    provider.addProcessingConversation(_conversation('off-page', status: ConversationStatus.processing));
+
+    final fetch = provider.fetchConversations();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.conversations.map((conversation) => conversation.id), ['existing']);
+    lifecycle.complete((item: _conversation('off-page', status: ConversationStatus.completed), ok: true));
+    await fetch;
+
+    expect(
+      provider.conversations.where((conversation) => conversation.status != ConversationStatus.completed),
+      isEmpty,
+    );
   });
 }
 

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -197,7 +197,7 @@ void main() {
     provider.dispose();
   });
 
-  test('generic upload failure uses a locale-neutral code with localized retry copy', () async {
+  test('generic upload failure uses a locale-neutral code with terminal localized failure copy', () async {
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
     SyncRateLimiter.instance.clear();
@@ -211,8 +211,12 @@ void main() {
 
     expect(provider.syncError, SyncProvider.pendingUploadErrorCode);
     expect(SyncProvider.isPendingUploadError(provider.syncError), isTrue);
-    // The pages own this mapping so a provider state never ships English.
-    expect(AppLocalizationsEn().syncStatusRetrying, contains('retrying'));
+    // The pages own this mapping so a provider state never ships English. The
+    // terminal error card has an explicit Retry action; it must not claim that
+    // an automatic retry is already in progress.
+    final localizedFailure = AppLocalizationsEn().syncStatusFailed;
+    expect(localizedFailure, contains('Failed'));
+    expect(localizedFailure, isNot(contains('retrying')));
     expect(provider.syncError, isNot(contains('connection')));
     provider.dispose();
   });

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/l10n/app_localizations_en.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/wals/recording_transfer_coordinator.dart';
 import 'package:omi/services/wals/sync_rate_limiter.dart';
@@ -196,7 +197,7 @@ void main() {
     provider.dispose();
   });
 
-  test('generic upload failure says the recording remains pending without blaming connectivity', () async {
+  test('generic upload failure uses a locale-neutral code with localized retry copy', () async {
     SharedPreferences.setMockInitialValues({});
     await SharedPreferencesUtil.init();
     SyncRateLimiter.instance.clear();
@@ -208,7 +209,10 @@ void main() {
 
     await provider.syncWal(wal);
 
-    expect(provider.syncError, contains('remains pending'));
+    expect(provider.syncError, SyncProvider.pendingUploadErrorCode);
+    expect(SyncProvider.isPendingUploadError(provider.syncError), isTrue);
+    // The pages own this mapping so a provider state never ships English.
+    expect(AppLocalizationsEn().syncStatusRetrying, contains('retrying'));
     expect(provider.syncError, isNot(contains('connection')));
     provider.dispose();
   });

--- a/app/test/providers/sync_provider_sync_wal_wake_test.dart
+++ b/app/test/providers/sync_provider_sync_wal_wake_test.dart
@@ -17,6 +17,7 @@ class _FakeSyncs {
   int syncWalCalls = 0;
   SyncLocalFilesResponse? nextSyncResult;
   Completer<SyncLocalFilesResponse?>? hangSyncWal;
+  Object? nextError;
 
   _FakeSyncs(this.wals);
 
@@ -33,6 +34,7 @@ class _FakeSyncs {
 
   Future<SyncLocalFilesResponse?> syncWal({required Wal wal, IWalSyncProgressListener? progress}) async {
     syncWalCalls++;
+    if (nextError case final error?) throw error;
     final hang = hangSyncWal;
     if (hang != null) return hang.future;
     final result = nextSyncResult ?? SyncLocalFilesResponse(newConversationIds: [], updatedConversationIds: []);
@@ -133,10 +135,11 @@ void main() {
     expect(provider.syncState.isIdle, isTrue);
     expect(wal.status, WalStatus.miss);
     expect(
-      wakes,
-      [WakeTrigger.cooldownElapsed],
-      reason: 'transient localUploadFailures must emit exactly one re-arm wake from _performSync',
-    );
+        wakes,
+        [
+          WakeTrigger.cooldownElapsed,
+        ],
+        reason: 'transient localUploadFailures must emit exactly one re-arm wake from _performSync');
     provider.dispose();
   });
 
@@ -170,7 +173,43 @@ void main() {
     await provider.syncWal(wal);
 
     expect(provider.syncState.hasError, isTrue);
+    expect(provider.syncError, isNot(contains('connection')));
     expect(wakes, isEmpty, reason: 'permanent refusals must not soft-retry via cooldown wake');
+    provider.dispose();
+  });
+
+  test('server upload failure keeps its retry classification without blaming connectivity', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final syncs = _FakeSyncs([wal])..nextError = Exception('Server is temporarily unavailable');
+    final provider = SyncProvider(walService: _FakeWalService(syncs), startBackgroundSync: false);
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(provider.syncError, contains('Server is temporarily unavailable'));
+    expect(provider.syncError, contains('phone audio file'));
+    expect(provider.syncError, isNot(contains('connection')));
+    provider.dispose();
+  });
+
+  test('generic upload failure says the recording remains pending without blaming connectivity', () async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    SyncRateLimiter.instance.clear();
+
+    final wal = Wal(timerStart: 1000, codec: BleAudioCodec.pcm16, seconds: 30, status: WalStatus.miss);
+    final syncs = _FakeSyncs([wal])..nextError = Exception('Upload failed unexpectedly');
+    final provider = SyncProvider(walService: _FakeWalService(syncs), startBackgroundSync: false);
+    await provider.initialized;
+
+    await provider.syncWal(wal);
+
+    expect(provider.syncError, contains('remains pending'));
+    expect(provider.syncError, isNot(contains('connection')));
     provider.dispose();
   });
 

--- a/app/test/services/sockets/transcription_service_onboarding_test.dart
+++ b/app/test/services/sockets/transcription_service_onboarding_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/services/sockets/pure_socket.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+
+class _FakeSocket implements IPureSocket {
+  dynamic sentMessage;
+  IPureSocketListener? listener;
+
+  @override
+  PureSocketStatus get status => PureSocketStatus.connected;
+
+  @override
+  Future<bool> connect() async => true;
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  void onClosed() {}
+
+  @override
+  void onConnected() {}
+
+  @override
+  void onError(Object err, StackTrace trace) {}
+
+  @override
+  void onMessage(dynamic message) {}
+
+  @override
+  void send(dynamic message) => sentMessage = message;
+
+  @override
+  void setListener(IPureSocketListener listener) => this.listener = listener;
+
+  @override
+  Future<void> stop() async {}
+}
+
+void main() {
+  test('serializes the explicit onboarding start request', () async {
+    final socket = _FakeSocket();
+    final service = TranscriptSegmentSocketService.withSocket(16000, BleAudioCodec.pcm16, 'en', socket);
+
+    await service.requestFirstOnboardingQuestion();
+
+    expect(socket.sentMessage, '{"type":"start_onboarding"}');
+  });
+}

--- a/backend/.env.dev.template
+++ b/backend/.env.dev.template
@@ -69,6 +69,10 @@ HUME_CALLBACK_URL=
 HOSTED_PUSHER_API_URL=
 HOSTED_SPEAKER_EMBEDDING_API_URL=
 HOSTED_VAD_API_URL=
+# Bound hosted VAD so an unreachable service fails over to local ONNX well
+# before the sync-job stale deadline. Both values must be positive seconds.
+HOSTED_VAD_CONNECT_TIMEOUT_SECONDS=3
+HOSTED_VAD_READ_TIMEOUT_SECONDS=30
 HOSTED_SPEECH_PROFILE_API_URL=
 HOSTED_PARAKEET_API_URL=
 

--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -119,7 +119,7 @@ surfaces:
     test_guardrail_coverage: backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: file_chat_assistants
     code_path: backend/utils/other/chat_file.py:FileChatTool
-    current_provider_model: openai/gpt-5.6-luna with Assistants, Threads, Files, File Search
+    current_provider_model: openai/gpt-4.1 with Assistants, Threads, Files, File Search
     request_shape: file upload, assistants, file_search, streaming run deltas
     gateway_lane_capability_needed: gateway-owned file/assistant lifecycle or replacement retrieval path
     migration_status: acknowledged_direct_file_lifecycle_surface; intentionally remains direct during OMI_LLM_GATEWAY_FEATURE_MODE=gateway and records direct-exception telemetry without raising (PR #11419)

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -472,6 +472,8 @@ class ListenReceiver:
             except ValueError:
                 self.host.state.close_code = 1008
                 self.host.state.active = False
+        elif kind == 'start_onboarding' and self.host.onboarding_handler:
+            await self.host.onboarding_handler.start()
         elif kind == 'skip_question' and self.host.onboarding_handler and not self.host.onboarding_handler.completed:
             await self.host.onboarding_handler.skip_current_question()
         elif kind == 'suggested_transcript' and self.host.use_custom_stt:

--- a/backend/tests/unit/test_chat_file_vision_request.py
+++ b/backend/tests/unit/test_chat_file_vision_request.py
@@ -76,3 +76,34 @@ async def test_vision_chat_uses_luna_completion_budget_field(monkeypatch):
     assert request['model'] == 'gpt-5.6-luna'
     assert request['max_completion_tokens'] == 2048
     assert 'max_tokens' not in request
+
+
+def test_file_search_assistant_uses_assistants_compatible_model(monkeypatch):
+    assistant_request: dict[str, object] = {}
+
+    def create_assistant(**kwargs):
+        assistant_request.update(kwargs)
+        return SimpleNamespace(id='assistant-1')
+
+    monkeypatch.setattr(
+        chat_file.openai,
+        'beta',
+        SimpleNamespace(
+            threads=SimpleNamespace(create=lambda **_kwargs: SimpleNamespace(id='thread-1')),
+            assistants=SimpleNamespace(create=create_assistant),
+        ),
+    )
+    monkeypatch.setattr(chat_file.chat_db, 'update_chat_session_openai_ids', lambda *_args: None)
+
+    tool = object.__new__(chat_file.FileChatTool)
+    tool.uid = 'user-1'
+    tool.chat_session_id = 'session-1'
+    tool.thread_id = None
+    tool.assistant_id = None
+
+    tool._ensure_thread_and_assistant()
+
+    assert tool.thread_id == 'thread-1'
+    assert tool.assistant_id == 'assistant-1'
+    assert assistant_request['model'] == 'gpt-4.1'
+    assert assistant_request['tools'] == [{'type': 'file_search'}]

--- a/backend/tests/unit/test_chat_file_vision_request.py
+++ b/backend/tests/unit/test_chat_file_vision_request.py
@@ -1,0 +1,78 @@
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+from models.chat import FileChat  # noqa: E402
+from utils.other import chat_file  # noqa: E402
+
+
+class _Callback:
+    def __init__(self) -> None:
+        self.chunks: list[str] = []
+        self.ended = False
+
+    async def put_data(self, text: str) -> None:
+        self.chunks.append(text)
+
+    async def end(self) -> None:
+        self.ended = True
+
+
+class _AsyncStream:
+    def __init__(self, chunks: list[object]) -> None:
+        self._chunks = iter(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._chunks)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+
+@pytest.mark.asyncio
+async def test_vision_chat_uses_luna_completion_budget_field(monkeypatch):
+    request: dict[str, object] = {}
+
+    async def get_file_content(_file_id: str):
+        return SimpleNamespace(read=lambda: b'image bytes')
+
+    async def create_completion(**kwargs):
+        request.update(kwargs)
+        return _AsyncStream(
+            [SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content='A test image.'))])]
+        )
+
+    client = SimpleNamespace(
+        files=SimpleNamespace(content=get_file_content),
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_completion)),
+    )
+    monkeypatch.setattr(chat_file, '_get_async_openai', lambda: client)
+
+    tool = object.__new__(chat_file.FileChatTool)
+    callback = _Callback()
+    image = FileChat(
+        id='file-1',
+        name='image.png',
+        mime_type='image/png',
+        openai_file_id='openai-file-1',
+        created_at=datetime.now(timezone.utc),
+    )
+
+    answer = await tool._ask_vision_stream('What do you see?', [image], callback)
+
+    assert answer == 'A test image.'
+    assert callback.chunks == ['A test image.']
+    assert callback.ended is True
+    assert request['model'] == 'gpt-5.6-luna'
+    assert request['max_completion_tokens'] == 2048
+    assert 'max_tokens' not in request

--- a/backend/tests/unit/test_clean_sweep_migrations.py
+++ b/backend/tests/unit/test_clean_sweep_migrations.py
@@ -217,7 +217,7 @@ class TestVadHttpxMigration:
     def test_vad_hosted_has_timeout(self):
         """Hosted VAD call must have explicit timeout to prevent hanging."""
         src = _read_source('utils/stt/vad.py')
-        assert 'timeout=300' in src
+        assert 'timeout=_hosted_vad_timeout_seconds()' in src
 
     def test_vad_no_threading_thread(self):
         """No bare threading.Thread usage in VAD module."""

--- a/backend/tests/unit/test_onboarding_question_start.py
+++ b/backend/tests/unit/test_onboarding_question_start.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from routers.listen.receiver import ListenReceiver
+from utils.onboarding import ONBOARDING_QUESTIONS, OnboardingHandler
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+@pytest.mark.anyio
+async def test_start_sends_question_zero_once_after_client_request():
+    events = []
+    transcript_batches = []
+
+    async def send_message(event):
+        events.append(event)
+
+    handler = OnboardingHandler('user-1', send_message, transcript_batches.append)
+
+    await handler.start()
+    await handler.start()
+
+    assert events == [
+        {
+            'type': 'onboarding_question',
+            'question': ONBOARDING_QUESTIONS[0]['question'],
+            'question_index': 0,
+            'total_questions': len(ONBOARDING_QUESTIONS),
+            'question_segment_id': events[0]['question_segment_id'],
+        }
+    ]
+    assert len(transcript_batches) == 1
+    assert transcript_batches[0][0]['text'] == ONBOARDING_QUESTIONS[0]['question']
+
+
+@pytest.mark.anyio
+async def test_receiver_routes_explicit_onboarding_start_to_handler():
+    handler = SimpleNamespace(start=AsyncMock(), completed=False)
+    receiver = object.__new__(ListenReceiver)
+    receiver.host = SimpleNamespace(onboarding_handler=handler, use_custom_stt=False)
+
+    await receiver._handle_text('{"type":"start_onboarding"}')
+
+    handler.start.assert_awaited_once_with()

--- a/backend/tests/unit/test_openglass_request.py
+++ b/backend/tests/unit/test_openglass_request.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+import pytest
+
+from utils.llm import openglass
+
+
+@pytest.mark.asyncio
+async def test_describe_image_passes_luna_completion_budget_as_request_kwarg(monkeypatch):
+    request: dict[str, object] = {}
+
+    class FakeLlm:
+        async def ainvoke(self, input, **kwargs):
+            request["input"] = input
+            request.update(kwargs)
+            return SimpleNamespace(content="A desk with a laptop.")
+
+    monkeypatch.setattr(openglass, "get_llm", lambda _feature: FakeLlm())
+
+    description = await openglass.describe_image("user-1", "aW1hZ2U=")
+
+    assert description == "A desk with a laptop."
+    assert request["max_completion_tokens"] == 150
+    assert "config" not in request

--- a/backend/tests/unit/test_production_like_memory_model.py
+++ b/backend/tests/unit/test_production_like_memory_model.py
@@ -57,6 +57,20 @@ def _run(pipeline_input):
     return asyncio.run(CoreMemoryPipeline(model_client=ProductionLikeMemoryModelClient()).run(pipeline_input))
 
 
+def test_memory_llm_omits_unsupported_luna_temperature_by_default(monkeypatch):
+    class FakeLlm:
+        def bind(self, **_kwargs):
+            raise AssertionError("default memories route must not bind a Luna temperature")
+
+    llm = FakeLlm()
+    monkeypatch.setattr(production_like_model, "get_llm", lambda _feature: llm)
+    monkeypatch.setattr(production_like_model, "get_provider", lambda _feature: "openai")
+    monkeypatch.setattr(production_like_model, "get_model", lambda _feature: "gpt-5.6-luna")
+    monkeypatch.setattr(production_like_model, "_memory_llm_logged", False)
+
+    assert production_like_model._memory_llm() is llm
+
+
 def test_prodlike_health_memories_route_to_review(monkeypatch):
     _patch_extractor(monkeypatch, "User's father has cancer and is receiving treatment.")
 

--- a/backend/tests/unit/test_vad_onnx.py
+++ b/backend/tests/unit/test_vad_onnx.py
@@ -283,7 +283,10 @@ class TestVadIsEmptyFallback:
         assert timeout.pool == 3.0
         mock_local.assert_called_once_with(wav_path)
 
-    @pytest.mark.parametrize('invalid_value', ['0', '-1', 'abc'])
+    @pytest.mark.parametrize(
+        'invalid_value',
+        ['0', '-1', 'abc', 'inf', 'Infinity', '1e309', '61', '301', '1000000000'],
+    )
     def test_invalid_hosted_timeouts_use_safe_defaults(self, invalid_value):
         with patch.dict(
             os.environ,

--- a/backend/tests/unit/test_vad_onnx.py
+++ b/backend/tests/unit/test_vad_onnx.py
@@ -12,10 +12,12 @@ import struct
 import tempfile
 import wave
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
+import httpx
 import numpy as np
 import pytest
+import requests
 
 from utils.stt import vad
 from utils.stt.vad import (
@@ -237,6 +239,60 @@ class TestVadIsEmptyFallback:
         result = vad_is_empty(wav_path)
         assert result is False
         mock_local.assert_called_once_with(wav_path)
+
+    @patch.dict(
+        os.environ,
+        {
+            'HOSTED_VAD_API_URL': 'http://vad.test/v1/vad',
+            'HOSTED_VAD_CONNECT_TIMEOUT_SECONDS': '1.25',
+            'HOSTED_VAD_READ_TIMEOUT_SECONDS': '12.5',
+        },
+    )
+    @patch('utils.stt.vad.requests.post', side_effect=requests.ConnectTimeout('unreachable'))
+    @patch('utils.stt.vad._run_file_vad', return_value=[])
+    @patch.object(vad, 'redis_db')
+    def test_hosted_connect_timeout_is_bounded_and_falls_back(self, mock_redis, mock_local, mock_post, tmp_wav_dir):
+        wav_path = str(tmp_wav_dir / 'test.wav')
+        _write_wav_file(wav_path, 1.0)
+
+        assert vad_is_empty(wav_path) is True
+
+        assert mock_post.call_args.kwargs['timeout'] == (1.25, 12.5)
+        mock_local.assert_called_once_with(wav_path)
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {'HOSTED_VAD_API_URL': 'http://vad.test/v1/vad'}, clear=False)
+    async def test_async_hosted_timeout_uses_safe_defaults_and_falls_back(self, tmp_wav_dir):
+        wav_path = str(tmp_wav_dir / 'test.wav')
+        _write_wav_file(wav_path, 1.0)
+        os.environ.pop('HOSTED_VAD_CONNECT_TIMEOUT_SECONDS', None)
+        os.environ.pop('HOSTED_VAD_READ_TIMEOUT_SECONDS', None)
+
+        client = MagicMock()
+        client.post = AsyncMock(side_effect=httpx.ConnectTimeout('unreachable'))
+        with (
+            patch.object(vad, 'get_stt_client', return_value=client),
+            patch.object(vad, '_run_file_vad', return_value=[]) as mock_local,
+        ):
+            assert await vad.async_vad_is_empty(wav_path) is True
+
+        timeout = client.post.call_args.kwargs['timeout']
+        assert timeout.connect == 3.0
+        assert timeout.read == 30.0
+        assert timeout.write == 30.0
+        assert timeout.pool == 3.0
+        mock_local.assert_called_once_with(wav_path)
+
+    @pytest.mark.parametrize('invalid_value', ['0', '-1', 'abc'])
+    def test_invalid_hosted_timeouts_use_safe_defaults(self, invalid_value):
+        with patch.dict(
+            os.environ,
+            {
+                'HOSTED_VAD_CONNECT_TIMEOUT_SECONDS': invalid_value,
+                'HOSTED_VAD_READ_TIMEOUT_SECONDS': invalid_value,
+            },
+        ):
+            assert vad._hosted_vad_timeout_seconds() == (3.0, 30.0)
 
     @patch.dict(os.environ, {'HOSTED_VAD_API_URL': 'http://vad.test/v1/vad'})
     @patch('utils.stt.vad.requests.post')

--- a/backend/utils/llm/openglass.py
+++ b/backend/utils/llm/openglass.py
@@ -8,7 +8,13 @@ ChatMessage = dict[str, object]
 
 
 class AsyncVisionLlm(Protocol):
-    async def ainvoke(self, input: object, *, config: dict[str, Any] | None = None) -> object: ...
+    async def ainvoke(
+        self,
+        input: object,
+        *,
+        config: dict[str, Any] | None = None,
+        max_completion_tokens: int | None = None,
+    ) -> object: ...
 
 
 def _response_text(response: object) -> str:
@@ -54,6 +60,6 @@ async def describe_image(uid: str, base64_data: str) -> str:
     }
 
     with track_usage(uid, Features.OPENGLASS):
-        response = await cast(AsyncVisionLlm, get_llm('openglass')).ainvoke([message], config={"max_tokens": 150})
+        response = await cast(AsyncVisionLlm, get_llm('openglass')).ainvoke([message], max_completion_tokens=150)
     description = _response_text(response).strip()
     return description if description != '""' else ""

--- a/backend/utils/memory_ingestion/adapters/production_like_model.py
+++ b/backend/utils/memory_ingestion/adapters/production_like_model.py
@@ -778,7 +778,7 @@ def _frame_polarity(memory: ProductionLikeMemory) -> Literal["negative", "neutra
 _memory_llm_logged = False  # module-level flag: has the LLM endpoint been logged?
 
 
-def _memory_llm(temperature: float | None = 0.0):
+def _memory_llm(temperature: float | None = None):
     global _memory_llm_logged
     # Log resolved endpoint once for debuggability — catches credential mismatches early
     if not _memory_llm_logged:

--- a/backend/utils/onboarding.py
+++ b/backend/utils/onboarding.py
@@ -44,6 +44,7 @@ class OnboardingHandler:
         self.silence_timer: Optional[asyncio.Task[None]] = None
         self.is_checking_answer = False
         self.completed = False
+        self.started = False
         self.start_time: Optional[float] = None  # Track when onboarding started
         self.last_segment_end: float = 0.0  # Track end time for question segment timing
 
@@ -161,6 +162,20 @@ class OnboardingHandler:
             await self._complete_onboarding()
         else:
             await self.send_current_question()
+
+    async def start(self) -> None:
+        """Start the question flow after the client has attached its listener.
+
+        The client explicitly requests this transition so the first question cannot
+        race the WebSocket subscription that consumes it. Repeated requests are safe
+        and do not inject duplicate question segments.
+        """
+        if self.completed or self.started:
+            return
+
+        self.start_time = time.time()
+        await self.send_current_question()
+        self.started = True
 
     async def _check_answer(self) -> None:
         """Use AI to check if question was answered"""

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -23,6 +23,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_FILE_SEARCH_ASSISTANT_MODEL = "gpt-4.1"
+
 
 def _safe_file_chats(files_data: List[Dict[str, Any]]) -> List[FileChat]:
     """Build FileChat objects from raw file docs, skipping (not raising on) a malformed one.
@@ -309,7 +311,9 @@ class FileChatTool:
                 assistant = openai.beta.assistants.create(  # type: ignore[reportDeprecated]  # Assistants API still in use
                     name="File Reader",
                     instructions="You are a helpful assistant that answers questions about the provided file. Use the file_search tool to search the file contents when needed.",
-                    model="gpt-5.6-luna",
+                    # Luna supports vision Chat Completions but not the
+                    # Assistants API. Keep file search on an Assistants model.
+                    model=_FILE_SEARCH_ASSISTANT_MODEL,
                     tools=[{"type": "file_search"}],
                     timeout=timeout,
                 )

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -257,7 +257,9 @@ class FileChatTool:
                 model="gpt-5.6-luna",
                 messages=messages,
                 stream=True,
-                max_tokens=2048,
+                # Luna uses the current Chat Completions output-budget field.
+                # `max_tokens` is rejected by the provider with HTTP 400.
+                max_completion_tokens=2048,
             )
             async for chunk in stream:
                 delta = chunk.choices[0].delta if chunk.choices else None

--- a/backend/utils/stt/vad.py
+++ b/backend/utils/stt/vad.py
@@ -17,6 +17,11 @@ from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
+HOSTED_VAD_CONNECT_TIMEOUT_SECONDS_ENV = 'HOSTED_VAD_CONNECT_TIMEOUT_SECONDS'
+HOSTED_VAD_READ_TIMEOUT_SECONDS_ENV = 'HOSTED_VAD_READ_TIMEOUT_SECONDS'
+DEFAULT_HOSTED_VAD_CONNECT_TIMEOUT_SECONDS = 3.0
+DEFAULT_HOSTED_VAD_READ_TIMEOUT_SECONDS = 30.0
+
 
 class VADAudioDecodeError(RuntimeError):
     """Audio could not be decoded for a strict speech-eligibility decision."""
@@ -24,6 +29,45 @@ class VADAudioDecodeError(RuntimeError):
 
 class VADProcessingError(RuntimeError):
     """The local VAD could not make a trustworthy speech decision."""
+
+
+def _positive_timeout_seconds(env_name: str, default: float) -> float:
+    raw_value = os.getenv(env_name)
+    if raw_value is None:
+        return default
+    try:
+        value = float(raw_value)
+        if value > 0:
+            return value
+    except ValueError:
+        pass
+    logger.warning('Invalid %s=%r; using safe default %.1fs', env_name, raw_value, default)
+    return default
+
+
+def _hosted_vad_timeout_seconds() -> Tuple[float, float]:
+    """Return bounded hosted-VAD connect/read deadlines from current env."""
+
+    return (
+        _positive_timeout_seconds(
+            HOSTED_VAD_CONNECT_TIMEOUT_SECONDS_ENV,
+            DEFAULT_HOSTED_VAD_CONNECT_TIMEOUT_SECONDS,
+        ),
+        _positive_timeout_seconds(
+            HOSTED_VAD_READ_TIMEOUT_SECONDS_ENV,
+            DEFAULT_HOSTED_VAD_READ_TIMEOUT_SECONDS,
+        ),
+    )
+
+
+def _hosted_vad_httpx_timeout() -> httpx.Timeout:
+    connect_timeout, read_timeout = _hosted_vad_timeout_seconds()
+    return httpx.Timeout(
+        connect=connect_timeout,
+        read=read_timeout,
+        write=read_timeout,
+        pool=connect_timeout,
+    )
 
 
 def _hosted_vad_fallback_reason(exc: BaseException) -> str:
@@ -160,7 +204,7 @@ def vad_is_empty(
         try:
             with open(file_path, 'rb') as file:
                 files = {'file': (file_path.split('/')[-1], file, 'audio/wav')}
-                response = requests.post(hosted_vad_url, files=files, timeout=300)
+                response = requests.post(hosted_vad_url, files=files, timeout=_hosted_vad_timeout_seconds())
                 response.raise_for_status()
                 segments = response.json()  # untyped external JSON response
         except Exception as e:
@@ -319,7 +363,7 @@ async def async_vad_is_empty(
             file_data = await run_blocking(storage_executor, _read_file, file_path)
             files = {'file': (file_path.split('/')[-1], file_data, 'audio/wav')}
             client = get_stt_client()
-            response = await client.post(hosted_vad_url, files=files)
+            response = await client.post(hosted_vad_url, files=files, timeout=_hosted_vad_httpx_timeout())
             response.raise_for_status()
             segments = response.json()  # untyped external JSON response
         except Exception as e:

--- a/backend/utils/stt/vad.py
+++ b/backend/utils/stt/vad.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 import threading
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
@@ -21,6 +22,8 @@ HOSTED_VAD_CONNECT_TIMEOUT_SECONDS_ENV = 'HOSTED_VAD_CONNECT_TIMEOUT_SECONDS'
 HOSTED_VAD_READ_TIMEOUT_SECONDS_ENV = 'HOSTED_VAD_READ_TIMEOUT_SECONDS'
 DEFAULT_HOSTED_VAD_CONNECT_TIMEOUT_SECONDS = 3.0
 DEFAULT_HOSTED_VAD_READ_TIMEOUT_SECONDS = 30.0
+MAX_HOSTED_VAD_CONNECT_TIMEOUT_SECONDS = 30.0
+MAX_HOSTED_VAD_READ_TIMEOUT_SECONDS = 60.0
 
 
 class VADAudioDecodeError(RuntimeError):
@@ -31,17 +34,23 @@ class VADProcessingError(RuntimeError):
     """The local VAD could not make a trustworthy speech decision."""
 
 
-def _positive_timeout_seconds(env_name: str, default: float) -> float:
+def _positive_timeout_seconds(env_name: str, default: float, maximum: float) -> float:
     raw_value = os.getenv(env_name)
     if raw_value is None:
         return default
     try:
         value = float(raw_value)
-        if value > 0:
+        if math.isfinite(value) and 0 < value <= maximum:
             return value
     except ValueError:
         pass
-    logger.warning('Invalid %s=%r; using safe default %.1fs', env_name, raw_value, default)
+    logger.warning(
+        'Invalid or excessive %s=%r; using safe default %.1fs (maximum %.1fs)',
+        env_name,
+        raw_value,
+        default,
+        maximum,
+    )
     return default
 
 
@@ -52,10 +61,12 @@ def _hosted_vad_timeout_seconds() -> Tuple[float, float]:
         _positive_timeout_seconds(
             HOSTED_VAD_CONNECT_TIMEOUT_SECONDS_ENV,
             DEFAULT_HOSTED_VAD_CONNECT_TIMEOUT_SECONDS,
+            MAX_HOSTED_VAD_CONNECT_TIMEOUT_SECONDS,
         ),
         _positive_timeout_seconds(
             HOSTED_VAD_READ_TIMEOUT_SECONDS_ENV,
             DEFAULT_HOSTED_VAD_READ_TIMEOUT_SECONDS,
+            MAX_HOSTED_VAD_READ_TIMEOUT_SECONDS,
         ),
     )
 

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -144,6 +144,15 @@ sequenceDiagram
     end
 ```
 
+### Speech-profile onboarding handshake
+
+Question-based speech-profile sessions connect with `onboarding=enabled`. After
+the mobile listener is subscribed, it sends `{"type":"start_onboarding"}`. The
+backend answers with question index `0` and treats duplicate start messages as
+no-ops, so the first prompt cannot be emitted before the client is able to
+consume it. Subsequent answers or `{"type":"skip_question"}` advance the same
+server-owned question index.
+
 ### Live STT observability
 
 For backend-provider `/v4/listen` sessions, `omi_live_stt_accepted_total`


### PR DESCRIPTION
## What changed and why

Fixes failures observed on a cable-connected iPhone development build: stale conversation processing cards, misleading/stalled WAL upload state, speech-profile onboarding opening without question zero, and image/file attachments failing after upload. It also bounds hosted VAD calls so an unavailable hosted service falls back promptly to local ONNX.

The attachment failure was two separate Sonnet-to-Luna migration regressions confirmed in development Cloud logs. Image vision Chat Completions sent Luna the rejected legacy `max_tokens` field; file-search follow-ups selected Luna for the unsupported Assistants API. Vision now uses `max_completion_tokens`, while Assistants/File Search stays on GPT-4.1. The audit also removed a Luna-incompatible `temperature=0.0` from the direct memory-ingestion fallback and moved the OpenGlass output limit from ignored LangChain config into the provider request.

Conversation reconciliation now resolves off-page processing IDs against the authoritative lifecycle endpoint. Sync UI distinguishes uploaded/server-processing work from recordings still pending upload. Speech-profile onboarding begins with an idempotent start handshake after the client listener is attached.

## Product invariants affected

- INV-MEM-1

## How it was verified

- Reproduced the original processing, onboarding, and attachment symptoms on the physical iPhone.
- Correlated both attachment failures in development Cloud logs: file operations returned 200; Luna Chat Completions rejected `max_tokens`; Luna Assistants creation returned `unsupported_model`.
- 19 focused Flutter processing, sync, and speech-profile tests passed; analyzer ratchet passed.
- 21 focused backend onboarding tests passed.
- 100 VAD and fallback-observability tests passed.
- 37 focused file-chat, vision, OpenGlass, and production-like memory tests passed.
- Python formatting, compilation, and `git diff --check` passed.
- Independent Cursor Grok reviews approved the earlier processing and image-budget changes.
- Three Luna subagents audited migration history and direct call sites; the integrated follow-up diff received a separate Luna correctness review.
- `make preflight` passed on the final tree.

Device end-to-end confirmation of question zero and the backend attachment fixes requires the development deployment triggered by merge.

## Tests

- Conversation tests cover completed, active, missing, failed-lookup, pagination, and synthetic-local processing states.
- Socket/onboarding tests prove question zero starts only after listener subscription and duplicate starts are no-ops.
- VAD tests cover bounded sync/async hosted calls and local fallback.
- File-chat tests lock Luna vision to `max_completion_tokens` and GPT-4.1 Assistants selection.
- Memory/OpenGlass tests prevent unsupported temperature and ignored output-budget regressions.

## Failure class (fixes)

Failure-Class: none
