### PR TITLE
fix(macos): route memory export fallbacks to main actor

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -202,7 +202,26 @@ private struct MemoryExportRow: View {
 }
 
 @MainActor
+struct MemoryExportWorkspace {
+  var installedApplicationURL: (ConnectorBrand) -> URL?
+  var defaultApplicationURL: (URL) -> URL?
+  var openWithApplication: ([URL], URL, NSWorkspace.OpenConfiguration, @escaping @Sendable (Error?) -> Void) -> Void
+  var open: (URL) -> Void
+
+  static let live = Self(
+    installedApplicationURL: { $0.installedApplicationURL },
+    defaultApplicationURL: { NSWorkspace.shared.urlForApplication(toOpen: $0) },
+    openWithApplication: { urls, applicationURL, configuration, completion in
+      NSWorkspace.shared.open(urls, withApplicationAt: applicationURL, configuration: configuration) { _, error in
+        completion(error)
+      }
+    },
+    open: { NSWorkspace.shared.open($0) })
+}
+
+@MainActor
 final class MemoryExportDestinationSheetModel: ObservableObject {
+  private let workspace: MemoryExportWorkspace
   @Published var isRunning = false
   @Published var statusMessage: String?
   @Published var errorMessage: String?
@@ -212,6 +231,10 @@ final class MemoryExportDestinationSheetModel: ObservableObject {
   @Published var mcpKey: String?
   @Published var isLoadingMCPKey = false
   @Published var isTestingAgentConnection = false
+
+  init(workspace: MemoryExportWorkspace = .live) {
+    self.workspace = workspace
+  }
 
   func loadConfiguration() async {
     obsidianVaultPath = await MemoryExportService.shared.obsidianVaultPath()
@@ -412,21 +435,20 @@ final class MemoryExportDestinationSheetModel: ObservableObject {
     NSWorkspace.shared.activateFileViewerSelecting([fileURL])
   }
 
-  private func openDestination(for destination: MemoryExportDestination, url: URL?) {
+  func openDestination(for destination: MemoryExportDestination, url: URL?) {
     guard let url else { return }
 
-    if let appURL = destination.brand.installedApplicationURL {
+    if let appURL = workspace.installedApplicationURL(destination.brand) {
       let configuration = NSWorkspace.OpenConfiguration()
       configuration.activates = true
 
-      NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: configuration) {
-        _, error in
+      workspace.openWithApplication([url], appURL, configuration) { [self] error in
         if let error {
           log(
             "MemoryExportDestinationSheetModel: Failed opening \(destination.title) with installed app: \(error.localizedDescription)"
           )
-          Self.performOnMainActor { [weak self] in
-            self?.openInDefaultHandler(url)
+          Self.performOnMainActor { [self] in
+            self.openInDefaultHandler(url)
           }
         }
       }
@@ -436,26 +458,25 @@ final class MemoryExportDestinationSheetModel: ObservableObject {
     openInDefaultHandler(url)
   }
 
-  private func openInDefaultHandler(_ url: URL) {
+  func openInDefaultHandler(_ url: URL) {
     let configuration = NSWorkspace.OpenConfiguration()
     configuration.activates = true
 
-    if let appURL = NSWorkspace.shared.urlForApplication(toOpen: url) {
-      NSWorkspace.shared.open([url], withApplicationAt: appURL, configuration: configuration) {
-        _, error in
+    if let appURL = workspace.defaultApplicationURL(url) {
+      workspace.openWithApplication([url], appURL, configuration) { [workspace] error in
         if let error {
           log(
             "MemoryExportDestinationSheetModel: Failed opening \(url.absoluteString): \(error.localizedDescription)"
           )
           Self.performOnMainActor {
-            NSWorkspace.shared.open(url)
+            workspace.open(url)
           }
         }
       }
       return
     }
 
-    NSWorkspace.shared.open(url)
+    workspace.open(url)
   }
 
   nonisolated static func performOnMainActor(_ operation: @escaping @MainActor @Sendable () -> Void) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -425,8 +425,8 @@ final class MemoryExportDestinationSheetModel: ObservableObject {
           log(
             "MemoryExportDestinationSheetModel: Failed opening \(destination.title) with installed app: \(error.localizedDescription)"
           )
-          Task { @MainActor in
-            self.openInDefaultHandler(url)
+          Self.performOnMainActor { [weak self] in
+            self?.openInDefaultHandler(url)
           }
         }
       }
@@ -447,13 +447,21 @@ final class MemoryExportDestinationSheetModel: ObservableObject {
           log(
             "MemoryExportDestinationSheetModel: Failed opening \(url.absoluteString): \(error.localizedDescription)"
           )
-          NSWorkspace.shared.open(url)
+          Self.performOnMainActor {
+            NSWorkspace.shared.open(url)
+          }
         }
       }
       return
     }
 
     NSWorkspace.shared.open(url)
+  }
+
+  nonisolated static func performOnMainActor(_ operation: @escaping @MainActor @Sendable () -> Void) {
+    Task { @MainActor in
+      operation()
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
@@ -1,8 +1,25 @@
+import Dispatch
 import XCTest
 
 @testable import Omi_Computer
 
 final class MemoryExportSetupTests: XCTestCase {
+  func testWorkspaceFallbackReroutesBackgroundCompletionToMainActor() async {
+    let callbackStarted = expectation(description: "background callback started")
+    let actionCompleted = expectation(description: "workspace fallback ran on main actor")
+
+    DispatchQueue.global().async {
+      XCTAssertFalse(Thread.isMainThread)
+      MemoryExportDestinationSheetModel.performOnMainActor {
+        XCTAssertTrue(Thread.isMainThread)
+        actionCompleted.fulfill()
+      }
+      callbackStarted.fulfill()
+    }
+
+    await fulfillment(of: [callbackStarted, actionCompleted], timeout: 1)
+  }
+
   func testOpenClawManualSetupUsesMCPConfigNotMemoryPromptSecret() throws {
     let setup = try XCTUnwrap(MemoryExportDestination.openclaw.mcpSetup(key: "test-key"))
     let copyText = try XCTUnwrap(setup.copyText)

--- a/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
@@ -4,20 +4,36 @@ import XCTest
 @testable import Omi_Computer
 
 final class MemoryExportSetupTests: XCTestCase {
-  func testWorkspaceFallbackReroutesBackgroundCompletionToMainActor() async {
-    let callbackStarted = expectation(description: "background callback started")
-    let actionCompleted = expectation(description: "workspace fallback ran on main actor")
-
-    DispatchQueue.global().async {
-      XCTAssertFalse(Thread.isMainThread)
-      MemoryExportDestinationSheetModel.performOnMainActor {
+  @MainActor
+  func testWorkspaceFallbackReroutesFailedApplicationLaunchToMainActor() async {
+    let exportURL = URL(fileURLWithPath: "/tmp/memory-export.md")
+    let installedApplicationURL = URL(fileURLWithPath: "/Applications/Installed.app")
+    let defaultApplicationURL = URL(fileURLWithPath: "/Applications/Default.app")
+    let fallbackOpened = expectation(description: "workspace fallback opened on main actor")
+    var openedApplications: [URL] = []
+    let workspace = MemoryExportWorkspace(
+      installedApplicationURL: { _ in installedApplicationURL },
+      defaultApplicationURL: { _ in defaultApplicationURL },
+      openWithApplication: { _, applicationURL, _, completion in
+        openedApplications.append(applicationURL)
+        DispatchQueue.global().async {
+          completion(URLError(.cannotOpenFile))
+        }
+      },
+      open: { url in
         XCTAssertTrue(Thread.isMainThread)
-        actionCompleted.fulfill()
-      }
-      callbackStarted.fulfill()
-    }
+        XCTAssertEqual(url, exportURL)
+        fallbackOpened.fulfill()
+      })
+    var model: MemoryExportDestinationSheetModel? = MemoryExportDestinationSheetModel(workspace: workspace)
+    weak var weakModel = model
 
-    await fulfillment(of: [callbackStarted, actionCompleted], timeout: 1)
+    model?.openDestination(for: .chatgpt, url: exportURL)
+    model = nil
+
+    await fulfillment(of: [fallbackOpened], timeout: 1)
+    XCTAssertEqual(openedApplications, [installedApplicationURL, defaultApplicationURL])
+    XCTAssertNil(weakModel)
   }
 
   func testOpenClawManualSetupUsesMCPConfigNotMemoryPromptSecret() throws {

--- a/desktop/macos/changelog/unreleased/20260812-memory-export-main-thread-fallback.json
+++ b/desktop/macos/changelog/unreleased/20260812-memory-export-main-thread-fallback.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash that could occur when opening exported memories in another app"
+}


### PR DESCRIPTION
## Summary

Route memory-export fallback opens to the main actor when NSWorkspace invokes its completion off-thread.

## Sentry issues

- [OMI-DESKTOP-2Z1](https://omi-nk3.sentry.io/issues/7630388038/?project=4511086024851456)
- [OMI-DESKTOP-2YF](https://omi-nk3.sentry.io/issues/7630358206/?project=4511086024851456)

## Product invariants affected

- INV-INT-1

## Failure class

Failure-Class: none

## Verification

- Swift format, test-quality, and diff checks passed.
- Focused XCTest is still compiling in the local SwiftPM cache.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow concurrency fix in export open fallbacks, with a unit test and no auth, data, or architectural changes.
> 
> **Overview**
> Ensures memory-export **fallback opens** hop back to the main actor when `NSWorkspace` completion handlers fire off-thread.
> 
> Adds a `nonisolated` `performOnMainActor` helper on `MemoryExportDestinationSheetModel` and uses it for both branded-app and default-handler fallbacks (with a weak self capture). Includes a focused XCTest that verifies a background callback is rerouted onto the main thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587751dff74eb0c6eda67e2937a66fff10e0ef7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->