### PR TITLE
fix(desktop): bound diagnostics log redaction

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -1083,8 +1083,8 @@ final class DesktopDiagnosticsManager {
     "conversation", "transcript", "prompt", "response", "message", "memory", "title",
     "window", "screen", "ocr", "clipboard",
   ]
-
   private func redactSensitive(_ line: String, strictCloudRedaction: Bool = false) -> String {
+    if DiagnosticLogRedactionPolicy.shouldSkipRegexRedaction(line) { return "[redacted-oversize-log-line]" }
     let normalized = line.lowercased()
     if strictCloudRedaction, normalized.contains("device=[") {
       return "[redacted-device-bearing-log-line]"

--- a/desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 enum DiagnosticLogRedactionPolicy {
+  static let maximumLineLengthForRegexRedaction = 16 * 1024
+
   static func shouldSkipRegexRedaction(_ line: String) -> Bool {
-    line.utf8.count > 16 * 1024
+    line.utf8.count > maximumLineLengthForRegexRedaction
   }
 }

--- a/desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 enum DiagnosticLogRedactionPolicy {
+  /// A single line larger than this is too costly to run the redaction regexes
+  /// over and carries little diagnostic value — the export replaces it with a
+  /// placeholder rather than partially scrubbing it, so a secret embedded in a
+  /// huge line cannot slip through incomplete regex matching.
   static let maximumLineLengthForRegexRedaction = 16 * 1024
 
   static func shouldSkipRegexRedaction(_ line: String) -> Bool {

--- a/desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum DiagnosticLogRedactionPolicy {
+  static func shouldSkipRegexRedaction(_ line: String) -> Bool {
+    line.utf8.count > 16 * 1024
+  }
+}

--- a/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
+++ b/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
@@ -133,7 +133,11 @@ import XCTest
     func testLocalBundleDropsOversizedLogLinesBeforeRegexRedaction() throws {
       let logPath = tempDir.appendingPathComponent("omi-dev.log").path
       let secret = "SUPERSECRETKEY123"
-      let oversizedLine = "[10:00:00.000] [app] api_key=\(secret) " + String(repeating: "x", count: 20 * 1024)
+      let oversizedLine =
+        "[10:00:00.000] [app] api_key=\(secret) "
+        + String(
+          repeating: "x",
+          count: DiagnosticLogRedactionPolicy.maximumLineLengthForRegexRedaction + 1)
       try oversizedLine.write(toFile: logPath, atomically: true, encoding: .utf8)
 
       let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(logPath: logPath)

--- a/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
+++ b/desktop/macos/Desktop/Tests/DiagnosticsExportTests.swift
@@ -129,5 +129,17 @@ import XCTest
       XCTAssertFalse(
         text.contains("HEAD_MARKER_beyond_window"), "head line should be outside the bounded tail")
     }
+
+    func testLocalBundleDropsOversizedLogLinesBeforeRegexRedaction() throws {
+      let logPath = tempDir.appendingPathComponent("omi-dev.log").path
+      let secret = "SUPERSECRETKEY123"
+      let oversizedLine = "[10:00:00.000] [app] api_key=\(secret) " + String(repeating: "x", count: 20 * 1024)
+      try oversizedLine.write(toFile: logPath, atomically: true, encoding: .utf8)
+
+      let text = DesktopDiagnosticsManager.shared.buildLocalDiagnosticsText(logPath: logPath)
+
+      XCTAssertTrue(text.contains("[redacted-oversize-log-line]"))
+      XCTAssertFalse(text.contains(secret))
+    }
   }
 #endif

--- a/desktop/macos/changelog/unreleased/20260812-diagnostics-export-redaction.json
+++ b/desktop/macos/changelog/unreleased/20260812-diagnostics-export-redaction.json
@@ -1,3 +1,3 @@
 {
-  "change": "Improved reliability when exporting desktop diagnostics."
+  "change": "Improved reliability when exporting desktop diagnostics"
 }

--- a/desktop/macos/changelog/unreleased/20260812-diagnostics-export-redaction.json
+++ b/desktop/macos/changelog/unreleased/20260812-diagnostics-export-redaction.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved reliability when exporting desktop diagnostics."
+}

--- a/desktop/macos/e2e/flows/feedback-payload-dryrun.yaml
+++ b/desktop/macos/e2e/flows/feedback-payload-dryrun.yaml
@@ -6,6 +6,8 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/FeedbackView.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+  - desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+  - desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
 preconditions:
   - automation_bridge_ready
 

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -41,7 +41,6 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
   - desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
   - desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
-  - desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
   - desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBackgroundModifier.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceWaveformBars.swift

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -41,6 +41,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceTurnCoordinator.swift
   - desktop/macos/Desktop/Sources/VoiceTurnDomain/VoiceTurnStateMachine.swift
   - desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+  - desktop/macos/Desktop/Sources/Observability/DiagnosticLogRedactionPolicy.swift
   - desktop/macos/Desktop/Sources/Generated/GeneratedRealtimeTools.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBackgroundModifier.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceWaveformBars.swift


### PR DESCRIPTION
## Summary

Bound diagnostics-log redaction by dropping oversized lines before regex processing.

## Sentry issue

- [OMI-DESKTOP-2YE](https://omi-nk3.sentry.io/issues/7630356494/?project=4511086024851456)

## Failure class

Failure-Class: none

## Verification

- Swift format and diff checks passed.
- Focused XCTest is still compiling in the local SwiftPM cache.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive change on diagnostics export redaction that tightens privacy and avoids regex cost on huge lines; normal-sized redaction behavior is unchanged.
> 
> **Overview**
> Diagnostics log export now **skips regex redaction on oversized lines** (UTF-8 length &gt; 16 KB) and emits **`[redacted-oversize-log-line]`** instead, so huge log lines cannot stall export or leak secrets through partial regex scrubbing.
> 
> A shared **`DiagnosticLogRedactionPolicy`** holds the limit and gate; **`redactSensitive`** in `DesktopDiagnosticsManager` checks it before existing strict-cloud and pattern redaction. Coverage adds an XCTest for secret-bearing oversize lines, an unreleased changelog note, and e2e flow **`covers`** for the new policy file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c438bf17ae88bd57ead829c55c247526997c4dc3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->