### PR TITLE
fix(macos): defer PCM audio recovery

### DIFF
--- a/.github/failure-classes/FC-audio-configuration-recovery-blocks-notification.json
+++ b/.github/failure-classes/FC-audio-configuration-recovery-blocks-notification.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "FC-audio-configuration-recovery-blocks-notification",
+  "violated_contract": "An AVAudioEngine configuration notification must not synchronously rebuild or restart the audio graph on the notification callback, and a queued recovery must not override an explicit playback stop.",
+  "canonical_prevention": "Defer and coalesce AVAudioEngine configuration recovery through DeferredConfigurationRecovery, which serializes pending state and invalidates queued work when playback stops.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift"
+  ],
+  "evidence_prs": [11450],
+  "scope_hints": ["desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift"],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
@@ -49,6 +49,22 @@ final class StreamingPCMPlaybackQueue<Buffer: AnyObject> {
   }
 }
 
+final class DeferredConfigurationRecovery {
+  private var isPending = false
+
+  func schedule(
+    onMainQueue: (@escaping () -> Void) -> Void,
+    action: @escaping () -> Void
+  ) {
+    guard !isPending else { return }
+    isPending = true
+    onMainQueue { [weak self] in
+      action()
+      self?.isPending = false
+    }
+  }
+}
+
 /// Plays streamed mono PCM16 audio incrementally (OpenAI Realtime / Gemini Live
 /// output is 24 kHz). Feed chunks with `enqueue(_:)`; they play back-to-back in
 /// arrival order. Used by `RealtimeHubController` to play the realtime model's
@@ -62,6 +78,7 @@ final class StreamingPCMPlayer: @unchecked Sendable {
   private let format: AVAudioFormat
   private var configObserver: NSObjectProtocol?
   private let playbackQueue = StreamingPCMPlaybackQueue<AVAudioPCMBuffer>()
+  private let configurationRecovery = DeferredConfigurationRecovery()
   private(set) var playbackEpoch = 0
   var onPlaybackScheduled: ((Int) -> Void)?
   var onPlaybackIdle: ((Int) -> Void)?
@@ -95,15 +112,11 @@ final class StreamingPCMPlayer: @unchecked Sendable {
       forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main
     ) { [weak self] _ in
       guard let self = self else { return }
-      log("StreamingPCMPlayer: audio config changed — rebuilding engine")
-      let buffersToReplay = self.playbackQueue.buffersToReplayAfterConfigurationChange()
-      self.player.stop()
-      self.engine.stop()
-      self.engine.disconnectNodeOutput(self.player)
-      self.engine.connect(self.player, to: self.engine.mainMixerNode, format: self.format)
-      _ = self.ensureRunning()
-      for buffer in buffersToReplay {
-        self.schedule(buffer)
+      self.configurationRecovery.schedule(
+        onMainQueue: { action in DispatchQueue.main.async(execute: action) }
+      ) { [weak self] in
+        guard let self = self else { return }
+        self.rebuildAfterConfigurationChange()
       }
     }
   }
@@ -135,6 +148,19 @@ final class StreamingPCMPlayer: @unchecked Sendable {
       player.play()
     }
     return player.isPlaying
+  }
+
+  private func rebuildAfterConfigurationChange() {
+    log("StreamingPCMPlayer: audio config changed — rebuilding engine")
+    let buffersToReplay = playbackQueue.buffersToReplayAfterConfigurationChange()
+    player.stop()
+    engine.stop()
+    engine.disconnectNodeOutput(player)
+    engine.connect(player, to: engine.mainMixerNode, format: format)
+    _ = ensureRunning()
+    for buffer in buffersToReplay {
+      schedule(buffer)
+    }
   }
 
   /// `data` = little-endian Int16 PCM, mono, at the configured sample rate.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/StreamingPCMPlayer.swift
@@ -49,19 +49,69 @@ final class StreamingPCMPlaybackQueue<Buffer: AnyObject> {
   }
 }
 
-final class DeferredConfigurationRecovery {
-  private var isPending = false
+private final class DeferredConfigurationRecoveryAction: @unchecked Sendable {
+  let action: () -> Void
 
-  func schedule(
-    onMainQueue: (@escaping () -> Void) -> Void,
-    action: @escaping () -> Void
-  ) {
-    guard !isPending else { return }
-    isPending = true
-    onMainQueue { [weak self] in
-      action()
-      self?.isPending = false
+  init(_ action: @escaping () -> Void) {
+    self.action = action
+  }
+}
+
+final class DeferredConfigurationRecovery: @unchecked Sendable {
+  typealias MainQueueScheduler = @Sendable (@escaping @Sendable () -> Void) -> Void
+
+  private let lock = NSLock()
+  private let onMainQueue: MainQueueScheduler
+  private var isPending = false
+  private var generation = 0
+
+  init(
+    onMainQueue: @escaping MainQueueScheduler = { action in
+      DispatchQueue.main.async(execute: action)
     }
+  ) {
+    self.onMainQueue = onMainQueue
+  }
+
+  func schedule(action: @escaping () -> Void) {
+    let scheduledGeneration: Int
+    lock.lock()
+    guard !isPending else {
+      lock.unlock()
+      return
+    }
+    isPending = true
+    generation += 1
+    scheduledGeneration = generation
+    lock.unlock()
+
+    let actionBox = DeferredConfigurationRecoveryAction(action)
+    onMainQueue { [weak self, actionBox] in
+      guard self?.isPendingRecovery(generation: scheduledGeneration) == true else { return }
+      actionBox.action()
+      self?.finishPendingRecovery(generation: scheduledGeneration)
+    }
+  }
+
+  func cancel() {
+    lock.lock()
+    generation += 1
+    isPending = false
+    lock.unlock()
+  }
+
+  private func isPendingRecovery(generation scheduledGeneration: Int) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return isPending && generation == scheduledGeneration
+  }
+
+  private func finishPendingRecovery(generation scheduledGeneration: Int) {
+    lock.lock()
+    if generation == scheduledGeneration {
+      isPending = false
+    }
+    lock.unlock()
   }
 }
 
@@ -112,9 +162,7 @@ final class StreamingPCMPlayer: @unchecked Sendable {
       forName: .AVAudioEngineConfigurationChange, object: engine, queue: .main
     ) { [weak self] _ in
       guard let self = self else { return }
-      self.configurationRecovery.schedule(
-        onMainQueue: { action in DispatchQueue.main.async(execute: action) }
-      ) { [weak self] in
+      self.configurationRecovery.schedule { [weak self] in
         guard let self = self else { return }
         self.rebuildAfterConfigurationChange()
       }
@@ -205,6 +253,7 @@ final class StreamingPCMPlayer: @unchecked Sendable {
 
   func stop() {
     playbackEpoch += 1
+    configurationRecovery.cancel()
     playbackQueue.clearForExplicitStop()
     player.stop()
     engine.stop()

--- a/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
+++ b/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
@@ -6,21 +6,6 @@ import XCTest
 final class StreamingPCMPlaybackQueueTests: XCTestCase {
   private final class BufferBox {}
 
-  func testStreamingPlayerPublishesEpochForEveryScheduledBuffer() throws {
-    let source = try String(
-      contentsOf: URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()
-        .deletingLastPathComponent()
-        .appendingPathComponent("Sources/FloatingControlBar/StreamingPCMPlayer.swift"),
-      encoding: .utf8
-    )
-
-    XCTAssertTrue(source.contains("var onPlaybackScheduled: ((Int) -> Void)?"))
-    XCTAssertTrue(
-      source.contains("let scheduledPlaybackEpoch = playbackEpoch\n    onPlaybackScheduled?(scheduledPlaybackEpoch)"))
-    XCTAssertTrue(source.contains("for buffer in buffersToReplay {\n        self.schedule(buffer)\n      }"))
-  }
-
   func testConfigurationChangeReturnsScheduledTailForReplay() {
     let queue = StreamingPCMPlaybackQueue<BufferBox>()
     let first = BufferBox()
@@ -34,6 +19,23 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
     XCTAssertTrue(replay[0] === first)
     XCTAssertTrue(replay[1] === second)
     XCTAssertTrue(queue.isEmpty)
+  }
+
+  func testConfigurationChangeReplayPreservesTailOrder() {
+    let queue = StreamingPCMPlaybackQueue<BufferBox>()
+    let first = BufferBox()
+    let second = BufferBox()
+
+    queue.appendScheduled(first)
+    queue.appendScheduled(second)
+    let replay = queue.buffersToReplayAfterConfigurationChange()
+    for buffer in replay {
+      queue.appendScheduled(buffer)
+    }
+
+    XCTAssertEqual(queue.scheduledBuffers.count, 2)
+    XCTAssertTrue(queue.scheduledBuffers[0] === first)
+    XCTAssertTrue(queue.scheduledBuffers[1] === second)
   }
 
   func testReplayedBuffersUseNewGenerationSoStaleCompletionsCannotDropThem() {
@@ -87,41 +89,70 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
   }
 
   func testConfigurationRecoveryDefersAndCoalescesNotificationWork() {
-    let recovery = DeferredConfigurationRecovery()
-    var pendingActions: [() -> Void] = []
+    let pendingActions = PendingRecoveryActions()
+    let recovery = DeferredConfigurationRecovery(onMainQueue: pendingActions.schedule)
     var recoveryCount = 0
 
-    recovery.schedule(
-      onMainQueue: { pendingActions.append($0) },
-      action: {
-        recoveryCount += 1
-        recovery.schedule(
-          onMainQueue: { pendingActions.append($0) },
-          action: { recoveryCount += 1 }
-        )
-      }
-    )
-    recovery.schedule(
-      onMainQueue: { pendingActions.append($0) },
-      action: { recoveryCount += 1 }
-    )
+    recovery.schedule {
+      recoveryCount += 1
+      recovery.schedule { recoveryCount += 1 }
+    }
+    recovery.schedule { recoveryCount += 1 }
 
     XCTAssertEqual(recoveryCount, 0)
     XCTAssertEqual(pendingActions.count, 1)
 
-    pendingActions.removeFirst()()
+    pendingActions.runFirst()
 
     XCTAssertEqual(recoveryCount, 1)
     XCTAssertTrue(pendingActions.isEmpty)
 
-    recovery.schedule(
-      onMainQueue: { pendingActions.append($0) },
-      action: { recoveryCount += 1 }
-    )
+    recovery.schedule { recoveryCount += 1 }
 
     XCTAssertEqual(pendingActions.count, 1)
-    pendingActions.removeFirst()()
+    pendingActions.runFirst()
     XCTAssertEqual(recoveryCount, 2)
+  }
+
+  func testConfigurationRecoveryCancellationDiscardsPendingWork() {
+    let pendingActions = PendingRecoveryActions()
+    let recovery = DeferredConfigurationRecovery(onMainQueue: pendingActions.schedule)
+    var recoveryCount = 0
+
+    recovery.schedule { recoveryCount += 1 }
+    recovery.cancel()
+    pendingActions.runFirst()
+
+    XCTAssertEqual(recoveryCount, 0)
+
+    recovery.schedule { recoveryCount += 1 }
+    pendingActions.runFirst()
+
+    XCTAssertEqual(recoveryCount, 1)
+  }
+}
+
+private final class PendingRecoveryActions: @unchecked Sendable {
+  private let lock = NSLock()
+  private var actions: [@Sendable () -> Void] = []
+
+  var count: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return actions.count
+  }
+
+  func schedule(_ action: @escaping @Sendable () -> Void) {
+    lock.lock()
+    actions.append(action)
+    lock.unlock()
+  }
+
+  func runFirst() {
+    lock.lock()
+    let action = actions.removeFirst()
+    lock.unlock()
+    action()
   }
 }
 

--- a/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
+++ b/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
@@ -85,6 +85,44 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
     XCTAssertEqual(queue.scheduledBuffers.count, 1)
     XCTAssertTrue(queue.scheduledBuffers[0] === second)
   }
+
+  func testConfigurationRecoveryDefersAndCoalescesNotificationWork() {
+    let recovery = DeferredConfigurationRecovery()
+    var pendingActions: [() -> Void] = []
+    var recoveryCount = 0
+
+    recovery.schedule(
+      onMainQueue: { pendingActions.append($0) },
+      action: {
+        recoveryCount += 1
+        recovery.schedule(
+          onMainQueue: { pendingActions.append($0) },
+          action: { recoveryCount += 1 }
+        )
+      }
+    )
+    recovery.schedule(
+      onMainQueue: { pendingActions.append($0) },
+      action: { recoveryCount += 1 }
+    )
+
+    XCTAssertEqual(recoveryCount, 0)
+    XCTAssertEqual(pendingActions.count, 1)
+
+    pendingActions.removeFirst()()
+
+    XCTAssertEqual(recoveryCount, 1)
+    XCTAssertTrue(pendingActions.isEmpty)
+
+    recovery.schedule(
+      onMainQueue: { pendingActions.append($0) },
+      action: { recoveryCount += 1 }
+    )
+
+    XCTAssertEqual(pendingActions.count, 1)
+    pendingActions.removeFirst()()
+    XCTAssertEqual(recoveryCount, 2)
+  }
 }
 
 final class StreamingPCMPlayerLevelTests: XCTestCase {

--- a/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
+++ b/desktop/macos/Desktop/Tests/StreamingPCMPlaybackQueueTests.swift
@@ -105,7 +105,7 @@ final class StreamingPCMPlaybackQueueTests: XCTestCase {
     pendingActions.runFirst()
 
     XCTAssertEqual(recoveryCount, 1)
-    XCTAssertTrue(pendingActions.isEmpty)
+    XCTAssertEqual(pendingActions.count, 0)
 
     recovery.schedule { recoveryCount += 1 }
 

--- a/desktop/macos/changelog/unreleased/20260812-realtime-audio-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260812-realtime-audio-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed realtime voice audio recovery after an audio-device change"
+}


### PR DESCRIPTION
## Summary

Defer and coalesce PCM recovery after AVAudioEngine configuration changes to keep the notification callback non-blocking.

## Sentry issue

- [OMI-DESKTOP-2X8](https://omi-nk3.sentry.io/issues/7630285270/?project=4511086024851456)

## Product invariants affected

- INV-CHAT-1

## Failure class

Failure-Class: new

## Verification

- Swift format, parse, and test-quality checks passed.
- Focused XCTest is pending local SwiftPM dependency resolution.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the realtime PCM playback path and audio-thread/main-queue coordination; behavior is localized and covered by new unit tests.
> 
> **Overview**
> Fixes realtime voice playback recovery when macOS audio routing changes by **not** rebuilding `AVAudioEngine` inside the `AVAudioEngineConfigurationChange` notification handler.
> 
> Introduces **`DeferredConfigurationRecovery`** to enqueue recovery on the main queue, **coalesce** duplicate notifications while one rebuild is pending, and **drop** stale work via a generation counter. **`StreamingPCMPlayer`** now schedules `rebuildAfterConfigurationChange()` through that helper (same stop/reconnect/replay-tail behavior as before) and calls **`configurationRecovery.cancel()`** on explicit **`stop()`** so a user stop cannot be undone by queued recovery.
> 
> Adds XCTests for defer/coalesce/cancel and queue replay ordering; removes a source-file string inspection test. Documents the invariant in a new failure-class entry and an unreleased changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e795fed2c7576117032a0b088e69193b2932e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->