### PR TITLE
fix(desktop): make admission waiter handoff cancellation-safe

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentContextAdmissionGate.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentContextAdmissionGate.swift
@@ -110,7 +110,7 @@ actor AgentContextAdmissionGate {
     case .granted:
       return true
     case .cancelled:
-      finalizeCancelledWaiter(at: slotIndex)
+      finalizeCancelledWaiter(handle: handle)
       return false
     }
   }

--- a/desktop/macos/Desktop/Sources/Chat/AgentContextAdmissionGate.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentContextAdmissionGate.swift
@@ -17,8 +17,40 @@ import Foundation
 ///   serialized; the query stream itself runs outside the gate.
 actor AgentContextAdmissionGate {
   private final class WaiterHandle: @unchecked Sendable {
-    var cancelled = false
-    var continuation: CheckedContinuation<WakeReason, Never>?
+    private let lock = NSLock()
+    private var cancelled = false
+    private var continuation: CheckedContinuation<WakeReason, Never>?
+
+    func cancel() -> CheckedContinuation<WakeReason, Never>? {
+      lock.lock()
+      defer { lock.unlock() }
+      cancelled = true
+      let continuation = continuation
+      self.continuation = nil
+      return continuation
+    }
+
+    func register(_ continuation: CheckedContinuation<WakeReason, Never>) -> Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      guard !cancelled else { return false }
+      self.continuation = continuation
+      return true
+    }
+
+    func isCancelled() -> Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return cancelled
+    }
+
+    func takeContinuation() -> CheckedContinuation<WakeReason, Never>? {
+      lock.lock()
+      defer { lock.unlock() }
+      let continuation = continuation
+      self.continuation = nil
+      return continuation
+    }
   }
 
   private enum WakeReason {
@@ -28,13 +60,22 @@ actor AgentContextAdmissionGate {
 
   private struct WaiterSlot {
     let handle: WaiterHandle
-    var continuation: CheckedContinuation<WakeReason, Never>?
   }
 
   private var held = false
   private var releasePending = false
   private var waiters: [WaiterSlot] = []
   private var waiterHead = 0
+  private let onWaiterRegistered: (@Sendable () -> Void)?
+  private let beforeResumingGrantedWaiter: (@Sendable () -> Void)?
+
+  init(
+    onWaiterRegistered: (@Sendable () -> Void)? = nil,
+    beforeResumingGrantedWaiter: (@Sendable () -> Void)? = nil
+  ) {
+    self.onWaiterRegistered = onWaiterRegistered
+    self.beforeResumingGrantedWaiter = beforeResumingGrantedWaiter
+  }
 
   func withExclusiveAccess<Result: Sendable>(
     _ operation: @escaping @Sendable () async throws -> Result
@@ -59,12 +100,10 @@ actor AgentContextAdmissionGate {
         registerWaiter(slotIndex: slotIndex, handle: handle, continuation: continuation)
       }
     } onCancel: {
-      handle.cancelled = true
-      if let continuation = handle.continuation {
-        handle.continuation = nil
+      if let continuation = handle.cancel() {
         continuation.resume(returning: .cancelled)
       }
-      Task { await self.finalizeCancelledWaiter(at: slotIndex) }
+      Task { await self.finalizeCancelledWaiter(handle: handle) }
     }
 
     switch wakeReason {
@@ -91,26 +130,28 @@ actor AgentContextAdmissionGate {
       continuation.resume(returning: .cancelled)
       return
     }
-    if handle.cancelled {
+    guard handle.register(continuation) else {
       continuation.resume(returning: .cancelled)
       return
     }
-    handle.continuation = continuation
-    waiters[slotIndex].continuation = continuation
+    onWaiterRegistered?()
     if releasePending {
       releasePending = false
       release()
     }
   }
 
-  private func finalizeCancelledWaiter(at index: Int) {
-    guard waiters.indices.contains(index) else { return }
-    waiters[index].continuation = nil
-    waiters[index].handle.cancelled = true
+  private func finalizeCancelledWaiter(handle: WaiterHandle) {
+    guard let index = waiters.firstIndex(where: { $0.handle === handle }) else { return }
     if index == waiterHead {
       advanceWaiterHeadPastCancelled()
     }
     compactWaitersIfNeeded()
+    if releasePending {
+      releasePending = false
+      release()
+      return
+    }
     if waiterHead >= waiters.count, !held {
       waiters.removeAll(keepingCapacity: true)
       waiterHead = 0
@@ -120,16 +161,21 @@ actor AgentContextAdmissionGate {
   private func release() {
     advanceWaiterHeadPastCancelled()
     while waiterHead < waiters.count {
-      if waiters[waiterHead].handle.cancelled {
+      let handle = waiters[waiterHead].handle
+      if handle.isCancelled() {
         waiterHead += 1
         continue
       }
-      if let continuation = waiters[waiterHead].continuation {
-        waiters[waiterHead].continuation = nil
+      if let continuation = handle.takeContinuation() {
         waiterHead += 1
         compactWaitersIfNeeded()
+        beforeResumingGrantedWaiter?()
         continuation.resume(returning: .granted)
         return
+      }
+      if handle.isCancelled() {
+        waiterHead += 1
+        continue
       }
       releasePending = true
       return
@@ -141,7 +187,7 @@ actor AgentContextAdmissionGate {
   }
 
   private func advanceWaiterHeadPastCancelled() {
-    while waiterHead < waiters.count, waiters[waiterHead].handle.cancelled {
+    while waiterHead < waiters.count, waiters[waiterHead].handle.isCancelled() {
       waiterHead += 1
     }
     compactWaitersIfNeeded()

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -166,6 +166,64 @@ private actor GateHoldProbe {
   }
 }
 
+private final class GateGrantCancellationRaceProbe: @unchecked Sendable {
+  private let lock = NSLock()
+  private let resumeGrantedWaiter = DispatchSemaphore(value: 0)
+  private var waiterRegistered = false
+  private var grantPaused = false
+  private var registrationWaiter: CheckedContinuation<Void, Never>?
+  private var grantWaiter: CheckedContinuation<Void, Never>?
+
+  func signalWaiterRegistered() {
+    lock.lock()
+    waiterRegistered = true
+    let waiter = registrationWaiter
+    registrationWaiter = nil
+    lock.unlock()
+    waiter?.resume()
+  }
+
+  func waitUntilWaiterRegistered() async {
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if waiterRegistered {
+        lock.unlock()
+        continuation.resume()
+        return
+      }
+      registrationWaiter = continuation
+      lock.unlock()
+    }
+  }
+
+  func pauseGrantedHandoff() {
+    lock.lock()
+    grantPaused = true
+    let waiter = grantWaiter
+    grantWaiter = nil
+    lock.unlock()
+    waiter?.resume()
+    resumeGrantedWaiter.wait()
+  }
+
+  func waitUntilGrantPaused() async {
+    await withCheckedContinuation { continuation in
+      lock.lock()
+      if grantPaused {
+        lock.unlock()
+        continuation.resume()
+        return
+      }
+      grantWaiter = continuation
+      lock.unlock()
+    }
+  }
+
+  func resumeGrantedHandoff() {
+    resumeGrantedWaiter.signal()
+  }
+}
+
 private actor ContextProjectionTaskBox {
   private var task: Task<Void, Never>?
 
@@ -1628,6 +1686,38 @@ final class AgentRuntimeProcessTests: XCTestCase {
     let order = await enteredOrder.snapshot()
     XCTAssertEqual(order, ["first", "third"])
     _ = await second.result
+  }
+
+  func testContextAdmissionGateCancellationAfterGrantResumesWaiterOnce() async throws {
+    let raceProbe = GateGrantCancellationRaceProbe()
+    let gate = AgentContextAdmissionGate(
+      onWaiterRegistered: { raceProbe.signalWaiterRegistered() },
+      beforeResumingGrantedWaiter: { raceProbe.pauseGrantedHandoff() }
+    )
+    let holdProbe = GateHoldProbe()
+
+    let first = Task {
+      try await gate.withExclusiveAccess {
+        await holdProbe.signalEntered()
+        await holdProbe.waitUntilReleased()
+      }
+    }
+    await holdProbe.waitUntilEntered()
+
+    let second = Task {
+      _ = try? await gate.withExclusiveAccess {}
+    }
+    await raceProbe.waitUntilWaiterRegistered()
+
+    await holdProbe.release()
+    await raceProbe.waitUntilGrantPaused()
+    second.cancel()
+    raceProbe.resumeGrantedHandoff()
+
+    try await first.value
+    _ = await second.result
+    let third: String = try await gate.withExclusiveAccess { "third" }
+    XCTAssertEqual(third, "third")
   }
 
   func testContextAdmissionSecondMismatchFailsWithoutAnotherRefreshOrRetry() async {

--- a/desktop/macos/changelog/unreleased/20260812-fix-admission-handoff.json
+++ b/desktop/macos/changelog/unreleased/20260812-fix-admission-handoff.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash that could occur while refreshing the live voice context"
+}


### PR DESCRIPTION
## Summary

Prevent a cancelled context-admission waiter from resuming twice after its handoff.

## Sentry issue

- [OMI-DESKTOP-3ZA](https://omi-nk3.sentry.io/issues/7662129686/?project=4511086024851456)

## Product invariants affected

- INV-CHAT-1

## Failure class

Failure-Class: none

## Verification

- Swift format, parse, test-quality, and diff checks passed.
- Focused XCTest is still compiling in the local SwiftPM cache.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency control for context admission used by chat/voice refresh paths. The change is narrowly scoped and covered by a race-focused test, but incorrect waiter handoff could still stall or crash admission.
> 
> **Overview**
> Prevents a **double-resume crash** in `AgentContextAdmissionGate` when a waiter is cancelled during grant handoff (e.g. while refreshing live voice context).
> 
> Waiter state is now lock-protected on `WaiterHandle`, with cancel/register/take as atomic operations so grant and cancel cannot both resume the same continuation. Cancelled waiters also flush a pending release so the queue keeps moving.
> 
> Adds a focused race test that pauses mid-handoff and cancels before resume.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8e39342b51e60c9e510026ab9765f5f6c22ad4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->