### PR TITLE
fix(desktop): present microphone alerts without blocking

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -278,6 +278,13 @@ struct FinishedRecordingEnvelope: Equatable, Sendable {
 @MainActor
 protocol DesktopAlertPresenting: AnyObject {
   func present(title: String, message: String, completion: (@MainActor () -> Void)?)
+  /// Stop draining the alert queue until Omi is the active app again.
+  ///
+  /// Completions that hand the foreground to another app (System Settings)
+  /// must call this *before* that hand-off. `NSWorkspace.open` can return
+  /// while Omi is still active, so inferring a pause from the current shell
+  /// window would drain the next alert and hide it behind Settings.
+  func pauseQueueUntilAppActive()
 }
 
 @MainActor
@@ -285,6 +292,8 @@ extension DesktopAlertPresenting {
   func present(title: String, message: String) {
     present(title: title, message: message, completion: nil)
   }
+
+  func pauseQueueUntilAppActive() {}
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -276,6 +276,11 @@ struct FinishedRecordingEnvelope: Equatable, Sendable {
 }
 
 @MainActor
+protocol DesktopAlertPresenting: AnyObject {
+  func present(title: String, message: String)
+}
+
+@MainActor
 class AppState: ObservableObject {
   /// Weak reference to the current AppState instance, set on init.
   /// Used by background services (e.g. TranscriptionRetryService) to check recording state.
@@ -298,6 +303,7 @@ class AppState: ObservableObject {
   /// continue into the WAL while the transport reconnects, so this stays
   /// visible until the backend is ready or the active session is reset.
   @Published var transcriptionServiceError: String?
+  var alertPresenter: any DesktopAlertPresenting = AppKitSheetAlertPresenter()
   /// Monotonically increasing counter — incremented for each recording start or stop request.
   /// Used to prevent asynchronous work from mutating a newer recording decision.
   var recordingGeneration: UInt64 = 0

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -277,7 +277,14 @@ struct FinishedRecordingEnvelope: Equatable, Sendable {
 
 @MainActor
 protocol DesktopAlertPresenting: AnyObject {
-  func present(title: String, message: String)
+  func present(title: String, message: String, completion: (@MainActor () -> Void)?)
+}
+
+@MainActor
+extension DesktopAlertPresenting {
+  func present(title: String, message: String) {
+    present(title: title, message: message, completion: nil)
+  }
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -18,13 +18,20 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     let message: String
   }
 
-  typealias SheetPresenter = (NSAlert, NSWindow, @escaping () -> Void) -> Void
+  typealias BeginSheetModal = (NSAlert, NSWindow, @escaping () -> Void) -> Void
+  struct AppKitAlertOperations {
+    let beginSheetModal: BeginSheetModal
+
+    static let live = AppKitAlertOperations { alert, window, completion in
+      alert.beginSheetModal(for: window) { _ in completion() }
+    }
+  }
   /// Whether `window` can host a sheet right now. Defaults to "has no sheet
   /// attached" — AppKit raises if a second sheet is attached to one window.
   typealias SheetHostChecker = (NSWindow) -> Bool
 
   private let shellWindowProvider: () -> NSWindow?
-  private let sheetPresenter: SheetPresenter
+  private let appKitOperations: AppKitAlertOperations
   private let revealMainWindow: () -> Void
   private let canHostSheet: SheetHostChecker
   private var pendingAlerts: [AlertRequest] = []
@@ -37,9 +44,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
       AppKitSheetAlertPresenter.presentableShellWindow(
         ShellSummon.shellWindow(), isActive: NSApp.isActive)
     },
-    sheetPresenter: @escaping SheetPresenter = { alert, window, completion in
-      alert.beginSheetModal(for: window) { _ in completion() }
-    },
+    appKitOperations: AppKitAlertOperations = .live,
     revealMainWindow: @escaping () -> Void = {
       if let appDelegate = AppDelegate.summonWindowTarget() {
         appDelegate.openMainAppWindow()
@@ -51,7 +56,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     canHostSheet: @escaping SheetHostChecker = { $0.attachedSheet == nil }
   ) {
     self.shellWindowProvider = shellWindowProvider
-    self.sheetPresenter = sheetPresenter
+    self.appKitOperations = appKitOperations
     self.revealMainWindow = revealMainWindow
     self.canHostSheet = canHostSheet
     NotificationCenter.default.addObserver(
@@ -103,7 +108,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     alert.informativeText = request.message
     alert.alertStyle = .warning
     alert.addButton(withTitle: "OK")
-    sheetPresenter(alert, window) { [weak self] in
+    appKitOperations.beginSheetModal(alert, window) { [weak self] in
       Task { @MainActor in
         self?.isPresentingAlert = false
         self?.activeAlert = nil

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -13,33 +13,41 @@ import SwiftUI
 
 @MainActor
 final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
-  private struct AlertRequest {
+  private struct AlertRequest: Equatable {
     let title: String
     let message: String
   }
 
   typealias SheetPresenter = (NSAlert, NSWindow, @escaping () -> Void) -> Void
 
-  private let windowProvider: () -> NSWindow?
+  private let shellWindowProvider: () -> NSWindow?
   private let sheetPresenter: SheetPresenter
-  private let activateApplication: () -> Void
+  private let revealMainWindow: () -> Void
   private var pendingAlerts: [AlertRequest] = []
+  private var activeAlert: AlertRequest?
   private var isPresentingAlert = false
+  private var isRevealingMainWindow = false
 
   init(
-    windowProvider: @escaping () -> NSWindow? = {
-      NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.isVisible })
+    shellWindowProvider: @escaping () -> NSWindow? = {
+      guard let window = ShellSummon.shellWindow(), window.isVisible, !window.isMiniaturized else { return nil }
+      return window
     },
     sheetPresenter: @escaping SheetPresenter = { alert, window, completion in
       alert.beginSheetModal(for: window) { _ in completion() }
     },
-    activateApplication: @escaping () -> Void = {
-      NSApp.activate(ignoringOtherApps: true)
+    revealMainWindow: @escaping () -> Void = {
+      if let appDelegate = AppDelegate.summonWindowTarget() {
+        appDelegate.openMainAppWindow()
+      } else {
+        NSApp.activate(ignoringOtherApps: true)
+        ShellSummon.summon()
+      }
     }
   ) {
-    self.windowProvider = windowProvider
+    self.shellWindowProvider = shellWindowProvider
     self.sheetPresenter = sheetPresenter
-    self.activateApplication = activateApplication
+    self.revealMainWindow = revealMainWindow
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(presentPendingAlertIfPossible),
@@ -57,19 +65,22 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
   }
 
   func present(title: String, message: String) {
-    pendingAlerts.append(.init(title: title, message: message))
+    let request = AlertRequest(title: title, message: message)
+    guard activeAlert != request, !pendingAlerts.contains(request) else { return }
+    pendingAlerts.append(request)
     presentPendingAlertIfPossible()
   }
 
   @objc private func presentPendingAlertIfPossible() {
-    guard !isPresentingAlert, let request = pendingAlerts.first else { return }
-    guard let window = windowProvider() else {
-      activateApplication()
+    guard !isPresentingAlert, !isRevealingMainWindow, let request = pendingAlerts.first else { return }
+    guard let window = shellWindowProvider() else {
+      revealMainWindowIfNeeded()
       return
     }
 
     pendingAlerts.removeFirst()
     isPresentingAlert = true
+    activeAlert = request
     let alert = NSAlert()
     alert.messageText = request.title
     alert.informativeText = request.message
@@ -78,9 +89,19 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     sheetPresenter(alert, window) { [weak self] in
       Task { @MainActor in
         self?.isPresentingAlert = false
+        self?.activeAlert = nil
         self?.presentPendingAlertIfPossible()
       }
     }
+  }
+
+  private func revealMainWindowIfNeeded() {
+    guard !isRevealingMainWindow else { return }
+    isRevealingMainWindow = true
+    revealMainWindow()
+    isRevealingMainWindow = false
+    guard shellWindowProvider() != nil else { return }
+    presentPendingAlertIfPossible()
   }
 }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -11,6 +11,26 @@ import SwiftUI
 /// cannot add storage to it; the value is meaningful only to `notePermissionGrants` below.
 @MainActor private var lastGrantedPermissionCount: Int?
 
+@MainActor
+final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
+  func present(title: String, message: String) {
+    guard
+      let window = NSApp.keyWindow ?? NSApp.mainWindow
+        ?? NSApp.windows.first(where: { $0.isVisible })
+    else {
+      log("Unable to present alert without a visible window")
+      return
+    }
+
+    let alert = NSAlert()
+    alert.messageText = title
+    alert.informativeText = message
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "OK")
+    alert.beginSheetModal(for: window)
+  }
+}
+
 /// The AppKit lookups the accessibility probe depends on, read once on the main
 /// actor and handed to the probe as plain values so the expensive cross-process
 /// AX round trips can run off it.
@@ -879,12 +899,7 @@ extension AppState {
   }
 
   func showAlert(title: String, message: String) {
-    let alert = NSAlert()
-    alert.messageText = title
-    alert.informativeText = message
-    alert.alertStyle = .warning
-    alert.addButton(withTitle: "OK")
-    alert.runModal()
+    alertPresenter.present(title: title, message: message)
   }
 
   // MARK: - Transcription

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -19,10 +19,14 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
   }
 
   typealias SheetPresenter = (NSAlert, NSWindow, @escaping () -> Void) -> Void
+  /// Whether `window` can host a sheet right now. Defaults to "has no sheet
+  /// attached" — AppKit raises if a second sheet is attached to one window.
+  typealias SheetHostChecker = (NSWindow) -> Bool
 
   private let shellWindowProvider: () -> NSWindow?
   private let sheetPresenter: SheetPresenter
   private let revealMainWindow: () -> Void
+  private let canHostSheet: SheetHostChecker
   private var pendingAlerts: [AlertRequest] = []
   private var activeAlert: AlertRequest?
   private var isPresentingAlert = false
@@ -30,8 +34,8 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
 
   init(
     shellWindowProvider: @escaping () -> NSWindow? = {
-      guard let window = ShellSummon.shellWindow(), window.isVisible, !window.isMiniaturized else { return nil }
-      return window
+      AppKitSheetAlertPresenter.presentableShellWindow(
+        ShellSummon.shellWindow(), isActive: NSApp.isActive)
     },
     sheetPresenter: @escaping SheetPresenter = { alert, window, completion in
       alert.beginSheetModal(for: window) { _ in completion() }
@@ -43,11 +47,13 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
         NSApp.activate(ignoringOtherApps: true)
         ShellSummon.summon()
       }
-    }
+    },
+    canHostSheet: @escaping SheetHostChecker = { $0.attachedSheet == nil }
   ) {
     self.shellWindowProvider = shellWindowProvider
     self.sheetPresenter = sheetPresenter
     self.revealMainWindow = revealMainWindow
+    self.canHostSheet = canHostSheet
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(presentPendingAlertIfPossible),
@@ -57,6 +63,11 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
       self,
       selector: #selector(presentPendingAlertIfPossible),
       name: NSWindow.didBecomeKeyNotification,
+      object: nil)
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(presentPendingAlertIfPossible),
+      name: NSWindow.didEndSheetNotification,
       object: nil)
   }
 
@@ -77,6 +88,12 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
       revealMainWindowIfNeeded()
       return
     }
+    guard canHostSheet(window) else {
+      // The shell already owns a sheet (a SwiftUI sheet, for example). AppKit
+      // cannot attach a second sheet to one window, so keep the request queued
+      // and retry when `NSWindow.didEndSheetNotification` fires.
+      return
+    }
 
     pendingAlerts.removeFirst()
     isPresentingAlert = true
@@ -93,6 +110,17 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
         self?.presentPendingAlertIfPossible()
       }
     }
+  }
+
+  /// The shell window an alert sheet may attach to, or `nil` when it must be
+  /// summoned first. Mirrors `ShellSummon.toggleAction`: a visible but inactive
+  /// shell is usually ordered in behind whatever the user is working in, so
+  /// attaching a sheet to it would leave the warning invisible behind the
+  /// foreground application. Requiring the app to be active forces the reveal
+  /// path (`openMainAppWindow` / `ShellSummon.summon`) before presenting.
+  static func presentableShellWindow(_ window: NSWindow?, isActive: Bool) -> NSWindow? {
+    guard isActive, let window, window.isVisible, !window.isMiniaturized else { return nil }
+    return window
   }
 
   private func revealMainWindowIfNeeded() {

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -13,21 +13,74 @@ import SwiftUI
 
 @MainActor
 final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
+  private struct AlertRequest {
+    let title: String
+    let message: String
+  }
+
+  typealias SheetPresenter = (NSAlert, NSWindow, @escaping () -> Void) -> Void
+
+  private let windowProvider: () -> NSWindow?
+  private let sheetPresenter: SheetPresenter
+  private let activateApplication: () -> Void
+  private var pendingAlerts: [AlertRequest] = []
+  private var isPresentingAlert = false
+
+  init(
+    windowProvider: @escaping () -> NSWindow? = {
+      NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.isVisible })
+    },
+    sheetPresenter: @escaping SheetPresenter = { alert, window, completion in
+      alert.beginSheetModal(for: window) { _ in completion() }
+    },
+    activateApplication: @escaping () -> Void = {
+      NSApp.activate(ignoringOtherApps: true)
+    }
+  ) {
+    self.windowProvider = windowProvider
+    self.sheetPresenter = sheetPresenter
+    self.activateApplication = activateApplication
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(presentPendingAlertIfPossible),
+      name: NSApplication.didBecomeActiveNotification,
+      object: nil)
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(presentPendingAlertIfPossible),
+      name: NSWindow.didBecomeKeyNotification,
+      object: nil)
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
   func present(title: String, message: String) {
-    guard
-      let window = NSApp.keyWindow ?? NSApp.mainWindow
-        ?? NSApp.windows.first(where: { $0.isVisible })
-    else {
-      log("Unable to present alert without a visible window")
+    pendingAlerts.append(.init(title: title, message: message))
+    presentPendingAlertIfPossible()
+  }
+
+  @objc private func presentPendingAlertIfPossible() {
+    guard !isPresentingAlert, let request = pendingAlerts.first else { return }
+    guard let window = windowProvider() else {
+      activateApplication()
       return
     }
 
+    pendingAlerts.removeFirst()
+    isPresentingAlert = true
     let alert = NSAlert()
-    alert.messageText = title
-    alert.informativeText = message
+    alert.messageText = request.title
+    alert.informativeText = request.message
     alert.alertStyle = .warning
     alert.addButton(withTitle: "OK")
-    alert.beginSheetModal(for: window)
+    sheetPresenter(alert, window) { [weak self] in
+      Task { @MainActor in
+        self?.isPresentingAlert = false
+        self?.presentPendingAlertIfPossible()
+      }
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -22,7 +22,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
   struct AppKitAlertOperations {
     let beginSheetModal: BeginSheetModal
 
-    static let live = AppKitAlertOperations { alert, window, completion in
+    @MainActor static let live = AppKitAlertOperations { alert, window, completion in
       alert.beginSheetModal(for: window) { _ in completion() }
     }
   }
@@ -44,7 +44,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
       AppKitSheetAlertPresenter.presentableShellWindow(
         ShellSummon.shellWindow(), isActive: NSApp.isActive)
     },
-    appKitOperations: AppKitAlertOperations = .live,
+    appKitOperations: AppKitAlertOperations? = nil,
     revealMainWindow: @escaping () -> Void = {
       if let appDelegate = AppDelegate.summonWindowTarget() {
         appDelegate.openMainAppWindow()
@@ -56,7 +56,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     canHostSheet: @escaping SheetHostChecker = { $0.attachedSheet == nil }
   ) {
     self.shellWindowProvider = shellWindowProvider
-    self.appKitOperations = appKitOperations
+    self.appKitOperations = appKitOperations ?? .live
     self.revealMainWindow = revealMainWindow
     self.canHostSheet = canHostSheet
     NotificationCenter.default.addObserver(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -18,6 +18,11 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     let message: String
   }
 
+  private struct PendingAlert {
+    let request: AlertRequest
+    let completion: (@MainActor () -> Void)?
+  }
+
   typealias BeginSheetModal = (NSAlert, NSWindow, @escaping () -> Void) -> Void
   struct AppKitAlertOperations {
     let beginSheetModal: BeginSheetModal
@@ -34,7 +39,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
   private let appKitOperations: AppKitAlertOperations
   private let revealMainWindow: () -> Void
   private let canHostSheet: SheetHostChecker
-  private var pendingAlerts: [AlertRequest] = []
+  private var pendingAlerts: [PendingAlert] = []
   private var activeAlert: AlertRequest?
   private var isPresentingAlert = false
   private var isRevealingMainWindow = false
@@ -80,15 +85,16 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     NotificationCenter.default.removeObserver(self)
   }
 
-  func present(title: String, message: String) {
+  func present(title: String, message: String, completion: (@MainActor () -> Void)? = nil) {
     let request = AlertRequest(title: title, message: message)
-    guard activeAlert != request, !pendingAlerts.contains(request) else { return }
-    pendingAlerts.append(request)
+    guard activeAlert != request, !pendingAlerts.contains(where: { $0.request == request }) else { return }
+    pendingAlerts.append(.init(request: request, completion: completion))
     presentPendingAlertIfPossible()
   }
 
   @objc private func presentPendingAlertIfPossible() {
-    guard !isPresentingAlert, !isRevealingMainWindow, let request = pendingAlerts.first else { return }
+    guard !isPresentingAlert, !isRevealingMainWindow, !pendingAlerts.isEmpty else { return }
+    let pending = pendingAlerts[0]
     guard let window = shellWindowProvider() else {
       revealMainWindowIfNeeded()
       return
@@ -102,16 +108,17 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
 
     pendingAlerts.removeFirst()
     isPresentingAlert = true
-    activeAlert = request
+    activeAlert = pending.request
     let alert = NSAlert()
-    alert.messageText = request.title
-    alert.informativeText = request.message
+    alert.messageText = pending.request.title
+    alert.informativeText = pending.request.message
     alert.alertStyle = .warning
     alert.addButton(withTitle: "OK")
     appKitOperations.beginSheetModal(alert, window) { [weak self] in
       Task { @MainActor in
         self?.isPresentingAlert = false
         self?.activeAlert = nil
+        pending.completion?()
         self?.presentPendingAlertIfPossible()
       }
     }
@@ -1005,8 +1012,8 @@ extension AppState {
     alert.runModal()
   }
 
-  func showAlert(title: String, message: String) {
-    alertPresenter.present(title: title, message: message)
+  func showAlert(title: String, message: String, completion: (@MainActor () -> Void)? = nil) {
+    alertPresenter.present(title: title, message: message, completion: completion)
   }
 
   // MARK: - Transcription

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -43,6 +43,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
   private var activeAlert: AlertRequest?
   private var isPresentingAlert = false
   private var isRevealingMainWindow = false
+  private var queuePausedUntilForeground = false
 
   init(
     shellWindowProvider: @escaping () -> NSWindow? = {
@@ -66,7 +67,7 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     self.canHostSheet = canHostSheet
     NotificationCenter.default.addObserver(
       self,
-      selector: #selector(presentPendingAlertIfPossible),
+      selector: #selector(applicationDidBecomeActive),
       name: NSApplication.didBecomeActiveNotification,
       object: nil)
     NotificationCenter.default.addObserver(
@@ -92,8 +93,17 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
     presentPendingAlertIfPossible()
   }
 
+  func pauseQueueUntilAppActive() {
+    queuePausedUntilForeground = true
+  }
+
+  @objc private func applicationDidBecomeActive() {
+    queuePausedUntilForeground = false
+    presentPendingAlertIfPossible()
+  }
+
   @objc private func presentPendingAlertIfPossible() {
-    guard !isPresentingAlert, !isRevealingMainWindow, !pendingAlerts.isEmpty else { return }
+    guard !queuePausedUntilForeground, !isPresentingAlert, !isRevealingMainWindow, !pendingAlerts.isEmpty else { return }
     let pending = pendingAlerts[0]
     guard let window = shellWindowProvider() else {
       revealMainWindowIfNeeded()
@@ -121,10 +131,13 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
         pending.completion?()
         // A completion can change the foreground application (for example the
         // microphone-permission alert opens System Settings once dismissed).
-        // If Omi is no longer the active app, do not summon it back over the
-        // user's task just to drain the next queued alert; the active / key /
-        // sheet observers resume presentation when Omi is in front again.
-        guard let self, self.shellWindowProvider() != nil else { return }
+        // The completion must request the pause explicitly: NSWorkspace.open
+        // can return before macOS deactivates Omi, so a synchronous
+        // shellWindowProvider() check would still drain the next alert.
+        // didBecomeActive resumes the queue when the user comes back.
+        guard let self else { return }
+        if self.queuePausedUntilForeground { return }
+        guard self.shellWindowProvider() != nil else { return }
         self.presentPendingAlertIfPossible()
       }
     }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
@@ -119,7 +119,13 @@ final class AppKitSheetAlertPresenter: DesktopAlertPresenting {
         self?.isPresentingAlert = false
         self?.activeAlert = nil
         pending.completion?()
-        self?.presentPendingAlertIfPossible()
+        // A completion can change the foreground application (for example the
+        // microphone-permission alert opens System Settings once dismissed).
+        // If Omi is no longer the active app, do not summon it back over the
+        // user's task just to drain the next queued alert; the active / key /
+        // sheet observers resume presentation when Omi is in front again.
+        guard let self, self.shellWindowProvider() != nil else { return }
+        self.presentPendingAlertIfPossible()
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -842,9 +842,10 @@ extension AppState {
         "macOS is not letting Omi hear the microphone. Enable Omi under "
         + "System Settings → Privacy & Security → Microphone, then start recording again."
     ) {
-      // Only send the user to the exact pane once they have seen the alert, so
-      // the non-blocking sheet stays visible instead of being buried under
-      // System Settings.
+      // Pause before the hand-off. NSWorkspace.open can return while Omi is
+      // still the active app, and a queued alert must not attach a sheet that
+      // System Settings then covers. didBecomeActive resumes the queue.
+      alertPresenter.pauseQueueUntilAppActive()
       if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
         NSWorkspace.shared.open(url)
       }

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -840,9 +840,14 @@ extension AppState {
       title: "Omi Needs Microphone Access",
       message:
         "macOS is not letting Omi hear the microphone. Enable Omi under "
-        + "System Settings → Privacy & Security → Microphone, then start recording again.")
-    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
-      NSWorkspace.shared.open(url)
+        + "System Settings → Privacy & Security → Microphone, then start recording again."
+    ) {
+      // Only send the user to the exact pane once they have seen the alert, so
+      // the non-blocking sheet stays visible instead of being buried under
+      // System Settings.
+      if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+        NSWorkspace.shared.open(url)
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -239,6 +239,48 @@ final class AppStateAlertPresentationTests: XCTestCase {
         .init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window),
       ])
   }
+
+  func testAppKitPresenterHonorsAnExplicitQueuePauseFromCompletion() async {
+    // Production ordering: the permission completion requests the pause, then
+    // NSWorkspace.open returns while the shell is still presentable. The next
+    // alert must stay queued until didBecomeActive, not drain synchronously.
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder(deferCompletions: true)
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { windowSource.window },
+      appKitOperations: .init(beginSheetModal: recorder.present),
+      revealMainWindow: {})
+
+    let window = NSWindow()
+    windowSource.window = window
+    presenter.present(title: "Omi Needs Microphone Access", message: "Enable Omi under System Settings.") {
+      presenter.pauseQueueUntilAppActive()
+    }
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+
+    await Task.yield()
+    await Task.yield()
+    XCTAssertEqual(recorder.presentations.count, 1, "only the permission alert presents first")
+
+    recorder.endSheet()
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(
+      recorder.presentations.count, 1,
+      "queued alert must not drain while the completion-requested pause is held")
+
+    NotificationCenter.default.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [
+        .init(title: "Omi Needs Microphone Access", message: "Enable Omi under System Settings.", window: window),
+        .init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window),
+      ])
+  }
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -102,6 +102,67 @@ final class AppStateAlertPresentationTests: XCTestCase {
       recorder.presentations,
       [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
   }
+
+  func testPresentableShellWindowRequiresTheAppToBeActive() {
+    let window = NSWindow()
+    XCTAssertNil(AppKitSheetAlertPresenter.presentableShellWindow(window, isActive: false))
+    XCTAssertNil(AppKitSheetAlertPresenter.presentableShellWindow(nil, isActive: true))
+  }
+
+  func testSheetPresenterDefersWhileTheShellAlreadyOwnsASheet() async {
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder()
+    let window = NSWindow()
+    var hostCanAccept = false
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { windowSource.window },
+      sheetPresenter: recorder.present,
+      revealMainWindow: { windowSource.window = window },
+      canHostSheet: { _ in hostCanAccept })
+
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+    presenter.present(title: "Couldn't Start Transcription", message: "Retry or switch input devices.")
+
+    XCTAssertTrue(recorder.presentations.isEmpty)
+
+    // The requests are not dropped while the shell owns a sheet; once the
+    // sheet ends (the host check passes again) the queued alerts drain in order.
+    hostCanAccept = true
+    NotificationCenter.default.post(name: NSWindow.didEndSheetNotification, object: window)
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [
+        .init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window),
+        .init(title: "Couldn't Start Transcription", message: "Retry or switch input devices.", window: window),
+      ])
+  }
+
+  func testSheetPresenterDefersWhileTheShellOwnsASheetThenRevealsWhenNoneRemains() {
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder()
+    var revealCount = 0
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { windowSource.window },
+      sheetPresenter: recorder.present,
+      revealMainWindow: { revealCount += 1 },
+      canHostSheet: { $0.attachedSheet == nil })
+
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+
+    XCTAssertTrue(recorder.presentations.isEmpty)
+    XCTAssertEqual(revealCount, 1)
+
+    let window = NSWindow()
+    windowSource.window = window
+    NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
+  }
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -20,14 +20,14 @@ final class AppStateAlertPresentationTests: XCTestCase {
       ])
   }
 
-  func testSheetPresenterRevealsTheMainWindowThenPresentsTheAlert() {
+  func testAppKitPresenterUsesTheNonBlockingSheetOperationAfterRevealingTheMainWindow() {
     let windowSource = WindowSource()
     let recorder = SheetPresentationRecorder()
     let window = NSWindow()
     var revealCount = 0
     let presenter = AppKitSheetAlertPresenter(
       shellWindowProvider: { windowSource.window },
-      sheetPresenter: recorder.present,
+      appKitOperations: .init(beginSheetModal: recorder.present),
       revealMainWindow: {
         revealCount += 1
         windowSource.window = window
@@ -41,13 +41,13 @@ final class AppStateAlertPresentationTests: XCTestCase {
       [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
   }
 
-  func testSheetPresenterRetainsAlertUntilTheMainWindowBecomesAvailable() {
+  func testAppKitPresenterRetainsAlertUntilTheMainWindowBecomesAvailable() {
     let windowSource = WindowSource()
     let recorder = SheetPresentationRecorder()
     var revealCount = 0
     let presenter = AppKitSheetAlertPresenter(
       shellWindowProvider: { windowSource.window },
-      sheetPresenter: recorder.present,
+      appKitOperations: .init(beginSheetModal: recorder.present),
       revealMainWindow: { revealCount += 1 })
 
     presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
@@ -64,13 +64,13 @@ final class AppStateAlertPresentationTests: XCTestCase {
       [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
   }
 
-  func testSheetPresenterCoalescesMatchingPendingAlerts() {
+  func testAppKitPresenterCoalescesMatchingPendingAlerts() {
     let windowSource = WindowSource()
     let recorder = SheetPresentationRecorder()
     var revealCount = 0
     let presenter = AppKitSheetAlertPresenter(
       shellWindowProvider: { windowSource.window },
-      sheetPresenter: recorder.present,
+      appKitOperations: .init(beginSheetModal: recorder.present),
       revealMainWindow: { revealCount += 1 })
 
     presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
@@ -87,12 +87,12 @@ final class AppStateAlertPresentationTests: XCTestCase {
       [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
   }
 
-  func testSheetPresenterCoalescesMatchingActiveAlerts() {
+  func testAppKitPresenterCoalescesMatchingActiveAlerts() {
     let window = NSWindow()
     let recorder = SheetPresentationRecorder()
     let presenter = AppKitSheetAlertPresenter(
       shellWindowProvider: { window },
-      sheetPresenter: recorder.present,
+      appKitOperations: .init(beginSheetModal: recorder.present),
       revealMainWindow: {})
 
     presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
@@ -109,14 +109,14 @@ final class AppStateAlertPresentationTests: XCTestCase {
     XCTAssertNil(AppKitSheetAlertPresenter.presentableShellWindow(nil, isActive: true))
   }
 
-  func testSheetPresenterDefersWhileTheShellAlreadyOwnsASheet() async {
+  func testAppKitPresenterDefersWhileTheShellAlreadyOwnsASheet() async {
     let windowSource = WindowSource()
     let recorder = SheetPresentationRecorder()
     let window = NSWindow()
     var hostCanAccept = false
     let presenter = AppKitSheetAlertPresenter(
       shellWindowProvider: { windowSource.window },
-      sheetPresenter: recorder.present,
+      appKitOperations: .init(beginSheetModal: recorder.present),
       revealMainWindow: { windowSource.window = window },
       canHostSheet: { _ in hostCanAccept })
 
@@ -140,13 +140,13 @@ final class AppStateAlertPresentationTests: XCTestCase {
       ])
   }
 
-  func testSheetPresenterDefersWhileTheShellOwnsASheetThenRevealsWhenNoneRemains() {
+  func testAppKitPresenterDefersWhileTheShellOwnsASheetThenRevealsWhenNoneRemains() {
     let windowSource = WindowSource()
     let recorder = SheetPresentationRecorder()
     var revealCount = 0
     let presenter = AppKitSheetAlertPresenter(
       shellWindowProvider: { windowSource.window },
-      sheetPresenter: recorder.present,
+      appKitOperations: .init(beginSheetModal: recorder.present),
       revealMainWindow: { revealCount += 1 },
       canHostSheet: { $0.attachedSheet == nil })
 

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class AppStateAlertPresentationTests: XCTestCase {
+  func testShowAlertPresentsThroughTheNonBlockingSheetSeam() {
+    let state = AppState()
+    let presenter = RecordingAlertPresenter()
+    state.alertPresenter = presenter
+
+    state.showAlert(title: "Microphone Isn't Capturing Audio", message: "Check your input device and try again.")
+
+    XCTAssertEqual(
+      presenter.presentations,
+      [
+        .init(
+          title: "Microphone Isn't Capturing Audio",
+          message: "Check your input device and try again.")
+      ])
+  }
+}
+
+@MainActor
+private final class RecordingAlertPresenter: DesktopAlertPresenting {
+  struct Presentation: Equatable {
+    let title: String
+    let message: String
+  }
+
+  private(set) var presentations: [Presentation] = []
+
+  func present(title: String, message: String) {
+    presentations.append(.init(title: title, message: message))
+  }
+}

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -194,6 +194,51 @@ final class AppStateAlertPresentationTests: XCTestCase {
 
     XCTAssertEqual(completions, 1, "completion runs once after the sheet ends")
   }
+
+  func testAppKitPresenterPausesQueuedAlertsAfterACompletionDropsTheForeground() async {
+    // The microphone-permission alert's completion opens System Settings, which
+    // deactivates Omi. The next queued alert must not immediately summon Omi
+    // back over the settings pane: presentation waits until Omi is active again.
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder(deferCompletions: true)
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { windowSource.window },
+      appKitOperations: .init(beginSheetModal: recorder.present),
+      revealMainWindow: {})
+
+    let window = NSWindow()
+    windowSource.window = window
+    presenter.present(title: "Omi Needs Microphone Access", message: "Enable Omi under System Settings.")
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+
+    await Task.yield()
+    await Task.yield()
+    XCTAssertEqual(recorder.presentations.count, 1, "only the permission alert presents first")
+
+    // The first sheet's completion opens System Settings: Omi is no longer the
+    // active app, so the shell provider returns no presentable window.
+    windowSource.window = nil
+    recorder.endSheet()
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(
+      recorder.presentations.count, 1,
+      "queued alert must not be dragged forward while Omi is behind System Settings")
+
+    // Omi becomes active again; the queued alert presents on the next window.
+    windowSource.window = window
+    NotificationCenter.default.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [
+        .init(title: "Omi Needs Microphone Access", message: "Enable Omi under System Settings.", window: window),
+        .init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window),
+      ])
+  }
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -20,21 +20,83 @@ final class AppStateAlertPresentationTests: XCTestCase {
       ])
   }
 
-  func testSheetPresenterDefersAlertUntilAWindowBecomesVisible() {
+  func testSheetPresenterRevealsTheMainWindowThenPresentsTheAlert() {
     let windowSource = WindowSource()
     let recorder = SheetPresentationRecorder()
+    let window = NSWindow()
+    var revealCount = 0
     let presenter = AppKitSheetAlertPresenter(
-      windowProvider: { windowSource.window },
+      shellWindowProvider: { windowSource.window },
       sheetPresenter: recorder.present,
-      activateApplication: {})
+      revealMainWindow: {
+        revealCount += 1
+        windowSource.window = window
+      })
 
     presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
 
+    XCTAssertEqual(revealCount, 1)
+    XCTAssertEqual(
+      recorder.presentations,
+      [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
+  }
+
+  func testSheetPresenterRetainsAlertUntilTheMainWindowBecomesAvailable() {
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder()
+    var revealCount = 0
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { windowSource.window },
+      sheetPresenter: recorder.present,
+      revealMainWindow: { revealCount += 1 })
+
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+
+    XCTAssertEqual(revealCount, 1)
     XCTAssertTrue(recorder.presentations.isEmpty)
 
     let window = NSWindow()
     windowSource.window = window
     NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
+  }
+
+  func testSheetPresenterCoalescesMatchingPendingAlerts() {
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder()
+    var revealCount = 0
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { windowSource.window },
+      sheetPresenter: recorder.present,
+      revealMainWindow: { revealCount += 1 })
+
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+
+    XCTAssertEqual(revealCount, 1)
+
+    let window = NSWindow()
+    windowSource.window = window
+    NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
+  }
+
+  func testSheetPresenterCoalescesMatchingActiveAlerts() {
+    let window = NSWindow()
+    let recorder = SheetPresentationRecorder()
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { window },
+      sheetPresenter: recorder.present,
+      revealMainWindow: {})
+
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
 
     XCTAssertEqual(
       recorder.presentations,

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -19,6 +19,27 @@ final class AppStateAlertPresentationTests: XCTestCase {
           message: "Check your input device and try again.")
       ])
   }
+
+  func testSheetPresenterDefersAlertUntilAWindowBecomesVisible() {
+    let windowSource = WindowSource()
+    let recorder = SheetPresentationRecorder()
+    let presenter = AppKitSheetAlertPresenter(
+      windowProvider: { windowSource.window },
+      sheetPresenter: recorder.present,
+      activateApplication: {})
+
+    presenter.present(title: "Device Not Connected", message: "Connect your wearable device first.")
+
+    XCTAssertTrue(recorder.presentations.isEmpty)
+
+    let window = NSWindow()
+    windowSource.window = window
+    NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+    XCTAssertEqual(
+      recorder.presentations,
+      [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
+  }
 }
 
 @MainActor
@@ -32,5 +53,30 @@ private final class RecordingAlertPresenter: DesktopAlertPresenting {
 
   func present(title: String, message: String) {
     presentations.append(.init(title: title, message: message))
+  }
+}
+
+@MainActor
+private final class WindowSource {
+  var window: NSWindow?
+}
+
+@MainActor
+private final class SheetPresentationRecorder {
+  struct Presentation: Equatable {
+    let title: String
+    let message: String
+    let window: NSWindow
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.title == rhs.title && lhs.message == rhs.message && lhs.window === rhs.window
+    }
+  }
+
+  private(set) var presentations: [Presentation] = []
+
+  func present(alert: NSAlert, window: NSWindow, completion: @escaping () -> Void) {
+    presentations.append(.init(title: alert.messageText, message: alert.informativeText, window: window))
+    completion()
   }
 }

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -6,17 +6,22 @@ import XCTest
 final class AppStateAlertPresentationTests: XCTestCase {
   func testShowAlertPresentsThroughTheNonBlockingSheetSeam() {
     let state = AppState()
-    let presenter = RecordingAlertPresenter()
-    state.alertPresenter = presenter
+    let recorder = SheetPresentationRecorder()
+    let window = NSWindow()
+    state.alertPresenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { window },
+      appKitOperations: .init(beginSheetModal: recorder.present),
+      revealMainWindow: {})
 
     state.showAlert(title: "Microphone Isn't Capturing Audio", message: "Check your input device and try again.")
 
     XCTAssertEqual(
-      presenter.presentations,
+      recorder.presentations,
       [
         .init(
           title: "Microphone Isn't Capturing Audio",
-          message: "Check your input device and try again.")
+          message: "Check your input device and try again.",
+          window: window)
       ])
   }
 
@@ -162,20 +167,6 @@ final class AppStateAlertPresentationTests: XCTestCase {
     XCTAssertEqual(
       recorder.presentations,
       [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
-  }
-}
-
-@MainActor
-private final class RecordingAlertPresenter: DesktopAlertPresenting {
-  struct Presentation: Equatable {
-    let title: String
-    let message: String
-  }
-
-  private(set) var presentations: [Presentation] = []
-
-  func present(title: String, message: String) {
-    presentations.append(.init(title: title, message: message))
   }
 }
 

--- a/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/AppStateAlertPresentationTests.swift
@@ -168,6 +168,32 @@ final class AppStateAlertPresentationTests: XCTestCase {
       recorder.presentations,
       [.init(title: "Device Not Connected", message: "Connect your wearable device first.", window: window)])
   }
+
+  func testAppKitPresenterRunsCompletionAfterTheSheetEnds() async {
+    let window = NSWindow()
+    let recorder = SheetPresentationRecorder(deferCompletions: true)
+    let presenter = AppKitSheetAlertPresenter(
+      shellWindowProvider: { window },
+      appKitOperations: .init(beginSheetModal: recorder.present),
+      revealMainWindow: {})
+
+    var completions = 0
+    presenter.present(title: "Omi Needs Microphone Access", message: "Enable Omi under System Settings.") {
+      completions += 1
+    }
+
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(recorder.presentations.count, 1)
+    XCTAssertEqual(completions, 0, "completion must not run before the sheet ends")
+
+    recorder.endSheet()
+    await Task.yield()
+    await Task.yield()
+
+    XCTAssertEqual(completions, 1, "completion runs once after the sheet ends")
+  }
 }
 
 @MainActor
@@ -188,9 +214,25 @@ private final class SheetPresentationRecorder {
   }
 
   private(set) var presentations: [Presentation] = []
+  private var deferredCompletions: [() -> Void] = []
+  private let deferCompletions: Bool
+
+  init(deferCompletions: Bool = false) {
+    self.deferCompletions = deferCompletions
+  }
 
   func present(alert: NSAlert, window: NSWindow, completion: @escaping () -> Void) {
     presentations.append(.init(title: alert.messageText, message: alert.informativeText, window: window))
-    completion()
+    if deferCompletions {
+      deferredCompletions.append(completion)
+    } else {
+      completion()
+    }
+  }
+
+  /// Simulate the sheet ending; the presenter's per-alert completion runs now.
+  func endSheet() {
+    guard !deferredCompletions.isEmpty else { return }
+    deferredCompletions.removeFirst()()
   }
 }

--- a/desktop/macos/changelog/unreleased/20260812-silent-microphone-alert.json
+++ b/desktop/macos/changelog/unreleased/20260812-silent-microphone-alert.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a microphone failure warning that could freeze Omi instead of letting you keep using the app"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -77,7 +77,7 @@ steps:
 
   - id: S4B
     name: Verify silent microphone failure alert
-    do: "If the active microphone returns no audio until Omi exhausts capture recovery, verify recording stops and 'Microphone Isn't Capturing Audio' appears with an OK action while the window remains responsive."
+    do: "If the active microphone returns no audio until Omi exhausts capture recovery, verify recording stops and 'Microphone Isn't Capturing Audio' appears with an OK action while the window remains responsive. Repeat with the main shell hidden: Omi should reveal its main window and present the same non-blocking alert instead of losing it or attaching it to the floating bar."
     expect:
       interactive_count: { min: 1 }
 

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -76,8 +76,8 @@ steps:
       interactive_count: { min: 1 }
 
   - id: S4B
-    name: Verify silent microphone failure alert
-    do: "If the active microphone returns no audio until Omi exhausts capture recovery, verify recording stops and 'Microphone Isn't Capturing Audio' appears with an OK action while the window remains responsive. Repeat with the main shell hidden: Omi should reveal its main window and present the same non-blocking alert instead of losing it or attaching it to the floating bar."
+    name: Verify silent microphone recovery outcome
+    do: "If the active microphone returns no audio until Omi exhausts capture recovery, verify recording stops and Omi remains usable without a repeated hardware alert. If microphone permission is not granted, verify 'Omi Needs Microphone Access' is presented with an OK action while the window remains responsive; repeat with the main shell hidden and confirm Omi reveals its main window before presenting that permission alert."
     expect:
       interactive_count: { min: 1 }
 

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -12,6 +12,7 @@ covers:
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+MeetingGatePause.swift
   - desktop/macos/Desktop/Sources/AppState/AppServicesCoordinator.swift
+  - desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
   - desktop/macos/Desktop/Sources/AudioCaptureService.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift
@@ -71,6 +72,12 @@ steps:
   - id: S4
     name: Verify recording or permission state
     do: "After clicking Start Recording, check the resulting state. If recording started: verify recording indicator is visible, note any waveform or timer display. If permission was requested: verify the permission dialog or settings page is shown with microphone grant options."
+    expect:
+      interactive_count: { min: 1 }
+
+  - id: S4B
+    name: Verify silent microphone failure alert
+    do: "If the active microphone returns no audio until Omi exhausts capture recovery, verify recording stops and 'Microphone Isn't Capturing Audio' appears with an OK action while the window remains responsive."
     expect:
       interactive_count: { min: 1 }
 


### PR DESCRIPTION
## Summary

Present microphone recovery alerts as non-blocking sheets instead of blocking the main actor. When no Omi window is available, queue the alert until the application becomes active or a window becomes key.

## Sentry issue

- [OMI-DESKTOP-3M5](https://omi-nk3.sentry.io/issues/7642270321/?project=4511086024851456)

Related: #11421 prevents repeated silent-mic recovery from reaching this alert; this PR removes the separate blocking modal when an alert is presented.

## Failure class

Failure-Class: none

## Verification

- Swift format, parse, test-quality, e2e coverage, and diff checks passed.
- The focused XCTest compiled and linked locally; its runtime is blocked by the host's missing Sparkle.framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes main-thread alert presentation and window activation for all `showAlert` call sites (transcription, permissions, device errors); incorrect queueing or summon logic could hide alerts or steal focus, though tests cover the main edge cases.
> 
> **Overview**
> Replaces **blocking** `NSAlert.runModal()` for shared `showAlert` paths with a **non-blocking sheet** on the main shell window, so microphone and transcription warnings no longer freeze the main actor (addresses the silent-mic / permission alert freeze).
> 
> Introduces **`DesktopAlertPresenting`** and **`AppKitSheetAlertPresenter`**, wired via `AppState.alertPresenter`. The presenter **queues** alerts, **coalesces** duplicates, **reveals** the main window when no shell is presentable, **defers** when another sheet is attached, and runs optional **completions after dismiss**—so opening **System Settings → Microphone** happens only after the user dismisses **"Omi Needs Microphone Access"**, not underneath it.
> 
> Adds **`AppStateAlertPresentationTests`** and extends the audio-recording e2e flow for silent-mic recovery and permission alert behavior; changelog notes the freeze fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ecd0cf8a5d24d3ebc4744ff90db63f58b69cbd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Line-Count-Exception: desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift | 1738 -> 1743 | permission alert gains a sheet-completion callback that opens the microphone settings pane only after the non-blocking alert is seen


