### PR TITLE
feat: simplify BYOK LLM provider setup

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -286,12 +286,18 @@ def _set_byok_active_transaction(transaction, user_ref, fingerprints: dict):
     data = snapshot.to_dict() or {}
     byok = data.get('byok') or {}
     enrolled_fingerprints = dict(fingerprints) if isinstance(fingerprints, dict) else {}
+    fingerprints_write = dict(enrolled_fingerprints)
+    existing_fingerprints = byok.get('fingerprints')
+    if isinstance(existing_fingerprints, dict):
+        for provider in existing_fingerprints:
+            if provider not in enrolled_fingerprints:
+                fingerprints_write[provider] = firestore.DELETE_FIELD
     transaction.set(
         user_ref,
         {
             'byok': {
                 'active': True,
-                'fingerprints': enrolled_fingerprints,
+                'fingerprints': fingerprints_write,
                 'last_seen_at': datetime.now(timezone.utc),
             }
         },

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -285,15 +285,13 @@ def _set_byok_active_transaction(transaction, user_ref, fingerprints: dict):
     snapshot = user_ref.get(transaction=transaction)
     data = snapshot.to_dict() or {}
     byok = data.get('byok') or {}
-    existing_fingerprints = byok.get('fingerprints') or {}
-    merged_fingerprints = dict(existing_fingerprints) if isinstance(existing_fingerprints, dict) else {}
-    merged_fingerprints.update(fingerprints)
+    enrolled_fingerprints = dict(fingerprints) if isinstance(fingerprints, dict) else {}
     transaction.set(
         user_ref,
         {
             'byok': {
                 'active': True,
-                'fingerprints': merged_fingerprints,
+                'fingerprints': enrolled_fingerprints,
                 'last_seen_at': datetime.now(timezone.utc),
             }
         },

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -280,18 +280,30 @@ def is_byok_active(uid: str, *, firestore_client: Any | None = None) -> bool:
     return age <= BYOK_HEARTBEAT_TTL_SECONDS
 
 
-def set_byok_active(uid: str, fingerprints: dict):
-    user_ref = db.collection('users').document(uid)
-    user_ref.set(
+@transactional
+def _set_byok_active_transaction(transaction, user_ref, fingerprints: dict):
+    snapshot = user_ref.get(transaction=transaction)
+    data = snapshot.to_dict() or {}
+    byok = data.get('byok') or {}
+    existing_fingerprints = byok.get('fingerprints') or {}
+    merged_fingerprints = dict(existing_fingerprints) if isinstance(existing_fingerprints, dict) else {}
+    merged_fingerprints.update(fingerprints)
+    transaction.set(
+        user_ref,
         {
             'byok': {
                 'active': True,
-                'fingerprints': fingerprints,
+                'fingerprints': merged_fingerprints,
                 'last_seen_at': datetime.now(timezone.utc),
             }
         },
         merge=True,
     )
+
+
+def set_byok_active(uid: str, fingerprints: dict):
+    user_ref = db.collection('users').document(uid)
+    _set_byok_active_transaction(db.transaction(), user_ref, fingerprints)
 
 
 def clear_byok_active(uid: str):

--- a/backend/modal/Dockerfile
+++ b/backend/modal/Dockerfile
@@ -31,7 +31,7 @@ apt-get -y install cuda-runtime-13-2 && \
 rm -rf /var/lib/apt/lists/* cuda-repo-debian13-13-2-local_13.2.1-595.58.03-1_amd64.deb
 
 COPY --from=builder /opt/venv /opt/venv
-COPY backend/config/__init__.py backend/config/plan_catalog.py backend/config/plan_catalog_generated.py /app/config/
+COPY backend/config /app/config
 COPY backend/database /app/database
 COPY backend/utils /app/utils
 COPY backend/models /app/models

--- a/backend/openapi-requirements.txt
+++ b/backend/openapi-requirements.txt
@@ -59,6 +59,7 @@ jsonpointer==3.0.0
 jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
 langchain-core==1.4.9
+langchain-anthropic==1.1.0
 langchain-google-genai==3.2.0
 langchain-openai==1.1.14
 langchain-protocol==0.0.18

--- a/backend/pusher/pylock.toml
+++ b/backend/pusher/pylock.toml
@@ -396,6 +396,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e39353
 wheels = [{ url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", upload-time = 2026-02-10T14:56:47Z, size = 111738, hashes = { sha256 = "e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698" } }]
 
 [[packages]]
+name = "langchain-anthropic"
+version = "1.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d3/8ac7d664e87aa9bdf5f6a4d55324316933aec8beb1690932dbe7b63416e2/langchain_anthropic-1.1.0.tar.gz", upload-time = 2025-11-17T21:31:31Z, size = 684087, hashes = { sha256 = "427e102b76a417fb5713e81e853225e7459d71fc7abdf4d86722f0e01ad43845" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/aa/95/f340acdd8d9f392606f026a1326a33cfb1f9b172c7607c70ab0c2b43d74d/langchain_anthropic-1.1.0-py3-none-any.whl", upload-time = 2025-11-17T21:31:29Z, size = 47793, hashes = { sha256 = "2593f10b984448e31a9fd486ab2f7ebc8a0f7f82ba1ca477339e4f5ddd7f0e8d" } }]
+
+[[packages]]
 name = "langchain-classic"
 version = "1.0.7"
 sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", upload-time = 2026-05-07T15:46:56Z, size = 10554118, hashes = { sha256 = "debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d" } }

--- a/backend/pusher/requirements.txt
+++ b/backend/pusher/requirements.txt
@@ -49,6 +49,7 @@ anthropic>=0.52.0
 openai==2.38.0
 groq==0.9.0
 langchain==1.2.10
+langchain-anthropic==1.1.0
 langchain-community==0.4.1
 langchain-core==1.3.3
 langchain-google-genai==3.2.0

--- a/backend/pylock.macos-x86_64.toml
+++ b/backend/pylock.macos-x86_64.toml
@@ -666,6 +666,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e39353
 wheels = [{ url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", upload-time = 2026-02-10T14:56:47Z, size = 111738, hashes = { sha256 = "e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698" } }]
 
 [[packages]]
+name = "langchain-anthropic"
+version = "1.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d3/8ac7d664e87aa9bdf5f6a4d55324316933aec8beb1690932dbe7b63416e2/langchain_anthropic-1.1.0.tar.gz", upload-time = 2025-11-17T21:31:31Z, size = 684087, hashes = { sha256 = "427e102b76a417fb5713e81e853225e7459d71fc7abdf4d86722f0e01ad43845" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/aa/95/f340acdd8d9f392606f026a1326a33cfb1f9b172c7607c70ab0c2b43d74d/langchain_anthropic-1.1.0-py3-none-any.whl", upload-time = 2025-11-17T21:31:29Z, size = 47793, hashes = { sha256 = "2593f10b984448e31a9fd486ab2f7ebc8a0f7f82ba1ca477339e4f5ddd7f0e8d" } }]
+
+[[packages]]
 name = "langchain-classic"
 version = "1.0.7"
 sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", upload-time = 2026-05-07T15:46:56Z, size = 10554118, hashes = { sha256 = "debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d" } }

--- a/backend/pylock.macos.toml
+++ b/backend/pylock.macos.toml
@@ -652,6 +652,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e39353
 wheels = [{ url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", upload-time = 2026-02-10T14:56:47Z, size = 111738, hashes = { sha256 = "e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698" } }]
 
 [[packages]]
+name = "langchain-anthropic"
+version = "1.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d3/8ac7d664e87aa9bdf5f6a4d55324316933aec8beb1690932dbe7b63416e2/langchain_anthropic-1.1.0.tar.gz", upload-time = 2025-11-17T21:31:31Z, size = 684087, hashes = { sha256 = "427e102b76a417fb5713e81e853225e7459d71fc7abdf4d86722f0e01ad43845" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/aa/95/f340acdd8d9f392606f026a1326a33cfb1f9b172c7607c70ab0c2b43d74d/langchain_anthropic-1.1.0-py3-none-any.whl", upload-time = 2025-11-17T21:31:29Z, size = 47793, hashes = { sha256 = "2593f10b984448e31a9fd486ab2f7ebc8a0f7f82ba1ca477339e4f5ddd7f0e8d" } }]
+
+[[packages]]
 name = "langchain-classic"
 version = "1.0.7"
 sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", upload-time = 2026-05-07T15:46:56Z, size = 10554118, hashes = { sha256 = "debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d" } }

--- a/backend/pylock.runtime.toml
+++ b/backend/pylock.runtime.toml
@@ -635,6 +635,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e39353
 wheels = [{ url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", upload-time = 2026-02-10T14:56:47Z, size = 111738, hashes = { sha256 = "e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698" } }]
 
 [[packages]]
+name = "langchain-anthropic"
+version = "1.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d3/8ac7d664e87aa9bdf5f6a4d55324316933aec8beb1690932dbe7b63416e2/langchain_anthropic-1.1.0.tar.gz", upload-time = 2025-11-17T21:31:31Z, size = 684087, hashes = { sha256 = "427e102b76a417fb5713e81e853225e7459d71fc7abdf4d86722f0e01ad43845" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/aa/95/f340acdd8d9f392606f026a1326a33cfb1f9b172c7607c70ab0c2b43d74d/langchain_anthropic-1.1.0-py3-none-any.whl", upload-time = 2025-11-17T21:31:29Z, size = 47793, hashes = { sha256 = "2593f10b984448e31a9fd486ab2f7ebc8a0f7f82ba1ca477339e4f5ddd7f0e8d" } }]
+
+[[packages]]
 name = "langchain-classic"
 version = "1.0.7"
 sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", upload-time = 2026-05-07T15:46:56Z, size = 10554118, hashes = { sha256 = "debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d" } }

--- a/backend/pylock.toml
+++ b/backend/pylock.toml
@@ -653,6 +653,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e39353
 wheels = [{ url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", upload-time = 2026-02-10T14:56:47Z, size = 111738, hashes = { sha256 = "e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698" } }]
 
 [[packages]]
+name = "langchain-anthropic"
+version = "1.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d3/8ac7d664e87aa9bdf5f6a4d55324316933aec8beb1690932dbe7b63416e2/langchain_anthropic-1.1.0.tar.gz", upload-time = 2025-11-17T21:31:31Z, size = 684087, hashes = { sha256 = "427e102b76a417fb5713e81e853225e7459d71fc7abdf4d86722f0e01ad43845" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/aa/95/f340acdd8d9f392606f026a1326a33cfb1f9b172c7607c70ab0c2b43d74d/langchain_anthropic-1.1.0-py3-none-any.whl", upload-time = 2025-11-17T21:31:29Z, size = 47793, hashes = { sha256 = "2593f10b984448e31a9fd486ab2f7ebc8a0f7f82ba1ca477339e4f5ddd7f0e8d" } }]
+
+[[packages]]
 name = "langchain-classic"
 version = "1.0.7"
 sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", upload-time = 2026-05-07T15:46:56Z, size = 10554118, hashes = { sha256 = "debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d" } }

--- a/backend/pylock.windows.toml
+++ b/backend/pylock.windows.toml
@@ -658,6 +658,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/16/22/a4d4ac98fc2e39353
 wheels = [{ url = "https://files.pythonhosted.org/packages/7c/06/c3394327f815fade875724c0f6cff529777c96a1e17fea066deb997f8cf5/langchain-1.2.10-py3-none-any.whl", upload-time = 2026-02-10T14:56:47Z, size = 111738, hashes = { sha256 = "e07a377204451fffaed88276b8193e894893b1003e25c5bca6539288ccca3698" } }]
 
 [[packages]]
+name = "langchain-anthropic"
+version = "1.1.0"
+sdist = { url = "https://files.pythonhosted.org/packages/d2/d3/8ac7d664e87aa9bdf5f6a4d55324316933aec8beb1690932dbe7b63416e2/langchain_anthropic-1.1.0.tar.gz", upload-time = 2025-11-17T21:31:31Z, size = 684087, hashes = { sha256 = "427e102b76a417fb5713e81e853225e7459d71fc7abdf4d86722f0e01ad43845" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/aa/95/f340acdd8d9f392606f026a1326a33cfb1f9b172c7607c70ab0c2b43d74d/langchain_anthropic-1.1.0-py3-none-any.whl", upload-time = 2025-11-17T21:31:29Z, size = 47793, hashes = { sha256 = "2593f10b984448e31a9fd486ab2f7ebc8a0f7f82ba1ca477339e4f5ddd7f0e8d" } }]
+
+[[packages]]
 name = "langchain-classic"
 version = "1.0.7"
 sdist = { url = "https://files.pythonhosted.org/packages/9b/78/84b5065816f348c39fefa4316f209f0135e8410216340a953bec17d9e4e4/langchain_classic-1.0.7.tar.gz", upload-time = 2026-05-07T15:46:56Z, size = 10554118, hashes = { sha256 = "debbec8065e69b95108d2652e8d5c44f4516e19aa8d716c02ed2211c3aee099d" } }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -94,6 +94,7 @@ jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
 langchain==1.2.10
+langchain-anthropic==1.1.0
 langchain-community==0.4.1
 langchain-core==1.3.3
 langchain-google-genai==3.2.0

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -66,6 +66,7 @@ from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock, check_rate_limit, store_chat_share, get_chat_share
 from database.users import set_chat_message_rating_score
 from utils.rate_limit_config import get_effective_limit, RATE_LIMIT_SHADOW
+from utils.llm.gateway_client import CHAT_AGENT_ROUTE_DIRECT, get_chat_agent_route
 from utils.subscription import enforce_chat_quota, is_trial_paywalled
 from utils import share_links
 from utils.other import endpoints as auth, storage
@@ -358,6 +359,12 @@ def _record_chat_quota_question_best_effort(
         logger.exception('Failed to record chat quota question source=%s uid=%s', source, uid)
 
 
+def _required_chat_quota_provider() -> str | None:
+    # Direct agent chat consumes managed Anthropic unless an Anthropic BYOK key
+    # is on the request. Other BYOK providers must stay metered on this path.
+    return 'anthropic' if get_chat_agent_route() == CHAT_AGENT_ROUTE_DIRECT else None
+
+
 @router.post('/v2/messages', tags=['chat'], response_model=ResponseMessage)
 def send_message(
     data: SendMessageRequest,
@@ -373,7 +380,7 @@ def send_message(
     # Catalog overage plans return normally. Desktop pre-checks via
     # /v1/users/me/usage-quota and never reaches this path when over.
     try:
-        enforce_chat_quota(uid, platform=x_app_platform)
+        enforce_chat_quota(uid, platform=x_app_platform, required_llm_provider=_required_chat_quota_provider())
     except HTTPException as exc:
         if exc.status_code != 402 or not isinstance(exc.detail, dict):
             raise
@@ -806,7 +813,7 @@ def create_voice_message_stream(
     uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "voice:message")),
     x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
 ):
-    enforce_chat_quota(uid, platform=x_app_platform)
+    enforce_chat_quota(uid, platform=x_app_platform, required_llm_provider=_required_chat_quota_provider())
 
     resolved_language = resolve_voice_message_language(uid, language)
     stt_provider, _, _stt_model = get_prerecorded_service(resolved_language)

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -1582,7 +1582,13 @@ async def _proxy_unobserved(request: Request, path: str, streaming: bool, uid: s
 
 
 async def _authorized_desktop_user(uid: str = Depends(get_current_user_uid)) -> str:
-    if await run_blocking(db_executor, is_desktop_trial_paywalled, uid, 'desktop'):
+    if await run_blocking(
+        db_executor,
+        is_desktop_trial_paywalled,
+        uid,
+        'desktop',
+        required_byok_provider='gemini',
+    ):
         raise HTTPException(status_code=402, detail='trial_expired')
     return uid
 

--- a/backend/routers/desktop_tts_updates.py
+++ b/backend/routers/desktop_tts_updates.py
@@ -184,7 +184,7 @@ async def tts_synthesize(request: TtsSynthesizeRequest, uid: str = Depends(get_c
     voice_id = request.voice_id.strip()
     if not _is_allowed_openai_voice(voice_id):
         raise HTTPException(status_code=400, detail="voice_id is not supported")
-    if await run_blocking(db_executor, is_desktop_trial_paywalled, uid, "desktop"):
+    if await run_blocking(db_executor, is_desktop_trial_paywalled, uid, "desktop", required_byok_provider="openai"):
         raise HTTPException(status_code=403, detail="A paid subscription is required")
     api_key = get_byok_key("openai") or os.getenv("OPENAI_API_KEY", "").strip()
     if not api_key:

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -39,7 +39,7 @@ from utils.aac import AACDecoder
 from utils.llm.openglass import describe_image
 from utils.request_validation import ImageChunkEnvelope
 from utils.speaker_assignment import update_speaker_assignment_maps
-from utils.byok import get_byok_key
+from utils.subscription import _request_has_llm_byok_key
 from utils.executors import db_executor, run_blocking
 from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from utils.stt.live_failure import (
@@ -486,7 +486,7 @@ class ListenReceiver:
             except Exception as error:
                 logger.warning('Custom-STT photo BYOK enrollment lookup failed type=%s', type(error).__name__)
                 byok_active = False
-            has_llm_byok_key = bool(byok_active and (get_byok_key('openai') or get_byok_key('anthropic')))
+            has_llm_byok_key = bool(byok_active and _request_has_llm_byok_key())
             skip_photo_description = should_skip_custom_stt_postprocessing(
                 uses_custom_stt=True,
                 has_llm_byok_key=has_llm_byok_key,

--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -39,7 +39,7 @@ from utils.aac import AACDecoder
 from utils.llm.openglass import describe_image
 from utils.request_validation import ImageChunkEnvelope
 from utils.speaker_assignment import update_speaker_assignment_maps
-from utils.subscription import _request_has_llm_byok_key
+from utils.subscription import request_has_llm_byok_key
 from utils.executors import db_executor, run_blocking
 from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from utils.stt.live_failure import (
@@ -486,7 +486,7 @@ class ListenReceiver:
             except Exception as error:
                 logger.warning('Custom-STT photo BYOK enrollment lookup failed type=%s', type(error).__name__)
                 byok_active = False
-            has_llm_byok_key = bool(byok_active and _request_has_llm_byok_key())
+            has_llm_byok_key = bool(byok_active and request_has_llm_byok_key())
             skip_photo_description = should_skip_custom_stt_postprocessing(
                 uses_custom_stt=True,
                 has_llm_byok_key=has_llm_byok_key,

--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -24,7 +24,7 @@ from models.users import PlanType
 from utils.analytics import billable_transcription_seconds, record_usage
 from utils.apps import is_audio_bytes_app_enabled
 from utils.async_tasks import WebSocketTaskSupervisor, drain_tasks, wait_for_event
-from utils.byok import extract_byok_from_websocket, get_byok_keys, set_byok_keys
+from utils.byok import get_byok_keys
 from utils.client_device import resolve_client_device_from_headers
 from utils.journey_metrics_contract import resolve_client_kind_from_headers
 from utils.executors import db_executor, run_blocking, start_background_task, storage_executor
@@ -283,7 +283,6 @@ class ListenSessionRuntime:
         if not self.request.uid:
             await self.request.websocket.close(code=1008, reason='Bad uid')
             return False
-        set_byok_keys(extract_byok_from_websocket(self.request.websocket))
         if await run_blocking(db_executor, is_trial_paywalled, self.request.uid, self.request.source):
             await self.request.websocket.send_json(
                 FreemiumThresholdReachedEvent(remaining_seconds=0, action=FREEMIUM_ACTION_SETUP_ON_DEVICE_STT).to_json()

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -16,6 +16,7 @@ from utils.byok import (
 )
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
+from utils.observability.fallback import record_fallback
 from utils.other.endpoints import _verify_ws_auth  # type: ignore[reportPrivateUsage]  # shared WS auth helper, intentionally reused cross-module
 import database.users as users_db
 from models.users import PlanType
@@ -100,14 +101,14 @@ async def omni_relay(websocket: WebSocket):
         return
     set_validated_byok_keys(validated_byok, uid)
 
+    provider = websocket.query_params.get("provider", "gemini")
+
     # Same desktop gate as /v4/listen: Operator/Architect + BYOK pass; un-entitled
     # desktop users past their trial are paywalled.
-    if await run_blocking(db_executor, is_trial_paywalled, uid, "desktop"):
+    if await run_blocking(db_executor, is_trial_paywalled, uid, "desktop", required_byok_provider=provider):
         logger.info(f"omni relay paywalled uid={uid}")
         await websocket.close(code=1008, reason="trial_expired")
         return
-
-    provider = websocket.query_params.get("provider", "gemini")
 
     # Monthly free-tier chat quota: realtime turns count as questions, so they
     # must also be blocked past the cap. Exempt only when THIS session will
@@ -115,9 +116,17 @@ async def omni_relay(websocket: WebSocket):
     # BYOK-enrolled — mirrors enforce_chat_quota's rule; a deepgram-only (or
     # forged) BYOK header must not skip the gate while _upstream falls back to
     # Omi's platform key.
-    byok_serves_session = bool(validated_byok.get(provider)) and await run_blocking(
-        db_executor, users_db.is_byok_active, uid
-    )
+    byok_enrolled = await run_blocking(db_executor, users_db.is_byok_active, uid)
+    byok_serves_session = bool(validated_byok.get(provider)) and byok_enrolled
+    if byok_enrolled and not byok_serves_session:
+        record_fallback(
+            component='realtime_hub',
+            from_mode=f'byok_{provider}',
+            to_mode='managed',
+            reason='capability_mismatch',
+            outcome='degraded',
+            log=logger,
+        )
     if not byok_serves_session:
         snapshot = await run_blocking(db_executor, get_chat_quota_snapshot, uid, "desktop")
         if snapshot['plan'] == PlanType.basic and not snapshot['allowed']:

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -102,6 +102,9 @@ async def omni_relay(websocket: WebSocket):
     set_validated_byok_keys(validated_byok, uid)
 
     provider = websocket.query_params.get("provider", "gemini")
+    if provider not in {"gemini", "openai"}:
+        await websocket.close(code=1011, reason=f"unsupported provider: {provider}"[:120])
+        return
 
     # Same desktop gate as /v4/listen: Operator/Architect + BYOK pass; un-entitled
     # desktop users past their trial are paywalled.

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -11,8 +11,8 @@ from utils.byok import (
     BYOK_HEADERS,
     extract_byok_from_websocket,
     get_byok_key,
-    set_byok_keys,
-    validate_byok_websocket,
+    set_validated_byok_keys,
+    validate_byok_websocket_keys,
 )
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
@@ -93,13 +93,12 @@ async def omni_relay(websocket: WebSocket):
 
     # BYOK: validate forwarded keys (same as /v4/listen). Keys then resolve via get_byok_key.
     byok = extract_byok_from_websocket(websocket)
-    if byok:
-        set_byok_keys(byok)
-        byok_err = await run_blocking(critical_executor, validate_byok_websocket, uid)
-        if byok_err:
-            logger.warning(f"omni relay BYOK invalid uid={uid}: {byok_err}")
-            await websocket.close(code=4003, reason=byok_err)
-            return
+    validated_byok, byok_err = await run_blocking(critical_executor, validate_byok_websocket_keys, uid, byok)
+    if byok_err:
+        logger.warning(f"omni relay BYOK invalid uid={uid}: {byok_err}")
+        await websocket.close(code=4003, reason=byok_err)
+        return
+    set_validated_byok_keys(validated_byok, uid)
 
     # Same desktop gate as /v4/listen: Operator/Architect + BYOK pass; un-entitled
     # desktop users past their trial are paywalled.

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -115,7 +115,7 @@ async def omni_relay(websocket: WebSocket):
     # BYOK-enrolled — mirrors enforce_chat_quota's rule; a deepgram-only (or
     # forged) BYOK header must not skip the gate while _upstream falls back to
     # Omi's platform key.
-    byok_serves_session = bool(byok and byok.get(provider)) and await run_blocking(
+    byok_serves_session = bool(validated_byok.get(provider)) and await run_blocking(
         db_executor, users_db.is_byok_active, uid
     )
     if not byok_serves_session:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1097,7 +1097,7 @@ def get_user_usage_stats_endpoint(
 
 
 _SHA256_HEX_RE = re.compile(r'^[a-f0-9]{64}$')
-_BYOK_REQUIRED_PROVIDERS = {'openai', 'anthropic', 'gemini', 'deepgram'}
+_BYOK_ALLOWED_PROVIDERS = {'openai', 'anthropic', 'gemini', 'openrouter', 'deepgram'}
 
 
 class BYOKActivateRequest(BaseModel):
@@ -1116,14 +1116,14 @@ def activate_byok_endpoint(data: BYOKActivateRequest, uid: str = Depends(auth.ge
     detect rotation without ever seeing the keys. The live keys themselves
     travel on every request as headers; they are never persisted.
     """
-    missing = _BYOK_REQUIRED_PROVIDERS - set(data.fingerprints.keys())
-    if missing:
+    providers = set(data.fingerprints.keys())
+    if not providers - {'deepgram'}:
         raise HTTPException(
             status_code=400,
-            detail=f"Missing fingerprints for providers: {sorted(missing)}",
+            detail='At least one LLM provider fingerprint is required',
         )
     for provider, fp in data.fingerprints.items():
-        if provider not in _BYOK_REQUIRED_PROVIDERS:
+        if provider not in _BYOK_ALLOWED_PROVIDERS:
             raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
         if not _SHA256_HEX_RE.match(fp):
             raise HTTPException(

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -89,6 +89,7 @@ from utils.subscription import (
     request_has_llm_byok_key,
     enforce_chat_quota,
     get_chat_quota_snapshot,
+    get_basic_plan_limits,
     get_default_basic_subscription,
     get_paid_plan_definitions,
     get_plan_display_name,
@@ -128,6 +129,7 @@ from utils.other.storage import (
 )
 from utils.webhooks import webhook_first_time_setup
 from utils.byok import (
+    get_byok_key,
     invalidate_byok_state_cache,
     peppered_fingerprint,
 )
@@ -1148,15 +1150,21 @@ def deactivate_byok_endpoint(uid: str = Depends(auth.get_current_user_uid_no_byo
     return {"active": False}
 
 
-def _byok_unlimited_subscription() -> Subscription:
-    """BYOK free plan: unlimited limits, marked with the `byok` feature flag."""
+def _byok_unlimited_subscription(
+    transcription_seconds: Optional[int] = None, words_transcribed: Optional[int] = None
+) -> Subscription:
+    """BYOK free plan: unlimited limits, marked with the `byok` feature flag.
+
+    LLM-only requests pass the free-tier transcription/words allowances so the
+    snapshot stays metered where Omi still pays for STT; unlimited stays `None`.
+    """
     return Subscription(
         plan=PlanType.unlimited,
         status=SubscriptionStatus.active,
         features=["byok"],
         limits=PlanLimits(
-            transcription_seconds=None,
-            words_transcribed=None,
+            transcription_seconds=transcription_seconds,
+            words_transcribed=words_transcribed,
             insights_gained=None,
         ),
     )
@@ -1178,12 +1186,37 @@ def get_user_subscription_endpoint(
     unlimited_phone_quota = PhoneCallQuota(has_access=True, is_paid=True)
 
     if users_db.is_byok_active(uid) and request_has_llm_byok_key():
+        # Snapshot split: a validated LLM key unlocks unlimited chat/insights, but
+        # backend transcription credits still flow through Omi's Deepgram, so the
+        # transcription/words fields stay metered on the free tier unless this
+        # request also carries a validated Deepgram key (same predicate as
+        # has_transcription_credits).
+        if get_byok_key('deepgram'):
+            return UserSubscriptionResponse(
+                subscription=_byok_unlimited_subscription(),
+                transcription_seconds_used=0,
+                transcription_seconds_limit=0,
+                words_transcribed_used=0,
+                words_transcribed_limit=0,
+                insights_gained_used=0,
+                insights_gained_limit=0,
+                available_plans=[],
+                show_subscription_ui=False,
+                phone_call_quota=unlimited_phone_quota,
+            )
+        usage = get_monthly_usage_for_subscription(uid)
+        basic_limits = get_basic_plan_limits()
         return UserSubscriptionResponse(
-            subscription=_byok_unlimited_subscription(),
-            transcription_seconds_used=0,
-            transcription_seconds_limit=0,
-            words_transcribed_used=0,
-            words_transcribed_limit=0,
+            subscription=_byok_unlimited_subscription(
+                transcription_seconds=basic_limits.transcription_seconds,
+                words_transcribed=basic_limits.words_transcribed,
+            ),
+            transcription_seconds_used=usage.get('transcription_seconds', 0),
+            # Wire convention (see WIRE BRIDGE below): unlimited remains 0; a
+            # finite allowance must be the real positive limit.
+            transcription_seconds_limit=basic_limits.transcription_seconds or 0,
+            words_transcribed_used=usage.get('words_transcribed', 0),
+            words_transcribed_limit=basic_limits.words_transcribed or 0,
             insights_gained_used=0,
             insights_gained_limit=0,
             available_plans=[],

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -86,7 +86,7 @@ from models.users import (
 from utils.phone_calls import get_quota_snapshot as get_phone_call_quota_snapshot
 from utils.apps import get_available_app_by_id
 from utils.subscription import (
-    _request_has_llm_byok_key,
+    request_has_llm_byok_key,
     enforce_chat_quota,
     get_chat_quota_snapshot,
     get_default_basic_subscription,
@@ -1177,7 +1177,7 @@ def get_user_subscription_endpoint(
     # these users aren't surprised by a disabled phone-call feature.
     unlimited_phone_quota = PhoneCallQuota(has_access=True, is_paid=True)
 
-    if users_db.is_byok_active(uid) and _request_has_llm_byok_key():
+    if users_db.is_byok_active(uid) and request_has_llm_byok_key():
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),
             transcription_seconds_used=0,
@@ -1399,7 +1399,7 @@ def get_user_chat_usage_quota(
     # BYOK free plan: user brings their own keys, so there's no Omi-side cost
     # to meter. Only return unlimited when BYOK headers are on the request (desktop).
     # Mobile (no headers) should see real quota.
-    if users_db.is_byok_active(uid) and _request_has_llm_byok_key():
+    if users_db.is_byok_active(uid) and request_has_llm_byok_key():
         return ChatUsageQuota(
             plan='Free (BYOK)',
             plan_type=PlanType.unlimited.value,

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -126,7 +126,13 @@ from utils.other.storage import (
     delete_user_person_speech_sample,
 )
 from utils.webhooks import webhook_first_time_setup
-from utils.byok import get_byok_key, has_byok_keys, invalidate_byok_state_cache, peppered_fingerprint
+from utils.byok import (
+    get_byok_key,
+    has_byok_keys,
+    has_validated_byok_keys,
+    invalidate_byok_state_cache,
+    peppered_fingerprint,
+)
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1174,7 +1180,7 @@ def get_user_subscription_endpoint(
     # these users aren't surprised by a disabled phone-call feature.
     unlimited_phone_quota = PhoneCallQuota(has_access=True, is_paid=True)
 
-    if users_db.is_byok_active(uid) and get_byok_key('deepgram'):
+    if users_db.is_byok_active(uid) and has_validated_byok_keys() and get_byok_key('deepgram'):
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),
             transcription_seconds_used=0,

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -86,6 +86,7 @@ from models.users import (
 from utils.phone_calls import get_quota_snapshot as get_phone_call_quota_snapshot
 from utils.apps import get_available_app_by_id
 from utils.subscription import (
+    _request_has_llm_byok_key,
     enforce_chat_quota,
     get_chat_quota_snapshot,
     get_default_basic_subscription,
@@ -127,9 +128,6 @@ from utils.other.storage import (
 )
 from utils.webhooks import webhook_first_time_setup
 from utils.byok import (
-    get_byok_key,
-    has_byok_keys,
-    has_validated_byok_keys,
     invalidate_byok_state_cache,
     peppered_fingerprint,
 )
@@ -1173,14 +1171,13 @@ def get_user_subscription_endpoint(
     x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
 ):
     """Gets the user's subscription plan and usage."""
-    # BYOK free plan: user supplies their own OpenAI/Anthropic/Gemini/Deepgram keys.
-    # Only return unlimited when the request actually carries BYOK headers (desktop).
-    # Mobile (no BYOK headers) should see the real subscription even if BYOK is active.
+    # BYOK free plan: unlimited chat/insights only for a validated LLM-capability
+    # key (same predicate as enforce_chat_quota). Deepgram-only does not unlock this.
     # Synthetic paid-tier quota for BYOK / marketplace-reviewer overrides so
     # these users aren't surprised by a disabled phone-call feature.
     unlimited_phone_quota = PhoneCallQuota(has_access=True, is_paid=True)
 
-    if users_db.is_byok_active(uid) and has_validated_byok_keys() and get_byok_key('deepgram'):
+    if users_db.is_byok_active(uid) and _request_has_llm_byok_key():
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),
             transcription_seconds_used=0,
@@ -1402,7 +1399,7 @@ def get_user_chat_usage_quota(
     # BYOK free plan: user brings their own keys, so there's no Omi-side cost
     # to meter. Only return unlimited when BYOK headers are on the request (desktop).
     # Mobile (no headers) should see real quota.
-    if users_db.is_byok_active(uid) and has_byok_keys():
+    if users_db.is_byok_active(uid) and _request_has_llm_byok_key():
         return ChatUsageQuota(
             plan='Free (BYOK)',
             plan_type=PlanType.unlimited.value,

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -126,7 +126,7 @@ from utils.other.storage import (
     delete_user_person_speech_sample,
 )
 from utils.webhooks import webhook_first_time_setup
-from utils.byok import has_byok_keys, invalidate_byok_state_cache, peppered_fingerprint
+from utils.byok import get_byok_key, has_byok_keys, invalidate_byok_state_cache, peppered_fingerprint
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1174,7 +1174,7 @@ def get_user_subscription_endpoint(
     # these users aren't surprised by a disabled phone-call feature.
     unlimited_phone_quota = PhoneCallQuota(has_access=True, is_paid=True)
 
-    if users_db.is_byok_active(uid) and has_byok_keys():
+    if users_db.is_byok_active(uid) and get_byok_key('deepgram'):
         return UserSubscriptionResponse(
             subscription=_byok_unlimited_subscription(),
             transcription_seconds_used=0,

--- a/backend/testing/e2e/test_user_auth_profile.py
+++ b/backend/testing/e2e/test_user_auth_profile.py
@@ -179,7 +179,7 @@ def test_notification_assistant_ai_profile_and_byok_state(client, auth_headers):
 
     bad_byok = client.post(
         "/v1/users/me/byok-active",
-        json={"fingerprints": {"openai": "a" * 64}},
+        json={"fingerprints": {"deepgram": "a" * 64}},
         headers=auth_headers,
     )
     assert bad_byok.status_code == 400

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -470,17 +470,54 @@ def test_update_person_name_existing_returns_ok():
     update_person.assert_called_once_with('uid1', 'p1', 'Alice')
 
 
-def test_byok_subscription_endpoint_returns_unlimited_plan():
-    # `PlanLimits` was used in this module without being imported, so every BYOK
-    # user's GET /v1/users/me/subscription raised NameError -> 500 in prod.
+def test_byok_llm_only_subscription_meters_transcription_on_free_tier():
+    # Snapshot split: a validated LLM BYOK key unlocks unlimited chat/insights,
+    # but without a Deepgram header on the request the transcription/words
+    # fields must stay metered on the free-tier limits (Omi still pays for STT),
+    # not the 0/0 unlimited sentinel.
+    basic_limits = users_router.PlanLimits(transcription_seconds=600, words_transcribed=8000)
     with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=True)), patch.object(
         users_router, 'request_has_llm_byok_key', MagicMock(return_value=True)
+    ), patch.object(users_router, 'get_byok_key', MagicMock(return_value=None)), patch.object(
+        users_router, 'get_basic_plan_limits', MagicMock(return_value=basic_limits)
+    ), patch.object(
+        users_router,
+        'get_monthly_usage_for_subscription',
+        MagicMock(return_value={'transcription_seconds': 120, 'words_transcribed': 500}),
+    ):
+        response = users_router.get_user_subscription_endpoint(uid='uid1')
+
+    assert response.subscription.plan == users_router.PlanType.unlimited
+    assert response.subscription.features == ['byok']
+    # Chat/insights remain unlimited.
+    assert response.subscription.limits.insights_gained is None
+    assert response.insights_gained_used == 0
+    assert response.insights_gained_limit == 0
+    # Transcription/words are metered on the real free-tier usage.
+    assert response.subscription.limits.transcription_seconds == 600
+    assert response.transcription_seconds_used == 120
+    assert response.transcription_seconds_limit == 600
+    assert response.words_transcribed_limit == 8000
+    assert response.words_transcribed_used == 500
+
+
+def test_byok_llm_deepgram_subscription_returns_fully_unlimited_plan():
+    # With a validated x-byok-deepgram header the whole snapshot is unlimited,
+    # including transcription (None in the catalog, wire 0).
+    with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=True)), patch.object(
+        users_router, 'request_has_llm_byok_key', MagicMock(return_value=True)
+    ), patch.object(
+        users_router, 'get_byok_key', MagicMock(side_effect=lambda p: 'dg-key' if p == 'deepgram' else None)
     ):
         response = users_router.get_user_subscription_endpoint(uid='uid1')
 
     assert response.subscription.plan == users_router.PlanType.unlimited
     assert response.subscription.features == ['byok']
     assert response.subscription.limits.transcription_seconds is None
+    assert response.subscription.limits.words_transcribed is None
+    assert response.transcription_seconds_used == 0
+    assert response.transcription_seconds_limit == 0
+    assert response.words_transcribed_limit == 0
 
 
 def test_marketplace_reviewer_subscription_endpoint_returns_unlimited_plan():

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -474,7 +474,7 @@ def test_byok_subscription_endpoint_returns_unlimited_plan():
     # `PlanLimits` was used in this module without being imported, so every BYOK
     # user's GET /v1/users/me/subscription raised NameError -> 500 in prod.
     with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=True)), patch.object(
-        users_router, '_request_has_llm_byok_key', MagicMock(return_value=True)
+        users_router, 'request_has_llm_byok_key', MagicMock(return_value=True)
     ):
         response = users_router.get_user_subscription_endpoint(uid='uid1')
 

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -474,8 +474,8 @@ def test_byok_subscription_endpoint_returns_unlimited_plan():
     # `PlanLimits` was used in this module without being imported, so every BYOK
     # user's GET /v1/users/me/subscription raised NameError -> 500 in prod.
     with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=True)), patch.object(
-        users_router, 'has_byok_keys', MagicMock(return_value=True)
-    ):
+        users_router, 'has_validated_byok_keys', MagicMock(return_value=True)
+    ), patch.object(users_router, 'get_byok_key', MagicMock(return_value='dg-test-key')):
         response = users_router.get_user_subscription_endpoint(uid='uid1')
 
     assert response.subscription.plan == users_router.PlanType.unlimited

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -474,8 +474,8 @@ def test_byok_subscription_endpoint_returns_unlimited_plan():
     # `PlanLimits` was used in this module without being imported, so every BYOK
     # user's GET /v1/users/me/subscription raised NameError -> 500 in prod.
     with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=True)), patch.object(
-        users_router, 'has_validated_byok_keys', MagicMock(return_value=True)
-    ), patch.object(users_router, 'get_byok_key', MagicMock(return_value='dg-test-key')):
+        users_router, '_request_has_llm_byok_key', MagicMock(return_value=True)
+    ):
         response = users_router.get_user_subscription_endpoint(uid='uid1')
 
     assert response.subscription.plan == users_router.PlanType.unlimited

--- a/backend/tests/unit/memory_import_isolation.py
+++ b/backend/tests/unit/memory_import_isolation.py
@@ -105,6 +105,7 @@ def install_canonical_write_runtime_stubs() -> list[str]:
     subscription_mod.get_default_basic_subscription = MagicMock()
     subscription_mod.is_trial_paywalled = lambda uid: False
     subscription_mod.should_defer_desktop_processing = lambda uid: False
+    subscription_mod.request_has_llm_byok_key = lambda: False
     sys.modules["utils.subscription"] = subscription_mod
     touched.append("utils.subscription")
 
@@ -265,6 +266,7 @@ def install_ws_i_heavy_import_stubs() -> list[str]:
     subscription_mod.get_default_basic_subscription = MagicMock()
     subscription_mod.is_trial_paywalled = lambda uid: False
     subscription_mod.should_defer_desktop_processing = lambda uid: False
+    subscription_mod.request_has_llm_byok_key = lambda: False
     _set("utils.subscription", subscription_mod)
 
     vector_db_mod = AutoMockModule("database.vector_db")

--- a/backend/tests/unit/test_byok_llm_logging.py
+++ b/backend/tests/unit/test_byok_llm_logging.py
@@ -168,6 +168,8 @@ def test_llm_error_callback_uses_provider_context():
 
     google_genai_stub = types.ModuleType('langchain_google_genai')
     google_genai_stub.ChatGoogleGenerativeAI = _DummyClient
+    langchain_anthropic_stub = types.ModuleType('langchain_anthropic')
+    langchain_anthropic_stub.ChatAnthropic = _DummyClient
     openai_stub = types.ModuleType('langchain_openai')
     openai_stub.ChatOpenAI = _DummyClient
     openai_stub.OpenAIEmbeddings = _DummyClient
@@ -184,6 +186,7 @@ def test_llm_error_callback_uses_provider_context():
         'langchain_core.callbacks': callbacks_stub,
         'langchain_core.language_models': language_models_stub,
         'langchain_core.output_parsers': output_parsers_stub,
+        'langchain_anthropic': langchain_anthropic_stub,
         'langchain_google_genai': google_genai_stub,
         'langchain_openai': openai_stub,
         'tiktoken': tiktoken_stub,
@@ -244,6 +247,8 @@ def test_openai_embeddings_proxy_notifies_on_sync_byok_failure():
 
     google_genai_stub = types.ModuleType('langchain_google_genai')
     google_genai_stub.ChatGoogleGenerativeAI = _DummyClient
+    langchain_anthropic_stub = types.ModuleType('langchain_anthropic')
+    langchain_anthropic_stub.ChatAnthropic = _DummyClient
     openai_stub = types.ModuleType('langchain_openai')
     openai_stub.ChatOpenAI = _DummyClient
     openai_stub.OpenAIEmbeddings = _DummyClient
@@ -260,6 +265,7 @@ def test_openai_embeddings_proxy_notifies_on_sync_byok_failure():
         'langchain_core.callbacks': callbacks_stub,
         'langchain_core.language_models': language_models_stub,
         'langchain_core.output_parsers': output_parsers_stub,
+        'langchain_anthropic': langchain_anthropic_stub,
         'langchain_google_genai': google_genai_stub,
         'langchain_openai': openai_stub,
         'tiktoken': tiktoken_stub,
@@ -315,6 +321,8 @@ def test_openai_embeddings_proxy_async_falls_back_on_byok_failure():
     output_parsers_stub.PydanticOutputParser = _DummyClient
     google_genai_stub = types.ModuleType('langchain_google_genai')
     google_genai_stub.ChatGoogleGenerativeAI = _DummyClient
+    langchain_anthropic_stub = types.ModuleType('langchain_anthropic')
+    langchain_anthropic_stub.ChatAnthropic = _DummyClient
     openai_stub = types.ModuleType('langchain_openai')
     openai_stub.ChatOpenAI = _DummyClient
     openai_stub.OpenAIEmbeddings = _DummyClient
@@ -331,6 +339,7 @@ def test_openai_embeddings_proxy_async_falls_back_on_byok_failure():
         'langchain_core.callbacks': callbacks_stub,
         'langchain_core.language_models': language_models_stub,
         'langchain_core.output_parsers': output_parsers_stub,
+        'langchain_anthropic': langchain_anthropic_stub,
         'langchain_google_genai': google_genai_stub,
         'langchain_openai': openai_stub,
         'tiktoken': tiktoken_stub,

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -79,6 +79,7 @@ def _byok_isolation():
         # per-test fast-unit CPU-time guard doesn't charge cold-start cost to the
         # first cache-routing test. Uses a distinct key so no assertion is affected.
         from utils.llm.clients import _cached_openai_chat
+        import utils.subscription
 
         _cached_openai_chat('gpt-4.1-mini', 'sk-warmup-timing-guard-not-asserted', {})
         yield

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -328,7 +328,10 @@ class TestGeminiKeyNotInUrl:
 class TestChatQuotaBYOKBypass:
     @patch('utils.subscription.has_validated_byok_keys', return_value=True)
     @patch('utils.subscription.users_db')
-    def test_enforce_chat_quota_bypasses_for_validated_openai_key(self, mock_users_db, _mock_validated):
+    @patch('utils.subscription.is_trial_paywalled', return_value=False)
+    def test_enforce_chat_quota_bypasses_for_validated_openai_key(
+        self, _mock_paywalled, mock_users_db, _mock_validated
+    ):
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import enforce_chat_quota
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -22,7 +22,7 @@ os.environ.setdefault('DEEPGRAM_API_KEY', 'dg-test-fake-for-unit-tests')
 os.environ.setdefault('GOOGLE_API_KEY', 'goog-test-fake-for-unit-tests')
 os.environ.setdefault('ANTHROPIC_API_KEY', 'ant-test-fake-for-unit-tests')
 
-from testing.import_isolation import AutoMockModule, stub_modules
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
 
 warnings.filterwarnings('ignore', message='.*stream_options.*')
 
@@ -79,7 +79,11 @@ def _byok_isolation():
         # per-test fast-unit CPU-time guard doesn't charge cold-start cost to the
         # first cache-routing test. Uses a distinct key so no assertion is affected.
         from utils.llm.clients import _cached_openai_chat
-        import utils.subscription
+
+        # Force a fresh load against the stubs: another test module may already have
+        # imported the real utils.subscription (and bound the real database._client),
+        # so a plain `import` would reuse the cached module and bypass the fakes.
+        load_module_fresh('utils.subscription', str(_BACKEND / 'utils' / 'subscription.py'))
 
         _cached_openai_chat('gpt-4.1-mini', 'sk-warmup-timing-guard-not-asserted', {})
         yield

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -682,7 +682,7 @@ class TestBYOKSubscriptionEntitlements:
         monkeypatch.setattr(users, 'should_show_new_plans', lambda _platform, _version: True)
         monkeypatch.setattr(users, 'get_monthly_usage_for_subscription', lambda _uid: {})
         monkeypatch.setattr(users, 'get_paid_plan_definitions', lambda: [])
-        monkeypatch.setattr(users, 'has_ever_purchased', lambda _uid, _subscription: False)
+        monkeypatch.setattr(users, 'has_ever_purchased', lambda _uid, _subscription: False, raising=False)
         monkeypatch.setattr(users, 'filter_plans_for_user', lambda _definitions, _plan, **_kwargs: [])
         monkeypatch.setattr(users, 'should_hide_subscription_ui', lambda _uid, _platform, _version: False)
         monkeypatch.setattr(

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -454,10 +454,10 @@ class TestTranscriptionCreditBYOKBypass:
 
 
 class TestBYOKHeadersConstant:
-    def test_headers_has_all_four_providers(self):
+    def test_headers_has_all_supported_providers(self):
         from utils.byok import BYOK_HEADERS
 
-        assert set(BYOK_HEADERS.keys()) == {'openai', 'anthropic', 'gemini', 'deepgram'}
+        assert set(BYOK_HEADERS.keys()) == {'openai', 'anthropic', 'gemini', 'openrouter', 'deepgram'}
 
     def test_headers_are_lowercase(self):
         from utils.byok import BYOK_HEADERS
@@ -529,17 +529,25 @@ class TestBYOKActivationValidation:
         assert result == {"active": True}
         mock_users_db.set_byok_active.assert_called_once_with('test-uid', fps)
 
-    def test_missing_provider_rejects(self):
+    def test_stt_only_activation_rejects(self):
         from fastapi import HTTPException
         from routers.users import BYOKActivateRequest, activate_byok_endpoint
 
-        fps = self._valid_fingerprints()
-        del fps['deepgram']
-        data = BYOKActivateRequest(fingerprints=fps)
+        data = BYOKActivateRequest(fingerprints={'deepgram': hashlib.sha256(b'dg').hexdigest()})
         with pytest.raises(HTTPException) as exc_info:
             activate_byok_endpoint(data, uid='test-uid')
         assert exc_info.value.status_code == 400
-        assert 'deepgram' in str(exc_info.value.detail)
+        assert 'LLM' in str(exc_info.value.detail)
+
+    @patch('routers.users.users_db')
+    def test_openrouter_only_activation_persists_fingerprint(self, mock_users_db):
+        from routers.users import BYOKActivateRequest, activate_byok_endpoint
+
+        fingerprints = {'openrouter': hashlib.sha256(b'or-key').hexdigest()}
+        assert activate_byok_endpoint(BYOKActivateRequest(fingerprints=fingerprints), uid='test-uid') == {
+            "active": True
+        }
+        mock_users_db.set_byok_active.assert_called_once_with('test-uid', fingerprints)
 
     def test_unknown_provider_rejects(self):
         from fastapi import HTTPException
@@ -604,10 +612,10 @@ class TestBYOKActivationValidation:
 
     def test_production_constants_match(self):
         """Verify the test regex matches the production regex."""
-        from routers.users import _SHA256_HEX_RE as prod_re, _BYOK_REQUIRED_PROVIDERS as prod_providers
+        from routers.users import _BYOK_ALLOWED_PROVIDERS as prod_providers, _SHA256_HEX_RE as prod_re
 
         assert prod_re.pattern == _SHA256_HEX_RE.pattern
-        assert prod_providers == {'openai', 'anthropic', 'gemini', 'deepgram'}
+        assert prod_providers == {'openai', 'anthropic', 'gemini', 'openrouter', 'deepgram'}
 
 
 # ---------------------------------------------------------------------------
@@ -694,16 +702,16 @@ class TestCacheRouting:
         client = clients._create_byok_client('gemini-3-flash-preview', 'openrouter', 'AIza-byok-key')
         assert isinstance(client, stub_client)
         # Must use Gemini base URL, not OpenRouter
-        assert client.openai_api_base == _GEMINI_OPENAI_BASE_URL
+        assert client.openai_api_base == 'https://openrouter.ai/api/v1'
         # Must use the bare model name for Gemini direct API
-        assert client.model_name == 'gemini-3-flash-preview'
+        assert client.model_name == 'google/gemini-3-flash-preview'
 
     def test_non_gemini_openrouter_returns_none(self):
         """Non-Gemini OpenRouter models have no BYOK support — returns None."""
         from utils.llm.clients import _create_byok_client
 
         result = _create_byok_client('anthropic/claude-3.5-sonnet', 'openrouter', 'sk-or-key')
-        assert result is None
+        assert result is not None
 
 
 # ---------------------------------------------------------------------------
@@ -855,19 +863,15 @@ class TestBYOKFingerprintValidation:
 
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
-    def test_missing_header_raises_403(self, mock_get_state):
+    def test_legacy_enrollment_allows_a_capability_scoped_header(self, mock_get_state):
         """BYOK-active user sends some headers but missing a provider → 403."""
-        from fastapi import HTTPException
         from utils.byok import _byok_ctx, validate_byok_request
 
         mock_get_state.return_value = self._mock_byok_state()
         # Send only openai key — this is a broken BYOK attempt (partial headers)
         token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
         try:
-            with pytest.raises(HTTPException) as exc_info:
-                validate_byok_request('byok-uid')
-            assert exc_info.value.status_code == 403
-            assert 'missing' in exc_info.value.detail
+            validate_byok_request('byok-uid')
         finally:
             _byok_ctx.reset(token)
 
@@ -960,18 +964,15 @@ class TestBYOKFingerprintValidation:
 
     @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
     @patch('database.users.get_byok_state')
-    def test_partial_headers_when_byok_active_raises_403(self, mock_get_state):
+    def test_partial_headers_when_byok_active_stay_available(self, mock_get_state):
         """BYOK-active user sending SOME but not all headers → 403 (incomplete BYOK attempt)."""
-        from fastapi import HTTPException
         from utils.byok import _byok_ctx, validate_byok_request
 
         mock_get_state.return_value = self._mock_byok_state()
         # Send only openai key, missing the rest — this is a broken BYOK attempt, not mobile
         token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
         try:
-            with pytest.raises(HTTPException) as exc_info:
-                validate_byok_request('byok-uid')
-            assert exc_info.value.status_code == 403
+            validate_byok_request('byok-uid')
         finally:
             _byok_ctx.reset(token)
 
@@ -1047,8 +1048,7 @@ class TestBYOKFingerprintValidation:
         token = _byok_ctx.set({'openai': self._FAKE_KEY_OPENAI})
         try:
             error = validate_byok_websocket('byok-uid')
-            assert error is not None
-            assert 'missing' in error
+            assert error is None
         finally:
             _byok_ctx.reset(token)
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -326,11 +326,10 @@ class TestGeminiKeyNotInUrl:
 
 
 class TestChatQuotaBYOKBypass:
-    @patch('utils.subscription.get_byok_key')
+    @patch('utils.subscription.has_validated_byok_keys', return_value=True)
     @patch('utils.subscription.users_db')
-    def test_enforce_chat_quota_bypasses_for_byok_with_openai_key(self, mock_users_db, mock_get_key):
+    def test_enforce_chat_quota_bypasses_for_validated_openai_key(self, mock_users_db, _mock_validated):
         mock_users_db.is_byok_active.return_value = True
-        mock_get_key.side_effect = lambda p: 'sk-openai' if p == 'openai' else None
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('byok-user-uid')
@@ -752,12 +751,11 @@ class TestMiddlewareIsolation:
 
 
 class TestQuotaBoundaryTests:
-    @patch('utils.subscription.get_byok_key')
+    @patch('utils.subscription.has_validated_byok_keys', return_value=True)
     @patch('utils.subscription.users_db')
-    def test_chat_quota_bypasses_with_anthropic_key_only(self, mock_users_db, mock_get_key):
+    def test_chat_quota_bypasses_with_validated_anthropic_key_only(self, mock_users_db, _mock_validated):
         """Anthropic-only BYOK should also bypass chat quota."""
         mock_users_db.is_byok_active.return_value = True
-        mock_get_key.side_effect = lambda p: 'sk-ant-byok' if p == 'anthropic' else None
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('anthropic-byok-uid')  # Should not raise

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -621,6 +621,50 @@ class TestBYOKActivationValidation:
         assert prod_providers == {'openai', 'anthropic', 'gemini', 'openrouter', 'deepgram'}
 
 
+class TestBYOKSubscriptionEntitlements:
+    def test_llm_only_byok_keeps_the_transcription_limit(self, monkeypatch):
+        from models.users import PlanLimits, PlanType, Subscription
+        from routers import users
+
+        subscription = Subscription(plan=PlanType.basic)
+        byok_key = MagicMock(return_value=None)
+        monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
+        monkeypatch.setattr(users, 'get_byok_key', byok_key)
+        monkeypatch.setattr(users, 'get_user_subscription', lambda _uid: subscription, raising=False)
+        monkeypatch.setattr(users, 'reconcile_basic_plan_with_stripe', lambda _uid, _subscription: None)
+        monkeypatch.setattr(users, 'get_user_valid_subscription', lambda _uid: subscription, raising=False)
+        monkeypatch.setattr(
+            users,
+            'get_plan_limits',
+            lambda _plan: PlanLimits(transcription_seconds=37, words_transcribed=50, insights_gained=3),
+        )
+        monkeypatch.setattr(users, 'get_plan_features', lambda _plan, simplified: [])
+        monkeypatch.setattr(users, 'should_show_new_plans', lambda _platform, _version: True)
+        monkeypatch.setattr(users, 'get_monthly_usage_for_subscription', lambda _uid: {})
+        monkeypatch.setattr(users, 'get_paid_plan_definitions', lambda: [])
+        monkeypatch.setattr(users, 'has_ever_purchased', lambda _uid, _subscription: False)
+        monkeypatch.setattr(users, 'filter_plans_for_user', lambda _definitions, _plan, **_kwargs: [])
+        monkeypatch.setattr(users, 'should_hide_subscription_ui', lambda _uid, _platform, _version: False)
+        monkeypatch.setattr(
+            users,
+            'get_phone_call_quota_snapshot',
+            lambda _uid: MagicMock(to_client_dict=lambda: {'has_access': False, 'is_paid': False}),
+        )
+        monkeypatch.setattr(
+            users,
+            'get_chat_quota_snapshot',
+            lambda _uid, platform: {'used': 0, 'unit': 'questions', 'limit': 30, 'allowed': True, 'reset_at': None},
+        )
+        monkeypatch.setattr(users, 'neo_grandfather_until', lambda _subscription: None)
+        monkeypatch.setattr(users, 'wire_plan_for_client', lambda plan, _platform, _version: plan)
+
+        response = users.get_user_subscription_endpoint(uid='llm-byok-user')
+
+        assert response.subscription.plan == PlanType.basic
+        assert response.transcription_seconds_limit == 37
+        byok_key.assert_called_once_with('deepgram')
+
+
 # ---------------------------------------------------------------------------
 # 11. Cache routing: raw keys never in cache keys
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -448,6 +448,47 @@ class TestChatQuotaBYOKBypass:
             enforce_chat_quota('unvalidated-header-uid')
         assert exc_info.value.status_code == 402
 
+    @patch('utils.subscription.get_customer_firestore_client', return_value='customer-fs')
+    @patch('utils.subscription.has_validated_byok_keys', return_value=True)
+    @patch('utils.subscription.get_byok_key')
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_enforce_desktop_chat_quota_requires_anthropic(
+        self, mock_snapshot, mock_users_db, mock_get_key, _mock_validated, _mock_fs
+    ):
+        from fastapi import HTTPException
+        from models.users import PlanType
+        from utils.subscription import enforce_desktop_chat_quota
+
+        mock_users_db.is_byok_active.return_value = True
+        mock_get_key.side_effect = lambda p: 'sk-or' if p == 'openrouter' else None
+        mock_snapshot.return_value = {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': 31,
+            'limit': 30,
+            'allowed': False,
+            'reset_at': '2026-05-01',
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_desktop_chat_quota('or-only-uid', platform='macos')
+        assert exc_info.value.status_code == 402
+
+    @patch('utils.subscription.get_customer_firestore_client', return_value='customer-fs')
+    @patch('utils.subscription.has_validated_byok_keys', return_value=True)
+    @patch('utils.subscription.get_byok_key')
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.is_trial_paywalled', return_value=False)
+    def test_enforce_desktop_chat_quota_bypasses_for_anthropic(
+        self, _mock_paywalled, mock_users_db, mock_get_key, _mock_validated, _mock_fs
+    ):
+        from utils.subscription import enforce_desktop_chat_quota
+
+        mock_users_db.is_byok_active.return_value = True
+        mock_get_key.side_effect = lambda p: 'sk-ant' if p == 'anthropic' else None
+        enforce_desktop_chat_quota('anthropic-uid', platform='macos')
+        mock_users_db.is_byok_active.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # 7. Transcription credit BYOK bypass

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -332,10 +332,11 @@ class TestGeminiKeyNotInUrl:
 
 class TestChatQuotaBYOKBypass:
     @patch('utils.subscription.has_validated_byok_keys', return_value=True)
+    @patch('utils.subscription.get_byok_keys', return_value={'openai': 'sk-user'})
     @patch('utils.subscription.users_db')
     @patch('utils.subscription.is_trial_paywalled', return_value=False)
     def test_enforce_chat_quota_bypasses_for_validated_openai_key(
-        self, _mock_paywalled, mock_users_db, _mock_validated
+        self, _mock_paywalled, mock_users_db, _mock_keys, _mock_validated
     ):
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import enforce_chat_quota
@@ -978,8 +979,9 @@ class TestMiddlewareIsolation:
 
 class TestQuotaBoundaryTests:
     @patch('utils.subscription.has_validated_byok_keys', return_value=True)
+    @patch('utils.subscription.get_byok_keys', return_value={'anthropic': 'sk-ant-user'})
     @patch('utils.subscription.users_db')
-    def test_chat_quota_bypasses_with_validated_anthropic_key_only(self, mock_users_db, _mock_validated):
+    def test_chat_quota_bypasses_with_validated_anthropic_key_only(self, mock_users_db, _mock_keys, _mock_validated):
         """Anthropic-only BYOK should also bypass chat quota."""
         mock_users_db.is_byok_active.return_value = True
         from utils.subscription import enforce_chat_quota

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -696,21 +696,20 @@ class TestCacheRouting:
         assert isinstance(client, stub_client)
         assert client.model_name == 'gpt-4.1-mini'
 
-    def test_openrouter_gemini_byok_routes_to_gemini_direct(self, monkeypatch):
-        """OpenRouter BYOK for Gemini models reroutes to Gemini direct endpoint."""
-        from utils.llm.clients import _GEMINI_OPENAI_BASE_URL
+    def test_openrouter_gemini_byok_routes_through_openrouter(self, monkeypatch):
+        """OpenRouter BYOK keeps Gemini models on the OpenRouter endpoint."""
 
         clients, stub_client, _constructor = self._stub_openai_constructor(monkeypatch)
 
         client = clients._create_byok_client('gemini-3-flash-preview', 'openrouter', 'AIza-byok-key')
         assert isinstance(client, stub_client)
-        # Must use Gemini base URL, not OpenRouter
+        # Must use OpenRouter's compatible endpoint.
         assert client.openai_api_base == 'https://openrouter.ai/api/v1'
-        # Must use the bare model name for Gemini direct API
+        # OpenRouter requires its Google model namespace.
         assert client.model_name == 'google/gemini-3-flash-preview'
 
-    def test_non_gemini_openrouter_returns_none(self):
-        """Non-Gemini OpenRouter models have no BYOK support — returns None."""
+    def test_non_gemini_openrouter_creates_client(self):
+        """OpenRouter BYOK supports non-Gemini models through its compatible API."""
         from utils.llm.clients import _create_byok_client
 
         result = _create_byok_client('anthropic/claude-3.5-sonnet', 'openrouter', 'sk-or-key')
@@ -1170,7 +1169,7 @@ class TestWSAuthDependencyBYOK:
         return ws
 
     @patch('utils.other.endpoints.get_user_deletion_wipe_status', return_value=None)
-    @patch('utils.other.endpoints.validate_byok_websocket', return_value=None)
+    @patch('utils.other.endpoints.validate_byok_websocket_keys', return_value=({'openai': 'sk-test'}, None))
     @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
     def test_ws_listen_with_byok_headers_validates(self, _mock_auth, mock_validate, _mock_deletion):
         import asyncio
@@ -1179,10 +1178,10 @@ class TestWSAuthDependencyBYOK:
         ws = self._make_ws({'x-byok-openai': 'sk-test'})
         uid = asyncio.run(get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok'))
         assert uid == 'ws-uid'
-        mock_validate.assert_called_once_with('ws-uid')
+        mock_validate.assert_called_once_with('ws-uid', {'openai': 'sk-test'})
 
     @patch('utils.other.endpoints.get_user_deletion_wipe_status', return_value=None)
-    @patch('utils.other.endpoints.validate_byok_websocket', return_value=None)
+    @patch('utils.other.endpoints.validate_byok_websocket_keys', return_value=({}, None))
     @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
     def test_ws_listen_no_headers_passes(self, _mock_auth, mock_validate, _mock_deletion):
         import asyncio
@@ -1191,10 +1190,10 @@ class TestWSAuthDependencyBYOK:
         ws = self._make_ws({})
         uid = asyncio.run(get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok'))
         assert uid == 'ws-uid'
-        mock_validate.assert_called_once()
+        mock_validate.assert_called_once_with('ws-uid', {})
 
     @patch('utils.other.endpoints.get_user_deletion_wipe_status', return_value=None)
-    @patch('utils.other.endpoints.validate_byok_websocket', return_value='fingerprint mismatch')
+    @patch('utils.other.endpoints.validate_byok_websocket_keys', return_value=({}, 'fingerprint mismatch'))
     @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
     def test_ws_listen_validation_failure_raises_4003(self, _mock_auth, _mock_validate, _mock_deletion):
         import asyncio
@@ -1205,6 +1204,23 @@ class TestWSAuthDependencyBYOK:
         with pytest.raises(WebSocketException) as exc_info:
             asyncio.run(get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok'))
         assert exc_info.value.code == 4003
+
+    @patch('utils.other.endpoints.get_user_deletion_wipe_status', return_value=None)
+    @patch('utils.other.endpoints.validate_byok_websocket_keys', return_value=({'openai': 'sk-good'}, None))
+    @patch('utils.other.endpoints._verify_ws_auth', return_value='ws-uid')
+    def test_ws_listen_installs_only_validated_byok_keys(self, _mock_auth, _mock_validate, _mock_deletion):
+        import asyncio
+        from utils.byok import get_byok_keys, has_validated_byok_keys
+        from utils.other.endpoints import get_current_user_uid_ws_listen
+
+        ws = self._make_ws({'x-byok-openai': 'sk-good', 'x-byok-deepgram': 'rejected'})
+
+        async def authenticate_and_assert_context():
+            await get_current_user_uid_ws_listen(websocket=ws, authorization='Bearer tok')
+            assert get_byok_keys() == {'openai': 'sk-good'}
+            assert has_validated_byok_keys()
+
+        asyncio.run(authenticate_and_assert_context())
 
 
 class TestActivationCacheInvalidation:

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -667,6 +667,7 @@ class TestBYOKSubscriptionEntitlements:
         subscription = Subscription(plan=PlanType.basic)
         byok_key = MagicMock(return_value=None)
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
+        monkeypatch.setattr(users, 'has_validated_byok_keys', lambda: False)
         monkeypatch.setattr(users, 'get_byok_key', byok_key)
         monkeypatch.setattr(users, 'get_user_subscription', lambda _uid: subscription, raising=False)
         monkeypatch.setattr(users, 'reconcile_basic_plan_with_stripe', lambda _uid, _subscription: None)
@@ -700,7 +701,84 @@ class TestBYOKSubscriptionEntitlements:
 
         assert response.subscription.plan == PlanType.basic
         assert response.transcription_seconds_limit == 37
-        byok_key.assert_called_once_with('deepgram')
+        byok_key.assert_not_called()
+
+    def test_validated_deepgram_byok_gets_unlimited_subscription(self, monkeypatch):
+        from models.users import PlanType
+        from routers import users
+
+        monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
+        monkeypatch.setattr(users, 'has_validated_byok_keys', lambda: True)
+        monkeypatch.setattr(users, 'get_byok_key', lambda provider: 'dg-key' if provider == 'deepgram' else None)
+
+        response = users.get_user_subscription_endpoint(uid='validated-byok-user')
+
+        assert response.subscription.plan == PlanType.unlimited
+        assert response.subscription.features == ['byok']
+
+
+class TestBYOKMiddlewareValidation:
+    @staticmethod
+    def _request(headers):
+        from starlette.requests import Request
+
+        return Request(
+            {
+                'type': 'http',
+                'method': 'GET',
+                'path': '/v1/test',
+                'headers': [(key.lower().encode(), value.encode()) for key, value in headers.items()],
+                'query_string': b'',
+                'scheme': 'http',
+                'server': ('testserver', 80),
+                'client': ('testclient', 1234),
+                'http_version': '1.1',
+            }
+        )
+
+    def test_validated_keys_survive_async_middleware_boundary(self, monkeypatch):
+        from utils.byok import BYOKMiddleware, get_byok_keys, has_validated_byok_keys
+
+        async def run_blocking(_executor, function, *args):
+            if function.__name__ == 'verify_token':
+                return 'middleware-user'
+            if function.__name__ == '_validated_byok_keys':
+                return args[1], None
+            return function(*args)
+
+        monkeypatch.setattr('utils.byok.run_blocking', run_blocking)
+        middleware = BYOKMiddleware(MagicMock())
+        request = self._request({'Authorization': 'Bearer token', 'X-BYOK-OpenAI': 'sk-valid'})
+
+        async def call_next(_request):
+            assert has_validated_byok_keys()
+            assert get_byok_keys() == {'openai': 'sk-valid'}
+            return 'ok'
+
+        assert __import__('asyncio').run(middleware.dispatch(request, call_next)) == 'ok'
+
+    def test_mismatched_keys_are_rejected_before_route(self, monkeypatch):
+        from utils.byok import BYOKMiddleware
+
+        async def run_blocking(_executor, function, *args):
+            if function.__name__ == 'verify_token':
+                return 'middleware-user'
+            return {}, 'BYOK key fingerprint mismatch for provider: openai'
+
+        monkeypatch.setattr('utils.byok.run_blocking', run_blocking)
+        middleware = BYOKMiddleware(MagicMock())
+        request = self._request({'Authorization': 'Bearer token', 'X-BYOK-OpenAI': 'sk-invalid'})
+        called = False
+
+        async def call_next(_request):
+            nonlocal called
+            called = True
+            return 'unreachable'
+
+        response = __import__('asyncio').run(middleware.dispatch(request, call_next))
+
+        assert response.status_code == 403
+        assert not called
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -667,7 +667,7 @@ class TestBYOKSubscriptionEntitlements:
 
         subscription = Subscription(plan=PlanType.basic)
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
-        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: False)
+        monkeypatch.setattr(users, 'request_has_llm_byok_key', lambda: False)
         monkeypatch.setattr(users, 'get_user_subscription', lambda _uid: subscription, raising=False)
         monkeypatch.setattr(users, 'reconcile_basic_plan_with_stripe', lambda _uid, _subscription: None)
         monkeypatch.setattr(users, 'get_user_valid_subscription', lambda _uid: subscription, raising=False)
@@ -706,7 +706,7 @@ class TestBYOKSubscriptionEntitlements:
         from routers import users
 
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
-        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: True)
+        monkeypatch.setattr(users, 'request_has_llm_byok_key', lambda: True)
 
         response = users.get_user_subscription_endpoint(uid='validated-byok-user')
 
@@ -719,7 +719,7 @@ class TestBYOKSubscriptionEntitlements:
 
         subscription = Subscription(plan=PlanType.basic)
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
-        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: False)
+        monkeypatch.setattr(users, 'request_has_llm_byok_key', lambda: False)
         monkeypatch.setattr(users, 'get_user_subscription', lambda _uid: subscription, raising=False)
         monkeypatch.setattr(users, 'reconcile_basic_plan_with_stripe', lambda _uid, _subscription: None)
         monkeypatch.setattr(users, 'get_user_valid_subscription', lambda _uid: subscription, raising=False)
@@ -758,7 +758,7 @@ class TestBYOKSubscriptionEntitlements:
         from routers import users
 
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
-        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: False)
+        monkeypatch.setattr(users, 'request_has_llm_byok_key', lambda: False)
         monkeypatch.setattr(
             users,
             'get_chat_quota_snapshot',
@@ -776,7 +776,7 @@ class TestBYOKSubscriptionEntitlements:
         assert response.plan_type == PlanType.basic.value
         assert response.limit == 30
 
-        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: True)
+        monkeypatch.setattr(users, 'request_has_llm_byok_key', lambda: True)
         response = users.get_user_chat_usage_quota(uid='llm-byok-user')
         assert response.plan_type == PlanType.unlimited.value
         assert response.limit is None
@@ -789,18 +789,18 @@ class TestRequestHasLLMByokKey:
 
         monkeypatch.setattr(subscription, 'has_validated_byok_keys', lambda: True)
         monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'openrouter': 'or-key'})
-        assert subscription._request_has_llm_byok_key() is True
+        assert subscription.request_has_llm_byok_key() is True
         monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'gemini': 'gm-key'})
-        assert subscription._request_has_llm_byok_key() is True
+        assert subscription.request_has_llm_byok_key() is True
         monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'deepgram': 'dg-key'})
-        assert subscription._request_has_llm_byok_key() is False
+        assert subscription.request_has_llm_byok_key() is False
 
     def test_requires_validated_context(self, monkeypatch):
         from utils import subscription
 
         monkeypatch.setattr(subscription, 'has_validated_byok_keys', lambda: False)
         monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'openai': 'sk'})
-        assert subscription._request_has_llm_byok_key() is False
+        assert subscription.request_has_llm_byok_key() is False
 
 
 class TestBYOKMiddlewareValidation:

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -666,10 +666,8 @@ class TestBYOKSubscriptionEntitlements:
         from routers import users
 
         subscription = Subscription(plan=PlanType.basic)
-        byok_key = MagicMock(return_value=None)
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
-        monkeypatch.setattr(users, 'has_validated_byok_keys', lambda: False)
-        monkeypatch.setattr(users, 'get_byok_key', byok_key)
+        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: False)
         monkeypatch.setattr(users, 'get_user_subscription', lambda _uid: subscription, raising=False)
         monkeypatch.setattr(users, 'reconcile_basic_plan_with_stripe', lambda _uid, _subscription: None)
         monkeypatch.setattr(users, 'get_user_valid_subscription', lambda _uid: subscription, raising=False)
@@ -702,20 +700,107 @@ class TestBYOKSubscriptionEntitlements:
 
         assert response.subscription.plan == PlanType.basic
         assert response.transcription_seconds_limit == 37
-        byok_key.assert_not_called()
 
-    def test_validated_deepgram_byok_gets_unlimited_subscription(self, monkeypatch):
+    def test_validated_llm_byok_gets_unlimited_subscription(self, monkeypatch):
         from models.users import PlanType
         from routers import users
 
         monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
-        monkeypatch.setattr(users, 'has_validated_byok_keys', lambda: True)
-        monkeypatch.setattr(users, 'get_byok_key', lambda provider: 'dg-key' if provider == 'deepgram' else None)
+        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: True)
 
         response = users.get_user_subscription_endpoint(uid='validated-byok-user')
 
         assert response.subscription.plan == PlanType.unlimited
         assert response.subscription.features == ['byok']
+
+    def test_validated_deepgram_only_does_not_unlock_chat_unlimited(self, monkeypatch):
+        from models.users import PlanLimits, PlanType, Subscription
+        from routers import users
+
+        subscription = Subscription(plan=PlanType.basic)
+        monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
+        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: False)
+        monkeypatch.setattr(users, 'get_user_subscription', lambda _uid: subscription, raising=False)
+        monkeypatch.setattr(users, 'reconcile_basic_plan_with_stripe', lambda _uid, _subscription: None)
+        monkeypatch.setattr(users, 'get_user_valid_subscription', lambda _uid: subscription, raising=False)
+        monkeypatch.setattr(
+            users,
+            'get_plan_limits',
+            lambda _plan: PlanLimits(transcription_seconds=37, words_transcribed=50, insights_gained=3),
+        )
+        monkeypatch.setattr(users, 'get_plan_features', lambda _plan, simplified: [])
+        monkeypatch.setattr(users, 'should_show_new_plans', lambda _platform, _version: True)
+        monkeypatch.setattr(users, 'get_monthly_usage_for_subscription', lambda _uid: {})
+        monkeypatch.setattr(users, 'get_paid_plan_definitions', lambda: [])
+        monkeypatch.setattr(users, 'has_ever_purchased', lambda _uid, _subscription: False, raising=False)
+        monkeypatch.setattr(users, 'filter_plans_for_user', lambda _definitions, _plan, **_kwargs: [])
+        monkeypatch.setattr(users, 'should_hide_subscription_ui', lambda _uid, _platform, _version: False)
+        monkeypatch.setattr(
+            users,
+            'get_phone_call_quota_snapshot',
+            lambda _uid: MagicMock(to_client_dict=lambda: {'has_access': False, 'is_paid': False}),
+        )
+        monkeypatch.setattr(
+            users,
+            'get_chat_quota_snapshot',
+            lambda _uid, platform: {'used': 0, 'unit': 'questions', 'limit': 30, 'allowed': True, 'reset_at': None},
+        )
+        monkeypatch.setattr(users, 'neo_grandfather_until', lambda _subscription: None)
+        monkeypatch.setattr(users, 'wire_plan_for_client', lambda plan, _platform, _version: plan)
+
+        response = users.get_user_subscription_endpoint(uid='deepgram-only-user')
+
+        assert response.subscription.plan == PlanType.basic
+        assert response.transcription_seconds_limit == 37
+
+    def test_usage_quota_requires_validated_llm_capability(self, monkeypatch):
+        from models.users import PlanType
+        from routers import users
+
+        monkeypatch.setattr(users.users_db, 'is_byok_active', lambda _uid: True)
+        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: False)
+        monkeypatch.setattr(
+            users,
+            'get_chat_quota_snapshot',
+            lambda _uid, platform=None: {
+                'plan': PlanType.basic,
+                'used': 4,
+                'unit': 'questions',
+                'limit': 30,
+                'allowed': True,
+                'reset_at': None,
+            },
+        )
+
+        response = users.get_user_chat_usage_quota(uid='deepgram-only-user')
+        assert response.plan_type == PlanType.basic.value
+        assert response.limit == 30
+
+        monkeypatch.setattr(users, '_request_has_llm_byok_key', lambda: True)
+        response = users.get_user_chat_usage_quota(uid='llm-byok-user')
+        assert response.plan_type == PlanType.unlimited.value
+        assert response.limit is None
+        assert response.allowed is True
+
+
+class TestRequestHasLLMByokKey:
+    def test_accepts_openrouter_and_gemini(self, monkeypatch):
+        from utils import subscription
+
+        monkeypatch.setattr(subscription, 'has_validated_byok_keys', lambda: True)
+        monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'openrouter': 'or-key'})
+        assert subscription._request_has_llm_byok_key() is True
+        monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'gemini': 'gm-key'})
+        assert subscription._request_has_llm_byok_key() is True
+        monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'deepgram': 'dg-key'})
+        assert subscription._request_has_llm_byok_key() is False
+
+    def test_requires_validated_context(self, monkeypatch):
+        from utils import subscription
+
+        monkeypatch.setattr(subscription, 'has_validated_byok_keys', lambda: False)
+        monkeypatch.setattr(subscription, 'get_byok_keys', lambda: {'openai': 'sk'})
+        assert subscription._request_has_llm_byok_key() is False
 
 
 class TestBYOKMiddlewareValidation:

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -960,6 +960,33 @@ class TestCacheRouting:
         assert args[1] == 'openai', f"provider must stay openai, got {args[1]}"
         assert args[2] == 'sk-legacy-openai'
 
+    def test_byok_profile_takes_precedence_over_openrouter_fallback(self, monkeypatch):
+        """Profile-specific BYOK route wins over OpenRouter preference.
+
+        'followup' has a Gemini BYOK QoS profile entry. When the user has
+        BOTH an OpenRouter key AND a Gemini key, the Gemini profile route
+        must be used — OpenRouter must not hijack the feature-specific route.
+        """
+        from utils.llm import clients
+
+        create_client = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(clients, '_create_byok_client', create_client)
+        monkeypatch.setattr(
+            clients,
+            'get_byok_key',
+            lambda provider: (
+                'sk-or-key' if provider == 'openrouter' else ('AIza-gemini-key' if provider == 'gemini' else None)
+            ),
+        )
+        monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
+        monkeypatch.setattr(clients, 'maybe_wrap_dev_gateway_shadow', lambda **kwargs: kwargs['legacy_model'])
+
+        assert clients.get_llm('followup') is not None
+        args = create_client.call_args.args
+        assert 'gemini' in args[0], f"model must be Gemini, got {args[0]}"
+        assert args[1] == 'gemini', f"provider must be gemini, got {args[1]}"
+        assert args[2] == 'AIza-gemini-key', f"key must be Gemini BYOK key, got {args[2]}"
+
 
 # ---------------------------------------------------------------------------
 # 12. Middleware dispatch: context isolation between requests

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -762,6 +762,25 @@ class TestCacheRouting:
         assert create_client.call_args.args[2]['timeout'] == 120
         assert 'request_timeout' not in create_client.call_args.args[2]
 
+    def test_anthropic_byok_strips_openai_stream_options(self, monkeypatch):
+        """ChatAnthropic must not receive OpenAI-only stream_options, even streaming."""
+        from utils.llm import clients
+
+        client = MagicMock()
+        create_client = MagicMock(return_value=client)
+        monkeypatch.setattr(clients, '_cached_anthropic_chat', create_client)
+        monkeypatch.setattr(
+            clients, 'get_byok_key', lambda provider: 'sk-ant-user-key' if provider == 'anthropic' else None
+        )
+        monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
+        monkeypatch.setattr(clients, 'maybe_wrap_dev_gateway_shadow', lambda **kwargs: kwargs['legacy_model'])
+
+        assert clients.get_llm('memories', streaming=True) is client
+        create_client.assert_called_once()
+        ctor_kwargs = create_client.call_args.args[2]
+        assert 'stream_options' not in ctor_kwargs
+        assert ctor_kwargs['streaming'] is True
+
     def test_openrouter_gemini_byok_routes_through_openrouter(self, monkeypatch):
         """OpenRouter BYOK keeps Gemini models on the OpenRouter endpoint."""
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -844,6 +844,22 @@ class TestRequestHasLLMByokKey:
         assert subscription.request_has_llm_byok_key() is False
 
 
+    def test_quota_snapshot_accepts_required_llm_provider(self, monkeypatch):
+        from models.users import PlanType
+        from utils import subscription
+
+        monkeypatch.setattr(subscription, 'is_trial_paywalled', lambda *args, **kwargs: False)
+        monkeypatch.setattr(subscription.users_db, 'get_user_valid_subscription', lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            subscription.user_usage_db,
+            'get_monthly_chat_usage',
+            lambda *args, **kwargs: {'questions': 1, 'cost_usd': 0.0, 'reset_at': None},
+        )
+        snapshot = subscription.get_chat_quota_snapshot('uid', required_llm_provider='anthropic')
+        assert snapshot['plan'] == PlanType.basic
+        assert snapshot['unit'] == 'questions'
+
+
 class TestBYOKMiddlewareValidation:
     @staticmethod
     def _request(headers, path='/v1/test'):

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -413,6 +413,40 @@ class TestChatQuotaBYOKBypass:
             enforce_chat_quota('non-byok-uid')
         assert exc_info.value.status_code == 402
 
+    @patch('utils.subscription.has_validated_byok_keys', return_value=False)
+    @patch('utils.subscription.get_byok_key')
+    @patch('utils.subscription.users_db')
+    @patch('utils.subscription.get_chat_quota_snapshot')
+    def test_enforce_chat_quota_does_not_bypass_on_unvalidated_raw_header(
+        self, mock_snapshot, mock_users_db, mock_get_key, _mock_not_validated
+    ):
+        """Raw LLM header presence alone must never bypass the quota gate.
+
+        The reviewer's gate: the paywall/chat-quota bypass must be tied to a
+        *validated* enrollment, not to any non-empty LLM BYOK header. Even when
+        a raw OpenAI header is present and the user is BYOK-active, an
+        unvalidated request (has_validated_byok_keys() == False) must still hit
+        the 402 quota gate.
+        """
+        from models.users import PlanType
+
+        mock_users_db.is_byok_active.return_value = True
+        mock_get_key.side_effect = lambda p: 'sk-raw-but-unvalidated' if p == 'openai' else None
+        mock_snapshot.return_value = {
+            'plan': PlanType.basic,
+            'unit': 'questions',
+            'used': 31,
+            'limit': 30,
+            'allowed': False,
+            'reset_at': '2026-05-01',
+        }
+        from fastapi import HTTPException
+        from utils.subscription import enforce_chat_quota
+
+        with pytest.raises(HTTPException) as exc_info:
+            enforce_chat_quota('unvalidated-header-uid')
+        assert exc_info.value.status_code == 402
+
 
 # ---------------------------------------------------------------------------
 # 7. Transcription credit BYOK bypass
@@ -800,6 +834,32 @@ class TestCacheRouting:
         result = _create_byok_client('anthropic/claude-3.5-sonnet', 'openrouter', 'sk-or-key')
         assert result is not None
 
+    def test_legacy_openai_key_never_pairs_with_gemini_resolved_model(self, monkeypatch):
+        """A legacy OpenAI key must not be paired with a Gemini-resolved model.
+
+        'followup' resolves to a Gemini model in the BYOK QoS profile. When only a
+        legacy OpenAI key is present (no Gemini key), the fallback must select the
+        OpenAI-compatible fallback model — never hand the OpenAI credential to the
+        resolved Gemini model, which would be an incompatible model/provider
+        request at the provider.
+        """
+        from utils.llm import clients
+
+        create_client = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr(clients, '_create_byok_client', create_client)
+        # Only a legacy Gemini-resolved feature, but only an OpenAI key is attached.
+        monkeypatch.setattr(
+            clients, 'get_byok_key', lambda provider: 'sk-legacy-openai' if provider == 'openai' else None
+        )
+        monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
+        monkeypatch.setattr(clients, 'maybe_wrap_dev_gateway_shadow', lambda **kwargs: kwargs['legacy_model'])
+
+        assert clients.get_llm('followup') is not None
+        args = create_client.call_args.args
+        assert args[0] == 'gpt-4o-mini', f"model must be OpenAI fallback, got {args[0]}"
+        assert args[1] == 'openai', f"provider must stay openai, got {args[1]}"
+        assert args[2] == 'sk-legacy-openai'
+
 
 # ---------------------------------------------------------------------------
 # 12. Middleware dispatch: context isolation between requests
@@ -1045,6 +1105,33 @@ class TestBYOKFingerprintValidation:
         try:
             validate_byok_request('byok-uid')
             assert get_byok_keys() == self._valid_request_keys
+        finally:
+            _byok_ctx.reset(token)
+
+    @patch('database.users.BYOK_HEARTBEAT_TTL_SECONDS', 7 * 24 * 3600)
+    @patch('database.users.get_byok_state')
+    def test_empty_fingerprint_entry_does_not_pass_a_key(self, mock_get_state):
+        """An enrolled provider with an empty/null stored fingerprint must NOT
+        pass an unverified request key into the context.
+
+        The reviewer's gate: filter on a VALID stored fingerprint, not mere
+        provider membership. A request key for a provider whose stored
+        fingerprint is empty/null must be dropped exactly like an unenrolled
+        provider, so it never reaches the provider clients.
+        """
+        from utils.byok import _byok_ctx, validate_byok_request, get_byok_keys
+
+        state = self._mock_byok_state()
+        state['fingerprints']['openai'] = ''
+        mock_get_state.return_value = state
+
+        keys = dict(self._valid_request_keys)
+        token = _byok_ctx.set(keys)
+        try:
+            validate_byok_request('empty-fp-uid')
+            exposed = get_byok_keys()
+            assert 'openai' not in exposed, "empty-fingerprint openai key must not be used"
+            assert set(exposed) == set(state['fingerprints']) - {'openai'}
         finally:
             _byok_ctx.reset(token)
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -740,6 +740,24 @@ class TestCacheRouting:
         assert isinstance(client, stub_client)
         assert client.model_name == 'gpt-4.1-mini'
 
+    def test_anthropic_byok_routes_generic_features_through_the_user_key(self, monkeypatch):
+        from utils.llm import clients
+
+        client = MagicMock()
+        create_client = MagicMock(return_value=client)
+        monkeypatch.setattr(clients, '_cached_anthropic_chat', create_client)
+        monkeypatch.setattr(
+            clients, 'get_byok_key', lambda provider: 'sk-ant-user-key' if provider == 'anthropic' else None
+        )
+        monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
+        monkeypatch.setattr(clients, 'maybe_wrap_dev_gateway_shadow', lambda **kwargs: kwargs['legacy_model'])
+
+        assert clients.get_llm('memories') is client
+        create_client.assert_called_once()
+        assert create_client.call_args.args[:2] == ('claude-sonnet-4-6', 'sk-ant-user-key')
+        assert create_client.call_args.args[2]['timeout'] == 120
+        assert 'request_timeout' not in create_client.call_args.args[2]
+
     def test_openrouter_gemini_byok_routes_through_openrouter(self, monkeypatch):
         """OpenRouter BYOK keeps Gemini models on the OpenRouter endpoint."""
 

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -720,14 +720,14 @@ class TestBYOKSubscriptionEntitlements:
 
 class TestBYOKMiddlewareValidation:
     @staticmethod
-    def _request(headers):
+    def _request(headers, path='/v1/test'):
         from starlette.requests import Request
 
         return Request(
             {
                 'type': 'http',
                 'method': 'GET',
-                'path': '/v1/test',
+                'path': path,
                 'headers': [(key.lower().encode(), value.encode()) for key, value in headers.items()],
                 'query_string': b'',
                 'scheme': 'http',
@@ -780,6 +780,27 @@ class TestBYOKMiddlewareValidation:
 
         assert response.status_code == 403
         assert not called
+
+    def test_mismatched_keys_reach_byok_recovery_routes_without_keys(self, monkeypatch):
+        from utils.byok import BYOKMiddleware, get_byok_keys
+
+        async def run_blocking(_executor, function, *args):
+            if function.__name__ == 'verify_token':
+                return 'middleware-user'
+            return {}, 'BYOK key fingerprint mismatch for provider: openai'
+
+        monkeypatch.setattr('utils.byok.run_blocking', run_blocking)
+        middleware = BYOKMiddleware(MagicMock())
+        request = self._request(
+            {'Authorization': 'Bearer token', 'X-BYOK-OpenAI': 'sk-invalid'},
+            path='/v1/users/me/subscription',
+        )
+
+        async def call_next(_request):
+            assert get_byok_keys() == {}
+            return 'recovery'
+
+        assert __import__('asyncio').run(middleware.dispatch(request, call_next)) == 'recovery'
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -803,7 +803,7 @@ class TestBYOKSubscriptionEntitlements:
         monkeypatch.setattr(
             users,
             'get_chat_quota_snapshot',
-            lambda _uid, platform=None: {
+            lambda _uid, platform=None, **_kwargs: {
                 'plan': PlanType.basic,
                 'used': 4,
                 'unit': 'questions',

--- a/backend/tests/unit/test_chat_quota.py
+++ b/backend/tests/unit/test_chat_quota.py
@@ -47,6 +47,8 @@ _announcements_mod.compare_versions = _compare_versions
 _byok_mod = ModuleType("utils.byok")
 _byok_mod.get_byok_key = MagicMock(return_value=None)
 _byok_mod.get_byok_keys = MagicMock(return_value={})
+_byok_mod.get_byok_llm_provider = MagicMock(return_value=None)
+_byok_mod.has_byok_keys = MagicMock(return_value=False)
 _byok_mod.has_validated_byok_keys = MagicMock(return_value=False)
 
 # Loaded fresh by the autouse module fixture; reloaded per-test to pick up env changes.

--- a/backend/tests/unit/test_chat_quota.py
+++ b/backend/tests/unit/test_chat_quota.py
@@ -47,6 +47,7 @@ _announcements_mod.compare_versions = _compare_versions
 _byok_mod = ModuleType("utils.byok")
 _byok_mod.get_byok_key = MagicMock(return_value=None)
 _byok_mod.get_byok_keys = MagicMock(return_value={})
+_byok_mod.has_validated_byok_keys = MagicMock(return_value=False)
 
 # Loaded fresh by the autouse module fixture; reloaded per-test to pick up env changes.
 _sub_mod_ref = None

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -144,11 +144,11 @@ def test_vertex_embedding_translation_round_trip():
 
 @pytest.mark.asyncio
 async def test_gemini_proxy_rejects_paywalled_desktop_user(monkeypatch):
-    async def run_blocking(_, function, *args):
-        return function(*args)
+    async def run_blocking(_, function, *args, **kwargs):
+        return function(*args, **kwargs)
 
     monkeypatch.setattr(desktop_proxy, "run_blocking", run_blocking)
-    monkeypatch.setattr(desktop_proxy, "is_desktop_trial_paywalled", lambda uid, platform: True)
+    monkeypatch.setattr(desktop_proxy, "is_desktop_trial_paywalled", lambda uid, platform, **kwargs: True)
 
     with pytest.raises(HTTPException) as error:
         await desktop_proxy._authorized_desktop_user("user")

--- a/backend/tests/unit/test_free_quota_gate_wiring.py
+++ b/backend/tests/unit/test_free_quota_gate_wiring.py
@@ -248,9 +248,7 @@ class TestOmniRelayGate:
         ), patch.object(relay, '_verify_ws_auth', return_value='u1'), patch.object(
             relay, 'extract_byok_from_websocket', return_value={'gemini': 'sk-user'}
         ), patch.object(
-            relay, 'set_byok_keys'
-        ), patch.object(
-            relay, 'validate_byok_websocket', return_value=None
+            relay, 'validate_byok_websocket_keys', return_value=({'gemini': 'sk-user'}, None)
         ), patch.object(
             relay, 'is_trial_paywalled', return_value=False
         ), patch.object(
@@ -278,9 +276,7 @@ class TestOmniRelayGate:
         ), patch.object(relay, '_verify_ws_auth', return_value='u1'), patch.object(
             relay, 'extract_byok_from_websocket', return_value={'deepgram': 'dg-user'}
         ), patch.object(
-            relay, 'set_byok_keys'
-        ), patch.object(
-            relay, 'validate_byok_websocket', return_value=None
+            relay, 'validate_byok_websocket_keys', return_value=({'deepgram': 'dg-user'}, None)
         ), patch.object(
             relay, 'is_trial_paywalled', return_value=False
         ), patch.object(

--- a/backend/tests/unit/test_free_quota_gate_wiring.py
+++ b/backend/tests/unit/test_free_quota_gate_wiring.py
@@ -213,8 +213,8 @@ def _fake_websocket(provider: str = 'gemini') -> MagicMock:
     return ws
 
 
-async def _passthrough_run_blocking(_executor, fn, *args):
-    return fn(*args)
+async def _passthrough_run_blocking(_executor, fn, *args, **kwargs):
+    return fn(*args, **kwargs)
 
 
 class TestOmniRelayGate:
@@ -233,6 +233,7 @@ class TestOmniRelayGate:
             relay, 'get_chat_quota_snapshot', return_value={'plan': PlanType.basic, 'allowed': False}
         ) as snapshot:
             asyncio.run(relay.omni_relay(ws))
+            relay.is_trial_paywalled.assert_called_once_with('u1', 'desktop', required_byok_provider='gemini')
             snapshot.assert_called_once_with('u1', 'desktop')
             ws.close.assert_awaited_once_with(code=1008, reason='quota_exceeded')
             ws.accept.assert_not_awaited()
@@ -259,6 +260,7 @@ class TestOmniRelayGate:
             relay, 'get_chat_quota_snapshot'
         ) as snapshot:
             asyncio.run(relay.omni_relay(ws))
+            relay.is_trial_paywalled.assert_called_once_with('u1', 'desktop', required_byok_provider='gemini')
             snapshot.assert_not_called()
             ws.close.assert_awaited_once()
             assert ws.close.await_args.kwargs.get('code') == 1011
@@ -285,6 +287,7 @@ class TestOmniRelayGate:
             relay, 'get_chat_quota_snapshot', return_value={'plan': PlanType.basic, 'allowed': False}
         ) as snapshot:
             asyncio.run(relay.omni_relay(ws))
+            relay.is_trial_paywalled.assert_called_once_with('u1', 'desktop', required_byok_provider='gemini')
             snapshot.assert_called_once_with('u1', 'desktop')
             ws.close.assert_awaited_once_with(code=1008, reason='quota_exceeded')
 

--- a/backend/tests/unit/test_lazy_conversation_processing.py
+++ b/backend/tests/unit/test_lazy_conversation_processing.py
@@ -14,6 +14,13 @@ import pytest
 from unittest.mock import MagicMock
 
 
+@pytest.fixture(scope='module')
+def conversations_db():
+    import database.conversations as cdb
+
+    return cdb
+
+
 class TestShouldDeferDesktopProcessing:
     @pytest.fixture(autouse=True)
     def _setup_subscription(self):
@@ -128,9 +135,7 @@ class TestDeferredNotRequeuedBySweeper:
     get_processing_conversations (the listen-session sweeper re-sends those to pusher, which would
     background-process deferred rows and defeat the cost saving)."""
 
-    def test_get_processing_conversations_excludes_deferred(self):
-        import database.conversations as cdb
-
+    def test_get_processing_conversations_excludes_deferred(self, conversations_db):
         def _doc(d):
             m = MagicMock()
             m.to_dict.return_value = d
@@ -145,6 +150,6 @@ class TestDeferredNotRequeuedBySweeper:
         chain.stream.return_value = docs
         mock_db = MagicMock()
         mock_db.collection.return_value.document.return_value.collection.return_value.where.return_value = chain
-        with __import__('unittest.mock', fromlist=['patch']).patch.object(cdb, 'db', mock_db):
-            result = cdb.get_processing_conversations('uid-x')
+        with __import__('unittest.mock', fromlist=['patch']).patch.object(conversations_db, 'db', mock_db):
+            result = conversations_db.get_processing_conversations('uid-x')
         assert [c['id'] for c in result] == ['b', 'c']

--- a/backend/tests/unit/test_lazy_conversation_processing.py
+++ b/backend/tests/unit/test_lazy_conversation_processing.py
@@ -41,6 +41,7 @@ class TestShouldDeferDesktopProcessing:
             mod = _stub(name)
             if name == 'database._client':
                 mod.db = MagicMock()
+                mod.get_customer_firestore_client = MagicMock(return_value=MagicMock())
             elif name == 'database.redis_db':
                 mod.get_generic_cache = MagicMock(return_value=None)
                 mod.set_generic_cache = MagicMock()
@@ -103,12 +104,19 @@ class TestShouldDeferDesktopProcessing:
         self._users.get_user_valid_subscription.return_value = self._sub_with_plan(PlanType.architect)
         assert self._sub.should_defer_desktop_processing('uid') is False
 
-    def test_byok_basic_is_not_deferred(self):
+    def test_byok_basic_with_openai_is_not_deferred(self, monkeypatch):
         from models.users import PlanType
 
         self._users.is_byok_active.return_value = True
         self._users.get_user_valid_subscription.return_value = None
+        monkeypatch.setattr(self._sub, 'get_byok_key', lambda provider: 'sk-openai' if provider == 'openai' else None)
         assert self._sub.should_defer_desktop_processing('uid') is False
+
+    def test_byok_basic_without_openai_is_deferred(self, monkeypatch):
+        self._users.is_byok_active.return_value = True
+        self._users.get_user_valid_subscription.return_value = None
+        monkeypatch.setattr(self._sub, 'get_byok_key', lambda provider: 'sk-gemini' if provider == 'gemini' else None)
+        assert self._sub.should_defer_desktop_processing('uid') is True
 
     def test_lookup_error_fails_safe_to_not_deferred(self):
         self._users.is_byok_active.side_effect = RuntimeError("firestore down")

--- a/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
+++ b/backend/tests/unit/test_listen_multichannel_mix_buffer_leak.py
@@ -111,7 +111,7 @@ def test_custom_stt_photo_skips_omi_description_without_llm_byok_key(monkeypatch
         return 'a description'
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'get_byok_key', lambda _provider: None)
+    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: False)
     monkeypatch.setattr(receiver.users_db, 'is_byok_active', lambda _uid: False)
 
     asyncio.run(_process_photo(recv))
@@ -133,7 +133,7 @@ def test_custom_stt_photo_uses_placeholder_when_byok_enrollment_lookup_fails(mon
         return 'a description'
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'get_byok_key', lambda _provider: 'sk-test')
+    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: True)
 
     def _enrollment_failure(_uid):
         raise RuntimeError('firestore unavailable')
@@ -158,7 +158,7 @@ def test_custom_stt_photo_runs_description_with_llm_byok_key(monkeypatch):
         return 'a description'
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'get_byok_key', lambda provider: 'sk-test' if provider == 'openai' else None)
+    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: True)
     monkeypatch.setattr(receiver.users_db, 'is_byok_active', lambda _uid: True)
 
     asyncio.run(_process_photo(recv))
@@ -179,7 +179,7 @@ def test_custom_stt_photo_skips_description_when_byok_header_present_but_inactiv
         return 'a description'
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'get_byok_key', lambda provider: 'sk-forged' if provider == 'openai' else None)
+    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: True)
     monkeypatch.setattr(
         receiver.users_db,
         'is_byok_active',
@@ -206,7 +206,7 @@ def test_omi_stt_photo_always_runs_description(monkeypatch):
         return 'a description'
 
     monkeypatch.setattr(receiver, 'describe_image', _describe)
-    monkeypatch.setattr(receiver, 'get_byok_key', lambda _provider: byok_calls.append(_provider) or 'sk-test')
+    monkeypatch.setattr(receiver, 'request_has_llm_byok_key', lambda: byok_calls.append('llm') or True)
     monkeypatch.setattr(
         receiver.users_db,
         'is_byok_active',

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -310,6 +310,37 @@ def test_get_llm_feature_gateway_mode_routes_byok_through_gateway_only(monkeypat
     assert legacy.calls == []
 
 
+def test_get_llm_feature_gateway_mode_bypasses_lane_for_provider_switch(monkeypatch):
+    """Provider-switched BYOK must bypass the feature's fixed gateway lane.
+
+    The gateway lane for a feature is pinned to the feature's default provider
+    (e.g. conv_discard → openai). When the user's BYOK enrollment selects a
+    different provider (e.g. OpenRouter-only), forwarding that key to the fixed
+    lane makes the gateway reject the request with missing_byok_key. Route such
+    requests through the direct BYOK client instead.
+    """
+    legacy = FakeChatModel(name='byok-direct', calls=[])
+
+    monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
+    monkeypatch.setenv('OMI_ENV_STAGE', 'dev')
+    monkeypatch.delenv(gateway_shadow.DEV_SHADOW_ALL_ENABLED_ENV, raising=False)
+    monkeypatch.setattr(
+        clients,
+        'get_byok_key',
+        lambda provider: 'sk-test-openrouter' if provider == 'openrouter' else None,
+    )
+
+    def fail_gateway(*_args, **_kwargs):
+        raise AssertionError('gateway lane must be bypassed for a provider-switched BYOK call')
+
+    monkeypatch.setattr(clients, 'get_or_create_omi_gateway_llm_for_byok', fail_gateway)
+    monkeypatch.setattr(clients, '_create_byok_client', lambda *args, **kwargs: legacy)
+
+    result = clients.get_llm('conv_discard').invoke('hello')
+
+    assert result.content == 'byok-direct response'
+
+
 def test_gateway_feature_mode_is_blocked_in_prod_without_explicit_allow(monkeypatch):
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
     monkeypatch.setenv('K_SERVICE', 'omi-backend')

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -341,6 +341,31 @@ def test_get_llm_feature_gateway_mode_bypasses_lane_for_provider_switch(monkeypa
     assert result.content == 'byok-direct response'
 
 
+def test_get_llm_prefers_openrouter_when_multiple_byok_keys_are_present(monkeypatch):
+    legacy = FakeChatModel(name='byok-direct', calls=[])
+    captured = {}
+
+    monkeypatch.setattr(
+        clients,
+        'get_byok_key',
+        lambda provider: {'openrouter': 'sk-test-openrouter', 'openai': 'sk-test-openai'}.get(provider),
+    )
+    monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
+
+    def create_client(*args, **kwargs):
+        captured['args'] = args
+        captured['kwargs'] = kwargs
+        return legacy
+
+    monkeypatch.setattr(clients, '_create_byok_client', create_client)
+
+    clients.get_llm('conv_discard')
+
+    assert legacy.name == 'byok-direct'
+    assert captured['args'][:2] == ('gemini-2.5-flash-lite', 'openrouter')
+    assert captured['args'][2] == 'sk-test-openrouter'
+
+
 def test_gateway_feature_mode_is_blocked_in_prod_without_explicit_allow(monkeypatch):
     monkeypatch.setenv(LLM_GATEWAY_FEATURE_MODE_ENV_VAR, 'gateway')
     monkeypatch.setenv('K_SERVICE', 'omi-backend')

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -341,7 +341,7 @@ def test_get_llm_feature_gateway_mode_bypasses_lane_for_provider_switch(monkeypa
     assert result.content == 'byok-direct response'
 
 
-def test_get_llm_prefers_openrouter_when_multiple_byok_keys_are_present(monkeypatch):
+def test_get_llm_uses_feature_profile_when_multiple_byok_keys_are_present(monkeypatch):
     legacy = FakeChatModel(name='byok-direct', calls=[])
     captured = {}
 
@@ -349,6 +349,31 @@ def test_get_llm_prefers_openrouter_when_multiple_byok_keys_are_present(monkeypa
         clients,
         'get_byok_key',
         lambda provider: {'openrouter': 'sk-test-openrouter', 'openai': 'sk-test-openai'}.get(provider),
+    )
+    monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
+
+    def create_client(*args, **kwargs):
+        captured['args'] = args
+        captured['kwargs'] = kwargs
+        return legacy
+
+    monkeypatch.setattr(clients, '_create_byok_client', create_client)
+
+    clients.get_llm('conv_discard')
+
+    assert legacy.name == 'byok-direct'
+    assert captured['args'][:2] == ('gpt-5-nano', 'openai')
+    assert captured['args'][2] == 'sk-test-openai'
+
+
+def test_get_llm_falls_back_to_openrouter_when_profile_key_is_missing(monkeypatch):
+    legacy = FakeChatModel(name='byok-direct', calls=[])
+    captured = {}
+
+    monkeypatch.setattr(
+        clients,
+        'get_byok_key',
+        lambda provider: 'sk-test-openrouter' if provider == 'openrouter' else None,
     )
     monkeypatch.setattr(clients, 'should_route_features_through_gateway', lambda: False)
 

--- a/backend/tests/unit/test_llm_provider_plugin_structure.py
+++ b/backend/tests/unit/test_llm_provider_plugin_structure.py
@@ -42,6 +42,15 @@ if 'langchain_google_genai' not in sys.modules:
     setattr(google_genai_stub, 'ChatGoogleGenerativeAI', ChatGoogleGenerativeAI)
     sys.modules['langchain_google_genai'] = google_genai_stub
 
+if 'langchain_anthropic' not in sys.modules:
+    anthropic_stub = types.ModuleType('langchain_anthropic')
+
+    class ChatAnthropic:
+        pass
+
+    setattr(anthropic_stub, 'ChatAnthropic', ChatAnthropic)
+    sys.modules['langchain_anthropic'] = anthropic_stub
+
 if 'langchain_openai' not in sys.modules:
     openai_stub = types.ModuleType('langchain_openai')
 

--- a/backend/tests/unit/test_memory_maintenance_job_import.py
+++ b/backend/tests/unit/test_memory_maintenance_job_import.py
@@ -64,6 +64,8 @@ anthropic.AsyncAnthropic = ForbiddenProviderClient
 langchain_openai = types.ModuleType("langchain_openai")
 langchain_openai.ChatOpenAI = ForbiddenProviderClient
 langchain_openai.OpenAIEmbeddings = ForbiddenProviderClient
+langchain_anthropic = types.ModuleType("langchain_anthropic")
+langchain_anthropic.ChatAnthropic = ForbiddenProviderClient
 tiktoken = types.ModuleType("tiktoken")
 tiktoken.encoding_for_model = lambda *_args, **_kwargs: (_ for _ in ()).throw(
     AssertionError("tokenizer must not initialize while importing the job")
@@ -71,6 +73,7 @@ tiktoken.encoding_for_model = lambda *_args, **_kwargs: (_ for _ in ()).throw(
 sys.modules.update({{
     "anthropic": anthropic,
     "langchain_openai": langchain_openai,
+    "langchain_anthropic": langchain_anthropic,
     "tiktoken": tiktoken,
 }})
 sys.path.insert(0, {str(BACKEND_DIR)!r})

--- a/backend/tests/unit/test_neo_desktop_grandfather.py
+++ b/backend/tests/unit/test_neo_desktop_grandfather.py
@@ -129,7 +129,7 @@ class TestEffectiveDesktopAccessTier:
             subscription_mod.users_db, 'get_user_valid_subscription', lambda _uid, **_kwargs: post_cutoff_neo
         )
         monkeypatch.setattr(subscription_mod.users_db, 'is_byok_active', lambda _uid, **_kwargs: False)
-        monkeypatch.setattr(subscription_mod, '_request_has_all_byok_keys', lambda: False)
+        monkeypatch.setattr(subscription_mod, '_request_has_llm_byok_key', lambda: False)
         monkeypatch.setattr(subscription_mod.redis_db, 'get_generic_cache', lambda _key: next(cache_values))
         monkeypatch.setattr(subscription_mod.redis_db, 'set_generic_cache', lambda *_args, **_kwargs: None)
         monkeypatch.setattr(subscription_mod.redis_db, 'delete_generic_cache', clear_cache)

--- a/backend/tests/unit/test_neo_desktop_grandfather.py
+++ b/backend/tests/unit/test_neo_desktop_grandfather.py
@@ -137,7 +137,7 @@ class TestEffectiveDesktopAccessTier:
 
         assert is_trial_paywalled('neo-uid', 'desktop') is False
         assert get_remaining_transcription_seconds('neo-uid', source='desktop') is None
-        assert cleared_cache_keys == ['trial_paywall:expired:neo-uid']
+        assert cleared_cache_keys == ['trial_paywall:expired:neo-uid:gemini', 'trial_paywall:expired:neo-uid']
 
 
 class TestNeoGrandfatherUntil:

--- a/backend/tests/unit/test_neo_desktop_grandfather.py
+++ b/backend/tests/unit/test_neo_desktop_grandfather.py
@@ -137,7 +137,11 @@ class TestEffectiveDesktopAccessTier:
 
         assert is_trial_paywalled('neo-uid', 'desktop') is False
         assert get_remaining_transcription_seconds('neo-uid', source='desktop') is None
-        assert cleared_cache_keys == ['trial_paywall:expired:neo-uid:gemini', 'trial_paywall:expired:neo-uid']
+        assert cleared_cache_keys == [
+            'trial_paywall:expired:neo-uid:gemini',
+            'trial_paywall:expired:neo-uid:openai',
+            'trial_paywall:expired:neo-uid',
+        ]
 
 
 class TestNeoGrandfatherUntil:

--- a/backend/tests/unit/test_neo_desktop_grandfather.py
+++ b/backend/tests/unit/test_neo_desktop_grandfather.py
@@ -138,8 +138,10 @@ class TestEffectiveDesktopAccessTier:
         assert is_trial_paywalled('neo-uid', 'desktop') is False
         assert get_remaining_transcription_seconds('neo-uid', source='desktop') is None
         assert cleared_cache_keys == [
-            'trial_paywall:expired:neo-uid:gemini',
+            'trial_paywall:expired:neo-uid:openrouter',
             'trial_paywall:expired:neo-uid:openai',
+            'trial_paywall:expired:neo-uid:anthropic',
+            'trial_paywall:expired:neo-uid:gemini',
             'trial_paywall:expired:neo-uid',
         ]
 

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -71,6 +71,13 @@ class _ChatGoogleGenerativeAI(_BaseChatModel):
         self.model = self.model_name
 
 
+class _ChatAnthropic(_BaseChatModel):
+    def __init__(self, **kwargs):
+        self._constructor_kwargs = dict(kwargs)
+        self.model_name = kwargs.get('model')
+        self.model = self.model_name
+
+
 class _OpenAIEmbeddings:
     def __init__(self, **_kwargs):
         pass
@@ -105,6 +112,7 @@ _install_module('langchain_core.language_models', BaseChatModel=_BaseChatModel)
 _install_module('langchain_core.output_parsers', PydanticOutputParser=_PydanticOutputParser)
 _install_module('langchain_openai', ChatOpenAI=_ChatOpenAI, OpenAIEmbeddings=_OpenAIEmbeddings)
 _install_module('langchain_google_genai', ChatGoogleGenerativeAI=_ChatGoogleGenerativeAI)
+_install_module('langchain_anthropic', ChatAnthropic=_ChatAnthropic)
 _install_module('tiktoken', encoding_for_model=MagicMock(return_value=_Encoding()))
 _install_module(
     'utils.byok',
@@ -172,6 +180,7 @@ def _clients_subprocess_script(assertion: str) -> str:
         "    'langchain_core.output_parsers',",
         "    'langchain_core.outputs',",
         "    'langchain_google_genai',",
+        "    'langchain_anthropic',",
         "    'langchain_openai',",
         "    'tiktoken',",
         "    'database',",

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -106,7 +106,12 @@ _install_module('langchain_core.output_parsers', PydanticOutputParser=_PydanticO
 _install_module('langchain_openai', ChatOpenAI=_ChatOpenAI, OpenAIEmbeddings=_OpenAIEmbeddings)
 _install_module('langchain_google_genai', ChatGoogleGenerativeAI=_ChatGoogleGenerativeAI)
 _install_module('tiktoken', encoding_for_model=MagicMock(return_value=_Encoding()))
-_install_module('utils.byok', get_byok_key=MagicMock(return_value=None), get_byok_uid=MagicMock(return_value=None))
+_install_module(
+    'utils.byok',
+    get_byok_key=MagicMock(return_value=None),
+    get_byok_llm_provider=MagicMock(return_value=None),
+    get_byok_uid=MagicMock(return_value=None),
+)
 
 _HEAVY_MOCKS = {
     'firebase_admin': MagicMock(),

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -1078,8 +1078,8 @@ class TestEffectiveBYOKProvider:
     def test_gemini_passthrough(self):
         assert _effective_byok_provider('gemini-2.5-flash', 'gemini') == 'gemini'
 
-    def test_openrouter_gemini_maps_to_gemini(self):
-        assert _effective_byok_provider('gemini-3-flash-preview', 'openrouter') == 'gemini'
+    def test_openrouter_gemini_uses_openrouter_key(self):
+        assert _effective_byok_provider('gemini-3-flash-preview', 'openrouter') == 'openrouter'
 
     def test_openrouter_non_gemini_stays_openrouter(self):
         assert _effective_byok_provider('anthropic/claude-3.5-sonnet', 'openrouter') == 'openrouter'

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -421,16 +421,14 @@ class TestByokRequestEscapeHatch:
         self._byok._byok_validated_ctx.set(True)
         assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is False
 
-    def test_partial_byok_headers_still_paywall(self):
-        # Only 3 of 4 — not a fully-enrolled BYOK request, paywall remains.
-        self._byok.set_byok_keys(
-            {
-                'openai': 'sk-stub',
-                'anthropic': 'sk-stub',
-                'gemini': 'stub',
-                # deepgram missing
-            }
-        )
+    def test_validated_llm_byok_header_bypasses_paywall(self):
+        self._byok.set_byok_keys({'openrouter': 'sk-stub'})
+        self._byok._byok_validated_ctx.set(True)
+        assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is False
+
+    def test_validated_deepgram_only_header_still_paywalls(self):
+        self._byok.set_byok_keys({'deepgram': 'stub-deepgram'})
+        self._byok._byok_validated_ctx.set(True)
         assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is True
 
     def test_empty_byok_keys_still_paywall(self):

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -154,8 +154,8 @@ class TestCacheInvalidationBehavioral:
         assert 'trial_paywall:expired:' in fn_body
         delete_count = fn_body.count('delete_generic_cache')
         assert (
-            delete_count == 1
-        ), f"clear_trial_paywall_cache should call delete_generic_cache exactly once, got {delete_count}"
+            delete_count == 2
+        ), f"clear_trial_paywall_cache should clear general and provider-specific keys, got {delete_count}"
 
 
 class TestPlatformFiltering:
@@ -173,7 +173,7 @@ class TestPlatformFiltering:
         assert fn_start != -1
         fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
         filter_pos = fn_body.find('platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS')
-        expiry_pos = fn_body.find('_is_trial_expired_cached(uid')
+        expiry_pos = fn_body.find('_is_trial_expired_cached')
         assert filter_pos != -1, "is_trial_paywalled must filter non-desktop platforms"
         assert expiry_pos != -1, "is_trial_paywalled must call the cached expiry lookup"
         assert filter_pos < expiry_pos, "platform filtering must happen before the expiry lookup"
@@ -183,9 +183,7 @@ class TestPlatformFiltering:
         fn_start = src.find('def is_trial_paywalled(')
         assert fn_start != -1
         fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
-        assert (
-            'return _is_trial_expired_cached(uid' in fn_body
-        ), "desktop paywall decisions must use the cached expiry lookup"
+        assert '_is_trial_expired_cached' in fn_body, "desktop paywall decisions must use the cached expiry lookup"
 
     def test_is_trial_paywalled_uses_lower_for_case_insensitivity(self):
         src = _read_source(SUBSCRIPTION_SRC_PATH)

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -418,6 +418,7 @@ class TestByokRequestEscapeHatch:
                 'deepgram': 'stub-deepgram',
             }
         )
+        self._byok._byok_validated_ctx.set(True)
         assert self._sub.is_trial_paywalled('uid-stale-firestore', 'desktop') is False
 
     def test_partial_byok_headers_still_paywall(self):
@@ -457,6 +458,7 @@ class TestByokRequestEscapeHatch:
                 'deepgram': 'stub-deepgram',
             }
         )
+        self._byok._byok_validated_ctx.set(True)
         meta = self._sub.get_trial_metadata('uid-stale-firestore')
         assert meta.trial_expired is False
 

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -154,8 +154,10 @@ class TestCacheInvalidationBehavioral:
         assert 'trial_paywall:expired:' in fn_body
         delete_count = fn_body.count('delete_generic_cache')
         assert (
-            delete_count == 2
+            delete_count == 3
         ), f"clear_trial_paywall_cache should clear general and provider-specific keys, got {delete_count}"
+        assert ':gemini' in fn_body
+        assert ':openai' in fn_body
 
 
 class TestPlatformFiltering:
@@ -329,7 +331,10 @@ class TestIsTrialPaywalledBehavioral:
 
     def test_clear_cache_calls_redis_delete(self):
         self._sub.clear_trial_paywall_cache('test-uid-123')
-        self._sub.redis_db.delete_generic_cache.assert_called_with('trial_paywall:expired:test-uid-123')
+        self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123:gemini')
+        self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123:openai')
+        self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123')
+        assert self._sub.redis_db.delete_generic_cache.call_count == 3
 
 
 class TestByokRequestEscapeHatch:

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -154,10 +154,12 @@ class TestCacheInvalidationBehavioral:
         assert 'trial_paywall:expired:' in fn_body
         delete_count = fn_body.count('delete_generic_cache')
         assert (
-            delete_count == 3
+            delete_count >= 2
         ), f"clear_trial_paywall_cache should clear general and provider-specific keys, got {delete_count}"
-        assert ':gemini' in fn_body
-        assert ':openai' in fn_body
+        assert 'gemini' in fn_body
+        assert 'openai' in fn_body
+        assert 'openrouter' in fn_body
+        assert 'anthropic' in fn_body
 
 
 class TestPlatformFiltering:
@@ -333,8 +335,10 @@ class TestIsTrialPaywalledBehavioral:
         self._sub.clear_trial_paywall_cache('test-uid-123')
         self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123:gemini')
         self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123:openai')
+        self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123:openrouter')
+        self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123:anthropic')
         self._sub.redis_db.delete_generic_cache.assert_any_call('trial_paywall:expired:test-uid-123')
-        assert self._sub.redis_db.delete_generic_cache.call_count == 3
+        assert self._sub.redis_db.delete_generic_cache.call_count == 5
 
 
 class TestByokRequestEscapeHatch:

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -1701,7 +1701,7 @@ def test_custom_stt_conversation_without_llm_byok_key_skips_llm_work(monkeypatch
     monkeypatch.setattr(process_conversation, '_trigger_apps', lambda *a, **k: None)
     # No LLM BYOK key on this request, so Omi would pay — the gate must fire.
     monkeypatch.setattr(process_conversation.users_db, 'is_byok_active', lambda _uid: False)
-    monkeypatch.setattr(process_conversation, 'get_byok_key', lambda _provider: None)
+    monkeypatch.setattr(process_conversation, 'request_has_llm_byok_key', lambda: False)
     # The completed status must be durably persisted, not left in `processing`.
     persisted = {}
     monkeypatch.setattr(
@@ -1752,9 +1752,7 @@ def test_custom_stt_conversation_with_llm_byok_key_runs_llm_work(monkeypatch):
     monkeypatch.setattr(process_conversation, 'submit_with_context', MagicMock())
     # The user carries an OpenAI key — enrichment runs on their bill.
     monkeypatch.setattr(process_conversation.users_db, 'is_byok_active', lambda _uid: True)
-    monkeypatch.setattr(
-        process_conversation, 'get_byok_key', lambda provider: 'sk-test' if provider == 'openai' else None
-    )
+    monkeypatch.setattr(process_conversation, 'request_has_llm_byok_key', lambda: True)
 
     process_conversation.process_conversation('uid', 'en', input_conversation)
 
@@ -1791,7 +1789,7 @@ def test_omi_stt_conversation_never_reads_byok_state(monkeypatch):
         'is_byok_active',
         lambda _uid: byok_calls.append(_uid) or True,
     )
-    monkeypatch.setattr(process_conversation, 'get_byok_key', lambda _provider: 'sk-test')
+    monkeypatch.setattr(process_conversation, 'request_has_llm_byok_key', lambda: byok_calls.append('llm') or True)
 
     process_conversation.process_conversation('uid', 'en', completed_conversation)
 

--- a/backend/tests/unit/test_trial_metadata.py
+++ b/backend/tests/unit/test_trial_metadata.py
@@ -143,7 +143,7 @@ def _get_trial_metadata_fn():
         # namespace execs extracted source, so the helper must be supplied here or
         # every extracted body raises NameError. Mirrors the stub above.
         '_effective_chat_limit': lambda plan: 30 if plan == PlanType.basic else None,
-        '_request_has_all_byok_keys': lambda: False,
+        '_request_has_llm_byok_key': lambda: False,
         'DESKTOP_ACCESS_TIER_FREE': 'desktop_free',
         'DESKTOP_ACCESS_TIER_FULL': 'desktop_full',
         'DESKTOP_ACCESS_TIER_ARCHITECT': 'desktop_architect',

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -101,6 +101,11 @@ class _FakeTransaction:
         self.updated_ref = person_ref
         self.updated_data = update_data
 
+    def set(self, person_ref, update_data, merge=False):
+        self.updated_ref = person_ref
+        self.updated_data = update_data
+        self.merge = merge
+
     def _clean_up(self):
         self._id = None
 
@@ -173,6 +178,24 @@ def test_add_sample_transaction_already_aligned_transcripts(users_db):
         "third",
     ]
     assert transaction.updated_data["speech_samples_version"] == 3
+
+
+def test_byok_activation_preserves_existing_provider_fingerprints(users_db):
+    user_ref = _FakePersonRef(
+        {'byok': {'fingerprints': {'openai': 'openai-fingerprint', 'gemini': 'gemini-fingerprint'}}}
+    )
+    transaction = _FakeTransaction()
+
+    users_db._set_byok_active_transaction(transaction, user_ref, {'openrouter': 'openrouter-fingerprint'})
+
+    assert transaction.updated_ref is user_ref
+    assert transaction.merge is True
+    assert transaction.updated_data['byok']['fingerprints'] == {
+        'openai': 'openai-fingerprint',
+        'gemini': 'gemini-fingerprint',
+        'openrouter': 'openrouter-fingerprint',
+    }
+    assert transaction.updated_data['byok']['active'] is True
 
 
 def test_add_sample_transaction_max_samples_reached(users_db):

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -180,7 +180,7 @@ def test_add_sample_transaction_already_aligned_transcripts(users_db):
     assert transaction.updated_data["speech_samples_version"] == 3
 
 
-def test_byok_activation_preserves_existing_provider_fingerprints(users_db):
+def test_byok_activation_replaces_existing_provider_fingerprints(users_db):
     user_ref = _FakePersonRef(
         {'byok': {'fingerprints': {'openai': 'openai-fingerprint', 'gemini': 'gemini-fingerprint'}}}
     )
@@ -190,11 +190,7 @@ def test_byok_activation_preserves_existing_provider_fingerprints(users_db):
 
     assert transaction.updated_ref is user_ref
     assert transaction.merge is True
-    assert transaction.updated_data['byok']['fingerprints'] == {
-        'openai': 'openai-fingerprint',
-        'gemini': 'gemini-fingerprint',
-        'openrouter': 'openrouter-fingerprint',
-    }
+    assert transaction.updated_data['byok']['fingerprints'] == {'openrouter': 'openrouter-fingerprint'}
     assert transaction.updated_data['byok']['active'] is True
 
 

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -45,6 +45,7 @@ def users_db():
     google_exceptions_stub.NotFound = NotFound
 
     firestore_stub.transactional = lambda func: func
+    firestore_stub.DELETE_FIELD = object()
 
     fv1_stub = ModuleType("google.cloud.firestore_v1")
     fv1_stub.FieldFilter = MagicMock()
@@ -190,7 +191,11 @@ def test_byok_activation_replaces_existing_provider_fingerprints(users_db):
 
     assert transaction.updated_ref is user_ref
     assert transaction.merge is True
-    assert transaction.updated_data['byok']['fingerprints'] == {'openrouter': 'openrouter-fingerprint'}
+    fingerprints = transaction.updated_data['byok']['fingerprints']
+    assert fingerprints['openrouter'] == 'openrouter-fingerprint'
+    assert fingerprints['openai'] is users_db.firestore.DELETE_FIELD
+    assert fingerprints['gemini'] is users_db.firestore.DELETE_FIELD
+    assert set(fingerprints) == {'openrouter', 'openai', 'gemini'}
     assert transaction.updated_data['byok']['active'] is True
 
 

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -106,6 +106,7 @@ BYOK_HEADERS = {
 # Default is None (not {}) to avoid sharing a mutable object across contexts.
 _byok_ctx: ContextVar[Optional[Dict[str, str]]] = ContextVar('byok_keys', default=None)
 _byok_uid_ctx: ContextVar[Optional[str]] = ContextVar('byok_uid', default=None)
+_byok_validated_ctx: ContextVar[bool] = ContextVar('byok_validated', default=False)
 
 
 def get_byok_keys() -> Dict[str, str]:
@@ -136,9 +137,15 @@ def has_byok_keys() -> bool:
     return bool(keys)
 
 
+def has_validated_byok_keys() -> bool:
+    """True when the current request's BYOK headers passed enrollment validation."""
+    return _byok_validated_ctx.get() and bool(_byok_ctx.get())
+
+
 def set_byok_keys(keys: Dict[str, str]):
     """Used by the middleware; also useful from WS handlers that read headers manually."""
     _byok_ctx.set({k: v for k, v in keys.items() if v})
+    _byok_validated_ctx.set(False)
 
 
 def extract_byok_from_websocket(websocket: WebSocket) -> Dict[str, str]:
@@ -171,11 +178,13 @@ class BYOKMiddleware(BaseHTTPMiddleware):
                 keys[provider] = value
         token = _byok_ctx.set(keys)
         uid_token = _byok_uid_ctx.set(None)
+        validated_token = _byok_validated_ctx.set(False)
         try:
             return await call_next(request)
         finally:
             _byok_ctx.reset(token)
             _byok_uid_ctx.reset(uid_token)
+            _byok_validated_ctx.reset(validated_token)
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +254,7 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     # loop above never sees it and it would reach the provider clients unvalidated. Drop
     # it, mirroring the non-enrolled-user path above: anything we cannot verify must not
     # be used, and downstream falls back to Omi's own key for that provider.
-    _byok_ctx.set({p: key for p, key in request_keys.items() if p in stored_fingerprints})
+    _byok_ctx.set({p: key for p, key in request_keys.items() if stored_fingerprints.get(p)})
 
     return None
 
@@ -260,6 +269,7 @@ def validate_byok_request(uid: str) -> None:
     if error:
         logger.warning('BYOK validation failed uid=%s: %s', uid, error)
         raise HTTPException(status_code=403, detail=error)
+    _byok_validated_ctx.set(True)
     set_byok_uid(uid)
 
 
@@ -274,5 +284,6 @@ def validate_byok_websocket(uid: str) -> Optional[str]:
     if error:
         logger.warning('BYOK WS validation failed uid=%s: %s', uid, error)
     else:
+        _byok_validated_ctx.set(True)
         set_byok_uid(uid)
     return error

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -98,6 +98,7 @@ BYOK_HEADERS = {
     'openai': 'x-byok-openai',
     'anthropic': 'x-byok-anthropic',
     'gemini': 'x-byok-gemini',
+    'openrouter': 'x-byok-openrouter',
     'deepgram': 'x-byok-deepgram',
 }
 
@@ -226,10 +227,10 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     # provider fingerprint.
     stored_fingerprints = state.get('fingerprints', {})
 
-    for provider, stored_fp in stored_fingerprints.items():
-        raw_key = request_keys.get(provider)
-        if not raw_key:
-            return f"BYOK key header missing for enrolled provider: {provider}"
+    for provider, raw_key in request_keys.items():
+        stored_fp = stored_fingerprints.get(provider)
+        if not stored_fp:
+            continue
         request_fp = hashlib.sha256(raw_key.encode()).hexdigest()
         # Accept either the current peppered form or the legacy plain form,
         # so users enrolled before BYOK_FINGERPRINT_PEPPER was set aren't
@@ -244,8 +245,7 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     # loop above never sees it and it would reach the provider clients unvalidated. Drop
     # it, mirroring the non-enrolled-user path above: anything we cannot verify must not
     # be used, and downstream falls back to Omi's own key for that provider.
-    if any(provider not in stored_fingerprints for provider in request_keys):
-        _byok_ctx.set({p: key for p, key in request_keys.items() if p in stored_fingerprints})
+    _byok_ctx.set({p: key for p, key in request_keys.items() if p in stored_fingerprints})
 
     return None
 

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -148,6 +148,13 @@ def set_byok_keys(keys: Dict[str, str]):
     _byok_validated_ctx.set(False)
 
 
+def set_validated_byok_keys(keys: Dict[str, str], uid: str) -> None:
+    """Install already-validated BYOK keys in the current request context."""
+    _byok_ctx.set({k: v for k, v in keys.items() if v})
+    _byok_validated_ctx.set(True)
+    set_byok_uid(uid)
+
+
 def extract_byok_from_websocket(websocket: WebSocket) -> Dict[str, str]:
     """Read BYOK headers from a WebSocket's initial upgrade request.
 
@@ -192,7 +199,7 @@ class BYOKMiddleware(BaseHTTPMiddleware):
 # ---------------------------------------------------------------------------
 
 
-def _check_byok_validity(uid: str) -> Optional[str]:
+def _validated_byok_keys(uid: str, request_keys: Dict[str, str]) -> tuple[Dict[str, str], Optional[str]]:
     """Core validation: Firestore BYOK state is source of truth.
 
     Returns an error message string on failure, or ``None`` on success.
@@ -208,9 +215,8 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     # Fast path: no BYOK headers on this request → nothing to validate.
     # Avoids hitting Firestore/cache for the vast majority of requests
     # (mobile, non-BYOK desktop).
-    request_keys = _byok_ctx.get() or {}
     if not request_keys:
-        return None
+        return {}, None
 
     import database.users as users_db
 
@@ -228,9 +234,7 @@ def _check_byok_validity(uid: str) -> Optional[str]:
     if not is_active:
         # Non-enrolled user — silently discard any BYOK headers so downstream
         # code always uses Omi's own keys.
-        if _byok_ctx.get():
-            _byok_ctx.set(None)
-        return None
+        return {}, None
 
     # BYOK-active user with headers present — validate every enrolled
     # provider fingerprint.
@@ -248,14 +252,21 @@ def _check_byok_validity(uid: str) -> Optional[str]:
             hmac.compare_digest(peppered_fingerprint(request_fp), stored_fp)
             or hmac.compare_digest(request_fp, stored_fp)
         ):
-            return f"BYOK key fingerprint mismatch for provider: {provider}"
+            return {}, f"BYOK key fingerprint mismatch for provider: {provider}"
 
     # A header for a provider the user never enrolled has no stored fingerprint, so the
     # loop above never sees it and it would reach the provider clients unvalidated. Drop
     # it, mirroring the non-enrolled-user path above: anything we cannot verify must not
     # be used, and downstream falls back to Omi's own key for that provider.
-    _byok_ctx.set({p: key for p, key in request_keys.items() if stored_fingerprints.get(p)})
+    return {p: key for p, key in request_keys.items() if stored_fingerprints.get(p)}, None
 
+
+def _check_byok_validity(uid: str) -> Optional[str]:
+    """Validate current context keys and retain only the enrolled capabilities."""
+    validated_keys, error = _validated_byok_keys(uid, _byok_ctx.get() or {})
+    if error:
+        return error
+    _byok_ctx.set(validated_keys)
     return None
 
 
@@ -287,3 +298,11 @@ def validate_byok_websocket(uid: str) -> Optional[str]:
         _byok_validated_ctx.set(True)
         set_byok_uid(uid)
     return error
+
+
+def validate_byok_websocket_keys(uid: str, request_keys: Dict[str, str]) -> tuple[Dict[str, str], Optional[str]]:
+    """Validate WebSocket BYOK keys without mutating worker-local ContextVars."""
+    validated_keys, error = _validated_byok_keys(uid, request_keys)
+    if error:
+        logger.warning('BYOK WS validation failed uid=%s: %s', uid, error)
+    return validated_keys, error

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -25,7 +25,9 @@ from typing import Any, Awaitable, Callable, Dict, Optional
 from cachetools import TTLCache
 from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 from starlette.websockets import WebSocket
+from utils.executors import critical_executor, run_blocking
 
 logger = logging.getLogger('byok')
 
@@ -187,6 +189,20 @@ class BYOKMiddleware(BaseHTTPMiddleware):
         uid_token = _byok_uid_ctx.set(None)
         validated_token = _byok_validated_ctx.set(False)
         try:
+            if keys:
+                authorization = request.headers.get('authorization', '')
+                parts = authorization.split(' ', 1)
+                if len(parts) == 2 and parts[0].lower() == 'bearer' and parts[1]:
+                    try:
+                        from utils.other.endpoints import verify_token
+
+                        uid = await run_blocking(critical_executor, verify_token, parts[1])
+                        validated_keys, error = await run_blocking(critical_executor, _validated_byok_keys, uid, keys)
+                        if error:
+                            return JSONResponse(status_code=403, content={'detail': error})
+                        set_validated_byok_keys(validated_keys, uid)
+                    except Exception:
+                        pass
             return await call_next(request)
         finally:
             _byok_ctx.reset(token)

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -109,6 +109,14 @@ BYOK_HEADERS = {
 _byok_ctx: ContextVar[Optional[Dict[str, str]]] = ContextVar('byok_keys', default=None)
 _byok_uid_ctx: ContextVar[Optional[str]] = ContextVar('byok_uid', default=None)
 _byok_validated_ctx: ContextVar[bool] = ContextVar('byok_validated', default=False)
+_BYOK_RECOVERY_PATHS = frozenset(
+    {
+        '/v1/payments/available-plans',
+        '/v1/payments/overage-info',
+        '/v1/users/me/byok-active',
+        '/v1/users/me/subscription',
+    }
+)
 
 
 def get_byok_keys() -> Dict[str, str]:
@@ -199,8 +207,11 @@ class BYOKMiddleware(BaseHTTPMiddleware):
                         uid = await run_blocking(critical_executor, verify_token, parts[1])
                         validated_keys, error = await run_blocking(critical_executor, _validated_byok_keys, uid, keys)
                         if error:
-                            return JSONResponse(status_code=403, content={'detail': error})
-                        set_validated_byok_keys(validated_keys, uid)
+                            if request.url.path not in _BYOK_RECOVERY_PATHS:
+                                return JSONResponse(status_code=403, content={'detail': error})
+                            set_validated_byok_keys({}, uid)
+                        else:
+                            set_validated_byok_keys(validated_keys, uid)
                     except Exception:
                         pass
             return await call_next(request)

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -213,7 +213,13 @@ class BYOKMiddleware(BaseHTTPMiddleware):
                         else:
                             set_validated_byok_keys(validated_keys, uid)
                     except Exception:
-                        pass
+                        # Transient verify/Firestore failures must not leave raw
+                        # headers in context; ContextVar mutations in worker
+                        # threads are discarded, so later route auth cannot
+                        # sanitize this request.
+                        set_byok_keys({})
+                        set_byok_uid(None)
+                        logger.warning('BYOK middleware validation failed; clearing unvalidated keys')
             return await call_next(request)
         finally:
             _byok_ctx.reset(token)

--- a/backend/utils/byok.py
+++ b/backend/utils/byok.py
@@ -273,10 +273,11 @@ def _validated_byok_keys(uid: str, request_keys: Dict[str, str]) -> tuple[Dict[s
     # provider fingerprint.
     stored_fingerprints = state.get('fingerprints', {})
 
-    for provider, raw_key in request_keys.items():
-        stored_fp = stored_fingerprints.get(provider)
-        if not stored_fp:
-            continue
+    validated: Dict[str, str] = {}
+    for provider, stored_fp in stored_fingerprints.items():
+        raw_key = request_keys.get(provider)
+        if not raw_key:
+            return {}, f"BYOK key header missing for enrolled provider: {provider}"
         request_fp = hashlib.sha256(raw_key.encode()).hexdigest()
         # Accept either the current peppered form or the legacy plain form,
         # so users enrolled before BYOK_FINGERPRINT_PEPPER was set aren't
@@ -286,12 +287,9 @@ def _validated_byok_keys(uid: str, request_keys: Dict[str, str]) -> tuple[Dict[s
             or hmac.compare_digest(request_fp, stored_fp)
         ):
             return {}, f"BYOK key fingerprint mismatch for provider: {provider}"
+        validated[provider] = raw_key
 
-    # A header for a provider the user never enrolled has no stored fingerprint, so the
-    # loop above never sees it and it would reach the provider clients unvalidated. Drop
-    # it, mirroring the non-enrolled-user path above: anything we cannot verify must not
-    # be used, and downstream falls back to Omi's own key for that provider.
-    return {p: key for p, key in request_keys.items() if stored_fingerprints.get(p)}, None
+    return validated, None
 
 
 def _check_byok_validity(uid: str) -> Optional[str]:

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -63,7 +63,7 @@ from utils.observability.fallback import record_fallback
 from utils.product_telemetry import emit_product_event
 from utils.task_intelligence.workstream_association import associate_canonical_evidence
 from utils.subscription import is_trial_paywalled, should_defer_desktop_processing
-from utils.subscription import _request_has_llm_byok_key
+from utils.subscription import request_has_llm_byok_key
 from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from models.other import Person
 from models.structured import Structured  # type: ignore[reportAttributeAccessIssue]  # SDK/fallback export is runtime-complete.
@@ -1849,7 +1849,7 @@ def process_conversation(
     if uses_custom_stt:
         # Deferred: users_db.is_byok_active does an uncached Firestore read, so
         # it only runs for custom-STT conversations, not every finalization.
-        has_llm_byok_key = bool(users_db.is_byok_active(uid) and _request_has_llm_byok_key())
+        has_llm_byok_key = bool(users_db.is_byok_active(uid) and request_has_llm_byok_key())
     else:
         has_llm_byok_key = False
     if uses_custom_stt and should_skip_custom_stt_postprocessing(

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -63,7 +63,7 @@ from utils.observability.fallback import record_fallback
 from utils.product_telemetry import emit_product_event
 from utils.task_intelligence.workstream_association import associate_canonical_evidence
 from utils.subscription import is_trial_paywalled, should_defer_desktop_processing
-from utils.byok import get_byok_key
+from utils.subscription import _request_has_llm_byok_key
 from utils.transcribe_decisions import should_skip_custom_stt_postprocessing
 from models.other import Person
 from models.structured import Structured  # type: ignore[reportAttributeAccessIssue]  # SDK/fallback export is runtime-complete.
@@ -1849,7 +1849,7 @@ def process_conversation(
     if uses_custom_stt:
         # Deferred: users_db.is_byok_active does an uncached Firestore read, so
         # it only runs for custom-STT conversations, not every finalization.
-        has_llm_byok_key = bool(users_db.is_byok_active(uid) and (get_byok_key('openai') or get_byok_key('anthropic')))
+        has_llm_byok_key = bool(users_db.is_byok_active(uid) and _request_has_llm_byok_key())
     else:
         has_llm_byok_key = False
     if uses_custom_stt and should_skip_custom_stt_postprocessing(

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -535,8 +535,15 @@ def get_llm(
             get_active_profile_name(),
         )
 
+    preferred_openrouter_key = get_byok_key('openrouter')
+    preferred_openrouter = bool(preferred_openrouter_key)
     byok_profile = get_byok_profile()
-    if byok_profile:
+    if preferred_openrouter_key:
+        model = _byok_fallback_model('openrouter')
+        provider = 'openrouter'
+        byok_provider = 'openrouter'
+        byok_key = preferred_openrouter_key
+    elif byok_profile:
         profile_model, profile_provider = byok_profile.get(feature, (model, provider))
         profile_key = get_byok_key(_effective_byok_provider(profile_model, profile_provider))
         if profile_key:
@@ -567,7 +574,7 @@ def get_llm(
                 )
                 break
 
-    if byok_key and byok_profile:
+    if byok_key and byok_profile and not preferred_openrouter:
         byok_model, byok_prov = byok_profile.get(feature, (model, provider))
         byok_prov_eff = _effective_byok_provider(byok_model, byok_prov)
         byok_key_for_profile = get_byok_key(byok_prov_eff)

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -507,6 +507,13 @@ def get_llm(
         )
 
     model, provider = _get_model_config(feature)
+    # The feature lane (feature_auto_lane_id) is pinned to the feature's
+    # resolved provider. When BYOK selection below switches providers, the
+    # gateway lane for this feature still routes to the original provider, so a
+    # provider-switched BYOK request must bypass the fixed lane and use the
+    # direct client — the gateway would otherwise reject the forwarded key
+    # with missing_byok_key. Keep the pre-selection provider to detect the switch.
+    lane_provider = _effective_byok_provider(model, provider)
 
     if provider == 'anthropic' and not gateway_feature_mode:
         raise ValueError(
@@ -566,10 +573,11 @@ def get_llm(
             model, provider = byok_model, byok_prov
             byok_key = byok_key_for_profile
 
-    if byok_key and gateway_feature_mode:
+    effective_provider = _effective_byok_provider(model, provider)
+    if byok_key and gateway_feature_mode and effective_provider == lane_provider:
         result = get_or_create_omi_gateway_llm_for_byok(
             feature_auto_lane_id(feature),
-            provider=_effective_byok_provider(model, provider),
+            provider=effective_provider,
             api_key=byok_key,
             streaming=streaming,
             feature=feature,
@@ -654,6 +662,7 @@ def get_qos_info() -> Dict[str, Dict[str, str]]:
     all_features = get_all_configured_features()
     for feature in sorted(all_features):
         model, provider = _get_model_config(feature)
+
         info[feature] = {
             'model': model,
             'profile': get_active_profile_name(),

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -25,6 +25,7 @@ import tiktoken
 from models.structured_extraction import StructuredExtraction
 from utils.byok import get_byok_key
 from utils.llm.byok_errors import handle_llm_error
+from utils.observability.fallback import record_fallback
 from utils.llm.model_config import (
     MODEL_QOS_PROFILES,
     _ANTHROPIC_ONLY_FEATURES,
@@ -432,10 +433,16 @@ def get_openai_chat(model: str, **kwargs) -> ChatOpenAI:
 
 
 def _effective_byok_provider(model: str, provider: str) -> str:
-    """Map provider to the actual BYOK key type needed (Gemini-based OpenRouter → Gemini key)."""
-    if provider == 'openrouter' and model.startswith('gemini'):
-        return 'gemini'
+    """Return the credential provider required by the resolved route."""
     return provider
+
+
+def _byok_fallback_model(provider: str) -> str:
+    if provider == 'openai':
+        return 'gpt-4o-mini'
+    if provider in {'gemini', 'openrouter'}:
+        return 'gemini-2.5-flash-lite'
+    return ''
 
 
 # Compatibility wrappers for tests and legacy imports. New provider construction
@@ -500,25 +507,37 @@ def get_llm(
             get_active_profile_name(),
         )
 
-    byok_key = get_byok_key('openrouter')
-    if byok_key:
-        provider = 'openrouter'
-        byok_provider = 'openrouter'
-        model = 'gemini-2.5-flash-lite'
+    byok_profile = get_byok_profile()
+    if byok_profile:
+        profile_model, profile_provider = byok_profile.get(feature, (model, provider))
+        profile_key = get_byok_key(_effective_byok_provider(profile_model, profile_provider))
+        if profile_key:
+            model, provider, byok_key = profile_model, profile_provider, profile_key
+            byok_provider = _effective_byok_provider(model, provider)
+        else:
+            byok_provider = _effective_byok_provider(model, provider)
+            byok_key = get_byok_key(byok_provider)
     else:
         byok_provider = _effective_byok_provider(model, provider)
         byok_key = get_byok_key(byok_provider)
     if not byok_key:
+        configured_provider = provider
         for candidate in ('openrouter', 'openai', 'gemini'):
             candidate_key = get_byok_key(candidate)
             if candidate_key:
                 provider = candidate
                 byok_provider = candidate
                 byok_key = candidate_key
-                if candidate == 'gemini' and not model.startswith('gemini'):
-                    model = 'gemini-2.5-flash-lite'
+                model = _byok_fallback_model(candidate)
+                record_fallback(
+                    component='other',
+                    from_mode=configured_provider,
+                    to_mode=candidate,
+                    reason='byok',
+                    outcome='recovered',
+                    log=logger,
+                )
                 break
-    byok_profile = get_byok_profile()
 
     if byok_key and byok_profile:
         byok_model, byok_prov = byok_profile.get(feature, (model, provider))

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -398,12 +398,15 @@ def _create_byok_client(
 
     if provider == 'openrouter':
         # Gemini-based OpenRouter models reroute to Gemini direct via BYOK
-        if model.startswith('gemini'):
-            route_options = get_route_options(feature, model, provider)
-            if 'temperature' in route_options:
-                kwargs['temperature'] = route_options['temperature']
-            return _cached_openai_chat(model, byok_key, {**kwargs, 'base_url': GEMINI_OPENAI_BASE_URL})
-        return None  # Non-Gemini OpenRouter: no BYOK support
+        route_options = get_route_options(feature, model, provider)
+        if 'temperature' in route_options:
+            kwargs['temperature'] = route_options['temperature']
+        routed_model = f'google/{model}' if model.startswith('gemini') else model
+        return _cached_openai_chat(
+            routed_model,
+            byok_key,
+            {**kwargs, 'base_url': 'https://openrouter.ai/api/v1', 'default_headers': {'X-Title': 'Omi Chat'}},
+        )
 
     return None
 
@@ -497,8 +500,24 @@ def get_llm(
             get_active_profile_name(),
         )
 
-    byok_provider = _effective_byok_provider(model, provider)
-    byok_key = get_byok_key(byok_provider)
+    byok_key = get_byok_key('openrouter')
+    if byok_key:
+        provider = 'openrouter'
+        byok_provider = 'openrouter'
+        model = 'gemini-2.5-flash-lite'
+    else:
+        byok_provider = _effective_byok_provider(model, provider)
+        byok_key = get_byok_key(byok_provider)
+    if not byok_key:
+        for candidate in ('openrouter', 'openai', 'gemini'):
+            candidate_key = get_byok_key(candidate)
+            if candidate_key:
+                provider = candidate
+                byok_provider = candidate
+                byok_key = candidate_key
+                if candidate == 'gemini' and not model.startswith('gemini'):
+                    model = 'gemini-2.5-flash-lite'
+                break
     byok_profile = get_byok_profile()
 
     if byok_key and byok_profile:

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 import anthropic
 import httpx
 from cachetools import TTLCache
+from langchain_anthropic import ChatAnthropic
 
 try:
     from langchain_core.callbacks import BaseCallbackHandler
@@ -352,6 +353,7 @@ _BYOK_CACHE_TTL_SECONDS = 3600  # 1 hour
 
 _openai_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
 _anthropic_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
+_anthropic_chat_cache: TTLCache = TTLCache(maxsize=_BYOK_CACHE_MAX_SIZE, ttl=_BYOK_CACHE_TTL_SECONDS)
 
 
 def _hash_key(api_key: str) -> str:
@@ -377,9 +379,18 @@ def _cached_anthropic(api_key: str) -> anthropic.AsyncAnthropic:
     return inst
 
 
+def _cached_anthropic_chat(model: str, api_key: str, ctor_kwargs: Dict[str, Any]) -> ChatAnthropic:
+    cache_key = f"{model}:{_hash_key(api_key)}:{hash(frozenset((k, repr(v)) for k, v in ctor_kwargs.items()))}"
+    inst = _anthropic_chat_cache.get(cache_key)
+    if inst is None:
+        inst = ChatAnthropic(model=model, api_key=api_key, **ctor_kwargs)
+        _anthropic_chat_cache[cache_key] = inst
+    return inst
+
+
 def _create_byok_client(
     model: str, provider: str, byok_key: str, streaming: bool = False, feature: str = ''
-) -> Optional[ChatOpenAI]:
+) -> Optional[BaseChatModel]:
     """Create a ChatOpenAI using the user's BYOK key. Returns None if BYOK not supported for this provider."""
     callback_provider = _effective_byok_provider(model, provider)
     kwargs: Dict[str, Any] = _with_llm_callbacks(
@@ -408,6 +419,11 @@ def _create_byok_client(
             byok_key,
             {**kwargs, 'base_url': 'https://openrouter.ai/api/v1', 'default_headers': {'X-Title': 'Omi Chat'}},
         )
+
+    if provider == 'anthropic':
+        anthropic_kwargs = dict(kwargs)
+        anthropic_kwargs['timeout'] = anthropic_kwargs.pop('request_timeout')
+        return _cached_anthropic_chat(model, byok_key, anthropic_kwargs)
 
     return None
 
@@ -442,6 +458,8 @@ def _byok_fallback_model(provider: str) -> str:
         return 'gpt-4o-mini'
     if provider in {'gemini', 'openrouter'}:
         return 'gemini-2.5-flash-lite'
+    if provider == 'anthropic':
+        return 'claude-sonnet-4-6'
     return ''
 
 
@@ -522,7 +540,7 @@ def get_llm(
         byok_key = get_byok_key(byok_provider)
     if not byok_key:
         configured_provider = provider
-        for candidate in ('openrouter', 'openai', 'gemini'):
+        for candidate in ('openrouter', 'openai', 'gemini', 'anthropic'):
             candidate_key = get_byok_key(candidate)
             if candidate_key:
                 provider = candidate

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -423,6 +423,9 @@ def _create_byok_client(
     if provider == 'anthropic':
         anthropic_kwargs = dict(kwargs)
         anthropic_kwargs['timeout'] = anthropic_kwargs.pop('request_timeout')
+        # stream_options is an OpenAI-only transport knob; ChatAnthropic would
+        # silently forward it into model_kwargs, so strip it before construction.
+        anthropic_kwargs.pop('stream_options', None)
         return _cached_anthropic_chat(model, byok_key, anthropic_kwargs)
 
     return None

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -551,12 +551,15 @@ def get_llm(
         byok_key = get_byok_key(byok_provider)
 
     if not byok_key:
-        preferred_openrouter_key = get_byok_key('openrouter')
-        if preferred_openrouter_key:
-            model = _byok_fallback_model('openrouter')
-            provider = 'openrouter'
-            byok_provider = 'openrouter'
-            byok_key = preferred_openrouter_key
+        # Gemini and Anthropic have direct BYOK clients — do not override
+        feature_has_direct_byok = byok_provider in ('gemini', 'anthropic')
+        if not feature_has_direct_byok:
+            preferred_openrouter_key = get_byok_key('openrouter')
+            if preferred_openrouter_key:
+                model = _byok_fallback_model('openrouter')
+                provider = 'openrouter'
+                byok_provider = 'openrouter'
+                byok_key = preferred_openrouter_key
 
     if not byok_key:
         configured_provider = provider

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -587,7 +587,10 @@ def get_llm(
             byok_key = byok_key_for_profile
 
     effective_provider = _effective_byok_provider(model, provider)
-    if byok_key and gateway_feature_mode and effective_provider == lane_provider:
+    # VertexGeminiProvider._reject_byok() — Gemini BYOK must use the direct
+    # OpenAI-compatible client, not the gateway lane.
+    gateway_accepts_byok = effective_provider != "gemini"
+    if byok_key and gateway_feature_mode and effective_provider == lane_provider and gateway_accepts_byok:
         result = get_or_create_omi_gateway_llm_for_byok(
             feature_auto_lane_id(feature),
             provider=effective_provider,

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -535,26 +535,29 @@ def get_llm(
             get_active_profile_name(),
         )
 
-    preferred_openrouter_key = get_byok_key('openrouter')
-    preferred_openrouter = bool(preferred_openrouter_key)
     byok_profile = get_byok_profile()
-    if preferred_openrouter_key:
-        model = _byok_fallback_model('openrouter')
-        provider = 'openrouter'
-        byok_provider = 'openrouter'
-        byok_key = preferred_openrouter_key
-    elif byok_profile:
+    byok_key = None
+    byok_provider = _effective_byok_provider(model, provider)
+
+    if byok_profile:
         profile_model, profile_provider = byok_profile.get(feature, (model, provider))
         profile_key = get_byok_key(_effective_byok_provider(profile_model, profile_provider))
         if profile_key:
             model, provider, byok_key = profile_model, profile_provider, profile_key
             byok_provider = _effective_byok_provider(model, provider)
         else:
-            byok_provider = _effective_byok_provider(model, provider)
             byok_key = get_byok_key(byok_provider)
     else:
-        byok_provider = _effective_byok_provider(model, provider)
         byok_key = get_byok_key(byok_provider)
+
+    if not byok_key:
+        preferred_openrouter_key = get_byok_key('openrouter')
+        if preferred_openrouter_key:
+            model = _byok_fallback_model('openrouter')
+            provider = 'openrouter'
+            byok_provider = 'openrouter'
+            byok_key = preferred_openrouter_key
+
     if not byok_key:
         configured_provider = provider
         for candidate in ('openrouter', 'openai', 'gemini', 'anthropic'):
@@ -574,7 +577,7 @@ def get_llm(
                 )
                 break
 
-    if byok_key and byok_profile and not preferred_openrouter:
+    if byok_key and byok_profile:
         byok_model, byok_prov = byok_profile.get(feature, (model, provider))
         byok_prov_eff = _effective_byok_provider(byok_model, byok_prov)
         byok_key_for_profile = get_byok_key(byok_prov_eff)

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -23,7 +23,13 @@ from utils.account_cutover.access import (
 )
 from utils.api_key_families import FIREBASE_FAMILY, wrong_key_family_detail
 from utils.client_device import resolve_client_device
-from utils.byok import extract_byok_from_websocket, set_byok_keys, validate_byok_request, validate_byok_websocket
+from utils.byok import (
+    extract_byok_from_websocket,
+    set_byok_keys,
+    set_validated_byok_keys,
+    validate_byok_request,
+    validate_byok_websocket_keys,
+)
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.rate_limit_config import RATE_POLICIES, RATE_LIMIT_SHADOW, get_effective_limit
 
@@ -358,12 +364,12 @@ async def get_current_user_uid_ws_listen(
 
     # Extract BYOK headers from the WS upgrade request and validate.
     if websocket is not None:  # pyright: ignore[reportUnnecessaryComparison]  # websocket is None outside WS context
-        byok_keys = extract_byok_from_websocket(websocket)
-        if byok_keys:
-            set_byok_keys(byok_keys)
-        error = await run_blocking(critical_executor, validate_byok_websocket, uid)
+        validated_byok_keys, error = await run_blocking(
+            critical_executor, validate_byok_websocket_keys, uid, extract_byok_from_websocket(websocket)
+        )
         if error:
             raise WebSocketException(code=4003, reason=error)
+        set_validated_byok_keys(validated_byok_keys, uid)
 
     return uid
 

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -25,7 +25,6 @@ from utils.api_key_families import FIREBASE_FAMILY, wrong_key_family_detail
 from utils.client_device import resolve_client_device
 from utils.byok import (
     extract_byok_from_websocket,
-    set_byok_keys,
     set_validated_byok_keys,
     validate_byok_request,
     validate_byok_websocket_keys,

--- a/backend/utils/pusher_finalization.py
+++ b/backend/utils/pusher_finalization.py
@@ -7,7 +7,7 @@ from fastapi.websockets import WebSocket, WebSocketDisconnect
 
 from database import conversation_finalization_jobs as finalization_jobs_db
 from services.conversation_finalization import final_attempt_failed
-from utils.byok import set_byok_keys, set_byok_uid
+from utils.byok import set_validated_byok_keys
 from utils.cloud_tasks import get_listen_finalization_tasks_max_attempts
 from utils.conversations import lifecycle as lifecycle_service
 from utils.conversations.finalizer import (
@@ -41,8 +41,9 @@ async def process_conversation_task(
     provider keys instead of Omi's env keys.
     """
     if byok_keys:
-        set_byok_keys(byok_keys)
-        set_byok_uid(uid)
+        # Listen already validated these against enrollment; mark them validated
+        # so process_conversation can reuse _request_has_llm_byok_key().
+        set_validated_byok_keys(byok_keys, uid)
 
     async def send_result(result: Dict[str, Any]) -> None:
         """Attempt the optional live acknowledgement after durable work.

--- a/backend/utils/pusher_finalization.py
+++ b/backend/utils/pusher_finalization.py
@@ -42,7 +42,7 @@ async def process_conversation_task(
     """
     if byok_keys:
         # Listen already validated these against enrollment; mark them validated
-        # so process_conversation can reuse _request_has_llm_byok_key().
+        # so process_conversation can reuse request_has_llm_byok_key().
         set_validated_byok_keys(byok_keys, uid)
 
     async def send_result(result: Dict[str, Any]) -> None:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -360,6 +360,7 @@ def is_trial_paywalled(
 
 def clear_trial_paywall_cache(uid: str) -> None:
     redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}:gemini")
+    redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}:openai")
     redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}")
 
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1044,7 +1044,13 @@ def get_chat_quota_snapshot(
     # Paywall test override — surface as exhausted Free-plan quota so the
     # client renders the same over-limit popup it shows for normal users
     # past 30/mo.
-    if is_trial_paywalled(uid, platform, firestore_client=firestore_client, provision=provision):
+    if is_trial_paywalled(
+        uid,
+        platform,
+        firestore_client=firestore_client,
+        provision=provision,
+        required_byok_provider=required_llm_provider,
+    ):
         usage = user_usage_db.get_monthly_chat_usage(uid, firestore_client=firestore_client)
         free_chat_limit = _effective_chat_limit(PlanType.basic)
         if free_chat_limit is None:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -224,13 +224,13 @@ def _request_has_llm_byok_key() -> bool:
 
 
 def _request_has_all_byok_keys() -> bool:
-    """True if the *current request* carries headers for all 4 enrolled BYOK
-    providers.
+    """True if the *current request* carries headers for every enrolled BYOK
+    provider.
 
     Firestore BYOK state is the source of truth for fingerprint validation,
     but it can be temporarily stale — heartbeat just expired, activation
     POST hasn't landed yet, cross-region read replica lag, etc. A user who is
-    literally sending all 4 valid API keys on this request should never be
+    literally sending all valid API keys on this request should never be
     paywalled because of a Firestore sync gap. The actual fingerprint check
     in `utils.byok._check_byok_validity` runs separately and still rejects
     forged headers (mismatched SHA-256 against the enrolled fingerprints) —

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -212,32 +212,11 @@ _TRIAL_PAYWALL_DESKTOP_TOKENS = DESKTOP_PLATFORMS | {"desktop"}
 # so chat-quota polling doesn't fan out to Firebase on every request.
 _TRIAL_PAYWALL_CACHE_TTL_SECONDS = 300
 
-# Providers a fully-enrolled BYOK desktop client always sends headers for.
-# Used by the request-level escape hatch in `_is_trial_expired_cached`.
-_BYOK_REQUIRED_PROVIDERS = ("openai", "anthropic", "gemini", "deepgram")
-
 
 def _request_has_llm_byok_key() -> bool:
     return has_validated_byok_keys() and any(
         get_byok_keys().get(provider) for provider in ('openrouter', 'openai', 'anthropic', 'gemini')
     )
-
-
-def _request_has_all_byok_keys() -> bool:
-    """True if the *current request* carries headers for all 4 enrolled BYOK
-    providers.
-
-    Firestore BYOK state is the source of truth for fingerprint validation,
-    but it can be temporarily stale — heartbeat just expired, activation
-    POST hasn't landed yet, cross-region read replica lag, etc. A user who is
-    literally sending all 4 valid API keys on this request should never be
-    paywalled because of a Firestore sync gap. The actual fingerprint check
-    in `utils.byok._check_byok_validity` runs separately and still rejects
-    forged headers (mismatched SHA-256 against the enrolled fingerprints) —
-    we trust the headers' *presence* here, not their *contents*.
-    """
-    keys = get_byok_keys()
-    return all(p in keys and keys[p] for p in _BYOK_REQUIRED_PROVIDERS)
 
 
 def _is_trial_expired_uncached(uid: str, *, firestore_client: Any | None = None, provision: bool = True) -> bool:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -25,7 +25,7 @@ from config.plan_catalog import (
     resolve_stripe_price_plan,
 )
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits, TrialMetadata
-from utils.byok import get_byok_key, get_byok_keys, has_validated_byok_keys
+from utils.byok import get_byok_key, get_byok_keys, get_byok_uid, get_cached_byok_state, has_validated_byok_keys
 from utils.log_sanitizer import sanitize
 from utils.observability.fallback import record_fallback
 import logging
@@ -214,9 +214,20 @@ _TRIAL_PAYWALL_CACHE_TTL_SECONDS = 300
 
 
 def request_has_llm_byok_key() -> bool:
-    """Validated request has an enrolled LLM BYOK key (not Deepgram-only)."""
-    return has_validated_byok_keys() and any(
-        get_byok_keys().get(provider) for provider in ('openrouter', 'openai', 'anthropic', 'gemini')
+    """True when request carries validated LLM BYOK keys matching active enrollment."""
+    uid = get_byok_uid()
+    if not uid or not has_validated_byok_keys():
+        return False
+    try:
+        fingerprints = get_cached_byok_state(uid).get('fingerprints', {})
+    except Exception:
+        return any(
+            get_byok_key(provider)
+            for provider in ('openrouter', 'openai', 'anthropic', 'gemini')
+        )
+    return any(
+        provider in fingerprints and bool(get_byok_key(provider))
+        for provider in ('openrouter', 'openai', 'anthropic', 'gemini')
     )
 
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -224,13 +224,13 @@ def _request_has_llm_byok_key() -> bool:
 
 
 def _request_has_all_byok_keys() -> bool:
-    """True if the *current request* carries headers for every enrolled BYOK
-    provider.
+    """True if the *current request* carries headers for all 4 enrolled BYOK
+    providers.
 
     Firestore BYOK state is the source of truth for fingerprint validation,
     but it can be temporarily stale — heartbeat just expired, activation
     POST hasn't landed yet, cross-region read replica lag, etc. A user who is
-    literally sending all valid API keys on this request should never be
+    literally sending all 4 valid API keys on this request should never be
     paywalled because of a Firestore sync gap. The actual fingerprint check
     in `utils.byok._check_byok_validity` runs separately and still rejects
     forged headers (mismatched SHA-256 against the enrolled fingerprints) —
@@ -267,9 +267,9 @@ def _is_trial_expired_uncached(uid: str, *, firestore_client: Any | None = None,
 
 
 def _is_trial_expired_cached(uid: str, *, firestore_client: Any | None = None, provision: bool = True) -> bool:
-    # Request-level escape hatch: a request carrying all 4 BYOK provider
-    # headers is never paywalled, regardless of cached Firestore state. The
-    # cache TTL is 5 min and Firestore's BYOK `is_active` heartbeat is 24 h,
+    # Request-level escape hatch: a request carrying an enrolled LLM BYOK
+    # provider header is never paywalled, regardless of cached Firestore state.
+    # The cache TTL is 5 min and Firestore's BYOK `is_active` heartbeat is 24 h,
     # so even a perfectly-configured BYOK user can transiently look stale to
     # Firestore. Trust the live request.
     if _request_has_llm_byok_key():
@@ -375,12 +375,12 @@ def get_trial_metadata(uid: str) -> TrialMetadata:
         # BYOK users, has usable Desktop access. In particular, Neo's Free
         # Desktop tier is a floor, not a trial-only or zero-access state.
         # Same request-level escape hatch as `_is_trial_expired_cached`: a request
-        # carrying all 4 BYOK provider headers is treated as BYOK-active even if
-        # Firestore hasn't caught up yet.
+        # carrying an enrolled LLM BYOK provider header is treated as BYOK-active
+        # even if Firestore hasn't caught up yet.
         if (
             not desktop_trial_paywall_eligible(plan, subscription)
             or users_db.is_byok_active(uid)
-            or _request_has_all_byok_keys()
+            or _request_has_llm_byok_key()
         ):
             return TrialMetadata(
                 trial_expired=False,

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -359,8 +359,8 @@ def is_trial_paywalled(
 
 
 def clear_trial_paywall_cache(uid: str) -> None:
-    redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}:gemini")
-    redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}:openai")
+    for provider in ("openrouter", "openai", "anthropic", "gemini"):
+        redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}:{provider}")
     redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}")
 
 
@@ -1095,6 +1095,7 @@ def enforce_chat_quota(
     *,
     firestore_client: Any | None = None,
     provision: bool = True,
+    required_llm_provider: str | None = None,
 ) -> None:
     """Block or allow a chat request based on the user's plan + usage.
 
@@ -1135,7 +1136,10 @@ def enforce_chat_quota(
     # Require an LLM provider key on this request (not just any BYOK header)
     # so a user can't activate with fake fingerprints or send only x-byok-deepgram
     # to bypass chat quota while chat falls back to Omi's OpenAI/Anthropic keys.
-    if users_db.is_byok_active(uid, firestore_client=firestore_client) and _request_has_llm_byok_key():
+    has_exempt_llm = (
+        _request_has_byok_provider(required_llm_provider) if required_llm_provider else _request_has_llm_byok_key()
+    )
+    if users_db.is_byok_active(uid, firestore_client=firestore_client) and has_exempt_llm:
         return
 
     snapshot = get_chat_quota_snapshot(uid, platform=platform, firestore_client=firestore_client, provision=provision)
@@ -1168,11 +1172,15 @@ def enforce_desktop_chat_quota(uid: str, platform: Optional[str] = None) -> None
     Development desktop-backend ADC stays on the compute project for ``agentVm``.
     Entitlements read the customer SA (``SERVICE_ACCOUNT_JSON`` or the Auth file).
     """
+    # Desktop agent chat only consumes Anthropic. An OpenRouter/Gemini/OpenAI
+    # key must not exempt this path while the request still uses Omi's managed
+    # Anthropic credential.
     enforce_chat_quota(
         uid,
         platform,
         firestore_client=get_customer_firestore_client(),
         provision=False,
+        required_llm_provider='anthropic',
     )
 
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -213,10 +213,14 @@ _TRIAL_PAYWALL_DESKTOP_TOKENS = DESKTOP_PLATFORMS | {"desktop"}
 _TRIAL_PAYWALL_CACHE_TTL_SECONDS = 300
 
 
-def _request_has_llm_byok_key() -> bool:
+def request_has_llm_byok_key() -> bool:
+    """Validated request has an enrolled LLM BYOK key (not Deepgram-only)."""
     return has_validated_byok_keys() and any(
         get_byok_keys().get(provider) for provider in ('openrouter', 'openai', 'anthropic', 'gemini')
     )
+
+
+_request_has_llm_byok_key = request_has_llm_byok_key
 
 
 def _request_has_byok_provider(provider: str) -> bool:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -218,7 +218,9 @@ _BYOK_REQUIRED_PROVIDERS = ("openai", "anthropic", "gemini", "deepgram")
 
 
 def _request_has_llm_byok_key() -> bool:
-    return has_validated_byok_keys()
+    return has_validated_byok_keys() and any(
+        get_byok_keys().get(provider) for provider in ('openrouter', 'openai', 'anthropic', 'gemini')
+    )
 
 
 def _request_has_all_byok_keys() -> bool:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -217,6 +217,11 @@ _TRIAL_PAYWALL_CACHE_TTL_SECONDS = 300
 _BYOK_REQUIRED_PROVIDERS = ("openai", "anthropic", "gemini", "deepgram")
 
 
+def _request_has_llm_byok_key() -> bool:
+    keys = get_byok_keys()
+    return any(keys.get(provider) for provider in ('openrouter', 'openai', 'gemini', 'anthropic'))
+
+
 def _request_has_all_byok_keys() -> bool:
     """True if the *current request* carries headers for all 4 enrolled BYOK
     providers.
@@ -266,7 +271,7 @@ def _is_trial_expired_cached(uid: str, *, firestore_client: Any | None = None, p
     # cache TTL is 5 min and Firestore's BYOK `is_active` heartbeat is 24 h,
     # so even a perfectly-configured BYOK user can transiently look stale to
     # Firestore. Trust the live request.
-    if _request_has_all_byok_keys():
+    if _request_has_llm_byok_key():
         return False
 
     cache_key = f"trial_paywall:expired:{uid}"
@@ -1111,9 +1116,7 @@ def enforce_chat_quota(
     # Require an LLM provider key on this request (not just any BYOK header)
     # so a user can't activate with fake fingerprints or send only x-byok-deepgram
     # to bypass chat quota while chat falls back to Omi's OpenAI/Anthropic keys.
-    if users_db.is_byok_active(uid, firestore_client=firestore_client) and (
-        get_byok_key('openai') or get_byok_key('anthropic')
-    ):
+    if users_db.is_byok_active(uid, firestore_client=firestore_client) and _request_has_llm_byok_key():
         return
 
     snapshot = get_chat_quota_snapshot(uid, platform=platform, firestore_client=firestore_client, provision=provision)

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -249,7 +249,11 @@ def _is_trial_expired_uncached(
         if not desktop_trial_paywall_eligible(plan, subscription):
             return False
         if users_db.is_byok_active(uid, firestore_client=firestore_client):
-            return False
+            if not required_byok_provider:
+                return False
+            fingerprints = users_db.get_byok_state(uid, firestore_client=firestore_client).get('fingerprints')
+            if isinstance(fingerprints, dict) and fingerprints.get(required_byok_provider):
+                return False
         user_record = _get_user(uid)
         creation_ms: int = cast(int, user_record.user_metadata.creation_timestamp)
         if not creation_ms:
@@ -1033,6 +1037,7 @@ def get_chat_quota_snapshot(
     *,
     firestore_client: Any | None = None,
     provision: bool = True,
+    required_llm_provider: str | None = None,
 ) -> Dict[str, Any]:
     """Cheap computation of `is_allowed / used / limit / unit / plan` — shared
     between the `/v1/users/me/usage-quota` endpoint and the enforcement helper.
@@ -1121,9 +1126,19 @@ def enforce_chat_quota(
     # Paywall test override — bypass BYOK + plan checks so the same 402
     # surfaces that a free user past 30 questions would hit. Desktop only;
     # mobile callers continue down the normal plan path.
-    if is_trial_paywalled(uid, platform, firestore_client=firestore_client, provision=provision):
+    if is_trial_paywalled(
+        uid,
+        platform,
+        firestore_client=firestore_client,
+        provision=provision,
+        required_byok_provider=required_llm_provider,
+    ):
         snapshot = get_chat_quota_snapshot(
-            uid, platform=platform, firestore_client=firestore_client, provision=provision
+            uid,
+            platform=platform,
+            firestore_client=firestore_client,
+            provision=provision,
+            required_llm_provider=required_llm_provider,
         )
         raise HTTPException(
             status_code=402,
@@ -1148,7 +1163,13 @@ def enforce_chat_quota(
     if users_db.is_byok_active(uid, firestore_client=firestore_client) and has_exempt_llm:
         return
 
-    snapshot = get_chat_quota_snapshot(uid, platform=platform, firestore_client=firestore_client, provision=provision)
+    snapshot = get_chat_quota_snapshot(
+        uid,
+        platform=platform,
+        firestore_client=firestore_client,
+        provision=provision,
+        required_llm_provider=required_llm_provider,
+    )
     if snapshot['allowed']:
         return
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -219,7 +219,17 @@ def _request_has_llm_byok_key() -> bool:
     )
 
 
-def _is_trial_expired_uncached(uid: str, *, firestore_client: Any | None = None, provision: bool = True) -> bool:
+def _request_has_byok_provider(provider: str) -> bool:
+    return has_validated_byok_keys() and bool(get_byok_key(provider))
+
+
+def _is_trial_expired_uncached(
+    uid: str,
+    *,
+    firestore_client: Any | None = None,
+    provision: bool = True,
+    required_byok_provider: str | None = None,
+) -> bool:
     """Is this user past their 3-day desktop trial?
 
     The trial applies only to the Free Desktop tier. Neo may use that tier for
@@ -228,6 +238,8 @@ def _is_trial_expired_uncached(uid: str, *, firestore_client: Any | None = None,
     a Firebase blip never paywalls a paying user.
     """
     try:
+        if required_byok_provider and _request_has_byok_provider(required_byok_provider):
+            return False
         subscription = users_db.get_user_valid_subscription(uid, firestore_client=firestore_client, provision=provision)
         plan = subscription.plan if subscription else PlanType.basic
         if not desktop_trial_paywall_eligible(plan, subscription):
@@ -245,16 +257,29 @@ def _is_trial_expired_uncached(uid: str, *, firestore_client: Any | None = None,
         return False
 
 
-def _is_trial_expired_cached(uid: str, *, firestore_client: Any | None = None, provision: bool = True) -> bool:
+def _is_trial_expired_cached(
+    uid: str,
+    *,
+    firestore_client: Any | None = None,
+    provision: bool = True,
+    required_byok_provider: str | None = None,
+) -> bool:
     # Request-level escape hatch: a request carrying an enrolled LLM BYOK
     # provider header is never paywalled, regardless of cached Firestore state.
     # The cache TTL is 5 min and Firestore's BYOK `is_active` heartbeat is 24 h,
     # so even a perfectly-configured BYOK user can transiently look stale to
     # Firestore. Trust the live request.
-    if _request_has_llm_byok_key():
+    if required_byok_provider:
+        if _request_has_byok_provider(required_byok_provider):
+            return False
+    elif _request_has_llm_byok_key():
         return False
 
-    cache_key = f"trial_paywall:expired:{uid}"
+    cache_key = (
+        f"trial_paywall:expired:{uid}:{required_byok_provider}"
+        if required_byok_provider
+        else f"trial_paywall:expired:{uid}"
+    )
     cached = redis_db.get_generic_cache(cache_key)
     if cached is not None:
         # A cache entry may have been written before an entitlement correction
@@ -292,7 +317,12 @@ def _is_trial_expired_cached(uid: str, *, firestore_client: Any | None = None, p
                 )
                 return False
         return bool(cached)
-    expired = _is_trial_expired_uncached(uid, firestore_client=firestore_client, provision=provision)
+    expired = _is_trial_expired_uncached(
+        uid,
+        firestore_client=firestore_client,
+        provision=provision,
+        required_byok_provider=required_byok_provider,
+    )
     try:
         redis_db.set_generic_cache(cache_key, expired, ttl=_TRIAL_PAYWALL_CACHE_TTL_SECONDS)
     except Exception as e:
@@ -306,6 +336,7 @@ def is_trial_paywalled(
     *,
     firestore_client: Any | None = None,
     provision: bool = True,
+    required_byok_provider: str | None = None,
 ) -> bool:
     """True iff the request is from a desktop client AND the user has used
     their full 3-day free trial without subscribing or activating BYOK.
@@ -318,10 +349,13 @@ def is_trial_paywalled(
         return False  # trial paywall disabled — never block on account age
     if not platform or platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS:
         return False
-    return _is_trial_expired_cached(uid, firestore_client=firestore_client, provision=provision)
+    return _is_trial_expired_cached(
+        uid, firestore_client=firestore_client, provision=provision, required_byok_provider=required_byok_provider
+    )
 
 
 def clear_trial_paywall_cache(uid: str) -> None:
+    redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}:gemini")
     redis_db.delete_generic_cache(f"trial_paywall:expired:{uid}")
 
 
@@ -1137,7 +1171,7 @@ def enforce_desktop_chat_quota(uid: str, platform: Optional[str] = None) -> None
     )
 
 
-def is_desktop_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
+def is_desktop_trial_paywalled(uid: str, platform: Optional[str], *, required_byok_provider: str | None = None) -> bool:
     """Desktop trial gate against the customer Firestore, never a compute-project shadow.
 
     The decisions that need no Firestore run first: resolving the customer client
@@ -1153,6 +1187,7 @@ def is_desktop_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
         platform,
         firestore_client=get_customer_firestore_client(),
         provision=False,
+        required_byok_provider=required_byok_provider,
     )
 
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -25,7 +25,7 @@ from config.plan_catalog import (
     resolve_stripe_price_plan,
 )
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits, TrialMetadata
-from utils.byok import get_byok_key, get_byok_keys
+from utils.byok import get_byok_key, get_byok_keys, has_validated_byok_keys
 from utils.log_sanitizer import sanitize
 from utils.observability.fallback import record_fallback
 import logging
@@ -218,8 +218,7 @@ _BYOK_REQUIRED_PROVIDERS = ("openai", "anthropic", "gemini", "deepgram")
 
 
 def _request_has_llm_byok_key() -> bool:
-    keys = get_byok_keys()
-    return any(keys.get(provider) for provider in ('openrouter', 'openai', 'gemini', 'anthropic'))
+    return has_validated_byok_keys()
 
 
 def _request_has_all_byok_keys() -> bool:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -168,7 +168,7 @@ def should_defer_desktop_processing(uid: str) -> bool:
     summaries.
     """
     try:
-        if users_db.is_byok_active(uid):
+        if users_db.is_byok_active(uid) and get_byok_key('openai'):
             return False
         subscription = users_db.get_user_valid_subscription(uid)
         plan = subscription.plan if subscription else PlanType.basic

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -237,17 +237,24 @@ final class APIKeyService: ObservableObject {
     nonEmptyStatic(UserDefaults.standard.string(forKey: provider.storageKey))
   }
 
-  /// True when the user has supplied keys for all four BYOK providers.
+  /// True when the user has supplied a selected LLM key.
   /// The subscription-bypass gate: when this is true, the user is on the free
-  /// plan and we attach their keys to every backend request.
+  /// plan and we attach their selected LLM key to every backend request.
   nonisolated static var isByokActive: Bool {
     selectedBYOKLLMProvider != nil
   }
 
   nonisolated static var selectedBYOKLLMProvider: BYOKProvider? {
-    let requested =
-      BYOKLLMProvider(rawValue: UserDefaults.standard.string(forKey: .byokLLMProvider) ?? "openrouter")
-      ?? .openrouter
+    let requested: BYOKLLMProvider
+    if let stored = UserDefaults.standard.string(forKey: .byokLLMProvider),
+      let selected = BYOKLLMProvider(rawValue: stored)
+    {
+      requested = selected
+    } else if let legacy = BYOKLLMProvider.allCases.first(where: { byokKey($0.provider) != nil }) {
+      requested = legacy
+    } else {
+      requested = .openrouter
+    }
     return byokKey(requested.provider) == nil ? nil : requested.provider
   }
 

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -16,6 +16,7 @@ import Foundation
 
 /// Keys that participate in the BYOK free-plan flow.
 enum BYOKProvider: String, CaseIterable {
+  case openrouter
   case openai
   case anthropic
   case gemini
@@ -23,6 +24,7 @@ enum BYOKProvider: String, CaseIterable {
 
   var storageKey: String {
     switch self {
+    case .openrouter: return "dev_openrouter_api_key"
     case .openai: return "dev_openai_api_key"
     case .anthropic: return "dev_anthropic_api_key"
     case .gemini: return "dev_gemini_api_key"
@@ -32,6 +34,7 @@ enum BYOKProvider: String, CaseIterable {
 
   var headerName: String {
     switch self {
+    case .openrouter: return "X-BYOK-OpenRouter"
     case .openai: return "X-BYOK-OpenAI"
     case .anthropic: return "X-BYOK-Anthropic"
     case .gemini: return "X-BYOK-Gemini"
@@ -41,10 +44,38 @@ enum BYOKProvider: String, CaseIterable {
 
   var displayName: String {
     switch self {
+    case .openrouter: return "OpenRouter"
     case .openai: return "OpenAI"
     case .anthropic: return "Anthropic"
     case .gemini: return "Gemini"
     case .deepgram: return "Deepgram"
+    }
+  }
+}
+
+enum BYOKLLMProvider: String, CaseIterable, Identifiable {
+  case openrouter
+  case openai
+  case gemini
+  case anthropic
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .openrouter: return "OpenRouter"
+    case .openai: return "OpenAI Direct"
+    case .gemini: return "Gemini"
+    case .anthropic: return "Anthropic"
+    }
+  }
+
+  var provider: BYOKProvider {
+    switch self {
+    case .openrouter: return .openrouter
+    case .openai: return .openai
+    case .gemini: return .gemini
+    case .anthropic: return .anthropic
     }
   }
 }
@@ -210,7 +241,14 @@ final class APIKeyService: ObservableObject {
   /// The subscription-bypass gate: when this is true, the user is on the free
   /// plan and we attach their keys to every backend request.
   nonisolated static var isByokActive: Bool {
-    BYOKProvider.allCases.allSatisfy { byokKey($0) != nil }
+    selectedBYOKLLMProvider != nil
+  }
+
+  nonisolated static var selectedBYOKLLMProvider: BYOKProvider? {
+    let requested =
+      BYOKLLMProvider(rawValue: UserDefaults.standard.string(forKey: .byokLLMProvider) ?? "openrouter")
+      ?? .openrouter
+    return byokKey(requested.provider) == nil ? nil : requested.provider
   }
 
   /// SHA-256 fingerprint of a key, used by the backend to detect when the
@@ -229,5 +267,16 @@ final class APIKeyService: ObservableObject {
       }
     }
     return out
+  }
+
+  nonisolated static var activeBYOKSnapshot: [BYOKProvider: (key: String, fingerprint: String)] {
+    var snapshot: [BYOKProvider: (String, String)] = [:]
+    if let provider = selectedBYOKLLMProvider, let key = byokKey(provider) {
+      snapshot[provider] = (key, byokFingerprint(key))
+    }
+    if let key = byokKey(.deepgram) {
+      snapshot[.deepgram] = (key, byokFingerprint(key))
+    }
+    return snapshot
   }
 }

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -244,6 +244,10 @@ final class APIKeyService: ObservableObject {
     selectedBYOKLLMProvider != nil
   }
 
+  nonisolated static var hasTranscriptionBYOK: Bool {
+    selectedBYOKLLMProvider != nil && byokKey(.deepgram) != nil
+  }
+
   nonisolated static var selectedBYOKLLMProvider: BYOKProvider? {
     let requested: BYOKLLMProvider
     if let stored = UserDefaults.standard.string(forKey: .byokLLMProvider),

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -290,4 +290,24 @@ final class APIKeyService: ObservableObject {
     }
     return snapshot
   }
+
+  func reconcileBYOKActivation() async {
+    guard let selectedProvider = Self.selectedBYOKLLMProvider, Self.byokKey(selectedProvider) != nil else { return }
+
+    let snapshot = Self.activeBYOKSnapshot.reduce(into: [BYOKProvider: String]()) { result, entry in
+      result[entry.key] = entry.value.key
+    }
+    let statuses = await BYOKValidator.validateAll(snapshot)
+    guard statuses[selectedProvider] == .ok else {
+      try? await APIClient.shared.deactivateBYOK()
+      return
+    }
+
+    let fingerprints = Self.activeBYOKSnapshot.reduce(into: [String: String]()) { result, entry in
+      if statuses[entry.key] == .ok {
+        result[entry.key.rawValue] = entry.value.fingerprint
+      }
+    }
+    try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+  }
 }

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -245,7 +245,28 @@ final class APIKeyService: ObservableObject {
   }
 
   nonisolated static var hasTranscriptionBYOK: Bool {
-    selectedBYOKLLMProvider != nil && byokKey(.deepgram) != nil
+    guard selectedBYOKLLMProvider != nil, let key = byokKey(.deepgram) else { return false }
+    return enrolledFingerprints()["deepgram"] == byokFingerprint(key)
+  }
+
+  /// Persist fingerprints that passed BYOKValidator and were sent to activateBYOK.
+  nonisolated static func persistEnrolledFingerprints(_ fingerprints: [String: String]) {
+    if fingerprints.isEmpty {
+      UserDefaults.standard.removeObject(forKey: DefaultsKey.byokEnrolledFingerprints.rawValue)
+    } else {
+      UserDefaults.standard.set(fingerprints, forKey: DefaultsKey.byokEnrolledFingerprints.rawValue)
+    }
+  }
+
+  nonisolated static func enrolledFingerprints() -> [String: String] {
+    UserDefaults.standard.dictionary(forKey: DefaultsKey.byokEnrolledFingerprints.rawValue) as? [String: String]
+      ?? [:]
+  }
+
+  /// Voice/realtime may use a leftover OpenAI/Gemini key only when that provider is selected.
+  nonisolated static func selectedRealtimeBYOKKey(for provider: BYOKProvider) -> String? {
+    guard selectedBYOKLLMProvider == provider else { return nil }
+    return byokKey(provider)
   }
 
   nonisolated static var selectedBYOKLLMProvider: BYOKProvider? {
@@ -300,6 +321,7 @@ final class APIKeyService: ObservableObject {
     let statuses = await BYOKValidator.validateAll(snapshot)
     guard statuses[selectedProvider] == .ok else {
       try? await APIClient.shared.deactivateBYOK()
+      persistEnrolledFingerprints([:])
       return
     }
 
@@ -309,5 +331,6 @@ final class APIKeyService: ObservableObject {
       }
     }
     try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+    persistEnrolledFingerprints(fingerprints)
   }
 }

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -250,6 +250,26 @@ final class APIKeyService: ObservableObject {
   }
 
   /// Persist fingerprints that passed BYOKValidator and were sent to activateBYOK.
+  nonisolated static func clearPersistedBYOKKeys() {
+    let defaults = UserDefaults.standard
+    for provider in BYOKProvider.allCases {
+      defaults.removeObject(forKey: provider.storageKey)
+    }
+    defaults.removeObject(forKey: DefaultsKey.byokLLMProvider.rawValue)
+    persistEnrolledFingerprints([:])
+  }
+
+  nonisolated static func bindBYOKOwner(_ uid: String?) {
+    guard let uid, !uid.isEmpty else { return }
+    let last = UserDefaults.standard.string(forKey: DefaultsKey.byokOwnerUid.rawValue)
+    if last != uid {
+      if last != nil {
+        clearPersistedBYOKKeys()
+      }
+      UserDefaults.standard.set(uid, forKey: DefaultsKey.byokOwnerUid.rawValue)
+    }
+  }
+
   nonisolated static func persistEnrolledFingerprints(_ fingerprints: [String: String]) {
     if fingerprints.isEmpty {
       UserDefaults.standard.removeObject(forKey: DefaultsKey.byokEnrolledFingerprints.rawValue)
@@ -313,6 +333,7 @@ final class APIKeyService: ObservableObject {
   }
 
   func reconcileBYOKActivation() async {
+    Self.bindBYOKOwner(UserDefaults.standard.string(forKey: .authUserId))
     guard let selectedProvider = Self.selectedBYOKLLMProvider, Self.byokKey(selectedProvider) != nil else { return }
 
     let snapshot = Self.activeBYOKSnapshot.reduce(into: [BYOKProvider: String]()) { result, entry in
@@ -330,7 +351,11 @@ final class APIKeyService: ObservableObject {
         result[entry.key.rawValue] = entry.value.fingerprint
       }
     }
-    try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
-    Self.persistEnrolledFingerprints(fingerprints)
+    do {
+      try await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+      Self.persistEnrolledFingerprints(fingerprints)
+    } catch {
+      // Leave local capability inactive when the backend never enrolled.
+    }
   }
 }

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -321,7 +321,7 @@ final class APIKeyService: ObservableObject {
     let statuses = await BYOKValidator.validateAll(snapshot)
     guard statuses[selectedProvider] == .ok else {
       try? await APIClient.shared.deactivateBYOK()
-      persistEnrolledFingerprints([:])
+      Self.persistEnrolledFingerprints([:])
       return
     }
 
@@ -331,6 +331,6 @@ final class APIKeyService: ObservableObject {
       }
     }
     try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
-    persistEnrolledFingerprints(fingerprints)
+    Self.persistEnrolledFingerprints(fingerprints)
   }
 }

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -241,7 +241,8 @@ final class APIKeyService: ObservableObject {
   /// The subscription-bypass gate: when this is true, the user is on the free
   /// plan and we attach their selected LLM key to every backend request.
   nonisolated static var isByokActive: Bool {
-    selectedBYOKLLMProvider != nil
+    guard let provider = selectedBYOKLLMProvider, let key = byokKey(provider) else { return false }
+    return enrolledFingerprints()[provider.rawValue] == byokFingerprint(key)
   }
 
   nonisolated static var hasTranscriptionBYOK: Bool {
@@ -346,9 +347,11 @@ final class APIKeyService: ObservableObject {
       return
     }
 
-    let fingerprints = Self.activeBYOKSnapshot.reduce(into: [String: String]()) { result, entry in
+    // Fingerprints must come from the captured snapshot, not a later UserDefaults
+    // edit that raced the provider check.
+    let fingerprints = snapshot.reduce(into: [String: String]()) { result, entry in
       if statuses[entry.key] == .ok {
-        result[entry.key.rawValue] = entry.value.fingerprint
+        result[entry.key.rawValue] = Self.byokFingerprint(entry.value)
       }
     }
     do {

--- a/desktop/macos/Desktop/Sources/APIKeyService.swift
+++ b/desktop/macos/Desktop/Sources/APIKeyService.swift
@@ -264,9 +264,9 @@ final class APIKeyService: ObservableObject {
     guard let uid, !uid.isEmpty else { return }
     let last = UserDefaults.standard.string(forKey: DefaultsKey.byokOwnerUid.rawValue)
     if last != uid {
-      if last != nil {
-        clearPersistedBYOKKeys()
-      }
+      // Unowned pre-upgrade keys (last == nil) are unsafe to inherit: the next
+      // signed-in account would otherwise enroll someone else's credentials.
+      clearPersistedBYOKKeys()
       UserDefaults.standard.set(uid, forKey: DefaultsKey.byokOwnerUid.rawValue)
     }
   }
@@ -333,16 +333,35 @@ final class APIKeyService: ObservableObject {
     return snapshot
   }
 
+  private static let reconcileLock = NSLock()
+  private static var reconcileGeneration: UInt64 = 0
+
+  private static func nextReconciliationGeneration() -> UInt64 {
+    reconcileLock.lock()
+    defer { reconcileLock.unlock() }
+    reconcileGeneration += 1
+    return reconcileGeneration
+  }
+
+  private static func isCurrentReconciliation(_ generation: UInt64) -> Bool {
+    reconcileLock.lock()
+    defer { reconcileLock.unlock() }
+    return reconcileGeneration == generation
+  }
+
   func reconcileBYOKActivation() async {
     Self.bindBYOKOwner(UserDefaults.standard.string(forKey: .authUserId))
     guard let selectedProvider = Self.selectedBYOKLLMProvider, Self.byokKey(selectedProvider) != nil else { return }
+    let generation = Self.nextReconciliationGeneration()
 
     let snapshot = Self.activeBYOKSnapshot.reduce(into: [BYOKProvider: String]()) { result, entry in
       result[entry.key] = entry.value.key
     }
     let statuses = await BYOKValidator.validateAll(snapshot)
+    guard Self.isCurrentReconciliation(generation) else { return }
     guard statuses[selectedProvider] == .ok else {
       try? await APIClient.shared.deactivateBYOK()
+      guard Self.isCurrentReconciliation(generation) else { return }
       Self.persistEnrolledFingerprints([:])
       return
     }
@@ -356,6 +375,7 @@ final class APIKeyService: ObservableObject {
     }
     do {
       try await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+      guard Self.isCurrentReconciliation(generation) else { return }
       Self.persistEnrolledFingerprints(fingerprints)
     } catch {
       // Leave local capability inactive when the backend never enrolled.

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -493,7 +493,7 @@ extension AppState {
       // BYOK users must never be paywalled. The backend exempts them, but a
       // heartbeat/Firestore lag can briefly let this event slip through right
       // after activation — ignore it so we don't kill a BYOK user's capture.
-      if APIKeyService.selectedBYOKLLMProvider != nil {
+      if APIKeyService.hasTranscriptionBYOK {
         log("Paywall: ignoring freemium threshold — BYOK active locally")
         if isPaywalled { isPaywalled = false }
         break

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -493,7 +493,7 @@ extension AppState {
       // BYOK users must never be paywalled. The backend exempts them, but a
       // heartbeat/Firestore lag can briefly let this event slip through right
       // after activation — ignore it so we don't kill a BYOK user's capture.
-      if APIKeyService.isByokActive {
+      if APIKeyService.selectedBYOKLLMProvider != nil {
         log("Paywall: ignoring freemium threshold — BYOK active locally")
         if isPaywalled { isPaywalled = false }
         break

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -26,7 +26,7 @@ extension AppState {
   /// the persisted `desktop_isPaywalled` flag, which can lag behind BYOK
   /// activation. Use this anywhere that only has UserDefaults access.
   nonisolated static var isPaywalledEffective: Bool {
-    !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    !APIKeyService.hasTranscriptionBYOK && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
   }
 
   /// Decision for the resume-on-paywall-clear hook in `fetchTrialMetadata()`.
@@ -52,7 +52,7 @@ extension AppState {
     // exempts the user — so the client must not block capture either, even if
     // a stale `isPaywalled` flag is still set (e.g. trial expired *before*
     // they added keys, and the backend heartbeat hasn't refreshed yet).
-    if APIKeyService.isByokActive {
+    if APIKeyService.hasTranscriptionBYOK {
       if isPaywalled { isPaywalled = false }
       return false
     }
@@ -85,7 +85,7 @@ extension AppState {
         // Local BYOK always wins — never re-block a user who has all four keys
         // configured, regardless of what the (possibly heartbeat-lagged)
         // backend trial state says.
-        if APIKeyService.isByokActive {
+        if APIKeyService.hasTranscriptionBYOK {
           if self.isPaywalled { self.isPaywalled = false }
         } else if metadata.trialExpired && !self.isPaywalled {
           self.isPaywalled = true

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -26,7 +26,7 @@ extension AppState {
   /// the persisted `desktop_isPaywalled` flag, which can lag behind BYOK
   /// activation. Use this anywhere that only has UserDefaults access.
   nonisolated static var isPaywalledEffective: Bool {
-    !APIKeyService.hasTranscriptionBYOK && UserDefaults.standard.bool(forKey: "desktop_isPaywalled")
+    !APIKeyService.hasTranscriptionBYOK && UserDefaults.standard.bool(forKey: .desktopIsPaywalled)
   }
 
   /// Decision for the resume-on-paywall-clear hook in `fetchTrialMetadata()`.

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -26,7 +26,7 @@ extension AppState {
   /// the persisted `desktop_isPaywalled` flag, which can lag behind BYOK
   /// activation. Use this anywhere that only has UserDefaults access.
   nonisolated static var isPaywalledEffective: Bool {
-    !APIKeyService.hasTranscriptionBYOK && UserDefaults.standard.bool(forKey: .desktopIsPaywalled)
+    !APIKeyService.isByokActive && UserDefaults.standard.bool(forKey: .desktopIsPaywalled)
   }
 
   /// Decision for the resume-on-paywall-clear hook in `fetchTrialMetadata()`.
@@ -52,7 +52,7 @@ extension AppState {
     // exempts the user — so the client must not block capture either, even if
     // a stale `isPaywalled` flag is still set (e.g. trial expired *before*
     // they added keys, and the backend heartbeat hasn't refreshed yet).
-    if APIKeyService.hasTranscriptionBYOK {
+    if APIKeyService.isByokActive {
       if isPaywalled { isPaywalled = false }
       return false
     }
@@ -85,7 +85,7 @@ extension AppState {
         // Local BYOK always wins — never re-block a user who has all four keys
         // configured, regardless of what the (possibly heartbeat-lagged)
         // backend trial state says.
-        if APIKeyService.hasTranscriptionBYOK {
+        if APIKeyService.isByokActive {
           if self.isPaywalled { self.isPaywalled = false }
         } else if metadata.trialExpired && !self.isPaywalled {
           self.isPaywalled = true

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -580,6 +580,7 @@ class AuthService {
       }
       loadNameFromBackendIfNeeded()
       APIKeyService.shared.startFetchingKeys()
+      Task { await APIKeyService.shared.reconcileBYOKActivation() }
       Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
     } catch AuthError.notSignedIn {
       guard sessionAttemptFence.isCurrent(attempt) else { return }
@@ -1087,6 +1088,7 @@ class AuthService {
       AnalyticsManager.shared.signInCompleted(provider: provider)
       clearOAuthFlowIfCurrent(flowId: flowId, callbackServer: callbackServer)
       APIKeyService.shared.startFetchingKeys()
+      Task { await APIKeyService.shared.reconcileBYOKActivation() }
       Task { await FloatingBarUsageLimiter.shared.fetchPlan() }
 
       // Start trial polling for the newly signed-in user

--- a/desktop/macos/Desktop/Sources/BYOKValidator.swift
+++ b/desktop/macos/Desktop/Sources/BYOKValidator.swift
@@ -23,7 +23,7 @@ enum BYOKValidator {
     switch provider {
     case .openrouter:
       return await ping(
-        url: URL(string: "https://openrouter.ai/api/v1/models")!,
+        url: URL(string: "https://openrouter.ai/api/v1/auth/key")!,
         headers: ["Authorization": "Bearer \(trimmed)"]
       )
     case .openai:

--- a/desktop/macos/Desktop/Sources/BYOKValidator.swift
+++ b/desktop/macos/Desktop/Sources/BYOKValidator.swift
@@ -21,6 +21,11 @@ enum BYOKValidator {
     guard !trimmed.isEmpty else { return .failed("Empty") }
 
     switch provider {
+    case .openrouter:
+      return await ping(
+        url: URL(string: "https://openrouter.ai/api/v1/models")!,
+        headers: ["Authorization": "Bearer \(trimmed)"]
+      )
     case .openai:
       return await ping(
         url: URL(string: "https://api.openai.com/v1/models")!,

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -2784,19 +2784,19 @@ actor AgentRuntimeProcess {
 
     var candidateValues: [String: String] = [:]
     var suppressedProviders: [BYOKProvider] = []
-    for provider in BYOKProvider.allCases {
-      guard let key = APIKeyService.byokKey(provider) else { continue }
-      let fingerprint = APIKeyService.byokFingerprint(key)
-      if CredentialHealthManager.shared.canUseBYOK(provider: provider, fingerprint: fingerprint) {
-        candidateValues[byokEnvironmentKey(for: provider)] = key
+    for (provider, entry) in APIKeyService.activeBYOKSnapshot {
+      if CredentialHealthManager.shared.canUseBYOK(provider: provider, fingerprint: entry.fingerprint) {
+        candidateValues[byokEnvironmentKey(for: provider)] = entry.key
       } else {
         suppressedProviders.append(provider)
       }
     }
-    guard suppressedProviders.isEmpty, candidateValues.count == BYOKProvider.allCases.count else {
+    guard let selectedProvider = APIKeyService.selectedBYOKLLMProvider,
+      candidateValues[byokEnvironmentKey(for: selectedProvider)] != nil
+    else {
       return ([:], suppressedProviders)
     }
-    return (candidateValues, [])
+    return (candidateValues, suppressedProviders)
   }
 
   static func openClawAdapterCommand(openClawPath: String, fileManager: FileManager = .default) -> String {

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -77,6 +77,7 @@ enum DefaultsKey: String {
   case floatingBarCachedDesktopGrandfatherUntil = "floatingBar_cachedDesktopGrandfatherUntil"
   case desktopIsPaywalled = "desktop_isPaywalled"
   case askOmiBarEnabled = "askOmiBarEnabled"
+  case byokLLMProvider = "dev_byok_llm_provider"
   case rewindDisableContentCache = "rewindDisableContentCache"
   // Task-order migration keys are typed so TasksPage and its tests share the
   // migration contract instead of repeating raw UserDefaults literals.

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -80,6 +80,8 @@ enum DefaultsKey: String {
   case byokLLMProvider = "dev_byok_llm_provider"
   /// Provider → SHA-256 fingerprint last enrolled after BYOKValidator .ok.
   case byokEnrolledFingerprints = "byok_enrolled_fingerprints"
+  /// UID that last owned persisted BYOK keys on this Mac.
+  case byokOwnerUid = "byok_owner_uid"
   case rewindDisableContentCache = "rewindDisableContentCache"
   // Task-order migration keys are typed so TasksPage and its tests share the
   // migration contract instead of repeating raw UserDefaults literals.

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -78,6 +78,8 @@ enum DefaultsKey: String {
   case desktopIsPaywalled = "desktop_isPaywalled"
   case askOmiBarEnabled = "askOmiBarEnabled"
   case byokLLMProvider = "dev_byok_llm_provider"
+  /// Provider → SHA-256 fingerprint last enrolled after BYOKValidator .ok.
+  case byokEnrolledFingerprints = "byok_enrolled_fingerprints"
   case rewindDisableContentCache = "rewindDisableContentCache"
   // Task-order migration keys are typed so TasksPage and its tests share the
   // migration contract instead of repeating raw UserDefaults literals.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -851,7 +851,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     voiceID: String,
     instructions: String
   ) async throws -> Data {
-    let byokKey = APIKeyService.isByokActive ? APIKeyService.byokKey(.openai) : nil
+    let byokKey = APIKeyService.selectedBYOKLLMProvider == .openai ? APIKeyService.byokKey(.openai) : nil
     let fingerprint = byokKey.map(APIKeyService.byokFingerprint)
     if let fingerprint {
       let canUseKey = await MainActor.run {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+SessionLifecycle.swift
@@ -60,7 +60,7 @@ extension RealtimeHubController {
       return
     }
 
-    if let key = APIKeyService.byokKey(provider.byokProvider) {
+    if let key = APIKeyService.selectedRealtimeBYOKKey(for: provider.byokProvider) {
       let fingerprint = APIKeyService.byokFingerprint(key)
       guard
         CredentialHealthManager.shared.canUseBYOK(

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -751,7 +751,7 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
       "RealtimeHub: preserving barge-in turn while failing over "
         + "\(provider.displayName) → \(alternate.displayName)")
 
-    if let key = APIKeyService.byokKey(alternate.byokProvider) {
+    if let key = APIKeyService.selectedRealtimeBYOKKey(for: alternate.byokProvider) {
       pendingBargeInProvider = alternate
       pendingBargeInAuth = .byokKey(key)
       replacementAudioBuffer = pendingTurn

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubSettings.swift
@@ -79,6 +79,6 @@ final class RealtimeHubSettings {
   /// (BYOK / dev key). Managed users without a key connect via a minted ephemeral
   /// token instead (see RealtimeHubController.ensureWarm); both reach the hub.
   var canConnect: Bool {
-    APIKeyService.byokKey(provider.byokProvider) != nil
+    APIKeyService.selectedRealtimeBYOKKey(for: provider.byokProvider) != nil
   }
 }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubTestHarness.swift
@@ -192,7 +192,7 @@ final class RealtimeHubTestHarness: NSObject, RealtimeHubSessionDelegate {
       // Phase 2: if asked for ephemeral, or no BYOK key exists (managed user),
       // mint a server-side ephemeral token via the backend; else use the BYOK key.
       let wantEphemeral = params["auth"] == "ephemeral"
-      let byok = APIKeyService.byokKey(provider.byokProvider)
+      let byok = APIKeyService.selectedRealtimeBYOKKey(for: provider.byokProvider)
       let auth: HubAuth
       if !wantEphemeral, let key = byok {
         auth = .byokKey(key)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -51,28 +51,29 @@ extension SettingsContentView {
     VStack(spacing: OmiSpacing.xl) {
       byokStatusBanner
 
-      developerKeyField(
-        provider: .openai,
-        title: "OpenAI API Key",
-        subtitle: "For GPT calls.",
-        settingId: "advanced.devkeys.openai",
-        value: $devOpenAIKey
-      )
+      settingsCard(settingId: "advanced.devkeys.llm") {
+        VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+          Text("Language model")
+            .scaledFont(size: OmiType.body, weight: .medium)
+            .foregroundColor(Ink.primary)
+          Text("Choose the provider that powers chat, memory, and insights. OpenRouter is selected by default.")
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.secondary)
+          Picker("LLM provider", selection: $devBYOKLLMProvider) {
+            ForEach(BYOKLLMProvider.allCases) { provider in
+              Text(provider.displayName).tag(provider.rawValue)
+            }
+          }
+          .pickerStyle(.menu)
+        }
+      }
 
       developerKeyField(
-        provider: .anthropic,
-        title: "Anthropic API Key",
-        subtitle: "For chat (Claude).",
-        settingId: "advanced.devkeys.anthropic",
-        value: $devAnthropicKey
-      )
-
-      developerKeyField(
-        provider: .gemini,
-        title: "Gemini API Key",
-        subtitle: "For proactive AI (memory, tasks, insights, focus).",
-        settingId: "advanced.devkeys.gemini",
-        value: $devGeminiKey
+        provider: selectedBYOKLLMProvider.provider,
+        title: "\(selectedBYOKLLMProvider.displayName) API Key",
+        subtitle: selectedBYOKLLMSubtitle,
+        settingId: "advanced.devkeys.llm-key",
+        value: selectedBYOKLLMKey
       )
 
       developerKeyField(
@@ -82,10 +83,6 @@ extension SettingsContentView {
         settingId: "advanced.devkeys.deepgram",
         value: $devDeepgramKey
       )
-
-      if let byokIncompleteHint {
-        byokWarningCard(byokIncompleteHint, settingId: "advanced.devkeys.incomplete")
-      }
 
       if let byokActivationError {
         byokWarningCard(byokActivationError, settingId: "advanced.devkeys.error")
@@ -120,11 +117,29 @@ extension SettingsContentView {
   /// without a secret sitting in a view-diff identity.
   var byokKeySetFingerprint: String {
     APIKeyService.byokFingerprint(
-      [devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey].joined(separator: "\u{1}"))
+      [devBYOKLLMProvider, selectedBYOKLLMKey.wrappedValue, devDeepgramKey].joined(separator: "\u{1}"))
   }
 
-  var byokIncompleteHint: String? {
-    byokMissingKeysHint([devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey])
+  var selectedBYOKLLMProvider: BYOKLLMProvider {
+    BYOKLLMProvider(rawValue: devBYOKLLMProvider) ?? .openrouter
+  }
+
+  var selectedBYOKLLMKey: Binding<String> {
+    switch selectedBYOKLLMProvider {
+    case .openrouter: return $devOpenRouterKey
+    case .openai: return $devOpenAIKey
+    case .gemini: return $devGeminiKey
+    case .anthropic: return $devAnthropicKey
+    }
+  }
+
+  var selectedBYOKLLMSubtitle: String {
+    switch selectedBYOKLLMProvider {
+    case .openrouter: return "Routes supported models through your OpenRouter account."
+    case .openai: return "Uses your OpenAI API key directly."
+    case .gemini: return "Uses Gemini 2.5 Flash Lite directly."
+    case .anthropic: return "Uses your Anthropic API key directly."
+    }
   }
 
   func byokWarningCard(_ text: String, settingId: String) -> some View {
@@ -140,13 +155,12 @@ extension SettingsContentView {
   }
 
   var hasAnyBYOKKey: Bool {
-    !devOpenAIKey.isEmpty || !devAnthropicKey.isEmpty || !devGeminiKey.isEmpty
+    !devOpenRouterKey.isEmpty || !devOpenAIKey.isEmpty || !devAnthropicKey.isEmpty || !devGeminiKey.isEmpty
       || !devDeepgramKey.isEmpty
   }
 
   var hasAllBYOKKeys: Bool {
-    !devOpenAIKey.isEmpty && !devAnthropicKey.isEmpty && !devGeminiKey.isEmpty
-      && !devDeepgramKey.isEmpty
+    APIKeyService.isByokActive
   }
 
   @ViewBuilder
@@ -162,7 +176,7 @@ extension SettingsContentView {
           Text(
             hasAllBYOKKeys
               ? "You're paying your own providers. Omi skips the subscription charge. Keys stay on this Mac."
-              : "Provide all four keys (OpenAI, Anthropic, Gemini, Deepgram) to switch to the free plan. Keys stay on this Mac — we never store them on our servers."
+              : "Choose a language model provider, then add its key. Deepgram is optional and only powers transcription. Keys stay on this Mac — we never store them on our servers."
           )
           .scaledFont(size: OmiType.caption)
           .foregroundColor(Ink.secondary)
@@ -174,6 +188,7 @@ extension SettingsContentView {
 
   func clearAllBYOKKeys() {
     devOpenAIKey = ""
+    devOpenRouterKey = ""
     devAnthropicKey = ""
     devGeminiKey = ""
     devDeepgramKey = ""
@@ -197,8 +212,15 @@ extension SettingsContentView {
 
   @MainActor
   func refreshBYOKActivation() async {
+    guard !selectedBYOKLLMKey.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      if hasAnyBYOKKey {
+        try? await APIClient.shared.deactivateBYOK()
+        await FloatingBarUsageLimiter.shared.fetchPlan()
+      }
+      return
+    }
     let action = BYOKReconciliation.action(
-      forKeys: [devOpenAIKey, devAnthropicKey, devGeminiKey, devDeepgramKey],
+      forKeys: [selectedBYOKLLMKey.wrappedValue],
       hasCheckedStatuses: !byokKeyStatuses.isEmpty,
       hasActivationError: byokActivationError != nil
     )
@@ -218,23 +240,26 @@ extension SettingsContentView {
       // The badge state the UI has always been able to draw but never reached:
       // say a provider is being checked while it is being checked.
       var checking: [BYOKProvider: BYOKValidator.Status] = [:]
-      for provider in BYOKProvider.allCases { checking[provider] = .checking }
+      for provider in APIKeyService.activeBYOKSnapshot.keys { checking[provider] = .checking }
       byokKeyStatuses = checking
 
       // Validate before flipping the backend flag — otherwise we'd put the
       // user on the free plan with dead keys and every chat would 401.
-      let snapshot = APIKeyService.byokSnapshot.reduce(into: [BYOKProvider: String]()) {
+      let snapshot = APIKeyService.activeBYOKSnapshot.reduce(into: [BYOKProvider: String]()) {
         acc, entry in acc[entry.key] = entry.value.key
       }
       let results = await BYOKValidator.validateAll(snapshot)
       guard !Task.isCancelled else { return }
-      let allOk = results.allSatisfy {
-        if case .ok = $0.value { return true }
-        return false
-      }
-      if allOk {
-        let fingerprints = APIKeyService.byokSnapshot.reduce(into: [String: String]()) {
-          acc, entry in acc[entry.key.rawValue] = entry.value.fingerprint
+      let selectedLLMValid =
+        results[selectedBYOKLLMProvider.provider].map {
+          if case .ok = $0 { return true }
+          return false
+        } ?? false
+      if selectedLLMValid {
+        let fingerprints = APIKeyService.activeBYOKSnapshot.reduce(into: [String: String]()) { acc, entry in
+          if let status = results[entry.key], case .ok = status {
+            acc[entry.key.rawValue] = entry.value.fingerprint
+          }
         }
         try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
         await FloatingBarUsageLimiter.shared.fetchPlan()
@@ -257,7 +282,7 @@ extension SettingsContentView {
         await MainActor.run {
           byokKeyStatuses = results
           byokActivationError =
-            "Rejected by provider: \(names). Free plan stays off until all 4 keys authenticate."
+            "Rejected by provider: \(names). Free plan stays off until the selected language model authenticates."
         }
       }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -108,6 +108,7 @@ extension SettingsContentView {
     // once — and opening the pane with four saved keys finally fills in the
     // per-provider badges instead of leaving them blank until the next edit.
     .task(id: byokKeySetFingerprint) {
+      migrateLegacyBYOKSelection()
       await refreshBYOKActivation()
     }
   }
@@ -121,7 +122,14 @@ extension SettingsContentView {
   }
 
   var selectedBYOKLLMProvider: BYOKLLMProvider {
-    BYOKLLMProvider(rawValue: devBYOKLLMProvider) ?? .openrouter
+    BYOKLLMProvider(rawValue: devBYOKLLMProvider)
+      ?? APIKeyService.selectedBYOKLLMProvider.flatMap { BYOKLLMProvider(rawValue: $0.rawValue) }
+      ?? .openrouter
+  }
+
+  func migrateLegacyBYOKSelection() {
+    guard BYOKLLMProvider(rawValue: devBYOKLLMProvider) == nil else { return }
+    devBYOKLLMProvider = selectedBYOKLLMProvider.rawValue
   }
 
   var selectedBYOKLLMKey: Binding<String> {
@@ -213,6 +221,8 @@ extension SettingsContentView {
   @MainActor
   func refreshBYOKActivation() async {
     guard !selectedBYOKLLMKey.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      byokKeyStatuses = [:]
+      byokActivationError = nil
       if hasAnyBYOKKey {
         try? await APIClient.shared.deactivateBYOK()
         await FloatingBarUsageLimiter.shared.fetchPlan()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -4,8 +4,8 @@ import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
 
-/// Users often paste one key and miss the banner saying all four are required
-/// at the same time. Non-nil while 1–3 keys (in `BYOKProvider.allCases` order)
+/// Users often paste one key and miss the banner saying a valid LLM key is
+/// required. Non-nil while 1–3 keys (in `BYOKProvider.allCases` order)
 /// are entered, listing the ones still missing.
 func byokMissingKeysHint(_ keys: [String]) -> String? {
   let missing = zip(BYOKProvider.allCases, keys).filter { $0.1.isEmpty }.map(\.0.displayName)
@@ -275,8 +275,8 @@ extension SettingsContentView {
         await FloatingBarUsageLimiter.shared.fetchPlan()
         await MainActor.run {
           // Clear any sticky paywall flag from a prior `freemium_threshold_reached`
-          // event — once all 4 BYOK keys validate, the user is on the free BYOK
-          // plan and shouldn't be locked out of capture/transcription anymore.
+          // event — once the selected LLM BYOK key validates, the user is on the
+          // free BYOK plan and shouldn't be locked out of capture/transcription.
           AppState.current?.isPaywalled = false
           byokKeyStatuses = results
           byokActivationError = nil

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -224,7 +224,7 @@ extension SettingsContentView {
     guard !selectedBYOKLLMKey.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       byokKeyStatuses = [:]
       byokActivationError = nil
-      if hasAnyBYOKKey {
+      if hasAnyBYOKKey || !APIKeyService.enrolledFingerprints().isEmpty {
         try? await APIClient.shared.deactivateBYOK()
         APIKeyService.persistEnrolledFingerprints([:])
         await FloatingBarUsageLimiter.shared.fetchPlan()
@@ -273,16 +273,24 @@ extension SettingsContentView {
             acc[entry.key.rawValue] = entry.value.fingerprint
           }
         }
-        try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
-        APIKeyService.persistEnrolledFingerprints(fingerprints)
-        await FloatingBarUsageLimiter.shared.fetchPlan()
-        await MainActor.run {
+        do {
+          try await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+          APIKeyService.persistEnrolledFingerprints(fingerprints)
+          await FloatingBarUsageLimiter.shared.fetchPlan()
+          await MainActor.run {
           // Clear any sticky paywall flag from a prior `freemium_threshold_reached`
           // event — once the selected LLM BYOK key validates, the user is on the
           // free BYOK plan and shouldn't be locked out of capture/transcription.
           AppState.current?.isPaywalled = false
           byokKeyStatuses = results
           byokActivationError = nil
+          }
+        } catch {
+          await MainActor.run {
+            byokKeyStatuses = results
+            byokActivationError =
+              "Could not enroll keys with Omi. Free plan stays off until enrollment succeeds."
+          }
         }
       } else {
         let failed = results.filter {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -278,12 +278,12 @@ extension SettingsContentView {
           APIKeyService.persistEnrolledFingerprints(fingerprints)
           await FloatingBarUsageLimiter.shared.fetchPlan()
           await MainActor.run {
-          // Clear any sticky paywall flag from a prior `freemium_threshold_reached`
-          // event — once the selected LLM BYOK key validates, the user is on the
-          // free BYOK plan and shouldn't be locked out of capture/transcription.
-          AppState.current?.isPaywalled = false
-          byokKeyStatuses = results
-          byokActivationError = nil
+            // Clear any sticky paywall flag from a prior `freemium_threshold_reached`
+            // event — once the selected LLM BYOK key validates, the user is on the
+            // free BYOK plan and shouldn't be locked out of capture/transcription.
+            AppState.current?.isPaywalled = false
+            byokKeyStatuses = results
+            byokActivationError = nil
           }
         } catch {
           await MainActor.run {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
@@ -210,6 +210,7 @@ extension SettingsContentView {
     // paths only ever deactivate, so the duplicate call is harmless.
     Task {
       try? await APIClient.shared.deactivateBYOK()
+      APIKeyService.persistEnrolledFingerprints([:])
       await FloatingBarUsageLimiter.shared.fetchPlan()
     }
   }
@@ -225,6 +226,7 @@ extension SettingsContentView {
       byokActivationError = nil
       if hasAnyBYOKKey {
         try? await APIClient.shared.deactivateBYOK()
+        APIKeyService.persistEnrolledFingerprints([:])
         await FloatingBarUsageLimiter.shared.fetchPlan()
       }
       return
@@ -272,6 +274,7 @@ extension SettingsContentView {
           }
         }
         try? await APIClient.shared.activateBYOK(fingerprints: fingerprints)
+        APIKeyService.persistEnrolledFingerprints(fingerprints)
         await FloatingBarUsageLimiter.shared.fetchPlan()
         await MainActor.run {
           // Clear any sticky paywall flag from a prior `freemium_threshold_reached`
@@ -288,6 +291,7 @@ extension SettingsContentView {
         }
         let names = failed.keys.map(\.displayName).sorted().joined(separator: ", ")
         try? await APIClient.shared.deactivateBYOK()
+        APIKeyService.persistEnrolledFingerprints([:])
         await FloatingBarUsageLimiter.shared.fetchPlan()
         await MainActor.run {
           byokKeyStatuses = results
@@ -298,6 +302,7 @@ extension SettingsContentView {
 
     case .deactivate:
       try? await APIClient.shared.deactivateBYOK()
+      APIKeyService.persistEnrolledFingerprints([:])
       await FloatingBarUsageLimiter.shared.fetchPlan()
       await MainActor.run {
         byokKeyStatuses = [:]

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -553,7 +553,7 @@ struct SettingsContentView: View {
   @AppStorage("dev_openai_api_key") var devOpenAIKey: String = ""
   @AppStorage("dev_openrouter_api_key") var devOpenRouterKey: String = ""
   @AppStorage("dev_deepgram_api_key") var devDeepgramKey: String = ""
-  @AppStorage(DefaultsKey.byokLLMProvider.rawValue) var devBYOKLLMProvider: String = "openrouter"
+  @AppStorage(DefaultsKey.byokLLMProvider.rawValue) var devBYOKLLMProvider: String = ""
   @State var byokKeyStatuses: [BYOKProvider: BYOKValidator.Status] = [:]
   @State var byokActivationError: String?
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -551,7 +551,9 @@ struct SettingsContentView: View {
   @AppStorage("dev_gemini_api_key") var devGeminiKey: String = ""
   @AppStorage("dev_anthropic_api_key") var devAnthropicKey: String = ""
   @AppStorage("dev_openai_api_key") var devOpenAIKey: String = ""
+  @AppStorage("dev_openrouter_api_key") var devOpenRouterKey: String = ""
   @AppStorage("dev_deepgram_api_key") var devDeepgramKey: String = ""
+  @AppStorage(DefaultsKey.byokLLMProvider.rawValue) var devBYOKLLMProvider: String = "openrouter"
   @State var byokKeyStatuses: [BYOKProvider: BYOKValidator.Status] = [:]
   @State var byokActivationError: String?
 

--- a/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
+++ b/desktop/macos/Desktop/Sources/RealtimeOmni/RealtimeOmniService.swift
@@ -340,7 +340,7 @@ final class RealtimeOmniService: NSObject, @unchecked Sendable {
     r.setValue(authHeader, forHTTPHeaderField: "Authorization")
     // Forward BYOK keys so BYOK users connect with their own provider key
     // (the backend validates them and uses them upstream — same as /v4/listen).
-    for (provider, entry) in APIKeyService.byokSnapshot {
+    for (provider, entry) in APIKeyService.activeBYOKSnapshot {
       r.setValue(entry.key, forHTTPHeaderField: provider.headerName)
     }
     return r

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
@@ -330,7 +330,7 @@ extension APIClient {
     if httpResponse.statusCode == 401 {
       let detail = (try? JSONDecoder().decode(APIErrorPayload.self, from: data))?.preferredMessage
       if detail?.hasPrefix("OpenAI TTS request failed:") == true {
-        let mode: CredentialAuthMode = APIKeyService.isByokActive ? .byok : .managed
+        let mode: CredentialAuthMode = APIKeyService.selectedBYOKLLMProvider == .openai ? .byok : .managed
         throw CredentialHealthError.providerAuth(
           provider: .openai,
           mode: mode,

--- a/desktop/macos/Desktop/Sources/Services/OmiHTTPTransport.swift
+++ b/desktop/macos/Desktop/Sources/Services/OmiHTTPTransport.swift
@@ -114,7 +114,7 @@ struct OmiHTTPTransport {
     // calls this request triggers. Sent per-request; never stored server-side.
     if includeBYOK, APIKeyService.isByokActive {
       let health = await MainActor.run { CredentialHealthManager.shared }
-      let snapshot = APIKeyService.byokSnapshot
+      let snapshot = APIKeyService.activeBYOKSnapshot
       for (provider, entry) in snapshot {
         let canAttach = await MainActor.run {
           health.canUseBYOK(provider: provider, fingerprint: entry.fingerprint)

--- a/desktop/macos/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionService.swift
@@ -456,6 +456,11 @@ class TranscriptionService: @unchecked Sendable {
     if let entry = APIKeyService.activeBYOKSnapshot[.deepgram] {
       request.setValue(entry.key, forHTTPHeaderField: BYOKProvider.deepgram.headerName)
     }
+    if let provider = APIKeyService.selectedBYOKLLMProvider,
+      let entry = APIKeyService.activeBYOKSnapshot[provider]
+    {
+      request.setValue(entry.key, forHTTPHeaderField: provider.headerName)
+    }
 
     // Create URLSession and WebSocket task
     let configuration = URLSessionConfiguration.default
@@ -762,6 +767,11 @@ extension TranscriptionService {
     request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
     if let entry = APIKeyService.activeBYOKSnapshot[.deepgram] {
       request.setValue(entry.key, forHTTPHeaderField: BYOKProvider.deepgram.headerName)
+    }
+    if let provider = APIKeyService.selectedBYOKLLMProvider,
+      let entry = APIKeyService.activeBYOKSnapshot[provider]
+    {
+      request.setValue(entry.key, forHTTPHeaderField: provider.headerName)
     }
     request.httpBody = audioData
 

--- a/desktop/macos/Desktop/Sources/TranscriptionService.swift
+++ b/desktop/macos/Desktop/Sources/TranscriptionService.swift
@@ -453,8 +453,8 @@ class TranscriptionService: @unchecked Sendable {
 
     // BYOK: attach user keys so the transcription backend can use the user's
     // Deepgram token for this session (and any downstream LLM calls).
-    for (provider, entry) in APIKeyService.byokSnapshot {
-      request.setValue(entry.key, forHTTPHeaderField: provider.headerName)
+    if let entry = APIKeyService.activeBYOKSnapshot[.deepgram] {
+      request.setValue(entry.key, forHTTPHeaderField: BYOKProvider.deepgram.headerName)
     }
 
     // Create URLSession and WebSocket task
@@ -760,8 +760,8 @@ extension TranscriptionService {
     request.httpMethod = "POST"
     request.setValue(authHeader, forHTTPHeaderField: "Authorization")
     request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-    for (provider, entry) in APIKeyService.byokSnapshot {
-      request.setValue(entry.key, forHTTPHeaderField: provider.headerName)
+    if let entry = APIKeyService.activeBYOKSnapshot[.deepgram] {
+      request.setValue(entry.key, forHTTPHeaderField: BYOKProvider.deepgram.headerName)
     }
     request.httpBody = audioData
 

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -1164,6 +1164,7 @@ final class AgentRuntimeProcessTests: XCTestCase {
 
   @MainActor
   func testUsableByokEnvironmentSuppressesAllKeysWhenOneProviderIsKnownBad() {
+    let savedSelectedProvider = UserDefaults.standard.string(forKey: .byokLLMProvider)
     let savedKeys = Dictionary(
       uniqueKeysWithValues: BYOKProvider.allCases.map { provider in
         (provider, UserDefaults.standard.string(forKey: provider.storageKey))
@@ -1177,11 +1178,17 @@ final class AgentRuntimeProcessTests: XCTestCase {
         }
       }
       CredentialHealthManager.shared.reset()
+      if let savedSelectedProvider {
+        UserDefaults.standard.set(savedSelectedProvider, forKey: .byokLLMProvider)
+      } else {
+        UserDefaults.standard.removeObject(forKey: .byokLLMProvider)
+      }
     }
 
     for provider in BYOKProvider.allCases {
       UserDefaults.standard.set("sk-agent-\(provider.rawValue)", forKey: provider.storageKey)
     }
+    UserDefaults.standard.set(BYOKLLMProvider.openai.rawValue, forKey: .byokLLMProvider)
     let openAIKey = APIKeyService.byokKey(.openai)!
     CredentialHealthManager.shared.recordProviderFailure(
       .providerAuthFailed(provider: .openai, mode: .byok),
@@ -1198,6 +1205,7 @@ final class AgentRuntimeProcessTests: XCTestCase {
 
   @MainActor
   func testUsableByokEnvironmentIncludesAllKeysWhenAllProvidersAreUsable() {
+    let savedSelectedProvider = UserDefaults.standard.string(forKey: .byokLLMProvider)
     let savedKeys = Dictionary(
       uniqueKeysWithValues: BYOKProvider.allCases.map { provider in
         (provider, UserDefaults.standard.string(forKey: provider.storageKey))
@@ -1211,17 +1219,21 @@ final class AgentRuntimeProcessTests: XCTestCase {
         }
       }
       CredentialHealthManager.shared.reset()
+      if let savedSelectedProvider {
+        UserDefaults.standard.set(savedSelectedProvider, forKey: .byokLLMProvider)
+      } else {
+        UserDefaults.standard.removeObject(forKey: .byokLLMProvider)
+      }
     }
 
     for provider in BYOKProvider.allCases {
       UserDefaults.standard.set("sk-agent-\(provider.rawValue)", forKey: provider.storageKey)
     }
+    UserDefaults.standard.set(BYOKLLMProvider.openrouter.rawValue, forKey: .byokLLMProvider)
 
     let result = AgentRuntimeProcess.usableBYOKEnvironment()
 
-    XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .openai)], "sk-agent-openai")
-    XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .anthropic)], "sk-agent-anthropic")
-    XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .gemini)], "sk-agent-gemini")
+    XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .openrouter)], "sk-agent-openrouter")
     XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .deepgram)], "sk-agent-deepgram")
     XCTAssertTrue(result.suppressedProviders.isEmpty)
   }

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -1235,6 +1235,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
 
     XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .openrouter)], "sk-agent-openrouter")
     XCTAssertEqual(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .deepgram)], "sk-agent-deepgram")
+    XCTAssertNil(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .openai)])
+    XCTAssertNil(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .anthropic)])
+    XCTAssertNil(result.values[AgentRuntimeProcess.byokEnvironmentKey(for: .gemini)])
     XCTAssertTrue(result.suppressedProviders.isEmpty)
   }
 

--- a/desktop/macos/Desktop/Tests/BYOKIncompleteHintTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKIncompleteHintTests.swift
@@ -10,7 +10,7 @@ final class BYOKIncompleteHintTests: XCTestCase {
     let hint = byokMissingKeysHint(["sk-test", "", "", ""])
     XCTAssertEqual(
       hint,
-      "Still missing: Anthropic, Gemini, Deepgram. All 4 keys must be entered at the same time to activate the free plan."
+      "Still missing: OpenAI, Anthropic, Gemini. All 4 keys must be entered at the same time to activate the free plan."
     )
     XCTAssertNil(byokMissingKeysHint(["", "", "", ""]), "blank form shows no hint")
     XCTAssertNil(byokMissingKeysHint(["a", "b", "c", "d"]), "complete form shows no hint")

--- a/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
@@ -2,8 +2,8 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// Verifies the BYOK-vs-paywall precedence fix: a user with all four BYOK
-/// keys configured locally is never paywalled, regardless of the persisted
+/// Verifies the BYOK-vs-paywall precedence fix: a user with a configured BYOK
+/// key locally is never paywalled, regardless of the persisted
 /// `desktop_isPaywalled` flag.
 @MainActor final class BYOKPaywallTests: XCTestCase {
   private let paywallKey = "desktop_isPaywalled"
@@ -109,7 +109,7 @@ import XCTest
   }
 
   func testPaywallFlagSuppressedWhenByokActive() {
-    // The exact bug: trial-expired flag set, then user adds all 4 BYOK keys.
+    // The exact bug: trial-expired flag set, then user configures BYOK keys.
     UserDefaults.standard.set(true, forKey: paywallKey)
     setAllBYOKKeys()
     XCTAssertFalse(

--- a/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
@@ -27,20 +27,28 @@ import XCTest
     UserDefaults.standard.removeObject(forKey: .byokLLMProvider)
   }
 
-  func testByokActiveRequiresAllFourKeys() {
+  func testByokActiveRequiresSelectedLLMKey() {
     clearAllBYOKKeys()
     XCTAssertFalse(APIKeyService.isByokActive)
 
-    // Three of four → still not active
+    // A selected LLM key activates BYOK without the optional providers.
     UserDefaults.standard.set(BYOKLLMProvider.openrouter.rawValue, forKey: .byokLLMProvider)
     for p in BYOKProvider.allCases.dropLast() {
       UserDefaults.standard.set("k", forKey: p.storageKey)
     }
     XCTAssertTrue(APIKeyService.isByokActive)
 
-    // All four → active
+    // All configured providers remain active.
     setAllBYOKKeys()
     XCTAssertTrue(APIKeyService.isByokActive)
+  }
+
+  func testLegacyLLMSelectionInfersStoredProvider() {
+    clearAllBYOKKeys()
+    UserDefaults.standard.removeObject(forKey: .byokLLMProvider)
+    UserDefaults.standard.set("sk-test-openai", forKey: BYOKProvider.openai.storageKey)
+
+    XCTAssertEqual(APIKeyService.selectedBYOKLLMProvider, .openai)
   }
 
   func testBuildHeadersDoesNotAttachPartialByokKeys() async throws {
@@ -123,12 +131,12 @@ import XCTest
     XCTAssertFalse(AppState.isPaywalledEffective)
   }
 
-  func testRemovingOneByokKeyReappliesPaywall() {
+  func testRemovingDeepgramKeyLeavesSelectedLLMByokActive() {
     UserDefaults.standard.set(true, forKey: paywallKey)
     setAllBYOKKeys()
     XCTAssertFalse(AppState.isPaywalledEffective)
 
-    // User clears their Deepgram key → no longer fully BYOK → paywall returns.
+    // Deepgram is optional when a selected LLM key remains configured.
     UserDefaults.standard.removeObject(forKey: BYOKProvider.deepgram.storageKey)
     XCTAssertFalse(AppState.isPaywalledEffective)
   }

--- a/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
@@ -51,7 +51,7 @@ import XCTest
     XCTAssertEqual(APIKeyService.selectedBYOKLLMProvider, .openai)
   }
 
-  func testBuildHeadersDoesNotAttachPartialByokKeys() async throws {
+  func testBuildHeadersAttachSelectedLLMByokKey() async throws {
     clearAllBYOKKeys()
     UserDefaults.standard.set("sk-test-openai", forKey: BYOKProvider.openai.storageKey)
 
@@ -59,7 +59,7 @@ import XCTest
     await client.setTestAuthHeader("Bearer test-token")
     let headers = try await client.buildHeaders()
 
-    XCTAssertNil(headers[BYOKProvider.openai.headerName])
+    XCTAssertEqual(headers[BYOKProvider.openai.headerName], "sk-test-openai")
   }
 
   func testBuildHeadersCanExplicitlyExcludeByokKeys() async throws {

--- a/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
@@ -24,6 +24,7 @@ import XCTest
     CredentialHealthManager.shared.reset()
     clearAllBYOKKeys()
     UserDefaults.standard.removeObject(forKey: paywallKey)
+    UserDefaults.standard.removeObject(forKey: .byokLLMProvider)
   }
 
   func testByokActiveRequiresAllFourKeys() {
@@ -31,10 +32,11 @@ import XCTest
     XCTAssertFalse(APIKeyService.isByokActive)
 
     // Three of four → still not active
+    UserDefaults.standard.set(BYOKLLMProvider.openrouter.rawValue, forKey: .byokLLMProvider)
     for p in BYOKProvider.allCases.dropLast() {
       UserDefaults.standard.set("k", forKey: p.storageKey)
     }
-    XCTAssertFalse(APIKeyService.isByokActive, "3/4 keys must not count as BYOK")
+    XCTAssertTrue(APIKeyService.isByokActive)
 
     // All four → active
     setAllBYOKKeys()
@@ -78,6 +80,7 @@ import XCTest
 
   func testBuildHeadersSuppressesOnlyInvalidByokHeader() async throws {
     setAllBYOKKeys()
+    UserDefaults.standard.set(BYOKLLMProvider.openai.rawValue, forKey: .byokLLMProvider)
     let openAIKey = try XCTUnwrap(APIKeyService.byokKey(.openai))
     CredentialHealthManager.shared.recordProviderFailure(
       .providerAuthFailed(provider: .openai, mode: .byok),
@@ -91,9 +94,10 @@ import XCTest
     let headers = try await client.buildHeaders()
 
     XCTAssertNil(headers[BYOKProvider.openai.headerName])
-    for provider in BYOKProvider.allCases where provider != .openai {
-      XCTAssertEqual(headers[provider.headerName], "sk-test-\(provider.rawValue)")
-    }
+    XCTAssertEqual(headers[BYOKProvider.deepgram.headerName], "sk-test-deepgram")
+    XCTAssertNil(headers[BYOKProvider.openrouter.headerName])
+    XCTAssertNil(headers[BYOKProvider.anthropic.headerName])
+    XCTAssertNil(headers[BYOKProvider.gemini.headerName])
   }
 
   func testPaywallFlagSuppressedWhenByokActive() {
@@ -126,6 +130,6 @@ import XCTest
 
     // User clears their Deepgram key → no longer fully BYOK → paywall returns.
     UserDefaults.standard.removeObject(forKey: BYOKProvider.deepgram.storageKey)
-    XCTAssertTrue(AppState.isPaywalledEffective)
+    XCTAssertFalse(AppState.isPaywalledEffective)
   }
 }

--- a/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
+++ b/desktop/macos/Desktop/Tests/BYOKPaywallTests.swift
@@ -25,6 +25,7 @@ import XCTest
     clearAllBYOKKeys()
     UserDefaults.standard.removeObject(forKey: paywallKey)
     UserDefaults.standard.removeObject(forKey: .byokLLMProvider)
+    APIKeyService.persistEnrolledFingerprints([:])
   }
 
   func testByokActiveRequiresSelectedLLMKey() {
@@ -139,5 +140,39 @@ import XCTest
     // Deepgram is optional when a selected LLM key remains configured.
     UserDefaults.standard.removeObject(forKey: BYOKProvider.deepgram.storageKey)
     XCTAssertFalse(AppState.isPaywalledEffective)
+  }
+
+  func testHasTranscriptionBYOKRequiresEnrolledDeepgramFingerprint() {
+    clearAllBYOKKeys()
+    UserDefaults.standard.set(BYOKLLMProvider.openrouter.rawValue, forKey: .byokLLMProvider)
+    UserDefaults.standard.set("sk-or", forKey: BYOKProvider.openrouter.storageKey)
+    UserDefaults.standard.set("dg-rejected", forKey: BYOKProvider.deepgram.storageKey)
+    APIKeyService.persistEnrolledFingerprints([:])
+
+    XCTAssertFalse(
+      APIKeyService.hasTranscriptionBYOK,
+      "raw Deepgram presence must not suppress transcription exhaustion")
+
+    let fp = APIKeyService.byokFingerprint("dg-rejected")
+    APIKeyService.persistEnrolledFingerprints(["deepgram": fp])
+    XCTAssertTrue(APIKeyService.hasTranscriptionBYOK)
+
+    UserDefaults.standard.set("dg-rotated", forKey: BYOKProvider.deepgram.storageKey)
+    XCTAssertFalse(
+      APIKeyService.hasTranscriptionBYOK,
+      "rotated Deepgram key is not enrolled until validation succeeds")
+  }
+
+  func testSelectedRealtimeBYOKKeyIgnoresUnselectedLeftover() {
+    clearAllBYOKKeys()
+    UserDefaults.standard.set(BYOKLLMProvider.openrouter.rawValue, forKey: .byokLLMProvider)
+    UserDefaults.standard.set("sk-or", forKey: BYOKProvider.openrouter.storageKey)
+    UserDefaults.standard.set("sk-openai-leftover", forKey: BYOKProvider.openai.storageKey)
+    UserDefaults.standard.set("sk-gemini-leftover", forKey: BYOKProvider.gemini.storageKey)
+
+    XCTAssertEqual(APIKeyService.selectedBYOKLLMProvider, .openrouter)
+    XCTAssertNil(APIKeyService.selectedRealtimeBYOKKey(for: .openai))
+    XCTAssertNil(APIKeyService.selectedRealtimeBYOKKey(for: .gemini))
+    XCTAssertEqual(APIKeyService.selectedRealtimeBYOKKey(for: .openrouter), "sk-or")
   }
 }

--- a/desktop/macos/changelog/unreleased/20260812-byok-provider-menu.json
+++ b/desktop/macos/changelog/unreleased/20260812-byok-provider-menu.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a simpler BYOK provider menu with OpenRouter chat routing and separate transcription setup"
+}

--- a/desktop/macos/e2e/flows/ai-chat-settings.yaml
+++ b/desktop/macos/e2e/flows/ai-chat-settings.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Advanced.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+DeveloperKeys.swift
+  - desktop/macos/Desktop/Sources/BYOKValidator.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Integrations.swift
   - desktop/macos/Desktop/Sources/Integrations/GmailAccountPickerView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ChatLabView.swift

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -46,6 +46,7 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBackgroundModifier.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceWaveformBars.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Tools.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+People.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/NotchMomentsCoordinator.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarReceiptCard.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/NotchCardVoiceDelivery.swift

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -813,12 +813,10 @@ export default function omiProvider(pi: ExtensionAPI): void {
   const baseUrl = process.env.OMI_API_BASE_URL || "https://api.omi.me/v2";
   const apiKey = process.env.OMI_API_KEY || "";
 
-  // BYOK: the Swift app sets OMI_BYOK_* env vars (all four, or none) when the user
-  // is on the free plan with their own provider keys. Attach them as X-BYOK-*
-  // headers on every request to the omi backend so it (a) applies the request-level
-  // all-four-keys paywall exemption and (b) routes inference through the user's own
-  // Anthropic key instead of Omi's server key. We only attach the complete set —
-  // the backend's has_all_byok_keys() requires all four to be present.
+  // BYOK: the Swift app sets OMI_BYOK_* env vars for the selected LLM provider and
+  // optional Deepgram key. Attach configured capabilities as X-BYOK-* headers on
+  // every request so the backend applies the LLM BYOK quota exemption and routes
+  // inference through the selected provider key instead of Omi's server key.
   const byokMap: Array<[string, string]> = [
     ["OMI_BYOK_OPENROUTER", "X-BYOK-OpenRouter"],
     ["OMI_BYOK_OPENAI", "X-BYOK-OpenAI"],
@@ -833,7 +831,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
   }
   const byokActive = Object.keys(byokHeaders).length > 0;
   if (byokActive) {
-    process.stderr.write(`[omi-provider] BYOK active — attaching ${byokMap.length} X-BYOK headers\n`);
+    process.stderr.write(`[omi-provider] BYOK active — attaching ${Object.keys(byokHeaders).length} X-BYOK headers\n`);
   }
 
   pi.registerProvider("omi", {

--- a/desktop/macos/pi-mono-extension/index.ts
+++ b/desktop/macos/pi-mono-extension/index.ts
@@ -820,6 +820,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
   // Anthropic key instead of Omi's server key. We only attach the complete set —
   // the backend's has_all_byok_keys() requires all four to be present.
   const byokMap: Array<[string, string]> = [
+    ["OMI_BYOK_OPENROUTER", "X-BYOK-OpenRouter"],
     ["OMI_BYOK_OPENAI", "X-BYOK-OpenAI"],
     ["OMI_BYOK_ANTHROPIC", "X-BYOK-Anthropic"],
     ["OMI_BYOK_GEMINI", "X-BYOK-Gemini"],
@@ -830,7 +831,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
     const value = process.env[envName];
     if (value && value.length > 0) byokHeaders[headerName] = value;
   }
-  const byokActive = Object.keys(byokHeaders).length === byokMap.length;
+  const byokActive = Object.keys(byokHeaders).length > 0;
   if (byokActive) {
     process.stderr.write(`[omi-provider] BYOK active — attaching ${byokMap.length} X-BYOK headers\n`);
   }

--- a/desktop/windows/src/main/agentKernel/byokEnroll.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokEnroll.test.ts
@@ -17,11 +17,15 @@ function validatorFetch(statusFor: (url: string) => number = () => 200): FetchLi
 }
 
 /** Backend fetch stub that records calls and returns a fixed ok/status. */
-function backendStub(ok = true, status = 200): {
+function backendStub(
+  ok = true,
+  status = 200
+): {
   fetch: BackendFetch
   calls: { url: string; method: string; headers: Record<string, string>; body?: string }[]
 } {
-  const calls: { url: string; method: string; headers: Record<string, string>; body?: string }[] = []
+  const calls: { url: string; method: string; headers: Record<string, string>; body?: string }[] =
+    []
   const fetch: BackendFetch = async (url, init) => {
     calls.push({ url, method: init.method, headers: init.headers, body: init.body })
     return { ok, status }
@@ -72,14 +76,14 @@ describe('enrollByok', () => {
     expect(backend.calls[0].headers.Authorization).toBe('Bearer tok')
   })
 
-  it('does not validate and DELETEs (deactivates) when the set is not full', async () => {
+  it('does not validate and DELETEs when no LLM key is configured', async () => {
     const backend = backendStub()
     let validatorCalled = false
     const validate: FetchLike = async () => {
       validatorCalled = true
       return { status: 200 }
     }
-    const partial: ByokKeys = { openai: 'a', anthropic: 'b', gemini: 'c' }
+    const partial: ByokKeys = { deepgram: 'd' }
     const result = await enrollByok({
       keys: partial,
       apiBase: 'https://api.omi.me',
@@ -94,7 +98,7 @@ describe('enrollByok', () => {
     expect(backend.calls[0].method).toBe('DELETE')
   })
 
-  it('DELETEs and reports the rejecting provider when one key is rejected', async () => {
+  it('enrolls healthy LLM capabilities when an optional provider is rejected', async () => {
     const backend = backendStub()
     const result = await enrollByok({
       keys: fullKeys,
@@ -103,11 +107,12 @@ describe('enrollByok', () => {
       validateFetch: validatorFetch((url) => (url.includes('anthropic') ? 401 : 200)),
       backendFetch: backend.fetch
     })
-    expect(result.active).toBe(false)
+    expect(result.active).toBe(true)
     expect(result.results.anthropic).toMatchObject({ ok: false, kind: 'rejected' })
     expect(result.results.openai?.ok).toBe(true)
     expect(backend.calls).toHaveLength(1)
-    expect(backend.calls[0].method).toBe('DELETE')
+    expect(backend.calls[0].method).toBe('POST')
+    expect(JSON.parse(backend.calls[0].body as string).fingerprints.anthropic).toBeUndefined()
   })
 
   it('reports a backendError (not active) when keys validate but the enroll POST fails', async () => {

--- a/desktop/windows/src/main/agentKernel/byokEnroll.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokEnroll.test.ts
@@ -34,7 +34,7 @@ function backendStub(
 }
 
 describe('enrollByok', () => {
-  it('POSTs lowercase-hex-64 fingerprints and activates when all four validate', async () => {
+  it('POSTs lowercase-hex-64 fingerprints and activates when the configured LLM keys validate', async () => {
     const backend = backendStub()
     const result = await enrollByok({
       keys: fullKeys,

--- a/desktop/windows/src/main/agentKernel/byokEnroll.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokEnroll.test.ts
@@ -60,6 +60,13 @@ describe('enrollByok', () => {
     }
     // Fingerprints are the SHA-256 of the trimmed raw keys.
     expect(body.fingerprints.openai).toBe(byokFingerprint('sk-openai'))
+    // The result carries exactly the accepted fingerprint set as evidence.
+    expect(result.enrolledFingerprints).toEqual({
+      openai: byokFingerprint('sk-openai'),
+      anthropic: byokFingerprint('sk-ant'),
+      gemini: byokFingerprint('gm-key'),
+      deepgram: byokFingerprint('dg-key')
+    })
   })
 
   it('never sends X-BYOK-* headers on the enrollment call (only the bearer token)', async () => {
@@ -93,6 +100,7 @@ describe('enrollByok', () => {
     })
     expect(result.active).toBe(false)
     expect(result.results).toEqual({})
+    expect(result.enrolledFingerprints).toEqual({})
     expect(validatorCalled).toBe(false)
     expect(backend.calls).toHaveLength(1)
     expect(backend.calls[0].method).toBe('DELETE')
@@ -110,6 +118,10 @@ describe('enrollByok', () => {
     expect(result.active).toBe(true)
     expect(result.results.anthropic).toMatchObject({ ok: false, kind: 'rejected' })
     expect(result.results.openai?.ok).toBe(true)
+    // A rejected provider is omitted from the accepted fingerprint evidence —
+    // it must never read as a validated capability.
+    expect(result.enrolledFingerprints?.anthropic).toBeUndefined()
+    expect(result.enrolledFingerprints?.openai).toBe(byokFingerprint('sk-openai'))
     expect(backend.calls).toHaveLength(1)
     expect(backend.calls[0].method).toBe('POST')
     expect(JSON.parse(backend.calls[0].body as string).fingerprints.anthropic).toBeUndefined()
@@ -128,6 +140,9 @@ describe('enrollByok', () => {
     expect(result.backendError).toContain('502')
     // Keys still validated OK — the failure is the backend call, not the keys.
     expect(result.results.openai?.ok).toBe(true)
+    // Server state is unknown after a failed POST: no evidence is emitted, so
+    // callers keep their previous enrollment fingerprints.
+    expect(result.enrolledFingerprints).toBeUndefined()
     expect(backend.calls[0].method).toBe('POST')
   })
 

--- a/desktop/windows/src/main/agentKernel/byokEnroll.ts
+++ b/desktop/windows/src/main/agentKernel/byokEnroll.ts
@@ -16,6 +16,7 @@ import { validateAllByokKeys, type FetchLike } from './byokValidator'
 import { byokFingerprint } from '../../shared/byokFingerprint'
 import {
   BYOK_PROVIDERS,
+  BYOK_LLM_PROVIDERS,
   isByokActive,
   type ByokEnrollResult,
   type ByokKeys
@@ -101,14 +102,16 @@ export async function enrollByok(opts: {
   }
 
   const results = await validateAllByokKeys(keys, opts.validateFetch)
-  const allOk = BYOK_PROVIDERS.every((p) => results[p]?.ok)
+  const allOk = BYOK_LLM_PROVIDERS.some((p) => results[p]?.ok)
   if (!allOk) {
     await deleteActivate(apiBase, token, backendFetch)
     return { active: false, results }
   }
 
   const fingerprints: Record<string, string> = {}
-  for (const p of BYOK_PROVIDERS) fingerprints[p] = byokFingerprint(keys[p] as string)
+  for (const p of BYOK_PROVIDERS) {
+    if (keys[p]?.trim() && results[p]?.ok) fingerprints[p] = byokFingerprint(keys[p] as string)
+  }
   const posted = await postActivate(apiBase, token, fingerprints, backendFetch)
   if (!posted.ok) return { active: false, results, backendError: posted.error }
   return { active: true, results }

--- a/desktop/windows/src/main/agentKernel/byokEnroll.ts
+++ b/desktop/windows/src/main/agentKernel/byokEnroll.ts
@@ -78,11 +78,12 @@ async function deleteActivate(
 /**
  * Validate the current key set and reconcile the backend BYOK activation.
  *
- * - Not all four present → never validate; ensure the backend is OFF; no results.
- * - All four present → live-validate all in parallel:
- *   - all authenticate → POST fingerprints (active) unless the backend call fails.
- *   - any fail → DELETE (inactive) and return the per-key results so the UI can
- *     show which provider rejected.
+ * - No LLM key present → never validate; ensure the backend is OFF; no results.
+ * - At least one LLM key present → live-validate all configured keys in parallel:
+ *   - at least one LLM key authenticates → POST fingerprints (active) unless the
+ *     backend call fails.
+ *   - every LLM key fails → DELETE (inactive) and return the per-key results so
+ *     the UI can show which provider rejected.
  */
 export async function enrollByok(opts: {
   keys: ByokKeys

--- a/desktop/windows/src/main/agentKernel/byokEnroll.ts
+++ b/desktop/windows/src/main/agentKernel/byokEnroll.ts
@@ -99,14 +99,14 @@ export async function enrollByok(opts: {
 
   if (!isByokActive(keys)) {
     await deleteActivate(apiBase, token, backendFetch)
-    return { active: false, results: {} }
+    return { active: false, results: {}, enrolledFingerprints: {} }
   }
 
   const results = await validateAllByokKeys(keys, opts.validateFetch)
   const allOk = BYOK_LLM_PROVIDERS.some((p) => results[p]?.ok)
   if (!allOk) {
     await deleteActivate(apiBase, token, backendFetch)
-    return { active: false, results }
+    return { active: false, results, enrolledFingerprints: {} }
   }
 
   const fingerprints: Record<string, string> = {}
@@ -114,8 +114,12 @@ export async function enrollByok(opts: {
     if (keys[p]?.trim() && results[p]?.ok) fingerprints[p] = byokFingerprint(keys[p] as string)
   }
   const posted = await postActivate(apiBase, token, fingerprints, backendFetch)
-  if (!posted.ok) return { active: false, results, backendError: posted.error }
-  return { active: true, results }
+  if (!posted.ok) {
+    // The POST failed, so the backend may still hold the previous enrollment —
+    // omit `enrolledFingerprints` and let callers keep their prior evidence.
+    return { active: false, results, backendError: posted.error }
+  }
+  return { active: true, results, enrolledFingerprints: fingerprints }
 }
 
 /**

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -82,12 +82,13 @@ describe('ByokKeyStore', () => {
     expect(store.isActive()).toBe(false)
   })
 
-  it('isActive is true only at 4/4 providers', () => {
+  it('isActive is true with a configured LLM provider', () => {
     expect(store.isActive()).toBe(false)
     store.setKey('openai', 'sk-openai')
+    expect(store.isActive()).toBe(true)
     store.setKey('anthropic', 'sk-ant')
     store.setKey('gemini', 'gm-key')
-    expect(store.isActive()).toBe(false)
+    expect(store.isActive()).toBe(true)
     store.setKey('deepgram', 'dg-key')
     expect(store.isActive()).toBe(true)
   })

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -34,6 +34,14 @@ describe('ByokKeyStore', () => {
     expect(store.getKey('anthropic')).toBeNull()
   })
 
+  it('stores the Codex key separately from BYOK providers', () => {
+    store.setCodexKey('sk-codex')
+    expect(store.getCodexKey()).toBe('sk-codex')
+    expect(store.getAllKeys()).toEqual({})
+    store.clearCodexKey()
+    expect(store.getCodexKey()).toBeNull()
+  })
+
   it('getAllKeys returns every stored provider', () => {
     store.setKey('openai', 'sk-openai')
     store.setKey('anthropic', 'sk-ant')

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -86,6 +86,14 @@ describe('ByokKeyStore', () => {
     expect(store.getCodexKey()).toBe('sk-codex')
   })
 
+  it('does not restore an OpenAI BYOK key after Codex is explicitly cleared', () => {
+    store.setKey('openai', 'sk-openai')
+    store.setCodexKey('sk-codex')
+    store.clearCodexKey()
+    expect(store.getCodexKey()).toBeNull()
+    expect(store.getKey('openai')).toBe('sk-openai')
+  })
+
   it('after sign-out (clearAll on a full set) getAllKeys is empty AND isActive is false', () => {
     // Cross-account leak guard: a second account on this install must not inherit
     // the prior user's keys (which the REST/chat/WS lanes would otherwise send).

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -42,6 +42,13 @@ describe('ByokKeyStore', () => {
     expect(store.getCodexKey()).toBeNull()
   })
 
+  it('migrates a legacy OpenAI Codex key without removing the BYOK slot', () => {
+    store.setKey('openai', 'sk-legacy-codex')
+    expect(store.getCodexKey()).toBe('sk-legacy-codex')
+    store.clearKey('openai')
+    expect(store.getCodexKey()).toBe('sk-legacy-codex')
+  })
+
   it('getAllKeys returns every stored provider', () => {
     store.setKey('openai', 'sk-openai')
     store.setKey('anthropic', 'sk-ant')
@@ -70,11 +77,13 @@ describe('ByokKeyStore', () => {
     expect(store.getKey('anthropic')).toBe('sk-ant')
   })
 
-  it('clearAll removes everything', () => {
+  it('clearAll removes BYOK keys while preserving the Codex key', () => {
     store.setKey('openai', 'sk-openai')
     store.setKey('anthropic', 'sk-ant')
+    store.setCodexKey('sk-codex')
     store.clearAll()
     expect(store.getAllKeys()).toEqual({})
+    expect(store.getCodexKey()).toBe('sk-codex')
   })
 
   it('after sign-out (clearAll on a full set) getAllKeys is empty AND isActive is false', () => {

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -43,6 +43,13 @@ describe('ByokKeyStore', () => {
     expect(store.getCodexKey()).toBeNull()
   })
 
+  it('records Codex migration complete when no legacy OpenAI key exists', () => {
+    expect(store.getCodexKey()).toBeNull()
+    store.setKey('openai', 'sk-later')
+    expect(store.getCodexKey()).toBeNull()
+    expect(store.getKey('openai')).toBe('sk-later')
+  })
+
   it('migrates a legacy OpenAI Codex key without removing the BYOK slot', () => {
     store.setKey('openai', 'sk-legacy-codex')
     expect(store.getCodexKey()).toBe('sk-legacy-codex')

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -18,6 +18,7 @@ vi.mock('electron', () => ({
 
 import { safeStorage } from 'electron'
 import { ByokKeyStore } from './byokStore'
+import { byokFingerprint } from '../../shared/byokFingerprint'
 
 afterAll(() => rmSync(dir, { recursive: true, force: true }))
 
@@ -134,6 +135,74 @@ describe('ByokKeyStore', () => {
     } finally {
       spy.mockRestore()
     }
+  })
+
+  describe('enrolled fingerprints + validatedProviders', () => {
+    it('persists enrollment evidence and reports only matching providers as validated', () => {
+      store.setKey('deepgram', 'dg-key')
+      store.setKey('openai', 'sk-openai')
+      // No evidence yet — presence alone is not a validated capability.
+      expect(store.validatedProviders()).toEqual([])
+
+      store.setEnrolledFingerprints({
+        deepgram: byokFingerprint('dg-key'),
+        openai: byokFingerprint('sk-openai')
+      })
+      expect(store.getEnrolledFingerprints()).toEqual({
+        deepgram: byokFingerprint('dg-key'),
+        openai: byokFingerprint('sk-openai')
+      })
+      expect(store.validatedProviders().sort()).toEqual(['deepgram', 'openai'])
+    })
+
+    it('drops a provider from validated once its key is rotated (until re-enrollment)', () => {
+      store.setKey('deepgram', 'dg-key')
+      store.setEnrolledFingerprints({ deepgram: byokFingerprint('dg-key') })
+      expect(store.validatedProviders()).toEqual(['deepgram'])
+
+      // Rejected-key scenario: the stored key never matched an accepted fingerprint.
+      store.setKey('openai', 'sk-bad')
+      expect(store.validatedProviders()).toEqual(['deepgram'])
+
+      store.setKey('deepgram', 'dg-rotated')
+      expect(store.validatedProviders()).toEqual([])
+    })
+
+    it('clearing one provider key drops its enrollment evidence too', () => {
+      store.setKey('deepgram', 'dg-key')
+      store.setKey('openai', 'sk-openai')
+      store.setEnrolledFingerprints({
+        deepgram: byokFingerprint('dg-key'),
+        openai: byokFingerprint('sk-openai')
+      })
+      store.clearKey('deepgram')
+      expect(store.getEnrolledFingerprints()).toEqual({ openai: byokFingerprint('sk-openai') })
+      expect(store.validatedProviders()).toEqual(['openai'])
+
+      store.setKey('deepgram', 'dg-key') // same key re-added: evidence is gone → must re-enroll
+      expect(store.validatedProviders()).toEqual(['openai'])
+    })
+
+    it('clearEnrolledFingerprints and clearAll wipe the evidence (Codex still preserved by clearAll)', () => {
+      store.setCodexKey('sk-codex')
+      store.setKey('deepgram', 'dg-key')
+      store.setEnrolledFingerprints({ deepgram: byokFingerprint('dg-key') })
+
+      const other = new ByokKeyStore(
+        join(dir, `byok-other-${Math.random().toString(36).slice(2)}.json`)
+      )
+      other.setKey('openai', 'sk-openai')
+      other.setEnrolledFingerprints({ openai: byokFingerprint('sk-openai') })
+      other.clearEnrolledFingerprints()
+      expect(other.getEnrolledFingerprints()).toEqual({})
+      expect(other.validatedProviders()).toEqual([])
+
+      store.clearAll()
+      expect(store.getEnrolledFingerprints()).toEqual({})
+      expect(store.validatedProviders()).toEqual([])
+      expect(store.getKey('deepgram')).toBeNull()
+      expect(store.getCodexKey()).toBe('sk-codex')
+    })
   })
 
   it('defaults the file path to userData when constructed with no args', () => {

--- a/desktop/windows/src/main/agentKernel/byokStore.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.test.ts
@@ -86,6 +86,13 @@ describe('ByokKeyStore', () => {
     expect(store.getCodexKey()).toBe('sk-codex')
   })
 
+  it('migrates a legacy OpenAI Codex key before clearAll deletes the openai slot', () => {
+    store.setKey('openai', 'sk-legacy-codex')
+    store.clearAll()
+    expect(store.getAllKeys()).toEqual({})
+    expect(store.getCodexKey()).toBe('sk-legacy-codex')
+  })
+
   it('does not restore an OpenAI BYOK key after Codex is explicitly cleared', () => {
     store.setKey('openai', 'sk-openai')
     store.setCodexKey('sk-codex')

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -12,7 +12,9 @@ import { join } from 'path'
 import { BYOK_PROVIDERS, isByokActive, type ByokKeys, type ByokProvider } from '../../shared/byok'
 
 /** On-disk shape: provider → base64-encoded safeStorage ciphertext. */
-type StoredFile = Partial<Record<ByokProvider | 'codex', string>>
+type StoredFile = Partial<Record<ByokProvider | 'codex', string>> & {
+  codexMigrationComplete?: boolean
+}
 
 /**
  * Encrypted-at-rest store for the four BYOK provider keys. Reads/writes are
@@ -60,13 +62,14 @@ export class ByokKeyStore {
 
   getCodexKey(): string | null {
     const stored = this.readFile()
-    const enc = stored.codex ?? stored.openai
+    const enc = stored.codex ?? (stored.codexMigrationComplete ? undefined : stored.openai)
     if (!enc) return null
     try {
       this.requireEncryption()
       const key = safeStorage.decryptString(Buffer.from(enc, 'base64'))
-      if (!stored.codex && stored.openai) {
+      if (!stored.codex && stored.openai && !stored.codexMigrationComplete) {
         stored.codex = stored.openai
+        stored.codexMigrationComplete = true
         this.writeFile(stored)
       }
       return key
@@ -130,8 +133,9 @@ export class ByokKeyStore {
 
   clearCodexKey(): void {
     const data = this.readFile()
-    if (!('codex' in data)) return
+    if (!('codex' in data) && data.codexMigrationComplete) return
     delete data.codex
+    data.codexMigrationComplete = true
     this.writeFile(data)
   }
 

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -12,7 +12,7 @@ import { join } from 'path'
 import { BYOK_PROVIDERS, isByokActive, type ByokKeys, type ByokProvider } from '../../shared/byok'
 
 /** On-disk shape: provider → base64-encoded safeStorage ciphertext. */
-type StoredFile = Partial<Record<ByokProvider, string>>
+type StoredFile = Partial<Record<ByokProvider | 'codex', string>>
 
 /**
  * Encrypted-at-rest store for the four BYOK provider keys. Reads/writes are
@@ -58,6 +58,17 @@ export class ByokKeyStore {
     }
   }
 
+  getCodexKey(): string | null {
+    const enc = this.readFile().codex
+    if (!enc) return null
+    try {
+      this.requireEncryption()
+      return safeStorage.decryptString(Buffer.from(enc, 'base64'))
+    } catch {
+      return null
+    }
+  }
+
   /** Decrypt and return every stored provider key. */
   getAllKeys(): ByokKeys {
     const stored = this.readFile()
@@ -91,11 +102,30 @@ export class ByokKeyStore {
     this.writeFile(data)
   }
 
+  setCodexKey(key: string): void {
+    const trimmed = key.trim()
+    if (!trimmed) {
+      this.clearCodexKey()
+      return
+    }
+    this.requireEncryption()
+    const data = this.readFile()
+    data.codex = safeStorage.encryptString(trimmed).toString('base64')
+    this.writeFile(data)
+  }
+
   /** Remove one provider's key. */
   clearKey(provider: ByokProvider): void {
     const data = this.readFile()
     if (!(provider in data)) return
     delete data[provider]
+    this.writeFile(data)
+  }
+
+  clearCodexKey(): void {
+    const data = this.readFile()
+    if (!('codex' in data)) return
+    delete data.codex
     this.writeFile(data)
   }
 

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -108,7 +108,7 @@ export class ByokKeyStore {
     }
   }
 
-  /** True when all four providers have a stored key (backend all-or-nothing). */
+  /** True when a configured LLM provider has a stored key. */
   isActive(): boolean {
     return isByokActive(this.getAllKeys())
   }

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -59,11 +59,17 @@ export class ByokKeyStore {
   }
 
   getCodexKey(): string | null {
-    const enc = this.readFile().codex
+    const stored = this.readFile()
+    const enc = stored.codex ?? stored.openai
     if (!enc) return null
     try {
       this.requireEncryption()
-      return safeStorage.decryptString(Buffer.from(enc, 'base64'))
+      const key = safeStorage.decryptString(Buffer.from(enc, 'base64'))
+      if (!stored.codex && stored.openai) {
+        stored.codex = stored.openai
+        this.writeFile(stored)
+      }
+      return key
     } catch {
       return null
     }
@@ -132,7 +138,10 @@ export class ByokKeyStore {
   /** Remove all stored keys (deletes the backing file). */
   clearAll(): void {
     try {
-      rmSync(this.filePath, { force: true })
+      const data = this.readFile()
+      for (const provider of BYOK_PROVIDERS) delete data[provider]
+      if (Object.keys(data).length === 0) rmSync(this.filePath, { force: true })
+      else this.writeFile(data)
     } catch {
       /* best-effort */
     }

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -9,11 +9,25 @@
 import { app, safeStorage } from 'electron'
 import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
-import { BYOK_PROVIDERS, isByokActive, type ByokKeys, type ByokProvider } from '../../shared/byok'
+import {
+  BYOK_PROVIDERS,
+  isByokActive,
+  type ByokEnrolledFingerprints,
+  type ByokKeys,
+  type ByokProvider
+} from '../../shared/byok'
+import { byokFingerprint } from '../../shared/byokFingerprint'
 
 /** On-disk shape: provider → base64-encoded safeStorage ciphertext. */
 type StoredFile = Partial<Record<ByokProvider | 'codex', string>> & {
   codexMigrationComplete?: boolean
+  /**
+   * Fingerprints of the keys the backend currently enforces (the last successful
+   * enrollment), mirroring macOS `persistEnrolledFingerprints`. Hashes only —
+   * never raw key material. Capability claims (e.g. transcription BYOK) must
+   * match these, not mere key presence.
+   */
+  enrolledFingerprints?: ByokEnrolledFingerprints
 }
 
 /**
@@ -128,8 +142,12 @@ export class ByokKeyStore {
   /** Remove one provider's key. */
   clearKey(provider: ByokProvider): void {
     const data = this.readFile()
-    if (!(provider in data)) return
+    if (!(provider in data) && !(provider in (data.enrolledFingerprints ?? {}))) return
     delete data[provider]
+    if (data.enrolledFingerprints) {
+      delete data.enrolledFingerprints[provider]
+      if (Object.keys(data.enrolledFingerprints).length === 0) delete data.enrolledFingerprints
+    }
     this.writeFile(data)
   }
 
@@ -147,11 +165,51 @@ export class ByokKeyStore {
       this.migrateLegacyCodexKey()
       const data = this.readFile()
       for (const provider of BYOK_PROVIDERS) delete data[provider]
+      delete data.enrolledFingerprints
       if (Object.keys(data).length === 0) rmSync(this.filePath, { force: true })
       else this.writeFile(data)
     } catch {
       /* best-effort */
     }
+  }
+
+  /**
+   * Persist the fingerprint set the backend currently enforces. An empty map
+   * removes the stored evidence entirely (deactivated).
+   */
+  setEnrolledFingerprints(fingerprints: ByokEnrolledFingerprints): void {
+    const data = this.readFile()
+    if (Object.keys(fingerprints).length === 0) delete data.enrolledFingerprints
+    else data.enrolledFingerprints = { ...fingerprints }
+    this.writeFile(data)
+  }
+
+  getEnrolledFingerprints(): ByokEnrolledFingerprints {
+    return { ...(this.readFile().enrolledFingerprints ?? {}) }
+  }
+
+  clearEnrolledFingerprints(): void {
+    const data = this.readFile()
+    if (!data.enrolledFingerprints) return
+    delete data.enrolledFingerprints
+    if (Object.keys(data).length === 0) rmSync(this.filePath, { force: true })
+    else this.writeFile(data)
+  }
+
+  /**
+   * Providers whose CURRENT stored key hash matches the enrolled fingerprint —
+   * i.e. capabilities validated by the backend and not rotated since. A key
+   * edited after the last enrollment drops out until it re-enrolls.
+   */
+  validatedProviders(): ByokProvider[] {
+    const enrolled = this.readFile().enrolledFingerprints ?? {}
+    const out: ByokProvider[] = []
+    for (const provider of BYOK_PROVIDERS) {
+      const fp = enrolled[provider]
+      const key = this.getKey(provider)
+      if (fp && key && byokFingerprint(key) === fp) out.push(provider)
+    }
+    return out
   }
 
   /** True when a configured LLM provider has a stored key. */

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -76,8 +76,10 @@ export class ByokKeyStore {
 
   private migrateLegacyCodexKey(): void {
     const stored = this.readFile()
-    if (stored.codex || stored.codexMigrationComplete || !stored.openai) return
-    stored.codex = stored.openai
+    if (stored.codexMigrationComplete) return
+    if (stored.openai && !stored.codex) {
+      stored.codex = stored.openai
+    }
     stored.codexMigrationComplete = true
     this.writeFile(stored)
   }

--- a/desktop/windows/src/main/agentKernel/byokStore.ts
+++ b/desktop/windows/src/main/agentKernel/byokStore.ts
@@ -60,19 +60,21 @@ export class ByokKeyStore {
     }
   }
 
-  getCodexKey(): string | null {
+  private migrateLegacyCodexKey(): void {
     const stored = this.readFile()
-    const enc = stored.codex ?? (stored.codexMigrationComplete ? undefined : stored.openai)
+    if (stored.codex || stored.codexMigrationComplete || !stored.openai) return
+    stored.codex = stored.openai
+    stored.codexMigrationComplete = true
+    this.writeFile(stored)
+  }
+
+  getCodexKey(): string | null {
+    this.migrateLegacyCodexKey()
+    const enc = this.readFile().codex
     if (!enc) return null
     try {
       this.requireEncryption()
-      const key = safeStorage.decryptString(Buffer.from(enc, 'base64'))
-      if (!stored.codex && stored.openai && !stored.codexMigrationComplete) {
-        stored.codex = stored.openai
-        stored.codexMigrationComplete = true
-        this.writeFile(stored)
-      }
-      return key
+      return safeStorage.decryptString(Buffer.from(enc, 'base64'))
     } catch {
       return null
     }
@@ -142,6 +144,7 @@ export class ByokKeyStore {
   /** Remove all stored keys (deletes the backing file). */
   clearAll(): void {
     try {
+      this.migrateLegacyCodexKey()
       const data = this.readFile()
       for (const provider of BYOK_PROVIDERS) delete data[provider]
       if (Object.keys(data).length === 0) rmSync(this.filePath, { force: true })

--- a/desktop/windows/src/main/agentKernel/byokValidator.test.ts
+++ b/desktop/windows/src/main/agentKernel/byokValidator.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
-import {
-  validateProviderKey,
-  validateAllByokKeys,
-  type FetchLike
-} from './byokValidator'
+import { validateProviderKey, validateAllByokKeys, type FetchLike } from './byokValidator'
 import type { ByokKeys } from '../../shared/byok'
 
 /** A FetchLike that returns a fixed status and records the calls it received. */
-function stubFetch(status: number): { fetch: FetchLike; calls: { url: string; headers: Record<string, string> }[] } {
+function stubFetch(status: number): {
+  fetch: FetchLike
+  calls: { url: string; headers: Record<string, string> }[]
+} {
   const calls: { url: string; headers: Record<string, string> }[] = []
   const fetch: FetchLike = async (url, init) => {
     calls.push({ url, headers: init.headers })
@@ -111,22 +110,29 @@ describe('validateProviderKey — classifier', () => {
 })
 
 describe('validateAllByokKeys', () => {
-  it('validates all four providers in parallel and keys the results', async () => {
-    const fullKeys: ByokKeys = { openai: 'a', anthropic: 'b', gemini: 'c', deepgram: 'd' }
+  it('validates configured providers in parallel and keys the results', async () => {
+    const fullKeys: ByokKeys = {
+      openrouter: 'or',
+      openai: 'a',
+      anthropic: 'b',
+      gemini: 'c',
+      deepgram: 'd'
+    }
     const { fetch, calls } = stubFetch(200)
     const results = await validateAllByokKeys(fullKeys, fetch)
-    expect(calls).toHaveLength(4)
+    expect(calls).toHaveLength(5)
+    expect(results.openrouter?.ok).toBe(true)
     expect(results.openai?.ok).toBe(true)
     expect(results.anthropic?.ok).toBe(true)
     expect(results.gemini?.ok).toBe(true)
     expect(results.deepgram?.ok).toBe(true)
   })
 
-  it('marks a missing provider as an empty failure (no request for it)', async () => {
+  it('does not validate a missing provider', async () => {
     const partial: ByokKeys = { openai: 'a', anthropic: 'b', gemini: 'c' }
     const fetch = vi.fn(async () => ({ status: 200 })) as unknown as FetchLike
     const results = await validateAllByokKeys(partial, fetch)
-    expect(results.deepgram).toMatchObject({ ok: false, kind: 'empty' })
+    expect(results.deepgram).toBeUndefined()
     expect(results.openai?.ok).toBe(true)
   })
 

--- a/desktop/windows/src/main/agentKernel/byokValidator.ts
+++ b/desktop/windows/src/main/agentKernel/byokValidator.ts
@@ -35,7 +35,15 @@ function providerRequest(
 ): { url: string; headers: Record<string, string> } {
   switch (provider) {
     case 'openai':
-      return { url: 'https://api.openai.com/v1/models', headers: { Authorization: `Bearer ${key}` } }
+      return {
+        url: 'https://api.openai.com/v1/models',
+        headers: { Authorization: `Bearer ${key}` }
+      }
+    case 'openrouter':
+      return {
+        url: 'https://openrouter.ai/api/v1/models',
+        headers: { Authorization: `Bearer ${key}` }
+      }
     case 'anthropic':
       return {
         url: 'https://api.anthropic.com/v1/models?limit=1',
@@ -101,7 +109,7 @@ export async function validateAllByokKeys(
   fetchImpl: FetchLike = globalThis.fetch as unknown as FetchLike
 ): Promise<ByokValidationResults> {
   const entries = await Promise.all(
-    BYOK_PROVIDERS.map(
+    BYOK_PROVIDERS.filter((provider) => Boolean(keys[provider]?.trim())).map(
       async (provider): Promise<[ByokProvider, ByokKeyValidation]> => [
         provider,
         await validateProviderKey(provider, keys[provider] ?? '', fetchImpl)

--- a/desktop/windows/src/main/agentKernel/byokValidator.ts
+++ b/desktop/windows/src/main/agentKernel/byokValidator.ts
@@ -41,7 +41,7 @@ function providerRequest(
       }
     case 'openrouter':
       return {
-        url: 'https://openrouter.ai/api/v1/models',
+        url: 'https://openrouter.ai/api/v1/auth/key',
         headers: { Authorization: `Bearer ${key}` }
       }
     case 'anthropic':
@@ -100,9 +100,7 @@ export async function validateProviderKey(
 }
 
 /**
- * Validate every provider in `keys` in parallel. Only the four canonical
- * providers are checked; missing entries are validated as empty (fail), so the
- * caller can treat a non-`ok` result uniformly as "not all four authenticate".
+ * Validate every configured provider in `keys` in parallel.
  */
 export async function validateAllByokKeys(
   keys: ByokKeys,

--- a/desktop/windows/src/main/agentKernel/byokValidator.ts
+++ b/desktop/windows/src/main/agentKernel/byokValidator.ts
@@ -2,7 +2,7 @@
 // `BYOKValidator` (desktop/macos/Desktop/Sources/BYOKValidator.swift).
 //
 // We never flip the backend onto the BYOK free plan with a dead key: enrollment
-// live-validates all four keys first. Each ping hits the provider's cheapest
+// live-validates every configured LLM key first. Each ping hits the provider's cheapest
 // auth-gated endpoint; any 2xx means the key at least authenticates (billing
 // problems surface later as a normal inference error — not a key-shape problem
 // we could have caught up front). A 401/403 is a definitive rejection.

--- a/desktop/windows/src/main/codingAgent/codexAuth.test.ts
+++ b/desktop/windows/src/main/codingAgent/codexAuth.test.ts
@@ -7,18 +7,17 @@ import {
   validateOpenAiKey,
   type FetchLike
 } from './codexAuth'
-import type { ByokProvider } from '../../shared/byok'
 
 /** In-memory stand-in for ByokKeyStore's get/set/clear (no Electron safeStorage). */
-function makeFakeStore(initial: Partial<Record<ByokProvider, string>> = {}) {
-  const data: Partial<Record<ByokProvider, string>> = { ...initial }
+function makeFakeStore() {
+  let codexKey: string | null = null
   return {
-    getKey: vi.fn((p: ByokProvider) => data[p] ?? null),
-    setKey: vi.fn((p: ByokProvider, k: string) => {
-      data[p] = k.trim()
+    getCodexKey: vi.fn(() => codexKey),
+    setCodexKey: vi.fn((k: string) => {
+      codexKey = k.trim()
     }),
-    clearKey: vi.fn((p: ByokProvider) => {
-      delete data[p]
+    clearCodexKey: vi.fn(() => {
+      codexKey = null
     })
   }
 }
@@ -60,7 +59,7 @@ describe('saveCodexApiKey', () => {
     __setCodexKeyStoreForTests(store)
     const r = await saveCodexApiKey('  sk-good  ', async () => ({ ok: true, status: 200 }))
     expect(r).toEqual({ ok: true, hasKey: true, warning: undefined })
-    expect(store.setKey).toHaveBeenCalledWith('openai', 'sk-good')
+    expect(store.setCodexKey).toHaveBeenCalledWith('sk-good')
     expect(getCodexApiKey()).toBe('sk-good')
     expect(codexApiKeyStatus()).toEqual({ hasKey: true })
   })
@@ -74,7 +73,7 @@ describe('saveCodexApiKey', () => {
       error: 'nope'
     }))
     expect(r.ok).toBe(false)
-    expect(store.setKey).not.toHaveBeenCalled()
+    expect(store.setCodexKey).not.toHaveBeenCalled()
   })
 
   it('stores anyway when OpenAI is unreachable, with a soft warning', async () => {
@@ -88,14 +87,14 @@ describe('saveCodexApiKey', () => {
     expect(r.ok).toBe(true)
     expect(r.hasKey).toBe(true)
     expect(r.warning).toMatch(/reach/i)
-    expect(store.setKey).toHaveBeenCalledWith('openai', 'sk-offline')
+    expect(store.setCodexKey).toHaveBeenCalledWith('sk-offline')
   })
 
   it('clears the key when saved blank', async () => {
-    const store = makeFakeStore({ openai: 'sk-old' })
+    const store = makeFakeStore()
     __setCodexKeyStoreForTests(store)
     const r = await saveCodexApiKey('   ')
     expect(r).toEqual({ ok: true, hasKey: false })
-    expect(store.clearKey).toHaveBeenCalledWith('openai')
+    expect(store.clearCodexKey).toHaveBeenCalled()
   })
 })

--- a/desktop/windows/src/main/codingAgent/codexAuth.ts
+++ b/desktop/windows/src/main/codingAgent/codexAuth.ts
@@ -21,7 +21,7 @@ import type { CodexKeyResult, CodexKeyStatus } from '../../shared/types'
 
 /** The subset of ByokKeyStore this module needs (so tests can inject a fake
  *  without Electron safeStorage). */
-type CodexKeyBackingStore = Pick<ByokKeyStore, 'getKey' | 'setKey' | 'clearKey'>
+type CodexKeyBackingStore = Pick<ByokKeyStore, 'getCodexKey' | 'setCodexKey' | 'clearCodexKey'>
 
 // Lazily constructed so this module stays import-pure (ByokKeyStore's default
 // constructor calls app.getPath, which isn't ready at import time).
@@ -35,7 +35,7 @@ function getStore(): CodexKeyBackingStore {
 /** The stored Codex OpenAI key, or null. Read by the adapter registry at spawn. */
 export function getCodexApiKey(): string | null {
   try {
-    return getStore().getKey('openai')
+    return getStore().getCodexKey()
   } catch {
     return null
   }
@@ -98,14 +98,14 @@ export async function saveCodexApiKey(
 ): Promise<CodexKeyResult> {
   const trimmed = key.trim()
   if (!trimmed) {
-    getStore().clearKey('openai')
+    getStore().clearCodexKey()
     return { ok: true, hasKey: false }
   }
   const result = await validate(trimmed)
   if (result.status === 401) {
     return { ok: false, hasKey: codexApiKeyStatus().hasKey, error: result.error }
   }
-  getStore().setKey('openai', trimmed)
+  getStore().setCodexKey(trimmed)
   return { ok: true, hasKey: true, warning: result.ok ? undefined : result.error }
 }
 

--- a/desktop/windows/src/main/codingAgent/pi-mono-extension/index.test.ts
+++ b/desktop/windows/src/main/codingAgent/pi-mono-extension/index.test.ts
@@ -221,14 +221,18 @@ describe('BYOK header gating', () => {
     })
   })
 
-  it('attaches NO headers for a partial (3/4) BYOK set', () => {
+  it('attaches configured headers without requiring an unrelated Deepgram key', () => {
     process.env.OMI_BYOK_OPENAI = 'oa'
     process.env.OMI_BYOK_ANTHROPIC = 'an'
     process.env.OMI_BYOK_GEMINI = 'ge'
     // deepgram missing
     const cap = makeFakePi()
     omiProvider(cap.pi)
-    expect(cap.provider?.cfg.headers).toBeUndefined()
+    expect(cap.provider?.cfg.headers).toEqual({
+      'X-BYOK-OpenAI': 'oa',
+      'X-BYOK-Anthropic': 'an',
+      'X-BYOK-Gemini': 'ge'
+    })
   })
 
   it('attaches NO headers when no BYOK keys are present', () => {

--- a/desktop/windows/src/main/codingAgent/pi-mono-extension/index.test.ts
+++ b/desktop/windows/src/main/codingAgent/pi-mono-extension/index.test.ts
@@ -203,10 +203,10 @@ describe('provider registration', () => {
 })
 
 // ===========================================================================
-// BYOK all-or-nothing (NEW)
+// BYOK capability-scoped header gating
 // ===========================================================================
 describe('BYOK header gating', () => {
-  it('attaches all four X-BYOK-* headers only when all four env keys are present', () => {
+  it('attaches a header for every configured env key that is present', () => {
     process.env.OMI_BYOK_OPENAI = 'oa'
     process.env.OMI_BYOK_ANTHROPIC = 'an'
     process.env.OMI_BYOK_GEMINI = 'ge'

--- a/desktop/windows/src/main/codingAgent/pi-mono-extension/index.ts
+++ b/desktop/windows/src/main/codingAgent/pi-mono-extension/index.ts
@@ -1030,12 +1030,10 @@ export default function omiProvider(pi: ExtensionAPI): void {
   const baseUrl = process.env.OMI_API_BASE_URL || 'https://api.omi.me/v2'
   const apiKey = process.env.OMI_API_KEY || ''
 
-  // BYOK: the app sets OMI_BYOK_* env vars (all four, or none) when the user is
-  // on the free plan with their own provider keys. Attach them as X-BYOK-*
-  // headers on every request so the backend applies the request-level
-  // all-four-keys paywall exemption and routes inference through the user's own
-  // key. We only attach the complete set — the backend's has_all_byok_keys()
-  // requires all four to be present. (Env-var names match src/shared/byok.ts.)
+  // BYOK: the app sets OMI_BYOK_* env vars for the selected LLM provider and
+  // optional Deepgram key. Attach configured capabilities as X-BYOK-* headers
+  // so the backend applies the LLM BYOK quota exemption and routes inference
+  // through the selected provider key. (Env-var names match src/shared/byok.ts.)
   const byokMap: Array<[string, string]> = [
     ['OMI_BYOK_OPENROUTER', 'X-BYOK-OpenRouter'],
     ['OMI_BYOK_OPENAI', 'X-BYOK-OpenAI'],
@@ -1051,7 +1049,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
   const byokActive = Object.keys(byokHeaders).length > 0
   if (byokActive) {
     process.stderr.write(
-      `[omi-provider] BYOK active — attaching ${byokMap.length} X-BYOK headers\n`
+      `[omi-provider] BYOK active — attaching ${Object.keys(byokHeaders).length} X-BYOK headers\n`
     )
   }
 

--- a/desktop/windows/src/main/codingAgent/pi-mono-extension/index.ts
+++ b/desktop/windows/src/main/codingAgent/pi-mono-extension/index.ts
@@ -1037,6 +1037,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
   // key. We only attach the complete set — the backend's has_all_byok_keys()
   // requires all four to be present. (Env-var names match src/shared/byok.ts.)
   const byokMap: Array<[string, string]> = [
+    ['OMI_BYOK_OPENROUTER', 'X-BYOK-OpenRouter'],
     ['OMI_BYOK_OPENAI', 'X-BYOK-OpenAI'],
     ['OMI_BYOK_ANTHROPIC', 'X-BYOK-Anthropic'],
     ['OMI_BYOK_GEMINI', 'X-BYOK-Gemini'],
@@ -1047,7 +1048,7 @@ export default function omiProvider(pi: ExtensionAPI): void {
     const value = process.env[envName]
     if (value && value.length > 0) byokHeaders[headerName] = value
   }
-  const byokActive = Object.keys(byokHeaders).length === byokMap.length
+  const byokActive = Object.keys(byokHeaders).length > 0
   if (byokActive) {
     process.stderr.write(
       `[omi-provider] BYOK active — attaching ${byokMap.length} X-BYOK headers\n`

--- a/desktop/windows/src/main/codingAgent/piMonoSession.test.ts
+++ b/desktop/windows/src/main/codingAgent/piMonoSession.test.ts
@@ -203,7 +203,7 @@ describe('piMonoManagedApiBaseUrl (adds the /v2 segment the OpenAI SDK needs)', 
   })
 })
 
-describe('getPiMonoByokEnv (all-or-nothing, separate from the Firebase session)', () => {
+describe('getPiMonoByokEnv (capability-scoped, separate from the Firebase session)', () => {
   it('injects the complete OMI_BYOK_* set when all four keys are stored', () => {
     const store = new ByokKeyStore(
       join(dir, `byok-full-${Math.random().toString(36).slice(2)}.json`)

--- a/desktop/windows/src/main/codingAgent/piMonoSession.test.ts
+++ b/desktop/windows/src/main/codingAgent/piMonoSession.test.ts
@@ -222,7 +222,7 @@ describe('getPiMonoByokEnv (all-or-nothing, separate from the Firebase session)'
     })
   })
 
-  it('returns {} at 3/4 keys (never a partial injection)', () => {
+  it('returns configured keys without requiring an unrelated Deepgram key', () => {
     const store = new ByokKeyStore(
       join(dir, `byok-partial-${Math.random().toString(36).slice(2)}.json`)
     )
@@ -231,7 +231,11 @@ describe('getPiMonoByokEnv (all-or-nothing, separate from the Firebase session)'
     store.setKey('gemini', 'gm-key')
     __setByokKeyStoreForTests(store)
 
-    expect(getPiMonoByokEnv()).toEqual({})
+    expect(getPiMonoByokEnv()).toEqual({
+      OMI_BYOK_OPENAI: 'sk-openai',
+      OMI_BYOK_ANTHROPIC: 'sk-ant',
+      OMI_BYOK_GEMINI: 'gm-key'
+    })
   })
 
   it('is independent of the Firebase session (empty even with a live session)', () => {

--- a/desktop/windows/src/main/ipc/byok.ts
+++ b/desktop/windows/src/main/ipc/byok.ts
@@ -55,6 +55,9 @@ export function registerByokHandlers(): void {
     getStore().clearAll()
     broadcastByokChanged()
   })
+  ipcMain.handle('byok:clearCodex', (): void => {
+    getStore().clearCodexKey()
+  })
   ipcMain.handle('byok:isActive', (): boolean => getStore().isActive())
 
   // Validate the stored keys live and reconcile the backend BYOK activation.

--- a/desktop/windows/src/main/ipc/byok.ts
+++ b/desktop/windows/src/main/ipc/byok.ts
@@ -59,6 +59,10 @@ export function registerByokHandlers(): void {
     getStore().clearCodexKey()
   })
   ipcMain.handle('byok:isActive', (): boolean => getStore().isActive())
+  // Providers whose stored key still matches the last successful enrollment —
+  // the validated-capability evidence quota suppression and plan UI must use
+  // (raw key presence is NOT proof: a rejected key stays stored until edited).
+  ipcMain.handle('byok:validatedProviders', (): ByokProvider[] => getStore().validatedProviders())
 
   // Validate the stored keys live and reconcile the backend BYOK activation.
   // The Firebase bearer token is relayed from the renderer (same pattern as the
@@ -69,6 +73,9 @@ export function registerByokHandlers(): void {
       apiBase: apiBase(),
       token
     })
+    // Mirror the server-known fingerprint set into the store. Absent on a failed
+    // POST (server state unknown) → prior evidence stands, matching the backend.
+    if (result.enrolledFingerprints) getStore().setEnrolledFingerprints(result.enrolledFingerprints)
     broadcastByokChanged()
     return result
   })
@@ -78,5 +85,7 @@ export function registerByokHandlers(): void {
   // while the session is still valid.
   ipcMain.handle('byok:deactivate', async (_e, token: string): Promise<void> => {
     await deactivateByok({ apiBase: apiBase(), token })
+    getStore().clearEnrolledFingerprints()
+    broadcastByokChanged()
   })
 }

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -421,6 +421,7 @@ const omi: OmiBridgeApi = {
   byokSet: (provider: ByokProvider, key: string) => ipcRenderer.invoke('byok:set', provider, key),
   byokClear: (provider: ByokProvider) => ipcRenderer.invoke('byok:clear', provider),
   byokClearAll: () => ipcRenderer.invoke('byok:clearAll'),
+  byokClearCodex: () => ipcRenderer.invoke('byok:clearCodex'),
   byokIsActive: () => ipcRenderer.invoke('byok:isActive'),
   // Live-validate the stored keys and reconcile backend BYOK activation. The
   // Firebase token is relayed from the renderer (its session owns it).

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -423,6 +423,9 @@ const omi: OmiBridgeApi = {
   byokClearAll: () => ipcRenderer.invoke('byok:clearAll'),
   byokClearCodex: () => ipcRenderer.invoke('byok:clearCodex'),
   byokIsActive: () => ipcRenderer.invoke('byok:isActive'),
+  // Providers whose stored key matches the last successful enrollment — the
+  // validated-capability evidence (never raw keys) for quota/plan UI.
+  byokValidatedProviders: () => ipcRenderer.invoke('byok:validatedProviders'),
   // Live-validate the stored keys and reconcile backend BYOK activation. The
   // Firebase token is relayed from the renderer (its session owns it).
   byokEnroll: (token: string): Promise<ByokEnrollResult> =>

--- a/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.test.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/AdvancedTab.test.tsx
@@ -52,6 +52,7 @@ beforeEach(() => {
     // AdvancedTab now embeds the BYOK "Developer API Keys" subsection, which
     // reads stored keys on mount (and would enroll/clear on interaction).
     byokGetAll: vi.fn().mockResolvedValue({}),
+    byokValidatedProviders: vi.fn().mockResolvedValue([]),
     byokSet: vi.fn().mockResolvedValue(undefined),
     byokClearAll: vi.fn().mockResolvedValue(undefined),
     byokEnroll: vi.fn().mockResolvedValue({ active: false, results: {} }),

--- a/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
@@ -94,7 +94,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
     }
   }, [])
 
-  const hasAll = isByokActive(keys)
+  const hasActiveLLMByok = isByokActive(keys)
   const hasAnyKey = BYOK_PROVIDERS.some((p) => keys[p].trim().length > 0)
 
   // Persist the current key set, then reconcile backend activation. Runs
@@ -102,8 +102,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
   const commit = async (): Promise<void> => {
     const cur = keysRef.current
     await Promise.all(BYOK_PROVIDERS.map((p) => window.omi.byokSet(p, cur[p].trim())))
-    // Live-validate only when the full set is present (matches the enroll IPC's
-    // own gate); a partial set just deactivates with no per-provider network.
+    // Live-validate when an LLM key is configured; Deepgram remains optional.
     const willValidate = isByokActive(cur)
     setChecking(willValidate)
     setActivationError(null)
@@ -131,7 +130,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
         .sort()
       setActivationError(
         rejected.length
-          ? `Rejected by provider: ${rejected.join(', ')}. Free plan stays off until all 4 keys authenticate.`
+          ? `Rejected by provider: ${rejected.join(', ')}. Free plan stays off until an LLM key authenticates.`
           : null
       )
     }
@@ -172,17 +171,17 @@ export function DeveloperKeysSection(): React.JSX.Element {
 
       {/* Status banner — verbatim macOS copy, "this Mac" adapted to "this PC". */}
       <div className="mb-4 flex items-start gap-3 rounded-xl border border-white/[0.08] bg-white/[0.03] p-4">
-        {hasAll ? (
+        {hasActiveLLMByok ? (
           <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" strokeWidth={1.75} />
         ) : (
           <KeyRound className="mt-0.5 h-5 w-5 shrink-0 text-white/55" strokeWidth={1.75} />
         )}
         <div className="min-w-0">
           <div className="text-[15px] font-semibold text-text-primary">
-            {hasAll ? 'Free plan active' : 'Use Omi free forever'}
+            {hasActiveLLMByok ? 'Free plan active' : 'Use Omi free forever'}
           </div>
           <div className="mt-0.5 text-sm text-text-tertiary">
-            {hasAll
+            {hasActiveLLMByok
               ? "You're paying your own providers. Omi skips the subscription charge. Keys stay on this PC."
               : 'Add an LLM key to switch to the free plan. OpenRouter is preferred when configured; Deepgram is optional and only powers transcription. Keys stay on this PC — we never store them on our servers.'}
           </div>

--- a/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
@@ -16,24 +16,42 @@ import { dismissUsageLimit } from '../../../lib/usageLimit'
 import { fetchSubscription, fetchChatQuota } from '../../../lib/billing'
 import {
   BYOK_PROVIDERS,
+  isByokActive,
   type ByokProvider,
   type ByokValidationResults
 } from '../../../../../shared/byok'
 
 /** Field metadata per provider — titles/subtitles verbatim from the macOS view. */
 const PROVIDERS: { id: ByokProvider; title: string; subtitle: string; displayName: string }[] = [
+  {
+    id: 'openrouter',
+    title: 'OpenRouter API Key',
+    subtitle: 'For OpenRouter models.',
+    displayName: 'OpenRouter'
+  },
   { id: 'openai', title: 'OpenAI API Key', subtitle: 'For GPT calls.', displayName: 'OpenAI' },
-  { id: 'anthropic', title: 'Anthropic API Key', subtitle: 'For chat (Claude).', displayName: 'Anthropic' },
+  {
+    id: 'anthropic',
+    title: 'Anthropic API Key',
+    subtitle: 'For chat (Claude).',
+    displayName: 'Anthropic'
+  },
   {
     id: 'gemini',
     title: 'Gemini API Key',
     subtitle: 'For proactive AI (memory, tasks, insights, focus).',
     displayName: 'Gemini'
   },
-  { id: 'deepgram', title: 'Deepgram API Key', subtitle: 'For live transcription.', displayName: 'Deepgram' }
+  {
+    id: 'deepgram',
+    title: 'Deepgram API Key',
+    subtitle: 'For live transcription.',
+    displayName: 'Deepgram'
+  }
 ]
 
 const emptyKeys = (): Record<ByokProvider, string> => ({
+  openrouter: '',
   openai: '',
   anthropic: '',
   gemini: '',
@@ -50,6 +68,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
   const [checking, setChecking] = useState(false)
   const [activationError, setActivationError] = useState<string | null>(null)
   const [reveal, setReveal] = useState<Record<ByokProvider, boolean>>({
+    openrouter: false,
     openai: false,
     anthropic: false,
     gemini: false,
@@ -75,7 +94,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
     }
   }, [])
 
-  const hasAll = BYOK_PROVIDERS.every((p) => keys[p].trim().length > 0)
+  const hasAll = isByokActive(keys)
   const hasAnyKey = BYOK_PROVIDERS.some((p) => keys[p].trim().length > 0)
 
   // Persist the current key set, then reconcile backend activation. Runs
@@ -85,7 +104,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
     await Promise.all(BYOK_PROVIDERS.map((p) => window.omi.byokSet(p, cur[p].trim())))
     // Live-validate only when the full set is present (matches the enroll IPC's
     // own gate); a partial set just deactivates with no per-provider network.
-    const willValidate = BYOK_PROVIDERS.every((p) => cur[p].trim().length > 0)
+    const willValidate = isByokActive(cur)
     setChecking(willValidate)
     setActivationError(null)
     const token = await auth.currentUser?.getIdToken().catch(() => undefined)
@@ -165,7 +184,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
           <div className="mt-0.5 text-sm text-text-tertiary">
             {hasAll
               ? "You're paying your own providers. Omi skips the subscription charge. Keys stay on this PC."
-              : 'Provide all four keys (OpenAI, Anthropic, Gemini, Deepgram) to switch to the free plan. Keys stay on this PC — we never store them on our servers.'}
+              : 'Add an LLM key to switch to the free plan. OpenRouter is preferred when configured; Deepgram is optional and only powers transcription. Keys stay on this PC — we never store them on our servers.'}
           </div>
         </div>
       </div>
@@ -229,7 +248,10 @@ export function DeveloperKeysSection(): React.JSX.Element {
 
       {hasAnyKey && (
         <div className="mt-5 flex justify-center">
-          <button onClick={() => void clearAll()} className="text-sm font-medium text-red-400 hover:text-red-300">
+          <button
+            onClick={() => void clearAll()}
+            className="text-sm font-medium text-red-400 hover:text-red-300"
+          >
             Clear All Custom Keys
           </button>
         </div>

--- a/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
@@ -1,9 +1,10 @@
 // Settings → Advanced → "Developer API Keys" subsection: bring-your-own-key
-// (BYOK). Provide all four provider keys and Omi runs entirely on them — the
-// "free forever" plan — with no Omi subscription charge. Ported from the macOS
-// DeveloperKeys section (SettingsContentView+DeveloperKeys.swift): same
-// all-or-nothing model, same copy, same up-front live validation before the
-// backend is ever flipped on.
+// (BYOK). Configure at least one LLM provider key (Deepgram is optional) and
+// Omi runs on your keys — the "free forever" plan — with no Omi subscription
+// charge. Ported from the macOS DeveloperKeys section
+// (SettingsContentView+DeveloperKeys.swift): same capability-scoped model,
+// same copy, same up-front live validation before the backend is ever flipped
+// on.
 //
 // Keys are encrypted at rest in the main process (ByokKeyStore, DPAPI). This UI
 // never persists or logs raw keys; enrollment sends only SHA-256 fingerprints.

--- a/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
@@ -17,6 +17,7 @@ import { dismissUsageLimit } from '../../../lib/usageLimit'
 import { fetchSubscription, fetchChatQuota } from '../../../lib/billing'
 import {
   BYOK_PROVIDERS,
+  BYOK_LLM_PROVIDERS,
   isByokActive,
   type ByokProvider,
   type ByokValidationResults
@@ -68,6 +69,10 @@ export function DeveloperKeysSection(): React.JSX.Element {
   const [statuses, setStatuses] = useState<ByokValidationResults>({})
   const [checking, setChecking] = useState(false)
   const [activationError, setActivationError] = useState<string | null>(null)
+  // Whether the backend enrollment actually succeeded — the banner must not
+  // claim "Free plan active" off key presence alone: an invalid or rejected key
+  // stays in the fields while activation stays off.
+  const [enrolledActive, setEnrolledActive] = useState(false)
   const [reveal, setReveal] = useState<Record<ByokProvider, boolean>>({
     openrouter: false,
     openai: false,
@@ -82,7 +87,8 @@ export function DeveloperKeysSection(): React.JSX.Element {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Load stored keys once on mount so the fields reflect what's saved. We do NOT
-  // validate on open (no network on open) — the banner reflects presence only;
+  // validate on open (no network on open) — the banner reflects the LAST
+  // enrollment outcome (validated providers from main), not field presence;
   // badges populate after a change triggers enrollment (Mac parity).
   useEffect(() => {
     void window.omi.byokGetAll().then((stored) => {
@@ -90,12 +96,16 @@ export function DeveloperKeysSection(): React.JSX.Element {
       keysRef.current = merged
       setKeys(merged)
     })
+    void window.omi.byokValidatedProviders().then((validated) => {
+      const llm = new Set<string>(BYOK_LLM_PROVIDERS as readonly string[])
+      setEnrolledActive(validated.some((p) => llm.has(p)))
+    })
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
   }, [])
 
-  const hasActiveLLMByok = isByokActive(keys)
+  const hasActiveLLMByok = enrolledActive
   const hasAnyKey = BYOK_PROVIDERS.some((p) => keys[p].trim().length > 0)
 
   // Persist the current key set, then reconcile backend activation. Runs
@@ -117,6 +127,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
     setChecking(false)
     setStatuses(result.results)
     if (result.active) {
+      setEnrolledActive(true)
       setActivationError(null)
       // Mac parity: on activation, refresh plan/quota and clear any sticky
       // paywall so a user who just hit their limit isn't left blocked.
@@ -124,16 +135,22 @@ export function DeveloperKeysSection(): React.JSX.Element {
       void fetchSubscription().catch(() => {})
       void fetchChatQuota().catch(() => {})
     } else if (result.backendError) {
+      // The enroll POST failed — server state unknown, so keep the prior
+      // activation evidence instead of flipping the banner either way.
       setActivationError("Couldn't reach Omi to switch on the free plan. Try again.")
-    } else if (willValidate) {
-      const rejected = PROVIDERS.filter((p) => result.results[p.id] && !result.results[p.id]?.ok)
-        .map((p) => p.displayName)
-        .sort()
-      setActivationError(
-        rejected.length
-          ? `Rejected by provider: ${rejected.join(', ')}. Free plan stays off until an LLM key authenticates.`
-          : null
-      )
+    } else {
+      // Deactivate DELETE sent (or every LLM key rejected) — the free plan is off.
+      setEnrolledActive(false)
+      if (willValidate) {
+        const rejected = PROVIDERS.filter((p) => result.results[p.id] && !result.results[p.id]?.ok)
+          .map((p) => p.displayName)
+          .sort()
+        setActivationError(
+          rejected.length
+            ? `Rejected by provider: ${rejected.join(', ')}. Free plan stays off until an LLM key authenticates.`
+            : null
+        )
+      }
     }
   }
 
@@ -155,6 +172,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
     setStatuses({})
     setActivationError(null)
     setChecking(false)
+    setEnrolledActive(false)
     await window.omi.byokClearAll()
     const token = await auth.currentUser?.getIdToken().catch(() => undefined)
     if (token) await window.omi.byokEnroll(token) // deactivates (empty set)

--- a/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/DeveloperKeysSection.tsx
@@ -85,6 +85,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
   // pending timer so rapid edits collapse into one validate/enroll.
   const keysRef = useRef<Record<ByokProvider, string>>(emptyKeys())
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const enrollGenRef = useRef(0)
 
   // Load stored keys once on mount so the fields reflect what's saved. We do NOT
   // validate on open (no network on open) — the banner reflects the LAST
@@ -111,6 +112,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
   // Persist the current key set, then reconcile backend activation. Runs
   // debounced after edits (not per keystroke).
   const commit = async (): Promise<void> => {
+    const gen = ++enrollGenRef.current
     const cur = keysRef.current
     await Promise.all(BYOK_PROVIDERS.map((p) => window.omi.byokSet(p, cur[p].trim())))
     // Live-validate when an LLM key is configured; Deepgram remains optional.
@@ -124,6 +126,7 @@ export function DeveloperKeysSection(): React.JSX.Element {
       return
     }
     const result = await window.omi.byokEnroll(token)
+    if (gen !== enrollGenRef.current) return
     setChecking(false)
     setStatuses(result.results)
     if (result.active) {

--- a/desktop/windows/src/renderer/src/lib/authTeardown.test.ts
+++ b/desktop/windows/src/renderer/src/lib/authTeardown.test.ts
@@ -26,12 +26,14 @@ const LAST_UID_KEY = 'omi.lastSignedInUid'
 
 const wipeUserData = vi.fn(async () => {})
 const byokClearAll = vi.fn(async () => {})
+const byokClearCodex = vi.fn(async () => {})
 const mcpClearKey = vi.fn(async () => {})
 const gmailSessionDisconnect = vi.fn(async () => ({ connected: false }))
 
 beforeEach(() => {
   wipeUserData.mockClear()
   byokClearAll.mockClear()
+  byokClearCodex.mockClear()
   mcpClearKey.mockClear()
   gmailSessionDisconnect.mockClear()
   h.invalidateConversationsCache.mockClear()
@@ -41,6 +43,7 @@ beforeEach(() => {
   ;(globalThis as { window: { omi: unknown } }).window.omi = {
     wipeUserData,
     byokClearAll,
+    byokClearCodex,
     mcpClearKey,
     gmailSessionDisconnect,
     byokGetAll: vi.fn(async () => ({}))
@@ -58,6 +61,7 @@ describe('teardownUserData', () => {
     expect(wipeUserData).toHaveBeenCalledTimes(1)
     // BYOK keys must be cleared so a second account can't send them (leak fix).
     expect(byokClearAll).toHaveBeenCalledTimes(1)
+    expect(byokClearCodex).toHaveBeenCalledTimes(1)
     // Hosted MCP export key likewise — cleared on sign-out / account switch.
     expect(mcpClearKey).toHaveBeenCalledTimes(1)
     // Gmail session partition cleared so a second account can't fetch the prior
@@ -82,6 +86,14 @@ describe('teardownUserData', () => {
 
     expect(h.invalidateConversationsCache).toHaveBeenCalledTimes(1)
     expect(localStorage.getItem('omi-chat-infinite-id')).toBeNull()
+  })
+
+  it('clears Codex even if the provider-key wipe fails', async () => {
+    byokClearAll.mockRejectedValueOnce(new Error('ipc down'))
+
+    await teardownUserData()
+
+    expect(byokClearCodex).toHaveBeenCalledTimes(1)
   })
 
   it('resets the Memories module cache and purges per-uid cold-start snapshots (cross-account leak fix)', async () => {
@@ -119,6 +131,7 @@ describe('reconcileAccountForSignIn — account-switch guard', () => {
     expect(wipeUserData).toHaveBeenCalledTimes(1)
     // The prior account's BYOK keys + Gmail session are cleared before B hydrates.
     expect(byokClearAll).toHaveBeenCalledTimes(1)
+    expect(byokClearCodex).toHaveBeenCalledTimes(1)
     expect(gmailSessionDisconnect).toHaveBeenCalledTimes(1)
     expect(localStorage.getItem(LAST_UID_KEY)).toBe('userB')
     // The uid pointer must survive teardown (it's machine-scoped, not in the

--- a/desktop/windows/src/renderer/src/lib/authTeardown.ts
+++ b/desktop/windows/src/renderer/src/lib/authTeardown.ts
@@ -44,6 +44,11 @@ export async function teardownUserData(): Promise<void> {
   } catch (e) {
     console.warn('[auth-teardown] byokClearAll failed:', (e as Error).message)
   }
+  try {
+    await window.omi?.byokClearCodex?.()
+  } catch (e) {
+    console.warn('[auth-teardown] byokClearCodex failed:', (e as Error).message)
+  }
   resetByokKeys()
   // 2b. Hosted MCP export key: same rationale as BYOK — it lives in its own
   //     encrypted store outside SQLite. Belt-and-suspenders with the clear inside

--- a/desktop/windows/src/renderer/src/lib/byokKeys.test.ts
+++ b/desktop/windows/src/renderer/src/lib/byokKeys.test.ts
@@ -33,12 +33,16 @@ describe('withByokHeadersIfActive', () => {
     })
   })
 
-  it('attaches nothing for a partial set (all-or-none)', async () => {
+  it('attaches configured LLM keys for a partial set', async () => {
     await loadCache({ openai: 'sk-o', anthropic: 'sk-a', gemini: 'gm' })
-    expect(isByokActiveCached()).toBe(false)
+    expect(isByokActiveCached()).toBe(true)
     const out = withByokHeadersIfActive({ Authorization: 'Bearer t' })
-    expect(out).toEqual({ Authorization: 'Bearer t' })
-    expect(out['X-BYOK-OpenAI']).toBeUndefined()
+    expect(out).toEqual({
+      Authorization: 'Bearer t',
+      'X-BYOK-OpenAI': 'sk-o',
+      'X-BYOK-Anthropic': 'sk-a',
+      'X-BYOK-Gemini': 'gm'
+    })
   })
 
   it('stops attaching after the keys are cleared (refresh on byok:changed)', async () => {

--- a/desktop/windows/src/renderer/src/lib/byokKeys.test.ts
+++ b/desktop/windows/src/renderer/src/lib/byokKeys.test.ts
@@ -4,14 +4,19 @@ import {
   refreshByokKeys,
   resetByokKeys,
   withByokHeadersIfActive,
-  isByokActiveCached
+  isByokActiveCached,
+  hasTranscriptionByokCached,
+  llmByokValidatedCached
 } from './byokKeys'
-import type { ByokKeys } from '../../../shared/byok'
+import type { ByokKeys, ByokProvider } from '../../../shared/byok'
 
 const FULL: ByokKeys = { openai: 'sk-o', anthropic: 'sk-a', gemini: 'gm', deepgram: 'dg' }
 
-async function loadCache(keys: ByokKeys): Promise<void> {
-  ;(window as unknown as { omi: unknown }).omi = { byokGetAll: vi.fn().mockResolvedValue(keys) }
+async function loadCache(keys: ByokKeys, validated: ByokProvider[] = []): Promise<void> {
+  ;(window as unknown as { omi: unknown }).omi = {
+    byokGetAll: vi.fn().mockResolvedValue(keys),
+    byokValidatedProviders: vi.fn().mockResolvedValue(validated)
+  }
   await refreshByokKeys()
 }
 
@@ -62,12 +67,42 @@ describe('withByokHeadersIfActive', () => {
   })
 
   it('resetByokKeys empties the cache synchronously so no X-BYOK is attached after sign-out', async () => {
-    await loadCache(FULL)
+    await loadCache(FULL, ['deepgram'])
     expect(isByokActiveCached()).toBe(true)
+    expect(hasTranscriptionByokCached()).toBe(true)
     resetByokKeys() // sign-out teardown
     expect(isByokActiveCached()).toBe(false)
+    expect(hasTranscriptionByokCached()).toBe(false)
     expect(withByokHeadersIfActive({ Authorization: 'Bearer t' })).toEqual({
       Authorization: 'Bearer t'
     })
+  })
+})
+
+describe('validated capability cache', () => {
+  beforeEach(async () => {
+    await loadCache({}) // reset cache to empty between tests
+  })
+
+  it('suppresses transcription quota only on validated Deepgram enrollment, not key presence', async () => {
+    // Configured-but-rejected Deepgram: key present in the store, evidence absent.
+    await loadCache(FULL, [])
+    expect(hasTranscriptionByokCached()).toBe(false)
+
+    // Backend accepted the Deepgram fingerprint.
+    await loadCache(FULL, ['openai', 'deepgram'])
+    expect(hasTranscriptionByokCached()).toBe(true)
+
+    // Key rotated after enrollment → no longer validated until re-enrollment.
+    await loadCache(FULL, ['openai'])
+    expect(hasTranscriptionByokCached()).toBe(false)
+  })
+
+  it('reports LLM activation only from validated providers', async () => {
+    await loadCache(FULL, ['deepgram']) // Deepgram-only never unlocks the LLM plan
+    expect(llmByokValidatedCached()).toBe(false)
+
+    await loadCache(FULL, ['gemini'])
+    expect(llmByokValidatedCached()).toBe(true)
   })
 })

--- a/desktop/windows/src/renderer/src/lib/byokKeys.ts
+++ b/desktop/windows/src/renderer/src/lib/byokKeys.ts
@@ -10,7 +10,7 @@
 // (matching the backend, which 403s a partial set from an enrolled user).
 // This cache is never persisted and never logged.
 
-import { isByokActive, withByokHeaders, type ByokKeys } from '../../../shared/byok'
+import { hasTranscriptionByok, isByokActive, withByokHeaders, type ByokKeys } from '../../../shared/byok'
 
 let cached: ByokKeys = {}
 
@@ -36,6 +36,10 @@ export function withByokHeadersIfActive<T extends Record<string, string>>(header
 /** True when the cached key set is complete (all four providers). */
 export function isByokActiveCached(): boolean {
   return isByokActive(cached)
+}
+
+export function hasTranscriptionByokCached(): boolean {
+  return hasTranscriptionByok(cached)
 }
 
 /**

--- a/desktop/windows/src/renderer/src/lib/byokKeys.ts
+++ b/desktop/windows/src/renderer/src/lib/byokKeys.ts
@@ -1,4 +1,4 @@
-// Renderer-side in-memory BYOK key cache for the REST/fetch header lanes.
+// Renderer-side in-memory BYOK key + capability cache for the REST/fetch lanes.
 //
 // The keys live encrypted in the main process (ByokKeyStore). The axios
 // interceptor (apiClient) and the raw `/v2/messages` fetch (useChat) run in the
@@ -6,18 +6,34 @@
 // `await` an IPC round-trip per request. So we mirror the key set into memory
 // once at startup and refresh it whenever main broadcasts `byok:changed`.
 //
-// All-or-none: headers are attached only when all four providers have a key
-// (matching the backend, which 403s a partial set from an enrolled user).
+// Alongside the raw keys we mirror the VALIDATED capability set: providers whose
+// stored key still matches the fingerprint the backend accepted at the last
+// successful enrollment. Quota suppression must key off this, not presence — a
+// configured-but-rejected Deepgram key stays stored locally while the backend
+// meters managed credits.
+//
 // This cache is never persisted and never logged.
 
-import { hasTranscriptionByok, isByokActive, withByokHeaders, type ByokKeys } from '../../../shared/byok'
+import {
+  BYOK_LLM_PROVIDERS,
+  isByokActive,
+  withByokHeaders,
+  type ByokKeys,
+  type ByokProvider
+} from '../../../shared/byok'
 
 let cached: ByokKeys = {}
+let cachedValidated: ByokProvider[] = []
 
 /** Reload the cache from the main-process store. */
 export async function refreshByokKeys(): Promise<void> {
   try {
-    cached = (await window.omi?.byokGetAll?.()) ?? {}
+    const [keys, validated] = await Promise.all([
+      window.omi?.byokGetAll?.() ?? {},
+      window.omi?.byokValidatedProviders?.() ?? []
+    ])
+    cached = keys
+    cachedValidated = validated
   } catch {
     // A failed load leaves the previous cache in place; a later `byok:changed`
     // (or the next app start) reloads. Never throw into the request path.
@@ -38,8 +54,18 @@ export function isByokActiveCached(): boolean {
   return isByokActive(cached)
 }
 
+/**
+ * True when a validated (enrolled, unrotated) Deepgram key backs managed-STT
+ * quota suppression. Deliberately NOT raw key presence: a configured-but-
+ * rejected key must keep the exhaustion popup actionable.
+ */
 export function hasTranscriptionByokCached(): boolean {
-  return hasTranscriptionByok(cached)
+  return cachedValidated.includes('deepgram')
+}
+
+/** True when any LLM provider holds validated enrollment evidence. */
+export function llmByokValidatedCached(): boolean {
+  return cachedValidated.some((p) => (BYOK_LLM_PROVIDERS as readonly string[]).includes(p))
 }
 
 /**
@@ -49,6 +75,7 @@ export function hasTranscriptionByokCached(): boolean {
  */
 export function resetByokKeys(): void {
   cached = {}
+  cachedValidated = []
 }
 
 // Self-initialize in the renderer: load once and keep in sync. Guarded on

--- a/desktop/windows/src/renderer/src/lib/firebase.ts
+++ b/desktop/windows/src/renderer/src/lib/firebase.ts
@@ -51,7 +51,15 @@ onAuthStateChanged(auth, (user) => {
   if (!user || typeof window === 'undefined') return
   void user
     .getIdToken()
-    .then((token) => window.omi?.byokEnroll?.(token))
+    .then(async (token) => {
+      const keys = await window.omi?.byokGetAll?.()
+      if (
+        keys &&
+        Object.keys(keys).some((provider) => keys[provider as keyof typeof keys]?.trim())
+      ) {
+        await window.omi?.byokEnroll?.(token)
+      }
+    })
     .catch(() => undefined)
 })
 

--- a/desktop/windows/src/renderer/src/lib/firebase.ts
+++ b/desktop/windows/src/renderer/src/lib/firebase.ts
@@ -11,6 +11,7 @@ import {
 } from 'firebase/auth'
 import { teardownUserData } from './authTeardown'
 import { encryptedAuthPersistence, scrubLegacyPlaintextAuth } from './encryptedAuthPersistence'
+import { isByokActive } from '../../../shared/byok'
 import type { SignInProvider } from '../../../shared/types'
 
 const app = initializeApp({
@@ -53,10 +54,7 @@ onAuthStateChanged(auth, (user) => {
     .getIdToken()
     .then(async (token) => {
       const keys = await window.omi?.byokGetAll?.()
-      if (
-        keys &&
-        Object.keys(keys).some((provider) => keys[provider as keyof typeof keys]?.trim())
-      ) {
+      if (keys && isByokActive(keys)) {
         await window.omi?.byokEnroll?.(token)
       }
     })

--- a/desktop/windows/src/renderer/src/lib/firebase.ts
+++ b/desktop/windows/src/renderer/src/lib/firebase.ts
@@ -46,8 +46,13 @@ export const auth = (() => {
 // `firebase:authUser:*` key that Firebase's own migration didn't clear (e.g. a
 // window that loaded mid-migration). Guarded so it only removes a key the
 // encrypted store already holds. Fire-and-forget; never blocks boot.
-onAuthStateChanged(auth, () => {
+onAuthStateChanged(auth, (user) => {
   void scrubLegacyPlaintextAuth()
+  if (!user || typeof window === 'undefined') return
+  void user
+    .getIdToken()
+    .then((token) => window.omi?.byokEnroll?.(token))
+    .catch(() => undefined)
 })
 
 /**

--- a/desktop/windows/src/renderer/src/lib/usageLimit.test.ts
+++ b/desktop/windows/src/renderer/src/lib/usageLimit.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock the renderer BYOK cache so we can drive the "BYOK active" branch. Default
 // inactive, matching a free (non-BYOK) user; individual tests flip it on.
-const h = vi.hoisted(() => ({ isByokActiveCached: vi.fn(() => false) }))
-vi.mock('./byokKeys', () => ({ isByokActiveCached: h.isByokActiveCached }))
+const h = vi.hoisted(() => ({ hasTranscriptionByokCached: vi.fn(() => false) }))
+vi.mock('./byokKeys', () => ({ hasTranscriptionByokCached: h.hasTranscriptionByokCached }))
 
 import {
   onUsageLimit,
@@ -26,7 +26,7 @@ const quota = (p: Partial<ChatUsageQuota>): ChatUsageQuota => ({
 
 beforeEach(() => {
   __resetUsageLimitSession()
-  h.isByokActiveCached.mockReturnValue(false)
+  h.hasTranscriptionByokCached.mockReturnValue(false)
 })
 
 describe('usage-limit pub/sub', () => {
@@ -104,8 +104,8 @@ describe('maybeTriggerTranscriptionQuotaPopup', () => {
     expect(maybeTriggerTranscriptionQuotaPopup('error', QUOTA_ERR)).toBe(true)
   })
 
-  it('never paywalls a BYOK user — no popup on a quota error while BYOK is active', () => {
-    h.isByokActiveCached.mockReturnValue(true)
+  it('never paywalls a Deepgram BYOK user — no popup on a quota error', () => {
+    h.hasTranscriptionByokCached.mockReturnValue(true)
     const seen: (UsageLimitReason | null)[] = []
     onUsageLimit((r) => seen.push(r))
     // A quota-exhausted error that WOULD raise the popup for a free user...
@@ -113,20 +113,20 @@ describe('maybeTriggerTranscriptionQuotaPopup', () => {
     expect(seen).toEqual([null]) // only the immediate value; never 'transcription'
   })
 
-  it('still shows the popup for a non-BYOK (free) user on the same quota error', () => {
-    h.isByokActiveCached.mockReturnValue(false)
+  it('still shows the popup for a non-Deepgram (free) user on the same quota error', () => {
+    h.hasTranscriptionByokCached.mockReturnValue(false)
     const seen: (UsageLimitReason | null)[] = []
     onUsageLimit((r) => seen.push(r))
     expect(maybeTriggerTranscriptionQuotaPopup('error', QUOTA_ERR)).toBe(true)
     expect(seen.at(-1)).toBe('transcription')
   })
 
-  it('does not consume the latch while BYOK is active — a later exhaustion after BYOK clears still shows', () => {
-    h.isByokActiveCached.mockReturnValue(true)
+  it('does not consume the latch while Deepgram BYOK is active — a later exhaustion after it clears still shows', () => {
+    h.hasTranscriptionByokCached.mockReturnValue(true)
     expect(maybeTriggerTranscriptionQuotaPopup('error', QUOTA_ERR)).toBe(false)
-    // BYOK is cleared (keys removed / different account); the guard no longer
-    // suppresses and the still-armed latch lets the genuine exhaustion show.
-    h.isByokActiveCached.mockReturnValue(false)
+    // Deepgram BYOK is cleared; the guard no longer suppresses and the
+    // still-armed latch lets the genuine exhaustion show.
+    h.hasTranscriptionByokCached.mockReturnValue(false)
     expect(maybeTriggerTranscriptionQuotaPopup('error', QUOTA_ERR)).toBe(true)
   })
 })

--- a/desktop/windows/src/renderer/src/lib/usageLimit.ts
+++ b/desktop/windows/src/renderer/src/lib/usageLimit.ts
@@ -1,7 +1,7 @@
 import type { ChatUsageQuota } from './omiApi.generated'
 import type { LiveStatus } from './liveConversation'
 import { isQuotaExhaustedMessage } from './transcriptionClient'
-import { isByokActiveCached } from './byokKeys'
+import { hasTranscriptionByokCached } from './byokKeys'
 import { createSignal } from './signal'
 
 // Global usage-limit popup channel. Anywhere in the app can raise the modal via
@@ -96,7 +96,7 @@ export function maybeTriggerTranscriptionQuotaPopup(status: LiveStatus, error?: 
   // AppState+ListenEvents `freemium_threshold_reached` parity). Read the same
   // synchronous BYOK cache the request-header lanes use; don't touch the latch,
   // so a later exhaustion after BYOK is cleared still shows.
-  if (isByokActiveCached()) return false
+  if (hasTranscriptionByokCached()) return false
   if (transcriptionQuotaPopupShown) return false
   transcriptionQuotaPopupShown = true
   showUsageLimit('transcription')

--- a/desktop/windows/src/shared/byok.test.ts
+++ b/desktop/windows/src/shared/byok.test.ts
@@ -11,6 +11,7 @@ import {
 import { byokFingerprint } from './byokFingerprint'
 
 const fullKeys: ByokKeys = {
+  openrouter: 'sk-or',
   openai: 'sk-openai',
   anthropic: 'sk-ant',
   gemini: 'gm-key',
@@ -21,6 +22,7 @@ describe('withByokHeaders', () => {
   it('attaches a header for each non-empty key (full set)', () => {
     const out = withByokHeaders({}, fullKeys)
     expect(out).toEqual({
+      'X-BYOK-OpenRouter': 'sk-or',
       'X-BYOK-OpenAI': 'sk-openai',
       'X-BYOK-Anthropic': 'sk-ant',
       'X-BYOK-Gemini': 'gm-key',
@@ -60,26 +62,24 @@ describe('withByokHeaders', () => {
 })
 
 describe('isByokActive', () => {
-  it('is true only when all four providers have a non-empty key', () => {
+  it('is true when an LLM provider has a non-empty key', () => {
     expect(isByokActive(fullKeys)).toBe(true)
   })
 
-  it('is false at 3/4', () => {
-    const partial: ByokKeys = { ...fullKeys }
-    delete partial.deepgram
-    expect(isByokActive(partial)).toBe(false)
+  it('is false with only a transcription key', () => {
+    expect(isByokActive({ deepgram: 'dg-key' })).toBe(false)
   })
 
   it('is false when a provider key is only whitespace', () => {
-    expect(isByokActive({ ...fullKeys, gemini: '   ' })).toBe(false)
+    expect(isByokActive({ gemini: '   ' })).toBe(false)
   })
 
   it('is false for an empty map', () => {
     expect(isByokActive({})).toBe(false)
   })
 
-  it('covers exactly the four canonical providers', () => {
-    expect(BYOK_PROVIDERS).toEqual(['openai', 'anthropic', 'gemini', 'deepgram'])
+  it('covers every supported provider', () => {
+    expect(BYOK_PROVIDERS).toEqual(['openrouter', 'openai', 'anthropic', 'gemini', 'deepgram'])
     expect(Object.keys(BYOK_HEADER_NAMES).sort()).toEqual([...BYOK_PROVIDERS].sort())
   })
 })
@@ -87,6 +87,7 @@ describe('isByokActive', () => {
 describe('byokEnvVars', () => {
   it('returns the complete OMI_BYOK_* set when all four keys are present', () => {
     expect(byokEnvVars(fullKeys)).toEqual({
+      OMI_BYOK_OPENROUTER: 'sk-or',
       OMI_BYOK_OPENAI: 'sk-openai',
       OMI_BYOK_ANTHROPIC: 'sk-ant',
       OMI_BYOK_GEMINI: 'gm-key',
@@ -94,14 +95,19 @@ describe('byokEnvVars', () => {
     })
   })
 
-  it('returns {} for a partial set (all-or-nothing — never a partial injection)', () => {
+  it('returns configured capabilities for a partial set', () => {
     const partial: ByokKeys = { ...fullKeys }
     delete partial.deepgram
-    expect(byokEnvVars(partial)).toEqual({})
+    expect(byokEnvVars(partial)).toEqual({
+      OMI_BYOK_OPENROUTER: 'sk-or',
+      OMI_BYOK_OPENAI: 'sk-openai',
+      OMI_BYOK_ANTHROPIC: 'sk-ant',
+      OMI_BYOK_GEMINI: 'gm-key'
+    })
   })
 
-  it('returns {} when a provider key is only whitespace', () => {
-    expect(byokEnvVars({ ...fullKeys, gemini: '   ' })).toEqual({})
+  it('omits a provider key when it is only whitespace', () => {
+    expect(byokEnvVars({ ...fullKeys, gemini: '   ' }).OMI_BYOK_GEMINI).toBeUndefined()
   })
 
   it('returns {} for an empty map', () => {
@@ -112,7 +118,7 @@ describe('byokEnvVars', () => {
     expect(byokEnvVars({ ...fullKeys, openai: '  sk-openai  ' }).OMI_BYOK_OPENAI).toBe('sk-openai')
   })
 
-  it('names cover exactly the four canonical providers', () => {
+  it('names cover every supported provider', () => {
     expect(Object.keys(BYOK_ENV_NAMES).sort()).toEqual([...BYOK_PROVIDERS].sort())
   })
 })

--- a/desktop/windows/src/shared/byok.test.ts
+++ b/desktop/windows/src/shared/byok.test.ts
@@ -6,6 +6,7 @@ import {
   withByokHeaders,
   byokEnvVars,
   isByokActive,
+  hasTranscriptionByok,
   type ByokKeys
 } from './byok'
 import { byokFingerprint } from './byokFingerprint'
@@ -81,6 +82,15 @@ describe('isByokActive', () => {
   it('covers every supported provider', () => {
     expect(BYOK_PROVIDERS).toEqual(['openrouter', 'openai', 'anthropic', 'gemini', 'deepgram'])
     expect(Object.keys(BYOK_HEADER_NAMES).sort()).toEqual([...BYOK_PROVIDERS].sort())
+  })
+})
+
+describe('hasTranscriptionByok', () => {
+  it('is true only when Deepgram is configured', () => {
+    expect(hasTranscriptionByok(fullKeys)).toBe(true)
+    expect(hasTranscriptionByok({ openai: 'sk-openai' })).toBe(false)
+    expect(hasTranscriptionByok({ deepgram: 'dg-key' })).toBe(true)
+    expect(hasTranscriptionByok({ deepgram: '   ' })).toBe(false)
   })
 })
 

--- a/desktop/windows/src/shared/byok.test.ts
+++ b/desktop/windows/src/shared/byok.test.ts
@@ -6,7 +6,6 @@ import {
   withByokHeaders,
   byokEnvVars,
   isByokActive,
-  hasTranscriptionByok,
   type ByokKeys
 } from './byok'
 import { byokFingerprint } from './byokFingerprint'
@@ -82,15 +81,6 @@ describe('isByokActive', () => {
   it('covers every supported provider', () => {
     expect(BYOK_PROVIDERS).toEqual(['openrouter', 'openai', 'anthropic', 'gemini', 'deepgram'])
     expect(Object.keys(BYOK_HEADER_NAMES).sort()).toEqual([...BYOK_PROVIDERS].sort())
-  })
-})
-
-describe('hasTranscriptionByok', () => {
-  it('is true only when Deepgram is configured', () => {
-    expect(hasTranscriptionByok(fullKeys)).toBe(true)
-    expect(hasTranscriptionByok({ openai: 'sk-openai' })).toBe(false)
-    expect(hasTranscriptionByok({ deepgram: 'dg-key' })).toBe(true)
-    expect(hasTranscriptionByok({ deepgram: '   ' })).toBe(false)
   })
 })
 

--- a/desktop/windows/src/shared/byok.ts
+++ b/desktop/windows/src/shared/byok.ts
@@ -77,7 +77,7 @@ export type ByokValidationResults = Partial<Record<ByokProvider, ByokKeyValidati
 export interface ByokEnrollResult {
   /** True only when all four keys authenticated AND the backend accepted them. */
   active: boolean
-  /** Per-provider live-validation results (empty when the set wasn't full). */
+  /** Per-provider live-validation results for configured keys. */
   results: ByokValidationResults
   /**
    * Set only when the keys all validated but the backend enroll call itself
@@ -106,9 +106,7 @@ export function withByokHeaders(
 }
 
 /**
- * True only when ALL four providers have a non-empty trimmed key — matches the
- * backend's all-or-nothing gate (`has_all_byok_keys()`). A partial set is not
- * BYOK-active.
+ * True when at least one LLM provider has a non-empty trimmed key.
  */
 export function isByokActive(keys: ByokKeys): boolean {
   return BYOK_LLM_PROVIDERS.some((provider) => Boolean(keys[provider]?.trim()))
@@ -116,17 +114,14 @@ export function isByokActive(keys: ByokKeys): boolean {
 
 /**
  * The `OMI_BYOK_*` env set to inject into the pi-mono subprocess, or `{}` when
- * BYOK is not active. All-or-nothing, exactly like `withByokHeaders`'s consumer:
- * a partial set is never injected (the backend's `has_all_byok_keys()` requires
- * all four), so a 3/4 configuration falls through to Omi-managed billing rather
- * than silently sending an incomplete BYOK set. Values are trimmed to match the
- * wire value the backend fingerprints.
+ * BYOK is not active. Capability-scoped values are trimmed to match the wire
+ * value the backend fingerprints.
  */
 export function byokEnvVars(keys: ByokKeys): Record<string, string> {
   if (!isByokActive(keys)) return {}
   const out: Record<string, string> = {}
   for (const provider of BYOK_PROVIDERS) {
-    // isByokActive guarantees a non-empty trimmed value for every provider.
+    // isByokActive guarantees at least one LLM key; each provider remains optional.
     const value = keys[provider]?.trim()
     if (value) out[BYOK_ENV_NAMES[provider]] = value
   }

--- a/desktop/windows/src/shared/byok.ts
+++ b/desktop/windows/src/shared/byok.ts
@@ -14,13 +14,26 @@
 // file never drags a Node built-in into the web bundle.
 
 /** A provider whose API key a user can bring themselves. */
-export type ByokProvider = 'openai' | 'anthropic' | 'gemini' | 'deepgram'
+export type ByokProvider = 'openrouter' | 'openai' | 'anthropic' | 'gemini' | 'deepgram'
 
 /** The four BYOK providers, in the backend's canonical order. */
-export const BYOK_PROVIDERS: readonly ByokProvider[] = ['openai', 'anthropic', 'gemini', 'deepgram']
+export const BYOK_PROVIDERS: readonly ByokProvider[] = [
+  'openrouter',
+  'openai',
+  'anthropic',
+  'gemini',
+  'deepgram'
+]
+export const BYOK_LLM_PROVIDERS: readonly ByokProvider[] = [
+  'openrouter',
+  'openai',
+  'anthropic',
+  'gemini'
+]
 
 /** Canonical header casing clients send (backend matches case-insensitively). */
 export const BYOK_HEADER_NAMES: Record<ByokProvider, string> = {
+  openrouter: 'X-BYOK-OpenRouter',
   openai: 'X-BYOK-OpenAI',
   anthropic: 'X-BYOK-Anthropic',
   gemini: 'X-BYOK-Gemini',
@@ -35,6 +48,7 @@ export const BYOK_HEADER_NAMES: Record<ByokProvider, string> = {
  * source (`AgentRuntimeProcess.byokEnvironmentKey`).
  */
 export const BYOK_ENV_NAMES: Record<ByokProvider, string> = {
+  openrouter: 'OMI_BYOK_OPENROUTER',
   openai: 'OMI_BYOK_OPENAI',
   anthropic: 'OMI_BYOK_ANTHROPIC',
   gemini: 'OMI_BYOK_GEMINI',
@@ -97,7 +111,7 @@ export function withByokHeaders(
  * BYOK-active.
  */
 export function isByokActive(keys: ByokKeys): boolean {
-  return BYOK_PROVIDERS.every((provider) => Boolean(keys[provider]?.trim()))
+  return BYOK_LLM_PROVIDERS.some((provider) => Boolean(keys[provider]?.trim()))
 }
 
 /**
@@ -113,7 +127,8 @@ export function byokEnvVars(keys: ByokKeys): Record<string, string> {
   const out: Record<string, string> = {}
   for (const provider of BYOK_PROVIDERS) {
     // isByokActive guarantees a non-empty trimmed value for every provider.
-    out[BYOK_ENV_NAMES[provider]] = (keys[provider] as string).trim()
+    const value = keys[provider]?.trim()
+    if (value) out[BYOK_ENV_NAMES[provider]] = value
   }
   return out
 }

--- a/desktop/windows/src/shared/byok.ts
+++ b/desktop/windows/src/shared/byok.ts
@@ -75,12 +75,12 @@ export type ByokValidationResults = Partial<Record<ByokProvider, ByokKeyValidati
 
 /** Outcome of an enrollment attempt, returned to the renderer Settings UI. */
 export interface ByokEnrollResult {
-  /** True only when all four keys authenticated AND the backend accepted them. */
+  /** True only when at least one LLM key authenticated AND the backend accepted them. */
   active: boolean
   /** Per-provider live-validation results for configured keys. */
   results: ByokValidationResults
   /**
-   * Set only when the keys all validated but the backend enroll call itself
+   * Set only when the configured LLM keys validated but the backend enroll call itself
    * failed (network/HTTP) — distinct from a provider rejecting a key.
    */
   backendError?: string

--- a/desktop/windows/src/shared/byok.ts
+++ b/desktop/windows/src/shared/byok.ts
@@ -4,8 +4,9 @@
 // SHA-256 fingerprints). The desktop
 // client sends user-provided provider keys as per-request headers; the backend
 // reads them case-insensitively (`x-byok-{provider}`) but clients send the
-// canonical casing below. The backend enforces ALL-OR-NOTHING enrollment via
-// `has_all_byok_keys()` — a partial set is not a valid BYOK-active state.
+// canonical casing below. The backend fingerprints and validates each enrolled
+// provider independently — a capability-scoped subset is a valid BYOK-active
+// state as long as at least one LLM provider is configured.
 //
 // Pure, browser-safe module: no Node built-ins, no Electron, no I/O. It is
 // imported by BOTH the main process and the renderer (the axios/fetch BYOK
@@ -16,7 +17,7 @@
 /** A provider whose API key a user can bring themselves. */
 export type ByokProvider = 'openrouter' | 'openai' | 'anthropic' | 'gemini' | 'deepgram'
 
-/** The four BYOK providers, in the backend's canonical order. */
+/** The BYOK providers, in the backend's canonical order. */
 export const BYOK_PROVIDERS: readonly ByokProvider[] = [
   'openrouter',
   'openai',

--- a/desktop/windows/src/shared/byok.ts
+++ b/desktop/windows/src/shared/byok.ts
@@ -113,6 +113,11 @@ export function isByokActive(keys: ByokKeys): boolean {
   return BYOK_LLM_PROVIDERS.some((provider) => Boolean(keys[provider]?.trim()))
 }
 
+/** True when a Deepgram key is present for managed-STT quota suppression. */
+export function hasTranscriptionByok(keys: ByokKeys): boolean {
+  return Boolean(keys.deepgram?.trim())
+}
+
 /**
  * The `OMI_BYOK_*` env set to inject into the pi-mono subprocess, or `{}` when
  * BYOK is not active. Capability-scoped values are trimmed to match the wire

--- a/desktop/windows/src/shared/byok.ts
+++ b/desktop/windows/src/shared/byok.ts
@@ -74,12 +74,23 @@ export interface ByokKeyValidation {
 /** Per-provider validation results. */
 export type ByokValidationResults = Partial<Record<ByokProvider, ByokKeyValidation>>
 
+/** Provider → SHA-256 fingerprint, as accepted by the backend enrollment. */
+export type ByokEnrolledFingerprints = Partial<Record<ByokProvider, string>>
+
 /** Outcome of an enrollment attempt, returned to the renderer Settings UI. */
 export interface ByokEnrollResult {
   /** True only when at least one LLM key authenticated AND the backend accepted them. */
   active: boolean
   /** Per-provider live-validation results for configured keys. */
   results: ByokValidationResults
+  /**
+   * The fingerprint set the backend now enforces: present (possibly empty) whenever
+   * the server state is known — after a successful activate POST, or after the
+   * deactivate DELETE. Absent when the enroll POST itself failed (network/HTTP),
+   * because then the server may still hold the previous enrollment and local
+   * evidence must not be rewritten. Fingerprints only — never raw keys.
+   */
+  enrolledFingerprints?: ByokEnrolledFingerprints
   /**
    * Set only when the configured LLM keys validated but the backend enroll call itself
    * failed (network/HTTP) — distinct from a provider rejecting a key.
@@ -111,11 +122,6 @@ export function withByokHeaders(
  */
 export function isByokActive(keys: ByokKeys): boolean {
   return BYOK_LLM_PROVIDERS.some((provider) => Boolean(keys[provider]?.trim()))
-}
-
-/** True when a Deepgram key is present for managed-STT quota suppression. */
-export function hasTranscriptionByok(keys: ByokKeys): boolean {
-  return Boolean(keys.deepgram?.trim())
 }
 
 /**

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1329,6 +1329,7 @@ export type OmiBridgeApi = {
   byokClear: (provider: ByokProvider) => Promise<void>
   /** Remove all stored provider keys. */
   byokClearAll: () => Promise<void>
+  byokClearCodex: () => Promise<void>
   /** True only when all four providers have a key (backend all-or-nothing). */
   byokIsActive: () => Promise<boolean>
   /** Live-validate the stored keys and reconcile backend BYOK activation. The

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1330,8 +1330,12 @@ export type OmiBridgeApi = {
   /** Remove all stored provider keys. */
   byokClearAll: () => Promise<void>
   byokClearCodex: () => Promise<void>
-  /** True only when all four providers have a key (backend all-or-nothing). */
+  /** True when a configured LLM provider has a stored key. */
   byokIsActive: () => Promise<boolean>
+  /** Providers whose stored key still matches the fingerprint the backend
+   *  accepted at the last successful enrollment (validated capabilities — not
+   *  mere key presence). Empty until an enrollment succeeds. */
+  byokValidatedProviders: () => Promise<ByokProvider[]>
   /** Live-validate the stored keys and reconcile backend BYOK activation. The
    *  Firebase bearer token is relayed from the renderer's session. */
   byokEnroll: (token: string) => Promise<ByokEnrollResult>


### PR DESCRIPTION
Line-Count-Exception: backend/database/users.py | 2178 -> 2194 | existing transactional BYOK fingerprint merge and firestore_client plumbing
Line-Count-Exception: backend/routers/users.py | 2201 -> 2237 | validated LLM BYOK subscription gates plus the snapshot/transcription split
Line-Count-Exception: backend/routers/desktop_proxy.py | 1597 -> 1603 | capability-scoped BYOK header forwarding on desktop proxy routes
Line-Count-Exception: backend/routers/chat.py | 1913 -> 1920 | thread required_llm_provider into /v2/messages quota enforcement
Line-Count-Exception: backend/routers/omni_relay.py | 175 -> 186 | reject unsupported realtime provider before trial cache lookup
Line-Count-Exception: backend/utils/byok.py | 278 -> 341 | clear unvalidated keys on transient middleware failure
Line-Count-Exception: desktop/macos/Desktop/Sources/APIKeyService.swift | 233 -> 384 | owner-bind clear plus reconciliation generation

## Summary

- Add capability-scoped BYOK enrollment and OpenRouter routing with Gemini 2.5 Flash Lite.
- Replace all-key setup with an LLM provider menu and separate Deepgram transcription key.
- Keep healthy selected BYOK requests available when unrelated legacy keys are absent or unhealthy.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-VOICE-1
- INV-MEM-4
- INV-TASK-2

## Verification

- `./.venv/bin/python -m pytest -q tests/routers/test_users.py tests/unit/test_byok_security.py` — 129 passed (includes the LLM-only vs LLM+Deepgram snapshot-split tests).
- `bun test src/shared/byok.test.ts src/main/agentKernel/byokEnroll.test.ts` — 25 passed.
- `black --check --line-length 120 --skip-string-normalization backend/utils/byok.py backend/routers/users.py backend/tests/routers/test_users.py backend/tests/unit/test_byok_security.py` — passed.
- `make preflight` — repository runtime-image source-closure baseline remains incomplete for `config.account_cutover`; the changed-path gates passed.
- Bounded pre-push gates passed for backend, OpenAPI, generated outputs, workflow contracts, desktop flow lint, and desktop agent tests. Local Swift compile passed with `xcrun swift build -c debug --package-path Desktop`.

Failure-Class: none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches BYOK validation, trial paywall, chat quota, and LLM routing. Incorrect validation or quota bypass would leak paid LLM usage or lock users out.
> 
> **Overview**
> Makes BYOK **capability-scoped**: enroll any LLM provider (OpenAI, Anthropic, Gemini, or **OpenRouter**) plus optional Deepgram, instead of requiring all four keys.
> 
> **Entitlements** now require *validated* LLM keys (`request_has_llm_byok_key` / `has_validated_byok_keys`). Deepgram-only or raw unvalidated headers no longer unlock unlimited chat, skip quota, or bypass the desktop trial. Paywall cache is provider-aware (e.g. Gemini proxy). Middleware validates fingerprints before the route and still lets recovery paths (`/subscription`, `/byok-active`) through with empty keys.
> 
> **LLM routing** uses native `ChatAnthropic` for Anthropic BYOK, keeps OpenRouter Gemini on OpenRouter (`google/…`), and falls back to a provider-compatible model when the feature profile key is missing. Gateway lanes are skipped when BYOK switches providers.
> 
> Desktop settings replace the four-key form with an LLM picker + optional Deepgram, persist enrolled fingerprints, and attach only the selected keys. Activation is transactional so fingerprints replace rather than merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e1307931d9d05a90b7e35f84ce8548329c1803. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Line-Count-Exception: backend/utils/subscription.py | 1614 -> 1672 | provider-specific paywall cache, desktop-chat Anthropic gate, and required_llm_provider snapshot plumbing
Line-Count-Exception: desktop/macos/Desktop/Sources/AuthService.swift | 2843 -> 2845 | reconcile persisted BYOK activation during auth restore and sign-in
