### PR TITLE
fix(desktop): avoid live transcript layout stalls

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
@@ -275,17 +275,36 @@ struct LiveTranscriptView: View {
     return "\(segments.count)-\(last.id)-\(last.text.count)"
   }
 
+  private var settledSegments: [SpeakerSegment] {
+    LiveTranscriptRenderPlan.settledSegments(from: segments)
+  }
+
+  private var liveSegment: SpeakerSegment? {
+    LiveTranscriptRenderPlan.liveSegment(from: segments)
+  }
+
   var body: some View {
     ScrollViewReader { proxy in
       ScrollView {
-        VStack(alignment: .leading, spacing: OmiSpacing.md) {
-          ForEach(segments) { segment in
+        LazyVStack(alignment: .leading, spacing: OmiSpacing.md) {
+          ForEach(settledSegments) { segment in
             LiveSegmentView(
               segment: segment,
               formatTime: formatTime,
               personName: speakerNames[segment.speaker],
               onSpeakerTapped: !segment.isUser ? { onSpeakerTapped?(segment) } : nil
             )
+            .equatable()
+          }
+
+          if let liveSegment {
+            LiveSegmentView(
+              segment: liveSegment,
+              formatTime: formatTime,
+              personName: speakerNames[liveSegment.speaker],
+              onSpeakerTapped: !liveSegment.isUser ? { onSpeakerTapped?(liveSegment) } : nil
+            )
+            .equatable()
           }
 
           // Stable bottom anchor that never changes ID
@@ -295,6 +314,7 @@ struct LiveTranscriptView: View {
         }
         .padding(OmiSpacing.lg)
       }
+      .textSelection(.disabled)
       .defaultScrollAnchor(.bottom)
       .onChange(of: scrollTrigger) { _, _ in
         proxy.scrollTo("transcript-bottom", anchor: .bottom)
@@ -303,8 +323,38 @@ struct LiveTranscriptView: View {
   }
 }
 
+enum LiveTranscriptRenderPlan {
+  static func settledSegments(from segments: [SpeakerSegment]) -> [SpeakerSegment] {
+    Array(segments.dropLast())
+  }
+
+  static func liveSegment(from segments: [SpeakerSegment]) -> SpeakerSegment? {
+    segments.last
+  }
+
+  static func canReuseSegmentLayout(
+    previous: SpeakerSegment,
+    next: SpeakerSegment,
+    previousSpeakerName: String?,
+    nextSpeakerName: String?,
+    previousHasTapAction: Bool,
+    nextHasTapAction: Bool
+  ) -> Bool {
+    previous.id == next.id
+      && previous.speaker == next.speaker
+      && previous.text == next.text
+      && previous.start == next.start
+      && previous.end == next.end
+      && previous.isUser == next.isUser
+      && previous.personId == next.personId
+      && previous.translations.map { ($0.lang, $0.text) } == next.translations.map { ($0.lang, $0.text) }
+      && previousSpeakerName == nextSpeakerName
+      && previousHasTapAction == nextHasTapAction
+  }
+}
+
 /// Individual segment view for live transcript
-private struct LiveSegmentView: View {
+private struct LiveSegmentView: View, Equatable {
   let segment: SpeakerSegment
   let formatTime: (Double) -> String
   var personName: String? = nil
@@ -324,6 +374,17 @@ private struct LiveSegmentView: View {
 
   private var bubbleColor: Color {
     isUser ? PageGlass.speakerTints[0] : Ink.rowFillHover
+  }
+
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    LiveTranscriptRenderPlan.canReuseSegmentLayout(
+      previous: lhs.segment,
+      next: rhs.segment,
+      previousSpeakerName: lhs.personName,
+      nextSpeakerName: rhs.personName,
+      previousHasTapAction: lhs.onSpeakerTapped != nil,
+      nextHasTapAction: rhs.onSpeakerTapped != nil
+    )
   }
 
   var body: some View {
@@ -391,7 +452,6 @@ private struct LiveSegmentView: View {
       Text(segment.text)
         .scaledFont(size: OmiType.body)
         .foregroundColor(Ink.primary)
-        .textSelection(.enabled)
         .padding(.horizontal, OmiSpacing.md)
         .padding(.vertical, OmiSpacing.sm)
         .background(
@@ -406,7 +466,6 @@ private struct LiveSegmentView: View {
             .scaledFont(size: OmiType.body)
             .foregroundColor(Ink.secondary)
             .italic()
-            .textSelection(.enabled)
             .padding(.horizontal, OmiSpacing.md)
             .padding(.vertical, OmiSpacing.xs)
             .background(

--- a/desktop/macos/Desktop/Tests/LiveTranscriptRenderPlanTests.swift
+++ b/desktop/macos/Desktop/Tests/LiveTranscriptRenderPlanTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class LiveTranscriptRenderPlanTests: XCTestCase {
+  func testOnlyTheLatestSegmentIsLive() {
+    let segments = [
+      segment(id: "first", text: "first"),
+      segment(id: "second", text: "second"),
+      segment(id: "live", text: "still speaking"),
+    ]
+
+    XCTAssertEqual(
+      LiveTranscriptRenderPlan.settledSegments(from: segments).map(\.id),
+      ["first", "second"]
+    )
+    XCTAssertEqual(LiveTranscriptRenderPlan.liveSegment(from: segments)?.id, "live")
+  }
+
+  func testUpdatingLiveTextLeavesSettledSegmentsUntouched() {
+    let initial = [
+      segment(id: "first", text: "unchanged"),
+      segment(id: "live", text: "partial"),
+    ]
+    let updated = [
+      segment(id: "first", text: "unchanged"),
+      segment(id: "live", text: "partial transcript completed"),
+    ]
+
+    XCTAssertEqual(
+      LiveTranscriptRenderPlan.settledSegments(from: initial).map(\.text),
+      LiveTranscriptRenderPlan.settledSegments(from: updated).map(\.text)
+    )
+    XCTAssertNotEqual(
+      LiveTranscriptRenderPlan.liveSegment(from: initial)?.text,
+      LiveTranscriptRenderPlan.liveSegment(from: updated)?.text
+    )
+  }
+
+  func testEmptyTranscriptHasNoLiveSegment() {
+    XCTAssertTrue(LiveTranscriptRenderPlan.settledSegments(from: []).isEmpty)
+    XCTAssertNil(LiveTranscriptRenderPlan.liveSegment(from: []))
+  }
+
+  func testUnchangedSegmentCanReuseItsLayout() {
+    let previous = segment(id: "first", text: "unchanged")
+    let next = segment(id: "first", text: "unchanged")
+
+    XCTAssertTrue(
+      LiveTranscriptRenderPlan.canReuseSegmentLayout(
+        previous: previous,
+        next: next,
+        previousSpeakerName: nil,
+        nextSpeakerName: nil,
+        previousHasTapAction: false,
+        nextHasTapAction: false
+      )
+    )
+  }
+
+  func testChangedTranscriptTextInvalidatesOnlyThatSegmentLayout() {
+    let previous = segment(id: "live", text: "partial")
+    let next = segment(id: "live", text: "partial transcript completed")
+
+    XCTAssertFalse(
+      LiveTranscriptRenderPlan.canReuseSegmentLayout(
+        previous: previous,
+        next: next,
+        previousSpeakerName: nil,
+        nextSpeakerName: nil,
+        previousHasTapAction: false,
+        nextHasTapAction: false
+      )
+    )
+  }
+
+  private func segment(id: String, text: String) -> SpeakerSegment {
+    SpeakerSegment(
+      segmentId: id,
+      speaker: 1,
+      text: text,
+      start: 0,
+      end: 1
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260812-live-transcript-layout.json
+++ b/desktop/macos/changelog/unreleased/20260812-live-transcript-layout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved live transcript responsiveness during long recordings"
+}


### PR DESCRIPTION
## Summary

- render the live transcript lazily and retain unchanged settled-segment layouts while the active segment updates
- disable native text selection in the live transcript, matching the established SelectionOverlay safety boundary
- cover segment partitioning and layout reuse with focused regression tests

## Sentry issue

- [OMI-DESKTOP-55: App Hanging — CoreText typesetting](https://omi-nk3.sentry.io/issues/7358803967/)

Related: #10904 applies the same SelectionOverlay protection to chat Markdown; this PR covers the separate live-transcript renderer.

## Verification

- `swiftc -parse` for the changed source and test files
- Swift format/lint for the changed source and test files
- `python3 scripts/check_desktop_test_quality.py`
- `python3 scripts/check-e2e-flow-coverage.py --base origin/main`
- `python3 scripts/desktop-flow-lint.py --flows-dir e2e/flows`

The focused XCTest is awaiting the existing shared SwiftPM dependency resolution.

Failure-Class: FC-selection-overlay-layout-loop


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot live-transcript render path during recording; incorrect Equatable/reuse logic could show stale bubbles, though focused tests cover partitioning and invalidation.
> 
> **Overview**
> Fixes live-transcript hangs during long recordings by **reusing settled segment layouts** while only the active segment updates.
> 
> `LiveTranscriptView` now renders via `LazyVStack`, partitions segments through `LiveTranscriptRenderPlan` (settled vs live), and makes `LiveSegmentView` `Equatable` so unchanged bubbles skip relayout. Also disables native text selection on the scroll view to avoid CoreText selection-overlay layout loops.
> 
> Adds focused XCTests covering segment partitioning and layout-reuse invalidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27adfa7366e9c7c7a9e7abe1f592a096b5aa27e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->