### PR TITLE
fix(chat): use max_completion_tokens in the image-chat vision call

### DIFF
--- a/backend/tests/unit/test_chat_file_vision_params.py
+++ b/backend/tests/unit/test_chat_file_vision_params.py
@@ -1,0 +1,70 @@
+"""The image-chat vision call must use max_completion_tokens, not max_tokens.
+
+PR #10907 swapped the vision model gpt-4.1 -> gpt-5.6-luna but kept max_tokens=2048, which
+gpt-5.x rejects with a 400 (use max_completion_tokens). The failure was masked until the
+gateway-mode upload block (#11419) was lifted; every image chat then failed with the canned
+stream-failure message.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import utils.other.chat_file as cf  # noqa: E402
+from models.chat import FileChat  # noqa: E402
+
+
+class _EmptyStream:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
+class _Callback:
+    async def put_data(self, _text):
+        pass
+
+    async def end(self):
+        pass
+
+
+def test_vision_stream_sends_max_completion_tokens():
+    captured = {}
+
+    async def fake_content(_file_id):
+        return SimpleNamespace(read=lambda: b'image-bytes')
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _EmptyStream()
+
+    fake_client = SimpleNamespace(
+        files=SimpleNamespace(content=fake_content),
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create)),
+    )
+
+    tool = object.__new__(cf.FileChatTool)
+    files = [
+        FileChat(
+            id='f1',
+            name='a.png',
+            mime_type='image/png',
+            openai_file_id='oai-1',
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+    ]
+
+    with patch.object(cf, '_get_async_openai', lambda: fake_client):
+        asyncio.run(cf.FileChatTool._ask_vision_stream(tool, 'what is this?', files, _Callback()))
+
+    assert 'max_tokens' not in captured
+    assert captured['max_completion_tokens'] == 2048
+    assert captured['messages'][0]['content'][1]['image_url']['url'].startswith('data:image/png;base64,')

--- a/backend/utils/other/chat_file.py
+++ b/backend/utils/other/chat_file.py
@@ -257,7 +257,7 @@ class FileChatTool:
                 model="gpt-5.6-luna",
                 messages=messages,
                 stream=True,
-                max_tokens=2048,
+                max_completion_tokens=2048,
             )
             async for chunk in stream:
                 delta = chunk.choices[0].delta if chunk.choices else None

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -204,9 +204,10 @@ async def _execute_file_chat_stream(
         yield None
     except Exception as error:
         logger.error(
-            'file chat stream failed route=file uid=%s reason=stream_failure error_type=%s',
+            'file chat stream failed route=file uid=%s reason=stream_failure error_type=%s error=%s',
             uid,
             type(error).__name__,
+            error,
         )
         if callback_data is not None:
             callback_data['error'] = 'stream_failure'


### PR DESCRIPTION
## Summary

Image chat answered every message with the canned "Unable to complete the response. Please try again." even after #11419 restored uploads. Prod log at the failure moment: `file chat stream failed error_type=BadRequestError`, one second after `[FileChat] All 1 files are images, using Chat Completions vision API`.

Root cause: PR #10907 (Jul 30) swapped the vision model `gpt-4.1` → `gpt-5.6-luna` but kept `max_tokens=2048`, which gpt-5.x rejects with a 400 (`max_completion_tokens` is required — the gateway client already uses it). The regression was invisible until now because the gateway-mode gate had been failing file chat at the upload step since Aug 8; lifting that block (#11419) exposed this one.

- `_ask_vision_stream` now sends `max_completion_tokens=2048`.
- The generic `file chat stream failed` log line now includes the exception message, so the next failure in this path shows the provider error instead of only `error_type`.

Failure-Class: none

Single-parameter API-contract fix; the new behavioral test pins the request shape.

## Test plan

- [x] `pytest tests/unit/test_chat_file_vision_params.py tests/unit/test_chat_file_gateway_surface.py tests/unit/test_chat_async_offload.py` → 29 passed
  - New `test_chat_file_vision_params.py` drives `_ask_vision_stream` with a fake client and asserts `max_completion_tokens=2048`, no `max_tokens`, and the base64 data-URL image content shape.
- [x] Prod verification after deploy: image attach + question answered (pending deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

