### PR TITLE
fix(desktop): index the turn-revision lookup so chat context snapshots finish

### DIFF
--- a/.github/failure-classes/FC-deadline-bounded-query-without-covering-index.json
+++ b/.github/failure-classes/FC-deadline-bounded-query-without-covering-index.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-deadline-bounded-query-without-covering-index",
+  "violated_contract": "A query that serves a deadline-bounded interactive contract must be covered by an index on every predicate it joins and filters on. An uncovered join degrades with accumulated user data, so a contract that passes on a small store becomes a guaranteed timeout on a large one \u2014 and when the query runs synchronously on a single-threaded runtime, it stalls every other request behind it rather than only itself.",
+  "canonical_prevention": "Declare the index in the same change as the query, and assert the plan in a behavioural test that runs the real engine: the query plan must show an equality seek on each join key, never a partial seek that leaves a predicate to a row-by-row scan. Assert the plan rather than a wall-clock threshold, which is unstable on shared hardware and passes on small fixtures for the wrong reason.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/agent/tests/context-snapshot-turn-revision-index.test.ts"
+  ],
+  "evidence_prs": [
+    9597,
+    9660
+  ],
+  "scope_hints": [
+    "desktop/macos/agent/src/runtime/**",
+    "desktop/macos/agent/tests/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/agent/src/runtime/sqlite-store.ts
+++ b/desktop/macos/agent/src/runtime/sqlite-store.ts
@@ -80,6 +80,7 @@ const CHAT_FIRST_MATERIALIZATION_RECEIPTS_MIGRATION_VERSION = 29;
 const CHAT_FIRST_COLD_START_SEQUENCE_RECEIPTS_MIGRATION_VERSION = 30;
 const LOCAL_ONLY_JOURNAL_DELIVERY_MIGRATION_VERSION = 31;
 const CHAT_FIRST_COLD_START_SEQUENCE_RECEIPTS_OWNER_SCOPE_MIGRATION_VERSION = 32;
+const CONVERSATION_TURN_REVISION_TURN_ID_INDEX_MIGRATION_VERSION = 33;
 
 const ACTIVE_ATTEMPT_STATUSES = ["queued", "starting", "running", "waiting_input", "waiting_approval", "cancelling"] as const;
 const TERMINAL_ATTEMPT_STATUSES = ["succeeded", "failed", "cancelled", "timed_out", "orphaned"] as const;
@@ -548,6 +549,9 @@ export class SqliteAgentStore implements AgentStore {
     }
     if (!this.hasMigration(CHAT_FIRST_COLD_START_SEQUENCE_RECEIPTS_OWNER_SCOPE_MIGRATION_VERSION)) {
       runChatFirstColdStartSequenceReceiptsOwnerScopeMigration(this.db, this.nowMs());
+    }
+    if (!this.hasMigration(CONVERSATION_TURN_REVISION_TURN_ID_INDEX_MIGRATION_VERSION)) {
+      runConversationTurnRevisionTurnIdIndexMigration(this.db, this.nowMs());
     }
   }
 
@@ -3387,6 +3391,35 @@ function runChatFirstColdStartSequenceReceiptsOwnerScopeMigration(
     `);
     db.prepare("INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)").run(
       CHAT_FIRST_COLD_START_SEQUENCE_RECEIPTS_OWNER_SCOPE_MIGRATION_VERSION,
+      appliedAtMs,
+    );
+  });
+}
+
+/// The context snapshot every chat turn waits on joins `conversation_turns` to
+/// `conversation_turn_revisions` on `turn_id` to recover each turn's durable
+/// insertion ordinal. That table is keyed `(conversation_id, turn_seq)`, so
+/// without an index carrying `turn_id` the join can only seek on
+/// `conversation_id` and then walks every revision row of the conversation for
+/// every turn in it - quadratic in conversation length. On an account with
+/// thousands of turns the snapshot query measured 27.65s against the 15s
+/// `get_context_snapshot` contract budget, so every chat turn timed out before
+/// the model was ever queried and the runtime's reply was discarded as late.
+///
+/// The index makes that join an equality seek: the same query measured 0.03s.
+/// It is deliberately additive - the query, its results and their order are
+/// untouched, so the chronology contract documented at the query stays intact.
+function runConversationTurnRevisionTurnIdIndexMigration(
+  db: Pick<DatabaseSync, "exec" | "prepare" | "isTransaction">,
+  appliedAtMs: number,
+): void {
+  runTransaction(db, () => {
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS conversation_turn_revisions_turn_id_idx
+        ON conversation_turn_revisions(conversation_id, turn_id);
+    `);
+    db.prepare("INSERT INTO schema_migrations (version, applied_at_ms) VALUES (?, ?)").run(
+      CONVERSATION_TURN_REVISION_TURN_ID_INDEX_MIGRATION_VERSION,
       appliedAtMs,
     );
   });

--- a/desktop/macos/agent/tests/context-snapshot-turn-revision-index.test.ts
+++ b/desktop/macos/agent/tests/context-snapshot-turn-revision-index.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildContextSnapshot } from "../src/runtime/context-snapshot.js";
+import { recordJournalExchange } from "../src/runtime/conversation-journal.js";
+import { SqliteAgentStore } from "../src/runtime/sqlite-store.js";
+
+/**
+ * The snapshot every chat turn waits on joins `conversation_turns` to
+ * `conversation_turn_revisions` on `turn_id`. That table is keyed
+ * `(conversation_id, turn_seq)`, so without an index carrying `turn_id` the join
+ * degrades to walking every revision row of the conversation for every turn in
+ * it. On a real account (7,263 turns) the query measured 27.65s against the 15s
+ * `get_context_snapshot` budget, so every chat turn timed out before the model
+ * was queried. With the index the same query measured 0.03s.
+ *
+ * These assert the plan and the migration rather than a wall-clock threshold: a
+ * timing assertion on shared CI hardware is the flaky kind this suite deletes,
+ * while the plan is the actual contract — an equality seek on both join keys.
+ */
+
+const createdDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of createdDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function newStateDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "omi-context-snapshot-index-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+const OWNER = "owner";
+const SURFACE = "main_chat";
+
+function newFixture(): { store: SqliteAgentStore; sessionId: string; conversationId: string } {
+  const store = new SqliteAgentStore({ stateDir: newStateDir(), reconcileOnOpen: false });
+  const session = store.insertSession({ ownerId: OWNER, surfaceKind: SURFACE, defaultAdapterId: "acp" });
+  const conversationId = "conv-context-snapshot-index";
+  store.insertSurfaceConversation({
+    ownerId: OWNER,
+    surfaceKind: SURFACE,
+    externalRefKind: "chat",
+    externalRefId: "context-snapshot-index",
+    conversationId,
+    agentSessionId: session.sessionId,
+    createdAtMs: 1,
+    lastActiveAtMs: 1,
+  });
+  return { store, sessionId: session.sessionId, conversationId };
+}
+
+function seedExchanges(store: SqliteAgentStore, conversationId: string, count: number): void {
+  for (let i = 0; i < count; i += 1) {
+    recordJournalExchange(store, {
+      ownerId: OWNER,
+      conversationId,
+      turns: [
+        {
+          role: "user",
+          surfaceKind: SURFACE,
+          origin: "local",
+          status: "completed",
+          content: `question ${i}`,
+          contentBlocks: [],
+          createdAtMs: 1_000 + i * 2,
+        },
+        {
+          role: "assistant",
+          surfaceKind: SURFACE,
+          origin: "local",
+          status: "completed",
+          content: `answer ${i}`,
+          contentBlocks: [],
+          createdAtMs: 1_001 + i * 2,
+        },
+      ],
+    });
+  }
+}
+
+/** The join predicate the snapshot depends on, isolated so the plan is readable. */
+const JOIN_PROBE_SQL = `
+  SELECT ct.turn_id, COALESCE(MIN(revision.turn_seq), ct.turn_seq) AS insertion_seq
+  FROM conversation_turns ct
+  LEFT JOIN conversation_turn_revisions revision
+    ON revision.conversation_id = ct.conversation_id
+   AND revision.turn_id = ct.turn_id
+  WHERE ct.conversation_id = ?
+  GROUP BY ct.conversation_id, ct.turn_id
+  ORDER BY ct.created_at_ms DESC, insertion_seq DESC
+  LIMIT 40`;
+
+describe("context snapshot turn-revision lookup", () => {
+  it("seeks the revision join on both keys instead of scanning the conversation", () => {
+    const { store, conversationId } = newFixture();
+    seedExchanges(store, conversationId, 5);
+
+    const plan = store
+      .allRows(`EXPLAIN QUERY PLAN ${JOIN_PROBE_SQL}`, [conversationId])
+      .map((row) => String(row.detail))
+      .join("\n");
+
+    // The revision side must be an equality seek on conversation_id AND turn_id.
+    // Seeking on conversation_id alone is the quadratic walk this index removes.
+    const revisionStep = plan
+      .split("\n")
+      .find((line) => line.includes("conversation_turn_revisions") || line.includes("revision"));
+    expect(revisionStep, `no revision step in plan:\n${plan}`).toBeDefined();
+    expect(revisionStep).toContain("conversation_turn_revisions_turn_id_idx");
+    expect(revisionStep).toContain("turn_id=?");
+  });
+
+  it("returns the same turns in the same order as the unindexed query", () => {
+    const { store, sessionId, conversationId } = newFixture();
+    seedExchanges(store, conversationId, 6);
+
+    const indexed = buildContextSnapshot(store, sessionId, OWNER, 10_000, SURFACE);
+    const indexedTurns = indexed.recentTurns.map((turn) => `${turn.role}:${turn.content}`);
+
+    // Drop the index and re-project: an additive index must not change results.
+    store.execute("DROP INDEX conversation_turn_revisions_turn_id_idx");
+    const unindexed = buildContextSnapshot(store, sessionId, OWNER, 10_000, SURFACE);
+
+    expect(unindexed.recentTurns.map((turn) => `${turn.role}:${turn.content}`)).toEqual(indexedTurns);
+    expect(indexedTurns.length).toBeGreaterThan(0);
+  });
+
+  it("creates the index on a database that predates the migration, and is idempotent on reopen", () => {
+    const stateDir = newStateDir();
+    const first = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
+    const indexRow = () =>
+      first.allRows(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?",
+        ["conversation_turn_revisions_turn_id_idx"],
+      );
+    expect(indexRow()).toHaveLength(1);
+
+    // A store upgraded from a build without this migration: remove the index and
+    // its version row, then reopen. The legacy principal must be migrated, not
+    // rejected.
+    first.execute("DROP INDEX conversation_turn_revisions_turn_id_idx");
+    first.execute("DELETE FROM schema_migrations WHERE version = 33");
+    expect(indexRow()).toHaveLength(0);
+
+    const reopened = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
+    expect(
+      reopened.allRows("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?", [
+        "conversation_turn_revisions_turn_id_idx",
+      ]),
+    ).toHaveLength(1);
+    expect(
+      reopened.allRows("SELECT version FROM schema_migrations WHERE version = 33", []),
+    ).toHaveLength(1);
+
+    // Already-migrated databases must reopen without re-running or throwing.
+    const again = new SqliteAgentStore({ stateDir, reconcileOnOpen: false });
+    expect(
+      again.allRows("SELECT version FROM schema_migrations WHERE version = 33", []),
+    ).toHaveLength(1);
+  });
+});

--- a/desktop/macos/agent/tests/sqlite-store.test.ts
+++ b/desktop/macos/agent/tests/sqlite-store.test.ts
@@ -21,9 +21,9 @@ describe("SqliteAgentStore", () => {
     store.migrate();
     store.migrate();
 
-    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(32);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(33);
     expect(store.allRows("SELECT version FROM schema_migrations ORDER BY version")).toEqual(
-      Array.from({ length: 32 }, (_, index) => ({ version: index + 1 })),
+      Array.from({ length: 33 }, (_, index) => ({ version: index + 1 })),
     );
     expect(tableNames(store)).toEqual([
       "adapter_bindings",

--- a/desktop/macos/agent/tests/workstream-continuity.test.ts
+++ b/desktop/macos/agent/tests/workstream-continuity.test.ts
@@ -119,7 +119,7 @@ describe("workstream continuity", () => {
       delivery_status: "blocked",
       status: "rejected",
     });
-    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(32);
+    expect(store.getRow("SELECT COUNT(*) AS count FROM schema_migrations").count).toBe(33);
     store.close();
   });
 

--- a/desktop/macos/changelog/unreleased/20260812-chat-context-snapshot-index.json
+++ b/desktop/macos/changelog/unreleased/20260812-chat-context-snapshot-index.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Ask AI failing to answer any question on accounts with a long chat history"
+}


### PR DESCRIPTION
## Problem

Desktop Ask AI answered **nothing**. Every turn returned "Omi couldn't answer this one. Try sending it again." and the model was never reached.

```
kernel contract timeout operation=get_context_snapshot elapsed_ms=15013
ChatProvider: kernel context preparation timed out before an agent query started
chat_agent_error duration_ms=15142 error_class=timeout partial_response=false watchdog_fired=false
```

Field counts from the affected machine: 8 context-preparation timeouts, **0** agent-query timeouts, **0** completed turns. 100% of turns died in setup.

## Cause

Each turn waits on the kernel's `get_context_snapshot`, budgeted at 15s by `AgentRuntimeKernelContractTimeoutPolicy`. `buildContextSnapshot` builds its recent-turn window with:

```sql
FROM conversation_turns ct
LEFT JOIN conversation_turn_revisions revision
  ON revision.conversation_id = ct.conversation_id
 AND revision.turn_id = ct.turn_id       -- no index carries turn_id
WHERE ct.conversation_id = ?
GROUP BY ct.conversation_id, ct.turn_id
ORDER BY ct.created_at_ms DESC, insertion_seq DESC
LIMIT ?
```

`conversation_turn_revisions` is keyed `PRIMARY KEY(conversation_id, turn_seq)` and carried **no index on `turn_id`**, so the join could only seek on `conversation_id` and then walked every revision row of the conversation for every turn in it — quadratic in conversation length. `GROUP BY` plus `ORDER BY insertion_seq` also prevents `LIMIT` from short-circuiting (`USE TEMP B-TREE FOR ORDER BY`).

That query runs synchronously through `node:sqlite` on the kernel's event loop, so the entire runtime stalls while it scans. The trivial `get_context_snapshot` handler cannot reply until it finishes, the Swift side abandons the turn at 15s, and the runtime's eventual answer is discarded as a late contract response.

This is why "fresh machine, long-lived account" was the shape that tripped it: cost scales with turns × revisions.

## Fix

One additive index. Migration 33, following the existing `hasMigration` / `runTransaction` pattern.

```sql
CREATE INDEX IF NOT EXISTS conversation_turn_revisions_turn_id_idx
  ON conversation_turn_revisions(conversation_id, turn_id);
```

## Verification

Measured on a real 35 MB database with 7,263 turn revisions in one conversation:

| | plan | time |
|---|---|---|
| before | `SEARCH revision USING INDEX sqlite_autoindex_conversation_turn_revisions_1 (conversation_id=?)` | **27.65 s** |
| after | `SEARCH revision USING INDEX conversation_turn_revisions_turn_id_idx (conversation_id=? AND turn_id=?)` | **0.03 s** |

Index builds in 0.03 s.

- `tsc --noEmit` clean; `npm run build` succeeds; `vitest run` → **58 files, 671 tests, all passing**
- **Negative check:** with the migration call removed, all 3 new tests fail, including `expected 'SEARCH revision USING INDEX sqlite_autoindex_...' to contain 'conversation_turn_revisions_turn_id_idx'`
- **Upgrade path:** applied to a pre-existing 7,291-revision database (what a shipped user has), plan became the two-key seek, query timed 0.043 s on the live file
- **Real path:** rebuilt dev bundle, one query → `chat_agent_query_completed duration_ms=3695`, reaching `APIClient: Quota plan=Operator unit=questions allowed=true`, which no previous turn ever got to
- **Sustained:** a combined build ran 11 turns — 9 completed, **0** `kernel contract timeout`, **0** `dropping late kernel`

Root cause was located with a Node inspector CPU profile of the live kernel (`SIGUSR1` + CDP `Profiler`): 20.9% of samples under `next(native) ← allRows ← buildContextSnapshot ← contextSnapshot ← get_context_snapshot`, with journal replay at 0.1%.

## Tests

Assert the **plan and the migration**, not a wall-clock threshold — a timing assertion on shared CI hardware is the flaky kind this suite is told to delete. The plan is the real contract: an equality seek on both join keys.

1. The revision step names the index and `turn_id=?`
2. Snapshot output is identical with and without the index (protects the chronology contract documented at the query)
3. The migration creates the index on a database that predates it, then reopens idempotently — including the already-migrated principal, which must not re-run or fail

## Known limit

The query still aggregates every turn in the conversation, so cost stays linear in conversation length (0.04 s at ~7,300 turns). Restructuring it to apply `LIMIT` before aggregating is riskier than this index because of the chronology semantics documented at the query, so that is tracked separately rather than bundled here.

## Product invariants affected

- INV-AGENT-* — *Omi owns session/run/attempt identity, authority, and lifecycle.* Matched via `desktop/macos/agent/src/runtime/sqlite-store.ts`. No guard-test update: this adds an index and changes no ownership, identity, authority or lifecycle behaviour.
- INV-CHAT-1 — *Every canonical conversation has one kernel-owned transcript.* Matched via the same file. No guard-test update: the transcript query's results and their order are unchanged — one of the new tests asserts snapshot output is identical with and without the index, precisely so the transcript contract is provably untouched.

Both are cited on the path-based rule. The change is additive to the schema and behaviour-preserving by construction, which is what the identical-output test exists to demonstrate.

Failure-Class: new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qmdS9crg5qFhan7PCbWvZ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

