### PR TITLE
fix(desktop): keep deleted-lane tasks retired so they stop resurfacing as live

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3688
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3697
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Suggestion triage: AI captures excluded from dashboard lanes, acceptSuggestedTask"
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Deleted-lane retirement authority: fetchDeletedPage stamps retirement after both transports so neither can write a retired row as live"
   },
   "threshold": 1500
 }

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -1405,17 +1405,26 @@ class TasksStore: ObservableObject {
     operations: OwnerBoundOperations
   ) async throws -> OwnerBoundOperations.ActionItemsPage {
     guard isCurrent(lease) else { throw LocalMutationAuthorizationError.revoked }
+    let page: OwnerBoundOperations.ActionItemsPage
     if let fetchDeletedPage = operations.fetchDeletedPage {
-      return try await fetchDeletedPage(offset, limit, lease.ownerID)
+      page = try await fetchDeletedPage(offset, limit, lease.ownerID)
+    } else {
+      let response = try await APIClient.shared.getActionItems(
+        limit: limit,
+        offset: offset,
+        deleted: true,
+        expectedOwnerId: lease.ownerID,
+        authorizationSnapshot: lease.authorizationSnapshot
+      )
+      page = .init(items: response.items, hasMore: response.hasMore)
     }
-    let response = try await APIClient.shared.getActionItems(
-      limit: limit,
-      offset: offset,
-      deleted: true,
-      expectedOwnerId: lease.ownerID,
-      authorizationSnapshot: lease.authorizationSnapshot
-    )
-    return .init(items: response.items, hasMore: response.hasMore)
+    // The lane is the authority on retirement, not `isRetired`'s re-derivation
+    // from whatever fields this response happened to carry. Stamping it here —
+    // after both transports, so neither can skip it — is what stops a retired
+    // row being written to the local cache as live and resurfacing as a live
+    // task. Every caller of this page (first load and auto-refresh) syncs it
+    // into SQLite, so normalizing anywhere later would leave one path wrong.
+    return .init(items: page.items.map { $0.retired() }, hasMore: page.hasMore)
   }
 
   private func syncPage(

--- a/desktop/macos/Desktop/Sources/TaskActionItem.swift
+++ b/desktop/macos/Desktop/Sources/TaskActionItem.swift
@@ -22,7 +22,7 @@ struct TaskActionItem: Codable, Identifiable, Equatable {
   /// Classification category: personal, work, feature, bug, code, research, communication, finance, health, other
   let category: String?
   /// Soft-delete: true if this task has been deleted by AI dedup
-  let deleted: Bool?
+  var deleted: Bool?
   /// Who deleted: "user", "ai_dedup"
   let deletedBy: String?
   /// When the task was soft-deleted
@@ -84,6 +84,24 @@ struct TaskActionItem: Codable, Identifiable, Equatable {
   /// projection here so every local cache and surface applies the same rule.
   var isRetired: Bool {
     deleted == true || taskStatus == "cancelled" || taskStatus == "superseded"
+  }
+
+  /// This row as the retired lane already knows it to be.
+  ///
+  /// `isRetired` re-derives retirement from fields the server may not send:
+  /// the doc comment above says list responses can omit legacy `deleted` and
+  /// project retirement through canonical lifecycle status, and that status
+  /// vocabulary is open — anything outside `cancelled`/`superseded` reads as
+  /// live. A row fetched from the deleted lane is retired because of *where it
+  /// came from*, so the lane states it rather than asking the projection to
+  /// guess. Without this, a retired row round-trips into the local cache with
+  /// `deleted = false` and comes back as a live task on any machine whose
+  /// cache was built from that lane.
+  func retired() -> TaskActionItem {
+    guard !isRetired else { return self }
+    var copy = self
+    copy.deleted = true
+    return copy
   }
 
   /// Custom Equatable: compares only display-relevant fields.

--- a/desktop/macos/Desktop/Tests/TasksStoreDeletedLaneRetirementTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreDeletedLaneRetirementTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the deleted lane's retirement contract.
+///
+/// `TaskActionItem.isRetired` re-derives retirement from the response body:
+/// `deleted == true`, or a canonical status of `cancelled`/`superseded`. Its own
+/// doc comment records that list responses may omit legacy `deleted` and project
+/// retirement through canonical lifecycle status — and that status vocabulary is
+/// open, so any value outside those two reads as live.
+///
+/// `ActionItemRecord.from(_:)` persists `deleted: item.isRetired`, and the
+/// `.deleted` scope query reads that column back. So a row arriving from the
+/// deleted lane without either marker was written to the local cache as **live**:
+/// the deleted list came back empty (`Fetched 100 deleted tasks` /
+/// `Showing 0 deleted tasks` in the field log) and the same rows reappeared as
+/// live tasks. Deleting a task on one device and then signing in on a new
+/// machine un-deleted it.
+///
+/// The lane is the authority on retirement, so `fetchDeletedPage` stamps it
+/// rather than asking the projection to infer it.
+@MainActor
+private final class DeletedLaneProbe {
+  var syncedPages: [[TaskActionItem]] = []
+  /// Stand-in for the SQLite cache. `syncTaskActionItems` persists
+  /// `deleted: item.isRetired` and the `.deleted` scope query reads that column,
+  /// so only rows the client considers retired come back in the deleted list.
+  var cache: [TaskActionItem] = []
+}
+
+final class TasksStoreDeletedLaneRetirementTests: XCTestCase {
+
+  /// The regression: a deleted-lane row that carries neither legacy `deleted`
+  /// nor a recognized retired status must still reach the cache retired.
+  @MainActor
+  func testDeletedLaneRowIsRetiredBeforeItReachesTheLocalCache() async throws {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    let serverRow = task(id: "deleted-on-phone", taskStatus: "active")
+    XCTAssertFalse(
+      serverRow.isRetired,
+      "fixture must reproduce the server shape that made this bug: retired by lane, live by projection")
+
+    let probe = DeletedLaneProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchDeletedPage: { _, _, _ in .init(items: [serverRow], hasMore: false) },
+      syncPage: { items, _, _ in
+        probe.syncedPages.append(items)
+        probe.cache = items.filter { $0.isRetired }
+      },
+      loadDeleted: { _ in probe.cache })
+
+    await store.loadDeletedTasks(operations: operations)
+
+    let synced = try XCTUnwrap(probe.syncedPages.first, "the deleted page must be synced to the cache")
+    XCTAssertEqual(synced.map(\.id), ["deleted-on-phone"])
+    XCTAssertTrue(
+      synced.allSatisfy { $0.isRetired },
+      "a row from the deleted lane must never be written to the local cache as live — that is the resurrection")
+    XCTAssertEqual(
+      store.deletedTasks.map(\.id),
+      ["deleted-on-phone"],
+      "the retired row must show up in the deleted list instead of vanishing from every surface")
+  }
+
+  /// A row the server already marked retired keeps its own marker: the lane
+  /// states retirement, it does not restate or overwrite provenance.
+  @MainActor
+  func testAlreadyRetiredRowIsPassedThroughUnchanged() async throws {
+    let store = TasksStore.shared
+    await prepareStore(store)
+
+    let serverRow = task(id: "cancelled-upstream", taskStatus: "cancelled")
+    XCTAssertTrue(serverRow.isRetired, "fixture must already satisfy the projection")
+
+    let probe = DeletedLaneProbe()
+    let operations = TasksStore.OwnerBoundOperations(
+      fetchDeletedPage: { _, _, _ in .init(items: [serverRow], hasMore: false) },
+      syncPage: { items, _, _ in
+        probe.syncedPages.append(items)
+        probe.cache = items.filter { $0.isRetired }
+      },
+      loadDeleted: { _ in probe.cache })
+
+    await store.loadDeletedTasks(operations: operations)
+
+    let synced = try XCTUnwrap(probe.syncedPages.first)
+    XCTAssertEqual(synced, [serverRow], "an already-retired row must round-trip untouched")
+    XCTAssertEqual(store.deletedTasks.map(\.id), ["cancelled-upstream"])
+  }
+
+  // MARK: - Helpers
+
+  @MainActor
+  private func task(id: String, taskStatus: String? = nil) -> TaskActionItem {
+    TaskActionItem(
+      id: id,
+      description: id,
+      completed: false,
+      createdAt: Date(timeIntervalSince1970: 0),
+      taskStatus: taskStatus)
+  }
+
+  @MainActor
+  private func prepareStore(_ store: TasksStore) async {
+    let defaults = UserDefaults.standard
+    let previousAuthOwner = defaults.string(forKey: .authUserId)
+    let previousOverride = defaults.string(forKey: .automationOwnerOverride)
+    addTeardownBlock { @MainActor [weak self] in
+      guard let self else { return }
+      await self.establishEffectiveOwner(
+        authOwnerID: previousAuthOwner,
+        automationOverrideID: previousOverride)
+      store.resetSessionState()
+    }
+    await establishEffectiveOwner(authOwnerID: "owner-a", automationOverrideID: nil)
+    store.resetSessionState()
+  }
+
+  @MainActor
+  private func establishEffectiveOwner(
+    authOwnerID: String?,
+    automationOverrideID: String?
+  ) async {
+    let finalOwner = normalizedOwner(automationOverrideID) ?? normalizedOwner(authOwnerID)
+    let bootstrap =
+      finalOwner == "deleted-lane-bootstrap-a"
+      ? "deleted-lane-bootstrap-b"
+      : "deleted-lane-bootstrap-a"
+    if RuntimeOwnerIdentity.currentOwnerId(allowAutomationOverride: true) == bootstrap {
+      await transitionEffectiveOwner(authOwnerID: nil, automationOverrideID: nil)
+    } else {
+      await transitionEffectiveOwner(authOwnerID: bootstrap, automationOverrideID: nil)
+    }
+    await transitionEffectiveOwner(
+      authOwnerID: authOwnerID,
+      automationOverrideID: automationOverrideID)
+  }
+
+  @MainActor
+  private func transitionEffectiveOwner(
+    authOwnerID: String?,
+    automationOverrideID: String?
+  ) async {
+    let plannedOwner = normalizedOwner(automationOverrideID) ?? normalizedOwner(authOwnerID)
+    do {
+      _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        allowAutomationOverride: true,
+        plannedNextOwner: { _, _ in plannedOwner },
+        quiesceVoice: { _, _ in },
+        revokeKernelOwner: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {
+          await MainActor.run {
+            NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+          }
+        },
+        { defaults in
+          if let authOwnerID {
+            defaults.set(authOwnerID, forKey: .authUserId)
+          } else {
+            defaults.removeObject(forKey: .authUserId)
+          }
+          if let automationOverrideID {
+            defaults.set(automationOverrideID, forKey: .automationOwnerOverride)
+          } else {
+            defaults.removeObject(forKey: .automationOwnerOverride)
+          }
+        }
+      )
+    } catch {
+      XCTFail("owner transition failed: \(error)")
+    }
+  }
+
+  private func normalizedOwner(_ value: String?) -> String? {
+    guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !trimmed.isEmpty
+    else { return nil }
+    return trimmed
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260812-deleted-task-retirement.json
+++ b/desktop/macos/changelog/unreleased/20260812-deleted-task-retirement.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed tasks you deleted on another device reappearing as live tasks, and the Removed list staying empty"
+}


### PR DESCRIPTION
## Problem

Tasks deleted on another device came back as **live** tasks on a fresh machine, and the Removed list stayed empty:

```
TasksStore: Fetched 100 deleted tasks from API
TasksStore: Showing 0 deleted tasks from merged local cache
```

## Cause

`TaskActionItem.isRetired` re-derives retirement from the response body (`deleted == true`, or a canonical status of `cancelled`/`superseded`). Its own doc comment records that list responses may omit legacy `deleted` and project retirement through canonical lifecycle status — and that status vocabulary is **open**, so any other value reads as live. `ActionItemRecord.from(_:)` persists `deleted: item.isRetired`, so a row arriving from the deleted lane without either marker was written to SQLite as live: absent from the `.deleted` scope query, present as a live task.

## Fix

The lane is the authority on retirement, not a re-derivation from whichever fields a response happened to carry. `fetchDeletedPage` stamps retirement after **both** transports — live API and injected operations — so neither path can skip it, and both callers of that page (first load and auto-refresh) sync a correctly retired row.

## Verification

macOS 27.0, Xcode 26.6 (stable, not the beta):

- `xcrun swift test --filter TasksStoreDeletedLaneRetirementTests` → **2 passed**
- Reverting both production files to the parent commit → **2 failed**, asserting the reported symptom: `XCTAssertEqual failed: ("[]") is not equal to ("["deleted-on-phone"]")`
- All **87** tests matching `TasksStore` pass together, so nothing leaks through the `TasksStore.shared` singleton
- `swift-format lint --strict` clean on all three files (linter confirmed live by checking it flags a deliberately malformed file)
- `desktop/macos/scripts/check-main-actor-xctest-hooks.py` passes
- Product-file line-count ratchet passes with the baseline raised 3688 → 3697

**App-level:** a combined build carrying this fix was run as the named bundle `omi-combined-verify`. The deleted lane now reports `Fetched 100 deleted tasks / Showing 20 deleted tasks` — `Showing 0` against a non-zero fetch was the entire symptom, so this is the first run with a populated Removed list. The live list still sheds rows as the lane pages through (581 → 547 → 513 → 483, `added=0`), which is now the correct outcome: those rows land in the `.deleted` scope instead of vanishing.

## Scope

Fixes retirement **state**, not refresh cadence — the deleted refresh still re-fetches and re-syncs a full page per tick. Tracked separately. Also corrects the write path only: rows already persisted as live by an affected build are reconciled by later refreshes, not rewritten.

Explicitly **not** a contributor to the desktop chat outage — that was measured to a missing index on `conversation_turn_revisions(conversation_id, turn_id)` and is fixed on its own branch.

Failure-Class: FC-split-mutation-authority

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qmdS9crg5qFhan7PCbWvZ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

