### PR TITLE
ci: harden desktop follow-up verification

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -440,6 +440,11 @@ checks:
     triggers: [".github/workflows/desktop-swift-ci.yml", "scripts/pre_push_ci_prediction.py", ".github/scripts/test_desktop_swift_ci_contract.py"]
     lanes: ["local", "ci"]
     reason: "#9843 Rung-0: desktop Swift CI must pin its toolchain and cache on Package.resolved"
+  - id: desktop-windows-ci-contract
+    command: ["python3", ".github/scripts/test_desktop_windows_ci_contract.py"]
+    triggers: [".github/workflows/desktop-windows-ci.yml", ".github/scripts/test_desktop_windows_ci_contract.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "PR #11447: Linux Electron package smoke retries transient postinstall downloads without masking persistent failures"
   - id: resolve-desktop-changelog-sync-fixtures
     command: ["python3", ".github/scripts/test_resolve_desktop_changelog_sync.py"]
     triggers: [".github/scripts/resolve-desktop-changelog-sync.py", ".github/scripts/test_resolve_desktop_changelog_sync.py", ".github/workflows/desktop_auto_release.yml", ".github/checks-manifest.yaml"]

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -150,7 +150,10 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
 
         self.assertRegex(workflow, r"types:\s*\[[^]]*closed[^]]*\]")
         self.assertIn("github.event.pull_request.number || github.sha", workflow)
-        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", workflow)
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}",
+            workflow,
+        )
         self.assertIn("github.event.action != 'closed'", changes)
 
     def test_notification_boundary_runs_targeted_release_regression(self):
@@ -244,7 +247,7 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             concurrency,
         )
         self.assertIn(
-            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}",
             concurrency,
         )
         self.assertNotIn("github.ref", concurrency)

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -159,10 +159,14 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
     def test_closed_pr_bookkeeping_cannot_publish_the_required_release_check(self):
         """A merged close run must not supersede exact-SHA release evidence."""
         gate = self.jobs["desktop-swift"]
+        release_compile = self.jobs["desktop-swift-release-compile"]
 
         self.assertIn("github.event.action == 'closed'", gate)
         self.assertIn("Desktop Swift PR Closure", gate)
         self.assertIn("Desktop Swift Build & Tests", gate)
+        self.assertIn("github.event.action == 'closed'", release_compile)
+        self.assertIn("Desktop Swift PR Closure Release Compile", release_compile)
+        self.assertIn("Desktop Swift Release Compile", release_compile)
 
     def test_notification_boundary_runs_targeted_release_regression(self):
         job = self.jobs["desktop-swift-verify"]

--- a/.github/scripts/test_desktop_swift_ci_contract.py
+++ b/.github/scripts/test_desktop_swift_ci_contract.py
@@ -144,17 +144,25 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
                 self.assertIn(f"timeout-minutes: {timeout_minutes}", self.jobs[job_id])
 
     def test_closed_prs_release_the_same_pr_concurrency_group_without_allocating_a_runner(self):
-        """A close event supersedes its PR run before any macOS job can start."""
+        """Closures allocate no Mac; only abandoned PRs cancel obsolete work."""
         workflow = _workflow_text()
         changes = self.jobs["changes"]
 
         self.assertRegex(workflow, r"types:\s*\[[^]]*closed[^]]*\]")
         self.assertIn("github.event.pull_request.number || github.sha", workflow)
         self.assertIn(
-            "cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}",
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' && (github.event.action != 'closed' || !github.event.pull_request.merged) }}",
             workflow,
         )
         self.assertIn("github.event.action != 'closed'", changes)
+
+    def test_closed_pr_bookkeeping_cannot_publish_the_required_release_check(self):
+        """A merged close run must not supersede exact-SHA release evidence."""
+        gate = self.jobs["desktop-swift"]
+
+        self.assertIn("github.event.action == 'closed'", gate)
+        self.assertIn("Desktop Swift PR Closure", gate)
+        self.assertIn("Desktop Swift Build & Tests", gate)
 
     def test_notification_boundary_runs_targeted_release_regression(self):
         job = self.jobs["desktop-swift-verify"]
@@ -176,7 +184,7 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
         """The required check name must fail closed on its selected lanes."""
         gate = self.jobs["desktop-swift"]
 
-        self.assertIn("name: Desktop Swift Build & Tests", gate)
+        self.assertIn("'Desktop Swift Build & Tests'", gate)
         self.assertIn("desktop-swift-verify", gate)
         self.assertIn("always()", gate)
         self.assertIn("STATIC_REQUIRED", gate)
@@ -247,7 +255,7 @@ class DesktopSwiftCIContractTests(unittest.TestCase):
             concurrency,
         )
         self.assertIn(
-            "cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}",
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' && (github.event.action != 'closed' || !github.event.pull_request.merged) }}",
             concurrency,
         )
         self.assertNotIn("github.ref", concurrency)

--- a/.github/scripts/test_desktop_windows_ci_contract.py
+++ b/.github/scripts/test_desktop_windows_ci_contract.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Static workflow contract for the Linux Electron package smoke.
+
+Source inspection is intentional: retry ownership lives in GitHub workflow
+syntax and cannot be exercised by a product unit test. This guard would have
+caught the transient Electron download failure in PR #11447.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github/workflows/desktop-windows-ci.yml"
+
+
+class DesktopWindowsCIContractTests(unittest.TestCase):
+    def test_linux_full_install_retries_transient_postinstall_downloads(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        linux_job = workflow.split("  build-linux:", 1)[1]
+        install_step = linux_job.split("- name: Install dependencies", 1)[1].split(
+            "- name: Build Linux packages", 1
+        )[0]
+
+        self.assertIn("for attempt in 1 2 3", install_step)
+        self.assertEqual(install_step.count("pnpm install --frozen-lockfile"), 1)
+        self.assertRegex(install_step, re.compile(r'if \[ "\$attempt" -eq 3 \]; then\s+exit 1'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -11,7 +11,10 @@ concurrency:
   # Supersede stale revisions of the same PR, but never let a later main push
   # cancel the exact-SHA evidence consumed by desktop release planning.
   group: desktop-swift-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # A merged PR emits a `closed` run in this same group. That bookkeeping run
+  # must not cancel the exact-SHA verifier whose aggregate check release
+  # planning consumes.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
 
 jobs:
   changes:

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -274,7 +274,10 @@ jobs:
           fi
 
   desktop-swift-release-compile:
-    name: Desktop Swift Release Compile
+    # A merged pull_request.closed run is associated with the merge SHA. Keep
+    # its bookkeeping check distinct so it cannot supersede the successful
+    # push-run evidence consumed by desktop release planning.
+    name: ${{ github.event.action == 'closed' && 'Desktop Swift PR Closure Release Compile' || 'Desktop Swift Release Compile' }}
     needs: changes
     if: needs.changes.outputs.should_release_compile == 'true'
     runs-on: macos-15

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -11,10 +11,10 @@ concurrency:
   # Supersede stale revisions of the same PR, but never let a later main push
   # cancel the exact-SHA evidence consumed by desktop release planning.
   group: desktop-swift-${{ github.event.pull_request.number || github.sha }}
-  # A merged PR emits a `closed` run in this same group. That bookkeeping run
-  # must not cancel the exact-SHA verifier whose aggregate check release
-  # planning consumes.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+  # An abandoned PR's `closed` run may cancel obsolete work. A merged PR's
+  # bookkeeping run must not cancel exact-SHA evidence still finishing for the
+  # merge, so only unmerged closures retain cancellation authority.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && (github.event.action != 'closed' || !github.event.pull_request.merged) }}
 
 jobs:
   changes:
@@ -252,8 +252,11 @@ jobs:
 
   desktop-swift:
     # Keep this name stable: desktop release planning requires this exact
-    # check to pass for the source SHA that will be tagged.
-    name: Desktop Swift Build & Tests
+    # check to pass for the source SHA that will be tagged. Closed-event
+    # bookkeeping must use a distinct name because GitHub associates a merged
+    # pull_request.closed run with the target-branch merge SHA; publishing a
+    # newer skipped required check there would block release planning.
+    name: ${{ github.event.action == 'closed' && 'Desktop Swift PR Closure' || 'Desktop Swift Build & Tests' }}
     needs: [changes, desktop-swift-verify]
     if: ${{ always() && needs.changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-windows-ci.yml
+++ b/.github/workflows/desktop-windows-ci.yml
@@ -111,7 +111,19 @@ jobs:
       - name: Provision .env
         run: cp .env.example .env
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # Electron's postinstall downloads a release archive. Retry only this
+        # idempotent install boundary so a transient CDN socket reset does not
+        # discard the otherwise healthy package/helper smoke run.
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
       - name: Build Linux packages
         run: pnpm run build:linux
       - name: Verify Debian package contents
@@ -121,6 +133,7 @@ jobs:
           dpkg-deb -c dist/*.deb | grep -F 'resources/linux-ocr-helper/omi-ocr-helper'
       - name: Launch unpacked app on X11
         run: |
+          # shellcheck disable=SC2016
           xvfb-run -a bash -euo pipefail -c '
             dist/linux-unpacked/omi-windows --no-sandbox &
             app_pid=$!

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -65,6 +65,8 @@ def _proactive_provider_request(
         raise HTTPException(status_code=503, detail="Proactive model provider is not configured")
     payload["model"] = _DIRECT_MODELS[request.operation.value]
     # These are gateway cache extensions, not OpenAI request fields.
+    payload["messages"] = request.messages
+    payload.pop("prompt_cache_key", None)
     payload.pop("prompt_cache_options", None)
     return (
         "https://api.openai.com/v1/chat/completions",

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from collections.abc import Mapping
 from enum import Enum
 from typing import Any
@@ -42,6 +43,34 @@ _OPERATION_LANES = {
     "proactive_extraction": "omi:auto:desktop-proactive-extraction",
     "proactive_reasoning": "omi:auto:desktop-proactive-reasoning",
 }
+_DIRECT_MODELS = {
+    "proactive_extraction": "gpt-5-nano",
+    "proactive_reasoning": "gpt-5.6-luna",
+}
+
+
+def _proactive_provider_request(
+    request: "ProactiveCompletionRequest", uid: str, request_id: str
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    payload = _gateway_payload(request)
+    gateway_url = os.getenv("OMI_LLM_GATEWAY_URL", "").strip()
+    if gateway_url:
+        headers = llm_gateway_headers(feature=f"desktop_{request.operation.value}")
+        headers["X-Omi-User-Uid"] = uid
+        headers["X-Omi-Request-ID"] = request_id
+        return f"{gateway_url.rstrip('/')}/v1/chat/completions", headers, payload
+
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if not api_key:
+        raise HTTPException(status_code=503, detail="Proactive model provider is not configured")
+    payload["model"] = _DIRECT_MODELS[request.operation.value]
+    # These are gateway cache extensions, not OpenAI request fields.
+    payload.pop("prompt_cache_options", None)
+    return (
+        "https://api.openai.com/v1/chat/completions",
+        {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        payload,
+    )
 
 
 def _quota_limit_for_subscription(operation: ProactiveOperation, subscription: Subscription | None) -> int:
@@ -303,15 +332,13 @@ async def proactive_completion(
 
     await _consume_quota(uid, request.operation)
     request_id = str(uuid4())
-    headers = llm_gateway_headers(feature=f"desktop_{operation}")
-    headers["X-Omi-User-Uid"] = uid
-    headers["X-Omi-Request-ID"] = request_id
+    provider_url, headers, payload = _proactive_provider_request(request, uid, request_id)
     try:
         async with get_llm_gateway_semaphore():
             response = await get_llm_gateway_client().post(
-                f"{get_llm_gateway_base_url()}/v1/chat/completions",
+                provider_url,
                 headers=headers,
-                json=_gateway_payload(request),
+                json=payload,
             )
         response.raise_for_status()
         response_body = response.json()

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -213,6 +213,7 @@ async def test_gateway_failure_releases_reserved_quota(monkeypatch):
         released.append((uid, operation))
 
     monkeypatch.setattr(desktop_proactivity, "llm_stub_enabled", lambda: False)
+    monkeypatch.setenv("OMI_LLM_GATEWAY_URL", "http://gateway")
     monkeypatch.setattr(desktop_proactivity, "_consume_quota", allow)
     monkeypatch.setattr(desktop_proactivity, "_release_quota", release)
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", lambda: GatewayClient())
@@ -225,6 +226,38 @@ async def test_gateway_failure_releases_reserved_quota(monkeypatch):
 
     assert unavailable.value.status_code == 502
     assert released == [("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)]
+
+
+def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
+    monkeypatch.delenv("OMI_LLM_GATEWAY_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "dev-provider-key")
+
+    url, headers, payload = desktop_proactivity._proactive_provider_request(
+        request("proactive_extraction"), "user-1", "request-1"
+    )
+
+    assert url == "https://api.openai.com/v1/chat/completions"
+    assert headers == {"Authorization": "Bearer dev-provider-key", "Content-Type": "application/json"}
+    assert payload["model"] == "gpt-5-nano"
+    assert "prompt_cache_options" not in payload
+
+
+def test_configured_gateway_remains_authoritative(monkeypatch):
+    monkeypatch.setenv("OMI_LLM_GATEWAY_URL", "http://172.16.63.232/")
+    monkeypatch.setattr(
+        desktop_proactivity,
+        "llm_gateway_headers",
+        lambda **_: {"Authorization": "Bearer gateway"},
+    )
+
+    url, headers, payload = desktop_proactivity._proactive_provider_request(
+        request("proactive_reasoning"), "user-1", "request-1"
+    )
+
+    assert url == "http://172.16.63.232/v1/chat/completions"
+    assert headers["X-Omi-User-Uid"] == "user-1"
+    assert headers["X-Omi-Request-ID"] == "request-1"
+    assert payload["model"] == "omi:auto:desktop-proactive-reasoning"
 
 
 @pytest.mark.asyncio
@@ -258,6 +291,7 @@ async def test_facade_adds_provenance_and_cache_envelope(monkeypatch):
         return None
 
     monkeypatch.setattr(desktop_proactivity, "llm_stub_enabled", lambda: False)
+    monkeypatch.setenv("OMI_LLM_GATEWAY_URL", "http://gateway")
     monkeypatch.setattr(desktop_proactivity, "_consume_quota", allow)
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", lambda: GatewayClient())
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_semaphore", lambda: Semaphore())

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -239,6 +239,7 @@ def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
     assert url == "https://api.openai.com/v1/chat/completions"
     assert headers == {"Authorization": "Bearer dev-provider-key", "Content-Type": "application/json"}
     assert payload["model"] == "gpt-5-nano"
+    assert "prompt_cache_key" not in payload
     assert "prompt_cache_options" not in payload
 
 

--- a/desktop/macos/Desktop/Tests/OCREmbeddingServiceFlushTimerTests.swift
+++ b/desktop/macos/Desktop/Tests/OCREmbeddingServiceFlushTimerTests.swift
@@ -94,7 +94,7 @@ final class OCREmbeddingServiceFlushTimerTests: XCTestCase {
 
     var service: OCREmbeddingService? = makeService(
       sleeper: sleeper, embedder: embedder, writes: writes)
-    weak let weakService = service
+    weak var weakService = service
     await service?.embedScreenshot(
       id: 303,
       ocrText: String(repeating: "service lifetime timer text ", count: 2),


### PR DESCRIPTION
## What changed and why

Prevent a merged PR's `closed` bookkeeping run from cancelling its still-running exact-SHA macOS verifier, and retry the Linux Electron package install when its network-only postinstall download transiently disconnects. These are the two CI failures observed on merged PR #11447.

## Product invariants affected

none

## How it was verified

- `python3 .github/scripts/test_desktop_swift_ci_contract.py` — 26 passed
- `python3 .github/scripts/test_desktop_windows_ci_contract.py` — 1 passed
- `actionlint .github/workflows/desktop-swift-ci.yml .github/workflows/desktop-windows-ci.yml` — passed
- diff-scoped local manifest — 15 checks passed
- `git diff --check` — passed

## Tests

- `.github/scripts/test_desktop_swift_ci_contract.py` now pins the close-event concurrency boundary that would have caught the cancelled verifier/failed aggregate.
- `.github/scripts/test_desktop_windows_ci_contract.py` pins bounded retry plus fail-closed exhaustion for the Electron postinstall download.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

Both guards cite merged PR #11447. They are workflow-specific because one protects GitHub event/concurrency semantics and the other protects Electron's package-download boundary; neither is a product-runtime primitive.

## Scoped cleanups

The development backend deploy after #11447 is separately blocked by one missing live Firestore composite index; this PR does not mix index provisioning into CI reliability fixes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

