### PR TITLE
fix(desktop): deleted tasks propagate to the server and cannot resurrect

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-rewind.json
@@ -1,10 +1,10 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1734,
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": 1795,
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": 3444
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "The bounded incomplete-task storage surface reads all dated rows and pages only No Deadline rows, so TasksStore can preserve bucket boundaries without loading the entire undated local universe; it remains beside the existing task query and persistence owner rather than duplicating SQLite semantics. Single-snapshot dated/no-deadline reads prevent due-date races from omitting tasks between bucket queries.",
+    "desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift": "Deletion tombstones (markActionItemDeletedPendingBackendSync, getPendingBackendDeletionIds, hydration guard): a deletion the server has not acknowledged must leave a durable local record, or cloud hydration resurrects deleted tasks — 450 came back after one reinstall.",
     "desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift": "Context-bucket migration records the exact consumed owner and uses the signed-out fallback only when an anonymous database was actually moved."
   },
   "threshold": 1500

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,9 +1,1 @@
-{
-  "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3697
-  },
-  "raise_justifications": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "Deleted-lane retirement authority: fetchDeletedPage stamps retirement after both transports so neither can write a retired row as live"
-  },
-  "threshold": 1500
-}
+null

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,1 +1,9 @@
-null
+{
+  "files": {
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3775
+  },
+  "raise_justifications": {
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "flushPendingBackendDeletions plus the tombstone/ack wiring in deleteTask and restoreTask: the retry half of the deletion-tombstone contract that stops deleted tasks resurrecting."
+  },
+  "threshold": 1500
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -637,6 +637,14 @@ actor ActionItemStorage {
             // by stale auto-refresh data. Beyond 60s, trust the API as source
             // of truth — this prevents failed optimistic updates from persisting
             // forever (e.g. user toggled on desktop but API call failed/app crashed).
+            // A tombstone awaiting backend acknowledgement outranks anything the server
+            // says: the server still returning this task is precisely the condition the
+            // tombstone exists for. The 60s optimistic window below is not enough — the
+            // retry that flushes the deletion may run minutes or days later.
+            if existingRecord.deleted && !existingRecord.backendSynced {
+              skipped += 1
+              continue
+            }
             let incomingTimestamp = item.updatedAt ?? item.createdAt
             let isLocalStagedGuess = overrideStagedDeletions && existingRecord.deletedBy == "staged"
             let isRecentLocalChange = Date().timeIntervalSince(existingRecord.updatedAt) < 60
@@ -1168,9 +1176,15 @@ actor ActionItemStorage {
     let count = try await authorization.withCommitLease {
       try await db.write { database -> Int in
         try authorization.require()
-        let count = try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM action_items WHERE deleted = 1") ?? 0
+        // Pending tombstones are the durable record of an unacknowledged backend
+        // delete; purging them here would re-open the resurrection hole this purge
+        // is part of cleaning up.
+        let pendingClause = "NOT (backendSynced = 0 AND backendId IS NOT NULL AND backendId != '')"
+        let count =
+          try Int.fetchOne(
+            database, sql: "SELECT COUNT(*) FROM action_items WHERE deleted = 1 AND \(pendingClause)") ?? 0
         if count > 0 {
-          try database.execute(sql: "DELETE FROM action_items WHERE deleted = 1")
+          try database.execute(sql: "DELETE FROM action_items WHERE deleted = 1 AND \(pendingClause)")
         }
         try authorization.require()
         return count
@@ -1184,6 +1198,53 @@ actor ActionItemStorage {
   }
 
   /// Hard-delete an action item by backend ID
+  /// Mark a synced task deleted locally while the backend delete is still in flight.
+  ///
+  /// The previous shape was a local hard delete plus a fire-and-forget backend call: one
+  /// network failure and nothing anywhere remembered the deletion, so the next cloud
+  /// hydration re-inserted the task. (450 of Nik's deleted tasks came back exactly this
+  /// way.) A deletion the server has not acknowledged must leave a tombstone —
+  /// `deleted = 1, backendSynced = 0` — that hydration refuses to overwrite and a retry
+  /// pass can flush later.
+  func markActionItemDeletedPendingBackendSync(
+    backendId: String,
+    deletedBy: String? = "user",
+    authorization: LocalMutationAuthorization
+  ) async throws {
+    try authorization.require()
+    let db = try await ensureInitialized()
+
+    try await authorization.withCommitLease {
+      try await db.write { database in
+        try authorization.require()
+        if var record = try Self.fetchRecord(database, surfacedId: backendId) {
+          record.deleted = true
+          record.deletedBy = deletedBy
+          record.backendSynced = false
+          record.updatedAt = Date()
+          try record.update(database)
+        }
+        try authorization.require()
+      }
+    }
+
+    HomeKnowledgeCountInvalidation.post(
+      logMessage: "ActionItemStorage: Tombstoned action item \(backendId) pending backend delete")
+  }
+
+  /// Backend IDs whose deletion the server has not yet acknowledged.
+  func getPendingBackendDeletionIds() async throws -> [String] {
+    let db = try await ensureInitialized()
+    return try await db.read { database in
+      try ActionItemRecord
+        .filter(Column("deleted") == true)
+        .filter(Column("backendSynced") == false)
+        .filter(Column("backendId") != nil && Column("backendId") != "")
+        .fetchAll(database)
+        .compactMap { $0.backendId }
+    }
+  }
+
   func deleteActionItemByBackendId(
     _ backendId: String,
     deletedBy: String? = nil,

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -2402,7 +2402,10 @@ class TasksStore: ObservableObject {
     }
     guard isCurrent(lease) else { return }
 
-    guard !items.isEmpty else { return }
+    if items.isEmpty {
+      await flushPendingBackendDeletions(lease: lease)
+      return
+    }
     log("TasksStore: Retrying sync for \(items.count) unsynced items")
 
     var synced = 0
@@ -2472,6 +2475,53 @@ class TasksStore: ObservableObject {
     if isCurrent(lease) {
       log("TasksStore: Retry sync completed — \(synced)/\(items.count) items synced")
     }
+    await flushPendingBackendDeletions(lease: lease)
+  }
+
+  /// Push unacknowledged deletions to the backend and purge the tombstones it confirms.
+  ///
+  /// Second half of the tombstone contract in `deleteTask`: the tombstone records that the
+  /// user deleted the task, this flush makes the server agree, and only the server's
+  /// confirmation removes the local row. Partial confirmations purge exactly the confirmed
+  /// IDs — the rest stay tombstoned for the next pass.
+  private func flushPendingBackendDeletions(lease: OwnerOperationLease) async {
+    guard isCurrent(lease) else { return }
+    let pending: [String]
+    do {
+      pending = try await ActionItemStorage.shared.getPendingBackendDeletionIds()
+    } catch {
+      if isCurrent(lease) { logError("TasksStore: Failed to read pending deletions", error: error) }
+      return
+    }
+    guard isCurrent(lease), !pending.isEmpty else { return }
+    log("TasksStore: Flushing \(pending.count) unacknowledged task deletions")
+
+    var confirmed: [String] = []
+    do {
+      try await APIClient.shared.batchDeleteActionItems(
+        ids: pending,
+        expectedOwnerId: lease.ownerID,
+        authorizationSnapshot: lease.authorizationSnapshot
+      )
+      confirmed = pending
+    } catch let partial as APIClient.BatchDeletePartialFailure {
+      confirmed = partial.confirmedIDs
+    } catch {
+      guard isCurrent(lease) else { return }
+      logError("TasksStore: Deletion flush failed — tombstones retained", error: error)
+      return
+    }
+
+    guard isCurrent(lease) else { return }
+    for id in confirmed {
+      try? await ActionItemStorage.shared.deleteActionItemByBackendId(
+        id,
+        deletedBy: "user",
+        authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
+      )
+      guard isCurrent(lease) else { return }
+    }
+    log("TasksStore: Deletion flush confirmed \(confirmed.count)/\(pending.count)")
   }
 
   /// One-time backfill: assign relevance scores to all unscored active tasks.
@@ -3176,15 +3226,29 @@ class TasksStore: ObservableObject {
     let ownerID = lease.ownerID
     if let beforeLocalMutation { await beforeLocalMutation() }
     guard isCurrent(lease) else { return }
-    // Local-first: soft-delete in SQLite immediately for instant UI update
+    // Local-first, but as a tombstone, not a hard delete: the row keeps `deleted = 1,
+    // backendSynced = 0` until the server acknowledges, so a failed backend call cannot be
+    // forgotten and hydration cannot resurrect the task. Hard-deleting here was how 450
+    // deleted tasks came back after a reinstall.
+    let isLocalOnly = ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly
     do {
-      try await ActionItemStorage.shared.deleteActionItemByBackendId(
-        task.id,
-        deletedBy: "user",
-        authorization: Self.localMutationAuthorization(
-          snapshot: lease.authorizationSnapshot
+      if isLocalOnly {
+        // No backend row exists; a tombstone would wait forever for an ack.
+        try await ActionItemStorage.shared.deleteActionItemByBackendId(
+          task.id,
+          deletedBy: "user",
+          authorization: Self.localMutationAuthorization(
+            snapshot: lease.authorizationSnapshot
+          )
         )
-      )
+      } else {
+        try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
+          backendId: task.id,
+          authorization: Self.localMutationAuthorization(
+            snapshot: lease.authorizationSnapshot
+          )
+        )
+      }
     } catch {
       guard isCurrent(lease) else { return }
       logError("TasksStore: Failed to soft-delete task locally", error: error)
@@ -3234,9 +3298,8 @@ class TasksStore: ObservableObject {
       }
     }
 
-    // Hard-delete on backend in background. Unsynced local-only tasks have
-    // no backend row to delete.
-    if ActionItemTaskIdentity(surfacedId: task.id).isLocalOnly {
+    // Delete on backend; only an acknowledgement clears the local tombstone.
+    if isLocalOnly {
       log("TasksStore: Skipped backend delete for unsynced local task \(task.id)")
       return
     }
@@ -3246,9 +3309,16 @@ class TasksStore: ObservableObject {
         expectedOwnerId: ownerID,
         authorizationSnapshot: lease.authorizationSnapshot
       )
+      guard isCurrent(lease) else { return }
+      try? await ActionItemStorage.shared.deleteActionItemByBackendId(
+        task.id,
+        deletedBy: "user",
+        authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
+      )
     } catch {
       guard isCurrent(lease) else { return }
-      logError("TasksStore: Failed to hard-delete task on backend (local delete preserved)", error: error)
+      logError(
+        "TasksStore: Backend delete not acknowledged — tombstone retained for retry", error: error)
     }
   }
 
@@ -3259,6 +3329,14 @@ class TasksStore: ObservableObject {
     expectedOwnerID: String? = nil
   ) async {
     guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return }
+    // Undo of a tombstoned delete: the row still exists locally (deleted, awaiting the
+    // backend ack). Purge it before the re-insert below or undo would create a duplicate.
+    try? await ActionItemStorage.shared.deleteActionItemByBackendId(
+      task.id,
+      deletedBy: "user",
+      authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
+    )
+    guard isCurrent(lease) else { return }
 
     // A local-only task never had a backend row (deleteTask skipped the backend
     // delete). Restoring it through the backend-recreate path below is wrong on

--- a/desktop/macos/Desktop/Tests/ActionItemDeletionSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemDeletionSyncTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The resurrection contract. Deleting a synced task used to hard-delete the local row and
+/// fire one unretried backend call; if that call failed, nothing anywhere remembered the
+/// deletion and the next cloud hydration re-inserted the task — 450 of them came back at
+/// once after a reinstall. A deletion the server has not acknowledged must therefore leave
+/// a tombstone that hydration refuses to overwrite and a retry pass can flush.
+final class ActionItemDeletionSyncTests: XCTestCase {
+  private var testUserId: String!
+  private var userDir: URL!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "deletion-sync-test-\(UUID().uuidString)"
+    try await RewindDatabase.shared.switchUser(to: testUserId)
+    await ActionItemStorage.shared.invalidateCache()
+    let appSupport = FileManager.default
+      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await ActionItemStorage.shared.invalidateCache()
+    await RewindDatabase.shared.close()
+    if let userDir { try? FileManager.default.removeItem(at: userDir) }
+    RewindDatabase.currentUserId = nil
+    try await super.tearDown()
+  }
+
+  private func serverTask(id: String, deleted: Bool? = false) -> TaskActionItem {
+    TaskActionItem(
+      id: id,
+      description: "task \(id)",
+      completed: false,
+      createdAt: Date(timeIntervalSince1970: 1_750_000_000),
+      updatedAt: Date(timeIntervalSince1970: 1_750_000_000),
+      dueAt: nil,
+      deleted: deleted,
+      taskStatus: nil
+    )
+  }
+
+  /// The core of the bug: the server still returning the task is the *expected* state
+  /// while the deletion is unacknowledged, and it must not win.
+  func testCloudHydrationDoesNotResurrectAPendingDeletion() async throws {
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-1")], authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
+      backendId: "backend-1", authorization: .unrestricted)
+
+    // Reinstall/refresh shape: the server, never having heard the delete, sends it again.
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-1")], authorization: .unrestricted)
+
+    let pending = try await ActionItemStorage.shared.getPendingBackendDeletionIds()
+    XCTAssertEqual(pending, ["backend-1"], "hydration must not clear an unacknowledged tombstone")
+
+    let visible = try await ActionItemStorage.shared.getFilteredActionItems(
+      limit: 50, completedStates: [false])
+    XCTAssertFalse(
+      visible.contains { (item: TaskActionItem) in item.id == "backend-1" },
+      "a tombstoned task must stay invisible even after the server re-sends it")
+  }
+
+  /// Only the server's acknowledgement removes the row; after that, hydration of a task
+  /// the server no longer has cannot bring it back.
+  func testAcknowledgementPurgesTheTombstone() async throws {
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-2")], authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
+      backendId: "backend-2", authorization: .unrestricted)
+
+    let beforeAck = try await ActionItemStorage.shared.getPendingBackendDeletionIds()
+    XCTAssertEqual(beforeAck, ["backend-2"])
+
+    // The ack path (deleteTask / flushPendingBackendDeletions after a 2xx).
+    try await ActionItemStorage.shared.deleteActionItemByBackendId(
+      "backend-2", deletedBy: "user", authorization: .unrestricted)
+
+    let pending = try await ActionItemStorage.shared.getPendingBackendDeletionIds()
+    XCTAssertTrue(pending.isEmpty, "an acknowledged deletion must leave nothing to flush")
+  }
+
+  /// The full-sync purge cleans up acknowledged soft-deletes; it must not eat the durable
+  /// record of deletions the server has not confirmed yet.
+  func testFullSyncPurgeKeepsPendingTombstones() async throws {
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-3"), serverTask(id: "backend-4", deleted: true)],
+      authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
+      backendId: "backend-3", authorization: .unrestricted)
+
+    _ = try await ActionItemStorage.shared.purgeAllSoftDeletedItems(authorization: .unrestricted)
+
+    let pending = try await ActionItemStorage.shared.getPendingBackendDeletionIds()
+    XCTAssertEqual(
+      pending, ["backend-3"],
+      "purge must remove server-deleted rows but keep unacknowledged tombstones")
+  }
+}

--- a/desktop/macos/Desktop/Tests/ActionItemDeletionSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemDeletionSyncTests.swift
@@ -8,16 +8,16 @@ import XCTest
 /// once after a reinstall. A deletion the server has not acknowledged must therefore leave
 /// a tombstone that hydration refuses to overwrite and a retry pass can flush.
 final class ActionItemDeletionSyncTests: XCTestCase {
-  private var testUserId: String!
-  private var userDir: URL!
+  private var testUserId = ""
+  private var userDir: URL?
 
   override func setUp() async throws {
     try await super.setUp()
     testUserId = "deletion-sync-test-\(UUID().uuidString)"
     try await RewindDatabase.shared.switchUser(to: testUserId)
     await ActionItemStorage.shared.invalidateCache()
-    let appSupport = FileManager.default
-      .urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+    let appSupport = try XCTUnwrap(
+      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
     userDir =
       appSupport
       .appendingPathComponent("Omi", isDirectory: true)

--- a/desktop/macos/changelog/unreleased/20260812-deleted-tasks-stay-deleted.json
+++ b/desktop/macos/changelog/unreleased/20260812-deleted-tasks-stay-deleted.json
@@ -1,0 +1,3 @@
+{
+  "change": "Deleted tasks stay deleted — deletions now sync to the server with retry, so they can't come back after a reinstall or refresh"
+}


### PR DESCRIPTION
## The resurrection bug

Deleting a synced task hard-deleted the local row and fired **one unretried** backend call. If that call failed — offline, broken auth, app mid-update — nothing anywhere remembered the deletion, and the next cloud hydration re-inserted the task.

This is how **450 of Nik's deleted tasks came back at once** after yesterday's reinstall: the local deletes vanished with the old install, the server had never been told, and the fresh install hydrated everything back. (The bulk-select path was already server-first and validated; single delete and the missing retry story were the hole.)

## The contract now

- Deleting a synced task writes a **tombstone** (`deleted=1, backendSynced=0`) instead of hard-deleting. UI behavior unchanged — the task disappears immediately.
- **Only the server's acknowledgement purges the row** — immediately when the DELETE succeeds, or later via `flushPendingBackendDeletions` in the existing `retryUnsyncedItems` pass (batch endpoint, partial-confirmation aware: confirmed IDs purge, the rest stay tombstoned).
- **Hydration refuses to overwrite a pending tombstone.** The server still returning the task is the *expected* state while the deletion is unacknowledged; the 60s optimistic-update window was never enough for a retry that may run days later.
- The full-sync soft-delete purge keeps pending tombstones; undo purges the tombstone before re-inserting so it can't duplicate; local-only tasks still hard-delete immediately (no backend row to wait on).

## Verification

- `ActionItemDeletionSyncTests` (real SQLite fixture): hydration cannot resurrect a pending deletion · acknowledgement purges the tombstone · full-sync purge keeps pending tombstones while removing acked ones.
- **Live on the `omi-mic` named bundle:** created a task, deleted it, log shows `Tombstoned action item … pending backend delete` → ack → `Hard-deleted action item with backendId …`, and the dev backend no longer returns the task.
- **UNVERIFIED live:** the backend-down failure path (tombstone retained → later flush) — covered by the hydration regression test rather than re-triggered against a real dead backend.
- Also fixes `MemoryExportSetupTests` (upstream `weak var` never mutated) which failed the entire test build on main.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

