### PR TITLE
fix(desktop): recover poisoned pi-mono workers in-process

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
@@ -27,6 +27,9 @@ struct AgentRuntimeFailure: Equatable, Sendable {
   let adapterId: String?
   let provider: String?
   let retryable: Bool?
+  let recoveryAction: String?
+  let recoveryOutcome: String?
+  let retryDisposition: String?
 
   init(
     code: String,
@@ -36,7 +39,10 @@ struct AgentRuntimeFailure: Equatable, Sendable {
     source: String? = nil,
     adapterId: String? = nil,
     provider: String? = nil,
-    retryable: Bool? = nil
+    retryable: Bool? = nil,
+    recoveryAction: String? = nil,
+    recoveryOutcome: String? = nil,
+    retryDisposition: String? = nil
   ) {
     self.code = code
     self.failureCode = failureCode
@@ -46,6 +52,9 @@ struct AgentRuntimeFailure: Equatable, Sendable {
     self.adapterId = adapterId
     self.provider = provider
     self.retryable = retryable
+    self.recoveryAction = recoveryAction
+    self.recoveryOutcome = recoveryOutcome
+    self.retryDisposition = retryDisposition
   }
 
   var displayMessage: String {
@@ -78,7 +87,10 @@ struct AgentRuntimeFailure: Equatable, Sendable {
       source: payload["source"] as? String,
       adapterId: payload["adapterId"] as? String,
       provider: payload["provider"] as? String,
-      retryable: payload["retryable"] as? Bool
+      retryable: payload["retryable"] as? Bool,
+      recoveryAction: payload["recoveryAction"] as? String,
+      recoveryOutcome: payload["recoveryOutcome"] as? String,
+      retryDisposition: payload["retryDisposition"] as? String
     )
   }
 }

--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -233,6 +233,20 @@ struct ChatQueryErrorDetail: Equatable, Sendable {
   let failureSource: String?
   let adapterId: String?
   let provider: String?
+  let recoveryAction: String?
+  let recoveryOutcome: String?
+  let retryDisposition: String?
+
+  private static func boundedFailureCode(_ code: String) -> String? {
+    switch code {
+    case "adapter_not_registered", "binding_failed", "stale_binding",
+      "adapter_execution_failed", "provider_auth_required", "adapter_process_exited",
+      "adapter_config_invalid", "adapter_process_error":
+      return code
+    default:
+      return nil
+    }
+  }
 
   static func from(_ error: Error?) -> ChatQueryErrorDetail? {
     guard let bridgeError = error as? BridgeError else { return nil }
@@ -245,7 +259,10 @@ struct ChatQueryErrorDetail: Equatable, Sendable {
         failureCode: nil,
         failureSource: nil,
         adapterId: nil,
-        provider: nil)
+        provider: nil,
+        recoveryAction: nil,
+        recoveryOutcome: nil,
+        retryDisposition: nil)
     case .agentRuntimePayloadIncomplete:
       // The missing components are diagnostics for the local log only; PostHog
       // gets the bounded code.
@@ -255,19 +272,50 @@ struct ChatQueryErrorDetail: Equatable, Sendable {
         failureCode: nil,
         failureSource: nil,
         adapterId: nil,
-        provider: nil)
+        provider: nil,
+        recoveryAction: nil,
+        recoveryOutcome: nil,
+        retryDisposition: nil)
     case .agentRuntimeFailure(let failure):
       return ChatQueryErrorDetail(
         errorCode: failure.failureCode.rawValue,
         retryable: failure.retryable,
-        failureCode: failure.code,
+        failureCode: boundedFailureCode(failure.code),
         failureSource: failure.source,
         adapterId: failure.adapterId,
-        provider: failure.provider)
+        provider: failure.provider,
+        recoveryAction: failure.recoveryAction == "worker_recycled" ? "worker_recycled" : nil,
+        recoveryOutcome: ["recovered", "stop_failed"].contains(failure.recoveryOutcome ?? "")
+          ? failure.recoveryOutcome : nil,
+        retryDisposition: failure.retryDisposition == "next_send" ? "next_send" : nil)
     default:
       return nil
     }
   }
+}
+
+func recordAgentRuntimeRecoveryDiagnostics(_ error: Error?) -> ChatQueryErrorDetail? {
+  let detail = ChatQueryErrorDetail.from(error)
+  if let bridgeError = error as? BridgeError,
+    case .agentRuntimeFailure(let failure) = bridgeError,
+    let technicalMessage = failure.technicalMessage
+  {
+    log("ChatProvider: agent runtime technical failure: \(technicalMessage)")
+  }
+  if detail?.recoveryAction == "worker_recycled" {
+    DesktopDiagnosticsManager.shared.recordFallback(
+      area: "agent_runtime",
+      from: "pi_mono_worker",
+      to: "fresh_pi_mono_worker",
+      reason: "local_heal",
+      outcome: detail?.recoveryOutcome == "recovered" ? .degraded : .exhausted,
+      extra: [
+        "retry_disposition": detail?.retryDisposition ?? "unknown",
+        "recovery_outcome": detail?.recoveryOutcome ?? "unknown",
+      ]
+    )
+  }
+  return detail
 }
 
 enum ChatQueryTelemetryEvent: Equatable, Sendable {
@@ -343,6 +391,9 @@ extension ChatQueryTelemetryEvent {
         if let failureSource = detail.failureSource { properties["failure_source"] = failureSource }
         if let adapterId = detail.adapterId { properties["adapter_id"] = adapterId }
         if let provider = detail.provider { properties["provider"] = provider }
+        if let recoveryAction = detail.recoveryAction { properties["recovery_action"] = recoveryAction }
+        if let recoveryOutcome = detail.recoveryOutcome { properties["recovery_outcome"] = recoveryOutcome }
+        if let retryDisposition = detail.retryDisposition { properties["retry_disposition"] = retryDisposition }
       }
     case .cancelled(let eventContext, let durationMs, let reason, let partialResponse):
       eventName = "chat_agent_query_cancelled"

--- a/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatQueryTelemetry.swift
@@ -285,7 +285,7 @@ struct ChatQueryErrorDetail: Equatable, Sendable {
         adapterId: failure.adapterId,
         provider: failure.provider,
         recoveryAction: failure.recoveryAction == "worker_recycled" ? "worker_recycled" : nil,
-        recoveryOutcome: ["recovered", "stop_failed"].contains(failure.recoveryOutcome ?? "")
+        recoveryOutcome: ["recovered", "stop_failed", "binding_stale_failed"].contains(failure.recoveryOutcome ?? "")
           ? failure.recoveryOutcome : nil,
         retryDisposition: failure.retryDisposition == "next_send" ? "next_send" : nil)
     default:
@@ -310,6 +310,7 @@ func recordAgentRuntimeRecoveryDiagnostics(_ error: Error?) -> ChatQueryErrorDet
       reason: "local_heal",
       outcome: detail?.recoveryOutcome == "recovered" ? .degraded : .exhausted,
       extra: [
+        "recovery_action": "worker_recycled",
         "retry_disposition": detail?.retryDisposition ?? "unknown",
         "recovery_outcome": detail?.recoveryOutcome ?? "unknown",
       ]

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5463,7 +5463,7 @@ class ChatProvider: ObservableObject {
           telemetryAttempt.fail(
             errorClass: errorClass,
             partialResponse: hadPartialResponse,
-            detail: .from(error),
+            detail: recordAgentRuntimeRecoveryDiagnostics(error),
             watchdogFired: watchdogFired
           )
           logError(

--- a/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatQueryTelemetryTests.swift
@@ -87,6 +87,50 @@ final class ChatQueryTelemetryTests: XCTestCase {
     XCTAssertEqual(detail?.retryable, false)
   }
 
+  func testWorkerRecoveryTelemetryIsBoundedAndExplainsTheNextSendContract() {
+    let failure = AgentRuntimeFailure(
+      code: "adapter_execution_failed",
+      userMessage: "Agent run failed",
+      technicalMessage: "private prompt /Users/person/secret.txt",
+      source: "adapter_execution",
+      adapterId: "pi-mono",
+      retryable: true,
+      recoveryAction: "worker_recycled",
+      recoveryOutcome: "recovered",
+      retryDisposition: "next_send"
+    )
+    let event = ChatQueryTelemetryEvent.failed(
+      ChatQueryTelemetryContext(attemptId: "attempt-recycled", surface: "main_chat", harness: "piMono"),
+      durationMs: 400,
+      errorClass: .agentError,
+      partialResponse: false,
+      detail: .from(BridgeError.agentRuntimeFailure(failure))
+    )
+    let properties = event.analyticsPayload.properties
+    XCTAssertEqual(properties["recovery_action"] as? String, "worker_recycled")
+    XCTAssertEqual(properties["recovery_outcome"] as? String, "recovered")
+    XCTAssertEqual(properties["retry_disposition"] as? String, "next_send")
+    XCTAssertFalse(String(describing: properties).contains("/Users/person"))
+    XCTAssertFalse(String(describing: properties).contains("private prompt"))
+  }
+
+  func testRuntimeDetailedFailureCodeMustBeInTheAnalyticsAllowlist() {
+    let failure = AgentRuntimeFailure(
+      code: "provider_error_/Users/person/secret.txt",
+      userMessage: "Agent run failed"
+    )
+    let event = ChatQueryTelemetryEvent.failed(
+      ChatQueryTelemetryContext(attemptId: "attempt-private-code", surface: "main_chat", harness: "piMono"),
+      durationMs: 100,
+      errorClass: .agentRuntime,
+      partialResponse: false,
+      detail: .from(BridgeError.agentRuntimeFailure(failure))
+    )
+    let properties = event.analyticsPayload.properties
+    XCTAssertNil(properties["failure_code"])
+    XCTAssertFalse(String(describing: properties).contains("/Users/person"))
+  }
+
   func testAnalyticsPayloadUsesTypedAllowlist() {
     let event = ChatQueryTelemetryEvent.failed(
       ChatQueryTelemetryContext(

--- a/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
@@ -26,7 +26,8 @@ final class MemoryExportSetupTests: XCTestCase {
         fallbackOpened.fulfill()
       })
     var model: MemoryExportDestinationSheetModel? = MemoryExportDestinationSheetModel(workspace: workspace)
-    weak var weakModel = model
+    weak var weakModel: MemoryExportDestinationSheetModel?
+    weakModel = model
 
     model?.openDestination(for: .chatgpt, url: exportURL)
     model = nil

--- a/desktop/macos/Desktop/Tests/OCREmbeddingServiceFlushTimerTests.swift
+++ b/desktop/macos/Desktop/Tests/OCREmbeddingServiceFlushTimerTests.swift
@@ -94,7 +94,8 @@ final class OCREmbeddingServiceFlushTimerTests: XCTestCase {
 
     var service: OCREmbeddingService? = makeService(
       sleeper: sleeper, embedder: embedder, writes: writes)
-    weak var weakService = service
+    weak var weakService: OCREmbeddingService?
+    weakService = service
     await service?.embedScreenshot(
       id: 303,
       ocrText: String(repeating: "service lifetime timer text ", count: 2),

--- a/desktop/macos/agent/src/adapters/pi-mono.ts
+++ b/desktop/macos/agent/src/adapters/pi-mono.ts
@@ -34,9 +34,11 @@ import type {
   EventCallback,
   WarmupSessionConfig,
 } from "./interface.js";
+import { StaleAdapterBindingError } from "../runtime/kernel-types.js";
 
 type PiMonoConfig = HarnessConfig & {
   onRestart?: (reason: string) => void;
+  onDisposed?: () => void;
 };
 
 // Pi-mono RPC command/event types
@@ -682,6 +684,14 @@ export class PiMonoAdapter implements HarnessAdapter {
     rmSync(this.contextFilePath, { force: true });
   }
 
+  async dispose(): Promise<void> {
+    try {
+      await this.stop();
+    } finally {
+      this.config.onDisposed?.();
+    }
+  }
+
   async createSession(opts: SessionOpts): Promise<string> {
     const mapped = opts.model ? mapModel(opts.model) : undefined;
     await this.setExecutionRole(opts.executionRole ?? "coordinator");
@@ -766,7 +776,7 @@ export class PiMonoAdapter implements HarnessAdapter {
     relayContext?: PiMonoRelayContext
   ): Promise<PromptResult> {
     if (!this.sessions.has(sessionId)) {
-      throw new Error(`pi-mono session is no longer active: ${sessionId}`);
+      throw new StaleAdapterBindingError(`pi-mono session is no longer active: ${sessionId}`);
     }
     // Serialization invariant: pi-mono RPC only handles one prompt at a time.
     // Do not supersede an in-flight prompt: pi-mono turn_end events do not carry
@@ -1523,7 +1533,7 @@ export class PiMonoRuntimeAdapter implements RuntimeAdapter {
   }
 
   stop(): Promise<void> {
-    return this.harness.stop();
+    return this.harness.dispose();
   }
 
   async openBinding(input: OpenBindingInput): Promise<OpenedBinding> {
@@ -1546,7 +1556,7 @@ export class PiMonoRuntimeAdapter implements RuntimeAdapter {
     // RuntimeAdapter instance is alive the opaque session id is still usable as
     // process-local state. Startup reconciliation marks these bindings stale.
     if (!this.harness.hasSession(input.adapterNativeSessionId)) {
-      throw new Error(`pi-mono binding is stale: ${input.adapterNativeSessionId}`);
+      throw new StaleAdapterBindingError(`pi-mono binding is stale: ${input.adapterNativeSessionId}`);
     }
     return this.binding(input, input.adapterNativeSessionId);
   }

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1593,6 +1593,7 @@ async function main(): Promise<void> {
         const harness = new piMonoClasses!.PiMonoAdapter({
           omiApiBaseUrl: process.env.OMI_API_BASE_URL,
           authToken: piMonoAuthToken,
+          onDisposed: () => piMonoAdapters.delete(harness),
         });
         piMonoAdapters.add(harness);
         return new piMonoClasses!.PiMonoRuntimeAdapter(harness);

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -812,6 +812,9 @@ export interface RuntimeFailurePayload {
   adapterId?: string;
   provider?: string;
   retryable?: boolean;
+  recoveryAction?: "worker_recycled";
+  recoveryOutcome?: "recovered" | "stop_failed";
+  retryDisposition?: "next_send";
 }
 
 export interface ToolActivityMessage extends QueryScopedOutbound {

--- a/desktop/macos/agent/src/protocol.ts
+++ b/desktop/macos/agent/src/protocol.ts
@@ -813,7 +813,7 @@ export interface RuntimeFailurePayload {
   provider?: string;
   retryable?: boolean;
   recoveryAction?: "worker_recycled";
-  recoveryOutcome?: "recovered" | "stop_failed";
+  recoveryOutcome?: "recovered" | "stop_failed" | "binding_stale_failed";
   retryDisposition?: "next_send";
 }
 

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -39,7 +39,7 @@ export interface RuntimeFailure {
   provider?: string;
   retryable?: boolean;
   recoveryAction?: "worker_recycled";
-  recoveryOutcome?: "recovered" | "stop_failed";
+  recoveryOutcome?: "recovered" | "stop_failed" | "binding_stale_failed";
   retryDisposition?: "next_send";
 }
 

--- a/desktop/macos/agent/src/runtime/failures.ts
+++ b/desktop/macos/agent/src/runtime/failures.ts
@@ -38,6 +38,9 @@ export interface RuntimeFailure {
   adapterId?: string;
   provider?: string;
   retryable?: boolean;
+  recoveryAction?: "worker_recycled";
+  recoveryOutcome?: "recovered" | "stop_failed";
+  retryDisposition?: "next_send";
 }
 
 export class AdapterRuntimeError extends Error {

--- a/desktop/macos/agent/src/runtime/jsonl-transport.ts
+++ b/desktop/macos/agent/src/runtime/jsonl-transport.ts
@@ -685,11 +685,16 @@ function boundedTerminalFailure(result: Awaited<ReturnType<AgentRuntimeKernel["e
     code,
     failureCode: persisted?.failureCode,
     userMessage,
-    technicalMessage: persisted?.technicalMessage,
+    technicalMessage: persisted?.technicalMessage
+      ? sanitizeProcessDiagnostic(persisted.technicalMessage)
+      : undefined,
     source: persisted?.source ?? "runtime",
     adapterId: persisted?.adapterId,
     provider: persisted?.provider,
     retryable: persisted?.retryable ?? false,
+    recoveryAction: persisted?.recoveryAction,
+    recoveryOutcome: persisted?.recoveryOutcome,
+    retryDisposition: persisted?.retryDisposition,
   });
 }
 

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -142,6 +142,7 @@ import type {
   AgentRuntimeKernelOptions,
 } from "./kernel-types.js";
 import { ExternalSurfaceAuthorityError, StaleAdapterBindingError } from "./kernel-types.js";
+import { AdapterWorkerRecycledError } from "./worker-pool.js";
 import { providerBoundaryForAdapter, resolveAdapterWithinBoundary } from "./execution-policy.js";
 import type { SurfaceRef } from "./surface-session.js";
 
@@ -973,6 +974,7 @@ export class KernelCore {
       let binding: AdapterBinding;
       let handle: AdapterBindingHandle;
       let bindingResolutionProtectedBindingId: string | null = null;
+      let adapterDispatchStarted = false;
       try {
         assertExecutionAuthority();
         const resolved = await this.withBindingResolutionLock(accepted.session.sessionId, adapterId, async () => {
@@ -1122,6 +1124,7 @@ export class KernelCore {
             { capabilityRef: toolCapability.capabilityRef },
           );
           this.markAttemptRunning(attempt, binding);
+          adapterDispatchStarted = true;
           return worker.adapter.executeAttempt(
             {
               sessionId: accepted.session.sessionId,
@@ -1141,7 +1144,24 @@ export class KernelCore {
             (event) => this.persistAdapterEvent(accepted.session.sessionId, accepted.run.runId, attempt.attemptId, event),
             abortController.signal,
           );
-        });
+        }, adapterId === "pi-mono" ? {
+          recycleWorkerOnError: true,
+          shouldRecycleWorkerOnError: () => adapterDispatchStarted,
+          onWorkerRecycled: () => {
+            this.markBindingStale(binding, attempt, "pinned_worker_recycled_after_execution_error");
+            this.appendEvent({
+              sessionId: accepted.session.sessionId,
+              runId: accepted.run.runId,
+              attemptId: attempt.attemptId,
+              type: "worker.recycled",
+              payload: {
+                adapterId,
+                recoveryAction: "worker_recycled",
+                retryDisposition: "next_send",
+              },
+            });
+          },
+        } : undefined);
         this.activeExecutions.delete(accepted.run.runId);
         assertExecutionAuthority();
         if (handle.bindingId && nextContextDelivery) {
@@ -1198,19 +1218,34 @@ export class KernelCore {
           resumeFromAttemptId = attempt.attemptId;
           continue;
         }
-        if (await this.tryRecoverAttempt(input, attempt, error, "adapter_execution_failed", attemptNo < maxAttempts)) {
+        const workerRecovery = error instanceof AdapterWorkerRecycledError ? error : null;
+        if (
+          !workerRecovery
+          && await this.tryRecoverAttempt(input, attempt, error, "adapter_execution_failed", attemptNo < maxAttempts)
+        ) {
           retryReason = "recoverable_error";
           resumeFromAttemptId = attempt.attemptId;
           continue;
         }
         const wasCancelling = this.runStatus(accepted.run.runId) === "cancelling";
         const status: AttemptStatus = wasCancelling ? "cancelled" : "failed";
-        const failure = wasCancelling ? null : failureFromError(error, {
-          code: "adapter_execution_failed",
-          source: "adapter_execution",
-          adapterId: attempt.adapterId,
-          retryable: false,
-        });
+        const baseFailure = wasCancelling ? null : failureFromError(
+          workerRecovery?.originalError ?? error,
+          {
+            code: "adapter_execution_failed",
+            source: "adapter_execution",
+            adapterId: attempt.adapterId,
+            retryable: Boolean(workerRecovery),
+          },
+        );
+        const failure = baseFailure && workerRecovery ? {
+          ...baseFailure,
+          userMessage: "The local agent reset its session after an error. Send your message again.",
+          retryable: true,
+          recoveryAction: "worker_recycled" as const,
+          recoveryOutcome: workerRecovery.stopSucceeded ? "recovered" as const : "stop_failed" as const,
+          retryDisposition: "next_send" as const,
+        } : baseFailure;
         this.finishAttemptAndRun({
           sessionId: accepted.session.sessionId,
           runId: accepted.run.runId,

--- a/desktop/macos/agent/src/runtime/kernel-core.ts
+++ b/desktop/macos/agent/src/runtime/kernel-core.ts
@@ -1146,9 +1146,17 @@ export class KernelCore {
           );
         }, adapterId === "pi-mono" ? {
           recycleWorkerOnError: true,
-          shouldRecycleWorkerOnError: () => adapterDispatchStarted,
-          onWorkerRecycled: () => {
+          shouldRecycleWorkerOnError: () => (
+            adapterDispatchStarted
+            && !input.authoritySignal?.aborted
+            && !abortController.signal.aborted
+            && this.runStatus(accepted.run.runId) !== "cancelling"
+            && this.readAttempt(attempt.attemptId).status !== "cancelling"
+          ),
+          onWorkerBindingInvalidated: () => {
             this.markBindingStale(binding, attempt, "pinned_worker_recycled_after_execution_error");
+          },
+          onWorkerRecycled: (_bindingId, outcome) => {
             this.appendEvent({
               sessionId: accepted.session.sessionId,
               runId: accepted.run.runId,
@@ -1157,6 +1165,12 @@ export class KernelCore {
               payload: {
                 adapterId,
                 recoveryAction: "worker_recycled",
+                recoveryOutcome: !outcome.stopSucceeded
+                  ? "stop_failed"
+                  : outcome.bindingInvalidationSucceeded
+                    ? "recovered"
+                    : "binding_stale_failed",
+                bindingStalePersisted: outcome.bindingInvalidationSucceeded,
                 retryDisposition: "next_send",
               },
             });
@@ -1205,9 +1219,13 @@ export class KernelCore {
           }
           break;
         }
-        if (isStaleBindingError(error)) {
-          this.markBindingStale(binding, attempt, messageFrom(error));
-          const failure = failureFromError(error, {
+        const workerRecovery = error instanceof AdapterWorkerRecycledError ? error : null;
+        const executionError = workerRecovery?.originalError ?? error;
+        if (isStaleBindingError(executionError)) {
+          if (!workerRecovery?.bindingInvalidationSucceeded) {
+            this.markBindingStale(binding, attempt, messageFrom(executionError));
+          }
+          const failure = failureFromError(executionError, {
             code: "stale_binding",
             source: "adapter_execution",
             adapterId: attempt.adapterId,
@@ -1218,7 +1236,6 @@ export class KernelCore {
           resumeFromAttemptId = attempt.attemptId;
           continue;
         }
-        const workerRecovery = error instanceof AdapterWorkerRecycledError ? error : null;
         if (
           !workerRecovery
           && await this.tryRecoverAttempt(input, attempt, error, "adapter_execution_failed", attemptNo < maxAttempts)
@@ -1243,7 +1260,11 @@ export class KernelCore {
           userMessage: "The local agent reset its session after an error. Send your message again.",
           retryable: true,
           recoveryAction: "worker_recycled" as const,
-          recoveryOutcome: workerRecovery.stopSucceeded ? "recovered" as const : "stop_failed" as const,
+          recoveryOutcome: !workerRecovery.stopSucceeded
+            ? "stop_failed" as const
+            : workerRecovery.bindingInvalidationSucceeded
+              ? "recovered" as const
+              : "binding_stale_failed" as const,
           retryDisposition: "next_send" as const,
         } : baseFailure;
         this.finishAttemptAndRun({

--- a/desktop/macos/agent/src/runtime/worker-pool.ts
+++ b/desktop/macos/agent/src/runtime/worker-pool.ts
@@ -28,6 +28,7 @@ export class AdapterWorker {
   private activeAttemptId: string | null = null;
   private activeBindingId: string | null = null;
   private pinnedBindingId: string | null = null;
+  private unhealthy = false;
 
   constructor(workerId: string, adapter: RuntimeAdapter) {
     this.workerId = workerId;
@@ -39,7 +40,7 @@ export class AdapterWorker {
   }
 
   canRun(binding?: AdapterBindingHandle): boolean {
-    if (this.isBusy) return false;
+    if (this.isBusy || this.unhealthy) return false;
     if (!this.adapter.capabilities.requiresPinnedWorker) return true;
     if (!this.pinnedBindingId) return true;
     return Boolean(binding?.bindingId && binding.bindingId === this.pinnedBindingId);
@@ -54,8 +55,16 @@ export class AdapterWorker {
   }
 
   get idlePinnedBindingId(): string | null {
-    if (this.isBusy) return null;
+    if (this.isBusy || this.unhealthy) return null;
     return this.pinnedBindingId;
+  }
+
+  get pinnedBindingIdForRecovery(): string | null {
+    return this.pinnedBindingId;
+  }
+
+  markUnhealthy(): void {
+    this.unhealthy = true;
   }
 
   releaseIdlePinnedBinding(): string | null {
@@ -129,6 +138,23 @@ type WorkerLeaseResolver = (worker: AdapterWorker) => void;
 interface WorkerLeaseOptions {
   onIdlePinnedBindingEvicted?: (bindingId: string) => void;
   protectPinnedBindingAfterWork?: boolean;
+  recycleWorkerOnError?: boolean;
+  shouldRecycleWorkerOnError?: (error: unknown) => boolean;
+  onWorkerRecycled?: (bindingId: string | null) => void;
+}
+
+export class AdapterWorkerRecycledError extends Error {
+  readonly bindingId: string | null;
+  readonly stopSucceeded: boolean;
+  readonly originalError: unknown;
+
+  constructor(originalError: unknown, bindingId: string | null, stopSucceeded: boolean) {
+    super(originalError instanceof Error ? originalError.message : String(originalError));
+    this.name = "AdapterWorkerRecycledError";
+    this.bindingId = bindingId;
+    this.stopSucceeded = stopSucceeded;
+    this.originalError = originalError;
+  }
 }
 
 interface PendingWorkerLease {
@@ -238,11 +264,50 @@ export class AdapterWorkerPool {
       const result = await worker.runExclusive(attemptId, binding, () => work(worker));
       succeeded = true;
       return result;
+    } catch (error) {
+      if (
+        !options?.recycleWorkerOnError
+        || options.shouldRecycleWorkerOnError?.(error) === false
+      ) throw error;
+      const bindingId = worker.pinnedBindingIdForRecovery;
+      // Poison synchronously before the finally block drains waiters. Otherwise
+      // a queued lease can reacquire this process-local worker after its throw.
+      worker.markUnhealthy();
+      const index = this.workers.indexOf(worker);
+      if (index >= 0) this.workers.splice(index, 1);
+      if (bindingId) this.protectedPinnedBindingIds.delete(bindingId);
+      this.rejectWaitersForRecycledBinding(bindingId);
+      try {
+        options.onWorkerRecycled?.(bindingId);
+      } catch {
+        // Cleanup must not depend on persistence/telemetry recovery succeeding.
+        // Removing the worker still makes the old binding self-heal as stale on
+        // its next resolution.
+      }
+      let stopSucceeded = true;
+      try {
+        await worker.adapter.stop();
+      } catch {
+        stopSucceeded = false;
+      }
+      throw new AdapterWorkerRecycledError(error, bindingId, stopSucceeded);
     } finally {
       if (succeeded && options?.protectPinnedBindingAfterWork) {
         this.protectPinnedBinding(worker.idlePinnedBindingId);
       }
       this.drainWaiters();
+    }
+  }
+
+  private rejectWaitersForRecycledBinding(bindingId: string | null): void {
+    if (!bindingId) return;
+    for (let i = this.waiters.length - 1; i >= 0; i -= 1) {
+      const waiter = this.waiters[i]!;
+      if (waiter.binding?.bindingId !== bindingId) continue;
+      this.waiters.splice(i, 1);
+      const error = new Error(`Adapter binding was recycled: ${bindingId}`);
+      error.name = "StaleAdapterBindingError";
+      waiter.reject(error);
     }
   }
 

--- a/desktop/macos/agent/src/runtime/worker-pool.ts
+++ b/desktop/macos/agent/src/runtime/worker-pool.ts
@@ -140,19 +140,30 @@ interface WorkerLeaseOptions {
   protectPinnedBindingAfterWork?: boolean;
   recycleWorkerOnError?: boolean;
   shouldRecycleWorkerOnError?: (error: unknown) => boolean;
-  onWorkerRecycled?: (bindingId: string | null) => void;
+  onWorkerBindingInvalidated?: (bindingId: string | null) => void;
+  onWorkerRecycled?: (
+    bindingId: string | null,
+    outcome: { stopSucceeded: boolean; bindingInvalidationSucceeded: boolean }
+  ) => void;
 }
 
 export class AdapterWorkerRecycledError extends Error {
   readonly bindingId: string | null;
   readonly stopSucceeded: boolean;
+  readonly bindingInvalidationSucceeded: boolean;
   readonly originalError: unknown;
 
-  constructor(originalError: unknown, bindingId: string | null, stopSucceeded: boolean) {
+  constructor(
+    originalError: unknown,
+    bindingId: string | null,
+    stopSucceeded: boolean,
+    bindingInvalidationSucceeded: boolean
+  ) {
     super(originalError instanceof Error ? originalError.message : String(originalError));
     this.name = "AdapterWorkerRecycledError";
     this.bindingId = bindingId;
     this.stopSucceeded = stopSucceeded;
+    this.bindingInvalidationSucceeded = bindingInvalidationSucceeded;
     this.originalError = originalError;
   }
 }
@@ -277,12 +288,13 @@ export class AdapterWorkerPool {
       if (index >= 0) this.workers.splice(index, 1);
       if (bindingId) this.protectedPinnedBindingIds.delete(bindingId);
       this.rejectWaitersForRecycledBinding(bindingId);
+      let bindingInvalidationSucceeded = true;
       try {
-        options.onWorkerRecycled?.(bindingId);
+        options.onWorkerBindingInvalidated?.(bindingId);
       } catch {
-        // Cleanup must not depend on persistence/telemetry recovery succeeding.
-        // Removing the worker still makes the old binding self-heal as stale on
-        // its next resolution.
+        bindingInvalidationSucceeded = false;
+        // Keep this bounded: persistence exceptions may contain database paths.
+        console.error("[agent-runtime] worker recovery binding invalidation failed");
       }
       let stopSucceeded = true;
       try {
@@ -290,7 +302,22 @@ export class AdapterWorkerPool {
       } catch {
         stopSucceeded = false;
       }
-      throw new AdapterWorkerRecycledError(error, bindingId, stopSucceeded);
+      try {
+        options.onWorkerRecycled?.(bindingId, {
+          stopSucceeded,
+          bindingInvalidationSucceeded,
+        });
+      } catch {
+        // Telemetry must not prevent deterministic worker cleanup. The thrown
+        // recovery error still carries both bounded lifecycle outcomes.
+        console.error("[agent-runtime] worker recovery event persistence failed");
+      }
+      throw new AdapterWorkerRecycledError(
+        error,
+        bindingId,
+        stopSucceeded,
+        bindingInvalidationSucceeded
+      );
     } finally {
       if (succeeded && options?.protectPinnedBindingAfterWork) {
         this.protectPinnedBinding(worker.idlePinnedBindingId);

--- a/desktop/macos/agent/tests/adapter-binding.test.ts
+++ b/desktop/macos/agent/tests/adapter-binding.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { baseRunInput, createKernelHarness } from "./kernel-fakes.js";
+import { baseRunInput, createKernelHarness, FakeRuntimeAdapter } from "./kernel-fakes.js";
 
 const createdDirs: string[] = [];
 
@@ -109,6 +109,76 @@ describe("AgentRuntimeKernel adapter binding resolution", () => {
     ]);
     expect(store.allRows("SELECT type FROM events ORDER BY event_seq").map((row) => row.type)).toContain("binding.stale");
     expect(store.allRows("SELECT type FROM events ORDER BY event_seq").map((row) => row.type)).toContain("binding.replaced");
+    store.close();
+  });
+
+  it("recycles a poisoned pi-mono worker so the next send succeeds in the same daemon", async () => {
+    const adapters: FakeRuntimeAdapter[] = [];
+    let genericRecoveryCalls = 0;
+    const makeAdapter = () => {
+      const adapter = new FakeRuntimeAdapter("pi-mono");
+      Object.assign(adapter.capabilities, {
+        resumeFidelity: "none",
+        supportsNativeResume: false,
+        requiresPinnedWorker: true,
+        restartBehavior: "process_local_bindings_stale",
+      });
+      adapters.push(adapter);
+      return adapter;
+    };
+    const { store, adapter, kernel } = createKernelHarness(
+      newDatabasePath(),
+      "pi-mono",
+      1,
+      undefined,
+      () => ({
+        maxAttempts: 2,
+        recoverAfterError: async () => {
+          genericRecoveryCalls += 1;
+          return true;
+        },
+      }),
+      makeAdapter,
+    );
+    adapter.failNextExecutionError = new Error("poisoned local adapter state");
+
+    const failed = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-poisoned",
+    });
+    expect(failed.terminalStatus).toBe("failed");
+    expect(adapters).toHaveLength(1);
+    expect(adapter.executed).toHaveLength(1);
+    expect(genericRecoveryCalls).toBe(0);
+    expect(adapter.stopped).toBe(1);
+    expect(store.getRow("SELECT status FROM adapter_bindings").status).toBe("stale");
+    expect(JSON.parse(failed.run.resultJson!)).toMatchObject({
+      failure: {
+        code: "adapter_execution_failed",
+        recoveryAction: "worker_recycled",
+        recoveryOutcome: "recovered",
+        retryDisposition: "next_send",
+        retryable: true,
+      },
+    });
+
+    const recovered = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-after-recycle",
+    });
+    expect(recovered.terminalStatus).toBe("succeeded");
+    expect(adapters).toHaveLength(2);
+    expect(adapters[1]?.executed).toHaveLength(1);
+    expect(store.allRows("SELECT status FROM adapter_bindings ORDER BY binding_generation"))
+      .toEqual([
+        expect.objectContaining({ status: "closed" }),
+        expect.objectContaining({ status: "active" }),
+      ]);
+    expect(store.allRows("SELECT type FROM events WHERE type = 'worker.recycled'")).toHaveLength(1);
     store.close();
   });
 });

--- a/desktop/macos/agent/tests/adapter-binding.test.ts
+++ b/desktop/macos/agent/tests/adapter-binding.test.ts
@@ -179,6 +179,85 @@ describe("AgentRuntimeKernel adapter binding resolution", () => {
         expect.objectContaining({ status: "active" }),
       ]);
     expect(store.allRows("SELECT type FROM events WHERE type = 'worker.recycled'")).toHaveLength(1);
+    expect(JSON.parse(store.getRow(
+      "SELECT payload_json FROM events WHERE type = 'worker.recycled'",
+    ).payload_json)).toMatchObject({
+      recoveryOutcome: "recovered",
+      bindingStalePersisted: true,
+    });
+    store.close();
+  });
+
+  it("unwraps a stale-binding execution failure and retries on a fresh pi-mono worker", async () => {
+    const adapters: FakeRuntimeAdapter[] = [];
+    const makeAdapter = () => {
+      const adapter = new FakeRuntimeAdapter("pi-mono");
+      Object.assign(adapter.capabilities, {
+        resumeFidelity: "none",
+        supportsNativeResume: false,
+        requiresPinnedWorker: true,
+        restartBehavior: "process_local_bindings_stale",
+      });
+      adapters.push(adapter);
+      return adapter;
+    };
+    const { store, adapter, kernel } = createKernelHarness(
+      newDatabasePath(), "pi-mono", 1, undefined, undefined, makeAdapter,
+    );
+    adapter.failNextExecutionAsStale = true;
+
+    const result = await kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-stale-during-execution",
+      maxAttempts: 2,
+    });
+
+    expect(result.terminalStatus).toBe("succeeded");
+    expect(adapters).toHaveLength(2);
+    expect(adapter.stopped).toBe(1);
+    expect(store.allRows("SELECT payload_json FROM events WHERE type = 'binding.stale'")
+      .map((row) => JSON.parse(row.payload_json as string))
+      .filter((payload) => payload.reason === "pinned_worker_recycled_after_execution_error"))
+      .toHaveLength(1);
+    expect(store.allRows(
+      "SELECT status FROM adapter_bindings ORDER BY binding_generation",
+    )).toEqual([
+      expect.objectContaining({ status: "closed" }),
+      expect.objectContaining({ status: "active" }),
+    ]);
+    store.close();
+  });
+
+  it("does not recycle a pi-mono worker when cancellation rejects in-flight execution", async () => {
+    const { store, adapter, kernel } = createKernelHarness(newDatabasePath(), "pi-mono", 1);
+    Object.assign(adapter.capabilities, {
+      resumeFidelity: "none",
+      supportsNativeResume: false,
+      requiresPinnedWorker: true,
+      restartBehavior: "process_local_bindings_stale",
+    });
+    adapter.deferResult();
+
+    const execution = kernel.executeRun({
+      ...baseRunInput,
+      adapterId: "pi-mono",
+      defaultAdapterId: "pi-mono",
+      requestId: "request-cancelled-in-flight",
+    });
+    while (adapter.executed.length === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    const runId = store.getRow("SELECT run_id FROM runs ORDER BY created_at_ms DESC LIMIT 1").run_id as string;
+    await kernel.cancelRun(runId);
+    adapter.rejectDeferred(new Error("adapter abort rejection"));
+
+    const result = await execution;
+    expect(result.terminalStatus).toBe("cancelled");
+    expect(adapter.stopped).toBe(0);
+    expect(store.getRow("SELECT status FROM adapter_bindings").status).toBe("active");
+    expect(store.allRows("SELECT type FROM events WHERE type = 'worker.recycled'")).toHaveLength(0);
     store.close();
   });
 });

--- a/desktop/macos/agent/tests/kernel-fakes.ts
+++ b/desktop/macos/agent/tests/kernel-fakes.ts
@@ -62,6 +62,7 @@ export class FakeRuntimeAdapter implements RuntimeAdapter {
     | {
         promise: Promise<AdapterAttemptResult>;
         resolve: (result: AdapterAttemptResult) => void;
+        reject: (error: unknown) => void;
       }
     | undefined;
 
@@ -177,8 +178,9 @@ export class FakeRuntimeAdapter implements RuntimeAdapter {
 
   deferResult(): void {
     this.pendingResult = {} as typeof this.pendingResult;
-    this.pendingResult!.promise = new Promise<AdapterAttemptResult>((resolve) => {
+    this.pendingResult!.promise = new Promise<AdapterAttemptResult>((resolve, reject) => {
       this.pendingResult!.resolve = resolve;
+      this.pendingResult!.reject = reject;
     });
   }
 
@@ -192,6 +194,14 @@ export class FakeRuntimeAdapter implements RuntimeAdapter {
       terminalStatus: result.terminalStatus ?? "cancelled",
       ...result,
     });
+    this.pendingResult = undefined;
+  }
+
+  rejectDeferred(error: unknown): void {
+    if (!this.pendingResult) {
+      throw new Error("No deferred result exists");
+    }
+    this.pendingResult.reject(error);
     this.pendingResult = undefined;
   }
 

--- a/desktop/macos/agent/tests/kernel-fakes.ts
+++ b/desktop/macos/agent/tests/kernel-fakes.ts
@@ -213,11 +213,19 @@ export function createKernelHarness(
     maxAttempts?: number;
     recoverAfterError?: (error: unknown) => Promise<boolean>;
   },
+  makeAdapter?: () => FakeRuntimeAdapter,
 ): KernelHarness {
   const store = new SqliteAgentStore({ databasePath, reconcileOnOpen: false });
-  const adapter = new FakeRuntimeAdapter(adapterId);
+  const adapter = makeAdapter?.() ?? new FakeRuntimeAdapter(adapterId);
+  let firstFactoryCall = true;
   const registry = new AdapterRegistry();
-  registry.register(adapterId, () => adapter, maxWorkers);
+  registry.register(adapterId, () => {
+    if (firstFactoryCall) {
+      firstFactoryCall = false;
+      return adapter;
+    }
+    return makeAdapter?.() ?? adapter;
+  }, maxWorkers);
   const kernel = new AgentRuntimeKernel({
     store,
     registry,

--- a/desktop/macos/agent/tests/pi-mono-adapter.test.ts
+++ b/desktop/macos/agent/tests/pi-mono-adapter.test.ts
@@ -948,6 +948,15 @@ describe("PiMonoAdapter restart lifecycle", () => {
     expect(onRestart).toHaveBeenCalledWith("systemPrompt");
     expect(spawn).toHaveBeenCalledTimes(2);
   });
+
+  it("runs disposal bookkeeping even when stop fails", async () => {
+    const onDisposed = vi.fn();
+    const adapter = new PiMonoAdapter({ authToken: "test-token", onDisposed });
+    vi.spyOn(adapter, "stop").mockRejectedValueOnce(new Error("stop failed"));
+
+    await expect(adapter.dispose()).rejects.toThrow("stop failed");
+    expect(onDisposed).toHaveBeenCalledOnce();
+  });
 });
 
 describe("PiMonoAdapter source-level invariants", () => {

--- a/desktop/macos/agent/tests/worker-pool-pinned.test.ts
+++ b/desktop/macos/agent/tests/worker-pool-pinned.test.ts
@@ -3,7 +3,7 @@ import type {
   AdapterAttemptContext,
   RuntimeAdapter,
 } from "../src/adapters/interface.js";
-import { AdapterWorkerPool } from "../src/runtime/worker-pool.js";
+import { AdapterWorkerPool, AdapterWorkerRecycledError } from "../src/runtime/worker-pool.js";
 
 function pinnedAdapter(): RuntimeAdapter {
   return {
@@ -396,5 +396,84 @@ describe("AdapterWorkerPool pinned workers", () => {
     const reused = pool.acquire(binding2);
     expect(reused?.workerId).toBe("worker-2");
     expect(pool.size).toBe(2);
+  });
+
+  it("poisons and removes a failed process-local worker before draining same-binding waiters", async () => {
+    let stopCount = 0;
+    let factoryCount = 0;
+    const pool = new AdapterWorkerPool(() => {
+      factoryCount += 1;
+      return { ...pinnedAdapter(), stop: async () => { stopCount += 1; } };
+    }, 1);
+    const binding = {
+      bindingId: "binding-poisoned",
+      sessionId: "session-1",
+      adapterId: "pi-mono",
+      adapterNativeSessionId: "native-1",
+      resumeFidelity: "none" as const,
+      cwd: "/tmp",
+    };
+    let release!: () => void;
+    const active = pool.runExclusiveQueued(binding, "attempt-failing", async () => {
+      await new Promise<void>((resolve) => { release = resolve; });
+      throw new Error("adapter wedged");
+    }, { recycleWorkerOnError: true });
+    const queued = pool.runExclusiveQueued(binding, "attempt-queued", async () => {
+      throw new Error("queued work must not reach the poisoned worker");
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    release();
+    await expect(active).rejects.toMatchObject({
+      name: "AdapterWorkerRecycledError",
+      bindingId: "binding-poisoned",
+      stopSucceeded: true,
+    } satisfies Partial<AdapterWorkerRecycledError>);
+    await expect(queued).rejects.toMatchObject({ name: "StaleAdapterBindingError" });
+    expect(stopCount).toBe(1);
+    expect(pool.size).toBe(0);
+
+    expect(pool.acquire(undefined)?.workerId).toBe("worker-2");
+    expect(factoryCount).toBe(2);
+  });
+
+  it("still removes a poisoned worker when recovery bookkeeping and stop fail", async () => {
+    let stopCount = 0;
+    const pool = new AdapterWorkerPool(() => ({
+      ...pinnedAdapter(),
+      stop: async () => {
+        stopCount += 1;
+        throw new Error("stop failed");
+      },
+    }), 1);
+
+    await expect(pool.runExclusiveQueued(undefined, "attempt-failing", async () => {
+      throw new Error("adapter wedged");
+    }, {
+      recycleWorkerOnError: true,
+      onWorkerRecycled: () => { throw new Error("persistence failed"); },
+    })).rejects.toMatchObject({
+      name: "AdapterWorkerRecycledError",
+      stopSucceeded: false,
+    });
+    expect(stopCount).toBe(1);
+    expect(pool.size).toBe(0);
+  });
+
+  it("does not recycle errors rejected by the dispatch predicate", async () => {
+    let stopCount = 0;
+    const pool = new AdapterWorkerPool(() => ({
+      ...pinnedAdapter(),
+      stop: async () => { stopCount += 1; },
+    }), 1);
+
+    await expect(pool.runExclusiveQueued(undefined, "attempt-cancelled", async () => {
+      throw new Error("cancelled_before_adapter_dispatch");
+    }, {
+      recycleWorkerOnError: true,
+      shouldRecycleWorkerOnError: () => false,
+    })).rejects.toThrow("cancelled_before_adapter_dispatch");
+    expect(stopCount).toBe(0);
+    expect(pool.size).toBe(1);
   });
 });

--- a/desktop/macos/agent/tests/worker-pool-pinned.test.ts
+++ b/desktop/macos/agent/tests/worker-pool-pinned.test.ts
@@ -439,6 +439,7 @@ describe("AdapterWorkerPool pinned workers", () => {
 
   it("still removes a poisoned worker when recovery bookkeeping and stop fail", async () => {
     let stopCount = 0;
+    let reportedOutcome: { stopSucceeded: boolean; bindingInvalidationSucceeded: boolean } | undefined;
     const pool = new AdapterWorkerPool(() => ({
       ...pinnedAdapter(),
       stop: async () => {
@@ -451,12 +452,18 @@ describe("AdapterWorkerPool pinned workers", () => {
       throw new Error("adapter wedged");
     }, {
       recycleWorkerOnError: true,
-      onWorkerRecycled: () => { throw new Error("persistence failed"); },
+      onWorkerBindingInvalidated: () => { throw new Error("persistence failed"); },
+      onWorkerRecycled: (_bindingId, outcome) => { reportedOutcome = outcome; },
     })).rejects.toMatchObject({
       name: "AdapterWorkerRecycledError",
       stopSucceeded: false,
+      bindingInvalidationSucceeded: false,
     });
     expect(stopCount).toBe(1);
+    expect(reportedOutcome).toEqual({
+      stopSucceeded: false,
+      bindingInvalidationSucceeded: false,
+    });
     expect(pool.size).toBe(0);
   });
 

--- a/desktop/macos/changelog/unreleased/20260812-pi-mono-chat-recovery.json
+++ b/desktop/macos/changelog/unreleased/20260812-pi-mono-chat-recovery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed desktop chat getting stuck after a local agent error"
+}

--- a/desktop/macos/e2e/flows/chat-fault-5xx.yaml
+++ b/desktop/macos/e2e/flows/chat-fault-5xx.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
   - desktop/macos/Desktop/Sources/Chat/ChatErrorState.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
   - desktop/macos/scripts/omi-fault-inject.sh
 preconditions:
   - automation_bridge_ready

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -7,7 +7,6 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/ChatTurnFailureNotice.swift
   - desktop/macos/Desktop/Sources/Theme/OmiTextEditor.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimePayload.swift
-  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/APIClient+AuthPolicy.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/ChatTurnFailureNotice.swift
   - desktop/macos/Desktop/Sources/Theme/OmiTextEditor.swift
   - desktop/macos/Desktop/Sources/Chat/AgentRuntimePayload.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeFailure.swift
   - desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/APIClient+AuthPolicy.swift


### PR DESCRIPTION
## Summary

- recycle only the failed pinned `pi-mono` worker after an execution throw, mark its process-local binding stale, and prevent queued same-binding work from reacquiring the poisoned worker
- avoid automatically replaying the failed turn; return a specific recoverable message and let the next send create a fresh worker in the same daemon
- add bounded recovery diagnostics (`worker_recycled`, recovery outcome, `next_send`) to runtime events, local fallback health telemetry, and the existing chat query event while keeping technical detail out of analytics
- classify missing Pi sessions as typed stale bindings and dispose recycled harness registrations so token refresh cannot revive them

Closes #11461

## Safety and telemetry

- recovery is scoped to the exact failed worker; unrelated sessions and adapters keep running
- the worker is marked unhealthy before the pool drains queued leases, closing the same-binding race
- no turn replay occurs after an adapter throw, avoiding duplicate tool effects or provider calls
- PostHog receives only allowlisted closed fields; sanitized technical detail remains local

## Verification

- `cd desktop/macos/agent && npm test` — 57 files, 674 tests passed
- `cd desktop/macos/agent && npm run build` — passed
- `cd desktop/macos && ./scripts/agent-logic-harness.sh --node-only` — runtime focused tests and exact Pi extension package tests passed
- `cd desktop/macos/Desktop && swift build` — passed
- same-daemon fault injection proves the first Pi execution fails once, the binding becomes stale, the exact worker stops, generic recovery does not replay, and a second send succeeds through a new worker
- independent subagent review completed after implementation; cleanup, disposal, replay-safety, cancellation, telemetry privacy, and queue-race findings were addressed; no release-blocking findings remained

## Known baseline test issue

`./scripts/dev-feedback.py --once swift 'ChatQueryTelemetryTests'` cannot run the filtered XCTest because the test target fails first on the pre-existing Swift 6 `WeakMutability` diagnostic in `Desktop/Tests/MemoryExportSetupTests.swift:29`. The changed app sources compile successfully via `swift build`; the new telemetry test is included for CI once that unrelated baseline diagnostic is cleared.

## Failure class

Failure-Class: none

## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

