### PR TITLE
fix(desktop): notification chips are ambient history, not the accent

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -146,9 +146,12 @@ struct ChatProactivePushRow: View {
     HStack(alignment: .top, spacing: OmiSpacing.sm) {
       Image(systemName: badge.systemImage)
         .scaledFont(size: OmiType.caption, weight: .semibold)
-        .foregroundColor(Ink.accent)
+        // Neutral, not accent: a notification badge is ambient history, not the one
+        // actionable element `Ink.accent` is reserved for (see Ink.swift). Blue here made
+        // every past notification shout for attention it does not want.
+        .foregroundColor(Ink.secondary)
         .frame(width: 24, height: 24)
-        .background(Ink.accent.opacity(0.1), in: Circle())
+        .background(Ink.rowFill, in: Circle())
         .accessibilityHidden(true)
       VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
         Text(badge.label)

--- a/desktop/macos/changelog/unreleased/20260812-neutral-notification-chip.json
+++ b/desktop/macos/changelog/unreleased/20260812-neutral-notification-chip.json
@@ -1,0 +1,3 @@
+{
+  "change": "Notification history rows use a neutral icon instead of shouting in blue"
+}


### PR DESCRIPTION
## What

The proactive-notification chip in chat painted its bell **and** its circle with `Ink.accent` (systemBlue) — added in today's `c039b0b534`. `Ink.swift` reserves the accent for *"the one thing that is actionable and is not already a button"*; a row recording a past notification is the opposite of that, and a transcript full of blue badges reads as a stack of alerts.

Now: neutral glyph (`Ink.secondary`) on the standard row fill, matching every other ambient status per INV-UI-1's ambient-state principle.

## Verification

Exercised live on the `omi-mic` bundle — posted a real notification through the app's delivery path, chat renders the chips with the neutral treatment (screenshot attached to the PR).

Failure-Class: none

## Product invariants affected

- INV-CHAT-1 — unchanged: this touches only the visual treatment of the notification chip inside chat bubbles (glyph and circle color); transcript content, ownership, and cross-surface continuity are untouched.
- INV-UI-1 — this change enforces it: strong color stays reserved for actionable/alert surfaces, ambient history is neutral.