### PR TITLE
fix: harden desktop proactivity provider recovery

### DIFF
--- a/backend/docs/llm/model_endpoint_inventory.yaml
+++ b/backend/docs/llm/model_endpoint_inventory.yaml
@@ -77,6 +77,13 @@ model_config_features:
     - backend/tests/unit/test_llm_gateway_coverage_guardrails.py::test_every_model_config_feature_has_inventory_and_gateway_lane
     - backend/tests/unit/test_llm_gateway_client_config.py::test_get_llm_feature_gateway_mode_uses_generated_auto_lane
 surfaces:
+  - surface: desktop_context_proactivity
+    code_path: backend/routers/desktop_proactivity.py:proactive_completion
+    current_provider_model: gateway lanes desktop_proactive_extraction and desktop_proactive_reasoning; direct OpenAI only when OMI_ENV_STAGE is dev or local and the gateway URL is absent
+    request_shape: non-streaming strict structured output with optional explicit prompt caching on reasoning
+    gateway_lane_capability_needed: OpenAI-compatible structured-output lanes with explicit-cache support for reasoning
+    migration_status: acknowledged_direct_dev_recovery_surface; production remains gateway-only and fails closed, while dev and local record shared fallback telemetry when recovering through direct OpenAI
+    test_guardrail_coverage: backend/tests/unit/test_desktop_proactivity.py and backend/tests/unit/test_llm_gateway_coverage_guardrails.py
   - surface: public_shared_conversation_chat
     code_path: backend/routers/public_shared_conversation_chat.py:public_shared_conversation_chat
     current_provider_model: gateway-only openai/gpt-5-nano

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from dataclasses import dataclass
 from collections.abc import Mapping
 from enum import Enum
 from typing import Any
@@ -15,10 +16,14 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from database import redis_db, users as users_db
 from models.users import PlanType, Subscription
+from utils.env_loader import EnvStage, resolve_stage_from_env
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.http_client import get_llm_gateway_client, get_llm_gateway_semaphore
 from utils.llm.desktop_llm_stub import llm_stub_enabled
-from utils.llm.gateway_client import get_llm_gateway_base_url, llm_gateway_headers
+from utils.llm.gateway_client import llm_gateway_headers
+from utils.llm.gateway_observability import record_direct_exception_surface
+from utils.llm.providers import get_openai_api_key
+from utils.observability.fallback import record_fallback
 from utils.other.endpoints import get_current_user_uid
 from utils.subscription import (
     DESKTOP_ACCESS_TIER_ARCHITECT,
@@ -49,18 +54,32 @@ _DIRECT_MODELS = {
 }
 
 
-def _proactive_provider_request(
-    request: "ProactiveCompletionRequest", uid: str, request_id: str
-) -> tuple[str, dict[str, str], dict[str, Any]]:
+@dataclass(frozen=True)
+class _ProviderRequest:
+    url: str
+    headers: dict[str, str]
+    payload: dict[str, Any]
+    fallback_class: str
+
+
+def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str, request_id: str) -> _ProviderRequest:
     payload = _gateway_payload(request)
     gateway_url = os.getenv("OMI_LLM_GATEWAY_URL", "").strip()
     if gateway_url:
         headers = llm_gateway_headers(feature=f"desktop_{request.operation.value}")
         headers["X-Omi-User-Uid"] = uid
         headers["X-Omi-Request-ID"] = request_id
-        return f"{gateway_url.rstrip('/')}/v1/chat/completions", headers, payload
+        return _ProviderRequest(
+            url=f"{gateway_url.rstrip('/')}/v1/chat/completions",
+            headers=headers,
+            payload=payload,
+            fallback_class="none",
+        )
 
-    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    stage = resolve_stage_from_env()
+    if stage not in {EnvStage.DEV.value, EnvStage.LOCAL.value}:
+        raise HTTPException(status_code=503, detail="Proactive model gateway is not configured")
+    api_key = get_openai_api_key()
     if not api_key:
         raise HTTPException(status_code=503, detail="Proactive model provider is not configured")
     payload["model"] = _DIRECT_MODELS[request.operation.value]
@@ -68,10 +87,20 @@ def _proactive_provider_request(
     payload["messages"] = request.messages
     payload.pop("prompt_cache_key", None)
     payload.pop("prompt_cache_options", None)
-    return (
-        "https://api.openai.com/v1/chat/completions",
-        {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        payload,
+    record_fallback(
+        component="llm_gateway",
+        from_mode="gateway",
+        to_mode="direct_openai",
+        reason="config_incomplete",
+        outcome="recovered",
+        log=logger,
+    )
+    record_direct_exception_surface(surface="desktop_context_proactivity.dev_direct_openai")
+    return _ProviderRequest(
+        url="https://api.openai.com/v1/chat/completions",
+        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        payload=payload,
+        fallback_class="dev_direct_openai",
     )
 
 
@@ -334,16 +363,19 @@ async def proactive_completion(
 
     await _consume_quota(uid, request.operation)
     request_id = str(uuid4())
-    provider_url, headers, payload = _proactive_provider_request(request, uid, request_id)
     try:
+        provider_request = _proactive_provider_request(request, uid, request_id)
         async with get_llm_gateway_semaphore():
             response = await get_llm_gateway_client().post(
-                provider_url,
-                headers=headers,
-                json=payload,
+                provider_request.url,
+                headers=provider_request.headers,
+                json=provider_request.payload,
             )
         response.raise_for_status()
         response_body = response.json()
+    except HTTPException:
+        await _release_quota(uid, request.operation)
+        raise
     except (httpx.HTTPError, ValueError, TypeError) as exc:
         await _release_quota(uid, request.operation)
         raise HTTPException(status_code=502, detail="Proactive model unavailable") from exc
@@ -363,7 +395,7 @@ async def proactive_completion(
         provider_model=provider_model if isinstance(provider_model, str) else "unknown",
         usage=usage,
         cache_write=usage.cache_write_tokens > 0,
-        fallback_class="unknown",
+        fallback_class=provider_request.fallback_class,
         response=response_body,
     )
 

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -94,6 +94,7 @@ def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str,
     payload["messages"] = request.messages
     payload.pop("prompt_cache_key", None)
     payload.pop("prompt_cache_options", None)
+    payload.pop("metadata", None)
     record_fallback(
         component="llm_gateway",
         from_mode="gateway",

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -62,6 +62,14 @@ class _ProviderRequest:
     fallback_class: str
 
 
+def _dev_direct_provider_allowed() -> bool:
+    stage = resolve_stage_from_env()
+    if stage in {EnvStage.DEV.value, EnvStage.LOCAL.value}:
+        return True
+    release_channel = os.getenv("OMI_DESKTOP_BACKEND_RELEASE_CHANNEL", "").strip().lower()
+    return release_channel in {"development", "local"}
+
+
 def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str, request_id: str) -> _ProviderRequest:
     payload = _gateway_payload(request)
     gateway_url = os.getenv("OMI_LLM_GATEWAY_URL", "").strip()
@@ -76,8 +84,7 @@ def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str,
             fallback_class="none",
         )
 
-    stage = resolve_stage_from_env()
-    if stage not in {EnvStage.DEV.value, EnvStage.LOCAL.value}:
+    if not _dev_direct_provider_allowed():
         raise HTTPException(status_code=503, detail="Proactive model gateway is not configured")
     api_key = get_openai_api_key()
     if not api_key:

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -218,7 +218,6 @@ async def test_gateway_failure_releases_reserved_quota(monkeypatch):
     monkeypatch.setattr(desktop_proactivity, "_release_quota", release)
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", lambda: GatewayClient())
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_semaphore", lambda: Semaphore())
-    monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_base_url", lambda: "http://gateway")
     monkeypatch.setattr(desktop_proactivity, "llm_gateway_headers", lambda **_: {})
 
     with pytest.raises(desktop_proactivity.HTTPException) as unavailable:
@@ -230,17 +229,32 @@ async def test_gateway_failure_releases_reserved_quota(monkeypatch):
 
 def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
     monkeypatch.delenv("OMI_LLM_GATEWAY_URL", raising=False)
-    monkeypatch.setenv("OPENAI_API_KEY", "dev-provider-key")
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
+    monkeypatch.setattr(desktop_proactivity, "get_openai_api_key", lambda: "dev-provider-key")
+    fallbacks = []
+    monkeypatch.setattr(desktop_proactivity, "record_fallback", lambda **values: fallbacks.append(values))
 
-    url, headers, payload = desktop_proactivity._proactive_provider_request(
-        request("proactive_extraction"), "user-1", "request-1"
-    )
+    provider = desktop_proactivity._proactive_provider_request(request("proactive_extraction"), "user-1", "request-1")
 
-    assert url == "https://api.openai.com/v1/chat/completions"
-    assert headers == {"Authorization": "Bearer dev-provider-key", "Content-Type": "application/json"}
-    assert payload["model"] == "gpt-5-nano"
-    assert "prompt_cache_key" not in payload
-    assert "prompt_cache_options" not in payload
+    assert provider.url == "https://api.openai.com/v1/chat/completions"
+    assert provider.headers == {"Authorization": "Bearer dev-provider-key", "Content-Type": "application/json"}
+    assert provider.payload["model"] == "gpt-5-nano"
+    assert "prompt_cache_key" not in provider.payload
+    assert "prompt_cache_options" not in provider.payload
+    assert provider.fallback_class == "dev_direct_openai"
+    assert fallbacks[0]["component"] == "llm_gateway"
+
+
+def test_direct_provider_fallback_fails_closed_outside_dev(monkeypatch):
+    monkeypatch.delenv("OMI_LLM_GATEWAY_URL", raising=False)
+    monkeypatch.setenv("OMI_ENV_STAGE", "prod")
+    monkeypatch.setattr(desktop_proactivity, "get_openai_api_key", lambda: "prod-provider-key")
+
+    with pytest.raises(desktop_proactivity.HTTPException) as unavailable:
+        desktop_proactivity._proactive_provider_request(request(), "user-1", "request-1")
+
+    assert unavailable.value.status_code == 503
+    assert unavailable.value.detail == "Proactive model gateway is not configured"
 
 
 def test_configured_gateway_remains_authoritative(monkeypatch):
@@ -251,14 +265,39 @@ def test_configured_gateway_remains_authoritative(monkeypatch):
         lambda **_: {"Authorization": "Bearer gateway"},
     )
 
-    url, headers, payload = desktop_proactivity._proactive_provider_request(
-        request("proactive_reasoning"), "user-1", "request-1"
+    provider = desktop_proactivity._proactive_provider_request(request("proactive_reasoning"), "user-1", "request-1")
+
+    assert provider.url == "http://172.16.63.232/v1/chat/completions"
+    assert provider.headers["X-Omi-User-Uid"] == "user-1"
+    assert provider.headers["X-Omi-Request-ID"] == "request-1"
+    assert provider.payload["model"] == "omi:auto:desktop-proactive-reasoning"
+    assert provider.fallback_class == "none"
+
+
+@pytest.mark.asyncio
+async def test_provider_configuration_failure_releases_reserved_quota(monkeypatch):
+    released = []
+
+    async def allow(*_):
+        return None
+
+    async def release(uid, operation):
+        released.append((uid, operation))
+
+    monkeypatch.setattr(desktop_proactivity, "llm_stub_enabled", lambda: False)
+    monkeypatch.setattr(desktop_proactivity, "_consume_quota", allow)
+    monkeypatch.setattr(desktop_proactivity, "_release_quota", release)
+    monkeypatch.setattr(
+        desktop_proactivity,
+        "_proactive_provider_request",
+        lambda *_: (_ for _ in ()).throw(desktop_proactivity.HTTPException(status_code=503, detail="missing")),
     )
 
-    assert url == "http://172.16.63.232/v1/chat/completions"
-    assert headers["X-Omi-User-Uid"] == "user-1"
-    assert headers["X-Omi-Request-ID"] == "request-1"
-    assert payload["model"] == "omi:auto:desktop-proactive-reasoning"
+    with pytest.raises(desktop_proactivity.HTTPException) as unavailable:
+        await desktop_proactivity.proactive_completion(request(), uid="user-1")
+
+    assert unavailable.value.status_code == 503
+    assert released == [("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)]
 
 
 @pytest.mark.asyncio
@@ -296,7 +335,6 @@ async def test_facade_adds_provenance_and_cache_envelope(monkeypatch):
     monkeypatch.setattr(desktop_proactivity, "_consume_quota", allow)
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", lambda: GatewayClient())
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_semaphore", lambda: Semaphore())
-    monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_base_url", lambda: "http://gateway")
     monkeypatch.setattr(
         desktop_proactivity,
         "llm_gateway_headers",
@@ -313,4 +351,4 @@ async def test_facade_adds_provenance_and_cache_envelope(monkeypatch):
     assert result.provider_model == "gpt-5.6-luna-2026-08-01"
     assert result.usage.cached_tokens == 1024
     assert result.cache_write is False
-    assert result.fallback_class == "unknown"
+    assert result.fallback_class == "none"

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -241,6 +241,7 @@ def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
     assert provider.payload["model"] == "gpt-5-nano"
     assert "prompt_cache_key" not in provider.payload
     assert "prompt_cache_options" not in provider.payload
+    assert "metadata" not in provider.payload
     assert provider.fallback_class == "dev_direct_openai"
     assert fallbacks[0]["component"] == "llm_gateway"
 

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -257,6 +257,13 @@ def test_direct_provider_fallback_fails_closed_outside_dev(monkeypatch):
     assert unavailable.value.detail == "Proactive model gateway is not configured"
 
 
+def test_development_release_channel_allows_direct_recovery_without_env_stage(monkeypatch):
+    monkeypatch.delenv("OMI_ENV_STAGE", raising=False)
+    monkeypatch.setenv("OMI_DESKTOP_BACKEND_RELEASE_CHANNEL", "development")
+
+    assert desktop_proactivity._dev_direct_provider_allowed() is True
+
+
 def test_configured_gateway_remains_authoritative(monkeypatch):
     monkeypatch.setenv("OMI_LLM_GATEWAY_URL", "http://172.16.63.232/")
     monkeypatch.setattr(

--- a/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
+++ b/backend/tests/unit/test_llm_gateway_coverage_guardrails.py
@@ -74,6 +74,7 @@ DIRECT_PROVIDER_ALLOWLIST = {
     DirectUse('routers/omni_relay.py', 'OPENAI_API_KEY'),
 }
 INVENTORIED_DIRECT_EXCEPTION_FILES = {
+    'routers/desktop_proactivity.py',
     'utils/other/chat_file.py',
     'routers/omni_relay.py',
 }
@@ -187,6 +188,7 @@ def test_direct_exception_files_follow_their_declared_gateway_policy():
     assert all(len(policies) == 1 for policies in policies_by_file.values())
     policy_by_file = {rel_path: next(iter(policies)) for rel_path, policies in policies_by_file.items()}
     assert policy_by_file['utils/other/chat_file.py'] == 'acknowledged'
+    assert policy_by_file['routers/desktop_proactivity.py'] == 'acknowledged'
     assert policy_by_file['routers/omni_relay.py'] == 'blocked'
 
     for rel_path, policy in policy_by_file.items():

--- a/backend/utils/llm/providers.py
+++ b/backend/utils/llm/providers.py
@@ -55,6 +55,12 @@ OPENAI_COMPATIBLE_PROVIDERS: Dict[str, OpenAICompatibleProviderConfig] = {
 _llm_cache: Dict[tuple, Any] = {}
 
 
+def get_openai_api_key() -> str:
+    """Return the platform OpenAI credential at the provider boundary."""
+
+    return os.environ.get(OPENAI_COMPATIBLE_PROVIDERS['openai'].api_key_env, '').strip()
+
+
 def _cache_key(provider: str, model_name: str, streaming: bool, options: Dict[str, Any]) -> tuple:
     option_items = tuple(sorted((key, repr(value)) for key, value in options.items()))
     return provider, model_name, streaming, option_items

--- a/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryExportSetupTests.swift
@@ -26,7 +26,8 @@ final class MemoryExportSetupTests: XCTestCase {
         fallbackOpened.fulfill()
       })
     var model: MemoryExportDestinationSheetModel? = MemoryExportDestinationSheetModel(workspace: workspace)
-    weak var weakModel = model
+    weak var weakModel: MemoryExportDestinationSheetModel?
+    weakModel = model
 
     model?.openDestination(for: .chatgpt, url: exportURL)
     model = nil

--- a/desktop/macos/Desktop/Tests/OCREmbeddingServiceFlushTimerTests.swift
+++ b/desktop/macos/Desktop/Tests/OCREmbeddingServiceFlushTimerTests.swift
@@ -94,7 +94,8 @@ final class OCREmbeddingServiceFlushTimerTests: XCTestCase {
 
     var service: OCREmbeddingService? = makeService(
       sleeper: sleeper, embedder: embedder, writes: writes)
-    weak var weakService = service
+    weak var weakService: OCREmbeddingService?
+    weakService = service
     await service?.embedScreenshot(
       id: 303,
       ocrText: String(repeating: "service lifetime timer text ", count: 2),


### PR DESCRIPTION
## Summary

- restrict the emergency desktop proactivity direct-provider recovery to `dev`/`local`; production remains gateway-only and fails closed
- move the OpenAI credential lookup behind the existing provider boundary
- record shared fallback telemetry plus direct-surface observability and return explicit provider provenance
- release a reserved proactive quota slot when provider selection/configuration fails
- fix the two weak lifetime regression tests for Swift 6 strict diagnostics

## Failure class (fixes)

Failure-Class: none

This is the first observed instance at this narrow provider-selection and quota-compensation boundary; the behavioral tests added here are the prevention artifact.

## Product invariants affected

none

## Verification

- `PYTHONPATH=backend .../pytest -q backend/tests/unit/test_desktop_proactivity.py backend/tests/unit/test_llm_gateway_coverage_guardrails.py` — 26 passed
- `xcrun swift test --package-path Desktop --filter 'MemoryExportSetupTests|OCREmbeddingServiceFlushTimerTests'` — 5 passed
- Black and `git diff --check` passed
- rebuilt `/Applications/omi-qa-main.app` with `OMI_FORCE_CONTEXT_BUCKETS=1 NO_WAIT=1 ./run.sh --yolo --full`
- named bundle signed in and owner-ready on automation port 47924; health reports development backend and agent runtime protocol 2
- `codesign --verify --deep --strict /Applications/omi-qa-main.app` passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

