### PR TITLE
fix: pin memory atlas Firestore composite for dev readiness

### DIFF
--- a/backend/tests/unit/test_firestore_indexes.py
+++ b/backend/tests/unit/test_firestore_indexes.py
@@ -68,6 +68,21 @@ def test_memory_firestore_indexes_are_checked_in_for_unified_memory_store():
             ("__name__", "DESCENDING"),
         ),
     ) in signatures
+    # Live firestore_readiness on based-hardware-dev failed this exact
+    # composite (run 31666135748). Registry identifier:
+    # memory_items_canonical_atlas_read. Keep it in the apply spec.
+    assert (
+        "memory_items",
+        "COLLECTION",
+        (
+            ("account_generation", "ASCENDING"),
+            ("tier", "ASCENDING"),
+            ("status", "ASCENDING"),
+            ("processing_state", "ASCENDING"),
+            ("updated_at", "DESCENDING"),
+            ("__name__", "DESCENDING"),
+        ),
+    ) in signatures
     assert (
         "memory_items",
         "COLLECTION",

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -506,14 +506,6 @@ class _StreamRecordingFirestore:
         return SimpleNamespace(document=lambda _uid: _StreamRecordingUserRef(self._recorder))
 
 
-def _required_index_signature(collection_group, filters, orders):
-    """The composite index Firestore requires for one equality-plus-ordering chain."""
-    fields = [(field_path, 'ASCENDING') for field_path, operator in filters if operator == '==']
-    fields.extend(orders)
-    fields.append(('__name__', orders[-1][1]))
-    return (collection_group, 'COLLECTION', tuple(fields))
-
-
 def _declared_index_signatures():
     return {
         (
@@ -547,7 +539,7 @@ def test_due_date_filtered_action_item_reads_have_a_declared_composite_index(mon
     assert compound, 'due-date filtered reads no longer build an equality + ordering chain'
     declared = _declared_index_signatures()
     for filters, orders in compound:
-        assert _required_index_signature('action_items', filters, orders) in declared
+        assert _equality_plus_order_signature('action_items', filters, orders) in declared
 
 
 def test_query_source_paths_are_posix_canonical_on_every_host_platform():

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -34,6 +34,7 @@ from database.firestore_index_registry import (
     firebase_index_manifest,
 )
 from scripts import firestore_query_coverage, generate_firestore_indexes
+from utils.memory import canonical_graph as canonical_graph_service
 
 
 class _RecordingQuery:
@@ -317,6 +318,58 @@ def test_generated_firestore_manifest_matches_the_checked_in_contract():
     )
     assert firebase_index_manifest()['indexes'].count(expected_conversations_status_finished) == 1
     assert CANONICAL_MEMORY_ATLAS_READ_QUERY.index_requirement.to_manifest() in firebase_index_manifest()['indexes']
+    assert CANONICAL_MEMORY_ATLAS_READ_QUERY.identifier == 'memory_items_canonical_atlas_read'
+    assert CANONICAL_MEMORY_ATLAS_READ_QUERY.index_requirement.signature == (
+        'memory_items',
+        'COLLECTION',
+        (
+            ('account_generation', 'ASCENDING'),
+            ('tier', 'ASCENDING'),
+            ('status', 'ASCENDING'),
+            ('processing_state', 'ASCENDING'),
+            ('updated_at', 'DESCENDING'),
+            ('__name__', 'DESCENDING'),
+        ),
+    )
+
+
+def _equality_plus_order_signature(collection_group, filters, orders):
+    """Composite Firestore requires for equality filters plus explicit orderings."""
+    fields = [(field_path, 'ASCENDING') for field_path, operator in filters if operator == '==']
+    fields.extend(orders)
+    if not fields or fields[-1][0] != '__name__':
+        fields.append(('__name__', orders[-1][1] if orders else 'ASCENDING'))
+    return (collection_group, 'COLLECTION', tuple(fields))
+
+
+def test_canonical_atlas_read_serving_query_requires_declared_composite():
+    """The live atlas list query must keep its apply-spec composite.
+
+    firestore_readiness failed on based-hardware-dev (run 31666135748) with
+    COLLECTION/memory_items (account_generation ASC, tier ASC, status ASC,
+    processing_state ASC, updated_at DESC, __name__ DESC)=MISSING. That tuple is
+    memory_items_canonical_atlas_read; dropping it from the apply spec while the
+    serving builder still uses it must fail here.
+    """
+    recorded = _StreamRecordingQuery(recorder=[])
+    client = SimpleNamespace(collection=lambda path: recorded)
+    revision = canonical_graph_service._CanonicalGraphRevision(
+        account_generation=3,
+        commit_sequence=1,
+        head_commit_id='head-atlas',
+    )
+
+    built = canonical_graph_service._build_canonical_graph_items_query(
+        client,
+        'atlas-index-user',
+        revision,
+        cursor_boundary=None,
+    )
+
+    assert built is not recorded
+    signature = _equality_plus_order_signature('memory_items', built._filters, built._orders)
+    assert signature == CANONICAL_MEMORY_ATLAS_READ_QUERY.index_requirement.signature
+    assert signature in _declared_index_signatures()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Bug

Auto Deploy Backend to Development is blocked on `firestore_readiness` for `aaa0eb0227`.

- Run: https://github.com/BasedHardware/omi/actions/runs/31666135748
- Command: `python3 backend/scripts/reconcile_firestore_indexes.py --project based-hardware-dev --check-only`
- Error: `COLLECTION/memory_items (account_generation:ASCENDING, tier:ASCENDING, status:ASCENDING, processing_state:ASCENDING, updated_at:DESCENDING, __name__:DESCENDING)=MISSING`
- Deploy job skipped. Desktop-backend is already on this SHA; this is the shared Python backend only.

## Root cause

That exact composite is the serving query `memory_items_canonical_atlas_read` (`CANONICAL_MEMORY_ATLAS_READ_QUERY`).

The live path is `utils.memory.canonical_graph._build_canonical_graph_items_query` (canonical memory atlas / knowledge-graph list). The query is not dead.

Registry and `firestore.indexes.json` already declare the composite — `#11447` added it. `--check-only` is correctly fail-closed because **development Firestore has not been provisioned** with that index yet. The apply-spec inventory test listed the `graph_ready` sibling and omitted this tuple, so a required-but-absent drift of this exact signature would not have been pinned.

## Fix

- Pin `memory_items_canonical_atlas_read` to the exact live-failing field tuple.
- Add a behavioral test that records the production atlas query builder (equality filters + `updated_at`/`__name__` DESC) and asserts the generated apply spec declares that composite.
- Add the same tuple to the checked-in memory index inventory test.

This PR does **not** weaken `--check-only`, does **not** create indexes, and does **not** deploy.

**After merge, an authorized person must run `gcp_firestore_indexes.yml` on `development` (confirmation `APPLY_FIRESTORE_INDEXES`) before auto-deploy can pass.** Then repeat for `prod` before a production backend deploy.

## Tested

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_firestore_indexes.py::test_memory_firestore_indexes_are_checked_in_for_unified_memory_store backend/tests/unit/test_firestore_query_contract.py::test_generated_firestore_manifest_matches_the_checked_in_contract backend/tests/unit/test_firestore_query_contract.py::test_canonical_atlas_read_serving_query_requires_declared_composite -q`: 3 passed
- New serving-query contract maps the recorded production builder to `memory_items_canonical_atlas_read` and requires that signature in `firebase_index_manifest()`
- Did not apply indexes or dispatch deploy

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: FC-undeclared-serving-query-index


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

