### PR TITLE
fix: expose desktop proactivity provider failure class

### DIFF
--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -386,14 +386,35 @@ async def proactive_completion(
         raise
     except (httpx.HTTPError, ValueError, TypeError) as exc:
         await _release_quota(uid, request.operation)
+        if isinstance(exc, httpx.HTTPStatusError):
+            logger.warning(
+                "desktop_proactivity_provider_http_error operation=%s fallback_class=%s status=%s",
+                operation,
+                provider_request.fallback_class,
+                exc.response.status_code,
+            )
+        else:
+            logger.warning(
+                "desktop_proactivity_provider_error operation=%s fallback_class=%s error_type=%s",
+                operation,
+                provider_request.fallback_class,
+                type(exc).__name__,
+            )
         raise HTTPException(status_code=502, detail="Proactive model unavailable") from exc
     if not isinstance(response_body, dict):
         await _release_quota(uid, request.operation)
         raise HTTPException(status_code=502, detail="Proactive model returned an invalid response")
     try:
         _validate_gateway_output(response_body, request)
-    except HTTPException:
+    except HTTPException as exc:
         await _release_quota(uid, request.operation)
+        logger.warning(
+            "desktop_proactivity_invalid_structured_output operation=%s fallback_class=%s provider_model=%s detail=%s",
+            operation,
+            provider_request.fallback_class,
+            response_body.get("model", "unknown"),
+            exc.detail,
+        )
         raise
     usage = _usage_envelope(response_body)
     provider_model = response_body.get("model")


### PR DESCRIPTION
Adds bounded, non-sensitive server diagnostics for desktop context-bucket provider failures so QA can distinguish upstream HTTP failures from strict structured-output rejection.\n\nVerification: py_compile; git diff --check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

