### PR TITLE
fix: return structured output from direct proactivity lane

### DIFF
--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -90,6 +90,10 @@ def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str,
     if not api_key:
         raise HTTPException(status_code=503, detail="Proactive model provider is not configured")
     payload["model"] = _DIRECT_MODELS[request.operation.value]
+    # OpenAI reasoning models otherwise default to spending the entire completion
+    # budget on hidden reasoning. Extraction then returns an empty message with
+    # finish_reason=length instead of the required strict JSON payload.
+    payload["reasoning_effort"] = "minimal"
     # These are gateway cache extensions, not OpenAI request fields.
     payload["messages"] = request.messages
     payload.pop("prompt_cache_key", None)

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -242,6 +242,7 @@ def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
     assert "prompt_cache_key" not in provider.payload
     assert "prompt_cache_options" not in provider.payload
     assert "metadata" not in provider.payload
+    assert provider.payload["reasoning_effort"] == "minimal"
     assert provider.fallback_class == "dev_direct_openai"
     assert fallbacks[0]["component"] == "llm_gateway"
 


### PR DESCRIPTION
Sets minimal reasoning effort on the dev-only direct OpenAI proactivity fallback. Without it, gpt-5-nano spends the 1200-token budget entirely on hidden reasoning and returns empty content with finish_reason=length, so every context-bucket extraction fails strict validation.\n\nLive reproduction: default => 1200 reasoning tokens, empty content; minimal => stop, valid JSON.\n\nVerification: py_compile; git diff --check; provider-shape assertion.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

