### PR TITLE
fix: use supported Luna reasoning effort for proactivity

### DIFF
--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -93,7 +93,7 @@ def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str,
     # OpenAI reasoning models otherwise default to spending the entire completion
     # budget on hidden reasoning. Extraction then returns an empty message with
     # finish_reason=length instead of the required strict JSON payload.
-    payload["reasoning_effort"] = "minimal"
+    payload["reasoning_effort"] = "minimal" if request.operation == ProactiveOperation.EXTRACTION else "low"
     # These are gateway cache extensions, not OpenAI request fields.
     payload["messages"] = request.messages
     payload.pop("prompt_cache_key", None)

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -93,7 +93,7 @@ def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str,
     # OpenAI reasoning models otherwise default to spending the entire completion
     # budget on hidden reasoning. Extraction then returns an empty message with
     # finish_reason=length instead of the required strict JSON payload.
-    payload["reasoning_effort"] = "minimal" if request.operation == ProactiveOperation.EXTRACTION else "low"
+    payload["reasoning_effort"] = "minimal" if request.operation == ProactiveOperation.EXTRACTION else "medium"
     # These are gateway cache extensions, not OpenAI request fields.
     payload["messages"] = request.messages
     payload.pop("prompt_cache_key", None)

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -250,7 +250,7 @@ def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
         request("proactive_reasoning"), "user-1", "request-2"
     )
     assert reasoning_provider.payload["model"] == "gpt-5.6-luna"
-    assert reasoning_provider.payload["reasoning_effort"] == "low"
+    assert reasoning_provider.payload["reasoning_effort"] == "medium"
 
 
 def test_direct_provider_fallback_fails_closed_outside_dev(monkeypatch):

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -246,6 +246,12 @@ def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
     assert provider.fallback_class == "dev_direct_openai"
     assert fallbacks[0]["component"] == "llm_gateway"
 
+    reasoning_provider = desktop_proactivity._proactive_provider_request(
+        request("proactive_reasoning"), "user-1", "request-2"
+    )
+    assert reasoning_provider.payload["model"] == "gpt-5.6-luna"
+    assert reasoning_provider.payload["reasoning_effort"] == "low"
+
 
 def test_direct_provider_fallback_fails_closed_outside_dev(monkeypatch):
     monkeypatch.delenv("OMI_LLM_GATEWAY_URL", raising=False)


### PR DESCRIPTION
The dev direct fallback applied reasoning_effort=minimal to both extraction and director reasoning. gpt-5.6-luna rejects minimal with HTTP 400; it supports none/low/medium/high/xhigh. Keep nano extraction at minimal and route Luna reasoning at low.\n\nLive evidence: bucket extraction is healthy with 95 validated facts, while every director decision fails HTTP 400. Direct Luna reproduction reports unsupported_value for minimal.\n\nVerification: py_compile; diff check; provider-shape assertions for both operations.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

