### PR TITLE
Require Open Omi and PTT shortcuts during onboarding

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
@@ -195,8 +195,9 @@ class GlobalShortcutManager: @unchecked Sendable {
     }
   }
 
-  func registerAskOmi() {
-    guard !isRegistrationSuspended else { return }
+  @discardableResult
+  func registerAskOmi() -> HotKeyRegistrationOutcome? {
+    guard !isRegistrationSuspended else { return nil }
     // Unregister previous Ask Omi hotkey if any
     if let ref = hotKeyRefs.removeValue(forKey: .askOmi) {
       _ = unregisterHotKey(ref)
@@ -209,11 +210,11 @@ class GlobalShortcutManager: @unchecked Sendable {
     }
     guard askOmiEnabled else {
       logger("GlobalShortcutManager: Ask Omi shortcut is disabled")
-      return
+      return nil
     }
     guard askOmiShortcut.supportsGlobalHotKey, let keyCode = askOmiShortcut.keyCode else {
       logger("GlobalShortcutManager: Ask Omi shortcut is not a registerable hotkey")
-      return
+      return .otherFailure
     }
     // Onboarding now offers ⌃⌘O — the chord `registerSummonHotkey` already holds unconditionally,
     // routed to the same `openOmiFromShortcut`. Registering it twice cannot add behaviour, and the
@@ -221,7 +222,7 @@ class GlobalShortcutManager: @unchecked Sendable {
     // hotkey-registration incident for a chord that is working perfectly.
     guard !isSummonChord else {
       logger("GlobalShortcutManager: Ask Omi shortcut is the summon hotkey; already registered")
-      return
+      return .registered
     }
     let outcome = registerHotKey(keyCode: Int(keyCode), modifiers: askOmiShortcut.carbonModifiers, id: .askOmi)
     // Gate the success log on the registration outcome. Previously this logged
@@ -230,6 +231,26 @@ class GlobalShortcutManager: @unchecked Sendable {
     if outcome == .registered {
       logger("GlobalShortcutManager: Registered Ask Omi shortcut: \(askOmiShortcut.displayLabel)")
     }
+    return outcome
+  }
+
+  /// Probe the selected Ask Omi chord while onboarding's local event monitor is armed. The monitor
+  /// intentionally suspends Carbon registration so it can observe the test press; this narrow probe
+  /// temporarily re-enables registration and then removes the probe before the stage advances. A
+  /// conflict therefore keeps onboarding active instead of claiming a shortcut that will not work
+  /// after the user finishes setup.
+  func validateAskOmiShortcutForOnboarding() -> HotKeyRegistrationOutcome {
+    let wasSuspended = isRegistrationSuspended
+    if wasSuspended {
+      isRegistrationSuspended = false
+      unregisterShortcuts()
+    }
+    let outcome = registerAskOmi() ?? .otherFailure
+    if wasSuspended {
+      unregisterShortcuts()
+      isRegistrationSuspended = true
+    }
+    return outcome
   }
 
   /// Outcome of a Carbon `RegisterEventHotKey` attempt, classified for telemetry.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -268,6 +268,13 @@ class ShortcutSettings: ObservableObject {
     }
   }
 
+  /// PTT is observed system-wide. A bare character would start a voice turn whenever the user types
+  /// that character in another app, so every PTT binding needs at least one modifier. Modifier-only
+  /// presets (Option, Fn, Control, or Right Command) remain valid.
+  static func isSafePushToTalkShortcut(_ shortcut: KeyboardShortcut) -> Bool {
+    !shortcut.modifiers.isEmpty
+  }
+
   static let askOmiCommandOShortcut = KeyboardShortcut(keyCode: 31, keyDisplay: "O", modifiers: .command)
   static let askOmiCommandReturnShortcut = KeyboardShortcut(keyCode: 36, keyDisplay: "↩", modifiers: .command)
   static let askOmiCommandShiftReturnShortcut = KeyboardShortcut(
@@ -580,11 +587,13 @@ class ShortcutSettings: ObservableObject {
   private static let pttShortcutDefaultsKey = "shortcut_pttKey"
 
   private init() {
+    let restoredPTT = Self.loadShortcut(
+      forKey: Self.pttShortcutDefaultsKey,
+      legacyMapper: Self.legacyPTTShortcut
+    )
     self.pttShortcut =
-      Self.loadShortcut(
-        forKey: Self.pttShortcutDefaultsKey,
-        legacyMapper: Self.legacyPTTShortcut
-      ) ?? Self.pttPresets[0]
+      restoredPTT.flatMap { Self.isSafePushToTalkShortcut($0) ? $0 : nil }
+      ?? Self.pttPresets[0]
 
     // A saved ⌘O binding is honored as-is — no ⌘O → ⌃⌥O migration. It does register and it does
     // fire globally; what it also does is consume ⌘O before any other app sees it. That is a cost

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -131,7 +131,7 @@ struct ShortcutsSettingsSection: View {
           shortcut: settings.pttShortcut,
           isRecording: recordingTarget == .pushToTalk,
           action: { startShortcutCapture(.pushToTalk) },
-          helperText: "One key or a key combination both work."
+          helperText: "Use a modifier key or a key combination."
         )
       }
     }
@@ -505,6 +505,10 @@ struct ShortcutsSettingsSection: View {
           event, allowModifierOnly: true)
       else {
         return false
+      }
+      guard ShortcutSettings.isSafePushToTalkShortcut(shortcut) else {
+        captureError = "Push-to-talk needs a modifier so regular typing won't start a voice turn."
+        return true
       }
       pendingModifierOnlyShortcut = nil
       settings.pttEnabled = true

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -270,8 +270,16 @@ enum ShellSummon {
         windowDisplayKey: window.screen.flatMap(ShellSummonPlacement.displayKey(for:)),
         cursorDisplayKey: landingScreen.flatMap(ShellSummonPlacement.displayKey(for:)))
 
-    if appliedPresentation == .summoned, repositions, let screen = landingScreen ?? window.screen {
-      window.setFrame(landingFrame(on: screen), display: true)
+    if repositions, let screen = landingScreen ?? window.screen {
+      // Onboarding is an anchored first-run surface, but it still needs a deterministic first
+      // placement. SwiftUI may restore the shell's previous frame at launch; leaving that frame in
+      // place puts a new user's onboarding card in a lower-right corner. Summoned shells keep their
+      // per-display placement policy; anchored shells are centred for the launch hand-off.
+      let frame =
+        appliedPresentation == .summoned
+        ? landingFrame(on: screen)
+        : ShellSummonPlacement.centered(window.frame.size, in: screen.visibleFrame)
+      window.setFrame(frame, display: true)
     } else if let screen = NSScreen.main, !screen.visibleFrame.intersects(window.frame) {
       // Anchored, or nothing to land on: the window may still be stranded on a display that went away.
       window.center()

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
@@ -234,11 +234,13 @@ enum OnboardingFlow {
     "onboardingStep",
     "onboardingFurthestStep",
     "onboardingHowDidYouHearSource",
-    // Second Brain onboarding keys: the resume step (SBOnboardingModel.resumeStepKey)
-    // and the picked role (DefaultsKey.onboardingRole). Both are account-scoped —
-    // without them here a mid-onboarding sign-out leaks the prior user's resume
-    // point + role to the next account on the same Mac.
+    // Second Brain onboarding keys: the resume step (SBOnboardingModel.resumeStepKey),
+    // the shortcut-completion flag (SBOnboardingModel.shortcutsCompletedKey), and the
+    // picked role (DefaultsKey.onboardingRole). All are account-scoped — without them
+    // here a mid-onboarding sign-out leaks the prior user's resume point, shortcut-
+    // completion status, and role to the next account on the same Mac.
     "sbOnboardingResumeStep",
+    "sbOnboardingShortcutsCompleted",
     "onboardingRole",
     "onboardingGoalDraft",
     "onboardingJustCompleted",

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingVoiceShortcutStepView.swift
@@ -168,7 +168,7 @@ struct OnboardingVoiceShortcutStepView: View {
         .disabled(isRecordingCustomShortcut)
       }
 
-      Text("You can use one key or a combination like ⌘ J.")
+      Text("Use a modifier key or a combination like ⌘ J.")
         .inkStyle(InkType.statusLabel, color: Ink.secondary)
         .fixedSize(horizontal: false, vertical: true)
 
@@ -347,6 +347,11 @@ struct OnboardingVoiceShortcutStepView: View {
     guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: true) else {
       captureError = "Press the key combination you want to use."
       return false
+    }
+
+    guard ShortcutSettings.isSafePushToTalkShortcut(shortcut) else {
+      captureError = "Push-to-talk needs a modifier so regular typing won't start a voice turn."
+      return true
     }
 
     pendingModifierOnlyShortcut = nil

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -489,6 +489,7 @@ extension SBOnboardingModel {
   /// NSMenu key equivalents that AppKit dispatches before local monitors). Both are
   /// restored on leave. This is why the earlier attempt's monitor never fired.
   func armShortcutSummon() {
+    shortcutRegistrationError = nil
     // Preserve a choice when the user returns with Back. A fresh stage still
     // starts empty, while an already-confirmed shortcut stays visible/editable.
     let rememberedSelection: ShortcutSettings.KeyboardShortcut?
@@ -609,6 +610,7 @@ extension SBOnboardingModel {
   /// Pick + persist a shortcut. `isTalk` → push-to-talk chord (held, drives the
   /// voice demo); otherwise the Ask-Omi open hotkey (tapped to open the window).
   func pickShortcut(_ shortcut: ShortcutSettings.KeyboardShortcut, isTalk: Bool) {
+    shortcutRegistrationError = nil
     chosenShortcut = shortcut
     chosenShortcutIsPTT = isTalk
     shortcutTokens = shortcut.displayTokens
@@ -628,6 +630,7 @@ extension SBOnboardingModel {
   }
 
   func beginShortcutRecording(isTalk: Bool) {
+    shortcutRegistrationError = nil
     chosenShortcut = nil
     chosenShortcutIsPTT = isTalk
     shortcutTokens = []
@@ -699,15 +702,22 @@ extension SBOnboardingModel {
   ///
   /// A key chord with no modifier is not a shortcut, it is a stolen letter: `askOmiShortcut` is
   /// registered as a **global** hotkey, so persisting a bare `L` makes every `L` typed anywhere on
-  /// the Mac open Omi, and the only way back is Settings. The copy invites it ("Press any key"),
-  /// and nothing downstream refuses it. Both offered open chords carry ⌘ and every offered talk
-  /// chord is modifier-only, so this rejects nothing the step actually presents.
+  /// the Mac open Omi, and the only way back is Settings. PTT is also observed system-wide, so a bare
+  /// letter would start a voice turn during ordinary typing. The copy invites it ("Press any key"),
+  /// and nothing downstream refuses it. Both offered open chords carry ⌘ and every offered talk chord
+  /// is modifier-only, so this rejects nothing the step actually presents.
   static func acceptsRecordedChord(_ shortcut: ShortcutSettings.KeyboardShortcut) -> Bool {
-    !shortcut.modifiers.isEmpty
+    ShortcutSettings.isSafePushToTalkShortcut(shortcut)
   }
 
   func answerShortcutOpen() {
     guard shortcutPicked, shortcutPressed else { return }
+    guard GlobalShortcutManager.shared.validateAskOmiShortcutForOnboarding() == .registered else {
+      shortcutRegistrationError =
+        "That shortcut is already in use. Choose a different Open Omi shortcut and test it again."
+      shortcutPressed = false
+      return
+    }
     advance(userAnswer: "Works", to: .shortcutTalk)
   }
   func answerShortcutTalk() {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -513,7 +513,12 @@ extension SBOnboardingModel {
       shortcutTokens = rememberedSelection.displayTokens
       chosenShortcut = rememberedSelection
     } else {
+      // Same reset as `beginShortcutRecording` but with recording left off: the fresh
+      // stage shows the preset rows + a Custom button instead of entering capture mode,
+      // so `handleShortcutEvent` only recognizes the three preset candidates until the
+      // user explicitly taps Custom.
       beginShortcutRecording(isTalk: isTalk)
+      shortcutRecording = false
     }
     GlobalShortcutManager.shared.setRegistrationSuspended(true)
     if savedMainMenu == nil { savedMainMenu = NSApp.mainMenu }
@@ -702,10 +707,13 @@ extension SBOnboardingModel {
   }
 
   func answerShortcutOpen() {
-    advance(userAnswer: shortcutPressed ? "Works" : (shortcutPicked ? "Set" : "Skip"), to: .shortcutTalk)
+    guard shortcutPicked, shortcutPressed else { return }
+    advance(userAnswer: "Works", to: .shortcutTalk)
   }
   func answerShortcutTalk() {
-    advance(userAnswer: shortcutPressed ? "Works" : (shortcutPicked ? "Set" : "Skip"), to: .screenDemo)
+    guard shortcutPicked, shortcutPressed else { return }
+    UserDefaults.standard.set(true, forKey: Self.shortcutsCompletedKey)
+    advance(userAnswer: "Works", to: .screenDemo)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -399,7 +399,11 @@ final class SBOnboardingModel: ObservableObject {
       // required gate. Clamp it back to the first shortcut stage so the user completes both.
       let shortcutsDone = UserDefaults.standard.bool(forKey: Self.shortcutsCompletedKey)
       var effective = resumed
-      if !shortcutsDone, effective.rawValue > Step.shortcutTalk.rawValue {
+      // Clamp values >= shortcutTalk (not just >) because a legacy resume at exactly
+      // shortcutTalk without the completion flag means the user never selected or
+      // exercised Open Omi — completing only the Talk stage would set the flag and
+      // bypass Open Omi entirely.
+      if !shortcutsDone, effective.rawValue >= Step.shortcutTalk.rawValue {
         effective = .shortcutOpen
         UserDefaults.standard.set(Step.shortcutOpen.rawValue, forKey: Self.resumeStepKey)
       }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -24,6 +24,7 @@ struct SBOnboardingWidgetShape: Equatable {
   var screenDemoReady: Bool
   var screenDemoUnavailable: Bool
   var screenDemoDone: Bool
+  var shortcutRegistrationError: String? = nil
 }
 
 /// Drives the Second Brain conversational onboarding: a real chat with Omi that
@@ -127,6 +128,10 @@ final class SBOnboardingModel: ObservableObject {
   @Published var shortcutPicked = false
   @Published var shortcutPressed = false
   @Published var shortcutRecording = false
+  /// Set when the chosen Open Omi chord passed the local test press but Carbon could not claim it.
+  /// Keep the stage active so the user can choose another chord instead of finishing with a shortcut
+  /// that appears to work only inside onboarding.
+  @Published var shortcutRegistrationError: String?
   /// Set when the user pressed a bare key while recording. `acceptsRecordedChord` refuses it — a
   /// bare `L` bound as a **global** hotkey makes every `L` typed anywhere open Omi — and the refusal
   /// used to be silent, so the step simply stopped responding with nothing said. Cleared the moment
@@ -347,7 +352,8 @@ final class SBOnboardingModel: ObservableObject {
       permission: permissionKey(for: step).map { permissionPrimaryAction($0) },
       screenDemoReady: screenDemoPTTReady,
       screenDemoUnavailable: screenDemoPTTUnavailable,
-      screenDemoDone: screenDemoDone
+      screenDemoDone: screenDemoDone,
+      shortcutRegistrationError: shortcutRegistrationError
     )
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -316,9 +316,9 @@ final class SBOnboardingModel: ObservableObject {
     // Both steps used to invite "press any key", and `acceptsRecordedChord` then refused a bare key
     // in silence — correct (a global bare `L` is unrecoverable) but unexplained. Name the rule.
     case .shortcutOpen:
-      return "How do you want to open me? Choose one, or press your own — it needs ⌘, ⌃ or ⌥."
+      return "How do you want to open me? Choose one, or pick Custom to set your own — it needs ⌘, ⌃ or ⌥."
     case .shortcutTalk:
-      return "And to talk to me hands-free? Choose one, or hold your own modifier key."
+      return "And to talk to me hands-free? Choose one, or pick Custom to hold your own modifier key."
     case .screenDemo:
       return "Here's the fun part."
     case .agents:
@@ -377,6 +377,11 @@ final class SBOnboardingModel: ObservableObject {
   /// in System Settings) resumes where you left off instead of restarting.
   static let resumeStepKey = "sbOnboardingResumeStep"
 
+  /// Persisted when the user completes both required shortcut stages through the
+  /// new onboarding flow. Legacy resume states persisted before shortcuts were
+  /// mandatory lacked this flag, so `begin()` clamps them back through the steps.
+  static let shortcutsCompletedKey = "sbOnboardingShortcutsCompleted"
+
   func begin() {
     guard thread.isEmpty && streamingText == nil else { return }
     // Re-hydrate the editable drafts from what was already saved, so stepping
@@ -390,8 +395,16 @@ final class SBOnboardingModel: ObservableObject {
     let savedRaw = UserDefaults.standard.integer(forKey: Self.resumeStepKey)
     recordSetupStateDisagreementAtRead(savedRaw: savedRaw)
     if savedRaw > Step.promise.rawValue, let resumed = Step(rawValue: savedRaw) {
+      // A legacy resume state persisted before shortcuts were mandatory bypasses the new
+      // required gate. Clamp it back to the first shortcut stage so the user completes both.
+      let shortcutsDone = UserDefaults.standard.bool(forKey: Self.shortcutsCompletedKey)
+      var effective = resumed
+      if !shortcutsDone, effective.rawValue > Step.shortcutTalk.rawValue {
+        effective = .shortcutOpen
+        UserDefaults.standard.set(Step.shortcutOpen.rawValue, forKey: Self.resumeStepKey)
+      }
       // Skip a resumed permission step the user granted while away.
-      let target = firstUnaskedStep(from: resumed)
+      let target = firstUnaskedStep(from: effective)
       step = target
       streamMessage(for: target)
       return
@@ -526,6 +539,15 @@ final class SBOnboardingModel: ObservableObject {
 
   var canGoBack: Bool {
     step != .promise
+  }
+
+  /// The full-onboarding escape hatch stays unavailable until both required shortcut stages have
+  /// been completed. A persisted flag records that the user went through both stages; legacy resume
+  /// states from before shortcuts were mandatory are clamped back in `begin()`, so the only way to
+  /// reach a stage past `shortcutTalk` with this flag set is through the guarded shortcut answers.
+  var canSkipOnboarding: Bool {
+    step.rawValue > Step.shortcutTalk.rawValue
+      && UserDefaults.standard.bool(forKey: Self.shortcutsCompletedKey)
   }
 
   /// Tear down any live monitors/tasks a step installed before leaving it.

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -69,19 +69,6 @@ struct SBOnboardingView: View {
     // Pins the panel's light appearance so `Ink`'s dynamic colours resolve dark here even on a
     // machine in Dark Mode. Without it this card is near-white type on a near-white ground.
     .glassContent()
-    .overlay(alignment: .topTrailing) {
-      ViewThatFits(in: .horizontal) {
-        HStack(spacing: 8) {
-          backButton
-          if model.canSkipOnboarding { skipButton }
-        }
-        VStack(alignment: .trailing, spacing: 8) {
-          backButton
-          if model.canSkipOnboarding { skipButton }
-        }
-      }
-      .padding(.top, 20).padding(.trailing, 24)
-    }
     .onAppear { model.begin() }
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       if model.step == .context { refreshContextStates() }
@@ -114,6 +101,25 @@ struct SBOnboardingView: View {
 
   private func panel(in panelSize: CGSize) -> some View {
     VStack(spacing: 0) {
+      // Navigation belongs to the onboarding card, not the window's corner. The window can be wider
+      // than the card (and may be repositioned independently), so an outer overlay makes Back look
+      // detached from the conversation it controls.
+      HStack {
+        Spacer(minLength: 0)
+        ViewThatFits(in: .horizontal) {
+          HStack(spacing: 8) {
+            backButton
+            if model.canSkipOnboarding { skipButton }
+          }
+          VStack(alignment: .trailing, spacing: 8) {
+            backButton
+            if model.canSkipOnboarding { skipButton }
+          }
+        }
+      }
+      .frame(minHeight: 44)
+      .padding(.horizontal, 16)
+      .padding(.top, 8)
       ScrollViewReader { proxy in
         ScrollView {
           VStack(alignment: .leading, spacing: 14) {
@@ -190,13 +196,10 @@ struct SBOnboardingView: View {
       .animation(OnboardingGlass.stepAnimation, value: model.showWidget)
   }
 
-  /// Back and Skip sit **outside** the card, in the window's top-right corner, so unlike everything
-  /// else on this screen they have no panel under them. `glassChip()` is a wash — the treatment for a
-  /// chip that already sits on a ground — and a wash on the desktop is the card's own defect at chip
-  /// scale: `Ink.secondary` on the wallpaper. So they are their own small pieces of glass, the same
-  /// way `RewindOnlyView`'s floating bar is. `.glassFloatingBar` and not a second `glassChip` on top
-  /// of it: the panel already draws the corner and the edge, and stacking the wash back on would be
-  /// two grounds on one 30 pt control.
+  /// Back and Skip sit in the card header, next to the conversation they control. `glassChip()` is a
+  /// wash — the treatment for a chip that already sits on a ground — and the card is already the
+  /// ground here. `.glassFloatingBar` keeps the compact control legible without making it look like a
+  /// second panel.
   private static let chipRadius: CGFloat = 999
 
   @ViewBuilder private var backButton: some View {
@@ -209,7 +212,6 @@ struct SBOnboardingView: View {
       }
       .buttonStyle(.plain)
       .help("Go back and change an earlier answer")
-      .padding(.trailing, 12)
     }
   }
 
@@ -682,6 +684,11 @@ struct SBOnboardingView: View {
         .inkStyle(InkType.rowCopy, color: Ink.primary)
         .fixedSize(horizontal: false, vertical: true)
         .padding(.top, 6)
+      } else if let error = model.shortcutRegistrationError {
+        Text(error)
+          .inkStyle(InkType.rowCopy, color: Ink.errorRed)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.top, 6)
       } else if model.shortcutPicked {
         VStack(alignment: .leading, spacing: 10) {
           HStack(spacing: 6) {

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -73,11 +73,11 @@ struct SBOnboardingView: View {
       ViewThatFits(in: .horizontal) {
         HStack(spacing: 8) {
           backButton
-          skipButton
+          if model.canSkipOnboarding { skipButton }
         }
         VStack(alignment: .trailing, spacing: 8) {
           backButton
-          skipButton
+          if model.canSkipOnboarding { skipButton }
         }
       }
       .padding(.top, 20).padding(.trailing, 24)
@@ -150,6 +150,10 @@ struct SBOnboardingView: View {
         .onChange(of: model.streamingText) { _, _ in scrollDown(proxy) }
         .onChange(of: model.shortcutPicked) { _, _ in scrollDown(proxy) }
         .onChange(of: model.shortcutPressed) { _, _ in scrollDown(proxy) }
+        // Tapping "Custom shortcut" enters recording mode, which expands the widget with
+        // instructions/refusal text below the preset rows. Without this scroll trigger the new
+        // content is clipped below the fold.
+        .onChange(of: model.shortcutRecording) { _, _ in scrollDown(proxy) }
         // Revealing the assistants list grows the widget *below* the fold, so without this the
         // rows it just opened are clipped by the card's lower edge and nothing moves.
         .onChange(of: showAIAssistants) { _, _ in scrollDown(proxy) }
@@ -631,9 +635,7 @@ struct SBOnboardingView: View {
             Text(opt.sub).inkStyle(InkType.statusLabel, color: Ink.secondary)
               .fixedSize(horizontal: false, vertical: true)
             Spacer()
-            if model.shortcutRecording {
-              Text("Press a key").inkStyle(InkType.statusLabel, color: Ink.secondary)
-            } else if model.chosenShortcut == opt.shortcut {
+            if model.chosenShortcut == opt.shortcut {
               Text("✓").inkStyle(InkType.statusLabel, color: Ink.primary)
             }
           }
@@ -649,6 +651,24 @@ struct SBOnboardingView: View {
         }
         .buttonStyle(.plain)
       }
+      Button {
+        model.beginShortcutRecording(isTalk: isTalk)
+      } label: {
+        HStack(spacing: 8) {
+          Image(systemName: "keyboard")
+            .font(.system(size: 13, weight: .medium))
+          Text("Custom shortcut").inkStyle(InkType.rowCopy, color: Ink.primary)
+          Spacer()
+          Text(model.shortcutRecording ? "Press it now" : "Set your own")
+            .inkStyle(InkType.statusLabel, color: Ink.secondary)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 11)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(shortcutOptionShape.fill(model.shortcutRecording ? Ink.rowFillHover : .clear))
+        .overlay(shortcutOptionShape.strokeBorder(Ink.hairline, lineWidth: 1))
+        .contentShape(shortcutOptionShape)
+      }
+      .buttonStyle(.plain)
       if model.shortcutRecording {
         // A bare key is refused (`acceptsRecordedChord`) because a global bare `L` would make every
         // `L` typed anywhere open Omi. The refusal used to be silent, so the step looked broken to
@@ -679,20 +699,13 @@ struct SBOnboardingView: View {
         }
         .padding(.top, 6)
       }
-      // Continue only appears once the key has actually been pressed; before that,
-      // the same secondary Skip capsule every other step offers, so the user is never stuck.
+      // Shortcut setup is required: Continue appears only after the selected shortcut has been
+      // pressed, and there is deliberately no skip action on either shortcut stage.
       Group {
-        if model.shortcutPressed {
+        if model.shortcutPicked, model.shortcutPressed {
           SBInkButton(title: "Continue", isDefaultAction: true) {
             isTalk ? model.answerShortcutTalk() : model.answerShortcutOpen()
           }
-        } else {
-          Button {
-            isTalk ? model.answerShortcutTalk() : model.answerShortcutOpen()
-          } label: {
-            Text("Skip for now").frame(maxWidth: .infinity)
-          }
-          .buttonStyle(InkButtonStyle(kind: .secondary))
         }
       }
       .padding(.top, 6)

--- a/desktop/macos/Desktop/Tests/GlobalShortcutManagerRegistrationTests.swift
+++ b/desktop/macos/Desktop/Tests/GlobalShortcutManagerRegistrationTests.swift
@@ -272,6 +272,30 @@ import XCTest
       XCTAssertEqual(attempts, [Attempt(keyCode: 31, modifiers: 256)])
     }
 
+    func testOnboardingValidationSurfacesAConflictingAskOmiChord() {
+      let original = savedRegistration()
+      defer { restoreRegistration(original) }
+      settings.updateAskOmiRegistration(enabled: true, shortcut: ShortcutSettings.askOmiCommandJShortcut)
+
+      var attempts: [Attempt] = []
+      let manager = makeManager(
+        registrar: { keyCode, modifiers in
+          attempts.append(Attempt(keyCode: keyCode, modifiers: modifiers))
+          return .testing(status: OSStatus(eventHotKeyExistsErr), reference: nil)
+        },
+        observesSettings: false
+      )
+      defer { manager.stopObservingSettingsForTests() }
+
+      manager.setRegistrationSuspended(true)
+
+      XCTAssertEqual(
+        manager.validateAskOmiShortcutForOnboarding(),
+        .alreadyInUse,
+        "onboarding must not advance after Carbon rejects the selected chord")
+      XCTAssertEqual(attempts, [Attempt(keyCode: 38, modifiers: 256)])
+    }
+
     private func savedRegistration() -> (enabled: Bool, shortcut: ShortcutSettings.KeyboardShortcut) {
       (settings.askOmiEnabled, settings.askOmiShortcut)
     }

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -39,6 +39,7 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
       // of the shared list, leaking the prior user's resume step + role to the
       // next account on the same Mac.
       "sbOnboardingResumeStep",
+      "sbOnboardingShortcutsCompleted",
       "onboardingRole",
     ]
     for key in required {

--- a/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
@@ -348,19 +348,32 @@ final class SBOnboardingBackNavigationTests: XCTestCase {
     UserDefaults.standard.set(SBOnboardingModel.Step.screenDemo.rawValue, forKey: resumeKey)
     UserDefaults.standard.set(false, forKey: completedKey)
 
+    // Hold a strong reference to AppState for the life of the test. SBOnboardingModel
+    // stores appState as `unowned`, so a temporary would be deallocated before begin()
+    // touches it.
+    let appState = AppState()
     let model = SBOnboardingModel(
-      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+      appState: appState, chatProvider: ChatProvider(), onComplete: nil)
     model.begin()
 
     // The model should clamp back to the first shortcut stage, not bypass it.
     XCTAssertEqual(model.step, .shortcutOpen)
     XCTAssertFalse(model.canSkipOnboarding)
 
+    // A legacy resume at exactly shortcutTalk (without the completion flag) is also
+    // clamped back to shortcutOpen — completing only Talk would bypass Open Omi.
+    UserDefaults.standard.set(SBOnboardingModel.Step.shortcutTalk.rawValue, forKey: resumeKey)
+    UserDefaults.standard.set(false, forKey: completedKey)
+    let modelMid = SBOnboardingModel(
+      appState: appState, chatProvider: ChatProvider(), onComplete: nil)
+    modelMid.begin()
+    XCTAssertEqual(modelMid.step, .shortcutOpen)
+
     // A user who genuinely completed shortcuts resumes past them.
     UserDefaults.standard.set(SBOnboardingModel.Step.screenDemo.rawValue, forKey: resumeKey)
     UserDefaults.standard.set(true, forKey: completedKey)
     let model2 = SBOnboardingModel(
-      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+      appState: appState, chatProvider: ChatProvider(), onComplete: nil)
     model2.begin()
     XCTAssertGreaterThan(model2.step.rawValue, SBOnboardingModel.Step.shortcutTalk.rawValue)
     XCTAssertTrue(model2.canSkipOnboarding)

--- a/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingBackNavigationTests.swift
@@ -126,6 +126,7 @@ final class SBOnboardingBackNavigationTests: XCTestCase {
     XCTAssertEqual(model.chosenShortcut?.keyCode, 35)
     XCTAssertEqual(model.chosenShortcut?.modifiers, [.control, .option])
     XCTAssertEqual(settings.askOmiShortcut.keyCode, 35)
+    XCTAssertFalse(model.shortcutPressed, "Recording a shortcut must not count as exercising it.")
   }
 
   func testCustomPushToTalkShortcutRecordsAnArbitraryChord() throws {
@@ -273,5 +274,95 @@ final class SBOnboardingBackNavigationTests: XCTestCase {
     XCTAssertEqual(model.chosenShortcut, option.shortcut)
     XCTAssertEqual(settings.pttShortcut, option.shortcut)
     XCTAssertTrue(settings.pttEnabled)
+  }
+
+  func testShortcutStagesCannotAdvanceUntilSelectedShortcutIsExercised() {
+    let settings = ShortcutSettings.shared
+    let previousOpenShortcut = settings.askOmiShortcut
+    let previousOpenEnabled = settings.askOmiEnabled
+    let previousTalkShortcut = settings.pttShortcut
+    let previousTalkEnabled = settings.pttEnabled
+    defer {
+      settings.askOmiShortcut = previousOpenShortcut
+      settings.askOmiEnabled = previousOpenEnabled
+      settings.pttShortcut = previousTalkShortcut
+      settings.pttEnabled = previousTalkEnabled
+    }
+
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+
+    model.step = .shortcutOpen
+    model.pickShortcut(ShortcutSettings.askOmiCommandOShortcut, isTalk: false)
+    model.answerShortcutOpen()
+    XCTAssertEqual(model.step, .shortcutOpen)
+
+    model.shortcutPressed = true
+    model.answerShortcutOpen()
+    XCTAssertEqual(model.step, .shortcutTalk)
+
+    model.pickShortcut(ShortcutSettings.KeyboardShortcut(modifierOnly: .option), isTalk: true)
+    model.answerShortcutTalk()
+    XCTAssertEqual(model.step, .shortcutTalk)
+
+    model.shortcutPressed = true
+    model.answerShortcutTalk()
+    XCTAssertEqual(model.step, .screenDemo)
+  }
+
+  func testFullOnboardingSkipUnlocksOnlyAfterRequiredShortcutStages() {
+    let key = SBOnboardingModel.shortcutsCompletedKey
+    let previous = UserDefaults.standard.bool(forKey: key)
+    defer { UserDefaults.standard.set(previous, forKey: key) }
+    UserDefaults.standard.set(false, forKey: key)
+
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+
+    model.step = .promise
+    XCTAssertFalse(model.canSkipOnboarding)
+    model.step = .shortcutOpen
+    XCTAssertFalse(model.canSkipOnboarding)
+    model.step = .shortcutTalk
+    XCTAssertFalse(model.canSkipOnboarding)
+    model.step = .screenDemo
+    // Without the completion flag, Skip stays hidden even at screenDemo.
+    XCTAssertFalse(model.canSkipOnboarding)
+    // After completing both shortcut stages, Skip unlocks.
+    UserDefaults.standard.set(true, forKey: key)
+    XCTAssertTrue(model.canSkipOnboarding)
+  }
+
+  func testLegacyResumeStateClampedBackThroughShortcutStages() {
+    let resumeKey = SBOnboardingModel.resumeStepKey
+    let completedKey = SBOnboardingModel.shortcutsCompletedKey
+    let prevResume = UserDefaults.standard.integer(forKey: resumeKey)
+    let prevCompleted = UserDefaults.standard.bool(forKey: completedKey)
+    defer {
+      UserDefaults.standard.set(prevResume, forKey: resumeKey)
+      UserDefaults.standard.set(prevCompleted, forKey: completedKey)
+    }
+
+    // Simulate a legacy user who persisted a resume state past the shortcut stages
+    // before shortcuts were mandatory, without the completion flag.
+    UserDefaults.standard.set(SBOnboardingModel.Step.screenDemo.rawValue, forKey: resumeKey)
+    UserDefaults.standard.set(false, forKey: completedKey)
+
+    let model = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model.begin()
+
+    // The model should clamp back to the first shortcut stage, not bypass it.
+    XCTAssertEqual(model.step, .shortcutOpen)
+    XCTAssertFalse(model.canSkipOnboarding)
+
+    // A user who genuinely completed shortcuts resumes past them.
+    UserDefaults.standard.set(SBOnboardingModel.Step.screenDemo.rawValue, forKey: resumeKey)
+    UserDefaults.standard.set(true, forKey: completedKey)
+    let model2 = SBOnboardingModel(
+      appState: AppState(), chatProvider: ChatProvider(), onComplete: nil)
+    model2.begin()
+    XCTAssertGreaterThan(model2.step.rawValue, SBOnboardingModel.Step.shortcutTalk.rawValue)
+    XCTAssertTrue(model2.canSkipOnboarding)
   }
 }

--- a/desktop/macos/Desktop/Tests/ShortcutSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/ShortcutSettingsTests.swift
@@ -4,6 +4,16 @@ import XCTest
 
 @MainActor
 final class ShortcutSettingsTests: XCTestCase {
+  func testPushToTalkRequiresAtLeastOneModifier() {
+    let bareU = ShortcutSettings.KeyboardShortcut(keyCode: 32, keyDisplay: "U")
+    let commandU = ShortcutSettings.KeyboardShortcut(keyCode: 32, keyDisplay: "U", modifiers: .command)
+    let optionOnly = ShortcutSettings.KeyboardShortcut(modifierOnly: .option)
+
+    XCTAssertFalse(ShortcutSettings.isSafePushToTalkShortcut(bareU))
+    XCTAssertTrue(ShortcutSettings.isSafePushToTalkShortcut(commandU))
+    XCTAssertTrue(ShortcutSettings.isSafePushToTalkShortcut(optionOnly))
+  }
+
   func testAskOmiDefaultShortcutIsCommandO() {
     XCTAssertEqual(ShortcutSettings.defaultAskOmiShortcut, ShortcutSettings.askOmiCommandOShortcut)
     XCTAssertEqual(ShortcutSettings.defaultAskOmiShortcut.displayTokens, ["⌘", "O"])

--- a/desktop/macos/changelog/unreleased/20260813-required-onboarding-shortcuts.json
+++ b/desktop/macos/changelog/unreleased/20260813-required-onboarding-shortcuts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Required choosing and testing Open Omi and push-to-talk shortcuts during onboarding, with custom shortcuts available for both"
+}


### PR DESCRIPTION
## What changed and why

Require every new macOS user to choose and exercise both the Open Omi and push-to-talk shortcuts before onboarding can continue. The shortcut steps now offer an explicit Custom shortcut choice, keep the full-onboarding skip unavailable until both required stages are complete, and reuse the existing persisted shortcut settings. PTT custom recording now rejects bare keys everywhere because a system-wide bare letter would start a voice turn during ordinary typing.

The onboarding shell is centered on first launch, and Back/Skip live in the onboarding card header instead of floating outside the card.

## Product invariants affected

- INV-CHAT-1

## How it was verified

- `./scripts/dev-feedback.py --once swift 'SBOnboardingBackNavigationTests|SBOnboardingShortcutRecordingTests|ShortcutSettingsTests|ShellSummonTests|GlobalShortcutManagerRegistrationTests'` — 68 tests passed.
- `./scripts/swift-format-wrapper.sh lint -r <changed Swift files>` — passed.
- `python3 scripts/check_desktop_test_quality.py` — passed.
- Built and launched the isolated signed `/Applications/omi-shortcut-onboarding.app` bundle from this branch with the development backend and automation bridge on port 47941. Relaunched in normal UI mode, reset onboarding, and visually confirmed the shell/card are centered and Back is inside the card header.
- In the real onboarding UI, confirmed both shortcut stages omit Skip, Custom shortcut is available, Continue remains absent after selection/recording, and appears only after the chosen shortcut is pressed. Exercised Open Omi with `⌃⌘O`; pressed bare `u` in custom PTT recording and confirmed the inline refusal; the offered modifier-only PTT choices remain available.

## Tests

`SBOnboardingBackNavigationTests.testShortcutStagesCannotAdvanceUntilSelectedShortcutIsExercised` covers the required selection/exercise gate. `testFullOnboardingSkipUnlocksOnlyAfterRequiredShortcutStages` covers the onboarding skip boundary, `ShortcutSettingsTests.testPushToTalkRequiresAtLeastOneModifier` covers the shared PTT policy, and `GlobalShortcutManagerRegistrationTests.testOnboardingValidationSurfacesAConflictingAskOmiChord` covers the Carbon registration check before Open Omi can advance.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
