### PR TITLE
Remove notification active period

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -2,7 +2,7 @@
   "files": {
     "desktop/macos/Desktop/Sources/AuthService.swift": 2844,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4592,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4564,
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1516,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1581,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1590
@@ -10,7 +10,7 @@
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/AuthService.swift": "Apple first-auth name capture signals observers (authNameDidUpdate) and persists the name to Firebase so it survives reinstalls. +32 keeps the durable accepted-deletion cleanup journal and owner-bound VM/sync drain inside the fenced sign-out commit so cleanup resumes after restart and credentials or owner visibility cannot change first (SCA-280).",
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": "Connector form automation remains in the owning desktop integration boundary so explicit user actions can complete the provider flow without duplicating browser/session state.",
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "Notification active-period read/write actions join the existing QA-only notification probes in the single automation action registry so the saved device-local gate can be exercised deterministically without bypassing production persistence; +5 declares the suggestion probe's real model and visible-notification side effects.",
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": "Retains the QA-only automation registry for settings, notification, conversation, and state snapshots plus real settings update actions; +5 covers the suggestion probe's real model and visible-notification side effects.",
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": "Adds the bounded shared-capture silent-microphone terminal incident so a persistent zero-sample CoreAudio route is queryable without recording sensitive content. +1 registers account-cutover retained-control fallback telemetry in the existing bounded diagnostic area.",
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": "Keeps export lifecycle, archive/read-state preservation, pagination status, and production OAuth/grant authority on one desktop export boundary so large canonical exports cannot report completion before the final page is durably written; +4 rejects repeated cursors and explicitly includes archive-tier memories.",
     "desktop/macos/Desktop/Sources/OmiApp.swift": "UserDefaults.didChangeNotification observer must document and implement the queue:nil + explicit-main-hop contract (synchronous main-queue delivery deadlocked the signed-out launch, #11396)."

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -124,6 +124,10 @@ struct ScopedDefaultsKey {
   static func importConnectorSourceCount(connectorID: String) -> Self {
     Self(rawValue: "appsImportConnectorSourceCount.\(connectorID)")
   }
+
+  static func taskInterruptionLedger(ownerID: String) -> Self {
+    Self(rawValue: "proactiveTaskInterruptionLedger.v1.\(ownerID)")
+  }
 }
 
 /// Typed accessors that take a `DefaultsKey` instead of a `String`.

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3415,6 +3415,7 @@ final class DesktopAutomationActionRegistry {
       let hasPermission = appState?.hasNotificationPermission ?? false
       let bannersDisabled = appState?.isNotificationBannerDisabled ?? false
       return [
+        "schema": "enabled,frequency,frequency_label,has_permission,banners_disabled",
         "enabled": settings.enabled ? "true" : "false",
         "frequency": "\(settings.frequency)",
         "frequency_label": settings.frequencyDescription,

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -933,8 +933,7 @@ final class DesktopAutomationActionRegistry {
       summary: "Configure the non-production contextual task interruption gate",
       params: [
         "enabled", "shipped_cohorts_enabled", "daily_limit", "minimum_spacing_seconds",
-        "quiet_start_minute", "quiet_end_minute", "notifications_enabled", "frequency",
-        "task_notifications_enabled",
+        "notifications_enabled", "frequency", "task_notifications_enabled",
       ]
     ) { params in
       var configuration = ProactiveTaskInterruptionSettings.load()
@@ -945,12 +944,6 @@ final class DesktopAutomationActionRegistry {
       configuration.minimumSpacing = TimeInterval(
         max(
           0, intParam(params["minimum_spacing_seconds"], default: Int(configuration.minimumSpacing))))
-      configuration.quietHoursStartMinute = min(
-        max(
-          0, intParam(params["quiet_start_minute"], default: configuration.quietHoursStartMinute)), 1439)
-      configuration.quietHoursEndMinute = min(
-        max(
-          0, intParam(params["quiet_end_minute"], default: configuration.quietHoursEndMinute)), 1439)
       ProactiveTaskInterruptionSettings.save(configuration)
       if params["notifications_enabled"] != nil {
         UserDefaults.standard.set(
@@ -1014,7 +1007,7 @@ final class DesktopAutomationActionRegistry {
       safety: "network_or_model",
       sideEffects: [
         "may call model/backend services",
-        "may deliver a user-visible suggestion during the configured active period",
+        "may deliver a user-visible suggestion when notification controls allow",
       ]
     ) { params in
       let app = params["app"].flatMap { $0.isEmpty ? nil : $0 }
@@ -3421,34 +3414,12 @@ final class DesktopAutomationActionRegistry {
       let appState = await MainActor.run { AppState.current }
       let hasPermission = appState?.hasNotificationPermission ?? false
       let bannersDisabled = appState?.isNotificationBannerDisabled ?? false
-      let activePeriod = await MainActor.run { NotificationService.currentActivePeriod() }
       return [
         "enabled": settings.enabled ? "true" : "false",
         "frequency": "\(settings.frequency)",
         "frequency_label": settings.frequencyDescription,
         "has_permission": hasPermission ? "true" : "false",
         "banners_disabled": bannersDisabled ? "true" : "false",
-        "active_start_minute": "\(activePeriod.startMinute)",
-        "active_end_minute": "\(activePeriod.endMinute)",
-      ]
-    }
-
-    register(
-      name: "set_notification_active_period",
-      summary: "Set the device-local proactive notification active period",
-      params: ["start_minute", "end_minute"]
-    ) { params in
-      let current = await MainActor.run { NotificationService.currentActivePeriod() }
-      let startMinute = intParam(params["start_minute"], default: current.startMinute)
-      let endMinute = intParam(params["end_minute"], default: current.endMinute)
-      let saved = await MainActor.run { () -> NotificationActivePeriod in
-        NotificationService.updateActivePeriod(startMinute: startMinute, endMinute: endMinute)
-        return NotificationService.currentActivePeriod()
-      }
-      return [
-        "saved": "true",
-        "active_start_minute": "\(saved.startMinute)",
-        "active_end_minute": "\(saved.endMinute)",
       ]
     }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+Controls.swift
@@ -92,24 +92,6 @@ enum SettingsControlMetrics {
     dailySummaryDate(forHour: dailySummaryHour(from: date, calendar: calendar), referenceDate: date, calendar: calendar)
   }
 
-  static func notificationPeriodLabel(forMinute minute: Int) -> String {
-    let normalizedMinute = min(max(0, minute), 1439)
-    return String(format: "%02d:%02d", normalizedMinute / 60, normalizedMinute % 60)
-  }
-
-  /// Equal Active Period endpoints mean all-day delivery; surface that in the UI instead of
-  /// leaving `06:00 → 06:00` looking like a zero-width or single-minute window.
-  static func notificationActivePeriodSubtitle(startMinute: Int, endMinute: Int) -> String {
-    if NotificationActivePeriod(startMinute: startMinute, endMinute: endMinute).isAllDay {
-      return "All day — proactive notifications may appear any time"
-    }
-    return "When proactive notifications may appear (24-hour time)"
-  }
-
-  static func notificationActivePeriodSummaryLabel(startMinute: Int, endMinute: Int) -> String? {
-    NotificationActivePeriod(startMinute: startMinute, endMinute: endMinute).isAllDay ? "All day" : nil
-  }
-
   /// General → Notifications mirrors macOS TCC/banner style only. Product enablement lives in
   /// Notifications & Privacy (master + frequency).
   static func generalNotificationPermissionStatusText(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
@@ -34,57 +34,6 @@ extension SettingsContentView {
 
             GlassSeparator()
 
-            settingRow(
-              title: "Active Period",
-              subtitle: SettingsControlMetrics.notificationActivePeriodSubtitle(
-                startMinute: notificationActiveStartMinute,
-                endMinute: notificationActiveEndMinute),
-              settingId: "notifications.activeperiod"
-            ) {
-              HStack(spacing: OmiSpacing.sm) {
-                if let allDayLabel = SettingsControlMetrics.notificationActivePeriodSummaryLabel(
-                  startMinute: notificationActiveStartMinute,
-                  endMinute: notificationActiveEndMinute)
-                {
-                  Text(allDayLabel)
-                    .scaledFont(size: OmiType.caption, weight: .semibold)
-                    .foregroundColor(Ink.primary)
-                    .padding(.horizontal, OmiSpacing.sm)
-                    .padding(.vertical, OmiSpacing.xxs)
-                    .background(
-                      RoundedRectangle(
-                        cornerRadius: SettingsGlassMetrics.controlRadius, style: .continuous
-                      )
-                      .fill(Ink.accent.opacity(0.16))
-                    )
-                    .accessibilityLabel("Active period is all day")
-                }
-
-                notificationActivePeriodPicker(
-                  selection: $notificationActiveStartMinute,
-                  accessibilityLabel: "Active period start"
-                )
-                .onChange(of: notificationActiveStartMinute) { _, _ in
-                  saveNotificationActivePeriod()
-                }
-
-                Image(systemName: "arrow.right")
-                  .font(.system(size: OmiType.caption, weight: .semibold))
-                  .foregroundColor(Ink.secondary)
-
-                notificationActivePeriodPicker(
-                  selection: $notificationActiveEndMinute,
-                  accessibilityLabel: "Active period end"
-                )
-                .onChange(of: notificationActiveEndMinute) { _, _ in
-                  saveNotificationActivePeriod()
-                }
-              }
-              .padding(.horizontal, OmiSpacing.sm)
-              .padding(.vertical, OmiSpacing.xs)
-              .settingsGlassWell(radius: SettingsGlassMetrics.controlRadius)
-            }
-
             // Sits under the master toggle and the frequency slider because both gate it:
             // frequency caps how often any proactive card is delivered, and this decides
             // whether live suggestions are generated at all.
@@ -230,43 +179,6 @@ extension SettingsContentView {
     taskNotificationsEnabled = TaskAssistantSettings.shared.notificationsEnabled
     insightNotificationsEnabled = InsightAssistantSettings.shared.notificationsEnabled
     memoryNotificationsEnabled = MemoryAssistantSettings.shared.notificationsEnabled
-  }
-
-  func notificationActivePeriodPicker(
-    selection: Binding<Int>, accessibilityLabel: String
-  ) -> some View {
-    Menu {
-      ForEach(Array(stride(from: 0, to: 24 * 60, by: 15)), id: \.self) { minute in
-        Button {
-          selection.wrappedValue = minute
-        } label: {
-          if selection.wrappedValue == minute {
-            Label(
-              SettingsControlMetrics.notificationPeriodLabel(forMinute: minute),
-              systemImage: "checkmark")
-          } else {
-            Text(SettingsControlMetrics.notificationPeriodLabel(forMinute: minute))
-          }
-        }
-      }
-    } label: {
-      Text(SettingsControlMetrics.notificationPeriodLabel(forMinute: selection.wrappedValue))
-        .monospacedDigit()
-        .scaledFont(size: OmiType.body, weight: .semibold)
-        .foregroundColor(Ink.primary)
-        .frame(minWidth: 52)
-    }
-    .menuStyle(.borderlessButton)
-    .menuIndicator(.hidden)
-    .buttonStyle(.plain)
-    .fixedSize()
-    .accessibilityLabel(accessibilityLabel)
-  }
-
-  func saveNotificationActivePeriod() {
-    NotificationService.updateActivePeriod(
-      startMinute: notificationActiveStartMinute,
-      endMinute: notificationActiveEndMinute)
   }
 
   // MARK: - Privacy Section

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -281,8 +281,6 @@ struct SettingsContentView: View {
   // Start from the synchronous persisted mirror so reopening Settings never flashes
   // Balanced while the authoritative backend value is still hydrating.
   @State var notificationFrequency: Int = NotificationService.currentFrequencyLevel()
-  @State var notificationActiveStartMinute: Int = NotificationActivePeriod.defaultValue.startMinute
-  @State var notificationActiveEndMinute: Int = NotificationActivePeriod.defaultValue.endMinute
 
   // Privacy settings (from backend)
   @State var recordingPermissionEnabled: Bool = false
@@ -597,9 +595,6 @@ struct SettingsContentView: View {
     _memoryNotificationsEnabled = State(
       initialValue: MemoryAssistantSettings.shared.notificationsEnabled)
     _memoryExcludedApps = State(initialValue: MemoryAssistantSettings.shared.excludedApps)
-    let activePeriod = NotificationService.currentActivePeriod()
-    _notificationActiveStartMinute = State(initialValue: activePeriod.startMinute)
-    _notificationActiveEndMinute = State(initialValue: activePeriod.endMinute)
     _vadGateEnabled = State(initialValue: settings.vadGateEnabled)
     _transcriptionLanguage = State(initialValue: settings.transcriptionLanguage)
     _transcriptionAutoDetect = State(initialValue: settings.transcriptionAutoDetect)

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -115,11 +115,6 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["frequency", "how often", "interval"], section: .notifications, icon: "bell",
       settingId: "notifications.frequency"),
     SettingsSearchItem(
-      name: "Notification Active Period", subtitle: "Choose when proactive notifications may appear",
-      keywords: ["active period", "quiet hours", "schedule", "24 hour", "time"],
-      section: .notifications, icon: "bell",
-      settingId: "notifications.activeperiod"),
-    SettingsSearchItem(
       name: "Task Notifications",
       subtitle: "Allow interruptions when a task needs attention",
       keywords: ["task", "action item", "notify task", "interruption", "proactive"],

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -579,12 +579,6 @@ actor InsightAssistant: ProactiveAssistant {
   private func processFrame(_ frame: CapturedFrame, since previousAnalysisTime: Date) async {
     guard let ownerID = RuntimeOwnerIdentity.currentOwnerId() else { return }
     guard await isEnabled else { return }
-    // Continue collecting frames during quiet hours, but do not enter either
-    // paid extraction phase when the result cannot be presented.
-    let isWithinActivePeriod = await MainActor.run {
-      NotificationService.isWithinActivePeriod(now: Date())
-    }
-    guard isWithinActivePeriod else { return }
     do {
       guard let result = try await extractAdvice(from: frame, since: previousAnalysisTime) else {
         return

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -133,9 +133,6 @@ actor SuggestionAssistant: ProactiveAssistant {
     let enabled = await isEnabled
     let excluded = await MainActor.run { SuggestionAssistantSettings.shared.isAppExcluded(frame.appName) }
     let snoozed = await MainActor.run { FloatingControlBarManager.shared.isSnoozed }
-    let isWithinActivePeriod = await MainActor.run {
-      NotificationService.isWithinActivePeriod(now: Date())
-    }
     let cooldown = await cooldownInterval
 
     let now = Date()
@@ -145,7 +142,6 @@ actor SuggestionAssistant: ProactiveAssistant {
       isEnabled: enabled,
       isAppExcluded: excluded,
       isSnoozed: snoozed,
-      isWithinActivePeriod: isWithinActivePeriod,
       now: now,
       lastEvaluationAt: lastEvaluationAt,
       cooldown: cooldown,
@@ -633,7 +629,6 @@ actor SuggestionAssistant: ProactiveAssistant {
       (
         SuggestionAssistantSettings.shared.isAppExcluded(frame.appName),
         FloatingControlBarManager.shared.isSnoozed,
-        NotificationService.isWithinActivePeriod(now: Date()),
         NotificationService.areNotificationsEnabled(),
         NotificationService.currentFrequencyLevel()
       )
@@ -643,7 +638,6 @@ actor SuggestionAssistant: ProactiveAssistant {
       isEnabled: assistantEnabled,
       isAppExcluded: gateState.0,
       isSnoozed: gateState.1,
-      isWithinActivePeriod: gateState.2,
       now: now,
       lastEvaluationAt: nil,
       cooldown: 0,
@@ -651,9 +645,9 @@ actor SuggestionAssistant: ProactiveAssistant {
       requiredDwell: Self.requiredDwell,
       evaluationsToday: dailyBudget.countToday(now: now),
       dailyBudget: Self.dailyEvaluationBudget)
-    guard gateState.3, gateState.4 > 0, decision.allowsEvaluation else {
-      if !gateState.3 { return ["outcome": "skipped_notifications_disabled"] }
-      if gateState.4 == 0 { return ["outcome": "skipped_frequency_off"] }
+    guard gateState.2, gateState.3 > 0, decision.allowsEvaluation else {
+      if !gateState.2 { return ["outcome": "skipped_notifications_disabled"] }
+      if gateState.3 == 0 { return ["outcome": "skipped_frequency_off"] }
       return ["outcome": SuggestionAssistantTelemetry.GateOutcome(decision).rawValue]
     }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
@@ -24,7 +24,6 @@ enum SuggestionAssistantTelemetry {
     case disabled
     case excludedApp = "excluded_app"
     case snoozed
-    case quietPeriod = "quiet_period"
     case dwell
     case cooldown
     case dailyBudget = "daily_budget"
@@ -36,7 +35,6 @@ enum SuggestionAssistantTelemetry {
       case .skippedDisabled: self = .disabled
       case .skippedExcludedApp: self = .excludedApp
       case .skippedSnoozed: self = .snoozed
-      case .skippedQuietPeriod: self = .quietPeriod
       case .skippedDwell: self = .dwell
       case .skippedCooldown: self = .cooldown
       case .skippedDailyBudget: self = .dailyBudget

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -134,7 +134,6 @@ enum SuggestionGateDecision: Equatable, Sendable {
   case skippedExcludedApp
   case skippedCooldown
   case skippedSnoozed
-  case skippedQuietPeriod
   /// The user has not settled in this context long enough to be working in it.
   case skippedDwell
   /// Today's evaluation budget is spent.
@@ -157,7 +156,6 @@ enum SuggestionGatePolicy {
     isEnabled: Bool,
     isAppExcluded: Bool,
     isSnoozed: Bool,
-    isWithinActivePeriod: Bool,
     now: Date,
     lastEvaluationAt: Date?,
     cooldown: TimeInterval,
@@ -169,7 +167,6 @@ enum SuggestionGatePolicy {
     guard isEnabled else { return .skippedDisabled }
     guard !isAppExcluded else { return .skippedExcludedApp }
     guard !isSnoozed else { return .skippedSnoozed }
-    guard isWithinActivePeriod else { return .skippedQuietPeriod }
     guard dwell >= requiredDwell else { return .skippedDwell }
     if let lastEvaluationAt, now.timeIntervalSince(lastEvaluationAt) < cooldown {
       return .skippedCooldown

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -6,8 +6,6 @@ struct ContextDeliveryGateInput: Equatable, Sendable {
   let frequencyLevel: Int
   let snoozed: Bool
   let paywalled: Bool
-  let minuteOfDay: Int
-  let activePeriod: NotificationActivePeriod
   let cooldownSeconds: TimeInterval
   let dailyLimit: Int
   let lastGlobalPresentationAt: Date?
@@ -17,8 +15,6 @@ struct ContextDeliveryGateInput: Equatable, Sendable {
     frequencyLevel: Int,
     snoozed: Bool,
     paywalled: Bool,
-    minuteOfDay: Int,
-    activePeriod: NotificationActivePeriod = .defaultValue,
     cooldownSeconds: TimeInterval,
     dailyLimit: Int? = nil,
     lastGlobalPresentationAt: Date? = nil
@@ -27,8 +23,6 @@ struct ContextDeliveryGateInput: Equatable, Sendable {
     self.frequencyLevel = frequencyLevel
     self.snoozed = snoozed
     self.paywalled = paywalled
-    self.minuteOfDay = minuteOfDay
-    self.activePeriod = activePeriod
     self.cooldownSeconds = cooldownSeconds
     self.dailyLimit = max(
       0,
@@ -37,32 +31,8 @@ struct ContextDeliveryGateInput: Equatable, Sendable {
   }
 }
 
-struct NotificationActivePeriod: Equatable, Sendable {
-  static let defaultValue = NotificationActivePeriod(startMinute: 8 * 60, endMinute: 22 * 60)
-
-  let startMinute: Int
-  let endMinute: Int
-
-  init(startMinute: Int, endMinute: Int) {
-    self.startMinute = min(max(0, startMinute), 1439)
-    self.endMinute = min(max(0, endMinute), 1439)
-  }
-
-  /// Equal endpoints are the explicit all-day encoding (any equal pair, including `00:00→00:00`
-  /// and `06:00→06:00`). This is not a zero-width window.
-  var isAllDay: Bool { startMinute == endMinute }
-
-  func contains(minuteOfDay: Int) -> Bool {
-    let minute = min(max(0, minuteOfDay), 1439)
-    if isAllDay { return true }
-    if startMinute < endMinute { return minute >= startMinute && minute < endMinute }
-    // Overnight wrap, e.g. 06:00→03:00: active across midnight; quiet is the complement.
-    return minute >= startMinute || minute < endMinute
-  }
-}
-
 enum ContextDeliveryGateReason: String, Equatable, Sendable {
-  case allowed, masterDisabled, frequencyDisabled, snoozed, paywalled, quietHours, cooldown, dailyBudget, duplicate
+  case allowed, masterDisabled, frequencyDisabled, snoozed, paywalled, cooldown, dailyBudget, duplicate
 }
 
 struct ContextDeliveryAttempt: Equatable, Sendable {
@@ -154,7 +124,6 @@ enum ContextDeliveryBudget {
     if input.frequencyLevel == 0 { return .frequencyDisabled }
     if input.snoozed { return .snoozed }
     if input.paywalled { return .paywalled }
-    if !input.activePeriod.contains(minuteOfDay: input.minuteOfDay) { return .quietHours }
     return .allowed
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -191,8 +191,8 @@ actor ContextProactivityEngine {
       return
     }
     // Settings can change while snapshot/frame/task context is assembled. Rebuild the
-    // free gate immediately before the paid model call so entering quiet hours, disabling
-    // notifications, snoozing, or becoming paywalled never spends director budget.
+    // free gate immediately before the paid model call so disabling notifications,
+    // snoozing, or becoming paywalled never spends director budget.
     let evaluationGate = await MainActor.run { Self.liveDeliveryGateInput() }
     let evaluationReason = ContextDeliveryBudget.freeGate(input: evaluationGate)
     guard evaluationReason == .allowed else {
@@ -324,8 +324,8 @@ actor ContextProactivityEngine {
         return
       }
       // Graduation and system-surface preflight can both await. Rebuild every
-      // free gate once more at the actual handoff so master-off, quiet hours,
-      // snooze, paywall, or another proactive presentation wins the race.
+      // free gate once more at the actual handoff so master-off, snooze, paywall,
+      // or another proactive presentation wins the race.
       let handoffGate = await MainActor.run { Self.liveDeliveryGateInput() }
       guard ContextDeliveryBudget.freeGate(input: handoffGate) == .allowed else {
         try await store.completeDelivery(
@@ -445,16 +445,13 @@ actor ContextProactivityEngine {
   }
 
   @MainActor
-  static func liveDeliveryGateInput(now: Date = Date()) -> ContextDeliveryGateInput {
-    let components = Calendar.current.dateComponents([.hour, .minute], from: now)
+  static func liveDeliveryGateInput() -> ContextDeliveryGateInput {
     let frequencyLevel = NotificationService.currentFrequencyLevel()
     return ContextDeliveryGateInput(
       masterEnabled: NotificationService.areNotificationsEnabled(),
       frequencyLevel: frequencyLevel,
       snoozed: FloatingControlBarManager.shared.isSnoozed,
       paywalled: AppState.isPaywalledEffective,
-      minuteOfDay: (components.hour ?? 0) * 60 + (components.minute ?? 0),
-      activePeriod: NotificationService.currentActivePeriod(),
       cooldownSeconds: ContextDeliveryBudget.cooldownSeconds(frequencyLevel: frequencyLevel),
       dailyLimit: ContextDeliveryBudget.dailyLimit(
         frequencyLevel: frequencyLevel,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -67,11 +67,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// `true` when the key is absent (first run before the Settings page hydrates).
   static let masterEnabledDefaultsKey = "notifications_enabled"
 
-  /// Device-local active period for proactive interruptions, stored as minutes since midnight.
-  /// The setting follows the Mac's local clock and defaults to 08:00–22:00.
-  static let activePeriodStartDefaultsKey = "notification_active_period_start_minute"
-  static let activePeriodEndDefaultsKey = "notification_active_period_end_minute"
-
   /// Default level used when the key has never been written (e.g. first run before
   /// the Settings page has hydrated from the backend). Mirrors the backend default.
   /// Proactive notifications are OFF by default — users opt in via the Settings slider.
@@ -408,17 +403,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
-    // Device-local active period gates every proactive path (not only the director).
-    if respectFrequency && !Self.isWithinActivePeriod(now: Date()) {
-      log("NotificationService: suppressing \(assistantId) notification outside active period")
-      recordInsightDeliveryOutcome(
-        insightDeliveryID,
-        outcome: .suppressed,
-        reason: .frequencyThrottled
-      )
-      return
-    }
-
     // Proactive notifications honor the user's frequency setting. Functional
     // notifications (Crisp support replies, screen-recording permission prompts,
     // onboarding test) pass `respectFrequency: false` to bypass the gate.
@@ -696,15 +680,12 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     now: Date
   ) -> Bool {
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
-    let components = Calendar.current.dateComponents([.hour, .minute], from: now)
     let level = Self.currentFrequencyLevel()
     let gate = ContextDeliveryGateInput(
       masterEnabled: Self.areNotificationsEnabled(),
       frequencyLevel: level,
       snoozed: FloatingControlBarManager.shared.isSnoozed,
       paywalled: AppState.isPaywalledEffective,
-      minuteOfDay: (components.hour ?? 0) * 60 + (components.minute ?? 0),
-      activePeriod: Self.currentActivePeriod(),
       cooldownSeconds: ContextDeliveryBudget.cooldownSeconds(frequencyLevel: level)
     )
     guard ContextDeliveryBudget.freeGate(input: gate) == .allowed else { return false }
@@ -982,41 +963,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     pendingAtLoadStart || pendingNow || currentRevision != revisionAtLoadStart
   }
 
-  static func currentActivePeriod(defaults: UserDefaults = .standard) -> NotificationActivePeriod {
-    let fallback = NotificationActivePeriod.defaultValue
-    let start =
-      defaults.object(forKey: activePeriodStartDefaultsKey) == nil
-      ? fallback.startMinute : defaults.integer(forKey: activePeriodStartDefaultsKey)
-    let end =
-      defaults.object(forKey: activePeriodEndDefaultsKey) == nil
-      ? fallback.endMinute : defaults.integer(forKey: activePeriodEndDefaultsKey)
-    return NotificationActivePeriod(startMinute: start, endMinute: end)
-  }
-
-  static func updateActivePeriod(startMinute: Int, endMinute: Int) {
-    let period = NotificationActivePeriod(startMinute: startMinute, endMinute: endMinute)
-    UserDefaults.standard.set(period.startMinute, forKey: activePeriodStartDefaultsKey)
-    UserDefaults.standard.set(period.endMinute, forKey: activePeriodEndDefaultsKey)
-
-    // Contextual task interruptions predate the shared notification setting and persist the
-    // inverse quiet period. Keep that legacy policy projection aligned with the user-facing
-    // active period until its versioned configuration is retired.
-    var taskConfiguration = ProactiveTaskInterruptionSettings.load()
-    taskConfiguration.quietHoursStartMinute = period.endMinute
-    taskConfiguration.quietHoursEndMinute = period.startMinute
-    ProactiveTaskInterruptionSettings.save(taskConfiguration)
-  }
-
-  static func isWithinActivePeriod(
-    now: Date = Date(),
-    calendar: Calendar = .current,
-    defaults: UserDefaults = .standard
-  ) -> Bool {
-    let components = calendar.dateComponents([.hour, .minute], from: now)
-    let minuteOfDay = (components.hour ?? 0) * 60 + (components.minute ?? 0)
-    return currentActivePeriod(defaults: defaults).contains(minuteOfDay: minuteOfDay)
-  }
-
   /// Minimum interval between proactive notifications for a given level.
   /// `nil` means no throttle (Maximum); `.infinity` means drop everything (Off).
   private static func minInterval(forLevel level: Int) -> TimeInterval? {
@@ -1153,7 +1099,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   ) -> Bool {
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
     prepareOwnerScopedState(for: authorizationSnapshot)
-    guard Self.isWithinActivePeriod(now: now) else { return false }
     let level = Self.currentFrequencyLevel()
     guard let interval = Self.minInterval(forLevel: level) else {
       return true  // Maximum

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
@@ -327,8 +327,6 @@ struct ProactiveTaskInterruptionConfiguration: Codable, Equatable {
     shippedCohortsEnabled: false,
     dailyLimit: 2,
     minimumSpacing: 90 * 60,
-    quietHoursStartMinute: 22 * 60,
-    quietHoursEndMinute: 8 * 60,
     allowedPreparationKinds: []
   )
 
@@ -337,8 +335,6 @@ struct ProactiveTaskInterruptionConfiguration: Codable, Equatable {
   var shippedCohortsEnabled: Bool
   var dailyLimit: Int
   var minimumSpacing: TimeInterval
-  var quietHoursStartMinute: Int
-  var quietHoursEndMinute: Int
   var allowedPreparationKinds: Set<String>
 
   init(
@@ -346,8 +342,6 @@ struct ProactiveTaskInterruptionConfiguration: Codable, Equatable {
     shippedCohortsEnabled: Bool,
     dailyLimit: Int,
     minimumSpacing: TimeInterval,
-    quietHoursStartMinute: Int,
-    quietHoursEndMinute: Int,
     allowedPreparationKinds: Set<String>
   ) {
     self.schemaVersion = Self.schemaVersion
@@ -355,8 +349,6 @@ struct ProactiveTaskInterruptionConfiguration: Codable, Equatable {
     self.shippedCohortsEnabled = shippedCohortsEnabled
     self.dailyLimit = max(0, dailyLimit)
     self.minimumSpacing = max(0, minimumSpacing)
-    self.quietHoursStartMinute = min(max(0, quietHoursStartMinute), 1439)
-    self.quietHoursEndMinute = min(max(0, quietHoursEndMinute), 1439)
     self.allowedPreparationKinds = allowedPreparationKinds
   }
 
@@ -384,8 +376,6 @@ enum ProactiveTaskInterruptionSettings {
       shippedCohortsEnabled: config.shippedCohortsEnabled,
       dailyLimit: config.dailyLimit,
       minimumSpacing: config.minimumSpacing,
-      quietHoursStartMinute: config.quietHoursStartMinute,
-      quietHoursEndMinute: config.quietHoursEndMinute,
       allowedPreparationKinds: config.allowedPreparationKinds
     )
   }
@@ -434,7 +424,6 @@ enum TaskInterruptionGateReason: String, Codable, Equatable {
   case taskDisabled = "task_disabled"
   case focusSuppressed = "focus_suppressed"
   case snoozed
-  case quietHours = "quiet_hours"
   case expired
   case canWait = "can_wait"
   case duplicate
@@ -543,8 +532,6 @@ final class ProactiveTaskInterruptionGate {
       reason = .focusSuppressed
     } else if environment.snoozed {
       reason = .snoozed
-    } else if Self.isQuietHours(configuration: configuration, environment: environment) {
-      reason = .quietHours
     } else if candidate.expiresAt <= environment.now {
       reason = .expired
     } else if candidate.canWait {
@@ -573,18 +560,6 @@ final class ProactiveTaskInterruptionGate {
     return trace
   }
 
-  private static func isQuietHours(
-    configuration: ProactiveTaskInterruptionConfiguration,
-    environment: TaskInterruptionEnvironment
-  ) -> Bool {
-    let components = environment.calendar.dateComponents([.hour, .minute], from: environment.now)
-    let minute = (components.hour ?? 0) * 60 + (components.minute ?? 0)
-    let start = configuration.quietHoursStartMinute
-    let end = configuration.quietHoursEndMinute
-    if start == end { return false }
-    if start < end { return minute >= start && minute < end }
-    return minute >= start || minute < end
-  }
 }
 
 struct ProactiveTaskArtifactProposal {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
@@ -503,13 +503,13 @@ final class TaskInterruptionLedgerDefaults: TaskInterruptionLedgerPersisting {
     fixedOwnerID = ownerID
   }
 
-  private var key: String {
+  private var key: ScopedDefaultsKey {
     let dynamicOwner =
       defaults === UserDefaults.standard
       ? RuntimeOwnerIdentity.currentOwnerId()
       : defaults.string(forKey: .authUserId)
     let owner = fixedOwnerID ?? dynamicOwner ?? "signed-out"
-    return "proactiveTaskInterruptionLedger.v1.\(owner)"
+    return .taskInterruptionLedger(ownerID: owner)
   }
 
   func load() -> TaskInterruptionLedger {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
@@ -430,6 +430,30 @@ enum TaskInterruptionGateReason: String, Codable, Equatable {
   case dailyBudget = "daily_budget"
   case minimumSpacing = "minimum_spacing"
   case staleOwner = "stale_owner"
+  /// Decodes the retired time-gate trace without restoring time-based delivery behavior.
+  /// New writes use this namespaced value instead of the removed `quiet_hours` wire value.
+  case legacyQuietHours = "legacy_quiet_hours"
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+    if rawValue == "quiet_hours" {
+      self = .legacyQuietHours
+      return
+    }
+    guard let reason = Self(rawValue: rawValue) else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unknown task interruption gate reason: \(rawValue)"
+      )
+    }
+    self = reason
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
 }
 
 struct TaskInterruptionGateTrace: Codable, Equatable {

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -34,15 +34,9 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
-          masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false, minuteOfDay: 12 * 60,
+          masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false,
           cooldownSeconds: 30 * 60)),
       .allowed)
-    XCTAssertEqual(
-      ContextDeliveryBudget.freeGate(
-        input: .init(
-          masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false, minuteOfDay: 23 * 60,
-          cooldownSeconds: 30 * 60)),
-      .quietHours)
     XCTAssertEqual(
       (0...5).map { ContextDeliveryBudget.dailyLimit(frequencyLevel: $0) },
       [0, 10, 20, 40, 60, 100]
@@ -60,137 +54,28 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
   func testFreeGateBoundariesAndSuppressionInputs() {
     let base = ContextDeliveryGateInput(
       masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false,
-      minuteOfDay: 8 * 60, cooldownSeconds: 30 * 60)
+      cooldownSeconds: 30 * 60)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: base), .allowed)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
-          masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false,
-          minuteOfDay: 22 * 60, cooldownSeconds: 0)), .quietHours)
-    XCTAssertEqual(
-      ContextDeliveryBudget.freeGate(
-        input: .init(
           masterEnabled: false, frequencyLevel: 3, snoozed: false, paywalled: false,
-          minuteOfDay: 12 * 60, cooldownSeconds: 0)), .masterDisabled)
+          cooldownSeconds: 0)), .masterDisabled)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
           masterEnabled: true, frequencyLevel: 0, snoozed: false, paywalled: false,
-          minuteOfDay: 12 * 60, cooldownSeconds: 0)), .frequencyDisabled)
+          cooldownSeconds: 0)), .frequencyDisabled)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
           masterEnabled: true, frequencyLevel: 3, snoozed: true, paywalled: false,
-          minuteOfDay: 12 * 60, cooldownSeconds: 0)), .snoozed)
+          cooldownSeconds: 0)), .snoozed)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
           masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: true,
-          minuteOfDay: 12 * 60, cooldownSeconds: 0)), .paywalled)
-  }
-
-  func testActivePeriodSupportsDaytimeOvernightAndAllDayWindows() {
-    let daytime = NotificationActivePeriod(startMinute: 8 * 60, endMinute: 22 * 60)
-    XCTAssertTrue(daytime.contains(minuteOfDay: 8 * 60))
-    XCTAssertTrue(daytime.contains(minuteOfDay: 21 * 60 + 59))
-    XCTAssertFalse(daytime.contains(minuteOfDay: 22 * 60))
-
-    let overnight = NotificationActivePeriod(startMinute: 20 * 60, endMinute: 6 * 60)
-    XCTAssertTrue(overnight.contains(minuteOfDay: 23 * 60))
-    XCTAssertTrue(overnight.contains(minuteOfDay: 5 * 60 + 59))
-    XCTAssertFalse(overnight.contains(minuteOfDay: 12 * 60))
-
-    let allDayMidnight = NotificationActivePeriod(startMinute: 0, endMinute: 0)
-    XCTAssertTrue(allDayMidnight.isAllDay)
-    XCTAssertTrue(allDayMidnight.contains(minuteOfDay: 0))
-    XCTAssertTrue(allDayMidnight.contains(minuteOfDay: 23 * 60 + 59))
-  }
-
-  func testEqualActivePeriodEndpointsMeanAllDayNotEmptyWindow() {
-    // Setting start == end (including 06:00→06:00) is the explicit all-day encoding,
-    // not a zero-width window and not "only at that minute".
-    let equalSix = NotificationActivePeriod(startMinute: 6 * 60, endMinute: 6 * 60)
-    XCTAssertTrue(equalSix.isAllDay)
-    XCTAssertTrue(equalSix.contains(minuteOfDay: 3 * 60))
-    XCTAssertTrue(equalSix.contains(minuteOfDay: 6 * 60))
-    XCTAssertTrue(equalSix.contains(minuteOfDay: 15 * 60))
-    XCTAssertTrue(equalSix.contains(minuteOfDay: 23 * 60 + 59))
-  }
-
-  func testOvernightActivePeriodPreservesSixToThreeActiveAndQuietComplement() {
-    // Product contract: 06:00→03:00 stays active overnight; 03:00→06:00 is the quiet gap.
-    let active = NotificationActivePeriod(startMinute: 6 * 60, endMinute: 3 * 60)
-    XCTAssertFalse(active.isAllDay)
-    XCTAssertTrue(active.contains(minuteOfDay: 6 * 60))
-    XCTAssertTrue(active.contains(minuteOfDay: 23 * 60))
-    XCTAssertTrue(active.contains(minuteOfDay: 2 * 60 + 59))
-    XCTAssertFalse(active.contains(minuteOfDay: 3 * 60))
-    XCTAssertFalse(active.contains(minuteOfDay: 5 * 60 + 59))
-
-    let quietComplement = NotificationActivePeriod(startMinute: 3 * 60, endMinute: 6 * 60)
-    XCTAssertTrue(quietComplement.contains(minuteOfDay: 3 * 60))
-    XCTAssertTrue(quietComplement.contains(minuteOfDay: 5 * 60 + 59))
-    XCTAssertFalse(quietComplement.contains(minuteOfDay: 6 * 60))
-    XCTAssertFalse(quietComplement.contains(minuteOfDay: 2 * 60))
-  }
-
-  func testActivePeriodAllDayLabelSurfacesEqualEndpoints() {
-    XCTAssertEqual(
-      SettingsControlMetrics.notificationActivePeriodSummaryLabel(
-        startMinute: 6 * 60, endMinute: 6 * 60),
-      "All day")
-    XCTAssertEqual(
-      SettingsControlMetrics.notificationActivePeriodSubtitle(
-        startMinute: 6 * 60, endMinute: 6 * 60),
-      "All day — proactive notifications may appear any time")
-    XCTAssertNil(
-      SettingsControlMetrics.notificationActivePeriodSummaryLabel(
-        startMinute: 6 * 60, endMinute: 3 * 60))
-    XCTAssertEqual(
-      SettingsControlMetrics.notificationActivePeriodSubtitle(
-        startMinute: 6 * 60, endMinute: 3 * 60),
-      "When proactive notifications may appear (24-hour time)")
-  }
-
-  @MainActor
-  func testActivePeriodDefaultsAndPersistenceClampMinutes() {
-    let suiteName = "ContextDeliveryAuthorityTests.\(UUID().uuidString)"
-    guard let defaults = UserDefaults(suiteName: suiteName) else {
-      XCTFail("failed to create isolated defaults suite")
-      return
-    }
-    defer { defaults.removePersistentDomain(forName: suiteName) }
-
-    XCTAssertEqual(NotificationService.currentActivePeriod(defaults: defaults), .defaultValue)
-    defaults.set(-30, forKey: NotificationService.activePeriodStartDefaultsKey)
-    defaults.set(1_500, forKey: NotificationService.activePeriodEndDefaultsKey)
-    XCTAssertEqual(
-      NotificationService.currentActivePeriod(defaults: defaults),
-      NotificationActivePeriod(startMinute: 0, endMinute: 1439))
-  }
-
-  @MainActor
-  func testActivePeriodHelperGatesMinutesOutsideConfiguredWindow() throws {
-    let suiteName = "ContextDeliveryAuthorityTests.activePeriod.\(UUID().uuidString)"
-    guard let defaults = UserDefaults(suiteName: suiteName) else {
-      XCTFail("failed to create isolated defaults suite")
-      return
-    }
-    defer { defaults.removePersistentDomain(forName: suiteName) }
-
-    defaults.set(8 * 60, forKey: NotificationService.activePeriodStartDefaultsKey)
-    defaults.set(22 * 60, forKey: NotificationService.activePeriodEndDefaultsKey)
-
-    var calendar = Calendar(identifier: .gregorian)
-    calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
-    let noon = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 8, day: 12, hour: 12)))
-    let late = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 8, day: 12, hour: 23)))
-
-    XCTAssertTrue(
-      NotificationService.isWithinActivePeriod(now: noon, calendar: calendar, defaults: defaults))
-    XCTAssertFalse(
-      NotificationService.isWithinActivePeriod(now: late, calendar: calendar, defaults: defaults),
-      "active period must suppress proactive paths outside the configured window")
+          cooldownSeconds: 0)), .paywalled)
   }
 
   func testCoolingDownHandlesMissingZeroAndElapsedCooldown() {

--- a/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
@@ -116,7 +116,6 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
         frequencyLevel: 3,
         snoozed: false,
         paywalled: false,
-        minuteOfDay: 12 * 60,
         cooldownSeconds: 10 * 60),
       now: now)
 
@@ -173,7 +172,6 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
         frequencyLevel: 4,
         snoozed: false,
         paywalled: false,
-        minuteOfDay: 12 * 60,
         cooldownSeconds: 3 * 60),
       now: now)
 
@@ -186,7 +184,6 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
       frequencyLevel: 5,
       snoozed: false,
       paywalled: false,
-      minuteOfDay: 12 * 60,
       cooldownSeconds: 0)
   }
 

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -161,7 +161,7 @@ final class ContextProactivityEngineTests: XCTestCase {
   }
 
   @MainActor
-  func testPresentationFreeGateRebuildSuppressesMasterAndQuietChanges() throws {
+  func testPresentationFreeGateRebuildSuppressesMasterChanges() throws {
     let suiteName = "ContextProactivityEngineTests.\(UUID().uuidString)"
     guard let defaults = UserDefaults(suiteName: suiteName) else {
       XCTFail("failed to create isolated defaults suite")
@@ -171,53 +171,25 @@ final class ContextProactivityEngineTests: XCTestCase {
 
     defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
     defaults.set(3, forKey: NotificationService.frequencyDefaultsKey)
-    defaults.set(8 * 60, forKey: NotificationService.activePeriodStartDefaultsKey)
-    defaults.set(22 * 60, forKey: NotificationService.activePeriodEndDefaultsKey)
-
-    let noonComponents = DateComponents(calendar: .current, year: 2026, month: 8, day: 12, hour: 12)
-    let noon = noonComponents.date ?? Date()
-    let lateComponents = DateComponents(calendar: .current, year: 2026, month: 8, day: 12, hour: 23)
-    let late = lateComponents.date ?? Date()
 
     // Mirror the production rebuild path: capture gate inputs, then re-evaluate
-    // after master/quiet flips before presentation.
+    // after the master toggle flips before presentation.
     let allowed = ContextDeliveryGateInput(
       masterEnabled: defaults.bool(forKey: NotificationService.masterEnabledDefaultsKey),
       frequencyLevel: defaults.integer(forKey: NotificationService.frequencyDefaultsKey),
       snoozed: false,
       paywalled: false,
-      minuteOfDay: 12 * 60,
-      activePeriod: NotificationService.currentActivePeriod(defaults: defaults),
       cooldownSeconds: ContextDeliveryBudget.cooldownSeconds(frequencyLevel: 3))
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: allowed), .allowed)
 
     defaults.set(false, forKey: NotificationService.masterEnabledDefaultsKey)
-    let noonMinute =
-      try XCTUnwrap(Calendar.current.dateComponents([.hour, .minute], from: noon).hour) * 60
-      + (try XCTUnwrap(Calendar.current.dateComponents([.hour, .minute], from: noon).minute))
-    let masterOff = ContextDeliveryGateInput(
+    let rebuilt = ContextDeliveryGateInput(
       masterEnabled: defaults.bool(forKey: NotificationService.masterEnabledDefaultsKey),
       frequencyLevel: defaults.integer(forKey: NotificationService.frequencyDefaultsKey),
       snoozed: false,
       paywalled: false,
-      minuteOfDay: noonMinute,
-      activePeriod: NotificationService.currentActivePeriod(defaults: defaults),
       cooldownSeconds: 0)
-    XCTAssertEqual(ContextDeliveryBudget.freeGate(input: masterOff), .masterDisabled)
-
-    defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
-    let lateMinute =
-      try XCTUnwrap(Calendar.current.dateComponents([.hour, .minute], from: late).hour) * 60
-      + (try XCTUnwrap(Calendar.current.dateComponents([.hour, .minute], from: late).minute))
-    let quiet = ContextDeliveryGateInput(
-      masterEnabled: true,
-      frequencyLevel: 3,
-      snoozed: false,
-      paywalled: false,
-      minuteOfDay: lateMinute,
-      activePeriod: NotificationService.currentActivePeriod(defaults: defaults),
-      cooldownSeconds: 0)
-    XCTAssertEqual(ContextDeliveryBudget.freeGate(input: quiet), .quietHours)
+    XCTAssertEqual(ContextDeliveryBudget.freeGate(input: rebuilt), .masterDisabled)
   }
 
   func testAttemptGateRebuildSuppressesBeforeBudgetReservation() {
@@ -226,7 +198,6 @@ final class ContextProactivityEngineTests: XCTestCase {
       frequencyLevel: 3,
       snoozed: false,
       paywalled: false,
-      minuteOfDay: 12 * 60,
       cooldownSeconds: 0)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: allowed), .allowed)
 
@@ -235,7 +206,6 @@ final class ContextProactivityEngineTests: XCTestCase {
       frequencyLevel: 3,
       snoozed: true,
       paywalled: false,
-      minuteOfDay: 12 * 60,
       cooldownSeconds: 0)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: snoozed), .snoozed)
 
@@ -244,7 +214,6 @@ final class ContextProactivityEngineTests: XCTestCase {
       frequencyLevel: 3,
       snoozed: false,
       paywalled: true,
-      minuteOfDay: 12 * 60,
       cooldownSeconds: 0)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: paywalled), .paywalled)
   }

--- a/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopAutomationSecondaryActionTests.swift
@@ -222,6 +222,25 @@ final class DesktopAutomationSecondaryActionTests: XCTestCase {
     XCTAssertTrue(body.contains("cloud_sync"))
   }
 
+  func testNotificationBridgeRetiresActivePeriodContract() throws {
+    let source = try bridgeSource()
+    for retiredSurface in [
+      "set_notification_active_period",
+      "notification_active_period_start_minute",
+      "notification_active_period_end_minute",
+      "active_period_start",
+      "active_period_end",
+    ] {
+      XCTAssertFalse(source.contains(retiredSurface), "retired notification surface remains: \(retiredSurface)")
+    }
+
+    let snapshotBody = try actionBody(named: "settings_notifications_snapshot", in: source)
+    for key in ["enabled", "frequency", "frequency_label", "has_permission", "banners_disabled"] {
+      XCTAssertTrue(snapshotBody.contains("\"\(key)\""))
+    }
+    XCTAssertTrue(snapshotBody.contains("\"schema\""))
+  }
+
   func testSubscriptionSnapshotReadsBillingAPI() throws {
     let source = try bridgeSource()
     let body = try actionBody(named: "subscription_snapshot", in: source)

--- a/desktop/macos/Desktop/Tests/SettingsControlMetricsTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsControlMetricsTests.swift
@@ -104,10 +104,4 @@ final class SettingsControlMetricsTests: XCTestCase {
       enabledCopy.lowercased().contains("proactive"),
       "General Notifications must not claim product proactive delivery is on")
   }
-
-  func testNotificationPeriodLabelUsesClamped24HourTime() {
-    XCTAssertEqual(SettingsControlMetrics.notificationPeriodLabel(forMinute: 0), "00:00")
-    XCTAssertEqual(SettingsControlMetrics.notificationPeriodLabel(forMinute: 20 * 60 + 45), "20:45")
-    XCTAssertEqual(SettingsControlMetrics.notificationPeriodLabel(forMinute: 1_500), "23:59")
-  }
 }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
@@ -24,7 +24,7 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
     XCTAssertEqual(
       Set(SuggestionAssistantTelemetry.GateOutcome.allCases.map(\.rawValue)),
       Set([
-        "eligible", "disabled", "excluded_app", "snoozed", "quiet_period", "dwell",
+        "eligible", "disabled", "excluded_app", "snoozed", "dwell",
         "cooldown", "daily_budget", "no_grounding",
       ])
     )

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -13,7 +13,6 @@ final class SuggestionGatePolicyTests: XCTestCase {
     isEnabled: Bool = true,
     isAppExcluded: Bool = false,
     isSnoozed: Bool = false,
-    isWithinActivePeriod: Bool = true,
     lastEvaluationAt: Date? = nil,
     cooldown: TimeInterval = 180,
     dwell: TimeInterval = 999,
@@ -25,7 +24,6 @@ final class SuggestionGatePolicyTests: XCTestCase {
       isEnabled: isEnabled,
       isAppExcluded: isAppExcluded,
       isSnoozed: isSnoozed,
-      isWithinActivePeriod: isWithinActivePeriod,
       now: now,
       lastEvaluationAt: lastEvaluationAt,
       cooldown: cooldown,
@@ -52,10 +50,6 @@ final class SuggestionGatePolicyTests: XCTestCase {
 
   func testSnoozedBarDoesNotEvaluate() {
     XCTAssertEqual(decide(isSnoozed: true), .skippedSnoozed)
-  }
-
-  func testQuietPeriodDoesNotEvaluate() {
-    XCTAssertEqual(decide(isWithinActivePeriod: false), .skippedQuietPeriod)
   }
 
   func testCooldownBlocksUntilItHasFullyElapsed() {

--- a/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
@@ -756,18 +756,10 @@ final class TaskContextualResurfacingTests: XCTestCase {
     let service = NotificationService(registerWithSystemNotificationCenter: false)
     let priorFrequency = UserDefaults.standard.object(
       forKey: NotificationService.frequencyDefaultsKey)
-    let priorActiveStart = UserDefaults.standard.object(
-      forKey: NotificationService.activePeriodStartDefaultsKey)
-    let priorActiveEnd = UserDefaults.standard.object(
-      forKey: NotificationService.activePeriodEndDefaultsKey)
     defer {
       Self.restoreDefault(priorFrequency, key: NotificationService.frequencyDefaultsKey)
-      Self.restoreDefault(priorActiveStart, key: NotificationService.activePeriodStartDefaultsKey)
-      Self.restoreDefault(priorActiveEnd, key: NotificationService.activePeriodEndDefaultsKey)
     }
     UserDefaults.standard.set(3, forKey: NotificationService.frequencyDefaultsKey)
-    UserDefaults.standard.set(0, forKey: NotificationService.activePeriodStartDefaultsKey)
-    UserDefaults.standard.set(0, forKey: NotificationService.activePeriodEndDefaultsKey)
 
     XCTAssertTrue(
       service.proactiveNotificationEligibleForTesting(
@@ -788,6 +780,37 @@ final class TaskContextualResurfacingTests: XCTestCase {
   }
 
   @MainActor
+  func testProactiveEligibilityIgnoresTimeOfDay() async throws {
+    await transitionContextTestOwner(to: "notification-always-on-owner")
+    let snapshot = try XCTUnwrap(RuntimeOwnerIdentity.captureAuthorizationSnapshot())
+    let service = NotificationService(registerWithSystemNotificationCenter: false)
+    let priorMasterEnabled = UserDefaults.standard.object(
+      forKey: NotificationService.masterEnabledDefaultsKey)
+    let priorFrequency = UserDefaults.standard.object(
+      forKey: NotificationService.frequencyDefaultsKey)
+    defer {
+      Self.restoreDefault(priorMasterEnabled, key: NotificationService.masterEnabledDefaultsKey)
+      Self.restoreDefault(priorFrequency, key: NotificationService.frequencyDefaultsKey)
+    }
+    UserDefaults.standard.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    UserDefaults.standard.set(5, forKey: NotificationService.frequencyDefaultsKey)
+
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+    let earlyMorning = try XCTUnwrap(
+      calendar.date(from: DateComponents(year: 2026, month: 8, day: 13, hour: 2)))
+    let lateNight = try XCTUnwrap(
+      calendar.date(from: DateComponents(year: 2026, month: 8, day: 13, hour: 23)))
+
+    XCTAssertTrue(
+      service.proactiveNotificationEligibleForTesting(
+        assistantId: "insight", authorizationSnapshot: snapshot, now: earlyMorning))
+    XCTAssertTrue(
+      service.proactiveNotificationEligibleForTesting(
+        assistantId: "insight", authorizationSnapshot: snapshot, now: lateNight))
+  }
+
+  @MainActor
   func testStaleContextualInterruptionCannotConsumeLedgerMetadataOrOwnerBThrottle() async throws {
     await transitionContextTestOwner(to: "notification-owner-a")
     let ownerASnapshot = try XCTUnwrap(RuntimeOwnerIdentity.captureAuthorizationSnapshot())
@@ -802,13 +825,7 @@ final class TaskContextualResurfacingTests: XCTestCase {
 
     let priorFrequency = UserDefaults.standard.object(
       forKey: NotificationService.frequencyDefaultsKey)
-    let priorActiveStart = UserDefaults.standard.object(
-      forKey: NotificationService.activePeriodStartDefaultsKey)
-    let priorActiveEnd = UserDefaults.standard.object(
-      forKey: NotificationService.activePeriodEndDefaultsKey)
     UserDefaults.standard.set(3, forKey: NotificationService.frequencyDefaultsKey)
-    UserDefaults.standard.set(0, forKey: NotificationService.activePeriodStartDefaultsKey)
-    UserDefaults.standard.set(0, forKey: NotificationService.activePeriodEndDefaultsKey)
     XCTAssertTrue(
       service.allowProactiveNotificationForTesting(
         assistantId: "task",
@@ -839,20 +856,6 @@ final class TaskContextualResurfacingTests: XCTestCase {
       UserDefaults.standard.set(priorFrequency, forKey: NotificationService.frequencyDefaultsKey)
     } else {
       UserDefaults.standard.removeObject(forKey: NotificationService.frequencyDefaultsKey)
-    }
-    if let priorActiveStart {
-      UserDefaults.standard.set(
-        priorActiveStart, forKey: NotificationService.activePeriodStartDefaultsKey)
-    } else {
-      UserDefaults.standard.removeObject(
-        forKey: NotificationService.activePeriodStartDefaultsKey)
-    }
-    if let priorActiveEnd {
-      UserDefaults.standard.set(
-        priorActiveEnd, forKey: NotificationService.activePeriodEndDefaultsKey)
-    } else {
-      UserDefaults.standard.removeObject(
-        forKey: NotificationService.activePeriodEndDefaultsKey)
     }
   }
 
@@ -1000,30 +1003,6 @@ final class TaskContextualResurfacingTests: XCTestCase {
         expected
       )
     }
-  }
-
-  func testInterruptionGateHonorsQuietHoursAcrossMidnight() {
-    var calendar = Calendar(identifier: .gregorian)
-    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-    let late = ISO8601DateFormatter().date(from: "2027-01-15T23:00:00Z")!
-    let midday = ISO8601DateFormatter().date(from: "2027-01-15T12:00:00Z")!
-
-    XCTAssertEqual(
-      gate().evaluate(
-        candidate: candidate(expiresAt: late.addingTimeInterval(60)),
-        configuration: configuration(quiet: true),
-        environment: environment(now: late, calendar: calendar)
-      ).reason,
-      .quietHours
-    )
-    XCTAssertEqual(
-      gate().evaluate(
-        candidate: candidate(expiresAt: midday.addingTimeInterval(60)),
-        configuration: configuration(),
-        environment: environment(now: midday, calendar: calendar)
-      ).reason,
-      .allowed
-    )
   }
 
   func testInterruptionGateEnforcesDedupeSpacingAndDailyBudget() {
@@ -1351,16 +1330,13 @@ final class TaskContextualResurfacingTests: XCTestCase {
     enabled: Bool = true,
     shipped: Bool = false,
     dailyLimit: Int = 2,
-    spacing: TimeInterval = 90 * 60,
-    quiet: Bool = false
+    spacing: TimeInterval = 90 * 60
   ) -> ProactiveTaskInterruptionConfiguration {
     ProactiveTaskInterruptionConfiguration(
       userOptedIn: enabled,
       shippedCohortsEnabled: shipped,
       dailyLimit: dailyLimit,
       minimumSpacing: spacing,
-      quietHoursStartMinute: quiet ? 22 * 60 : 0,
-      quietHoursEndMinute: quiet ? 8 * 60 : 0,
       allowedPreparationKinds: []
     )
   }

--- a/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
@@ -135,20 +135,23 @@ private func transitionContextTestOwner(to ownerID: String?) async {
 final class TaskInterruptionLedgerOwnerIsolationTests: XCTestCase {
   func testDefaultOwnerTracksAuthenticationChanges() {
     let suite = "TaskInterruptionLedgerOwnerIsolationTests.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suite)!
+    guard let defaults = UserDefaults(suiteName: suite) else {
+      XCTFail("Failed to create isolated defaults suite")
+      return
+    }
     defer { defaults.removePersistentDomain(forName: suite) }
     let persistence = TaskInterruptionLedgerDefaults(defaults: defaults)
-    defaults.set("owner-a", forKey: "auth_userId")
+    defaults.set("owner-a", forKey: .authUserId)
     persistence.save(TaskInterruptionLedger(sentAt: [Date(timeIntervalSince1970: 42)]))
-    defaults.set("owner-b", forKey: "auth_userId")
+    defaults.set("owner-b", forKey: .authUserId)
     XCTAssertTrue(persistence.load().sentAt.isEmpty)
-    defaults.set("owner-a", forKey: "auth_userId")
+    defaults.set("owner-a", forKey: .authUserId)
     XCTAssertEqual(persistence.load().sentAt.count, 1)
   }
 
   func testLegacyQuietHoursTraceDecodesWithoutResettingLedger() throws {
     let suite = "TaskInterruptionLedgerOwnerIsolationTests.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suite)!
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
     defer { defaults.removePersistentDomain(forName: suite) }
     let persistence = TaskInterruptionLedgerDefaults(defaults: defaults, ownerID: "owner-a")
     let payload: [String: Any] = [
@@ -167,7 +170,7 @@ final class TaskInterruptionLedgerOwnerIsolationTests: XCTestCase {
     ]
     defaults.set(
       try JSONSerialization.data(withJSONObject: payload),
-      forKey: "proactiveTaskInterruptionLedger.v1.owner-a"
+      forKey: .taskInterruptionLedger(ownerID: "owner-a")
     )
 
     let loaded = persistence.load()
@@ -176,7 +179,9 @@ final class TaskInterruptionLedgerOwnerIsolationTests: XCTestCase {
     XCTAssertEqual(loaded.lastTrace?.reason, .legacyQuietHours)
 
     persistence.save(loaded)
-    let saved = try XCTUnwrap(defaults.data(forKey: "proactiveTaskInterruptionLedger.v1.owner-a"))
+    let saved = try XCTUnwrap(
+      defaults.data(forKey: .taskInterruptionLedger(ownerID: "owner-a"))
+    )
     let savedJSON = try XCTUnwrap(String(data: saved, encoding: .utf8))
     XCTAssertFalse(savedJSON.contains("\"quiet_hours\""))
     XCTAssertTrue(savedJSON.contains("\"legacy_quiet_hours\""))

--- a/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
@@ -145,6 +145,42 @@ final class TaskInterruptionLedgerOwnerIsolationTests: XCTestCase {
     defaults.set("owner-a", forKey: "auth_userId")
     XCTAssertEqual(persistence.load().sentAt.count, 1)
   }
+
+  func testLegacyQuietHoursTraceDecodesWithoutResettingLedger() throws {
+    let suite = "TaskInterruptionLedgerOwnerIsolationTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let persistence = TaskInterruptionLedgerDefaults(defaults: defaults, ownerID: "owner-a")
+    let payload: [String: Any] = [
+      "sentAt": [42.0],
+      "dedupeExpirations": ["dedupe-key": 4_200.0],
+      "lastTrace": [
+        "schemaVersion": 1,
+        "decisionID": "decision",
+        "recommendationID": "recommendation",
+        "interventionID": "intervention",
+        "dedupeHash": "sha256:legacy",
+        "cohort": "dogfood",
+        "reason": "quiet_hours",
+        "evaluatedAt": 123.0,
+      ],
+    ]
+    defaults.set(
+      try JSONSerialization.data(withJSONObject: payload),
+      forKey: "proactiveTaskInterruptionLedger.v1.owner-a"
+    )
+
+    let loaded = persistence.load()
+    XCTAssertEqual(loaded.sentAt, [Date(timeIntervalSinceReferenceDate: 42)])
+    XCTAssertEqual(loaded.dedupeExpirations["dedupe-key"], Date(timeIntervalSinceReferenceDate: 4_200))
+    XCTAssertEqual(loaded.lastTrace?.reason, .legacyQuietHours)
+
+    persistence.save(loaded)
+    let saved = try XCTUnwrap(defaults.data(forKey: "proactiveTaskInterruptionLedger.v1.owner-a"))
+    let savedJSON = try XCTUnwrap(String(data: saved, encoding: .utf8))
+    XCTAssertFalse(savedJSON.contains("\"quiet_hours\""))
+    XCTAssertTrue(savedJSON.contains("\"legacy_quiet_hours\""))
+  }
 }
 
 final class FakeTaskContextualResurfacingClient: TaskContextualResurfacingClient, @unchecked Sendable {
@@ -784,16 +820,13 @@ final class TaskContextualResurfacingTests: XCTestCase {
     await transitionContextTestOwner(to: "notification-always-on-owner")
     let snapshot = try XCTUnwrap(RuntimeOwnerIdentity.captureAuthorizationSnapshot())
     let service = NotificationService(registerWithSystemNotificationCenter: false)
-    let priorMasterEnabled = UserDefaults.standard.object(
-      forKey: NotificationService.masterEnabledDefaultsKey)
     let priorFrequency = UserDefaults.standard.object(
       forKey: NotificationService.frequencyDefaultsKey)
     defer {
-      Self.restoreDefault(priorMasterEnabled, key: NotificationService.masterEnabledDefaultsKey)
       Self.restoreDefault(priorFrequency, key: NotificationService.frequencyDefaultsKey)
     }
-    UserDefaults.standard.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
-    UserDefaults.standard.set(5, forKey: NotificationService.frequencyDefaultsKey)
+    // Level 3 exercises the real cooldown path; Maximum would return before any timestamp check.
+    UserDefaults.standard.set(3, forKey: NotificationService.frequencyDefaultsKey)
 
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))

--- a/desktop/macos/changelog/unreleased/20260813-always-on-notifications.json
+++ b/desktop/macos/changelog/unreleased/20260813-always-on-notifications.json
@@ -1,0 +1,3 @@
+{
+  "change": "Removed notification active hours so enabled alerts can arrive at any time"
+}

--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -33,6 +33,7 @@ steps:
       name: settings_notifications_snapshot
     expect:
       ok: true
+      result.detail.schema: "enabled,frequency,frequency_label,has_permission,banners_disabled"
 
   - id: S3
     name: Set notification frequency balanced

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -44,8 +44,8 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
-SOURCE_INSPECTION_FILE_BASELINE = 55
-SOURCE_INSPECTION_SITE_BASELINE = 148
+SOURCE_INSPECTION_FILE_BASELINE = 54
+SOURCE_INSPECTION_SITE_BASELINE = 147
 WALL_CLOCK_WAIT_BASELINE = 16
 
 MIN_REASON_LENGTH = 12


### PR DESCRIPTION
## What changed and why

Remove the legacy macOS notification Active Period setting and every corresponding delivery-time gate. When Notifications is enabled and Frequency is above Off, proactive notifications are now eligible at any time of day, subject only to the existing non-time policy such as snooze, paywall, cooldown, budget, and deduplication.

This also removes the obsolete persisted active-period projection, task-interruption quiet-hours configuration, automation action and snapshot fields, and quiet-period telemetry.

## Product invariants affected

none

## How it was verified

- Built and launched the real app as the isolated `omi-notifications-always-on` bundle, navigated to Notifications & Privacy through the automation bridge, and inspected the live accessibility tree. Frequency now flows directly to Live Suggestions with no Active Period row, and the automation snapshot has no active-period fields.
- Ran the focused proactive notification, context delivery, task resurfacing, suggestion, and settings tests: 71 tests passed with 0 failures.
- Ran the time-of-day regression independently after explicitly enabling Notifications and setting Frequency to Maximum; both 02:00 and 23:00 were eligible.
- Ran `make preflight`: all 20 selected checks passed, including full pinned swift-format, SwiftLint (0 violations across 1,218 files), desktop test quality, changelog, UI invariant, and e2e coverage checks.
- Ran all 577 Swift suite filters: 576 passed. The sole failing filter, `APIClientAssistantSettingsTests`, has two unrelated task-prompt size assertions (`13,120 > 10,000`); both failures reproduce unchanged in a fresh detached worktree at exact base `8442e89f03c71c2fa266b2d3c888b6ebbd3d40de`.

## Tests

Regression coverage: `TaskContextualResurfacingTests.testProactiveEligibilityIgnoresTimeOfDay` proves notification eligibility no longer depends on the clock when the master switch and frequency allow delivery. Existing tests were updated to remove obsolete active-period and quiet-hours inputs and expectations.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

