### PR TITLE
feat(desktop): re-enable proactive notifications at Balanced by default (focus + insights)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
@@ -3,27 +3,6 @@ import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
 
-@MainActor
-private final class NotificationSettingsSyncQueue {
-  static let shared = NotificationSettingsSyncQueue()
-
-  private var tail: Task<Void, Never>?
-
-  func enqueue(enabled: Bool, frequency: Int, revision: Int) {
-    let previous = tail
-    tail = Task {
-      await previous?.value
-      do {
-        _ = try await APIClient.shared.updateNotificationSettings(
-          enabled: enabled, frequency: frequency)
-        NotificationService.completeNotificationSettingsSync(revision: revision)
-      } catch {
-        logError("Failed to update notification settings", error: error)
-      }
-    }
-  }
-}
-
 extension SettingsContentView {
   func openURLInDefaultBrowser(_ url: URL) {
     if let appURL = NSWorkspace.shared.urlForApplication(toOpen: url) {

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -339,10 +339,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
       }
     }
 
-    // Proactive notifications are now OFF by default for everyone. Run the one-time
-    // migration before any assistant can fire, so existing users are flipped to Off
-    // once (they can re-enable in Settings).
-    NotificationService.migrateToOffByDefaultIfNeeded()
+    // Proactive notifications are back ON by default at Balanced (focus/insight
+    // categories only). Run the one-time migration before any assistant can fire;
+    // turning notifications off again in Settings sticks.
+    NotificationService.migrateToBalancedDefaultIfNeeded()
 
     // Force macOS to use the correct app icon (bypasses icon cache).
     // Apply squircle mask with proper margins because NSApp.applicationIconImage

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -10,6 +10,33 @@ private struct UNCompletionHandlerBox: @unchecked Sendable {
   init(_ value: @escaping (UNNotificationPresentationOptions) -> Void) { self.value = value }
 }
 
+/// Serializes notification-settings PATCHes so every mutation — user slider/toggle
+/// changes and the launch migration alike — reaches the backend in request order.
+/// An unordered send could let an earlier mutation land last and clear the
+/// pending-sync journal against a state the server never stored.
+@MainActor
+final class NotificationSettingsSyncQueue {
+  static let shared = NotificationSettingsSyncQueue()
+
+  private var tail: Task<Void, Never>?
+
+  /// `enabled: nil` leaves the master toggle untouched server-side (used by the
+  /// launch migration, which only moves the frequency).
+  func enqueue(enabled: Bool?, frequency: Int, revision: Int) {
+    let previous = tail
+    tail = Task {
+      await previous?.value
+      do {
+        _ = try await APIClient.shared.updateNotificationSettings(
+          enabled: enabled, frequency: frequency)
+        NotificationService.completeNotificationSettingsSync(revision: revision)
+      } catch {
+        logError("Failed to update notification settings", error: error)
+      }
+    }
+  }
+}
+
 /// Sound options for notifications
 enum NotificationSound {
   case `default`
@@ -927,19 +954,13 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   static func migrateToBalancedDefaultIfNeeded() {
     guard let target = applyBalancedDefaultMigration(defaults: .standard) else { return }
     log("NotificationService: applied balanced-by-default migration (frequency=\(target))")
-    // Route the backend push through the pending-sync journal: if it fails (offline,
-    // signed out during onboarding), the next Settings load preserves the local value
-    // and retries the push instead of hydrating the stale server value back over it.
+    // Route the backend push through the pending-sync journal and the shared send
+    // queue: a failed push (offline, signed out during onboarding) is retried by the
+    // next Settings load instead of the stale server value hydrating back over the
+    // local re-enable, and a slow launch push can never land after — and overwrite —
+    // a frequency change the user makes right after startup.
     let revision = beginNotificationSettingsSync()
-    Task {
-      do {
-        _ = try await APIClient.shared.updateNotificationSettings(enabled: nil, frequency: target)
-        completeNotificationSettingsSync(revision: revision)
-      } catch {
-        logError(
-          "NotificationService: balanced-by-default migration backend push failed", error: error)
-      }
-    }
+    NotificationSettingsSyncQueue.shared.enqueue(enabled: nil, frequency: target, revision: revision)
   }
 
   /// Local half of the balanced-by-default migration, split from the backend push so the

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -52,13 +52,17 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// 0=Off (default), 1=Minimal, 2=Low, 3=Balanced, 4=High, 5=Maximum.
   /// The Settings page writes this on load and on slider change; `sendNotification`
   /// reads it synchronously to throttle proactive notifications.
-  static let frequencyDefaultsKey = "notification_frequency"
+  nonisolated static let frequencyDefaultsKey = "notification_frequency"
   static let settingsPendingSyncDefaultsKey = "notification_settings_pending_sync"
   static let settingsSyncRevisionDefaultsKey = "notification_settings_sync_revision"
 
-  /// One-time migration flag: when set, the notifications-off-by-default migration
-  /// has already run for this install, so we never re-disable a user who opted back in.
-  static let offByDefaultMigrationKey = "notificationsOffByDefaultMigrationDone"
+  /// One-time migration flag: when set, the balanced-by-default re-enable migration
+  /// has already run for this install, so we never re-enable a user who turns
+  /// notifications off after the migration.
+  nonisolated static let balancedByDefaultMigrationKey = "notificationsBalancedByDefaultMigrationDone"
+
+  /// Frequency level the re-enable migration applies (3 = Balanced).
+  nonisolated static let balancedFrequencyLevel = 3
 
   /// UserDefaults key mirroring the master `notifications_enabled` toggle from the backend.
   /// The Settings page writes it on load and on toggle change; `sendNotification` reads it
@@ -74,7 +78,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
   /// Default level used when the key has never been written (e.g. first run before
   /// the Settings page has hydrated from the backend). Mirrors the backend default.
-  /// Proactive notifications are OFF by default — users opt in via the Settings slider.
+  /// Kept at 0 (fail-closed) only for the window before `migrateToBalancedDefaultIfNeeded`
+  /// writes the key at launch; the effective default is Balanced via that migration.
   private static let defaultFrequencyLevel = 0
 
   private struct NotificationMetadata {
@@ -911,26 +916,49 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
   // MARK: - Frequency throttle
 
-  /// One-time migration to make proactive notifications OFF by default for ALL users.
-  /// Runs once per install (guarded by `offByDefaultMigrationKey`): sets the local
-  /// frequency to Off and persists it to the backend so the choice sticks across
-  /// devices and is reflected in Settings. Because it is guarded by the flag, a user
-  /// who later turns notifications back on is never re-disabled on subsequent launches.
+  /// One-time migration to re-enable proactive notifications at Balanced for users the
+  /// notifications-off-by-default migration (`48239de8`) turned off. A user at Off — or a
+  /// fresh install with no stored level — moves to Balanced; a user who opted in to any
+  /// other level keeps it. Per-assistant toggles are not touched, so only the categories
+  /// that default on (Live Suggestions, Insight) fire; Task and Memory stay opt-in.
+  /// Because it is guarded by `balancedByDefaultMigrationKey`, a user who turns
+  /// notifications off after the migration is never re-enabled on subsequent launches.
   /// Call early at launch, before any proactive assistant can fire.
-  static func migrateToOffByDefaultIfNeeded() {
-    guard !UserDefaults.standard.bool(forKey: Self.offByDefaultMigrationKey) else { return }
-    UserDefaults.standard.set(0, forKey: Self.frequencyDefaultsKey)
-    UserDefaults.standard.set(true, forKey: Self.offByDefaultMigrationKey)
-    log("NotificationService: applied notifications-off-by-default migration (frequency=0)")
-    guard AuthService.shared.isSignedIn else { return }
+  static func migrateToBalancedDefaultIfNeeded() {
+    guard let target = applyBalancedDefaultMigration(defaults: .standard) else { return }
+    log("NotificationService: applied balanced-by-default migration (frequency=\(target))")
+    // Route the backend push through the pending-sync journal: if it fails (offline,
+    // signed out during onboarding), the next Settings load preserves the local value
+    // and retries the push instead of hydrating the stale server value back over it.
+    let revision = beginNotificationSettingsSync()
     Task {
       do {
-        _ = try await APIClient.shared.updateNotificationSettings(enabled: nil, frequency: 0)
+        _ = try await APIClient.shared.updateNotificationSettings(enabled: nil, frequency: target)
+        completeNotificationSettingsSync(revision: revision)
       } catch {
         logError(
-          "NotificationService: off-by-default migration backend push failed", error: error)
+          "NotificationService: balanced-by-default migration backend push failed", error: error)
       }
     }
+  }
+
+  /// Local half of the balanced-by-default migration, split from the backend push so the
+  /// decision is synchronously unit-testable. Returns the level to push to the backend,
+  /// or nil when nothing changed (already migrated, or the user opted in to another level).
+  @discardableResult
+  nonisolated static func applyBalancedDefaultMigration(defaults: UserDefaults) -> Int? {
+    guard !defaults.bool(forKey: Self.balancedByDefaultMigrationKey) else { return nil }
+    defaults.set(true, forKey: Self.balancedByDefaultMigrationKey)
+    // The raw stored value, not `currentFrequencyLevel()`: an absent key (fresh install)
+    // must migrate so the level is written locally AND to the backend — otherwise the
+    // backend's off default would hydrate 0 over the in-memory fallback later.
+    if defaults.object(forKey: Self.frequencyDefaultsKey) != nil,
+      defaults.integer(forKey: Self.frequencyDefaultsKey) != 0
+    {
+      return nil
+    }
+    defaults.set(Self.balancedFrequencyLevel, forKey: Self.frequencyDefaultsKey)
+    return Self.balancedFrequencyLevel
   }
 
   /// Whether the master Notifications toggle is on. Reads the mirrored UserDefaults key,

--- a/desktop/macos/Desktop/Tests/UserNotificationCallbackBridgeTests.swift
+++ b/desktop/macos/Desktop/Tests/UserNotificationCallbackBridgeTests.swift
@@ -42,6 +42,54 @@ final class UserNotificationCallbackBridgeTests: XCTestCase {
     XCTAssertFalse(NotificationService.hasPendingNotificationSettingsSync(defaults: defaults))
   }
 
+  func testBalancedDefaultMigrationEnablesFreshInstallAndOffUsers() throws {
+    let suiteName = "UserNotificationCallbackBridgeTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    // Fresh install: no stored level. Must write the key (not just rely on the
+    // in-memory fallback) so the backend's off default cannot hydrate 0 over it.
+    XCTAssertEqual(
+      NotificationService.applyBalancedDefaultMigration(defaults: defaults),
+      NotificationService.balancedFrequencyLevel)
+    XCTAssertEqual(
+      defaults.integer(forKey: NotificationService.frequencyDefaultsKey),
+      NotificationService.balancedFrequencyLevel)
+
+    // Second run is a no-op: the migration is once per install.
+    XCTAssertNil(NotificationService.applyBalancedDefaultMigration(defaults: defaults))
+
+    // A user turned off by the off-by-default migration moves to Balanced.
+    let offSuite = "UserNotificationCallbackBridgeTests.\(UUID().uuidString)"
+    let offDefaults = try XCTUnwrap(UserDefaults(suiteName: offSuite))
+    defer { offDefaults.removePersistentDomain(forName: offSuite) }
+    offDefaults.set(0, forKey: NotificationService.frequencyDefaultsKey)
+    XCTAssertEqual(
+      NotificationService.applyBalancedDefaultMigration(defaults: offDefaults),
+      NotificationService.balancedFrequencyLevel)
+  }
+
+  func testBalancedDefaultMigrationNeverOverridesAnExplicitUserChoice() throws {
+    // A user who opted in to another level keeps it.
+    let suiteName = "UserNotificationCallbackBridgeTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
+    XCTAssertNil(NotificationService.applyBalancedDefaultMigration(defaults: defaults))
+    XCTAssertEqual(defaults.integer(forKey: NotificationService.frequencyDefaultsKey), 5)
+
+    // A user who turns notifications off AFTER the migration is never re-enabled.
+    let optOutSuite = "UserNotificationCallbackBridgeTests.\(UUID().uuidString)"
+    let optOutDefaults = try XCTUnwrap(UserDefaults(suiteName: optOutSuite))
+    defer { optOutDefaults.removePersistentDomain(forName: optOutSuite) }
+    NotificationService.applyBalancedDefaultMigration(defaults: optOutDefaults)
+    optOutDefaults.set(0, forKey: NotificationService.frequencyDefaultsKey)
+    XCTAssertNil(NotificationService.applyBalancedDefaultMigration(defaults: optOutDefaults))
+    XCTAssertEqual(
+      optOutDefaults.integer(forKey: NotificationService.frequencyDefaultsKey), 0,
+      "re-running the migration must not resurrect notifications the user re-disabled")
+  }
+
   @MainActor
   func testNotificationSettingsAccessorsPreserveCompleteDesiredStateAcrossPartialMutations() throws {
     let suiteName = "UserNotificationCallbackBridgeTests.\(UUID().uuidString)"

--- a/desktop/macos/changelog/unreleased/20260813-notifications-balanced-default.json
+++ b/desktop/macos/changelog/unreleased/20260813-notifications-balanced-default.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive notifications are on by default again at Balanced — focus suggestions and insights only; task and memory notifications stay opt-in, and your own frequency choice is kept"
+}

--- a/desktop/macos/scripts/check_desktop_test_quality.py
+++ b/desktop/macos/scripts/check_desktop_test_quality.py
@@ -44,8 +44,8 @@ TEST_ROOT = "desktop/macos/Desktop/Tests"
 
 # Pinned debt ceilings. These may only decrease. Escaped sites are not counted.
 # Run with --print after improving tests, then lower both relevant values.
-SOURCE_INSPECTION_FILE_BASELINE = 55
-SOURCE_INSPECTION_SITE_BASELINE = 148
+SOURCE_INSPECTION_FILE_BASELINE = 54
+SOURCE_INSPECTION_SITE_BASELINE = 147
 WALL_CLOCK_WAIT_BASELINE = 16
 
 MIN_REASON_LENGTH = 12


### PR DESCRIPTION
# Re-enable proactive notifications at Balanced by default

## Summary

Replaces the notifications-off-by-default migration (`48239de8`, PR #7681) with a one-time balanced-by-default re-enable:

- Users at **Off** — and fresh installs with no stored level — move to **frequency 3 (Balanced)** once at launch. Any explicit opt-in level (1–5) is kept.
- Turning notifications off *after* the migration sticks: the run-once flag (`notificationsBalancedByDefaultMigrationDone`) guarantees no re-enable on later launches.
- Per-assistant toggles are untouched, so only the default-on categories fire: **Live Suggestions** (focus nudges) and **Insight**. Task and Memory notifications stay opt-in.
- The backend push rides the existing pending-sync journal (`beginNotificationSettingsSync`) and the shared `NotificationSettingsSyncQueue` (moved from the Settings pane into `NotificationService`, now taking `enabled: Bool?`): a failed PATCH (offline, signed out during onboarding) is retried by the next Settings load, and the launch push is ordered behind any frequency change the user makes right after startup, so a slow migration PATCH can never overwrite a newer user choice.
- The backend default (`get_notification_settings` → frequency 0) is deliberately unchanged, so users on current stable builds are unaffected. **Beta picks this up with the next beta release; stable inherits it automatically when that release is promoted to stable** — no backend flip or second change needed.

## Product invariants affected

- INV-AUTH-1 — path-matched only (`OmiApp.swift` launch sequence swaps one migration call; `NotificationService.swift` settings-sync statics). No auth/session behavior changes.

## Verification

- `xcrun swift test --package-path Desktop --filter UserNotificationCallbackBridgeTests` — 11/11 pass, including two new regression tests: fresh-install/off users migrate to Balanced exactly once and write the key (so backend off-default cannot hydrate 0 over it); explicit user levels are never overridden; a user who re-disables after the migration is never re-enabled.
- Real path: built and ran a named dev bundle (`omi-notif-balanced`, dev backend, seeded account). On first launch the migration set `notification_frequency=3`, set the flag, and the backend PATCH completed (pending-sync journal cleared). Settings → Notifications & Privacy shows master ON, Frequency **Balanced**, Live Suggestions ON, Insight ON, Task OFF, Memory OFF — hydrated from the server, confirming the round-trip. State survived two relaunches. Re-verified end-to-end after routing the push through the shared queue (reset migration state, relaunched: frequency=3, flag set, queued PATCH completed).
- Independent agent review: approved ("correct, tightly scoped, well-tested"); its one actionable finding — the bare-`Task` push being unordered vs user PATCHes — is fixed in the second commit. Its second note (a fresh install on a second machine pushes Balanced over an explicit non-zero level set elsewhere) is accepted intent: a fresh beta install re-enabling at Balanced is the point of this change.
- Server-authoritative hydration observed working: a locally forged frequency (0) with no pending journal entry was corrected back to the server value on Settings load — the identical path that keeps a real user's slider choice authoritative across devices.
- UNVERIFIED end-to-end: dragging the slider to Off through the real UI and relaunching (custom SwiftUI slider is not reachable cursor-free); the guard for that path is unit-tested (`testBalancedDefaultMigrationNeverOverridesAnExplicitUserChoice`) and the slider/persistence code is untouched by this PR.

## Rider: unblocks a red main

A third commit repairs `APIClientAssistantSettingsTests` (added in 38d3b8eb2f yesterday), which asserted that the shipped default task prompt fits its sync bound — never true (~13.7k chars vs the 10k backend bound since at least June), so the desktop Swift suite was red on main and blocked this PR's gate and the hourly release train. The tests now assert the shipped contract (oversized default prompt is omitted from sync; all three assistants share the 10k bound); the intended bound raise with its backend-deploy sequencing is tracked in #11481.