### PR TITLE
feat(desktop): measure repeated bucket fact identities

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -56,7 +56,9 @@ enum BucketFactValidator {
     }
     let unique = Set(normalized)
     guard !unique.isEmpty else { return nil }
-    return unique.sorted().joined(separator: "\u{1F}")
+    let sorted = unique.sorted()
+    guard let encoded = try? JSONEncoder().encode(sorted) else { return nil }
+    return String(data: encoded, encoding: .utf8)
   }
 
   static func hasParaphraseMatch(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -36,7 +36,12 @@ enum BucketFactDisposition: String {
 enum BucketFactValidator {
   struct ExistingFactIdentity: Equatable, Sendable {
     let statement: String
-    let identifiers: [String]
+    let canonicalIdentifierSetKey: String?
+
+    init(statement: String, identifiers: [String]) {
+      self.statement = statement
+      canonicalIdentifierSetKey = BucketFactValidator.canonicalIdentifierSetKey(identifiers)
+    }
   }
 
   static func resolvableEvidenceRefs(_ refs: [String], allowed: Set<String>) -> [String] {
@@ -69,7 +74,7 @@ enum BucketFactValidator {
     guard let identityKey = canonicalIdentifierSetKey(identifiers) else { return false }
     return existingFacts.contains { existing in
       existing.statement != statement
-        && canonicalIdentifierSetKey(existing.identifiers) == identityKey
+        && existing.canonicalIdentifierSetKey == identityKey
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -270,9 +270,10 @@ extension ContextBucketStore {
         sql: """
           SELECT statement, identifiersJson FROM bucket_facts
           WHERE bucketID = ? AND validityState = 'validated'
-          ORDER BY createdAt DESC LIMIT 250
+            AND (expiresAt IS NULL OR expiresAt > ?)
+          ORDER BY id DESC LIMIT 250
           """,
-        arguments: [bucketID]
+        arguments: [bucketID, now]
       ).compactMap { row -> BucketFactValidator.ExistingFactIdentity? in
         guard
           let existingStatement = row["statement"] as String?,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -34,8 +34,41 @@ enum BucketFactDisposition: String {
 }
 
 enum BucketFactValidator {
+  struct ExistingFactIdentity: Equatable, Sendable {
+    let statement: String
+    let identifiers: [String]
+  }
+
   static func resolvableEvidenceRefs(_ refs: [String], allowed: Set<String>) -> [String] {
     refs.map { String($0.prefix(200)) }.filter { allowed.contains($0) }
+  }
+
+  /// Shadow-only identity candidate for measuring paraphrase repetition. This
+  /// is intentionally not used for validity, suppression, or candidate writes:
+  /// an identifier can name a subject while its status or claim changes.
+  static func canonicalIdentifierSetKey(_ identifiers: [String]) -> String? {
+    let normalized = identifiers.compactMap { identifier -> String? in
+      let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else { return nil }
+      let collapsed = trimmed.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+      guard !collapsed.isEmpty else { return nil }
+      return collapsed.precomposedStringWithCanonicalMapping.lowercased()
+    }
+    let unique = Set(normalized)
+    guard !unique.isEmpty else { return nil }
+    return unique.sorted().joined(separator: "\u{1F}")
+  }
+
+  static func hasParaphraseMatch(
+    statement: String,
+    identifiers: [String],
+    existingFacts: [ExistingFactIdentity]
+  ) -> Bool {
+    guard let identityKey = canonicalIdentifierSetKey(identifiers) else { return false }
+    return existingFacts.contains { existing in
+      existing.statement != statement
+        && canonicalIdentifierSetKey(existing.identifiers) == identityKey
+    }
   }
 
   static func validity(
@@ -193,7 +226,7 @@ extension ContextBucketStore {
     let pool = try await poolForRollup(fence)
     let evidenceEncoder = JSONEncoder()
     let safeNarrative = String(extraction.narrative.prefix(2_400))
-    return try await pool.write { db in
+    let result: (versionID: Int64, paraphraseObserved: Bool) = try await pool.write { db in
       guard
         let visit = try Row.fetchOne(
           db,
@@ -229,6 +262,25 @@ extension ContextBucketStore {
         ])
 
       var maximumWorthiness = 0.0
+      var paraphraseObserved = false
+      var existingFactIdentities = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT statement, identifiersJson FROM bucket_facts
+          WHERE bucketID = ? AND validityState = 'validated'
+          ORDER BY createdAt DESC LIMIT 250
+          """,
+        arguments: [bucketID]
+      ).compactMap { row -> BucketFactValidator.ExistingFactIdentity? in
+        guard
+          let existingStatement = row["statement"] as String?,
+          let encodedIdentifiers = row["identifiersJson"] as String?,
+          let data = encodedIdentifiers.data(using: .utf8),
+          let existingIdentifiers = try? JSONDecoder().decode([String].self, from: data)
+        else { return nil }
+        return BucketFactValidator.ExistingFactIdentity(
+          statement: existingStatement, identifiers: existingIdentifiers)
+      }
       for fact in extraction.facts.prefix(20) {
         let statement = String(fact.statement.prefix(500))
         let evidenceText = String(fact.evidenceText.prefix(1_000))
@@ -238,6 +290,10 @@ extension ContextBucketStore {
           String($0.prefix(200)).trimmingCharacters(in: .whitespacesAndNewlines)
         }
         .filter { !$0.isEmpty }
+        paraphraseObserved =
+          paraphraseObserved
+          || BucketFactValidator.hasParaphraseMatch(
+            statement: statement, identifiers: identifiers, existingFacts: existingFactIdentities)
         let duplicate =
           try Bool.fetchOne(
             db,
@@ -265,6 +321,10 @@ extension ContextBucketStore {
             String(data: try evidenceEncoder.encode(evidenceRefs), encoding: .utf8) ?? "[]",
             validity.rawValue, min(max(fact.confidence, 0), 1), worthiness, now, now,
           ])
+        if validity == .validated {
+          existingFactIdentities.append(
+            BucketFactValidator.ExistingFactIdentity(statement: statement, identifiers: identifiers))
+        }
       }
       try db.execute(
         sql: "UPDATE context_buckets SET notifyWorthiness = MAX(notifyWorthiness, ?), updatedAt = ? WHERE id = ?",
@@ -273,8 +333,12 @@ extension ContextBucketStore {
       try db.execute(
         sql: "UPDATE bucket_entries SET bucketVersionID = ? WHERE id = ?",
         arguments: [versionID, entryID])
-      return versionID
+      return (versionID: versionID, paraphraseObserved: paraphraseObserved)
     }
+    if result.paraphraseObserved {
+      await ContextProactivityTelemetry.recordFactIdentityShadow()
+    }
+    return result.versionID
   }
 
   func purgeExcludedApp(_ appName: String, now: Date = Date()) async throws -> Set<String> {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -145,6 +145,17 @@ enum ScreenDerivedContent {
 }
 
 enum ContextProactivityTelemetry {
+  /// Shadow-only repetition signal. The event intentionally carries no
+  /// identifier, statement, bucket, app, or owner data; it is never consulted
+  /// for fact validity, delivery, or candidate graduation.
+  static func recordFactIdentityShadow() async {
+    await MainActor.run {
+      PostHogManager.shared.track(
+        "context_bucket_fact_identity_shadow",
+        properties: ["classification": "same_identifier_different_statement"])
+    }
+  }
+
   static func boundedProviderModel(_ value: String) -> String {
     switch value.lowercased() {
     case "gpt-5.6-luna": "gpt-5.6-luna"

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -135,7 +135,7 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
   func testCanonicalIdentifierSetKeyIsNormalizationOnlyAndKeepsDistinctSetsSeparate() {
     XCTAssertEqual(
       BucketFactValidator.canonicalIdentifierSetKey([" Handoff-013 ", "handoff-013", ""]),
-      "handoff-013")
+      "[\"handoff-013\"]")
     XCTAssertEqual(
       BucketFactValidator.canonicalIdentifierSetKey(["task-014", "task-013"]),
       BucketFactValidator.canonicalIdentifierSetKey([" TASK-013 ", "task-014 "]))

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -132,6 +132,58 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       .superseded)
   }
 
+  func testCanonicalIdentifierSetKeyIsNormalizationOnlyAndKeepsDistinctSetsSeparate() {
+    XCTAssertEqual(
+      BucketFactValidator.canonicalIdentifierSetKey([" Handoff-013 ", "handoff-013", ""]),
+      "handoff-013")
+    XCTAssertEqual(
+      BucketFactValidator.canonicalIdentifierSetKey(["task-014", "task-013"]),
+      BucketFactValidator.canonicalIdentifierSetKey([" TASK-013 ", "task-014 "]))
+    XCTAssertNotEqual(
+      BucketFactValidator.canonicalIdentifierSetKey(["task-013"]),
+      BucketFactValidator.canonicalIdentifierSetKey(["task-014"]))
+    XCTAssertNil(BucketFactValidator.canonicalIdentifierSetKey([" ", "\n"]))
+  }
+
+  func testParaphraseShadowMatchRequiresDifferentStatementAndSameIdentifierSet() {
+    let existing = [
+      BucketFactValidator.ExistingFactIdentity(
+        statement: "Check the handoff status.", identifiers: ["handoff-013"])
+    ]
+    XCTAssertTrue(
+      BucketFactValidator.hasParaphraseMatch(
+        statement: "Verify the handoff is complete.",
+        identifiers: [" HANDOFF-013 "],
+        existingFacts: existing))
+    XCTAssertFalse(
+      BucketFactValidator.hasParaphraseMatch(
+        statement: "Check the handoff status.",
+        identifiers: ["handoff-013"],
+        existingFacts: existing))
+    XCTAssertFalse(
+      BucketFactValidator.hasParaphraseMatch(
+        statement: "Verify another handoff.", identifiers: ["handoff-014"], existingFacts: existing))
+  }
+
+  func testShadowParaphraseObservationDoesNotSuppressAChangedClaim() {
+    let existing = [
+      BucketFactValidator.ExistingFactIdentity(
+        statement: "The handoff is pending.", identifiers: ["handoff-013"])
+    ]
+    XCTAssertTrue(
+      BucketFactValidator.hasParaphraseMatch(
+        statement: "The handoff is complete.",
+        identifiers: ["handoff-013"],
+        existingFacts: existing))
+    XCTAssertEqual(
+      BucketFactValidator.validity(
+        identifiers: ["handoff-013"],
+        evidenceText: "The handoff is complete.",
+        evidenceRefs: ["visit:2"],
+        duplicate: false),
+      .validated)
+  }
+
   func testEvidenceRefsMustResolveAgainstTheCompletedVisit() {
     let refs = BucketFactValidator.resolvableEvidenceRefs(
       ["screenshot:42", "screenshot:999", "instructions:ignore-policy"],


### PR DESCRIPTION
## Summary

- add a privacy-safe shadow classifier for same-identifier, different-statement bucket facts
- emit one bounded PostHog event per matching extraction without changing fact validity, delivery, or candidate behavior
- keep identifier normalization conservative and bucket-scoped

## Product invariants affected

none

Failure-Class: none

## Validation

- `xcrun swift test --package-path Desktop --filter ContextBucketPromptAssemblerTests/` (13 passed)
- `xcrun swift test --package-path Desktop --filter ProactiveLaneClientTests/` (2 passed)
- Swift format lint, desktop test-quality check, and `git diff --check`

## Safety

The event contains only a fixed classification string. It includes no identifier, statement, bucket, app, owner, or screen-derived content and is never consulted for suppression or candidate creation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

