### PR TITLE
fix(ci): keep unconfigured proactive monitor neutral

### DIFF
--- a/.github/scripts/test_desktop_proactive_delivery_health.py
+++ b/.github/scripts/test_desktop_proactive_delivery_health.py
@@ -124,6 +124,15 @@ class ProactiveDeliveryHealthTests(unittest.TestCase):
         self.assertIn("gh issue edit", scheduled_job)
         self.assertIn("gh issue close", scheduled_job)
 
+    def test_workflow_treats_missing_posthog_config_as_neutral(self) -> None:
+        # omi-test-quality: source-inspection -- the scheduled job must not turn missing Actions config into a red alarm.
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        scheduled_job = workflow.split("  proactive-health:\n", 1)[1]
+        self.assertIn("required_config=(POSTHOG_PERSONAL_API_KEY POSTHOG_PROJECT_ID POSTHOG_HOST)", scheduled_job)
+        self.assertIn("status=unconfigured", scheduled_job)
+        self.assertIn("No health alarm was created or updated.", scheduled_job)
+        self.assertNotIn("steps.health.outputs.status == 'unconfigured'", scheduled_job)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_desktop_proactive_delivery_health.py
+++ b/.github/scripts/test_desktop_proactive_delivery_health.py
@@ -131,6 +131,7 @@ class ProactiveDeliveryHealthTests(unittest.TestCase):
         self.assertIn("required_config=(POSTHOG_PERSONAL_API_KEY POSTHOG_PROJECT_ID POSTHOG_HOST)", scheduled_job)
         self.assertIn("status=unconfigured", scheduled_job)
         self.assertIn("No health alarm was created or updated.", scheduled_job)
+        self.assertIn('"status": "monitor_error"', scheduled_job)
         self.assertNotIn("steps.health.outputs.status == 'unconfigured'", scheduled_job)
 
 

--- a/.github/workflows/desktop_release_doctor.yml
+++ b/.github/workflows/desktop_release_doctor.yml
@@ -81,21 +81,51 @@ jobs:
           POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: |
           set -euo pipefail
-          set +e
-          python3 .github/scripts/desktop_proactive_delivery_health.py \
-            --output /tmp/proactive-delivery-health.json \
-            --summary /tmp/proactive-delivery-health.txt
-          query_exit=$?
-          set -e
+          required_config=(POSTHOG_PERSONAL_API_KEY POSTHOG_PROJECT_ID POSTHOG_HOST)
+          missing_config=()
+          for variable in "${required_config[@]}"; do
+            if [[ -z "${!variable:-}" ]]; then
+              missing_config+=("$variable")
+            fi
+          done
 
-          if [[ "$query_exit" -ne 0 ]]; then
-            status=monitor_error
+          if (( ${#missing_config[@]} > 0 )); then
+            status=unconfigured
+            missing_config_csv="$(IFS=', '; echo "${missing_config[*]}")"
             printf '%s\n' \
-              'Proactive delivery health: MONITOR_ERROR' \
-              'The bounded PostHog query failed; inspect this workflow run.' \
+              'Proactive delivery health: UNCONFIGURED' \
+              "Missing required PostHog configuration: $missing_config_csv." \
+              'Set the POSTHOG_PERSONAL_API_KEY secret and POSTHOG_PROJECT_ID/POSTHOG_HOST variables for this workflow.' \
+              'No health alarm was created or updated.' \
               > /tmp/proactive-delivery-health.txt
+            python3 - "${missing_config[@]}" > /tmp/proactive-delivery-health.json <<'PY'
+          import json
+          import sys
+
+          print(json.dumps({
+              "metric": "proactive_delivery",
+              "status": "unconfigured",
+              "missing_config": sys.argv[1:],
+              "privacy": {"user_identifiers_included": False, "content_included": False},
+          }, indent=2, sort_keys=True))
+          PY
           else
-            status="$(python3 -c 'import json; print(json.load(open("/tmp/proactive-delivery-health.json", encoding="utf-8"))["status"])')"
+            set +e
+            python3 .github/scripts/desktop_proactive_delivery_health.py \
+              --output /tmp/proactive-delivery-health.json \
+              --summary /tmp/proactive-delivery-health.txt
+            query_exit=$?
+            set -e
+
+            if [[ "$query_exit" -ne 0 ]]; then
+              status=monitor_error
+              printf '%s\n' \
+                'Proactive delivery health: MONITOR_ERROR' \
+                'The bounded PostHog query failed; inspect this workflow run.' \
+                > /tmp/proactive-delivery-health.txt
+            else
+              status="$(python3 -c 'import json; print(json.load(open("/tmp/proactive-delivery-health.json", encoding="utf-8"))["status"])')"
+            fi
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
           cat /tmp/proactive-delivery-health.txt >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop_release_doctor.yml
+++ b/.github/workflows/desktop_release_doctor.yml
@@ -123,6 +123,15 @@ jobs:
                 'Proactive delivery health: MONITOR_ERROR' \
                 'The bounded PostHog query failed; inspect this workflow run.' \
                 > /tmp/proactive-delivery-health.txt
+              python3 - > /tmp/proactive-delivery-health.json <<'PY'
+          import json
+
+          print(json.dumps({
+              "metric": "proactive_delivery",
+              "status": "monitor_error",
+              "privacy": {"user_identifiers_included": False, "content_included": False},
+          }, indent=2, sort_keys=True))
+          PY
             else
               status="$(python3 -c 'import json; print(json.load(open("/tmp/proactive-delivery-health.json", encoding="utf-8"))["status"])')"
             fi

--- a/desktop/macos/docs/release-health-metrics.md
+++ b/desktop/macos/docs/release-health-metrics.md
@@ -160,8 +160,9 @@ the release-evidence layer (`#9523`) will consume.
 - **Monitor credentials:** the scheduled job reads the repository Actions secret
   `POSTHOG_PERSONAL_API_KEY` and Actions variables `POSTHOG_PROJECT_ID` and `POSTHOG_HOST`. It deliberately
   does not use the approval-protected `prod` environment, which would leave hourly
-  checks waiting for a human. Missing/invalid credentials produce `monitor_error`
-  and open the same durable issue; they never turn the metric green.
+  checks waiting for a human. Missing configuration produces a neutral `unconfigured`
+  result and no health alarm because no measurement occurred. A configured query that
+  fails produces `monitor_error` and opens the durable issue; neither state turns the metric green.
 - **Delivery outcomes:** each `Advice Generated` event carries an opaque
   process-local `delivery_id`. `Advice Delivery Outcome` records a closed
   `outcome` (`delivered`, `suppressed`, or `failed`) and bounded `reason`.


### PR DESCRIPTION
## Summary

- detect missing PostHog monitor configuration before the scheduled query
- report a neutral `unconfigured` state without opening a false health alarm or failing the workflow
- keep configured query failures fail-closed as `monitor_error`

## Product invariants affected

none

Failure-Class: none

## Validation

- `actionlint`
- `python3 -m unittest .github/scripts/test_desktop_proactive_delivery_health.py` (7 passed)
- extracted empty-env workflow execution returns `unconfigured` and creates no alarm

## Context

The scheduled run had empty PostHog key/project/host values and opened issue #11434 even though product health was not measured. No non-approval GitHub environment currently carries the required credentials; this makes missing configuration explicit and neutral rather than misreporting an outage.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


