### PR TITLE
chore(desktop): add proactive monitor changelog

### DIFF
--- a/desktop/macos/changelog/unreleased/20260813-proactive-monitor-config.json
+++ b/desktop/macos/changelog/unreleased/20260813-proactive-monitor-config.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved proactive-notification monitoring so missing analytics configuration is reported accurately"
+}


### PR DESCRIPTION
## Summary

- add the unreleased changelog fragment required by the merged proactive monitor documentation update

## Product invariants affected

none

Failure-Class: none

## Validation

- valid one-line desktop changelog JSON

## Context

Follow-up for the main-push hygiene failure after #11483; the source checks themselves passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

