### PR TITLE
test(desktop): expose synthetic director wording

### DIFF
--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
 import sys
 from urllib import error, request
 
@@ -32,6 +33,8 @@ DIRECTOR_CASES = {
     "commitment-explicit-due-date",
     "commitment-ambiguous-mention",
 }
+
+STABLE_PROACTIVE_ERROR = re.compile(r"\bproactive_(?:http_error status=\d{3}|invalid_response|owner_changed)\b")
 
 
 def map_case(case: dict) -> dict[str, str]:
@@ -128,7 +131,15 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
         with request.urlopen(bridge_request, timeout=45) as response:
             envelope = json.load(response)
     except error.HTTPError as exc:
-        raise RuntimeError(f"{case['id']}: probe returned HTTP {exc.code}") from exc
+        stable_error = None
+        try:
+            error_envelope = json.loads(exc.read(4096))
+            match = STABLE_PROACTIVE_ERROR.search(str(error_envelope.get("error", "")))
+            stable_error = match.group(0) if match else None
+        except (AttributeError, json.JSONDecodeError, UnicodeDecodeError):
+            pass
+        suffix = f" ({stable_error})" if stable_error else ""
+        raise RuntimeError(f"{case['id']}: probe returned HTTP {exc.code}{suffix}") from exc
     if envelope.get("ok") is not True:
         raise RuntimeError(f"{case['id']}: probe failed: {envelope.get('error', 'unknown error')}")
     result = envelope.get("result", envelope)

--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -13,7 +13,7 @@ import json
 import os
 from pathlib import Path
 import sys
-from urllib import request
+from urllib import error, request
 
 
 DIRECTOR_CASES = {
@@ -105,7 +105,7 @@ def validate(deck: dict) -> tuple[int, int]:
     return len(cases), len(DIRECTOR_CASES)
 
 
-def invoke_case(case: dict, port: int) -> dict:
+def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
     """Invoke the no-delivery DEBUG probe against a local named QA bundle."""
     scripts_dir = Path(__file__).resolve().parent
     sys.path.insert(0, str(scripts_dir))
@@ -124,8 +124,11 @@ def invoke_case(case: dict, port: int) -> dict:
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
         method="POST",
     )
-    with request.urlopen(bridge_request, timeout=45) as response:
-        envelope = json.load(response)
+    try:
+        with request.urlopen(bridge_request, timeout=45) as response:
+            envelope = json.load(response)
+    except error.HTTPError as exc:
+        raise RuntimeError(f"{case['id']}: probe returned HTTP {exc.code}") from exc
     if envelope.get("ok") is not True:
         raise RuntimeError(f"{case['id']}: probe failed: {envelope.get('error', 'unknown error')}")
     result = envelope.get("result", envelope)
@@ -133,7 +136,7 @@ def invoke_case(case: dict, port: int) -> dict:
     decision = detail.get("decision")
     polarity = "silence" if decision == "silence" else "notify"
     expected = case["expectedAction"]
-    return {
+    result = {
         "id": case["id"],
         "expectedAction": expected,
         "decision": decision,
@@ -142,6 +145,13 @@ def invoke_case(case: dict, port: int) -> dict:
         "model": detail.get("model"),
         "latency_ms": detail.get("latency_ms"),
     }
+    if include_text:
+        result.update(
+            title=detail.get("title"),
+            message=detail.get("message"),
+            reasoning=detail.get("reasoning"),
+        )
+    return result
 
 
 def main() -> int:
@@ -153,6 +163,11 @@ def main() -> int:
     )
     parser.add_argument("--emit-probe-params", action="store_true")
     parser.add_argument("--invoke", action="store_true")
+    parser.add_argument(
+        "--include-text",
+        action="store_true",
+        help="Include synthetic probe title/message/reasoning in live replay output.",
+    )
     parser.add_argument("--port", type=int, default=47910)
     args = parser.parse_args()
     deck = json.loads(Path(args.fixture).read_text(encoding="utf-8"))
@@ -162,7 +177,21 @@ def main() -> int:
         print(json.dumps([{"id": case["id"], "params": map_case(case)} for case in director_cases], indent=2))
         return 0
     if args.invoke:
-        results = [invoke_case(case, args.port) for case in director_cases]
+        results = []
+        for case in director_cases:
+            try:
+                results.append(invoke_case(case, args.port, include_text=args.include_text))
+            except (RuntimeError, OSError, ValueError) as exc:
+                results.append(
+                    {
+                        "id": case["id"],
+                        "expectedAction": case["expectedAction"],
+                        "decision": None,
+                        "polarity": "error",
+                        "matched": False,
+                        "error": str(exc),
+                    }
+                )
         print(json.dumps(results, indent=2))
         matched = sum(result["matched"] for result in results)
         print(f"context bucket director replay: {matched}/{len(results)} polarity matches")

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -3,3 +3,84 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../../.."
 python3 desktop/macos/scripts/context-bucket-benchmark.py
+
+python3 - <<'PY'
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest.mock import patch
+from urllib import error
+
+path = Path("desktop/macos/scripts/context-bucket-benchmark.py")
+spec = importlib.util.spec_from_file_location("context_bucket_benchmark", path)
+benchmark = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(benchmark)
+
+case = {
+    "id": "synthetic-text-output",
+    "expectedAction": "notify",
+    "synthetic": {
+        "bucket": {"id": "bucket-1", "version": 1, "notifyWorthiness": 1, "entries": []},
+        "frames": [
+            {
+                "capturedAt": "2026-08-13T16:00:00Z",
+                "appName": "SyntheticEditor",
+                "windowTitle": "Synthetic window",
+            }
+        ],
+        "tasks": [],
+    },
+}
+envelope = {
+    "ok": True,
+    "result": {
+        "detail": {
+            "decision": "suggest",
+            "model": "synthetic-model",
+            "latency_ms": "1",
+            "title": "Synthetic title",
+            "message": "Synthetic message",
+            "reasoning": "Synthetic reasoning",
+        }
+    },
+}
+
+
+class Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        import json
+
+        return json.dumps(envelope).encode()
+
+
+token_module = types.ModuleType("automation_token_lib")
+token_module.automation_token = lambda _port: "synthetic-token"
+sys.modules["automation_token_lib"] = token_module
+with patch.object(benchmark.request, "urlopen", return_value=Response()):
+    terse = benchmark.invoke_case(case, 47910)
+    detailed = benchmark.invoke_case(case, 47910, include_text=True)
+
+assert "title" not in terse and "message" not in terse and "reasoning" not in terse
+assert detailed["title"] == "Synthetic title"
+assert detailed["message"] == "Synthetic message"
+assert detailed["reasoning"] == "Synthetic reasoning"
+
+with patch.object(
+    benchmark.request,
+    "urlopen",
+    side_effect=error.HTTPError("http://127.0.0.1", 400, "Bad Request", None, None),
+):
+    try:
+        benchmark.invoke_case(case, 47910)
+    except RuntimeError as exc:
+        assert str(exc) == "synthetic-text-output: probe returned HTTP 400"
+    else:
+        raise AssertionError("HTTP probe failure must carry the scenario ID")
+PY

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -6,6 +6,7 @@ python3 desktop/macos/scripts/context-bucket-benchmark.py
 
 python3 - <<'PY'
 import importlib.util
+import io
 from pathlib import Path
 import sys
 import types
@@ -83,4 +84,21 @@ with patch.object(
         assert str(exc) == "synthetic-text-output: probe returned HTTP 400"
     else:
         raise AssertionError("HTTP probe failure must carry the scenario ID")
+
+stable_error_body = io.BytesIO(
+    b'{"ok":false,"error":"action failed: proactive_http_error status=429"}'
+)
+with patch.object(
+    benchmark.request,
+    "urlopen",
+    side_effect=error.HTTPError("http://127.0.0.1", 400, "Bad Request", None, stable_error_body),
+):
+    try:
+        benchmark.invoke_case(case, 47910)
+    except RuntimeError as exc:
+        assert str(exc) == (
+            "synthetic-text-output: probe returned HTTP 400 (proactive_http_error status=429)"
+        )
+    else:
+        raise AssertionError("stable proactive failure must survive the bridge envelope")
 PY


### PR DESCRIPTION
## Summary
- add an opt-in `--include-text` mode for the synthetic context-bucket live replay
- preserve terse default output and the no-delivery probe boundary
- cover the output contract without a network or model call

## Verification
- `bash desktop/macos/tests/test-context-bucket-benchmark.sh`
- `python3 -m py_compile desktop/macos/scripts/context-bucket-benchmark.py`
- `git diff --check`

## Failure-Class
- none; this is a developer-only qualitative QA improvement


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

