### PR TITLE
fix: omi-lib Swift SDK resolves and builds on macOS (#11442)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "omi-lib",
     platforms: [
-        .iOS(.v17)  // Set minimum version to iOS 17
+        .iOS(.v17),  // Set minimum version to iOS 17
+        .macOS(.v14)  // SwiftData parity with iOS 17; AudioKit needs macOS 11+
     ],
     products: [
         .library(

--- a/sdks/swift/Sources/omi-lib/FriendManager.swift
+++ b/sdks/swift/Sources/omi-lib/FriendManager.swift
@@ -5,7 +5,6 @@
 //  Created by Ash Bhat on 9/28/24.
 //
 
-import UIKit
 import CoreBluetooth
 import Speech
 import AVFoundation


### PR DESCRIPTION
## Bug

`#11442` — the repository-root `Package.swift` (the `omi-lib` Swift SDK, sources in `sdks/swift`) declared iOS-only platforms, so SwiftPM assumed macOS 10.13 and refused to resolve against AudioKit (macOS 11+):

```
$ xcrun swift build --package-path .
error: the library 'omi-lib' requires macos 10.13, but depends on the product 'AudioKit'
which requires macos 11.0; consider changing the library 'omi-lib' to require macos 11.0
or later, ...
```

The SDK could not be built or resolved on a macOS host at all. Because the file sits at the repo root it also shadows `desktop/macos/Desktop` for anyone running `swift build`/`swift test` from the root — the AudioKit platform error gives no hint that the directory is the problem, after a ~300 MB dependency checkout.

## Root cause

`platforms:` listed only `.iOS(.v17)`. With no `.macOS` entry SwiftPM falls back to the 10.13 default, which is below every macOS-capable dependency's floor.

## Fix

- Declare `.macOS(.v14)` alongside the existing iOS 17 floor — v14 rather than v11 because `sdks/swift` uses SwiftData (`UserDevice.swift`, `Recording.swift`), whose macOS floor is 14 and which is the macOS parity of the declared iOS 17.
- Drop the unused `import UIKit` in `FriendManager.swift`, the only remaining macOS-incompatible line in the target. No `UI*` symbol is referenced anywhere in the file (`SFSpeechRecognizer` comes from `Speech`, already imported), so this is a dead import, not a port.

Two lines total; no runtime behavior changes on any platform.

## Verified

Both builds run on this machine (macOS 26.x, Xcode 26.4, Swift 6.x):

- `xcrun swift build --package-path .` → `Build complete! (6.91s)`. Before the change, the same command failed with the AudioKit 10.13/11.0 resolution error quoted above.
- `xcodebuild -scheme omi-lib -destination 'generic/platform=iOS' build` → `** BUILD SUCCEEDED **`, confirming the iOS path is unaffected by the dropped import.
- `make preflight` (deterministic check manifest, local lane) passes.

No regression test is added: the guard for this defect would be a macOS build lane for the SDK package, and repo policy is that a new check lands wired into an existing CI lane — out of scope for a two-line manifest fix, and this PR deliberately does not touch `.github/workflows/`.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

