### PR TITLE
fix(desktop): distinguish existing task nudges

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -176,6 +176,8 @@ enum ContextProactivityPromptBuilder {
       \(ScreenDerivedContent.untrustedPreamble)
       Decide whether interrupting now adds concrete value. Return silence unless the validated
       facts support a specific, timely action. Use only supplied bucket-entry refs.
+      Use resurface or suggest for an open task already supplied below. Use task_candidate only
+      for a new validated commitment that is not already in the supplied task list.
 
       \(stableBucket)
       """

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -64,6 +64,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       ScreenDerivedContent.untrustedPreamble,
       "Decide whether interrupting now adds concrete value. Return silence unless the validated",
       "facts support a specific, timely action. Use only supplied bucket-entry refs.",
+      "Use resurface or suggest for an open task already supplied below. Use task_candidate only",
+      "for a new validated commitment that is not already in the supplied task list.",
       "",
       bucket,
       "",


### PR DESCRIPTION
## Summary
- tell the context director to use suggest/resurface for an already supplied open task
- reserve task_candidate for a newly validated commitment not already in the task list
- prevent stochastic duplicate task creation for the same existing commitment

## Evidence
A five-run synthetic replay of the same already-open one-hour commitment was behaviorally correct 5/5, but varied once between resurface and suggest. Earlier runs also produced task_candidate. The user-facing reminder was good; the durable action type was not stable enough.

## Validation
- swift-format lint on changed files
- desktop test-quality policy passes
- diff check clean
- focused prompt expectation updated

## Invariants
- [x] INV-GROUNDING-1 decision remains grounded in validated facts and supplied tasks
- [x] INV-IDEMPOTENCY-1 existing tasks are not recreated as candidates


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

