### PR TITLE
test(desktop): assert director decision types

### DIFF
--- a/desktop/macos/e2e/fixtures/context-bucket-proactivity-benchmark.json
+++ b/desktop/macos/e2e/fixtures/context-bucket-proactivity-benchmark.json
@@ -1061,6 +1061,7 @@
         ]
       },
       "expectedAction": "notify",
+      "allowedDecisions": ["suggest", "resurface"],
       "expectedEvidenceRefs": ["evidence:privacy:025-deadline"],
       "expectedSubject": {"kind": "task", "id": "task-privacy-025", "workstreamId": "workstream-alpha"},
       "expectedMaxAge": 3600,
@@ -1186,6 +1187,7 @@
         ]
       },
       "expectedAction": "notify",
+      "allowedDecisions": ["suggest", "resurface"],
       "expectedEvidenceRefs": ["evidence:commit:022"],
       "expectedSubject": {"kind": "commitment", "id": "commitment-022", "workstreamId": "workstream-alpha"},
       "expectedMaxAge": 3600,

--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -36,6 +36,7 @@ DIRECTOR_CASES = {
 }
 
 STABLE_PROACTIVE_ERROR = re.compile(r"\bproactive_(?:http_error status=\d{3}|invalid_response|owner_changed)\b")
+DIRECTOR_DECISIONS = {"suggest", "insight", "task_candidate", "resurface", "silence"}
 
 
 def map_case(case: dict) -> dict[str, str]:
@@ -103,6 +104,11 @@ def validate(deck: dict) -> tuple[int, int]:
             not isinstance(term, str) or not term.strip() for term in forbidden_output_terms
         ):
             raise ValueError(f"{case['id']}: forbiddenOutputTerms must be non-empty strings")
+        allowed_decisions = case.get("allowedDecisions", [])
+        if not isinstance(allowed_decisions, list) or any(
+            decision not in DIRECTOR_DECISIONS for decision in allowed_decisions
+        ):
+            raise ValueError(f"{case['id']}: allowedDecisions must use director decision values")
         if case["id"] in DIRECTOR_CASES:
             params = map_case(case)
             required = {
@@ -151,7 +157,7 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
     result = envelope.get("result", envelope)
     detail = result.get("detail", result)
     decision = detail.get("decision")
-    if decision not in {"suggest", "insight", "task_candidate", "resurface", "silence"}:
+    if decision not in DIRECTOR_DECISIONS:
         raise RuntimeError(f"{case['id']}: probe returned invalid decision")
     polarity = "silence" if decision == "silence" else "notify"
     expected = case["expectedAction"]
@@ -163,13 +169,16 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
         term for term in forbidden_output_terms if term.casefold() in response_text
     ]
     polarity_matched = expected == "either" or expected == polarity
+    allowed_decisions = case.get("allowedDecisions", [])
+    decision_matched = not allowed_decisions or decision in allowed_decisions
     result = {
         "id": case["id"],
         "expectedAction": expected,
         "decision": decision,
         "polarity": polarity,
-        "matched": polarity_matched and not forbidden_terms_matched,
+        "matched": polarity_matched and decision_matched and not forbidden_terms_matched,
         "polarity_matched": polarity_matched,
+        "decision_matched": decision_matched,
         "forbidden_output_matched": bool(forbidden_terms_matched),
         "forbidden_terms_matched": forbidden_terms_matched,
         "model": detail.get("model"),

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -21,6 +21,7 @@ spec.loader.exec_module(benchmark)
 case = {
     "id": "synthetic-text-output",
     "expectedAction": "notify",
+    "allowedDecisions": ["suggest", "resurface"],
     "forbiddenOutputTerms": ["forbidden phrase"],
     "synthetic": {
         "bucket": {"id": "bucket-1", "version": 1, "notifyWorthiness": 1, "entries": []},
@@ -74,6 +75,7 @@ assert detailed["title"] == "Synthetic title"
 assert detailed["message"] == "Synthetic message"
 assert detailed["reasoning"] == "Synthetic reasoning"
 assert detailed["polarity_matched"] is True
+assert detailed["decision_matched"] is True
 assert detailed["forbidden_output_matched"] is False
 assert detailed["forbidden_terms_matched"] == []
 
@@ -81,9 +83,17 @@ leaking_case = {**case, "forbiddenOutputTerms": ["synthetic MESSAGE"]}
 with patch.object(benchmark.request, "urlopen", return_value=Response()):
     leaking = benchmark.invoke_case(leaking_case, 47910)
 assert leaking["polarity_matched"] is True
+assert leaking["decision_matched"] is True
 assert leaking["forbidden_output_matched"] is True
 assert leaking["forbidden_terms_matched"] == ["synthetic MESSAGE"]
 assert leaking["matched"] is False
+
+wrong_type_case = {**case, "allowedDecisions": ["resurface"]}
+with patch.object(benchmark.request, "urlopen", return_value=Response()):
+    wrong_type = benchmark.invoke_case(wrong_type_case, 47910)
+assert wrong_type["polarity_matched"] is True
+assert wrong_type["decision_matched"] is False
+assert wrong_type["matched"] is False
 
 envelope["result"]["detail"]["decision"] = "unexpected"
 with patch.object(benchmark.request, "urlopen", return_value=Response()):


### PR DESCRIPTION
## Summary
- let synthetic director cases constrain allowed decision subtypes, not only notify/silence polarity
- require suggest/resurface for the two supplied existing-task scenarios
- fail the replay if either drifts back to task_candidate

## Validation
- offline benchmark contract: 25 cases / 15 mappings
- focused benchmark shell tests pass
- diff check clean

## Scope
This is a replay contract, not fuzzy production task deduplication. Durable identity remains a separate design problem.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

