### PR TITLE
test(desktop): report replay contract failures

### DIFF
--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -171,6 +171,13 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
     polarity_matched = expected == "either" or expected == polarity
     allowed_decisions = case.get("allowedDecisions", [])
     decision_matched = not allowed_decisions or decision in allowed_decisions
+    failure_reasons = []
+    if not polarity_matched:
+        failure_reasons.append("polarity")
+    if not decision_matched:
+        failure_reasons.append("decision")
+    if forbidden_terms_matched:
+        failure_reasons.append("forbidden_output")
     result = {
         "id": case["id"],
         "expectedAction": expected,
@@ -181,6 +188,7 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
         "decision_matched": decision_matched,
         "forbidden_output_matched": bool(forbidden_terms_matched),
         "forbidden_terms_matched": forbidden_terms_matched,
+        "failure_reasons": failure_reasons,
         "model": detail.get("model"),
         "latency_ms": detail.get("latency_ms"),
     }
@@ -233,7 +241,7 @@ def main() -> int:
                 )
         print(json.dumps(results, indent=2))
         matched = sum(result["matched"] for result in results)
-        print(f"context bucket director replay: {matched}/{len(results)} polarity matches")
+        print(f"context bucket director replay: {matched}/{len(results)} behavioral contracts passed")
         return 0 if matched == len(results) else 1
     print(f"context bucket benchmark contract passed: {total} cases, {director} director mappings")
     return 0

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -78,6 +78,7 @@ assert detailed["polarity_matched"] is True
 assert detailed["decision_matched"] is True
 assert detailed["forbidden_output_matched"] is False
 assert detailed["forbidden_terms_matched"] == []
+assert detailed["failure_reasons"] == []
 
 leaking_case = {**case, "forbiddenOutputTerms": ["synthetic MESSAGE"]}
 with patch.object(benchmark.request, "urlopen", return_value=Response()):
@@ -86,6 +87,7 @@ assert leaking["polarity_matched"] is True
 assert leaking["decision_matched"] is True
 assert leaking["forbidden_output_matched"] is True
 assert leaking["forbidden_terms_matched"] == ["synthetic MESSAGE"]
+assert leaking["failure_reasons"] == ["forbidden_output"]
 assert leaking["matched"] is False
 
 wrong_type_case = {**case, "allowedDecisions": ["resurface"]}
@@ -93,6 +95,7 @@ with patch.object(benchmark.request, "urlopen", return_value=Response()):
     wrong_type = benchmark.invoke_case(wrong_type_case, 47910)
 assert wrong_type["polarity_matched"] is True
 assert wrong_type["decision_matched"] is False
+assert wrong_type["failure_reasons"] == ["decision"]
 assert wrong_type["matched"] is False
 
 envelope["result"]["detail"]["decision"] = "unexpected"


### PR DESCRIPTION
## Summary
- report whether replay failed polarity, decision subtype, or forbidden output
- rename the aggregate from polarity matches to behavioral contracts passed
- keep per-case diagnosis machine-readable

## Validation
- offline benchmark contract passes
- focused benchmark shell tests pass
- diff check clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

