### PR TITLE
test(desktop): match director task horizon

### DIFF
--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -9,6 +9,7 @@ keeps lifecycle-only cases explicitly separated.
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timedelta
 import json
 import os
 from pathlib import Path
@@ -47,6 +48,8 @@ def map_case(case: dict) -> dict[str, str]:
     if not frames:
         raise ValueError(f"{case['id']}: director case requires a synthetic frame")
     frame = frames[-1]
+    evaluation_time = datetime.fromisoformat(frame["capturedAt"].replace("Z", "+00:00"))
+    task_cutoff = evaluation_time + timedelta(hours=48)
     facts = []
     for entry in entries:
         for fact in entry.get("facts", []):
@@ -62,6 +65,10 @@ def map_case(case: dict) -> dict[str, str]:
         {"description": task["description"], "due_at": task.get("dueAt")}
         for task in synthetic.get("tasks", [])
         if task.get("status") == "open"
+        and (
+            not task.get("dueAt")
+            or datetime.fromisoformat(task["dueAt"].replace("Z", "+00:00")) <= task_cutoff
+        )
     ]
     return {
         "bucket_id": bucket["id"],

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -98,6 +98,22 @@ assert wrong_type["decision_matched"] is False
 assert wrong_type["failure_reasons"] == ["decision"]
 assert wrong_type["matched"] is False
 
+horizon_case = {
+    **case,
+    "synthetic": {
+        **case["synthetic"],
+        "tasks": [
+            {"description": "overdue", "status": "open", "dueAt": "2026-08-13T15:00:00Z"},
+            {"description": "near", "status": "open", "dueAt": "2026-08-15T16:00:00Z"},
+            {"description": "far", "status": "open", "dueAt": "2026-08-15T16:00:01Z"},
+            {"description": "undated", "status": "open"},
+            {"description": "done", "status": "completed", "dueAt": "2026-08-13T17:00:00Z"},
+        ],
+    },
+}
+mapped_tasks = __import__("json").loads(benchmark.map_case(horizon_case)["tasks"])
+assert [task["description"] for task in mapped_tasks] == ["overdue", "near", "undated"]
+
 envelope["result"]["detail"]["decision"] = "unexpected"
 with patch.object(benchmark.request, "urlopen", return_value=Response()):
     try:


### PR DESCRIPTION
## Summary
- make synthetic replay map the same open/undated/due-within-48-hours task horizon as production
- exclude completed and farther-future tasks before the director probe
- add exact 48-hour boundary coverage

## Validation
- offline benchmark 25/15 contract passes
- focused benchmark shell tests pass
- freshness-new-identifier now maps no 3-4 day tasks, matching production


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

