### PR TITLE
fix(desktop): prevent duplicate far-future tasks

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -187,8 +187,14 @@ enum ContextProactivityPromptBuilder {
     tasks: [ContextDirectorTaskContext],
     frame: CapturedFrame
   ) -> String {
+    let actionableCutoff = frame.captureTime.addingTimeInterval(
+      ContextDirectorTaskSelection.futureHorizon)
     let taskLines: [String] = tasks.prefix(20).map { task -> String in
       guard let dueAt = task.dueAt else { return "- \(task.description)" }
+      if dueAt > actionableCutoff {
+        return
+          "- \(task.description)\n  Due at (UTC): \(utcTimestamp(dueAt))\n  Reference only: already exists; do not resurface or create it yet."
+      }
       return "- \(task.description)\n  Due at (UTC): \(utcTimestamp(dueAt))"
     }
     let taskContext = taskLines.joined(separator: "\n")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -48,9 +48,11 @@ enum ContextDirectorTaskSelection {
       tasks
       .filter { task in
         !task.completed && !task.isRetired && !task.isPendingSuggestion
-          && task.dueAt.map { $0 <= cutoff } != false
       }
       .sorted { lhs, rhs in
+        let leftIsReference = lhs.dueAt.map { $0 > cutoff } ?? false
+        let rightIsReference = rhs.dueAt.map { $0 > cutoff } ?? false
+        if leftIsReference != rightIsReference { return !leftIsReference }
         let left = lhs.dueAt ?? .distantFuture
         let right = rhs.dueAt ?? .distantFuture
         if left != right { return left < right }

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -93,7 +93,7 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertEqual(task.description.count, ContextDirectorTaskContext.maximumDescriptionLength)
   }
 
-  func testDirectorTaskSelectionIncludesNearFutureAndUndatedButExcludesFarFutureAndCompleted() {
+  func testDirectorTaskSelectionIncludesFarFutureAsReferenceAfterActionableTasks() {
     let now = Date(timeIntervalSince1970: 1_700_000_000)
     let tasks = [
       task("tomorrow", dueAt: now.addingTimeInterval(24 * 60 * 60)),
@@ -104,7 +104,24 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
 
     XCTAssertEqual(
       ContextDirectorTaskSelection.select(from: tasks, now: now).map(\.description),
-      ["tomorrow", "undated"])
+      ["tomorrow", "undated", "far"])
+  }
+
+  func testDirectorPromptMarksFarFutureTaskReferenceOnly() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000)
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket", versionID: 1, version: 1, header: "header",
+      frozenRankedSegment: Data(), tail: [], validatedFacts: ["fact"], notifyWorthiness: 1)
+    let prompt = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot,
+      tasks: [
+        ContextDirectorTaskContext(
+          description: "Far task", dueAt: now.addingTimeInterval(72 * 60 * 60))
+      ],
+      frame: CapturedFrame(jpegData: Data(), appName: "Notes", captureTime: now))
+
+    XCTAssertTrue(
+      prompt.contains("Reference only: already exists; do not resurface or create it yet."))
   }
 
   func testFrozenRankedSegmentIsConcatenatedByteForByte() {

--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -9,7 +9,6 @@ keeps lifecycle-only cases explicitly separated.
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timedelta
 import json
 import os
 from pathlib import Path
@@ -48,8 +47,6 @@ def map_case(case: dict) -> dict[str, str]:
     if not frames:
         raise ValueError(f"{case['id']}: director case requires a synthetic frame")
     frame = frames[-1]
-    evaluation_time = datetime.fromisoformat(frame["capturedAt"].replace("Z", "+00:00"))
-    task_cutoff = evaluation_time + timedelta(hours=48)
     facts = []
     for entry in entries:
         for fact in entry.get("facts", []):
@@ -65,10 +62,6 @@ def map_case(case: dict) -> dict[str, str]:
         {"description": task["description"], "due_at": task.get("dueAt")}
         for task in synthetic.get("tasks", [])
         if task.get("status") == "open"
-        and (
-            not task.get("dueAt")
-            or datetime.fromisoformat(task["dueAt"].replace("Z", "+00:00")) <= task_cutoff
-        )
     ]
     return {
         "bucket_id": bucket["id"],

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -112,7 +112,7 @@ horizon_case = {
     },
 }
 mapped_tasks = __import__("json").loads(benchmark.map_case(horizon_case)["tasks"])
-assert [task["description"] for task in mapped_tasks] == ["overdue", "near", "undated"]
+assert [task["description"] for task in mapped_tasks] == ["overdue", "near", "far", "undated"]
 
 envelope["result"]["detail"]["decision"] = "unexpected"
 with patch.object(benchmark.request, "urlopen", return_value=Response()):


### PR DESCRIPTION
## Summary
- retain bounded far-future existing tasks as reference-only director context
- place actionable <=48h and undated work before reference-only tasks
- tell the director not to resurface or recreate far-future references
- keep synthetic replay aligned with the production selection

## Evidence
Production-faithful replay of Follow-up 014 hid its existing 3-4 day task, causing Luna to return task_candidate for an item that already existed. Fuzzy task matching would risk suppressing changed commitments; bounded reference-only context prevents the duplicate without making far-future work actionable.

## Validation
- swift-format lint on changed Swift files
- desktop test-quality policy passes
- offline 25/15 benchmark contract passes
- focused benchmark shell tests pass
- new prompt/ordering assertions


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

