### PR TITLE
test(desktop): supply captured frame number

### DIFF
--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -119,7 +119,7 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
         ContextDirectorTaskContext(
           description: "Far task", dueAt: now.addingTimeInterval(72 * 60 * 60))
       ],
-      frame: CapturedFrame(jpegData: Data(), appName: "Notes", captureTime: now))
+      frame: CapturedFrame(jpegData: Data(), appName: "Notes", frameNumber: 10, captureTime: now))
 
     XCTAssertTrue(
       prompt.contains("Reference only: already exists; do not resurface or create it yet."))


### PR DESCRIPTION
## Summary
- update the context prompt test fixture for the required `CapturedFrame.frameNumber` initializer argument
- restore Swift test compilation on current main

## Verification
- `git diff --check`
- `swift-format-wrapper.sh lint --strict Desktop/Tests/ContextBucketPromptAssemblerTests.swift`
- `swiftc -parse -swift-version 6 Desktop/Tests/ContextBucketPromptAssemblerTests.swift`
- bounded pre-push checks passed; full Swift compile deferred to CI because the local FluidAudio dependency cache was missing pinned commit `19600a4`

## Invariants
- INV-DESKTOP-SWIFT-CI
- INV-CONTEXT-BUCKET-PROMPT-CONTRACT

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

