### PR TITLE
fix(backend): product memory search 500s on every non-empty page (#11438)

### DIFF
--- a/.github/failure-classes/FC-response-model-decoupled-from-projection.json
+++ b/.github/failure-classes/FC-response-model-decoupled-from-projection.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-response-model-decoupled-from-projection",
+  "violated_contract": "A route's declared response model must validate the exact payload that route returns. When the model names an internal record type the read seam never emits, response validation fails on every populated page while empty pages still succeed, so the route 500s exactly when it has results.",
+  "canonical_prevention": "Declare the response model on the projection the route actually emits, and cover it with a test that serializes a real non-empty projection through a real framework route so the framework's own response validation executes. Route tests that stub the web framework out never run that validation and cannot catch the divergence.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_product_memory_search_response_contract.py"
+  ],
+  "evidence_prs": [
+    11501
+  ],
+  "scope_hints": [
+    "backend/models/*.py",
+    "backend/routers/*.py"
+  ],
+  "status": "open"
+}

--- a/backend/models/memory_product.py
+++ b/backend/models/memory_product.py
@@ -7,10 +7,39 @@ these fields.
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from models.memory_admin import ReadRolloutConsumerObservability
 from models.product_memory import MemoryItem
+
+
+class ProductMemorySearchItem(BaseModel):
+    """One product memory search result row.
+
+    This is the projection the read seam emits (``_product_memory_result`` in
+    ``utils.memory.memory_read_api`` and the equivalent universal projection in
+    ``MemoryService.default_product_search``) — not a raw ``MemoryItem``.
+    Unknown keys are preserved so a projection gaining a field does not silently
+    drop it from the wire.
+    """
+
+    model_config = ConfigDict(extra='allow')
+
+    memory_id: str = Field(description='Logical memory id.')
+    memory_layer: str = Field(description='Read layer that produced the row (always product_memory here).')
+    tier: str = Field(description='Memory tier value (short_term, long_term, archive).')
+    content: str = Field(description='Memory content text.')
+    lifecycle_status: str = Field(description='Lifecycle status of the underlying item.')
+    processing_state: str = Field(description='Processing state of the underlying item.')
+    confidence: Optional[float] = Field(default=None, description='Confidence score when the layer emits one.')
+    visibility: Optional[str] = Field(default=None, description='Visibility of the memory.')
+    visibility_source: str = Field(description='Which read seam decided the visibility value.')
+    source: Optional[str] = Field(default=None, description='Primary evidence source id, when present.')
+    date: str = Field(description='ISO-8601 timestamp of the last update.')
+    evidence: List[Dict[str, Any]] = Field(default_factory=list, description='Evidence payloads for the row.')
+    agent_use: str = Field(description='How an agent may use this row.')
+    access_reason: str = Field(description='Why this row was admitted by the access policy.')
+    superseded_by: Optional[str] = Field(default=None, description='Memory id that supersedes this row, if any.')
 
 
 class MemorySearchPolicyPayload(BaseModel):
@@ -56,7 +85,7 @@ class ProductMemorySearchResponse(BaseModel):
 
     uid: str = Field(description='Authenticated user id.')
     query: str = Field(description='Search query string.')
-    items: List[MemoryItem] = Field(description='Default-visible memory items for the current page.')
+    items: List[ProductMemorySearchItem] = Field(description='Default-visible memory rows for the current page.')
     total_count: int = Field(description='Total default-visible items matching the query.')
     returned_count: int = Field(description='Number of items returned in this page.')
     limit: int = Field(description='Bounded page size used for this response.')

--- a/backend/tests/unit/test_product_memory_search_response_contract.py
+++ b/backend/tests/unit/test_product_memory_search_response_contract.py
@@ -1,0 +1,190 @@
+"""Response-contract tests for the product memory search routes.
+
+The routers declare ``response_model=ProductMemorySearchResponse`` /
+``ArchiveProductMemorySearchResponse``, so FastAPI validates every response
+body against those models. The rest of the product-memory router suite stubs
+``fastapi`` out entirely and calls the endpoint functions directly, which never
+exercises that validation — the shipped default page 500'd on any non-empty
+result while the suite stayed green (issue #11438). These tests run the real
+projection through the real response model behind a real FastAPI route.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+import pytest  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from config.memory_rollout import universal_memory_capabilities  # noqa: E402
+from models.memory_evidence import (  # noqa: E402
+    ArtifactPreservationState,
+    MemoryEvidence,
+    SourceState,
+)
+from models.memory_product import (  # noqa: E402
+    ArchiveProductMemorySearchResponse,
+    ProductMemorySearchResponse,
+)
+from models.product_memory import (  # noqa: E402
+    MemoryAccessPolicy,
+    MemoryItem,
+    MemoryItemStatus,
+    MemoryLayer,
+    ProcessingState,
+)
+from utils.memory.default_read_rollout import (  # noqa: E402
+    DefaultReadRolloutDecision,
+    build_default_read_rollout_observability,
+)
+from utils.memory.memory_read_api import (  # noqa: E402
+    query_archive_product_memory_items,
+    query_default_product_memory_items,
+)
+
+NOW = datetime(2026, 6, 19, 12, 0, tzinfo=timezone.utc)
+CAPTURED_AT = NOW - timedelta(days=1)
+
+
+def _memory_item(memory_id: str, *, tier: MemoryLayer) -> MemoryItem:
+    return MemoryItem(
+        memory_id=memory_id,
+        uid='u1',
+        version=1,
+        tier=tier,
+        status=MemoryItemStatus.active,
+        processing_state=ProcessingState.processed,
+        content='prefers strong coffee before software review',
+        evidence=[
+            MemoryEvidence(
+                evidence_id=f'ev-{memory_id}',
+                source_id='conv1',
+                source_type='conversation',
+                source_version='v1',
+                artifact_preservation=ArtifactPreservationState.preserved,
+                source_state=SourceState.active,
+            )
+        ],
+        source_state=SourceState.active,
+        sensitivity_labels=[],
+        visibility='private',
+        user_asserted=False,
+        captured_at=CAPTURED_AT,
+        updated_at=CAPTURED_AT,
+        ledger_commit_id='commit-1',
+        ledger_sequence=1,
+    )
+
+
+def _policy_payload(policy: MemoryAccessPolicy) -> dict:
+    return {
+        'consumer': policy.consumer.value,
+        'app_has_default_memory_grant': policy.app_has_default_memory_grant,
+        'archive_capability': policy.archive_capability,
+        'raw_provenance_capability': policy.raw_provenance_capability,
+    }
+
+
+def _rollout_payload(policy: MemoryAccessPolicy, *, archive: bool) -> dict:
+    decision = DefaultReadRolloutDecision(
+        uid='u1',
+        source_path='users/u1/memory_control/default_read_rollout',
+        consumer=policy.consumer.value,
+        rollout_capabilities=universal_memory_capabilities('u1'),
+        app_has_default_memory_grant=policy.app_has_default_memory_grant,
+        archive_capability=policy.archive_capability,
+    )
+    observability = build_default_read_rollout_observability(decision)
+    observability.update(
+        {
+            'surface': 'product_archive_search' if archive else 'product_default_search',
+            'archive_capability_required': archive,
+            'archive_capability_granted': policy.archive_capability,
+            'explicit_archive_request': archive,
+            'app_context': {},
+        }
+    )
+    return observability
+
+
+def _envelope(policy: MemoryAccessPolicy, items: list, *, archive: bool) -> dict:
+    payload = {
+        'uid': 'u1',
+        'query': 'coffee',
+        'items': items,
+        'total_count': len(items),
+        'returned_count': len(items),
+        'limit': 100,
+        'offset': 0,
+        'archive_default_visible': False,
+        'policy': _policy_payload(policy),
+        'global_read_gate': {
+            'source_path': 'memory_control/global_read_gate',
+            'read_decision': 'USE_MEMORY',
+            'fallback_reason': None,
+            'reason': 'ok',
+        },
+        'rollout': _rollout_payload(policy, archive=archive),
+    }
+    if archive:
+        payload['archive_capability_required'] = True
+        payload['archive_capability_granted'] = policy.archive_capability
+    return payload
+
+
+def _client(response_model, payload: dict) -> TestClient:
+    app = FastAPI()
+
+    @app.get('/memory/search', response_model=response_model)
+    def _search():
+        return payload
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize('query', ['coffee', 'zzzznomatch'])
+def test_default_product_search_response_serializes_matching_and_empty_pages(query: str):
+    policy = MemoryAccessPolicy.for_omi_chat(archive_capability=False)
+    items = query_default_product_memory_items(
+        query,
+        [_memory_item('mem-long-term', tier=MemoryLayer.long_term)],
+        policy=policy,
+        now=NOW,
+    )
+    assert len(items) == (1 if query == 'coffee' else 0)
+
+    response = _client(ProductMemorySearchResponse, _envelope(policy, items, archive=False)).get('/memory/search')
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item['memory_id'] for item in body['items']] == [item['memory_id'] for item in items]
+    if items:
+        assert body['items'][0]['memory_layer'] == 'product_memory'
+        assert body['items'][0]['content'] == items[0]['content']
+        assert body['items'][0]['date'] == items[0]['date']
+        assert body['items'][0]['access_reason'] == items[0]['access_reason']
+        assert body['items'][0]['evidence'] == items[0]['evidence']
+
+
+def test_archive_product_search_response_serializes_matching_page():
+    policy = MemoryAccessPolicy.for_omi_chat(archive_capability=True)
+    items = query_archive_product_memory_items(
+        'coffee',
+        [_memory_item('mem-archive', tier=MemoryLayer.archive)],
+        policy=policy,
+        now=NOW,
+    )
+    assert len(items) == 1
+
+    response = _client(ArchiveProductMemorySearchResponse, _envelope(policy, items, archive=True)).get('/memory/search')
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item['memory_id'] for item in body['items']] == ['mem-archive']
+    assert body['items'][0]['agent_use'] == 'explicit_archive_memory'
+    assert body['archive_capability_granted'] is True


### PR DESCRIPTION
## Bug

`GET /v1/memory/search` (and `/v1/memory/archive/search`) return **500 on any page that has at least one result**. Empty result pages return 200, which is why it went unnoticed — the memory-platform web surface cannot render real search results at all (#11438).

## Root cause

Both routes declare `response_model=ProductMemorySearchResponse`, whose `items` was typed `List[MemoryItem]`. Neither route ever emits `MemoryItem` rows. Both read seams — `_product_memory_result` in `backend/utils/memory/memory_read_api.py` and the universal projection in `MemoryService.default_product_search` — emit the same 15-key projection (`memory_id`, `memory_layer`, `tier`, `content`, `lifecycle_status`, `processing_state`, `confidence`, `visibility`, `visibility_source`, `source`, `date`, `evidence`, `agent_use`, `access_reason`, `superseded_by`). `MemoryItem` requires `version`, `uid`, `status`, `source_state`, `sensitivity_labels`, `user_asserted`, `captured_at`, `updated_at` — none of which the projection carries, so FastAPI response validation raised on every row.

The existing router suite (`backend/tests/unit/test_product_memory_router.py`) stubs `fastapi` out entirely and calls the endpoint functions directly, so it never executed response validation and stayed green through the whole outage.

## Fix

- New `ProductMemorySearchItem` models the projection the routes actually emit; `ProductMemorySearchResponse.items` (and, by inheritance, the archive response) is typed on it. `extra='allow'` so a projection gaining a field is not silently dropped from the wire.
- `VectorMemorySearchResponse` keeps `List[MemoryItem]` — it dumps real `MemoryItem` records and was never affected.
- Regression test serializes a real projection through a real FastAPI route, so the framework's own response validation runs.

## Tested

Backend canonical venv (`backend/.venv`, python 3.11, locked fastapi/pydantic):

- `pytest tests/unit/test_product_memory_search_response_contract.py tests/unit/test_product_memory_router.py` → **21 passed**
- Same new test with `models/memory_product.py` reverted → **2 failed, 1 passed**: the populated default page and the populated archive page 500 with `ResponseValidationError` (`{'type': 'missing', 'loc': ('response', 'items', 0, 'version')}`, …), the empty page passes — reproducing the reported symptom exactly.
- `make preflight` (local lane, 10 manifest checks) → passed; bounded pre-push gate → passed.

Not run: the full `PROVIDER_MODE=offline make dev-up` harness the issue used. The regression test drives the same seam that 500s — the real projection through the real response model behind a real FastAPI route.

Fixes #11438

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

