### PR TITLE
test(desktop): unwrap async capture status result

### DIFF
--- a/desktop/macos/Desktop/Tests/ProactiveCaptureStatusSnapshotTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveCaptureStatusSnapshotTests.swift
@@ -30,8 +30,8 @@
       XCTAssertTrue(descriptor.sideEffects.contains { $0.contains("app names") })
       XCTAssertEqual(descriptor.params, [])
 
-      let detail = try XCTUnwrap(
-        await registry.perform("proactive_capture_status_snapshot", params: [:]))
+      let result = await registry.perform("proactive_capture_status_snapshot", params: [:])
+      let detail = try XCTUnwrap(result)
       XCTAssertEqual(
         Set(detail.keys),
         Set([


### PR DESCRIPTION
## Summary
- await the capture-status action before passing its optional result to `XCTUnwrap`
- restore Swift 6 test compilation and the sentinel launcher contract

## Verification
- `git diff --check`
- `swift-format-wrapper.sh lint --strict Desktop/Tests/ProactiveCaptureStatusSnapshotTests.swift`
- `swiftc -parse -swift-version 6 Desktop/Tests/ProactiveCaptureStatusSnapshotTests.swift`
- bounded pre-push checks passed; full Swift compile deferred to CI

## Invariants
- INV-DESKTOP-SWIFT-CI
- INV-CONTEXT-BUCKET-CAPTURE-DIAGNOSTICS

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

