### PR TITLE
test(desktop): await throwing capture status result

### DIFF
--- a/desktop/macos/Desktop/Tests/ProactiveCaptureStatusSnapshotTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveCaptureStatusSnapshotTests.swift
@@ -30,7 +30,7 @@
       XCTAssertTrue(descriptor.sideEffects.contains { $0.contains("app names") })
       XCTAssertEqual(descriptor.params, [])
 
-      let result = await registry.perform("proactive_capture_status_snapshot", params: [:])
+      let result = try await registry.perform("proactive_capture_status_snapshot", params: [:])
       let detail = try XCTUnwrap(result)
       XCTAssertEqual(
         Set(detail.keys),


### PR DESCRIPTION
## Summary
- use `try await` for the throwing capture-status registry action before synchronous `XCTUnwrap`
- complete the Swift 6 test compilation repair exposed by exact-main CI

## Verification
- `git diff --check`
- targeted swift-format lint
- `swiftc -parse -swift-version 6`
- bounded pre-push checks passed; full Swift type-check deferred to CI

## Invariants
- INV-DESKTOP-SWIFT-CI
- INV-CONTEXT-BUCKET-CAPTURE-DIAGNOSTICS

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

