### PR TITLE
test(desktop): align assistant prompt bounds

### DIFF
--- a/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
@@ -5,10 +5,19 @@ import XCTest
 final class APIClientAssistantSettingsTests: XCTestCase {
 
   @MainActor
-  func testShippedTaskPromptFitsBackendSyncContract() {
-    XCTAssertLessThanOrEqual(
-      TaskAssistantSettings.defaultAnalysisPrompt.count,
+  func testShippedTaskPromptExceedsBackendBoundAndIsOmittedFromSync() {
+    // The shipped default task prompt has been over the backend's 10k-code-point
+    // bound since at least June 2026, so it is deliberately omitted from sync
+    // (partial PATCH semantics) rather than truncated or sent to be 422-rejected.
+    // Raising the bound needs the backend limit deployed first: issue #11481.
+    XCTAssertGreaterThan(
+      TaskAssistantSettings.defaultAnalysisPrompt.unicodeScalars.count,
       TaskAssistantSettings.maximumSyncedAnalysisPromptLength)
+    XCTAssertNil(
+      SettingsSyncManager.promptForSync(
+        TaskAssistantSettings.defaultAnalysisPrompt,
+        assistantName: "task",
+        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength))
   }
 
   @MainActor
@@ -39,20 +48,18 @@ final class APIClientAssistantSettingsTests: XCTestCase {
 
   @MainActor
   func testEachAssistantPromptUsesItsBackendBound() {
-    let legacyMaximum = 10_000
-    let prompt = String(repeating: "x", count: legacyMaximum + 1)
+    // All three assistants share the backend's 10k bound today; task has no raised
+    // bound until the backend limit ships first (issue #11481).
+    let backendMaximum = 10_000
+    XCTAssertEqual(TaskAssistantSettings.maximumSyncedAnalysisPromptLength, backendMaximum)
+    let prompt = String(repeating: "x", count: backendMaximum + 1)
 
-    XCTAssertNotNil(
-      SettingsSyncManager.promptForSync(
-        prompt,
-        assistantName: "task",
-        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength))
-    XCTAssertNil(
-      SettingsSyncManager.promptForSync(
-        prompt, assistantName: "insight", maximumLength: legacyMaximum))
-    XCTAssertNil(
-      SettingsSyncManager.promptForSync(
-        prompt, assistantName: "memory", maximumLength: legacyMaximum))
+    for assistant in ["task", "insight", "memory"] {
+      XCTAssertNil(
+        SettingsSyncManager.promptForSync(
+          prompt, assistantName: assistant, maximumLength: backendMaximum),
+        "an oversized \(assistant) prompt must be omitted, not truncated or sent")
+    }
   }
 
   @MainActor


### PR DESCRIPTION
## Summary
- align desktop assistant-settings tests with the deployed 10,000-scalar backend contract
- assert the shipped oversized task prompt is intentionally omitted from sync rather than truncated
- preserve the existing per-owner local prompt behavior; no runtime source changes

## Verification
- `xcrun swift test --package-path desktop/macos/Desktop --filter APIClientAssistantSettingsTests` (10/10 passed)
- `python3 desktop/macos/scripts/check_desktop_test_quality.py`

The future backend-first prompt limit increase remains tracked separately in #11481.

Failure-Class: FC-test-contract-ahead-of-deployed-boundary

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

