### PR TITLE
fix(listen): send the first onboarding question when a speech-profile session starts

### DIFF
--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -350,6 +350,7 @@ class ListenSessionRuntime:
                     await request.websocket.send_json(event)
 
             self.onboarding_handler = OnboardingHandler(request.uid, send_onboarding, self.transcripts.enqueue)
+            self.spawn(self.onboarding_handler.send_current_question(), name='onboarding_first_question')
         return True
 
     async def _send_ping(self) -> bool:

--- a/backend/tests/unit/test_listen_runtime_regressions.py
+++ b/backend/tests/unit/test_listen_runtime_regressions.py
@@ -10,7 +10,9 @@ import pytest
 from routers.listen.contracts import ListenRequest
 from routers.listen.runtime import ListenSessionRuntime
 from routers.listen.transcripts import TranscriptProcessor
+from utils.async_tasks import WebSocketTaskSupervisor
 from utils.listen_session_bootstrap import ListenConnectBase
+from utils.onboarding import ONBOARDING_QUESTIONS, OnboardingHandler
 from utils.stt.streaming import STTService
 from starlette.websockets import WebSocketState
 
@@ -190,6 +192,7 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     runtime.request = request
     runtime.use_custom_stt = False
     runtime.state = SimpleNamespace(speaker_id_enabled=False, audio_ring_buffer=None)
+    runtime.task_supervisor = WebSocketTaskSupervisor(uid=request.uid, label='listen')
 
     async def bootstrap_persistence_call(*_args, **_kwargs):
         return False
@@ -219,10 +222,78 @@ async def test_bootstrap_forces_single_language_before_selecting_stt_for_onboard
     monkeypatch.setattr(runtime_module, 'FAIR_USE_ENABLED', False)
     monkeypatch.setattr(runtime_module, 'should_load_speech_profile', lambda **_kwargs: False)
     monkeypatch.setattr(runtime_module, 'should_enable_speaker_identification', lambda **_kwargs: False)
-    monkeypatch.setattr(runtime_module, 'OnboardingHandler', lambda *_args: SimpleNamespace())
+
+    async def _noop_question():
+        return None
+
+    monkeypatch.setattr(
+        runtime_module, 'OnboardingHandler', lambda *_args: SimpleNamespace(send_current_question=_noop_question)
+    )
 
     assert await runtime._bootstrap() is True
+    await runtime.task_supervisor.drain_all(timeout=1.0, cancel=False)
     assert selected_multi_language_options == [('es', False, None)]
+
+
+@pytest.mark.anyio
+async def test_bootstrap_sends_first_onboarding_question_before_any_audio(monkeypatch):
+    """An onboarding session's question flow is server-driven: the first question
+    must reach the client at connect time, before any segments arrive. Dropping
+    this kickoff leaves the speech-profile page frozen at 0% with no question."""
+    import routers.listen.runtime as runtime_module
+
+    sent_events = []
+
+    async def send_json(event):
+        sent_events.append(event)
+
+    request = ListenRequest(
+        websocket=SimpleNamespace(client_state=WebSocketState.CONNECTED, send_json=send_json),
+        uid='onboarding-user',
+        language='en',
+        onboarding_mode=True,
+    )
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.request = request
+    runtime.use_custom_stt = False
+    runtime.state = SimpleNamespace(speaker_id_enabled=False, audio_ring_buffer=None, active=True)
+    runtime.task_supervisor = WebSocketTaskSupervisor(uid=request.uid, label='listen')
+
+    async def bootstrap_persistence_call(*_args, **_kwargs):
+        return False
+
+    runtime.persistence = SimpleNamespace(call=bootstrap_persistence_call)
+    runtime.is_multi_channel = False
+    runtime.has_speech_profile = False
+    enqueued_segments = []
+    runtime.transcripts = SimpleNamespace(enqueue=enqueued_segments.extend)
+    runtime._build_components = lambda: None
+
+    base = ListenConnectBase(
+        user_exists=True,
+        user_has_credits=True,
+        transcription_prefs={'single_language_mode': False, 'uses_custom_stt': False},
+        fair_use_init_stage=None,
+        fair_use_track_dg_usage=False,
+        fair_use_dg_budget_exhausted=False,
+    )
+    monkeypatch.setattr(runtime_module, 'load_listen_connect_base', lambda *_args, **_kwargs: _async_result(base))
+    monkeypatch.setattr(
+        runtime_module, 'get_stt_service_for_language', lambda language, **_kwargs: ('test-stt', 'en', 'test-model')
+    )
+    monkeypatch.setattr(runtime_module, 'FAIR_USE_ENABLED', False)
+    monkeypatch.setattr(runtime_module, 'should_load_speech_profile', lambda **_kwargs: False)
+    monkeypatch.setattr(runtime_module, 'should_enable_speaker_identification', lambda **_kwargs: False)
+
+    assert await runtime._bootstrap() is True
+    await runtime.task_supervisor.drain_all(timeout=2.0, cancel=False)
+
+    assert [event['type'] for event in sent_events] == ['onboarding_question']
+    first_question = sent_events[0]
+    assert first_question['question'] == ONBOARDING_QUESTIONS[0]['question']
+    assert first_question['question_index'] == 0
+    assert first_question['total_questions'] == len(ONBOARDING_QUESTIONS)
+    assert enqueued_segments and enqueued_segments[0]['speaker_id'] == OnboardingHandler.OMI_SPEAKER_ID
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
# fix(listen): send the first onboarding question when a speech-profile session starts

## Problem

The speech profile page (onboarding and Settings > Profile > Speech Profile) shows no question and its progress bar never moves. Audio still streams and a conversation/recording appears later, so the session looks half-alive.

The question flow is server-driven: the client renders whatever `onboarding_question` event the backend pushes, and computes progress as `question_index / total_questions`. PR #9853 split `transcribe.py` into `routers/listen/`, and the split dropped the one-shot kickoff `spawn(onboarding_handler.send_current_question(), ...)` that existed since the flow shipped (#3859). `ListenSessionRuntime._bootstrap` still constructs the `OnboardingHandler`, but nothing ever sends question 0 — `OnboardingHandler.send_current_question` is only reachable after an answer or a skip, which can never happen before the first question exists. The client waits forever on an empty screen at 0%.

## Fix

Restore the kickoff at handler creation in `_bootstrap`, spawned through the session task supervisor (same placement and semantics as the pre-refactor code).

## Regression test

`test_bootstrap_sends_first_onboarding_question_before_any_audio` runs the real `_bootstrap` with a real `OnboardingHandler` and a recording websocket, and asserts that — with no segments having arrived — the client receives exactly one `onboarding_question` event (question 0 of `len(ONBOARDING_QUESTIONS)`) and the question transcript segment is enqueued with the Omi speaker id. This test fails on `main` today and would have caught the drop in #9853.

The existing `_bootstrap` onboarding test's stub handler grew a `send_current_question` coroutine and a real task supervisor, since the production path now calls it.

## Failure class

Failure-Class: none

No existing class matches "one-shot side effect dropped while splitting a module"; this is the first known instance of that cause in this subsystem, so it lands as an instance fix plus the behavioral guard test above.

## Verification

- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-target.txt bash test.sh` (file = `tests/unit/test_listen_runtime_regressions.py`): **20 passed** (includes the new test and the two updated bootstrap tests).
- Full unit-suite run surfaced 7 unrelated files exiting status 1 with **all assertions passing** (e.g. "13 passed" + status 1) — the fast-unit CPU duration guard tripping under heavy parallel load on my machine; those files pass when run normally and none touch the listen runtime.
- Not exercised against a live device end-to-end: the fix is backend-only and the affected path needs a prod-like STT session; the regression test drives the real `_bootstrap` + `OnboardingHandler` wiring.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

