### PR TITLE
fix(desktop): latch the gate-hold test probe so a first-arriving signal is not lost (#11507)

### DIFF
--- a/.github/failure-classes/FC-edge-triggered-test-handoff-signal.json
+++ b/.github/failure-classes/FC-edge-triggered-test-handoff-signal.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-edge-triggered-test-handoff-signal",
+  "violated_contract": "A test probe that hands off between concurrent tasks must latch its signal. When the signal only resumes an already-registered continuation, nothing orders the signalling task before the waiting one, so the interleaving where the signal lands first drops it and suspends the waiter forever. The suite then dies to its per-suite timeout budget rather than failing an assertion, and it does so intermittently, so a rerun looks like a fix.",
+  "canonical_prevention": "Record the signal in probe state and check that state before suspending (`if hasEntered { return }`), so a signal delivered before its waiter is still observed. Cover the probe itself with a test that forces the signal-first ordering.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift"
+  ],
+  "evidence_prs": [
+    11509
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Tests/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -143,24 +143,36 @@ private actor GateAdmissionOrderProbe {
   }
 }
 
+/// Signals are latched, not edge-triggered. The signaller and its waiter run on
+/// separate tasks, so nothing orders `signalEntered()` before `waitUntilEntered()`
+/// (or `release()` before `waitUntilReleased()`); an unlatched signal that lands
+/// first is dropped and its waiter suspends forever, which hangs the whole suite
+/// until the per-suite budget kills it. The other probes in this file latch the
+/// same way.
 private actor GateHoldProbe {
+  private var hasEntered = false
+  private var hasReleased = false
   private var enteredWaiter: CheckedContinuation<Void, Never>?
   private var releaseContinuation: CheckedContinuation<Void, Never>?
 
   func waitUntilEntered() async {
+    if hasEntered { return }
     await withCheckedContinuation { enteredWaiter = $0 }
   }
 
   func signalEntered() {
+    hasEntered = true
     enteredWaiter?.resume()
     enteredWaiter = nil
   }
 
   func waitUntilReleased() async {
+    if hasReleased { return }
     await withCheckedContinuation { releaseContinuation = $0 }
   }
 
   func release() {
+    hasReleased = true
     releaseContinuation?.resume()
     releaseContinuation = nil
   }
@@ -1639,6 +1651,18 @@ final class AgentRuntimeProcessTests: XCTestCase {
     )
     let finalEvents = await harness.snapshot()
     XCTAssertEqual(finalEvents.last, "admission_attempt_2")
+  }
+
+  /// The interleaving the two gate-hold tests below hit when the signalling task wins
+  /// the race: an edge-triggered probe drops both signals and suspends here forever.
+  func testGateHoldProbeObservesSignalsDeliveredBeforeItsWaitersSuspend() async {
+    let holdProbe = GateHoldProbe()
+
+    await holdProbe.signalEntered()
+    await holdProbe.release()
+
+    await holdProbe.waitUntilEntered()
+    await holdProbe.waitUntilReleased()
   }
 
   func testContextAdmissionGateCancelledWaiterDoesNotStealTurn() async throws {


### PR DESCRIPTION
## Bug

`AgentRuntimeProcessTests` intermittently hangs until `swift-test-suites.sh` kills it at the 300s per-suite budget. On `main` at `d1046bb819` that failed `Desktop Swift Static & Test Contracts` → `Desktop Swift Build & Tests` (run 31701243760 attempt 2, job 94455347380; attempt 3 of the same SHA passed):

```
13:19:03Z swift-test-suites.sh: line 112: 52335 Terminated: 15 ...
13:33:56Z --- FAILED: AgentRuntimeProcessTests ---
          suite timed out after 300s
```

Downstream, the 13:39Z `Build Desktop Release Candidate` run saw the newest releasable SHA as blocked, fell back to an older green SHA, and `desktop-release-source-identity.py` hard-failed — no desktop candidate was cut. Fixes #11507.

## Root cause

`GateHoldProbe` is edge-triggered: `signalEntered()`/`release()` resume a stored continuation and drop the signal when no waiter has registered yet. Nothing orders the signalling task against the waiting one in `testContextAdmissionGateCancelledWaiterDoesNotStealTurn` or `testContextAdmissionGateCancellationAfterGrantResumesWaiterOnce`, so on the interleaving where the signaller wins, `waitUntilEntered()` (or `waitUntilReleased()`) suspends forever. Every other probe in the same file — `GatedRuntimeStartupHarness`, `GateGrantCancellationRaceProbe`, the token-refresh harness — latches its signal with a bool checked before awaiting; this one did not.

## Fix

Latch both signals in `GateHoldProbe`, mirroring those probes, and add a regression test that forces the signal-first ordering. Test-only change; no production code touched.

## Tested

- Standalone reproduction of the exact interleaving (`signalEntered()`; `release()`; then the waits) compiled against both probe versions: the current edge-triggered probe never resumes (killed at 5s), the latched probe returns immediately.
- `AgentRuntimeProcessTests` run in isolation via `xcrun swift test --filter AgentRuntimeProcessTests/`: 68 tests, 0 failures — repeated 20x, every run clean (~1.4s).
- `make preflight`: 18/18 manifest checks pass (`scripts/pr-preflight --pr-body-file`). The bounded pre-push gate passed with `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`: its fast debug compile could not resolve the pinned FluidAudio commit from this machine's SwiftPM cache, and the full test-bundle build above already covers that compile.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

