### PR TITLE
fix(app): drop duplicate transcription reconnect attempts

### DIFF
--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -631,7 +631,7 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
               Center(
                 child: Padding(
                   padding: const EdgeInsets.only(bottom: 16.0),
-                  child: Image.asset(DeviceUtils.getDeviceImagePathByModel(widget.wal.deviceModel), height: 60),
+                  child: Image.asset(DeviceUtils.getDeviceImagePath(deviceName: widget.wal.deviceModel), height: 60),
                 ),
               ),
               _buildDetailRow(context.l10n.recordingIdLabel, widget.wal.id),

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -368,13 +368,13 @@ class CaptureController extends ChangeNotifier
   /// on the device connection (e.g. Limitless re-sends enable-data-stream).
   bool _socketReconnectPending = false;
 
-  /// Identifies the transcription socket attempt currently running, or null
-  /// when none is. The keep-alive timer's callback is async, so a tick could
-  /// start the same attempt again before the previous one finished and open a
-  /// duplicate /v4/listen session (issue #11305). Only an identical repeat is
-  /// dropped: an attempt with different parameters is a new intent (starting
-  /// phone mic, a codec change), and a forced one replaces the socket outright.
-  String? _websocketInitInFlightKey;
+  /// How many transcription socket attempts are running, per configuration.
+  /// The keep-alive timer's callback is async, so a tick could start the same
+  /// attempt again before the previous one finished and open a duplicate
+  /// /v4/listen session (issue #11305). Only an identical repeat is dropped:
+  /// an attempt with different parameters is a new intent (starting phone mic,
+  /// a codec change), and a forced one replaces the socket outright.
+  final Map<String, int> _websocketInitInFlight = {};
 
   /// Returns unsynced WALs belonging to the current capture session.
   /// Empty when all frames have been streamed successfully (clean UI).
@@ -646,25 +646,35 @@ class CaptureController extends ChangeNotifier
     bool force = false,
     String? source,
   }) async {
-    final attemptKey = '$audioCodec|$sampleRate|$channels|$isPcm|$source';
-    if (!force && _websocketInitInFlightKey == attemptKey) {
+    // Resolve the defaults here so two callers that spell the same
+    // configuration differently (null vs the value it defaults to) share a key.
+    final effectiveSampleRate = sampleRate ?? mapCodecToSampleRate(audioCodec);
+    final effectiveChannels =
+        channels ?? ((audioCodec == BleAudioCodec.pcm16 || audioCodec == BleAudioCodec.pcm8) ? 1 : 2);
+    final attemptKey = '$audioCodec|$effectiveSampleRate|$effectiveChannels|$isPcm|$source';
+
+    if (!force && _websocketInitInFlight.containsKey(attemptKey)) {
       Logger.debug('initiateWebsocket skipped - an identical connection attempt is already in flight');
       return;
     }
-    _websocketInitInFlightKey = attemptKey;
+    // Counted, because a forced attempt can share the key of the non-forced one
+    // it is replacing; whichever finishes first must not ungate the other.
+    _websocketInitInFlight.update(attemptKey, (running) => running + 1, ifAbsent: () => 1);
     try {
       await _connectTranscriptionSocket(
         audioCodec: audioCodec,
-        sampleRate: sampleRate,
-        channels: channels,
+        sampleRate: effectiveSampleRate,
+        channels: effectiveChannels,
         isPcm: isPcm,
         force: force,
         source: source,
       );
     } finally {
-      // A later attempt owns the key once it starts; only clear our own.
-      if (_websocketInitInFlightKey == attemptKey) {
-        _websocketInitInFlightKey = null;
+      final running = (_websocketInitInFlight[attemptKey] ?? 1) - 1;
+      if (running > 0) {
+        _websocketInitInFlight[attemptKey] = running;
+      } else {
+        _websocketInitInFlight.remove(attemptKey);
       }
     }
   }
@@ -692,8 +702,8 @@ class CaptureController extends ChangeNotifier
 
   Future<void> _connectTranscriptionSocket({
     required BleAudioCodec audioCodec,
-    int? sampleRate,
-    int? channels,
+    required int sampleRate,
+    required int channels,
     bool? isPcm,
     bool force = false,
     String? source,
@@ -709,8 +719,6 @@ class CaptureController extends ChangeNotifier
     }
 
     BleAudioCodec codec = audioCodec;
-    sampleRate ??= mapCodecToSampleRate(codec);
-    channels ??= (codec == BleAudioCodec.pcm16 || codec == BleAudioCodec.pcm8) ? 1 : 2;
 
     Logger.debug('is ws null: ${_socket == null}');
     Logger.debug('Initiating WebSocket with: codec=$codec, sampleRate=$sampleRate, channels=$channels, isPcm=$isPcm');

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -368,6 +368,14 @@ class CaptureController extends ChangeNotifier
   /// on the device connection (e.g. Limitless re-sends enable-data-stream).
   bool _socketReconnectPending = false;
 
+  /// Identifies the transcription socket attempt currently running, or null
+  /// when none is. The keep-alive timer's callback is async, so a tick could
+  /// start the same attempt again before the previous one finished and open a
+  /// duplicate /v4/listen session (issue #11305). Only an identical repeat is
+  /// dropped: an attempt with different parameters is a new intent (starting
+  /// phone mic, a codec change), and a forced one replaces the socket outright.
+  String? _websocketInitInFlightKey;
+
   /// Returns unsynced WALs belonging to the current capture session.
   /// Empty when all frames have been streamed successfully (clean UI).
   List<Wal> get unsyncedSessionWals {
@@ -638,6 +646,58 @@ class CaptureController extends ChangeNotifier
     bool force = false,
     String? source,
   }) async {
+    final attemptKey = '$audioCodec|$sampleRate|$channels|$isPcm|$source';
+    if (!force && _websocketInitInFlightKey == attemptKey) {
+      Logger.debug('initiateWebsocket skipped - an identical connection attempt is already in flight');
+      return;
+    }
+    _websocketInitInFlightKey = attemptKey;
+    try {
+      await _connectTranscriptionSocket(
+        audioCodec: audioCodec,
+        sampleRate: sampleRate,
+        channels: channels,
+        isPcm: isPcm,
+        force: force,
+        source: source,
+      );
+    } finally {
+      // A later attempt owns the key once it starts; only clear our own.
+      if (_websocketInitInFlightKey == attemptKey) {
+        _websocketInitInFlightKey = null;
+      }
+    }
+  }
+
+  /// Opens the transcription socket. Overridden in tests to control the timing
+  /// of an attempt; production always goes through the socket service pool.
+  @visibleForTesting
+  Future<TranscriptSegmentSocketService?> openConversationSocket({
+    required BleAudioCodec codec,
+    required int sampleRate,
+    required String language,
+    required bool force,
+    String? source,
+    CustomSttConfig? customSttConfig,
+  }) {
+    return ServiceManager.instance().socket.conversation(
+          codec: codec,
+          sampleRate: sampleRate,
+          language: language,
+          force: force,
+          source: source,
+          customSttConfig: customSttConfig,
+        );
+  }
+
+  Future<void> _connectTranscriptionSocket({
+    required BleAudioCodec audioCodec,
+    int? sampleRate,
+    int? channels,
+    bool? isPcm,
+    bool force = false,
+    String? source,
+  }) async {
     Logger.debug('initiateWebsocket in capture_provider');
 
     // Batch (offline) mode: never open the realtime transcription socket. The
@@ -670,14 +730,14 @@ class CaptureController extends ChangeNotifier
     }
 
     // Connect to the transcript socket
-    _socket = await ServiceManager.instance().socket.conversation(
-          codec: codec,
-          sampleRate: sampleRate,
-          language: language,
-          force: force,
-          source: source,
-          customSttConfig: effectiveConfig,
-        );
+    _socket = await openConversationSocket(
+      codec: codec,
+      sampleRate: sampleRate,
+      language: language,
+      force: force,
+      source: source,
+      customSttConfig: effectiveConfig,
+    );
     if (_socket == null) {
       _startKeepAliveServices();
       Logger.debug("Can not create new conversation socket");

--- a/app/lib/utils/device.dart
+++ b/app/lib/utils/device.dart
@@ -245,10 +245,4 @@ class DeviceUtils {
 
     return getDeviceImagePath(deviceType: deviceType, modelNumber: modelNumber, deviceName: deviceName);
   }
-
-  /// Legacy method - kept for backwards compatibility
-  @Deprecated('Use getDeviceImagePath with deviceType parameter')
-  static String getDeviceImagePathByModel(String? deviceModel) {
-    return getDeviceImagePath(deviceName: deviceModel);
-  }
 }

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -84,11 +84,13 @@ TranscriptSegment _segment(String id, String text) {
 BtDevice _device({required String id, required DeviceType type, String name = 'TestDevice'}) =>
     BtDevice(id: id, name: name, type: type, rssi: -50);
 
-/// CaptureProvider whose socket opening is held on a gate, so a connection
-/// attempt can be kept in flight while another caller tries to start one.
+/// CaptureProvider whose socket opening is held on a per-call gate, so a
+/// connection attempt can be kept in flight while another caller tries to
+/// start one, and each attempt can be released independently.
 class _GatedSocketCaptureProvider extends CaptureProvider {
-  int openCalls = 0;
-  Completer<void> gate = Completer<void>();
+  final List<Completer<void>> gates = [];
+
+  int get openCalls => gates.length;
 
   @override
   Future<TranscriptSegmentSocketService?> openConversationSocket({
@@ -99,9 +101,18 @@ class _GatedSocketCaptureProvider extends CaptureProvider {
     String? source,
     CustomSttConfig? customSttConfig,
   }) async {
-    openCalls++;
+    final gate = Completer<void>();
+    gates.add(gate);
     await gate.future;
     return null;
+  }
+
+  void release(int attempt) => gates[attempt].complete();
+
+  void releaseAll() {
+    for (final gate in gates) {
+      if (!gate.isCompleted) gate.complete();
+    }
   }
 }
 
@@ -1231,13 +1242,16 @@ void main() {
       await startAttempt(provider);
       expect(provider.openCalls, 1, reason: 'an overlapping attempt must not open a second socket');
 
-      provider.gate.complete();
+      provider.release(0);
       await first;
 
       // The guard clears once the attempt finishes, so reconnects still work.
-      provider.gate = Completer<void>()..complete();
-      await startAttempt(provider);
+      final next = startAttempt(provider);
+      await settle();
       expect(provider.openCalls, 2, reason: 'a later attempt must connect again');
+
+      provider.releaseAll();
+      await next;
       provider.dispose();
     });
 
@@ -1255,8 +1269,34 @@ void main() {
       await settle();
       expect(provider.openCalls, 2, reason: 'a forced reconnect must not be gated');
 
-      provider.gate.complete();
+      provider.releaseAll();
       await first;
+      await forced;
+      provider.dispose();
+    });
+
+    test('stays gated while a forced attempt with the same parameters runs', () async {
+      final provider = _GatedSocketCaptureProvider();
+
+      final first = startAttempt(provider);
+      await settle();
+      expect(provider.openCalls, 1);
+
+      // Same parameters as the attempt in flight, so both share a guard key.
+      provider.updateRecordingState(RecordingState.record);
+      final forced = provider.onTranscriptionSettingsChanged();
+      await settle();
+      expect(provider.openCalls, 2);
+
+      // The first attempt finishing must not ungate the forced one still
+      // connecting, or the next keep-alive tick opens a third socket.
+      provider.release(0);
+      await first;
+
+      await startAttempt(provider);
+      expect(provider.openCalls, 2, reason: 'a repeat must stay gated while the forced attempt is in flight');
+
+      provider.releaseAll();
       await forced;
       provider.dispose();
     });
@@ -1274,7 +1314,7 @@ void main() {
       await settle();
       expect(provider.openCalls, 2, reason: 'a differently configured attempt must not be gated');
 
-      provider.gate.complete();
+      provider.releaseAll();
       await first;
       await other;
       provider.dispose();

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -17,9 +17,11 @@ import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/app_globals.dart';
+import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/services/capture/capture_external_actions.dart';
 import 'package:omi/services/services.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
 import 'package:omi/utils/enums.dart';
 
 /// Fake external actions that tracks people-refresh calls.
@@ -81,6 +83,27 @@ TranscriptSegment _segment(String id, String text) {
 
 BtDevice _device({required String id, required DeviceType type, String name = 'TestDevice'}) =>
     BtDevice(id: id, name: name, type: type, rssi: -50);
+
+/// CaptureProvider whose socket opening is held on a gate, so a connection
+/// attempt can be kept in flight while another caller tries to start one.
+class _GatedSocketCaptureProvider extends CaptureProvider {
+  int openCalls = 0;
+  Completer<void> gate = Completer<void>();
+
+  @override
+  Future<TranscriptSegmentSocketService?> openConversationSocket({
+    required BleAudioCodec codec,
+    required int sampleRate,
+    required String language,
+    required bool force,
+    String? source,
+    CustomSttConfig? customSttConfig,
+  }) async {
+    openCalls++;
+    await gate.future;
+    return null;
+  }
+}
 
 /// Minimal EnvFields stub so Env-backed code paths (e.g. native BLE stream
 /// config reading Env.apiBaseUrl) don't hit a LateInitializationError.
@@ -1163,6 +1186,97 @@ void main() {
       // A socket close is the only thing that should end readiness.
       provider.onClosed();
       expect(provider.transcriptServiceReady, isFalse, reason: 'socket close must end transcript readiness');
+      provider.dispose();
+    });
+  });
+
+  // Regression coverage for issue #11305: the keep-alive reconnect callback is
+  // async, so a tick could call _initiateWebsocket() again while the previous
+  // attempt was still connecting. The capture log showed reconnect attempts 24
+  // and 25 overlapping (12s apart, both reaching service-ready), which opens
+  // duplicate /v4/listen sessions and races the controller state.
+  group('no duplicate transcription connection attempt (#11305)', () {
+    Future<void> settle() async {
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    setUp(() {
+      // Batch mode short-circuits the socket entirely; an earlier test leaves
+      // the shared preference on.
+      SharedPreferencesUtil().batchModeEnabled = false;
+    });
+
+    Future<void> startAttempt(
+      _GatedSocketCaptureProvider provider, {
+      BleAudioCodec codec = BleAudioCodec.pcm16,
+      int sampleRate = 16000,
+    }) =>
+        provider.changeAudioRecordProfile(
+          audioCodec: codec,
+          sampleRate: sampleRate,
+          source: ConversationSource.phone.name,
+        );
+
+    test('drops a reconnect attempt while one is still in flight', () async {
+      final provider = _GatedSocketCaptureProvider();
+
+      final first = startAttempt(provider);
+      await settle();
+      expect(provider.openCalls, 1, reason: 'the first attempt must reach the socket service');
+
+      // Second attempt arrives before the first completes: previously it opened
+      // a second socket, now it is dropped.
+      await startAttempt(provider);
+      expect(provider.openCalls, 1, reason: 'an overlapping attempt must not open a second socket');
+
+      provider.gate.complete();
+      await first;
+
+      // The guard clears once the attempt finishes, so reconnects still work.
+      provider.gate = Completer<void>()..complete();
+      await startAttempt(provider);
+      expect(provider.openCalls, 2, reason: 'a later attempt must connect again');
+      provider.dispose();
+    });
+
+    test('does not drop a forced attempt', () async {
+      final provider = _GatedSocketCaptureProvider();
+
+      final first = startAttempt(provider);
+      await settle();
+      expect(provider.openCalls, 1);
+
+      // Settings/profile changes stop the current socket and must replace it
+      // even while an attempt is in flight.
+      provider.updateRecordingState(RecordingState.record);
+      final forced = provider.onTranscriptionSettingsChanged();
+      await settle();
+      expect(provider.openCalls, 2, reason: 'a forced reconnect must not be gated');
+
+      provider.gate.complete();
+      await first;
+      await forced;
+      provider.dispose();
+    });
+
+    test('does not drop an attempt with different parameters', () async {
+      final provider = _GatedSocketCaptureProvider();
+
+      final first = startAttempt(provider);
+      await settle();
+      expect(provider.openCalls, 1);
+
+      // A different codec is a new intent (e.g. the user starts phone mic while
+      // a device reconnect is in flight), not the same attempt repeated.
+      final other = startAttempt(provider, codec: BleAudioCodec.opus, sampleRate: 16000);
+      await settle();
+      expect(provider.openCalls, 2, reason: 'a differently configured attempt must not be gated');
+
+      provider.gate.complete();
+      await first;
+      await other;
       provider.dispose();
     });
   });


### PR DESCRIPTION
## What

The Flutter capture controller could have two live-transcription connection attempts running at once. `_startKeepAliveServices()` drives reconnects from a `Timer.periodic` whose callback is `async`, so a 15s tick could call `_initiateWebsocket()` again while the previous attempt was still awaiting `_getAudioCodec()` / the socket connect. `SocketServicePool.socket()` holds a `Mutex`, so the second attempt was serialized — but never deduplicated: it created a second `/v4/listen` session and raced the controller/UI state.

This counts the attempts in flight per configuration (codec, sample rate, channels, isPcm, source — codec defaults resolved first, so `null` and the value it defaults to share a key) and drops a **non-forced repeat of a running attempt**. Deliberately narrow:

- a **differently configured** attempt still runs — e.g. the user starts phone mic (pcm16/16000) while a device reconnect is in flight, which must not be swallowed;
- a **forced** attempt still runs — settings change, record-profile change and `_ensureDeviceSocketConnection()` intentionally replace the current socket;
- the key is released in a `finally`, and only when the last attempt holding it finishes — a forced attempt sharing the key of the one it replaces cannot be ungated early (caught in review by cubic), and `PureSocket` uses a 15s `connectTimeout`, so it cannot wedge reconnects. The keep-alive timer keeps ticking, so a dropped repeat retries on the next tick.

## Evidence from the issue

#11305 (production iOS app, freshly paired CV1 on stock firmware 3.0.21): reconnect attempt 24 started at 2026-08-09 20:21:26.820 UTC and attempt 25 at 20:21:39.015 — before 24 completed — and both reached service-ready. The reporter asked for "at most one pending live-transcription connection attempt per capture session".

## What I tested

- `app/test.sh` — **1272 passed**, including four new tests in `test/providers/capture_provider_test.dart` driven through a `@visibleForTesting` socket-open seam whose completion is gated by a `Completer`:
  - an identical repeat while an attempt is in flight opens no second socket, and reconnects still work once the attempt finishes;
  - a forced attempt is not gated;
  - a differently configured attempt is not gated;
  - a repeat stays gated while a forced attempt with the *same* parameters is still connecting.
- The duplicate-attempt test **fails against the unpatched controller** (the repeat opens a second socket), and the interleaving test **fails if the guard releases its key without counting** — both are real regression tests, not tautologies.
- `app/scripts/analyze_ratchet.sh` — passed (see the second commit).
- `make preflight` — passed.

**Not verified on a device.** The reported path needs an iOS build with a CV1 and a real network drop; this ran headless, so the guard is proven by the controller-level tests above, not by a live reconnect.

## Second commit

`DeviceUtils.getDeviceImagePathByModel` was `@Deprecated` with one remaining caller, and that occurrence is already on `main` while `analysis_baseline.json` has `deprecated_member_use_from_same_package: 0` — so `scripts/analyze_ratchet.sh` (a CI gate on every `app/` PR) was failing before this change. The caller now makes the identical `getDeviceImagePath(deviceName: ...)` call and the wrapper is gone, per the repo's no-compatibility-layer rule.

Failure-Class: none

Auto-generated from issue feedback by the mini issues-improver — tested and merged.
