### PR TITLE
fix(desktop): derive the sequential test cluster from the owner-authority fixture (#11511)

### DIFF
--- a/.github/failure-classes/FC-hand-listed-test-isolation-membership.json
+++ b/.github/failure-classes/FC-hand-listed-test-isolation-membership.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-hand-listed-test-isolation-membership",
+  "violated_contract": "A test runner that must serialize the suites touching a process-global domain has to derive that membership from the property that makes a suite unsafe, not from a hand-maintained list. A list drifts silently: the next suite to adopt the same fixture stays in the parallel pool, a concurrent sibling mutates the shared state underneath it, and the suite fails with a production error payload that looks like a product bug rather than a scheduling defect.",
+  "canonical_prevention": "Derive the isolation cluster from the source signal (here: a test file's use of RuntimeOwnerAuthorityTestFixture, which transitions the process-global owner authority through the standard UserDefaults domain) and union it with any explicit list, so omission is not an opt-out. Prove the derivation in the runner's hermetic self-test with an adopter suite that is deliberately absent from the explicit list.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/scripts/swift-test-suites.sh",
+    "desktop/macos/tests/test-swift-test-suites.sh"
+  ],
+  "evidence_prs": [
+    9597
+  ],
+  "scope_hints": [
+    "desktop/macos/scripts/swift-test-suites.sh",
+    "desktop/macos/tests/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -19,6 +19,8 @@ WORKERS="${OMI_SWIFT_TEST_SUITE_WORKERS:-${SWIFT_TEST_SUITE_WORKERS:-4}}"
 # cfprefsd service even when workers have distinct CFFIXED_USER_HOME values.
 # Keep the small auth cluster sequential and give each suite a fresh runtime;
 # the remaining hundreds of suites retain worker-level parallelism.
+# Membership is also derived from the source below, so a new adopter of the
+# owner-authority fixture cannot silently rejoin the parallel pool.
 SERIAL_SUITES="${OMI_SWIFT_TEST_SERIAL_SUITES:-APIClientAuthRetryTests AuthRefreshResilienceTests AuthSessionAttemptFenceTests AuthTokenStorageTests ChatToolExecutorCreateMemoryTests FirebaseAuthAvailabilityTests KernelJournalOwnerBoundAuthTests RuntimeOwnerIdentityTests}"
 PREBUILD="${OMI_SWIFT_TEST_PREBUILD:-1}"
 # The per-suite budget must clear the slowest legitimate suite, not the median
@@ -173,19 +175,49 @@ fi
 
 # Discover suites recursively so tests in subfolders of Desktop/Tests are not
 # silently skipped (SwiftPM compiles the whole Tests target; this must match).
+suite_class_pattern='^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) [A-Za-z0-9_]+:.*XCTestCase'
+suite_class_name='s/^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) ([A-Za-z0-9_]+):.*/\5/'
+
 declare -a suites=()
 while IFS= read -r suite; do
   suites+=("$suite")
 done < <(find "$TESTS_ROOT" -type f -name '*.swift' -print0 \
-  | xargs -0 grep -hE '^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) [A-Za-z0-9_]+:.*XCTestCase' \
-  | sed -E 's/^[[:space:]]*(@[A-Za-z0-9_]+[[:space:]]+)*(public |internal |private |fileprivate |open )?(final )?(class|extension) ([A-Za-z0-9_]+):.*/\5/' \
+  | xargs -0 grep -hE "$suite_class_pattern" \
+  | sed -E "$suite_class_name" \
   | sort -u)
+
+# A suite that drives RuntimeOwnerAuthorityTestFixture transitions the
+# process-global owner authority through that same standard domain, so it
+# belongs to the sequential cluster whether or not anyone remembered to list
+# it. ChatToolExecutorPolicyTests did not, and a concurrent suite moving
+# `auth_userId` underneath it failed its tool calls with
+# `authorized_execution_owner_changed`, which blocked a release cut (#11511).
+declare -a fixture_files=()
+while IFS= read -r fixture_file; do
+  fixture_files+=("$fixture_file")
+done < <(find "$TESTS_ROOT" -type f -name '*.swift' \
+  -exec grep -l 'RuntimeOwnerAuthorityTestFixture' {} +)
+
+declare -a derived_serial_suites=()
+if [ "${#fixture_files[@]}" -gt 0 ]; then
+  while IFS= read -r suite; do
+    derived_serial_suites+=("$suite")
+  done < <(grep -hE "$suite_class_pattern" "${fixture_files[@]}" \
+    | sed -E "$suite_class_name" \
+    | sort -u)
+fi
 
 is_serial_suite() {
   case " $SERIAL_SUITES " in
     *" $1 "*) return 0 ;;
-    *) return 1 ;;
   esac
+  local candidate
+  for candidate in ${derived_serial_suites[@]+"${derived_serial_suites[@]}"}; do
+    if [ "$candidate" = "$1" ]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 declare -a parallel_suites=()

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -69,6 +69,15 @@ final class AuthTokenStorageTests: XCTestCase {
     func testOne() {}
 }
 SWIFT
+# Never listed in OMI_SWIFT_TEST_SERIAL_SUITES below: the runner must derive its
+# sequential membership from the owner-authority fixture it drives.
+cat >"$TMPDIR/tests/OwnerAuthorityAdopterTests.swift" <<'SWIFT'
+import XCTest
+final class OwnerAuthorityAdopterTests: XCTestCase {
+    private var ownerFixture: RuntimeOwnerAuthorityTestFixture!
+    func testOne() {}
+}
+SWIFT
 
 cat >"$TMPDIR/bin/xcrun" <<'SH'
 #!/usr/bin/env bash
@@ -113,7 +122,8 @@ if [[ "$*" == *"swift test"* ]]; then
   # Do not rendezvous on specific suite names: xargs -P 2 starts the first two
   # suites alphabetically, which are not guaranteed to be AlphaTests/BetaTests.
   active_count="$(find "$active_dir" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')"
-  if [[ "$suite" == AuthRefreshResilienceTests || "$suite" == AuthTokenStorageTests ]] \
+  if [[ "$suite" == AuthRefreshResilienceTests || "$suite" == AuthTokenStorageTests \
+    || "$suite" == OwnerAuthorityAdopterTests ]] \
     && [ "$active_count" -ge 2 ]; then
     touch "$FAKE_XCRUN_SYNC_DIR/serial-overlap"
   fi
@@ -173,12 +183,21 @@ fi
 if ! grep -q "alpha failed" "$TMPDIR/runner.out"; then
   fail "runner did not preserve the failed suite log"
 fi
-if ! grep -q "Ran 8 Swift suites in isolation with 2 worker(s)." "$TMPDIR/runner.out"; then
+if ! grep -q "Ran 9 Swift suites in isolation with 2 worker(s)." "$TMPDIR/runner.out"; then
   fail "runner did not report suite count and worker count"
 fi
 if [ -f "$FAKE_XCRUN_SYNC_DIR/serial-overlap" ]; then
   fail "shared-auth-domain suites overlapped another suite"
 fi
+derived_serial_scratch="$(awk -F '\t' '$1 == "OwnerAuthorityAdopterTests" {print $2}' \
+  "$FAKE_XCRUN_SCRATCH_LOG")"
+if [ -z "$derived_serial_scratch" ]; then
+  fail "runner did not execute the owner-authority fixture suite"
+fi
+case "$derived_serial_scratch" in
+  */serial-*.build) ;;
+  *) fail "runner did not derive sequential execution from the owner-authority fixture" ;;
+esac
 if ! grep -q -- "--skip ChatDiscoverabilityTests/testAgentControlCapabilitiesMatchCanonicalManifest" "$FAKE_XCRUN_LOG"; then
   fail "runner did not pass ratcheted skips to SwiftPM"
 fi
@@ -202,7 +221,7 @@ unset OMI_SWIFT_TEST_SUITE_WORKERS SWIFT_TEST_SUITE_WORKERS
 if "$RUNNER" >"$TMPDIR/default-runner.out" 2>"$TMPDIR/default-runner.err"; then
   fail "default runner unexpectedly succeeded despite AlphaTests failure"
 fi
-if ! grep -q "Ran 8 Swift suites in isolation with 4 worker(s)," "$TMPDIR/default-runner.out"; then
+if ! grep -q "Ran 9 Swift suites in isolation with 4 worker(s)," "$TMPDIR/default-runner.out"; then
   fail "runner did not default local suite execution to four workers"
 fi
 
@@ -212,7 +231,7 @@ export OMI_SWIFT_TEST_SERIAL_SUITES="ActionItemsFTSRepairTests AlphaTests APICli
 if "$RUNNER" >"$TMPDIR/all-serial-runner.out" 2>"$TMPDIR/all-serial-runner.err"; then
   fail "all-serial runner unexpectedly succeeded despite AlphaTests failure"
 fi
-if ! grep -q "Ran 8 Swift suites in isolation with 1 worker(s)," "$TMPDIR/all-serial-runner.out"; then
+if ! grep -q "Ran 9 Swift suites in isolation with 1 worker(s)," "$TMPDIR/all-serial-runner.out"; then
   fail "all-serial runner did not report one effective worker"
 fi
 export OMI_SWIFT_TEST_SERIAL_SUITES="AuthRefreshResilienceTests AuthTokenStorageTests"


### PR DESCRIPTION
Fixes #11511.

## Bug

`ChatToolExecutorPolicyTests.testTaskDeleteAndCompleteReachTaskStorage` failed on `main` at `bdc5bc2233` (Desktop Swift CI run 31710277815, job 94481412653). Both tool calls returned the owner-authority revocation payload:

```
complete_task returned: {"ok":false,"error":{"code":"authorized_execution_owner_changed",
 "message":"The signed-in account changed while the authorized tool was executing."}}
```

That reddened `Desktop Swift Build & Tests` for the SHA, so the 14:33Z `Build Desktop Release Candidate` run (31710846941) refused to cut: `Desktop candidate source gate blocked: required check Desktop Swift Build & Tests for exact source SHA bdc5bc2233... completed with failure`. One release cycle lost to a test-scheduling defect.

## Root cause

`RuntimeOwnerAuthorityTestFixture` transitions the process-global owner authority by writing `auth_userId` into the **production-standard** `UserDefaults` domain. `swift-test-suites.sh` already knows that domain cannot be parallelized — hosted runners route it through the shared `cfprefsd` even with per-worker `CFFIXED_USER_HOME` — and keeps a `SERIAL_SUITES` cluster for it. But membership was a hand-maintained string: of the six suites using the fixture, only `ChatToolExecutorCreateMemoryTests` was listed. The other five ran in the parallel pool, so a concurrent sibling establishing its own owner moved `auth_userId` underneath the running suite, `RuntimeOwnerAuthorizationAuthority.revokeUnexpectedOwnerMismatch()` fired, and every subsequent tool call returned `authorized_execution_owner_changed`.

## Fix

Derive the sequential membership from the source signal instead of restating it: any suite whose file uses `RuntimeOwnerAuthorityTestFixture` joins the cluster, unioned with the explicit `SERIAL_SUITES` list. That covers `CaptureScreenToolTests`, `ChatToolExecutorPolicyTests`, `CreateCalendarEventToolTests`, `HomeSuggestionsStoreTests` and `StartupWarmupPolicyTests` today, and any future adopter automatically — omission is no longer an opt-out. The five suites are small; they add ~1 min to the serial phase of a ~30 min job.

## Verification

- `desktop/macos/tests/test-swift-test-suites.sh` — extended with `OwnerAuthorityAdopterTests`, a fixture-using suite deliberately **absent** from `OMI_SWIFT_TEST_SERIAL_SUITES`. It asserts the suite ran on a `serial-*.build` scratch path and never overlapped another suite. Passes with this change; with `swift-test-suites.sh` reverted it fails with `FAIL: shared-auth-domain suites overlapped another suite` — the guard reproduces the defect.
- Real suites on this branch: driving the runner over the real `Desktop/Tests` tree with a recording `xcrun` shim, all six fixture suites (`CaptureScreenToolTests`, `ChatToolExecutorCreateMemoryTests`, `ChatToolExecutorPolicyTests`, `CreateCalendarEventToolTests`, `HomeSuggestionsStoreTests`, `StartupWarmupPolicyTests`) now land on `serial-*.build`; before the change five of them ran on `worker-0/1/2.build`, i.e. genuinely concurrently. 582 suites discovered, 13 sequential, 569 still parallel.
- **Mechanism reproduced against the real suite.** With a foreign writer flipping `auth_userId` in the shared `com.apple.dt.xctest.tool` domain — exactly what a concurrent fixture suite is — `ChatToolExecutorPolicyTests` failed 6/6 runs with the identical CI signature (`complete_task`/`delete_task` returning `authorized_execution_owner_changed`); with the writer stopped it passed 3/3. The suite alone, and all six fixture suites run concurrently in 8 rounds without a foreign writer, are green — which is why this only bites on a loaded hosted runner.
- `make preflight`: passed, 10 checks (`PYTHON=python3.12`, python3 shimmed to 3.12 — the repo tooling needs >=3.10).

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

