### PR TITLE
Keep onboarding content clear of progress and permission controls

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -271,8 +271,6 @@ struct OnboardingChatView: View {
               .id("quick-replies")
             }
 
-            // Retry "Open System Settings" button — shown when a permission grant
-            // is pending but System Settings didn't open (or user closed it)
             if let pending = pendingPermissionType,
               quickReplyOptions.isEmpty && !chatProvider.isSending
             {
@@ -280,7 +278,8 @@ struct OnboardingChatView: View {
                 switch pending {
                 case "screen_recording": return !appState.hasScreenRecordingPermission
                 case "microphone": return !appState.hasMicrophonePermission
-                case "accessibility": return !appState.hasAccessibilityPermission
+                case "notifications": return !appState.hasNotificationPermission
+                case "accessibility": return !appState.hasAccessibilityPermission || appState.isAccessibilityBroken
                 case "automation": return !appState.hasAutomationPermission
                 case "full_disk_access": return !appState.hasFullDiskAccess
                 default: return false
@@ -291,26 +290,23 @@ struct OnboardingChatView: View {
                   .frame(maxWidth: .infinity, alignment: .leading)
                   .padding(.leading, OmiSpacing.page)
 
-                Button(action: {
-                  openSettingsForPermission(pending)
-                }) {
-                  HStack(spacing: OmiSpacing.xs) {
-                    Image(systemName: "gear")
-                      .font(.system(size: 12))
-                    Text("Open \(permissionLabel(pending)) Settings")
-                      .font(.system(size: 13, weight: .medium))
+                HStack(spacing: OmiSpacing.md) {
+                  Button("Open \(permissionLabel(pending)) Settings") { openSettingsForPermission(pending) }
+                    .buttonStyle(InkButtonStyle(kind: .primary))
+                  Button("Skip for now") {
+                    guard pendingPermissionType == pending else { return }
+                    pendingPermissionType = nil
+                    permissionHelpTimer?.cancel()
+                    permissionHelpTimer = nil
+                    PermissionDragGuidance.dismiss()
+                    Task { await chatProvider.sendMessage("Skip") }
                   }
-                  .foregroundColor(Ink.surface)
-                  .padding(.horizontal, OmiSpacing.lg)
-                  .padding(.vertical, OmiSpacing.sm)
-                  .background(Capsule(style: .continuous).fill(Ink.primary))
+                  .buttonStyle(InkButtonStyle(kind: .secondary))
                 }
-                .buttonStyle(.plain)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, OmiSpacing.page)
               }
             }
-
             // "Continue" button — shown only after AI calls complete_onboarding
             // and no pending questions or permissions remain.
             if onboardingCompleted && !chatProvider.isSending && quickReplyOptions.isEmpty
@@ -513,6 +509,10 @@ struct OnboardingChatView: View {
   private func openSettingsForPermission(_ type: String) {
     if type == "screen_recording" {
       ScreenCaptureService.openScreenRecordingPreferences()
+      return
+    }
+    if type == "notifications" {
+      appState.openNotificationPreferences()
       return
     }
     let urlString: String? = {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingGlassChrome.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingGlassChrome.swift
@@ -58,6 +58,12 @@ enum OnboardingGlass {
   /// How far a step drifts as it arrives, as a fraction of the card's height.
   static let stepOffsetFraction: CGFloat = 0.015
 
+  /// Extra scroll-content runway below the final row. The progress band is a sibling of the
+  /// scroll view, but a `scrollTo` sentinel at the content edge can still place a tall widget's
+  /// last control flush against that sibling while SwiftUI is settling its layout. Keeping more
+  /// than one band's height here makes the separation structural rather than timing-dependent.
+  static let scrollContentBottomPadding: CGFloat = InkLayout.progressBandHeight + 12
+
   /// The alpha an inactive dot is set at.
   ///
   /// Deliberately an opacity on `Ink.primary` rather than `Ink.secondary`: this is a *fill*, not

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -139,9 +139,13 @@ struct SBOnboardingView: View {
               currentStepContainer(in: panelSize)
                 .id("widget")
             }
-            Color.clear.frame(height: 4).id("bottom")
+            // Keep the last control above the progress band while ScrollViewReader settles after a
+            // growing widget or a streamed message. A tiny sentinel spacer can leave an input or
+            // permission action visually underneath the dots even though the band is a VStack
+            // sibling, so reserve a full band's height plus a small breathing room here as well.
+            Color.clear.frame(height: OnboardingGlass.scrollContentBottomPadding).id("bottom")
           }
-          .padding(.horizontal, 28).padding(.top, 26).padding(.bottom, 10)
+          .padding(.horizontal, 28).padding(.top, 26)
         }
         // **The thread sits on the floor of the card, not its ceiling.** The panel is a fixed
         // 540 × 640 so it never jumps as the conversation grows, which means the first three steps

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -425,6 +425,23 @@ final class OnboardingFlowTests: XCTestCase {
       "SBInkButton must wire opted-in proceed actions to Return")
   }
 
+  func testDirectPermissionRequestsKeepAVisibleSkipEscape() throws {
+    // omi-test-quality: source-inspection -- the direct request_permission path is private SwiftUI state; verify its rendered escape hatch for every advertised permission.
+    let source = try desktopSourceFile("Onboarding/OnboardingChatView.swift")
+    XCTAssertTrue(
+      source.contains("Button(\"Skip for now\")")
+        && source.contains("pendingPermissionType = nil")
+        && source.contains("chatProvider.sendMessage(\"Skip\")"),
+      "a direct permission request must expose the same visible skip control as quick replies")
+    XCTAssertTrue(
+      source.contains("case \"notifications\": return !appState.hasNotificationPermission")
+        && source.contains("appState.isAccessibilityBroken"),
+      "all advertised permissions must participate in the pending-row escape hatch")
+    XCTAssertTrue(
+      source.contains("if type == \"notifications\" {\n      appState.openNotificationPreferences()"),
+      "notifications must keep a working Settings retry beside Skip for now")
+  }
+
   func testSecondBrainCaptureDefaultsToMeetingsWithoutShortcutReminder() throws {
     // omi-test-quality: source-inspection -- static contract: verifies the SwiftUI capture-choice hierarchy and copy
     let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")

--- a/desktop/macos/Desktop/Tests/OnboardingGlassChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingGlassChromeTests.swift
@@ -88,6 +88,13 @@ final class OnboardingGlassChromeTests: XCTestCase {
       "a step without dots must reserve the same strip or the copy shifts by 40 pt between cards")
   }
 
+  func testScrollContentKeepsAFullBandOfClearanceAboveTheProgressBand() {
+    XCTAssertGreaterThan(
+      OnboardingGlass.scrollContentBottomPadding,
+      InkLayout.progressBandHeight,
+      "the scroll sentinel needs more room than the band itself to avoid covering the last control")
+  }
+
   // MARK: - Behaviour: the step transition
 
   /// The drift is a fraction of the card, not a fixed number of points: the same modifier has to read
@@ -128,6 +135,9 @@ final class OnboardingGlassChromeTests: XCTestCase {
     XCTAssertTrue(
       body.contains("OnboardingProgressBand("),
       "the live current-step container must consume the fixed progress reservation")
+    XCTAssertTrue(
+      body.contains("OnboardingGlass.scrollContentBottomPadding"),
+      "the live scroll content must leave structural clearance above the progress band")
     XCTAssertFalse(
       body.contains("Color.clear.frame(height: 14)"),
       "the old ad hoc footer is not the tested fixed progress band")

--- a/desktop/macos/changelog/unreleased/20260813-onboarding-layout-permission-escape.json
+++ b/desktop/macos/changelog/unreleased/20260813-onboarding-layout-permission-escape.json
@@ -1,0 +1,3 @@
+{
+  "change": "Keep onboarding actions clear of progress indicators and add a visible skip option to permission requests"
+}


### PR DESCRIPTION
## What changed and why

Keep onboarding content clear of the fixed progress band by reserving the full progress height plus clearance at the bottom of the scroll column. Direct permission requests now show a visible “Skip for now” action for every permission, including Accessibility and Notifications, while retaining the Settings retry.

## How it was verified

- `./scripts/dev-feedback.py --once swift 'OnboardingFlowTests/testDirectPermissionRequestsKeepAVisibleSkipEscape|OnboardingGlassChromeTests'` — 16 tests passed.
- `swift build -c debug` — complete.
- Pinned swift-format and SwiftLint checks passed in the pre-push gate.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

