### PR TITLE
fix(backend): macos.omi.me/beta must serve the beta identity, not a prod build

### DIFF
--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -924,8 +924,11 @@ async def download_latest_desktop_release(
     channel in the legacy release metadata; the requested channel is strict
     (404 when empty — QA/tooling contract).
     Defaults to stable channel (for macos.omi.me). Use channel=beta for QA.
-    identity=beta serves the separately-installable "Omi Beta" DMG, which runs
-    side-by-side with stable.
+    identity selects which installer that channel serves: identity=beta is the
+    separately-installable "Omi Beta" DMG that runs side-by-side with stable.
+    When identity is absent it follows the channel (channel=beta alone serves
+    the beta-identity DMG — the macos.omi.me/beta redirect contract); pass
+    identity explicitly to request the cross product.
     """
     if identity is None:
         # macos.omi.me/beta redirects here with only channel=beta — the URL-map redirect

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -916,7 +916,7 @@ async def get_desktop_appcast_xml(
 async def download_latest_desktop_release(
     platform: str = Query(default="macos", pattern="^(macos|windows|linux)$"),
     channel: str = Query(default="stable", pattern="^(beta|stable)$"),
-    identity: str = Query(default="stable", pattern="^(stable|beta)$"),
+    identity: Optional[str] = Query(default=None, pattern="^(stable|beta)$"),
 ):
     """
     Serve the latest desktop release installer as an auto-download landing page.
@@ -927,6 +927,14 @@ async def download_latest_desktop_release(
     identity=beta serves the separately-installable "Omi Beta" DMG, which runs
     side-by-side with stable.
     """
+    if identity is None:
+        # macos.omi.me/beta redirects here with only channel=beta — the URL-map redirect
+        # cannot add identity=beta, and defaulting identity to "stable" made the public
+        # beta link serve the stable-identity omi.dmg (production bundle id, production
+        # services) from the beta pointer. A user who asked for a channel implicitly
+        # asked for that channel's identity; explicit identity=stable&channel=beta stays
+        # available for tooling that genuinely wants the cross product.
+        identity = channel
     if identity == "beta":
         channel = "beta"
     desktop_releases = await _get_live_desktop_releases(platform)

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1884,6 +1884,46 @@ class TestBetaIdentityServing:
         assert "https://example.com/dl/omi-beta.dmg" in resp.text
 
     @pytest.mark.asyncio
+    async def test_channel_beta_alone_serves_beta_identity_dmg(self):
+        # The exact request shape macos.omi.me/beta produces: the URL-map redirect carries
+        # only channel=beta and cannot append identity=beta. With identity defaulting to
+        # "stable", the public beta link served the stable-identity omi.dmg (production
+        # bundle id + production services) from the beta pointer — so "download the beta"
+        # installed a prod build. The channel a user asks for implies its identity.
+        entries = [
+            _beta_live_entry(
+                channel="beta",
+                assets=[_zip_asset(), _dmg_asset(), _beta_dmg_asset("https://example.com/dl/omi-beta.dmg")],
+                metadata={"edSignature": "sig"},
+            ),
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/latest", params={"channel": "beta"})
+
+        assert resp.status_code == 200
+        assert "https://example.com/dl/omi-beta.dmg" in resp.text
+        assert "https://example.com/omi.dmg" not in resp.text
+
+    @pytest.mark.asyncio
+    async def test_explicit_identity_stable_on_beta_channel_is_preserved(self):
+        # Tooling may genuinely want the cross product; deriving identity only applies
+        # when the parameter is absent.
+        entries = [
+            _beta_live_entry(
+                channel="beta",
+                assets=[_zip_asset(), _dmg_asset(), _beta_dmg_asset("https://example.com/dl/omi-beta.dmg")],
+                metadata={"edSignature": "sig"},
+            ),
+        ]
+        with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=entries):
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
+                resp = await client.get("/v2/desktop/download/latest", params={"channel": "beta", "identity": "stable"})
+
+        assert resp.status_code == 200
+        assert "https://example.com/omi.dmg" in resp.text
+
+    @pytest.mark.asyncio
     async def test_download_beta_endpoint_falls_back_to_stable_dmg_pre_rollout(self):
         # Public macos.omi.me/beta must not 404 while no live beta release ships
         # beta-identity artifacts; the strict guard stays on the Sparkle feed.


### PR DESCRIPTION
## macos.omi.me/beta was handing out a prod build

The URL-map redirect behind `macos.omi.me/beta` targets `/v2/desktop/download/latest?channel=beta` — and cannot append `identity=beta`. With `identity` defaulting to `"stable"`, the public beta link served the **stable-identity `omi.dmg`** (production bundle id, production services) from the beta pointer.

Verified against production before the fix:

| request | serves |
|---|---|
| `channel=beta` (what the redirect sends) | `omi.dmg` ← **the bug** |
| `channel=beta&identity=beta` | `omi-beta.dmg` |
| legacy `/v2/desktop/download/beta` | `omi-beta.dmg` |

Real-world blast radius: TCC permission state follows the bundle id, so a user re-downloading "the beta" to escape a broken microphone permission entry kept installing the same prod bundle id and landing in the same broken entry — the alert loop survived a full reinstall.

## Fix

An absent `identity` now derives from the requested channel. `channel=beta` alone serves `omi-beta.dmg` (the side-by-side Omi Beta identity). Explicit `identity=stable&channel=beta` is preserved for tooling; the legacy route is unchanged.

## Tests

- `channel=beta` alone serves the beta DMG and never the stable one (the exact redirect shape)
- explicit `identity=stable` on the beta channel still serves the stable DMG
- full `test_desktop_updates.py`: **128 passed**

Note: the live link changes behavior only after the next prod backend deploy (`gcp_backend.yml`).

Failure-Class: none

## Product invariants affected

- **INV-BETA-1** (Omi Beta is a separate app that runs beside stable) — this change *enforces* the invariant at the public download link: `channel=beta` now serves the separately-installable Omi Beta identity instead of silently handing out the stable-identity installer. The strict identity guard on the Sparkle feed is untouched; the pre-rollout fallback (no beta artifact published → stable installer, with `record_fallback`) is preserved.
