### PR TITLE
fix(desktop): keep completed chat task cards visible

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-stores.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3775
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": 3713
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/Stores/TasksStore.swift": "flushPendingBackendDeletions plus the tombstone/ack wiring in deleteTask and restoreTask: the retry half of the deletion-tombstone contract that stops deleted tasks resurrecting."

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
@@ -101,6 +101,7 @@ struct TaskCardView: View {
   @State private var isToggling = false
   @State private var showCompletionAcknowledgement = false
   @State private var hydrationFinished = false
+  @State private var retainedCompletedTask: TaskActionItem?
 
   init(taskID: String, tasksStore: TasksStore, navigation: ChatFirstShellNavigation) {
     self.taskID = taskID
@@ -108,8 +109,23 @@ struct TaskCardView: View {
     self.navigation = navigation
   }
 
+  private var liveTask: TaskActionItem? {
+    tasksStore.tasks.first { $0.id == taskID && !$0.isRetired }
+  }
+
+  private var isExplicitlyRetired: Bool {
+    (tasksStore.tasks + tasksStore.deletedTasks).contains { $0.id == taskID && $0.isRetired }
+  }
+
   private var task: TaskActionItem? {
-    tasksStore.tasks.first { $0.id == taskID && $0.deleted != true }
+    ChatFirstTaskCardPresentation.displayTask(
+      liveTask: liveTask,
+      retainedCompletedTask: retainedCompletedTask?.id == taskID ? retainedCompletedTask : nil
+    )
+  }
+
+  private var hydrationKey: String {
+    "\(taskID):\(liveTask == nil)"
   }
 
   var body: some View {
@@ -117,6 +133,7 @@ struct TaskCardView: View {
       if let task {
         card(task)
           .onAppear {
+            retainCompletedTaskIfNeeded(liveTask)
             AnalyticsManager.shared.chatFirst(
               .richBlock(kind: .taskCard, outcome: .rendered, action: .none)
             )
@@ -133,12 +150,27 @@ struct TaskCardView: View {
       }
     }
     .accessibilityIdentifier("chat-first-task-\(taskID)")
-    .task(id: taskID) {
-      guard task == nil else {
+    .onChange(of: liveTask) { _, updatedTask in
+      retainCompletedTaskIfNeeded(updatedTask)
+    }
+    .onChange(of: isExplicitlyRetired) { _, retired in
+      if retired {
+        retainedCompletedTask = nil
+      }
+    }
+    .task(id: hydrationKey) {
+      guard liveTask == nil else {
         hydrationFinished = true
         return
       }
-      _ = await tasksStore.resolveCanonicalTask(id: taskID)
+      if retainedCompletedTask == nil {
+        hydrationFinished = false
+      }
+      let resolvedTask = await tasksStore.resolveCanonicalTask(id: taskID)
+      retainCompletedTaskIfNeeded(resolvedTask)
+      if resolvedTask == nil {
+        retainedCompletedTask = nil
+      }
       hydrationFinished = true
     }
   }
@@ -150,15 +182,9 @@ struct TaskCardView: View {
         Label("Task", systemImage: "checklist")
           .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundStyle(Ink.secondary)
-        Spacer(minLength: 0)
-        if task.completed {
-          Text("Completed")
-            .scaledFont(size: OmiType.micro, weight: .medium)
-            .foregroundStyle(Ink.listeningGreen)
-        }
       }
 
-      HStack(alignment: .top, spacing: OmiSpacing.md) {
+      HStack(alignment: .center, spacing: OmiSpacing.md) {
         Button {
           toggle(task)
         } label: {
@@ -224,6 +250,11 @@ struct TaskCardView: View {
     )
   }
 
+  private func retainCompletedTaskIfNeeded(_ task: TaskActionItem?) {
+    guard let task else { return }
+    retainedCompletedTask = task.completed && !task.isRetired ? task : nil
+  }
+
   private func toggle(_ task: TaskActionItem) {
     guard !isToggling else { return }
     let intendedCompletion = !task.completed
@@ -271,6 +302,22 @@ struct TaskCardView: View {
         }
       }
     }
+  }
+}
+
+enum ChatFirstTaskCardPresentation {
+  static func displayTask(
+    liveTask: TaskActionItem?,
+    retainedCompletedTask: TaskActionItem?
+  ) -> TaskActionItem? {
+    if let liveTask {
+      return liveTask.isRetired ? nil : liveTask
+    }
+    guard let retainedCompletedTask,
+      retainedCompletedTask.completed,
+      !retainedCompletedTask.isRetired
+    else { return nil }
+    return retainedCompletedTask
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore+CanonicalTask.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore+CanonicalTask.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+extension TasksStore {
+  /// Hydrates a canonical task through the owner-fenced store before a card or detail page mutates it.
+  func resolveCanonicalTask(
+    id: String,
+    expectedOwnerID: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
+    operations: OwnerBoundOperations = OwnerBoundOperations()
+  ) async -> TaskActionItem? {
+    let normalizedID = id.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalizedID.isEmpty,
+      let lease = captureOwnerLease(
+        expectedOwnerID: expectedOwnerID,
+        authorizationSnapshot: authorizationSnapshot
+      )
+    else { return nil }
+
+    if let existing = tasks.first(where: { $0.id == normalizedID && !$0.isRetired }) {
+      return existing
+    }
+    do {
+      let localTask: TaskActionItem?
+      if let loadTaskDetail = operations.loadTaskDetail {
+        localTask = try await loadTaskDetail(normalizedID, lease.ownerID)
+      } else {
+        localTask = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: normalizedID)
+      }
+      guard isCurrent(lease) else { return nil }
+      if let localTask, localTask.id == normalizedID, !localTask.isRetired {
+        publishHydratedCanonicalTask(localTask)
+        return localTask
+      }
+
+      let remoteTask: TaskActionItem?
+      if let fetchTaskDetail = operations.fetchTaskDetail {
+        remoteTask = try await fetchTaskDetail(normalizedID, lease.ownerID)
+      } else {
+        remoteTask = try await APIClient.shared.getActionItem(
+          id: normalizedID,
+          expectedOwnerId: lease.ownerID,
+          authorizationSnapshot: lease.authorizationSnapshot
+        )
+      }
+      guard isCurrent(lease), let remoteTask, remoteTask.id == normalizedID, !remoteTask.isRetired
+      else { return nil }
+      try await syncPage([remoteTask], lease: lease, operations: operations)
+      guard isCurrent(lease),
+        let hydratedTask = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: normalizedID),
+        !hydratedTask.isRetired
+      else { return nil }
+      publishHydratedCanonicalTask(hydratedTask)
+      await refreshDashboard(lease: lease, operations: operations)
+      guard isCurrent(lease) else { return nil }
+      return hydratedTask
+    } catch {
+      guard isCurrent(lease) else { return nil }
+      self.error = "This task is no longer available."
+      logError("TasksStore: Failed to hydrate canonical task", error: error)
+      return nil
+    }
+  }
+
+  private func publishHydratedCanonicalTask(_ task: TaskActionItem) {
+    incompleteTasks.removeAll { $0.id == task.id }
+    completedTasks.removeAll { $0.id == task.id }
+    deletedTasks.removeAll { $0.id == task.id }
+    if task.deleted == true {
+      deletedTasks.insert(task, at: 0)
+    } else if task.completed {
+      completedTasks.insert(task, at: 0)
+    } else {
+      incompleteTasks.insert(task, at: 0)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -2838,8 +2838,8 @@ class TasksStore: ObservableObject {
 
     // 4. Update in-memory arrays immediately (optimistic UI)
     if newCompleted {
-      incompleteTasks.removeAll { $0.id == task.id }
       completedTasks.insert(updatedTask, at: 0)
+      incompleteTasks.removeAll { $0.id == task.id }
 
       // Compact relevance scores to fill the gap
       if let score = task.relevanceScore {
@@ -2873,8 +2873,8 @@ class TasksStore: ObservableObject {
         }
       }
     } else {
-      completedTasks.removeAll { $0.id == task.id }
       incompleteTasks.insert(updatedTask, at: 0)
+      completedTasks.removeAll { $0.id == task.id }
     }
 
     // 5. Refresh dashboard arrays immediately (SQLite was already updated in step 1)
@@ -3011,11 +3011,11 @@ class TasksStore: ObservableObject {
     }
     guard isCurrent(lease) else { return }
     if attemptedCompleted {
-      completedTasks.removeAll { $0.id == task.id }
       incompleteTasks.insert(task, at: 0)
+      completedTasks.removeAll { $0.id == task.id }
     } else {
-      incompleteTasks.removeAll { $0.id == task.id }
       completedTasks.insert(task, at: 0)
+      incompleteTasks.removeAll { $0.id == task.id }
     }
     self.error = backendError.localizedDescription
   }

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -127,6 +127,7 @@ class TasksStore: ObservableObject {
     var fetchAllTaskIds: ((_ ownerID: String) async throws -> [String])?
     var fetchSelectionTaskIds: ((_ completed: Bool, _ ownerID: String) async throws -> [String])?
     var fetchTaskDetail: ((_ id: String, _ ownerID: String) async throws -> TaskActionItem?)?
+    var loadTaskDetail: ((_ id: String, _ ownerID: String) async throws -> TaskActionItem?)?
     var reconcileVisibility: ((_ items: [TaskActionItem], _ ownerID: String) async throws -> Int)?
     var fetchDeletedPage: ((_ offset: Int, _ limit: Int, _ ownerID: String) async throws -> ActionItemsPage)?
     var syncPage:
@@ -158,6 +159,7 @@ class TasksStore: ObservableObject {
       fetchAllTaskIds: ((_ ownerID: String) async throws -> [String])? = nil,
       fetchSelectionTaskIds: ((_ completed: Bool, _ ownerID: String) async throws -> [String])? = nil,
       fetchTaskDetail: ((_ id: String, _ ownerID: String) async throws -> TaskActionItem?)? = nil,
+      loadTaskDetail: ((_ id: String, _ ownerID: String) async throws -> TaskActionItem?)? = nil,
       reconcileVisibility: ((_ items: [TaskActionItem], _ ownerID: String) async throws -> Int)? = nil,
       fetchDeletedPage: ((_ offset: Int, _ limit: Int, _ ownerID: String) async throws -> ActionItemsPage)? = nil,
       syncPage: (
@@ -185,6 +187,7 @@ class TasksStore: ObservableObject {
       self.fetchAllTaskIds = fetchAllTaskIds
       self.fetchSelectionTaskIds = fetchSelectionTaskIds
       self.fetchTaskDetail = fetchTaskDetail
+      self.loadTaskDetail = loadTaskDetail
       self.reconcileVisibility = reconcileVisibility
       self.fetchDeletedPage = fetchDeletedPage
       self.syncPage = syncPage
@@ -1427,7 +1430,7 @@ class TasksStore: ObservableObject {
     return .init(items: page.items.map { $0.retired() }, hasMore: page.hasMore)
   }
 
-  private func syncPage(
+  func syncPage(
     _ items: [TaskActionItem],
     overrideStagedDeletions: Bool = false,
     lease: OwnerOperationLease,
@@ -1682,7 +1685,7 @@ class TasksStore: ObservableObject {
     }
   }
 
-  private func refreshDashboard(
+  func refreshDashboard(
     lease: OwnerOperationLease,
     operations: OwnerBoundOperations
   ) async {
@@ -2772,71 +2775,6 @@ class TasksStore: ObservableObject {
   ) -> LocalMutationAuthorization {
     LocalMutationAuthorization {
       RuntimeOwnerIdentity.isAuthorizationCurrent(snapshot)
-    }
-  }
-
-  /// Hydrates a canonical goal-detail task through the owner-fenced store
-  /// before a goal page attempts any mutation.
-  func resolveCanonicalTask(
-    id: String,
-    expectedOwnerID: String? = nil,
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil,
-    operations: OwnerBoundOperations = OwnerBoundOperations()
-  ) async -> TaskActionItem? {
-    let normalizedID = id.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalizedID.isEmpty,
-      let lease = captureOwnerLease(
-        expectedOwnerID: expectedOwnerID,
-        authorizationSnapshot: authorizationSnapshot
-      )
-    else { return nil }
-
-    if let existing = tasks.first(where: { $0.id == normalizedID && $0.deleted != true }) {
-      return existing
-    }
-    do {
-      let remoteTask: TaskActionItem?
-      if let fetchTaskDetail = operations.fetchTaskDetail {
-        remoteTask = try await fetchTaskDetail(normalizedID, lease.ownerID)
-      } else {
-        remoteTask = try await APIClient.shared.getActionItem(
-          id: normalizedID,
-          expectedOwnerId: lease.ownerID,
-          authorizationSnapshot: lease.authorizationSnapshot
-        )
-      }
-      guard isCurrent(lease),
-        let remoteTask,
-        remoteTask.id == normalizedID,
-        remoteTask.deleted != true
-      else { return nil }
-      try await syncPage([remoteTask], lease: lease, operations: operations)
-      guard isCurrent(lease),
-        let hydratedTask = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: normalizedID),
-        hydratedTask.deleted != true
-      else { return nil }
-      publishHydratedCanonicalTask(hydratedTask)
-      await refreshDashboard(lease: lease, operations: operations)
-      guard isCurrent(lease) else { return nil }
-      return hydratedTask
-    } catch {
-      guard isCurrent(lease) else { return nil }
-      self.error = "This task is no longer available."
-      logError("TasksStore: Failed to hydrate canonical task", error: error)
-      return nil
-    }
-  }
-
-  private func publishHydratedCanonicalTask(_ task: TaskActionItem) {
-    incompleteTasks.removeAll { $0.id == task.id }
-    completedTasks.removeAll { $0.id == task.id }
-    deletedTasks.removeAll { $0.id == task.id }
-    if task.deleted == true {
-      deletedTasks.insert(task, at: 0)
-    } else if task.completed {
-      completedTasks.insert(task, at: 0)
-    } else {
-      incompleteTasks.insert(task, at: 0)
     }
   }
 

--- a/desktop/macos/Desktop/Tests/ChatFirstRichBlockTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstRichBlockTests.swift
@@ -230,6 +230,30 @@ final class ChatFirstRichBlockTests: XCTestCase {
     )
   }
 
+  func testTaskCardRetainsCompletedPresentationWhileCanonicalTaskRehydrates() {
+    let completed = task(id: "task-1", completed: true)
+
+    XCTAssertEqual(
+      ChatFirstTaskCardPresentation.displayTask(
+        liveTask: nil,
+        retainedCompletedTask: completed
+      ),
+      completed
+    )
+    XCTAssertNil(
+      ChatFirstTaskCardPresentation.displayTask(
+        liveTask: nil,
+        retainedCompletedTask: task(id: "task-1", completed: false)
+      )
+    )
+    XCTAssertNil(
+      ChatFirstTaskCardPresentation.displayTask(
+        liveTask: task(id: "task-1", completed: true, taskStatus: "superseded"),
+        retainedCompletedTask: completed
+      )
+    )
+  }
+
   func testTaskCaptureLinksFailClosedOutsideTheOmiDeviceArchive() {
     let omiCaptureTask = task(
       id: "omi-task",
@@ -258,7 +282,8 @@ final class ChatFirstRichBlockTests: XCTestCase {
     id: String,
     completed: Bool,
     conversationID: String? = nil,
-    source: String? = nil
+    source: String? = nil,
+    taskStatus: String? = nil
   ) -> TaskActionItem {
     TaskActionItem(
       id: id,
@@ -266,7 +291,8 @@ final class ChatFirstRichBlockTests: XCTestCase {
       completed: completed,
       createdAt: Date(timeIntervalSince1970: 0),
       conversationId: conversationID,
-      source: source
+      source: source,
+      taskStatus: taskStatus
     )
   }
 }

--- a/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
@@ -42,6 +42,34 @@ private final class TasksStoreOperationProbe {
 
 final class TasksStoreOwnerBoundaryTests: XCTestCase {
   @MainActor
+  func testCanonicalTaskResolutionRepublishesCompletedLocalTaskBeforeRemoteFetch() async {
+    let store = TasksStore.shared
+    await prepareOwnerBoundaryTest(store: store)
+    let completed = task(id: "completed-chat-card", completed: true)
+    var remoteFetches = 0
+
+    let resolved = await store.resolveCanonicalTask(
+      id: completed.id,
+      operations: TasksStore.OwnerBoundOperations(
+        fetchTaskDetail: { _, _ in
+          remoteFetches += 1
+          return nil
+        },
+        loadTaskDetail: { id, ownerID in
+          XCTAssertEqual(id, completed.id)
+          XCTAssertEqual(ownerID, "owner-a")
+          return completed
+        }
+      )
+    )
+
+    XCTAssertEqual(resolved, completed)
+    XCTAssertEqual(store.completedTasks, [completed])
+    XCTAssertTrue(store.incompleteTasks.isEmpty)
+    XCTAssertEqual(remoteFetches, 0)
+  }
+
+  @MainActor
   func testNoDeadlinePaginationUsesAPIConsumptionOffsetInsteadOfLocalPresentationCount() async {
     let store = TasksStore.shared
     await prepareOwnerBoundaryTest(store: store)

--- a/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 
 @testable import Omi_Computer
@@ -41,6 +42,70 @@ private final class TasksStoreOperationProbe {
 }
 
 final class TasksStoreOwnerBoundaryTests: XCTestCase {
+  @MainActor
+  func testToggleNeverPublishesAnIntervalWithoutTheCanonicalTask() async {
+    let store = TasksStore.shared
+    await prepareOwnerBoundaryTest(store: store)
+    let original = task(id: "published-toggle")
+    let completed = task(id: original.id, completed: true)
+    store.incompleteTasks = [original]
+    var visibility: [Bool] = []
+    let observation = Publishers.CombineLatest(store.$incompleteTasks, store.$completedTasks)
+      .dropFirst()
+      .sink { incomplete, completed in
+        visibility.append((incomplete + completed).contains { $0.id == original.id })
+      }
+
+    await store.toggleTask(
+      original,
+      operationOverrides: TasksStore.ToggleOperationOverrides(
+        updateLocal: { _, _ in completed },
+        refreshDashboard: { _ in },
+        updateRemote: { _, _ in completed },
+        syncRemote: { _, _ in },
+        rollbackLocal: {}
+      )
+    )
+
+    withExtendedLifetime(observation) {
+      XCTAssertFalse(visibility.isEmpty)
+      XCTAssertTrue(visibility.allSatisfy { $0 })
+    }
+  }
+
+  @MainActor
+  func testToggleRollbackNeverPublishesAnIntervalWithoutTheCanonicalTask() async {
+    let store = TasksStore.shared
+    await prepareOwnerBoundaryTest(store: store)
+    let original = task(id: "published-toggle-rollback")
+    let completed = task(id: original.id, completed: true)
+    store.incompleteTasks = [original]
+    var visibility: [Bool] = []
+    let observation = Publishers.CombineLatest(store.$incompleteTasks, store.$completedTasks)
+      .dropFirst()
+      .sink { incomplete, completed in
+        visibility.append((incomplete + completed).contains { $0.id == original.id })
+      }
+
+    await store.toggleTask(
+      original,
+      operationOverrides: TasksStore.ToggleOperationOverrides(
+        updateLocal: { _, _ in completed },
+        refreshDashboard: { _ in },
+        updateRemote: { _, _ in throw TasksStoreOwnerBoundaryFailure.backendRejected },
+        syncRemote: { _, _ in },
+        rollbackLocal: {}
+      )
+    )
+
+    withExtendedLifetime(observation) {
+      XCTAssertFalse(visibility.isEmpty)
+      XCTAssertTrue(visibility.allSatisfy { $0 })
+    }
+    XCTAssertEqual(store.incompleteTasks, [original])
+    XCTAssertTrue(store.completedTasks.isEmpty)
+  }
+
   @MainActor
   func testCanonicalTaskResolutionRepublishesCompletedLocalTaskBeforeRemoteFetch() async {
     let store = TasksStore.shared

--- a/desktop/macos/changelog/unreleased/20260813-chat-completed-task-card.json
+++ b/desktop/macos/changelog/unreleased/20260813-chat-completed-task-card.json
@@ -1,0 +1,3 @@
+{
+  "change": "Kept completed tasks checked and crossed out in Chat"
+}

--- a/desktop/macos/e2e/flows/chat-first-cohesive.yaml
+++ b/desktop/macos/e2e/flows/chat-first-cohesive.yaml
@@ -40,6 +40,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstCaptureLinkPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstGoalsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstTasksPage.swift
+  - desktop/macos/Desktop/Sources/Stores/TasksStore+CanonicalTask.swift
   # S3-S6 load canonical goals, acknowledge focus, and mutate focused-goal state.
   - desktop/macos/Desktop/Sources/MainWindow/ChatFirst/CanonicalGoalsStore.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+TaskCatalog.swift


### PR DESCRIPTION
## What changed and why

Completed task cards in Chat disappeared because the task store moves completed rows out of the live incomplete-task projection immediately, while the card treated that projection miss as permanent unavailability. Retain the reconciled completed record during that projection transition and restore canonical task detail from local storage before falling back to the network.

The completed card now stays visible with a checked circle and struck-through description, without the redundant green `Completed` label. The circle and description are vertically centered, while cancelled, superseded, and deleted tasks still retire.

## Product invariants affected

- INV-CHAT-1: structured task blocks remain usable and preserve their canonical task state after mutation.

## How it was verified

- `swift test --scratch-path /Users/dazheng/workspace/omi/upstream-keep-clean/desktop/macos/Desktop/.build --filter ChatFirstRichBlockTests` — 9 tests passed.
- `swift test --scratch-path /Users/dazheng/workspace/omi/upstream-keep-clean/desktop/macos/Desktop/.build --filter TasksStoreOwnerBoundaryTests/testCanonicalTaskResolutionRepublishesCompletedLocalTaskBeforeRemoteFetch` — passed against the final commit.
- `scripts/pr-preflight --pr-body-file /tmp/omi-chat-task-card-pr-body.md` — all 20 selected checks passed.
- `git diff --check` and desktop changelog JSON validation passed.
- Built and launched `/Applications/omi-chat-task-completion-card.app` from exact commit `bb9b4113a7990c0a2b2f24a22dfe3c1177fd2b1b`; bundle ID and strict code signature verified.
- The pre-push wrapper's separate desktop flow-lint step used its documented `PRE_PUSH_SKIP_DESKTOP_FLOW_LINT=1` hatch because this checkout lacks PyYAML; strict desktop e2e flow coverage passed in `scripts/pr-preflight`.

## Tests

- `ChatFirstRichBlockTests.testTaskCardRetainsCompletedPresentationWhileCanonicalTaskRehydrates` covers retained checked/struck-through presentation and rejects incomplete or retired records.
- `TasksStoreOwnerBoundaryTests.testCanonicalTaskResolutionRepublishesCompletedLocalTaskBeforeRemoteFetch` covers local canonical restoration without an unnecessary remote request.

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

