### PR TITLE
fix(desktop): keep chat-first prompts out of notch

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift
@@ -2,6 +2,19 @@ import Foundation
 import OmiTheme
 import SwiftUI
 
+extension FloatingControlBarWindow {
+  func routePrimaryTextInputToMainAppAfterAgentExit() -> Bool {
+    guard
+      FloatingPrimaryTextInputRouting.shouldRouteAgentExitToMainApp(
+        hasMainConversation: state.hasMainConversation)
+    else { return false }
+
+    closeAIConversation()
+    AppDelegate.summonWindowTarget()?.openMainAppChat()
+    return true
+  }
+}
+
 /// Whether a presentation request is allowed to change the user's durable
 /// Floating Bar preference. Onboarding may borrow the real bar for a demo, but
 /// must leave that preference exactly as it found it.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -1037,7 +1037,7 @@ struct FloatingControlBarView: View {
       isVoicePresentationActive: state.isVoicePresentationActive,
       isShowingConversation: state.showingAIConversation,
       openMainChat: {
-        (NSApp.delegate as? AppDelegate)?.openMainAppChat()
+        AppDelegate.summonWindowTarget()?.openMainAppChat()
       }
     )
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1493,7 +1493,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       closeAIConversation()
       return
     }
-
+    if routePrimaryTextInputToMainAppAfterAgentExit() { return }
     state.leaveAgentSurface()
     if state.conversationSurface == .mainInput {
       resizeForMainInputAfterAgentExit()

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -196,11 +196,9 @@ struct DesktopHomeView: View {
       .onAppear {
         log("DesktopHomeView: Showing mainContent (signed in and onboarded)")
 
-        // Post-onboarding guidance. The popup's overlay is this view's
-        // (`mainContentWithOverlays`), so arming it is this view's job too. While the only trigger
-        // was `DashboardPage.onAppear`, the default Home — which is no longer `DashboardPage` —
-        // never fired it, and a user who had just finished setup was handed a silent app.
-        if PostOnboardingPromptSuggestions.shouldArmPopup() {
+        // Chat-first renders starter prompts in main chat; only legacy may arm the floating popup.
+        FloatingPrimaryTextInputRouting.configure(routesToMainApp: usesChatFirstShell)
+        if !usesChatFirstShell && PostOnboardingPromptSuggestions.shouldArmPopup() {
           showTryAskingPopup = true
         }
         updatePolicyManager.refresh(force: true)
@@ -1125,20 +1123,19 @@ struct DesktopHomeView: View {
         GoalCelebrationView()
       }
       .overlay {
-        if showTryAskingPopup {
+        if !usesChatFirstShell && showTryAskingPopup {
           let suggestions = PostOnboardingPromptSuggestions.suggestions()
           if !suggestions.isEmpty {
             TryAskingPopupView(
               suggestions: suggestions,
               onAsk: { suggestion in
                 showTryAskingPopup = false
-                PostOnboardingPromptSuggestions.shouldShowPopup = false
+                PostOnboardingPromptSuggestions.consume()
                 FloatingControlBarManager.shared.openAIInputWithQuery(suggestion)
               },
               onDismiss: {
                 showTryAskingPopup = false
-                PostOnboardingPromptSuggestions.shouldShowPopup = false
-                PostOnboardingPromptSuggestions.isDismissed = true
+                PostOnboardingPromptSuggestions.consume()
               }
             )
           }
@@ -1149,6 +1146,7 @@ struct DesktopHomeView: View {
   private func mainContentWithNotifications<Content: View>(_ content: Content) -> some View {
     content
       .onReceive(NotificationCenter.default.publisher(for: .showTryAskingPopup)) { _ in
+        guard !usesChatFirstShell else { return }
         showTryAskingPopup = true
       }
       .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindSettings)) { _ in
@@ -1242,6 +1240,8 @@ struct DesktopHomeView: View {
       .onChange(of: chatFirstNavigation.visibleRoute) { _, _ in reportAutomationState() }
       .onChange(of: chatFirstNavigation.isSidebarCollapsed) { _, _ in reportAutomationState() }
       .onChange(of: useLegacyHomeDesign) { _, newValue in
+        FloatingPrimaryTextInputRouting.configure(routesToMainApp: usesChatFirstShell)
+        if usesChatFirstShell { showTryAskingPopup = false }
         OmiMotion.withGated(.easeInOut(duration: 0.2)) {
           isSidebarCollapsed = !newValue
         }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopShellPresentationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopShellPresentationPolicy.swift
@@ -4,6 +4,28 @@ enum DesktopShellPresentationPolicy {
     if case .chatFirst = capabilityVariant { return true }
     return false
   }
+
+  /// The floating "Try asking" popup belongs to the legacy shell. Chat-first owns its starter
+  /// prompts inside the main chat and must never expose the notch as a primary text-entry surface.
+  static func usesLegacyPostOnboardingPopup(
+    _ useLegacyHomeDesign: Bool,
+    _ capabilityVariant: ChatFirstShellVariant
+  ) -> Bool {
+    !usesChatFirst(useLegacyHomeDesign, capabilityVariant)
+  }
+}
+
+@MainActor
+enum FloatingPrimaryTextInputRouting {
+  private(set) static var routesToMainApp = false
+
+  static func configure(routesToMainApp: Bool) {
+    self.routesToMainApp = routesToMainApp
+  }
+
+  static func shouldRouteAgentExitToMainApp(hasMainConversation: Bool) -> Bool {
+    routesToMainApp && !hasMainConversation
+  }
 }
 
 /// Whether the Home stage — `HomeStageMode`'s hub / chat / connect — is mounted at all, and therefore

--- a/desktop/macos/Desktop/Sources/MainWindow/OnboardingOpenerView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/OnboardingOpenerView.swift
@@ -57,6 +57,7 @@ struct OnboardingOpenerView: View {
   private func startFromOpener(_ question: String) {
     AnalyticsManager.shared.chatMessageSent(
       messageLength: question.count, hasSelectedAppContext: false, source: "onboarding_opener")
+    PostOnboardingPromptSuggestions.consume()
     chatProvider.dismissOnboardingOpener()
     Task { await chatProvider.sendMainDraft(question) }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -2213,16 +2213,16 @@ struct DashboardPage: View {
   }
 
   private var shouldShowSuggestionBanner: Bool {
-    !postOnboardingSuggestions.isEmpty && !PostOnboardingPromptSuggestions.isDismissed
+    !routesChatToPrimaryShell && !postOnboardingSuggestions.isEmpty
+      && !PostOnboardingPromptSuggestions.isDismissed
   }
 
   private func dismissSuggestionBanner() {
-    PostOnboardingPromptSuggestions.shouldShowPopup = false
-    PostOnboardingPromptSuggestions.isDismissed = true
+    PostOnboardingPromptSuggestions.consume()
   }
 
   private func handleSuggestedPrompt(_ suggestion: String) {
-    PostOnboardingPromptSuggestions.shouldShowPopup = false
+    PostOnboardingPromptSuggestions.consume()
     FloatingControlBarManager.shared.openAIInputWithQuery(suggestion)
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingPromptSuggestions.swift
@@ -50,6 +50,16 @@ enum PostOnboardingPromptSuggestions {
   static func shouldArmPopup() -> Bool {
     shouldShowPopup && !isDismissed && !suggestions().isEmpty
   }
+
+  /// Consume the one-shot post-onboarding guidance regardless of which shell handled it.
+  ///
+  /// The main-chat opener and the legacy floating popup read the same saved suggestions. Keeping
+  /// separate dismissal writes let either surface remain armed after the user had already acted on
+  /// the other one, so chat-first users could see (and submit) the same prompt through both chats.
+  static func consume() {
+    shouldShowPopup = false
+    isDismissed = true
+  }
 }
 
 @MainActor

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -490,10 +490,21 @@ import XCTest
       ))
     XCTAssertTrue(source.contains("private func openMainChatFromIdleNotch()"))
     XCTAssertTrue(source.contains("NotchIdleTapRoute.perform("))
-    XCTAssertTrue(source.contains("(NSApp.delegate as? AppDelegate)?.openMainAppChat()"))
+    XCTAssertTrue(source.contains("AppDelegate.summonWindowTarget()?.openMainAppChat()"))
+    XCTAssertFalse(source.contains("(NSApp.delegate as? AppDelegate)?.openMainAppChat()"))
     XCTAssertFalse(source.contains("gearshape.fill"))
     XCTAssertFalse(source.contains("openFloatingBarSettings()"))
     XCTAssertTrue(source.contains("openAgentChatsFromNotchLogo()"))
+  }
+
+  func testChatFirstCanRoutePrimaryFloatingTextEntryToTheMainApp() {
+    FloatingPrimaryTextInputRouting.configure(routesToMainApp: false)
+    defer { FloatingPrimaryTextInputRouting.configure(routesToMainApp: false) }
+
+    XCTAssertFalse(FloatingPrimaryTextInputRouting.shouldRouteAgentExitToMainApp(hasMainConversation: false))
+    FloatingPrimaryTextInputRouting.configure(routesToMainApp: true)
+    XCTAssertTrue(FloatingPrimaryTextInputRouting.shouldRouteAgentExitToMainApp(hasMainConversation: false))
+    XCTAssertFalse(FloatingPrimaryTextInputRouting.shouldRouteAgentExitToMainApp(hasMainConversation: true))
   }
 
   func testNotchChatSizingPreservesSurfaceWidthAndGlowList() throws {
@@ -1542,7 +1553,8 @@ import XCTest
 
     // Both the Omi Chat header and subagent header should enter one shared
     // window transition. Back from a subagent goes to the row list on every
-    // display mode when pills exist; otherwise main-input/main-response.
+    // display mode when pills exist. Without a remaining row, chat-first hands typed entry to the
+    // main app while legacy can still restore its main-input/main-response surface.
     XCTAssertTrue(viewSource.contains("          onBackToAgentRows: {\n            showAgentListFromConversation()"))
     XCTAssertTrue(
       viewSource.contains(
@@ -1554,6 +1566,7 @@ import XCTest
     )
     XCTAssertTrue(windowSource.contains("private func showAgentRowsFromConversation()"))
     XCTAssertTrue(windowSource.contains("private func showMainConversationFromAgent()"))
+    XCTAssertTrue(windowSource.contains("routePrimaryTextInputToMainAppAfterAgentExit()"))
     XCTAssertTrue(windowSource.contains("state.hideConversationSurface()"))
     XCTAssertTrue(windowSource.contains("openNotchHoverMenuUntilExit()"))
     XCTAssertTrue(windowSource.contains("resizeForMainInputAfterAgentExit()"))

--- a/desktop/macos/Desktop/Tests/ChatFirstShellTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstShellTests.swift
@@ -44,6 +44,25 @@ final class ChatFirstShellTests: XCTestCase {
     XCTAssertEqual(projection.controlGeneration, 9)
   }
 
+  func testOnlyLegacyShellUsesThePostOnboardingFloatingPopup() {
+    var enabled = ChatFirstShellCapabilitySample()
+    enabled.resolve(
+      control: enabledControl(),
+      requestedOwnerID: "owner-a",
+      ownerIsStillCurrent: true
+    )
+
+    XCTAssertFalse(
+      DesktopShellPresentationPolicy.usesLegacyPostOnboardingPopup(false, enabled.variant),
+      "chat-first starter prompts belong to the main chat")
+    XCTAssertTrue(
+      DesktopShellPresentationPolicy.usesLegacyPostOnboardingPopup(false, .legacy),
+      "the server-selected legacy shell retains its floating prompt")
+    XCTAssertTrue(
+      DesktopShellPresentationPolicy.usesLegacyPostOnboardingPopup(true, enabled.variant),
+      "the explicit legacy preference remains authoritative")
+  }
+
   func testMissingStaleAndOwnerChangedSamplesFailClosed() {
     var missing = ChatFirstShellCapabilitySample()
     missing.resolve(control: nil, requestedOwnerID: "owner-a", ownerIsStillCurrent: true)

--- a/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
@@ -192,11 +192,11 @@ final class SBPostOnboardingGuidanceWiringTests: XCTestCase {
     model.skip()
     XCTAssertTrue(PostOnboardingPromptSuggestions.shouldArmPopup())
 
-    // What the popup's dismiss handler persists.
-    PostOnboardingPromptSuggestions.shouldShowPopup = false
-    PostOnboardingPromptSuggestions.isDismissed = true
+    PostOnboardingPromptSuggestions.consume()
 
     XCTAssertFalse(PostOnboardingPromptSuggestions.shouldArmPopup())
+    XCTAssertFalse(PostOnboardingPromptSuggestions.shouldShowPopup)
+    XCTAssertTrue(PostOnboardingPromptSuggestions.isDismissed)
   }
 
   /// The flag alone must never raise an empty popup — that is the shape the first half of this bug

--- a/desktop/macos/changelog/unreleased/20260813-chat-first-onboarding-prompts.json
+++ b/desktop/macos/changelog/unreleased/20260813-chat-first-onboarding-prompts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed onboarding suggestions opening the notch composer instead of the main chat"
+}


### PR DESCRIPTION
## What changed and why

Keep the legacy Try Asking flow on the floating/notch composer, while making the chat-first onboarding opener the sole owner of primary text input. The bug came from independent main-chat and persisted-popup consumption state: both surfaces rendered the same starter, and the popup dispatched through the floating query route.

The chat-first shell now suppresses the legacy popup, all starter actions consume the shared one-shot guidance state, orphaned subagent exits route to main chat, and idle-notch handoff uses the shared app resolver. Notifications, push-to-talk, and subagent presentation remain available in the notch.

## Product invariants affected

INV-CHAT-1

## How it was verified

- `swift test --package-path Desktop --filter 'ChatFirstShellTests|SBPostOnboardingGuidanceWiringTests|AgentPillLifecycleTests'` — 128 tests passed after rebasing onto current `origin/main`.
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — Swift and agent cross-surface contract smokes passed.
- A signed named bundle was launched in `chat_first`; automation state reported `askOmiOpen=false` and `askOmiFocused=false`, and captures showed the composer only in the main app while the notch remained compact.
- `scripts/pr-preflight --lane local --base origin/main --head HEAD --head-branch codex/remove-new-chat-notch-input --pr-body-file /tmp/omi-chat-first-notch-pr-body.md` — full local PR policy gate.

## Tests

- `ChatFirstShellTests` covers legacy versus chat-first popup ownership and primary-input routing.
- `SBPostOnboardingGuidanceWiringTests` covers one-shot guidance consumption.
- `AgentPillLifecycleTests` covers agent-exit routing and the idle-notch main-app resolver.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

