### PR TITLE
feat(desktop): unify audio recording modes

### DIFF
--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-appstate.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1644
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": 1683
   },
   "raise_justifications": {
-    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds local transcript duplicate suppression and persistence flushes before stop or rotation so source-aware deduplication cannot leave stale rows. +9 fences both sides of the awaited local capture rebuild so a concurrent stop cannot resurrect transcription after teardown. +24 preserves the active meeting role across sleep, STT fallback, max-duration rotation, and deferred session ownership, replaying boundary edges only after the new session is ready. +20 carries the silent-mic healed route and close-state guards through the same restart boundary."
+    "desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift": "Adds local transcript duplicate suppression and persistence flushes before stop or rotation so source-aware deduplication cannot leave stale rows. +9 fences both sides of the awaited local capture rebuild so a concurrent stop cannot resurrect transcription after teardown. +24 preserves the active meeting role across sleep, STT fallback, max-duration rotation, and deferred session ownership, replaying boundary edges only after the new session is ready. +20 carries the silent-mic healed route and close-state guards through the same restart boundary. +39 centralizes the user-owned Audio Recording Off/Always/Only Meetings policy while retaining detector-driven boundaries and meeting-end finalization."
   },
   "threshold": 1500
 }

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,14 +1,14 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 2023,
-    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1607,
+    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1595,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3433,
-    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4318,
+    "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4280,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3468,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift": 4399,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasForceLayout.swift": 1636,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift": 6806,
-    "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1505
+    "desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift": 1501
   },
   "raise_justifications": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": "Assistant metadata controls now occupy a real in-layout hit-test strip with shared top/leading insets and stable pointer targets; chat-first blocks, timestamps, ratings, and copy/context actions remain one row-level rendering boundary rather than parallel transcript renderers. +15 projects the typed conversationLink through the existing exhaustive row grouping and rendering switches; the card view itself remains extracted in ChatFirstContentBlockViews.",

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-root.json
@@ -1,8 +1,8 @@
 {
   "files": {
-    "desktop/macos/Desktop/Sources/AuthService.swift": 2844,
+    "desktop/macos/Desktop/Sources/AuthService.swift": 2843,
     "desktop/macos/Desktop/Sources/CloudConnectorFormAutomation.swift": 1678,
-    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4566,
+    "desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift": 4565,
     "desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift": 1516,
     "desktop/macos/Desktop/Sources/MemoryExportService.swift": 1581,
     "desktop/macos/Desktop/Sources/OmiApp.swift": 1590

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -450,7 +450,7 @@ class AppState: ObservableObject {
   /// rebuild creates a fresh service (and therefore a fresh service-local watchdog).
   var silentMicRecoveryAttempts = 0
   var currentConversationRole: MeetingConversationBoundaryPolicy.Role = .ambient
-  var meetingDetectorMode: AssistantSettings.SystemAudioCaptureMode?
+  var meetingDetectorMode: AssistantSettings.AudioRecordingMode?
   var meetingBoundaryInProgress = false
   var pendingMeetingState: Bool?
 
@@ -465,9 +465,14 @@ class AppState: ObservableObject {
   var meetingEndFinalizationInProgress = false
   @Published var isAwaitingMeeting = false
 
-  var effectiveSystemAudioMode: AssistantSettings.SystemAudioCaptureMode {
-    if UserDefaults.standard.bool(forKey: "disableSystemAudioCapture") { return .never }
-    return AssistantSettings.shared.systemAudioCaptureMode
+  var audioRecordingMode: AssistantSettings.AudioRecordingMode {
+    AssistantSettings.shared.audioRecordingMode
+  }
+
+  /// A hidden developer override may suppress the system tap, but it cannot change the user's
+  /// recording policy or whether the microphone/meeting gate runs.
+  var shouldCaptureSystemAudio: Bool {
+    !UserDefaults.standard.bool(forKey: .disableSystemAudioCapture)
   }
   var vadGateService: VADGateService? {
     get { servicesCoordinator.vadGateService }
@@ -561,9 +566,9 @@ class AppState: ObservableObject {
     get { servicesCoordinator.screenCaptureKitBrokenObserver }
     set { servicesCoordinator.screenCaptureKitBrokenObserver = newValue }
   }
-  var systemAudioCaptureModeObserver: NSObjectProtocol? {
-    get { servicesCoordinator.systemAudioCaptureModeObserver }
-    set { servicesCoordinator.systemAudioCaptureModeObserver = newValue }
+  var audioRecordingModeObserver: NSObjectProtocol? {
+    get { servicesCoordinator.audioRecordingModeObserver }
+    set { servicesCoordinator.audioRecordingModeObserver = newValue }
   }
   var coreAudioCaptureRecoveryObserver: NSObjectProtocol? {
     get { servicesCoordinator.coreAudioCaptureRecoveryObserver }
@@ -831,7 +836,7 @@ class AppState: ObservableObject {
       // Restart transcription if it was active before sleep
       Task { @MainActor in
         guard let self = self else { return }
-        if self.wasTranscribingBeforeSleep && AssistantSettings.shared.transcriptionEnabled {
+        if self.wasTranscribingBeforeSleep && AssistantSettings.shared.audioRecordingMode != .off {
           log("System wake: Restarting transcription (was active before sleep)")
           // Brief delay to let audio subsystem settle after wake
           try? await Task.sleep(for: .seconds(2))
@@ -877,14 +882,25 @@ class AppState: ObservableObject {
       }
     }
 
-    // System Audio capture mode changed — re-apply the capture gate live if a recording is armed.
-    systemAudioCaptureModeObserver = NotificationCenter.default.addObserver(
-      forName: .systemAudioCaptureModeDidChange,
+    // One preference owns both intent and meeting gating. Apply every change live so no stale
+    // boolean or secondary picker can disagree with the selected mode.
+    audioRecordingModeObserver = NotificationCenter.default.addObserver(
+      forName: .audioRecordingModeDidChange,
       object: nil,
       queue: .main
     ) { [weak self] _ in
       Task { @MainActor in
-        await self?.reconcileCapture()
+        guard let self else { return }
+        switch AssistantSettings.shared.audioRecordingMode {
+        case .off:
+          self.stopTranscription()
+        case .always, .onlyMeetings:
+          if self.isTranscribing {
+            await self.reconcileCapture()
+          } else {
+            self.startTranscription()
+          }
+        }
       }
     }
 
@@ -993,5 +1009,4 @@ extension Notification.Name {
   /// Posted when file indexing completes (userInfo: ["totalFiles": Int])
   static let fileIndexingComplete = Notification.Name("fileIndexingComplete")
   /// Posted from menu bar to toggle transcription (userInfo: ["enabled": Bool])
-  static let toggleTranscriptionRequested = Notification.Name("toggleTranscriptionRequested")
 }

--- a/desktop/macos/Desktop/Sources/AppState/AppServicesCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppServicesCoordinator.swift
@@ -22,7 +22,7 @@ final class AppServicesCoordinator {
   var screenUnlockedObserver: NSObjectProtocol?
   var screenCapturePermissionLostObserver: NSObjectProtocol?
   var screenCaptureKitBrokenObserver: NSObjectProtocol?
-  var systemAudioCaptureModeObserver: NSObjectProtocol?
+  var audioRecordingModeObserver: NSObjectProtocol?
   var coreAudioCaptureRecoveryObserver: NSObjectProtocol?
 
   var buttonStreamTask: Task<Void, Never>?
@@ -67,9 +67,9 @@ final class AppServicesCoordinator {
       NotificationCenter.default.removeObserver(observer)
       screenCaptureKitBrokenObserver = nil
     }
-    if let observer = systemAudioCaptureModeObserver {
+    if let observer = audioRecordingModeObserver {
       NotificationCenter.default.removeObserver(observer)
-      systemAudioCaptureModeObserver = nil
+      audioRecordingModeObserver = nil
     }
     if let observer = coreAudioCaptureRecoveryObserver {
       NotificationCenter.default.removeObserver(observer)

--- a/desktop/macos/Desktop/Sources/AppState/AppState+MeetingBoundaries.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+MeetingBoundaries.swift
@@ -14,7 +14,7 @@ extension AppState {
   }
 
   /// Keeps the probe's evidence policy aligned with settings changes during a recording.
-  func ensureMeetingDetector(for mode: AssistantSettings.SystemAudioCaptureMode) {
+  func ensureMeetingDetector(for mode: AssistantSettings.AudioRecordingMode) {
     if meetingDetector != nil, meetingDetectorMode != mode {
       meetingDetector?.stop()
       meetingDetector = nil
@@ -27,12 +27,12 @@ extension AppState {
         if ConferencingApps.callAppIsUsingMicrophone() { return true }
         // On modern macOS, browser titles are only a capture-gating fallback;
         // Always mode keeps the stronger CoreAudio mic signal authoritative.
-        return mode == .onlyDuringMeetings && ConferencingApps.browserCallWindowPresent()
+        return mode == .onlyMeetings && ConferencingApps.browserCallWindowPresent()
       }
       // macOS 14.0-14.3 has no CoreAudio process-input API. Keep the browser
       // title signal for Always and meetings-only capture, but never construct
       // meeting provenance while system-audio capture is disabled.
-      return mode != .never && ConferencingApps.browserCallWindowPresent()
+      return mode != .off && ConferencingApps.browserCallWindowPresent()
     }
     let detector = MeetingDetector(
       isMeetingNow: meetingProbe,

--- a/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
@@ -7,9 +7,10 @@ import SwiftUI
 extension AppState {
   func toggleTranscription() {
     if isTranscribing {
-      stopTranscription()
+      AssistantSettings.shared.audioRecordingMode = .off
     } else {
-      startTranscription()
+      let selected = AssistantSettings.shared.audioRecordingMode
+      AssistantSettings.shared.audioRecordingMode = selected == .off ? .onlyMeetings : selected
     }
   }
 
@@ -20,6 +21,10 @@ extension AppState {
     conversationRole: MeetingConversationBoundaryPolicy.Role = .ambient
   ) {
     guard !isTranscribing else { return }
+    guard AssistantSettings.shared.audioRecordingMode != .off else {
+      log("Transcription: start ignored because Audio Recording is Off")
+      return
+    }
     sttSession.prepareForStart()
     silentMicRecoveryAttempts = 0
     currentConversationRole = conversationRole
@@ -125,18 +130,17 @@ extension AppState {
         // VAD gate not used for Python backend streaming (backend handles its own VAD)
         vadGateService = nil
 
-        // Initialize system audio capture if supported (macOS 14.4+) and not in "Never" mode.
-        // The actual start/stop is driven by reconcileCapture() based on the user's System Audio
-        // mode (Always / Only during meetings / Never) and meeting state. `.never` is also forced
-        // by the hidden `disableSystemAudioCapture` debug flag — see effectiveSystemAudioMode.
+        // Initialize system audio capture if supported (macOS 14.4+). The user's one Audio
+        // Recording mode controls intent + meeting gating; a hidden developer override may suppress
+        // only the system tap without creating another user-facing policy.
         // Toggle the debug flag with: defaults write <bundle> disableSystemAudioCapture -bool true
-        let systemAudioMode = effectiveSystemAudioMode
-        if systemAudioMode == .never {
-          log("Transcription: System audio capture mode = never — not initializing")
+        let recordingMode = audioRecordingMode
+        if !shouldCaptureSystemAudio {
+          log("Transcription: System audio capture disabled by developer override")
         } else if #available(macOS 14.4, *) {
           systemAudioCaptureService = SystemAudioCaptureService()
           log(
-            "Transcription: System audio capture initialized (mode=\(systemAudioMode.rawValue), macOS 14.4+)"
+            "Transcription: System audio capture initialized (mode=\(recordingMode.rawValue), macOS 14.4+)"
           )
         } else {
           log("Transcription: System audio capture not available (requires macOS 14.4+)")
@@ -191,7 +195,6 @@ extension AppState {
 
       isTranscribing = true
       recordingGeneration &+= 1
-      AssistantSettings.shared.transcriptionEnabled = true
       audioSource = effectiveSource
       currentTranscript = ""
       speakerSegments = []
@@ -533,7 +536,7 @@ extension AppState {
         return
       }
       recordSystemAudioCaptureOutcome(.granted)
-      log("Transcription: System audio capture started (mode=\(effectiveSystemAudioMode.rawValue))")
+      log("Transcription: System audio capture started (mode=\(audioRecordingMode.rawValue))")
     } catch {
       // Mirror the success path's staleness guards: if recording stopped or the
       // service was replaced while startCapture was suspended, the failure says
@@ -574,15 +577,22 @@ extension AppState {
       return
     }
 
-    let mode = effectiveSystemAudioMode
+    let mode = audioRecordingMode
+    guard mode != .off else {
+      stopTranscription()
+      return
+    }
+
+    // The detector supplies meeting boundaries in every active microphone mode. Only Meetings
+    // uses the signal to gate capture; Always uses it to label/rotate conversations.
     ensureMeetingDetector(for: mode)
 
-    let meetingStateReady = mode != .onlyDuringMeetings || meetingDetector?.hasObservedState == true
+    let meetingStateReady = mode != .onlyMeetings || meetingDetector?.hasObservedState == true
     let meetingActive = meetingDetector?.isMeetingActive ?? false
-    // Only during meetings → capture (mic + system) only while in a call. Always/Never → the mic
-    // runs continuously (system audio still respects the mode below).
-    let shouldCapture = mode != .onlyDuringMeetings || meetingActive
-    isAwaitingMeeting = mode == .onlyDuringMeetings && !meetingActive
+    // Only Meetings captures mic + system only while a call is active. Always captures both
+    // continuously, subject to OS capability and the hidden developer system-tap override.
+    let shouldCapture = mode == .always || meetingActive
+    isAwaitingMeeting = mode == .onlyMeetings && !meetingActive
 
     guard meetingStateReady else {
       log("Transcription: waiting for meeting detector before changing capture state")
@@ -610,9 +620,9 @@ extension AppState {
       }
     }
 
-    // System audio (macOS 14.4+). Captured when we should capture AND the mode isn't "never".
+    // System audio (macOS 14.4+). Captured whenever the chosen policy is actively recording.
     if #available(macOS 14.4, *) {
-      let systemShouldCapture = shouldCapture && mode != .never
+      let systemShouldCapture = shouldCapture && shouldCaptureSystemAudio
       if systemShouldCapture, systemAudioCaptureService == nil {
         systemAudioCaptureService = SystemAudioCaptureService()
         log("Transcription: System audio capture service created on demand (mode=\(mode.rawValue))")
@@ -625,6 +635,35 @@ extension AppState {
           AudioLevelMonitor.shared.updateSystemLevel(0)
           log("Transcription: System audio capture paused")
         }
+      }
+    }
+
+    if !meetingEndFinalizationInProgress,
+      MeetingConversationBoundaryPolicy.shouldFinishConversation(
+        mode: mode,
+        meetingStateReady: meetingStateReady,
+        shouldCapture: shouldCapture,
+        segmentCount: totalSegmentCount,
+        hasSpeakerSegments: !speakerSegments.isEmpty
+      )
+    {
+      meetingEndFinalizationInProgress = true
+      log("Transcription: Meeting ended — finishing conversation and waiting for the next meeting")
+      Task { @MainActor in
+        defer { self.meetingEndFinalizationInProgress = false }
+        guard
+          MeetingConversationBoundaryPolicy.shouldFinishConversation(
+            mode: self.audioRecordingMode,
+            meetingStateReady: self.meetingDetector?.hasObservedState == true,
+            shouldCapture: self.meetingDetector?.isMeetingActive == true,
+            segmentCount: self.totalSegmentCount,
+            hasSpeakerSegments: !self.speakerSegments.isEmpty
+          )
+        else {
+          log("Transcription: skipped meeting-ended finalization because meeting state changed")
+          return
+        }
+        _ = await self.finishConversation(finalizationReason: .meetingEnded)
       }
     }
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift
@@ -203,7 +203,7 @@ extension AppState {
     // grant). Counting .unknown as missing would permanently suppress the
     // "All permissions granted" banner for default users, so only a proven
     // denial counts.
-    if isSystemAudioSupported, effectiveSystemAudioMode != .never,
+    if isSystemAudioSupported, audioRecordingMode != .off, shouldCaptureSystemAudio,
       systemAudioPermissionStatus == .denied
     {
       missing.append("System Audio")

--- a/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
@@ -25,4 +25,17 @@ enum MeetingConversationBoundaryPolicy {
   static func committedRole(previousRole: Role, transition: Transition, rotationSucceeded: Bool) -> Role {
     rotationSucceeded ? transition.nextRole : previousRole
   }
+
+  static func shouldFinishConversation(
+    mode: AssistantSettings.AudioRecordingMode,
+    meetingStateReady: Bool,
+    shouldCapture: Bool,
+    segmentCount: Int,
+    hasSpeakerSegments: Bool
+  ) -> Bool {
+    mode == .onlyMeetings
+      && meetingStateReady
+      && !shouldCapture
+      && (segmentCount > 0 || hasSpeakerSegments)
+  }
 }

--- a/desktop/macos/Desktop/Sources/AuthService.swift
+++ b/desktop/macos/Desktop/Sources/AuthService.swift
@@ -2550,8 +2550,7 @@ class AuthService {
     // screenAnalysisEnabled: Don't removeObject here — SettingsSyncManager overwrites
     // it from the server within ~200ms of sign-in. Instead, onboarding force-starts
     // monitoring regardless of this setting.
-    // transcriptionEnabled: removeObject works since nothing writes it back.
-    UserDefaults.standard.removeObject(forKey: "transcriptionEnabled")
+    UserDefaults.standard.removeObject(forKey: AssistantSettings.audioRecordingModeDefaultsKey)
 
     if acceptedAccountDeletion {
       UserDefaults.standard.removeObject(forKey: .acceptedAccountDeletionOwnerId)

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -78,6 +78,7 @@ enum DefaultsKey: String {
   case onboardingChatGPTImportedMemories = "onboardingChatGPTImportedMemoriesCount"
   case gmailSelectedCookiePath = "gmailSelectedCookiePath"
   case gmailSelectedAccountLabel = "gmailSelectedAccountLabel"
+  case disableSystemAudioCapture = "disableSystemAudioCapture"
 }
 
 /// Compile-checked owner-scoped defaults keys whose final storage key is

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1242,9 +1242,7 @@ final class DesktopAutomationActionRegistry {
       params: ["enabled"]
     ) { params in
       let enabled = boolParam(params["enabled"], default: true)
-      AssistantSettings.shared.transcriptionEnabled = enabled
-      NotificationCenter.default.post(
-        name: .toggleTranscriptionRequested, object: nil, userInfo: ["enabled": enabled])
+      AssistantSettings.shared.audioRecordingMode = enabled ? .onlyMeetings : .off
       return ["enabled": enabled ? "true" : "false"]
     }
 
@@ -3516,7 +3514,8 @@ final class DesktopAutomationActionRegistry {
         "insight_enabled": insight.isEnabled ? "true" : "false",
         "memory_enabled": memory.isEnabled ? "true" : "false",
         "screen_analysis_enabled": assistant.screenAnalysisEnabled ? "true" : "false",
-        "transcription_enabled": assistant.transcriptionEnabled ? "true" : "false",
+        "transcription_enabled": assistant.audioRecordingMode != .off ? "true" : "false",
+        "audio_recording_mode": assistant.audioRecordingMode.rawValue,
         "multi_chat_enabled": UserDefaults.standard.bool(forKey: .multiChatEnabled) ? "true" : "false",
       ]
     }

--- a/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
+++ b/desktop/macos/Desktop/Sources/DesktopDiagnosticsManager.swift
@@ -989,7 +989,7 @@ final class DesktopDiagnosticsManager {
     var header = ["# Omi Desktop Diagnostics"]
     header.append("generated_at: \(ISO8601DateFormatter.desktopDiagnostics.string(from: Date()))")
     header.append("privacy: redacted_local_export")
-    for key in ["build", "build_number", "os_version", "device_model", "system_audio_mode"] {
+    for key in ["build", "build_number", "os_version", "device_model", "audio_recording_mode"] {
       if let value = meta[key] {
         header.append("\(key): \(value)")
       }
@@ -1267,8 +1267,8 @@ final class DesktopDiagnosticsManager {
       "os_version": osVersionString(),
       "device_model": deviceModel(),
     ]
-    properties["system_audio_mode"] =
-      UserDefaults.standard.string(forKey: "systemAudioCaptureMode") ?? "onlyDuringMeetings"
+    properties["audio_recording_mode"] =
+      UserDefaults.standard.string(forKey: AssistantSettings.audioRecordingModeDefaultsKey) ?? "onlyMeetings"
     return properties
   }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/SystemCaptureControls.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/SystemCaptureControls.swift
@@ -37,7 +37,7 @@ enum SystemCaptureControls {
   }
 
   static var isAudioRecordingOn: Bool {
-    !AppState.isPaywalledEffective && AssistantSettings.shared.transcriptionEnabled
+    !AppState.isPaywalledEffective && AssistantSettings.shared.audioRecordingMode != .off
   }
 
   // MARK: - Transitions
@@ -84,13 +84,8 @@ enum SystemCaptureControls {
       return .blockedPaywall
     }
 
-    AssistantSettings.shared.transcriptionEnabled = enabled
-    // Starting/stopping transcription needs AppState, which lives on the main view.
-    NotificationCenter.default.post(
-      name: .toggleTranscriptionRequested,
-      object: nil,
-      userInfo: ["enabled": enabled]
-    )
+    let current = AssistantSettings.shared.audioRecordingMode
+    AssistantSettings.shared.audioRecordingMode = enabled ? (current == .off ? .onlyMeetings : current) : .off
     return enabled ? .enabled : .disabled
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
@@ -21,8 +21,8 @@ enum CaptureListeningLogic {
     isCaptureMonitoring || ProactiveAssistantsPlugin.shared.isMonitoring
   }
 
-  static func listeningCaptureMode(raw: String) -> AssistantSettings.SystemAudioCaptureMode {
-    AssistantSettings.SystemAudioCaptureMode(rawValue: raw) ?? .onlyDuringMeetings
+  static func audioRecordingMode(raw: String) -> AssistantSettings.AudioRecordingMode {
+    AssistantSettings.AudioRecordingMode(rawValue: raw) ?? .onlyMeetings
   }
 
   static func listeningModeTitle(appState: AppState, raw: String) -> String {
@@ -45,50 +45,36 @@ enum CaptureListeningLogic {
         return name
       }
     }
-    switch listeningCaptureMode(raw: raw) {
+    switch audioRecordingMode(raw: raw) {
+    case .off:
+      return "Off"
     case .always:
-      return "Always"
-    case .onlyDuringMeetings:
-      return appState.isAwaitingMeeting ? "Meetings only" : "In meeting"
-    case .never:
-      return "Mic only"
+      return "Always On"
+    case .onlyMeetings:
+      return appState.isAwaitingMeeting ? "Only Meetings" : "In Meeting"
     }
   }
 
   // MARK: Actions
 
   static func toggleListening(
-    appState: AppState, transcriptionEnabled: Binding<Bool>, isTogglingListening: Binding<Bool>
+    appState: AppState, audioRecordingModeRaw: Binding<String>, isTogglingListening: Binding<Bool>
   ) {
-    let enabled = !appState.isTranscribing
+    let currentMode = audioRecordingMode(raw: audioRecordingModeRaw.wrappedValue)
+    let nextMode: AssistantSettings.AudioRecordingMode = currentMode == .off ? .onlyMeetings : .off
+    let enabled = nextMode != .off
     if enabled && !appState.hasMicrophonePermission {
       appState.requestMicrophonePermission()
       return
     }
 
     isTogglingListening.wrappedValue = true
-    transcriptionEnabled.wrappedValue = enabled
-    AssistantSettings.shared.transcriptionEnabled = enabled
-    AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
-    NotificationCenter.default.post(
-      name: .toggleTranscriptionRequested,
-      object: nil,
-      userInfo: ["enabled": enabled]
-    )
+    audioRecordingModeRaw.wrappedValue = nextMode.rawValue
+    AssistantSettings.shared.audioRecordingMode = nextMode
+    AnalyticsManager.shared.settingToggled(setting: "audio_recording_mode_\(nextMode.rawValue)", enabled: enabled)
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
       isTogglingListening.wrappedValue = false
     }
-  }
-
-  static func toggleListeningMode(raw: Binding<String>) {
-    let nextMode: AssistantSettings.SystemAudioCaptureMode =
-      listeningCaptureMode(raw: raw.wrappedValue) == .onlyDuringMeetings ? .always : .onlyDuringMeetings
-    raw.wrappedValue = nextMode.rawValue
-    AssistantSettings.shared.systemAudioCaptureMode = nextMode
-    AnalyticsManager.shared.settingToggled(
-      setting: "meetings_only_listening",
-      enabled: nextMode == .onlyDuringMeetings
-    )
   }
 
   static func toggleCapture(

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -291,18 +291,6 @@ struct DesktopHomeView: View {
         log("DesktopHomeView: app terminating — cancelling startup warmups")
         resetSessionScopedStartupWarmups()
       }
-      // Handle transcription toggle from menu bar
-      .onReceive(NotificationCenter.default.publisher(for: .toggleTranscriptionRequested)) {
-        notification in
-        if let enabled = notification.userInfo?["enabled"] as? Bool {
-          log("DesktopHomeView: Menu bar toggled transcription: \(enabled)")
-          if enabled {
-            appState.startTranscription()
-          } else {
-            appState.stopTranscription()
-          }
-        }
-      }
       // Periodic file re-scan (every 3 hours)
       .task {
         while !Task.isCancelled {
@@ -926,7 +914,7 @@ struct DesktopHomeView: View {
   private func restorePersistedCaptureServices(reason: String) {
     let settings = AssistantSettings.shared
     if PersistedCaptureLaunchPolicy.shouldStartTranscription(
-      intentEnabled: settings.transcriptionEnabled,
+      intentEnabled: settings.audioRecordingMode != .off,
       isTranscribing: appState.isTranscribing
     ) {
       log("DesktopHomeView: Restoring transcription from persisted intent (\(reason))")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -16,10 +16,10 @@ struct ConversationsPage: View {
 
   // Listening mode — used only to decide whether the manual "Start Recording"
   // affordance is meaningful (see startRecordingButton gating).
-  @AppStorage("systemAudioCaptureMode") private var systemAudioCaptureModeRaw =
-    AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue
-  private var listeningCaptureMode: AssistantSettings.SystemAudioCaptureMode {
-    CaptureListeningLogic.listeningCaptureMode(raw: systemAudioCaptureModeRaw)
+  @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) private var audioRecordingModeRaw =
+    AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
+  private var audioRecordingMode: AssistantSettings.AudioRecordingMode {
+    CaptureListeningLogic.audioRecordingMode(raw: audioRecordingModeRaw)
   }
 
   // Search state
@@ -227,7 +227,7 @@ struct ConversationsPage: View {
         // nothing is transcribing misleads the user into thinking capture is
         // active — during an actual meeting isTranscribing is already true and
         // the live transcript replaces this button.
-        if !appState.isTranscribing && listeningCaptureMode == .always {
+        if !appState.isTranscribing && audioRecordingMode == .always {
           startRecordingButton
         }
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -253,9 +253,8 @@ struct DashboardPage: View {
   @State private var showingGoalDetail = false
   @AppStorage("dashboardWidgetsCollapsed") private var widgetsCollapsed = false
   @AppStorage("screenAnalysisEnabled") private var screenAnalysisEnabled = true
-  @AppStorage("transcriptionEnabled") private var transcriptionEnabled = true
-  @AppStorage("systemAudioCaptureMode") private var systemAudioCaptureModeRaw =
-    AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue
+  @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) private var audioRecordingModeRaw =
+    AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
   @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
   @State private var homeMode: HomeStageMode = .hub
   @State private var didReportChatFirstTranscriptPage = false
@@ -282,12 +281,8 @@ struct DashboardPage: View {
     CaptureListeningLogic.isCaptureLive(isCaptureMonitoring: isCaptureMonitoring)
   }
 
-  private var listeningCaptureMode: AssistantSettings.SystemAudioCaptureMode {
-    CaptureListeningLogic.listeningCaptureMode(raw: systemAudioCaptureModeRaw)
-  }
-
   private var listeningModeTitle: String {
-    CaptureListeningLogic.listeningModeTitle(appState: appState, raw: systemAudioCaptureModeRaw)
+    CaptureListeningLogic.listeningModeTitle(appState: appState, raw: audioRecordingModeRaw)
   }
 
   private static let homeStageMaxWidth: CGFloat = 1360
@@ -1642,10 +1637,8 @@ struct DashboardPage: View {
             : (appState.isTranscribing ? "waveform.circle.fill" : "mic.circle"),
           status: transcriptionUnavailable ? .blocked : (appState.isTranscribing ? .active : .inactive),
           modeTitle: listeningModeTitle,
-          isMeetingsOnly: listeningCaptureMode == .onlyDuringMeetings,
           isToggling: isTogglingListening,
-          action: toggleListening,
-          modeAction: toggleListeningMode
+          action: toggleListening
         )
         // Settings lives in the nav rail (bottom-left) — no duplicate gear here.
       }
@@ -1806,11 +1799,8 @@ struct DashboardPage: View {
 
   private func toggleListening() {
     CaptureListeningLogic.toggleListening(
-      appState: appState, transcriptionEnabled: $transcriptionEnabled, isTogglingListening: $isTogglingListening)
-  }
-
-  private func toggleListeningMode() {
-    CaptureListeningLogic.toggleListeningMode(raw: $systemAudioCaptureModeRaw)
+      appState: appState, audioRecordingModeRaw: $audioRecordingModeRaw,
+      isTogglingListening: $isTogglingListening)
   }
 
   private func toggleCapture() {
@@ -3882,13 +3872,10 @@ struct HomeListeningStatusButton: View {
   let systemImage: String
   let status: HomeStatusState
   let modeTitle: String
-  let isMeetingsOnly: Bool
   let isToggling: Bool
   let action: () -> Void
-  let modeAction: () -> Void
 
-  // Single pill-level hover flag so moving between the title and the mode
-  // toggle never flickers the revealed controls.
+  // Hover reveals the selected mode, but Settings owns the only picker.
   @State private var isHovering = false
 
   var body: some View {
@@ -3932,27 +3919,6 @@ struct HomeListeningStatusButton: View {
       .disabled(isToggling)
       .help("Listening: \(status.text), \(modeTitle)")
       .accessibilityLabel("Listening \(status.text), \(modeTitle)")
-
-      // Divider + mode toggle are revealed only on hover to keep the
-      // resting pill compact.
-      if isHovering {
-        Rectangle()
-          .fill(Ink.separator)
-          .frame(width: 1, height: 18)
-          .transition(.opacity)
-
-        Button(action: modeAction) {
-          Image(systemName: isMeetingsOnly ? "person.2.fill" : "person.fill")
-            .scaledFont(size: OmiType.caption, weight: .semibold)
-            .foregroundStyle(modeIconColor)
-            .frame(width: 30, height: 34)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .help(isMeetingsOnly ? "Switch to always listening" : "Switch to meetings only")
-        .accessibilityLabel(isMeetingsOnly ? "Switch Listening to Always" : "Switch Listening to Meetings Only")
-        .transition(.opacity)
-      }
     }
     .foregroundStyle(status.isActive ? HomePalette.ink : (status.isBlocked ? status.indicator : HomePalette.muted))
     .background(
@@ -3967,10 +3933,6 @@ struct HomeListeningStatusButton: View {
     .frame(height: 34)
     .onHover { isHovering = $0 }
     .omiAnimation(.easeInOut(duration: 0.14), value: isHovering)
-  }
-
-  private var modeIconColor: Color {
-    status.isActive ? HomePalette.green : HomePalette.muted
   }
 
   private var statusFill: Color {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -666,14 +666,6 @@ struct SystemAudioPermissionSection: View {
     appState.systemAudioPermissionStatus
   }
 
-  private var mode: AssistantSettings.SystemAudioCaptureMode {
-    appState.effectiveSystemAudioMode
-  }
-
-  private var isDisabledBySetting: Bool {
-    mode == .never
-  }
-
   private var isGranted: Bool {
     status == .granted
   }
@@ -774,10 +766,6 @@ struct SystemAudioPermissionSection: View {
   }
 
   private var descriptionText: String {
-    if isDisabledBySetting {
-      return "Disabled in Settings > General"
-    }
-
     switch status {
     case .granted:
       return "Captures audio from calls, videos, and other apps"
@@ -791,9 +779,6 @@ struct SystemAudioPermissionSection: View {
   }
 
   private var systemAudioStatusBadge: some View {
-    if isDisabledBySetting {
-      return SettingsStatusChip(text: "Disabled", tint: Ink.secondary)
-    }
     switch status {
     case .granted: return SettingsStatusChip(text: "Granted", tint: Ink.listeningGreen)
     case .denied: return SettingsStatusChip(text: "Not Granted", tint: SettingsInk.notice)
@@ -804,11 +789,7 @@ struct SystemAudioPermissionSection: View {
 
   private var expandedContent: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-      if isDisabledBySetting {
-        Text("System audio capture is set to Never in Settings > General. Change that setting before testing access.")
-          .scaledFont(size: OmiType.body, weight: .medium)
-          .foregroundColor(Ink.primary)
-      } else if status == .unsupported {
+      if status == .unsupported {
         Text("System audio capture requires macOS 14.4 or later.")
           .scaledFont(size: OmiType.body, weight: .medium)
           .foregroundColor(Ink.primary)
@@ -854,8 +835,8 @@ struct SystemAudioPermissionSection: View {
         )
       }
       .buttonStyle(.plain)
-      .disabled(isTesting || isDisabledBySetting || status == .unsupported)
-      .opacity((isTesting || isDisabledBySetting || status == .unsupported) ? 0.6 : 1)
+      .disabled(isTesting || status == .unsupported)
+      .opacity((isTesting || status == .unsupported) ? 0.6 : 1)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -607,42 +607,6 @@ extension SettingsContentView {
     AssistantSettings.shared.screenAnalysisEnabled = enabled
   }
 
-  func toggleTranscription(enabled: Bool) {
-    // Check microphone permission
-    if enabled && !appState.hasMicrophonePermission {
-      transcriptionError = "Microphone permission required"
-      isTranscribing = false
-      return
-    }
-
-    transcriptionError = nil
-    isTogglingTranscription = true
-
-    // Track setting change
-    AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
-
-    if enabled {
-      appState.startTranscription()
-      isTogglingTranscription = false
-      isTranscribing = true
-    } else {
-      appState.stopTranscription()
-      isTogglingTranscription = false
-      isTranscribing = false
-    }
-
-    // Persist the setting
-    AssistantSettings.shared.transcriptionEnabled = enabled
-  }
-
-  func setSystemAudioCaptureMode(_ mode: AssistantSettings.SystemAudioCaptureMode) {
-    AnalyticsManager.shared.settingToggled(
-      setting: "system_audio_capture_mode_\(mode.rawValue)", enabled: mode != .never)
-    // Persisting posts .systemAudioCaptureModeDidChange; AppState re-applies the gate live for
-    // any in-progress recording.
-    AssistantSettings.shared.systemAudioCaptureMode = mode
-  }
-
   func startGlowPreview() {
     isPreviewRunning = true
 
@@ -772,8 +736,6 @@ extension SettingsContentView {
     let notificationSettingsPendingAtLoadStart =
       NotificationService.hasPendingNotificationSettingsSync()
     vadGateEnabled = AssistantSettings.shared.vadGateEnabled
-    systemAudioCaptureMode = AssistantSettings.shared.systemAudioCaptureMode
-
     Task {
       do {
         // Load all settings in parallel

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+General.swift
@@ -67,48 +67,27 @@ extension SettingsContentView {
         }
       }
 
-      // Audio Recording toggle
+      // One recording policy; no independent enable switch or system-audio mode.
       settingsCard(settingId: "general.audiorecording") {
-        HStack(spacing: OmiSpacing.lg) {
-          SettingsIconTile(symbol: "mic.fill")
+        VStack(alignment: .leading, spacing: OmiSpacing.md) {
+          HStack(spacing: OmiSpacing.lg) {
+            SettingsIconTile(symbol: "mic.fill")
 
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            Text("Audio Recording")
-              .scaledFont(size: OmiType.subheading, weight: .semibold)
-              .foregroundColor(Ink.primary)
+            VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+              Text("Audio Recording")
+                .scaledFont(size: OmiType.subheading, weight: .semibold)
+                .foregroundColor(Ink.primary)
 
-            Text(
-              transcriptionError
-                ?? (isTranscribing
-                  ? (appState.isAwaitingMeeting
-                    ? "Waiting for a meeting…" : "Recording and transcribing audio")
-                  : "Audio recording is paused")
-            )
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(transcriptionError != nil ? SettingsInk.notice : Ink.secondary)
+              Text(audioRecordingStatusText)
+                .scaledFont(size: OmiType.body)
+                .foregroundColor(audioRecordingNeedsAttention ? SettingsInk.notice : Ink.secondary)
+            }
+
+            Spacer()
+
+            AudioRecordingModeSwitcher(selection: audioRecordingModeBinding)
           }
 
-          Spacer()
-
-          if isTogglingTranscription {
-            ProgressView()
-              .scaleEffect(0.8)
-              .frame(width: 36, height: 20)
-          } else {
-            Toggle(
-              "",
-              isOn: Binding(
-                get: { isTranscribing },
-                set: { newValue in
-                  isTranscribing = newValue
-                  toggleTranscription(enabled: newValue)
-                }
-              )
-            )
-            .toggleStyle(OmiToggleStyle())
-            .labelsHidden()
-            .frame(width: 36, height: 20)
-          }
         }
       }
 
@@ -191,53 +170,6 @@ extension SettingsContentView {
         }
       }
 
-      // System Audio capture mode (macOS 14.4+ — system audio capture requires Core Audio taps)
-      if #available(macOS 14.4, *) {
-        settingsCard(settingId: "general.systemaudio") {
-          VStack(alignment: .leading, spacing: OmiSpacing.md) {
-            HStack(spacing: OmiSpacing.lg) {
-              SettingsIconTile(symbol: "speaker.wave.2.fill")
-
-              VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-                Text("System Audio")
-                  .scaledFont(size: OmiType.subheading, weight: .semibold)
-                  .foregroundColor(Ink.primary)
-
-                Text("Choose when Omi records audio from other apps (calls, videos, music).")
-                  .scaledFont(size: OmiType.body)
-                  .foregroundColor(Ink.secondary)
-              }
-
-              Spacer()
-
-              SettingsMenuPicker(
-                selection: Binding(
-                  get: { systemAudioCaptureMode },
-                  set: { newValue in
-                    systemAudioCaptureMode = newValue
-                    setSystemAudioCaptureMode(newValue)
-                  }
-                )
-              ) {
-                Text("Always").tag(AssistantSettings.SystemAudioCaptureMode.always)
-                Text("Only during meetings").tag(
-                  AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings)
-                Text("Never").tag(AssistantSettings.SystemAudioCaptureMode.never)
-              }
-            }
-
-            if systemAudioCaptureMode == .onlyDuringMeetings {
-              Text(
-                "Omi captures other apps' audio only while you're in a call (e.g. Zoom, Teams, FaceTime). Detecting browser-based calls like Google Meet requires Screen Recording permission."
-              )
-              .scaledFont(size: OmiType.caption)
-              .foregroundColor(Ink.secondary)
-              .fixedSize(horizontal: false, vertical: true)
-            }
-          }
-        }
-      }
-
       // Interface Sounds
       settingsCard(settingId: "general.interfacesounds") {
         InterfaceSoundsRow()
@@ -311,6 +243,94 @@ extension SettingsContentView {
     }
   }
 
+  private var audioRecordingMode: AssistantSettings.AudioRecordingMode {
+    AssistantSettings.AudioRecordingMode(rawValue: audioRecordingModeRaw) ?? .onlyMeetings
+  }
+
+  private var audioRecordingModeBinding: Binding<AssistantSettings.AudioRecordingMode> {
+    Binding(
+      get: { audioRecordingMode },
+      set: { mode in
+        audioRecordingModeRaw = mode.rawValue
+        AnalyticsManager.shared.settingToggled(
+          setting: "audio_recording_mode_\(mode.rawValue)", enabled: mode != .off)
+        AssistantSettings.shared.audioRecordingMode = mode
+      }
+    )
+  }
+
+  private var audioRecordingNeedsAttention: Bool {
+    audioRecordingMode != .off && !appState.hasMicrophonePermission
+  }
+
+  private var audioRecordingStatusText: String {
+    if audioRecordingNeedsAttention { return "Microphone permission required" }
+    switch audioRecordingMode {
+    case .off:
+      return "Off — no ambient audio is recorded"
+    case .always:
+      return appState.isTranscribing ? "Always on — recording audio" : "Always on — ready to record"
+    case .onlyMeetings:
+      if appState.isAwaitingMeeting { return "Only Meetings — waiting for a call" }
+      return appState.isTranscribing ? "Only Meetings — recording a call" : "Only Meetings — ready"
+    }
+  }
+}
+
+/// The recording policy is a mode, so keep all three choices visible and one click away.
+/// This intentionally uses the same raised-segment treatment as the chat mode switcher instead of
+/// a menu: users should be able to compare the policies without opening another surface.
+private struct AudioRecordingModeSwitcher: View {
+  @Binding var selection: AssistantSettings.AudioRecordingMode
+
+  var body: some View {
+    HStack(spacing: 2) {
+      segment(.off, label: "Off")
+      segment(.always, label: "Always On")
+      segment(.onlyMeetings, label: "Only Meetings")
+    }
+    .padding(3)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+        .fill(Ink.rowFill)
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: OmiChrome.controlRadius, style: .continuous)
+        .strokeBorder(Ink.hairline, lineWidth: 1)
+    )
+    .frame(width: 310)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel("Audio Recording")
+  }
+
+  private func segment(
+    _ mode: AssistantSettings.AudioRecordingMode,
+    label: String
+  ) -> some View {
+    let isSelected = selection == mode
+    return Button {
+      guard !isSelected else { return }
+      OmiMotion.withGated(.easeOut(duration: InkMotion.checkbox)) {
+        selection = mode
+      }
+    } label: {
+      Text(label)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .foregroundColor(isSelected ? Ink.primary : Ink.secondary)
+        .lineLimit(1)
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, OmiSpacing.xs)
+        .padding(.vertical, OmiSpacing.sm)
+        .background(
+          RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous)
+            .fill(isSelected ? Ink.surface : Color.clear)
+        )
+        .contentShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+    .accessibilityLabel(label)
+  }
 }
 
 /// The app's mute for its own interface sounds.
@@ -356,4 +376,5 @@ private struct InterfaceSoundsRow: View {
       .frame(width: 36, height: 20)
     }
   }
+
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -197,10 +197,9 @@ struct SettingsContentView: View {
   @AppStorage(DefaultsKey.chatScreenshotSharingEnabled.rawValue)
   var chatScreenshotSharingEnabled: Bool = true
 
-  // Transcription state
-  @State var isTranscribing: Bool
-  @State var isTogglingTranscription: Bool = false
-  @State var transcriptionError: String?
+  // The sole ambient-audio preference. Runtime activity remains on AppState.
+  @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) var audioRecordingModeRaw =
+    AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
 
   // Log export state
 
@@ -358,7 +357,6 @@ struct SettingsContentView: View {
   @State var transcriptionAutoDetect: Bool = true
   @State var transcriptionLanguage: String = "en"
   @State var vadGateEnabled: Bool = false
-  @State var systemAudioCaptureMode: AssistantSettings.SystemAudioCaptureMode = .always
 
   // Multi-chat mode setting
   @AppStorage("multiChatEnabled") var multiChatEnabled = false
@@ -568,7 +566,6 @@ struct SettingsContentView: View {
     let settings = AssistantSettings.shared
     _isMonitoring = State(initialValue: ProactiveAssistantsPlugin.shared.isMonitoring)
     _screenCaptureHealth = State(initialValue: ProactiveAssistantsPlugin.shared.screenCaptureHealth)
-    _isTranscribing = State(initialValue: appState.isTranscribing)
     _glowOverlayEnabled = State(initialValue: settings.glowOverlayEnabled)
     _analysisDelay = State(initialValue: settings.analysisDelay)
     _liveSuggestionsEnabled = State(initialValue: SuggestionAssistantSettings.shared.isEnabled)
@@ -598,7 +595,6 @@ struct SettingsContentView: View {
     _vadGateEnabled = State(initialValue: settings.vadGateEnabled)
     _transcriptionLanguage = State(initialValue: settings.transcriptionLanguage)
     _transcriptionAutoDetect = State(initialValue: settings.transcriptionAutoDetect)
-    _systemAudioCaptureMode = State(initialValue: settings.systemAudioCaptureMode)
   }
 
   /// Computed status text for notifications — OS permission/banner mirror only.
@@ -669,8 +665,6 @@ struct SettingsContentView: View {
       }
       loadBackendSettings()
       loadSubscriptionInfo()
-      // Sync transcription state with appState
-      isTranscribing = appState.isTranscribing
       // Sync floating bar state with persisted preference (not transient visibility)
       showAskOmiBar = FloatingControlBarManager.shared.isEnabled
       playwrightExtensionToken =
@@ -686,9 +680,6 @@ struct SettingsContentView: View {
         isMonitoring = state
       }
       screenCaptureHealth = ProactiveAssistantsPlugin.shared.screenCaptureHealth
-    }
-    .onChange(of: appState.isTranscribing) { _, newValue in
-      isTranscribing = newValue
     }
     .onChange(of: selectedSection) { _, newValue in
       if AppBuild.isProductionBundle && newValue == .aiChat {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
@@ -321,9 +321,8 @@ struct ShellStatusIcons: View {
   @State private var isTogglingListening = false
 
   @AppStorage("screenAnalysisEnabled") private var screenAnalysisEnabled = true
-  @AppStorage("transcriptionEnabled") private var transcriptionEnabled = true
-  @AppStorage("systemAudioCaptureMode") private var systemAudioCaptureModeRaw =
-    AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue
+  @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) private var audioRecordingModeRaw =
+    AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
 
   var body: some View {
     HStack(spacing: 2) {
@@ -367,7 +366,7 @@ struct ShellStatusIcons: View {
     ShellStatusTooltip.audio(
       state: listeningState,
       mode: CaptureListeningLogic.listeningModeTitle(
-        appState: appState, raw: systemAudioCaptureModeRaw))
+        appState: appState, raw: audioRecordingModeRaw))
   }
 
   private var captureState: HomeStatusState {
@@ -381,7 +380,7 @@ struct ShellStatusIcons: View {
   private func toggleListening() {
     CaptureListeningLogic.toggleListening(
       appState: appState,
-      transcriptionEnabled: $transcriptionEnabled,
+      audioRecordingModeRaw: $audioRecordingModeRaw,
       isTogglingListening: $isTogglingListening)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -23,12 +23,6 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["monitor", "screenshot", "capture", "audio", "recording", "microphone", "speech"],
       section: .general, icon: "gearshape", settingId: "general.screencapture"),
     SettingsSearchItem(
-      name: "System Audio", subtitle: "When to record audio from other apps",
-      keywords: [
-        "system audio", "meeting", "zoom", "google meet", "teams", "call", "capture", "recording",
-        "speaker",
-      ], section: .general, icon: "speaker.wave.2", settingId: "general.systemaudio"),
-    SettingsSearchItem(
       name: "Notifications", subtitle: "macOS permission and banner status",
       keywords: ["alerts", "notify", "banners", "system settings", "permission"], section: .general,
       icon: "gearshape",
@@ -60,8 +54,11 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["screen capture", "screenshot", "monitor", "recording", "rewind"],
       section: .general, icon: "rectangle.dashed.badge.record", settingId: "general.screencapture"),
     SettingsSearchItem(
-      name: "Audio Recording", subtitle: "Toggle audio recording and transcription",
-      keywords: ["audio", "microphone", "recording", "transcription", "mic"], section: .general,
+      name: "Audio Recording", subtitle: "Off, Always On, or Only Meetings",
+      keywords: [
+        "audio", "microphone", "recording", "transcription", "mic", "meeting", "zoom", "google meet",
+        "teams", "call", "system audio",
+      ], section: .general,
       icon: "mic.fill", settingId: "general.audiorecording"),
     SettingsSearchItem(
       name: "Storage", subtitle: "View frame count and disk usage",

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
@@ -16,7 +16,8 @@ struct SidebarView: View {
 
   // Toggle states for quick controls
   @AppStorage("screenAnalysisEnabled") private var screenAnalysisEnabled = true
-  @AppStorage("transcriptionEnabled") private var transcriptionEnabled = true
+  @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) private var audioRecordingModeRaw =
+    AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
   @State private var isMonitoring = false
   @State private var isTogglingMonitoring = false
   @State private var isTogglingTranscription = false
@@ -628,7 +629,7 @@ struct SidebarView: View {
   private func microphonePermissionRow(isExpanded: Bool) -> some View {
     let isDenied = appState.isMicrophonePermissionDenied()
     let isToggleable = appState.hasMicrophonePermission
-    let isActive = transcriptionEnabled && isToggleable
+    let isActive = audioRecordingModeRaw != AssistantSettings.AudioRecordingMode.off.rawValue && isToggleable
     let color: Color =
       isToggleable
       ? Ink.secondary
@@ -698,7 +699,7 @@ struct SidebarView: View {
 
     if isToggleable {
       Button(action: {
-        toggleTranscription(enabled: !transcriptionEnabled)
+        toggleTranscription(enabled: audioRecordingModeRaw == AssistantSettings.AudioRecordingMode.off.rawValue)
       }) {
         row
       }
@@ -800,14 +801,9 @@ struct SidebarView: View {
     // Track setting change
     AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
 
-    // Persist the setting first for immediate feedback
-    AssistantSettings.shared.transcriptionEnabled = enabled
-
-    if enabled {
-      appState.startTranscription()
-    } else {
-      appState.stopTranscription()
-    }
+    let mode: AssistantSettings.AudioRecordingMode = enabled ? .onlyMeetings : .off
+    audioRecordingModeRaw = mode.rawValue
+    AssistantSettings.shared.audioRecordingMode = mode
 
     // Small delay to show the loading state visually
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -920,7 +920,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     let audioRecordingView = makeToggleItemView(
       title: "Audio Recording",
       iconName: "mic.fill",
-      isOn: !paywalled && AssistantSettings.shared.transcriptionEnabled,
+      isOn: !paywalled && AssistantSettings.shared.audioRecordingMode != .off,
       action: #selector(audioRecordingToggled(_:))
     )
     audioRecordingItem.view = audioRecordingView
@@ -1227,7 +1227,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     screenCaptureSwitch?.state =
       (!paywalled && ProactiveAssistantsPlugin.shared.isMonitoring) ? .on : .off
     audioRecordingSwitch?.state =
-      (!paywalled && AssistantSettings.shared.transcriptionEnabled) ? .on : .off
+      (!paywalled && AssistantSettings.shared.audioRecordingMode != .off) ? .on : .off
   }
 
   func menuDidClose(_ menu: NSMenu) {

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -656,7 +656,7 @@ struct OnboardingView: View {
     }
     if AppBuild.usesLazyDevPermissions {
       AssistantSettings.shared.screenAnalysisEnabled = false
-      AssistantSettings.shared.transcriptionEnabled = false
+      AssistantSettings.shared.audioRecordingMode = .off
       log("OnboardingView: Lazy dev permissions enabled, skipping monitoring/transcription autostart")
     } else {
       startMonitoringIfNeeded()

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -39,22 +39,18 @@ struct SBOnboardingWidgetShape: Equatable {
 @MainActor
 final class SBOnboardingModel: ObservableObject {
   enum CaptureSelection: Equatable {
-    case onlyDuringMeetings
-    case continuous
+    case onlyMeetings
+    case always
 
-    var systemAudioCaptureMode: AssistantSettings.SystemAudioCaptureMode {
+    var audioRecordingMode: AssistantSettings.AudioRecordingMode {
       switch self {
-      case .onlyDuringMeetings: .onlyDuringMeetings
-      case .continuous: .always
+      case .onlyMeetings: .onlyMeetings
+      case .always: .always
       }
-    }
-
-    var startsListeningImmediately: Bool {
-      self == .continuous
     }
   }
 
-  static let defaultCaptureSelection: CaptureSelection = .onlyDuringMeetings
+  static let defaultCaptureSelection: CaptureSelection = .onlyMeetings
 
   enum Step: Int, CaseIterable {
     case promise, name, howHeard, language, role
@@ -692,13 +688,13 @@ final class SBOnboardingModel: ObservableObject {
   // MARK: capture choice → completes onboarding
 
   func capture(_ selection: CaptureSelection) {
-    AssistantSettings.shared.systemAudioCaptureMode = selection.systemAudioCaptureMode
-    complete(startListening: selection.startsListeningImmediately)
+    AssistantSettings.shared.audioRecordingMode = selection.audioRecordingMode
+    complete()
   }
 
   /// The one handoff both exit paths run when onboarding ends.
   ///
-  /// `skip()` and `complete(startListening:)` used to carry byte-identical
+  /// `skip()` and `complete()` used to carry byte-identical
   /// copies of this sequence, which is how the post-onboarding guidance came to
   /// be produced by neither: there was no single place that owned "onboarding is
   /// over, hand the user to the app". There is now, so a step added here can
@@ -741,7 +737,7 @@ final class SBOnboardingModel: ObservableObject {
   }
 
   /// Replicates the essential real side-effects of the legacy handleOnboardingComplete().
-  private func complete(startListening: Bool) {
+  private func complete() {
     // Do NOT mark file indexing complete here. Onboarding never actually scans, so
     // setting this flag "faked" the Files connector as connected while indexing
     // nothing — and, worse, permanently suppressed the Home view's automatic
@@ -766,7 +762,7 @@ final class SBOnboardingModel: ObservableObject {
       }
     }
     Task { [appState] in
-      if startListening { appState.startTranscription() }
+      appState.startTranscription()
       await appState.reconcileCapture()
     }
     // NOTE: previously this created a "Run omi for two days…" welcome task. That

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -914,27 +914,14 @@ struct SBOnboardingView: View {
       Button {
         model.capture(SBOnboardingModel.defaultCaptureSelection)
       } label: {
-        // **One `Text`, not an `HStack` of two.** The label is wider than the capsule's 340 pt
-        // measure, and side by side the first run wrapped to two lines while the qualifier stayed on
-        // one and centred itself against them — a lopsided block inside the pill, on the last card
-        // of the flow. Concatenated, the whole label wraps as a single centred paragraph.
-        //
-        // The qualifier still steps down in *alpha* on the label colour rather than moving to another
-        // rung — the ladder is for type on the panel, and there is no second ink inside a primary
-        // button. `Ink.surface` restated here because a per-run colour is the only way to vary one
-        // inside a concatenation, and `Ink.surface` is exactly what `InkButtonStyle` sets for
-        // `.primary`.
-        (Text("● Only during meetings ")
-          + Text("· from my calendar").foregroundColor(Ink.surface.opacity(0.75)))
-          .multilineTextAlignment(.center)
-          .frame(maxWidth: .infinity)
+        Text("Only Meetings").frame(maxWidth: .infinity)
       }
       .buttonStyle(InkButtonStyle(kind: .primary))
       .keyboardShortcut(.defaultAction)
       Button {
-        model.capture(.continuous)
+        model.capture(.always)
       } label: {
-        Text("Start listening — continuously").frame(maxWidth: .infinity)
+        Text("Always On").frame(maxWidth: .infinity)
       }
       .buttonStyle(InkButtonStyle(kind: .secondary))
     }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBPostOnboardingGuidance.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBPostOnboardingGuidance.swift
@@ -14,25 +14,21 @@ import Foundation
 struct SBSetupSnapshot: Equatable, Sendable {
   enum Listening: String, Equatable, Sendable {
     case disabled
-    case continuous
+    case always
     case meetingsOnly
-    case microphoneOnly
 
-    /// Keeps the setup snapshot independent of the live settings object while
-    /// preserving the capture semantics users see elsewhere in the app:
-    /// `.never` disables system audio, but leaves the microphone listening.
-    init(systemAudioModeRaw: String, canHear: Bool) {
+    init(audioRecordingModeRaw: String, canHear: Bool) {
       guard canHear else {
         self = .disabled
         return
       }
-      switch systemAudioModeRaw {
-      case AssistantSettings.SystemAudioCaptureMode.always.rawValue:
-        self = .continuous
-      case AssistantSettings.SystemAudioCaptureMode.onlyDuringMeetings.rawValue:
+      switch audioRecordingModeRaw {
+      case AssistantSettings.AudioRecordingMode.always.rawValue:
+        self = .always
+      case AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue:
         self = .meetingsOnly
-      case AssistantSettings.SystemAudioCaptureMode.never.rawValue:
-        self = .microphoneOnly
+      case AssistantSettings.AudioRecordingMode.off.rawValue:
+        self = .disabled
       default:
         // An unknown persisted value is not evidence for a more permissive
         // mode. AssistantSettings normally heals this before it reaches us,
@@ -224,7 +220,7 @@ enum SBPostOnboardingGuidance {
         symbol: "mic.slash",
         title: "I can't hear yet. Turn on the microphone in Settings whenever you want me to.",
         keys: [])
-    case .continuous:
+    case .always:
       return SBOrientationCue(
         id: "listening",
         symbol: "ear",
@@ -233,14 +229,8 @@ enum SBPostOnboardingGuidance {
     case .meetingsOnly:
       return SBOrientationCue(
         id: "listening",
-        symbol: "calendar",
-        title: "I'll start listening when your meetings start.",
-        keys: [])
-    case .microphoneOnly:
-      return SBOrientationCue(
-        id: "listening",
-        symbol: "mic",
-        title: "I'm listening through your microphone only.",
+        symbol: "person.2",
+        title: "I'll start listening when a call starts.",
         keys: [])
     }
   }
@@ -278,7 +268,7 @@ extension SBOnboardingModel {
     return SBSetupSnapshot(
       role: role ?? roleDraft,
       listening: SBSetupSnapshot.Listening(
-        systemAudioModeRaw: appState.effectiveSystemAudioMode.rawValue,
+        audioRecordingModeRaw: appState.audioRecordingMode.rawValue,
         canHear: canHear),
       // Match the dashboard's capture health contract. TCC can remain granted
       // after signing changes or a ScreenCaptureKit failure, so permission or

--- a/desktop/macos/Desktop/Sources/PostOnboardingPromptViews.swift
+++ b/desktop/macos/Desktop/Sources/PostOnboardingPromptViews.swift
@@ -28,11 +28,11 @@ struct TryAskingPopupView: View {
   private var cues: [SBOrientationCue] {
     var setup = SBSetupSnapshot()
     setup.canHear = AudioCaptureService.checkPermission()
-    let systemAudioMode =
-      AppState.current?.effectiveSystemAudioMode.rawValue
-      ?? AssistantSettings.shared.systemAudioCaptureMode.rawValue
+    let recordingMode =
+      AppState.current?.audioRecordingMode.rawValue
+      ?? AssistantSettings.shared.audioRecordingMode.rawValue
     setup.listening = SBSetupSnapshot.Listening(
-      systemAudioModeRaw: systemAudioMode,
+      audioRecordingModeRaw: recordingMode,
       canHear: setup.canHear)
     return SBPostOnboardingGuidance.orientationCues(
       openShortcutTokens: ShortcutSettings.shared.askOmiShortcut.displayTokens,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AssistantSettings.swift
@@ -5,14 +5,16 @@ import Foundation
 class AssistantSettings {
   static let shared = AssistantSettings()
 
-  /// Controls when system audio (audio from other apps — calls, videos, music) is captured
-  /// during a recording. `always` = capture for the whole recording; `onlyDuringMeetings` =
-  /// capture only while a conferencing call is detected (default); `never` = never.
-  enum SystemAudioCaptureMode: String {
+  /// The one user-owned policy for ambient audio recording.
+  /// Runtime permission/provider failures may prevent the selected policy from running, but no
+  /// second preference is allowed to override it.
+  enum AudioRecordingMode: String, CaseIterable {
+    case off
     case always
-    case onlyDuringMeetings
-    case never
+    case onlyMeetings
   }
+
+  nonisolated static let audioRecordingModeDefaultsKey = "audioRecordingMode"
 
   // MARK: - UserDefaults Keys
 
@@ -20,14 +22,14 @@ class AssistantSettings {
   private let glowOverlayEnabledKey = "assistantsGlowOverlayEnabled"
   private let analysisDelayKey = "assistantsAnalysisDelay"
   private let screenAnalysisEnabledKey = "screenAnalysisEnabled"
-  private let transcriptionEnabledKey = "transcriptionEnabled"
   private let transcriptionLanguageKey = "transcriptionLanguage"
   private let transcriptionAutoDetectKey = "transcriptionAutoDetect"
   private let voiceLanguagesKey = "voiceAssistantLanguages"
   private let transcriptionVocabularyKey = "transcriptionVocabulary"
   private let vadGateEnabledKey = "vadGateEnabled"
   private let batchTranscriptionEnabledKey = "batchTranscriptionEnabled"
-  private let systemAudioCaptureModeKey = "systemAudioCaptureMode"
+  private let legacyTranscriptionEnabledKey = "transcriptionEnabled"
+  private let legacySystemAudioCaptureModeKey = "systemAudioCaptureMode"
 
   // MARK: - Default Values
 
@@ -35,30 +37,61 @@ class AssistantSettings {
   private let defaultGlowOverlayEnabled = false
   private let defaultAnalysisDelay = 60  // seconds (1 minute)
   private let defaultScreenAnalysisEnabled = true
-  private let defaultTranscriptionEnabled = true
   private let defaultTranscriptionLanguage = "en"
   private let defaultTranscriptionAutoDetect = true
   private let defaultTranscriptionVocabulary: [String] = []
   private let defaultVadGateEnabled = false
   private let defaultBatchTranscriptionEnabled = false
-  private let defaultSystemAudioCaptureMode: SystemAudioCaptureMode = .onlyDuringMeetings
+  private let defaultAudioRecordingMode: AudioRecordingMode = .onlyMeetings
   private(set) var transcriptionVocabularyRevision: UInt64 = 0
 
   private init() {
+    migrateLegacyAudioRecordingSettings()
     // Register defaults
     UserDefaults.standard.register(defaults: [
       cooldownIntervalKey: defaultCooldownInterval,
       glowOverlayEnabledKey: defaultGlowOverlayEnabled,
       analysisDelayKey: defaultAnalysisDelay,
       screenAnalysisEnabledKey: defaultScreenAnalysisEnabled,
-      transcriptionEnabledKey: defaultTranscriptionEnabled,
+      Self.audioRecordingModeDefaultsKey: defaultAudioRecordingMode.rawValue,
       transcriptionLanguageKey: defaultTranscriptionLanguage,
       transcriptionAutoDetectKey: defaultTranscriptionAutoDetect,
       transcriptionVocabularyKey: defaultTranscriptionVocabulary,
       vadGateEnabledKey: defaultVadGateEnabled,
       batchTranscriptionEnabledKey: defaultBatchTranscriptionEnabled,
-      systemAudioCaptureModeKey: defaultSystemAudioCaptureMode.rawValue,
     ])
+  }
+
+  /// Collapses the former enable switch + system-audio picker into one policy. A user who had
+  /// system audio disabled but ambient microphone recording enabled remains in Always rather than
+  /// being silently turned off; system-audio permission is now a runtime capability, not a mode.
+  static func migratedAudioRecordingMode(
+    legacyTranscriptionEnabled: Bool?,
+    legacySystemAudioModeRaw: String?
+  ) -> AudioRecordingMode {
+    if legacyTranscriptionEnabled == false { return .off }
+    switch legacySystemAudioModeRaw {
+    case "always", "never": return .always
+    case "onlyDuringMeetings": return .onlyMeetings
+    default: return .onlyMeetings
+    }
+  }
+
+  private func migrateLegacyAudioRecordingSettings() {
+    let defaults = UserDefaults.standard
+    if defaults.object(forKey: Self.audioRecordingModeDefaultsKey) == nil {
+      let legacyEnabled = defaults.object(forKey: legacyTranscriptionEnabledKey) as? Bool
+      let legacyMode = defaults.string(forKey: legacySystemAudioCaptureModeKey)
+      defaults.set(
+        Self.migratedAudioRecordingMode(
+          legacyTranscriptionEnabled: legacyEnabled,
+          legacySystemAudioModeRaw: legacyMode
+        ).rawValue,
+        forKey: Self.audioRecordingModeDefaultsKey
+      )
+    }
+    defaults.removeObject(forKey: legacyTranscriptionEnabledKey)
+    defaults.removeObject(forKey: legacySystemAudioCaptureModeKey)
   }
 
   // MARK: - Properties
@@ -120,12 +153,15 @@ class AssistantSettings {
     }
   }
 
-  /// Whether transcription should be enabled
-  var transcriptionEnabled: Bool {
-    get { UserDefaults.standard.bool(forKey: transcriptionEnabledKey) }
+  /// The single persisted source of truth for whether and when ambient audio is recorded.
+  var audioRecordingMode: AudioRecordingMode {
+    get {
+      let raw = UserDefaults.standard.string(forKey: Self.audioRecordingModeDefaultsKey)
+      return AudioRecordingMode(rawValue: raw ?? "") ?? defaultAudioRecordingMode
+    }
     set {
-      UserDefaults.standard.set(newValue, forKey: transcriptionEnabledKey)
-      NotificationCenter.default.post(name: .transcriptionSettingsDidChange, object: nil)
+      UserDefaults.standard.set(newValue.rawValue, forKey: Self.audioRecordingModeDefaultsKey)
+      NotificationCenter.default.post(name: .audioRecordingModeDidChange, object: nil)
     }
   }
 
@@ -270,23 +306,6 @@ class AssistantSettings {
     }
   }
 
-  /// When system audio (audio from other apps) is captured during a recording.
-  /// Default `.onlyDuringMeetings` limits system audio capture to detected conferencing calls.
-  /// The hidden `disableSystemAudioCapture` debug UserDefault still forces "never" — see `AppState.effectiveSystemAudioMode`.
-  /// Posts `.systemAudioCaptureModeDidChange` so an active recording can re-apply the gate live.
-  var systemAudioCaptureMode: SystemAudioCaptureMode {
-    get {
-      let raw =
-        UserDefaults.standard.string(forKey: systemAudioCaptureModeKey)
-        ?? defaultSystemAudioCaptureMode.rawValue
-      return SystemAudioCaptureMode(rawValue: raw) ?? defaultSystemAudioCaptureMode
-    }
-    set {
-      UserDefaults.standard.set(newValue.rawValue, forKey: systemAudioCaptureModeKey)
-      NotificationCenter.default.post(name: .systemAudioCaptureModeDidChange, object: nil)
-    }
-  }
-
   /// Returns vocabulary with "Omi" always included (for DeepGram)
   var effectiveVocabulary: [String] {
     var vocab = Set(transcriptionVocabulary)
@@ -300,13 +319,12 @@ class AssistantSettings {
     glowOverlayEnabled = defaultGlowOverlayEnabled
     analysisDelay = defaultAnalysisDelay
     screenAnalysisEnabled = defaultScreenAnalysisEnabled
-    transcriptionEnabled = defaultTranscriptionEnabled
+    audioRecordingMode = defaultAudioRecordingMode
     transcriptionLanguage = defaultTranscriptionLanguage
     transcriptionAutoDetect = defaultTranscriptionAutoDetect
     transcriptionVocabulary = defaultTranscriptionVocabulary
     vadGateEnabled = defaultVadGateEnabled
     batchTranscriptionEnabled = defaultBatchTranscriptionEnabled
-    systemAudioCaptureMode = defaultSystemAudioCaptureMode
   }
 
   // MARK: - Supported Languages
@@ -501,7 +519,7 @@ extension Notification.Name {
   static let assistantMonitoringStateDidChange = Notification.Name("assistantMonitoringStateDidChange")
   static let assistantMonitoringToggleRequested = Notification.Name("assistantMonitoringToggleRequested")
   static let transcriptionSettingsDidChange = Notification.Name("transcriptionSettingsDidChange")
-  static let systemAudioCaptureModeDidChange = Notification.Name("systemAudioCaptureModeDidChange")
+  static let audioRecordingModeDidChange = Notification.Name("audioRecordingModeDidChange")
   static let voiceLanguagesDidChange = Notification.Name("voiceLanguagesDidChange")
 }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -5575,7 +5575,7 @@ class ChatProvider: ObservableObject {
   func presentOnboardingOpener() {
     let name = Self.firstName(AuthService.shared.givenName)
     let mode: OnboardingOpenerComposer.ListeningMode =
-      AssistantSettings.shared.systemAudioCaptureMode == .always ? .always : .meetingsOnly
+      AssistantSettings.shared.audioRecordingMode == .always ? .always : .meetingsOnly
     let baseStarters = HomeSuggestionComposer.compose(
       personalized: HomeSuggestionsStore.shared.personalizedQuestions,
       onboarding: PostOnboardingPromptSuggestions.suggestions())

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -1409,11 +1409,7 @@ struct RewindPage: View {
         .omiAnimation(.easeInOut(duration: 0.15), value: appState.isTranscribing)
     }
     .onTapGesture {
-      if appState.isTranscribing {
-        appState.stopTranscription()
-      } else {
-        appState.startTranscription()
-      }
+      appState.toggleTranscription()
     }
     .help(appState.isTranscribing ? "Audio is on - click to stop" : "Audio is off - click to start")
   }

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -62,20 +62,17 @@ final class DashboardCaptureStateTests: XCTestCase {
     )
   }
 
-  func testListeningPillShowsAndTogglesCaptureMode() throws {
+  func testListeningPillReflectsTheUnifiedAudioRecordingMode() throws {
     let source = try dashboardSource()
     let logic = try captureLogicSource()
 
-    XCTAssertTrue(source.contains("@AppStorage(\"systemAudioCaptureMode\")"))
+    XCTAssertTrue(source.contains("@AppStorage(AssistantSettings.audioRecordingModeDefaultsKey)"))
     XCTAssertTrue(source.contains("private var listeningModeTitle: String"))
-    XCTAssertTrue(logic.contains("return appState.isAwaitingMeeting ? \"Meetings only\" : \"In meeting\""))
+    XCTAssertTrue(logic.contains("return appState.isAwaitingMeeting ? \"Only Meetings\" : \"In Meeting\""))
     XCTAssertTrue(source.contains("HomeListeningStatusButton("))
-    XCTAssertTrue(source.contains("modeAction: toggleListeningMode"))
-    XCTAssertTrue(logic.contains("AssistantSettings.shared.systemAudioCaptureMode = nextMode"))
-    XCTAssertTrue(source.contains("Image(systemName: isMeetingsOnly ? \"person.2.fill\" : \"person.fill\")"))
-    XCTAssertTrue(source.contains("private var modeIconColor: Color"))
+    XCTAssertFalse(source.contains("modeAction: toggleListeningMode"))
+    XCTAssertFalse(logic.contains("toggleListeningMode"))
     XCTAssertTrue(source.contains(".frame(height: 34)"))
-    XCTAssertFalse(source.contains("Image(systemName: isMeetingsOnly ? \"person.2.fill\" : \"infinity\")"))
     XCTAssertFalse(source.contains("Circle()\n                    .fill(status.indicator)"))
     XCTAssertFalse(source.contains("OmiColors.purplePrimary"))
   }

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -313,11 +313,11 @@ import XCTest
     }
   }
 
-  // MARK: - AssistantSettings.systemAudioCaptureMode
+  // MARK: - AssistantSettings.audioRecordingMode
 
   @MainActor
-  final class SystemAudioCaptureModeSettingsTests: XCTestCase {
-    private let key = "systemAudioCaptureMode"
+  final class AudioRecordingModeSettingsTests: XCTestCase {
+    private let key = AssistantSettings.audioRecordingModeDefaultsKey
 
     override func setUp() {
       super.setUp()
@@ -330,21 +330,45 @@ import XCTest
     }
 
     func testDefaultsToOnlyDuringMeetings() {
-      XCTAssertEqual(AssistantSettings.shared.systemAudioCaptureMode, .onlyDuringMeetings)
+      XCTAssertEqual(AssistantSettings.shared.audioRecordingMode, .onlyMeetings)
     }
 
     func testPersistsAndReadsBack() {
-      AssistantSettings.shared.systemAudioCaptureMode = .onlyDuringMeetings
-      XCTAssertEqual(UserDefaults.standard.string(forKey: key), "onlyDuringMeetings")
-      XCTAssertEqual(AssistantSettings.shared.systemAudioCaptureMode, .onlyDuringMeetings)
+      AssistantSettings.shared.audioRecordingMode = .onlyMeetings
+      XCTAssertEqual(UserDefaults.standard.string(forKey: key), "onlyMeetings")
+      XCTAssertEqual(AssistantSettings.shared.audioRecordingMode, .onlyMeetings)
 
-      AssistantSettings.shared.systemAudioCaptureMode = .never
-      XCTAssertEqual(AssistantSettings.shared.systemAudioCaptureMode, .never)
+      AssistantSettings.shared.audioRecordingMode = .off
+      XCTAssertEqual(AssistantSettings.shared.audioRecordingMode, .off)
     }
 
     func testUnknownRawValueFallsBackToDefault() {
       UserDefaults.standard.set("garbage", forKey: key)
-      XCTAssertEqual(AssistantSettings.shared.systemAudioCaptureMode, .onlyDuringMeetings)
+      XCTAssertEqual(AssistantSettings.shared.audioRecordingMode, .onlyMeetings)
+    }
+
+    func testLegacySettingsCollapseIntoOneMode() {
+      XCTAssertEqual(
+        AssistantSettings.migratedAudioRecordingMode(
+          legacyTranscriptionEnabled: false,
+          legacySystemAudioModeRaw: "always"),
+        .off)
+      XCTAssertEqual(
+        AssistantSettings.migratedAudioRecordingMode(
+          legacyTranscriptionEnabled: true,
+          legacySystemAudioModeRaw: "onlyDuringMeetings"),
+        .onlyMeetings)
+      XCTAssertEqual(
+        AssistantSettings.migratedAudioRecordingMode(
+          legacyTranscriptionEnabled: true,
+          legacySystemAudioModeRaw: "always"),
+        .always)
+      XCTAssertEqual(
+        AssistantSettings.migratedAudioRecordingMode(
+          legacyTranscriptionEnabled: true,
+          legacySystemAudioModeRaw: "never"),
+        .always,
+        "Legacy mic-only users should remain recording rather than become Off")
     }
   }
 
@@ -382,7 +406,6 @@ import XCTest
       let transition = try XCTUnwrap(
         MeetingConversationBoundaryPolicy.transition(previousRole: .ambient, meetingActive: true)
       )
-
       XCTAssertEqual(
         MeetingConversationBoundaryPolicy.committedRole(
           previousRole: .ambient, transition: transition, rotationSucceeded: false),
@@ -392,6 +415,87 @@ import XCTest
         MeetingConversationBoundaryPolicy.committedRole(
           previousRole: .ambient, transition: transition, rotationSucceeded: true),
         .meeting
+      )
+    }
+
+    func testMeetingGateClosingWithSegmentsFinishesConversation() {
+      XCTAssertTrue(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .onlyMeetings,
+          meetingStateReady: true,
+          shouldCapture: false,
+          segmentCount: 12,
+          hasSpeakerSegments: false
+        )
+      )
+    }
+
+    func testMeetingGateClosingWithOnlyInMemorySegmentsFinishesConversation() {
+      XCTAssertTrue(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .onlyMeetings,
+          meetingStateReady: true,
+          shouldCapture: false,
+          segmentCount: 0,
+          hasSpeakerSegments: true
+        )
+      )
+    }
+
+    func testWaitingForFirstMeetingDoesNotFinishEmptySession() {
+      XCTAssertFalse(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .onlyMeetings,
+          meetingStateReady: true,
+          shouldCapture: false,
+          segmentCount: 0,
+          hasSpeakerSegments: false
+        )
+      )
+    }
+
+    func testNonMeetingModesDoNotUseMeetingEndBoundary() {
+      XCTAssertFalse(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .always,
+          meetingStateReady: true,
+          shouldCapture: false,
+          segmentCount: 12,
+          hasSpeakerSegments: true
+        )
+      )
+      XCTAssertFalse(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .off,
+          meetingStateReady: true,
+          shouldCapture: false,
+          segmentCount: 12,
+          hasSpeakerSegments: true
+        )
+      )
+    }
+
+    func testActiveMeetingDoesNotFinishConversation() {
+      XCTAssertFalse(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .onlyMeetings,
+          meetingStateReady: true,
+          shouldCapture: true,
+          segmentCount: 12,
+          hasSpeakerSegments: true
+        )
+      )
+    }
+
+    func testUnreadyMeetingStateDoesNotFinishExistingConversation() {
+      XCTAssertFalse(
+        MeetingConversationBoundaryPolicy.shouldFinishConversation(
+          mode: .onlyMeetings,
+          meetingStateReady: false,
+          shouldCapture: false,
+          segmentCount: 12,
+          hasSpeakerSegments: true
+        )
       )
     }
   }

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -447,7 +447,7 @@ final class OnboardingFlowTests: XCTestCase {
     let secondBrainSource = try desktopSourceFile("Onboarding/SecondBrain/SBOnboardingView.swift")
     let defaultChoice = try XCTUnwrap(
       secondBrainSource.range(of: "model.capture(SBOnboardingModel.defaultCaptureSelection)"))
-    let continuousChoice = try XCTUnwrap(secondBrainSource.range(of: "model.capture(.continuous)"))
+    let continuousChoice = try XCTUnwrap(secondBrainSource.range(of: "model.capture(.always)"))
 
     XCTAssertLessThan(
       defaultChoice.lowerBound,
@@ -458,6 +458,9 @@ final class OnboardingFlowTests: XCTestCase {
         .contains(".keyboardShortcut(.defaultAction)"),
       "Return must choose the meeting-only capture default")
     XCTAssertFalse(secondBrainSource.contains("reaches me anytime"))
+    XCTAssertTrue(secondBrainSource.contains("Text(\"Only Meetings\")"))
+    XCTAssertTrue(secondBrainSource.contains("Text(\"Always On\")"))
+    XCTAssertFalse(secondBrainSource.contains("from my calendar"))
   }
 
   // Regression: arrow navigation must be computed from persisted step state and

--- a/desktop/macos/Desktop/Tests/SBOnboardingCaptureSelectionTests.swift
+++ b/desktop/macos/Desktop/Tests/SBOnboardingCaptureSelectionTests.swift
@@ -7,14 +7,12 @@ final class SBOnboardingCaptureSelectionTests: XCTestCase {
   func testDefaultCaptureSelectionRecordsOnlyDuringMeetings() {
     let selection = SBOnboardingModel.defaultCaptureSelection
 
-    XCTAssertEqual(selection.systemAudioCaptureMode, .onlyDuringMeetings)
-    XCTAssertFalse(selection.startsListeningImmediately)
+    XCTAssertEqual(selection.audioRecordingMode, .onlyMeetings)
   }
 
-  func testContinuousCaptureSelectionStartsListeningImmediately() {
-    let selection = SBOnboardingModel.CaptureSelection.continuous
+  func testAlwaysSelectionMapsToAlwaysOn() {
+    let selection = SBOnboardingModel.CaptureSelection.always
 
-    XCTAssertEqual(selection.systemAudioCaptureMode, .always)
-    XCTAssertTrue(selection.startsListeningImmediately)
+    XCTAssertEqual(selection.audioRecordingMode, .always)
   }
 }

--- a/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceTests.swift
+++ b/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceTests.swift
@@ -221,7 +221,7 @@ final class SBPostOnboardingGuidanceTests: XCTestCase {
     var setup = SBSetupSnapshot()
     setup.canHear = true
 
-    setup.listening = .continuous
+    setup.listening = .always
     XCTAssertEqual(
       SBPostOnboardingGuidance.listeningCue(for: setup).title,
       "I'm listening now, and I'll remember what matters.")
@@ -229,29 +229,27 @@ final class SBPostOnboardingGuidanceTests: XCTestCase {
     setup.listening = .meetingsOnly
     XCTAssertEqual(
       SBPostOnboardingGuidance.listeningCue(for: setup).title,
-      "I'll start listening when your meetings start.")
+      "I'll start listening when a call starts.")
   }
 
-  func testNeverSystemAudioMeansMicrophoneOnly() {
+  func testOffMeansListeningDisabled() {
     XCTAssertEqual(
-      SBSetupSnapshot.Listening(systemAudioModeRaw: "never", canHear: true),
-      .microphoneOnly,
-      "Never disables system audio, not microphone capture")
+      SBSetupSnapshot.Listening(audioRecordingModeRaw: "off", canHear: true),
+      .disabled)
 
     var setup = SBSetupSnapshot()
     setup.canHear = true
-    setup.listening = .microphoneOnly
+    setup.listening = .disabled
 
     let cue = SBPostOnboardingGuidance.listeningCue(for: setup)
-    XCTAssertEqual(cue.title, "I'm listening through your microphone only.")
-    XCTAssertFalse(cue.title.lowercased().contains("meeting"))
+    XCTAssertEqual(cue.title, "I can't hear yet. Turn on the microphone in Settings whenever you want me to.")
   }
 
   func testUnavailableMicrophoneProducesDisabledListeningCue() {
     let setup = SBSetupSnapshot()
 
     XCTAssertEqual(
-      SBSetupSnapshot.Listening(systemAudioModeRaw: "always", canHear: false),
+      SBSetupSnapshot.Listening(audioRecordingModeRaw: "always", canHear: false),
       .disabled)
     XCTAssertEqual(SBPostOnboardingGuidance.listeningCue(for: setup).symbol, "mic.slash")
   }

--- a/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
@@ -91,14 +91,14 @@ final class SBPostOnboardingGuidanceWiringTests: XCTestCase {
     XCTAssertTrue(setup.connectedAgentNames.isEmpty)
   }
 
-  func testSetupSnapshotUsesMicrophoneOnlyForNeverSystemAudio() {
+  func testSetupSnapshotReportsAudioRecordingOff() {
     let model = makeModel()
     appState?.hasMicrophonePermission = true
-    let previousMode = AssistantSettings.shared.systemAudioCaptureMode
-    AssistantSettings.shared.systemAudioCaptureMode = .never
-    defer { AssistantSettings.shared.systemAudioCaptureMode = previousMode }
+    let previousMode = AssistantSettings.shared.audioRecordingMode
+    AssistantSettings.shared.audioRecordingMode = .off
+    defer { AssistantSettings.shared.audioRecordingMode = previousMode }
 
-    XCTAssertEqual(model.postOnboardingSetup.listening, .microphoneOnly)
+    XCTAssertEqual(model.postOnboardingSetup.listening, .disabled)
   }
 
   func testSetupSnapshotRejectsStaleOrBrokenScreenCapture() {

--- a/desktop/macos/changelog/unreleased/20260813-audio-recording-modes.json
+++ b/desktop/macos/changelog/unreleased/20260813-audio-recording-modes.json
@@ -1,0 +1,3 @@
+{
+  "change": "Audio Recording now has one simple control: Off, Always On, or Only Meetings"
+}

--- a/desktop/macos/e2e/flows/audio-recording.yaml
+++ b/desktop/macos/e2e/flows/audio-recording.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/Desktop/Sources/AudioMixer.swift
   - desktop/Desktop/Sources/AppState.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
+  - desktop/macos/Desktop/Sources/AppState/AppServicesCoordinator.swift
   - desktop/macos/Desktop/Sources/AudioCaptureService.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
   - desktop/macos/Desktop/Sources/Bluetooth/Transports/BleTransport.swift

--- a/desktop/macos/scripts/omi-settings-seed.sh
+++ b/desktop/macos/scripts/omi-settings-seed.sh
@@ -56,7 +56,7 @@ KEYS = [
     "playwrightUseExtension",
     "disabledSkillsJSON",
     "screenAnalysisEnabled",
-    "transcriptionEnabled",
+    "audioRecordingMode",
     "dashboardWidgetsCollapsed",
     "tasksChatPanelWidth",
 
@@ -92,6 +92,23 @@ def defaults_export(domain):
     return plistlib.loads(proc.stdout)
 
 
+def source_audio_recording_mode(source):
+    mode = source.get("audioRecordingMode")
+    if mode in {"off", "always", "onlyMeetings"}:
+        return mode
+
+    # Preserve intent from bundles created before Audio Recording became the
+    # single preference. The old "never" value disabled only system audio, so
+    # "always" is the closest equivalent for its still-enabled microphone.
+    if source.get("transcriptionEnabled") is False:
+        return "off"
+    return {
+        "always": "always",
+        "onlyDuringMeetings": "onlyMeetings",
+        "never": "always",
+    }.get(source.get("systemAudioCaptureMode"), "onlyMeetings")
+
+
 source = defaults_export(src)
 if not source:
     print(f"No defaults found for {src}; applying target-only dev defaults")
@@ -108,14 +125,7 @@ if not env_truthy("OMI_DEV_EAGER_PERMISSIONS"):
         {
             "devLazyPermissionsEnabled": True,
             "screenAnalysisEnabled": True,
-            "transcriptionEnabled": False,
-            # Use systemAudioCaptureMode="never" (a user-visible setting) instead of
-            # disableSystemAudioCapture (a hidden kill switch). The hidden flag is
-            # checked by AppState.effectiveSystemAudioMode BEFORE the user-visible
-            # mode, so seeding it would trap system audio off even after the
-            # developer picks "Always" in Settings. systemAudioCaptureMode can be
-            # toggled freely from the Settings UI.
-            "systemAudioCaptureMode": "never",
+            "audioRecordingMode": "off",
         }
     )
     # Never carry over the hidden kill switch from a previous seed or the source.
@@ -128,12 +138,10 @@ else:
     selected.update(
         {
             "devLazyPermissionsEnabled": False,
-            # Restore capture flags so a previously quiet-seeded bundle runs
-            # the full eager startup path. Fall back to True (normal default)
-            # when the source domain doesn't define them.
+            # Restore the one user-facing audio preference so a previously
+            # quiet-seeded bundle runs the normal startup path.
             "screenAnalysisEnabled": source.get("screenAnalysisEnabled", True),
-            "transcriptionEnabled": source.get("transcriptionEnabled", True),
-            "systemAudioCaptureMode": source.get("systemAudioCaptureMode", "always"),
+            "audioRecordingMode": source_audio_recording_mode(source),
         }
     )
     target_data.pop("screenAnalysisAutoStartFixed_v2", None)
@@ -148,7 +156,13 @@ with tempfile.NamedTemporaryFile(suffix=".plist") as plist:
 
 # Keys removed from target_data above need to be explicitly deleted from the
 # target domain — `defaults import` merges and never removes keys.
-for key in ("disableSystemAudioCapture", "screenAnalysisAutoStartFixed_v2", "screenAnalysisAutoStartFixed_v3"):
+for key in (
+    "disableSystemAudioCapture",
+    "screenAnalysisAutoStartFixed_v2",
+    "screenAnalysisAutoStartFixed_v3",
+    "transcriptionEnabled",
+    "systemAudioCaptureMode",
+):
     if key not in target_data:
         subprocess.run(["defaults", "delete", target, key], check=False)
 

--- a/desktop/macos/scripts/prepare-qualification-profile.sh
+++ b/desktop/macos/scripts/prepare-qualification-profile.sh
@@ -24,8 +24,7 @@ defaults delete "$BUNDLE_ID" >/dev/null 2>&1 || true
 defaults write "$BUNDLE_ID" hasCompletedOnboarding -bool true
 defaults write "$BUNDLE_ID" devLazyPermissionsEnabled -bool true
 defaults write "$BUNDLE_ID" screenAnalysisEnabled -bool false
-defaults write "$BUNDLE_ID" transcriptionEnabled -bool false
-defaults write "$BUNDLE_ID" systemAudioCaptureMode -string never
+defaults write "$BUNDLE_ID" audioRecordingMode -string off
 defaults write "$BUNDLE_ID" screenAnalysisAutoStartFixed_v2 -bool true
 defaults write "$BUNDLE_ID" shortcut_floatingBarTypedQuestionVoiceAnswersEnabled -bool false
 

--- a/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
+++ b/desktop/macos/tests/test-qualify-desktop-beta-contract.sh
@@ -47,7 +47,7 @@ require_text 'Application Support/$BUNDLE_NAME' "$PROFILE_PREP"
 require_text 'defaults write "$BUNDLE_ID" hasCompletedOnboarding -bool true' "$PROFILE_PREP"
 require_text 'defaults write "$BUNDLE_ID" devLazyPermissionsEnabled -bool true' "$PROFILE_PREP"
 require_text 'defaults write "$BUNDLE_ID" screenAnalysisEnabled -bool false' "$PROFILE_PREP"
-require_text 'defaults write "$BUNDLE_ID" transcriptionEnabled -bool false' "$PROFILE_PREP"
+require_text 'defaults write "$BUNDLE_ID" audioRecordingMode -string off' "$PROFILE_PREP"
 require_text '"$SCRIPT_DIR/prepare-qualification-profile.sh" "$BUNDLE"' "$QUALIFIER"
 require_text 'OMI_SKIP_SETTINGS_SEED=1'
 require_text 'make desktop-run-local DESKTOP_APP_NAME="$BUNDLE" DESKTOP_USER=alice'

--- a/desktop/macos/tests/test-settings-seed.sh
+++ b/desktop/macos/tests/test-settings-seed.sh
@@ -46,14 +46,16 @@ cleanup_domains+=("$source_domain" "$quiet_target" "$eager_target" "$missing_tar
 
 defaults write "$source_domain" screenAnalysisEnabled -bool true
 defaults write "$source_domain" transcriptionEnabled -bool true
+defaults write "$source_domain" systemAudioCaptureMode -string onlyDuringMeetings
 defaults write "$source_domain" shortcut_askOmiEnabled -bool true
 # Set the hidden kill switch in the source to verify it is NOT copied to targets.
 defaults write "$source_domain" disableSystemAudioCapture -bool true
 
 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_target" "$source_domain" >"$prefs_home/omi-settings-seed-quiet.out"
 assert_defaults "$quiet_target" screenAnalysisEnabled 1
-assert_defaults "$quiet_target" transcriptionEnabled 0
-assert_defaults "$quiet_target" systemAudioCaptureMode never
+assert_defaults "$quiet_target" audioRecordingMode off
+assert_unset "$quiet_target" transcriptionEnabled
+assert_unset "$quiet_target" systemAudioCaptureMode
 assert_defaults "$quiet_target" devLazyPermissionsEnabled 1
 assert_unset "$quiet_target" screenAnalysisAutoStartFixed_v2
 assert_unset "$quiet_target" screenAnalysisAutoStartFixed_v3
@@ -63,16 +65,17 @@ assert_unset "$quiet_target" hasCompletedFileIndexing
 
 OMI_DEV_EAGER_PERMISSIONS=1 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$eager_target" "$source_domain" >"$prefs_home/omi-settings-seed-eager.out"
 assert_defaults "$eager_target" screenAnalysisEnabled 1
-assert_defaults "$eager_target" transcriptionEnabled 1
+assert_defaults "$eager_target" audioRecordingMode onlyMeetings
 assert_defaults "$eager_target" devLazyPermissionsEnabled 0
 assert_unset "$eager_target" disableSystemAudioCapture
-assert_defaults "$eager_target" systemAudioCaptureMode always
+assert_unset "$eager_target" transcriptionEnabled
+assert_unset "$eager_target" systemAudioCaptureMode
 assert_unset "$eager_target" screenAnalysisAutoStartFixed_v2
 assert_unset "$eager_target" screenAnalysisAutoStartFixed_v3
 
 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$missing_target" "com.omi.missing-source-$$" >"$prefs_home/omi-settings-seed-missing.out"
 assert_defaults "$missing_target" screenAnalysisEnabled 1
-assert_defaults "$missing_target" transcriptionEnabled 0
+assert_defaults "$missing_target" audioRecordingMode off
 assert_defaults "$missing_target" devLazyPermissionsEnabled 1
 
 # Verify eager mode fully undoes quiet defaults when re-seeding the same target.
@@ -86,9 +89,10 @@ cleanup_domains+=("$bare_source")
 defaults write "$bare_source" shortcut_askOmiEnabled -bool true
 OMI_DEV_EAGER_PERMISSIONS=1 "$MACOS_DIR/scripts/omi-settings-seed.sh" "$quiet_then_eager_target" "$bare_source" >/dev/null
 assert_defaults "$quiet_then_eager_target" screenAnalysisEnabled 1
-assert_defaults "$quiet_then_eager_target" transcriptionEnabled 1
+assert_defaults "$quiet_then_eager_target" audioRecordingMode onlyMeetings
 assert_defaults "$quiet_then_eager_target" devLazyPermissionsEnabled 0
-assert_defaults "$quiet_then_eager_target" systemAudioCaptureMode always
+assert_unset "$quiet_then_eager_target" transcriptionEnabled
+assert_unset "$quiet_then_eager_target" systemAudioCaptureMode
 assert_unset "$quiet_then_eager_target" disableSystemAudioCapture
 assert_unset "$quiet_then_eager_target" screenAnalysisAutoStartFixed_v2
 assert_unset "$quiet_then_eager_target" screenAnalysisAutoStartFixed_v3


### PR DESCRIPTION
## Summary

- Make Audio Recording the single macOS capture policy: Off, Always On, or Only Meetings.
- Replace the old dropdown with a three-item segmented switcher and simplify onboarding labels.
- Keep meeting detection and conversation boundaries aligned with the selected policy.
- Remove the explanatory Only Meetings caption from General settings.

## QA

- Isolated QA bundle: `/Applications/omi-audio-recording-mode.app`
- Build: `xcrun swift build -c debug --package-path desktop/macos/Desktop`
- Focused tests: AudioRecordingModeSettingsTests, MeetingDetectorTests, MeetingConversationBoundaryPolicyTests, DashboardCaptureStateTests, OnboardingFlowTests, SBOnboardingCaptureSelectionTests, SBPostOnboardingGuidanceTests, SBPostOnboardingGuidanceWiringTests
- Bundle verification: `codesign --verify --deep --strict /Applications/omi-audio-recording-mode.app`

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

