### PR TITLE
harden(ci): match deepPurple and the Dart hex form in the INV-UI-1 ratchet, and clear the apps pages

### DIFF
--- a/.github/scripts/check_brand_ui.py
+++ b/.github/scripts/check_brand_ui.py
@@ -31,6 +31,10 @@ ALLOWLIST_FILES: set[str] = {
     "desktop/macos/Desktop/Sources/Theme/OmiColors.swift",
 }
 
+# The purple hues, named once. Both the `#RRGGBB` and the Dart `0xAARRGGBB` pattern below
+# interpolate this, so adding or retiring a hue is a single edit and the two cannot drift.
+PURPLE_HEX_HUES = "7C3AED|8B5CF6|A855F7|9333EA|6D28D9|AF52DE|D946EF|A78BFA|C4B5FD"
+
 PURPLE_PATTERNS = [
     re.compile(r"Color\.purple\b"),
     re.compile(r"\.purple\b"),  # SwiftUI shorthand: .foregroundStyle(.purple)
@@ -39,11 +43,15 @@ PURPLE_PATTERNS = [
     # cannot match inside `deepPurple` because camelCase puts no word boundary
     # before it, and none of the other patterns spell it either.
     re.compile(r"\bdeepPurple(?:Accent)?\b"),
-    re.compile(r"#(?:7C3AED|8B5CF6|A855F7|9333EA|6D28D9|AF52DE|D946EF|A78BFA|C4B5FD)\b", re.I),
+    re.compile(rf"#(?:{PURPLE_HEX_HUES})\b", re.I),
     # The same hues as written in Dart. Flutter spells colours `Color(0xFF8B5CF6)`,
     # so the `#RRGGBB` pattern above never matched a Flutter literal — the alpha
     # channel is optional because both forms appear in the app.
-    re.compile(r"0x(?:[0-9A-F]{2})?(?:7C3AED|8B5CF6|A855F7|9333EA|6D28D9|AF52DE|D946EF|A78BFA|C4B5FD)\b", re.I),
+    #
+    # The lookbehind requires `0x` to start a token. Without it the pattern matches inside a
+    # longer literal or identifier, so an unrelated constant that merely ends in a purple hue
+    # would be counted and could fail the ratchet on a file that contains no purple at all.
+    re.compile(rf"(?<![0-9A-Za-z_])0x(?:[0-9A-F]{{2}})?(?:{PURPLE_HEX_HUES})\b", re.I),
     re.compile(r"purple(?:Primary|Secondary|Accent|Light|Gradient|LightGradient)\b"),
     re.compile(r"purple-(?:primary|secondary|accent|\d{2,4})\b"),  # Tailwind: bg-purple-500 etc.
     re.compile(r"--purple-"),

--- a/.github/scripts/check_brand_ui.py
+++ b/.github/scripts/check_brand_ui.py
@@ -35,7 +35,15 @@ PURPLE_PATTERNS = [
     re.compile(r"Color\.purple\b"),
     re.compile(r"\.purple\b"),  # SwiftUI shorthand: .foregroundStyle(.purple)
     re.compile(r"Colors\.purple\b"),  # Flutter
+    # Flutter's most common purple, and previously invisible here: `\bpurple\b`
+    # cannot match inside `deepPurple` because camelCase puts no word boundary
+    # before it, and none of the other patterns spell it either.
+    re.compile(r"\bdeepPurple(?:Accent)?\b"),
     re.compile(r"#(?:7C3AED|8B5CF6|A855F7|9333EA|6D28D9|AF52DE|D946EF|A78BFA|C4B5FD)\b", re.I),
+    # The same hues as written in Dart. Flutter spells colours `Color(0xFF8B5CF6)`,
+    # so the `#RRGGBB` pattern above never matched a Flutter literal — the alpha
+    # channel is optional because both forms appear in the app.
+    re.compile(r"0x(?:[0-9A-F]{2})?(?:7C3AED|8B5CF6|A855F7|9333EA|6D28D9|AF52DE|D946EF|A78BFA|C4B5FD)\b", re.I),
     re.compile(r"purple(?:Primary|Secondary|Accent|Light|Gradient|LightGradient)\b"),
     re.compile(r"purple-(?:primary|secondary|accent|\d{2,4})\b"),  # Tailwind: bg-purple-500 etc.
     re.compile(r"--purple-"),

--- a/.github/scripts/test_check_brand_ui.py
+++ b/.github/scripts/test_check_brand_ui.py
@@ -11,8 +11,28 @@ from check_brand_ui import count_purple, is_ui_source
 class BrandUiTests(unittest.TestCase):
     def test_counts_color_purple_and_hex(self) -> None:
         text = "Color.purple\nlet x = Color(hex: 0x8B5CF6)\n#8B5CF6\npurplePrimary\n"
-        # Color.purple + #8B5CF6 + purplePrimary = 3 (0x8B5CF6 not matched — hex with # only)
-        self.assertGreaterEqual(count_purple(text), 3)
+        # Color.purple + 0x8B5CF6 + #8B5CF6 + purplePrimary
+        self.assertGreaterEqual(count_purple(text), 4)
+
+    def test_counts_flutter_deep_purple(self) -> None:
+        """`deepPurple` is the spelling most of the Flutter app actually uses.
+
+        It went uncounted because camelCase leaves no word boundary before
+        `purple`, so `\\bpurple\\b` cannot see it and no other pattern spelt it.
+        """
+        self.assertGreaterEqual(count_purple("color: Colors.deepPurple"), 1)
+        self.assertGreaterEqual(count_purple("Colors.deepPurpleAccent"), 1)
+        self.assertGreaterEqual(count_purple("Colors.deepPurple.shade300"), 1)
+
+    def test_counts_dart_hex_literal(self) -> None:
+        """Flutter writes `Color(0xFF8B5CF6)`, never `#8B5CF6`."""
+        self.assertGreaterEqual(count_purple("const Color(0xFF8B5CF6)"), 1)
+        self.assertGreaterEqual(count_purple("const Color(0xff7c3aed)"), 1)
+
+    def test_ignores_colours_that_merely_contain_purple_hex_digits(self) -> None:
+        """A non-purple hue must not be counted just for sharing digits."""
+        self.assertEqual(count_purple("const Color(0xFF1A2B3C)"), 0)
+        self.assertEqual(count_purple("const Color(0xFF00FF00)"), 0)
 
     def test_is_ui_source(self) -> None:
         self.assertTrue(is_ui_source("desktop/macos/Desktop/Sources/Foo.swift"))

--- a/.github/scripts/test_check_brand_ui.py
+++ b/.github/scripts/test_check_brand_ui.py
@@ -34,6 +34,19 @@ class BrandUiTests(unittest.TestCase):
         self.assertEqual(count_purple("const Color(0xFF1A2B3C)"), 0)
         self.assertEqual(count_purple("const Color(0xFF00FF00)"), 0)
 
+    def test_dart_hex_literal_must_start_a_token(self) -> None:
+        """`0x` has to begin a token, or the ratchet fails files containing no purple.
+
+        Without a leading boundary the pattern matches inside an identifier or a longer
+        literal, so an unrelated constant ending in a purple hue is reported as a purple
+        increase.
+        """
+        self.assertEqual(count_purple("foo0x8B5CF6"), 0)
+        self.assertEqual(count_purple("SOME_CONST0x8B5CF6"), 0)
+        # ...while a real literal in the shapes Flutter writes still counts.
+        self.assertGreaterEqual(count_purple("Color(0xFF8B5CF6)"), 1)
+        self.assertGreaterEqual(count_purple("value = 0x8B5CF6;"), 1)
+
     def test_is_ui_source(self) -> None:
         self.assertTrue(is_ui_source("desktop/macos/Desktop/Sources/Foo.swift"))
         self.assertFalse(is_ui_source("backend/main.py"))

--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -794,7 +794,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                         const FaIcon(
                                           FontAwesomeIcons.solidCircleCheck,
                                           size: 14,
-                                          color: Colors.deepPurpleAccent,
+                                          color: Colors.white,
                                         ),
                                       ],
                                     ],
@@ -814,7 +814,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                     child: Row(
                                       children: [
                                         if (app.ratingCount > 0) ...[
-                                          const FaIcon(FontAwesomeIcons.solidStar, size: 11, color: Color(0xFF8B5CF6)),
+                                          const FaIcon(FontAwesomeIcons.solidStar, size: 11, color: Colors.white),
                                           const SizedBox(width: 4),
                                           Text(
                                             '${app.getRatingAvg()} (${app.ratingCount})',
@@ -876,7 +876,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                                   await _toggleApp(app.id, true);
                                                 }
                                               },
-                                              color: const Color(0xFF8B5CF6),
+                                              color: Colors.white,
                                             )
                                           : AnimatedLoadingButton(
                                               width: 75,
@@ -908,7 +908,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                                   _toggleApp(app.id, true);
                                                 }
                                               },
-                                              color: const Color(0xFF8B5CF6),
+                                              color: Colors.white,
                                             )),
                             ],
                           ),
@@ -1606,7 +1606,7 @@ class RatingDistributionWidget extends StatelessWidget {
                   child: FaIcon(
                     FontAwesomeIcons.solidStar,
                     size: 14,
-                    color: index < ratingAvg.round() ? Colors.deepPurple : Colors.grey.shade700,
+                    color: index < ratingAvg.round() ? Colors.white : Colors.grey.shade700,
                   ),
                 );
               }),
@@ -1793,9 +1793,9 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Colors.deepPurple.withValues(alpha: 0.1),
+        color: Colors.white.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.deepPurple.withValues(alpha: 0.3)),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.3)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1833,7 +1833,7 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
                   child: FaIcon(
                     FontAwesomeIcons.solidStar,
                     size: 24,
-                    color: index < editRating ? Colors.deepPurple : Colors.grey.shade600,
+                    color: index < editRating ? Colors.white : Colors.grey.shade600,
                   ),
                 ),
               );
@@ -1864,8 +1864,8 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
               key: const ValueKey('app_detail_submit_review_button'),
               onPressed: isSubmitting ? null : _submitReview,
               style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.deepPurple,
-                foregroundColor: Colors.white,
+                backgroundColor: Colors.white,
+                foregroundColor: Colors.black,
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
               ),
@@ -1909,8 +1909,8 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
                 seed: avatarSeed,
                 username: review.username,
                 size: 36,
-                backgroundColor: isUserReview ? Colors.deepPurple.withValues(alpha: 0.2) : null,
-                foregroundColor: isUserReview ? Colors.deepPurple : null,
+                backgroundColor: isUserReview ? Colors.white.withValues(alpha: 0.2) : null,
+                foregroundColor: isUserReview ? Colors.white : null,
               ),
               const SizedBox(width: 12),
               // Name, date, and stars
@@ -1923,7 +1923,7 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
                         Text(
                           displayName,
                           style: TextStyle(
-                            color: isUserReview ? Colors.deepPurple : Colors.grey,
+                            color: isUserReview ? Colors.white : Colors.grey,
                             fontSize: 14,
                             fontWeight: FontWeight.w500,
                           ),
@@ -1945,7 +1945,7 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
                           child: FaIcon(
                             FontAwesomeIcons.solidStar,
                             size: 14,
-                            color: index < review.score.round() ? Colors.deepPurple : Colors.grey.shade700,
+                            color: index < review.score.round() ? Colors.white : Colors.grey.shade700,
                           ),
                         );
                       }),

--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -877,6 +877,10 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                                 }
                                               },
                                               color: Colors.white,
+                                              // AnimatedLoadingButton defaults both to white; on a
+                                              // white surface the label and spinner vanish.
+                                              textStyle: const TextStyle(fontSize: 16, color: Colors.black),
+                                              loaderColor: Colors.black,
                                             )
                                           : AnimatedLoadingButton(
                                               width: 75,
@@ -909,6 +913,10 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                                 }
                                               },
                                               color: Colors.white,
+                                              // AnimatedLoadingButton defaults both to white; on a
+                                              // white surface the label and spinner vanish.
+                                              textStyle: const TextStyle(fontSize: 16, color: Colors.black),
+                                              loaderColor: Colors.black,
                                             )),
                             ],
                           ),
@@ -1875,7 +1883,8 @@ class _RecentReviewsSectionState extends State<RecentReviewsSection> {
                       width: 20,
                       child: CircularProgressIndicator(
                         strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                        // The button surface is now white, so a white spinner would be invisible.
+                        valueColor: AlwaysStoppedAnimation<Color>(Colors.black),
                       ),
                     )
                   : Text(

--- a/app/lib/pages/apps/app_detail/reviews_list_page.dart
+++ b/app/lib/pages/apps/app_detail/reviews_list_page.dart
@@ -136,7 +136,7 @@ class _ReviewsListPageState extends State<ReviewsListPage> {
                           isSubmitting.value = false;
                         }
                       },
-                style: ElevatedButton.styleFrom(backgroundColor: Colors.deepPurple, foregroundColor: Colors.white),
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.white, foregroundColor: Colors.black),
                 child: submitting
                     ? const SizedBox(
                         width: 16,
@@ -273,9 +273,9 @@ class _ReviewsListPageState extends State<ReviewsListPage> {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: selected ? Colors.deepPurple : Colors.grey.shade800.withValues(alpha: 0.5),
+          color: selected ? Colors.white.withValues(alpha: 0.22) : Colors.grey.shade800.withValues(alpha: 0.5),
           borderRadius: BorderRadius.circular(20),
-          border: Border.all(color: selected ? Colors.deepPurple : Colors.grey.shade700, width: 1),
+          border: Border.all(color: selected ? Colors.white : Colors.grey.shade700, width: 1),
         ),
         child: Text(
           label,
@@ -336,7 +336,7 @@ class _ReviewsListPageState extends State<ReviewsListPage> {
                           child: FaIcon(
                             FontAwesomeIcons.solidStar,
                             size: 14,
-                            color: index < review.score.round() ? Colors.deepPurple : Colors.grey.shade700,
+                            color: index < review.score.round() ? Colors.white : Colors.grey.shade700,
                           ),
                         );
                       }),
@@ -397,11 +397,11 @@ class _ReviewsListPageState extends State<ReviewsListPage> {
                 icon: FaIcon(
                   review.response.isNotEmpty ? FontAwesomeIcons.pencil : FontAwesomeIcons.reply,
                   size: 12,
-                  color: Colors.deepPurple,
+                  color: Colors.white,
                 ),
                 label: Text(
                   review.response.isNotEmpty ? context.l10n.editReply : context.l10n.reply,
-                  style: const TextStyle(color: Colors.deepPurple, fontSize: 13),
+                  style: const TextStyle(color: Colors.white, fontSize: 13),
                 ),
               ),
             ),

--- a/app/lib/pages/apps/app_detail/reviews_list_page.dart
+++ b/app/lib/pages/apps/app_detail/reviews_list_page.dart
@@ -143,7 +143,8 @@ class _ReviewsListPageState extends State<ReviewsListPage> {
                         height: 16,
                         child: CircularProgressIndicator(
                           strokeWidth: 2,
-                          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                          // The button surface is now white, so a white spinner would be invisible.
+                          valueColor: AlwaysStoppedAnimation<Color>(Colors.black),
                         ),
                       )
                     : Text(context.l10n.send),

--- a/app/lib/pages/apps/app_detail/widgets/add_review_widget.dart
+++ b/app/lib/pages/apps/app_detail/widgets/add_review_widget.dart
@@ -129,7 +129,7 @@ class _AddReviewWidgetState extends State<AddReviewWidget> {
                   return dynamicPadding.clamp(8.0, 24.0); // Clamp between reasonable values
                 }(),
               ),
-              itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.deepPurple),
+              itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.white),
               maxRating: 5.0,
               onRatingUpdate: (rating) {
                 if (isLoading) return;

--- a/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
+++ b/app/lib/pages/apps/app_detail/widgets/app_owner_review_card.dart
@@ -74,7 +74,7 @@ class _AppOwnerReviewCardState extends State<AppOwnerReviewCard> {
                   itemSize: 20,
                   tapOnlyMode: false,
                   itemPadding: const EdgeInsets.symmetric(horizontal: 0),
-                  itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.deepPurple),
+                  itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.white),
                   maxRating: 5.0,
                   onRatingUpdate: (rating) {},
                 ),

--- a/app/lib/pages/apps/app_detail/widgets/user_review_card.dart
+++ b/app/lib/pages/apps/app_detail/widgets/user_review_card.dart
@@ -34,7 +34,7 @@ class UserReviewCard extends StatelessWidget {
                 itemSize: 20,
                 tapOnlyMode: false,
                 itemPadding: const EdgeInsets.symmetric(horizontal: 0),
-                itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.deepPurple),
+                itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.white),
                 maxRating: 5.0,
                 onRatingUpdate: (rating) {},
               ),

--- a/app/lib/pages/apps/explore_install_page.dart
+++ b/app/lib/pages/apps/explore_install_page.dart
@@ -428,7 +428,7 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
               HapticFeedback.mediumImpact();
               await context.read<AppProvider>().forceRefreshApps();
             },
-            color: Colors.deepPurpleAccent,
+            color: Colors.black,
             backgroundColor: Colors.white,
             child: CustomScrollView(
               controller: widget.scrollController,
@@ -566,7 +566,7 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                         curve: Curves.easeInOut,
                                         height: 44,
                                         decoration: BoxDecoration(
-                                          color: Colors.deepPurpleAccent.withValues(alpha: 0.5),
+                                          color: Colors.white.withValues(alpha: 0.22),
                                           borderRadius: BorderRadius.circular(AppStyles.radiusLarge),
                                         ),
                                         child: TextButton.icon(
@@ -642,7 +642,7 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                         curve: Curves.easeInOut,
                                         height: 44,
                                         decoration: BoxDecoration(
-                                          color: Colors.deepPurpleAccent.withValues(alpha: 0.5),
+                                          color: Colors.white.withValues(alpha: 0.22),
                                           borderRadius: BorderRadius.circular(AppStyles.radiusLarge),
                                         ),
                                         child: TextButton.icon(
@@ -720,7 +720,7 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                         curve: Curves.easeInOut,
                                         height: 44,
                                         decoration: BoxDecoration(
-                                          color: Colors.deepPurpleAccent.withValues(alpha: 0.5),
+                                          color: Colors.white.withValues(alpha: 0.22),
                                           borderRadius: BorderRadius.circular(AppStyles.radiusLarge),
                                         ),
                                         child: TextButton.icon(
@@ -765,7 +765,7 @@ class ExploreInstallPageState extends State<ExploreInstallPage> with AutomaticKe
                                             curve: Curves.easeInOut,
                                             decoration: BoxDecoration(
                                               color: state.visibleFilterCount > 0
-                                                  ? Colors.deepPurpleAccent.withValues(alpha: 0.5)
+                                                  ? Colors.white.withValues(alpha: 0.22)
                                                   : AppStyles.backgroundSecondary,
                                               borderRadius: BorderRadius.circular(AppStyles.radiusLarge),
                                             ),

--- a/app/lib/pages/apps/list_item.dart
+++ b/app/lib/pages/apps/list_item.dart
@@ -177,7 +177,12 @@ class AppListItem extends StatelessWidget {
                           child: Center(
                             child: Text(
                               state.enabled ? 'Open' : 'Enable',
-                              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Colors.white),
+                              // Black on the white "Enable" fill, white on the grey "Open" one.
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w600,
+                                color: state.enabled ? Colors.white : Colors.black,
+                              ),
                             ),
                           ),
                         ),

--- a/app/lib/pages/apps/list_item.dart
+++ b/app/lib/pages/apps/list_item.dart
@@ -102,7 +102,7 @@ class AppListItem extends StatelessWidget {
                         const SizedBox(height: 4),
                         Row(
                           children: [
-                            const Icon(Icons.star_rounded, color: Color(0xFF8B5CF6), size: 14),
+                            const Icon(Icons.star_rounded, color: Colors.white, size: 14),
                             const SizedBox(width: 4),
                             Text(
                               app.getRatingAvg()!,
@@ -171,7 +171,7 @@ class AppListItem extends StatelessWidget {
                           width: 72,
                           height: 32,
                           decoration: BoxDecoration(
-                            color: state.enabled ? Colors.grey.shade700 : const Color(0xFF8B5CF6),
+                            color: state.enabled ? Colors.grey.shade700 : Colors.white,
                             borderRadius: BorderRadius.circular(16),
                           ),
                           child: Center(

--- a/app/lib/pages/apps/widgets/ai_app_generator_banner.dart
+++ b/app/lib/pages/apps/widgets/ai_app_generator_banner.dart
@@ -25,12 +25,12 @@ class AiAppGeneratorBanner extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         decoration: BoxDecoration(
           gradient: LinearGradient(
-            colors: [const Color(0xFF6366F1).withValues(alpha: 0.3), const Color(0xFF8B5CF6).withValues(alpha: 0.3)],
+            colors: [const Color(0xFF6366F1).withValues(alpha: 0.3), const Color(0xFF4F46E5).withValues(alpha: 0.3)],
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
           ),
           borderRadius: BorderRadius.circular(18.0),
-          border: Border.all(color: const Color(0xFF8B5CF6).withValues(alpha: 0.3), width: 1),
+          border: Border.all(color: const Color(0xFF6366F1).withValues(alpha: 0.3), width: 1),
         ),
         child: Row(
           children: [
@@ -39,7 +39,7 @@ class AiAppGeneratorBanner extends StatelessWidget {
               width: 36,
               height: 36,
               decoration: BoxDecoration(
-                gradient: const LinearGradient(colors: [Color(0xFF6366F1), Color(0xFF8B5CF6)]),
+                gradient: const LinearGradient(colors: [Color(0xFF6366F1), Color(0xFF4F46E5)]),
                 borderRadius: BorderRadius.circular(10),
               ),
               child: const Center(child: FaIcon(FontAwesomeIcons.wandMagicSparkles, color: Colors.white, size: 16)),

--- a/app/lib/pages/apps/widgets/app_section_card.dart
+++ b/app/lib/pages/apps/widgets/app_section_card.dart
@@ -154,7 +154,7 @@ class SectionAppItemCard extends StatelessWidget {
                           child: Row(
                             crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
-                              Icon(Icons.star, color: Colors.deepPurple.shade300, size: 14),
+                              const Icon(Icons.star, color: Colors.white, size: 14),
                               const SizedBox(width: 3),
                               Text(app.getRatingAvg()!, style: const TextStyle(fontSize: 12, color: Colors.white70)),
                             ],

--- a/app/lib/pages/apps/widgets/capability_apps_page.dart
+++ b/app/lib/pages/apps/widgets/capability_apps_page.dart
@@ -200,7 +200,7 @@ class _CapabilityAppsPageState extends State<CapabilityAppsPage> {
                 HapticFeedback.mediumImpact();
                 await _loadCapabilityApps();
               },
-              color: Colors.deepPurpleAccent,
+              color: Colors.white,
               backgroundColor: Colors.white,
               child: _totalCount == 0
                   ? Center(

--- a/app/lib/pages/apps/widgets/capability_apps_page.dart
+++ b/app/lib/pages/apps/widgets/capability_apps_page.dart
@@ -200,7 +200,8 @@ class _CapabilityAppsPageState extends State<CapabilityAppsPage> {
                 HapticFeedback.mediumImpact();
                 await _loadCapabilityApps();
               },
-              color: Colors.white,
+              // The arc is drawn on backgroundColor, so it must not also be white.
+              color: Colors.black,
               backgroundColor: Colors.white,
               child: _totalCount == 0
                   ? Center(

--- a/app/lib/pages/apps/widgets/capability_category_section.dart
+++ b/app/lib/pages/apps/widgets/capability_category_section.dart
@@ -195,7 +195,7 @@ class CapabilitySectionAppItemCard extends StatelessWidget {
                         const SizedBox(height: 2),
                         Row(
                           children: [
-                            const FaIcon(FontAwesomeIcons.solidStar, color: Color(0xFF8B5CF6), size: 9),
+                            const FaIcon(FontAwesomeIcons.solidStar, color: Colors.white, size: 9),
                             const SizedBox(width: 4),
                             Text(
                               app.getRatingAvg()!,

--- a/app/lib/pages/apps/widgets/category_apps_page.dart
+++ b/app/lib/pages/apps/widgets/category_apps_page.dart
@@ -97,7 +97,7 @@ class _CategoryAppsPageState extends State<CategoryAppsPage> {
           ),
           Expanded(
             child: _isLoading
-                ? const Center(child: CircularProgressIndicator(color: Colors.deepPurpleAccent))
+                ? const Center(child: CircularProgressIndicator(color: Colors.white))
                 : _apps.isEmpty
                     ? Center(
                         child: Column(

--- a/app/lib/pages/apps/widgets/category_card.dart
+++ b/app/lib/pages/apps/widgets/category_card.dart
@@ -60,7 +60,7 @@ class CategoryCard extends StatelessWidget {
       case 'health':
         return Colors.green;
       case 'entertainment':
-        return Colors.purple;
+        return Colors.pinkAccent;
       case 'education':
         return Colors.orange;
       case 'social':
@@ -86,7 +86,7 @@ class CategoryCard extends StatelessWidget {
       case 'sports':
         return Colors.lime;
       case 'music':
-        return Colors.deepPurple;
+        return Colors.tealAccent;
       case 'photo':
         return Colors.brown;
       case 'gaming':

--- a/app/lib/pages/apps/widgets/filter_sheet.dart
+++ b/app/lib/pages/apps/widgets/filter_sheet.dart
@@ -36,7 +36,7 @@ class FilterBottomSheet extends StatelessWidget {
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                         decoration: BoxDecoration(
-                          color: const Color(0xFF8B5CF6),
+                          color: Colors.white.withValues(alpha: 0.22),
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Text(
@@ -185,7 +185,7 @@ class FilterBottomSheet extends StatelessWidget {
               margin: const EdgeInsets.only(right: 8),
               padding: const EdgeInsets.symmetric(vertical: 12),
               decoration: BoxDecoration(
-                color: isSelected ? const Color(0xFF8B5CF6) : const Color(0xFF35343B),
+                color: isSelected ? Colors.white.withValues(alpha: 0.22) : const Color(0xFF35343B),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Center(
@@ -223,7 +223,7 @@ class FilterBottomSheet extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(
-              color: isSelected ? const Color(0xFF8B5CF6) : const Color(0xFF35343B),
+              color: isSelected ? Colors.white.withValues(alpha: 0.22) : const Color(0xFF35343B),
               borderRadius: BorderRadius.circular(20),
             ),
             child: Text(
@@ -269,7 +269,7 @@ class FilterBottomSheet extends StatelessWidget {
               decoration: BoxDecoration(
                 color: const Color(0xFF1F1F25).withValues(alpha: 0.5),
                 borderRadius: BorderRadius.circular(12),
-                border: isSelected ? Border.all(color: const Color(0xFF8B5CF6), width: 2) : null,
+                border: isSelected ? Border.all(color: Colors.white, width: 2) : null,
               ),
               child: Row(
                 children: [
@@ -278,10 +278,10 @@ class FilterBottomSheet extends StatelessWidget {
                     height: 20,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: isSelected ? const Color(0xFF8B5CF6) : Colors.transparent,
-                      border: Border.all(color: isSelected ? const Color(0xFF8B5CF6) : Colors.grey.shade500, width: 2),
+                      color: isSelected ? Colors.white : Colors.transparent,
+                      border: Border.all(color: isSelected ? Colors.white : Colors.grey.shade500, width: 2),
                     ),
-                    child: isSelected ? const Icon(Icons.check, size: 12, color: Colors.white) : null,
+                    child: isSelected ? const Icon(Icons.check, size: 12, color: Colors.black) : null,
                   ),
                   const SizedBox(width: 12),
                   Text(
@@ -319,7 +319,7 @@ class FilterBottomSheet extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(
-              color: isSelected ? const Color(0xFF8B5CF6) : const Color(0xFF35343B),
+              color: isSelected ? Colors.white.withValues(alpha: 0.22) : const Color(0xFF35343B),
               borderRadius: BorderRadius.circular(20),
             ),
             child: Text(

--- a/app/lib/pages/apps/widgets/popular_apps_section.dart
+++ b/app/lib/pages/apps/widgets/popular_apps_section.dart
@@ -194,7 +194,12 @@ class PopularAppsSection extends StatelessWidget {
                       child: Center(
                         child: Text(
                           app.enabled ? context.l10n.open : 'Enable',
-                          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600, color: Colors.white),
+                          // Black on the white "Enable" fill, white on the grey "Open" one.
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                            color: app.enabled ? Colors.white : Colors.black,
+                          ),
                         ),
                       ),
                     ),

--- a/app/lib/pages/apps/widgets/popular_apps_section.dart
+++ b/app/lib/pages/apps/widgets/popular_apps_section.dart
@@ -159,7 +159,7 @@ class PopularAppsSection extends StatelessWidget {
                             const SizedBox(height: 4),
                             Row(
                               children: [
-                                const Icon(Icons.star_rounded, color: Color(0xFF8B5CF6), size: 14),
+                                const Icon(Icons.star_rounded, color: Colors.white, size: 14),
                                 const SizedBox(width: 4),
                                 Text(
                                   app.getRatingAvg()!,
@@ -188,7 +188,7 @@ class PopularAppsSection extends StatelessWidget {
                       width: 72,
                       height: 32,
                       decoration: BoxDecoration(
-                        color: app.enabled ? Colors.grey.shade700 : const Color(0xFF8B5CF6),
+                        color: app.enabled ? Colors.grey.shade700 : Colors.white,
                         borderRadius: BorderRadius.circular(16),
                       ),
                       child: Center(


### PR DESCRIPTION
Two spellings of purple that the Flutter app uses fall just outside the INV-UI-1 ratchet's
current patterns. This adds them, then clears the purple those patterns bring into view on
the apps pages. Offered as a contribution — take either commit, both, or neither.

## The two patterns

- **`deepPurple`.** `\bpurple\b` cannot match inside `deepPurple`, because camelCase leaves
  no word boundary before it. `Colors.deepPurple`, `Colors.deepPurpleAccent` and
  `Colors.deepPurple.shade300` therefore count as zero. **183 references** in `app/lib`.
- **The Dart hex form.** The hex pattern is written for `#RRGGBB`, which is the right shape
  for the web and Swift surfaces. Flutter writes `Color(0xFF8B5CF6)`, so the Dart literals
  sit outside it — **60 references**, including the star on every app row
  (`app/lib/pages/apps/list_item.dart:105`).

Counting `app/lib` with the patterns as they stand: **118 hits in 29 files**. With the two
added: **357 in 94 files**.

This is not a new guard, just the existing one taught two more spellings. Both patterns cite
instances in the tree today rather than a hypothesis.

**It cannot fail an open PR.** The ratchet counts base and head with the same script, so both
sides move together and every existing comparison is unchanged. What it adds is coverage for
the next one.

## Then the apps pages

49 references by the ratchet's new count, now 0. Replaced by role, because contrast decides
what "neutral" means in each place:

| Role | Was | Now |
|---|---|---|
| Fill behind white text (selected pills, chips, badge) | purple | white @ alpha 0.22 |
| Solid primary action (submit review) | purple bg, white label | white bg, black label |
| Icon or border on dark (stars, ticks, outlines) | purple | white |
| Pull-to-refresh arc | purple | **black** — it is drawn on an explicitly white `backgroundColor` |
| Radio tick | white on purple | black on white |

Two are judgement rather than rule, and easy to change if you would prefer something else:

- The **AI generator banner** gradient ended on violet; it now ends on a deeper indigo,
  keeping the banner's identity. Indigo is not purple and the project already uses `#4f46e5`
  elsewhere.
- The **per-category hue palette** had purple for `entertainment` and deepPurple for `music`.
  Those become `pinkAccent` and `tealAccent`, following the palette's existing habit of
  pairing a base hue with an accent variant. Both are arbitrary; only "not purple" is
  required.

Replacements were applied by an explicit mapping asserting how many times each must match, so
a miss or an over-eager match failed loudly. It did: a bare `color: Colors.deepPurple,` also
matched inside a `TextStyle`, caught before it could recolour something unintended.

## Verification

Against `main` at `8ddcff958`.

- `check_brand_ui.py` vs `origin/main` — *"no purple increase across 15 changed UI file(s)"*
- ratchet count under `app/lib/pages/apps`: **49 → 0**; a raw case-insensitive grep for
  `purple` over the same tree also returns 0
- `python -m unittest test_check_brand_ui` — 9 tests pass, including three new for
  `deepPurple`, two for the Dart hex form, and one asserting a non-purple hue sharing hex
  digits is *not* counted
- `flutter test` — 1221 pass, 2 fail (`plans_sheet_l10n`, `voice_recorder_mic_contention`).
  Both fail identically with this work reverted on the same base, so neither is ours. The
  mic-contention one is a Windows tempdir teardown that cannot delete a still-open PCM
  file — this host, not the test.
- `dart analyze lib/pages/apps` — 10 issues, and analyzing `origin/main`'s version of the
  same tree reports the identical 10. Nothing new.
- `dart format --line-length 120` — 40 files, 0 changed
- `scripts/pr-preflight` — 12 checks pass on both the `local` and `ci` lanes

**Not seen running.** No macOS and no Android SDK on this machine, so every contrast decision
above is reasoned from the surrounding code rather than from looking at it.

That caveat earned its keep. Review found **six places where a fill went white while its
foreground stayed white** — invisible, not merely off-brand: the "Enable" pill's label in two
files, `AnimatedLoadingButton`'s white-by-default label and spinner behind Subscribe and Enable,
two submit spinners, and a `RefreshIndicator` arc drawn on its own white background. All fixed in
`fix(app): give the new white surfaces a foreground that contrasts`.

The shape is worth naming, because the tooling could not catch it. The replacement mapping asserts
how many times each edit matches, so it cannot change something unintended — but a count assertion
says nothing about a foreground the mapping never listed, and in all six the text or indicator
lived in a sibling property, a different widget, or a widget default. I have since swept the whole
diff for the same shape: everything else is either alpha-0.22 behind white text on a dark sheet or
an icon on a dark surface, and the filter-sheet radio already flips its tick to black.

Eyes on a running build would still be worth more than my reading of it.

## Product invariants

**INV-UI-1.** `pr-preflight --suggest` reports no required citation, and
`docs/product/invariants/brand-ui.md` asks that routine UI PRs not name it. Naming it anyway
only because the first commit changes what the guard detects, which is adjacent to the
"changing brand color policy or the allowlist" case the doc reserves the ID for. Happy to
drop the mention if you would rather keep that line bright.

## Failure class

Failure-Class: none

No existing class covers "a pattern did not reach a spelling its subject uses in practice".
`new` felt like overreach — a new class wants a canonical prevention artifact and a reusable
guard surface, and the honest prevention here is the widened pattern this PR already
contains. Happy to classify it differently if you would rather it were tracked.

---

*Written with Claude Code. Every count above is reproducible from
`.github/scripts/check_brand_ui.py` at this commit.*
