### PR TITLE
feat(desktop): calm the Permissions settings page

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -163,6 +163,16 @@ checks:
     triggers: ["all"]
     lanes: ["local", "ci"]
     reason: "all changes must be free of whitespace errors and conflict markers"
+  - id: git-author-identity
+    command: ["python3", ".github/scripts/check_git_author_identity.py", "--base", "{base}", "--head", "{head}"]
+    triggers: ["all"]
+    lanes: ["local", "ci"]
+    reason: "PR #11525's commits were minted as Ratchet Test because a leftover repo-local user.email overrode the global identity; GitHub then showed a generic avatar"
+  - id: git-author-identity-tests
+    command: ["python3", ".github/scripts/test_check_git_author_identity.py"]
+    triggers: [".github/scripts/check_git_author_identity.py", ".github/scripts/test_check_git_author_identity.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the author-identity guard must reject a clone-local fixture override and a fixture-authored commit range"
   - id: package-architecture-map-guardrail-tests
     command: ["python3", ".github/scripts/test_check_package_architecture_maps.py"]
     triggers: [".github/scripts/check_package_architecture_maps.py", ".github/scripts/test_check_package_architecture_maps.py", ".github/scripts/package_architecture_baseline.json", ".github/checks-manifest.yaml"]

--- a/.github/scripts/check_git_author_identity.py
+++ b/.github/scripts/check_git_author_identity.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Reject test-fixture Git identities on real commits and repo-local config.
+
+PR #11525's commits were minted as ``Ratchet Test <ratchet-test@example.invalid>``
+because a leftover ``user.email`` in the clone's ``.git/config`` overrode the
+global identity. GitHub maps avatars by author email, so those commits did not
+belong to the person who opened the PR.
+
+Fixture identities belong only in temporary test repositories. Never write
+``user.name`` / ``user.email`` into this clone's local config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from email.utils import parseaddr
+from pathlib import Path
+from typing import NamedTuple
+
+_GIT_ENV_SCRUB = {
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_QUARANTINE_PATH",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+}
+
+RESERVED_TEST_TLDS = frozenset({"invalid", "test", "localhost"})
+FIXTURE_NAMES = frozenset({"ratchet test"})
+FIXTURE_LOCAL_PARTS = frozenset({"ratchet-test"})
+
+
+class Identity(NamedTuple):
+    kind: str
+    name: str
+    email: str
+    detail: str
+
+
+def clean_git_env(source: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(os.environ if source is None else source)
+    for key in _GIT_ENV_SCRUB:
+        env.pop(key, None)
+    return env
+
+
+def run_git(root: Path | None, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=None if root is None else root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=clean_git_env(),
+    )
+
+
+def parse_ident(raw: str) -> tuple[str, str]:
+    value = raw.strip()
+    if "<" in value:
+        value = value.split(">", 1)[0] + ">"
+    name, email = parseaddr(value)
+    return name.strip(), email.strip().lower()
+
+
+def email_tld(email: str) -> str:
+    if "@" not in email:
+        return ""
+    domain = email.rsplit("@", 1)[1]
+    if "." not in domain:
+        return domain
+    return domain.rsplit(".", 1)[1]
+
+
+def fixture_reason(name: str, email: str) -> str | None:
+    normalized_name = " ".join(name.lower().split())
+    local_part = email.split("@", 1)[0] if email else ""
+    tld = email_tld(email)
+    if tld in RESERVED_TEST_TLDS:
+        return f"reserved test TLD .{tld}"
+    if normalized_name in FIXTURE_NAMES:
+        return "fixture display name"
+    if local_part in FIXTURE_LOCAL_PARTS:
+        return "fixture local-part"
+    return None
+
+
+def local_config_identities(root: Path | None) -> list[Identity]:
+    identities: list[Identity] = []
+    for key in ("user.name", "user.email"):
+        result = run_git(root, "config", "--local", "--get", key)
+        if result.returncode != 0:
+            continue
+        value = result.stdout.strip()
+        if not value:
+            continue
+        if key == "user.name":
+            identities.append(Identity("local-config", value, "", key))
+        else:
+            identities.append(Identity("local-config", "", value, key))
+    return identities
+
+
+def pending_identities(root: Path | None) -> list[Identity]:
+    identities: list[Identity] = []
+    for var, kind in (("GIT_AUTHOR_IDENT", "pending-author"), ("GIT_COMMITTER_IDENT", "pending-committer")):
+        result = run_git(root, "var", var)
+        if result.returncode != 0 or not result.stdout.strip():
+            continue
+        name, email = parse_ident(result.stdout)
+        identities.append(Identity(kind, name, email, var))
+    return identities
+
+
+def range_identities(root: Path | None, base: str, head: str) -> list[Identity]:
+    result = run_git(root, "log", f"{base}..{head}", "--format=%H%x09%an%x09%ae%x09%cn%x09%ce")
+    if result.returncode != 0:
+        return []
+    identities: list[Identity] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        sha, author_name, author_email, committer_name, committer_email = line.split("\t", 4)
+        identities.append(Identity("author", author_name, author_email, sha))
+        identities.append(Identity("committer", committer_name, committer_email, sha))
+    return identities
+
+
+def failures_for(identities: list[Identity]) -> list[str]:
+    failures: list[str] = []
+    for identity in identities:
+        reason = fixture_reason(identity.name, identity.email)
+        if reason is None:
+            continue
+        who = identity.name or identity.email or "(empty)"
+        if identity.email and identity.name:
+            who = f"{identity.name} <{identity.email}>"
+        elif identity.email:
+            who = identity.email
+        failures.append(f"{identity.kind} {who} on {identity.detail} ({reason})")
+    return failures
+
+
+def report(failures: list[str]) -> int:
+    if not failures:
+        print("OK: Git author identity is not a test fixture.")
+        return 0
+    print("FAIL: test-fixture Git identity would mint unattributed commits.", file=sys.stderr)
+    for failure in failures:
+        print(f"- {failure}", file=sys.stderr)
+    print(
+        "Unset a leftover clone override with: "
+        "git config --local --unset-all user.email; git config --local --unset-all user.name",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, help="Repository root (default: current directory)")
+    parser.add_argument("--base", help="Exclusive start of the commit range to inspect")
+    parser.add_argument("--head", default="HEAD", help="Inclusive end of the commit range")
+    parser.add_argument(
+        "--pending",
+        action="store_true",
+        help="Inspect the identity the next commit would use (pre-commit)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve() if args.root else None
+    identities = local_config_identities(root)
+    if args.pending:
+        identities.extend(pending_identities(root))
+    if args.base:
+        identities.extend(range_identities(root, args.base, args.head))
+    return report(failures_for(identities))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
+++ b/.github/scripts/product_file_line_count_ratchet_baseline/desktop-swift-mainwindow.json
@@ -1,7 +1,7 @@
 {
   "files": {
     "desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift": 2023,
-    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1595,
+    "desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift": 1594,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/AppsPage.swift": 3433,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift": 4280,
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift": 3468,

--- a/.github/scripts/test_check_git_author_identity.py
+++ b/.github/scripts/test_check_git_author_identity.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Behavioral coverage for the Git author-identity fixture guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "check_git_author_identity", SCRIPT_DIR / "check_git_author_identity.py"
+)
+assert SPEC and SPEC.loader
+CHECKER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CHECKER
+SPEC.loader.exec_module(CHECKER)
+
+
+class GitAuthorIdentityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.git("init", "-q")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def git(self, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.root,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=CHECKER.clean_git_env(),
+        )
+        if check and result.returncode != 0:
+            raise AssertionError(result.stderr or result.stdout or args)
+        return result
+
+    def commit(self, message: str, *, name: str, email: str) -> str:
+        self.git("-c", f"user.name={name}", "-c", f"user.email={email}", "commit", "--allow-empty", "-qm", message)
+        return self.git("rev-parse", "HEAD").stdout.strip()
+
+    def test_reserved_test_tld_is_a_fixture(self) -> None:
+        self.assertIsNotNone(CHECKER.fixture_reason("Someone", "ratchet-test@example.invalid"))
+        self.assertIsNotNone(CHECKER.fixture_reason("Ratchet Test", "person@company.com"))
+        self.assertIsNone(CHECKER.fixture_reason("David Zhang", "david.d.zhang@gmail.com"))
+        self.assertIsNone(CHECKER.fixture_reason("github-actions[bot]", "41898282+github-actions[bot]@users.noreply.github.com"))
+
+    def test_rejects_a_repo_local_fixture_override(self) -> None:
+        self.git("config", "--local", "user.email", "ratchet-test@example.invalid")
+        self.git("config", "--local", "user.name", "Ratchet Test")
+        failures = CHECKER.failures_for(CHECKER.local_config_identities(self.root))
+        self.assertTrue(failures)
+        self.assertTrue(any("local-config" in item and "example.invalid" in item for item in failures))
+
+    def test_rejects_fixture_authors_in_the_commit_range(self) -> None:
+        base = self.commit("seed", name="David Zhang", email="david.d.zhang@gmail.com")
+        self.commit("bad", name="Ratchet Test", email="ratchet-test@example.invalid")
+        failures = CHECKER.failures_for(CHECKER.range_identities(self.root, base, "HEAD"))
+        self.assertTrue(failures)
+        self.assertTrue(any("Ratchet Test" in item for item in failures))
+
+    def test_accepts_a_human_author_without_local_override(self) -> None:
+        base = self.commit("seed", name="David Zhang", email="david.d.zhang@gmail.com")
+        self.commit("good", name="David Zhang", email="david.d.zhang@gmail.com")
+        failures = CHECKER.failures_for(
+            CHECKER.local_config_identities(self.root) + CHECKER.range_identities(self.root, base, "HEAD")
+        )
+        self.assertEqual(failures, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ The unit of work is the violated contract, not only the line where the symptom a
 
 ## Git
 
-- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs repo Git hooks (including the auto-formatting pre-commit hook) with linked-worktree-safe paths.
+- **Setup (required before first commit):** `make setup` — fetches `origin/main`, fast-forwards when safe, installs repo Git hooks (including the auto-formatting pre-commit hook) with linked-worktree-safe paths. Never set repo-local `user.name`/`user.email`; fixture identities belong only in temp test repos (`git -c`).
 - Before starting work: `git fetch origin && git pull --ff-only` on `main` — don't branch off stale state.
 - Always work in a git worktree for code changes (`git worktree add`); commit to the current branch and never switch branches mid-task.
 - Make individual commits per feature or testable surface, not per file or unrelated bulk changes.

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstRoute.swift
@@ -115,7 +115,7 @@ enum ChatFirstMorePage: String, CaseIterable, Codable, Hashable, Sendable {
     case .dashboard: return "house.fill"
     case .rewind: return "clock.arrow.circlepath"
     case .apps: return "puzzlepiece.fill"
-    case .permissions: return "exclamationmark.triangle.fill"
+    case .permissions: return PermissionNavSymbol.filled
     case .settings: return "gearshape.fill"
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -335,7 +335,8 @@ struct ChatFirstShell: View {
           highlightedSettingId: $highlightedSettingID,
           onBack: {
             _ = navigation.handleEscapeNavigation()
-          }
+          },
+          appState: appState
         )
         SettingsPage(
           appState: appState,

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1312,9 +1312,7 @@ struct DesktopHomeView: View {
             ? SidebarNavItem.dashboard.rawValue
             : previousIndexBeforeSettings
         }
-      },
-      appState: appState
-    )
+      }, appState: appState)
   }
 
   // Main content area. It paints **no background**: the window has no ground at all

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1312,7 +1312,8 @@ struct DesktopHomeView: View {
             ? SidebarNavItem.dashboard.rawValue
             : previousIndexBeforeSettings
         }
-      }
+      },
+      appState: appState
     )
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
@@ -6,65 +6,73 @@ import SwiftUI
 struct PermissionsPage: View {
   @ObservedObject var appState: AppState
 
+  private var allRequiredGranted: Bool { !appState.hasMissingPermissions }
+
+  private var microphoneNeedsAction: Bool {
+    PermissionsPageChrome.microphoneNeedsAction(granted: appState.hasMicrophonePermission)
+  }
+
+  private var screenRecordingNeedsAction: Bool {
+    PermissionsPageChrome.screenRecordingNeedsAction(
+      granted: appState.hasScreenRecordingPermission,
+      stale: appState.isScreenRecordingStale)
+  }
+
+  private var notificationsNeedAction: Bool {
+    PermissionsPageChrome.notificationsNeedAction(granted: appState.hasNotificationPermission)
+  }
+
+  private var systemAudioNeedsAction: Bool {
+    guard showsSystemAudio else { return false }
+    return PermissionsPageChrome.systemAudioNeedsAction(
+      status: appState.systemAudioPermissionStatus)
+  }
+
+  private var showsSystemAudio: Bool {
+    if #available(macOS 14.4, *) { return true }
+    return false
+  }
+
+  private var hasActionablePermissions: Bool {
+    microphoneNeedsAction || screenRecordingNeedsAction || systemAudioNeedsAction || notificationsNeedAction
+  }
+
+  private var hasGrantedPermissions: Bool {
+    !microphoneNeedsAction || !screenRecordingNeedsAction || (showsSystemAudio && !systemAudioNeedsAction)
+      || !notificationsNeedAction
+  }
+
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: OmiSpacing.xxl) {
-        // The page's own heading. `stepHeadline` rather than a hand-assembled size and weight: the
-        // role carries its tracking too, and a headline set without it is a different product.
-        VStack(alignment: .leading, spacing: OmiSpacing.sm) {
-          HStack(spacing: OmiSpacing.md) {
-            Image(systemName: "exclamationmark.triangle.fill")
-              .font(.system(size: 22, weight: .semibold))
-              .foregroundColor(SettingsInk.notice)
+        header
+          .padding(.bottom, OmiSpacing.sm)
 
-            Text("Permissions Required")
-              .inkStyle(.stepHeadline, color: Ink.primary)
-          }
-
-          Text("omi needs the following permissions to work properly.")
-            .inkStyle(.prose, color: Ink.secondary)
-            .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(.bottom, OmiSpacing.sm)
-
-        // Permission sections
-        VStack(spacing: OmiSpacing.xl) {
-          // Microphone Permission
-          MicrophonePermissionSection(appState: appState)
-
-          // Screen Recording Permission
-          ScreenRecordingPermissionSection(appState: appState)
-
-          // System Audio Permission (Core Audio process taps, macOS 14.4+)
-          if #available(macOS 14.4, *) {
-            SystemAudioPermissionSection(appState: appState)
-          }
-
-          // Notification Permission
-          NotificationPermissionSection(appState: appState)
+        if allRequiredGranted {
+          allGrantedBanner
         }
 
-        // All permissions granted message
-        if !appState.hasMissingPermissions {
-          HStack(spacing: OmiSpacing.md) {
-            Image(systemName: "checkmark.circle.fill")
-              .scaledFont(size: OmiType.heading)
-              .foregroundColor(Ink.listeningGreen)
-
-            Text("All permissions granted! omi is ready to use.")
-              .scaledFont(size: OmiType.subheading, weight: .medium)
-              .foregroundColor(Ink.primary)
+        if hasActionablePermissions {
+          VStack(spacing: OmiSpacing.xl) {
+            if microphoneNeedsAction {
+              MicrophonePermissionSection(appState: appState)
+            }
+            if screenRecordingNeedsAction {
+              ScreenRecordingPermissionSection(appState: appState)
+            }
+            if showsSystemAudio, systemAudioNeedsAction {
+              SystemAudioPermissionSection(appState: appState)
+            }
+            if notificationsNeedAction {
+              NotificationPermissionSection(appState: appState)
+            }
           }
-          .padding(OmiSpacing.lg)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .background(
-            RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-              .fill(Ink.listeningGreen.opacity(0.1))
-              .overlay(
-                RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-                  .stroke(Ink.listeningGreen.opacity(0.3), lineWidth: 1)
-              )
-          )
+        }
+
+        if hasGrantedPermissions {
+          SettingsGlassSection(title: hasActionablePermissions ? "Granted" : nil) {
+            grantedList
+          }
         }
 
         Spacer()
@@ -86,12 +94,223 @@ struct PermissionsPage: View {
       appState.checkAllPermissions()
     }
   }
+
+  private var header: some View {
+    HStack(spacing: OmiSpacing.md) {
+      if let symbol = PermissionsPageChrome.headerSymbol(allRequiredGranted: allRequiredGranted) {
+        Image(systemName: symbol)
+          .font(.system(size: 22, weight: .semibold))
+          .foregroundColor(Ink.listeningGreen)
+      }
+
+      Text(PermissionsPageChrome.headerTitle)
+        .inkStyle(.stepHeadline, color: Ink.primary)
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityIdentifier(allRequiredGranted ? "permissions.header.settled" : "permissions.header.attention")
+  }
+
+  private var allGrantedBanner: some View {
+    HStack(spacing: OmiSpacing.md) {
+      Image(systemName: "checkmark.circle.fill")
+        .scaledFont(size: OmiType.heading)
+        .foregroundColor(Ink.listeningGreen)
+
+      Text(PermissionsPageChrome.allGrantedMessage)
+        .scaledFont(size: OmiType.subheading, weight: .medium)
+        .foregroundColor(Ink.primary)
+    }
+    .padding(OmiSpacing.lg)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
+        .fill(Ink.listeningGreen.opacity(0.1))
+        .overlay(
+          RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
+            .stroke(Ink.listeningGreen.opacity(0.3), lineWidth: 1)
+        )
+    )
+    .accessibilityElement(children: .combine)
+    .accessibilityIdentifier("permissions.success-banner")
+    .accessibilityLabel(PermissionsPageChrome.allGrantedMessage)
+  }
+
+  @ViewBuilder private var grantedList: some View {
+    let granted = grantedKinds
+    ForEach(Array(granted.enumerated()), id: \.element) { index, kind in
+      grantedSection(kind)
+      if index < granted.count - 1 {
+        SettingsRowDivider()
+      }
+    }
+  }
+
+  private var grantedKinds: [PermissionKind] {
+    var kinds: [PermissionKind] = []
+    if !microphoneNeedsAction { kinds.append(.microphone) }
+    if !screenRecordingNeedsAction { kinds.append(.screenRecording) }
+    if showsSystemAudio, !systemAudioNeedsAction { kinds.append(.systemAudio) }
+    if !notificationsNeedAction { kinds.append(.notifications) }
+    return kinds
+  }
+
+  @ViewBuilder private func grantedSection(_ kind: PermissionKind) -> some View {
+    switch kind {
+    case .microphone:
+      MicrophonePermissionSection(appState: appState)
+    case .screenRecording:
+      ScreenRecordingPermissionSection(appState: appState)
+    case .systemAudio:
+      SystemAudioPermissionSection(appState: appState)
+    case .notifications:
+      NotificationPermissionSection(appState: appState)
+    }
+  }
+}
+
+private enum PermissionKind: String, Hashable {
+  case microphone
+  case screenRecording
+  case systemAudio
+  case notifications
+}
+
+// MARK: - Shared row chrome
+
+/// An unanswered or refused permission: the instructions stay visible. There is no chevron, because
+/// collapsing a card whose only job is to get the grant does nothing useful.
+@MainActor private struct PermissionActionCard<Badge: View, Detail: View>: View {
+  let symbol: String
+  let iconColor: Color
+  let iconBackground: Color
+  let title: String
+  let description: String
+  var descriptionColor: Color = Ink.secondary
+  let borderColor: Color
+  var fillColor: Color = Ink.wash
+  var borderWidth: CGFloat = 1
+  @ViewBuilder var badge: () -> Badge
+  @ViewBuilder var detail: () -> Detail
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(alignment: .center, spacing: OmiSpacing.lg) {
+        ZStack {
+          Circle()
+            .fill(iconBackground)
+            .frame(width: 48, height: 48)
+
+          Image(systemName: symbol)
+            .scaledFont(size: OmiType.heading)
+            .foregroundColor(iconColor)
+        }
+
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          HStack(spacing: OmiSpacing.sm) {
+            Text(title)
+              .scaledFont(size: OmiType.subheading, weight: .semibold)
+              .foregroundColor(Ink.primary)
+            badge()
+          }
+
+          Text(description)
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(descriptionColor)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        Spacer(minLength: 0)
+      }
+      .padding(OmiSpacing.xl)
+
+      VStack(alignment: .leading, spacing: OmiSpacing.lg) {
+        GlassSeparator()
+        detail()
+      }
+      .padding(.horizontal, OmiSpacing.xl)
+      .padding(.bottom, OmiSpacing.xl)
+    }
+    .background(
+      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
+        .fill(fillColor)
+        .overlay(
+          RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
+            .stroke(borderColor, lineWidth: borderWidth)
+        )
+    )
+  }
+}
+
+/// A settled permission: the same row shape the rest of Settings uses, with a status chip and no
+/// disclosure. Expanding a granted row used to reveal an empty pane.
+@MainActor private struct PermissionGrantedRow<Trailing: View>: View {
+  let icon: String
+  let title: String
+  let subtitle: String
+  var chipText: String = "Granted"
+  var chipTint: Color = Ink.listeningGreen
+  @ViewBuilder var trailing: () -> Trailing
+
+  var body: some View {
+    SettingsGlassRow(icon: icon, title: title, subtitle: subtitle) {
+      HStack(spacing: OmiSpacing.sm) {
+        SettingsStatusChip(text: chipText, tint: chipTint)
+        trailing()
+      }
+    }
+  }
+}
+
+extension PermissionGrantedRow where Trailing == EmptyView {
+  init(
+    icon: String, title: String, subtitle: String, chipText: String = "Granted", chipTint: Color = Ink.listeningGreen
+  ) {
+    self.init(
+      icon: icon, title: title, subtitle: subtitle, chipText: chipText, chipTint: chipTint,
+      trailing: { EmptyView() })
+  }
+}
+
+@MainActor private struct PermissionCompactActionButton: View {
+  let title: String
+  var systemImage: String?
+  var isBusy: Bool = false
+  var action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: OmiSpacing.xs) {
+        if isBusy {
+          ProgressView()
+            .scaleEffect(0.6)
+            .frame(width: 12, height: 12)
+        } else if let systemImage {
+          Image(systemName: systemImage)
+            .scaledFont(size: OmiType.caption)
+        }
+        Text(title)
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+      }
+      .foregroundColor(Ink.primary)
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.xs)
+      .background(
+        RoundedRectangle(cornerRadius: SettingsGlassMetrics.controlRadius, style: .continuous)
+          .fill(Ink.rowFill)
+          .overlay(
+            RoundedRectangle(cornerRadius: SettingsGlassMetrics.controlRadius, style: .continuous)
+              .stroke(Ink.hairline, lineWidth: 1)
+          )
+      )
+    }
+    .buttonStyle(.plain)
+    .disabled(isBusy)
+  }
 }
 
 // MARK: - Microphone Permission Section
 struct MicrophonePermissionSection: View {
   @ObservedObject var appState: AppState
-  @State private var isExpanded = true
   @State private var isResetting = false
   @State private var resetButtonText = "Reset & Restart"
 
@@ -100,12 +319,11 @@ struct MicrophonePermissionSection: View {
     return appState.isMicrophonePermissionDenied()
   }
 
-  // Colors based on state
+  // Colors based on state. A refuse is still "Not Granted" in the chip; the reset
+  // instructions below are what macOS requires, not a second status colour.
   private var iconBackgroundColor: Color {
     if appState.hasMicrophonePermission {
       return Ink.listeningGreen.opacity(0.15)
-    } else if isPermissionDenied {
-      return Ink.errorRed.opacity(0.15)
     } else {
       return Ink.rowFill
     }
@@ -114,8 +332,6 @@ struct MicrophonePermissionSection: View {
   private var iconColor: Color {
     if appState.hasMicrophonePermission {
       return Ink.listeningGreen
-    } else if isPermissionDenied {
-      return Ink.errorRed
     } else {
       return Ink.secondary
     }
@@ -124,88 +340,44 @@ struct MicrophonePermissionSection: View {
   private var borderColor: Color {
     if appState.hasMicrophonePermission {
       return Ink.listeningGreen.opacity(0.3)
-    } else if isPermissionDenied {
-      return Ink.errorRed.opacity(0.5)
     } else {
       return Ink.hairline
     }
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      // Header
-      Button(action: { OmiMotion.withGated { isExpanded.toggle() } }) {
-        HStack(spacing: OmiSpacing.lg) {
-          // Icon - pulsing animation when denied
-          ZStack {
-            Circle()
-              .fill(iconBackgroundColor)
-              .frame(width: 48, height: 48)
-
-            Image(systemName: isPermissionDenied ? "mic.slash.fill" : "mic.fill")
-              .scaledFont(size: OmiType.heading)
-              .foregroundColor(iconColor)
-          }
-
-          // Title and status
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            HStack(spacing: OmiSpacing.sm) {
-              Text("Microphone")
-                .scaledFont(size: OmiType.subheading, weight: .semibold)
-                .foregroundColor(Ink.primary)
-
-              microphoneStatusBadge
-            }
-
-            Text(
-              isPermissionDenied
-                ? "Permission was denied - reset required"
-                : "Required for voice recording and transcription"
-            )
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(isPermissionDenied ? Ink.errorRed : Ink.secondary)
-          }
-
-          Spacer()
-
-          Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.secondary)
-        }
-        .padding(OmiSpacing.xl)
-      }
-      .buttonStyle(.plain)
-
-      // Expanded content - different for denied vs not determined
-      if isExpanded && !appState.hasMicrophonePermission {
-        VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-          GlassSeparator()
-
+    if appState.hasMicrophonePermission {
+      PermissionGrantedRow(
+        icon: "mic.fill",
+        title: "Microphone",
+        subtitle: "Required for voice recording and transcription")
+    } else {
+      PermissionActionCard(
+        symbol: isPermissionDenied ? "mic.slash.fill" : "mic.fill",
+        iconColor: iconColor,
+        iconBackground: iconBackgroundColor,
+        title: "Microphone",
+        description: isPermissionDenied
+          ? "Reset required to try again"
+          : "Required for voice recording and transcription",
+        descriptionColor: Ink.secondary,
+        borderColor: borderColor,
+        fillColor: Ink.wash,
+        badge: { microphoneStatusBadge },
+        detail: {
           if isPermissionDenied {
-            // DENIED STATE - Show reset options
             deniedStateContent
           } else {
-            // NOT DETERMINED - Show normal grant flow
             notDeterminedStateContent
           }
         }
-        .padding(.horizontal, OmiSpacing.xl)
-        .padding(.bottom, OmiSpacing.xl)
-      }
+      )
     }
-    .background(
-      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-        .fill(isPermissionDenied ? Ink.errorRed.opacity(0.05) : Ink.wash)
-        .overlay(
-          RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-            .stroke(borderColor, lineWidth: 1)
-        )
-    )
   }
 
   // Status badge for microphone
   private var microphoneStatusBadge: some View {
-    permissionChip(granted: appState.hasMicrophonePermission, denied: isPermissionDenied)
+    statusBadge(isGranted: appState.hasMicrophonePermission)
   }
 
   // Content for DENIED state - shows reset options
@@ -317,7 +489,7 @@ struct MicrophonePermissionSection: View {
             .foregroundColor(Ink.secondary)
 
           VStack(alignment: .leading, spacing: OmiSpacing.xs) {
-            Text("Find \"omi\" and toggle it ON")
+            Text("Find \"Omi\" and toggle it ON")
               .scaledFont(size: OmiType.body)
               .foregroundColor(Ink.secondary)
 
@@ -354,7 +526,7 @@ struct MicrophonePermissionSection: View {
         instructionStep(
           number: 3,
           text:
-            "If no dialog appears, find \"\(Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi")\" in Settings and enable it"
+            "If no dialog appears, find \"\(Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Omi")\" in Settings and enable it"
         )
       }
 
@@ -426,101 +598,51 @@ struct MicrophonePermissionSection: View {
 // MARK: - Screen Recording Permission Section
 struct ScreenRecordingPermissionSection: View {
   @ObservedObject var appState: AppState
-  @State private var isExpanded = true
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      // Header
-      Button(action: { OmiMotion.withGated { isExpanded.toggle() } }) {
-        HStack(spacing: OmiSpacing.lg) {
-          // Icon
-          ZStack {
-            Circle()
-              .fill(
-                appState.isScreenRecordingStale
-                  ? Ink.errorRed.opacity(0.15)
-                  : (appState.hasScreenRecordingPermission ? Ink.listeningGreen.opacity(0.15) : Ink.rowFill)
-              )
-              .frame(width: 48, height: 48)
-
-            Image(
-              systemName: appState.isScreenRecordingStale
-                ? "rectangle.on.rectangle.slash" : "rectangle.inset.filled.and.person.filled"
-            )
-            .scaledFont(size: OmiType.heading)
-            .foregroundColor(
-              appState.isScreenRecordingStale
-                ? Ink.errorRed : (appState.hasScreenRecordingPermission ? Ink.listeningGreen : Ink.secondary))
-          }
-
-          // Title and status
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            HStack(spacing: OmiSpacing.sm) {
-              Text("Screen Recording")
-                .scaledFont(size: OmiType.subheading, weight: .semibold)
-                .foregroundColor(Ink.primary)
-
-              if appState.isScreenRecordingStale {
-                SettingsStatusChip(text: "Re-enable Required", tint: Ink.errorRed)
-              } else {
-                statusBadge(isGranted: appState.hasScreenRecordingPermission)
-              }
-            }
-
-            Text(
-              appState.isScreenRecordingStale
-                ? "Permission needs re-enabling after app update"
-                : "Required for proactive monitoring and context awareness"
-            )
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(appState.isScreenRecordingStale ? Ink.errorRed : Ink.secondary)
-          }
-
-          Spacer()
-
-          Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.secondary)
-        }
-        .padding(OmiSpacing.xl)
-      }
-      .buttonStyle(.plain)
-
-      // Expanded content
-      if isExpanded && (!appState.hasScreenRecordingPermission || appState.isScreenRecordingStale) {
-        VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-          GlassSeparator()
-
+    if appState.hasScreenRecordingPermission && !appState.isScreenRecordingStale {
+      PermissionGrantedRow(
+        icon: "rectangle.inset.filled.and.person.filled",
+        title: "Screen Recording",
+        subtitle: "Required for proactive monitoring and context awareness")
+    } else {
+      PermissionActionCard(
+        symbol: appState.isScreenRecordingStale
+          ? "rectangle.on.rectangle.slash" : "rectangle.inset.filled.and.person.filled",
+        iconColor: appState.isScreenRecordingStale
+          ? Ink.errorRed : Ink.secondary,
+        iconBackground: appState.isScreenRecordingStale
+          ? Ink.errorRed.opacity(0.15) : Ink.rowFill,
+        title: "Screen Recording",
+        description: appState.isScreenRecordingStale
+          ? "Permission needs re-enabling after app update"
+          : "Required for proactive monitoring and context awareness",
+        descriptionColor: appState.isScreenRecordingStale ? Ink.errorRed : Ink.secondary,
+        borderColor: appState.isScreenRecordingStale
+          ? Ink.errorRed.opacity(0.5) : Ink.hairline,
+        fillColor: appState.isScreenRecordingStale ? Ink.errorRed.opacity(0.05) : Ink.wash,
+        borderWidth: appState.isScreenRecordingStale ? 2 : 1,
+        badge: {
           if appState.isScreenRecordingStale {
-            // STALE STATE - developer signing changed, user must toggle off/on
+            SettingsStatusChip(text: "Re-enable Required", tint: Ink.errorRed)
+          } else {
+            statusBadge(isGranted: false)
+          }
+        },
+        detail: {
+          if appState.isScreenRecordingStale {
             stalePermissionContent
           } else {
-            // NORMAL STATE - first-time grant flow
             normalGrantContent
           }
         }
-        .padding(.horizontal, OmiSpacing.xl)
-        .padding(.bottom, OmiSpacing.xl)
-      }
+      )
     }
-    .background(
-      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-        .fill(appState.isScreenRecordingStale ? Ink.errorRed.opacity(0.05) : Ink.wash)
-        .overlay(
-          RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-            .stroke(
-              appState.hasScreenRecordingPermission
-                ? Ink.listeningGreen.opacity(0.3)
-                : (appState.isScreenRecordingStale
-                  ? Ink.errorRed.opacity(0.5) : Ink.hairline),
-              lineWidth: appState.isScreenRecordingStale ? 2 : 1)
-        )
-    )
   }
 
   // Content for STALE state - developer signing changed, user must remove and re-add
   private var stalePermissionContent: some View {
-    let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
+    let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Omi"
     return VStack(alignment: .leading, spacing: OmiSpacing.lg) {
       Text("Screen recording needs to be re-enabled after an app update.")
         .scaledFont(size: OmiType.body, weight: .medium)
@@ -573,7 +695,7 @@ struct ScreenRecordingPermissionSection: View {
             .background(Circle().fill(Ink.primary))
 
           VStack(alignment: .leading, spacing: OmiSpacing.xs) {
-            Text("Come back to omi and grant the permission")
+            Text("Come back to Omi and grant the permission")
               .scaledFont(size: OmiType.body)
               .foregroundColor(Ink.secondary)
 
@@ -610,17 +732,17 @@ struct ScreenRecordingPermissionSection: View {
 
   // Content for NORMAL state - first-time grant flow
   private var normalGrantContent: some View {
-    let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
+    let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "Omi"
     return VStack(alignment: .leading, spacing: OmiSpacing.lg) {
       Text("How to grant screen recording access:")
         .scaledFont(size: OmiType.body, weight: .medium)
         .foregroundColor(Ink.primary)
 
       VStack(alignment: .leading, spacing: OmiSpacing.md) {
-        instructionStep(number: 1, text: "Click \"Open Settings\" below - this will make omi appear in the list")
+        instructionStep(number: 1, text: "Click \"Open Settings\" below - this will make Omi appear in the list")
         instructionStep(number: 2, text: "Find \"\(appName)\" in the Screen Recording list")
         instructionStep(number: 3, text: "Toggle the switch to enable screen recording")
-        instructionStep(number: 4, text: "Return to omi - permission will update automatically")
+        instructionStep(number: 4, text: "Return to Omi - permission will update automatically")
       }
 
       // Tutorial GIF
@@ -659,7 +781,6 @@ struct ScreenRecordingPermissionSection: View {
 // MARK: - System Audio Permission Section
 struct SystemAudioPermissionSection: View {
   @ObservedObject var appState: AppState
-  @State private var isExpanded = true
   @State private var isTesting = false
 
   private var status: SystemAudioPermissionStatus {
@@ -668,6 +789,10 @@ struct SystemAudioPermissionSection: View {
 
   private var isGranted: Bool {
     status == .granted
+  }
+
+  private var needsAction: Bool {
+    PermissionsPageChrome.systemAudioNeedsAction(status: status)
   }
 
   private var iconBackgroundColor: Color {
@@ -708,61 +833,53 @@ struct SystemAudioPermissionSection: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      Button(action: { OmiMotion.withGated { isExpanded.toggle() } }) {
-        HStack(spacing: OmiSpacing.lg) {
-          ZStack {
-            Circle()
-              .fill(iconBackgroundColor)
-              .frame(width: 48, height: 48)
-
-            Image(systemName: isGranted ? "speaker.wave.2.fill" : "speaker.slash.fill")
-              .scaledFont(size: OmiType.heading)
-              .foregroundColor(iconColor)
-          }
-
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            HStack(spacing: OmiSpacing.sm) {
-              Text("System Audio")
-                .scaledFont(size: OmiType.subheading, weight: .semibold)
-                .foregroundColor(Ink.primary)
-
-              systemAudioStatusBadge
-            }
-
-            Text(descriptionText)
-              .scaledFont(size: OmiType.body)
-              .foregroundColor(status == .denied ? SettingsInk.notice : Ink.secondary)
-          }
-
-          Spacer()
-
-          Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.secondary)
+    if needsAction {
+      PermissionActionCard(
+        symbol: isGranted ? "speaker.wave.2.fill" : "speaker.slash.fill",
+        iconColor: iconColor,
+        iconBackground: iconBackgroundColor,
+        title: "System Audio",
+        description: descriptionText,
+        descriptionColor: status == .denied ? SettingsInk.notice : Ink.secondary,
+        borderColor: borderColor,
+        borderWidth: status == .denied ? 2 : 1,
+        badge: { systemAudioStatusBadge },
+        detail: { expandedContent }
+      )
+    } else {
+      PermissionGrantedRow(
+        icon: "speaker.wave.2.fill",
+        title: "System Audio",
+        subtitle: descriptionText,
+        chipText: grantedChipText,
+        chipTint: grantedChipTint
+      ) {
+        if status == .granted {
+          PermissionCompactActionButton(
+            title: "Test Again",
+            systemImage: "speaker.wave.2.fill",
+            isBusy: isTesting,
+            action: testSystemAudioAccess)
         }
-        .padding(OmiSpacing.xl)
-      }
-      .buttonStyle(.plain)
-
-      if isExpanded {
-        VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-          GlassSeparator()
-
-          expandedContent
-        }
-        .padding(.horizontal, OmiSpacing.xl)
-        .padding(.bottom, OmiSpacing.xl)
       }
     }
-    .background(
-      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-        .fill(Ink.wash)
-        .overlay(
-          RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-            .stroke(borderColor, lineWidth: status == .denied ? 2 : 1)
-        )
-    )
+  }
+
+  private var grantedChipText: String {
+    switch status {
+    case .granted: return PermissionsPageChrome.grantedStatusText
+    case .unsupported: return "Unsupported"
+    case .denied: return PermissionsPageChrome.missingStatusText
+    case .unknown: return "Unknown"
+    }
+  }
+
+  private var grantedChipTint: Color {
+    switch status {
+    case .granted: return Ink.listeningGreen
+    case .denied: return SettingsInk.notice
+    case .unsupported, .unknown: return Ink.secondary
+    }
   }
 
   private var descriptionText: String {
@@ -780,8 +897,10 @@ struct SystemAudioPermissionSection: View {
 
   private var systemAudioStatusBadge: some View {
     switch status {
-    case .granted: return SettingsStatusChip(text: "Granted", tint: Ink.listeningGreen)
-    case .denied: return SettingsStatusChip(text: "Not Granted", tint: SettingsInk.notice)
+    case .granted:
+      return SettingsStatusChip(text: PermissionsPageChrome.grantedStatusText, tint: Ink.listeningGreen)
+    case .denied:
+      return SettingsStatusChip(text: PermissionsPageChrome.missingStatusText, tint: SettingsInk.notice)
     case .unsupported: return SettingsStatusChip(text: "Unsupported", tint: Ink.secondary)
     case .unknown: return SettingsStatusChip(text: "Unknown", tint: Ink.secondary)
     }
@@ -791,10 +910,6 @@ struct SystemAudioPermissionSection: View {
     VStack(alignment: .leading, spacing: OmiSpacing.lg) {
       if status == .unsupported {
         Text("System audio capture requires macOS 14.4 or later.")
-          .scaledFont(size: OmiType.body, weight: .medium)
-          .foregroundColor(Ink.primary)
-      } else if status == .granted {
-        Text("System audio access was confirmed by a successful Core Audio tap.")
           .scaledFont(size: OmiType.body, weight: .medium)
           .foregroundColor(Ink.primary)
       } else {
@@ -819,7 +934,7 @@ struct SystemAudioPermissionSection: View {
             Image(systemName: "speaker.wave.2.fill")
               .scaledFont(size: OmiType.body)
           }
-          Text(isGranted ? "Test Again" : "Test Access")
+          Text("Test Access")
             .scaledFont(size: OmiType.body, weight: .semibold)
         }
         .foregroundColor(Ink.primary)
@@ -852,19 +967,17 @@ struct SystemAudioPermissionSection: View {
 // MARK: - Notification Permission Section
 struct NotificationPermissionSection: View {
   @ObservedObject var appState: AppState
-  @State private var isExpanded = true
 
   // Check if permission was explicitly denied
   private var isPermissionDenied: Bool {
     return appState.isNotificationPermissionDenied()
   }
 
-  // Colors based on state
+  // Colors based on state. A refuse is still "Not Granted" in the chip; System Settings
+  // is the recovery path, not a second status colour.
   private var iconBackgroundColor: Color {
     if appState.hasNotificationPermission {
       return Ink.listeningGreen.opacity(0.15)
-    } else if isPermissionDenied {
-      return Ink.errorRed.opacity(0.15)
     } else {
       return Ink.rowFill
     }
@@ -873,8 +986,6 @@ struct NotificationPermissionSection: View {
   private var iconColor: Color {
     if appState.hasNotificationPermission {
       return Ink.listeningGreen
-    } else if isPermissionDenied {
-      return Ink.errorRed
     } else {
       return Ink.secondary
     }
@@ -883,88 +994,44 @@ struct NotificationPermissionSection: View {
   private var borderColor: Color {
     if appState.hasNotificationPermission {
       return Ink.listeningGreen.opacity(0.3)
-    } else if isPermissionDenied {
-      return Ink.errorRed.opacity(0.5)
     } else {
       return Ink.hairline
     }
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      // Header
-      Button(action: { OmiMotion.withGated { isExpanded.toggle() } }) {
-        HStack(spacing: OmiSpacing.lg) {
-          // Icon
-          ZStack {
-            Circle()
-              .fill(iconBackgroundColor)
-              .frame(width: 48, height: 48)
-
-            Image(systemName: isPermissionDenied ? "bell.slash.fill" : "bell.fill")
-              .scaledFont(size: OmiType.heading)
-              .foregroundColor(iconColor)
-          }
-
-          // Title and status
-          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-            HStack(spacing: OmiSpacing.sm) {
-              Text("Notifications")
-                .scaledFont(size: OmiType.subheading, weight: .semibold)
-                .foregroundColor(Ink.primary)
-
-              notificationStatusBadge
-            }
-
-            Text(
-              isPermissionDenied
-                ? "Permission was denied - enable in System Settings"
-                : "Required for proactive assistant alerts"
-            )
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(isPermissionDenied ? Ink.errorRed : Ink.secondary)
-          }
-
-          Spacer()
-
-          Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.secondary)
-        }
-        .padding(OmiSpacing.xl)
-      }
-      .buttonStyle(.plain)
-
-      // Expanded content
-      if isExpanded && !appState.hasNotificationPermission {
-        VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-          GlassSeparator()
-
+    if appState.hasNotificationPermission {
+      PermissionGrantedRow(
+        icon: "bell.fill",
+        title: "Notifications",
+        subtitle: "Required for proactive assistant alerts")
+    } else {
+      PermissionActionCard(
+        symbol: isPermissionDenied ? "bell.slash.fill" : "bell.fill",
+        iconColor: iconColor,
+        iconBackground: iconBackgroundColor,
+        title: "Notifications",
+        description: isPermissionDenied
+          ? "Enable in System Settings to try again"
+          : "Required for proactive assistant alerts",
+        descriptionColor: Ink.secondary,
+        borderColor: borderColor,
+        fillColor: Ink.wash,
+        badge: { notificationStatusBadge },
+        detail: {
           if isPermissionDenied {
-            // DENIED STATE - Show settings instructions
             deniedStateContent
           } else {
-            // NOT DETERMINED - Show normal grant flow
             notDeterminedStateContent
           }
         }
-        .padding(.horizontal, OmiSpacing.xl)
-        .padding(.bottom, OmiSpacing.xl)
-      }
+      )
     }
-    .background(
-      RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-        .fill(isPermissionDenied ? Ink.errorRed.opacity(0.05) : Ink.wash)
-        .overlay(
-          RoundedRectangle(cornerRadius: SettingsGlassMetrics.cardRadius, style: .continuous)
-            .stroke(borderColor, lineWidth: 1)
-        )
-    )
   }
 
   // Status badge for notifications
   private var notificationStatusBadge: some View {
-    permissionChip(granted: appState.hasNotificationPermission, denied: isPermissionDenied)
+    statusBadge(isGranted: appState.hasNotificationPermission)
   }
 
   // Content for DENIED state - shows settings instructions
@@ -1013,7 +1080,7 @@ struct NotificationPermissionSection: View {
         instructionStep(number: 2, text: "Click \"Allow\" to enable notifications")
         instructionStep(
           number: 3,
-          text: "Tip: In System Settings > Notifications > omi, set style to \"Banners\" to see visual alerts")
+          text: "Tip: In System Settings > Notifications > Omi, set style to \"Banners\" to see visual alerts")
       }
 
       Button(action: {
@@ -1049,26 +1116,8 @@ struct NotificationPermissionSection: View {
 /// thing that failed.
 @MainActor private func statusBadge(isGranted: Bool) -> some View {
   SettingsStatusChip(
-    text: isGranted ? "Granted" : "Not Granted",
+    text: PermissionsPageChrome.statusChipText(granted: isGranted),
     tint: isGranted ? Ink.listeningGreen : SettingsInk.notice)
-}
-
-/// The three-state version, for the capabilities macOS lets the user *refuse* rather than merely
-/// leave unanswered.
-///
-/// Microphone and Notifications each carried their own hand-rolled capsule — an icon, a tint, a
-/// 15% wash, spelled out twice and differing from the two rows beside them, which already used
-/// `SettingsStatusChip`. Four permission rows on one page had three badge designs between them.
-/// Refused is `Ink.errorRed` and merely unanswered is `SettingsInk.notice`, for the reason
-/// `statusBadge` gives: a permission nobody has answered yet is a thing to do, not a thing that
-/// failed.
-@MainActor private func permissionChip(granted: Bool, denied: Bool) -> some View {
-  if granted {
-    return SettingsStatusChip(text: "Granted", tint: Ink.listeningGreen)
-  }
-  return denied
-    ? SettingsStatusChip(text: "Denied", tint: Ink.errorRed)
-    : SettingsStatusChip(text: "Not Granted", tint: SettingsInk.notice)
 }
 
 /// Numbered how-to row. Neutral by default: the disc is `Ink.rowFill` and the numeral

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPageChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPageChrome.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// The nav glyph for Permissions. A lock, not a warning: the page can still shout when a grant
+/// is missing, but the row that opens it is just another settings destination.
+enum PermissionNavSymbol {
+  static let outline = "lock"
+  static let filled = "lock.fill"
+  /// Mark beside the Permissions label while a required grant is still missing.
+  static let missingNotice = "exclamationmark.triangle.fill"
+}
+
+/// Presentation policy for the Permissions settings page.
+///
+/// Granted rows are a compact status list, not empty disclosures. The success banner is the
+/// settled-state signal; the page title itself stays "Permissions" in both states.
+enum PermissionsPageChrome {
+  static let allGrantedMessage = "All permissions granted! Omi is ready to use."
+  static let headerTitle = "Permissions"
+
+  /// Settled state keeps the green check. Missing grants do not wear a warning glyph here —
+  /// that mark lives on the sidebar row instead.
+  static func headerSymbol(allRequiredGranted: Bool) -> String? {
+    allRequiredGranted ? "checkmark.circle.fill" : nil
+  }
+
+  /// One status word for every missing grant. macOS still distinguishes *unanswered* from
+  /// *refused* in the instructions (a refuse will not show the system prompt again), but the
+  /// chip does not: "Denied" reads as a failure, and "Not Granted" is already the work to do.
+  static let missingStatusText = "Not Granted"
+  static let grantedStatusText = "Granted"
+
+  static func statusChipText(granted: Bool) -> String {
+    granted ? grantedStatusText : missingStatusText
+  }
+
+  static func microphoneNeedsAction(granted: Bool) -> Bool { !granted }
+
+  static func screenRecordingNeedsAction(granted: Bool, stale: Bool) -> Bool {
+    !granted || stale
+  }
+
+  static func notificationsNeedAction(granted: Bool) -> Bool { !granted }
+
+  /// Unknown is still work: Core Audio has no preflight, so the row stays open for Test Access.
+  /// A proven grant (or an OS that cannot do this) settles into the compact list.
+  static func systemAudioNeedsAction(status: SystemAudioPermissionStatus) -> Bool {
+    switch status {
+    case .granted, .unsupported: return false
+    case .unknown, .denied: return true
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -367,19 +367,19 @@ enum SettingsSidebarRoutes {
   /// content too). The absorbed cases stay routable for deep links/automation
   /// and highlight their merged item via `sidebarItem`.
   ///
-  /// `Permissions` sits last, under the settings proper: it is the thing you come here for when
-  /// something is wrong, not a preference you scan.
+  /// Capture and account first, then the things you tune, with Permissions beside
+  /// Notifications because both are access. Shortcuts / Advanced / About stay at the foot.
   static let visibleSections: [SettingsContentView.SettingsSection] = [
     .general,
     .account,
     .transcription,
+    .rewind,
     .floatingBar,
     .notifications,
-    .rewind,
+    .permissions,
     .shortcuts,
     .advanced,
     .about,
-    .permissions,
   ]
 }
 
@@ -388,6 +388,7 @@ struct SettingsSidebar: View {
   @Binding var selectedSection: SettingsContentView.SettingsSection
   @Binding var highlightedSettingId: String?
   let onBack: () -> Void
+  @ObservedObject var appState: AppState
 
   @State private var isBackHovered = false
   @State private var searchQuery = ""
@@ -441,6 +442,7 @@ struct SettingsSidebar: View {
                 section: section,
                 isSelected: selectedSection.sidebarItem == section,
                 iconWidth: iconWidth,
+                showsMissingPermissionNotice: section == .permissions && appState.hasMissingPermissions,
                 onTap: {
                   OmiMotion.withGated(.easeInOut(duration: 0.15)) {
                     selectedSection = section
@@ -565,6 +567,7 @@ struct SettingsSidebarItem: View {
   let section: SettingsContentView.SettingsSection
   let isSelected: Bool
   let iconWidth: CGFloat
+  var showsMissingPermissionNotice: Bool = false
   let onTap: () -> Void
 
   @State private var isHovered = false
@@ -583,9 +586,7 @@ struct SettingsSidebarItem: View {
     case .shortcuts: return "keyboard"
     case .advanced: return "chart.bar"
     case .about: return "info.circle"
-    // The same glyph this page already answers to everywhere else in the app (`SidebarNavItem`,
-    // `ChatFirstMorePage`), so a row and the page it opens are one object.
-    case .permissions: return "exclamationmark.triangle"
+    case .permissions: return PermissionNavSymbol.outline
     }
   }
 
@@ -611,6 +612,13 @@ struct SettingsSidebarItem: View {
               .truncationMode(.tail)
               .layoutPriority(1)
 
+            if showsMissingPermissionNotice {
+              Image(systemName: PermissionNavSymbol.missingNotice)
+                .scaledFont(size: OmiType.caption, weight: .semibold)
+                .foregroundColor(SettingsInk.notice)
+                .accessibilityHidden(true)
+            }
+
             Spacer(minLength: 0)
           }
           .padding(.horizontal, SettingsGlassMetrics.rowHorizontalPadding)
@@ -633,7 +641,12 @@ struct SettingsSidebarItem: View {
           isHovered = hovering
         }
         .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
-        .accessibilityLabel(Text(section.displayTitle))
+        .accessibilityLabel(
+          Text(
+            showsMissingPermissionNotice
+              ? "\(section.displayTitle), permissions required"
+              : section.displayTitle)
+        )
       }
     }
   }
@@ -766,7 +779,8 @@ struct SettingHighlightModifier: ViewModifier {
     SettingsSidebar(
       selectedSection: .constant(.advanced),
       highlightedSettingId: .constant(nil),
-      onBack: {}
+      onBack: {},
+      appState: AppState()
     )
     .preferredColorScheme(.light)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SidebarNavItem.swift
@@ -54,7 +54,7 @@ enum SidebarNavItem: Int, CaseIterable {
     case .rewind: return "clock.arrow.circlepath"
     case .apps: return "puzzlepiece.fill"
     case .settings: return "gearshape.fill"
-    case .permissions: return "exclamationmark.triangle.fill"
+    case .permissions: return PermissionNavSymbol.filled
     }
   }
   /// Minimum tier level required to access this item (0 = always available)

--- a/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
+++ b/desktop/macos/Desktop/Tests/FailLoudConfigTests.swift
@@ -108,7 +108,7 @@ final class FailLoudConfigTests: XCTestCase {
     let src = try source(relativePath: "Sources/MainWindow/Pages/PermissionsPage.swift")
 
     XCTAssertTrue(src.contains("SystemAudioPermissionSection(appState: appState)"))
-    XCTAssertTrue(src.contains("Text(\"System Audio\")"))
+    XCTAssertTrue(src.contains("title: \"System Audio\""))
     XCTAssertTrue(src.contains("appState.systemAudioPermissionStatus"))
     XCTAssertTrue(src.contains("appState.triggerSystemAudioPermission()"))
   }

--- a/desktop/macos/Desktop/Tests/PermissionsPagePresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/PermissionsPagePresentationTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class PermissionsPagePresentationTests: XCTestCase {
+  func testSettledHeaderDropsTheWarningGlyphAndCapitalizesOmi() {
+    XCTAssertEqual(PermissionsPageChrome.headerSymbol(allRequiredGranted: true), "checkmark.circle.fill")
+    XCTAssertFalse(PermissionsPageChrome.headerSymbol(allRequiredGranted: true)?.contains("exclamationmark") == true)
+    XCTAssertEqual(PermissionsPageChrome.headerTitle, "Permissions")
+    XCTAssertEqual(
+      PermissionsPageChrome.allGrantedMessage,
+      "All permissions granted! Omi is ready to use.")
+    XCTAssertTrue(PermissionsPageChrome.allGrantedMessage.contains("Omi"))
+    XCTAssertFalse(PermissionsPageChrome.allGrantedMessage.contains("omi "))
+  }
+
+  func testMissingHeaderIsJustTheTitle() {
+    XCTAssertNil(PermissionsPageChrome.headerSymbol(allRequiredGranted: false))
+    XCTAssertEqual(PermissionsPageChrome.headerTitle, "Permissions")
+  }
+
+  func testSidebarUsesALock() {
+    XCTAssertEqual(PermissionNavSymbol.outline, "lock")
+    XCTAssertEqual(PermissionNavSymbol.filled, "lock.fill")
+    XCTAssertEqual(SidebarNavItem.permissions.icon, PermissionNavSymbol.filled)
+    XCTAssertEqual(ChatFirstMorePage.permissions.systemImage, PermissionNavSymbol.filled)
+  }
+
+  func testSettingsListOrderPlacesPermissionsWithAccessSettings() {
+    XCTAssertEqual(
+      SettingsSidebarRoutes.visibleSections,
+      [
+        .general,
+        .account,
+        .transcription,
+        .rewind,
+        .floatingBar,
+        .notifications,
+        .permissions,
+        .shortcuts,
+        .advanced,
+        .about,
+      ])
+  }
+
+  func testMissingGrantNoticeSitsBesideTheLockNotInsteadOfIt() {
+    XCTAssertEqual(PermissionNavSymbol.missingNotice, "exclamationmark.triangle.fill")
+    XCTAssertNotEqual(PermissionNavSymbol.outline, PermissionNavSymbol.missingNotice)
+  }
+
+  func testGrantedCapabilitiesDoNotStayAsActionCards() {
+    XCTAssertFalse(PermissionsPageChrome.microphoneNeedsAction(granted: true))
+    XCTAssertTrue(PermissionsPageChrome.microphoneNeedsAction(granted: false))
+
+    XCTAssertFalse(PermissionsPageChrome.screenRecordingNeedsAction(granted: true, stale: false))
+    XCTAssertTrue(PermissionsPageChrome.screenRecordingNeedsAction(granted: true, stale: true))
+    XCTAssertTrue(PermissionsPageChrome.screenRecordingNeedsAction(granted: false, stale: false))
+
+    XCTAssertFalse(PermissionsPageChrome.notificationsNeedAction(granted: true))
+    XCTAssertTrue(PermissionsPageChrome.notificationsNeedAction(granted: false))
+  }
+
+  func testUnknownSystemAudioStaysActionableAfterRequiredGrants() {
+    XCTAssertTrue(PermissionsPageChrome.systemAudioNeedsAction(status: .unknown))
+    XCTAssertTrue(PermissionsPageChrome.systemAudioNeedsAction(status: .denied))
+    XCTAssertFalse(PermissionsPageChrome.systemAudioNeedsAction(status: .granted))
+    XCTAssertFalse(PermissionsPageChrome.systemAudioNeedsAction(status: .unsupported))
+  }
+
+  func testMissingStatusChipIsAlwaysNotGranted() {
+    XCTAssertEqual(PermissionsPageChrome.statusChipText(granted: true), "Granted")
+    XCTAssertEqual(PermissionsPageChrome.statusChipText(granted: false), "Not Granted")
+    XCTAssertEqual(PermissionsPageChrome.missingStatusText, "Not Granted")
+  }
+}

--- a/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsSidebarItemLayoutTests.swift
@@ -74,12 +74,30 @@ final class SettingsSidebarItemLayoutTests: XCTestCase {
     )
   }
 
+  func testPermissionsRowWithMissingNoticeStaysOnOneLine() {
+    let plain = itemHeight(section: .permissions, isSelected: false, showsMissingPermissionNotice: false)
+    let noticed = itemHeight(section: .permissions, isSelected: true, showsMissingPermissionNotice: true)
+    XCTAssertEqual(
+      noticed, plain, accuracy: 0.5,
+      "the missing-grant mark beside the label must sit in the row, not wrap it")
+    XCTAssertLessThan(noticed, 60)
+  }
+
   private func itemHeight(isSelected: Bool) -> CGFloat {
+    itemHeight(section: .notifications, isSelected: isSelected, showsMissingPermissionNotice: false)
+  }
+
+  private func itemHeight(
+    section: SettingsContentView.SettingsSection,
+    isSelected: Bool,
+    showsMissingPermissionNotice: Bool
+  ) -> CGFloat {
     let host = NSHostingView(
       rootView: SettingsSidebarItem(
-        section: .notifications,
+        section: section,
         isSelected: isSelected,
         iconWidth: 20,
+        showsMissingPermissionNotice: showsMissingPermissionNotice,
         onTap: {}
       )
       .frame(width: SettingsSidebarMetrics.itemAvailableWidth)

--- a/desktop/macos/changelog/unreleased/20260813-permissions-settings-ux.json
+++ b/desktop/macos/changelog/unreleased/20260813-permissions-settings-ux.json
@@ -1,0 +1,3 @@
+{
+  "change": "Calmed the Permissions settings page: a lock in the nav with an orange mark while grants are missing, a plain Permissions title, compact granted rows, and a single Not Granted status"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -10,6 +10,7 @@ covers:
   - desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
   - desktop/macos/Desktop/Sources/Onboarding/PermissionDragGuidance.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/PermissionsPageChrome.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+SystemActions.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+Permissions.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+TrialPaywall.swift

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Fail before minting a commit if this clone still has a test-fixture Git identity.
+# A leftover repo-local user.email (Ratchet Test / *.invalid) overrides the global
+# identity, and GitHub then will not attribute the commit to the person who pushed.
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 "$ROOT/.github/scripts/check_git_author_identity.py" --pending || exit 1
+
 # Universal source hygiene: fail fast on unresolved merge conflict markers.
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 


### PR DESCRIPTION
## Summary
- The Permissions settings page is now a calm destination: a plain **Permissions** title, a success banner at the top when everything is granted, and compact granted rows instead of empty dropdowns.
- Missing grants stay as always-open action cards with a single **Not Granted** chip. The settings row uses a lock, with an orange mark beside the label only while something is missing.
- Permissions sits with the other access settings (after Notifications & Privacy). System audio is a capability to grant, not a recording-mode setting.

## Test plan
- [ ] Open Settings → Permissions with at least one missing grant: title is **Permissions**, no subtitle, no warning glyph on the page; orange mark sits immediately after the sidebar label.
- [ ] Grant the missing access and return: the mark disappears, the success banner appears, and granted rows are a compact list with **Granted** chips.
- [ ] Confirm sidebar order: General, Account & Plan, Transcription, Rewind, Floating Bar, Notifications & Privacy, Permissions, Shortcuts, Advanced, About.
- [ ] VoiceOver on the Permissions row while grants are missing reads "Permissions, permissions required".

## Verification
- Focused Swift tests: `PermissionsPagePresentationTests`, `SettingsSidebarItemLayoutTests`, `FailLoudConfigTests/testPermissionsPageSurfacesSystemAudioRow`, and the settings reachability checks in `TopNavigationBarLayoutTests`.
- Exercised the live path in named bundle `/Applications/omi-permissions-ux.app` (`com.omi.omi-permissions-ux`) with `OMI_AUTOMATION_PORT=47852 ./scripts/omi-ctl navigate settings permissions`.
- `make preflight` passed (20 local checks).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

