### PR TITLE
perf(backend): serve app search from the catalog the browse endpoints already cache

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -667,6 +667,97 @@ def _name_match_tier(app: App, query: str) -> int:
     return 2
 
 
+def _serves_public_catalog(my_apps: bool | None, installed_apps: bool | None) -> bool:
+    """Whether this search reads the shared public catalog rather than one user's own apps.
+
+    `my_apps` and `installed_apps` both scope the result to the caller, so they cannot be served
+    from a catalog shared between users. Everything else is the same approved public list for
+    everybody.
+    """
+    return not my_apps and not installed_apps
+
+
+def _public_catalog_for_search(category: str | None, capability: str | None) -> List[App]:
+    """The approved public apps for a search, taken from the catalog the browse endpoints share.
+
+    `search_apps_db`'s default branch selects `approved == True AND private == False`, which is
+    exactly what `get_approved_available_apps()` already holds: a 10-minute Redis copy behind a
+    singleflight memory cache, invalidated by `invalidate_approved_apps_cache()` on every approve,
+    publish, unpublish and visibility change.
+
+    Reading it here is what removes the per-keystroke Firestore scan. It deliberately reuses the
+    existing catalog rather than adding a second cached copy, because a second copy would need its
+    own invalidation — and a public list that goes stale independently is how an unpublished app
+    stays visible after its owner hides it.
+    """
+    apps = get_approved_available_apps(include_reviews=True)
+    # Re-assert visibility on the way out, exactly as the browse endpoints do. The source is
+    # already approved-and-public, so this changes nothing today; it is here so a future widening
+    # of the shared catalog cannot quietly make search the endpoint that leaks a private app.
+    apps = [app for app in apps if app.approved and not app.private]
+    if category:
+        apps = [app for app in apps if app.category == category]
+    if capability:
+        apps = filter_apps_by_capability(apps, capability)
+
+    # Copy before returning. These App objects are the cache's own, handed to every request that
+    # asks for the catalog, so the caller stamping a per-user `enabled` onto them would publish one
+    # user's installs to everyone served from the same cached list until it expired.
+    return [app.model_copy() for app in apps]
+
+
+def _personal_apps_for_search(
+    uid: str,
+    category: str | None,
+    capability: str | None,
+    my_apps: bool,
+    installed_apps: bool,
+) -> List[App]:
+    """The caller's own or installed apps, read live because they are not shareable between users."""
+    enabled_app_ids = list(get_enabled_apps(uid)) if installed_apps else None
+    apps_data = search_apps_db(
+        uid=uid,
+        category=category,
+        capability=capability,
+        my_apps=my_apps,
+        installed_apps=installed_apps,
+        enabled_app_ids=enabled_app_ids,
+    )
+
+    # Drop any malformed record missing an id before enrichment: id drives the installs/reviews
+    # lookups below and the pre-loop app_ids list, so a missing id would KeyError before the
+    # per-record ValidationError guard can catch it.
+    valid_apps_data = [a for a in apps_data if a.get('id')]
+    skipped_no_id = len(apps_data) - len(valid_apps_data)
+    if skipped_no_id:
+        logger.warning("Skipping %d malformed app record(s) without an id in search results", skipped_no_id)
+
+    app_ids = [app['id'] for app in valid_apps_data]
+    apps_installs = get_apps_installs_count(app_ids)
+    apps_reviews = get_apps_reviews(app_ids)
+
+    apps: List[App] = []
+    for app_dict in valid_apps_data:
+        app_dict['installs'] = apps_installs.get(app_dict['id'], 0)
+
+        # Calculate average from reviews
+        reviews = apps_reviews.get(app_dict['id'], {})
+        scores = [_clamp_review_score(x['score']) for x in reviews.values()]
+        app_dict['rating_avg'] = sum(scores) / len(scores) if scores else None
+        app_dict['rating_count'] = len(scores)
+
+        # Skip a malformed/legacy app document rather than 500 the whole search page.
+        try:
+            apps.append(App(**app_dict))
+        except ValidationError as e:
+            logger.warning(
+                "Skipping malformed app %s in search results: %s",
+                app_dict.get('id'),
+                [err['loc'][0] for err in e.errors() if err.get('loc')],
+            )
+    return apps
+
+
 @router.get('/v2/apps/search', tags=['v2'], response_model=AppSearchResponse)
 def search_apps(
     q: str | None = Query(default=None, description='Search query for app name or description'),
@@ -687,56 +778,23 @@ def search_apps(
     Returns a flat list of apps matching the search and filter criteria.
     """
 
-    enabled_app_ids = None
-    if installed_apps:
-        enabled_app_ids = list(get_enabled_apps(uid))
-
-    apps_data = search_apps_db(
-        uid=uid,
-        category=category,
-        capability=capability,
-        my_apps=my_apps or False,
-        installed_apps=installed_apps or False,
-        enabled_app_ids=enabled_app_ids,
-    )
-
     user_enabled = set(get_enabled_apps(uid))
 
-    # Drop any malformed record missing an id before enrichment: id drives the installs/reviews/
-    # enabled lookups below and the pre-loop app_ids list, so a missing id would KeyError before the
-    # per-record ValidationError guard can catch it.
-    valid_apps_data = [a for a in apps_data if a.get('id')]
-    skipped_no_id = len(apps_data) - len(valid_apps_data)
-    if skipped_no_id:
-        logger.warning("Skipping %d malformed app record(s) without an id in search results", skipped_no_id)
-    apps_data = valid_apps_data
+    if _serves_public_catalog(my_apps, installed_apps):
+        apps = _public_catalog_for_search(category, capability)
+    else:
+        apps = _personal_apps_for_search(
+            uid=uid,
+            category=category,
+            capability=capability,
+            my_apps=bool(my_apps),
+            installed_apps=bool(installed_apps),
+        )
 
-    app_ids = [app['id'] for app in apps_data]
-    apps_installs = get_apps_installs_count(app_ids)
-    apps_reviews = get_apps_reviews(app_ids)
-
-    apps = []
-
-    for app_dict in apps_data:
-        app_dict['enabled'] = app_dict['id'] in user_enabled
-        app_dict['rejected'] = app_dict.get('approved') is False
-        app_dict['installs'] = apps_installs.get(app_dict['id'], 0)
-
-        # Calculate average from reviews
-        reviews = apps_reviews.get(app_dict['id'], {})
-        scores = [_clamp_review_score(x['score']) for x in reviews.values()]
-        app_dict['rating_avg'] = sum(scores) / len(scores) if scores else None
-        app_dict['rating_count'] = len(scores)
-
-        # Skip a malformed/legacy app document rather than 500 the whole search page.
-        try:
-            apps.append(App(**app_dict))
-        except ValidationError as e:
-            logger.warning(
-                "Skipping malformed app %s in search results: %s",
-                app_dict.get('id'),
-                [err['loc'][0] for err in e.errors() if err.get('loc')],
-            )
+    # Whether the caller has this app installed is the one per-user fact in the result, so it is
+    # stamped per request and never enters the shared catalog cache.
+    for app in apps:
+        app.enabled = app.id in user_enabled
 
     # Always exclude persona type apps from results
     filtered_apps = [app for app in apps if not app.is_a_persona()]

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -698,7 +698,11 @@ def _public_catalog_for_search(category: str | None, capability: str | None) -> 
     if category:
         apps = [app for app in apps if app.category == category]
     if capability:
-        apps = filter_apps_by_capability(apps, capability)
+        # Membership, matching the `array_contains` this replaces. Not `filter_apps_by_capability`,
+        # which answers a different question for the browse sections: it resolves each app to a
+        # single primary capability by priority order and drops notification apps outside their own
+        # section, so an app would stop being findable by any capability but its first.
+        apps = [app for app in apps if app.has_capability(capability)]
 
     # Copy before returning. These App objects are the cache's own, handed to every request that
     # asks for the catalog, so the caller stamping a per-user `enabled` onto them would publish one

--- a/backend/tests/unit/test_app_review_score_clamp.py
+++ b/backend/tests/unit/test_app_review_score_clamp.py
@@ -61,11 +61,19 @@ def _search_app_dict(app_id='a1'):
         'description': 'Does things',
         'image': 'http://img',
         'capabilities': ['chat'],
+        'approved': True,
+        'private': False,
     }
 
 
 def _search_with_reviews(monkeypatch, reviews):
-    """Run the real /v2/apps/search handler over one app carrying `reviews`."""
+    """Run the real /v2/apps/search handler over one app carrying `reviews`.
+
+    Driven through `my_apps`, which is the scope that still reads raw documents and computes
+    rating_avg in the handler. The public catalog moved to `get_approved_available_apps`, whose own
+    averaging already clamps — the static sweep at the bottom of this file is what keeps both
+    aggregation sites honest.
+    """
     from routers import apps as routers_apps
 
     app_dict = _search_app_dict()
@@ -79,7 +87,7 @@ def _search_with_reviews(monkeypatch, reviews):
         rating=None,
         capability=None,
         sort=None,
-        my_apps=None,
+        my_apps=True,
         installed_apps=None,
         offset=0,
         limit=20,

--- a/backend/tests/unit/test_apps_catalog_missing_id_guard.py
+++ b/backend/tests/unit/test_apps_catalog_missing_id_guard.py
@@ -1,0 +1,66 @@
+"""The shared marketplace catalog must drop a record with no id, not 500 every listing.
+
+`get_approved_available_apps` reads `app['id']` unguarded — once to build the ids for the installs
+and reviews lookups, and again per app inside the loop. One legacy document without that field
+therefore raises KeyError out of the shared builder, which is worse than the same record reaching
+`search_apps`: this list is Redis- and process-cached and serves the marketplace to every user, so
+a single bad document takes out browse for everyone rather than one person's search page.
+
+`search_apps` was already hardened against exactly this (test_apps_search_poison_guard.py); the
+shared path it now reads was not.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+from utils import apps as apps_utils  # noqa: E402
+
+
+class _PassThroughCache:
+    """Memory cache stand-in that always runs the fetcher, so the builder itself is exercised."""
+
+    def get_or_fetch(self, _key, fetcher, ttl=None):
+        return fetcher()
+
+    def delete(self, _key):
+        return None
+
+
+def _valid_app(app_id='a1'):
+    return {
+        'id': app_id,
+        'name': 'Good App',
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': 'Does things',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+        'approved': True,
+        'private': False,
+    }
+
+
+def _catalog(monkeypatch, records):
+    monkeypatch.setattr(apps_utils, 'get_memory_cache', _PassThroughCache)
+    monkeypatch.setattr(apps_utils, 'get_generic_cache', lambda _key: None)
+    monkeypatch.setattr(apps_utils, 'set_generic_cache', lambda *a, **kw: None)
+    monkeypatch.setattr(apps_utils, 'get_public_approved_apps_db', lambda: [dict(r) for r in records])
+    monkeypatch.setattr(apps_utils, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_utils, 'get_apps_reviews', lambda ids: {})
+    return apps_utils.get_approved_available_apps()
+
+
+def test_catalog_drops_a_record_without_an_id(monkeypatch):
+    no_id = {'name': 'No Id App', 'category': 'productivity', 'author': 'Someone'}
+
+    apps = _catalog(monkeypatch, [no_id, _valid_app('a1')])
+
+    assert [app.id for app in apps] == ['a1']
+
+
+def test_catalog_still_returns_every_well_formed_record(monkeypatch):
+    apps = _catalog(monkeypatch, [_valid_app('a1'), _valid_app('a2')])
+
+    assert sorted(app.id for app in apps) == ['a1', 'a2']

--- a/backend/tests/unit/test_apps_search_matches_description.py
+++ b/backend/tests/unit/test_apps_search_matches_description.py
@@ -11,6 +11,11 @@ regardless of installs, or the app the user typed the name of falls off page 1.
 
 Test isolation follows test_apps_search_poison_guard.py: import routers.apps normally, patch the
 import-cheap db helpers, and call the handler directly.
+
+The seam moved but the assertions did not: the public search path now reads the catalog shared with
+the browse endpoints (`get_approved_available_apps`) rather than calling `search_apps_db` itself, so
+that is what these tests feed. Every expected result below is unchanged from when this file was
+written — only where the apps come from is different.
 """
 
 import os
@@ -18,6 +23,7 @@ import os
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
+from models.app import App  # noqa: E402
 from routers import apps as apps_mod  # noqa: E402
 
 
@@ -30,14 +36,16 @@ def _app_dict(app_id, name, description):
         'description': description,
         'image': 'http://img',
         'capabilities': ['chat'],
+        # The shared catalog holds approved public apps, and search re-asserts that on the way out.
+        'approved': True,
+        'private': False,
     }
 
 
 def _search(monkeypatch, records, q, installs=None):
-    monkeypatch.setattr(apps_mod, 'search_apps_db', lambda **kw: [dict(r) for r in records])
+    catalog = [App(**{**record, 'installs': (installs or {}).get(record['id'], 0)}) for record in records]
+    monkeypatch.setattr(apps_mod, 'get_approved_available_apps', lambda include_reviews=False: catalog)
     monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda uid: set())
-    monkeypatch.setattr(apps_mod, 'get_apps_installs_count', lambda ids: installs or {})
-    monkeypatch.setattr(apps_mod, 'get_apps_reviews', lambda ids: {})
 
     return apps_mod.search_apps(
         q=q,

--- a/backend/tests/unit/test_apps_search_poison_guard.py
+++ b/backend/tests/unit/test_apps_search_poison_guard.py
@@ -4,6 +4,11 @@ search_apps builds App(**app_dict) in a loop over raw Firestore app documents. O
 malformed app document (missing a required field like name/category/author) previously raised
 ValidationError and 500'd the entire search result for the user. The guard skips + logs it.
 
+These now run against `my_apps=True`, which is the scope that still reads raw documents through
+`search_apps_db`. The public catalog moved to the shared, already-built list the browse endpoints
+use, and carries the same guard upstream in `_safe_build_app` — covered by
+test_apps_search_shared_catalog.py. The assertions here are unchanged.
+
 Test isolation: routers.apps imports cleanly, so the test imports it normally, patches the
 import-cheap db helpers with monkeypatch.setattr, and calls the handler directly.
 """
@@ -42,7 +47,7 @@ def test_search_apps_skips_malformed_record(monkeypatch):
         rating=None,
         capability=None,
         sort=None,
-        my_apps=None,
+        my_apps=True,
         installed_apps=None,
         offset=0,
         limit=20,
@@ -69,7 +74,7 @@ def test_search_apps_skips_record_without_id(monkeypatch):
         rating=None,
         capability=None,
         sort=None,
-        my_apps=None,
+        my_apps=True,
         installed_apps=None,
         offset=0,
         limit=20,

--- a/backend/tests/unit/test_apps_search_shared_catalog.py
+++ b/backend/tests/unit/test_apps_search_shared_catalog.py
@@ -28,7 +28,15 @@ from models.app import App  # noqa: E402
 from routers import apps as apps_mod  # noqa: E402
 
 
-def _app(app_id, name, description='Something', category='productivity', approved=True, private=False):
+def _app(
+    app_id,
+    name,
+    description='Something',
+    category='productivity',
+    approved=True,
+    private=False,
+    capabilities=None,
+):
     return App(
         id=app_id,
         name=name,
@@ -36,7 +44,7 @@ def _app(app_id, name, description='Something', category='productivity', approve
         author='Someone',
         description=description,
         image='http://img',
-        capabilities={'chat'},
+        capabilities=set(capabilities or {'chat'}),
         approved=approved,
         private=private,
     )
@@ -99,6 +107,19 @@ def test_category_filter_applies_over_the_shared_catalog(monkeypatch):
     result = _catalog_search(monkeypatch, catalog, category='cooking')
 
     assert [a['id'] for a in result['data']] == ['a2']
+
+
+def test_capability_filter_matches_any_capability_not_just_the_first(monkeypatch):
+    # The predicate this replaces was Firestore `array_contains`, i.e. membership. Filtering on a
+    # single primary capability would make a multi-capability app unfindable by its secondary ones.
+    catalog = [
+        _app('multi', 'Both', capabilities={'chat', 'memories'}),
+        _app('chat_only', 'Chatter', capabilities={'chat'}),
+    ]
+
+    result = _catalog_search(monkeypatch, catalog, capability='memories')
+
+    assert [a['id'] for a in result['data']] == ['multi']
 
 
 @pytest.mark.parametrize('scope', ['my_apps', 'installed_apps'])

--- a/backend/tests/unit/test_apps_search_shared_catalog.py
+++ b/backend/tests/unit/test_apps_search_shared_catalog.py
@@ -1,0 +1,146 @@
+"""GET /v2/apps/search serves the public catalog from the cache the browse endpoints already share.
+
+The endpoint used to call `search_apps_db` on every request, which streams the whole approved
+public catalog out of Firestore before any text filter runs — so typing 's' cost the same as
+typing 'sports', and every keystroke was a collection scan. `get_approved_available_apps()` already
+holds that same set (`approved == True AND private == False`) behind a 10-minute Redis copy with a
+singleflight in front of it, invalidated on approve/publish/unpublish.
+
+Two things must stay true after the switch, and both are asserted here:
+
+- the personal views (`my_apps`, `installed_apps`) still read live, because they are not shareable;
+- `enabled` is stamped per request onto a copy, never onto the cached objects themselves. The
+  cache hands the same `App` instances to every caller, so mutating them in place would publish one
+  user's installed apps to everyone served from that list until it expired.
+
+Test isolation follows test_apps_search_matches_description.py: import routers.apps normally, patch
+the import-cheap db helpers, and call the handler directly.
+"""
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+
+from models.app import App  # noqa: E402
+from routers import apps as apps_mod  # noqa: E402
+
+
+def _app(app_id, name, description='Something', category='productivity', approved=True, private=False):
+    return App(
+        id=app_id,
+        name=name,
+        category=category,
+        author='Someone',
+        description=description,
+        image='http://img',
+        capabilities={'chat'},
+        approved=approved,
+        private=private,
+    )
+
+
+def _catalog_search(monkeypatch, catalog, *, uid='u1', enabled=None, **kwargs):
+    """Run a search whose public catalog is `catalog`, failing if it falls back to Firestore."""
+
+    def _forbidden(**_):
+        raise AssertionError('search_apps_db must not be called for the shared public catalog')
+
+    monkeypatch.setattr(apps_mod, 'get_approved_available_apps', lambda include_reviews=False: catalog)
+    monkeypatch.setattr(apps_mod, 'search_apps_db', _forbidden)
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda _uid: set(enabled or []))
+
+    params = dict(q=None, category=None, rating=None, capability=None, sort=None, my_apps=None, installed_apps=None)
+    params.update(kwargs)
+    return apps_mod.search_apps(offset=0, limit=20, uid=uid, **params)
+
+
+def test_public_search_reads_the_shared_catalog_not_firestore(monkeypatch):
+    # _catalog_search asserts search_apps_db is never reached; results proving the catalog was used.
+    result = _catalog_search(monkeypatch, [_app('a1', 'Focus Coach'), _app('a2', 'Recipe Finder')])
+
+    assert [a['id'] for a in result['data']] == ['a1', 'a2']
+
+
+def test_enabled_is_per_user_and_does_not_persist_into_the_shared_catalog(monkeypatch):
+    # The regression this guards: the cache returns the same App objects to every request, so
+    # stamping `enabled` in place would carry one user's installs into the next user's results.
+    catalog = [_app('a1', 'Focus Coach'), _app('a2', 'Recipe Finder')]
+
+    installed = _catalog_search(monkeypatch, catalog, uid='u1', enabled={'a1'})
+    assert {a['id']: a['enabled'] for a in installed['data']} == {'a1': True, 'a2': False}
+
+    fresh = _catalog_search(monkeypatch, catalog, uid='u2', enabled=set())
+    assert {a['id']: a['enabled'] for a in fresh['data']} == {'a1': False, 'a2': False}
+
+    # The catalog objects themselves must be untouched by either request.
+    assert [app.enabled for app in catalog] == [False, False]
+
+
+def test_public_search_excludes_an_unapproved_or_private_app_in_the_catalog(monkeypatch):
+    # Defence in depth: the shared source is already approved-and-public, but search must not be
+    # the endpoint that leaks if that ever widens.
+    catalog = [
+        _app('ok', 'Focus Coach'),
+        _app('unapproved', 'Draft App', approved=False),
+        _app('private', 'Secret App', private=True),
+    ]
+
+    result = _catalog_search(monkeypatch, catalog)
+
+    assert [a['id'] for a in result['data']] == ['ok']
+
+
+def test_category_filter_applies_over_the_shared_catalog(monkeypatch):
+    catalog = [_app('a1', 'Focus Coach', category='productivity'), _app('a2', 'Chef', category='cooking')]
+
+    result = _catalog_search(monkeypatch, catalog, category='cooking')
+
+    assert [a['id'] for a in result['data']] == ['a2']
+
+
+@pytest.mark.parametrize('scope', ['my_apps', 'installed_apps'])
+def test_personal_scopes_still_read_live(monkeypatch, scope):
+    # my_apps and installed_apps are per-user, so they must never be served from the shared catalog.
+    called = {}
+
+    def _record(**kwargs):
+        called.update(kwargs)
+        return [
+            {
+                'id': 'mine',
+                'name': 'My App',
+                'category': 'productivity',
+                'author': 'Me',
+                'description': 'Mine',
+                'image': 'http://img',
+                'capabilities': ['chat'],
+            }
+        ]
+
+    def _forbidden(include_reviews=False):
+        raise AssertionError('the shared catalog must not serve a per-user scope')
+
+    monkeypatch.setattr(apps_mod, 'search_apps_db', _record)
+    monkeypatch.setattr(apps_mod, 'get_approved_available_apps', _forbidden)
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda _uid: {'mine'})
+    monkeypatch.setattr(apps_mod, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_mod, 'get_apps_reviews', lambda ids: {})
+
+    result = apps_mod.search_apps(
+        q=None,
+        category=None,
+        rating=None,
+        capability=None,
+        sort=None,
+        my_apps=True if scope == 'my_apps' else None,
+        installed_apps=True if scope == 'installed_apps' else None,
+        offset=0,
+        limit=20,
+        uid='u1',
+    )
+
+    assert called[scope] is True
+    assert [a['id'] for a in result['data']] == ['mine']

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -507,13 +507,22 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
             set_generic_cache(redis_cache_key, reduced_apps, 60 * 10)  # 10 minutes cached
             all_apps = reduced_apps
 
+        # Drop any record missing an id before the lookups below. `id` is read unguarded to build
+        # app_ids and again per app, so one legacy document without it raises KeyError and 500s the
+        # whole marketplace listing for every user — the same failure `search_apps` was hardened
+        # against, on the path that serves the listing to everyone.
+        usable_apps = [app for app in all_apps if app.get('id')]
+        skipped_no_id = len(all_apps) - len(usable_apps)
+        if skipped_no_id:
+            logger.warning("Skipping %d marketplace app record(s) without an id", skipped_no_id)
+
         # Process apps (add installs, reviews, etc.)
-        app_ids = [app['id'] for app in all_apps]
+        app_ids = [app['id'] for app in usable_apps]
         apps_installs = get_apps_installs_count(app_ids)
         apps_reviews = get_apps_reviews(app_ids) if include_reviews else {}
 
         apps: List[App] = []
-        for app in all_apps:
+        for app in usable_apps:
             if app.get('disabled'):
                 continue
             app_dict = app


### PR DESCRIPTION
Follows #11292 and #11294. This is the *cheap* option from that thread, not the pushdown — the
`search_terms` / Typesense question is still open and still waiting on your read of catalog size.

## What it does

`/v2/apps/search` called `search_apps_db` on every request, which streams the whole approved public
catalog out of Firestore before any text filter runs. Typing `s` cost the same as typing `sports`,
and each keystroke was a collection scan.

`get_approved_available_apps()` already holds that exact set. `search_apps_db`'s default branch
selects `approved == True AND private == False` (`backend/database/apps.py:131-132`); so does
`get_public_approved_apps_db()` (`:67`). The difference is that the second one is already behind a
10-minute Redis copy with a singleflight memory cache in front of it, and is already invalidated by
`invalidate_approved_apps_cache()` on approve, publish, unpublish and visibility change — eight
call sites in `routers/apps.py`. The browse endpoints above search already read it.

So search now reads the same catalog instead of scanning Firestore itself.

**I did not add a cache.** My comment on #11292 proposed a new snapshot behind `set_generic_cache`;
reading the code, reusing the existing one is strictly better. A second cached copy of the public
catalog would need its own invalidation, and a public list that can go stale on its own is exactly
how an unpublished app stays visible after its owner hides it. There is no new cache key here and
no new thing to keep true.

The handler splits into two paths:

| Path | Source | Why |
|---|---|---|
| default (public catalog) | `get_approved_available_apps()` — shared, cached | identical for every user |
| `my_apps` / `installed_apps` | `search_apps_db()` — live, per-user | not shareable, unchanged |

## The per-user field, which is the part worth reviewing

`enabled` is the one fact in the response that differs per caller. The cache hands the *same* `App`
instances to every request that asks for the catalog, so stamping `enabled` onto them in place
would publish one user's installed apps to everyone served from that list until it expired.

The catalog is therefore copied before it is stamped (`_public_catalog_for_search`, last line), and
a test pins it: two users search the same catalog object, and the catalog must still read
`enabled=False` afterwards. This was a real bug in my first draft, not a hypothetical.

## Capability filtering — caught in review

The first version filtered capability with `filter_apps_by_capability`, already imported for the
browse sections in this file. It answers a different question: `_get_app_capability` resolves each
app to one section by priority order and notification apps are dropped outside their own section.
The predicate it replaced was `array_contains`, i.e. membership — so an app declaring
`{external_integration, chat}` would have stopped being findable by `chat`.

Now `app.has_capability(capability)`. Caught by cubic on this PR; the regression test fails on the
commit before the fix.

## A latent 500 on the shared path, fixed first

Switching search onto the shared builder surfaced that `get_approved_available_apps` reads
`app['id']` unguarded — once to build the ids for the installs and reviews lookups, and again per
app in the loop. A legacy document without that field raises `KeyError` out of the builder.

That is the same failure `search_apps` was already hardened against
(`test_apps_search_poison_guard.py`), on a worse path: this list is Redis- and process-cached and
serves the marketplace to everyone, so one bad document takes out browse for every user rather than
one person's search page. Fixed in its own commit ahead of the perf change, with its own test.

I have not seen this fire in production — I found it by reading the path I was about to depend on.

## Why six existing tests moved

`test_apps_search_matches_description.py` and `test_apps_search_poison_guard.py` both patched
`search_apps_db` and drove the default public path. That path no longer calls it, so the fixtures
had to move. **No assertion changed** — only where the apps come from:

- the description-matching tests now feed `get_approved_available_apps`, so the name-or-description
  predicate and the #11294 relevance tiers are asserted exactly as before;
- the poison guard now runs against `my_apps=True`, which is the scope that still builds apps from
  raw documents. The public path's equivalent guard is `_safe_build_app` upstream, plus the new
  missing-id test above.

Flagging this explicitly because a rewritten test in the same PR as its subject is worth a second
look, and I would rather point at it than have it found.

## One behaviour change, declared

The shared catalog skips apps flagged `disabled` (`backend/utils/apps.py:517`). The old search path
did not, so a platform-disabled app — one whose endpoints failed health validation, per
`validate_app_endpoints_for_reenable` — was reachable from search while being absent from browse.

After this change search agrees with browse and those apps are excluded. I believe that is the
correct behaviour and it is why I did not work around it, but it is a change in what the endpoint
returns and it is yours to overrule. Say the word and I will preserve the old inclusion explicitly.

## What this does not do

It does not push the query down, so cost is still proportional to catalog size rather than to the
query — it is just no longer paid in Firestore reads on every keystroke. The A-vs-B design question
in #11292 is untouched and still needs your call on how large the catalog is and how fast it grows.

Worth noting for #11282: the removed call was an unbounded Firestore collection scan on an
interactive path, which is the shape that issue is chasing. I am not claiming it is *the* cause —
just that it is one instance, measured rather than speculative.

## Verification

- `backend/tests/unit/test_apps_search_shared_catalog.py` — 6 new tests: the public path never
  reaches `search_apps_db`; `enabled` is per-user and does not persist into the shared catalog;
  unapproved and private apps are excluded even if present in the source; the category filter
  applies over the shared list; and both `my_apps` and `installed_apps` still read live
- `backend/tests/unit/test_apps_catalog_missing_id_guard.py` — 2 new tests for the second commit;
  both fail with `KeyError` before it
- 14 passed across the four apps-search files; 57 more across
  `test_apps_marketplace_poison_guard.py` (4), `test_app_visibility_cache_invalidation.py` (3),
  `test_firestore_read_ops_cache.py` (48 passed, 3 skipped) and `test_apps_installs_count_clamp.py` (2)
- `black --line-length 120 --skip-string-normalization` — clean
- `scripts/pr-preflight` — 21 of 23 selected checks pass. Two could not run here and neither is
  reachable from this diff:
  - `backend-route-policy-baseline` provisions its own venv from `backend/.python-version`
    (3.11). This machine has no 3.11, so the runner fell back to 3.13 and `onnxruntime==1.19.0`
    has no cp313 wheel. It fails identically with an empty diff (`--base-ref HEAD`), so the
    failure is venv provisioning, not the change.
  - `desktop-backend-candidate-probe-fixtures` reports *"total response deadline is unsupported
    on this runner"*. Its test file is not in this diff.

  The remaining checks were run individually after the first failure stopped the runner:
  `firestore-query-coverage`, `lifecycle-headers`, `version-prefixed-filenames`,
  `backend-import-purity`, `backend-runtime-image-source-closure`, `backend-module-isolation`,
  `backend-workflow-contracts`, `conversation-lifecycle-write-guard`,
  `desktop-backend-release-boundary` and its fixtures — all pass.

**Not exercised against a live backend.** No deployment or Firestore/Redis instance here, so the
cache-sharing behaviour is proven by unit test against a controllable seam rather than by watching
real requests. The claims about which fields the shared source already populates are read from
`get_approved_available_apps` rather than measured. If you want a live smoke before this lands, that
is a reasonable ask and I cannot supply it.

## Line-count exceptions

Both files are already over the 1,500-line threshold. Splitting a 2,400-line router is not in scope
for a perf change, so both declare their growth.

Line-Count-Exception: backend/routers/apps.py | 2425 -> 2487 | splits /v2/apps/search by whether its result is shareable so the public catalog reads the list the browse endpoints already cache while my_apps and installed_apps stay live; the seam and the per-user `enabled` copy belong in the handler that owns the response contract, and the extracted helpers carry the reasoning that makes the aliasing hazard visible

Line-Count-Exception: backend/utils/apps.py | 1652 -> 1661 | drops marketplace records with no id before the shared catalog builder reads `app['id']` unguarded, keeping the guard at the builder that serves every browse and search caller rather than at each call site

## Failure class

Failure-Class: none

This is a `perf:` change rather than a `fix:`, so no declaration is strictly required; recording
`none` because the aliasing bug it would otherwise have shipped was caught in review here rather
than in production, and no existing class covers "per-user field stamped onto a shared cached
object". Happy to file one if you would rather it were tracked.

---

*Written with Claude Code. Every file:line above verified against `8ddcff958`.*
