### PR TITLE
fix(desktop): classify proactive-lane failures and honor 429 Retry-After

### DIFF
--- a/.github/failure-classes/FC-typed-failure-collapsed-to-generic.json
+++ b/.github/failure-classes/FC-typed-failure-collapsed-to-generic.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-typed-failure-collapsed-to-generic",
+  "violated_contract": "When a client already produces a typed failure (HTTP status, decode, transport), the caller that records the terminal outcome must persist that class. Collapsing it into a generic bucket makes the true cause unrecoverable from client telemetry, and ignoring a typed 429's Retry-After keeps firing the same exhausted quota.",
+  "canonical_prevention": "Classify at the catch boundary into a bounded provenance JSON (http_error with status, decode, invalid_response, network with a bounded error_type). For HTTP 429, surface Retry-After on the typed error and skip further lane attempts until that deadline (conservative default when the header is missing), with an injected clock so tests do not sleep.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift",
+    "desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift",
+    "desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift"
+  ],
+  "evidence_prs": [
+    11487
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -641,6 +641,9 @@ actor ContextBucketRollupWriter {
         normalizedContextKey: ContextTitleNormalizer.identityKey(
           appName: frame.appName, windowTitle: frame.windowTitle) ?? "")
     } catch {
+      if case .http(let status, _) = error as? ProactiveLaneClientError, status == 429 {
+        return
+      }
       log("Context bucket extraction failed silently: \(error.localizedDescription)")
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -380,13 +380,20 @@ actor ContextProactivityEngine {
         return
       }
     } catch {
-      await terminalize(
-        deliveryID: deliveryID,
-        decisionType: "silence",
-        provenanceJSON: "{\"failure\":\"network_or_parse\"}",
-        state: "failed")
-      // Network and model failures are intentionally silent.
+      await recordDirectorFailure(deliveryID: deliveryID, error: error)
+      // Network and model failures stay user-silent; provenance carries the class.
     }
+  }
+
+  func recordDirectorFailure(deliveryID: String, error: Error) async {
+    let classification = ProactiveLaneFailureClassification.classify(error)
+    log(
+      "Context director \(ModelQoS.Proactivity.reasoningOperation) failed: \(classification.logDescription)")
+    await terminalize(
+      deliveryID: deliveryID,
+      decisionType: "silence",
+      provenanceJSON: classification.provenanceJSON,
+      state: "failed")
   }
 
   nonisolated static func presentationSurfaceAvailable(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -110,17 +110,23 @@ struct ProactiveLaneFailureClassification: Equatable, Sendable {
 actor ProactiveLaneClient {
   static let shared = ProactiveLaneClient()
   static var backendBaseURL: String { DesktopBackendEnvironment.rustBackendURL() }
+  static let defaultQuotaCooldownSeconds = 10 * 60
   private let session: URLSession
   private let baseURL: () -> String
   private let authorization: () async throws -> String
+  private let now: @Sendable () -> Date
+  private var quotaCooldownUntil: Date?
+  private var loggedQuotaSkip = false
 
   init(
     session: URLSession = .shared,
     baseURL: @escaping () -> String = { ProactiveLaneClient.backendBaseURL },
-    authorization: (() async throws -> String)? = nil
+    authorization: (() async throws -> String)? = nil,
+    now: @escaping @Sendable () -> Date = { Date() }
   ) {
     self.session = session
     self.baseURL = baseURL
+    self.now = now
     self.authorization =
       authorization ?? {
         let authService = await MainActor.run { AuthService.shared }
@@ -138,6 +144,7 @@ actor ProactiveLaneClient {
     maxCompletionTokens: Int = 1024,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> ProactiveLaneResult {
+    try checkQuotaCooldown()
     if let authorizationSnapshot {
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
         throw ProactiveLaneClientError.ownerChanged
@@ -194,9 +201,43 @@ actor ProactiveLaneClient {
     }
     guard let http = response as? HTTPURLResponse else { throw ProactiveLaneClientError.invalidResponse }
     guard (200..<300).contains(http.statusCode) else {
-      throw ProactiveLaneClientError.http(status: http.statusCode, retryAfterSeconds: nil)
+      let retryAfter: Int?
+      if http.statusCode == 429 {
+        retryAfter = Self.parseRetryAfterSeconds(from: http)
+        armQuotaCooldown(retryAfterSeconds: retryAfter)
+      } else {
+        retryAfter = nil
+      }
+      throw ProactiveLaneClientError.http(status: http.statusCode, retryAfterSeconds: retryAfter)
     }
     return try Self.parseEnvelope(data)
+  }
+
+  private func checkQuotaCooldown() throws {
+    guard let until = quotaCooldownUntil else { return }
+    let current = now()
+    if current >= until {
+      quotaCooldownUntil = nil
+      loggedQuotaSkip = false
+      return
+    }
+    if !loggedQuotaSkip {
+      loggedQuotaSkip = true
+      log("Proactive lane skipped: quota_cooldown")
+    }
+    let remaining = max(1, Int(ceil(until.timeIntervalSince(current))))
+    throw ProactiveLaneClientError.http(status: 429, retryAfterSeconds: remaining)
+  }
+
+  private func armQuotaCooldown(retryAfterSeconds: Int?) {
+    let delay = retryAfterSeconds.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultQuotaCooldownSeconds
+    quotaCooldownUntil = now().addingTimeInterval(TimeInterval(delay))
+    loggedQuotaSkip = false
+  }
+
+  static func parseRetryAfterSeconds(from response: HTTPURLResponse) -> Int? {
+    guard let raw = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
+    return Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
   }
 
   static func parseEnvelope(_ data: Data) throws -> ProactiveLaneResult {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -17,18 +17,93 @@ struct ProactiveLaneResult: Equatable, Sendable {
 
 enum ProactiveLaneClientError: LocalizedError {
   case invalidResponse
-  case http(Int)
+  case http(status: Int, retryAfterSeconds: Int?)
   case ownerChanged
 
   var errorDescription: String? {
     switch self {
     case .invalidResponse:
       return "proactive_invalid_response"
-    case .http(let statusCode):
+    case .http(let statusCode, _):
       return "proactive_http_error status=\(statusCode)"
     case .ownerChanged:
       return "proactive_owner_changed"
     }
+  }
+}
+
+/// Bounded failure class recorded on a director delivery when the lane call
+/// or decision decode fails. Prompt and response bodies never enter this JSON.
+struct ProactiveLaneFailureClassification: Equatable, Sendable {
+  let failure: String
+  let status: Int?
+  let errorType: String?
+
+  var provenanceJSON: String {
+    var object: [String: Any] = ["failure": failure]
+    if let status {
+      object["status"] = status
+    }
+    if let errorType {
+      object["error_type"] = errorType
+    }
+    guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{\"failure\":\"network\"}"
+    }
+    return json
+  }
+
+  var logDescription: String {
+    switch failure {
+    case "http_error":
+      return "http_error status=\(status ?? 0)"
+    case "network":
+      return "network error_type=\(errorType ?? "unknown")"
+    default:
+      return failure
+    }
+  }
+
+  static func classify(_ error: Error) -> ProactiveLaneFailureClassification {
+    if let laneError = error as? ProactiveLaneClientError {
+      switch laneError {
+      case .http(let status, _):
+        return ProactiveLaneFailureClassification(failure: "http_error", status: status, errorType: nil)
+      case .invalidResponse:
+        return ProactiveLaneFailureClassification(failure: "invalid_response", status: nil, errorType: nil)
+      case .ownerChanged:
+        return ProactiveLaneFailureClassification(failure: "owner_changed", status: nil, errorType: nil)
+      }
+    }
+    if error is DecodingError {
+      return ProactiveLaneFailureClassification(failure: "decode", status: nil, errorType: nil)
+    }
+    return ProactiveLaneFailureClassification(
+      failure: "network", status: nil, errorType: boundedNetworkErrorType(error))
+  }
+
+  static func boundedNetworkErrorType(_ error: Error) -> String {
+    if let urlError = error as? URLError {
+      switch urlError.code {
+      case .timedOut: return "timed_out"
+      case .notConnectedToInternet: return "not_connected"
+      case .networkConnectionLost: return "connection_lost"
+      case .cannotFindHost: return "cannot_find_host"
+      case .cannotConnectToHost: return "cannot_connect"
+      case .dnsLookupFailed: return "dns_lookup_failed"
+      case .secureConnectionFailed: return "secure_connection_failed"
+      default: return "url_error"
+      }
+    }
+    let typeName = String(describing: type(of: error))
+    let collapsed = typeName.map { character -> Character in
+      character.isLetter || character.isNumber ? character : "_"
+    }
+    let trimmed = String(collapsed).split(separator: "_").joined(separator: "_")
+    let bounded = String(trimmed.prefix(40))
+    return bounded.isEmpty ? "unknown" : bounded
   }
 }
 
@@ -118,12 +193,20 @@ actor ProactiveLaneClient {
       }
     }
     guard let http = response as? HTTPURLResponse else { throw ProactiveLaneClientError.invalidResponse }
-    guard (200..<300).contains(http.statusCode) else { throw ProactiveLaneClientError.http(http.statusCode) }
+    guard (200..<300).contains(http.statusCode) else {
+      throw ProactiveLaneClientError.http(status: http.statusCode, retryAfterSeconds: nil)
+    }
     return try Self.parseEnvelope(data)
   }
 
   static func parseEnvelope(_ data: Data) throws -> ProactiveLaneResult {
-    guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+    let object: Any
+    do {
+      object = try JSONSerialization.jsonObject(with: data)
+    } catch {
+      throw ProactiveLaneClientError.invalidResponse
+    }
+    guard let root = object as? [String: Any],
       let operation = root["operation"] as? String,
       let lane = root["lane"] as? String,
       let providerModel = root["provider_model"] as? String,

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -226,6 +226,55 @@ final class ContextProactivityEngineTests: XCTestCase {
     XCTAssertFalse(ContextProactivityEngine.presentationSurfaceAvailable(.presented))
   }
 
+  func testHttpLaneErrorRecordsStatusInTerminalProvenanceJSON() throws {
+    let classified = ProactiveLaneFailureClassification.classify(
+      ProactiveLaneClientError.http(status: 429, retryAfterSeconds: 12))
+    XCTAssertEqual(classified.failure, "http_error")
+    XCTAssertEqual(classified.status, 429)
+    XCTAssertEqual(classified.logDescription, "http_error status=429")
+    let json = try provenanceObject(classified.provenanceJSON)
+    XCTAssertEqual(json["failure"] as? String, "http_error")
+    XCTAssertEqual((json["status"] as? NSNumber)?.intValue, 429)
+    XCTAssertNil(json["error_type"])
+  }
+
+  func testDecisionDecodeFailureRecordsADistinctClassFromHttpFailure() throws {
+    let http = ProactiveLaneFailureClassification.classify(
+      ProactiveLaneClientError.http(status: 429, retryAfterSeconds: nil))
+    let decodeError: Error
+    do {
+      _ = try JSONDecoder().decode(ContextDirectorDecision.self, from: Data(#"{"decision":1}"#.utf8))
+      return XCTFail("expected the production decision decoder to reject a malformed payload")
+    } catch {
+      decodeError = error
+    }
+    XCTAssertTrue(decodeError is DecodingError)
+    let decoded = ProactiveLaneFailureClassification.classify(decodeError)
+    XCTAssertEqual(decoded.failure, "decode")
+    XCTAssertNotEqual(decoded.failure, http.failure)
+    let json = try provenanceObject(decoded.provenanceJSON)
+    XCTAssertEqual(json["failure"] as? String, "decode")
+    XCTAssertNil(json["status"])
+  }
+
+  func testInvalidResponseAndNetworkFailuresUseBoundedClasses() throws {
+    let invalid = ProactiveLaneFailureClassification.classify(ProactiveLaneClientError.invalidResponse)
+    XCTAssertEqual(invalid.failure, "invalid_response")
+    XCTAssertEqual(try provenanceObject(invalid.provenanceJSON)["failure"] as? String, "invalid_response")
+
+    let timedOut = ProactiveLaneFailureClassification.classify(URLError(.timedOut))
+    XCTAssertEqual(timedOut.failure, "network")
+    XCTAssertEqual(timedOut.errorType, "timed_out")
+    let json = try provenanceObject(timedOut.provenanceJSON)
+    XCTAssertEqual(json["failure"] as? String, "network")
+    XCTAssertEqual(json["error_type"] as? String, "timed_out")
+  }
+
+  private func provenanceObject(_ json: String) throws -> [String: Any] {
+    let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+    return try XCTUnwrap(object as? [String: Any])
+  }
+
   private func contextBucketDatabase() throws -> DatabaseQueue {
     let queue = try DatabaseQueue()
     try queue.write { db in
@@ -323,5 +372,128 @@ final class ContextProactivityEngineTests: XCTestCase {
         arguments: [now.addingTimeInterval(-1)])
     }
     return queue
+  }
+}
+
+final class ContextProactivityDirectorFailureTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "director-lane-failure")
+  }
+
+  override func tearDown() async throws {
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testEngineRecordsHttp429ProvenanceOnTypedLaneError() async throws {
+    let deliveryID = try await seedAttemptedDelivery()
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: .shared,
+      dwellNanoseconds: 0)
+
+    await engine.recordDirectorFailure(
+      deliveryID: deliveryID,
+      error: ProactiveLaneClientError.http(status: 429, retryAfterSeconds: 30))
+
+    let row = try await fetchDelivery(id: deliveryID)
+    XCTAssertEqual(row["lifecycleState"] as String?, "failed")
+    XCTAssertEqual(row["decisionType"] as String?, "silence")
+    let provenance = try provenanceObject(try XCTUnwrap(row["provenanceJson"] as String?))
+    XCTAssertEqual(provenance["failure"] as? String, "http_error")
+    XCTAssertEqual((provenance["status"] as? NSNumber)?.intValue, 429)
+  }
+
+  func testEngineRecordsDecodeProvenanceDistinctFromHttpError() async throws {
+    let deliveryID = try await seedAttemptedDelivery()
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: .shared,
+      dwellNanoseconds: 0)
+    let decodeError: Error
+    do {
+      _ = try JSONDecoder().decode(ContextDirectorDecision.self, from: Data(#"{"decision":1}"#.utf8))
+      return XCTFail("expected the production decision decoder to reject a malformed payload")
+    } catch {
+      decodeError = error
+    }
+
+    await engine.recordDirectorFailure(deliveryID: deliveryID, error: decodeError)
+
+    let row = try await fetchDelivery(id: deliveryID)
+    XCTAssertEqual(row["lifecycleState"] as String?, "failed")
+    let provenance = try provenanceObject(try XCTUnwrap(row["provenanceJson"] as String?))
+    XCTAssertEqual(provenance["failure"] as? String, "decode")
+    XCTAssertNil(provenance["status"])
+  }
+
+  private func seedAttemptedDelivery() async throws -> String {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    let versionID = try await pool.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+          VALUES ('bucket', 'task', 'director-failure', ?, ?)
+          """,
+        arguments: [now, now])
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_versions (bucketID, version, header, frozenRankedSegment, createdAt)
+          VALUES ('bucket', 1, 'header', ?, ?)
+          """,
+        arguments: [Data(), now])
+      try db.execute(
+        sql: """
+          INSERT INTO context_visits
+            (id, contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+             normalizedContextKey, referenceHash, startedAt, outcome, createdAt, updatedAt)
+          VALUES (1, 1, ?, 'bucket', 'Director Failure', 'raw', 'normalized', 'reference', ?, 'active', ?, ?)
+          """,
+        arguments: [poolEpoch, now, now, now])
+      return try Int64.fetchOne(
+        db,
+        sql: "SELECT id FROM bucket_versions WHERE bucketID = 'bucket' AND version = 1")
+        ?? 0
+    }
+    let attempt = try await ContextBucketStore.shared.beginDeliveryAttempt(
+      fence: ContextVisitFence(
+        visitID: 1, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket", startedAt: now),
+      snapshot: ContextBucketSnapshot(
+        bucketID: "bucket",
+        versionID: versionID,
+        version: 1,
+        header: "header",
+        frozenRankedSegment: Data(),
+        tail: ["entry:one"],
+        validatedFacts: ["fact:one statement"],
+        notifyWorthiness: 1),
+      gate: ContextDeliveryGateInput(
+        masterEnabled: true,
+        frequencyLevel: 5,
+        snoozed: false,
+        paywalled: false,
+        cooldownSeconds: 0),
+      now: now)
+    return try XCTUnwrap(attempt.id)
+  }
+
+  private func fetchDelivery(id: String) async throws -> Row {
+    let (database, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    return try await pool.read { db in
+      try XCTUnwrap(
+        Row.fetchOne(db, sql: "SELECT * FROM proactive_deliveries WHERE id = ?", arguments: [id]))
+    }
+  }
+
+  private func provenanceObject(_ json: String) throws -> [String: Any] {
+    let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+    return try XCTUnwrap(object as? [String: Any])
   }
 }

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -43,13 +43,15 @@ final class ProactiveLaneClientTests: XCTestCase {
     }
   }
 
-  func testRetryAfterHeaderIsParsedAsSeconds() {
-    let response = HTTPURLResponse(
-      url: URL(string: "https://proactive.test/v1/desktop/proactivity/completions")!,
-      statusCode: 429,
-      httpVersion: nil,
-      headerFields: ["Retry-After": " 45 "])
-    XCTAssertEqual(ProactiveLaneClient.parseRetryAfterSeconds(from: response!), 45)
+  func testRetryAfterHeaderIsParsedAsSeconds() throws {
+    let url = try XCTUnwrap(URL(string: "https://proactive.test/v1/desktop/proactivity/completions"))
+    let response = try XCTUnwrap(
+      HTTPURLResponse(
+        url: url,
+        statusCode: 429,
+        httpVersion: nil,
+        headerFields: ["Retry-After": " 45 "]))
+    XCTAssertEqual(ProactiveLaneClient.parseRetryAfterSeconds(from: response), 45)
   }
 
   func testExtractionSkipsNetworkDuringQuotaCooldownThenResumesAfterDeadline() async throws {
@@ -216,8 +218,13 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
       return
     }
-    let response = HTTPURLResponse(
-      url: url, statusCode: stub.statusCode, httpVersion: nil, headerFields: stub.headers)!
+    guard
+      let response = HTTPURLResponse(
+        url: url, statusCode: stub.statusCode, httpVersion: nil, headerFields: stub.headers)
+    else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+      return
+    }
     client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
     client?.urlProtocol(self, didLoad: stub.body)
     client?.urlProtocolDidFinishLoading(self)

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -26,7 +26,20 @@ final class ProactiveLaneClientTests: XCTestCase {
 
   func testClientErrorsExposeOnlyStableSafeClassifications() {
     XCTAssertEqual(ProactiveLaneClientError.invalidResponse.localizedDescription, "proactive_invalid_response")
-    XCTAssertEqual(ProactiveLaneClientError.http(429).localizedDescription, "proactive_http_error status=429")
+    XCTAssertEqual(
+      ProactiveLaneClientError.http(status: 429, retryAfterSeconds: nil).localizedDescription,
+      "proactive_http_error status=429")
     XCTAssertEqual(ProactiveLaneClientError.ownerChanged.localizedDescription, "proactive_owner_changed")
+  }
+
+  func testGarbageEnvelopeThrowsInvalidResponseNotARawSerializationError() {
+    do {
+      _ = try ProactiveLaneClient.parseEnvelope(Data("not-json".utf8))
+      XCTFail("expected invalid_response")
+    } catch ProactiveLaneClientError.invalidResponse {
+      // Expected: envelope parse failures are a bounded class, not a Cocoa error.
+    } catch {
+      XCTFail("unexpected error: \(error)")
+    }
   }
 }

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -42,4 +42,186 @@ final class ProactiveLaneClientTests: XCTestCase {
       XCTFail("unexpected error: \(error)")
     }
   }
+
+  func testRetryAfterHeaderIsParsedAsSeconds() {
+    let response = HTTPURLResponse(
+      url: URL(string: "https://proactive.test/v1/desktop/proactivity/completions")!,
+      statusCode: 429,
+      httpVersion: nil,
+      headerFields: ["Retry-After": " 45 "])
+    XCTAssertEqual(ProactiveLaneClient.parseRetryAfterSeconds(from: response!), 45)
+  }
+
+  func testExtractionSkipsNetworkDuringQuotaCooldownThenResumesAfterDeadline() async throws {
+    ProactiveLaneURLStub.reset()
+    let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      now: { clock.now })
+
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 429,
+      body: Data(#"{"detail":"Proactive request limit exceeded"}"#.utf8),
+      headers: ["Retry-After": "30"])
+
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected the first extraction attempt to throw 429")
+    } catch ProactiveLaneClientError.http(let status, let retryAfter) {
+      XCTAssertEqual(status, 429)
+      XCTAssertEqual(retryAfter, 30)
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+
+    clock.advance(by: 10)
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected the in-window extraction attempt to skip the network")
+    } catch ProactiveLaneClientError.http(let status, let retryAfter) {
+      XCTAssertEqual(status, 429)
+      XCTAssertEqual(retryAfter, 20)
+    }
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestCount, 1,
+      "an extraction attempt before Retry-After must not hit the network")
+
+    clock.advance(by: 21)
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try JSONSerialization.data(withJSONObject: [
+        "operation": ModelQoS.Proactivity.extractionOperation,
+        "lane": "omi:auto:desktop-proactive-extraction",
+        "provider_model": "gpt-5.6-luna",
+        "usage": ["cached_tokens": 0, "cache_write_tokens": 0],
+        "cache_write": false,
+        "fallback_class": "unknown",
+        "response": ["choices": [["message": ["content": "{\"narrative\":\"ok\",\"facts\":[]}"]]]],
+      ]))
+
+    let result = try await completeExtraction(on: client)
+    XCTAssertEqual(result.operation, ModelQoS.Proactivity.extractionOperation)
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 2)
+  }
+
+  func testMissingRetryAfterUsesConservativeDefaultCooldown() async throws {
+    ProactiveLaneURLStub.reset()
+    let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      now: { clock.now })
+
+    ProactiveLaneURLStub.enqueue(statusCode: 429, body: Data(), headers: [:])
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected 429")
+    } catch ProactiveLaneClientError.http(let status, let retryAfter) {
+      XCTAssertEqual(status, 429)
+      XCTAssertNil(retryAfter)
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+
+    clock.advance(by: TimeInterval(ProactiveLaneClient.defaultQuotaCooldownSeconds - 1))
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected cooldown skip")
+    } catch ProactiveLaneClientError.http(let status, _) {
+      XCTAssertEqual(status, 429)
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+  }
+
+  private func completeExtraction(on client: ProactiveLaneClient) async throws -> ProactiveLaneResult {
+    try await client.complete(
+      operation: ModelQoS.Proactivity.extractionOperation,
+      prompt: "extract",
+      jsonSchema: ["type": "object"])
+  }
+
+  private func makeStubSession() -> URLSession {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [ProactiveLaneURLStub.self]
+    configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+    return URLSession(configuration: configuration)
+  }
+}
+
+private final class ManualDateClock: @unchecked Sendable {
+  private let lock = NSLock()
+  private var date: Date
+
+  init(_ date: Date) {
+    self.date = date
+  }
+
+  var now: Date {
+    lock.lock()
+    defer { lock.unlock() }
+    return date
+  }
+
+  func advance(by interval: TimeInterval) {
+    lock.lock()
+    date = date.addingTimeInterval(interval)
+    lock.unlock()
+  }
+}
+
+private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
+  struct StubResponse {
+    let statusCode: Int
+    let body: Data
+    let headers: [String: String]
+  }
+
+  private static let lock = NSLock()
+  private nonisolated(unsafe) static var responses: [StubResponse] = []
+  private nonisolated(unsafe) static var served = 0
+
+  static var requestCount: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return served
+  }
+
+  static func reset() {
+    lock.lock()
+    responses = []
+    served = 0
+    lock.unlock()
+  }
+
+  static func enqueue(statusCode: Int, body: Data, headers: [String: String] = [:]) {
+    lock.lock()
+    responses.append(StubResponse(statusCode: statusCode, body: body, headers: headers))
+    lock.unlock()
+  }
+
+  override class func canInit(with request: URLRequest) -> Bool { true }
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+  override func startLoading() {
+    guard let url = request.url else {
+      client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+      return
+    }
+    Self.lock.lock()
+    let stub = Self.responses.isEmpty ? nil : Self.responses.removeFirst()
+    Self.served += 1
+    Self.lock.unlock()
+    guard let stub else {
+      client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
+      return
+    }
+    let response = HTTPURLResponse(
+      url: url, statusCode: stub.statusCode, httpVersion: nil, headerFields: stub.headers)!
+    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+    client?.urlProtocol(self, didLoad: stub.body)
+    client?.urlProtocolDidFinishLoading(self)
+  }
+
+  override func stopLoading() {}
 }

--- a/desktop/macos/changelog/unreleased/20260813-proactive-lane-quota-backoff.json
+++ b/desktop/macos/changelog/unreleased/20260813-proactive-lane-quota-backoff.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped repeating background proactive requests after the daily limit is reached"
+}


### PR DESCRIPTION
## What changed and why

Omi Beta 0.12.169 QA found two client defects in the context-bucket proactive pipeline. Director model-boundary failures were terminalized as hardcoded `{"failure":"network_or_parse"}`, so a quota 429 was indistinguishable from a decode or transport fault. Extraction ignored `Retry-After` and kept firing after the per-uid daily quota was exhausted.

Today's producer/consumer evidence: **37/37** director attempts on Omi Beta terminated as `network_or_parse`; Cloud Run logs showed every one was HTTP 429 `"Proactive request limit exceeded"` (the account's quota had been drained by a QA bundle sharing the same uid). Extraction logged `Context bucket extraction failed silently: proactive_http_error status=429` in bursts (~8 failures / 76s) with no backoff.

This PR records a bounded failure class (and HTTP status) on the delivery row, and skips further lane attempts until the 429 `Retry-After` deadline (10 minutes when the header is missing). Decision semantics are unchanged: terminal state stays `silence`/`failed`, still no user-visible surface, no director retry.

## Product invariants affected

none

## How it was verified

- `cd desktop/macos && xcrun swift build -c debug --package-path Desktop` — package compiled after a temporary `RewindPage.body` split. That type-check timeout (`unable to type-check this expression in reasonable time`) reproduces on `origin/main` with local Xcode 26.2 / Swift 6.2.3; CI pins Xcode 16.4. The split was reverted as out of scope; it is not in this PR.
- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ContextProactivityEngineTests'` — **15/15 passed** (0 failures).
- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ContextProactivityDirectorFailureTests'` — store-backed tests passed: typed 429 writes `{"failure":"http_error","status":429}` onto a real delivery row; decode writes a distinct `{"failure":"decode"}`.
- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ProactiveLaneClientTests'` — **7/7 passed**, including URLProtocol stub: after 429 with `Retry-After: 30`, a second `complete(extraction)` before the injected-clock deadline makes **no** network call; after the deadline it does. Missing `Retry-After` uses the 10-minute default.
- Local private log line at the failure site names the operation and class (`Context director proactive_reasoning failed: http_error status=429`); prompt/response content is not logged.
- `scripts/failure-class validate --pr-body-file /tmp/pr-body-proactive-lane.md` — `ok: true`, declaration `new`.
- `OMI_PR_BODY_FILE=/tmp/pr-body-proactive-lane.md make preflight` — **21/21 passed** (40.66s). `architecture-guardrails` warned that `contextEntered` is 276 lines; left as-is (do not restructure the engine for cooldown).
- `scripts/pr-preflight --pr-body-file /tmp/pr-body-proactive-lane.md` — **21/21 passed** (41.16s, ci lane).
- Local pre-push `xcrun swift build -c debug --package-path Desktop` fails on unmodified `RewindPage.body` under Xcode 26.2 / Swift 6.2.3 (same failure on `origin/main`). Pushed with the documented hatch `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`. CI pins Xcode 16.4.
- I did not re-run the live Omi Beta quota-exhaustion path against a signed bundle; the regression is the hermetic store/client tests above.

## Tests

- `ContextProactivityEngineTests.testHttpLaneErrorRecordsStatusInTerminalProvenanceJSON` / `testDecisionDecodeFailureRecordsADistinctClassFromHttpFailure` — classify typed 429 vs decode without a store.
- `ContextProactivityDirectorFailureTests.testEngineRecordsHttp429ProvenanceOnTypedLaneError` / `testEngineRecordsDecodeProvenanceDistinctFromHttpError` — `recordDirectorFailure` writes those classes onto a real delivery row via `RewindStorageTestIsolation`.
- `ProactiveLaneClientTests.testExtractionSkipsNetworkDuringQuotaCooldownThenResumesAfterDeadline` / `testMissingRetryAfterUsesConservativeDefaultCooldown` — production `complete()` with an injected clock; no wall-clock sleep.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

**Violated contract:** when a client already produces a typed failure (HTTP status, decode, transport), the caller that records the terminal outcome must persist that class. Collapsing it into a generic bucket makes the true cause unrecoverable from client telemetry, and ignoring a typed 429's `Retry-After` keeps firing the same exhausted quota.

**Canonical guard:** `ProactiveLaneFailureClassification` at the engine catch writes bounded provenance JSON (`http_error`+status, `decode`, `invalid_response`, `network`+bounded `error_type`). `ProactiveLaneClient.complete` surfaces `Retry-After` on 429 and holds an actor-scoped cooldown (injected clock; 10-minute default). Behavioral tests call those production APIs and assert the delivery row / network-skip outcome.

**Evidence:** #11487 already bounded the log string (`proactive_http_error status=429`) but the director catch still discarded it as `network_or_parse`. Today's Beta 0.12.169 QA: 37/37 director terminals were that generic bucket and were actually HTTP 429; extraction 429 bursts had no backoff. Server logs confirmed per-uid quota exhaustion.

## New guards (only when adding a check or ratchet)

Not a new CI check. The reusable surface is the shared classifier plus the cooldown inside `ProactiveLaneClient` (one actor-held deadline, not a new counter subsystem), proven by the engine and client tests above. #11487 is the merged PR that would have caught the discarded class if provenance had been asserted.

🤖 Generated with Cursor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

