### PR TITLE
feat(desktop): speak proactive notifications aloud (off-by-default Advanced setting) + unified voice speed

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -40,6 +40,8 @@ enum DefaultsKey: String {
   case chatBridgeMode = "chatBridgeMode"
   case preferredMicrophoneDeviceUID = "preferredMicrophoneDeviceUID"
   case multiChatEnabled = "multiChatEnabled"
+  /// Opt-in: proactive notifications are also spoken out loud on delivery.
+  case speakNotificationsAloud = "speakNotificationsAloud"
   case aiChatWorkingDirectory = "aiChatWorkingDirectory"
   case hasCompletedOnboarding = "hasCompletedOnboarding"
   case onboardingStep = "onboardingStep"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -637,6 +637,20 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
     return true
   }
 
+  /// The system voice must honor the same Voice Speed setting the OpenAI audio path
+  /// applies via `AVAudioPlayer.rate`. It used to hardcode `0.47`, so with the default
+  /// speed of 1.4× every system-voice utterance (spoken notifications, TTS fallbacks)
+  /// crawled at ~1× while push-to-talk answers played at 1.4× — the same reply sounded
+  /// like two different products. `AVSpeechUtterance.rate` is a 0…1 scale where ~0.47 is
+  /// conversational pace, so the user's multiplier scales that base, clamped to the
+  /// framework's legal range.
+  nonisolated static func systemSpeechRate(playbackSpeed: Float) -> Float {
+    let base: Float = 0.47
+    return min(
+      AVSpeechUtteranceMaximumSpeechRate,
+      max(AVSpeechUtteranceMinimumSpeechRate, base * playbackSpeed))
+  }
+
   private func enqueueSystemSpeech(_ text: String) {
     guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       if let lease = activePTTLease {
@@ -652,7 +666,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate, AV
       return
     }
     let utterance = AVSpeechUtterance(string: text)
-    utterance.rate = 0.47
+    utterance.rate = Self.systemSpeechRate(playbackSpeed: playbackRate)
     utterance.pitchMultiplier = 1.02
     utterance.volume = 1.0
     utterance.voice = preferredSystemVoice()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
@@ -897,6 +897,31 @@ extension SettingsContentView {
         }
       }
 
+      settingsCard(settingId: "advanced.preferences.speaknotifications") {
+        HStack(spacing: OmiSpacing.lg) {
+          Image(systemName: "speaker.wave.2")
+            .scaledFont(size: OmiType.subheading)
+            .foregroundColor(Ink.secondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+            Text("Speak Notifications Aloud")
+              .scaledFont(size: OmiType.subheading, weight: .semibold)
+              .foregroundColor(Ink.primary)
+
+            Text("Read proactive notifications out loud when they arrive, using your chat voice")
+              .scaledFont(size: OmiType.body)
+              .foregroundColor(Ink.secondary)
+          }
+
+          Spacer()
+
+          Toggle("", isOn: $speakNotificationsAloud)
+            .toggleStyle(OmiToggleStyle())
+            .labelsHidden()
+        }
+      }
+
       // Launch at Login toggle
       settingsCard(settingId: "advanced.preferences.launchatlogin") {
         HStack(spacing: OmiSpacing.lg) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -362,6 +362,7 @@ struct SettingsContentView: View {
   @AppStorage("multiChatEnabled") var multiChatEnabled = false
   @AppStorage("conversationsCompactView") var conversationsCompactView = true
   @AppStorage("useLegacyHomeDesign") var useLegacyHomeDesign = false
+  @AppStorage("speakNotificationsAloud") var speakNotificationsAloud = false
 
   // AI Chat settings
   @AppStorage("chatBridgeMode") var chatBridgeMode: String = "piMono"

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -464,7 +464,12 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
+    // `respectFrequency` is the existing proactive/functional split: assistants leave it
+    // true; functional notices (onboarding test, screen-repair prompts) pass false and
+    // must never be spoken.
+    let speech = NotificationSpeechOnDelivery(message: message, isProactive: respectFrequency)
     let recordPresentation = { [weak self] in
+      speech.notificationWasPresented()
       if respectFrequency {
         self?.recordProactiveNotificationPresented(
           assistantId: assistantId,
@@ -657,7 +662,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     let deliverSystemBanner = FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
       previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled, deliverSystemBanner: false)
 
+    let speech = NotificationSpeechOnDelivery(message: message, isProactive: true)
     let recordPresented = { [weak self] in
+      speech.notificationWasPresented()
       self?.recordProactiveNotificationPresented(
         assistantId: "context-director",
         authorizationSnapshot: authorizationSnapshot)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Decides whether a delivered proactive notification is also spoken out loud, and what
+/// exactly is said.
+///
+/// Off by default: a voice in a quiet room is a far bigger intrusion than a banner, so
+/// speech only ever comes from an explicit opt-in (Advanced settings → Preferences).
+/// Pure policy so the default-off contract and the spoken text are testable without a
+/// speech synthesizer or a delivered banner.
+enum NotificationSpeech {
+  nonisolated static let enabledDefaultsKey = DefaultsKey.speakNotificationsAloud.rawValue
+
+  static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+    defaults.bool(forKey: enabledDefaultsKey)
+  }
+
+  /// What to say for a delivered notification, or nil to stay silent.
+  ///
+  /// Only proactive notifications speak (`isProactive` = the caller's `respectFrequency`
+  /// marker): functional notices — the onboarding test banner, screen-recording repair
+  /// prompts, support replies — are system chrome, not omi talking to you, and reading
+  /// them aloud would be exactly the wrong voice for the feature.
+  ///
+  /// Only the message is spoken: the title is banner chrome ("Suggestion", "Insight")
+  /// that would read as a spoken label prefix, not something a person would say.
+  static func utterance(message: String, isEnabled: Bool, isProactive: Bool) -> String? {
+    guard isEnabled, isProactive else { return nil }
+    let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    return trimmed
+  }
+}
+
+/// Speaks a delivered notification at most once, at the moment a surface actually
+/// presents it.
+///
+/// Presentation — not sending — is the right trigger: the default proactive path is
+/// floating-bar only and never reaches the system banner, the bar can queue a
+/// notification for later, and a muted-preview fallback can deliver both surfaces for
+/// one message. All of those report through the same presentation callback, so speaking
+/// there covers every surface, and the once-guard keeps a dual delivery from reading
+/// the same message twice.
+@MainActor
+final class NotificationSpeechOnDelivery {
+  private let text: String?
+  private let speak: (String) -> Void
+  private var hasSpoken = false
+
+  init(
+    text: String?,
+    speak: @escaping (String) -> Void = { FloatingBarVoicePlaybackService.shared.speakOneShot($0) }
+  ) {
+    self.text = text
+    self.speak = speak
+  }
+
+  convenience init(message: String, isProactive: Bool) {
+    self.init(
+      text: NotificationSpeech.utterance(
+        message: message, isEnabled: NotificationSpeech.isEnabled(), isProactive: isProactive))
+  }
+
+  func notificationWasPresented() {
+    guard let text, !hasSpoken else { return }
+    hasSpoken = true
+    log("NotificationSpeech: speaking delivered notification (\(text.count) chars)")
+    speak(text)
+  }
+}

--- a/desktop/macos/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarVoiceResponseSettingsTests.swift
@@ -1,9 +1,28 @@
+import AVFoundation
 import XCTest
 
 @testable import Omi_Computer
 
 @MainActor
 final class FloatingBarVoiceResponseSettingsTests: XCTestCase {
+
+  /// The system voice honors the user's Voice Speed multiplier the same way the OpenAI
+  /// audio path does — a hardcoded utterance rate made spoken notifications crawl at ~1×
+  /// while push-to-talk answers played at the default 1.4×.
+  func testSystemSpeechRateScalesWithVoiceSpeed() {
+    let normal = FloatingBarVoicePlaybackService.systemSpeechRate(playbackSpeed: 1.0)
+    let fast = FloatingBarVoicePlaybackService.systemSpeechRate(playbackSpeed: 1.4)
+    XCTAssertEqual(normal, 0.47, accuracy: 0.001)
+    XCTAssertEqual(fast, 0.658, accuracy: 0.001)
+    XCTAssertGreaterThan(fast, normal)
+    // Extreme multipliers stay inside AVSpeechUtterance's legal range.
+    XCTAssertLessThanOrEqual(
+      FloatingBarVoicePlaybackService.systemSpeechRate(playbackSpeed: 10),
+      AVSpeechUtteranceMaximumSpeechRate)
+    XCTAssertGreaterThanOrEqual(
+      FloatingBarVoicePlaybackService.systemSpeechRate(playbackSpeed: 0),
+      AVSpeechUtteranceMinimumSpeechRate)
+  }
 
   func testDefaultVoiceIsShimmerOpenAIHumanVoice() {
     XCTAssertEqual(ShortcutSettings.defaultVoiceID, ShortcutSettings.openAIShimmerVoiceID)

--- a/desktop/macos/Desktop/Tests/NotificationSpeechTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationSpeechTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class NotificationSpeechTests: XCTestCase {
+  /// The opt-in contract: a fresh install (no stored value) must never speak.
+  func testDisabledByDefault() throws {
+    let suiteName = "NotificationSpeechTests-\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    XCTAssertFalse(NotificationSpeech.isEnabled(defaults: defaults))
+
+    defaults.set(true, forKey: NotificationSpeech.enabledDefaultsKey)
+    XCTAssertTrue(NotificationSpeech.isEnabled(defaults: defaults))
+  }
+
+  func testSilentWhenDisabledEvenWithText() {
+    XCTAssertNil(
+      NotificationSpeech.utterance(message: "Call dad tonight", isEnabled: false, isProactive: true))
+  }
+
+  func testSpeaksTrimmedMessageWhenEnabled() {
+    XCTAssertEqual(
+      NotificationSpeech.utterance(message: "  Call dad tonight \n", isEnabled: true, isProactive: true),
+      "Call dad tonight")
+  }
+
+  func testSilentForWhitespaceOnlyMessage() {
+    XCTAssertNil(NotificationSpeech.utterance(message: "   \n  ", isEnabled: true, isProactive: true))
+  }
+
+  /// Functional notices (onboarding test, screen-recording repair, support replies —
+  /// the `respectFrequency: false` callers) must stay silent even when the user opted
+  /// into spoken notifications.
+  func testFunctionalNotificationStaysSilentEvenWhenEnabled() {
+    XCTAssertNil(
+      NotificationSpeech.utterance(
+        message: "Notifications are working 🎉", isEnabled: true, isProactive: false))
+  }
+
+  /// A muted-preview fallback can present the same message on the floating bar AND the
+  /// system banner; both report through the same presentation callback, so the speaker
+  /// must say it exactly once.
+  @MainActor
+  func testEnabledDeliverySpeaksOnceAcrossDualPresentation() {
+    var spoken: [String] = []
+    let speaker = NotificationSpeechOnDelivery(text: "Call dad tonight") { spoken.append($0) }
+    speaker.notificationWasPresented()
+    speaker.notificationWasPresented()
+    XCTAssertEqual(spoken, ["Call dad tonight"])
+  }
+
+  @MainActor
+  func testDisabledDeliveryNeverSpeaks() {
+    var spoken: [String] = []
+    let speaker = NotificationSpeechOnDelivery(
+      text: NotificationSpeech.utterance(message: "Call dad tonight", isEnabled: false, isProactive: true)
+    ) { spoken.append($0) }
+    speaker.notificationWasPresented()
+    XCTAssertTrue(spoken.isEmpty)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260813-spoken-notifications.json
+++ b/desktop/macos/changelog/unreleased/20260813-spoken-notifications.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added an off-by-default Speak Notifications Aloud option (Advanced settings → Preferences) that reads proactive notifications out loud using your chat voice"
+}

--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift
   - desktop/macos/Desktop/Sources/PostHogManager.swift


### PR DESCRIPTION
## What

Demo feature: **Speak Notifications Aloud** — an off-by-default toggle in Advanced settings → Preferences. When enabled, proactive notifications (suggestions, insights, tasks, context-director) are read out loud through the existing floating-bar voice pipeline (user's chat voice, system-voice fallback) at the moment a surface actually presents them. Plus a voice-speed parity fix the demo surfaced: the system-voice path ignored the Voice Speed setting.

- `NotificationSpeech`: pure policy — speaks only when the user opted in, only for proactive notifications (`respectFrequency` marker; functional notices like the onboarding test and screen-repair prompts never speak), only non-empty messages.
- `NotificationSpeechOnDelivery`: once-per-notification speaker hooked into the shared presentation callbacks in `NotificationService`, so bar-immediate, bar-queued, and system-banner deliveries each speak exactly once and a muted-preview dual delivery cannot speak twice.
- `FloatingBarVoicePlaybackService.systemSpeechRate`: system voice scales its utterance rate by `ShortcutSettings.voicePlaybackSpeed` (default 1.4×) exactly like the OpenAI audio path applies it via `AVAudioPlayer.rate`, clamped to `AVSpeechUtterance`'s legal range — one Voice Speed setting drives both output paths.

## Product invariants

- **INV-CHAT-1** — path-matched (`NotificationService.swift`). No transcript behavior change: delivery surfaces, chat journaling, and notification persistence are untouched; the change only adds a speech side-effect at the existing presentation callbacks.
- **INV-VOICE-1** — path-matched (`FloatingBarVoicePlaybackService.swift`). Voice-turn lifecycle ownership unchanged: speech goes through the existing `speakOneShot`, which already acquires/validates PTT leases via `VoiceTurnCoordinator`; the rate fix only changes `AVSpeechUtterance.rate` arithmetic.

Failure-Class: none

## Verification

- Focused suites green: `xcrun swift test --filter "NotificationSpeechTests|FloatingBarVoiceResponseSettingsTests"` — NotificationSpeechTests 7/7 (default-off contract, proactive gate, once-guard dedup, functional-notice silence) + `testSystemSpeechRateScalesWithVoiceSpeed` (scaling + clamping).
- Live on `omi-ankara` (this branch on top of main, real signed-in account):
  - Default off → `probe_suggestion_nudge` delivered a nudge with **no** voice activity (no speech logs, `floatingBarVoiceResponseActive=false`).
  - Toggle ON (Advanced → Preferences card, screenshot in `.cross-review-verify.png`) → repeated real deliveries spoke: app log `Suggestion: delivering [95%] "TikTok is fine — but you said you'd send the investor update tonight."` → `NotificationSpeech: speaking delivered notification (69 chars)` 4 ms later, `floatingBarVoiceResponseActive` true ~5 s while audio played; heard live by Nik during the demo (user-requested triggers at 19:07, 19:09, 19:12).
  - Speed fix exercised on the rebuilt bundle: the 19:12 utterance played at the unified 1.4× pace.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

