### PR TITLE
fix(desktop): queue live-tail ratings until the journal remote id lands

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
@@ -39,15 +39,17 @@ struct ChatMessageRatingQueue: Equatable {
   }
 
   func contains(_ messageId: String) -> Bool {
-    pending[messageId] != nil
+    pending.keys.contains(messageId)
   }
 
   /// Drain ratings whose messages can persist now. Failed-journal and missing
   /// rows are dropped without a persist payload so a 404 cannot revert them.
+  /// A queued `nil` is a clear-rating and must persist after sync; do not
+  /// collapse it with a missing key.
   mutating func drain(using messages: [ChatMessage]) -> [(messageId: String, rating: Int?)] {
     var persist: [(messageId: String, rating: Int?)] = []
-    for messageId in Array(pending.keys) {
-      guard let rating = pending[messageId] else { continue }
+    let snapshot = pending
+    for (messageId, rating) in snapshot {
       guard let message = messages.first(where: { $0.id == messageId }) else {
         pending.removeValue(forKey: messageId)
         continue

--- a/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
@@ -46,18 +46,24 @@ struct ChatMessageRatingQueue: Equatable {
   /// rows are dropped without a persist payload so a 404 cannot revert them.
   /// A queued `nil` is a clear-rating and must persist after sync; do not
   /// collapse it with a missing key.
+  ///
+  /// A queued rating is keyed by the live-tail message id (the in-memory id at
+  /// tap time). Journal projection can later replace that row with a projected
+  /// message whose `id` is the kernel `turnId`, while the original id survives
+  /// only as `clientTurnId`. Match on either so the rating survives the remap,
+  /// and PATCH with the projected (remote) id so the backend row is found.
   mutating func drain(using messages: [ChatMessage]) -> [(messageId: String, rating: Int?)] {
     var persist: [(messageId: String, rating: Int?)] = []
     let snapshot = pending
     for (messageId, rating) in snapshot {
-      guard let message = messages.first(where: { $0.id == messageId }) else {
+      guard let message = messages.first(where: { $0.id == messageId || $0.clientTurnId == messageId }) else {
         pending.removeValue(forKey: messageId)
         continue
       }
       switch ChatMessageRatingPersistence.of(message) {
       case .persistNow:
         pending.removeValue(forKey: messageId)
-        persist.append((messageId, rating))
+        persist.append((message.id, rating))
       case .localOnly:
         pending.removeValue(forKey: messageId)
       case .waitForSync:

--- a/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// When a finished assistant reply can persist a thumbs rating to the backend.
+///
+/// The live tail shows rating actions as soon as there is copyable text
+/// (`ChatBubbleMetadataBand.actions`). The backend row is keyed by the kernel
+/// turn id and only exists after journal sync (`isSynced`). A PATCH before that
+/// 404s and used to revert the optimistic local rating.
+enum ChatMessageRatingPersistence: Equatable {
+  /// Backend row exists; PATCH immediately.
+  case persistNow
+  /// Journal sync is still in flight; queue the PATCH.
+  case waitForSync
+  /// The journal failed, so a backend row will never appear. Keep the local rating.
+  case localOnly
+
+  static func of(_ message: ChatMessage) -> Self {
+    if message.journalStatus == .failed { return .localOnly }
+    return message.isSynced ? .persistNow : .waitForSync
+  }
+}
+
+/// Last-write-wins queue of ratings that must wait for journal sync.
+struct ChatMessageRatingQueue: Equatable {
+  private var pending: [String: Int?] = [:]
+
+  var isEmpty: Bool { pending.isEmpty }
+
+  mutating func enqueue(messageId: String, rating: Int?) {
+    pending.updateValue(rating, forKey: messageId)
+  }
+
+  mutating func cancel(messageId: String) {
+    pending.removeValue(forKey: messageId)
+  }
+
+  mutating func removeAll() {
+    pending.removeAll()
+  }
+
+  func contains(_ messageId: String) -> Bool {
+    pending[messageId] != nil
+  }
+
+  /// Drain ratings whose messages can persist now. Failed-journal and missing
+  /// rows are dropped without a persist payload so a 404 cannot revert them.
+  mutating func drain(using messages: [ChatMessage]) -> [(messageId: String, rating: Int?)] {
+    var persist: [(messageId: String, rating: Int?)] = []
+    for messageId in Array(pending.keys) {
+      guard let rating = pending[messageId] else { continue }
+      guard let message = messages.first(where: { $0.id == messageId }) else {
+        pending.removeValue(forKey: messageId)
+        continue
+      }
+      switch ChatMessageRatingPersistence.of(message) {
+      case .persistNow:
+        pending.removeValue(forKey: messageId)
+        persist.append((messageId, rating))
+      case .localOnly:
+        pending.removeValue(forKey: messageId)
+      case .waitForSync:
+        break
+      }
+    }
+    return persist
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -249,6 +249,8 @@ struct BackgroundAgentSummary: Equatable {
 /// Footer actions for an assistant row. A finished reply is rateable as soon as
 /// it has copyable text; waiting for `isSynced` hid thumbs on the live tail
 /// because completion clears streaming before the journal remote id lands.
+/// Persistence of that rating is `ChatMessageRatingPersistence` — show the
+/// buttons now, PATCH after sync.
 enum ChatBubbleMetadataBand: Equatable {
   case hidden
   case timestampOnly

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -89,6 +89,7 @@ extension ChatProvider {
       divergences.insert(.ordering)
     }
     messages = updatedMessages
+    flushPendingMessageRatings()
 
     for divergence in divergences {
       DesktopDiagnosticsManager.shared.recordStateAuthoritySignal(

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+extension ChatProvider {
+  /// Rate a message (thumbs up/down).
+  /// - Parameters:
+  ///   - messageId: The message ID to rate
+  ///   - rating: 1 for thumbs up, -1 for thumbs down, nil to clear rating
+  func rateMessage(_ messageId: String, rating: Int?) async {
+    switch queueMessageRating(messageId, rating: rating) {
+    case .persistNow:
+      await persistMessageRating(messageId, rating: rating)
+    case .waitForSync, .localOnly, nil:
+      break
+    }
+  }
+
+  /// Apply the rating locally and decide whether a backend PATCH can run yet.
+  @discardableResult
+  func queueMessageRating(_ messageId: String, rating: Int?) -> ChatMessageRatingPersistence? {
+    guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return nil }
+    messages[index].rating = rating
+    let decision = ChatMessageRatingPersistence.of(messages[index])
+    switch decision {
+    case .persistNow:
+      pendingMessageRatings.cancel(messageId: messageId)
+    case .waitForSync:
+      pendingMessageRatings.enqueue(messageId: messageId, rating: rating)
+    case .localOnly:
+      pendingMessageRatings.cancel(messageId: messageId)
+    }
+    return decision
+  }
+
+  func flushPendingMessageRatings() {
+    let ready = pendingMessageRatings.drain(using: messages)
+    for item in ready {
+      Task { await persistMessageRating(item.messageId, rating: item.rating) }
+    }
+  }
+
+  func persistMessageRating(_ messageId: String, rating: Int?) async {
+    do {
+      if let persistMessageRatingHandler {
+        try await persistMessageRatingHandler(messageId, rating)
+      } else {
+        try await APIClient.shared.rateMessage(messageId: messageId, rating: rating)
+      }
+      log("Rated message \(messageId) with rating: \(String(describing: rating))")
+      if let rating {
+        AnalyticsManager.shared.messageRated(rating: rating)
+      }
+    } catch {
+      logError("Failed to rate message", error: error)
+      if let index = messages.firstIndex(where: { $0.id == messageId }),
+        messages[index].rating == rating
+      {
+        messages[index].rating = nil
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
@@ -33,12 +33,25 @@ extension ChatProvider {
 
   func flushPendingMessageRatings() {
     let ready = pendingMessageRatings.drain(using: messages)
+    guard !ready.isEmpty else { return }
+    // Fence against an account/owner transition: if the owner changes while a
+    // drained PATCH is in flight, `resetSessionStateForAuthChange` clears the
+    // queue and messages, so the stale owner captured here no longer matches
+    // and the PATCH is dropped instead of mutating the new owner's session.
+    let ownerAtFlush = runtimeOwnerId
     for item in ready {
-      Task { await persistMessageRating(item.messageId, rating: item.rating) }
+      Task { [weak self] in
+        await self?.persistMessageRating(
+          item.messageId, rating: item.rating, expectedOwner: ownerAtFlush)
+      }
     }
   }
 
-  func persistMessageRating(_ messageId: String, rating: Int?) async {
+  func persistMessageRating(_ messageId: String, rating: Int?, expectedOwner: String? = nil) async {
+    // Owner fence: if an auth change happened between the flush drain and this
+    // call, the rating belongs to the previous account and must not be written
+    // under the new session.
+    if let expectedOwner, runtimeOwnerId != expectedOwner { return }
     do {
       if let persistMessageRatingHandler {
         try await persistMessageRatingHandler(messageId, rating)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
@@ -38,7 +38,7 @@ extension ChatProvider {
     // drained PATCH is in flight, `resetSessionStateForAuthChange` clears the
     // queue and messages, so the stale owner captured here no longer matches
     // and the PATCH is dropped instead of mutating the new owner's session.
-    let ownerAtFlush = runtimeOwnerId
+    let ownerAtFlush = RuntimeOwnerIdentity.currentOwnerId()
     for item in ready {
       Task { [weak self] in
         await self?.persistMessageRating(
@@ -51,7 +51,7 @@ extension ChatProvider {
     // Owner fence: if an auth change happened between the flush drain and this
     // call, the rating belongs to the previous account and must not be written
     // under the new session.
-    if let expectedOwner, runtimeOwnerId != expectedOwner { return }
+    if let expectedOwner, RuntimeOwnerIdentity.currentOwnerId() != expectedOwner { return }
     do {
       if let persistMessageRatingHandler {
         try await persistMessageRatingHandler(messageId, rating)

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1176,6 +1176,8 @@ class ChatProvider: ObservableObject {
   lazy var kernelTurnProjection = KernelTurnProjection(host: self)
   private let journalWriteCoordinator = ChatJournalWriteCoordinator()
   private var journalOwnerByMessageID: [String: String] = [:]
+  var pendingMessageRatings = ChatMessageRatingQueue()
+  var persistMessageRatingHandler: ((String, Int?) async throws -> Void)?
   private var journalTerminalTargets = ChatTerminalTargetRegistry<ChatJournalTerminalTarget>()
   private var agentBridgeStarted = false
   /// The root shell supplies one server-authoritative sample before this
@@ -1679,6 +1681,7 @@ class ChatProvider: ObservableObject {
     kernelTurnProjection.invalidateOwnerState()
     journalWriteCoordinator.cancelAll()
     journalOwnerByMessageID.removeAll()
+    pendingMessageRatings.removeAll()
     journalTerminalTargets = ChatTerminalTargetRegistry<ChatJournalTerminalTarget>()
     // A ChatErrorCard belongs to the session that produced it. Retaining an
     // auth-required card after a successful account switch incorrectly asks
@@ -3492,6 +3495,7 @@ class ChatProvider: ObservableObject {
   func resetJournalProjection(surface: AgentSurfaceReference) {
     guard surface == mainChatSurfaceReference() else { return }
     messages = []
+    pendingMessageRatings.removeAll()
     resetMessagesPagination()
   }
 
@@ -6424,36 +6428,6 @@ class ChatProvider: ObservableObject {
       if changed {
         messages[messageIndex].resources = updatedResources
         scheduleJournalUpdate(messageId: messages[messageIndex].id)
-      }
-    }
-  }
-
-  // MARK: - Message Rating
-
-  /// Rate a message (thumbs up/down)
-  /// - Parameters:
-  ///   - messageId: The message ID to rate
-  ///   - rating: 1 for thumbs up, -1 for thumbs down, nil to clear rating
-  func rateMessage(_ messageId: String, rating: Int?) async {
-    // Update local state immediately for responsive UI
-    if let index = messages.firstIndex(where: { $0.id == messageId }) {
-      messages[index].rating = rating
-    }
-
-    // Persist to backend
-    do {
-      try await APIClient.shared.rateMessage(messageId: messageId, rating: rating)
-      log("Rated message \(messageId) with rating: \(String(describing: rating))")
-
-      // Track analytics
-      if let rating = rating {
-        AnalyticsManager.shared.messageRated(rating: rating)
-      }
-    } catch {
-      logError("Failed to rate message", error: error)
-      // Revert local state on failure
-      if let index = messages.firstIndex(where: { $0.id == messageId }) {
-        messages[index].rating = nil
       }
     }
   }

--- a/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
@@ -157,6 +157,98 @@ final class ChatMessageRatingPersistenceTests: XCTestCase {
     XCTAssertFalse(provider.pendingMessageRatings.contains(messageId))
   }
 
+  /// Thread 2 regression: a thumbs tap on the live tail is keyed by the local
+  /// in-memory id, but journal projection replaces that row with the kernel
+  /// turnId. The queued rating must survive the remap and PATCH with the
+  /// projected (remote) id, not the stale local id.
+  func testQueuedRatingSurvivesProjectionIdRemap() async throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    let localId = "live-tail-local"
+    let remoteId = "srv-42"
+    let persisted = expectation(description: "queued rating PATCHes with remote id after id remap")
+    provider.persistMessageRatingHandler = { persistedId, rating in
+      XCTAssertEqual(persistedId, remoteId, "drain must PATCH with the projected remote id")
+      XCTAssertEqual(rating, 1)
+      persisted.fulfill()
+    }
+    provider.messages = [
+      ChatMessage(
+        id: localId,
+        text: "I'll look that up.",
+        sender: .ai,
+        isStreaming: false,
+        isSynced: false,
+        journalStatus: .completed)
+    ]
+
+    XCTAssertEqual(provider.queueMessageRating(localId, rating: 1), .waitForSync)
+
+    // The journal turn has a *different* turnId from the live-tail id, with a
+    // matching clientTurnId so projection remaps the row by continuity.
+    var dictionary: [String: Any] = [
+      "conversationId": "conversation-1",
+      "turnId": remoteId,
+      "turnSeq": 1,
+      "conversationGeneration": 1,
+      "generationBaseTurnSeq": 0,
+      "producerId": "producer:\(remoteId)",
+      "payloadHash": "sha256:\(remoteId)",
+      "role": "assistant",
+      "surfaceKind": surface.surfaceKind,
+      "externalRefKind": surface.externalRefKind,
+      "externalRefId": surface.externalRefId,
+      "content": "I'll look that up.",
+      "origin": "test",
+      "status": KernelJournalTurnStatus.completed.rawValue,
+      "contentBlocks": [],
+      "resources": [],
+      "metadataJson": "{\"continuityKey\":\"\(localId)\"}",
+      "createdAtMs": 1_700_000_000_000,
+      "updatedAtMs": 1_700_000_000_000,
+    ]
+    dictionary["remoteId"] = remoteId
+    provider.projectJournalTurn(try XCTUnwrap(KernelJournalTurn(dictionary: dictionary)))
+
+    await fulfillment(of: [persisted], timeout: 1.0)
+    XCTAssertEqual(provider.messages.first?.id, remoteId)
+    XCTAssertEqual(provider.messages.first?.rating, 1)
+    XCTAssertFalse(provider.pendingMessageRatings.contains(localId))
+  }
+
+  /// Queue-level regression for the id-remap fix: drain must match by
+  /// clientTurnId when the id has changed.
+  func testQueueDrainsByClientTurnIdAfterIdRemap() {
+    var queue = ChatMessageRatingQueue()
+    let localId = "local-1"
+    let remoteId = "remote-1"
+    queue.enqueue(messageId: localId, rating: 1)
+
+    // The message has been remapped: id=remoteId, clientTurnId=localId
+    let remapped = ChatMessage(
+      id: remoteId, clientTurnId: localId,
+      text: "Done.", sender: .ai, isSynced: true)
+    let ready = queue.drain(using: [remapped])
+    XCTAssertEqual(ready.count, 1)
+    XCTAssertEqual(ready.first?.messageId, remoteId, "drain must PATCH with the projected remote id")
+    XCTAssertEqual(ready.first?.rating, 1)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
+  /// Thread 1 regression: a drained rating PATCH that is in flight when an
+  /// owner transition fires must not write under the new session.
+  func testPersistMessageRatingFencedByOwner() async {
+    let provider = ChatProvider()
+    let persisted = expectation(description: "owner-fenced PATCH is dropped")
+    persisted.isInverted = true
+    provider.persistMessageRatingHandler = { _, _ in
+      persisted.fulfill()
+    }
+    // Simulate a PATCH whose captured owner no longer matches the current owner.
+    await provider.persistMessageRating("m1", rating: 1, expectedOwner: "stale-owner")
+    await fulfillment(of: [persisted], timeout: 0.2)
+  }
+
   private func makeTurn(
     surface: AgentSurfaceReference,
     turnId: String,

--- a/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
@@ -61,6 +61,23 @@ final class ChatMessageRatingPersistenceTests: XCTestCase {
     XCTAssertTrue(queue.isEmpty)
   }
 
+  func testQueueDrainsClearedRatingAfterSync() {
+    var queue = ChatMessageRatingQueue()
+    queue.enqueue(messageId: "m1", rating: 1)
+    queue.enqueue(messageId: "m1", rating: nil)
+
+    XCTAssertTrue(queue.contains("m1"))
+    let unsynced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: false)
+    XCTAssertTrue(queue.drain(using: [unsynced]).isEmpty)
+
+    let synced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: true)
+    let ready = queue.drain(using: [synced])
+    XCTAssertEqual(ready.count, 1)
+    XCTAssertEqual(ready.first?.messageId, "m1")
+    XCTAssertNil(ready.first?.rating)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
   func testQueueDropsFailedJournalWithoutPersist() {
     var queue = ChatMessageRatingQueue()
     queue.enqueue(messageId: "m1", rating: 1)

--- a/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
@@ -175,6 +175,7 @@ final class ChatMessageRatingPersistenceTests: XCTestCase {
     provider.messages = [
       ChatMessage(
         id: localId,
+        clientTurnId: localId,
         text: "I'll look that up.",
         sender: .ai,
         isStreaming: false,

--- a/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatMessageRatingPersistenceTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ChatMessageRatingPersistenceTests: XCTestCase {
+
+  func testFinishedUnsyncedReplyWaitsForJournalSync() {
+    let message = ChatMessage(
+      id: "live-tail",
+      text: "Done.",
+      sender: .ai,
+      isStreaming: false,
+      isSynced: false,
+      journalStatus: .completed)
+
+    XCTAssertEqual(ChatMessageRatingPersistence.of(message), .waitForSync)
+    XCTAssertEqual(ChatBubbleMetadataBand.of(message), .actions)
+  }
+
+  func testSyncedReplyPersistsImmediately() {
+    let message = ChatMessage(
+      id: "synced",
+      text: "Done.",
+      sender: .ai,
+      isStreaming: false,
+      isSynced: true,
+      journalStatus: .completed)
+
+    XCTAssertEqual(ChatMessageRatingPersistence.of(message), .persistNow)
+  }
+
+  func testFailedJournalStaysLocalOnly() {
+    let message = ChatMessage(
+      id: "failed-tail",
+      text: "Partial answer.",
+      sender: .ai,
+      isStreaming: false,
+      isSynced: false,
+      journalStatus: .failed)
+
+    XCTAssertEqual(ChatMessageRatingPersistence.of(message), .localOnly)
+    XCTAssertEqual(ChatBubbleMetadataBand.of(message), .actions)
+  }
+
+  func testQueueLastWriteWinsUntilDrain() {
+    var queue = ChatMessageRatingQueue()
+    let unsynced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: false)
+    queue.enqueue(messageId: "m1", rating: 1)
+    queue.enqueue(messageId: "m1", rating: -1)
+
+    XCTAssertTrue(queue.contains("m1"))
+    XCTAssertTrue(queue.drain(using: [unsynced]).isEmpty, "Unsynced rows must stay queued")
+    XCTAssertTrue(queue.contains("m1"))
+
+    let synced = ChatMessage(id: "m1", text: "Done.", sender: .ai, isSynced: true)
+    let ready = queue.drain(using: [synced])
+    XCTAssertEqual(ready.count, 1)
+    XCTAssertEqual(ready.first?.messageId, "m1")
+    XCTAssertEqual(ready.first?.rating, -1)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
+  func testQueueDropsFailedJournalWithoutPersist() {
+    var queue = ChatMessageRatingQueue()
+    queue.enqueue(messageId: "m1", rating: 1)
+    let failed = ChatMessage(
+      id: "m1",
+      text: "Partial answer.",
+      sender: .ai,
+      isSynced: false,
+      journalStatus: .failed)
+
+    XCTAssertTrue(queue.drain(using: [failed]).isEmpty)
+    XCTAssertTrue(queue.isEmpty)
+  }
+
+  func testUnsyncedReplyQueuesRatingUntilJournalRemoteIdLands() async throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    let messageId = "assistant-live-rating"
+    let persisted = expectation(description: "queued rating PATCHes after journal remote id")
+    provider.persistMessageRatingHandler = { persistedId, rating in
+      XCTAssertEqual(persistedId, messageId)
+      XCTAssertEqual(rating, 1)
+      persisted.fulfill()
+    }
+    provider.messages = [
+      ChatMessage(
+        id: messageId,
+        text: "I'll look that up.",
+        sender: .ai,
+        isStreaming: false,
+        isSynced: false,
+        journalStatus: .completed)
+    ]
+
+    XCTAssertEqual(provider.queueMessageRating(messageId, rating: 1), .waitForSync)
+    XCTAssertEqual(provider.messages.first?.rating, 1)
+    XCTAssertTrue(provider.pendingMessageRatings.contains(messageId))
+
+    provider.projectJournalTurn(
+      try makeTurn(surface: surface, turnId: messageId, content: "I'll look that up.", remoteId: "srv-42"))
+
+    await fulfillment(of: [persisted], timeout: 1.0)
+    XCTAssertEqual(provider.messages.first?.rating, 1)
+    XCTAssertFalse(provider.pendingMessageRatings.contains(messageId))
+  }
+
+  func testFailedJournalKeepsLocalRatingWithoutPatch() async throws {
+    let provider = ChatProvider()
+    let surface = provider.mainChatSurfaceReference()
+    let messageId = "assistant-failed-rating"
+    let persisted = expectation(description: "failed journal must not PATCH")
+    persisted.isInverted = true
+    provider.persistMessageRatingHandler = { _, _ in
+      persisted.fulfill()
+    }
+    provider.messages = [
+      ChatMessage(
+        id: messageId,
+        text: "Partial answer.",
+        sender: .ai,
+        isStreaming: false,
+        isSynced: false,
+        journalStatus: .completed)
+    ]
+
+    XCTAssertEqual(provider.queueMessageRating(messageId, rating: -1), .waitForSync)
+
+    provider.projectJournalTurn(
+      try makeTurn(
+        surface: surface,
+        turnId: messageId,
+        content: "Partial answer.",
+        status: .failed))
+
+    await fulfillment(of: [persisted], timeout: 0.2)
+    XCTAssertEqual(provider.messages.first?.rating, -1)
+    XCTAssertFalse(provider.pendingMessageRatings.contains(messageId))
+  }
+
+  private func makeTurn(
+    surface: AgentSurfaceReference,
+    turnId: String,
+    content: String,
+    status: KernelJournalTurnStatus = .completed,
+    remoteId: String? = nil
+  ) throws -> KernelJournalTurn {
+    var dictionary: [String: Any] = [
+      "conversationId": "conversation-1",
+      "turnId": turnId,
+      "turnSeq": 1,
+      "conversationGeneration": 1,
+      "generationBaseTurnSeq": 0,
+      "producerId": "producer:\(turnId)",
+      "payloadHash": "sha256:\(turnId)",
+      "role": "assistant",
+      "surfaceKind": surface.surfaceKind,
+      "externalRefKind": surface.externalRefKind,
+      "externalRefId": surface.externalRefId,
+      "content": content,
+      "origin": "test",
+      "status": status.rawValue,
+      "contentBlocks": [],
+      "resources": [],
+      "metadataJson": "{}",
+      "createdAtMs": 1_700_000_000_000,
+      "updatedAtMs": 1_700_000_000_000,
+    ]
+    if let remoteId {
+      dictionary["remoteId"] = remoteId
+    }
+    return try XCTUnwrap(KernelJournalTurn(dictionary: dictionary))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260813-chat-rating-until-sync.json
+++ b/desktop/macos/changelog/unreleased/20260813-chat-rating-until-sync.json
@@ -1,0 +1,3 @@
+{
+  "change": "Thumbs on a just-finished reply now wait for the message to sync before saving, so the rating no longer disappears"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -32,8 +32,6 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift
   - desktop/macos/Desktop/Sources/Chat/KernelTurnJournal.swift
-  - desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
-  - desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
   - desktop/macos/Desktop/Sources/Chat/WritingToolsFix.swift
   - desktop/macos/Desktop/Sources/BrowserExtensionSetup.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -32,6 +32,8 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
   - desktop/macos/Desktop/Sources/Chat/KernelJournalEventHub.swift
   - desktop/macos/Desktop/Sources/Chat/KernelTurnJournal.swift
+  - desktop/macos/Desktop/Sources/Chat/ChatMessageRatingPersistence.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatProvider+MessageRating.swift
   - desktop/macos/Desktop/Sources/Chat/WritingToolsFix.swift
   - desktop/macos/Desktop/Sources/BrowserExtensionSetup.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift


### PR DESCRIPTION
## Summary
- Follow-up to #11522: thumbs stay visible on a just-finished reply, but the rating PATCH waits until journal sync so a 404 cannot wipe the optimistic rating.
- Failed journal turns keep a local-only rating and never PATCH a missing backend row. Clearing thumbs before sync now still PATCHes after the remote id lands (a queued `nil` is not treated as a missing map entry).
- Last write wins while sync is in flight; the queue flushes when the journal projection lands a remote id.

The dual-client quota stub repair from #11522 landed separately in #11535, so this PR is desktop-only.

## Test plan
- [x] `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ChatMessageRatingPersistenceTests'` — 8 tests passed
- [ ] Named-bundle check: send a chat, tap thumbs on the live tail before the backend id appears, confirm the rating sticks after sync

## Product invariants
- INV-CHAT-1
- INV-AUTH-1

Failure-Class: none