### PR TITLE
docs(app): point mobile setup at the local backend harness, not api.omiapi.com

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -8,12 +8,30 @@ The Omi App is a Flutter-based mobile application that serves as the companion a
 
 Before getting started, make sure your device is connected and unlocked. If you're using an iPhone, ensure that Developer Mode is enabled — you can toggle this in the iPhone settings. For Android devices, make sure the device is connected and USB debugging is enabled in Developer Options
 
-1. Navigate to the app directory:
+1. Start the local backend harness from the **repo root**. `setup.sh` builds
+   against it but does not start it, so do this first or the app will launch with
+   nothing to talk to:
+   ```bash
+   make dev-init   # once: creates backend/.venv and copies the env template
+   make dev-up     # Firestore + Auth emulators and the Python API on :8000
+
+   # No provider API keys? Use fake providers:
+   PROVIDER_MODE=offline make dev-up
+   ```
+
+   `make dev-init` builds `backend/.venv` from whatever `python3` resolves to,
+   and the backend requires **Python 3.11** (not 3.12+). The harness also needs a
+   Java runtime and `firebase-tools`/`npx`; `make dev-up` names what's missing.
+
+   `make dev-status` shows what came up; `make dev-down` stops it. Ports, seeded
+   users, and troubleshooting: [`docs/runbooks/local-emulator-manual-qa.md`](../docs/runbooks/local-emulator-manual-qa.md).
+
+2. Navigate to the app directory:
    ```bash
    cd app
    ```
 
-2. Run the setup script for your platform:
+3. Run the setup script for your platform:
    ```bash
    # macOS/Linux: iOS
    bash setup.sh ios
@@ -57,12 +75,12 @@ scheme. Product traffic uses the beta serving API, while Google and Apple OAuth
 remain on `https://api.omi.me/`; the beta must not be treated as a local-emulator
 build.
  
-3. Ensure GitHub SSH access is set up correctly for pulling certificates from repositories. After running the command below, if you're prompted for a passphrase, enter your SSH passphrase — or simply press Enter/Return if you haven't set one.
+4. Ensure GitHub SSH access is set up correctly for pulling certificates from repositories. After running the command below, if you're prompted for a passphrase, enter your SSH passphrase — or simply press Enter/Return if you haven't set one.
     ```bash
    cd ~/.ssh; ssh-add
    ```
 
-4. To run the app, navigate to the app directory and use the following command:
+5. To run the app, navigate to the app directory and use the following command:
    ```bash
    flutter run --flavor dev
    ```

--- a/docs/doc/developer/AppSetup.mdx
+++ b/docs/doc/developer/AppSetup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "App Setup"
 icon: "mobile"
-description: "Set up the Omi Flutter app for development. Build automatically with our dev backend, or manually with your own."
+description: "Set up the Omi Flutter app for development. Build automatically against the local backend harness, or manually with your own."
 ---
 
 ## Overview
@@ -12,7 +12,7 @@ There are two ways to set up the Omi app for development:
   <Card title="Automatic Setup" icon="wand-magic-sparkles" href="#build-the-app-automatically">
     **Recommended for most developers**
 
-    One command setup using Omi's development backend
+    One command setup against the local backend harness
   </Card>
   <Card title="Manual Setup" icon="wrench" href="#build-the-app-manually">
     **For custom backends**
@@ -50,11 +50,33 @@ Before starting, make sure you have the following installed:
 You'll also need [NDK](https://developer.android.com/ndk/downloads) to build Opus for ARM devices.
 </Note>
 
+<Note>
+The local backend harness additionally needs **Python 3.11** (not 3.12+ — the
+backend pins 3.11), a **Java runtime** for the Firestore emulator, and
+**firebase-tools** (or `npx`). `make dev-up` names any of these that are missing.
+</Note>
+
 ---
 
 ## Build the App Automatically
 
-This is the **recommended** way to get started. It sets up your environment to use Omi's development backend with just one command.
+This is the **recommended** way to get started. `setup.sh` builds the `dev` flavor
+against the **local backend harness** — the Python API on port `8000` and the
+Firebase Auth emulator on port `9099`, using the `demo-omi-local` Firebase
+project. iOS builds address them as `127.0.0.1`; Android builds default to the
+emulator's host alias `10.0.2.2`.
+
+<Warning>
+`setup.sh` does **not** start the backend or the emulator — start the harness
+first (step 1 below), or the app builds and launches but every request fails to
+connect.
+
+Do not point this build at `https://api.omiapi.com/`. That API verifies Firebase
+ID tokens against Omi's production Firebase project, and Firebase tokens are
+project-scoped, so a `demo-omi-local` token is rejected with **401 Unauthorized**
+on every call — sign-in appears to succeed and nothing else works. Production
+data requires the explicit `beta` profile (see [Mobile beta](https://github.com/BasedHardware/omi/blob/main/app/README.md#mobile-beta--dogfood)).
+</Warning>
 
 ### Video Walkthrough
 
@@ -71,6 +93,28 @@ This is the **recommended** way to get started. It sets up your environment to u
 ### Setup Steps
 
 <Steps>
+  <Step title="Start the local backend harness" icon="server">
+    From the **root of the repository**, one-time setup then start the services:
+
+    ```bash
+    make dev-init   # once: creates backend/.venv and copies the env template
+    make dev-up     # starts the Firestore + Auth emulators and the Python API
+    ```
+
+    `make dev-init` builds `backend/.venv` from whatever `python3` resolves to,
+    and the backend requires **Python 3.11** — make sure that's what you get, or
+    the harness fails later with import errors.
+
+    No provider API keys? Use fake providers instead:
+
+    ```bash
+    PROVIDER_MODE=offline make dev-up
+    ```
+
+    Check what came up with `make dev-status`, and stop it later with
+    `make dev-down`. Ports, seeded local users, and troubleshooting live in the
+    [local emulator runbook](https://github.com/BasedHardware/omi/blob/main/docs/runbooks/local-emulator-manual-qa.md).
+  </Step>
   <Step title="Navigate to the app directory" icon="folder">
     ```bash
     cd app
@@ -103,7 +147,10 @@ This is the **recommended** way to get started. It sets up your environment to u
 </Steps>
 
 <Tip>
-The automatic setup uses Omi's development backend, making it the fastest way to start building apps and making changes.
+The automatic setup runs entirely on your machine — local API, local emulators,
+no production data — making it the fastest way to start building apps and making
+changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN address so
+the device can reach the harness.
 </Tip>
 
 ---
@@ -176,11 +223,20 @@ Manual setup gives you full control, allowing you to use your own backend.
 
     | Key | Description |
     |-----|-------------|
-    | `API_BASE_URL` | Your backend URL (use `https://api.omiapi.com/` for dev, or [set up your own](/doc/developer/backend/Backend_Setup)) |
+    | `API_BASE_URL` | Your backend URL — `http://127.0.0.1:8000/` for the local harness, or [set up your own](/doc/developer/backend/Backend_Setup) |
     | `GOOGLE_MAPS_API_KEY` | Optional - for location features |
 
     <Warning>
     Be sure to include the trailing `/` in `API_BASE_URL` or you'll get malformed URLs. If you change this later, delete the builds folder and recreate the runner.
+    </Warning>
+
+    <Warning>
+    Whatever backend you point at must verify Firebase ID tokens against the
+    **same Firebase project** the app signs into. Tokens are project-scoped, so a
+    mismatch returns **401 Unauthorized** on every authenticated call while
+    sign-in still appears to succeed. Omi's shared `https://api.omiapi.com/`
+    verifies against the production project and will reject tokens from the
+    `demo-omi-local` emulator or from your own Firebase project.
     </Warning>
   </Step>
   <Step title="Run Build Runner" icon="hammer">
@@ -194,7 +250,11 @@ Manual setup gives you full control, allowing you to use your own backend.
     Firebase is **mandatory** for the app to run.
 
     <Warning>
-    The repo ships **prebuilt Firebase configs** for both dev and prod. If you're using Omi's development backend (the common case), they're already in place after `setup.sh` — skip to the next step.
+    `setup.sh` installs **local emulator Firebase configs** (the `demo-omi-local`
+    project) for the `dev` flavor. If you're using the local backend harness (the
+    common case), they're already in place — skip to the next step. These configs
+    only work against the Firebase Auth emulator; they are not credentials for
+    any hosted Firebase project.
 
     **Never run `flutterfire configure`** against Omi's bundle IDs — it overwrites the prebuilt prod credentials in `app/ios/Config/Prod/`, `app/lib/firebase_options_prod.dart`, and `app/android/app/src/prod/`.
     </Warning>
@@ -260,6 +320,31 @@ ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit
     - Enable Google/Apple sign-in in Firebase Console
     - Verify SHA1/SHA256 keys are added to Firebase
     - Check bundle IDs match your Firebase configuration
+  </Accordion>
+  <Accordion title="App can't reach the backend (connection refused / timeouts)" icon="plug">
+    `setup.sh` builds against `http://127.0.0.1:8000` but does not start anything.
+    Run `make dev-up` from the repo root first, and confirm with `make dev-status`.
+
+    On a physical device, `127.0.0.1` is the phone — set `OMI_DEV_HOST` to your
+    Mac's LAN address before running `setup.sh` so the build points at your
+    machine. The Android emulator uses `10.0.2.2` by default.
+  </Accordion>
+  <Accordion title="Sign-in works but every request returns 401" icon="triangle-exclamation">
+    The app and the backend are on **different Firebase projects**. Firebase ID
+    tokens are project-scoped: a token minted for one project cannot be verified
+    by a backend initialized for another, so authentication succeeds locally and
+    every authenticated API call is rejected.
+
+    This shows up on the manual path, where you choose both sides: your own
+    Firebase project signs the user in while `API_BASE_URL` points at a backend
+    initialized for a different project. Point `API_BASE_URL` at a backend that
+    verifies against *your* project.
+
+    Omi's shared `https://api.omiapi.com/` is never a valid target for a
+    self-configured build — it verifies against Omi's own Firebase project, and
+    the `demo-omi-local` configs `setup.sh` installs are emulator-only fakes that
+    no hosted backend can verify. Production data requires the explicit `beta`
+    profile.
   </Accordion>
   <Accordion title="iOS: Unable to flip between RX and RW memory protection" icon="apple">
     **Error Message:**


### PR DESCRIPTION
## Problem

`docs/doc/developer/AppSetup.mdx` and `app/README.md` point a new mobile developer at `https://api.omiapi.com/`, but `app/setup.sh ios` configures the app for **local development**: it writes `API_BASE_URL=http://127.0.0.1:8000/` into `app/.dev.env` and passes `--dart-define=OMI_FIREBASE_AUTH_EMULATOR_HOST` (`setup.sh:417-420`). The documented target and the actual one disagree.

Following the docs as written, a developer gets an app that builds, installs, launches — and then sits on the splash screen, because it is waiting on a backend nobody told them to start. There is no error and no hint of the cause.

Production Firebase makes the documented path worse than useless: the app authenticates against Omi's production Firebase project, and those tokens are rejected on every call, so sign-in appears to succeed and nothing else works.

## Change

Documents what `setup.sh` actually does, and what it does **not** do:

- The build targets the **local backend harness** — the Python API on port `8000` and the Firestore emulator — not production.
- **`setup.sh` does not start either of them.** This prerequisite was previously undocumented and is the single thing most likely to strand a new contributor.
- Its real prerequisites: **Python 3.11** (not 3.12+ — the backend pins 3.11) and a **Java runtime** for the Firestore emulator.
- Addressing differs by platform: iOS reaches the harness at `127.0.0.1`, Android defaults differently. Both are overridable via `OMI_DEV_HOST` / `OMI_LOCAL_API_BASE_URL`.
- A one-command path (`make dev-init`) for creating `backend/.venv` and the env template.

## Verification

Rebased onto current `main`; both files have zero upstream commits since the change was written, so it applies cleanly. `main` still contains the stale `api.omiapi.com` reference in each file, so the correction is still needed.

The splash-screen symptom was reproduced today on an iOS device build: `setup.sh ios` completed, the app installed and launched, and hung on the logo with nothing listening on port 8000.

## Scope

Documentation only. It does not change `setup.sh`, and deliberately does not try to make the script detect or start the harness — that is a separate change, filed as its own issue.

Note that the prod-simulating path (`setup.sh ios beta`, which targets `https://api.omiapi.com/`) is gated behind `FIREBASE_SERVICE_ACCOUNT_KEY` and so is unavailable to community contributors by design. These docs therefore describe the local harness as the supported route rather than implying production is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qmdS9crg5qFhan7PCbWvZ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

