### PR TITLE
fix(backend): unwedge Backend Unit Tests after the customer-Firestore split (#11531)

### DIFF
--- a/.github/failure-classes/FC-credentialed-dependency-resolved-before-guard.json
+++ b/.github/failure-classes/FC-credentialed-dependency-resolved-before-guard.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-credentialed-dependency-resolved-before-guard",
+  "violated_contract": "A gate must answer the cases it can decide without an external dependency before resolving that dependency. Passing a credentialed client in argument position resolves it first, so an answer that needs no read still requires ambient credentials and fails where they are absent.",
+  "canonical_prevention": "Resolve credentialed clients inside the branch that actually reads them, after the guards that can decide without one, and cover it with a test whose fake client raises on resolution so any path that resolves it needlessly fails.",
+  "canonical_prevention_artifact": ["backend/tests/unit/test_paywall_reconnect_gate.py"],
+  "evidence_prs": [11522],
+  "scope_hints": ["backend/utils/subscription.py", "backend/database/_client.py", "backend/routers/desktop_*.py"],
+  "status": "open"
+}

--- a/backend/tests/unit/memory_import_isolation.py
+++ b/backend/tests/unit/memory_import_isolation.py
@@ -73,6 +73,7 @@ def make_database_client_stub() -> ModuleType:
     client_mod.db = MagicMock()
     client_mod.delete_collection_recursive = MagicMock()
     client_mod.get_firestore_client = lambda: client_mod.db
+    client_mod.get_customer_firestore_client = lambda: client_mod.db
 
     def _document_id_from_seed(seed: str) -> str:
         seed_hash = hashlib.sha256(seed.encode("utf-8")).digest()

--- a/backend/tests/unit/test_byok_security.py
+++ b/backend/tests/unit/test_byok_security.py
@@ -334,7 +334,7 @@ class TestChatQuotaBYOKBypass:
         from utils.subscription import enforce_chat_quota
 
         enforce_chat_quota('byok-user-uid')
-        mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid')
+        mock_users_db.is_byok_active.assert_called_once_with('byok-user-uid', firestore_client=None)
 
     @patch('utils.byok.get_byok_key', return_value=None)
     @patch('utils.subscription.users_db')

--- a/backend/tests/unit/test_neo_desktop_grandfather.py
+++ b/backend/tests/unit/test_neo_desktop_grandfather.py
@@ -125,8 +125,10 @@ class TestEffectiveDesktopAccessTier:
             cleared_cache_keys.append(key)
 
         monkeypatch.setattr(subscription_mod, 'TRIAL_PAYWALL_ENABLED', True)
-        monkeypatch.setattr(subscription_mod.users_db, 'get_user_valid_subscription', lambda _uid: post_cutoff_neo)
-        monkeypatch.setattr(subscription_mod.users_db, 'is_byok_active', lambda _uid: False)
+        monkeypatch.setattr(
+            subscription_mod.users_db, 'get_user_valid_subscription', lambda _uid, **_kwargs: post_cutoff_neo
+        )
+        monkeypatch.setattr(subscription_mod.users_db, 'is_byok_active', lambda _uid, **_kwargs: False)
         monkeypatch.setattr(subscription_mod, '_request_has_all_byok_keys', lambda: False)
         monkeypatch.setattr(subscription_mod.redis_db, 'get_generic_cache', lambda _key: next(cache_values))
         monkeypatch.setattr(subscription_mod.redis_db, 'set_generic_cache', lambda *_args, **_kwargs: None)

--- a/backend/tests/unit/test_paywall_reconnect_gate.py
+++ b/backend/tests/unit/test_paywall_reconnect_gate.py
@@ -173,7 +173,7 @@ class TestPlatformFiltering:
         assert fn_start != -1
         fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
         filter_pos = fn_body.find('platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS')
-        expiry_pos = fn_body.find('_is_trial_expired_cached(uid)')
+        expiry_pos = fn_body.find('_is_trial_expired_cached(uid')
         assert filter_pos != -1, "is_trial_paywalled must filter non-desktop platforms"
         assert expiry_pos != -1, "is_trial_paywalled must call the cached expiry lookup"
         assert filter_pos < expiry_pos, "platform filtering must happen before the expiry lookup"
@@ -184,7 +184,7 @@ class TestPlatformFiltering:
         assert fn_start != -1
         fn_body = src[fn_start : src.find('\ndef ', fn_start + 1)]
         assert (
-            'return _is_trial_expired_cached(uid)' in fn_body
+            'return _is_trial_expired_cached(uid' in fn_body
         ), "desktop paywall decisions must use the cached expiry lookup"
 
     def test_is_trial_paywalled_uses_lower_for_case_insensitivity(self):
@@ -317,11 +317,13 @@ class TestIsTrialPaywalledBehavioral:
 
     def test_desktop_uid_delegates_to_expiry_cache(self):
         assert self._sub.is_trial_paywalled('uid1', 'desktop') is True
-        self._mock_expired.assert_called_with('uid1')
+        # Routing kwargs (which Firestore client, whether to provision) belong to
+        # the caller; this asserts only that the decision is delegated for this uid.
+        assert self._mock_expired.call_args.args == ('uid1',)
 
     def test_different_desktop_uid_uses_same_expiry_path(self):
         assert self._sub.is_trial_paywalled('uid99', 'desktop') is True
-        self._mock_expired.assert_called_with('uid99')
+        assert self._mock_expired.call_args.args == ('uid99',)
 
     def test_not_expired_returns_false(self):
         self._mock_expired.return_value = False
@@ -457,3 +459,33 @@ class TestByokRequestEscapeHatch:
         )
         meta = self._sub.get_trial_metadata('uid-stale-firestore')
         assert meta.trial_expired is False
+
+
+class TestDesktopTrialGateClientResolution:
+    """`is_desktop_trial_paywalled` reads the customer Firestore, so resolving its
+    client initializes credentials. Decisions that need no Firestore must be made
+    before that: the paywall is off by default, and mobile is never gated.
+    """
+
+    @staticmethod
+    def _subscription_with_exploding_client(monkeypatch):
+        import utils.subscription as sub
+
+        def _explode():
+            raise AssertionError('customer Firestore client resolved without a Firestore decision')
+
+        monkeypatch.setattr(sub, 'get_customer_firestore_client', _explode)
+        return sub
+
+    def test_disabled_paywall_never_resolves_the_customer_client(self, monkeypatch):
+        sub = self._subscription_with_exploding_client(monkeypatch)
+        monkeypatch.setattr(sub, 'TRIAL_PAYWALL_ENABLED', False)
+
+        assert sub.is_desktop_trial_paywalled('uid1', 'desktop') is False
+
+    def test_non_desktop_platform_never_resolves_the_customer_client(self, monkeypatch):
+        sub = self._subscription_with_exploding_client(monkeypatch)
+        monkeypatch.setattr(sub, 'TRIAL_PAYWALL_ENABLED', True)
+
+        assert sub.is_desktop_trial_paywalled('uid1', 'ios') is False
+        assert sub.is_desktop_trial_paywalled('uid1', None) is False

--- a/backend/tests/unit/test_users_add_sample_transaction.py
+++ b/backend/tests/unit/test_users_add_sample_transaction.py
@@ -27,6 +27,9 @@ def users_db():
     client_stub.delete_collection_recursive = MagicMock(name="delete_collection_recursive")
     client_stub.document_id_from_seed = MagicMock(name="document_id_from_seed")
     client_stub.get_firestore_client = MagicMock(name="get_firestore_client", return_value=client_stub.db)
+    client_stub.get_customer_firestore_client = MagicMock(
+        name="get_customer_firestore_client", return_value=client_stub.db
+    )
 
     firestore_stub = ModuleType("google.cloud.firestore")
     google_pkg = ModuleType("google")

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -947,7 +947,16 @@ def enforce_desktop_chat_quota(uid: str, platform: Optional[str] = None) -> None
 
 
 def is_desktop_trial_paywalled(uid: str, platform: Optional[str]) -> bool:
-    """Desktop trial gate against the customer Firestore, never a compute-project shadow."""
+    """Desktop trial gate against the customer Firestore, never a compute-project shadow.
+
+    The decisions that need no Firestore run first: resolving the customer client
+    initializes credentials, so a disabled paywall or a non-desktop platform must
+    neither pay for that nor require ambient ADC to answer "not paywalled".
+    """
+    if not TRIAL_PAYWALL_ENABLED:
+        return False
+    if not platform or platform.lower() not in _TRIAL_PAYWALL_DESKTOP_TOKENS:
+        return False
     return is_trial_paywalled(
         uid,
         platform,


### PR DESCRIPTION
## Bug

`Backend Unit Tests` has been red on `main` since `0a8d0ffe98` (#11522) — 9 unit files fail ([run 31753492154](https://github.com/BasedHardware/omi/actions/runs/31753492154)). The lane is path-filtered on `backend/**`, so the desktop-only commits merged after it (`00cc9ed9`, `6083f7de`) never re-ran it and the red state is still live. Filed as #11531. Reproduced locally at `6083f7de58` with the CI runner: same 9 files.

## Root cause

#11522 added `from database._client import get_customer_firestore_client` to `utils/subscription.py` plus `firestore_client=` / `provision=` routing kwargs on the entitlement lookups. Three distinct consequences:

1. **Import-isolation stubs don't export the new symbol** — `memory_import_isolation.make_database_client_stub` and the file-local stub in `test_users_add_sample_transaction` build a synthetic `database._client` with `get_firestore_client` only, so importing `database.users` → `utils.subscription` raises `ImportError: cannot import name 'get_customer_firestore_client' from 'database._client' (unknown location)` at fixture setup (5 files).
2. **Tests pin the old call shapes** — `test_byok_security`, `test_paywall_reconnect_gate`, `test_neo_desktop_grandfather` (3 files). In the last one the resulting `TypeError` is swallowed by the fail-open `except` in `_is_trial_expired_cached`, so it surfaced one step downstream as a missing cache clear.
3. **`is_desktop_trial_paywalled` resolves the customer client before the guards that make it unnecessary** — argument evaluation calls `get_customer_firestore_client()` first, even though `TRIAL_PAYWALL_ENABLED` defaults to `false` and mobile is never gated. Any environment without ambient ADC gets an exception out of `/v1/screen-activity/sync` instead of "not paywalled"; CI saw `BlockedNetworkError: Blocked outbound network connection to ('169.254.169.254', 80)` in `test_desktop_screen_crisp`. These routes did no credential work here before #11522.

## Fix

- `is_desktop_trial_paywalled` applies the Firestore-free guards (paywall enabled, desktop platform) before resolving the customer client — production behavior is unchanged when the gate does apply.
- Both `database._client` stubs export `get_customer_firestore_client`.
- The pinned assertions now assert the delegation (callee + uid) instead of the caller's routing kwargs.
- New regression coverage: `TestDesktopTrialGateClientResolution` fails if the desktop gate resolves the customer client when the paywall is off or the platform is mobile.

## Verified

- `BACKEND_UNIT_TEST_FILE_LIST=<the 9 CI failures> bash test.sh` → **216 passed, exit 0**. The identical command on `main` at `6083f7de58` fails all 9 files.
- Real route, credentials unavailable (`_build_customer_firestore_client` raising): `POST /v1/screen-activity/sync` through the real router returns **200 `{"synced":1,"last_id":7}`**; on the parent commit the same request raises `RuntimeError` out of the admission gate.
- Full `backend/test.sh` locally.

## Failure class

New class `FC-credentialed-dependency-resolved-before-guard`, added in this PR: a caller resolved a credentialed dependency in argument position, ahead of the guards that decide the answer without it. Guard artifact: `backend/tests/unit/test_paywall_reconnect_gate.py::TestDesktopTrialGateClientResolution`. The test-repair commit declares `none`.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

