### PR TITLE
fix(desktop): do not turn other people's commitments into the user's tasks

### DIFF
--- a/.github/failure-classes/FC-task-candidate-unowned-commitment.json
+++ b/.github/failure-classes/FC-task-candidate-unowned-commitment.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-task-candidate-unowned-commitment",
+  "violated_contract": "A durable user-surface action may be gated on the existence of a commitment only when that commitment is the user's own. task_candidate graduates into the user's task list and presents an interactive interruption; a third-party commitment, however explicit or dated, must not satisfy that gate.",
+  "canonical_prevention": "State first-person ownership as an explicit precondition of task_candidate in the director prompt, keep the third-party insight-or-silence rule beside it, and retain a full-equality prompt-contract test that includes both sentences.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift"
+  ],
+  "evidence_prs": [
+    11536
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift",
+    "desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -181,10 +181,14 @@ enum ContextProactivityPromptBuilder {
       Use resurface or suggest for an actionable open task supplied below. Entries marked
       reference-only are identity context: do not notify about or recreate them yet. Use
       task_candidate only when a validated fact explicitly records a new commitment, promise,
-      or request with an accountable action, and that commitment is absent from the supplied
-      task list. A material change, status update, recommendation, or useful follow-up without
-      an explicit commitment, promise, or request is insight or suggest; never infer an owner or
-      due date and never create a task candidate from actionability alone.
+      or request with an accountable action that the user personally made or accepted (first
+      person), and that commitment is absent from the supplied task list. A commitment made by
+      another person is never a task candidate, however explicit or well-dated it is; if it
+      genuinely bears on the user's tracked work it may at most be insight, and a commitment
+      between other parties that does not involve the user is silence. A material change, status
+      update, recommendation, or useful follow-up without an explicit commitment, promise, or
+      request is insight or suggest; never infer an owner or due date and never create a task
+      candidate from actionability alone.
 
       \(stableBucket)
       """

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -64,13 +64,19 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       ScreenDerivedContent.untrustedPreamble,
       "Decide whether interrupting now adds concrete value. Return silence unless the validated",
       "facts support a specific, timely action. Use only supplied bucket-entry refs.",
+      "Never announce that meeting notes, a transcript, or a call summary are ready. The",
+      "conversation-finalization lane owns that claim and attaches the exact conversation link.",
       "Use resurface or suggest for an actionable open task supplied below. Entries marked",
       "reference-only are identity context: do not notify about or recreate them yet. Use",
       "task_candidate only when a validated fact explicitly records a new commitment, promise,",
-      "or request with an accountable action, and that commitment is absent from the supplied",
-      "task list. A material change, status update, recommendation, or useful follow-up without",
-      "an explicit commitment, promise, or request is insight or suggest; never infer an owner or",
-      "due date and never create a task candidate from actionability alone.",
+      "or request with an accountable action that the user personally made or accepted (first",
+      "person), and that commitment is absent from the supplied task list. A commitment made by",
+      "another person is never a task candidate, however explicit or well-dated it is; if it",
+      "genuinely bears on the user's tracked work it may at most be insight, and a commitment",
+      "between other parties that does not involve the user is silence. A material change, status",
+      "update, recommendation, or useful follow-up without an explicit commitment, promise, or",
+      "request is insight or suggest; never infer an owner or due date and never create a task",
+      "candidate from actionability alone.",
       "",
       bucket,
       "",
@@ -88,6 +94,26 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertTrue(prompt.contains("== FROZEN RANKED CONTEXT ==\nfrozen:entry-1"))
     XCTAssertTrue(prompt.contains("== RECENT TAIL ==\ntail:entry-2"))
     XCTAssertTrue(prompt.contains("== VALIDATED FACTS ==\nfact:PR-123"))
+  }
+
+  func testDirectorStablePromptRequiresFirstPersonOwnershipForTaskCandidate() {
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket", versionID: 1, version: 1, header: "header",
+      frozenRankedSegment: Data(), tail: [], validatedFacts: ["fact"], notifyWorthiness: 1)
+    let prompt = ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot)
+
+    XCTAssertTrue(
+      prompt.contains(
+        "or request with an accountable action that the user personally made or accepted (first"))
+    XCTAssertTrue(
+      prompt.contains(
+        "another person is never a task candidate, however explicit or well-dated it is"))
+    XCTAssertTrue(
+      prompt.contains(
+        "genuinely bears on the user's tracked work it may at most be insight"))
+    XCTAssertTrue(
+      prompt.contains(
+        "between other parties that does not involve the user is silence."))
   }
 
   func testDirectorTaskContextBoundsDescription() {

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -96,26 +96,6 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertTrue(prompt.contains("== VALIDATED FACTS ==\nfact:PR-123"))
   }
 
-  func testDirectorStablePromptRequiresFirstPersonOwnershipForTaskCandidate() {
-    let snapshot = ContextBucketSnapshot(
-      bucketID: "bucket", versionID: 1, version: 1, header: "header",
-      frozenRankedSegment: Data(), tail: [], validatedFacts: ["fact"], notifyWorthiness: 1)
-    let prompt = ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot)
-
-    XCTAssertTrue(
-      prompt.contains(
-        "or request with an accountable action that the user personally made or accepted (first"))
-    XCTAssertTrue(
-      prompt.contains(
-        "another person is never a task candidate, however explicit or well-dated it is"))
-    XCTAssertTrue(
-      prompt.contains(
-        "genuinely bears on the user's tracked work it may at most be insight"))
-    XCTAssertTrue(
-      prompt.contains(
-        "between other parties that does not involve the user is silence."))
-  }
-
   func testDirectorTaskContextBoundsDescription() {
     let task = ContextDirectorTaskContext(
       description: String(repeating: "x", count: ContextDirectorTaskContext.maximumDescriptionLength + 10),

--- a/desktop/macos/changelog/unreleased/20260813-director-first-person-task-candidates.json
+++ b/desktop/macos/changelog/unreleased/20260813-director-first-person-task-candidates.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped turning other people's commitments into your tasks"
+}


### PR DESCRIPTION
## What changed and why

The context director used `task_candidate` whenever a validated fact recorded an explicit commitment that was absent from the task list. It never required that commitment to be the user's own, so other people's obligations became interactive interruptions and durable entries on the user's task surface.

Tightened `ContextProactivityPromptBuilder.directorStablePrompt` so `task_candidate` requires a first-person commitment the user made or accepted. A third-party commitment that bears on the user's tracked work may at most be `insight`; a commitment between other parties is `silence`. Decision semantics, schema, grounding rules, and delivery gates are unchanged.

## Prompt sentence being tightened

Before:

> Use task_candidate only when a validated fact explicitly records a new commitment, promise, or request with an accountable action, and that commitment is absent from the supplied task list. ... never infer an owner or due date ...

"Never infer an owner" was read as "don't invent an owner", not as "only act on the user's commitments". An explicit third-party commitment satisfied every stated condition.

After (ownership precondition plus third-party rule, existing constraints kept):

> Use task_candidate only when a validated fact explicitly records a new commitment, promise, or request with an accountable action that the user personally made or accepted (first person), and that commitment is absent from the supplied task list. A commitment made by another person is never a task candidate, however explicit or well-dated it is; if it genuinely bears on the user's tracked work it may at most be insight, and a commitment between other parties that does not involve the user is silence.

## Reproduced against gpt-5.6-luna (`probe_context_bucket_director`, faithful snapshot wire format)

**Third party commits to a third party.** Fact: *"Dmitri Vance committed to publish the adapter rollback runbook by Friday."* Director returned `task_candidate`, title *"Track rollback runbook publication"*, message *"Dmitri committed to publish the adapter rollback runbook by Friday. Add this as an open task..."*, reasoning *"The validated thread records an explicit commitment with a deadline, and no corresponding task appears in the open task list."*

**Third party owes the user.** Fact: *"Rina Okonkwo committed to send the updated pricing table tomorrow."* Director returned `task_candidate`, *"Track pricing table delivery"*, message *"Rina Okonkwo committed to send the updated pricing table tomorrow... Consider tracking this as an open follow-up."*

**Third party, different domain, user absent from the thread.** Fact: *"Priya Raman committed to return the signed DPA to the Helio team by Wednesday."* Director returned `task_candidate`, title *"Follow up on overdue signed DPA"*, message *"Priya committed to return the signed DPA by Wednesday, which has passed as of Aug 14. Follow up with Priya or the Helio team on the outstanding DPA."*

**Control cases in the same run behaved correctly**, so this is ownership-specific, not general over-firing: a first-person commitment ("You replied that you will post the cutover plan by tomorrow morning") correctly produced `task_candidate`; the same commitment already present in the task list produced `resurface`; an already-fulfilled first-person commitment produced `silence`; a >48h "reference only" task produced `silence`; injected instruction-shaped screen text produced `silence`.

## Stale prompt-contract test (already red on main)

`testDirectorPromptContainsSafetyPreambleBucketTasksAndFrameMetadata` is a full-equality contract. It has been failing since `8fda810a1e` ("fix: link meeting notes from always-on capture (#11468)") added the two meeting-notes lines to `directorStablePrompt` and did not update the expected string. This PR brings the expected string back in line with the real prompt (those two lines plus the new ownership sentences). It does not weaken `XCTAssertEqual` into a `contains` check.

The desktop Swift test lane **does run this test**. `swift-test-suites.sh` auto-discovers every `XCTestCase` under `Desktop/Tests/`; `ContextBucketPromptAssemblerTests` is not in the skip ratchet. Changing `ContextBucketRollup.swift` selects `desktop-swift-tests`. After #11468 merged, the main-push `Desktop Swift Build & Tests` run executed this suite (14 tests) and failed on exactly `testDirectorPromptContainsSafetyPreambleBucketTasksAndFrameMetadata` (`https://github.com/BasedHardware/omi/actions/runs/31734789303`). The red equality test reached `main` because #11468 merged while that required check was red / completed after merge, not because CI omits the suite.

## Product invariants affected

none

## How it was verified

- Source and test expected instruction lines match 1:1 (Python line diff of `directorStablePrompt` vs the equality fixture): MATCH, 15/15 lines.
- `python3 scripts/check_desktop_test_quality.py`: OK, debt at or below baseline.
- `./scripts/dev-feedback.py --once swift 'ContextBucketPromptAssemblerTests'`: compile blocked only by the known pre-existing `RewindPage.swift:153` type-check timeout on this machine's Xcode 26.2 / Swift 6.2.3. CI pins Xcode 16.4 and is unaffected. Pushed with `PRE_PUSH_SKIP_DESKTOP_SWIFT=1` for that unrelated file only.
- Could not re-run the live `probe_context_bucket_director` dogfood on this toolchain for the same `RewindPage.swift` compile block. The production prompt string is what the probe sends; the equality test is the hermetic guard. Original dogfood against gpt-5.6-luna is quoted above.

## Tests

- Restored and extended `testDirectorPromptContainsSafetyPreambleBucketTasksAndFrameMetadata` (full prompt equality, including the #11468 meeting-notes lines and the new ownership sentences).
- Added `testDirectorStablePromptRequiresFirstPersonOwnershipForTaskCandidate`, which calls `directorStablePrompt` and asserts the first-person precondition and third-party insight/silence rule.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

**Violated contract:** a durable user-surface action (`task_candidate` graduation into the user's task list, plus an interactive interruption) was gated on the existence of a commitment but not on who owns it.

**Canonical prevention:** state first-person ownership as an explicit `task_candidate` precondition in the director prompt, keep the third-party insight-or-silence rule beside it, and retain a full-equality prompt-contract test that includes both sentences.

**Evidence:** the three gpt-5.6-luna reproductions above. Registry file: `.github/failure-classes/FC-task-candidate-unowned-commitment.json`. Guard artifact: `desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift`.

## New guards

The prompt-contract test is the existing production-API equality guard for this prompt, not a new shared primitive. It is the check that would have caught both the #11468 expected-string drift and a future drop of the ownership sentences. A model-eval / shadow-scoring gate is deliberately not added.

🤖 Generated with Cursor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

