### PR TITLE
fix(desktop): split RewindPage.body so Swift 6.2 can type-check it

### DIFF
--- a/.github/failure-classes/FC-swiftui-body-typecheck-timeout.json
+++ b/.github/failure-classes/FC-swiftui-body-typecheck-timeout.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-swiftui-body-typecheck-timeout",
+  "violated_contract": "A SwiftUI View.body that compiles on CI's pinned Xcode must also compile on the current maintainer local toolchain. A single modifier chain the Swift 6.2 type checker cannot solve in reasonable time blocks every local named-bundle QA path while CI stays green.",
+  "canonical_prevention": "Break the failing body into named some View sub-expressions and extract Combine publishers from the SwiftUI modifier chain so each expression type-checks independently, preserving original modifier order.",
+  "evidence_prs": [
+    11536
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/**/*.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -151,6 +151,16 @@ struct RewindPage: View {
   }
 
   var body: some View {
+    keyboardHandledContent
+  }
+
+  // MARK: - Page modifier groups
+  //
+  // `body` used to be one ~15-modifier chain. Swift 6.2 cannot type-check that expression in
+  // reasonable time (Xcode 26.2). Each helper below is a distinct sub-expression; modifier order
+  // matches the original chain and is semantically significant.
+
+  private var chromeContent: some View {
     pageContent
       .glassContent()
       // The page answers arrow keys wherever the pointer is, so it holds keyboard focus itself. The
@@ -159,6 +169,10 @@ struct RewindPage: View {
       // window with no visible extent is a blue rectangle on the wallpaper. See
       // `shellPageKeyboardTarget`.
       .shellPageKeyboardTarget($isPageFocused)
+  }
+
+  private var lifecycleAttachedContent: some View {
+    chromeContent
       .task {
         await viewModel.loadInitialData()
         await resolveCitationFocusIfNeeded()
@@ -168,6 +182,10 @@ struct RewindPage: View {
         screenCaptureHealth = ProactiveAssistantsPlugin.shared.screenCaptureHealth
         isPageFocused = true
       }
+  }
+
+  private var monitoringNotificationContent: some View {
+    lifecycleAttachedContent
       .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { _ in
         let pluginState = ProactiveAssistantsPlugin.shared.isMonitoring
         let state = RewindCaptureState.afterMonitoringChange(
@@ -181,6 +199,10 @@ struct RewindPage: View {
       .onReceive(NotificationCenter.default.publisher(for: .rewindCitationFocusRequested)) { _ in
         Task { await resolveCitationFocusIfNeeded() }
       }
+  }
+
+  private var notificationObservedContent: some View {
+    monitoringNotificationContent
       .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
         // RewindPage itself owns the decoded NSImage and frame-load task. Clearing
         // only the view model would leave the previous owner's last frame visible
@@ -199,6 +221,10 @@ struct RewindPage: View {
           isTranscriptExpanded = true
         }
       }
+  }
+
+  private var focusObservedContent: some View {
+    notificationObservedContent
       .onChange(of: isSearchFocused) { _, focused in
         if !focused {
           isPageFocused = true
@@ -207,6 +233,10 @@ struct RewindPage: View {
       .onChange(of: isTranscriptExpanded) { _, expanded in
         viewModel.isTranscriptExpanded = expanded
       }
+  }
+
+  private var screenshotObservedContent: some View {
+    focusObservedContent
       .onChange(of: viewModel.screenshots) { oldScreenshots, newScreenshots in
         // Try to preserve position on the same screenshot the user was viewing
         if !oldScreenshots.isEmpty,
@@ -230,10 +260,18 @@ struct RewindPage: View {
           scheduleLoadCurrentFrame()
         }
       }
-      .onReceive(
-        trackWindow.$start.combineLatest(trackWindow.$span)
-          .debounce(for: .milliseconds(120), scheduler: DispatchQueue.main)
-      ) { start, span in
+  }
+
+  /// Debounced track-window range, extracted so Combine's `combineLatest`/`debounce` overloads are
+  /// not solved inside the SwiftUI modifier chain.
+  private var trackWindowRangePublisher: some Publisher<(Double, Double), Never> {
+    trackWindow.$start.combineLatest(trackWindow.$span)
+      .debounce(for: .milliseconds(120), scheduler: DispatchQueue.main)
+  }
+
+  private var viewModelObservedContent: some View {
+    screenshotObservedContent
+      .onReceive(trackWindowRangePublisher) { start, span in
         guard span > 0, viewModel.activeSearchQuery == nil else { return }
         Task { await viewModel.loadTimelineWindow(from: start, to: start + span) }
       }
@@ -254,6 +292,10 @@ struct RewindPage: View {
           scheduleLoadCurrentFrame()
         }
       }
+  }
+
+  private var escapeHandledContent: some View {
+    viewModelObservedContent
       // Global keyboard handlers
       .onEscapeKey {
         // Expanded transcript → collapse
@@ -279,6 +321,10 @@ struct RewindPage: View {
         }
         return false
       }
+  }
+
+  private var timelineArrowHandledContent: some View {
+    escapeHandledContent
       .onKeyPress(.leftArrow) {
         // Arrow keys only work in timeline mode
         // Left = older = lower index (ASC order: oldest first)
@@ -296,6 +342,10 @@ struct RewindPage: View {
         }
         return .ignored
       }
+  }
+
+  private var keyboardHandledContent: some View {
+    timelineArrowHandledContent
       .onKeyPress(.upArrow) {
         // Up/down navigate search result groups
         if searchViewMode == .results {

--- a/desktop/macos/changelog/unreleased/20260813-rewind-page-typecheck.json
+++ b/desktop/macos/changelog/unreleased/20260813-rewind-page-typecheck.json
@@ -1,0 +1,3 @@
+{
+  "change": "Internal: split the Rewind page view body into smaller sub-expressions so it compiles on newer Swift toolchains; no change to how Rewind looks or behaves"
+}


### PR DESCRIPTION
## What

`RewindPage.body` was a single ~15-modifier chain. On the current maintainer-local toolchain it does not compile:

```
desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift:153:23: error: the compiler is unable to
type-check this expression in reasonable time; try breaking up the expression into distinct
sub-expressions
```

Toolchain: Xcode 26.2 (build 17C52), Apple Swift 6.2.3 (swiftlang-6.2.3.3.21), target `arm64-apple-macosx26.0`.

This reproduces on **unmodified `origin/main`** (verified at `6083f7de58` in a clean detached worktree before any edit) — it is not caused by recent feature work. CI pins Xcode 16.4, so the release lane is green and structurally cannot observe this.

**Impact:** `./run.sh` cannot build any local named QA bundle from `main` on this toolchain, so every local desktop dogfooding and QA path is blocked. This was found while trying to build a bundle to dogfood the context-bucket proactive pipeline.

## Change

`body` is now `keyboardHandledContent`, and the original chain is split into named `some View` helpers applied in the same order: `chromeContent` → `lifecycleAttachedContent` → notification-observer groups → view-model-observer groups → keyboard-handler groups. The track-window Combine chain is extracted to `trackWindowRangePublisher` so `combineLatest`/`debounce` overloads are no longer solved inside the SwiftUI modifier chain.

Behavior is unchanged:

- 43 view modifiers before, 43 after, in the same applied order. (`.debounce` moves earlier in *file text* only, because the publisher is now a computed property declared above its use; `.onReceive(trackWindowRangePublisher)` keeps its exact position in the chain, still followed by `.onChange(of: viewModel.activeSearchQuery)`.)
- No closure body was edited, no observer added or removed.
- Comments moved with the modifiers they explain, including the focus-ring rationale, the owner-change frame-invalidation note, and the preserve-position note.

## Verification

Local debug build with the toolchain that previously failed:

```
cd desktop/macos && xcrun swift build -c debug --package-path Desktop
```

succeeds, producing `.build/debug/Omi Computer` (238 MB). No `RewindPage.body` type-check warning remains.

Not claimed: this PR was not exercised at runtime. It is a compile-time restructuring with no behavior change, and the app was not launched from this build.

## Line-Count-Exception

Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift | 1493 -> 1543 | Splitting one oversized type-check expression into named sub-expressions necessarily adds declaration lines. Moving the helpers to a separate file would force the `private` state they read (`isPageFocused`, `currentImage`, `searchViewMode`, the view model) to widen to internal across the module, which trades a local line count for a wider API surface.

Failure-Class: new

🤖 Generated with Cursor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

