### PR TITLE
fix(desktop): scope proactive-lane quota cooldown per operation

### DIFF
--- a/.github/failure-classes/FC-shared-backoff-conflated-independent-budgets.json
+++ b/.github/failure-classes/FC-shared-backoff-conflated-independent-budgets.json
@@ -8,7 +8,7 @@
     "desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift"
   ],
   "evidence_prs": [
-    11527
+    11538
   ],
   "scope_hints": [
     "desktop/macos/Desktop/Sources/ProactiveAssistants/**"

--- a/.github/failure-classes/FC-shared-backoff-conflated-independent-budgets.json
+++ b/.github/failure-classes/FC-shared-backoff-conflated-independent-budgets.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-shared-backoff-conflated-independent-budgets",
+  "violated_contract": "A client-side cooldown that backs off from a server quota must be keyed to the same identity the server uses to reserve that quota. Sharing one process-wide deadline across independently governed operations converts a partial exhaustion into a total outage of unrelated lanes.",
+  "canonical_prevention": "Key the cooldown by the operation string the server reserves, clamp Retry-After into a closed [60s, 3600s] range so the lane re-checks within an hour, and record self-suppressed attempts as quota_cooldown rather than http_error.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift",
+    "desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift"
+  ],
+  "evidence_prs": [
+    11527
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -641,10 +641,14 @@ actor ContextBucketRollupWriter {
         normalizedContextKey: ContextTitleNormalizer.identityKey(
           appName: frame.appName, windowTitle: frame.windowTitle) ?? "")
     } catch {
-      if case .http(let status, _) = error as? ProactiveLaneClientError, status == 429 {
+      switch error as? ProactiveLaneClientError {
+      case .http(let status, _) where status == 429:
         return
+      case .quotaCooldown(_):
+        return
+      default:
+        log("Context bucket extraction failed silently: \(error.localizedDescription)")
       }
-      log("Context bucket extraction failed silently: \(error.localizedDescription)")
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -127,6 +127,7 @@ actor ProactiveLaneClient {
   private var quotaCooldownUntil: [String: Date] = [:]
   private var loggedQuotaSkip: Set<String> = []
   private var loggedQuotaClamp: Set<String> = []
+  private var cooldownOwner: String?
 
   init(
     session: URLSession = .shared,
@@ -154,6 +155,8 @@ actor ProactiveLaneClient {
     maxCompletionTokens: Int = 1024,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> ProactiveLaneResult {
+    let currentOwner = authorizationSnapshot?.ownerID
+    clearCooldownsIfOwnerChanged(currentOwner)
     try checkQuotaCooldown(operation: operation)
     if let authorizationSnapshot {
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
@@ -223,6 +226,16 @@ actor ProactiveLaneClient {
     return try Self.parseEnvelope(data)
   }
 
+  private func clearCooldownsIfOwnerChanged(_ owner: String?) {
+    guard cooldownOwner != owner else { return }
+    cooldownOwner = owner
+    guard !quotaCooldownUntil.isEmpty || !loggedQuotaSkip.isEmpty || !loggedQuotaClamp.isEmpty else { return }
+    quotaCooldownUntil.removeAll()
+    loggedQuotaSkip.removeAll()
+    loggedQuotaClamp.removeAll()
+    log("Proactive lane cooldowns cleared: owner changed")
+  }
+
   private func checkQuotaCooldown(operation: String) throws {
     guard let until = quotaCooldownUntil[operation] else { return }
     let current = now()
@@ -243,7 +256,11 @@ actor ProactiveLaneClient {
   private func armQuotaCooldown(operation: String, retryAfterSeconds: Int?) {
     let requested = retryAfterSeconds.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultQuotaCooldownSeconds
     let delay = min(max(requested, Self.minQuotaCooldownSeconds), Self.maxQuotaCooldownSeconds)
-    quotaCooldownUntil[operation] = now().addingTimeInterval(TimeInterval(delay))
+    let newDeadline = now().addingTimeInterval(TimeInterval(delay))
+    if let existing = quotaCooldownUntil[operation], existing > newDeadline {
+      return
+    }
+    quotaCooldownUntil[operation] = newDeadline
     loggedQuotaSkip.remove(operation)
     if delay != requested, !loggedQuotaClamp.contains(operation) {
       loggedQuotaClamp.insert(operation)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -18,6 +18,7 @@ struct ProactiveLaneResult: Equatable, Sendable {
 enum ProactiveLaneClientError: LocalizedError {
   case invalidResponse
   case http(status: Int, retryAfterSeconds: Int?)
+  case quotaCooldown(retryAfterSeconds: Int)
   case ownerChanged
 
   var errorDescription: String? {
@@ -26,6 +27,8 @@ enum ProactiveLaneClientError: LocalizedError {
       return "proactive_invalid_response"
     case .http(let statusCode, _):
       return "proactive_http_error status=\(statusCode)"
+    case .quotaCooldown(_):
+      return "proactive_quota_cooldown status=429"
     case .ownerChanged:
       return "proactive_owner_changed"
     }
@@ -59,6 +62,8 @@ struct ProactiveLaneFailureClassification: Equatable, Sendable {
     switch failure {
     case "http_error":
       return "http_error status=\(status ?? 0)"
+    case "quota_cooldown":
+      return "quota_cooldown status=\(status ?? 0)"
     case "network":
       return "network error_type=\(errorType ?? "unknown")"
     default:
@@ -71,6 +76,8 @@ struct ProactiveLaneFailureClassification: Equatable, Sendable {
       switch laneError {
       case .http(let status, _):
         return ProactiveLaneFailureClassification(failure: "http_error", status: status, errorType: nil)
+      case .quotaCooldown(_):
+        return ProactiveLaneFailureClassification(failure: "quota_cooldown", status: 429, errorType: nil)
       case .invalidResponse:
         return ProactiveLaneFailureClassification(failure: "invalid_response", status: nil, errorType: nil)
       case .ownerChanged:
@@ -111,12 +118,15 @@ actor ProactiveLaneClient {
   static let shared = ProactiveLaneClient()
   static var backendBaseURL: String { DesktopBackendEnvironment.rustBackendURL() }
   static let defaultQuotaCooldownSeconds = 10 * 60
+  static let minQuotaCooldownSeconds = 60
+  static let maxQuotaCooldownSeconds = 60 * 60
   private let session: URLSession
   private let baseURL: () -> String
   private let authorization: () async throws -> String
   private let now: @Sendable () -> Date
-  private var quotaCooldownUntil: Date?
-  private var loggedQuotaSkip = false
+  private var quotaCooldownUntil: [String: Date] = [:]
+  private var loggedQuotaSkip: Set<String> = []
+  private var loggedQuotaClamp: Set<String> = []
 
   init(
     session: URLSession = .shared,
@@ -144,7 +154,7 @@ actor ProactiveLaneClient {
     maxCompletionTokens: Int = 1024,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) async throws -> ProactiveLaneResult {
-    try checkQuotaCooldown()
+    try checkQuotaCooldown(operation: operation)
     if let authorizationSnapshot {
       guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
         throw ProactiveLaneClientError.ownerChanged
@@ -204,7 +214,7 @@ actor ProactiveLaneClient {
       let retryAfter: Int?
       if http.statusCode == 429 {
         retryAfter = Self.parseRetryAfterSeconds(from: http)
-        armQuotaCooldown(retryAfterSeconds: retryAfter)
+        armQuotaCooldown(operation: operation, retryAfterSeconds: retryAfter)
       } else {
         retryAfter = nil
       }
@@ -213,26 +223,32 @@ actor ProactiveLaneClient {
     return try Self.parseEnvelope(data)
   }
 
-  private func checkQuotaCooldown() throws {
-    guard let until = quotaCooldownUntil else { return }
+  private func checkQuotaCooldown(operation: String) throws {
+    guard let until = quotaCooldownUntil[operation] else { return }
     let current = now()
     if current >= until {
-      quotaCooldownUntil = nil
-      loggedQuotaSkip = false
+      quotaCooldownUntil[operation] = nil
+      loggedQuotaSkip.remove(operation)
+      loggedQuotaClamp.remove(operation)
       return
     }
-    if !loggedQuotaSkip {
-      loggedQuotaSkip = true
-      log("Proactive lane skipped: quota_cooldown")
+    if !loggedQuotaSkip.contains(operation) {
+      loggedQuotaSkip.insert(operation)
+      log("Proactive lane skipped: quota_cooldown operation=\(operation)")
     }
     let remaining = max(1, Int(ceil(until.timeIntervalSince(current))))
-    throw ProactiveLaneClientError.http(status: 429, retryAfterSeconds: remaining)
+    throw ProactiveLaneClientError.quotaCooldown(retryAfterSeconds: remaining)
   }
 
-  private func armQuotaCooldown(retryAfterSeconds: Int?) {
-    let delay = retryAfterSeconds.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultQuotaCooldownSeconds
-    quotaCooldownUntil = now().addingTimeInterval(TimeInterval(delay))
-    loggedQuotaSkip = false
+  private func armQuotaCooldown(operation: String, retryAfterSeconds: Int?) {
+    let requested = retryAfterSeconds.flatMap { $0 > 0 ? $0 : nil } ?? Self.defaultQuotaCooldownSeconds
+    let delay = min(max(requested, Self.minQuotaCooldownSeconds), Self.maxQuotaCooldownSeconds)
+    quotaCooldownUntil[operation] = now().addingTimeInterval(TimeInterval(delay))
+    loggedQuotaSkip.remove(operation)
+    if delay != requested, !loggedQuotaClamp.contains(operation) {
+      loggedQuotaClamp.insert(operation)
+      log("Proactive lane quota cooldown clamped: operation=\(operation) duration=\(delay)")
+    }
   }
 
   static func parseRetryAfterSeconds(from response: HTTPURLResponse) -> Int? {

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -238,6 +238,23 @@ final class ContextProactivityEngineTests: XCTestCase {
     XCTAssertNil(json["error_type"])
   }
 
+  func testQuotaCooldownIsADistinctProvenanceClassFromHttp429() throws {
+    let skipped = ProactiveLaneFailureClassification.classify(
+      ProactiveLaneClientError.quotaCooldown(retryAfterSeconds: 12))
+    XCTAssertEqual(skipped.failure, "quota_cooldown")
+    XCTAssertEqual(skipped.status, 429)
+    XCTAssertEqual(skipped.logDescription, "quota_cooldown status=429")
+    let json = try provenanceObject(skipped.provenanceJSON)
+    XCTAssertEqual(json["failure"] as? String, "quota_cooldown")
+    XCTAssertEqual((json["status"] as? NSNumber)?.intValue, 429)
+    XCTAssertNil(json["error_type"])
+
+    let http = ProactiveLaneFailureClassification.classify(
+      ProactiveLaneClientError.http(status: 429, retryAfterSeconds: 12))
+    XCTAssertNotEqual(skipped.failure, http.failure)
+    XCTAssertEqual(try provenanceObject(http.provenanceJSON)["failure"] as? String, "http_error")
+  }
+
   func testDecisionDecodeFailureRecordsADistinctClassFromHttpFailure() throws {
     let http = ProactiveLaneFailureClassification.classify(
       ProactiveLaneClientError.http(status: 429, retryAfterSeconds: nil))
@@ -406,6 +423,26 @@ final class ContextProactivityDirectorFailureTests: XCTestCase {
     let provenance = try provenanceObject(try XCTUnwrap(row["provenanceJson"] as String?))
     XCTAssertEqual(provenance["failure"] as? String, "http_error")
     XCTAssertEqual((provenance["status"] as? NSNumber)?.intValue, 429)
+  }
+
+  func testEngineRecordsQuotaCooldownProvenanceOnSelfSuppressedLaneError() async throws {
+    let deliveryID = try await seedAttemptedDelivery()
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: .shared,
+      dwellNanoseconds: 0)
+
+    await engine.recordDirectorFailure(
+      deliveryID: deliveryID,
+      error: ProactiveLaneClientError.quotaCooldown(retryAfterSeconds: 30))
+
+    let row = try await fetchDelivery(id: deliveryID)
+    XCTAssertEqual(row["lifecycleState"] as String?, "failed")
+    XCTAssertEqual(row["decisionType"] as String?, "silence")
+    let provenance = try provenanceObject(try XCTUnwrap(row["provenanceJson"] as String?))
+    XCTAssertEqual(provenance["failure"] as? String, "quota_cooldown")
+    XCTAssertEqual((provenance["status"] as? NSNumber)?.intValue, 429)
+    XCTAssertNil(provenance["error_type"])
   }
 
   func testEngineRecordsDecodeProvenanceDistinctFromHttpError() async throws {

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -30,6 +30,9 @@ final class ProactiveLaneClientTests: XCTestCase {
       ProactiveLaneClientError.http(status: 429, retryAfterSeconds: nil).localizedDescription,
       "proactive_http_error status=429")
     XCTAssertEqual(ProactiveLaneClientError.ownerChanged.localizedDescription, "proactive_owner_changed")
+    XCTAssertEqual(
+      ProactiveLaneClientError.quotaCooldown(retryAfterSeconds: 12).localizedDescription,
+      "proactive_quota_cooldown status=429")
   }
 
   func testGarbageEnvelopeThrowsInvalidResponseNotARawSerializationError() {
@@ -66,14 +69,14 @@ final class ProactiveLaneClientTests: XCTestCase {
     ProactiveLaneURLStub.enqueue(
       statusCode: 429,
       body: Data(#"{"detail":"Proactive request limit exceeded"}"#.utf8),
-      headers: ["Retry-After": "30"])
+      headers: ["Retry-After": "120"])
 
     do {
       _ = try await completeExtraction(on: client)
       XCTFail("expected the first extraction attempt to throw 429")
     } catch ProactiveLaneClientError.http(let status, let retryAfter) {
       XCTAssertEqual(status, 429)
-      XCTAssertEqual(retryAfter, 30)
+      XCTAssertEqual(retryAfter, 120)
     }
     XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
 
@@ -81,26 +84,17 @@ final class ProactiveLaneClientTests: XCTestCase {
     do {
       _ = try await completeExtraction(on: client)
       XCTFail("expected the in-window extraction attempt to skip the network")
-    } catch ProactiveLaneClientError.http(let status, let retryAfter) {
-      XCTAssertEqual(status, 429)
-      XCTAssertEqual(retryAfter, 20)
+    } catch ProactiveLaneClientError.quotaCooldown(let retryAfter) {
+      XCTAssertEqual(retryAfter, 110)
     }
     XCTAssertEqual(
       ProactiveLaneURLStub.requestCount, 1,
       "an extraction attempt before Retry-After must not hit the network")
 
-    clock.advance(by: 21)
+    clock.advance(by: 111)
     ProactiveLaneURLStub.enqueue(
       statusCode: 200,
-      body: try JSONSerialization.data(withJSONObject: [
-        "operation": ModelQoS.Proactivity.extractionOperation,
-        "lane": "omi:auto:desktop-proactive-extraction",
-        "provider_model": "gpt-5.6-luna",
-        "usage": ["cached_tokens": 0, "cache_write_tokens": 0],
-        "cache_write": false,
-        "fallback_class": "unknown",
-        "response": ["choices": [["message": ["content": "{\"narrative\":\"ok\",\"facts\":[]}"]]]],
-      ]))
+      body: try successEnvelope(operation: ModelQoS.Proactivity.extractionOperation))
 
     let result = try await completeExtraction(on: client)
     XCTAssertEqual(result.operation, ModelQoS.Proactivity.extractionOperation)
@@ -130,17 +124,178 @@ final class ProactiveLaneClientTests: XCTestCase {
     do {
       _ = try await completeExtraction(on: client)
       XCTFail("expected cooldown skip")
-    } catch ProactiveLaneClientError.http(let status, _) {
-      XCTAssertEqual(status, 429)
+    } catch ProactiveLaneClientError.quotaCooldown(_) {
+      // Expected: a missing Retry-After still arms the conservative default.
     }
     XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
   }
 
+  func testExtractionQuotaCooldownDoesNotSuppressReasoning() async throws {
+    ProactiveLaneURLStub.reset()
+    let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      now: { clock.now })
+
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 429,
+      body: Data(#"{"detail":"Proactive request limit exceeded"}"#.utf8),
+      headers: ["Retry-After": "120"])
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected extraction 429")
+    } catch ProactiveLaneClientError.http(let status, _) {
+      XCTAssertEqual(status, 429)
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestedOperations, [ModelQoS.Proactivity.extractionOperation])
+
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try successEnvelope(operation: ModelQoS.Proactivity.reasoningOperation))
+    let reasoning = try await completeReasoning(on: client)
+    XCTAssertEqual(reasoning.operation, ModelQoS.Proactivity.reasoningOperation)
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestedOperations,
+      [ModelQoS.Proactivity.extractionOperation, ModelQoS.Proactivity.reasoningOperation],
+      "reasoning must still reach the network after an extraction 429")
+
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected extraction to remain in cooldown")
+    } catch ProactiveLaneClientError.quotaCooldown(_) {
+      // Extraction stays suppressed in its own window.
+    }
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestedOperations,
+      [ModelQoS.Proactivity.extractionOperation, ModelQoS.Proactivity.reasoningOperation],
+      "a later extraction attempt in the same window must not hit the network")
+  }
+
+  func testRetryAfterAboveADayIsClampedToOneHour() async throws {
+    ProactiveLaneURLStub.reset()
+    let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      now: { clock.now })
+
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 429,
+      body: Data(),
+      headers: ["Retry-After": "86400"])
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected 429")
+    } catch ProactiveLaneClientError.http(let status, let retryAfter) {
+      XCTAssertEqual(status, 429)
+      XCTAssertEqual(retryAfter, 86400)
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+
+    clock.advance(by: TimeInterval(ProactiveLaneClient.maxQuotaCooldownSeconds - 1))
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected the clamped hour cooldown to still skip the network")
+    } catch ProactiveLaneClientError.quotaCooldown(_) {
+      // Still inside the 3600s ceiling.
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+
+    clock.advance(by: 2)
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try successEnvelope(operation: ModelQoS.Proactivity.extractionOperation))
+    let result = try await completeExtraction(on: client)
+    XCTAssertEqual(result.operation, ModelQoS.Proactivity.extractionOperation)
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 2)
+  }
+
+  func testTinyOrZeroRetryAfterArmsAtLeastTheFloor() async throws {
+    ProactiveLaneURLStub.reset()
+    let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      now: { clock.now })
+
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 429,
+      body: Data(),
+      headers: ["Retry-After": "1"])
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected 429")
+    } catch ProactiveLaneClientError.http(_, _) {
+      // Server 429 with a sub-floor Retry-After.
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+
+    clock.advance(by: TimeInterval(ProactiveLaneClient.minQuotaCooldownSeconds - 1))
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected the 60s floor to still skip the network")
+    } catch ProactiveLaneClientError.quotaCooldown(_) {
+      // Tiny Retry-After is raised to the 60s floor.
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 1)
+
+    clock.advance(by: 2)
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 200,
+      body: try successEnvelope(operation: ModelQoS.Proactivity.extractionOperation))
+    _ = try await completeExtraction(on: client)
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 2)
+
+    ProactiveLaneURLStub.enqueue(statusCode: 429, body: Data(), headers: ["Retry-After": "0"])
+    do {
+      _ = try await completeReasoning(on: client)
+      XCTFail("expected 429")
+    } catch ProactiveLaneClientError.http(_, _) {
+      // Zero Retry-After falls through to the conservative default.
+    }
+    clock.advance(by: TimeInterval(ProactiveLaneClient.minQuotaCooldownSeconds - 1))
+    do {
+      _ = try await completeReasoning(on: client)
+      XCTFail("expected at least the 60s floor")
+    } catch ProactiveLaneClientError.quotaCooldown(_) {
+      // Zero/absent Retry-After must not arm a sub-floor cooldown.
+    }
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 3)
+  }
+
   private func completeExtraction(on client: ProactiveLaneClient) async throws -> ProactiveLaneResult {
+    try await complete(operation: ModelQoS.Proactivity.extractionOperation, prompt: "extract", on: client)
+  }
+
+  private func completeReasoning(on client: ProactiveLaneClient) async throws -> ProactiveLaneResult {
+    try await complete(operation: ModelQoS.Proactivity.reasoningOperation, prompt: "reason", on: client)
+  }
+
+  private func complete(
+    operation: String,
+    prompt: String,
+    on client: ProactiveLaneClient
+  ) async throws -> ProactiveLaneResult {
     try await client.complete(
-      operation: ModelQoS.Proactivity.extractionOperation,
-      prompt: "extract",
+      operation: operation,
+      prompt: prompt,
       jsonSchema: ["type": "object"])
+  }
+
+  private func successEnvelope(operation: String) throws -> Data {
+    try JSONSerialization.data(withJSONObject: [
+      "operation": operation,
+      "lane": "omi:auto:desktop-\(operation.replacingOccurrences(of: "_", with: "-"))",
+      "provider_model": "gpt-5.6-luna",
+      "usage": ["cached_tokens": 0, "cache_write_tokens": 0],
+      "cache_write": false,
+      "fallback_class": "unknown",
+      "response": ["choices": [["message": ["content": "{\"narrative\":\"ok\",\"facts\":[]}"]]]],
+    ])
   }
 
   private func makeStubSession() -> URLSession {
@@ -182,6 +337,7 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
   private static let lock = NSLock()
   private nonisolated(unsafe) static var responses: [StubResponse] = []
   private nonisolated(unsafe) static var served = 0
+  private nonisolated(unsafe) static var operations: [String] = []
 
   static var requestCount: Int {
     lock.lock()
@@ -189,10 +345,17 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     return served
   }
 
+  static var requestedOperations: [String] {
+    lock.lock()
+    defer { lock.unlock() }
+    return operations
+  }
+
   static func reset() {
     lock.lock()
     responses = []
     served = 0
+    operations = []
     lock.unlock()
   }
 
@@ -210,7 +373,9 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
       client?.urlProtocol(self, didFailWithError: URLError(.badURL))
       return
     }
+    let operation = Self.operation(from: request)
     Self.lock.lock()
+    Self.operations.append(operation)
     let stub = Self.responses.isEmpty ? nil : Self.responses.removeFirst()
     Self.served += 1
     Self.lock.unlock()
@@ -231,4 +396,28 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
   }
 
   override func stopLoading() {}
+
+  private static func operation(from request: URLRequest) -> String {
+    guard let data = bodyData(from: request),
+      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let operation = object["operation"] as? String
+    else { return "" }
+    return operation
+  }
+
+  private static func bodyData(from request: URLRequest) -> Data? {
+    if let body = request.httpBody { return body }
+    guard let stream = request.httpBodyStream else { return nil }
+    stream.open()
+    defer { stream.close() }
+    var data = Data()
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 4_096)
+    defer { buffer.deallocate() }
+    while stream.hasBytesAvailable {
+      let count = stream.read(buffer, maxLength: 4_096)
+      guard count > 0 else { break }
+      data.append(buffer, count: count)
+    }
+    return data.isEmpty ? nil : data
+  }
 }

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -275,6 +275,45 @@ final class ProactiveLaneClientTests: XCTestCase {
     try await complete(operation: ModelQoS.Proactivity.reasoningOperation, prompt: "reason", on: client)
   }
 
+  func testLaterShorterRetryWindowDoesNotShortenActiveCooldown() async throws {
+    ProactiveLaneURLStub.reset()
+    let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let client = ProactiveLaneClient(
+      session: makeStubSession(),
+      baseURL: { "https://proactive.test" },
+      authorization: { "Bearer test" },
+      now: { clock.now })
+
+    // First 429 arms a long cooldown (300s).
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 429, body: Data(), headers: ["Retry-After": "300"])
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected 429")
+    } catch ProactiveLaneClientError.http(_, _) {}
+
+    // A second overlapping 429 with a much shorter window must not shorten it.
+    ProactiveLaneURLStub.enqueue(
+      statusCode: 429, body: Data(), headers: ["Retry-After": "60"])
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected quota cooldown")
+    } catch ProactiveLaneClientError.quotaCooldown(_) {}
+
+    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 2)
+
+    // Advance 70s — past the short window but inside the long one.
+    clock.advance(by: 70)
+    do {
+      _ = try await completeExtraction(on: client)
+      XCTFail("expected quota cooldown — longer deadline must be preserved")
+    } catch ProactiveLaneClientError.quotaCooldown(_) {}
+
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestCount, 2,
+      "the later shorter Retry-After must not have shortened the active cooldown")
+  }
+
   private func complete(
     operation: String,
     prompt: String,

--- a/desktop/macos/changelog/unreleased/20260813-proactive-lane-quota-scope.json
+++ b/desktop/macos/changelog/unreleased/20260813-proactive-lane-quota-scope.json
@@ -1,0 +1,3 @@
+{
+  "change": "Kept proactive notifications running when only the extraction budget is exhausted"
+}

--- a/desktop/macos/changelog/unreleased/20260813-proactive-lane-quota-scope.json
+++ b/desktop/macos/changelog/unreleased/20260813-proactive-lane-quota-scope.json
@@ -1,3 +1,3 @@
 {
-  "change": "Kept proactive notifications running when only the extraction budget is exhausted"
+  "change": "Improved the reliability of proactive notifications so they keep working even when one background task hits its usage limit"
 }


### PR DESCRIPTION
## What changed and why

PR #11527 added a quota cooldown to `ProactiveLaneClient` so a 429 stops the client from hammering the desktop backend. That was the right idea, but the cooldown was scoped wrong and unbounded. This PR keys it per operation, clamps `Retry-After` to `[60s, 3600s]`, and records self-suppressed attempts as `quota_cooldown` instead of a fake server 429.

Decision semantics are unchanged: terminal state stays `silence`/`failed`, no user-visible surface, no retry loop.

## Defects (confirmed against the server policy)

### 1. One cooldown covered two independent server quotas

Server side, `backend/routers/desktop_proactivity.py` reserves quota under a **per-operation** Redis key: `f"desktop_{operation_value}"`, with separate ceilings `_OPERATION_DAILY_LIMITS = {"proactive_extraction": 200, "proactive_reasoning": 100}`. Extraction and reasoning have completely independent budgets.

Client side, `ProactiveLaneClient.complete(...)` called `checkQuotaCooldown()` at the very top — before the `operation` argument was considered at all. Both callers share `ProactiveLaneClient.shared`:
- `ContextBucketRollupWriter` (extraction) at `ContextBucketRollup.swift:609`, `ModelQoS.Proactivity.extractionOperation`
- `ContextProactivityEngine` (director / reasoning) at `ContextProactivityEngine.swift:97`, `ModelQoS.Proactivity.reasoningOperation`

Extraction runs on every qualified visit departure and has the larger ceiling (200), so it exhausts first. One 429 then suppressed the director's reasoning lane too, even though reasoning has its own untouched budget. The director is the only path that can produce a user-visible proactive notification, so a partial quota problem became a total notification outage.

### 2. The cooldown was unbounded

`backend/database/redis_db.py` `reserve_rate_limit` returns `retry_after = ttl`, the remaining TTL of a **fixed 24-hour window key** (`_QUOTA_WINDOW_SECONDS = 24 * 60 * 60`) — not a short per-slot delay. So `Retry-After` can legitimately be many hours. `armQuotaCooldown` accepted it verbatim with no upper bound, so a single late-in-window 429 could disable the proactive lane for the rest of the day in that process. Nothing re-checked sooner if the operator raised the limit or the window rolled.

### 3. A self-suppressed attempt was indistinguishable from a real server 429

`checkQuotaCooldown()` threw `.http(status: 429, ...)`, which `ProactiveLaneFailureClassification` recorded as `{"failure":"http_error","status":429}` — byte-identical to an actual server rejection. In the delivery ledger you could not tell "we asked the server and it refused" from "we never sent anything".

## Product invariants affected

none

## How it was verified

- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ProactiveLaneClientTests'` — **10/10 passed**. Headline: a 429 on `proactive_extraction` does **not** suppress a subsequent `proactive_reasoning` call (the reasoning request reaches the URLProtocol stub; a later extraction attempt in the same window does not). Same-operation suppress-then-resume, `Retry-After: 86400` clamped to 3600s, and tiny/zero `Retry-After` armed at least the 60s floor all passed. Injected clock; no wall-clock sleeps.
- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ContextProactivityEngineTests|ContextProactivityDirectorFailureTests'` — **19/19 passed**. Stored delivery row is `{"failure":"quota_cooldown","status":429}` for a cooldown-skipped director attempt and `{"failure":"http_error","status":429}` for a real server 429.
- Local test compile required a temporary copy of the `RewindPage.swift` split from open PR #11537. That type-check timeout (`unable to type-check this expression in reasonable time`) is pre-existing on unmodified `origin/main` with local Xcode 26.2 / Swift 6.2.3; CI pins Xcode 16.4. The split was reverted after the tests ran and is **not** in this PR.
- I did not re-run the live quota-exhaustion path against a signed bundle; the regression is the hermetic client/engine tests above.

## Tests

- `ProactiveLaneClientTests.testExtractionQuotaCooldownDoesNotSuppressReasoning` — the headline test that fails on the pre-change shared cooldown.
- `ProactiveLaneClientTests.testExtractionSkipsNetworkDuringQuotaCooldownThenResumesAfterDeadline` — same operation is suppressed before the deadline and resumes after the injected clock passes it.
- `ProactiveLaneClientTests.testRetryAfterAboveADayIsClampedToOneHour` / `testTinyOrZeroRetryAfterArmsAtLeastTheFloor` — ceiling 3600s, floor 60s.
- `ContextProactivityDirectorFailureTests.testEngineRecordsQuotaCooldownProvenanceOnSelfSuppressedLaneError` / `testEngineRecordsHttp429ProvenanceOnTypedLaneError` — assert on the stored delivery row, not a source string.

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative

**Violated contract:** a client-side cooldown that backs off from a server quota must be keyed to the same identity the server uses to reserve that quota. Sharing one process-wide deadline across independently governed operations converts a partial exhaustion into a total outage of unrelated lanes.

**Canonical guard:** `ProactiveLaneClient` now keys `quotaCooldownUntil` by the `operation` string, clamps `Retry-After` into `[60s, 3600s]`, and throws `.quotaCooldown` so provenance records `{"failure":"quota_cooldown","status":429}` instead of `http_error`. Behavioral tests drive production `complete()` through a URLProtocol stub with an injected clock, and assert the director delivery row.

**Evidence:** #11527 shipped the actor-wide cooldown. Server policy is per-operation (`desktop_{operation}` Redis key; extraction 200 / reasoning 100) with a fixed 24h window TTL feeding `Retry-After`. This PR is recorded as `evidence_prs: [11538]`.

## New guards

Not a new CI check. The reusable surface is the per-operation cooldown inside `ProactiveLaneClient` (not a new subsystem), proven by `testExtractionQuotaCooldownDoesNotSuppressReasoning`. #11527 is the merged PR that would have caught this if the headline test had existed.

## Local build hatch

Local pre-push `xcrun swift build -c debug --package-path Desktop` fails on unmodified `RewindPage.swift` under Xcode 26.2 / Swift 6.2.3 (same failure on `origin/main`; being fixed in #11537). This PR does not touch that file. Push uses the documented hatch `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`. CI pins Xcode 16.4 and is unaffected. The focused test targets above still ran and passed.

🤖 Generated with Cursor
