### PR TITLE
fix(dev-harness): make dev-init install hooks through the worktree-safe installer (#11533)

### DIFF
--- a/scripts/dev-harness/dev-init.sh
+++ b/scripts/dev-harness/dev-init.sh
@@ -30,13 +30,12 @@ fi
 "$PYTHON_BIN" -m pip install -q -r backend/requirements.txt
 echo "Backend Python dependencies installed"
 
-hook=".git/hooks/pre-commit"
-if [ ! -f "$hook" ]; then
-  ln -s -f ../../scripts/pre-commit "$hook"
-  echo "Installed pre-commit hook"
-else
-  echo "Pre-commit hook already present"
-fi
+# scripts/install-git-hooks.sh owns hook installation. A linked worktree's
+# `.git` is a file holding a gitdir pointer, so a literal `.git/hooks` path does
+# not exist there; the installer resolves the shared hook directory with
+# `git rev-parse --git-path hooks` and installs dispatchers rather than symlinks
+# into a directory every worktree shares.
+bash scripts/install-git-hooks.sh
 
 echo ""
 echo "Next: add your four API keys to backend/.env.local-dev, then run:"

--- a/scripts/dev-harness/tests/test_dev_init.py
+++ b/scripts/dev-harness/tests/test_dev_init.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HARNESS_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = HARNESS_ROOT.parents[1]
+DEV_INIT = HARNESS_ROOT / "dev-init.sh"
+RESOLVER = HARNESS_ROOT / "_resolve_python.sh"
+INSTALL_HOOKS = REPO_ROOT / "scripts/install-git-hooks.sh"
+HOOK_SOURCES = ("changed-files", "pre-commit", "pre-push", "pre-push-singleflight", "pr-preflight")
+
+
+def _clean_env() -> dict[str, str]:
+    """Environment with Git's repository-local variables stripped.
+
+    Git exports GIT_DIR and friends to hooks, so this module runs under them
+    whenever the pre-push gate invokes it. Left in place, `git init <fixture>`
+    re-opens the *caller's* repository instead of creating the fixture.
+    """
+    env = os.environ.copy()
+    local_vars = subprocess.run(
+        ["git", "rev-parse", "--local-env-vars"], text=True, stdout=subprocess.PIPE, check=True
+    ).stdout.split()
+    for var in local_vars:
+        env.pop(var, None)
+    env.pop("PYTHON", None)
+    return env
+
+
+def _git(*args: str) -> None:
+    subprocess.run(["git", *args], env=_clean_env(), check=True, stdout=subprocess.DEVNULL)
+
+
+def _bash() -> str:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("Bash is required for dev-init tests")
+    return bash
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _fixture_repo(root: Path) -> Path:
+    """A checkout carrying just enough of the repo for dev-init.sh to run."""
+    repo = root / "repo"
+    repo.mkdir()
+    _git("init", "-q", "--initial-branch=main", str(repo))
+
+    (repo / "scripts/dev-harness").mkdir(parents=True)
+    shutil.copy2(DEV_INIT, repo / "scripts/dev-harness/dev-init.sh")
+    shutil.copy2(RESOLVER, repo / "scripts/dev-harness/_resolve_python.sh")
+    shutil.copy2(INSTALL_HOOKS, repo / "scripts/install-git-hooks.sh")
+    for name in HOOK_SOURCES:
+        _write_executable(repo / "scripts" / name, "#!/usr/bin/env bash\nexit 0\n")
+
+    (repo / "backend").mkdir()
+    (repo / "backend/.env.local-dev.template").write_text("OMI_FIXTURE=1\n", encoding="utf-8")
+    (repo / "backend/requirements.txt").write_text("", encoding="utf-8")
+    # Stand in for the backend venv so the dependency install is a no-op and the
+    # test exercises the hook step without touching the network.
+    _write_executable(repo / "backend/.venv/bin/python", "#!/usr/bin/env bash\nexit 0\n")
+
+    _git("-C", str(repo), "add", "-A")
+    _git(
+        "-C",
+        str(repo),
+        "-c",
+        "user.name=omi",
+        "-c",
+        "user.email=omi@example.invalid",
+        "commit",
+        "-qm",
+        "init",
+    )
+    return repo
+
+
+def _run_dev_init(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [_bash(), "scripts/dev-harness/dev-init.sh"],
+        cwd=cwd,
+        env=_clean_env(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=120,
+        check=False,
+    )
+
+
+def _hooks_dir(cwd: Path) -> Path:
+    result = subprocess.run(
+        ["git", "-C", str(cwd), "rev-parse", "--git-path", "hooks"],
+        env=_clean_env(),
+        text=True,
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    # `--git-path` answers relative to the work tree in a main checkout and
+    # absolutely in a linked worktree; joining handles both.
+    return (cwd / result.stdout.strip()).resolve()
+
+
+def test_dev_init_installs_hooks_from_a_linked_worktree(tmp_path: Path) -> None:
+    """A linked worktree's `.git` is a file, so `.git/hooks/pre-commit` does not exist.
+
+    dev-init.sh used to symlink that literal path and died with
+    `ln: .git/hooks/pre-commit: Not a directory` — after `pip install`, so the
+    failure cost a full dependency install first.
+    """
+    repo = _fixture_repo(tmp_path)
+    worktree = tmp_path / "linked"
+    _git("-C", str(repo), "worktree", "add", "-q", "-b", "work", str(worktree))
+    assert (worktree / ".git").is_file()
+
+    result = _run_dev_init(worktree)
+
+    assert result.returncode == 0, result.stdout
+    hook = _hooks_dir(worktree) / "pre-commit"
+    assert hook.is_file() and os.access(hook, os.X_OK), result.stdout
+
+
+def test_dev_init_installs_hooks_in_a_main_checkout(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+
+    result = _run_dev_init(repo)
+
+    assert result.returncode == 0, result.stdout
+    hook = _hooks_dir(repo) / "pre-commit"
+    assert hook.is_file() and os.access(hook, os.X_OK), result.stdout
+    assert (repo / "backend/.env.local-dev").is_file(), result.stdout

--- a/scripts/dev-harness/tests/test_python_resolver.py
+++ b/scripts/dev-harness/tests/test_python_resolver.py
@@ -76,6 +76,24 @@ def _as_bash_path(path: Path) -> str:
     return result.stdout.strip()
 
 
+def _git_init(repo: Path) -> None:
+    """Create a fixture repository without re-opening the caller's repository.
+
+    Git exports GIT_DIR and friends to hooks, so this module runs under them
+    whenever the pre-push gate invokes it. Left in place, `git init <fixture>`
+    re-inits the caller's repository instead — which sets `core.bare=true` on a
+    linked-worktree parent and breaks every later `git rev-parse --show-toplevel`
+    in the same push.
+    """
+    env = os.environ.copy()
+    local_vars = subprocess.run(
+        ["git", "rev-parse", "--local-env-vars"], text=True, stdout=subprocess.PIPE, check=True
+    ).stdout.split()
+    for var in local_vars:
+        env.pop(var, None)
+    subprocess.run(["git", "init", "-q", str(repo)], env=env, check=True)
+
+
 def _make_executable(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
@@ -217,7 +235,7 @@ def test_pythonpath_uses_selected_windows_interpreter_separator(tmp_path: Path) 
 def test_make_uses_git_bash_when_bare_bash_resolves_to_wsl(tmp_path: Path) -> None:
     repo = tmp_path / "omi 路径 powershell"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    _git_init(repo)
     shutil.copy2(MAKEFILE, repo / "Makefile")
 
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
@@ -272,7 +290,7 @@ def test_make_uses_git_bash_when_bare_bash_resolves_to_wsl(tmp_path: Path) -> No
 def test_pre_push_singleflight_runs_shell_child_with_native_windows_python(tmp_path: Path) -> None:
     repo = tmp_path / "omi 路径 hook"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    _git_init(repo)
 
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
     resolver.parent.mkdir(parents=True)
@@ -320,7 +338,7 @@ def test_pre_push_singleflight_runs_shell_child_with_native_windows_python(tmp_p
 def test_make_harness_targets_run_resolved_python_from_checkout_with_unicode_and_spaces(tmp_path: Path) -> None:
     repo = tmp_path / "omi 路径 pr-10017 space"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    _git_init(repo)
     shutil.copy2(MAKEFILE, repo / "Makefile")
 
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
@@ -489,7 +507,7 @@ def test_make_harness_does_not_execute_checkout_name_and_resolves_python(tmp_pat
     repo = tmp_path / "omi pr-10017'; touch injected-marker; #"
     marker = repo / "injected-marker"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    _git_init(repo)
     shutil.copy2(MAKEFILE, repo / "Makefile")
 
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"
@@ -531,7 +549,7 @@ def test_make_harness_does_not_execute_double_quote_in_checkout_name(tmp_path: P
     repo = tmp_path / 'omi "; touch double-quote-marker; #'
     marker = repo / "double-quote-marker"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    _git_init(repo)
     shutil.copy2(MAKEFILE, repo / "Makefile")
 
     resolver = repo / "scripts/dev-harness/_resolve_python.sh"


### PR DESCRIPTION
## Bug

`make dev-init` fails in any linked git worktree (#11533). `scripts/dev-harness/dev-init.sh` symlinked the literal path `.git/hooks/pre-commit`, but a linked worktree's `.git` is a **file** holding a `gitdir:` pointer, so `.git/hooks/` does not exist:

```
ln: .git/hooks/pre-commit: Not a directory
```

With `set -euo pipefail` that aborts the script — and it lands *after* `pip install -r backend/requirements.txt`, so the failure costs a full dependency install first. `AGENTS.md` tells contributors to work in a worktree, so following the repo's own guidance hits this immediately.

## Root cause

Hook installation has an owner — `scripts/install-git-hooks.sh` — which resolves the shared hook directory with `git rev-parse --git-path hooks` and installs runtime dispatchers rather than symlinks into a directory every worktree shares. `dev-init.sh` carried a second, worktree-broken implementation of the same step.

## Fix

`dev-init.sh` delegates to `scripts/install-git-hooks.sh` instead of duplicating it. `dev-init.sh:33` was the only `.git/` path assumption in `scripts/dev-harness/`.

## Second commit (found while fixing the first)

Every `git init` in `scripts/dev-harness/tests/test_python_resolver.py` ran with Git's repository-local env vars still set. Under the pre-push gate (Git exports `GIT_DIR` to hooks) those re-init the **caller's** repository and, from a linked worktree, leave `core.bare=true` on the shared clone — after which every `git rev-parse --show-toplevel` in that push dies with "this operation must be run in a work tree" and the checkout stays broken until someone runs `scripts/repair-git-primary-worktree.sh`. That is what blocked this PR's own push. The five fixture inits now go through a helper that strips `git rev-parse --local-env-vars`, the same guard `scripts/test-make-setup.sh` already documents.

## What I tested

- Reproduced on unmodified `main` in a linked worktree: `ln: .git/hooks/pre-commit: Not a directory`, exit 1.
- New `scripts/dev-harness/tests/test_dev_init.py` (hermetic, fixture repo + real `git worktree add`) fails on the pre-fix script with that exact error and passes after the fix. It also covers the main-checkout path, which passes both before and after.
- **Real path:** `make dev-init` in a linked worktree now completes — `Installed Git hook dispatchers in …/.git/hooks.` — and the installed hook then actually fired on the commit in this PR (`OK: Git author identity is not a test fixture.`).
- `bash scripts/dev-harness/run-tests.sh` (the `dev-harness-unit-tests` lane): **82 passed, 8 skipped**.
- `make preflight`: **12/12 checks pass**.
- For the second commit: with `GIT_DIR` exported, `bash scripts/dev-harness/run-tests.sh` flipped `core.bare` false → true before it and leaves it false after (82 passed both times); bisected per file, `test_python_resolver.py` was the only corrupting one. The push of this branch then passed the full pre-push gate and left the clone healthy.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

