### PR TITLE
fix(desktop): split RewindPage.body so release compile type-checks

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -151,6 +151,12 @@ struct RewindPage: View {
   }
 
   var body: some View {
+    // Split so the release compiler can type-check. One 160-line modifier
+    // chain here fails `swift build -c release` (Codemagic 170 / #11519).
+    rewindPageKeyHandlers(rewindPageLifecycle(pageChrome))
+  }
+
+  private var pageChrome: some View {
     pageContent
       .glassContent()
       // The page answers arrow keys wherever the pointer is, so it holds keyboard focus itself. The
@@ -159,6 +165,10 @@ struct RewindPage: View {
       // window with no visible extent is a blue rectangle on the wallpaper. See
       // `shellPageKeyboardTarget`.
       .shellPageKeyboardTarget($isPageFocused)
+  }
+
+  private func rewindPageLifecycle<Content: View>(_ content: Content) -> some View {
+    content
       .task {
         await viewModel.loadInitialData()
         await resolveCitationFocusIfNeeded()
@@ -254,6 +264,10 @@ struct RewindPage: View {
           scheduleLoadCurrentFrame()
         }
       }
+  }
+
+  private func rewindPageKeyHandlers<Content: View>(_ content: Content) -> some View {
+    content
       // Global keyboard handlers
       .onEscapeKey {
         // Expanded transcript → collapse

--- a/desktop/macos/changelog/unreleased/20260813-rewind-page-release-typecheck.json
+++ b/desktop/macos/changelog/unreleased/20260813-rewind-page-release-typecheck.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a Rewind page compile failure that blocked the signed macOS Beta build"
+}


### PR DESCRIPTION
## Summary
- Split `RewindPage.body` into `pageChrome` + `rewindPageLifecycle` + `rewindPageKeyHandlers` so the **release** compiler can type-check.
- No behavior change. Same modifiers, notifications, citation focus, and key handlers.
- Unblocks the next macOS Beta candidate after `v0.12.170+12170-macos` failed Codemagic `swift build -c release`.

## Failure class

Failure-Class: none

## Product invariants affected

None. Compile-only expression split.

Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift | 1493 -> 1507 | split body into three type-checkable views; no file split without a behavior rewrite

## Verification
- `xcrun swift build -c release --package-path Desktop` from `desktop/macos`
  - result: `Build complete!` (561s) on this branch before rebase onto current `main`
- RewindPage.swift was not touched on `origin/main` after the compile-verified base (`6083f7de58` → current main is hook/test/backend only)

## Release safety
- Do not retag `v0.12.170+12170-macos` (burned). Next candidate is `v0.12.171+12171-macos` after merge.
- No publication, promotion, or Stable mutation in this PR.

Changelog: `desktop/macos/changelog/unreleased/20260813-rewind-page-release-typecheck.json`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

