### PR TITLE
test(desktop): sync director-prompt expectation with the meeting-notes ownership clause (#11468 collision)

### DIFF
--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -64,6 +64,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       ScreenDerivedContent.untrustedPreamble,
       "Decide whether interrupting now adds concrete value. Return silence unless the validated",
       "facts support a specific, timely action. Use only supplied bucket-entry refs.",
+      "Never announce that meeting notes, a transcript, or a call summary are ready. The",
+      "conversation-finalization lane owns that claim and attaches the exact conversation link.",
       "Use resurface or suggest for an actionable open task supplied below. Entries marked",
       "reference-only are identity context: do not notify about or recreate them yet. Use",
       "task_candidate only when a validated fact explicitly records a new commitment, promise,",


### PR DESCRIPTION
## Main is red — release train blocked

`Desktop Swift Static & Test Contracts` fails on main (`ContextBucketPromptAssemblerTests`, 1 failure): #11468 added the *'Never announce that meeting notes…'* paragraph to the production director preamble while the test's expected transcript predated it — a mid-air collision between two green PRs. The desktop release train's source gate cannot pass while this is red (tonight's planner run 31749695347 failed on it).

## Fix

Two lines added to the expected transcript, matching the production preamble text introduced by merged PR #11468 (`ContextBucketRollup.swift`) — that merged PR is the external source for the new expected value.

## Verification

`swift test --filter ContextBucketPromptAssemblerTests` → **14 tests, 0 failures** (1 failure before).

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

