### PR TITLE
fix(desktop): add 5 pt of space between chat lines

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatMessagesView.swift
@@ -142,7 +142,9 @@ enum ChatTranscriptLayout {
   static let regularRowSpacing: CGFloat = OmiSpacing.lg
   static let consecutiveUserRowSpacing: CGFloat = OmiSpacing.sm
   /// A reply and the question that caused it are one exchange, not two events.
-  static let replySpacing: CGFloat = OmiSpacing.sm
+  /// `md` rather than `sm`: the user bubble's own bottom padding already hugs
+  /// the text, so `sm` left the next assistant line sitting on the bubble.
+  static let replySpacing: CGFloat = OmiSpacing.md
 
   /// The gap *before* `current`, given the row above it.
   ///

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
@@ -179,13 +179,9 @@ struct OmiMarkdownContent: View, Equatable {
       } else if let s = Self.styledAttributedString(
         from: processed, style: style, fontSize: fontSize, fontScale: fontScale
       ) {
-        Text(s)
-          .if_available_writingToolsNone()
+        OmiMarkdownChatText(s, fontSize: fontSize)
       } else {
-        Text(content)
-          .font(.system(size: fontSize))
-          .foregroundColor(Self.baseColor(for: style))
-          .if_available_writingToolsNone()
+        OmiMarkdownChatText(content, fontSize: fontSize, style: style)
       }
     }
   }
@@ -786,12 +782,14 @@ private struct OmiMarkdownInlineCopyText: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 0) {
+    VStack(alignment: .leading, spacing: OmiMarkdownContent.chatLineSpacing(fontSize: fontSize)) {
       ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
         if line.isEmpty {
           Color.clear.frame(height: fontSize * 0.45)
         } else {
-          OmiMarkdownInlineFlowLayout(spacing: 0, lineSpacing: 2) {
+          OmiMarkdownInlineFlowLayout(
+            spacing: 0, lineSpacing: OmiMarkdownContent.chatLineSpacing(fontSize: fontSize)
+          ) {
             ForEach(Array(line.enumerated()), id: \.offset) { _, segment in
               switch segment {
               case .text(let value):
@@ -809,6 +807,7 @@ private struct OmiMarkdownInlineCopyText: View {
   @ViewBuilder
   private func inlineText(_ value: AttributedString) -> some View {
     Text(value)
+      .lineSpacing(OmiMarkdownContent.chatLineSpacing(fontSize: fontSize))
       .fixedSize(horizontal: false, vertical: true)
       .if_available_writingToolsNone()
   }
@@ -974,7 +973,7 @@ private struct OmiMarkdownCitationContent: View {
       let attributed = OmiMarkdownContent.styledAttributedString(
         from: interactiveMask.markdown, style: style, fontSize: fontSize, fontScale: fontScale)
     {
-      VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: OmiMarkdownContent.chatLineSpacing(fontSize: fontSize)) {
         ForEach(
           Array(
             ChatCitationMask.units(
@@ -988,11 +987,14 @@ private struct OmiMarkdownCitationContent: View {
           if line.isEmpty {
             Color.clear.frame(height: fontSize * 0.45)
           } else {
-            OmiMarkdownInlineFlowLayout(spacing: 0, lineSpacing: 2) {
+            OmiMarkdownInlineFlowLayout(
+              spacing: 0, lineSpacing: OmiMarkdownContent.chatLineSpacing(fontSize: fontSize)
+            ) {
               ForEach(Array(line.enumerated()), id: \.offset) { _, unit in
                 switch unit {
                 case .text(let value):
                   Text(value)
+                    .lineSpacing(OmiMarkdownContent.chatLineSpacing(fontSize: fontSize))
                     .fixedSize(horizontal: false, vertical: true)
                     .if_available_writingToolsNone()
                 case .citation(let reference):
@@ -1515,11 +1517,9 @@ private struct OmiMarkdownTableView: View {
           fontScale: fontScale
         )
       } else if let styled {
-        Text(styled)
+        OmiMarkdownChatText(styled, fontSize: fontSize)
       } else {
-        Text(content)
-          .font(.system(size: fontSize))
-          .foregroundColor(OmiMarkdownContent.baseColor(for: style))
+        OmiMarkdownChatText(content, fontSize: fontSize, style: style)
       }
     }
     .fontWeight(row == 0 ? .semibold : .regular)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdownChatTypography.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdownChatTypography.swift
@@ -1,13 +1,17 @@
 import SwiftUI
 
 extension OmiMarkdownContent {
-  /// Extra leading between adjacent chat lines: half the body size.
+  /// Extra leading between adjacent chat lines: 5 pt at the default 14 pt body.
+  ///
+  /// Tracks the chat font-size setting (`fontSize` already includes `fontScale`).
+  /// It does not grow with window size — line leading that followed the panel
+  /// would loosen on a large display and tighten on a small one.
   static func chatLineSpacing(fontSize: CGFloat) -> CGFloat {
-    fontSize * 0.5
+    round(5 * fontSize / 14)
   }
 }
 
-/// Chat prose with the extra half-line of leading the transcript uses everywhere.
+/// Chat prose with the extra 5 pt of leading the transcript uses everywhere.
 struct OmiMarkdownChatText: View {
   private enum Content {
     case attributed(AttributedString)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdownChatTypography.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdownChatTypography.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+extension OmiMarkdownContent {
+  /// Extra leading between adjacent chat lines: half the body size.
+  static func chatLineSpacing(fontSize: CGFloat) -> CGFloat {
+    fontSize * 0.5
+  }
+}
+
+/// Chat prose with the extra half-line of leading the transcript uses everywhere.
+struct OmiMarkdownChatText: View {
+  private enum Content {
+    case attributed(AttributedString)
+    case plain(String, OmiMarkdown.Style)
+  }
+
+  private let content: Content
+  private let fontSize: CGFloat
+
+  init(_ attributed: AttributedString, fontSize: CGFloat) {
+    self.content = .attributed(attributed)
+    self.fontSize = fontSize
+  }
+
+  init(_ text: String, fontSize: CGFloat, style: OmiMarkdown.Style) {
+    self.content = .plain(text, style)
+    self.fontSize = fontSize
+  }
+
+  var body: some View {
+    text
+      .lineSpacing(OmiMarkdownContent.chatLineSpacing(fontSize: fontSize))
+      .if_available_writingToolsNone()
+  }
+
+  @ViewBuilder private var text: some View {
+    switch content {
+    case .attributed(let value):
+      Text(value)
+    case .plain(let value, let style):
+      Text(value)
+        .font(.system(size: fontSize))
+        .foregroundColor(OmiMarkdownContent.baseColor(for: style))
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/OmiMarkdownLineSpacingTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiMarkdownLineSpacingTests.swift
@@ -6,12 +6,12 @@ import XCTest
 
 @MainActor
 final class OmiMarkdownLineSpacingTests: XCTestCase {
-  func testChatLineSpacingIsHalfTheBodySize() {
-    XCTAssertEqual(OmiMarkdownContent.chatLineSpacing(fontSize: 14), 7)
-    XCTAssertEqual(OmiMarkdownContent.chatLineSpacing(fontSize: 16), 8)
+  func testChatLineSpacingIsFivePointsAtTheDefaultBody() {
+    XCTAssertEqual(OmiMarkdownContent.chatLineSpacing(fontSize: 14), 5)
+    XCTAssertEqual(OmiMarkdownContent.chatLineSpacing(fontSize: 28), 10)
   }
 
-  func testHardBrokenChatLinesIncludeHalfLineLeading() {
+  func testHardBrokenChatLinesIncludeTheExtraLeading() {
     let single = measureHeight("Hello")
     let stacked = measureHeight("Hello\nWorld")
     let extra = stacked - (2 * single)
@@ -19,10 +19,10 @@ final class OmiMarkdownLineSpacingTests: XCTestCase {
       extra,
       OmiMarkdownContent.chatLineSpacing(fontSize: 14),
       accuracy: 1.5,
-      "adjacent chat lines must sit a half-line apart, not flush")
+      "adjacent chat lines must sit 5 pt apart at the default body, not flush")
   }
 
-  func testWrappedChatLinesAreTallerThanASingleLineByAtLeastHalfALine() {
+  func testWrappedChatLinesAreTallerThanASingleLineByAtLeastTheExtraLeading() {
     let long =
       "This completed answer wraps several times so the extra leading between chat lines is visible."
     let wrapped = measureHeight(long, width: 220)
@@ -30,7 +30,7 @@ final class OmiMarkdownLineSpacingTests: XCTestCase {
     XCTAssertGreaterThan(
       wrapped,
       single + OmiMarkdownContent.chatLineSpacing(fontSize: 14),
-      "wrapped chat prose must include the extra half-line of leading")
+      "wrapped chat prose must include the extra 5 pt of leading")
   }
 
   private func measureHeight(_ text: String, width: CGFloat = 400) -> CGFloat {

--- a/desktop/macos/Desktop/Tests/OmiMarkdownLineSpacingTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiMarkdownLineSpacingTests.swift
@@ -1,0 +1,45 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class OmiMarkdownLineSpacingTests: XCTestCase {
+  func testChatLineSpacingIsHalfTheBodySize() {
+    XCTAssertEqual(OmiMarkdownContent.chatLineSpacing(fontSize: 14), 7)
+    XCTAssertEqual(OmiMarkdownContent.chatLineSpacing(fontSize: 16), 8)
+  }
+
+  func testHardBrokenChatLinesIncludeHalfLineLeading() {
+    let single = measureHeight("Hello")
+    let stacked = measureHeight("Hello\nWorld")
+    let extra = stacked - (2 * single)
+    XCTAssertEqual(
+      extra,
+      OmiMarkdownContent.chatLineSpacing(fontSize: 14),
+      accuracy: 1.5,
+      "adjacent chat lines must sit a half-line apart, not flush")
+  }
+
+  func testWrappedChatLinesAreTallerThanASingleLineByAtLeastHalfALine() {
+    let long =
+      "This completed answer wraps several times so the extra leading between chat lines is visible."
+    let wrapped = measureHeight(long, width: 220)
+    let single = measureHeight("Hello", width: 220)
+    XCTAssertGreaterThan(
+      wrapped,
+      single + OmiMarkdownContent.chatLineSpacing(fontSize: 14),
+      "wrapped chat prose must include the extra half-line of leading")
+  }
+
+  private func measureHeight(_ text: String, width: CGFloat = 400) -> CGFloat {
+    let host = NSHostingView(
+      rootView: OmiMarkdown(text: text, style: .assistant)
+        .frame(width: width, alignment: .leading)
+    )
+    host.frame = NSRect(x: 0, y: 0, width: width, height: 800)
+    host.layoutSubtreeIfNeeded()
+    return host.fittingSize.height
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260814-chat-line-spacing.json
+++ b/desktop/macos/changelog/unreleased/20260814-chat-line-spacing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added half a line of space between lines in chat messages"
+}

--- a/desktop/macos/changelog/unreleased/20260814-chat-line-spacing.json
+++ b/desktop/macos/changelog/unreleased/20260814-chat-line-spacing.json
@@ -1,3 +1,3 @@
 {
-  "change": "Added half a line of space between lines in chat messages"
+  "change": "Added 5 pt of space between lines in chat messages and more room after a user bubble before the next reply"
 }

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -36,6 +36,7 @@ covers:
   - desktop/macos/Desktop/Sources/BrowserExtensionSetup.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdownChatTypography.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
   - desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift


### PR DESCRIPTION
## What changed and why

Chat replies were stacked with SwiftUI's default leading and a 2pt wrap gap, so multi-line answers read as flush. Every chat markdown path now adds 5 pt of extra space between lines at the default 14 pt body. That leading tracks the chat font-size setting, not window size. The gap after a user bubble is `OmiSpacing.md` so the next assistant reply is not sitting on the bubble.

## Product invariants affected

- INV-CHAT-1 (path glob on `Chat*.swift`; this PR only changes transcript row spacing, not transcript ownership)

## How it was verified

- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'OmiMarkdownLineSpacingTests|DesktopChatDriftGuardTests/testAReplySitsCloserToItsQuestionThanTheNextExchangeDoes|ChatTimelineContinuityTests/testCompletedChatTranscriptLayoutConvergesAcrossRepeatedResizes'` — 5 tests passed. Line-spacing measurements use the production `OmiMarkdown` renderer; user→assistant gap stays tighter than the next-exchange gap (`md` < `lg`); layout still converges across resizes.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — OK.
- `python3 desktop/macos/scripts/check-e2e-flow-coverage.py --base origin/main` — `OmiMarkdown.swift` and `OmiMarkdownChatTypography.swift` covered by `chat-hermetic.yaml`; `ChatMessagesView.swift` covered by `home-stage.yaml`.
- Named bundle `/Applications/omi-chat-line-spacing.app` (`com.omi.omi-chat-line-spacing`) launched and sampled on a real signed-in Chat transcript. 5 pt leading plus the extra user→assistant gap looked right. A relaunch of the same binary stayed at 0–4% CPU for 2.5+ minutes (the earlier 100% CPU stall was first-launch ingest, not this spacing change).

## Tests

- `OmiMarkdownLineSpacingTests.testChatLineSpacingIsFivePointsAtTheDefaultBody` — 5 pt at 14 pt body, 10 pt at 28 pt.
- `OmiMarkdownLineSpacingTests.testHardBrokenChatLinesIncludeTheExtraLeading` — `Hello\nWorld` is 5 pt taller than two stacked singles.
- `OmiMarkdownLineSpacingTests.testWrappedChatLinesAreTallerThanASingleLineByAtLeastTheExtraLeading` — wrapped prose includes the extra leading.
- `DesktopChatDriftGuardTests.testAReplySitsCloserToItsQuestionThanTheNextExchangeDoes` — existing guard; reply gap remains smaller than the next-exchange gap after the `sm` → `md` bump.

## Failure class (fixes)

Failure-Class: none
