### PR TITLE
fix(ios): stop background audio keep-alive and back off BLE timeouts

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -4,6 +4,7 @@ import UserNotifications
 import app_links
 import WatchConnectivity
 import AVFoundation
+import CallKit
 import Speech
 import WidgetKit
 
@@ -205,6 +206,20 @@ final class QuickActionsIconPatcher: NSObject {
                     options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
                 )
                 try audioSession.setActive(true)
+                result(true)
+            } catch {
+                result(FlutterError(code: "AUDIO_SESSION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        } else if call.method == "deactivateForBluetooth" {
+            // CallKit owns the session during a phone call. Phone-mic and
+            // Ray-Ban paths deactivate themselves; this is the matching
+            // teardown for BLE/wearable capture keep-alive.
+            if CXCallObserver().calls.contains(where: { !$0.hasEnded }) {
+                result(true)
+                return
+            }
+            do {
+                try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
                 result(true)
             } catch {
                 result(FlutterError(code: "AUDIO_SESSION_ERROR", message: error.localizedDescription, details: nil))

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -90,6 +90,9 @@ final class QuickActionsIconPatcher: NSObject {
   private var phoneMicController: PhoneMicController?
   private var notificationTitleOnKill: String?
   private var notificationBodyOnKill: String?
+  /// Retained so `calls` is populated; a throwaway `CXCallObserver()` can
+  /// report empty during an active call (see PhoneMicInterruptionMonitor).
+  private let bluetoothAudioCallObserver = CXCallObserver()
 
   var session: WCSession?
     var flutterWatchAPI: WatchRecorderFlutterAPI?
@@ -104,6 +107,7 @@ final class QuickActionsIconPatcher: NSObject {
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     QuickActionsIconPatcher.shared.startObserving()
+    bluetoothAudioCallObserver.setDelegate(self, queue: nil)
       
       
       if WCSession.isSupported() {
@@ -214,7 +218,7 @@ final class QuickActionsIconPatcher: NSObject {
             // CallKit owns the session during a phone call. Phone-mic and
             // Ray-Ban paths deactivate themselves; this is the matching
             // teardown for BLE/wearable capture keep-alive.
-            if CXCallObserver().calls.contains(where: { !$0.hasEnded }) {
+            if self.bluetoothAudioCallObserver.calls.contains(where: { !$0.hasEnded }) {
                 result(true)
                 return
             }
@@ -459,6 +463,10 @@ final class QuickActionsIconPatcher: NSObject {
 
 func registerPlugins(registry: FlutterPluginRegistry) {
   GeneratedPluginRegistrant.register(with: registry)
+}
+
+extension AppDelegate: CXCallObserverDelegate {
+    func callObserver(_ callObserver: CXCallObserver, callChanged call: CXCall) {}
 }
 
 extension AppDelegate: WCSessionDelegate {

--- a/app/ios/Runner/Ble/BleHostApiImpl.swift
+++ b/app/ios/Runner/Ble/BleHostApiImpl.swift
@@ -84,11 +84,11 @@ final class BleHostApiImpl: BleHostApi {
     // ── Diagnostics ──
 
     func startRssiStreaming(uuid: String) throws {
-        bleManager.isRssiStreamingEnabled = true
+        bleManager.setRssiStreamingEnabled(true, uuid: uuid)
     }
 
     func stopRssiStreaming(uuid: String) throws {
-        bleManager.isRssiStreamingEnabled = false
+        bleManager.setRssiStreamingEnabled(false, uuid: uuid)
     }
 
     func getDeviceDiagnostics(uuid: String, completion: @escaping (Result<BleDeviceDiagnostics, Error>) -> Void) {

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -69,6 +69,10 @@ final class OmiBleManager: NSObject {
     private var reconnectAttempt: [String: Int] = [:]
     /// In-flight delayed reconnects — at most one parked connect per peripheral.
     private var pendingReconnectWork: [String: DispatchWorkItem] = [:]
+    /// Deadline + peripheral for delayed reconnects, so a CoreBluetooth wake
+    /// can fire overdue work if `asyncAfter` was lost to suspend.
+    private var pendingReconnectDeadline: [String: Date] = [:]
+    private var pendingReconnectPeripheral: [String: CBPeripheral] = [:]
 
     /// Last battery sample actually written to the plist ring, per peripheral.
     private var lastPersistedBatteryLevel: [String: Int] = [:]
@@ -212,12 +216,38 @@ final class OmiBleManager: NSObject {
     private func cancelPendingReconnect(uuid: String) {
         pendingReconnectWork[uuid]?.cancel()
         pendingReconnectWork.removeValue(forKey: uuid)
+        pendingReconnectDeadline.removeValue(forKey: uuid)
+        pendingReconnectPeripheral.removeValue(forKey: uuid)
     }
 
     private func isTimeoutOrFailToConnectReason(_ reason: String) -> Bool {
         return reason == "connection_timeout" ||
             reason == "fail_to_connect" ||
             reason == "connection_failed_instant_passed"
+    }
+
+    /// Fire overdue delayed reconnects. CoreBluetooth wake / restore / poweredOn
+    /// and foreground entry call this because `DispatchQueue.main.asyncAfter`
+    /// does not wake a suspended process.
+    func flushDueReconnects() {
+        let now = Date()
+        let due = pendingReconnectDeadline.compactMap { uuid, deadline -> String? in
+            now >= deadline ? uuid : nil
+        }
+        for uuid in due {
+            guard let peripheral = pendingReconnectPeripheral[uuid] else {
+                cancelPendingReconnect(uuid: uuid)
+                continue
+            }
+            fireReconnect(uuid: uuid, peripheral: peripheral)
+        }
+    }
+
+    private func fireReconnect(uuid: String, peripheral: CBPeripheral) {
+        cancelPendingReconnect(uuid: uuid)
+        if manuallyDisconnected.contains(uuid) { return }
+        if peripheral.state == .connected { return }
+        centralManager.connect(peripheral, options: nil)
     }
 
     /// At most one parked `central.connect` per peripheral. First drop is
@@ -231,7 +261,7 @@ final class OmiBleManager: NSObject {
         cancelPendingReconnect(uuid: uuid)
 
         let attempt = reconnectAttempt[uuid] ?? 0
-        let isBackground = UIApplication.shared.applicationState == .background
+        let isBackground = UIApplication.shared.applicationState != .active
         let delayMs = OmiBleReconnectPolicy.reconnectDelayMs(
             attempt: attempt,
             isBackground: isBackground,
@@ -241,20 +271,16 @@ final class OmiBleManager: NSObject {
 
         NSLog("[OmiBle] scheduleReconnect uuid=\(uuid) reason=\(reason) attempt=\(attempt) delayMs=\(delayMs) background=\(isBackground)")
 
-        let connect = { [weak self] in
-            guard let self = self else { return }
-            self.pendingReconnectWork.removeValue(forKey: uuid)
-            if self.manuallyDisconnected.contains(uuid) { return }
-            if peripheral.state == .connected { return }
-            self.centralManager.connect(peripheral, options: nil)
-        }
-
         if delayMs <= 0 {
-            connect()
+            fireReconnect(uuid: uuid, peripheral: peripheral)
             return
         }
 
-        let work = DispatchWorkItem(block: connect)
+        pendingReconnectPeripheral[uuid] = peripheral
+        pendingReconnectDeadline[uuid] = Date().addingTimeInterval(Double(delayMs) / 1000.0)
+        let work = DispatchWorkItem { [weak self] in
+            self?.flushDueReconnects()
+        }
         pendingReconnectWork[uuid] = work
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMs), execute: work)
     }
@@ -267,6 +293,7 @@ final class OmiBleManager: NSObject {
     /// foreground — `centralManager.connect` is idempotent and pending connects
     /// cost nothing while iOS waits at the chipset level.
     func reconnectStalePeripherals() {
+        flushDueReconnects()
         guard centralManager.state == .poweredOn else { return }
         for (uuid, peripheral) in peripherals {
             guard everConnected.contains(uuid) else { continue }
@@ -673,6 +700,10 @@ extension OmiBleManager: CBCentralManagerDelegate {
         NSLog("[OmiBle] centralManagerDidUpdateState: \(state), flutterApi=\(flutterApi != nil)")
         flutterApi?.onBluetoothStateChanged(state: state) { _ in }
 
+        if central.state == .poweredOn {
+            flushDueReconnects()
+        }
+
         // Execute queued scan if Bluetooth just became ready
         if central.state == .poweredOn, let pending = pendingScan {
             NSLog("[OmiBle] Executing queued scan (timeout=\(pending.timeout))")
@@ -681,6 +712,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
     }
 
     func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any]) {
+        flushDueReconnects()
         // Restore previously connected peripherals after app relaunch
         if let restoredPeripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
             var uuids: [String] = []
@@ -760,6 +792,8 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
+        flushDueReconnects()
+
         // Retry previously-connected peripherals — otherwise a failed connect silently
         // drops the user. First attempt is a parked chipset-level connect; later
         // background timeout storms back off instead of 200ms forever.
@@ -798,6 +832,8 @@ extension OmiBleManager: CBCentralManagerDelegate {
         connectionStartTimes.removeValue(forKey: uuid)
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
+
+        flushDueReconnects()
 
         // Auto-reconnect unless manually disconnected. Prefer a synchronous
         // parked connect — iOS can suspend before asyncAfter fires.

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -350,20 +350,33 @@ final class OmiBleManager: NSObject {
         }
     }
 
-    // MARK: - RSSI Keep-Alive
+    // MARK: - RSSI diagnostics polling
 
-    private func startRssiKeepAlive(for peripheral: CBPeripheral) {
-        stopRssiKeepAlive()
+    /// Periodic `readRSSI` is only for the diagnostics graph. It is not a
+    /// connection keep-alive — a 3s timer in the background costs radio/CPU
+    /// and does not prevent `connection_timeout`.
+    func setRssiStreamingEnabled(_ enabled: Bool, uuid: String) {
+        isRssiStreamingEnabled = enabled
+        if enabled, let peripheral = peripherals[uuid], peripheral.state == .connected {
+            startRssiPolling(for: peripheral)
+        } else {
+            stopRssiPolling()
+        }
+    }
+
+    private func startRssiPolling(for peripheral: CBPeripheral) {
+        stopRssiPolling()
         rssiTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self, weak peripheral] _ in
             guard let peripheral = peripheral, peripheral.state == .connected else {
-                self?.stopRssiKeepAlive()
+                self?.stopRssiPolling()
                 return
             }
             peripheral.readRSSI()
         }
+        peripheral.readRSSI()
     }
 
-    private func stopRssiKeepAlive() {
+    private func stopRssiPolling() {
         rssiTimer?.invalidate()
         rssiTimer = nil
     }
@@ -425,7 +438,7 @@ final class OmiBleManager: NSObject {
     private static func classifyRssiTrend(samples: [(ts: Int64, rssi: Int64)], nowMs: Int64) -> String {
         let windowStart = nowMs - rssiTrendWindowMs
         let recent = samples.filter { $0.ts >= windowStart }
-        // No recent samples — keep-alive wasn't running, so we can't say.
+        // No recent samples — diagnostics RSSI polling was off, so we can't say.
         if recent.isEmpty { return "gap" }
         if recent.count < 3 { return "unknown" }
         // Compare the average of the oldest third to the newest third. A drop of
@@ -634,7 +647,7 @@ final class OmiBleManager: NSObject {
     // MARK: - Audio Batch Helpers
 
     private func cleanupPeripheral(_ peripheralUuid: String) {
-        stopRssiKeepAlive()
+        stopRssiPolling()
         discoveredServices.removeValue(forKey: peripheralUuid)
 
         // Clean up pending completions
@@ -828,7 +841,12 @@ extension OmiBleManager: CBPeripheralDelegate {
             
             flutterApi?.onDeviceReady(peripheralUuid: uuid, services: bleServices) { _ in }
             LimitlessFlashDrainEngine.shared.onDeviceReady(uuid)
-            startRssiKeepAlive(for: peripheral)
+            // One sample for disconnect annotation. Do not start a 3s timer
+            // here — that was a fake keep-alive and a background battery cost.
+            peripheral.readRSSI()
+            if isRssiStreamingEnabled {
+                startRssiPolling(for: peripheral)
+            }
         }
     }
 

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -2,6 +2,40 @@ import CoreBluetooth
 import Flutter
 import UIKit
 
+/// Keep in sync with `app/lib/services/devices/ble_reconnect_policy.dart`.
+enum OmiBleReconnectPolicy {
+    static let timeoutBackoffMs: [Int] = [200, 2_000, 10_000, 30_000, 60_000]
+    static let backoffCapMs = 60_000
+    static let batteryMinDeltaPercent = 5
+    static let batteryMinIntervalMs: Int64 = 15 * 60 * 1_000
+    static let batteryLowThresholdPercent = 20
+
+    /// 0 = first parked connect (no delay). Later background timeout/fail
+    /// attempts walk 200ms → 2s → 10s → 30s → 60s.
+    static func reconnectDelayMs(attempt: Int, isBackground: Bool, isTimeoutOrFailToConnect: Bool) -> Int {
+        if attempt <= 0 || !isBackground || !isTimeoutOrFailToConnect {
+            return 0
+        }
+        let idx = min(max(attempt - 1, 0), timeoutBackoffMs.count - 1)
+        return min(timeoutBackoffMs[idx], backoffCapMs)
+    }
+
+    static func shouldPersistBatteryReading(
+        previousLevel: Int?,
+        lastPersistedAtMs: Int64?,
+        newLevel: Int,
+        nowMs: Int64
+    ) -> Bool {
+        guard let previousLevel, let lastPersistedAtMs else { return true }
+        let delta = abs(previousLevel - newLevel)
+        let elapsed = nowMs - lastPersistedAtMs
+        let crossedLow =
+            (newLevel < batteryLowThresholdPercent && previousLevel >= batteryLowThresholdPercent) ||
+            (newLevel >= batteryLowThresholdPercent && previousLevel < batteryLowThresholdPercent)
+        return delta >= batteryMinDeltaPercent || elapsed >= batteryMinIntervalMs || crossedLow
+    }
+}
+
 /// Native CoreBluetooth manager that handles BLE lifecycle, state restoration,
 /// reconnection, service discovery, and audio batching.
 ///
@@ -30,6 +64,15 @@ final class OmiBleManager: NSObject {
 
     /// Whether the user explicitly disconnected (suppress auto-reconnect).
     private var manuallyDisconnected: Set<String> = []
+
+    /// Consecutive reconnect attempts since the last audio notification.
+    private var reconnectAttempt: [String: Int] = [:]
+    /// In-flight delayed reconnects — at most one parked connect per peripheral.
+    private var pendingReconnectWork: [String: DispatchWorkItem] = [:]
+
+    /// Last battery sample actually written to the plist ring, per peripheral.
+    private var lastPersistedBatteryLevel: [String: Int] = [:]
+    private var lastPersistedBatteryAtMs: [String: Int64] = [:]
 
     /// RSSI keep-alive timer — periodic reads prevent connection supervision timeout.
     private var rssiTimer: Timer?
@@ -146,6 +189,8 @@ final class OmiBleManager: NSObject {
 
     func disconnectPeripheral(uuid: String) {
         manuallyDisconnected.insert(uuid)
+        cancelPendingReconnect(uuid: uuid)
+        reconnectAttempt[uuid] = 0
         persistDisconnectEvent(uuid: uuid, reason: "manual", reasonCode: 0, isManual: true, eventType: "disconnect")
         guard let peripheral = peripherals[uuid] else { return }
         centralManager.cancelPeripheralConnection(peripheral)
@@ -154,12 +199,64 @@ final class OmiBleManager: NSObject {
     func disconnectAllPeripherals() {
         for (uuid, peripheral) in peripherals {
             manuallyDisconnected.insert(uuid)
+            cancelPendingReconnect(uuid: uuid)
+            reconnectAttempt[uuid] = 0
             centralManager.cancelPeripheralConnection(peripheral)
         }
     }
 
     func isPeripheralConnected(uuid: String) -> Bool {
         return peripherals[uuid]?.state == .connected
+    }
+
+    private func cancelPendingReconnect(uuid: String) {
+        pendingReconnectWork[uuid]?.cancel()
+        pendingReconnectWork.removeValue(forKey: uuid)
+    }
+
+    private func isTimeoutOrFailToConnectReason(_ reason: String) -> Bool {
+        return reason == "connection_timeout" ||
+            reason == "fail_to_connect" ||
+            reason == "connection_failed_instant_passed"
+    }
+
+    /// At most one parked `central.connect` per peripheral. First drop is
+    /// synchronous (iOS can suspend before `asyncAfter` fires). Later
+    /// background timeout/fail storms back off.
+    private func scheduleReconnect(peripheral: CBPeripheral, reason: String) {
+        let uuid = peripheralUuidString(peripheral)
+        if manuallyDisconnected.contains(uuid) { return }
+        if reason == "pairing_lost" { return }
+
+        cancelPendingReconnect(uuid: uuid)
+
+        let attempt = reconnectAttempt[uuid] ?? 0
+        let isBackground = UIApplication.shared.applicationState == .background
+        let delayMs = OmiBleReconnectPolicy.reconnectDelayMs(
+            attempt: attempt,
+            isBackground: isBackground,
+            isTimeoutOrFailToConnect: isTimeoutOrFailToConnectReason(reason)
+        )
+        reconnectAttempt[uuid] = attempt + 1
+
+        NSLog("[OmiBle] scheduleReconnect uuid=\(uuid) reason=\(reason) attempt=\(attempt) delayMs=\(delayMs) background=\(isBackground)")
+
+        let connect = { [weak self] in
+            guard let self = self else { return }
+            self.pendingReconnectWork.removeValue(forKey: uuid)
+            if self.manuallyDisconnected.contains(uuid) { return }
+            if peripheral.state == .connected { return }
+            self.centralManager.connect(peripheral, options: nil)
+        }
+
+        if delayMs <= 0 {
+            connect()
+            return
+        }
+
+        let work = DispatchWorkItem(block: connect)
+        pendingReconnectWork[uuid] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMs), execute: work)
     }
 
     /// Re-issue `connect()` on any previously-connected peripheral that isn't
@@ -309,6 +406,11 @@ final class OmiBleManager: NSObject {
     private static let batteryHistoryRetentionMs: Int64 = 7 * 24 * 3600 * 1000
 
     private static let batteryLevelCharUuid = CBUUID(string: "2A19")
+    private static let audioCharUuids: Set<CBUUID> = [
+        CBUUID(string: "19B10001-E8F2-537E-4F6C-D104768A1214"),
+        CBUUID(string: "01000000-1111-1111-1111-111111111111"),
+        CBUUID(string: "632DE003-604C-446B-A80F-7963E950F3FB"),
+    ]
 
     private static let diagnosticsKeyPrefix = "ble_diagnostics_disconnect_history_"
     private static let reconnectCountKeyPrefix = "ble_diagnostics_reconnect_count_"
@@ -486,11 +588,23 @@ final class OmiBleManager: NSObject {
     private static func batteryHistoryKey(_ uuid: String) -> String { "\(batteryHistoryKeyPrefix)\(uuid)" }
 
     private func persistBatteryReading(uuid: String, level: Int) {
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        guard OmiBleReconnectPolicy.shouldPersistBatteryReading(
+            previousLevel: lastPersistedBatteryLevel[uuid],
+            lastPersistedAtMs: lastPersistedBatteryAtMs[uuid],
+            newLevel: level,
+            nowMs: now
+        ) else {
+            return
+        }
+
+        lastPersistedBatteryLevel[uuid] = level
+        lastPersistedBatteryAtMs[uuid] = now
+
         let defaults = UserDefaults.standard
         let key = OmiBleManager.batteryHistoryKey(uuid)
         var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
 
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
         let cutoff = now - OmiBleManager.batteryHistoryRetentionMs
         history.removeAll { ($0["ts"] as? Int64 ?? 0) < cutoff }
 
@@ -562,6 +676,8 @@ extension OmiBleManager: CBCentralManagerDelegate {
                 peripheral.delegate = self
                 peripherals[uuid] = peripheral
                 uuids.append(uuid)
+                // Restored peripherals are reconnect-eligible after a later drop.
+                everConnected.insert(uuid)
 
                 // Re-establish connection if not already connected
                 if peripheral.state != .connected {
@@ -603,6 +719,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
         }
         everConnected.insert(uuid)
         connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
+        cancelPendingReconnect(uuid: uuid)
 
         peripheral.delegate = self
         peripheral.discoverServices(nil)
@@ -631,12 +748,12 @@ extension OmiBleManager: CBCentralManagerDelegate {
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
         // Retry previously-connected peripherals — otherwise a failed connect silently
-        // drops the user. iOS queues this at the chipset level; it's free while waiting.
+        // drops the user. First attempt is a parked chipset-level connect; later
+        // background timeout storms back off instead of 200ms forever.
         if !isManual, !pairingLost, everConnected.contains(uuid) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
-                guard let self = self else { return }
-                self.centralManager.connect(peripheral, options: nil)
-            }
+            let reason = Self.bleReasonString(from: error)
+            let reconnectReason = reason == "connection_timeout" ? reason : "fail_to_connect"
+            scheduleReconnect(peripheral: peripheral, reason: reconnectReason)
         }
     }
 
@@ -669,13 +786,11 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: pairingLost ? "pairing_lost" : error?.localizedDescription) { _ in }
 
-        // Auto-reconnect unless manually disconnected
+        // Auto-reconnect unless manually disconnected. Prefer a synchronous
+        // parked connect — iOS can suspend before asyncAfter fires.
         if !isManual, !pairingLost {
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
-                guard let self = self else { return }
-                // iOS handles this at the BLE chipset level — zero CPU/radio cost while waiting
-                self.centralManager.connect(peripheral, options: nil)
-            }
+            let reason = Self.bleReasonString(from: error)
+            scheduleReconnect(peripheral: peripheral, reason: reason)
         }
     }
 }
@@ -765,6 +880,10 @@ extension OmiBleManager: CBPeripheralDelegate {
 
         if characteristic.uuid == OmiBleManager.batteryLevelCharUuid, let firstByte = data.first {
             persistBatteryReading(uuid: uuid, level: Int(firstByte))
+        }
+
+        if OmiBleManager.audioCharUuids.contains(characteristic.uuid) {
+            reconnectAttempt[uuid] = 0
         }
 
         // Limitless Transcribe Later: while batch mode targets this pendant's RX

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 
 import 'package:calendar_date_picker2/calendar_date_picker2.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
-import 'package:geolocator/geolocator.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
@@ -384,11 +383,10 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final permission = await Geolocator.checkPermission();
-      if (permission == LocationPermission.always || permission == LocationPermission.whileInUse) {
-        await ForegroundUtil.initializeForegroundService();
-        await ForegroundUtil.startForegroundTask();
-      }
+      // Do not start flutter_foreground_task from location permission. On iOS
+      // that holds AVAudioSession (green mic) all day even when locationEnabled
+      // is false and nothing is capturing. CaptureController starts/stops the
+      // keep-alive only while a live capture session has audio.
       if (mounted) {
         await Provider.of<HomeProvider>(context, listen: false).setUserPeople();
       }

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -30,6 +30,7 @@ import 'package:omi/services/capture/capture_metrics_tracker.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
+import 'package:omi/services/capture/capture_keepalive_policy.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/services/voice_playback/omi_voice_playback_service.dart';
@@ -47,6 +48,7 @@ import 'package:omi/utils/image/image_utils.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/services/battery_widget_service.dart';
 import 'package:omi/utils/logger.dart';
+import 'package:omi/utils/audio/foreground.dart';
 import 'package:omi/app_globals.dart';
 
 import 'package:omi/backend/schema/message_event.dart'
@@ -81,6 +83,11 @@ class CaptureController extends ChangeNotifier
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
   DateTime? _keepAliveLastExecutedAt;
+  DateTime? _lastAudioFrameAt;
+  DateTime? _captureRecordingStartedAt;
+  bool _captureForegroundHeld = false;
+  int _fgSyncGen = 0;
+  Timer? _foregroundLivenessTimer;
   Timer? _inProgressConversationRefreshTimer;
   int _inProgressConversationRefreshAttempts = 0;
   bool _isRefreshingInProgressConversation = false;
@@ -216,6 +223,7 @@ class CaptureController extends ChangeNotifier
     _phoneMicWalActive = true;
     await ServiceManager.instance().phoneMic.start(
           onByteReceived: (bytes) {
+            _noteAudioFrame();
             final frames = _activeSource?.processBytes(bytes) ?? [];
             for (final frame in frames) {
               _wal.getSyncs().phone.onFrameCaptured(frame);
@@ -957,6 +965,7 @@ class CaptureController extends ChangeNotifier
 
         // Track bytes received from BLE
         _metrics.addBleBytes(snapshot.length);
+        _noteAudioFrame();
 
         // Command button triggered
         bool voiceCommandSupported = _recordingDevice != null
@@ -1390,6 +1399,7 @@ class CaptureController extends ChangeNotifier
     _bleButtonStream?.cancel();
     _socket?.unsubscribe(this);
     _keepAliveTimer?.cancel();
+    _foregroundLivenessTimer?.cancel();
     _inProgressConversationRefreshTimer?.cancel();
     _connectionStateListener?.cancel();
     _metrics.dispose();
@@ -1401,8 +1411,56 @@ class CaptureController extends ChangeNotifier
   }
 
   void updateRecordingState(RecordingState state) {
+    final wasLive = isLiveCaptureRecordingState(recordingState);
     recordingState = state;
+    if (isLiveCaptureRecordingState(state) && !wasLive) {
+      _captureRecordingStartedAt = DateTime.now();
+    } else if (!isLiveCaptureRecordingState(state)) {
+      _captureRecordingStartedAt = null;
+    }
+    unawaited(_syncCaptureForegroundKeepAlive());
     notifyListeners();
+  }
+
+  void _noteAudioFrame() {
+    _lastAudioFrameAt = DateTime.now();
+  }
+
+  Future<void> _syncCaptureForegroundKeepAlive() async {
+    if (!(Platform.isIOS || Platform.isAndroid)) return;
+    final gen = ++_fgSyncGen;
+    final hold = shouldHoldCaptureForegroundTask(
+      recordingState: recordingState,
+      lastAudioFrameAt: _lastAudioFrameAt,
+      recordingStartedAt: _captureRecordingStartedAt,
+      now: DateTime.now(),
+    );
+    _foregroundLivenessTimer?.cancel();
+    if (hold && isLiveCaptureRecordingState(recordingState)) {
+      _foregroundLivenessTimer = Timer(captureForegroundAudioStaleAfter, () {
+        unawaited(_syncCaptureForegroundKeepAlive());
+      });
+    }
+    if (hold == _captureForegroundHeld) {
+      return;
+    }
+    try {
+      if (hold) {
+        await ForegroundUtil.initializeForegroundService();
+        if (gen != _fgSyncGen) return;
+        await ForegroundUtil.ensureForegroundTask();
+        if (gen != _fgSyncGen) return;
+        _captureForegroundHeld = true;
+      } else {
+        await ForegroundUtil.stopForegroundTask();
+        if (gen != _fgSyncGen) return;
+        await ForegroundUtil.deactivateBluetoothAudioSession();
+        if (gen != _fgSyncGen) return;
+        _captureForegroundHeld = false;
+      }
+    } catch (e) {
+      Logger.debug('Capture foreground keep-alive sync failed: $e');
+    }
   }
 
   streamRecording() async {
@@ -1448,6 +1506,7 @@ class CaptureController extends ChangeNotifier
       await ServiceManager.instance().phoneMic.start(
             onByteReceived: (bytes) {
               // Process through AudioSource for frame splitting and sync key generation
+              _noteAudioFrame();
               final frames = _activeSource?.processBytes(bytes) ?? [];
 
               for (final frame in frames) {
@@ -1671,6 +1730,7 @@ class CaptureController extends ChangeNotifier
       }
 
       _keepAliveLastExecutedAt = DateTime.now();
+      unawaited(_syncCaptureForegroundKeepAlive());
       if (!recordingDeviceServiceReady || _socket?.state == SocketServiceState.connected) {
         t.cancel();
         return;
@@ -1679,6 +1739,21 @@ class CaptureController extends ChangeNotifier
       if (!AuthService.instance.isSignedIn()) {
         Logger.debug("[Provider] keep alive - user not signed in, cancelling reconnect");
         t.cancel();
+        return;
+      }
+
+      final shouldReconnect = shouldReconnectSttKeepAlive(
+        recordingDeviceServiceReady: recordingDeviceServiceReady,
+        socketConnected: _socket?.state == SocketServiceState.connected,
+        signedIn: true,
+        hasRecordingDevice: _recordingDevice != null,
+        isPhoneMicKeepAliveState:
+            recordingState == RecordingState.record || recordingState == RecordingState.interrupted,
+        lastAudioFrameAt: _lastAudioFrameAt,
+        now: DateTime.now(),
+      );
+      if (!shouldReconnect) {
+        Logger.debug("[Provider] keep alive - no recent audio frames, skip websocket reconnect");
         return;
       }
 

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -30,6 +30,7 @@ import 'package:omi/services/capture/capture_metrics_tracker.dart';
 import 'package:omi/services/capture/conversation_source_for_device.dart';
 import 'package:omi/services/capture/conversation_location_capture.dart';
 import 'package:omi/services/capture/freemium_threshold_tracker.dart';
+import 'package:omi/services/capture/capture_foreground_keepalive_sync.dart';
 import 'package:omi/services/capture/capture_keepalive_policy.dart';
 import 'package:omi/services/connectivity_service.dart';
 import 'package:omi/services/services.dart';
@@ -85,8 +86,7 @@ class CaptureController extends ChangeNotifier
   DateTime? _keepAliveLastExecutedAt;
   DateTime? _lastAudioFrameAt;
   DateTime? _captureRecordingStartedAt;
-  bool _captureForegroundHeld = false;
-  int _fgSyncGen = 0;
+  final CaptureForegroundKeepAliveSync _captureForegroundKeepAlive = CaptureForegroundKeepAliveSync();
   Timer? _foregroundLivenessTimer;
   Timer? _inProgressConversationRefreshTimer;
   int _inProgressConversationRefreshAttempts = 0;
@@ -1412,10 +1412,14 @@ class CaptureController extends ChangeNotifier
 
   void updateRecordingState(RecordingState state) {
     final wasLive = isLiveCaptureRecordingState(recordingState);
+    final isLive = isLiveCaptureRecordingState(state);
     recordingState = state;
-    if (isLiveCaptureRecordingState(state) && !wasLive) {
+    if (shouldClearCaptureAudioTimestamp(wasLive: wasLive, isLive: isLive)) {
+      _lastAudioFrameAt = null;
+    }
+    if (isLive && !wasLive) {
       _captureRecordingStartedAt = DateTime.now();
-    } else if (!isLiveCaptureRecordingState(state)) {
+    } else if (!isLive) {
       _captureRecordingStartedAt = null;
     }
     unawaited(_syncCaptureForegroundKeepAlive());
@@ -1424,40 +1428,43 @@ class CaptureController extends ChangeNotifier
 
   void _noteAudioFrame() {
     _lastAudioFrameAt = DateTime.now();
+    if (shouldResyncCaptureForegroundOnAudioFrame(
+      currentlyHeld: _captureForegroundKeepAlive.held,
+      recordingState: recordingState,
+    )) {
+      unawaited(_syncCaptureForegroundKeepAlive());
+    }
   }
 
   Future<void> _syncCaptureForegroundKeepAlive() async {
     if (!(Platform.isIOS || Platform.isAndroid)) return;
-    final gen = ++_fgSyncGen;
-    final hold = shouldHoldCaptureForegroundTask(
-      recordingState: recordingState,
-      lastAudioFrameAt: _lastAudioFrameAt,
-      recordingStartedAt: _captureRecordingStartedAt,
-      now: DateTime.now(),
-    );
-    _foregroundLivenessTimer?.cancel();
-    if (hold && isLiveCaptureRecordingState(recordingState)) {
-      _foregroundLivenessTimer = Timer(captureForegroundAudioStaleAfter, () {
-        unawaited(_syncCaptureForegroundKeepAlive());
-      });
-    }
-    if (hold == _captureForegroundHeld) {
-      return;
-    }
     try {
-      if (hold) {
-        await ForegroundUtil.initializeForegroundService();
-        if (gen != _fgSyncGen) return;
-        await ForegroundUtil.ensureForegroundTask();
-        if (gen != _fgSyncGen) return;
-        _captureForegroundHeld = true;
-      } else {
-        await ForegroundUtil.stopForegroundTask();
-        if (gen != _fgSyncGen) return;
-        await ForegroundUtil.deactivateBluetoothAudioSession();
-        if (gen != _fgSyncGen) return;
-        _captureForegroundHeld = false;
-      }
+      await _captureForegroundKeepAlive.apply(
+        desiredHold: () {
+          final hold = shouldHoldCaptureForegroundTask(
+            recordingState: recordingState,
+            lastAudioFrameAt: _lastAudioFrameAt,
+            recordingStartedAt: _captureRecordingStartedAt,
+            now: DateTime.now(),
+          );
+          _foregroundLivenessTimer?.cancel();
+          // Wearable FGS is frame-driven; re-check after the stale window.
+          // Phone-mic / system-audio hold for the whole session.
+          if (hold && isBluetoothCaptureForegroundOwner(recordingState)) {
+            _foregroundLivenessTimer = Timer(captureForegroundAudioStaleAfter, () {
+              unawaited(_syncCaptureForegroundKeepAlive());
+            });
+          }
+          return hold;
+        },
+        bluetoothSessionOwner: () => isBluetoothCaptureForegroundOwner(recordingState),
+        start: () async {
+          await ForegroundUtil.initializeForegroundService();
+          await ForegroundUtil.ensureForegroundTask();
+        },
+        stop: ForegroundUtil.stopForegroundTask,
+        deactivateBluetoothAudioSession: ForegroundUtil.deactivateBluetoothAudioSession,
+      );
     } catch (e) {
       Logger.debug('Capture foreground keep-alive sync failed: $e');
     }

--- a/app/lib/services/capture/capture_foreground_keepalive_sync.dart
+++ b/app/lib/services/capture/capture_foreground_keepalive_sync.dart
@@ -1,0 +1,74 @@
+/// Serializes capture FGS start/stop so a stop that arrives while start is
+/// still in flight still tears the task down (and retries a failed Bluetooth
+/// audio-session deactivate).
+class CaptureForegroundKeepAliveSync {
+  bool held = false;
+  bool bluetoothAudioSessionHeld = false;
+
+  bool _inFlight = false;
+  bool _dirty = false;
+
+  Future<void> apply({
+    required bool Function() desiredHold,
+    required bool Function() bluetoothSessionOwner,
+    required Future<void> Function() start,
+    required Future<void> Function() stop,
+    required Future<bool> Function() deactivateBluetoothAudioSession,
+  }) async {
+    if (_inFlight) {
+      _dirty = true;
+      return;
+    }
+    _inFlight = true;
+    try {
+      while (true) {
+        _dirty = false;
+        final hold = desiredHold();
+        final needsDeactivate = !hold && bluetoothAudioSessionHeld;
+        if (hold == held && !needsDeactivate) {
+          if (!_dirty) break;
+          continue;
+        }
+        try {
+          if (hold) {
+            final bluetoothOwner = bluetoothSessionOwner();
+            await start();
+            held = true;
+            if (bluetoothOwner) {
+              bluetoothAudioSessionHeld = true;
+            } else {
+              // Phone-mic / system-audio own AVAudioSession; do not retry a
+              // previous BLE deactivate underneath them.
+              bluetoothAudioSessionHeld = false;
+            }
+          } else {
+            if (held) {
+              await stop();
+              held = false;
+            }
+            if (bluetoothAudioSessionHeld) {
+              final deactivated = await deactivateBluetoothAudioSession();
+              if (deactivated) {
+                bluetoothAudioSessionHeld = false;
+              }
+            }
+          }
+        } catch (_) {
+          // Leave flags unchanged so the next apply retries the failed step.
+        }
+        if (!_dirty) break;
+      }
+    } finally {
+      _inFlight = false;
+    }
+    if (_dirty) {
+      await apply(
+        desiredHold: desiredHold,
+        bluetoothSessionOwner: bluetoothSessionOwner,
+        start: start,
+        stop: stop,
+        deactivateBluetoothAudioSession: deactivateBluetoothAudioSession,
+      );
+    }
+  }
+}

--- a/app/lib/services/capture/capture_keepalive_policy.dart
+++ b/app/lib/services/capture/capture_keepalive_policy.dart
@@ -27,7 +27,10 @@ bool isBleAudioCharacteristicUuid(String characteristicUuid) {
   final c = characteristicUuid.toLowerCase();
   return c == audioDataStreamCharacteristicUuid.toLowerCase() ||
       c == friendPendantAudioCharacteristicUuid.toLowerCase() ||
-      c == limitlessRxCharUuid.toLowerCase();
+      c == limitlessRxCharUuid.toLowerCase() ||
+      c == beeAudioCharacteristicUuid.toLowerCase() ||
+      c == fieldyAudioCharacteristicUuid.toLowerCase() ||
+      c == plaudNotifyCharUuid.toLowerCase();
 }
 
 bool isLiveCaptureRecordingState(RecordingState state) {
@@ -36,8 +39,23 @@ bool isLiveCaptureRecordingState(RecordingState state) {
       state == RecordingState.systemAudioRecord;
 }
 
+/// Phone-mic (`record`) and system-audio own AVAudioSession for the whole
+/// session, including Transcribe Later batch (no Dart frames). Wearable
+/// `deviceRecord` is the BLE path that may configure-and-deactivate Bluetooth.
+bool isSessionLongCaptureForegroundState(RecordingState state) {
+  return state == RecordingState.record || state == RecordingState.systemAudioRecord;
+}
+
+bool isBluetoothCaptureForegroundOwner(RecordingState state) {
+  return state == RecordingState.deviceRecord;
+}
+
 /// Hold flutter_foreground_task / iOS audio session only while capture is
 /// actually running and audio is flowing (or still within startup grace).
+///
+/// Phone-mic and system-audio own the session for the whole recording — a
+/// talk gap must not flap FGS or deactivate AVAudioSession under them.
+/// Wearable `deviceRecord` holds during startup grace or while frames flow.
 bool shouldHoldCaptureForegroundTask({
   required RecordingState recordingState,
   required DateTime? lastAudioFrameAt,
@@ -47,6 +65,9 @@ bool shouldHoldCaptureForegroundTask({
   if (!isLiveCaptureRecordingState(recordingState)) {
     return false;
   }
+  if (isSessionLongCaptureForegroundState(recordingState)) {
+    return true;
+  }
   if (recordingStartedAt != null && now.difference(recordingStartedAt) <= captureForegroundStartGrace) {
     return true;
   }
@@ -54,6 +75,24 @@ bool shouldHoldCaptureForegroundTask({
     return false;
   }
   return now.difference(lastAudioFrameAt) <= captureForegroundAudioStaleAfter;
+}
+
+/// After wearable FGS is released for stale audio, a new frame must re-sync
+/// or the keep-alive stays off for the rest of the session.
+bool shouldResyncCaptureForegroundOnAudioFrame({
+  required bool currentlyHeld,
+  required RecordingState recordingState,
+}) {
+  return !currentlyHeld && isLiveCaptureRecordingState(recordingState);
+}
+
+/// Drop the previous session's last-frame timestamp when entering or leaving
+/// live capture so a new/stopped session cannot inherit a 15s keep-alive hit.
+bool shouldClearCaptureAudioTimestamp({
+  required bool wasLive,
+  required bool isLive,
+}) {
+  return !isLive || !wasLive;
 }
 
 /// Whether the 15s STT keep-alive should open a new websocket.

--- a/app/lib/services/capture/capture_keepalive_policy.dart
+++ b/app/lib/services/capture/capture_keepalive_policy.dart
@@ -1,0 +1,79 @@
+import 'package:omi/services/devices/models.dart';
+import 'package:omi/utils/enums.dart';
+
+/// Window after reconnect in which an audio CCCD notification must arrive
+/// before the GATT link is treated as a dead capture path.
+const captureAudioLivenessWindow = Duration(seconds: 4);
+
+/// One CCCD re-subscribe is allowed when the liveness window expires silent.
+const captureAudioSilenceResubscribeLimit = 1;
+
+/// STT keep-alive may reconnect the websocket only if audio bytes arrived
+/// within this window. Matches the existing 15s keep-alive period.
+const captureKeepAliveRecentAudioWindow = Duration(seconds: 15);
+
+/// After entering a live recording state, hold the iOS audio/FGS keep-alive
+/// this long even before the first frame so startup is not a flap.
+const captureForegroundStartGrace = Duration(seconds: 5);
+
+/// Audio is stale (stop treating the path as live capture) after this silence.
+const captureForegroundAudioStaleAfter = Duration(seconds: 5);
+
+/// Location permission alone must never start `flutter_foreground_task`.
+/// On iOS that plugin holds AVAudioSession (green mic indicator) all day.
+bool shouldStartForegroundTaskFromLocationPermission() => false;
+
+bool isBleAudioCharacteristicUuid(String characteristicUuid) {
+  final c = characteristicUuid.toLowerCase();
+  return c == audioDataStreamCharacteristicUuid.toLowerCase() ||
+      c == friendPendantAudioCharacteristicUuid.toLowerCase() ||
+      c == limitlessRxCharUuid.toLowerCase();
+}
+
+bool isLiveCaptureRecordingState(RecordingState state) {
+  return state == RecordingState.record ||
+      state == RecordingState.deviceRecord ||
+      state == RecordingState.systemAudioRecord;
+}
+
+/// Hold flutter_foreground_task / iOS audio session only while capture is
+/// actually running and audio is flowing (or still within startup grace).
+bool shouldHoldCaptureForegroundTask({
+  required RecordingState recordingState,
+  required DateTime? lastAudioFrameAt,
+  required DateTime? recordingStartedAt,
+  required DateTime now,
+}) {
+  if (!isLiveCaptureRecordingState(recordingState)) {
+    return false;
+  }
+  if (recordingStartedAt != null && now.difference(recordingStartedAt) <= captureForegroundStartGrace) {
+    return true;
+  }
+  if (lastAudioFrameAt == null) {
+    return false;
+  }
+  return now.difference(lastAudioFrameAt) <= captureForegroundAudioStaleAfter;
+}
+
+/// Whether the 15s STT keep-alive should open a new websocket.
+bool shouldReconnectSttKeepAlive({
+  required bool recordingDeviceServiceReady,
+  required bool socketConnected,
+  required bool signedIn,
+  required bool hasRecordingDevice,
+  required bool isPhoneMicKeepAliveState,
+  required DateTime? lastAudioFrameAt,
+  required DateTime now,
+}) {
+  if (!recordingDeviceServiceReady || socketConnected || !signedIn) {
+    return false;
+  }
+  if (!hasRecordingDevice && !isPhoneMicKeepAliveState) {
+    return false;
+  }
+  if (lastAudioFrameAt == null) {
+    return false;
+  }
+  return now.difference(lastAudioFrameAt) <= captureKeepAliveRecentAudioWindow;
+}

--- a/app/lib/services/devices/ble_reconnect_policy.dart
+++ b/app/lib/services/devices/ble_reconnect_policy.dart
@@ -1,0 +1,50 @@
+// BLE reconnect + battery-history policy.
+//
+// Dart is the testable SoT. iOS `OmiBleManager` / `OmiBleReconnectPolicy`
+// must keep the same numbers and branches.
+
+/// Immediate parked `central.connect` after the first unexpected drop, then
+/// exponential backoff for background `connection_timeout` / `fail_to_connect`.
+const bleReconnectTimeoutBackoffMs = <int>[200, 2000, 10000, 30000, 60000];
+const bleReconnectBackoffCapMs = 60000;
+
+/// Delay before the next `central.connect`.
+///
+/// [attempt] is 0 for the first reconnect after an unexpected disconnect
+/// (chipset-cheap parked connect, no delay). Later attempts back off only
+/// while the app is backgrounded and the failure is a timeout or failed
+/// connect. Foreground reconnects stay immediate so the user is not waiting
+/// on a 60s cap.
+int bleReconnectDelayMs({
+  required int attempt,
+  required bool isBackground,
+  required bool isTimeoutOrFailToConnect,
+}) {
+  if (attempt <= 0 || !isBackground || !isTimeoutOrFailToConnect) {
+    return 0;
+  }
+  final idx = (attempt - 1).clamp(0, bleReconnectTimeoutBackoffMs.length - 1);
+  final delay = bleReconnectTimeoutBackoffMs[idx];
+  return delay > bleReconnectBackoffCapMs ? bleReconnectBackoffCapMs : delay;
+}
+
+const bleBatteryPersistMinDeltaPercent = 5;
+const bleBatteryPersistMinInterval = Duration(minutes: 15);
+const bleBatteryLowThresholdPercent = 20;
+
+/// Matches Dart UI throttle in `device_provider.dart` `initiateBleBatteryListener`.
+bool shouldPersistBleBatteryReading({
+  required int? previousLevel,
+  required DateTime? lastPersistedAt,
+  required int newLevel,
+  required DateTime now,
+}) {
+  if (previousLevel == null || lastPersistedAt == null) {
+    return true;
+  }
+  final delta = (previousLevel - newLevel).abs();
+  final elapsed = now.difference(lastPersistedAt);
+  final crossedLow = (newLevel < bleBatteryLowThresholdPercent && previousLevel >= bleBatteryLowThresholdPercent) ||
+      (newLevel >= bleBatteryLowThresholdPercent && previousLevel < bleBatteryLowThresholdPercent);
+  return delta >= bleBatteryPersistMinDeltaPercent || elapsed >= bleBatteryPersistMinInterval || crossedLow;
+}

--- a/app/lib/services/devices/ble_reconnect_policy.dart
+++ b/app/lib/services/devices/ble_reconnect_policy.dart
@@ -8,6 +8,20 @@
 const bleReconnectTimeoutBackoffMs = <int>[200, 2000, 10000, 30000, 60000];
 const bleReconnectBackoffCapMs = 60000;
 
+/// iOS `.inactive` (lock / transition) is not foreground: timeout backoff
+/// must apply. Keep in sync with `OmiBleManager.scheduleReconnect`.
+bool isBleReconnectBackgrounded({required bool isActive}) => !isActive;
+
+/// Whether a delayed `central.connect` should fire after a CoreBluetooth wake.
+/// Keep in sync with `OmiBleManager.flushDueReconnects`.
+bool isBleReconnectDelayElapsed({
+  required DateTime scheduledAt,
+  required int delayMs,
+  required DateTime now,
+}) {
+  return !now.isBefore(scheduledAt.add(Duration(milliseconds: delayMs)));
+}
+
 /// Delay before the next `central.connect`.
 ///
 /// [attempt] is 0 for the first reconnect after an unexpected disconnect

--- a/app/lib/services/devices/connectors/bee_connection.dart
+++ b/app/lib/services/devices/connectors/bee_connection.dart
@@ -20,7 +20,7 @@ class BeeDeviceConnection extends CustomDeviceConnection {
   String get controlCharacteristicUuid => "05e1f93c-d8d0-5ed8-dd88-379e4c1a3e3e";
 
   @override
-  String get audioCharacteristicUuid => "b189a505-a86c-11ee-a5fb-8f2089a49e7e";
+  String get audioCharacteristicUuid => beeAudioCharacteristicUuid;
 
   @override
   int get unmuteCommandCode => 0xC006;

--- a/app/lib/services/devices/connectors/fieldy_connection.dart
+++ b/app/lib/services/devices/connectors/fieldy_connection.dart
@@ -15,7 +15,7 @@ class FieldyDeviceConnection extends CustomDeviceConnection {
   String get controlCharacteristicUuid => "82a48422-3ca9-4156-ae67-4170f58666e0";
 
   @override
-  String get audioCharacteristicUuid => "82a48422-3ca9-4156-ae67-4170f58666e0";
+  String get audioCharacteristicUuid => fieldyAudioCharacteristicUuid;
 
   @override
   BleAudioCodec get audioCodec => BleAudioCodec.opusFS320;

--- a/app/lib/services/devices/models.dart
+++ b/app/lib/services/devices/models.dart
@@ -49,8 +49,10 @@ const String plaudWriteCharUuid = "00002bb1-0000-1000-8000-00805f9b34fb";
 const String plaudNotifyCharUuid = "00002bb0-0000-1000-8000-00805f9b34fb";
 
 const String beeServiceUuid = "03d5d5c4-a86c-11ee-9d89-8f2089a49e7e";
+const String beeAudioCharacteristicUuid = "b189a505-a86c-11ee-a5fb-8f2089a49e7e";
 
 const String fieldyServiceUuid = "4fafc201-1fb5-459e-8fcc-c5c9c331914b";
+const String fieldyAudioCharacteristicUuid = "82a48422-3ca9-4156-ae67-4170f58666e0";
 
 const String friendPendantServiceUuid = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da";
 const String friendPendantAudioCharacteristicUuid = "01000000-1111-1111-1111-111111111111";

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/services/devices/bluetooth_readiness.dart';
+import 'package:omi/services/capture/capture_keepalive_policy.dart';
 import 'package:omi/utils/logger.dart';
 import 'device_transport.dart';
 
@@ -27,6 +28,8 @@ class NativeBleTransport extends DeviceTransport {
   Completer<List<BleService>>? _deviceReadyCompleter;
 
   DeviceTransportState _state = DeviceTransportState.disconnected;
+  Timer? _audioLivenessTimer;
+  int _audioSilenceResubscribes = 0;
 
   NativeBleTransport(this._peripheralUuid, {this.requiresBond = false, BleHostApi? hostApi})
       : _hostApi = hostApi ?? BleHostApi() {
@@ -100,6 +103,8 @@ class NativeBleTransport extends DeviceTransport {
 
     _activeSubscriptionKeys.clear();
     _subscribedSubscriptionKeys.clear();
+    _audioLivenessTimer?.cancel();
+    _audioSilenceResubscribes = 0;
     _closeAllStreams();
     _services = [];
 
@@ -157,9 +162,9 @@ class NativeBleTransport extends DeviceTransport {
     return _streamControllers[key]!.stream;
   }
 
-  Future<void> _subscribeCharacteristic(String serviceUuid, String characteristicUuid) async {
+  Future<void> _subscribeCharacteristic(String serviceUuid, String characteristicUuid, {bool force = false}) async {
     final key = '${serviceUuid.toLowerCase()}:${characteristicUuid.toLowerCase()}';
-    if (_subscribedSubscriptionKeys.contains(key)) return;
+    if (!force && _subscribedSubscriptionKeys.contains(key)) return;
     _subscribedSubscriptionKeys.add(key);
     try {
       await _hostApi.subscribeCharacteristic(_peripheralUuid, serviceUuid, characteristicUuid);
@@ -213,6 +218,7 @@ class NativeBleTransport extends DeviceTransport {
     BleBridge.instance.unregisterPeripheral(_peripheralUuid);
     _activeSubscriptionKeys.clear();
     _subscribedSubscriptionKeys.clear();
+    _audioLivenessTimer?.cancel();
     _closeAllStreams();
     await _connectionStateController.close();
   }
@@ -259,6 +265,8 @@ class NativeBleTransport extends DeviceTransport {
       }
 
       _subscribedSubscriptionKeys.clear();
+      _audioLivenessTimer?.cancel();
+      _audioSilenceResubscribes = 0;
       _services = [];
       _updateState(DeviceTransportState.disconnected);
 
@@ -314,6 +322,8 @@ class NativeBleTransport extends DeviceTransport {
       }
 
       _updateState(DeviceTransportState.connected);
+      _audioSilenceResubscribes = 0;
+      _armAudioLivenessWatch();
     } catch (e) {
       Logger.debug('[NativeBleTransport] Failed to re-subscribe after reconnect: $e');
       _updateState(DeviceTransportState.disconnected);
@@ -323,6 +333,42 @@ class NativeBleTransport extends DeviceTransport {
   }
 
   void _handleCharacteristicValue(String serviceUuid, String characteristicUuid, Uint8List value) {
+    if (isBleAudioCharacteristicUuid(characteristicUuid) && value.isNotEmpty) {
+      _audioSilenceResubscribes = 0;
+      _audioLivenessTimer?.cancel();
+    }
     _addToStream(serviceUuid, characteristicUuid, value);
+  }
+
+  bool get _hasAudioSubscription {
+    return _activeSubscriptionKeys.any((key) {
+      final parts = key.split(':');
+      return parts.length == 2 && isBleAudioCharacteristicUuid(parts[1]);
+    });
+  }
+
+  void _armAudioLivenessWatch() {
+    _audioLivenessTimer?.cancel();
+    if (_state != DeviceTransportState.connected || !_hasAudioSubscription) {
+      return;
+    }
+    _audioLivenessTimer = Timer(captureAudioLivenessWindow, _onAudioLivenessTimeout);
+  }
+
+  void _onAudioLivenessTimeout() {
+    if (_state != DeviceTransportState.connected) return;
+    if (_audioSilenceResubscribes < captureAudioSilenceResubscribeLimit) {
+      _audioSilenceResubscribes++;
+      Logger.debug('[NativeBleTransport] no audio after reconnect, retrying CCCD subscribe once');
+      for (final key in _activeSubscriptionKeys) {
+        final parts = key.split(':');
+        if (parts.length == 2 && isBleAudioCharacteristicUuid(parts[1]) && _hasCharacteristic(parts[0], parts[1])) {
+          unawaited(_subscribeCharacteristic(parts[0], parts[1], force: true));
+        }
+      }
+      _armAudioLivenessWatch();
+      return;
+    }
+    Logger.debug('[NativeBleTransport] audio path silent after reconnect — GATT connected is not capturing');
   }
 }

--- a/app/lib/utils/audio/foreground.dart
+++ b/app/lib/utils/audio/foreground.dart
@@ -158,12 +158,17 @@ class ForegroundUtil {
   /// Release AVAudioSession after BLE/wearable capture stops. Phone-mic and
   /// CallKit paths deactivate themselves; this is the matching teardown for
   /// `configureForBluetooth` / FGS audio. No-op on Android.
-  static Future<void> deactivateBluetoothAudioSession() async {
-    if (!Platform.isIOS) return;
+  ///
+  /// Returns false when native deactivation fails so the caller can retry
+  /// instead of treating cleanup as done.
+  static Future<bool> deactivateBluetoothAudioSession() async {
+    if (!Platform.isIOS) return true;
     try {
       await _audioSessionChannel.invokeMethod('deactivateForBluetooth');
+      return true;
     } catch (e) {
       Logger.debug('deactivateForBluetooth failed: $e');
+      return false;
     }
   }
 

--- a/app/lib/utils/audio/foreground.dart
+++ b/app/lib/utils/audio/foreground.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:geolocator/geolocator.dart';
 
@@ -69,6 +70,7 @@ class _ForegroundFirstTaskHandler extends TaskHandler {
 class ForegroundUtil {
   static bool _isInitialized = false;
   static bool _isStarting = false;
+  static const _audioSessionChannel = MethodChannel('com.omi.ios/audioSession');
 
   static Future<void> requestPermissions() async {
     // Android 13+, you need to allow notification permission to display foreground service notification.
@@ -135,6 +137,33 @@ class ForegroundUtil {
     } catch (e) {
       Logger.debug('ForegroundService initialization failed: $e');
       _isInitialized = false;
+    }
+  }
+
+  /// Start the keep-alive only if it is not already running. Unlike
+  /// [startForegroundTask], this does not restart a live service (restart
+  /// would bounce the iOS audio session).
+  static Future<ServiceRequestResult> ensureForegroundTask() async {
+    try {
+      if (await FlutterForegroundTask.isRunningService) {
+        Logger.debug('ForegroundTask already running, not restarting');
+        return const ServiceRequestSuccess();
+      }
+    } catch (e) {
+      Logger.debug('ForegroundTask running-state check failed: $e');
+    }
+    return startForegroundTask();
+  }
+
+  /// Release AVAudioSession after BLE/wearable capture stops. Phone-mic and
+  /// CallKit paths deactivate themselves; this is the matching teardown for
+  /// `configureForBluetooth` / FGS audio. No-op on Android.
+  static Future<void> deactivateBluetoothAudioSession() async {
+    if (!Platform.isIOS) return;
+    try {
+      await _audioSessionChannel.invokeMethod('deactivateForBluetooth');
+    } catch (e) {
+      Logger.debug('deactivateForBluetooth failed: $e');
     }
   }
 

--- a/app/test/unit/ble_reconnect_policy_test.dart
+++ b/app/test/unit/ble_reconnect_policy_test.dart
@@ -10,6 +10,31 @@ void main() {
       );
     });
 
+    test('inactive and background are both backgrounded for backoff', () {
+      expect(isBleReconnectBackgrounded(isActive: true), isFalse);
+      expect(isBleReconnectBackgrounded(isActive: false), isTrue);
+    });
+
+    test('overdue delayed reconnects fire after a CoreBluetooth wake', () {
+      final scheduledAt = DateTime.utc(2026, 8, 14, 12);
+      expect(
+        isBleReconnectDelayElapsed(
+          scheduledAt: scheduledAt,
+          delayMs: 2000,
+          now: scheduledAt.add(const Duration(milliseconds: 1999)),
+        ),
+        isFalse,
+      );
+      expect(
+        isBleReconnectDelayElapsed(
+          scheduledAt: scheduledAt,
+          delayMs: 2000,
+          now: scheduledAt.add(const Duration(milliseconds: 2000)),
+        ),
+        isTrue,
+      );
+    });
+
     test('foreground never backs off', () {
       for (final attempt in [1, 2, 8]) {
         expect(

--- a/app/test/unit/ble_reconnect_policy_test.dart
+++ b/app/test/unit/ble_reconnect_policy_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/services/devices/ble_reconnect_policy.dart';
+
+void main() {
+  group('bleReconnectDelayMs', () {
+    test('first reconnect is a parked connect with no delay', () {
+      expect(
+        bleReconnectDelayMs(attempt: 0, isBackground: true, isTimeoutOrFailToConnect: true),
+        0,
+      );
+    });
+
+    test('foreground never backs off', () {
+      for (final attempt in [1, 2, 8]) {
+        expect(
+          bleReconnectDelayMs(attempt: attempt, isBackground: false, isTimeoutOrFailToConnect: true),
+          0,
+          reason: 'attempt $attempt',
+        );
+      }
+    });
+
+    test('non-timeout disconnects stay immediate even in background', () {
+      expect(
+        bleReconnectDelayMs(attempt: 3, isBackground: true, isTimeoutOrFailToConnect: false),
+        0,
+      );
+    });
+
+    test('background timeout/fail uses 200ms → 2s → 10s → 30s then cap 60s', () {
+      expect(bleReconnectDelayMs(attempt: 1, isBackground: true, isTimeoutOrFailToConnect: true), 200);
+      expect(bleReconnectDelayMs(attempt: 2, isBackground: true, isTimeoutOrFailToConnect: true), 2000);
+      expect(bleReconnectDelayMs(attempt: 3, isBackground: true, isTimeoutOrFailToConnect: true), 10000);
+      expect(bleReconnectDelayMs(attempt: 4, isBackground: true, isTimeoutOrFailToConnect: true), 30000);
+      expect(bleReconnectDelayMs(attempt: 5, isBackground: true, isTimeoutOrFailToConnect: true), 60000);
+      expect(bleReconnectDelayMs(attempt: 9, isBackground: true, isTimeoutOrFailToConnect: true), 60000);
+    });
+  });
+
+  group('shouldPersistBleBatteryReading', () {
+    final t0 = DateTime.utc(2026, 8, 14, 12);
+
+    test('persists the first sample', () {
+      expect(
+        shouldPersistBleBatteryReading(
+          previousLevel: null,
+          lastPersistedAt: null,
+          newLevel: 87,
+          now: t0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('skips a 1% change inside 15 minutes', () {
+      expect(
+        shouldPersistBleBatteryReading(
+          previousLevel: 87,
+          lastPersistedAt: t0,
+          newLevel: 86,
+          now: t0.add(const Duration(minutes: 5)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('persists a 5% change', () {
+      expect(
+        shouldPersistBleBatteryReading(
+          previousLevel: 87,
+          lastPersistedAt: t0,
+          newLevel: 82,
+          now: t0.add(const Duration(seconds: 5)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('persists after 15 minutes even with no change', () {
+      expect(
+        shouldPersistBleBatteryReading(
+          previousLevel: 50,
+          lastPersistedAt: t0,
+          newLevel: 50,
+          now: t0.add(const Duration(minutes: 15)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('persists crossing the 20% threshold in both directions', () {
+      expect(
+        shouldPersistBleBatteryReading(
+          previousLevel: 21,
+          lastPersistedAt: t0,
+          newLevel: 19,
+          now: t0.add(const Duration(seconds: 1)),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldPersistBleBatteryReading(
+          previousLevel: 19,
+          lastPersistedAt: t0,
+          newLevel: 20,
+          now: t0.add(const Duration(seconds: 1)),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/app/test/unit/capture_foreground_keepalive_sync_test.dart
+++ b/app/test/unit/capture_foreground_keepalive_sync_test.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/capture/capture_foreground_keepalive_sync.dart';
+
+void main() {
+  late CaptureForegroundKeepAliveSync sync;
+  late List<String> events;
+
+  Future<void> apply({
+    required bool Function() desiredHold,
+    bool Function()? bluetoothSessionOwner,
+    required Future<void> Function() start,
+    required Future<void> Function() stop,
+    Future<bool> Function()? deactivate,
+  }) {
+    return sync.apply(
+      desiredHold: desiredHold,
+      bluetoothSessionOwner: bluetoothSessionOwner ?? () => true,
+      start: start,
+      stop: stop,
+      deactivateBluetoothAudioSession: deactivate ??
+          () async {
+            events.add('deactivate');
+            return true;
+          },
+    );
+  }
+
+  setUp(() {
+    sync = CaptureForegroundKeepAliveSync();
+    events = <String>[];
+  });
+
+  test('stop during in-flight start still tears down FGS', () async {
+    var hold = true;
+    final startGate = Completer<void>();
+    final started = Completer<void>();
+
+    final first = apply(
+      desiredHold: () => hold,
+      start: () async {
+        events.add('start');
+        started.complete();
+        await startGate.future;
+      },
+      stop: () async {
+        events.add('stop');
+      },
+    );
+
+    await started.future;
+    hold = false;
+    final second = apply(
+      desiredHold: () => hold,
+      start: () async {
+        events.add('start-again');
+      },
+      stop: () async {
+        events.add('stop');
+      },
+    );
+    startGate.complete();
+    await first;
+    await second;
+
+    expect(sync.held, isFalse);
+    expect(events, ['start', 'stop', 'deactivate']);
+  });
+
+  test('does not leave FGS held when start throws', () async {
+    await apply(
+      desiredHold: () => true,
+      start: () async {
+        throw StateError('start failed');
+      },
+      stop: () async {
+        events.add('stop');
+      },
+    );
+
+    expect(sync.held, isFalse);
+    expect(events, isEmpty);
+  });
+
+  test('retries Bluetooth audio-session deactivate after a failure', () async {
+    var deactivateOk = false;
+    Future<bool> deactivate() async {
+      events.add(deactivateOk ? 'deactivate-ok' : 'deactivate-fail');
+      return deactivateOk;
+    }
+
+    await apply(
+      desiredHold: () => true,
+      start: () async {
+        events.add('start');
+      },
+      stop: () async {},
+      deactivate: deactivate,
+    );
+    expect(sync.held, isTrue);
+    expect(sync.bluetoothAudioSessionHeld, isTrue);
+
+    await apply(
+      desiredHold: () => false,
+      start: () async {},
+      stop: () async {
+        events.add('stop');
+      },
+      deactivate: deactivate,
+    );
+    expect(sync.held, isFalse);
+    expect(sync.bluetoothAudioSessionHeld, isTrue);
+
+    deactivateOk = true;
+    await apply(
+      desiredHold: () => false,
+      start: () async {},
+      stop: () async {
+        events.add('stop-again');
+      },
+      deactivate: deactivate,
+    );
+    expect(sync.bluetoothAudioSessionHeld, isFalse);
+    expect(events, ['start', 'stop', 'deactivate-fail', 'deactivate-ok']);
+  });
+
+  test('does not deactivate AVAudioSession for a non-Bluetooth capture owner', () async {
+    await apply(
+      desiredHold: () => true,
+      bluetoothSessionOwner: () => false,
+      start: () async {
+        events.add('start');
+      },
+      stop: () async {},
+    );
+    await apply(
+      desiredHold: () => false,
+      bluetoothSessionOwner: () => false,
+      start: () async {},
+      stop: () async {
+        events.add('stop');
+      },
+    );
+
+    expect(sync.held, isFalse);
+    expect(sync.bluetoothAudioSessionHeld, isFalse);
+    expect(events, ['start', 'stop']);
+  });
+}

--- a/app/test/unit/capture_keepalive_policy_test.dart
+++ b/app/test/unit/capture_keepalive_policy_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+
+import 'package:omi/services/capture/capture_keepalive_policy.dart';
+import 'package:omi/services/devices/models.dart';
+import 'package:omi/utils/enums.dart';
+
+void main() {
+  test('location permission alone does not start the foreground keep-alive', () {
+    expect(shouldStartForegroundTaskFromLocationPermission(), isFalse);
+    // The production HomePage used to start FGS for these two values.
+    expect(LocationPermission.always, isNot(LocationPermission.denied));
+    expect(LocationPermission.whileInUse, isNot(LocationPermission.denied));
+  });
+
+  test('identifies Omi / pendant / Limitless audio characteristics', () {
+    expect(isBleAudioCharacteristicUuid(audioDataStreamCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(friendPendantAudioCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(limitlessRxCharUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(batteryLevelCharacteristicUuid), isFalse);
+  });
+
+  group('shouldHoldCaptureForegroundTask', () {
+    final started = DateTime.utc(2026, 8, 14, 12);
+
+    test('does not hold when capture is stopped, paused, or interrupted', () {
+      for (final state in [
+        RecordingState.stop,
+        RecordingState.pause,
+        RecordingState.interrupted,
+        RecordingState.initialising,
+      ]) {
+        expect(
+          shouldHoldCaptureForegroundTask(
+            recordingState: state,
+            lastAudioFrameAt: started,
+            recordingStartedAt: started,
+            now: started,
+          ),
+          isFalse,
+          reason: '$state',
+        );
+      }
+    });
+
+    test('holds during startup grace before the first audio frame', () {
+      expect(
+        shouldHoldCaptureForegroundTask(
+          recordingState: RecordingState.deviceRecord,
+          lastAudioFrameAt: null,
+          recordingStartedAt: started,
+          now: started.add(const Duration(seconds: 2)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not hold after grace if no audio frames arrived', () {
+      expect(
+        shouldHoldCaptureForegroundTask(
+          recordingState: RecordingState.deviceRecord,
+          lastAudioFrameAt: null,
+          recordingStartedAt: started,
+          now: started.add(const Duration(seconds: 6)),
+        ),
+        isFalse,
+      );
+    });
+
+    test('holds while recent audio frames are flowing', () {
+      expect(
+        shouldHoldCaptureForegroundTask(
+          recordingState: RecordingState.record,
+          lastAudioFrameAt: started.add(const Duration(seconds: 10)),
+          recordingStartedAt: started,
+          now: started.add(const Duration(seconds: 12)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('releases the keep-alive when audio has gone stale', () {
+      expect(
+        shouldHoldCaptureForegroundTask(
+          recordingState: RecordingState.deviceRecord,
+          lastAudioFrameAt: started,
+          recordingStartedAt: started,
+          now: started.add(const Duration(seconds: 6)),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('shouldReconnectSttKeepAlive', () {
+    final now = DateTime.utc(2026, 8, 14, 12);
+
+    test('does not reconnect the websocket without recent audio frames', () {
+      expect(
+        shouldReconnectSttKeepAlive(
+          recordingDeviceServiceReady: true,
+          socketConnected: false,
+          signedIn: true,
+          hasRecordingDevice: true,
+          isPhoneMicKeepAliveState: false,
+          lastAudioFrameAt: null,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReconnectSttKeepAlive(
+          recordingDeviceServiceReady: true,
+          socketConnected: false,
+          signedIn: true,
+          hasRecordingDevice: true,
+          isPhoneMicKeepAliveState: false,
+          lastAudioFrameAt: now.subtract(const Duration(seconds: 16)),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('reconnects when a device is present and frames are recent', () {
+      expect(
+        shouldReconnectSttKeepAlive(
+          recordingDeviceServiceReady: true,
+          socketConnected: false,
+          signedIn: true,
+          hasRecordingDevice: true,
+          isPhoneMicKeepAliveState: false,
+          lastAudioFrameAt: now.subtract(const Duration(seconds: 3)),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('skips when the socket is already connected or the user is signed out', () {
+      expect(
+        shouldReconnectSttKeepAlive(
+          recordingDeviceServiceReady: true,
+          socketConnected: true,
+          signedIn: true,
+          hasRecordingDevice: true,
+          isPhoneMicKeepAliveState: false,
+          lastAudioFrameAt: now,
+          now: now,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldReconnectSttKeepAlive(
+          recordingDeviceServiceReady: true,
+          socketConnected: false,
+          signedIn: false,
+          hasRecordingDevice: true,
+          isPhoneMicKeepAliveState: false,
+          lastAudioFrameAt: now,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/app/test/unit/capture_keepalive_policy_test.dart
+++ b/app/test/unit/capture_keepalive_policy_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:geolocator/geolocator.dart';
 
 import 'package:omi/services/capture/capture_keepalive_policy.dart';
 import 'package:omi/services/devices/models.dart';
@@ -8,16 +7,17 @@ import 'package:omi/utils/enums.dart';
 void main() {
   test('location permission alone does not start the foreground keep-alive', () {
     expect(shouldStartForegroundTaskFromLocationPermission(), isFalse);
-    // The production HomePage used to start FGS for these two values.
-    expect(LocationPermission.always, isNot(LocationPermission.denied));
-    expect(LocationPermission.whileInUse, isNot(LocationPermission.denied));
   });
 
-  test('identifies Omi / pendant / Limitless audio characteristics', () {
+  test('identifies Omi, pendant, Limitless, Bee, Fieldy, and Plaud audio characteristics', () {
     expect(isBleAudioCharacteristicUuid(audioDataStreamCharacteristicUuid), isTrue);
     expect(isBleAudioCharacteristicUuid(friendPendantAudioCharacteristicUuid), isTrue);
     expect(isBleAudioCharacteristicUuid(limitlessRxCharUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(beeAudioCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(fieldyAudioCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(plaudNotifyCharUuid), isTrue);
     expect(isBleAudioCharacteristicUuid(batteryLevelCharacteristicUuid), isFalse);
+    expect(isBleAudioCharacteristicUuid(plaudWriteCharUuid), isFalse);
   });
 
   group('shouldHoldCaptureForegroundTask', () {
@@ -67,10 +67,10 @@ void main() {
       );
     });
 
-    test('holds while recent audio frames are flowing', () {
+    test('holds while recent wearable audio frames are flowing', () {
       expect(
         shouldHoldCaptureForegroundTask(
-          recordingState: RecordingState.record,
+          recordingState: RecordingState.deviceRecord,
           lastAudioFrameAt: started.add(const Duration(seconds: 10)),
           recordingStartedAt: started,
           now: started.add(const Duration(seconds: 12)),
@@ -79,7 +79,7 @@ void main() {
       );
     });
 
-    test('releases the keep-alive when audio has gone stale', () {
+    test('releases wearable keep-alive when audio has gone stale', () {
       expect(
         shouldHoldCaptureForegroundTask(
           recordingState: RecordingState.deviceRecord,
@@ -90,6 +90,65 @@ void main() {
         isFalse,
       );
     });
+
+    test('re-acquires wearable keep-alive when frames resume after silence', () {
+      final resumed = started.add(const Duration(seconds: 20));
+      expect(
+        shouldHoldCaptureForegroundTask(
+          recordingState: RecordingState.deviceRecord,
+          lastAudioFrameAt: resumed,
+          recordingStartedAt: started,
+          now: resumed,
+        ),
+        isTrue,
+      );
+    });
+
+    test('holds phone-mic and system-audio for the whole session without frames', () {
+      for (final state in [RecordingState.record, RecordingState.systemAudioRecord]) {
+        expect(
+          shouldHoldCaptureForegroundTask(
+            recordingState: state,
+            lastAudioFrameAt: null,
+            recordingStartedAt: started,
+            now: started.add(const Duration(minutes: 2)),
+          ),
+          isTrue,
+          reason: '$state',
+        );
+      }
+    });
+  });
+
+  test('audio resume after silence must re-sync when FGS is not held', () {
+    expect(
+      shouldResyncCaptureForegroundOnAudioFrame(
+        currentlyHeld: false,
+        recordingState: RecordingState.deviceRecord,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldResyncCaptureForegroundOnAudioFrame(
+        currentlyHeld: true,
+        recordingState: RecordingState.deviceRecord,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldResyncCaptureForegroundOnAudioFrame(
+        currentlyHeld: false,
+        recordingState: RecordingState.stop,
+      ),
+      isFalse,
+    );
+  });
+
+  test('clears inherited audio timestamps at session boundaries', () {
+    expect(shouldClearCaptureAudioTimestamp(wasLive: true, isLive: false), isTrue);
+    expect(shouldClearCaptureAudioTimestamp(wasLive: false, isLive: true), isTrue);
+    expect(shouldClearCaptureAudioTimestamp(wasLive: true, isLive: true), isFalse);
+    expect(shouldClearCaptureAudioTimestamp(wasLive: false, isLive: false), isTrue);
   });
 
   group('shouldReconnectSttKeepAlive', () {

--- a/app/test/unit/native_ble_transport_resync_test.dart
+++ b/app/test/unit/native_ble_transport_resync_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/gen/pigeon_communicator.g.dart';
@@ -74,5 +75,42 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(states, [DeviceTransportState.disconnected, DeviceTransportState.connected]);
+  });
+
+  test('after reconnect, silent audio CCCD is retried once then left dead', () {
+    fakeAsync((async) {
+      transport.dispose();
+      final hostApi = _FakeBleHostApi();
+      transport = NativeBleTransport(uuid, hostApi: hostApi);
+
+      const audioChar = '19b10001-e8f2-537e-4f6c-d104768a1214';
+      final audioServices = [
+        BleService(uuid: serviceUuid, characteristicUuids: [audioChar]),
+      ];
+
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      transport.getCharacteristicStream(serviceUuid, audioChar).listen((_) {});
+      async.flushMicrotasks();
+
+      BleBridge.instance.onPeripheralDisconnected(uuid, null);
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      async.flushMicrotasks();
+
+      final subscribesBeforeWatch = hostApi.subscribed.where((s) => s.contains(audioChar)).length;
+      expect(subscribesBeforeWatch, greaterThanOrEqualTo(1));
+
+      async.elapse(const Duration(seconds: 4));
+      async.flushMicrotasks();
+      final afterFirstSilence = hostApi.subscribed.where((s) => s.contains(audioChar)).length;
+      expect(afterFirstSilence, subscribesBeforeWatch + 1, reason: 'one CCCD resubscribe on silence');
+
+      async.elapse(const Duration(seconds: 4));
+      async.flushMicrotasks();
+      expect(
+        hostApi.subscribed.where((s) => s.contains(audioChar)).length,
+        afterFirstSilence,
+        reason: 'do not tight-loop resubscribe after the single retry',
+      );
+    });
   });
 }

--- a/app/test/unit/native_ble_transport_resync_test.dart
+++ b/app/test/unit/native_ble_transport_resync_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/devices/transports/device_transport.dart';
 import 'package:omi/services/devices/transports/native_ble_transport.dart';
 
@@ -110,6 +111,38 @@ void main() {
         hostApi.subscribed.where((s) => s.contains(audioChar)).length,
         afterFirstSilence,
         reason: 'do not tight-loop resubscribe after the single retry',
+      );
+    });
+  });
+
+  test('Bee audio UUID silence after reconnect still schedules one CCCD retry', () {
+    fakeAsync((async) {
+      transport.dispose();
+      final hostApi = _FakeBleHostApi();
+      transport = NativeBleTransport(uuid, hostApi: hostApi);
+
+      final audioServices = [
+        BleService(uuid: beeServiceUuid, characteristicUuids: [beeAudioCharacteristicUuid]),
+      ];
+
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      transport.getCharacteristicStream(beeServiceUuid, beeAudioCharacteristicUuid).listen((_) {});
+      async.flushMicrotasks();
+
+      BleBridge.instance.onPeripheralDisconnected(uuid, null);
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      async.flushMicrotasks();
+
+      final subscribesBeforeWatch =
+          hostApi.subscribed.where((s) => s.toLowerCase().contains(beeAudioCharacteristicUuid.toLowerCase())).length;
+      expect(subscribesBeforeWatch, greaterThanOrEqualTo(1));
+
+      async.elapse(const Duration(seconds: 4));
+      async.flushMicrotasks();
+      expect(
+        hostApi.subscribed.where((s) => s.toLowerCase().contains(beeAudioCharacteristicUuid.toLowerCase())).length,
+        subscribesBeforeWatch + 1,
+        reason: 'Bee audio UUID must be recognized so CCCD retry arms',
       );
     });
   });


### PR DESCRIPTION
## What changed and why

Home was starting `flutter_foreground_task` from location permission alone, which held `AVAudioSession` (green mic) all day even when nothing was capturing. Pair that with a 200ms BLE reconnect on every background `connection_timeout` and a 3s `readRSSI` "keep-alive". This stops those keep-alives, backs off background BLE timeouts, and holds audio/FGS only while capture actually has frames.

Leave issue 11307 open. Firmware AAD/store-when-unsubscribed is a separate device-side defect and is unchanged here. `voip` stays in Info.plist (CallKit).

## Related issues

- Related: #11307 — iOS background BLE `connection_timeout` leaves live transcription unavailable
- Relates to #5491 — idle/background battery drain from BLE scan + keep-alives
- Relates to #6570 — GATT connected but app not consuming audio
- Relates to #6610 (closed) — iOS background BLE reconnect stall; remaining gap is #11307
- Overlaps draft PR #10573 — serialize iOS BLE recovery / drop RSSI keepalive (this PR takes the idea plus backoff; not a wholesale merge)

## Product invariants affected

none

## How it was verified

```
cd app && flutter test test/unit test/providers
```

1024 tests passed (including `capture_keepalive_policy_test`, `capture_foreground_keepalive_sync_test`, `ble_reconnect_policy_test`, and Bee CCCD silence retry in `native_ble_transport_resync_test`).

Targeted `dart analyze` on the policy/transport/controller files: no issues. Worktree `analyze_ratchet.sh` could not run (missing `lib/env/dev_env.g.dart` / `lib/firebase_options_dev.dart`).

Not exercised on a physical iPhone in this PR. On-device evidence for the bug (TestFlight 1.0.543, iPhone 15 Pro Max, Omi CV1 3.0.21): 51% battery / 16h background, `backgroundServiceAction=API_START`, 19/20 last disconnects `connection_timeout` in `background`, green mic held while idle.

## Tests

- `app/test/unit/capture_keepalive_policy_test.dart` — FGS must not start from location permission; Bee/Fieldy/Plaud audio UUIDs; phone-mic/system-audio hold for the whole session; wearable hold is frame-driven and re-acquires after silence; STT keep-alive requires audio in the last 15s
- `app/test/unit/capture_foreground_keepalive_sync_test.dart` — stop during in-flight start still tears down FGS; Bluetooth audio-session deactivate is retried on failure and skipped for phone-mic
- `app/test/unit/ble_reconnect_policy_test.dart` — first reconnect is immediate; `.inactive` counts as background; overdue delayed reconnects fire after a CoreBluetooth wake; background timeout/fail backs off 200ms → 2s → 10s → 30s → 60s; battery persist first / ≥5% / 15 min / cross 20%
- `app/test/unit/native_ble_transport_resync_test.dart` — after reconnect, one CCCD resubscribe if no audio in 4s, including Bee audio UUIDs

## Failure class (fixes)

Failure-Class: none

## Test plan

- [ ] Cold launch with location While Using the App and no capture: no green mic, no "Transcription service is running in the background" notification
- [ ] Start wearable capture: FGS + audio session come up; stop capture: both go away (CallKit call in progress should not deactivate the session)
- [ ] Background BLE timeout storm: reconnects back off (200ms → 2s → 10s → 30s → 60s), not a 200ms loop; foreground reconnect stays immediate
- [ ] Diagnostics RSSI graph still updates only while that screen is open
- [ ] Phone-mic recording still starts/stops FGS; in-app playback after capture still works
- [ ] Android Dart FGS now starts from capture, not Home location permission (native Android FGS unchanged)