### PR TITLE
fix(desktop): keep live transcript on glass and honest in meetings-only

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -465,6 +465,13 @@ class AppState: ObservableObject {
   var meetingEndFinalizationInProgress = false
   @Published var isAwaitingMeeting = false
 
+  /// Audio is actually reaching STT — not merely that a transcription session is armed.
+  ///
+  /// Only Meetings keeps `isTranscribing` true while waiting for a call so capture can start
+  /// instantly, and sets `isAwaitingMeeting` while the mic is paused. Live UI (the Conversations
+  /// card, the expanded transcript, the top-bar mic dot) must follow this, not `isTranscribing`.
+  var isLiveCapturing: Bool { isTranscribing && !isAwaitingMeeting }
+
   var audioRecordingMode: AssistantSettings.AudioRecordingMode {
     AssistantSettings.shared.audioRecordingMode
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/CaptureListeningLogic.swift
@@ -21,6 +21,13 @@ enum CaptureListeningLogic {
     isCaptureMonitoring || ProactiveAssistantsPlugin.shared.isMonitoring
   }
 
+  /// The top-bar / Home listening readout. A session that is only *armed* (Only Meetings, no
+  /// call) is inactive — the mic is paused, so lighting the green dot would lie.
+  static func listeningStatus(appState: AppState) -> HomeStatusState {
+    if appState.transcriptionServiceError != nil { return .blocked }
+    return appState.isLiveCapturing ? .active : .inactive
+  }
+
   static func audioRecordingMode(raw: String) -> AssistantSettings.AudioRecordingMode {
     AssistantSettings.AudioRecordingMode(rawValue: raw) ?? .onlyMeetings
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/LiveTranscriptView.swift
@@ -169,9 +169,9 @@ private struct LiveTranscriptExpandTap: ViewModifier {
   /// and the pointing-hand cursor is always popped when the card stops being
   /// hovered — SwiftUI doesn't deliver an `onHover(false)` when the view leaves
   /// the hierarchy. Two exit paths are handled explicitly: `onDisappear`
-  /// (recording stops and the `if appState.isTranscribing` card is removed) and
-  /// the tap handler (expanding draws the full-screen overlay over the card,
-  /// which stays mounted, so `onDisappear` never fires there).
+  /// (capture pauses and the `if appState.isLiveCapturing` card is removed) and
+  /// the tap handler (expanding replaces the page, which also unmounts the card;
+  /// popping here keeps the cursor from lingering for a frame).
   @State private var didPushCursor = false
 
   private func setHovered(_ hovering: Bool) {
@@ -189,8 +189,7 @@ private struct LiveTranscriptExpandTap: ViewModifier {
     if let onExpand {
       content
         .onTapGesture {
-          // Pop the pointing-hand before the overlay covers the still-mounted
-          // card, otherwise it lingers over the full-screen transcript.
+          // Pop the pointing-hand before the page swaps away the card.
           setHovered(false)
           onExpand()
         }
@@ -203,8 +202,9 @@ private struct LiveTranscriptExpandTap: ViewModifier {
   }
 }
 
-/// Full-screen live transcript, presented when the user clicks the compact live
-/// transcript card. Observes the monitor directly so it keeps updating live.
+/// Full-panel live transcript, presented in place of the Conversations list when
+/// the user expands the compact live card. Observes the monitor directly so it
+/// keeps updating live. Hosted on the same glass panel — paints no ground of its own.
 struct ConversationsLiveTranscriptFullScreen: View {
   @ObservedObject private var monitor = LiveTranscriptMonitor.shared
   var onCollapse: () -> Void
@@ -251,7 +251,6 @@ struct ConversationsLiveTranscriptFullScreen: View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color.clear)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
@@ -203,6 +203,30 @@ struct ConversationsPage: View {
   // MARK: - Main View with Recording Header + List
 
   private var mainConversationsView: some View {
+    Group {
+      if isLiveTranscriptExpanded && appState.isLiveCapturing {
+        ConversationsLiveTranscriptFullScreen(
+          onCollapse: {
+            OmiMotion.withGated(.easeInOut(duration: 0.2)) {
+              isLiveTranscriptExpanded = false
+            }
+          }
+        )
+        .transition(.opacity)
+      } else {
+        conversationsListLayout
+      }
+    }
+    // Collapse if capture pauses (meeting ends) or the session stops while expanded.
+    .onChange(of: appState.isLiveCapturing) { _, isLive in
+      if !isLive {
+        isLiveTranscriptExpanded = false
+      }
+    }
+  }
+
+  /// The Conversations list chrome: pinned title row, then the scrolling live card + list.
+  private var conversationsListLayout: some View {
     VStack(spacing: 0) {
       // Fixed page header — title + actions stay pinned; everything below it
       // (live transcript, search, filters, list) scrolls together as one.
@@ -243,24 +267,6 @@ struct ConversationsPage: View {
         floatingActionBars
       }
     }
-    .overlay {
-      if isLiveTranscriptExpanded {
-        ConversationsLiveTranscriptFullScreen(
-          onCollapse: {
-            OmiMotion.withGated(.easeInOut(duration: 0.2)) {
-              isLiveTranscriptExpanded = false
-            }
-          }
-        )
-        .transition(.opacity)
-      }
-    }
-    // Collapse the full-screen transcript if transcription stops while it's open.
-    .onChange(of: appState.isTranscribing) { _, isTranscribing in
-      if !isTranscribing {
-        isLiveTranscriptExpanded = false
-      }
-    }
   }
 
   /// Everything below the fixed header, rendered inside a single scroll so the
@@ -268,9 +274,9 @@ struct ConversationsPage: View {
   /// together. When `embedded`, the parent owns the scroll and this renders bare.
   @ViewBuilder private var scrollingBody: some View {
     let content = VStack(spacing: 0) {
-      // Live transcript while recording — updates as it's spoken. Click to
-      // expand it full screen.
-      if appState.isTranscribing {
+      // Live transcript while actually capturing. Only Meetings keeps a session
+      // armed with the mic paused (`isAwaitingMeeting`); that is not Live.
+      if appState.isLiveCapturing {
         ConversationsLiveTranscript(
           onExpand: {
             OmiMotion.withGated(.easeInOut(duration: 0.2)) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1637,6 +1637,7 @@ struct DashboardPage: View {
             : (appState.isLiveCapturing ? "waveform.circle.fill" : "mic.circle"),
           status: CaptureListeningLogic.listeningStatus(appState: appState),
           modeTitle: listeningModeTitle,
+          isAwaitingMeeting: appState.isAwaitingMeeting,
           isToggling: isTogglingListening,
           action: toggleListening
         )
@@ -3872,8 +3873,23 @@ struct HomeListeningStatusButton: View {
   let systemImage: String
   let status: HomeStatusState
   let modeTitle: String
+  /// Only Meetings wait: the session is armed, the mic is paused, and a click turns
+  /// listening off. Help/VoiceOver must not reuse the "Off" sentence for that.
+  let isAwaitingMeeting: Bool
   let isToggling: Bool
   let action: () -> Void
+
+  /// Hover / VoiceOver copy. An armed Only Meetings wait is inactive (mic paused)
+  /// but not off — a click turns listening off, it does not start it.
+  static func helpText(
+    status: HomeStatusState, modeTitle: String, isAwaitingMeeting: Bool
+  ) -> String {
+    if status == .inactive && isAwaitingMeeting {
+      return
+        "Listening: waiting for a call (\(modeTitle)). Nothing is being transcribed. Click to turn off."
+    }
+    return "Listening: \(status.text), \(modeTitle)"
+  }
 
   // Hover reveals the selected mode, but Settings owns the only picker.
   @State private var isHovering = false
@@ -3917,8 +3933,9 @@ struct HomeListeningStatusButton: View {
       }
       .buttonStyle(.plain)
       .disabled(isToggling)
-      .help("Listening: \(status.text), \(modeTitle)")
-      .accessibilityLabel("Listening \(status.text), \(modeTitle)")
+      .help(Self.helpText(status: status, modeTitle: modeTitle, isAwaitingMeeting: isAwaitingMeeting))
+      .accessibilityLabel(
+        Self.helpText(status: status, modeTitle: modeTitle, isAwaitingMeeting: isAwaitingMeeting))
     }
     .foregroundStyle(status.isActive ? HomePalette.ink : (status.isBlocked ? status.indicator : HomePalette.muted))
     .background(

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -1634,8 +1634,8 @@ struct DashboardPage: View {
           title: transcriptionUnavailable ? "Transcription unavailable" : "Listening",
           systemImage: transcriptionUnavailable
             ? "exclamationmark.triangle.fill"
-            : (appState.isTranscribing ? "waveform.circle.fill" : "mic.circle"),
-          status: transcriptionUnavailable ? .blocked : (appState.isTranscribing ? .active : .inactive),
+            : (appState.isLiveCapturing ? "waveform.circle.fill" : "mic.circle"),
+          status: CaptureListeningLogic.listeningStatus(appState: appState),
           modeTitle: listeningModeTitle,
           isToggling: isTogglingListening,
           action: toggleListening

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/HomePresentationTokens.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/HomePresentationTokens.swift
@@ -77,7 +77,7 @@ enum HomeAskBarPalette {
   }
 }
 
-enum HomeStatusState {
+enum HomeStatusState: Equatable {
   case active
   case inactive
   case blocked

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ShellStatusIcons.swift
@@ -222,13 +222,20 @@ enum ShellStatusTooltip {
   /// `mode` is `CaptureListeningLogic.listeningModeTitle` — "In meeting", "Always", a named mic. The
   /// mode is not decoration: "listening" with no qualifier is a claim the meetings-only mode does not
   /// actually make.
-  static func audio(state: HomeStatusState, mode: String) -> String {
+  ///
+  /// `isAwaitingMeeting` is the Only Meetings wait: the session is armed, the mic is paused, and a
+  /// click turns listening *off* rather than starting it. That must not reuse the "off / click to
+  /// start" sentence.
+  static func audio(state: HomeStatusState, mode: String, isAwaitingMeeting: Bool = false) -> String {
     switch state {
     case .blocked:
       return "Audio — transcription unavailable. Open Settings to reconnect."
     case .active:
       return "Audio — listening (\(mode)). Click to stop."
     case .inactive:
+      if isAwaitingMeeting {
+        return "Audio — waiting for a call (\(mode)). Nothing is being transcribed. Click to turn off."
+      }
       return "Audio — off. Nothing is being transcribed. Click to start."
     }
   }
@@ -355,18 +362,16 @@ struct ShellStatusIcons: View {
 
   // MARK: Derived state
 
-  private var transcriptionUnavailable: Bool { appState.transcriptionServiceError != nil }
-
   private var listeningState: HomeStatusState {
-    if transcriptionUnavailable { return .blocked }
-    return appState.isTranscribing ? .active : .inactive
+    CaptureListeningLogic.listeningStatus(appState: appState)
   }
 
   private var listeningTooltip: String {
     ShellStatusTooltip.audio(
       state: listeningState,
       mode: CaptureListeningLogic.listeningModeTitle(
-        appState: appState, raw: audioRecordingModeRaw))
+        appState: appState, raw: audioRecordingModeRaw),
+      isAwaitingMeeting: appState.isAwaitingMeeting)
   }
 
   private var captureState: HomeStatusState {

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -4,6 +4,33 @@ import XCTest
 
 final class DashboardCaptureStateTests: XCTestCase {
   @MainActor
+  func testLiveCapturingIsFalseWhileAwaitingAMeeting() {
+    let appState = AppState()
+    appState.isTranscribing = true
+    appState.isAwaitingMeeting = true
+    XCTAssertFalse(
+      appState.isLiveCapturing,
+      "Only Meetings with no call pauses the mic; Live UI must not treat the armed session as capture.")
+
+    appState.isAwaitingMeeting = false
+    XCTAssertTrue(appState.isLiveCapturing)
+
+    appState.isTranscribing = false
+    XCTAssertFalse(appState.isLiveCapturing)
+  }
+
+  @MainActor
+  func testListeningStatusIsInactiveWhileAwaitingAMeeting() {
+    let appState = AppState()
+    appState.isTranscribing = true
+    appState.isAwaitingMeeting = true
+    XCTAssertEqual(CaptureListeningLogic.listeningStatus(appState: appState), .inactive)
+
+    appState.isAwaitingMeeting = false
+    XCTAssertEqual(CaptureListeningLogic.listeningStatus(appState: appState), .active)
+  }
+
+  @MainActor
   func testListeningModeTitlePreservesOakleyMetaName() {
     let appState = AppState()
     appState.isTranscribing = true
@@ -75,6 +102,28 @@ final class DashboardCaptureStateTests: XCTestCase {
     XCTAssertTrue(source.contains(".frame(height: 34)"))
     XCTAssertFalse(source.contains("Circle()\n                    .fill(status.indicator)"))
     XCTAssertFalse(source.contains("OmiColors.purplePrimary"))
+  }
+
+  func testListeningStatusIsSharedAndLiveTranscriptExpandReplacesThePage() throws {
+    let dashboard = try dashboardSource()
+    let logic = try captureLogicSource()
+    let conversations = try source(named: "ConversationsPage.swift")
+    let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let shellURL =
+      testsURL
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/QueryShell/ShellStatusIcons.swift")
+    // omi-test-quality: source-inspection -- static contract: which predicate the Live card and listening dot name is not observable from a running view without a window server
+    let shell = try String(contentsOf: shellURL, encoding: .utf8)
+
+    XCTAssertTrue(logic.contains("return appState.isLiveCapturing ? .active : .inactive"))
+    XCTAssertTrue(dashboard.contains("CaptureListeningLogic.listeningStatus(appState: appState)"))
+    XCTAssertTrue(shell.contains("CaptureListeningLogic.listeningStatus(appState: appState)"))
+    XCTAssertTrue(conversations.contains("if appState.isLiveCapturing {"))
+    XCTAssertTrue(conversations.contains("if isLiveTranscriptExpanded && appState.isLiveCapturing"))
+    XCTAssertFalse(
+      conversations.contains(".overlay {\n      if isLiveTranscriptExpanded"),
+      "Expanding the live transcript must replace the Conversations page body, not overlay it.")
   }
 
   func testRedesignedHomeUsesResponsiveStageSizing() throws {

--- a/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardCaptureStateTests.swift
@@ -31,6 +31,20 @@ final class DashboardCaptureStateTests: XCTestCase {
   }
 
   @MainActor
+  func testHomeListeningHelpDoesNotClaimOffWhileAwaitingAMeeting() {
+    let help = HomeListeningStatusButton.helpText(
+      status: .inactive, modeTitle: "Only Meetings", isAwaitingMeeting: true)
+    XCTAssertTrue(help.contains("waiting for a call"))
+    XCTAssertTrue(help.contains("Only Meetings"))
+    XCTAssertTrue(help.contains("Click to turn off"))
+    XCTAssertFalse(help.contains("Off"))
+    XCTAssertEqual(
+      HomeListeningStatusButton.helpText(
+        status: .inactive, modeTitle: "Always On", isAwaitingMeeting: false),
+      "Listening: Off, Always On")
+  }
+
+  @MainActor
   func testListeningModeTitlePreservesOakleyMetaName() {
     let appState = AppState()
     appState.isTranscribing = true
@@ -118,6 +132,7 @@ final class DashboardCaptureStateTests: XCTestCase {
 
     XCTAssertTrue(logic.contains("return appState.isLiveCapturing ? .active : .inactive"))
     XCTAssertTrue(dashboard.contains("CaptureListeningLogic.listeningStatus(appState: appState)"))
+    XCTAssertTrue(dashboard.contains("isAwaitingMeeting: appState.isAwaitingMeeting"))
     XCTAssertTrue(shell.contains("CaptureListeningLogic.listeningStatus(appState: appState)"))
     XCTAssertTrue(conversations.contains("if appState.isLiveCapturing {"))
     XCTAssertTrue(conversations.contains("if isLiveTranscriptExpanded && appState.isLiveCapturing"))

--- a/desktop/macos/Desktop/Tests/ShellStatusIconLegibilityTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellStatusIconLegibilityTests.swift
@@ -624,4 +624,16 @@ final class ShellStatusIconLegibilityTests: XCTestCase {
       "listening" overclaims whenever the mode is armed rather than live.
       """)
   }
+
+  func testTheAwaitingMeetingAudioTooltipDoesNotClaimOffOrStart() {
+    let tooltip = ShellStatusTooltip.audio(
+      state: .inactive, mode: "Only Meetings", isAwaitingMeeting: true)
+    XCTAssertTrue(tooltip.hasPrefix("Audio"))
+    XCTAssertTrue(tooltip.contains("waiting for a call"))
+    XCTAssertTrue(tooltip.contains("Only Meetings"))
+    XCTAssertTrue(tooltip.contains("Click to turn off"))
+    XCTAssertFalse(
+      tooltip.contains("Click to start"),
+      "An armed Only Meetings wait is not off; clicking turns listening off, it does not start it.")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260814-live-transcript-overlay-cover.json
+++ b/desktop/macos/changelog/unreleased/20260814-live-transcript-overlay-cover.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the live transcript expand view so it fills the Conversations panel on glass, and hid the Live card when Only Meetings is waiting for a call"
+}

--- a/desktop/macos/changelog/unreleased/20260814-live-transcript-overlay-cover.json
+++ b/desktop/macos/changelog/unreleased/20260814-live-transcript-overlay-cover.json
@@ -1,3 +1,3 @@
 {
-  "change": "Fixed the live transcript expand view so it fills the Conversations panel on glass, and hid the Live card when Only Meetings is waiting for a call"
+  "change": "Fixed the live transcript expand view so it fills the Conversations panel on glass, hid the Live card when Only Meetings is waiting for a call, and stopped that wait from reading as Off"
 }


### PR DESCRIPTION
## Summary
- Expanding the Live card now replaces the Conversations page on the same glass panel, instead of overlaying a white sheet over the list.
- The Live card and the top-bar mic dot follow actual capture (`isTranscribing && !isAwaitingMeeting`), so Only Meetings no longer looks live while waiting for a call.
- The armed-wait mic tooltip (shell) and Home Listening help/VoiceOver now say it is waiting for a call and that a click turns listening off, not that audio is off and a click starts it.

## Test plan
- [ ] On Conversations while Always On and capturing, click expand: the list is replaced by a full-panel Live Transcript on glass; collapse restores the list.
- [ ] Switch to Only Meetings with no call: Live card and green mic dot go away; shell tooltip and Home Listening help say waiting-for-a-call, not "off / click to start".
- [ ] Start or join a meeting in Only Meetings: Live card and green mic return, and speech appears.
- [ ] `xcrun swift test -c debug --package-path Desktop --filter DashboardCaptureStateTests --filter ShellStatusIconLegibilityTests`

## Product invariants affected

- INV-CHAT-1

## Failure-Class
Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift | 4280 -> 4297 | Home listening help for the armed Only Meetings wait; splitting this file is out of scope.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

