### PR TITLE
fix(desktop): keep pinned Omi chat runnable after a provider switch

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
@@ -873,14 +873,18 @@ actor AgentBridge {
       generation: generation,
       authorizationSnapshot: authorizationSnapshot)
     let registeredThisCall = !registered || !processWasAlive
-    let requiresManagedCredentials =
-      isPiMonoHarness
-      && AgentRuntimeCredentialPolicy.requiresManagedCredentials(
-        requestedCredentials: requiresCredentials,
-        isNonProduction: AppBuild.isNonProduction,
-        hermeticFaultModelToken: AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
-          isNonProduction: AppBuild.isNonProduction,
-          bundleIdentifier: AppBuild.bundleIdentifier))
+    let hermeticFaultModelToken = AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+      isNonProduction: AppBuild.isNonProduction,
+      bundleIdentifier: AppBuild.bundleIdentifier)
+    let shouldFetchManagedToken = AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+      requestedCredentials: requiresCredentials,
+      isNonProduction: AppBuild.isNonProduction,
+      hermeticFaultModelToken: hermeticFaultModelToken)
+    let requiresPiMonoCredentials = AgentRuntimeCredentialPolicy.shouldRequirePiMonoCredentials(
+      preferredAdapterIsPiMono: isPiMonoHarness,
+      requestedCredentials: requiresCredentials,
+      isNonProduction: AppBuild.isNonProduction,
+      hermeticFaultModelToken: hermeticFaultModelToken)
     var acquiredRegistration = false
     do {
       if registeredThisCall {
@@ -908,13 +912,14 @@ actor AgentBridge {
       let authorityNeedsSynchronization =
         !status.isSynchronized(
           ownerID: ownerID,
-          requiresCredentials: requiresManagedCredentials)
+          requiresCredentials: requiresPiMonoCredentials)
         || synchronizedRuntimeAuthorityEpoch != status.epoch
         || synchronizedRuntimeAuthorityOwnerID != ownerID
+        || (shouldFetchManagedToken && status.credentialOwnerID != ownerID)
       if authorityNeedsSynchronization {
         await synchronizeRuntimeAuthority(
           authorizationSnapshot: authorizationSnapshot,
-          requiresCredentials: requiresManagedCredentials)
+          requiresCredentials: shouldFetchManagedToken)
         try assertLifecycleFlightCurrent(
           id: flightID,
           generation: generation,
@@ -927,7 +932,7 @@ actor AgentBridge {
         guard
           synchronized.isSynchronized(
             ownerID: ownerID,
-            requiresCredentials: requiresManagedCredentials)
+            requiresCredentials: requiresPiMonoCredentials)
         else {
           throw BridgeError.authMissing
         }
@@ -993,9 +998,21 @@ actor AgentBridge {
       id: flightID,
       generation: generation,
       authorizationSnapshot: authorizationSnapshot)
+    let hermeticFaultModelToken = AgentRuntimeCredentialPolicy.hermeticFaultModelToken(
+      isNonProduction: AppBuild.isNonProduction,
+      bundleIdentifier: AppBuild.bundleIdentifier)
+    let shouldFetchManagedToken = AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+      requestedCredentials: true,
+      isNonProduction: AppBuild.isNonProduction,
+      hermeticFaultModelToken: hermeticFaultModelToken)
+    let requiresPiMonoCredentials = AgentRuntimeCredentialPolicy.shouldRequirePiMonoCredentials(
+      preferredAdapterIsPiMono: isPiMonoHarness,
+      requestedCredentials: true,
+      isNonProduction: AppBuild.isNonProduction,
+      hermeticFaultModelToken: hermeticFaultModelToken)
     await synchronizeRuntimeAuthority(
       authorizationSnapshot: authorizationSnapshot,
-      requiresCredentials: isPiMonoHarness)
+      requiresCredentials: shouldFetchManagedToken)
     try assertLifecycleFlightCurrent(
       id: flightID,
       generation: generation,
@@ -1009,7 +1026,7 @@ actor AgentBridge {
     guard
       status.isSynchronized(
         ownerID: ownerID,
-        requiresCredentials: isPiMonoHarness)
+        requiresCredentials: requiresPiMonoCredentials)
     else {
       throw BridgeError.authMissing
     }
@@ -1157,10 +1174,8 @@ actor AgentBridge {
   ) async throws -> AgentDefaultExecutionProfile {
     let authorization = try captureAuthorization()
     try await start(authorizationSnapshot: authorization)
-    if adapterId == AgentAdapterId.piMono.rawValue {
-      ensureTokenRefreshTask(authorizationSnapshot: authorization)
-      _ = try? await refreshAuthToken(authorizationSnapshot: authorization)
-    }
+    ensureTokenRefreshTask(authorizationSnapshot: authorization)
+    _ = try? await refreshAuthToken(authorizationSnapshot: authorization)
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorization) else {
       throw BridgeError.authMissing
     }
@@ -1899,9 +1914,9 @@ actor AgentBridge {
   }
 
   /// Node starts with a non-authoritative local placeholder owner. Every
-  /// harness must replace it before the first owner-scoped RPC; pi-mono also
-  /// receives the credential it needs, while local adapters use an owner-only
-  /// handshake and remain independent of managed-cloud token availability.
+  /// harness must replace it before the first owner-scoped RPC. When a managed
+  /// token is available it is pushed even for ACP/Hermes/OpenClaw so a pinned
+  /// pi-mono session can still register; missing token only fails a pi-mono start.
   nonisolated static func synchronizeAuthorityForStart(
     requiresCredentials: Bool,
     refreshCredentials: () async throws -> Bool,

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeCredentialPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeCredentialPolicy.swift
@@ -29,6 +29,21 @@ enum AgentRuntimeCredentialPolicy {
     (requestedCredentials || !isNonProduction) && hermeticFaultModelToken == nil
   }
 
+  /// Refuse a pi-mono *start* when the managed token is required. Alternate
+  /// harnesses must still fetch that token so a pinned pi-mono session can run.
+  static func shouldRequirePiMonoCredentials(
+    preferredAdapterIsPiMono: Bool,
+    requestedCredentials: Bool,
+    isNonProduction: Bool,
+    hermeticFaultModelToken: String? = nil
+  ) -> Bool {
+    preferredAdapterIsPiMono
+      && requiresManagedCredentials(
+        requestedCredentials: requestedCredentials,
+        isNonProduction: isNonProduction,
+        hermeticFaultModelToken: hermeticFaultModelToken)
+  }
+
   /// Named QA bundles have a valid owner-bound token seeded from another app,
   /// but intentionally lack that app's Firebase SDK session. Let AuthService
   /// reuse the token until its normal expiry path refreshes it.

--- a/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentRuntimeProcess.swift
@@ -2619,12 +2619,12 @@ actor AgentRuntimeProcess {
       log("AgentRuntimeProcess: pi-mono BYOK active, forwarding \(byok.values.count) usable user keys")
     }
 
+    let shouldFetchManagedToken = AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+      requestedCredentials: requiresCredentials,
+      isNonProduction: AppBuild.isNonProduction,
+      hermeticFaultModelToken: hermeticFaultModelToken)
     let requiresPiMonoCredentials =
-      preferredAdapterId == .piMono
-      && AgentRuntimeCredentialPolicy.requiresManagedCredentials(
-        requestedCredentials: requiresCredentials,
-        isNonProduction: AppBuild.isNonProduction,
-        hermeticFaultModelToken: hermeticFaultModelToken)
+      preferredAdapterId == .piMono && shouldFetchManagedToken
     let authService = await MainActor.run { AuthService.shared }
     let forceRefreshToken =
       preferredAdapterId == .piMono
@@ -2632,7 +2632,7 @@ actor AgentRuntimeProcess {
         isNonProduction: AppBuild.isNonProduction,
         isDesktopLocalProfile: DesktopLocalProfile.isEnabled)
     let authHeader = try? await Self.startupAuthHeader(
-      requiresCredentials: requiresPiMonoCredentials,
+      requiresCredentials: shouldFetchManagedToken,
       fetchAuthHeader: {
         try await authService.getAuthHeader(
           forceRefresh: forceRefreshToken,

--- a/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentRuntimeProcessTests.swift
@@ -372,6 +372,49 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertEqual(snapshot.ownerSynchronizations, 1)
   }
 
+  func testPinnedPiMonoSessionsFetchTokenAfterHarnessSwitch() async throws {
+    XCTAssertFalse(
+      AgentRuntimeCredentialPolicy.shouldRequirePiMonoCredentials(
+        preferredAdapterIsPiMono: false,
+        requestedCredentials: true,
+        isNonProduction: false),
+      "ACP/Hermes/OpenClaw must still start without a managed token")
+    XCTAssertTrue(
+      AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: true,
+        isNonProduction: false),
+      "production alternate-harness starts must still fetch the managed token")
+    XCTAssertTrue(
+      AgentRuntimeCredentialPolicy.shouldRequirePiMonoCredentials(
+        preferredAdapterIsPiMono: true,
+        requestedCredentials: true,
+        isNonProduction: false))
+
+    var fetches = 0
+    let header = try await AgentRuntimeProcess.startupAuthHeader(
+      requiresCredentials: AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: true,
+        isNonProduction: false),
+      fetchAuthHeader: {
+        fetches += 1
+        return "Bearer pinned-session-token"
+      })
+    XCTAssertEqual(fetches, 1)
+    XCTAssertEqual(header, "Bearer pinned-session-token")
+
+    var skippedFetches = 0
+    let skipped = try await AgentRuntimeProcess.startupAuthHeader(
+      requiresCredentials: AgentRuntimeCredentialPolicy.requiresManagedCredentials(
+        requestedCredentials: false,
+        isNonProduction: true),
+      fetchAuthHeader: {
+        skippedFetches += 1
+        return "Bearer should-not-fetch"
+      })
+    XCTAssertEqual(skippedFetches, 0)
+    XCTAssertNil(skipped)
+  }
+
   func testNamedBundleStartupUsesValidSeededCredentialWithoutForcedRefresh() {
     XCTAssertFalse(
       AgentRuntimeCredentialPolicy.shouldForceRefreshAtStartup(
@@ -927,10 +970,9 @@ final class AgentRuntimeProcessTests: XCTestCase {
     XCTAssertTrue(
       bridgeSource.contains(
         "AgentRuntimeProcess.adapterId(forHarnessMode: harnessMode) == AgentAdapterId.piMono.rawValue"))
-    XCTAssertTrue(
-      bridgeSource.contains(
-        "isPiMonoHarness\n      && AgentRuntimeCredentialPolicy.requiresManagedCredentials"))
-    XCTAssertTrue(bridgeSource.contains("if adapterId == AgentAdapterId.piMono.rawValue"))
+    XCTAssertTrue(bridgeSource.contains("shouldRequirePiMonoCredentials("))
+    XCTAssertTrue(bridgeSource.contains("shouldFetchManagedToken"))
+    XCTAssertFalse(bridgeSource.contains("if adapterId == AgentAdapterId.piMono.rawValue"))
     XCTAssertTrue(
       bridgeSource.contains(
         "if requiresCredentials {\n      ensureTokenRefreshTask(authorizationSnapshot: authorizationSnapshot)"))

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1921,7 +1921,9 @@ async function main(): Promise<void> {
             await startAcpProcess();
             await initializeAcp();
           } else if (adapterId === "pi-mono") {
-            await ensurePiMonoAdapter(process.env.OMI_AUTH_TOKEN);
+            if (!(await ensurePiMonoAdapter(process.env.OMI_AUTH_TOKEN))) {
+              throw new Error(adapterActivationError("pi-mono"));
+            }
           } else if (adapterId === "hermes") {
             if (!(await ensureHermesAdapter())) {
               throw new Error(adapterActivationError("hermes"));

--- a/desktop/macos/agent/src/runtime/adapter-selection.ts
+++ b/desktop/macos/agent/src/runtime/adapter-selection.ts
@@ -95,7 +95,7 @@ export function adapterActivationError(adapterId: ProductionAdapterId): string |
   if (adapterId === "hermes" || adapterId === "openclaw") {
     return `${label} is not available. Make sure ${label} is installed first, then try again.`;
   }
-  return `${label} adapter is unavailable.`;
+  return "Omi AI is not available. Sign in and try again.";
 }
 
 export function ensureRegisteredAdapter(

--- a/desktop/macos/agent/tests/adapter-selection.test.ts
+++ b/desktop/macos/agent/tests/adapter-selection.test.ts
@@ -57,6 +57,10 @@ describe("adapter selection and activation", () => {
       "OpenClaw is not available. Make sure OpenClaw is installed first, then try again."
     );
     expect(adapterActivationError("openclaw")).not.toContain("OMI_OPENCLAW_ADAPTER_COMMAND");
+    expect(adapterActivationError("pi-mono")).toBe(
+      "Omi AI is not available. Sign in and try again."
+    );
+    expect(adapterActivationError("pi-mono")).not.toContain("OMI_AUTH_TOKEN");
   });
 
   it("source: daemon registers Hermes/OpenClaw explicitly and does not stamp MCP env as ACP", () => {
@@ -68,6 +72,7 @@ describe("adapter selection and activation", () => {
     expect(indexSource).toContain("ensureRegisteredAdapter(registry, \"openclaw\"");
     expect(indexSource).toContain('adapterActivationError("hermes")');
     expect(indexSource).toContain('adapterActivationError("openclaw")');
+    expect(indexSource).toContain('adapterActivationError("pi-mono")');
     expect(indexSource).toContain("query.ownerId = queryOwnerId");
     expect(indexSource).toContain('{ name: "OMI_ADAPTER_ID", value: context?.adapterId ?? "acp" }');
     expect(indexSource).not.toContain('{ name: "OMI_ADAPTER_ID", value: "acp" }');

--- a/desktop/macos/changelog/unreleased/20260814-chat-survives-provider-switch.json
+++ b/desktop/macos/changelog/unreleased/20260814-chat-survives-provider-switch.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat failing immediately after switching to Claude, Hermes, or OpenClaw while an Omi AI conversation was still open"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -41,6 +41,7 @@ covers:
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
   - desktop/macos/Desktop/Sources/Providers/ChatProvider+OrphanRepair.swift
   - desktop/macos/Desktop/Sources/Chat/AgentBridge.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentRuntimeCredentialPolicy.swift
   - desktop/macos/Desktop/Sources/Chat/ChatComposerDraft.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatDraftScope.swift
   # The marker query enters AgentClient.Session through the serialized context


### PR DESCRIPTION
## What changed and why

Switching the chat provider to Claude, Hermes, or OpenClaw left the already-open Omi AI thread unrunnable: ACP starts skipped the Firebase token, and query-time `ensurePiMonoAdapter` failures were discarded, so the pinned `pi-mono` session died with `Adapter not registered: pi-mono`.

This keeps token fetch as a process-wide duty whenever managed credentials apply, while still refusing a *pi-mono start* without a token. Existing threads stay on Omi AI; new sessions use the selected provider. No session migration and no daemon restart.

Line-Count-Exception: desktop/macos/Desktop/Sources/Chat/AgentBridge.swift | 2199 -> 2214 | Split fetch vs start-refuse so ACP can inject a token for pinned pi-mono sessions.

## Product invariants affected

- INV-CHAT-1
- INV-AGENT-*

Pinned sessions keep their persisted adapter (`MUST NOT` mutate a live session because the default preference changed). Alternate-harness starts still establish the signed-in owner before the first owner-scoped RPC; missing token only fails a pi-mono start.

## How it was verified

- `xcodebuild test` focused Swift cases: `testPinnedPiMonoSessionsFetchTokenAfterHarnessSwitch`, journal-control, alias auth guards, hermetic fault token — 4/4 passed.
- `vitest` `desktop/macos/agent/tests/adapter-selection.test.ts` — 4/4 passed.
- `check_desktop_test_quality.py` OK; `check-e2e-flow-coverage.py` 3/3 covered; AgentRuntimeProcess line-count ratchet still 4404/4404.
- Bugbot review of branch changes: no bugs.
- I did not exercise the live named-bundle path (switch provider in Settings, send on the default chat). Production Omi / Omi Beta were left untouched.

## Tests

- `AgentRuntimeProcessTests.testPinnedPiMonoSessionsFetchTokenAfterHarnessSwitch` — ACP-preferred starts still fetch the managed token; pi-mono start-refuse stays gated on the preferred adapter.
- `adapter-selection.test.ts` — query-time pi-mono registration failure throws `adapterActivationError("pi-mono")` instead of being discarded.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

