### PR TITLE
fix(desktop): pass clicks through transparent dead zones of the shell and notch windows

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3,6 +3,7 @@ import CryptoKit
 import Foundation
 import Network
 import OmiSupport
+import OmiTheme
 import VoiceTurnDomain
 
 enum DesktopAutomationLaunchOptions {
@@ -1703,11 +1704,20 @@ final class DesktopAutomationActionRegistry {
         ? "none"
         : containing.map { window in
           var extras = ""
+          let local = NSPoint(
+            x: cocoaPoint.x - window.frame.minX, y: cocoaPoint.y - window.frame.minY)
           if let bar = window as? FloatingControlBarWindow {
-            let local = NSPoint(
-              x: cocoaPoint.x - window.frame.minX, y: cocoaPoint.y - window.frame.minY)
             extras =
               " acceptsHit=\(bar.automationAcceptsMouseHit(inContentPoint: local)) ignores=\(window.ignoresMouseEvents)"
+          } else {
+            // Shell click-through verdict (ShellClickThrough.swift): whether this point owns the
+            // pointer, per the same policy the ignoresMouseEvents sync runs.
+            let accepts = ShellClickThroughPolicy.acceptsMouseHit(
+              localPoint: local,
+              windowSize: window.frame.size,
+              isResizable: window.styleMask.contains(.resizable),
+              contentContains: { InkGlassHitRegions.shared.containsPoint($0, in: window) })
+            extras = " shellAccepts=\(accepts) ignores=\(window.ignoresMouseEvents)"
           }
           return
             "\(String(describing: type(of: window)))(\"\(window.title)\" level=\(window.level.rawValue) key=\(window.isKeyWindow) idx=\(window.orderedIndex)\(extras))"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -194,6 +194,24 @@ enum FloatingControlBarGeometry {
     return showingAIConversation && showingAIResponse
   }
 
+  /// Hit region for surface-filling content states (expanded response panel,
+  /// notification card). The window frame still carries transparent glow
+  /// outsets beside and below the visible surface; content owns exactly the
+  /// surface, so the glow ring keeps passing clicks through to other apps.
+  static func notchSurfaceContentContainsLocal(
+    localPoint: NSPoint,
+    windowSize: NSSize,
+    bottomOutset: CGFloat,
+    horizontalOutset: CGFloat
+  ) -> Bool {
+    notchChromeActivationContainsLocal(
+      localPoint: localPoint,
+      windowSize: windowSize,
+      chromeHeight: max(0, windowSize.height - bottomOutset),
+      horizontalOutset: horizontalOutset
+    )
+  }
+
   static func notchChromeActivationContainsLocal(
     localPoint: NSPoint,
     windowSize: NSSize,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1132,7 +1132,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         horizontalOutset: horizontalOutset
       )
     }
-    return true
+    // Surface-filling content (expanded response, notification card) owns the visible
+    // surface only, never the whole window: the frame keeps transparent glow outsets
+    // around the surface, and those margins must keep passing clicks through to other
+    // apps beneath — otherwise they are an invisible dead zone that also stops the
+    // click-away from reaching (and activating) whatever the user clicked on.
+    return FloatingControlBarGeometry.notchSurfaceContentContainsLocal(
+      localPoint: point,
+      windowSize: frame.size,
+      bottomOutset: Self.notchGlowOutsetBottom,
+      horizontalOutset: Self.notchGlowOutsetX
+    )
   }
 
   private func observeNotchAgentPills() {

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -1,0 +1,123 @@
+//
+//  ShellClickThrough.swift — the transparent shell window stops swallowing the desktop's clicks.
+//
+//  `ShellWindowChrome` made the main window a transparent rectangle noticeably larger than the
+//  panels floating inside it. The window server routes every click to the window under the cursor
+//  no matter what is drawn there, so all of that air — the reserved title-bar band, the margins
+//  beside the lane, the gaps between panels — was an invisible click sink: clicks aimed at another
+//  app landed on Omi, the other app never activated, and Omi never receded. Same failure class as
+//  the notch panel's dead zone (PR #11372), on the shell window.
+//
+//  Same mechanism, too: a view-level `hitTest` nil cannot make a window click-through, so the
+//  window-level `ignoresMouseEvents` is kept in sync with the pointer — ignored over air,
+//  interactive over content. "Content" is answered by `InkGlassHitRegions`: every glass surface
+//  registers its live extent, and a modal barrier registers the whole host while it is up.
+//
+//  What is deliberately given up: dragging the window from the *invisible* title-bar band above
+//  the top bar. The visible top bar still drags (`ShellWindowDragHandle`), and a band the user
+//  cannot see is exactly where they expect clicks to reach the app behind — that expectation is
+//  the bug report this file exists to fix. Resizing survives via an interactive rim along the
+//  window's frame edge.
+//
+
+import AppKit
+import Combine
+import OmiTheme
+
+/// Pure policy: which points of the shell window own the pointer.
+enum ShellClickThroughPolicy {
+  /// Interactive band kept along the window's frame edge so the chrome-less, resizable window can
+  /// still be resized by grabbing its (invisible) edge. Matches AppKit's effective resize zone.
+  static let resizeRim: CGFloat = 8
+
+  static func acceptsMouseHit(
+    localPoint: NSPoint,
+    windowSize: NSSize,
+    isResizable: Bool,
+    contentContains: (NSPoint) -> Bool
+  ) -> Bool {
+    if isResizable {
+      let nearEdge =
+        localPoint.x <= resizeRim || localPoint.x >= windowSize.width - resizeRim
+        || localPoint.y <= resizeRim || localPoint.y >= windowSize.height - resizeRim
+      if nearEdge { return true }
+    }
+    return contentContains(localPoint)
+  }
+}
+
+/// Keeps the shell window's `ignoresMouseEvents` in sync with the pointer. One instance per shell
+/// window, owned by `ShellWindowAttachmentView` so it binds to the exact `NSWindow` hosting the
+/// shell and dies with it.
+@MainActor
+final class ShellMouseInterceptionSync {
+  private nonisolated(unsafe) var monitors: [Any] = []
+  private var pollingCancellable: AnyCancellable?
+  private weak var window: NSWindow?
+
+  init(window: NSWindow) {
+    self.window = window
+    let scheduleReconciliation: @Sendable () -> Void = {
+      DispatchQueue.main.async { [weak self] in self?.sync() }
+    }
+    if let global = NSEvent.addGlobalMonitorForEvents(
+      matching: [.mouseMoved, .leftMouseDragged],
+      handler: { _ in scheduleReconciliation() })
+    {
+      monitors.append(global)
+    }
+    if let local = NSEvent.addLocalMonitorForEvents(
+      matching: [.mouseMoved],
+      handler: { event in
+        scheduleReconciliation()
+        return event
+      })
+    {
+      monitors.append(local)
+    }
+    sync()
+  }
+
+  deinit {
+    monitors.forEach(NSEvent.removeMonitor)
+  }
+
+  /// Restores the ordinary always-interactive window before the sync goes away (e.g. the
+  /// automation harness snapshots/restores presentation): a window left with
+  /// `ignoresMouseEvents == true` and nobody updating it is unreachable.
+  func detach() {
+    window?.ignoresMouseEvents = false
+    window = nil
+    pollingCancellable = nil
+  }
+
+  func sync() {
+    guard let window else { return }
+    setPollingActive(window.isVisible)
+    let shouldIgnore = FloatingBarMouseInterceptionPolicy.shouldIgnoreMouseEvents(
+      mouseLocation: NSEvent.mouseLocation,
+      windowFrame: window.frame,
+      isVisible: window.isVisible,
+      acceptsMouseHit: { [weak window] local in
+        guard let window else { return true }
+        return ShellClickThroughPolicy.acceptsMouseHit(
+          localPoint: local,
+          windowSize: window.frame.size,
+          isResizable: window.styleMask.contains(.resizable),
+          contentContains: { InkGlassHitRegions.shared.containsPoint($0, in: window) })
+      })
+    if window.ignoresMouseEvents != shouldIgnore {
+      window.ignoresMouseEvents = shouldIgnore
+    }
+  }
+
+  private func setPollingActive(_ active: Bool) {
+    guard active != (pollingCancellable != nil) else { return }
+    pollingCancellable =
+      active
+      ? Timer.publish(every: 1.0 / 30.0, on: .main, in: .common)
+        .autoconnect()
+        .sink { [weak self] _ in self?.sync() }
+      : nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellModalScrim.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellModalScrim.swift
@@ -198,10 +198,14 @@ struct ShellModalScrim: View {
       ZStack {
         if blocksInteraction {
           // Modality, at the host's full size — the part that was never wrong to draw host-wide,
-          // because it draws nothing.
+          // because it draws nothing. The reporter keeps the transparent barrier inside the
+          // window's pointer ownership: without it, the shell's click-through sync would pass
+          // clicks on the barrier straight to whatever is behind the window (see
+          // `ShellClickThrough.swift`), and the modal would stop being modal.
           Color.clear
             .contentShape(Rectangle())
             .onTapGesture { onTap?() }
+            .background(InkGlassHitRegionReporter())
         }
 
         RoundedRectangle(cornerRadius: ShellModalScrimLayout.cornerRadius, style: .continuous)

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -259,6 +259,7 @@ extension View {
 final class ShellWindowAttachmentView: NSView {
   private weak var attachedWindow: NSWindow?
   private var updateObserver: NSObjectProtocol?
+  private var mouseInterceptionSync: ShellMouseInterceptionSync?
 
   override func viewWillMove(toWindow newWindow: NSWindow?) {
     super.viewWillMove(toWindow: newWindow)
@@ -271,6 +272,9 @@ final class ShellWindowAttachmentView: NSView {
     guard let window else { return }
     attachedWindow = window
     reassertIfNeeded(force: true)
+    // The transparent shell must pass clicks on its dead margins through to whatever is behind
+    // the window — see `ShellClickThrough.swift`.
+    mouseInterceptionSync = ShellMouseInterceptionSync(window: window)
     updateObserver = NotificationCenter.default.addObserver(
       forName: NSWindow.didUpdateNotification,
       object: window,
@@ -294,6 +298,8 @@ final class ShellWindowAttachmentView: NSView {
       NotificationCenter.default.removeObserver(updateObserver)
       self.updateObserver = nil
     }
+    mouseInterceptionSync?.detach()
+    mouseInterceptionSync = nil
     attachedWindow = nil
   }
 }

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -487,6 +487,17 @@ package final class InkGlassView: NSView {
   private let shadowHost = NSView()
   private let observer = InkGlassObserverToken()
 
+  // A glass surface is visible content: report its extent so transparent windows can keep
+  // pass-through margins without ever passing a click through the glass itself.
+  package override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    if window == nil {
+      InkGlassHitRegions.shared.unregister(self)
+    } else {
+      InkGlassHitRegions.shared.register(self)
+    }
+  }
+
   package init(frame: NSRect, style: InkGlassStyle = .floating) {
     self.style = style
     super.init(frame: frame)
@@ -751,6 +762,9 @@ package struct InkGlassPanelModifier: ViewModifier {
     content
       .environment(\.colorScheme, .light)
       .clipShape(shape)
+      // Report the panel's extent as interactive content regardless of Reduce Transparency: the
+      // material may be replaced by a flat wash, but the surface still owns the pointer.
+      .background(InkGlassHitRegionReporter())
       .background {
         ZStack(alignment: .top) {
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {

--- a/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
@@ -1,0 +1,81 @@
+//
+//  InkGlassHitRegions.swift — where the visible glass actually is, for windows that are mostly air.
+//
+//  The main shell window is a transparent rectangle noticeably larger than the panels floating
+//  inside it (`ShellWindowChrome`). The window server routes a click to the window under the
+//  cursor regardless of what is drawn there, so every transparent region of that rectangle is an
+//  invisible click sink over other apps — the "dead zone" class of bug first fixed for the notch
+//  panel in PR #11372. The only working pass-through mechanism is `NSWindow.ignoresMouseEvents`,
+//  and deciding when to set it needs one fact: is the pointer over visible content or over air?
+//
+//  This registry answers that with zero per-page wiring. Every glass surface in the product is
+//  built from the two `InkGlass` primitives (`inkGlassPanel` / `InkGlassView` — "one glass"), so
+//  those primitives register their extent here and a window-level policy can ask whether a point
+//  lands on any of them. Pull-based on purpose: rects are read live from the AppKit views at
+//  query time, so there is no stale-frame bookkeeping to drift during resizes or animations.
+//
+//  A surface that is *not* glass but must own the pointer (a modal barrier) mounts an
+//  `InkGlassHitRegionReporter` explicitly — the marker is about interactivity, not material.
+//
+
+import AppKit
+import SwiftUI
+
+/// Registry of the views whose extent counts as visible, interactive content inside an otherwise
+/// transparent window. Weakly held; querying skips views that left the window or are hidden.
+@MainActor
+package final class InkGlassHitRegions {
+  package static let shared = InkGlassHitRegions()
+
+  private let views = NSHashTable<NSView>.weakObjects()
+
+  package func register(_ view: NSView) {
+    views.add(view)
+  }
+
+  package func unregister(_ view: NSView) {
+    views.remove(view)
+  }
+
+  /// Whether `pointInWindow` (window base coordinates, bottom-left origin) lies on any visible
+  /// registered surface belonging to `window`.
+  package func containsPoint(_ pointInWindow: NSPoint, in window: NSWindow) -> Bool {
+    for view in views.allObjects {
+      guard view.window === window,
+        !view.isHiddenOrHasHiddenAncestor,
+        view.alphaValue > 0
+      else { continue }
+      if view.convert(view.bounds, to: nil).contains(pointInWindow) {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+/// Zero-drawing marker view: its own extent is reported as interactive content. Never intercepts
+/// events itself — it exists only so `InkGlassHitRegions` can read its live frame.
+package final class InkGlassHitRegionView: NSView {
+  package override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    if window == nil {
+      InkGlassHitRegions.shared.unregister(self)
+    } else {
+      InkGlassHitRegions.shared.register(self)
+    }
+  }
+
+  package override func hitTest(_ point: NSPoint) -> NSView? { nil }
+}
+
+/// SwiftUI mount for the marker. Attach as a `.background` so it spans exactly the surface that
+/// should own the pointer.
+package struct InkGlassHitRegionReporter: NSViewRepresentable {
+  package init() {}
+
+  package func makeNSView(context: Context) -> InkGlassHitRegionView {
+    InkGlassHitRegionView(frame: .zero)
+  }
+
+  package func updateNSView(_ view: InkGlassHitRegionView, context: Context) {}
+}

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -515,6 +515,42 @@ final class FloatingBarGeometryTests: XCTestCase {
         showingAIConversation: false, showingAIResponse: false, hasNotification: true))
   }
 
+  /// Regression: while an expanded response panel or a notification card was showing, the
+  /// whole window frame accepted clicks — including the transparent glow outsets around the
+  /// visible surface. Clicks on other apps landing in that ring were silently swallowed and
+  /// the clicked app never activated (the "dead zone" report). Surface-filling content owns
+  /// exactly the surface: frame minus the horizontal and bottom glow outsets.
+  func testSurfaceFillingContentDoesNotOwnTheTransparentGlowRing() {
+    // Response-panel shaped window: 382×527 surface + 24pt glow on each side and below.
+    let windowSize = NSSize(width: 430, height: 551)
+
+    XCTAssertTrue(
+      FloatingControlBarGeometry.notchSurfaceContentContainsLocal(
+        localPoint: NSPoint(x: 215, y: 300),
+        windowSize: windowSize, bottomOutset: 24, horizontalOutset: 24),
+      "the visible surface stays interactive")
+    XCTAssertTrue(
+      FloatingControlBarGeometry.notchSurfaceContentContainsLocal(
+        localPoint: NSPoint(x: 24, y: 24),
+        windowSize: windowSize, bottomOutset: 24, horizontalOutset: 24),
+      "the surface's bottom-left corner is still content (resize grip corner)")
+    XCTAssertFalse(
+      FloatingControlBarGeometry.notchSurfaceContentContainsLocal(
+        localPoint: NSPoint(x: 12, y: 300),
+        windowSize: windowSize, bottomOutset: 24, horizontalOutset: 24),
+      "left glow ring passes clicks through")
+    XCTAssertFalse(
+      FloatingControlBarGeometry.notchSurfaceContentContainsLocal(
+        localPoint: NSPoint(x: 424, y: 300),
+        windowSize: windowSize, bottomOutset: 24, horizontalOutset: 24),
+      "right glow ring passes clicks through")
+    XCTAssertFalse(
+      FloatingControlBarGeometry.notchSurfaceContentContainsLocal(
+        localPoint: NSPoint(x: 215, y: 10),
+        windowSize: windowSize, bottomOutset: 24, horizontalOutset: 24),
+      "glow margin below the surface passes clicks through")
+  }
+
   func testNotchChromeActivationIgnoresHorizontalGlowOutsets() {
     let windowFrame = NSRect(x: 500, y: 800, width: 360, height: 58)
 

--- a/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression: the transparent shell window (`ShellWindowChrome`) accepted clicks across its whole
+/// frame — the reserved title-bar band, lane margins, and gaps between panels swallowed clicks
+/// aimed at other apps, which never activated (the shell-window dead zone). The policy passes the
+/// pointer through everywhere except visible content, the modal barrier's host, and the resize rim.
+final class ShellClickThroughPolicyTests: XCTestCase {
+  private let windowSize = NSSize(width: 960, height: 712)
+
+  func testDeadAirPassesClicksThrough() {
+    XCTAssertFalse(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: 480, y: 690),
+        windowSize: windowSize,
+        isResizable: true,
+        contentContains: { _ in false }),
+      "the reserved title-bar band above the top bar must not swallow clicks")
+    XCTAssertFalse(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: 480, y: 350),
+        windowSize: windowSize,
+        isResizable: true,
+        contentContains: { _ in false }),
+      "a gap between panels must not swallow clicks")
+  }
+
+  func testVisibleContentOwnsThePointer() {
+    let panel = NSRect(x: 100, y: 100, width: 760, height: 400)
+    XCTAssertTrue(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: 480, y: 300),
+        windowSize: windowSize,
+        isResizable: true,
+        contentContains: panel.contains))
+    XCTAssertFalse(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: 480, y: 550),
+        windowSize: windowSize,
+        isResizable: false,
+        contentContains: panel.contains))
+  }
+
+  func testResizableWindowKeepsAnInteractiveEdgeRim() {
+    XCTAssertTrue(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: 4, y: 350),
+        windowSize: windowSize,
+        isResizable: true,
+        contentContains: { _ in false }),
+      "the frame edge stays grabbable for resizing")
+    XCTAssertFalse(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: 4, y: 350),
+        windowSize: windowSize,
+        isResizable: false,
+        contentContains: { _ in false }),
+      "a fixed-size window has no resize affordance to preserve")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260814-shell-click-deadzone.json
+++ b/desktop/macos/changelog/unreleased/20260814-shell-click-deadzone.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed invisible dead zones around the main window and notch panel swallowing clicks: clicking another app now reaches it and brings it forward"
+}

--- a/desktop/macos/e2e/flows/dashboard.yaml
+++ b/desktop/macos/e2e/flows/dashboard.yaml
@@ -4,6 +4,7 @@ tier: 2
 description: Dashboard load and refresh via automation bridge
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
   - desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshService.swift

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -4,6 +4,7 @@ tier: manual
 description: Top navigation bar smoke — the flat destination row (Home, Library, Tasks, Rewind, Apps), the Memory hub's own three-way switcher, the Settings gear and Rewind all reach their real pages with no menu and nothing opening on hover
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
   - desktop/macos/Desktop/Sources/Sound/OmiUISound.swift
   - desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift


### PR DESCRIPTION
## Problem

Clicking "somewhere else" while the Omi shell or notch surfaces are up hit an invisible dead zone: the click landed on Omi instead of the app the user aimed at, and that app never came forward.

Two windows had transparent regions that swallowed clicks:

1. **Main chat-first shell** — deliberately a transparent window noticeably larger than its floating panels (`ShellWindowChrome`). The window server routes clicks by window frame, so the reserved title-bar band, the lane margins, and the gaps between the pills bar / search bar / response card were all invisible click sinks.
2. **Notch panel** — in its response and notification states the whole fixed frame accepted hits, including the transparent glow ring around the visible surface.

## Fix

- **Shell**: `ignoresMouseEvents` is synced to the pointer (same mechanism as PR #11372's notch fix). Visible content is answered by `InkGlassHitRegions`: both InkGlass primitives (`inkGlassPanel`, `InkGlassView`) register their live extent, so every page is covered through the one-glass seam with no per-page wiring; the `ShellModalScrim` barrier registers its host so dialogs stay modal; an 8 pt rim along the frame edge stays interactive so edge-resize survives. Deliberate trade-off: dragging from the invisible title-bar band no longer works — the visible top bar still drags (`ShellWindowDragHandle`).
- **Notch panel**: response/notification states now own only the visible surface (frame minus glow outsets) via `notchSurfaceContentContainsLocal`; the resize grip sits inside the surface, so response resizing is unaffected.
- `debug_hit_probe` now reports the shell policy verdict (`shellAccepts=`) for non-bar windows.

## Product invariants

- INV-CHAT-1 — chat surfaces touched (`FloatingControlBarWindow/Geometry`, QueryShell-hosting shell chrome). Chat behavior itself is unchanged: only pointer ownership of transparent margins changed; the invariant's guarded flows (ask → answer in the shell) were exercised live (`ask_main_chat` produced a streamed answer in the response card).

Failure-Class: FC-transparent-top-level-window-occlusion

## Verification

- Built and ran the `omi-deadzone` dev bundle (run.sh --yolo, bridge on 47805).
- Exercised the real chat path (`ask_main_chat` → streamed answer rendered in the response card; window capture attached to the review).
- `debug_hit_probe` sweeps: title-bar band, side margins, panel gaps, and the notch glow ring report `accepts=false` (clicks pass through); pills bar, search bar, response card, input field, resize rim, and notch response panel report `accepts=true`.
- `swift test --filter "ShellClickThroughPolicyTests|FloatingBarGeometryTests"`: 32/32 pass (new: `testSurfaceFillingContentDoesNotOwnTheTransparentGlowRing`, `ShellClickThroughPolicyTests`).
- User-confirmed on the running build: clicks beside/between the panels now reach the app behind and bring it forward.

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4565 -> 4575 | debug_hit_probe gains the shell click-through verdict; splitting the bridge is out of scope for this fix
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5209 -> 5219 | acceptsMouseHit surface-rect branch for the glow-ring fix; splitting the window class is out of scope for this fix


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

