### PR TITLE
fix(desktop): Hide-for-2h keeps notifications; Maximum level nudges in ~10s with 30s repeats; unsilence suggestions from the buckets flag

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -826,7 +826,7 @@ struct FloatingControlBarView: View {
 
   @ViewBuilder
   private var barContextMenu: some View {
-    Button("Disable for 2 hours") {
+    Button("Hide for 2 hours") {
       FloatingControlBarManager.shared.snooze(
         for: FloatingControlBarManager.snoozeTwoHoursDuration
       )

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4158,7 +4158,10 @@ class FloatingControlBarManager {
       }
     }
 
-    if notificationWasTemporarilyShown && !isEnabled && !window.state.showingAIConversation {
+    // "Hide for 2 hours" keeps `isEnabled` true (it is not the persisted enable
+    // preference), so the snoozed state must arm the re-hide too — otherwise the first
+    // temp-shown nudge would bring the bar back for the rest of the hide window.
+    if notificationWasTemporarilyShown && (!isEnabled || isSnoozed) && !window.state.showingAIConversation {
       window.orderOut(nil)
     }
     notificationWasTemporarilyShown = false

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2840,21 +2840,14 @@ class FloatingControlBarManager {
     return snoozedUntil > Date()
   }
 
-  /// Hide the bar and suppress notifications for the given duration.
+  /// Hide the bar for the given duration. This is a statement about the BAR only:
+  /// notifications keep flowing and present via the temp-show path (card pops over the
+  /// hidden bar, then the bar re-hides). It used to also drop the queue and gate all
+  /// proactive delivery, which silently muted an hour of movie-watching after one
+  /// right-click on "Disable for 2 hours".
   func snooze(for duration: TimeInterval) {
     let until = Date().addingTimeInterval(duration)
     snoozedUntil = until
-    notificationDismissWorkItem?.cancel()
-    notificationDismissWorkItem = nil
-    Self.recordQueuedInsightOutcomes(pendingNotifications, reason: .snoozed)
-    let droppedCallbacks = pendingNotifications.compactMap {
-      notificationAuthorizationSnapshots.removeValue(forKey: $0.id)
-      return notificationPresentationCallbacks.removeValue(forKey: $0.id)
-    }
-    pendingNotifications.removeAll()
-    for callback in droppedCallbacks {
-      callback.onDropped()
-    }
     if let window, window.state.currentNotification != nil {
       window.dismissNotification(animated: false)
     }
@@ -3425,13 +3418,6 @@ class FloatingControlBarManager {
       return .windowUnavailable
     }
 
-    if isSnoozed {
-      log(
-        "FloatingControlBarManager: dropping notification because bar is snoozed until \(snoozedUntil?.description ?? "?")"
-      )
-      onDropped?()
-      return .suppressed
-    }
     notificationAuthorizationSnapshots[notification.id] = authorizationSnapshot
 
     if !window.state.showingAIConversation {
@@ -3476,7 +3462,6 @@ class FloatingControlBarManager {
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot)
     else { return .rejectedOwnerChange }
     guard window != nil else { return .windowUnavailable }
-    guard !isSnoozed else { return .suppressed }
     return .queued
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantTelemetry.swift
@@ -18,7 +18,6 @@ enum InsightAssistantTelemetry {
     case masterNotificationsDisabled = "master_notifications_disabled"
     case frequencyOff = "frequency_off"
     case frequencyThrottled = "frequency_throttled"
-    case snoozed
     case floatingBarPresented = "floating_bar_presented"
     case floatingBarUnavailable = "floating_bar_unavailable"
     case queueCancelled = "queue_cancelled"

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -132,7 +132,6 @@ actor SuggestionAssistant: ProactiveAssistant {
 
     let enabled = await isEnabled
     let excluded = await MainActor.run { SuggestionAssistantSettings.shared.isAppExcluded(frame.appName) }
-    let snoozed = await MainActor.run { FloatingControlBarManager.shared.isSnoozed }
     let cooldown = await cooldownInterval
 
     let now = Date()
@@ -141,7 +140,6 @@ actor SuggestionAssistant: ProactiveAssistant {
     let decision = SuggestionGatePolicy.decide(
       isEnabled: enabled,
       isAppExcluded: excluded,
-      isSnoozed: snoozed,
       now: now,
       lastEvaluationAt: lastEvaluationAt,
       cooldown: cooldown,
@@ -628,7 +626,6 @@ actor SuggestionAssistant: ProactiveAssistant {
     let gateState = await MainActor.run {
       (
         SuggestionAssistantSettings.shared.isAppExcluded(frame.appName),
-        FloatingControlBarManager.shared.isSnoozed,
         NotificationService.areNotificationsEnabled(),
         NotificationService.currentFrequencyLevel()
       )
@@ -637,7 +634,6 @@ actor SuggestionAssistant: ProactiveAssistant {
     let decision = SuggestionGatePolicy.decide(
       isEnabled: assistantEnabled,
       isAppExcluded: gateState.0,
-      isSnoozed: gateState.1,
       now: now,
       lastEvaluationAt: nil,
       cooldown: 0,
@@ -645,9 +641,9 @@ actor SuggestionAssistant: ProactiveAssistant {
       requiredDwell: Self.requiredDwell,
       evaluationsToday: dailyBudget.countToday(now: now),
       dailyBudget: Self.dailyEvaluationBudget)
-    guard gateState.2, gateState.3 > 0, decision.allowsEvaluation else {
-      if !gateState.2 { return ["outcome": "skipped_notifications_disabled"] }
-      if gateState.3 == 0 { return ["outcome": "skipped_frequency_off"] }
+    guard gateState.1, gateState.2 > 0, decision.allowsEvaluation else {
+      if !gateState.1 { return ["outcome": "skipped_notifications_disabled"] }
+      if gateState.2 == 0 { return ["outcome": "skipped_frequency_off"] }
       return ["outcome": SuggestionAssistantTelemetry.GateOutcome(decision).rawValue]
     }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -41,11 +41,11 @@ actor SuggestionAssistant: ProactiveAssistant {
   private let geminiClient: GeminiClient
   private let telemetryModel: SuggestionAssistantTelemetry.Model
 
-  /// How long the user must stay in a context before it is worth spending on. People
-  /// switch apps hundreds of times a day and almost none of those are a request for
-  /// advice; half a minute of dwell is the difference between passing through a window and
-  /// working in it.
-  private static let requiredDwell: TimeInterval = 30.0
+  /// Dwell before a context is worth spending on — level-aware, see
+  /// `SuggestionGatePolicy.requiredDwell(frequencyLevel:)` (10 s at Maximum, 30 s otherwise).
+  private static func requiredDwell(frequencyLevel: Int) -> TimeInterval {
+    SuggestionGatePolicy.requiredDwell(frequencyLevel: frequencyLevel)
+  }
 
   /// Hard ceiling on paid evaluations per day, so cost is a number we choose rather than a
   /// function of how much the user alt-tabs.
@@ -132,6 +132,7 @@ actor SuggestionAssistant: ProactiveAssistant {
 
     let enabled = await isEnabled
     let excluded = await MainActor.run { SuggestionAssistantSettings.shared.isAppExcluded(frame.appName) }
+    let frequencyLevel = await MainActor.run { NotificationService.currentFrequencyLevel() }
     let cooldown = await cooldownInterval
 
     let now = Date()
@@ -144,7 +145,7 @@ actor SuggestionAssistant: ProactiveAssistant {
       lastEvaluationAt: lastEvaluationAt,
       cooldown: cooldown,
       dwell: dwell,
-      requiredDwell: Self.requiredDwell,
+      requiredDwell: Self.requiredDwell(frequencyLevel: frequencyLevel),
       evaluationsToday: dailyBudget.countToday(now: now),
       dailyBudget: Self.dailyEvaluationBudget
     )
@@ -637,8 +638,8 @@ actor SuggestionAssistant: ProactiveAssistant {
       now: now,
       lastEvaluationAt: nil,
       cooldown: 0,
-      dwell: Self.requiredDwell,
-      requiredDwell: Self.requiredDwell,
+      dwell: Self.requiredDwell(frequencyLevel: gateState.2),
+      requiredDwell: Self.requiredDwell(frequencyLevel: gateState.2),
       evaluationsToday: dailyBudget.countToday(now: now),
       dailyBudget: Self.dailyEvaluationBudget)
     guard gateState.1, gateState.2 > 0, decision.allowsEvaluation else {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -143,7 +143,7 @@ actor SuggestionAssistant: ProactiveAssistant {
       isAppExcluded: excluded,
       now: now,
       lastEvaluationAt: lastEvaluationAt,
-      cooldown: cooldown,
+      cooldown: SuggestionGatePolicy.cooldown(base: cooldown, frequencyLevel: frequencyLevel),
       dwell: dwell,
       requiredDwell: Self.requiredDwell(frequencyLevel: frequencyLevel),
       evaluationsToday: dailyBudget.countToday(now: now),

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -20,8 +20,14 @@ actor SuggestionAssistant: ProactiveAssistant {
 
   var isEnabled: Bool {
     get async {
+      // Deliberately independent of ContextBucketsFeature. The buckets rollout gated this
+      // on `!ContextBucketsFeature.isEnabled`, betting the context director would replace
+      // live suggestions — it delivered almost nothing, and with the flag at 100% of all
+      // users focus nudges went silent fleet-wide with no error logged (Aug 13–14 2026).
+      // If the director is ever meant to replace this assistant again, that must be an
+      // explicit, evidenced change — never a side effect of a rollout flag.
       await MainActor.run {
-        !ContextBucketsFeature.isEnabled && SuggestionAssistantSettings.shared.isEnabled
+        SuggestionAssistantSettings.shared.isEnabled
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
@@ -23,7 +23,6 @@ enum SuggestionAssistantTelemetry {
     case eligible
     case disabled
     case excludedApp = "excluded_app"
-    case snoozed
     case dwell
     case cooldown
     case dailyBudget = "daily_budget"
@@ -34,7 +33,6 @@ enum SuggestionAssistantTelemetry {
       case .evaluate: self = .eligible
       case .skippedDisabled: self = .disabled
       case .skippedExcludedApp: self = .excludedApp
-      case .skippedSnoozed: self = .snoozed
       case .skippedDwell: self = .dwell
       case .skippedCooldown: self = .cooldown
       case .skippedDailyBudget: self = .dailyBudget

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -133,7 +133,6 @@ enum SuggestionGateDecision: Equatable, Sendable {
   case skippedDisabled
   case skippedExcludedApp
   case skippedCooldown
-  case skippedSnoozed
   /// The user has not settled in this context long enough to be working in it.
   case skippedDwell
   /// Today's evaluation budget is spent.
@@ -155,7 +154,6 @@ enum SuggestionGatePolicy {
   static func decide(
     isEnabled: Bool,
     isAppExcluded: Bool,
-    isSnoozed: Bool,
     now: Date,
     lastEvaluationAt: Date?,
     cooldown: TimeInterval,
@@ -166,7 +164,6 @@ enum SuggestionGatePolicy {
   ) -> SuggestionGateDecision {
     guard isEnabled else { return .skippedDisabled }
     guard !isAppExcluded else { return .skippedExcludedApp }
-    guard !isSnoozed else { return .skippedSnoozed }
     guard dwell >= requiredDwell else { return .skippedDwell }
     if let lastEvaluationAt, now.timeIntervalSince(lastEvaluationAt) < cooldown {
       return .skippedCooldown

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -147,6 +147,15 @@ enum SuggestionGateDecision: Equatable, Sendable {
 /// model, no I/O — so the cost contract ("no context switch, no Gemini call") is provable
 /// in a unit test.
 enum SuggestionGatePolicy {
+  /// How long the user must sit in a context before it is worth an evaluation.
+  ///
+  /// Maximum (level 5) is an explicit "show me everything, fast": open TikTok and the
+  /// nudge should land in seconds, so dwell drops to 10 s there. Every other level keeps
+  /// the deliberate 30 s — passing through a window is not a request for advice.
+  static func requiredDwell(frequencyLevel: Int) -> TimeInterval {
+    frequencyLevel >= 5 ? 10 : 30
+  }
+
   /// Ordered cheapest-first, and every branch is free. Switching apps is not evidence that
   /// the user wants advice — people cmd-tab hundreds of times a day — so dwell and the
   /// daily budget do most of the work here, and the caller adds a grounding check before

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -156,6 +156,14 @@ enum SuggestionGatePolicy {
     frequencyLevel >= 5 ? 10 : 30
   }
 
+  /// Between-nudge cooldown, from the user's configured base.
+  ///
+  /// Maximum caps it at 30 s — a user who chose "Maximum" wants back-to-back nudges, not
+  /// one per three minutes. Every other level keeps the configured value untouched.
+  static func cooldown(base: TimeInterval, frequencyLevel: Int) -> TimeInterval {
+    frequencyLevel >= 5 ? min(base, 30) : base
+  }
+
   /// Ordered cheapest-first, and every branch is free. Switching apps is not evidence that
   /// the user wants advice — people cmd-tab hundreds of times a day — so dwell and the
   /// daily budget do most of the work here, and the caller adds a grounding check before

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -4,7 +4,6 @@ import Foundation
 struct ContextDeliveryGateInput: Equatable, Sendable {
   let masterEnabled: Bool
   let frequencyLevel: Int
-  let snoozed: Bool
   let paywalled: Bool
   let cooldownSeconds: TimeInterval
   let dailyLimit: Int
@@ -13,7 +12,6 @@ struct ContextDeliveryGateInput: Equatable, Sendable {
   init(
     masterEnabled: Bool,
     frequencyLevel: Int,
-    snoozed: Bool,
     paywalled: Bool,
     cooldownSeconds: TimeInterval,
     dailyLimit: Int? = nil,
@@ -21,7 +19,6 @@ struct ContextDeliveryGateInput: Equatable, Sendable {
   ) {
     self.masterEnabled = masterEnabled
     self.frequencyLevel = frequencyLevel
-    self.snoozed = snoozed
     self.paywalled = paywalled
     self.cooldownSeconds = cooldownSeconds
     self.dailyLimit = max(
@@ -122,7 +119,6 @@ enum ContextDeliveryBudget {
   static func freeGate(input: ContextDeliveryGateInput) -> ContextDeliveryGateReason {
     if !input.masterEnabled { return .masterDisabled }
     if input.frequencyLevel == 0 { return .frequencyDisabled }
-    if input.snoozed { return .snoozed }
     if input.paywalled { return .paywalled }
     return .allowed
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -457,7 +457,6 @@ actor ContextProactivityEngine {
     return ContextDeliveryGateInput(
       masterEnabled: NotificationService.areNotificationsEnabled(),
       frequencyLevel: frequencyLevel,
-      snoozed: FloatingControlBarManager.shared.isSnoozed,
       paywalled: AppState.isPaywalledEffective,
       cooldownSeconds: ContextDeliveryBudget.cooldownSeconds(frequencyLevel: frequencyLevel),
       dailyLimit: ContextDeliveryBudget.dailyLimit(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -137,6 +137,16 @@ enum ProactiveAssistantOrchestrationPolicy {
     return .capture(nextCounter: 0, didLeaveCall: currentCounter > 0)
   }
 
+  /// How long the same context waits between frame re-flushes to the assistants.
+  ///
+  /// Maximum (level 5) is the "nudge me in seconds" demo mode: a 10 s fallback pairs with
+  /// the 10 s suggestion dwell so the first eligible evaluation lands ~10-13 s after the
+  /// switch. Every other level keeps the 60 s cadence; assistant-side gates still bound
+  /// actual model spend either way.
+  static func distributionFallbackInterval(frequencyLevel: Int) -> TimeInterval {
+    frequencyLevel >= 5 ? 10 : 60
+  }
+
   static func distributionDecision(
     lastDistributedApp: String?,
     lastDistributedWindowTitle: String?,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -113,7 +113,13 @@ public class ProactiveAssistantsPlugin: NSObject {
   private var distributionDebounceTimer: Timer?
   private(set) var latestCapturedFrame: CapturedFrame?
   /// Fallback interval: re-distribute even without context change to catch visual-only updates.
-  private let distributionFallbackInterval: TimeInterval = 60
+  /// Level-aware: Maximum re-flushes every 10 s so the suggestion dwell gate (10 s at
+  /// Maximum) sees an eligible frame seconds after a switch instead of at the next
+  /// minute mark. See `ProactiveAssistantOrchestrationPolicy.distributionFallbackInterval`.
+  private var distributionFallbackInterval: TimeInterval {
+    ProactiveAssistantOrchestrationPolicy.distributionFallbackInterval(
+      frequencyLevel: NotificationService.currentFrequencyLevel())
+  }
   private let messagingDistributionFallbackInterval: TimeInterval = 15
 
   /// Apps where new content can arrive while the user stays focused. Reusing the same

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -401,7 +401,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     // NOTE: only READ the "already shown" flag here. The flag is SET at actual
     // delivery time (just before showNotification below), NOT here — setting it
     // before the snooze/enabled/frequency gates meant that if any gate suppressed
-    // this delivery (e.g. the user is snoozed when capture breaks), the flag was
+    // this delivery (e.g. notifications are disabled when capture breaks), the flag was
     // still persisted, and since it is only cleared on capture RECOVERY — which
     // never happens while capture stays broken — every later retry hit this early
     // return and the "screen recording needs reset" notice was never delivered.
@@ -412,13 +412,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
-    // Honor the floating-bar snooze for both the in-bar preview and the native
-    // macOS banner — the user opted into "no notifications for 2h".
-    if FloatingControlBarManager.shared.isSnoozed {
-      log("NotificationService: suppressing notification because floating bar is snoozed")
-      recordInsightDeliveryOutcome(insightDeliveryID, outcome: .suppressed, reason: .snoozed)
-      return
-    }
+    // Hiding the floating bar ("Hide for 2 hours") is a statement about the BAR, not
+    // about notifications: an hour of a movie with the bar hidden must still nudge.
+    // Delivery while hidden goes through the existing temp-show path, which pops the
+    // card and re-hides the bar afterwards. It deliberately does not gate here.
 
     // Proactive notifications honor the master Notifications toggle. When the user
     // turns Notifications off in Settings, suppress the floating-bar popup and the
@@ -510,7 +507,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         // later presentation boundary (or a system-banner fallback) can emit the terminal event.
         floatingBarQueued = true
       case .suppressed:
-        recordInsightDeliveryOutcome(insightDeliveryID, outcome: .suppressed, reason: .snoozed)
+        // Unreachable today (a hidden bar presents via temp-show instead of suppressing),
+        // kept for the shared result type; label with the surface, not a retired reason.
+        recordInsightDeliveryOutcome(insightDeliveryID, outcome: .suppressed, reason: .floatingBarUnavailable)
         return
       case .rejectedOwnerChange:
         recordInsightDeliveryOutcome(
@@ -723,7 +722,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     let gate = ContextDeliveryGateInput(
       masterEnabled: Self.areNotificationsEnabled(),
       frequencyLevel: level,
-      snoozed: FloatingControlBarManager.shared.isSnoozed,
       paywalled: AppState.isPaywalledEffective,
       cooldownSeconds: ContextDeliveryBudget.cooldownSeconds(frequencyLevel: level)
     )
@@ -761,7 +759,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       ),
       taskNotificationsEnabled: TaskAssistantSettings.shared.notificationsEnabled,
       focusSuppressed: ProactiveTaskInterruptionSettings.isFocusSuppressed,
-      snoozed: FloatingControlBarManager.shared.isSnoozed,
       now: now,
       calendar: calendar
     )
@@ -823,7 +820,6 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         ambientFrequencyEligible: false,
         taskNotificationsEnabled: false,
         focusSuppressed: false,
-        snoozed: false,
         now: now,
         calendar: .current
       ),

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
@@ -410,7 +410,6 @@ struct TaskInterruptionEnvironment {
   let ambientFrequencyEligible: Bool
   let taskNotificationsEnabled: Bool
   let focusSuppressed: Bool
-  let snoozed: Bool
   let now: Date
   let calendar: Calendar
 }
@@ -554,8 +553,6 @@ final class ProactiveTaskInterruptionGate {
       reason = .taskDisabled
     } else if environment.focusSuppressed {
       reason = .focusSuppressed
-    } else if environment.snoozed {
-      reason = .snoozed
     } else if candidate.expiresAt <= environment.now {
       reason = .expired
     } else if candidate.canWait {

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -34,7 +34,7 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
-          masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false,
+          masterEnabled: true, frequencyLevel: 3, paywalled: false,
           cooldownSeconds: 30 * 60)),
       .allowed)
     XCTAssertEqual(
@@ -53,28 +53,23 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
 
   func testFreeGateBoundariesAndSuppressionInputs() {
     let base = ContextDeliveryGateInput(
-      masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: false,
+      masterEnabled: true, frequencyLevel: 3, paywalled: false,
       cooldownSeconds: 30 * 60)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: base), .allowed)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
-          masterEnabled: false, frequencyLevel: 3, snoozed: false, paywalled: false,
+          masterEnabled: false, frequencyLevel: 3, paywalled: false,
           cooldownSeconds: 0)), .masterDisabled)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
-          masterEnabled: true, frequencyLevel: 0, snoozed: false, paywalled: false,
+          masterEnabled: true, frequencyLevel: 0, paywalled: false,
           cooldownSeconds: 0)), .frequencyDisabled)
     XCTAssertEqual(
       ContextDeliveryBudget.freeGate(
         input: .init(
-          masterEnabled: true, frequencyLevel: 3, snoozed: true, paywalled: false,
-          cooldownSeconds: 0)), .snoozed)
-    XCTAssertEqual(
-      ContextDeliveryBudget.freeGate(
-        input: .init(
-          masterEnabled: true, frequencyLevel: 3, snoozed: false, paywalled: true,
+          masterEnabled: true, frequencyLevel: 3, paywalled: true,
           cooldownSeconds: 0)), .paywalled)
   }
 

--- a/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
@@ -114,7 +114,6 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
       gate: ContextDeliveryGateInput(
         masterEnabled: true,
         frequencyLevel: 3,
-        snoozed: false,
         paywalled: false,
         cooldownSeconds: 10 * 60),
       now: now)
@@ -170,7 +169,6 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
       gate: ContextDeliveryGateInput(
         masterEnabled: true,
         frequencyLevel: 4,
-        snoozed: false,
         paywalled: false,
         cooldownSeconds: 3 * 60),
       now: now)
@@ -182,7 +180,6 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
     ContextDeliveryGateInput(
       masterEnabled: true,
       frequencyLevel: 5,
-      snoozed: false,
       paywalled: false,
       cooldownSeconds: 0)
   }

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -177,7 +177,6 @@ final class ContextProactivityEngineTests: XCTestCase {
     let allowed = ContextDeliveryGateInput(
       masterEnabled: defaults.bool(forKey: NotificationService.masterEnabledDefaultsKey),
       frequencyLevel: defaults.integer(forKey: NotificationService.frequencyDefaultsKey),
-      snoozed: false,
       paywalled: false,
       cooldownSeconds: ContextDeliveryBudget.cooldownSeconds(frequencyLevel: 3))
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: allowed), .allowed)
@@ -186,7 +185,6 @@ final class ContextProactivityEngineTests: XCTestCase {
     let rebuilt = ContextDeliveryGateInput(
       masterEnabled: defaults.bool(forKey: NotificationService.masterEnabledDefaultsKey),
       frequencyLevel: defaults.integer(forKey: NotificationService.frequencyDefaultsKey),
-      snoozed: false,
       paywalled: false,
       cooldownSeconds: 0)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: rebuilt), .masterDisabled)
@@ -196,23 +194,13 @@ final class ContextProactivityEngineTests: XCTestCase {
     let allowed = ContextDeliveryGateInput(
       masterEnabled: true,
       frequencyLevel: 3,
-      snoozed: false,
       paywalled: false,
       cooldownSeconds: 0)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: allowed), .allowed)
 
-    let snoozed = ContextDeliveryGateInput(
-      masterEnabled: true,
-      frequencyLevel: 3,
-      snoozed: true,
-      paywalled: false,
-      cooldownSeconds: 0)
-    XCTAssertEqual(ContextDeliveryBudget.freeGate(input: snoozed), .snoozed)
-
     let paywalled = ContextDeliveryGateInput(
       masterEnabled: true,
       frequencyLevel: 3,
-      snoozed: false,
       paywalled: true,
       cooldownSeconds: 0)
     XCTAssertEqual(ContextDeliveryBudget.freeGate(input: paywalled), .paywalled)
@@ -513,7 +501,6 @@ final class ContextProactivityDirectorFailureTests: XCTestCase {
       gate: ContextDeliveryGateInput(
         masterEnabled: true,
         frequencyLevel: 5,
-        snoozed: false,
         paywalled: false,
         cooldownSeconds: 0),
       now: now)

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
@@ -3,6 +3,15 @@ import XCTest
 @testable import Omi_Computer
 
 final class ProactiveAssistantOrchestrationPolicyTests: XCTestCase {
+  /// Maximum (5) pairs a 10 s re-flush with the 10 s suggestion dwell so a nudge can land
+  /// seconds after a switch; every other level keeps the 60 s cadence.
+  func testDistributionFallbackIsTenSecondsOnlyAtMaximumLevel() {
+    XCTAssertEqual(ProactiveAssistantOrchestrationPolicy.distributionFallbackInterval(frequencyLevel: 5), 10)
+    XCTAssertEqual(ProactiveAssistantOrchestrationPolicy.distributionFallbackInterval(frequencyLevel: 4), 60)
+    XCTAssertEqual(ProactiveAssistantOrchestrationPolicy.distributionFallbackInterval(frequencyLevel: 3), 60)
+    XCTAssertEqual(ProactiveAssistantOrchestrationPolicy.distributionFallbackInterval(frequencyLevel: 0), 60)
+  }
+
   func testUnavailableTargetResetsEngineFailuresWithoutHidingCaptureHealth() {
     var failures = ScreenCaptureFailureTracker()
 

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
@@ -24,7 +24,7 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
     XCTAssertEqual(
       Set(SuggestionAssistantTelemetry.GateOutcome.allCases.map(\.rawValue)),
       Set([
-        "eligible", "disabled", "excluded_app", "snoozed", "dwell",
+        "eligible", "disabled", "excluded_app", "dwell",
         "cooldown", "daily_budget", "no_grounding",
       ])
     )

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -91,6 +91,15 @@ final class SuggestionGatePolicyTests: XCTestCase {
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 0), 30)
   }
 
+  /// Maximum caps the between-nudge cooldown at 30 s; other levels keep the user's
+  /// configured value (180 s default) untouched.
+  func testCooldownCapsAtThirtySecondsOnlyAtMaximumLevel() {
+    XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 5), 30)
+    XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 20, frequencyLevel: 5), 20)
+    XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 4), 180)
+    XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 3), 180)
+  }
+
   func testFirstEverEvaluationIsNotBlockedByAbsentHistory() {
     XCTAssertEqual(decide(lastEvaluationAt: nil, cooldown: 86400), .evaluate)
   }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -12,7 +12,6 @@ final class SuggestionGatePolicyTests: XCTestCase {
   private func decide(
     isEnabled: Bool = true,
     isAppExcluded: Bool = false,
-    isSnoozed: Bool = false,
     lastEvaluationAt: Date? = nil,
     cooldown: TimeInterval = 180,
     dwell: TimeInterval = 999,
@@ -23,7 +22,6 @@ final class SuggestionGatePolicyTests: XCTestCase {
     SuggestionGatePolicy.decide(
       isEnabled: isEnabled,
       isAppExcluded: isAppExcluded,
-      isSnoozed: isSnoozed,
       now: now,
       lastEvaluationAt: lastEvaluationAt,
       cooldown: cooldown,
@@ -48,8 +46,11 @@ final class SuggestionGatePolicyTests: XCTestCase {
     XCTAssertEqual(decide(isAppExcluded: true), .skippedExcludedApp)
   }
 
-  func testSnoozedBarDoesNotEvaluate() {
-    XCTAssertEqual(decide(isSnoozed: true), .skippedSnoozed)
+  /// Hiding the floating bar is about the bar, not delivery: the gate no longer has a
+  /// snooze input at all, so a hidden bar cannot silently mute an hour of nudges the way
+  /// "Disable for 2 hours" once did (the compiler now enforces what this test documents).
+  func testHiddenBarStillEvaluates() {
+    XCTAssertEqual(decide(), .evaluate)
   }
 
   func testCooldownBlocksUntilItHasFullyElapsed() {
@@ -69,16 +70,15 @@ final class SuggestionGatePolicyTests: XCTestCase {
     let decision = decide(
       isEnabled: false,
       isAppExcluded: true,
-      isSnoozed: true,
       lastEvaluationAt: now
     )
     XCTAssertEqual(decision, .skippedDisabled)
   }
 
-  /// A privacy exclusion must outrank snooze and cooldown: "do not look at this app" is a
+  /// A privacy exclusion must outrank cooldown: "do not look at this app" is a
   /// stronger statement than "not right now".
-  func testExclusionTakesPrecedenceOverSnoozeAndCooldown() {
-    let decision = decide(isAppExcluded: true, isSnoozed: true, lastEvaluationAt: now)
+  func testExclusionTakesPrecedenceOverCooldown() {
+    let decision = decide(isAppExcluded: true, lastEvaluationAt: now)
     XCTAssertEqual(decision, .skippedExcludedApp)
   }
 

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -82,6 +82,15 @@ final class SuggestionGatePolicyTests: XCTestCase {
     XCTAssertEqual(decision, .skippedExcludedApp)
   }
 
+  /// Maximum (5) is the "nudge me in seconds" demo mode: 10 s dwell. Everything below —
+  /// including Balanced (3) — keeps the deliberate 30 s so ordinary use is unchanged.
+  func testDwellIsTenSecondsOnlyAtMaximumLevel() {
+    XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 5), 10)
+    XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 4), 30)
+    XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 3), 30)
+    XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 0), 30)
+  }
+
   func testFirstEverEvaluationIsNotBlockedByAbsentHistory() {
     XCTAssertEqual(decide(lastEvaluationAt: nil, cooldown: 86400), .evaluate)
   }

--- a/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskContextualResurfacingTests.swift
@@ -1027,7 +1027,6 @@ final class TaskContextualResurfacingTests: XCTestCase {
       (environment(ambientFrequency: false), candidate(), .frequencyBudget),
       (environment(task: false), candidate(), .taskDisabled),
       (environment(focus: true), candidate(), .focusSuppressed),
-      (environment(snoozed: true), candidate(), .snoozed),
       (environment(), candidate(expiresAt: baseDate), .expired),
       (environment(), candidate(canWait: true), .canWait),
     ]
@@ -1386,7 +1385,6 @@ final class TaskContextualResurfacingTests: XCTestCase {
     ambientFrequency: Bool = true,
     task: Bool = true,
     focus: Bool = false,
-    snoozed: Bool = false,
     now: Date? = nil,
     calendar: Calendar = Calendar(identifier: .gregorian)
   ) -> TaskInterruptionEnvironment {
@@ -1397,7 +1395,6 @@ final class TaskContextualResurfacingTests: XCTestCase {
       ambientFrequencyEligible: ambientFrequency,
       taskNotificationsEnabled: task,
       focusSuppressed: focus,
-      snoozed: snoozed,
       now: now ?? baseDate,
       calendar: calendar
     )

--- a/desktop/macos/changelog/unreleased/20260814-hide-bar-keeps-notifications.json
+++ b/desktop/macos/changelog/unreleased/20260814-hide-bar-keeps-notifications.json
@@ -1,0 +1,3 @@
+{
+  "change": "Renamed the floating bar's right-click action to Hide for 2 hours — it now only hides the bar; notifications keep arriving (previously it silently muted all of them)"
+}

--- a/desktop/macos/changelog/unreleased/20260814-maximum-level-fast-nudges.json
+++ b/desktop/macos/changelog/unreleased/20260814-maximum-level-fast-nudges.json
@@ -1,3 +1,3 @@
 {
-  "change": "At Maximum notification level, suggestion nudges now arrive within ~10 seconds of switching into an app (10s dwell + 10s frame cadence); Balanced and below keep the usual 30s pace"
+  "change": "At Maximum notification level, nudges arrive within ~10 seconds of switching into an app and can repeat every 30 seconds; Balanced and below keep the usual pace"
 }

--- a/desktop/macos/changelog/unreleased/20260814-maximum-level-fast-nudges.json
+++ b/desktop/macos/changelog/unreleased/20260814-maximum-level-fast-nudges.json
@@ -1,0 +1,3 @@
+{
+  "change": "At Maximum notification level, suggestion nudges now arrive within ~10 seconds of switching into an app (10s dwell + 10s frame cadence); Balanced and below keep the usual 30s pace"
+}


### PR DESCRIPTION
## What

Four verified fixes/features for proactive notifications, driven by tonight's live debugging with Nik:

1. **"Hide for 2 hours" hides the bar without muting notifications** (was "Disable for 2 hours"). One right-click before a movie silently suppressed every proactive notification for two hours (root-caused from `omi.log`: 9 `snoozed` suppressions in one movie hour). The hide state is structurally removed from every delivery gate — `sendNotification`, `showNotification`, `ContextDeliveryGateInput`, `TaskInterruptionEnvironment`, `SuggestionGatePolicy` no longer accept a snoozed input (compiler-enforced). Cards present via the existing temp-show path over the hidden bar.
2. **Re-hide after temp-show**: hide keeps `isEnabled == true`, so the re-hide in `dismissNotificationAndAdvanceQueue` must also arm on the hidden state — otherwise the first nudge brought the bar back for the rest of the window (peer-review finding).
3. **Maximum = fast demo mode**: 10 s suggestion dwell + 10 s same-context frame cadence + 30 s between-nudge cooldown cap — all only at frequency level 5; Balanced and below keep 30 s dwell / 60 s cadence / configured cooldown. Assistant-side gates (grounding, daily budget) still bound spend.
4. **context_buckets flag no longer silences live suggestions** — verbatim copy of the concurrent fix on `kodjima33/buckets-starve-suggestions` (credited in the commit): with the PostHog flag at 100%, `SuggestionAssistant.isEnabled` returned false on every fresh sign-in and focus nudges went silent fleet-wide; observed live on this account ("disabled" probe outcome at 02:24).

## Product invariants

- **INV-CHAT-1** — path-matched (`NotificationService.swift`); transcript behavior unchanged, only the snooze suppression gate is removed.
- **INV-VOICE-1** — path-matched (`FloatingControlBarWindow.swift`, `FloatingControlBarView.swift`); voice-turn lifecycle untouched; bar-visibility policies still honor the hidden state for the bar itself.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 1755 -> 1761 | the level-aware distribution fallback replaces a one-line constant with a documented computed property; the policy logic itself lives in ProactiveAssistantOrchestrationPolicy (tested there), only the 6-line accessor lands in the plugin

## Verification (all live on named bundles, real signed-in account, Maximum level)

- **Hide keeps notifications**: with `floatingBar_snoozedUntil` set 2 h ahead — the exact state that returned six consecutive `snoozed` probe outcomes on the previous build — `probe_suggestion_nudge` delivered AND spoke (01:24:18 log: `Suggestion: delivering [90%]…` → `NotificationSpeech: speaking…`).
- **~10 s nudges at Maximum**: gate re-checks observed every ~10–25 s on real app switches (previously ~60 s); organic delivery at 02:04:58 after settling in Warp.
- **30 s cooldown**: two real deliveries 76 s apart (02:25:02 organic → 02:26:18 probe) passed the gate where the old 180 s cooldown would have refused until 02:28; second pair 45 s apart on the next build (02:30:10 → 02:30:55). Policy test pins 30 s only at level 5.
- **Flag fix**: before — probe outcome `disabled` on fresh sign-in with the flag at 100%; after — delivered.
- Focused suites green across the branch: suggestion gate 14/14 (incl. new dwell + cooldown pins), orchestration policy (fallback-cadence pin), context delivery, task resurfacing, bar launch policy — 137+ tests, 0 failures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

