### PR TITLE
fix(desktop): context-buckets mode must not silence the focus suggestion assistant

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -20,8 +20,14 @@ actor SuggestionAssistant: ProactiveAssistant {
 
   var isEnabled: Bool {
     get async {
+      // Deliberately independent of ContextBucketsFeature. The buckets rollout gated this
+      // on `!ContextBucketsFeature.isEnabled`, betting the context director would replace
+      // live suggestions — it delivered almost nothing, and with the flag at 100% of all
+      // users focus nudges went silent fleet-wide with no error logged (Aug 13–14 2026).
+      // If the director is ever meant to replace this assistant again, that must be an
+      // explicit, evidenced change — never a side effect of a rollout flag.
       await MainActor.run {
-        !ContextBucketsFeature.isEnabled && SuggestionAssistantSettings.shared.isEnabled
+        SuggestionAssistantSettings.shared.isEnabled
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/AssistantCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/AssistantCoordinator.swift
@@ -114,8 +114,13 @@ class AssistantCoordinator {
   /// and window title changes — one unified path with one delay mechanism.
   /// - Returns: `true` if a context switch was detected and fired.
   @discardableResult
-  func checkContextSwitch(newApp: String, newWindowTitle: String?) async -> Bool {
-    let bucketsEnabled = ContextBucketsFeature.isEnabled
+  func checkContextSwitch(
+    newApp: String,
+    newWindowTitle: String?,
+    bucketsEnabled: Bool? = nil
+  ) async -> Bool {
+    // Injectable for tests only; production always reads the live flag.
+    let bucketsEnabled = bucketsEnabled ?? ContextBucketsFeature.isEnabled
     let transitionRequest = ContextTransitionRequest(app: newApp, windowTitle: newWindowTitle)
     guard lastTrackedApp != nil else {
       if bucketsEnabled {
@@ -129,12 +134,14 @@ class AssistantCoordinator {
         do {
           let transition = try await ContextVisitCoordinator.shared.transition(
             toApp: newApp, windowTitle: newWindowTitle, departingFrame: nil)
-          lastTrackedApp = newApp
-          lastTrackedWindowTitle = newWindowTitle
           Task { await ContextProactivityEngine.shared.contextEntered(transition.arrivingFence) }
         } catch {
           logError("Context buckets: failed to persist initial visit", error: error)
         }
+        // Context tracking must not depend on bucket-visit persistence: an unprimed
+        // tracker means no context switch is ever detected and every assistant starves.
+        lastTrackedApp = newApp
+        lastTrackedWindowTitle = newWindowTitle
       } else {
         lastTrackedApp = newApp
         lastTrackedWindowTitle = newWindowTitle
@@ -181,22 +188,16 @@ class AssistantCoordinator {
         do {
           let departure = try await ContextVisitCoordinator.shared.leaveForExcludedContext(
             departingFrame: departingFrame)
-          lastTrackedApp = newApp
-          lastTrackedWindowTitle = newWindowTitle
           if departure.qualified, let fence = departure.fence, let departingFrame {
             Task { await ContextBucketRollupWriter.shared.extract(frame: departingFrame, fence: fence) }
-          }
-          if let taskAssistant = assistants["task-extraction"] {
-            Task {
-              await taskAssistant.onContextSwitch(
-                departingFrame: departingFrame,
-                newApp: newApp,
-                newWindowTitle: newWindowTitle)
-            }
           }
         } catch {
           logError("Context buckets: failed to close visit before excluded context", error: error)
         }
+        lastTrackedApp = newApp
+        lastTrackedWindowTitle = newWindowTitle
+        await fireContextSwitchOnAllAssistants(
+          departingFrame: departingFrame, newApp: newApp, newWindowTitle: newWindowTitle)
         return true
       }
       do {
@@ -204,39 +205,23 @@ class AssistantCoordinator {
           toApp: newApp,
           windowTitle: newWindowTitle,
           departingFrame: departingFrame)
-        lastTrackedApp = newApp
-        lastTrackedWindowTitle = newWindowTitle
         if transition.departingQualified, let departingFence = transition.departingFence, let departingFrame {
           Task { await ContextBucketRollupWriter.shared.extract(frame: departingFrame, fence: departingFence) }
-        }
-        // TaskAssistant keeps its timer fallback and messaging fast path. The
-        // coordinator is the only exit writer while the flag is enabled.
-        if let taskAssistant = assistants["task-extraction"] {
-          Task {
-            await taskAssistant.onContextSwitch(
-              departingFrame: departingFrame,
-              newApp: newApp,
-              newWindowTitle: newWindowTitle)
-          }
         }
         Task { await ContextProactivityEngine.shared.contextEntered(transition.arrivingFence) }
       } catch {
         logError("Context buckets: context transition failed", error: error)
       }
+      lastTrackedApp = newApp
+      lastTrackedWindowTitle = newWindowTitle
+      await fireContextSwitchOnAllAssistants(
+        departingFrame: departingFrame, newApp: newApp, newWindowTitle: newWindowTitle)
       return true
     }
 
     // Flag-off rollback path: fire today's independent assistants unchanged.
-    for (_, assistant) in assistants {
-      Task {
-        await assistant.onContextSwitch(
-          departingFrame: departingFrame,
-          newApp: newApp,
-          newWindowTitle: newWindowTitle
-        )
-      }
-    }
-
+    await fireContextSwitchOnAllAssistants(
+      departingFrame: departingFrame, newApp: newApp, newWindowTitle: newWindowTitle)
     return true
   }
 
@@ -244,6 +229,29 @@ class AssistantCoordinator {
   /// during its persistence await. The follow-up runs on the main actor, so it
   /// cannot race the coordinator's tracked state or start a second write in
   /// parallel with the completed request.
+  /// Every registered assistant hears every context switch, in buckets mode and out of it.
+  ///
+  /// The context-buckets rollout forwarded switches only to the task assistant, which
+  /// silently starved the suggestion and memory assistants: `SuggestionAssistant.analyze`
+  /// returns nil before any logging when no context switch ever armed its dwell anchor,
+  /// so focus nudges stopped fleet-wide for everyone in the flag cohort with no error
+  /// anywhere (Aug 13–14 2026). Buckets mode changes who WRITES bucket exits, never who
+  /// HEARS switches — and hearing a switch must not depend on bucket-visit persistence,
+  /// so this fires outside the transition do/catch.
+  func fireContextSwitchOnAllAssistants(
+    departingFrame: CapturedFrame?,
+    newApp: String,
+    newWindowTitle: String?
+  ) async {
+    for (_, assistant) in assistants {
+      await assistant.onContextSwitch(
+        departingFrame: departingFrame,
+        newApp: newApp,
+        newWindowTitle: newWindowTitle
+      )
+    }
+  }
+
   private func finishContextTransition(_ request: ContextTransitionRequest) {
     guard let next = contextTransitionQueue.finish(request) else { return }
     Task { @MainActor [weak self] in

--- a/desktop/macos/Desktop/Tests/AssistantCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AssistantCoordinatorTests.swift
@@ -46,4 +46,59 @@ final class AssistantCoordinatorTests: XCTestCase {
     XCTAssertEqual(queue.inFlight, destinationB)
     XCTAssertEqual(queue.finish(destinationB), nil)
   }
+
+  /// Regression (Aug 13–14 2026): the context-buckets rollout forwarded context switches
+  /// only to the task assistant, silently starving the suggestion and memory assistants —
+  /// focus nudges stopped for everyone in the flag cohort with no error logged anywhere.
+  /// Buckets mode changes who writes bucket exits, never who hears switches.
+  @MainActor
+  func testBucketsModeDispatchesContextSwitchToEveryAssistant() async {
+    let spy = ContextSwitchSpyAssistant(identifier: "context-switch-spy-\(UUID().uuidString)")
+    AssistantCoordinator.shared.register(spy)
+    defer { AssistantCoordinator.shared.unregister(identifier: spy.spyIdentifier) }
+
+    // register() stores the assistant from a MainActor task; yield until it is visible.
+    for _ in 0..<1000 where AssistantCoordinator.shared.assistant(withIdentifier: spy.spyIdentifier) == nil {
+      await Task.yield()
+    }
+    XCTAssertNotNil(AssistantCoordinator.shared.assistant(withIdentifier: spy.spyIdentifier))
+
+    // First call primes the tracked context; the second is a real switch. The dispatch is
+    // awaited inside checkContextSwitch, so by the time it returns the spy has heard it.
+    _ = await AssistantCoordinator.shared.checkContextSwitch(
+      newApp: "SpyBaselineApp", newWindowTitle: "baseline", bucketsEnabled: true)
+    _ = await AssistantCoordinator.shared.checkContextSwitch(
+      newApp: "SpyTargetApp", newWindowTitle: "target", bucketsEnabled: true)
+
+    let apps = await spy.switchedApps()
+    XCTAssertTrue(
+      apps.contains("SpyTargetApp"),
+      "buckets mode must deliver onContextSwitch to every registered assistant, got \(apps)")
+  }
+}
+
+private actor ContextSwitchSpyAssistant: ProactiveAssistant {
+  nonisolated let spyIdentifier: String
+  var identifier: String { spyIdentifier }
+  var displayName: String { "Context Switch Spy" }
+  var isEnabled: Bool { true }
+  var needsFrameDuringDelay: Bool { false }
+
+  private var apps: [String] = []
+
+  init(identifier: String) {
+    self.spyIdentifier = identifier
+  }
+
+  func switchedApps() -> [String] { apps }
+
+  func analyze(frame: CapturedFrame) async -> AssistantResult? { nil }
+  func handleResult(
+    _ result: AssistantResult, sendEvent: @escaping @Sendable (String, [String: Any]) -> Void
+  ) async {}
+  func onContextSwitch(departingFrame: CapturedFrame?, newApp: String, newWindowTitle: String?) async {
+    apps.append(newApp)
+  }
+  func clearPendingWork() async {}
+  func stop() async {}
 }

--- a/desktop/macos/changelog/unreleased/20260814-buckets-context-switch-starvation.json
+++ b/desktop/macos/changelog/unreleased/20260814-buckets-context-switch-starvation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed focus suggestions going silent when the context-buckets rollout was enabled: every assistant hears context switches again, not just the task assistant"
+}


### PR DESCRIPTION
## What

The `context_buckets` rollout silently killed focus (suggestion) nudges for everyone in the flag cohort — and the flag was at **100% of all users**. Nik's last delivered focus nudge before the fix: Aug 12 23:06; nothing after, with zero errors logged anywhere. Insights/memories/tasks kept working, which is exactly the signature: focus is the only assistant whose pipeline starts from a context switch.

Three defects, one per commit hunk:

1. **Coordinator starved the assistants.** The buckets path of `AssistantCoordinator.checkContextSwitch` fired `onContextSwitch` only on `assistants["task-extraction"]`. `SuggestionAssistant.analyze` returns nil before any logging when no switch ever armed its dwell anchor. Now a shared `fireContextSwitchOnAllAssistants` fires on every registered assistant in buckets mode and out of it — awaited, and outside the bucket-persistence do/catch.
2. **`SuggestionAssistant.isEnabled` was hard-gated on `!ContextBucketsFeature.isEnabled`** — the context director was supposed to replace live suggestions and delivered almost nothing. The gate is removed; replacing the assistant must be an explicit evidenced change, not a rollout side effect.
3. **Context tracking died with the bucket DB.** `lastTrackedApp` was only assigned inside the `do` blocks, so any bucket-visit write failure left tracking unprimed and every assistant starved. Tracking now updates regardless of persistence health. (Found by the new regression test failing in the hermetic test host, where the bucket store throws.)

Live mitigation already shipped separately: the PostHog flag (id 817239) was disabled at 02:00; this PR makes re-enabling it safe.

## Product invariants

None matched (`scripts/pr-preflight --suggest`: no invariant IDs emitted for these paths).

Failure-Class: none

## Verification

- New deterministic regression test `testBucketsModeDispatchesContextSwitchToEveryAssistant` (spy assistant hears switches with buckets forced on; no wall-clock sleeps — dispatch is awaited, registration visibility via bounded `Task.yield()`); `AssistantCoordinatorTests` 4/4 green; `check_desktop_test_quality.py` at/below baseline (16 waits, unchanged).
- Live on `omi-ankara` built from this branch with `OMI_FORCE_CONTEXT_BUCKETS=1` (real signed-in account):
  - `probe_suggestion_nudge` pre-fix returned `{"outcome": "disabled"}`; post-fix it ran the full pipeline — `{commitments: 3, goals: 5, confidence: 80, outcome: filtered_low_confidence}` (honest below-bar refusal).
  - Organic proof: the running bundle logged real `Suggestion: skipped (skippedDwell) app=Warp` / `below bar [80% < 85%]` lines from the user's own app switches with buckets ON — the exact signature absent all day on broken builds.
- Fleet evidence of the outage: PostHog fleet gate outcomes continued (other users mostly weren't on builds with the buckets code yet); the affected machine logged zero `Suggestion:` lines across every app instance from Aug 13 02:59 (first build carrying the rollout) until the flag was disabled.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

