### PR TITLE
fix(backend): bind MEMORY_V3_CURSOR_SECRET in prod serving config

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -148,6 +148,11 @@ env:
     value: "off"
   - name: MEMORY_V3_GET_ENABLED
     value: "false"
+  - name: MEMORY_V3_CURSOR_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: MEMORY_V3_CURSOR_SECRET
   - name: MEMORY_CANONICAL_MAINTENANCE_ENABLED
     value: "false"
   - name: FAL_KEY

--- a/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
+++ b/backend/charts/backend-secrets/prod_omi_backend_secrets_values.yaml
@@ -68,6 +68,8 @@ externalSecret:
       remoteKey: OPENROUTER_API_KEY
     - secretKey: ENCRYPTION_SECRET
       remoteKey: ENCRYPTION_SECRET
+    - secretKey: MEMORY_V3_CURSOR_SECRET
+      remoteKey: MEMORY_V3_CURSOR_SECRET
     - secretKey: GEMINI_API_KEY
       remoteKey: GEMINI_API_KEY
     - secretKey: TWILIO_AUTH_TOKEN

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1160,6 +1160,10 @@ environments:
           OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE:
             value: 'true'
             category: rollout
+          MEMORY_V3_CURSOR_SECRET:
+            secret:
+              name: prod-omi-backend-secrets
+              key: MEMORY_V3_CURSOR_SECRET
           MCP_OAUTH_CLIENTS_JSON:
             secret:
               name: prod-omi-backend-secrets
@@ -1250,6 +1254,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            MEMORY_V3_CURSOR_SECRET:
+              secret: MEMORY_V3_CURSOR_SECRET
               version: latest
             DESKTOP_PREVIEW_PUBLISH_KEY:
               secret: DESKTOP_PREVIEW_PUBLISH_KEY
@@ -1384,6 +1391,9 @@ environments:
             OMI_LLM_GATEWAY_ALLOW_PROD_FEATURE_MODE:
               value: 'true'
               category: rollout
+            MEMORY_V3_CURSOR_SECRET_VERSION:
+              value: prod-v1
+              category: memory_rollout
             MCP_OAUTH_CLAUDE_CLIENT_ID:
               env_var: MCP_OAUTH_CLAUDE_CLIENT_ID
               category: oauth_metadata

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -62,6 +62,11 @@ overlay:
           value: 'off'
         MEMORY_V3_GET_ENABLED:
           value: 'false'
+        # Canonical graph and /v3/memories first-page cursors fail closed without this HMAC.
+        MEMORY_V3_CURSOR_SECRET:
+          secret:
+            name: prod-omi-backend-secrets
+            key: MEMORY_V3_CURSOR_SECRET
         MCP_OAUTH_CLIENTS_JSON:
           secret:
             name: prod-omi-backend-secrets
@@ -194,6 +199,10 @@ overlay:
             value: 'off'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
+          # `/v1/knowledge-graph` and signed memory cursors fail closed until this binding is present.
+          MEMORY_V3_CURSOR_SECRET_VERSION:
+            value: prod-v1
+            category: memory_rollout
           MCP_OAUTH_CLAUDE_CLIENT_ID:
             env_var: MCP_OAUTH_CLAUDE_CLIENT_ID
             category: oauth_metadata
@@ -204,6 +213,9 @@ overlay:
             env_var: MCP_OAUTH_CLAUDE_REDIRECT_URIS
             category: oauth_metadata
         secrets:
+          MEMORY_V3_CURSOR_SECRET:
+            secret: MEMORY_V3_CURSOR_SECRET
+            version: latest
           DESKTOP_PREVIEW_PUBLISH_KEY:
             secret: DESKTOP_PREVIEW_PUBLISH_KEY
             version: latest


### PR DESCRIPTION
## Summary
- Bind `MEMORY_V3_CURSOR_SECRET` in prod Cloud Run and GKE `backend-listen` config so the next deploy does not drop the live HMAC required by fail-closed canonical graph reads.
- Prod GSM already has a dedicated `MEMORY_V3_CURSOR_SECRET` (new prod-specific value, not copied from dev). Live Cloud Run `backend` revision `backend-01207-bwc` and GKE `prod-omi-backend-listen` already consume it.
- Do not merge until you want Helm/Cloud Run deploys to keep this binding; live prod is already fixed.

## Test plan
- [x] `GET https://api.omi.me/v1/knowledge-graph` as a synthetic uid no longer fails at `missing_cursor_secret` (secret fence passed; remaining 503 is per-account `missing_state_head` / canonical scan).
- [x] Cloud Run prod `backend` traffic is 100% on `backend-01207-bwc` with `MEMORY_V3_CURSOR_SECRET` bound from GSM `latest`.
- [x] GKE `prod-omi-backend-listen` pods have the env set (length 64); ExternalSecret synced the key.
- [ ] Next prod Cloud Run / Helm deploy keeps the binding (this PR).
- [ ] Accounts with a valid V3 `users/{uid}/memory_state/head` can load Mind Map.

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

