### PR TITLE
fix(desktop): media playback exempts the capture idle gate

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/MediaPlaybackIdleExemption.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/MediaPlaybackIdleExemption.swift
@@ -1,0 +1,76 @@
+import Foundation
+import IOKit.pwr_mgt
+
+/// Watching a movie is not being away from the machine.
+///
+/// The capture loop's idle gate reads HID idle time, and a person watching video
+/// produces no HID input — so after 60 quiet seconds every capture tick was skipped
+/// and the proactive assistants went blind exactly when the user asked "why no nudges
+/// while I watch TikTok for an hour?" (measured live: 14 idle-skip cycles in one
+/// movie hour, near-zero analyses at Maximum frequency).
+///
+/// The system already knows the difference: video players and browsers hold a
+/// power-management assertion that prevents display sleep while media plays
+/// (`PreventUserIdleDisplaySleep`, or the legacy `NoDisplaySleepAssertion`). While any
+/// other process holds one, the display would stay lit for a human who is presumed to
+/// be watching — the same presumption the idle gate should make.
+enum MediaPlaybackIdlePolicy {
+  /// The idle value the capture gate should act on. Media playback pins it to zero —
+  /// the viewer is present — and otherwise the HID value passes through untouched.
+  static func effectiveIdleSeconds(
+    hidIdleSeconds: TimeInterval,
+    isDisplaySleepPrevented: Bool
+  ) -> TimeInterval {
+    isDisplaySleepPrevented ? 0 : hidIdleSeconds
+  }
+}
+
+/// Polls the power-management assertion table, cached so the capture loop's fast tick
+/// does not shell into IOKit every second.
+final class MediaPlaybackDetector {
+  private let probe: () -> Bool
+  private let cacheTTL: TimeInterval
+  private var cachedValue = false
+  private var cachedAt: Date = .distantPast
+
+  init(
+    cacheTTL: TimeInterval = 10,
+    probe: @escaping () -> Bool = MediaPlaybackDetector.displaySleepPreventedByAnotherProcess
+  ) {
+    self.cacheTTL = cacheTTL
+    self.probe = probe
+  }
+
+  func isDisplaySleepPrevented(now: Date = Date()) -> Bool {
+    if now.timeIntervalSince(cachedAt) < cacheTTL {
+      return cachedValue
+    }
+    cachedValue = probe()
+    cachedAt = now
+    return cachedValue
+  }
+
+  /// Whether any process other than this one holds a display-sleep-prevention
+  /// assertion. Our own capture/recording stack can hold assertions of its own, and
+  /// those must not count as "the user is watching something".
+  static func displaySleepPreventedByAnotherProcess() -> Bool {
+    var assertionsRef: Unmanaged<CFDictionary>?
+    guard IOPMCopyAssertionsByProcess(&assertionsRef) == kIOReturnSuccess,
+      let byProcess = assertionsRef?.takeRetainedValue() as? [Int: [[String: Any]]]
+    else { return false }
+
+    let ownPID = Int(ProcessInfo.processInfo.processIdentifier)
+    for (pid, assertions) in byProcess where pid != ownPID {
+      for assertion in assertions {
+        guard
+          let type = assertion["AssertionTrueType"] as? String
+            ?? assertion[kIOPMAssertionTypeKey as String] as? String
+        else { continue }
+        if type == "PreventUserIdleDisplaySleep" || type == "NoDisplaySleepAssertion" {
+          return true
+        }
+      }
+    }
+    return false
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -180,6 +180,10 @@ public class ProactiveAssistantsPlugin: NSObject {
   )
   /// Fast poll interval for checking idle/app/window state without capturing.
   private let capturePollInterval: TimeInterval = 1.0
+  /// Exempts HID idleness while another process plays media (movie night ≠ away).
+  private let mediaPlaybackDetector = MediaPlaybackDetector()
+  /// One log line per idle-but-watching episode, not one per poll tick.
+  private var didLogMediaIdleExemption = false
   /// Apps whose content changes slowly. The value is the heartbeat interval in seconds.
   /// Uses bundle ID when available, falling back to localized app name.
   private let appSpecificHeartbeatIntervals: [String: TimeInterval] = [
@@ -770,8 +774,22 @@ public class ProactiveAssistantsPlugin: NSObject {
       return
     }
 
-    // Cheap early exits before resolving the active window.
-    let idleSeconds = systemIdleSeconds()
+    // Cheap early exits before resolving the active window. Media playback exempts
+    // HID idleness: a movie viewer types nothing for an hour but is still watching,
+    // and skipping every tick blinded the assistants exactly then (see
+    // MediaPlaybackIdlePolicy).
+    let hidIdleSeconds = systemIdleSeconds()
+    let idleSeconds = MediaPlaybackIdlePolicy.effectiveIdleSeconds(
+      hidIdleSeconds: hidIdleSeconds,
+      isDisplaySleepPrevented: mediaPlaybackDetector.isDisplaySleepPrevented())
+    if hidIdleSeconds >= captureTrigger.idleThreshold, idleSeconds < captureTrigger.idleThreshold,
+      !didLogMediaIdleExemption
+    {
+      didLogMediaIdleExemption = true
+      log("CaptureGate: HID-idle but media playback active — capture continues")
+    } else if hidIdleSeconds < captureTrigger.idleThreshold {
+      didLogMediaIdleExemption = false
+    }
     if idleSeconds >= captureTrigger.idleThreshold {
       logCaptureGate("idle")
       return

--- a/desktop/macos/Desktop/Tests/MediaPlaybackIdleExemptionTests.swift
+++ b/desktop/macos/Desktop/Tests/MediaPlaybackIdleExemptionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MediaPlaybackIdleExemptionTests: XCTestCase {
+  /// The regression this exists for: an hour of movie-watching (no HID input) must not
+  /// read as "user away" while something is holding the display awake for them.
+  func testMediaPlaybackPinsIdleToZero() {
+    XCTAssertEqual(
+      MediaPlaybackIdlePolicy.effectiveIdleSeconds(
+        hidIdleSeconds: 3600, isDisplaySleepPrevented: true),
+      0)
+  }
+
+  func testWithoutPlaybackHIDIdlePassesThrough() {
+    XCTAssertEqual(
+      MediaPlaybackIdlePolicy.effectiveIdleSeconds(
+        hidIdleSeconds: 90, isDisplaySleepPrevented: false),
+      90)
+  }
+
+  /// The capture loop polls every second; the IOKit assertion table must not be
+  /// walked on every tick.
+  func testDetectorCachesProbeWithinTTL() {
+    var probeCalls = 0
+    var playbackActive = true
+    let detector = MediaPlaybackDetector(cacheTTL: 10) {
+      probeCalls += 1
+      return playbackActive
+    }
+    let t0 = Date(timeIntervalSince1970: 1_000_000)
+    XCTAssertTrue(detector.isDisplaySleepPrevented(now: t0))
+    XCTAssertTrue(detector.isDisplaySleepPrevented(now: t0.addingTimeInterval(5)))
+    XCTAssertEqual(probeCalls, 1)
+    // TTL elapsed and playback stopped: the next read re-probes and sees the change.
+    playbackActive = false
+    XCTAssertFalse(detector.isDisplaySleepPrevented(now: t0.addingTimeInterval(11)))
+    XCTAssertEqual(probeCalls, 2)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260814-media-playback-not-idle.json
+++ b/desktop/macos/changelog/unreleased/20260814-media-playback-not-idle.json
@@ -1,0 +1,3 @@
+{
+  "change": "Screen analysis keeps running while you watch videos — media playback no longer counts as being away from the machine, so proactive notifications work during movies"
+}

--- a/desktop/macos/e2e/flows/screen-recording-permission.yaml
+++ b/desktop/macos/e2e/flows/screen-recording-permission.yaml
@@ -26,6 +26,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveExternalCaptureYield.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/MediaPlaybackIdleExemption.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+CaptureStatus.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveCaptureStatusSnapshot.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveCaptureStatusSnapshotRegistration.swift


### PR DESCRIPTION
## What

Movie-watching no longer counts as being away: the capture loop's idle gate skipped every tick after 60 s without HID input, so an hour of passive video (Nik's report: Maximum notifications, one nudge in a movie hour, 14 `skipping capture ticks (idle)` cycles logged) produced almost no screen analyses and therefore almost no proactive notifications.

- `MediaPlaybackIdlePolicy.effectiveIdleSeconds` pins the gate's idle value to 0 while another process holds a display-sleep-prevention assertion (`PreventUserIdleDisplaySleep` / legacy `NoDisplaySleepAssertion` — what browsers and video players hold during playback). No media → HID idle passes through untouched.
- `MediaPlaybackDetector`: 10 s-cached `IOPMCopyAssertionsByProcess` walk, ignoring our own pid (our capture stack's own assertions must not count as "the user is watching").
- One log line per idle-but-watching episode (`CaptureGate: HID-idle but media playback active — capture continues`) for observability.

## Product invariants

None matched (path-based check: none).

Failure-Class: none

## Verification

- `MediaPlaybackIdleExemptionTests` 3/3 (policy pass-through / pin-to-zero, detector TTL cache re-probe).
- IOKit probe live-tested both ways on the target machine: standalone run of the identical assertion-walk code printed `PREVENTED=false` at rest and `PREVENTED=true` under a held `PreventUserIdleDisplaySleep` assertion.
- **End-to-end on the running app** (omi-notch built from this branch, real user idleness, real assertion): `02:44:46 CaptureGate: HID-idle but media playback active — capture continues` → `02:45:09 RewindIndexer: Last 60s — 4 frames…`, zero idle skips during the hold.
- **Negative path live**: with the assertion lapsed and the user idle, `02:27:09 CaptureGate: skipping capture ticks (idle)` — no media keeps the old power-saving behavior.

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 1761 -> 1779 | The idle-gate exemption must live at the gate check itself (effective-idle computation + once-per-episode log flag); the policy and detector logic already live in the new MediaPlaybackIdleExemption.swift, and splitting the plugin for 18 gate-site lines would fragment the capture-gate sequence.
