### PR TITLE
fix(backend): stop parking Cloud Run slots on idle GET /v1/mcp/sse keepalive streams

### DIFF
--- a/.github/failure-classes/FC-idle-stream-parks-serving-slot.json
+++ b/.github/failure-classes/FC-idle-stream-parks-serving-slot.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-idle-stream-parks-serving-slot",
+  "violated_contract": "A serving endpoint must not hold a request slot open for a stream that carries no protocol value; every long-lived response must either deliver data the connected client consumes or terminate immediately, because parked idle streams spend the service's bounded concurrency budget and starve real requests while CPU sits idle.",
+  "canonical_prevention": "When a transport makes a long-lived response optional, return the spec-mandated immediate refusal (405 for MCP Streamable HTTP GET) instead of an idle keepalive stream, and assert with a contract test that the endpoint cannot answer with an unbounded stream.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_mcp_sse_get_no_stream.py"
+  ],
+  "evidence_prs": [
+    11557
+  ],
+  "scope_hints": [
+    "backend/**"
+  ],
+  "status": "open"
+}

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -7,7 +7,6 @@ allowing clients to connect without running a local MCP server.
 Implements the MCP 2025-03-26 Streamable HTTP Transport specification.
 """
 
-import asyncio
 import json
 import logging
 import os
@@ -1803,44 +1802,23 @@ async def mcp_streamable_http(
 
 
 @router.get("/v1/mcp/sse", tags=["mcp"], response_class=Response)
-async def mcp_sse_get(
-    request: Request,
-    authorization: Optional[str] = Header(None, alias="Authorization"),
-    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
-):
+def mcp_sse_get():
     """
-    SSE endpoint for server-initiated messages (optional).
+    GET on the Streamable HTTP endpoint: this server offers no server-initiated stream.
 
-    Clients can GET this endpoint to listen for server-initiated notifications.
-    This is optional per the MCP spec and mainly used for long-polling scenarios.
+    Per the MCP Streamable HTTP transport spec (2025-03-26), a server that does not
+    offer server-initiated messages MUST return 405 Method Not Allowed for GET, and
+    clients MUST NOT treat that as an error.
+
+    This used to return an infinite keepalive-ping SSE stream that carried no protocol
+    data (this transport is stateless; nothing is ever pushed, and the deprecated
+    HTTP+SSE transport's required ``endpoint`` event was never sent). Every connected
+    MCP client parked one such stream for the full Cloud Run request timeout (3600s),
+    which exhausted the service's concurrency slots while CPU sat idle and drove
+    tool-call tail latency to minutes ("no available instance" aborts). Do not
+    reintroduce a long-lived GET stream here without accounting for that capacity.
     """
-    # Authenticate
-    auth_context = await run_blocking(db_executor, authenticate_mcp_request, authorization)
-    if not auth_context:
-        raise invalid_mcp_auth_exception()
-
-    await run_blocking(critical_executor, check_rate_limit_inline, auth_context.uid, "mcp:sse")
-
-    # For backwards compatibility, also support the old SSE flow
-    # Return an empty SSE stream that just sends keepalives
-    async def event_generator():
-        try:
-            while True:
-                if await request.is_disconnected():
-                    break
-                yield f"event: ping\ndata: {{}}\n\n"
-                await asyncio.sleep(30)
-        except asyncio.CancelledError:
-            # Normal cancellation when client disconnects
-            pass
-        except Exception as e:
-            logging.warning(f"MCP SSE event generator error: {e}")
-
-    return StreamingResponse(
-        event_generator(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
-    )
+    return Response(status_code=405, headers={"Allow": "POST, HEAD, DELETE"})
 
 
 @router.head("/v1/mcp/sse", tags=["mcp"], response_class=Response)

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -1802,9 +1802,16 @@ async def mcp_streamable_http(
 
 
 @router.get("/v1/mcp/sse", tags=["mcp"], response_class=Response)
-def mcp_sse_get():
+def mcp_sse_get(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    mcp_session_id: Optional[str] = Header(None, alias="Mcp-Session-Id"),
+):
     """
     GET on the Streamable HTTP endpoint: this server offers no server-initiated stream.
+
+    The two header parameters are accepted and ignored: released app-client OpenAPI
+    contracts describe them on this operation, and removing them reads as a breaking
+    request-shape change to the compatibility checker.
 
     Per the MCP Streamable HTTP transport spec (2025-03-26), a server that does not
     offer server-initiated messages MUST return 405 Method Not Allowed for GET, and

--- a/backend/scripts/check_response_model_coverage.py
+++ b/backend/scripts/check_response_model_coverage.py
@@ -31,7 +31,7 @@ LEGIT_NON_JSON: dict[tuple[str, str], str] = {
     ("chat.py", "create_voice_message_stream"): "StreamingResponse audio",
     ("chat.py", "transcribe_voice_message_stream"): "StreamingResponse audio",
     ("mcp_sse.py", "mcp_streamable_http"): "SSE stream",
-    ("mcp_sse.py", "mcp_sse_get"): "SSE stream",
+    ("mcp_sse.py", "mcp_sse_get"): "405 Method Not Allowed sentinel (no SSE stream offered)",
     ("mcp_sse.py", "mcp_sse_head"): "SSE stream",
     # --- OAuth / redirect callbacks (return RedirectResponse or HTML) ---
     ("auth.py", "auth_authorize"): "OAuth authorize redirect",
@@ -61,10 +61,10 @@ LEGIT_NON_JSON: dict[tuple[str, str], str] = {
     ("sync.py", "download_audio_file_endpoint"): "binary audio file download (StreamingResponse)",
     ("users.py", "export_all_user_data"): "StreamingResponse data-export download",
     # --- 204 No Content (genuine empty-body deletes; FastAPI rejects response_model+204) ---
-    ("developer.py", "delete_key"): "204 No Content",
+    ("api_key_management.py", "delete_mcp_key"): "204 No Content",
+    ("api_key_management.py", "delete_developer_key"): "204 No Content",
     ("folders.py", "delete_folder"): "204 No Content",
     ("integrations.py", "delete_integration"): "204 No Content",
-    ("mcp.py", "delete_key"): "204 No Content",
     ("mcp.py", "revoke_oauth_grant"): "204 No Content",
     ("action_items.py", "delete_action_item"): "204 No Content",
     ("task_integrations.py", "delete_task_integration"): "204 No Content",

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -311,20 +311,14 @@ async def test_sse_post_tools_list_ignores_stale_session_id():
     assert 'get_memories' in names
 
 
-@pytest.mark.asyncio
-async def test_sse_get_keepalive_uses_transport_rate_limit():
-    auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
-    request = _JsonRequest({})
+def test_sse_get_returns_405_without_holding_a_stream():
+    # GET no longer serves a keepalive SSE stream (it exhausted Cloud Run
+    # concurrency slots; see tests/unit/test_mcp_sse_get_no_stream.py). The
+    # spec-mandated 405 must be immediate: no auth or rate-limit work either.
+    response = sse.mcp_sse_get()
 
-    with (
-        patch.object(sse, 'run_blocking', side_effect=_run_blocking_inline),
-        patch.object(sse, 'authenticate_mcp_request', return_value=auth_context),
-        patch.object(sse, 'check_rate_limit_inline') as check_rate_limit,
-    ):
-        response = await sse.mcp_sse_get(request, authorization='Bearer token')
-
-    assert response.status_code == 200
-    check_rate_limit.assert_called_once_with(UID, 'mcp:sse')
+    assert response.status_code == 405
+    assert response.headers.get('allow') == 'POST, HEAD, DELETE'
 
 
 def test_sse_tool_security_schemes_match_runtime_scope_map():

--- a/backend/tests/unit/test_mcp_sse_get_no_stream.py
+++ b/backend/tests/unit/test_mcp_sse_get_no_stream.py
@@ -1,0 +1,50 @@
+"""Regression test: GET /v1/mcp/sse must not offer a long-lived SSE stream.
+
+The handler used to return an infinite keepalive-ping SSE stream that carried no
+protocol data (the transport is stateless, nothing is ever pushed, and the
+deprecated HTTP+SSE transport's required ``endpoint`` event was never sent).
+Every connected MCP client parked one such stream for the full Cloud Run request
+timeout (3600s). In production (2026-08-14) ~1,100-1,400 hour-long GET streams
+per hour saturated the service's entire concurrency budget (maxScale 25 x
+containerConcurrency 80, p95 concurrency ~84/80) while CPU sat at ~4%, causing
+"no available instance" aborts and minutes-long tool-call tail latency
+(measured p90 ~122s, max 300s) for every MCP consumer.
+
+Per the MCP Streamable HTTP transport spec (2025-03-26), a server that does not
+offer server-initiated messages MUST return 405 Method Not Allowed for GET on
+the endpoint, and clients MUST NOT treat that as an error. External contract:
+https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+("listening for messages from the server": the server MUST either return
+text/event-stream or HTTP 405 Method Not Allowed).
+
+These tests exercise the real router through FastAPI's TestClient (conftest
+sets the fake env vars needed for import).
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+
+@pytest.fixture(scope="module")
+def client():
+    from routers import mcp_sse
+
+    app = FastAPI()
+    app.include_router(mcp_sse.router)
+    return TestClient(app)
+
+
+def test_get_mcp_sse_returns_405_not_a_stream(client):
+    """GET must return 405 immediately instead of holding an infinite SSE stream."""
+    response = client.get("/v1/mcp/sse")
+    assert response.status_code == 405
+    assert "text/event-stream" not in response.headers.get("content-type", "")
+    # Spec-friendly: advertise the methods the endpoint does serve.
+    assert "POST" in response.headers.get("allow", "")
+
+
+def test_post_mcp_sse_still_routed(client):
+    """The 405 is method-scoped: POST (the real transport) must still reach auth, not 405."""
+    response = client.post("/v1/mcp/sse", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert response.status_code != 405

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -44423,7 +44423,7 @@
         ]
       },
       "get": {
-        "description": "SSE endpoint for server-initiated messages (optional).\n\nClients can GET this endpoint to listen for server-initiated notifications.\nThis is optional per the MCP spec and mainly used for long-polling scenarios.",
+        "description": "GET on the Streamable HTTP endpoint: this server offers no server-initiated stream.\n\nThe two header parameters are accepted and ignored: released app-client OpenAPI\ncontracts describe them on this operation, and removing them reads as a breaking\nrequest-shape change to the compatibility checker.\n\nPer the MCP Streamable HTTP transport spec (2025-03-26), a server that does not\noffer server-initiated messages MUST return 405 Method Not Allowed for GET, and\nclients MUST NOT treat that as an error.\n\nThis used to return an infinite keepalive-ping SSE stream that carried no protocol\ndata (this transport is stateless; nothing is ever pushed, and the deprecated\nHTTP+SSE transport's required ``endpoint`` event was never sent). Every connected\nMCP client parked one such stream for the full Cloud Run request timeout (3600s),\nwhich exhausted the service's concurrency slots while CPU sat idle and drove\ntool-call tail latency to minutes (\"no available instance\" aborts). Do not\nreintroduce a long-lived GET stream here without accounting for that capacity.",
         "operationId": "mcp_sse_get_v1_mcp_sse_get",
         "parameters": [
           {


### PR DESCRIPTION
## Problem

MCP tool calls against `api.omi.me` (omi-memory et al.) show minutes-long tail latency: measured from real client sessions on 2026-08-14, `search_memories` p50 3.3s but p90 ~122s and max 300s. Server-side request logs show every completed search finishing in 0.7–1.5s — the time is lost in front of the app, not in it.

## Root cause

`GET /v1/mcp/sse` returned an **infinite keepalive-ping SSE stream that carries zero protocol data**: the Streamable HTTP transport here is stateless and never pushes server-initiated messages, and the deprecated HTTP+SSE transport's required `endpoint` event was never sent (so no client could ever have depended on this stream for protocol traffic). Every connected MCP client parked one such stream for the full Cloud Run request timeout (3600s) on service `backend-integration`.

Evidence from prod logs/monitoring (2026-08-14):
- 1,371 / 1,162 / 1,077 hour-long (≥3500s) GET `/v1/mcp/sse` streams ended in hours 03/04/05Z alone → ~1,200+ concurrently parked streams; completed GET streams mean 426s, max 3601.0s.
- `max_request_concurrencies` p95 ≈ 84.7 against `containerConcurrency=80`, instances pinned at `maxScale=25` for hours, while CPU sat at ~4% and memory ~30% — the concurrency budget was spent on idle streams.
- Recurring `"The request was aborted because there was no available instance"` aborts plus `"Truncated response body"` floods; a live 32.4s search outlier coincided exactly with an abort burst (06:28:37–06:29:31Z).

## Fix

`GET /v1/mcp/sse` now returns **405 Method Not Allowed** with `Allow: POST, HEAD, DELETE`, exactly as the MCP Streamable HTTP transport spec (2025-03-26) prescribes for a server that offers no server-initiated stream; the spec requires clients not to treat this as an error (external contract: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports, "listening for messages from the server" — the server MUST return either `text/event-stream` or HTTP 405). POST (the real transport), HEAD, and DELETE are untouched.

Also in this PR (opportunistic, separate commits): re-pointed two stale `delete_key` allowlist entries in `scripts/check_response_model_coverage.py` to their moved routes (unjustified count 38→36), and registered the new failure class below.

## Failure class

Failure-Class: new

New definition: `FC-idle-stream-parks-serving-slot` — a serving endpoint must not hold a request slot open for a stream that carries no protocol value; guard artifact `backend/tests/unit/test_mcp_sse_get_no_stream.py` asserts GET can never answer with an unbounded stream again.

## Product invariants affected

none

## Verification

- `backend/test.sh` scoped run (test_mcp_sse_get_no_stream, test_mcp_data_endpoints, pagination_bounds, rate_limiting, search_date_utc): all passed (2+7+67+10+71).
- Real local exercise through the full ASGI stack under uvicorn: `GET /v1/mcp/sse → 405` in 2ms with correct `Allow` header; unauthenticated `HEAD`/`POST` still 401; authed `tools/call search_memories` still dispatches through auth into the tool.
- `make preflight`: all deterministic manifest checks pass (failure-class declaration validated with `scripts/failure-class`).
- **Prod relief is verified only after deploy**: parked streams recycle hourly, so concurrency slots drain within ~1h of rollout; post-deploy verification = live `GET /v1/mcp/sse` returns 405, real MCP clients (Claude Code, `mcp-remote`) still list/call tools, and `no available instance` aborts stop.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

