### PR TITLE
feat(desktop): unify Suggested tasks with regular task rows

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -74,8 +74,8 @@ enum DefaultsKey: String {
   // migration contract instead of repeating raw UserDefaults literals.
   case tasksCategoryOrder = "TasksCategoryOrder"
   case tasksSortOrderMigrated = "TasksSortOrderMigrated"
-  /// Whether the Suggestions section on the Tasks page is expanded. Shared by the
-  /// view (@AppStorage) and the view model's keyboard-navigation/select-all scope.
+  /// Whether the Suggested candidate section on the Tasks page is expanded.
+  /// Shared by the view (@AppStorage) and deep-link expand-before-scroll.
   case tasksSuggestionsSectionExpanded = "tasksSuggestionsSectionExpanded"
   case onboardingChatGPTImportedMemories = "onboardingChatGPTImportedMemoriesCount"
   case gmailSelectedCookiePath = "gmailSelectedCookiePath"

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -12,10 +12,6 @@ enum TaskCategory: String, CaseIterable {
   case tomorrow = "Tomorrow"
   case later = "Later"
   case noDeadline = "No Deadline"
-  /// AI-captured tasks the user has not accepted yet. Renders last and collapsed
-  /// by default so automatic captures never interrupt attention; Accept moves a
-  /// task into the due-date categories above.
-  case suggestions = "Suggestions"
 
   var icon: String {
     switch self {
@@ -23,7 +19,6 @@ enum TaskCategory: String, CaseIterable {
     case .tomorrow: return "sunrise.fill"
     case .later: return "calendar"
     case .noDeadline: return "tray.fill"
-    case .suggestions: return "sparkles"
     }
   }
 
@@ -33,7 +28,6 @@ enum TaskCategory: String, CaseIterable {
     case .tomorrow: return Ink.secondary
     case .later: return Ink.secondary
     case .noDeadline: return Ink.secondary
-    case .suggestions: return Ink.secondary
     }
   }
 }
@@ -517,23 +511,10 @@ class TasksViewModel: ObservableObject {
   var lastEnterPressTime: Date?
   var scrollProxy: ScrollViewProxy?
 
-  /// Mirrors the view's `@AppStorage("tasksSuggestionsSectionExpanded")` toggle. Collapsed
-  /// suggestions render no rows, so they must not be reachable by keyboard navigation or
-  /// select-all either — an invisible focused row scrolls to nothing and bulk operations
-  /// would silently hit tasks the user cannot see.
-  var suggestionsSectionExpandedForNavigation: Bool {
-    UserDefaults.standard.bool(forKey: DefaultsKey.tasksSuggestionsSectionExpanded.rawValue)
-  }
-
-  /// The categories whose rows are actually rendered in the categorized list.
-  private var renderedCategories: [TaskCategory] {
-    TaskCategory.allCases.filter { $0 != .suggestions || suggestionsSectionExpandedForNavigation }
-  }
-
   /// Flat task list matching visual order (for arrow key navigation)
   var navigationOrder: [TaskActionItem] {
     if !showCompleted && !isMultiSelectMode {
-      return renderedCategories.flatMap { getOrderedTasks(for: $0) }
+      return TaskCategory.allCases.flatMap { getOrderedTasks(for: $0) }
     } else {
       return displayTasks
     }
@@ -568,7 +549,7 @@ class TasksViewModel: ObservableObject {
   var selectedTaskIds: Set<String> { multiSelection.selectedIDs }
   var visibleTaskIDsForSelection: [String] {
     if !showCompleted && !isMultiSelectMode {
-      return renderedCategories.flatMap { getOrderedTasks(for: $0).map(\.id) }
+      return TaskCategory.allCases.flatMap { getOrderedTasks(for: $0).map(\.id) }
     }
     return displayTasks.map(\.id)
   }
@@ -1585,8 +1566,25 @@ class TasksViewModel: ObservableObject {
 
   /// Find a task by ID across all store arrays
   func findTask(_ id: String) -> TaskActionItem? {
-    store.incompleteTasks.first(where: { $0.id == id })
-      ?? store.completedTasks.first(where: { $0.id == id })
+    store.incompleteTasks.first(where: { $0.matchesTaskIdentifier(id) })
+      ?? store.completedTasks.first(where: { $0.matchesTaskIdentifier(id) })
+  }
+
+  /// Accept a Suggested candidate, then mark the created task complete.
+  /// Reloads once more if the first fetch races the accept receipt.
+  func completeNewlyCreatedTask(id: String) async {
+    await loadTasks()
+    if await completeLoadedTask(id: id) { return }
+    await loadTasks()
+    _ = await completeLoadedTask(id: id)
+  }
+
+  private func completeLoadedTask(id: String) async -> Bool {
+    guard let task = findTask(id) else { return false }
+    if !task.completed {
+      await toggleTask(task)
+    }
+    return true
   }
 
   /// Move keyboard selection up or down
@@ -2581,11 +2579,6 @@ class TasksViewModel: ObservableObject {
   // MARK: - Category Helpers
 
   private func categoryFor(task: TaskActionItem, startOfTomorrow: Date, startOfDayAfterTomorrow: Date) -> TaskCategory {
-    // Unaccepted AI captures never enter the due-date categories, whatever their
-    // due date — auto-added work goes to Suggestions until the user accepts it.
-    if task.isPendingSuggestion {
-      return .suggestions
-    }
     guard let dueAt = task.dueAt else {
       return .noDeadline
     }
@@ -3150,7 +3143,6 @@ class TasksViewModel: ObservableObject {
     case "tomorrow": return .tomorrow
     case "later": return .later
     case "nodeadline", "no_deadline", "none": return .noDeadline
-    case "suggestions": return .suggestions
     default: return nil
     }
   }
@@ -3187,15 +3179,6 @@ class TasksViewModel: ObservableObject {
       if clearDueAt && updated.dueAt != nil {
         return
       }
-      updateInDisplay(updated)
-    }
-  }
-
-  /// Accept an AI-suggested task into the normal due-date categories.
-  func acceptSuggestedTask(_ task: TaskActionItem) async {
-    await store.acceptSuggestedTask(task)
-    // Surgical display update, mirroring updateTaskDetails.
-    if let updated = store.tasks.first(where: { $0.id == task.id }) {
       updateInDisplay(updated)
     }
   }
@@ -3311,7 +3294,7 @@ class TasksViewModel: ObservableObject {
     case .today: return cal.date(bySettingHour: 23, minute: 59, second: 0, of: Date())
     case .tomorrow: return cal.date(byAdding: .day, value: 1, to: startOfToday)
     case .later: return cal.date(byAdding: .day, value: 7, to: startOfToday)
-    case .noDeadline, .suggestions: return nil
+    case .noDeadline: return nil
     }
   }
 
@@ -3379,8 +3362,7 @@ struct TasksPage: View {
   /// the default hero view; the list stays for fast keyboard-driven triage.
   @AppStorage("tasksViewIsBoard") private var tasksViewIsBoard = true
 
-  /// Suggestions stay collapsed until the user opens them — AI captures must not
-  /// interrupt attention. Persisted so the choice survives relaunch.
+  /// Suggested Candidates stay collapsed until the user opens them.
   @AppStorage(DefaultsKey.tasksSuggestionsSectionExpanded.rawValue)
   private var suggestionsSectionExpanded = false
 
@@ -3928,11 +3910,7 @@ struct TasksPage: View {
     ScrollView(.vertical, showsIndicators: false) {
       HStack(alignment: .top, spacing: OmiSpacing.md) {
         ForEach(TaskCategory.allCases, id: \.self) { category in
-          // An empty Suggestions column is noise on a planning board; the other
-          // columns keep their "Nothing here" placeholders as drop targets.
-          if category != .suggestions || !(viewModel.categorizedTasks[.suggestions] ?? []).isEmpty {
-            boardColumn(category)
-          }
+          boardColumn(category)
         }
       }
       .padding(.horizontal, OmiSpacing.lg)
@@ -3944,9 +3922,6 @@ struct TasksPage: View {
 
   private func boardColumn(_ category: TaskCategory) -> some View {
     let tasks = viewModel.categorizedTasks[category] ?? []
-    // Same collapsed-by-default contract as the list view, sharing the same
-    // persisted flag: AI captures never spread across the board uninvited.
-    let isCollapsedSuggestions = category == .suggestions && !suggestionsSectionExpanded
     return VStack(alignment: .leading, spacing: OmiSpacing.sm) {
       HStack(spacing: OmiSpacing.xs) {
         Image(systemName: category.icon)
@@ -3955,11 +3930,6 @@ struct TasksPage: View {
         Text(category.rawValue)
           .scaledFont(size: OmiType.caption, weight: .semibold)
           .foregroundColor(Ink.secondary)
-        if category == .suggestions {
-          Image(systemName: isCollapsedSuggestions ? "chevron.right" : "chevron.down")
-            .scaledFont(size: OmiType.micro, weight: .semibold)
-            .foregroundColor(Ink.secondary)
-        }
         Text("\(tasks.count)")
           .scaledFont(size: OmiType.micro, weight: .semibold)
           .foregroundColor(Ink.secondary)
@@ -3970,23 +3940,9 @@ struct TasksPage: View {
       }
       .padding(.horizontal, OmiSpacing.xs)
       .padding(.bottom, OmiSpacing.xxs)
-      .contentShape(Rectangle())
-      .onTapGesture {
-        if category == .suggestions { suggestionsSectionExpanded.toggle() }
-      }
-      .accessibilityElement(children: .combine)
-      .accessibilityAddTraits(category == .suggestions ? .isButton : [])
-      .accessibilityAction {
-        if category == .suggestions { suggestionsSectionExpanded.toggle() }
-      }
-      .accessibilityIdentifier(
-        category == .suggestions
-          ? "task-board-toggle-\(category.rawValue)" : "task-board-header-\(category.rawValue)"
-      )
+      .accessibilityIdentifier("task-board-header-\(category.rawValue)")
 
-      if isCollapsedSuggestions {
-        EmptyView()
-      } else if tasks.isEmpty {
+      if tasks.isEmpty {
         RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
           .stroke(Ink.rowFillHover.opacity(0.6), style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
           .frame(height: 44)
@@ -4002,23 +3958,6 @@ struct TasksPage: View {
             onToggle: { await viewModel.toggleTask(task) },
             onOpen: { selectTask(task) }
           )
-          .overlay(alignment: .bottomTrailing) {
-            if category == .suggestions {
-              Button {
-                Task { await viewModel.acceptSuggestedTask(task) }
-              } label: {
-                Text("Accept")
-                  .scaledFont(size: OmiType.micro, weight: .semibold)
-                  .foregroundColor(Ink.primary)
-                  .padding(.horizontal, OmiSpacing.xs)
-                  .padding(.vertical, 2)
-                  .background(Capsule().fill(Ink.rowFillHover))
-              }
-              .buttonStyle(.plain)
-              .padding(OmiSpacing.xxs)
-              .accessibilityIdentifier("task-board-accept-\(task.id)")
-            }
-          }
         }
       }
     }
@@ -4327,7 +4266,7 @@ struct TasksPage: View {
   private var tasksListView: some View {
     ScrollViewReader { proxy in
       ScrollView {
-        LazyVStack(spacing: OmiSpacing.lg) {
+        LazyVStack(alignment: .leading, spacing: OmiSpacing.lg) {
           // Show tasks grouped by due-date category (Today, Tomorrow, Later, No Deadline)
           if !viewModel.showCompleted && !viewModel.isMultiSelectMode {
             SuggestedTasksSection(
@@ -4335,6 +4274,9 @@ struct TasksPage: View {
               isExpanded: $suggestionsSectionExpanded,
               onCanonicalChange: {
                 await viewModel.loadTasks()
+              },
+              onCompleteCreatedTask: { taskID in
+                await viewModel.completeNewlyCreatedTask(id: taskID)
               }
             )
 
@@ -4355,11 +4297,6 @@ struct TasksPage: View {
                 TaskCategorySection(
                   category: category,
                   orderedTasks: orderedTasks,
-                  isCollapsed: category == .suggestions && !suggestionsSectionExpanded,
-                  onToggleCollapse: category == .suggestions
-                    ? { suggestionsSectionExpanded.toggle() } : nil,
-                  onAccept: category == .suggestions
-                    ? { task in await viewModel.acceptSuggestedTask(task) } : nil,
                   isMultiSelectMode: viewModel.isMultiSelectMode,
                   indentLevelFor: { viewModel.getIndentLevel(for: $0) },
                   isSelectedFor: { viewModel.multiSelection.selectedIDs.contains($0) },
@@ -4645,13 +4582,10 @@ private struct TaskChatSidePanelView: View {
 struct TaskCategorySection: View {
   let category: TaskCategory
   let orderedTasks: [TaskActionItem]
-  /// Collapsed sections render only their header row (used by Suggestions).
+  /// Collapsed sections render only their header row.
   var isCollapsed: Bool = false
   /// Present only on collapsible sections; makes the header a disclosure toggle.
   var onToggleCollapse: (() -> Void)?
-  /// Present only on the Suggestions section; accepts an AI-captured task into
-  /// the normal due-date categories.
-  var onAccept: ((TaskActionItem) async -> Void)?
   var isMultiSelectMode: Bool = false
 
   // Callbacks for row data and actions (passed through to TaskRow)
@@ -4726,6 +4660,16 @@ struct TaskCategorySection: View {
           .scaledFont(size: OmiType.subheading, weight: .semibold)
           .foregroundColor(Ink.primary)
 
+        Text("\(orderedTasks.count)")
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundColor(Ink.secondary)
+          .padding(.horizontal, OmiSpacing.sm)
+          .padding(.vertical, OmiSpacing.hairline)
+          .background(
+            Capsule()
+              .fill(Ink.secondary.opacity(0.1))
+          )
+
         if onToggleCollapse != nil {
           Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
             .scaledFont(size: OmiType.caption, weight: .semibold)
@@ -4746,16 +4690,6 @@ struct TaskCategorySection: View {
           .buttonStyle(.plain)
           .contentShape(Rectangle())
           .help("Clean today's tasks")
-        } else {
-          Text("\(orderedTasks.count)")
-            .scaledFont(size: OmiType.caption, weight: .medium)
-            .foregroundColor(Ink.secondary)
-            .padding(.horizontal, OmiSpacing.sm)
-            .padding(.vertical, OmiSpacing.hairline)
-            .background(
-              Capsule()
-                .fill(Ink.secondary.opacity(0.1))
-            )
         }
 
       }
@@ -4848,21 +4782,6 @@ struct TaskCategorySection: View {
                   onStartEditing: onStartEditing,
                   animateToggleTaskId: animateToggleTaskId
                 )
-                if let onAccept {
-                  Button {
-                    Task { await onAccept(task) }
-                  } label: {
-                    Text("Accept")
-                      .scaledFont(size: OmiType.caption, weight: .semibold)
-                      .foregroundColor(Ink.primary)
-                      .padding(.horizontal, OmiSpacing.sm)
-                      .padding(.vertical, 3)
-                      .background(Capsule().fill(Ink.rowFillHover))
-                  }
-                  .buttonStyle(.plain)
-                  .padding(.trailing, OmiSpacing.xs)
-                  .accessibilityIdentifier("task-accept-\(task.id)")
-                }
               }
               .id(task.id)
               .modifier(
@@ -5216,6 +5135,12 @@ private struct TaskBoardCard: View {
   }()
 }
 
+/// Shared leading chrome for categorized task rows and Suggested rows so
+/// checkboxes line up. Categorized rows fill this with the drag handle.
+enum TaskRowChrome {
+  static let leadingHandleWidth: CGFloat = 16
+}
+
 struct TaskRow: View {
   let task: TaskActionItem
   var category: TaskCategory? = nil  // Optional for flat list views
@@ -5317,7 +5242,7 @@ struct TaskRow: View {
         Image(systemName: "line.3.horizontal")
           .scaledFont(size: OmiType.micro)
           .foregroundColor(isHovering ? Ink.secondary : .clear)
-          .frame(width: 16, height: 24)
+          .frame(width: TaskRowChrome.leadingHandleWidth, height: 24)
           .contentShape(Rectangle())
           .onDrag {
             log("DRAG: onDrag started for task \(task.id) — \(task.description.prefix(40))")

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksSection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksSection.swift
@@ -1,3 +1,4 @@
+import AppKit
 import OmiTheme
 import SwiftUI
 
@@ -23,6 +24,33 @@ enum SuggestedTasksPresentationPolicy {
   }
 }
 
+/// Exit timing matches `TaskRow.handleToggle`: confirm the control, then fade
+/// the row, then mutate so the row never pops away under the click.
+enum SuggestedRowDismissal {
+  static let checkmarkBounceNanos: UInt64 = 150_000_000
+  static let checkmarkSettleNanos: UInt64 = 250_000_000
+  static let exitStartNanos: UInt64 = 400_000_000
+  static let exitDuration: TimeInterval = 0.3
+  static let exitDurationNanos: UInt64 = 300_000_000
+  static let exitOffset: CGFloat = 50
+
+  enum Kind: Equatable {
+    case complete
+    case accept
+    case reject
+
+    /// Complete/accept keep the task, so the row leaves to the right like a
+    /// checked item. Reject dismisses the other way so the two actions read
+    /// as opposites without extra chrome.
+    var offset: CGFloat {
+      switch self {
+      case .complete, .accept: return SuggestedRowDismissal.exitOffset
+      case .reject: return -SuggestedRowDismissal.exitOffset
+      }
+    }
+  }
+}
+
 /// One optional dismiss-attribution choice. An explicit `Identifiable` type
 /// keeps ForEach and release type-checking off tuple key-paths.
 struct SuggestedCandidateDismissChoice: Identifiable, Equatable {
@@ -32,7 +60,7 @@ struct SuggestedCandidateDismissChoice: Identifiable, Equatable {
   var id: String { reason.rawValue }
 }
 
-/// Optional dismiss attribution choices shared by the Suggested card UI and tests.
+/// Optional dismiss attribution choices shared by Suggested reject and tests.
 enum SuggestedCandidateDismissReasons {
   static let choices: [SuggestedCandidateDismissChoice] = [
     SuggestedCandidateDismissChoice(label: "Already handled", reason: .already_handled),
@@ -67,51 +95,33 @@ struct SuggestedTasksSection: View {
   @ObservedObject var store: SuggestedTasksStore
   @Binding var isExpanded: Bool
   let onCanonicalChange: () async -> Void
+  let onCompleteCreatedTask: (String) async -> Void
 
-  // Keep the type checker from inferring the header, candidate list, error,
-  // and chrome in one expression. Behavior and accessibility IDs are unchanged.
   var body: some View {
     if SuggestedTasksPresentationPolicy.showsSection(candidateCount: store.candidates.count) {
-      SuggestedTasksSectionChrome {
-        VStack(alignment: .leading, spacing: 10) {
-          SuggestedTasksSectionHeader(
-            candidateCount: store.candidates.count,
-            isExpanded: $isExpanded
+      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+        SuggestedTasksSectionHeader(
+          candidateCount: store.candidates.count,
+          isExpanded: $isExpanded
+        )
+        if SuggestedTasksPresentationPolicy.showsCandidates(
+          candidateCount: store.candidates.count,
+          isExpanded: isExpanded
+        ) {
+          SuggestedTasksCandidateList(
+            store: store,
+            onCanonicalChange: onCanonicalChange,
+            onCompleteCreatedTask: onCompleteCreatedTask
           )
-          if SuggestedTasksPresentationPolicy.showsCandidates(
-            candidateCount: store.candidates.count,
-            isExpanded: isExpanded
-          ) {
-            SuggestedTasksCandidateList(store: store, onCanonicalChange: onCanonicalChange)
-          }
-          if let error = store.error {
-            SuggestedTasksErrorText(message: error)
-          }
+        }
+        if let error = store.error {
+          SuggestedTasksErrorText(message: error)
         }
       }
-    }
-  }
-}
-
-private struct SuggestedTasksSectionChrome<Content: View>: View {
-  let content: Content
-
-  init(@ViewBuilder content: () -> Content) {
-    self.content = content()
-  }
-
-  var body: some View {
-    content
-      .padding(12)
-      .background(
-        RoundedRectangle(cornerRadius: 12)
-          .fill(Ink.rowFill.opacity(0.72))
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 12)
-          .stroke(Ink.separator.opacity(0.8), lineWidth: 1)
-      )
+      .accessibilityElement(children: .contain)
       .accessibilityIdentifier("suggested-section")
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
   }
 }
 
@@ -135,40 +145,91 @@ private struct SuggestedTasksSectionHeader: View {
   }
 
   private var headerLabel: some View {
-    HStack(spacing: 8) {
-      Image(systemName: "tray")
-        .scaledFont(size: 13)
+    HStack(spacing: OmiSpacing.sm) {
+      Image(systemName: "sparkles")
+        .scaledFont(size: OmiType.body)
         .foregroundColor(Ink.secondary)
       Text("Suggested")
-        .scaledFont(size: 15, weight: .semibold)
+        .scaledFont(size: OmiType.subheading, weight: .semibold)
         .foregroundColor(Ink.primary)
       Text("\(candidateCount)")
-        .scaledFont(size: 11, weight: .medium)
+        .scaledFont(size: OmiType.caption, weight: .medium)
         .foregroundColor(Ink.secondary)
+        .padding(.horizontal, OmiSpacing.sm)
+        .padding(.vertical, OmiSpacing.hairline)
+        .background(
+          Capsule()
+            .fill(Ink.secondary.opacity(0.1))
+        )
       Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-        .scaledFont(size: 10, weight: .semibold)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
         .foregroundColor(Ink.secondary)
       Spacer()
-      Text("Quietly captured for your review")
-        .scaledFont(size: 11)
-        .foregroundColor(Ink.secondary)
     }
+    .padding(.horizontal, OmiSpacing.xxs)
     .contentShape(Rectangle())
+  }
+}
+
+/// SwiftUI `frame(width:)` + `Color.clear` compresses to 0 next to a
+/// `maxWidth: .infinity` title. AppKit compression resistance does not.
+private struct RigidLeadingGutter: NSViewRepresentable {
+  var width: CGFloat
+
+  func makeNSView(context: Context) -> NSView {
+    let view = RigidLeadingGutterView(width: width)
+    view.setContentHuggingPriority(.required, for: .horizontal)
+    view.setContentCompressionResistancePriority(.required, for: .horizontal)
+    return view
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    nsView.setContentHuggingPriority(.required, for: .horizontal)
+    nsView.setContentCompressionResistancePriority(.required, for: .horizontal)
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSView, context: Context) -> CGSize? {
+    CGSize(width: width, height: 24)
+  }
+}
+
+private final class RigidLeadingGutterView: NSView {
+  private let rigidWidth: CGFloat
+
+  init(width: CGFloat) {
+    self.rigidWidth = width
+    super.init(frame: NSRect(x: 0, y: 0, width: width, height: 24))
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var intrinsicContentSize: NSSize {
+    NSSize(width: rigidWidth, height: 24)
   }
 }
 
 private struct SuggestedTasksCandidateList: View {
   @ObservedObject var store: SuggestedTasksStore
   let onCanonicalChange: () async -> Void
+  let onCompleteCreatedTask: (String) async -> Void
 
   var body: some View {
-    ForEach(store.candidates) { candidate in
-      SuggestedTasksCandidateRow(
-        store: store,
-        candidate: candidate,
-        onCanonicalChange: onCanonicalChange
-      )
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      ForEach(store.candidates) { candidate in
+        HStack(spacing: OmiSpacing.sm) {
+          SuggestedTasksCandidateRow(
+            store: store,
+            candidate: candidate,
+            onCanonicalChange: onCanonicalChange,
+            onCompleteCreatedTask: onCompleteCreatedTask
+          )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }
 
@@ -176,30 +237,33 @@ private struct SuggestedTasksCandidateRow: View {
   @ObservedObject var store: SuggestedTasksStore
   let candidate: SuggestedCandidate
   let onCanonicalChange: () async -> Void
+  let onCompleteCreatedTask: (String) async -> Void
 
   var body: some View {
-    SuggestedCandidateCard(
+    SuggestedCandidateRow(
       candidate: candidate,
       isBusy: store.busyCandidateIDs.contains(candidate.id),
-      onDoNow: handleDoNow,
-      onLater: handleLater,
-      onDismiss: handleDismiss
+      onAccept: handleAccept,
+      onCheckOff: handleCheckOff,
+      onReject: handleReject
     )
     .id("suggested-\(candidate.id)")
     .task { await handlePresented() }
   }
 
-  private func handleDoNow(_ editedTitle: String?) async {
+  private func handleAccept(_ editedTitle: String?) async {
     _ = await store.doNow(candidateID: candidate.id, editedTitle: editedTitle)
     await onCanonicalChange()
   }
 
-  private func handleLater() async {
-    await store.later(candidateID: candidate.id)
+  private func handleCheckOff(_ editedTitle: String?) async {
+    guard let taskID = await store.doNow(candidateID: candidate.id, editedTitle: editedTitle)
+    else { return }
+    await onCompleteCreatedTask(taskID)
   }
 
-  private func handleDismiss(_ reason: OmiAPI.TaskIntelligenceFeedbackReason?) async {
-    await store.dismiss(candidateID: candidate.id, reason: reason)
+  private func handleReject() async {
+    await store.dismiss(candidateID: candidate.id, reason: nil)
   }
 
   private func handlePresented() async {
@@ -212,97 +276,193 @@ private struct SuggestedTasksErrorText: View {
 
   var body: some View {
     Text(message)
-      .scaledFont(size: 11)
+      .scaledFont(size: OmiType.caption)
       .foregroundColor(Ink.secondary)
       .accessibilityIdentifier("suggested-error")
   }
 }
 
-private struct SuggestedCandidateCard: View {
+private struct SuggestedCandidateRow: View {
   let candidate: SuggestedCandidate
   let isBusy: Bool
-  let onDoNow: (String?) async -> Void
-  let onLater: () async -> Void
-  let onDismiss: (OmiAPI.TaskIntelligenceFeedbackReason?) async -> Void
+  let onAccept: (String?) async -> Void
+  let onCheckOff: (String?) async -> Void
+  let onReject: () async -> Void
 
   @State private var title: String
-  @State private var showDismissReasons = false
-  @State private var selectedDismissReason = false
+  @State private var dismissal: SuggestedRowDismissal.Kind?
+  @State private var rowOpacity: Double = 1.0
+  @State private var rowOffset: CGFloat = 0
+  @State private var checkmarkScale: CGFloat = 1.0
+
+  private var isDismissing: Bool { dismissal != nil }
+  private var isCompletingAnimation: Bool { dismissal == .complete }
 
   init(
     candidate: SuggestedCandidate,
     isBusy: Bool,
-    onDoNow: @escaping (String?) async -> Void,
-    onLater: @escaping () async -> Void,
-    onDismiss: @escaping (OmiAPI.TaskIntelligenceFeedbackReason?) async -> Void
+    onAccept: @escaping (String?) async -> Void,
+    onCheckOff: @escaping (String?) async -> Void,
+    onReject: @escaping () async -> Void
   ) {
     self.candidate = candidate
     self.isBusy = isBusy
-    self.onDoNow = onDoNow
-    self.onLater = onLater
-    self.onDismiss = onDismiss
+    self.onAccept = onAccept
+    self.onCheckOff = onCheckOff
+    self.onReject = onReject
     _title = State(initialValue: candidate.title)
   }
 
+  private var isAcceptDisabled: Bool {
+    title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
   var body: some View {
-    SuggestedCandidateCardChrome {
-      VStack(alignment: .leading, spacing: 9) {
-        SuggestedCandidateTitle(candidate: candidate, title: $title)
-        if let detail = candidate.detail, !detail.isEmpty {
-          Text(detail)
-            .scaledFont(size: 12)
-            .foregroundColor(Ink.secondary)
-            .lineLimit(2)
+    HStack(alignment: .center, spacing: 0) {
+      RigidLeadingGutter(width: TaskRowChrome.leadingHandleWidth)
+        .frame(width: TaskRowChrome.leadingHandleWidth, height: 24)
+        .accessibilityHidden(true)
+        .allowsHitTesting(false)
+
+      HStack(alignment: .center, spacing: OmiSpacing.md) {
+        Button(action: handleCheckOff) {
+          ZStack {
+            Circle()
+              .stroke(
+                isCompletingAnimation ? Ink.primary : Ink.secondary, lineWidth: 1.5
+              )
+              .frame(width: 20, height: 20)
+
+            if isCompletingAnimation {
+              Circle()
+                .fill(Ink.primary)
+                .frame(width: 20, height: 20)
+                .scaleEffect(checkmarkScale)
+
+              Image(systemName: "checkmark")
+                .scaledFont(size: OmiType.caption, weight: .bold)
+                .foregroundColor(Ink.surface)
+                .scaleEffect(checkmarkScale)
+            }
+          }
+          .frame(width: 24, height: 24)
+          .contentShape(Rectangle())
         }
-        SuggestedCandidateActions(
-          candidateID: candidate.id,
-          isEditableTask: candidate.isEditableTask,
-          isBusy: isBusy,
-          title: title,
-          showDismissReasons: $showDismissReasons,
-          selectedDismissReason: $selectedDismissReason,
-          onDoNow: onDoNow,
-          onLater: onLater,
-          onDismiss: onDismiss
-        )
+        .buttonStyle(.plain)
+        .disabled(isBusy || isAcceptDisabled || isDismissing)
+        .accessibilityLabel("Complete suggested task")
+        .accessibilityIdentifier("suggested-complete-\(candidate.id)")
+
+        VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
+          SuggestedCandidateTitle(candidate: candidate, title: $title)
+          if let detail = candidate.detail, !detail.isEmpty {
+            Text(detail)
+              .scaledFont(size: OmiType.caption)
+              .foregroundColor(Ink.secondary)
+              .lineLimit(2)
+          }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+
+        HStack(spacing: OmiSpacing.xs) {
+          ForEach(SuggestedActionPolicy.actions(for: isBusy ? .busy : .ready), id: \.self) { action in
+            suggestedActionButton(action)
+          }
+          if isBusy && !isDismissing { ProgressView().controlSize(.small) }
+        }
+      }
+      .padding(.leading, OmiSpacing.md)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.vertical, OmiSpacing.xxs)
+    .opacity(rowOpacity)
+    .offset(x: rowOffset)
+    .disabled(isBusy || isDismissing)
+    .allowsHitTesting(!isDismissing)
+    .onChange(of: candidate.title) { _, updated in
+      if !isBusy { title = updated }
+    }
+  }
+
+  private func handleCheckOff() {
+    playDismissal(.complete) {
+      await onCheckOff(candidate.isEditableTask ? title : nil)
+    }
+  }
+
+  private func playDismissal(
+    _ kind: SuggestedRowDismissal.Kind,
+    then commit: @escaping () async -> Void
+  ) {
+    guard !isBusy, dismissal == nil else { return }
+    if kind != .reject, isAcceptDisabled { return }
+    dismissal = kind
+    if kind == .complete {
+      OmiMotion.withGated(.spring(response: 0.3, dampingFraction: 0.5)) {
+        checkmarkScale = 1.2
       }
     }
-    .onChange(of: candidate.title) { _, updated in
-      handleTitleChange(updated)
+    Task { @MainActor in
+      if !OmiMotion.reduceMotion {
+        if kind == .complete {
+          try? await Task.sleep(nanoseconds: SuggestedRowDismissal.checkmarkBounceNanos)
+          OmiMotion.withGated(.spring(response: 0.2, dampingFraction: 0.7)) {
+            checkmarkScale = 1.0
+          }
+          try? await Task.sleep(nanoseconds: SuggestedRowDismissal.checkmarkSettleNanos)
+        } else {
+          try? await Task.sleep(nanoseconds: SuggestedRowDismissal.exitStartNanos)
+        }
+        OmiMotion.withGated(.easeInOut(duration: SuggestedRowDismissal.exitDuration)) {
+          rowOpacity = 0
+          rowOffset = kind.offset
+        }
+        try? await Task.sleep(nanoseconds: SuggestedRowDismissal.exitDurationNanos)
+      }
+      await commit()
+      restoreRowIfStillPresent()
     }
-    .onChange(of: showDismissReasons) { wasShowing, isShowing in
-      handleDismissPopoverChange(wasShowing: wasShowing, isShowing: isShowing)
+  }
+
+  private func restoreRowIfStillPresent() {
+    guard dismissal != nil else { return }
+    OmiMotion.withGated(.easeOut(duration: 0.2)) {
+      rowOpacity = 1
+      rowOffset = 0
+      checkmarkScale = 1
+      dismissal = nil
     }
   }
 
-  private func handleTitleChange(_ updated: String) {
-    if !isBusy { title = updated }
-  }
-
-  private func handleDismissPopoverChange(wasShowing: Bool, isShowing: Bool) {
-    guard wasShowing, !isShowing, !selectedDismissReason else { return }
-    Task { await onDismiss(nil) }
-  }
-}
-
-private struct SuggestedCandidateCardChrome<Content: View>: View {
-  let content: Content
-
-  init(@ViewBuilder content: () -> Content) {
-    self.content = content()
-  }
-
-  var body: some View {
-    content
-      .padding(12)
-      .background(
-        RoundedRectangle(cornerRadius: 10)
-          .fill(Ink.rowFillHover.opacity(0.75))
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 10)
-          .stroke(Ink.separator.opacity(0.6), lineWidth: 1)
-      )
+  @ViewBuilder
+  private func suggestedActionButton(_ action: SuggestedCardAction) -> some View {
+    let isConfirmed =
+      (action == .doNow && dismissal == .accept)
+      || (action == .dismiss && dismissal == .reject)
+    Button(action.label) {
+      switch action {
+      case .doNow:
+        playDismissal(.accept) {
+          await onAccept(candidate.isEditableTask ? title : nil)
+        }
+      case .dismiss:
+        playDismissal(.reject) {
+          await onReject()
+        }
+      case .later, .saveEdit, .cancelEdit:
+        break
+      }
+    }
+    .buttonStyle(.plain)
+    .scaledFont(size: OmiType.caption, weight: .semibold)
+    .foregroundColor(isConfirmed ? Ink.surface : Ink.primary)
+    .padding(.horizontal, OmiSpacing.sm)
+    .padding(.vertical, 3)
+    .background(Capsule().fill(isConfirmed ? Ink.primary : Ink.rowFillHover))
+    .opacity(dismissal == nil || isConfirmed ? 1 : 0.35)
+    .disabled(action == .doNow && isAcceptDisabled)
+    .accessibilityIdentifier("suggested-\(action.accessibilityID)-\(candidate.id)")
   }
 }
 
@@ -314,131 +474,16 @@ private struct SuggestedCandidateTitle: View {
     if candidate.isEditableTask {
       TextField("Suggested task", text: $title, axis: .vertical)
         .textFieldStyle(.plain)
-        .scaledFont(size: 14, weight: .medium)
+        .scaledFont(size: OmiType.body, weight: .medium)
         .foregroundColor(Ink.primary)
         .lineLimit(1...3)
         .accessibilityIdentifier("suggested-title-\(candidate.id)")
     } else {
       Text(candidate.title)
-        .scaledFont(size: 14, weight: .medium)
+        .scaledFont(size: OmiType.body, weight: .medium)
         .foregroundColor(Ink.primary)
         .lineLimit(3)
     }
-  }
-}
-
-private struct SuggestedCandidateActions: View {
-  let candidateID: String
-  let isEditableTask: Bool
-  let isBusy: Bool
-  let title: String
-  @Binding var showDismissReasons: Bool
-  @Binding var selectedDismissReason: Bool
-  let onDoNow: (String?) async -> Void
-  let onLater: () async -> Void
-  let onDismiss: (OmiAPI.TaskIntelligenceFeedbackReason?) async -> Void
-
-  private var isDoNowDisabled: Bool {
-    title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-  }
-
-  var body: some View {
-    HStack(spacing: 8) {
-      Button("Do now", action: handleDoNow)
-        .buttonStyle(.borderedProminent)
-        .tint(Ink.primary)
-        .foregroundColor(Ink.surface)
-        // Empty-title gate applies only to task creation — Later/Dismiss must stay
-        // usable even when the editable title is cleared.
-        .disabled(isDoNowDisabled)
-        .accessibilityIdentifier("suggested-do-now-\(candidateID)")
-
-      Button("Later", action: handleLater)
-        .buttonStyle(.bordered)
-        .accessibilityIdentifier("suggested-later-\(candidateID)")
-
-      Button("Dismiss", action: handleDismissTap)
-        .buttonStyle(.bordered)
-        .popover(isPresented: $showDismissReasons, arrowEdge: .bottom) {
-          SuggestedCandidateDismissReasonsView(
-            candidateID: candidateID,
-            selectedDismissReason: $selectedDismissReason,
-            showDismissReasons: $showDismissReasons,
-            onDismiss: onDismiss
-          )
-        }
-        .accessibilityIdentifier("suggested-dismiss-\(candidateID)")
-
-      Spacer()
-      if isBusy { ProgressView().controlSize(.small) }
-    }
-    .disabled(isBusy)
-  }
-
-  private func handleDoNow() {
-    let editedTitle = isEditableTask ? title : nil
-    Task { await onDoNow(editedTitle) }
-  }
-
-  private func handleLater() {
-    Task { await onLater() }
-  }
-
-  private func handleDismissTap() {
-    selectedDismissReason = false
-    showDismissReasons = true
-  }
-}
-
-private struct SuggestedCandidateDismissReasonsView: View {
-  let candidateID: String
-  @Binding var selectedDismissReason: Bool
-  @Binding var showDismissReasons: Bool
-  let onDismiss: (OmiAPI.TaskIntelligenceFeedbackReason?) async -> Void
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      Text("Optional reason")
-        .scaledFont(size: 12, weight: .semibold)
-        .foregroundColor(Ink.primary)
-      Text("Close this menu to dismiss without a reason.")
-        .scaledFont(size: 10)
-        .foregroundColor(Ink.secondary)
-
-      ForEach(SuggestedCandidateDismissReasons.choices) { choice in
-        SuggestedCandidateDismissReasonButton(
-          choice: choice,
-          candidateID: candidateID,
-          selectedDismissReason: $selectedDismissReason,
-          showDismissReasons: $showDismissReasons,
-          onDismiss: onDismiss
-        )
-      }
-    }
-    .padding(12)
-    .frame(width: 230)
-  }
-}
-
-private struct SuggestedCandidateDismissReasonButton: View {
-  let choice: SuggestedCandidateDismissChoice
-  let candidateID: String
-  @Binding var selectedDismissReason: Bool
-  @Binding var showDismissReasons: Bool
-  let onDismiss: (OmiAPI.TaskIntelligenceFeedbackReason?) async -> Void
-
-  var body: some View {
-    Button(choice.label, action: handleSelect)
-      .buttonStyle(.bordered)
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .accessibilityIdentifier("suggested-reason-\(choice.reason.rawValue)-\(candidateID)")
-  }
-
-  private func handleSelect() {
-    selectedDismissReason = true
-    let reason = choice.reason
-    Task { await onDismiss(reason) }
-    showDismissReasons = false
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/SuggestedTasksStore.swift
@@ -135,12 +135,34 @@ final class PendingCanonicalReceiptInvalidationDefaults: PendingCanonicalReceipt
   }
 }
 
-enum SuggestedCardAction: String, Equatable {
+enum SuggestedCardAction: String, Equatable, Hashable {
   case doNow
   case later
   case dismiss
   case saveEdit
   case cancelEdit
+
+  /// User-facing label for the Tasks-page review row.
+  var label: String {
+    switch self {
+    case .doNow: return "Accept"
+    case .later: return "Later"
+    case .dismiss: return "Reject"
+    case .saveEdit: return "Save"
+    case .cancelEdit: return "Cancel"
+    }
+  }
+
+  /// Stable accessibility suffix used as `suggested-<id>-<candidateID>`.
+  var accessibilityID: String {
+    switch self {
+    case .doNow: return "accept"
+    case .later: return "later"
+    case .dismiss: return "reject"
+    case .saveEdit: return "save"
+    case .cancelEdit: return "cancel"
+    }
+  }
 }
 
 enum SuggestedCardState: Equatable {
@@ -152,7 +174,7 @@ enum SuggestedCardState: Equatable {
 enum SuggestedActionPolicy {
   static func actions(for state: SuggestedCardState) -> [SuggestedCardAction] {
     switch state {
-    case .ready: return [.doNow, .later, .dismiss]
+    case .ready: return [.doNow, .dismiss]
     case .editing: return [.saveEdit, .cancelEdit]
     case .busy: return []
     }

--- a/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
+++ b/desktop/macos/Desktop/Sources/Stores/DashboardTaskRefreshPolicy.swift
@@ -12,6 +12,15 @@ enum DashboardTaskRefreshPolicy {
   static let maxServerFetchPages = 3
 }
 
+/// Dashboard widgets, SuggestionAssistant grounding, and realtime `getTasks`
+/// stay gated on explicit acceptance. The Tasks page reads `incompleteTasks`
+/// and shows leftover extractor rows as ordinary due-date tasks.
+enum DashboardTaskLanePolicy {
+  static func admits(_ task: TaskActionItem) -> Bool {
+    !task.isPendingSuggestion
+  }
+}
+
 enum DashboardExactTaskFetchPolicy {
   static let maxConcurrentRequests = 6
 

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -499,9 +499,15 @@ class TasksStore: ObservableObject {
         )
       }
       guard isCurrent(lease) else { return }
-      let sortedOverdue = snapshot.overdue.sorted(by: Self.sortByDueDateThenSource)
-      let sortedToday = snapshot.today.sorted(by: Self.sortByDueDateThenSource)
-      let sortedNoDueDate = snapshot.noDueDate.sorted(by: Self.sortByDueDateThenSource)
+      // Unreviewed AI captures stay out of dashboard / nudge / realtime lanes.
+      // The Tasks page uses incompleteTasks and shows those rows as ordinary
+      // due-date tasks after Candidate review replaced the sparkle list.
+      let sortedOverdue = snapshot.overdue.filter(DashboardTaskLanePolicy.admits)
+        .sorted(by: Self.sortByDueDateThenSource)
+      let sortedToday = snapshot.today.filter(DashboardTaskLanePolicy.admits)
+        .sorted(by: Self.sortByDueDateThenSource)
+      let sortedNoDueDate = snapshot.noDueDate.filter(DashboardTaskLanePolicy.admits)
+        .sorted(by: Self.sortByDueDateThenSource)
       // Only update @Published properties if values actually changed to avoid unnecessary objectWillChange
       if overdueTasks != sortedOverdue { overdueTasks = sortedOverdue }
       if todaysTasks != sortedToday { todaysTasks = sortedToday }

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -499,14 +499,9 @@ class TasksStore: ObservableObject {
         )
       }
       guard isCurrent(lease) else { return }
-      // Unaccepted AI captures stay out of the dashboard lanes (and out of every
-      // consumer of these lists, e.g. proactive-nudge grounding) until accepted.
-      let sortedOverdue = snapshot.overdue.filter { !$0.isPendingSuggestion }
-        .sorted(by: Self.sortByDueDateThenSource)
-      let sortedToday = snapshot.today.filter { !$0.isPendingSuggestion }
-        .sorted(by: Self.sortByDueDateThenSource)
-      let sortedNoDueDate = snapshot.noDueDate.filter { !$0.isPendingSuggestion }
-        .sorted(by: Self.sortByDueDateThenSource)
+      let sortedOverdue = snapshot.overdue.sorted(by: Self.sortByDueDateThenSource)
+      let sortedToday = snapshot.today.sorted(by: Self.sortByDueDateThenSource)
+      let sortedNoDueDate = snapshot.noDueDate.sorted(by: Self.sortByDueDateThenSource)
       // Only update @Published properties if values actually changed to avoid unnecessary objectWillChange
       if overdueTasks != sortedOverdue { overdueTasks = sortedOverdue }
       if todaysTasks != sortedToday { todaysTasks = sortedToday }
@@ -3524,40 +3519,6 @@ class TasksStore: ObservableObject {
       if rolledBack { return .rolledBackAfterRemoteFailure }
       return isCurrent(lease) ? .rollbackFailed : .ownerChanged
     }
-  }
-
-  /// Accept an AI-suggested task: rewrite `source` to "manual" so it leaves the
-  /// Suggestions category and joins the due-date categories on every device.
-  /// Remote-first — a failed accept leaves the suggestion in place with an error.
-  @discardableResult
-  func acceptSuggestedTask(
-    _ task: TaskActionItem,
-    expectedOwnerID: String? = nil,
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
-  ) async -> TaskUpdateOutcome {
-    await updateTask(
-      task,
-      expectedOwnerID: expectedOwnerID,
-      authorizationSnapshot: authorizationSnapshot,
-      operationOverrides: TaskUpdateOperationOverrides(
-        updateLocal: { _ in task },
-        updateRemote: { ownerID in
-          try await APIClient.shared.updateActionItem(
-            id: task.id,
-            source: "manual",
-            expectedOwnerId: ownerID
-          )
-        },
-        syncRemote: { apiResult, _ in
-          guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
-          try await ActionItemStorage.shared.syncTaskActionItems(
-            [apiResult],
-            authorization: Self.localMutationAuthorization(snapshot: snapshot)
-          )
-        },
-        rollbackLocal: {}
-      )
-    )
   }
 
   @discardableResult

--- a/desktop/macos/Desktop/Sources/TaskActionItem.swift
+++ b/desktop/macos/Desktop/Sources/TaskActionItem.swift
@@ -79,6 +79,13 @@ struct TaskActionItem: Codable, Identifiable, Equatable {
     return true
   }
 
+  /// Accept receipts expose the canonical `task_id`; local rows key `id` to the
+  /// backend action-item id. Completing a just-accepted Suggested task must
+  /// match either.
+  func matchesTaskIdentifier(_ identifier: String) -> Bool {
+    id == identifier || taskId == identifier
+  }
+
   /// Server list/detail responses project soft retirement through canonical
   /// lifecycle status and may omit the legacy `deleted` field. Keep that
   /// projection here so every local cache and surface applies the same rule.
@@ -306,9 +313,8 @@ struct TaskActionItem: Codable, Identifiable, Equatable {
   /// "legacy" rows must stay in the normal due-date categories.
   static let aiCaptureSources: Set<String> = ["screenshot", "conversation", "ai_suggested"]
 
-  /// An AI-captured task the user has not accepted yet. Accepting rewrites
-  /// `source` to "manual", which moves it into the due-date categories and
-  /// syncs the acceptance across devices without a new backend field.
+  /// An AI-captured task. Used to keep leftover extractor rows out of
+  /// proactive-nudge grounding; they are ordinary due-date tasks on Tasks.
   var isPendingSuggestion: Bool {
     guard !completed, !isRetired else { return false }
     guard let source else { return false }

--- a/desktop/macos/Desktop/Tests/SuggestedTasksPresentationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestedTasksPresentationPolicyTests.swift
@@ -51,4 +51,36 @@ final class SuggestedTasksPresentationPolicyTests: XCTestCase {
       SuggestedCandidateDismissReasons.choices.map(\.reason),
       [.already_handled, .not_mine, .not_useful])
   }
+
+  func testSuggestedRowsReserveTheSameLeadingHandleWidthAsCategorizedTaskRows() {
+    XCTAssertEqual(TaskRowChrome.leadingHandleWidth, 16)
+  }
+
+  func testCreatedTaskIdentifierMatchesCanonicalTaskIdFromAcceptReceipt() {
+    let task = TaskActionItem(
+      id: "backend-action-item",
+      description: "Follow up with Codemagic",
+      completed: false,
+      createdAt: Date(),
+      taskId: "canonical-task"
+    )
+    XCTAssertTrue(task.matchesTaskIdentifier("backend-action-item"))
+    XCTAssertTrue(task.matchesTaskIdentifier("canonical-task"))
+    XCTAssertFalse(task.matchesTaskIdentifier("other"))
+  }
+
+  func testAcceptAndCompleteSlideWithTheTaskWhileRejectSlidesAway() {
+    XCTAssertEqual(SuggestedRowDismissal.Kind.complete.offset, 50)
+    XCTAssertEqual(SuggestedRowDismissal.Kind.accept.offset, 50)
+    XCTAssertEqual(SuggestedRowDismissal.Kind.reject.offset, -50)
+  }
+
+  func testSuggestedRowExitUsesTheSameHoldThenFadeBudgetAsCheckingATask() {
+    XCTAssertEqual(SuggestedRowDismissal.exitStartNanos, 400_000_000)
+    XCTAssertEqual(SuggestedRowDismissal.exitDurationNanos, 300_000_000)
+    XCTAssertEqual(
+      SuggestedRowDismissal.checkmarkBounceNanos + SuggestedRowDismissal.checkmarkSettleNanos,
+      SuggestedRowDismissal.exitStartNanos
+    )
+  }
 }

--- a/desktop/macos/Desktop/Tests/SuggestedTasksStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestedTasksStoreTests.swift
@@ -28,13 +28,15 @@ final class SuggestedTasksStoreTests: XCTestCase {
     RewindDatabase.currentUserId = nil
   }
 
-  func testActionPolicyNeverOffersMoreThanThreeChoices() {
-    for state in [
-      SuggestedCardState.ready, .editing, .busy,
-    ] {
-      XCTAssertLessThanOrEqual(SuggestedActionPolicy.actions(for: state).count, 3)
-    }
-    XCTAssertEqual(SuggestedActionPolicy.actions(for: .ready), [.doNow, .later, .dismiss])
+  func testActionPolicyOffersAcceptAndRejectOnlyWhenReady() {
+    XCTAssertEqual(SuggestedActionPolicy.actions(for: .ready), [.doNow, .dismiss])
+    XCTAssertEqual(SuggestedCardAction.doNow.label, "Accept")
+    XCTAssertEqual(SuggestedCardAction.dismiss.label, "Reject")
+    XCTAssertEqual(
+      SuggestedActionPolicy.actions(for: .ready).map(\.label),
+      ["Accept", "Reject"])
+    XCTAssertEqual(SuggestedActionPolicy.actions(for: .editing), [.saveEdit, .cancelEdit])
+    XCTAssertEqual(SuggestedActionPolicy.actions(for: .busy), [])
   }
 
   func testLoadProjectsOnlyPendingCandidatesWithoutManagedNounLeak() async {

--- a/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
@@ -2,10 +2,9 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// `TaskActionItem.isPendingSuggestion` is the single triage rule that keeps
-/// AI-captured tasks out of the due-date categories (TasksPage) and out of the
-/// dashboard/nudge lanes (TasksStore) until the user accepts them. Regression
-/// coverage for the rule that fixed "deleted tasks keep reappearing in Today".
+/// `TaskActionItem.isPendingSuggestion` still names AI-captured action items so
+/// proactive nudges can skip leftover extractor rows. Those rows are ordinary
+/// due-date tasks on the Tasks page; Candidate review is a separate surface.
 final class TaskSuggestionTriageTests: XCTestCase {
 
   private func task(
@@ -31,53 +30,33 @@ final class TaskSuggestionTriageTests: XCTestCase {
 
   func testUserCreatedTasksAreNeverSuggestions() {
     XCTAssertFalse(task(source: "manual").isPendingSuggestion)
-    // Tasks predating the source field are user history, not AI spam.
     XCTAssertFalse(task(source: nil).isPendingSuggestion)
     XCTAssertFalse(task(source: "legacy").isPendingSuggestion)
   }
 
-  func testRecurringSpawnsStayInDueDateCategories() {
-    // TasksStore spawns recurrence instances with source "recurring"; they derive
-    // from a task the user already accepted and must never triage as suggestions.
+  func testRecurringSpawnsAreNotPendingSuggestions() {
     XCTAssertFalse(task(source: "recurring").isPendingSuggestion)
   }
 
-  func testAcceptingRewritesSourceSoTheTaskLeavesSuggestions() {
-    // Accept = source rewritten to "manual" (TasksStore.acceptSuggestedTask);
-    // the same task must then triage out of Suggestions.
-    XCTAssertTrue(task(source: "screenshot").isPendingSuggestion)
-    XCTAssertFalse(task(source: "manual").isPendingSuggestion)
-  }
-
-  func testCompletedOrDeletedCapturesAreNotResurfaced() {
+  func testCompletedOrDeletedCapturesAreNotPendingSuggestions() {
     XCTAssertFalse(task(source: "screenshot", completed: true).isPendingSuggestion)
     XCTAssertFalse(task(source: "screenshot", deleted: true).isPendingSuggestion)
   }
 }
 
-/// Collapsed Suggestions render no rows, so keyboard navigation and select-all
-/// must skip them too — otherwise arrow keys focus an invisible row and bulk
-/// actions silently hit tasks the user cannot see.
+/// Removing the sparkle Suggestions category put leftover AI captures back into
+/// the due-date list, so keyboard nav and select-all must include them.
 @MainActor
-final class TasksPageCollapsedSuggestionsNavigationTests: XCTestCase {
-  private let expandedKey = DefaultsKey.tasksSuggestionsSectionExpanded.rawValue
-  private var savedExpanded: Any?
-
+final class TasksPageAICaptureNavigationTests: XCTestCase {
   override func setUp() async throws {
-    savedExpanded = UserDefaults.standard.object(forKey: expandedKey)
     TasksStore.shared.resetSessionState()
   }
 
   override func tearDown() async throws {
-    if let savedExpanded {
-      UserDefaults.standard.set(savedExpanded, forKey: expandedKey)
-    } else {
-      UserDefaults.standard.removeObject(forKey: expandedKey)
-    }
     TasksStore.shared.resetSessionState()
   }
 
-  private func seedViewModel() -> TasksViewModel {
+  func testAICapturedTasksAreIncludedInKeyboardNavAndSelectAll() {
     let accepted = TaskActionItem(
       id: "accepted", description: "Send the investor update email to Bob",
       completed: false, createdAt: Date(timeIntervalSince1970: 0), source: "manual")
@@ -87,20 +66,9 @@ final class TasksPageCollapsedSuggestionsNavigationTests: XCTestCase {
     TasksStore.shared.incompleteTasks = [accepted, capture]
     let vm = TasksViewModel()
     vm.selectedTags = [.todo]
-    return vm
-  }
-
-  func testCollapsedSuggestionsAreExcludedFromKeyboardNavAndSelectAll() {
-    UserDefaults.standard.set(false, forKey: expandedKey)
-    let vm = seedViewModel()
-    XCTAssertEqual(vm.navigationOrder.map(\.id), ["accepted"])
-    XCTAssertEqual(vm.visibleTaskIDsForSelection, ["accepted"])
-  }
-
-  func testExpandedSuggestionsAreReachableAgain() {
-    UserDefaults.standard.set(true, forKey: expandedKey)
-    let vm = seedViewModel()
-    XCTAssertEqual(vm.navigationOrder.map(\.id), ["accepted", "capture"])
-    XCTAssertEqual(vm.visibleTaskIDsForSelection, ["accepted", "capture"])
+    XCTAssertEqual(Set(vm.navigationOrder.map(\.id)), Set(["accepted", "capture"]))
+    XCTAssertEqual(Set(vm.visibleTaskIDsForSelection), Set(["accepted", "capture"]))
+    XCTAssertEqual(vm.getOrderedTasks(for: .noDeadline).map(\.id).sorted(), ["accepted", "capture"])
+    XCTAssertTrue(TaskCategory.allCases.map(\.rawValue).allSatisfy { $0 != "Suggestions" })
   }
 }

--- a/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskSuggestionTriageTests.swift
@@ -42,6 +42,13 @@ final class TaskSuggestionTriageTests: XCTestCase {
     XCTAssertFalse(task(source: "screenshot", completed: true).isPendingSuggestion)
     XCTAssertFalse(task(source: "screenshot", deleted: true).isPendingSuggestion)
   }
+
+  func testDashboardLanesExcludeUnreviewedAICaptures() {
+    XCTAssertFalse(DashboardTaskLanePolicy.admits(task(source: "screenshot")))
+    XCTAssertFalse(DashboardTaskLanePolicy.admits(task(source: "transcription:omi")))
+    XCTAssertTrue(DashboardTaskLanePolicy.admits(task(source: "manual")))
+    XCTAssertTrue(DashboardTaskLanePolicy.admits(task(source: "recurring")))
+  }
 }
 
 /// Removing the sparkle Suggestions category put leftover AI captures back into

--- a/desktop/macos/changelog/unreleased/20260814-unify-suggested-tasks-ui.json
+++ b/desktop/macos/changelog/unreleased/20260814-unify-suggested-tasks-ui.json
@@ -1,0 +1,3 @@
+{
+  "change": "Suggested tasks now use regular task rows with a working checkbox plus Accept and Reject, those actions confirm then fade the row like checking a task, Suggested checkboxes line up with Today/Tomorrow/Later, count badges sit next to category titles, and the old sparkle Suggestions list is gone"
+}


### PR DESCRIPTION
## Summary
- Keep Candidate Suggested review on the Tasks page, but render those rows like ordinary tasks: checkbox, title, Accept, and Reject. The old sparkle Suggestions list is gone.
- Leftover AI-captured action items now live in Today / Tomorrow / Later. Checking a Suggested circle accepts the candidate and completes the created task; Accept still adds it incomplete. Accept and Reject confirm, then fade the row the same way checking a task does.
- Count badges sit next to category titles. Suggested checkboxes line up with the other categories.
- Dashboard widgets, SuggestionAssistant grounding, and realtime `getTasks` still exclude unreviewed AI captures. Only the Tasks page list shows those leftover extractor rows as ordinary due-date tasks.

## Invariants
Path globs for proposed invariants match this diff; locked invariants do not require a citation (`scripts/pr-preflight --suggest`).
- **INV-TASK-1**: dated Today / Tomorrow / Later buckets stay complete. Leftover extractor rows join those buckets instead of a separate Suggestions category. No Deadline paging is unchanged.
- **INV-NAV-1**: the chat-first Tasks tab still routes to the established `TasksPage` (editing, drag/reorder, keyboard, suggested review, details).

Failure-Class: none

## Test plan
- [x] `xcrun swift test -c debug --package-path Desktop --filter 'SuggestedTasksPresentationPolicyTests|SuggestedTasksStoreTests|TaskSuggestionTriageTests|DashboardTaskRefreshPolicyTests|TasksPageAICaptureNavigationTests'`
- [x] Named-bundle QA (`omi-suggested-rows`): Suggested and Today checkbox AX `x` match; checking a Suggested circle removes it from Suggested and does not leave it open in Today; Accept / Reject still resolve the candidate
- [ ] CI Desktop Swift Build & Tests

## Test evidence
- Focused Swift tests passed locally after the UI unification, including `testDashboardLanesExcludeUnreviewedAICaptures`.
- Live named bundle `/Applications/omi-suggested-rows.app`: Suggested and Today checkboxes at the same x; check-off completed the created task; Accept / Reject no longer pop the row away with no motion.
