### PR TITLE
fix(desktop): keep user-deletion provenance so "Removed by me" is not empty (#11517)

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemModels.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemModels.swift
@@ -374,7 +374,15 @@ extension ActionItemRecord {
     self.description = item.description
     self.completed = item.completed
     self.deleted = item.isRetired
-    self.deletedBy = item.deletedBy
+    // The backend has no `deleted_by` field, so a server row always reports nil here.
+    // Retirement provenance ("user" / "ai_dedup" / "staged") is local-only state: taking
+    // the server's nil re-attributed every user deletion to the AI on the next hydration.
+    // A task the server reports as live has no retirement left to attribute.
+    if let itemDeletedBy = item.deletedBy {
+      self.deletedBy = itemDeletedBy
+    } else if !self.deleted {
+      self.deletedBy = nil
+    }
     self.source = item.source
     self.conversationId = item.conversationId
     self.priority = item.priority

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -1197,7 +1197,6 @@ actor ActionItemStorage {
     return count
   }
 
-  /// Hard-delete an action item by backend ID
   /// Mark a synced task deleted locally while the backend delete is still in flight.
   ///
   /// The previous shape was a local hard delete plus a fire-and-forget backend call: one
@@ -1232,6 +1231,39 @@ actor ActionItemStorage {
       logMessage: "ActionItemStorage: Tombstoned action item \(backendId) pending backend delete")
   }
 
+  /// The server acknowledged the delete: clear the pending flag but keep the tombstone.
+  ///
+  /// Hard-deleting the row here (the previous shape) threw away the only record of *who*
+  /// retired the task. The backend has no `deleted_by` field, so the row the Removed lane
+  /// re-fetches always reports `deletedBy: nil` — every user deletion came back attributed
+  /// to the AI, "Removed by me" was structurally empty, and `getRecentDeletedTasks(deletedBy:
+  /// "user")` returned nothing, so task extraction kept re-suggesting tasks the user had
+  /// explicitly removed. The retirement is already durable server-side; keeping the local
+  /// row costs one tombstone and preserves the provenance.
+  func markActionItemDeletionAcknowledged(
+    backendId: String,
+    authorization: LocalMutationAuthorization
+  ) async throws {
+    try authorization.require()
+    let db = try await ensureInitialized()
+
+    try await authorization.withCommitLease {
+      try await db.write { database in
+        try authorization.require()
+        if var record = try Self.fetchRecord(database, surfacedId: backendId) {
+          record.deleted = true
+          record.backendSynced = true
+          record.updatedAt = Date()
+          try record.update(database)
+        }
+        try authorization.require()
+      }
+    }
+
+    HomeKnowledgeCountInvalidation.post(
+      logMessage: "ActionItemStorage: Backend acknowledged deletion of \(backendId)")
+  }
+
   /// Backend IDs whose deletion the server has not yet acknowledged.
   func getPendingBackendDeletionIds() async throws -> [String] {
     let db = try await ensureInitialized()
@@ -1245,9 +1277,12 @@ actor ActionItemStorage {
     }
   }
 
+  /// Hard-delete a row. Only for rows that must leave no trace: a local-only task the
+  /// server never saw, and the undo purge before a restore re-inserts the task. A synced
+  /// deletion goes through `markActionItemDeletedPendingBackendSync` +
+  /// `markActionItemDeletionAcknowledged` instead, so its provenance survives.
   func deleteActionItemByBackendId(
     _ backendId: String,
-    deletedBy: String? = nil,
     authorization: LocalMutationAuthorization
   ) async throws {
     try authorization.require()

--- a/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/macos/Desktop/Sources/Stores/TasksStore.swift
@@ -2517,9 +2517,8 @@ class TasksStore: ObservableObject {
 
     guard isCurrent(lease) else { return }
     for id in confirmed {
-      try? await ActionItemStorage.shared.deleteActionItemByBackendId(
-        id,
-        deletedBy: "user",
+      try? await ActionItemStorage.shared.markActionItemDeletionAcknowledged(
+        backendId: id,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
       guard isCurrent(lease) else { return }
@@ -3174,7 +3173,6 @@ class TasksStore: ObservableObject {
         // No backend row exists; a tombstone would wait forever for an ack.
         try await ActionItemStorage.shared.deleteActionItemByBackendId(
           task.id,
-          deletedBy: "user",
           authorization: Self.localMutationAuthorization(
             snapshot: lease.authorizationSnapshot
           )
@@ -3248,9 +3246,8 @@ class TasksStore: ObservableObject {
         authorizationSnapshot: lease.authorizationSnapshot
       )
       guard isCurrent(lease) else { return }
-      try? await ActionItemStorage.shared.deleteActionItemByBackendId(
-        task.id,
-        deletedBy: "user",
+      try? await ActionItemStorage.shared.markActionItemDeletionAcknowledged(
+        backendId: task.id,
         authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
       )
     } catch {
@@ -3267,11 +3264,10 @@ class TasksStore: ObservableObject {
     expectedOwnerID: String? = nil
   ) async {
     guard let lease = captureOwnerLease(expectedOwnerID: expectedOwnerID) else { return }
-    // Undo of a tombstoned delete: the row still exists locally (deleted, awaiting the
-    // backend ack). Purge it before the re-insert below or undo would create a duplicate.
+    // Undo of a tombstoned delete: the row still exists locally (deleted, whether or not
+    // the backend acked). Purge it before the re-insert below or undo would duplicate it.
     try? await ActionItemStorage.shared.deleteActionItemByBackendId(
       task.id,
-      deletedBy: "user",
       authorization: Self.localMutationAuthorization(snapshot: lease.authorizationSnapshot)
     )
     guard isCurrent(lease) else { return }

--- a/desktop/macos/Desktop/Tests/ActionItemDeletionSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemDeletionSyncTests.swift
@@ -33,13 +33,17 @@ final class ActionItemDeletionSyncTests: XCTestCase {
     try await super.tearDown()
   }
 
-  private func serverTask(id: String, deleted: Bool? = false) -> TaskActionItem {
+  private func serverTask(
+    id: String,
+    deleted: Bool? = false,
+    updatedAt: Date = Date(timeIntervalSince1970: 1_750_000_000)
+  ) -> TaskActionItem {
     TaskActionItem(
       id: id,
       description: "task \(id)",
       completed: false,
       createdAt: Date(timeIntervalSince1970: 1_750_000_000),
-      updatedAt: Date(timeIntervalSince1970: 1_750_000_000),
+      updatedAt: updatedAt,
       dueAt: nil,
       deleted: deleted,
       taskStatus: nil
@@ -68,9 +72,10 @@ final class ActionItemDeletionSyncTests: XCTestCase {
       "a tombstoned task must stay invisible even after the server re-sends it")
   }
 
-  /// Only the server's acknowledgement removes the row; after that, hydration of a task
-  /// the server no longer has cannot bring it back.
-  func testAcknowledgementPurgesTheTombstone() async throws {
+  /// The acknowledgement clears the pending flag — and nothing else. Purging the row here
+  /// (the old shape) destroyed the only record of *who* retired the task: the backend has no
+  /// `deleted_by` field, so the row the Removed lane re-fetches always reports nil.
+  func testAcknowledgementClearsPendingButKeepsUserProvenance() async throws {
     try await ActionItemStorage.shared.syncTaskActionItems(
       [serverTask(id: "backend-2")], authorization: .unrestricted)
     try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
@@ -80,11 +85,71 @@ final class ActionItemDeletionSyncTests: XCTestCase {
     XCTAssertEqual(beforeAck, ["backend-2"])
 
     // The ack path (deleteTask / flushPendingBackendDeletions after a 2xx).
-    try await ActionItemStorage.shared.deleteActionItemByBackendId(
-      "backend-2", deletedBy: "user", authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletionAcknowledged(
+      backendId: "backend-2", authorization: .unrestricted)
 
     let pending = try await ActionItemStorage.shared.getPendingBackendDeletionIds()
     XCTAssertTrue(pending.isEmpty, "an acknowledged deletion must leave nothing to flush")
+
+    let record = try await ActionItemStorage.shared.getActionItemByBackendId("backend-2")
+    XCTAssertEqual(record?.deleted, true, "the ack confirms the retirement, it does not undo it")
+    XCTAssertEqual(
+      record?.deletedBy, "user",
+      "'Removed by me' and the extraction dedup list both read this column")
+
+    let visible = try await ActionItemStorage.shared.getFilteredActionItems(
+      limit: 50, completedStates: [false])
+    XCTAssertFalse(
+      visible.contains { (item: TaskActionItem) in item.id == "backend-2" },
+      "a confirmed tombstone must stay out of the live lane")
+  }
+
+  /// The Removed lane refetches deleted tasks from the server and syncs them back in. That
+  /// hydration used to take the server's absent `deleted_by` as nil, re-filing every user
+  /// deletion under "Removed by AI" and emptying the extraction dedup list.
+  func testDeletedPageHydrationKeepsUserProvenance() async throws {
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-5")], authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
+      backendId: "backend-5", authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletionAcknowledged(
+      backendId: "backend-5", authorization: .unrestricted)
+
+    // What `loadDeletedTasks` syncs back: the server's soft-deleted row, no deleted_by.
+    // Stamped after the local ack so the 60s optimistic-update guard does not skip it.
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-5", deleted: true, updatedAt: Date().addingTimeInterval(300))],
+      authorization: .unrestricted)
+
+    let record = try await ActionItemStorage.shared.getActionItemByBackendId("backend-5")
+    XCTAssertEqual(record?.deleted, true)
+    XCTAssertEqual(
+      record?.deletedBy, "user",
+      "hydration must not re-attribute a user deletion to the AI")
+
+    let userDeleted = try await ActionItemStorage.shared.getRecentDeletedTasks(deletedBy: "user")
+    XCTAssertTrue(
+      userDeleted.contains { $0.description == "task backend-5" },
+      "task extraction reads this list to stop re-suggesting what the user removed")
+  }
+
+  /// The mirror case: a task the server reports as live again has no retirement left to
+  /// attribute, so stale provenance must not survive the un-delete.
+  func testHydrationClearsProvenanceWhenTheServerRevivesTheTask() async throws {
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-6")], authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletedPendingBackendSync(
+      backendId: "backend-6", authorization: .unrestricted)
+    try await ActionItemStorage.shared.markActionItemDeletionAcknowledged(
+      backendId: "backend-6", authorization: .unrestricted)
+
+    try await ActionItemStorage.shared.syncTaskActionItems(
+      [serverTask(id: "backend-6", deleted: false, updatedAt: Date().addingTimeInterval(300))],
+      authorization: .unrestricted)
+
+    let record = try await ActionItemStorage.shared.getActionItemByBackendId("backend-6")
+    XCTAssertEqual(record?.deleted, false)
+    XCTAssertNil(record?.deletedBy, "a live task carries no deletion provenance")
   }
 
   /// The full-sync purge cleans up acknowledged soft-deletes; it must not eat the durable

--- a/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/ActionItemLocalIdentityMutationTests.swift
@@ -57,7 +57,7 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
     XCTAssertTrue(surfacedId.hasPrefix("local_"), "unsynced row must surface a local_ id")
 
     try await ActionItemStorage.shared.deleteActionItemByBackendId(
-      surfacedId, deletedBy: "user", authorization: .unrestricted)
+      surfacedId, authorization: .unrestricted)
 
     let after = try await ActionItemStorage.shared.getLocalActionItem(byBackendId: surfacedId)
     XCTAssertNil(after, "delete by surfaced local_ id must remove the SQLite row, not no-op")
@@ -130,7 +130,7 @@ final class ActionItemLocalIdentityMutationTests: XCTestCase {
 
     // Delete removes the local row (deleteTask hard-deletes for a local_ id).
     try await ActionItemStorage.shared.deleteActionItemByBackendId(
-      surfacedId, deletedBy: "user", authorization: .unrestricted)
+      surfacedId, authorization: .unrestricted)
 
     // Restore via the store's local-only restore record. localOnlyRestoreRecord
     // is a @MainActor static, so the call hops to the main actor (await).

--- a/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
+++ b/desktop/macos/Desktop/Tests/TasksStoreOwnerBoundaryTests.swift
@@ -390,6 +390,7 @@ final class TasksStoreOwnerBoundaryTests: XCTestCase {
       "updateCompletionStatus(",
       "updateActionItemFields(",
       "deleteActionItemByBackendId(",
+      "markActionItemDeletionAcknowledged(",
       "deleteActionItemsByBackendIds(",
       "compactScoresAfterRemoval(",
       "hardDeleteAbsentTasks(",

--- a/desktop/macos/changelog/unreleased/20260814-removed-by-me-attribution.json
+++ b/desktop/macos/changelog/unreleased/20260814-removed-by-me-attribution.json
@@ -1,0 +1,3 @@
+{
+  "change": "Tasks you delete now show up under “Removed by me” instead of “Removed by AI”, and Omi stops re-suggesting them"
+}

--- a/desktop/macos/e2e/flows/tasks-crud.yaml
+++ b/desktop/macos/e2e/flows/tasks-crud.yaml
@@ -6,6 +6,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/TaskSortOrderPlanner.swift
+  - desktop/macos/Desktop/Sources/Rewind/Core/ActionItemModels.swift
   - desktop/macos/Desktop/Sources/Services/LocalMutationAuthorization.swift
   - desktop/macos/Desktop/Sources/Stores/APIClient+Tasks.swift
   - desktop/macos/Desktop/Sources/Stores/TasksStore.swift


### PR DESCRIPTION
## Bug (#11517)

Desktop **"Removed by me" is structurally empty**, and task extraction never learns which tasks the user deleted.

`TasksStore.deleteTask` tombstones a synced task with `deletedBy = "user"` — and then the acknowledgement path **hard-deleted** the row (`deleteActionItemByBackendId`, whose `deletedBy:` argument was accepted and never read). The Removed lane re-fetches deleted tasks from the backend, and the backend has no `deleted_by` field, so the row came back with `deletedBy: nil`. `TasksPage` partitions the lane on exactly that column:

```swift
case .removedByAI: return task.deleted == true && task.deletedBy != "user"
case .removedByMe: return task.deleted == true && task.deletedBy == "user"
```

so every user deletion landed under "Removed by AI". The same NULL empties `getRecentDeletedTasks(deletedBy: "user")` (SQL `= ?` never matches NULL) — the list `TaskAssistant` feeds the extraction model as "don't re-extract these" — so the model kept re-suggesting tasks the user had explicitly removed.

Second clobber on the same column: `ActionItemRecord.updateFrom(_ item: TaskActionItem)` copied the server's (always nil) `deleted_by` over the local value, so hydration erased the attribution even inside the pending window.

## Fix

- **`ActionItemStorage.markActionItemDeletionAcknowledged(backendId:)`** — the ack now clears the pending flag and keeps the tombstone (`deleted = 1`, `deletedBy` intact) instead of purging the row. The retirement is already durable server-side; the local row is the only place the provenance exists. Used by both ack callers (`deleteTask` after a 2xx, and the pending-deletion flush).
- **`updateFrom(_:)`** keeps local provenance when the server omits `deleted_by`, and clears it only when the server reports the task live again (nothing left to attribute).
- Dropped the never-read `deletedBy:` parameter from `deleteActionItemByBackendId` and documented its two genuine hard-delete callers (a local-only task the server never saw; the undo purge before a restore re-inserts).

Every live-lane query in `ActionItemStorage` already pairs `completed` with `deleted == false` (audited all 17), so a retained tombstone stays invisible — asserted in the test.

## Tested

`swift test --filter ActionItemDeletionSyncTests` — **5 passed, 0 failures** (3 new/updated: the ack keeps `deleted = 1` + `deletedBy = "user"` and stays out of the live lane; the deleted-page hydration keeps that attribution and the row shows up in `getRecentDeletedTasks(deletedBy: "user")`; a server row that comes back live clears the stale provenance).

**The regression test provably catches the bug.** Reverting only the `updateFrom` hunk and re-running:

```
ActionItemDeletionSyncTests.swift:126: XCTAssertEqual failed: ("nil") is not equal to ("Optional("user")")
  - hydration must not re-attribute a user deletion to the AI
ActionItemDeletionSyncTests.swift:131: XCTAssertTrue failed
  - task extraction reads this list to stop re-suggesting what the user removed
Executed 5 tests, with 2 failures
```

Adjacent suites green after the change: `ActionItemLocalIdentityMutationTests` (6), `TasksStoreOwnerBoundaryTests` (29, including the static mutation-authority guard the new function is registered in), `LocalMutationAuthorizationTests` (5), `ActionItemStorageVisibilityReconciliationTests` (2). `swift build --build-tests` clean.

Not verified through the running app: exercising the lane end-to-end needs a signed-in desktop build against the real backend. The lane predicate is a direct read of the column this PR fixes (`task.deleted == true && task.deletedBy == "user"`), and the storage-level assertions cover the write and both hydration directions.

Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift | 1795 -> 1830 | adds the acknowledgement path next to the tombstone write it pairs with; splitting this file is out of scope for a bug fix

## Known gap (tracked, not this PR)

Bulk delete (`Select All → Delete` → `ActionItemStorage.deleteActionItemsByBackendIds`) still hard-deletes its rows, so bulk deletions remain unattributed. Same failure class, different function; noted on #11517 rather than widened into this fix.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

