### PR TITLE
fix(app): daily journey list no longer collapses empty locations to one row

### DIFF
--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -14,6 +14,7 @@ import 'package:omi/backend/schema/daily_summary.dart';
 import 'package:omi/pages/conversation_detail/maps_util.dart';
 import 'package:omi/pages/conversation_detail/page.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/daily_summary_journey.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 
@@ -511,23 +512,6 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
     );
   }
 
-  // Get short name from full address (first part before comma)
-  String _getShortLocationName(String? address) {
-    if (address == null || address.isEmpty) return context.l10n.unknown;
-    final parts = address.split(',');
-    return parts.first.trim();
-  }
-
-  // Parse time string to minutes for comparison (e.g., "14:42" -> 882)
-  int _parseTimeToMinutes(String? timeStr) {
-    if (timeStr == null || timeStr.isEmpty) return 0;
-    final parts = timeStr.split(':');
-    if (parts.length != 2) return 0;
-    final hours = int.tryParse(parts[0]) ?? 0;
-    final minutes = int.tryParse(parts[1]) ?? 0;
-    return hours * 60 + minutes;
-  }
-
   // Format time from "17:00" to "5PM" format
   String _formatTimeTo12Hour(String? timeStr) {
     if (timeStr == null || timeStr.isEmpty) return '';
@@ -544,42 +528,8 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
     }
   }
 
-  // Merge adjacent same locations and return timeline data (chronologically sorted)
-  List<_TimelineLocation> _buildTimelineLocations(List<LocationPin> locations) {
-    if (locations.isEmpty) return [];
-
-    // Sort locations by time chronologically (earliest first)
-    final sortedLocations = List<LocationPin>.from(locations);
-    sortedLocations.sort((a, b) => _parseTimeToMinutes(a.time).compareTo(_parseTimeToMinutes(b.time)));
-
-    final timeline = <_TimelineLocation>[];
-    _TimelineLocation? current;
-
-    for (final loc in sortedLocations) {
-      final shortName = _getShortLocationName(loc.address);
-
-      if (current == null || current.shortName != shortName) {
-        // New location (different from previous)
-        current = _TimelineLocation(
-          shortName: shortName,
-          latitude: loc.latitude,
-          longitude: loc.longitude,
-          startTime: loc.time,
-          endTime: loc.time,
-        );
-        timeline.add(current);
-      } else {
-        // Same location as previous, extend the end time
-        current.endTime = loc.time;
-      }
-    }
-
-    return timeline;
-  }
-
   Widget _buildLocationsMap(DailySummary summary) {
-    // Build timeline with merged adjacent locations
-    final timelineLocations = _buildTimelineLocations(summary.locations);
+    final timelineLocations = buildTimelineLocations(summary.locations, unknownLabel: context.l10n.unknown);
 
     // Get all coordinates as LatLng
     final points = summary.locations.map((l) => LatLng(l.latitude, l.longitude)).toList();
@@ -869,7 +819,7 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
     );
   }
 
-  Widget _buildTimelineItem(_TimelineLocation location, int index) {
+  Widget _buildTimelineItem(TimelineLocation location, int index) {
     final startFormatted = _formatTimeTo12Hour(location.startTime);
     final endFormatted = _formatTimeTo12Hour(location.endTime);
     final timeText = startFormatted.isNotEmpty
@@ -970,21 +920,4 @@ Future<bool?> showDeleteRecapConfirmDialog(BuildContext context) {
       ],
     ),
   );
-}
-
-// Helper class for timeline locations
-class _TimelineLocation {
-  final String shortName;
-  final double latitude;
-  final double longitude;
-  final String? startTime;
-  String? endTime;
-
-  _TimelineLocation({
-    required this.shortName,
-    required this.latitude,
-    required this.longitude,
-    this.startTime,
-    this.endTime,
-  });
 }

--- a/app/lib/utils/daily_summary_journey.dart
+++ b/app/lib/utils/daily_summary_journey.dart
@@ -1,0 +1,81 @@
+import 'package:latlong2/latlong.dart';
+
+import 'package:omi/backend/schema/daily_summary.dart';
+
+/// Consecutive pins within this radius are one stay; farther pins stay distinct
+/// rows even when reverse-geocoding left the address empty.
+const double kJourneyMergeRadiusMeters = 100;
+
+const Distance _distance = Distance();
+
+class TimelineLocation {
+  final String shortName;
+  final double latitude;
+  final double longitude;
+  final String? startTime;
+  String? endTime;
+
+  TimelineLocation({
+    required this.shortName,
+    required this.latitude,
+    required this.longitude,
+    this.startTime,
+    this.endTime,
+  });
+}
+
+String shortLocationName(String? address, {required String unknownLabel}) {
+  if (address == null || address.isEmpty) return unknownLabel;
+  return address.split(',').first.trim();
+}
+
+int parseTimeToMinutes(String? timeStr) {
+  if (timeStr == null || timeStr.isEmpty) return 0;
+  final parts = timeStr.split(':');
+  if (parts.length != 2) return 0;
+  final hours = int.tryParse(parts[0]) ?? 0;
+  final minutes = int.tryParse(parts[1]) ?? 0;
+  return hours * 60 + minutes;
+}
+
+bool _withinMergeRadius(TimelineLocation current, LocationPin next, double radiusMeters) {
+  final meters = _distance.as(
+    LengthUnit.Meter,
+    LatLng(current.latitude, current.longitude),
+    LatLng(next.latitude, next.longitude),
+  );
+  return meters <= radiusMeters;
+}
+
+/// Cluster a day's pins by coordinates and time, not by empty "Unknown" names.
+List<TimelineLocation> buildTimelineLocations(
+  List<LocationPin> locations, {
+  required String unknownLabel,
+  double mergeRadiusMeters = kJourneyMergeRadiusMeters,
+}) {
+  if (locations.isEmpty) return [];
+
+  final sortedLocations = List<LocationPin>.from(locations);
+  sortedLocations.sort((a, b) => parseTimeToMinutes(a.time).compareTo(parseTimeToMinutes(b.time)));
+
+  final timeline = <TimelineLocation>[];
+  TimelineLocation? current;
+
+  for (final loc in sortedLocations) {
+    final name = shortLocationName(loc.address, unknownLabel: unknownLabel);
+    if (current == null || !_withinMergeRadius(current, loc, mergeRadiusMeters)) {
+      current = TimelineLocation(
+        shortName: name,
+        latitude: loc.latitude,
+        longitude: loc.longitude,
+        startTime: loc.time,
+        endTime: loc.time,
+      );
+      timeline.add(current);
+    } else {
+      current.endTime = loc.time;
+    }
+  }
+
+  return timeline;
+}

--- a/app/test/utils/daily_summary_journey_test.dart
+++ b/app/test/utils/daily_summary_journey_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/daily_summary.dart';
+import 'package:omi/utils/daily_summary_journey.dart';
+
+void main() {
+  const unknown = 'Unknown';
+
+  group('buildTimelineLocations', () {
+    test('empty-address pins at distinct GPS points stay distinct rows', () {
+      // Regression: merging by short name collapsed every empty address to one
+      // "Unknown" row spanning first→last time.
+      final timeline = buildTimelineLocations([
+        LocationPin(latitude: 37.7749, longitude: -122.4194, time: '08:00'),
+        LocationPin(latitude: 37.7849, longitude: -122.4094, time: '10:00'),
+        LocationPin(latitude: 37.8044, longitude: -122.2711, time: '13:30'),
+      ], unknownLabel: unknown);
+
+      expect(timeline, hasLength(3));
+      expect(timeline.map((row) => row.shortName).toList(), [unknown, unknown, unknown]);
+      expect(timeline.map((row) => row.startTime).toList(), ['08:00', '10:00', '13:30']);
+      expect(timeline.map((row) => row.endTime).toList(), ['08:00', '10:00', '13:30']);
+    });
+
+    test('nearby empty-address pins still merge into one stay', () {
+      final timeline = buildTimelineLocations([
+        LocationPin(latitude: 37.77490, longitude: -122.41940, time: '08:00'),
+        LocationPin(latitude: 37.77500, longitude: -122.41940, time: '08:20'),
+      ], unknownLabel: unknown);
+
+      expect(timeline, hasLength(1));
+      expect(timeline.single.shortName, unknown);
+      expect(timeline.single.startTime, '08:00');
+      expect(timeline.single.endTime, '08:20');
+    });
+
+    test('named places still split when coordinates differ', () {
+      final timeline = buildTimelineLocations([
+        LocationPin(latitude: 37.7749, longitude: -122.4194, address: 'Home, San Francisco', time: '08:00'),
+        LocationPin(latitude: 37.7849, longitude: -122.4094, address: 'Office, San Francisco', time: '10:00'),
+      ], unknownLabel: unknown);
+
+      expect(timeline.map((row) => row.shortName).toList(), ['Home', 'Office']);
+    });
+
+    test('sorts by time before clustering', () {
+      final timeline = buildTimelineLocations([
+        LocationPin(latitude: 37.7849, longitude: -122.4094, time: '10:00'),
+        LocationPin(latitude: 37.7749, longitude: -122.4194, time: '08:00'),
+      ], unknownLabel: unknown);
+
+      expect(timeline.first.latitude, 37.7749);
+      expect(timeline.first.startTime, '08:00');
+      expect(timeline.last.latitude, 37.7849);
+    });
+  });
+}

--- a/app/test/widgets/daily_summary_detail_page_test.dart
+++ b/app/test/widgets/daily_summary_detail_page_test.dart
@@ -41,9 +41,36 @@ void main() {
     expect(rowSemantics.properties.onTap, isNotNull);
     semantics.dispose();
   });
+
+  testWidgets('empty-address pins at distinct GPS points render as separate Unknown rows', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: ThemeData.dark(),
+        home: DailySummaryDetailPage(
+          summaryId: 'summary-empty-addr',
+          summary: _summary(
+            locations: [
+              LocationPin(latitude: 37.7749, longitude: -122.4194, time: '08:00'),
+              LocationPin(latitude: 37.7849, longitude: -122.4094, time: '10:00'),
+            ],
+          ),
+          tileProvider: _MemoryTileProvider(),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 900));
+
+    expect(find.byKey(const ValueKey('daily_summary_location_row_0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('daily_summary_location_row_1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('daily_summary_location_row_2')), findsNothing);
+    expect(find.text('Unknown'), findsNWidgets(2));
+  });
 }
 
-DailySummary _summary() {
+DailySummary _summary({List<LocationPin>? locations}) {
   return DailySummary(
     id: 'summary-1',
     date: '2026-07-15',
@@ -51,10 +78,11 @@ DailySummary _summary() {
     headline: 'A day around the city',
     overview: 'A productive day.',
     stats: DayStats(totalConversations: 1, totalDurationMinutes: 30),
-    locations: [
-      LocationPin(latitude: 37.7749, longitude: -122.4194, address: 'Home, San Francisco', time: '08:00'),
-      LocationPin(latitude: 37.7849, longitude: -122.4094, address: 'Office, San Francisco', time: '10:00'),
-    ],
+    locations: locations ??
+        [
+          LocationPin(latitude: 37.7749, longitude: -122.4194, address: 'Home, San Francisco', time: '08:00'),
+          LocationPin(latitude: 37.7849, longitude: -122.4094, address: 'Office, San Francisco', time: '10:00'),
+        ],
   );
 }
 

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -491,6 +491,9 @@ environments:
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
               version: latest
+            GOOGLE_MAPS_API_KEY:
+              secret: GOOGLE_MAPS_API_KEY
+              version: latest
             SERVICE_ACCOUNT_JSON:
               secret: SERVICE_ACCOUNT_JSON
               version: latest
@@ -1416,6 +1419,9 @@ environments:
               version: latest
             OMI_LLM_GATEWAY_SERVICE_TOKEN:
               secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
+              version: latest
+            GOOGLE_MAPS_API_KEY:
+              secret: GOOGLE_MAPS_API_KEY
               version: latest
           env:
             OMI_LLM_GATEWAY_URL:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -409,6 +409,9 @@ environment_shared:
           OMI_LLM_GATEWAY_SERVICE_TOKEN:
             secret: OMI_LLM_GATEWAY_SERVICE_TOKEN
             version: latest
+          GOOGLE_MAPS_API_KEY:
+            secret: GOOGLE_MAPS_API_KEY
+            version: latest
         env:
           OMI_LLM_GATEWAY_URL:
             env_var: OMI_LLM_GATEWAY_URL

--- a/backend/scripts/runtime_env_durable_dispatch_contracts.py
+++ b/backend/scripts/runtime_env_durable_dispatch_contracts.py
@@ -18,6 +18,8 @@ _ACCOUNT_DELETION_DYNAMIC_ENV = frozenset(
     {'ACCOUNT_DELETION_HANDLER_URL', 'SYNC_TASKS_INVOKER_SA', 'SYNC_TASKS_HANDLER_URL'}
 )
 _LISTEN_FINALIZATION_PROD_CLOUD_RUN_SERVICES = ('backend', 'backend-sync')
+_LISTEN_FINALIZATION_GEOCODE_WORKER_SERVICES = ('backend-sync',)
+_LISTEN_FINALIZATION_GEOCODE_SECRET = 'GOOGLE_MAPS_API_KEY'
 _LISTEN_FINALIZATION_LITERAL_ENV = {
     'LISTEN_FINALIZATION_DISPATCH_MODE': 'cloud_tasks',
     'LISTEN_FINALIZATION_TASKS_QUEUE': 'conversation-finalization',
@@ -65,12 +67,25 @@ def validate_account_deletion_dispatch_contract(env: str, env_config: ConfigDict
 
 def validate_listen_finalization_dispatch_contract(env: str, env_config: ConfigDict) -> list[ValidationError]:
     """Keep the customer exact-ID route on its deployed durable worker boundary."""
-    if env != 'prod':
-        return []
-
     errors: list[ValidationError] = []
     cloud_run = _as_config_dict(env_config.get('cloud_run')) or {}
     services = _as_config_dict(cloud_run.get('services')) or {}
+
+    for service in _LISTEN_FINALIZATION_GEOCODE_WORKER_SERVICES:
+        service_config = _as_config_dict(services.get(service)) or {}
+        secrets = _as_config_dict(service_config.get('secrets')) or {}
+        entry = _as_config_dict(secrets.get(_LISTEN_FINALIZATION_GEOCODE_SECRET))
+        if entry is None or entry.get('secret') != _LISTEN_FINALIZATION_GEOCODE_SECRET:
+            errors.append(
+                ValidationError(
+                    f'{env}/cloud_run/{service}',
+                    f'missing required listen-finalization secret {_LISTEN_FINALIZATION_GEOCODE_SECRET}',
+                )
+            )
+
+    if env != 'prod':
+        return errors
+
     for service in _LISTEN_FINALIZATION_PROD_CLOUD_RUN_SERVICES:
         service_config = _as_config_dict(services.get(service)) or {}
         _validate_listen_finalization_env_entries(

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -132,7 +132,8 @@ def with_parity_pack_env(payload: str) -> str:
 GOOGLE_OAUTH_SECRETS = '''\
         {"name": "MEMORY_V3_CURSOR_SECRET", "valueFrom": {"secretKeyRef": {"name": "MEMORY_V3_CURSOR_SECRET", "key": "latest"}}},
         {"name": "GOOGLE_CLIENT_SECRET", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_CLIENT_SECRET"}}},
-        {"name": "MODULATE_API_KEY", "valueFrom": {"secretKeyRef": {"name": "MODULATE_API_KEY", "key": "latest"}}},'''
+        {"name": "MODULATE_API_KEY", "valueFrom": {"secretKeyRef": {"name": "MODULATE_API_KEY", "key": "latest"}}},
+        {"name": "GOOGLE_MAPS_API_KEY", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_MAPS_API_KEY", "key": "latest"}}},'''
 
 
 def with_cloud_run_oauth_secrets(payload: str) -> str:
@@ -274,6 +275,25 @@ def test_prod_listen_finalization_contract_requires_the_dedicated_worker_binding
         ) in validator._validate_listen_finalization_dispatch_contract('prod', prod)
     finally:
         backend_env['LISTEN_FINALIZATION_TASKS_HANDLER_URL'] = missing_entry
+
+
+def test_listen_finalization_contract_requires_maps_key_on_backend_sync():
+    validator = load_validator()
+    manifest = validator._load_yaml(validator.DEFAULT_MANIFEST)
+
+    for env in ('dev', 'prod'):
+        env_config = manifest['environments'][env]
+        secrets = env_config['cloud_run']['services']['backend-sync']['secrets']
+        assert secrets['GOOGLE_MAPS_API_KEY'] == {'secret': 'GOOGLE_MAPS_API_KEY', 'version': 'latest'}
+
+        missing = secrets.pop('GOOGLE_MAPS_API_KEY')
+        try:
+            assert validator.ValidationError(
+                f'{env}/cloud_run/backend-sync',
+                'missing required listen-finalization secret GOOGLE_MAPS_API_KEY',
+            ) in validator._validate_listen_finalization_dispatch_contract(env, env_config)
+        finally:
+            secrets['GOOGLE_MAPS_API_KEY'] = missing
 
 
 def test_gke_config_map_contract_rejects_missing_config_map(tmp_path):

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -195,6 +195,7 @@ def test_render_prod_keeps_memory_maintenance_job_promotion_off(capsys, monkeypa
     assert 'MEMORY_ENABLED_USERS' not in job_env
 
     assert 'DESKTOP_PREVIEW_PUBLISH_KEY=DESKTOP_PREVIEW_PUBLISH_KEY:latest' in _job_secret_lines(out, 'backend')
+    assert 'GOOGLE_MAPS_API_KEY=GOOGLE_MAPS_API_KEY:latest' in _job_secret_lines(out, 'backend_sync')
 
     notifications_env = _job_env_block(out, 'notifications_job')
     assert 'MEMORY_CANONICAL_MAINTENANCE_ENABLED' not in notifications_env


### PR DESCRIPTION
## Summary
- Daily recap **Your Day's Journey** merged consecutive pins by short name. Empty reverse-geocode results all became `Unknown`, so the list collapsed to one row spanning first→last time. Clustering is now by coordinates (~100m) and time; unnamed places with distinct GPS stay distinct rows and still show `Unknown`.
- Cloud Run `backend-sync` (conversation-finalization worker) was missing `GOOGLE_MAPS_API_KEY`. GKE listen/pusher already had it. The worker now binds the existing Secret Manager key so a deploy can geocode addresses. No secret values were copied or live-bound.

Related: #10506 (Unknown Location in recaps — this PR does not implement saved place names). Not related to #11307.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

## Test plan
- [x] `cd app && bash test.sh test/utils/daily_summary_journey_test.dart test/widgets/daily_summary_detail_page_test.dart` — 6 passed (empty addresses at distinct GPS stay 3 rows; nearby empties merge; named Home/Office still split; widget shows two `Unknown` rows)
- [x] `cd app && bash scripts/analyze_ratchet.sh` — passed
- [x] `pytest tests/unit/test_backend_runtime_env_validator.py tests/unit/test_render_backend_runtime_env.py` — 100 passed
- [ ] Open a daily recap whose conversations have empty addresses at different coordinates: journey list has multiple `Unknown` rows, not one
- [ ] Named places a day apart still merge only when consecutive and within ~100m
- [ ] After a backend-sync deploy, new conversation finalization writes `geolocation.address` when Maps succeeds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

