### PR TITLE
fix(desktop): keep graduation provenance and stop repeating the same bucket nudge

### DIFF
--- a/.github/failure-classes/FC-typed-failure-collapsed-to-generic.json
+++ b/.github/failure-classes/FC-typed-failure-collapsed-to-generic.json
@@ -5,7 +5,9 @@
   "canonical_prevention": "Classify at the catch boundary into a bounded provenance JSON (http_error with status, decode, invalid_response, network with a bounded error_type). For HTTP 429, surface Retry-After on the typed error and skip further lane attempts until that deadline (conservative default when the header is missing), with an injected clock so tests do not sleep.",
   "canonical_prevention_artifact": [
     "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift",
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/CandidateSink.swift",
     "desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift",
+    "desktop/macos/Desktop/Tests/CandidateSinkGraduationTests.swift",
     "desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift"
   ],
   "evidence_prs": [

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbe.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbe.swift
@@ -88,7 +88,8 @@
         frameNumber: 0,
         captureTime: input.capturedAt)
       let prompt = ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot)
-      let uncachedPrompt = ContextProactivityPromptBuilder.directorVolatilePrompt(tasks: input.tasks, frame: frame)
+      let uncachedPrompt = ContextProactivityPromptBuilder.directorVolatilePrompt(
+        tasks: input.tasks, frame: frame, recentDeliveries: input.recentDeliveries)
       let cacheKey = "bucket:\(snapshot.bucketID):v\(snapshot.version)"
       let started = DispatchTime.now().uptimeNanoseconds
       let result = try await completion(
@@ -136,6 +137,9 @@
       let window: String
       let capturedAt: Date
       let notifyWorthiness: Double
+      /// Optional. Lets a probe exercise the recent-delivery prompt section, which is
+      /// otherwise only reachable from the live ledger.
+      let recentDeliveries: [ContextBucketRecentDelivery]
 
       init(params: [String: String]) throws {
         bucketID = try Self.requiredString(params, key: "bucket_id", maxLength: 200)
@@ -162,6 +166,39 @@
           throw ContextBucketDirectorProbeError.invalidParams("notify_worthiness")
         }
         notifyWorthiness = parsedWorthiness
+        recentDeliveries = try Self.optionalRecentDeliveryList(
+          params, key: "recent_deliveries",
+          maxCount: ContextBucketRecentDelivery.promptCap)
+      }
+
+      /// Absent means "no recent deliveries", so existing probe callers keep their behaviour.
+      private static func optionalRecentDeliveryList(
+        _ params: [String: String],
+        key: String,
+        maxCount: Int
+      ) throws -> [ContextBucketRecentDelivery] {
+        guard let raw = params[key], !raw.isEmpty else { return [] }
+        guard let data = raw.data(using: .utf8),
+          let values = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
+          values.count <= maxCount
+        else {
+          throw ContextBucketDirectorProbeError.invalidParams(key)
+        }
+        return try values.map { value in
+          guard let decisionType = value["decision_type"] as? String,
+            !decisionType.isEmpty, decisionType.count <= 32,
+            let rawDeliveredAt = value["delivered_at"] as? String,
+            let deliveredAt = Self.parseTimestamp(rawDeliveredAt)
+          else {
+            throw ContextBucketDirectorProbeError.invalidParams(key)
+          }
+          let message = value["message"] as? String
+          guard (message?.count ?? 0) <= 2_400 else {
+            throw ContextBucketDirectorProbeError.invalidParams(key)
+          }
+          return ContextBucketRecentDelivery(
+            decisionType: decisionType, message: message, deliveredAt: deliveredAt)
+        }
       }
 
       private static func requiredString(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/CandidateSink.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/CandidateSink.swift
@@ -1,16 +1,56 @@
 import Foundation
 @preconcurrency import GRDB
 
+/// Bounded outcome of graduating a context-director `task_candidate`. Interactive
+/// presentation is allowed only for `.graduated`; every other case is a distinct
+/// reason the ledger can record without collapsing them into a generic failure.
+enum CandidateGraduationReason: String, Equatable, Sendable {
+  case graduated
+  case noFactIDs = "no_fact_ids"
+  case ownerChanged = "owner_changed"
+  case storeUnavailable = "store_unavailable"
+  case workflowNotReadable = "workflow_not_readable"
+  case ineligibleDisposition = "ineligible_disposition"
+  case stale
+}
+
+/// Merges a bounded graduation-failure token into an existing director
+/// provenance object so bucket refs survive the failed path.
+enum CandidateGraduationProvenance {
+  static let failureToken = "candidate_graduation_failed"
+
+  static func mergingFailure(
+    into provenanceJSON: String,
+    reason: CandidateGraduationReason
+  ) -> String {
+    var object: [String: Any] = [:]
+    if let data = provenanceJSON.data(using: .utf8),
+      let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    {
+      object = parsed
+    }
+    object["failure"] = failureToken
+    object["graduation_reason"] = reason.rawValue
+    guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return
+        "{\"failure\":\"\(failureToken)\",\"graduation_reason\":\"\(reason.rawValue)\"}"
+    }
+    return json
+  }
+}
+
 /// Presentation gate for context-director task candidates. Interactive
 /// notifications must not become user-visible until graduation has produced
 /// (or confirmed) a durable canonical candidate.
 enum CandidateSinkDeliveryGate {
   static func mayPresentInteractively(
     decisionType: String,
-    graduationSucceeded: Bool
+    graduation: CandidateGraduationReason
   ) -> Bool {
     guard decisionType == "task_candidate" else { return true }
-    return graduationSucceeded
+    return graduation == .graduated
   }
 
   static func hasCompleteValidatedFactSet(requestedIDs: [String], fetchedIDs: [String]) -> Bool {
@@ -65,47 +105,59 @@ actor CandidateSink {
   func graduateValidatedFacts(
     deliveryID: String,
     factIDs: [String],
-    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
-  ) async -> Bool {
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    now: Date = Date()
+  ) async -> CandidateGraduationReason {
     let normalizedFactIDs = Array(
       Set(factIDs.map { $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0 })
     ).sorted()
-    guard !normalizedFactIDs.isEmpty else { return false }
-    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
+    guard !normalizedFactIDs.isEmpty else { return .noFactIDs }
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
+      return .ownerChanged
+    }
     let (pool, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
-    guard let pool else { return false }
-    let now = Date()
+    guard let pool else { return .storeUnavailable }
     do {
       let facts = try await pool.read { db in
         try Self.graduationFacts(
           in: db, deliveryID: deliveryID, factIDs: normalizedFactIDs, now: now)
       }
+      guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
+        return .ownerChanged
+      }
       guard
-        RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
         CandidateSinkDeliveryGate.hasCompleteValidatedFactSet(
           requestedIDs: normalizedFactIDs,
           fetchedIDs: facts.map(\.id))
       else {
-        return false
+        return .stale
       }
-      let control = try await APIClient.shared.getCandidateWorkflowControl(
-        expectedOwnerId: authorizationSnapshot.ownerID,
-        authorizationSnapshot: authorizationSnapshot)
-      guard control.workflowMode == .read, let generation = control.accountGeneration else {
-        return false
+      let needsCreate = facts.contains { $0.dispositionState == "none" }
+      var generation: Int?
+      if needsCreate {
+        let control = try await APIClient.shared.getCandidateWorkflowControl(
+          expectedOwnerId: authorizationSnapshot.ownerID,
+          authorizationSnapshot: authorizationSnapshot)
+        guard control.workflowMode == .read, let accountGeneration = control.accountGeneration else {
+          return .workflowNotReadable
+        }
+        generation = accountGeneration
       }
       for fact in facts {
-        guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
+        guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
+          return .ownerChanged
+        }
         guard CandidateSinkDeliveryGate.isGraduationEligibleDisposition(fact.dispositionState) else {
-          return false
+          return .ineligibleDisposition
         }
         if fact.dispositionState == "none" {
+          guard let accountGeneration = generation else { return .workflowNotReadable }
           let stillFresh = try await pool.read { db in
             try Self.graduationFacts(
-              in: db, deliveryID: deliveryID, factIDs: [fact.id], now: Date()
+              in: db, deliveryID: deliveryID, factIDs: [fact.id], now: now
             ).count == 1
           }
-          guard stillFresh else { return false }
+          guard stillFresh else { return .stale }
           let excerptHash = ContextBucketStore.referenceHash(fact.evidenceText)
           let candidate = OmiAPI.CandidateCreate.taskCreate(
             OmiAPI.TaskCreateCandidate(
@@ -126,10 +178,12 @@ actor CandidateSink {
           _ = try await APIClient.shared.createCanonicalCandidate(
             candidate,
             idempotencyKey: CandidateSinkDeliveryGate.canonicalCandidateIdempotencyKey(factID: fact.id),
-            accountGeneration: generation,
+            accountGeneration: accountGeneration,
             expectedOwnerId: authorizationSnapshot.ownerID,
             authorizationSnapshot: authorizationSnapshot)
-          guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
+          guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
+            return .ownerChanged
+          }
           let mutationAuthorization = LocalMutationAuthorization {
             RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot)
           }
@@ -142,16 +196,19 @@ actor CandidateSink {
               try db.execute(
                 sql:
                   "UPDATE bucket_facts SET dispositionState = 'candidate_pending', updatedAt = ? WHERE id = ? AND validityState = 'validated' AND dispositionState = 'none' AND (expiresAt IS NULL OR expiresAt > ?)",
-                arguments: [Date(), fact.id, Date()])
+                arguments: [now, fact.id, now])
               guard db.changesCount == 1 else { throw ContextBucketStoreError.staleFence }
             }
           }
         }
       }
-      return true
+      return .graduated
     } catch {
       log("CandidateSink: canonical candidate graduation deferred: \(error.localizedDescription)")
-      return false
+      if case .databaseUnavailable = error as? ContextBucketStoreError {
+        return .storeUnavailable
+      }
+      return .stale
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -165,9 +165,14 @@ enum ContextProactivityPromptBuilder {
   static func directorPrompt(
     snapshot: ContextBucketSnapshot,
     tasks: [ContextDirectorTaskContext],
-    frame: CapturedFrame
+    frame: CapturedFrame,
+    recentDeliveries: [ContextBucketRecentDelivery] = []
   ) -> String {
-    "\(directorStablePrompt(snapshot: snapshot))\n\n\(directorVolatilePrompt(tasks: tasks, frame: frame))"
+    """
+    \(directorStablePrompt(snapshot: snapshot))
+
+    \(directorVolatilePrompt(tasks: tasks, frame: frame, recentDeliveries: recentDeliveries))
+    """
   }
 
   static func directorStablePrompt(snapshot: ContextBucketSnapshot) -> String {
@@ -189,6 +194,8 @@ enum ContextProactivityPromptBuilder {
       update, recommendation, or useful follow-up without an explicit commitment, promise, or
       request is insight or suggest; never infer an owner or due date and never create a task
       candidate from actionability alone.
+      Do not re-deliver a point already delivered for this bucket unless the validated facts
+      add something materially new. Prefer silence over restating.
 
       \(stableBucket)
       """
@@ -196,7 +203,8 @@ enum ContextProactivityPromptBuilder {
 
   static func directorVolatilePrompt(
     tasks: [ContextDirectorTaskContext],
-    frame: CapturedFrame
+    frame: CapturedFrame,
+    recentDeliveries: [ContextBucketRecentDelivery] = []
   ) -> String {
     let actionableCutoff = frame.captureTime.addingTimeInterval(
       ContextDirectorTaskSelection.futureHorizon)
@@ -209,7 +217,7 @@ enum ContextProactivityPromptBuilder {
       return "- \(task.description)\n  Due at (UTC): \(utcTimestamp(dueAt))"
     }
     let taskContext = taskLines.joined(separator: "\n")
-    return """
+    var prompt = """
       == OPEN OR OVERDUE TASKS ==
       \(taskContext)
 
@@ -218,6 +226,49 @@ enum ContextProactivityPromptBuilder {
       Window: \(frame.windowTitle ?? "")
       Captured at (UTC): \(utcTimestamp(frame.captureTime))
       """
+    if let recent = recentDeliveriesSection(recentDeliveries, now: frame.captureTime) {
+      prompt += "\n\n\(recent)"
+    }
+    return prompt
+  }
+
+  static func recentDeliveriesSection(
+    _ deliveries: [ContextBucketRecentDelivery],
+    now: Date
+  ) -> String? {
+    let entries = Array(deliveries.prefix(ContextBucketRecentDelivery.promptCap))
+    guard !entries.isEmpty else { return nil }
+    let lines = entries.map { delivery -> String in
+      let decision = String(delivery.decisionType.prefix(32))
+      let age = relativeAge(from: delivery.deliveredAt, now: now)
+      let summary = boundedSummary(delivery.message)
+      if summary.isEmpty {
+        return "- \(decision) (\(age))"
+      }
+      return "- \(decision) (\(age)): \(summary)"
+    }
+    return """
+      == RECENTLY DELIVERED FOR THIS BUCKET ==
+      \(lines.joined(separator: "\n"))
+      """
+  }
+
+  static func relativeAge(from deliveredAt: Date, now: Date) -> String {
+    let seconds = max(0, Int(now.timeIntervalSince(deliveredAt).rounded(.down)))
+    if seconds < 60 { return "\(seconds)s ago" }
+    let minutes = seconds / 60
+    if minutes < 60 { return "\(minutes)m ago" }
+    let hours = minutes / 60
+    if hours < 48 { return "\(hours)h ago" }
+    return "\(hours / 24)d ago"
+  }
+
+  static func boundedSummary(_ message: String?) -> String {
+    let collapsed =
+      (message ?? "")
+      .replacingOccurrences(of: "\n", with: " ")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return String(collapsed.prefix(ContextBucketRecentDelivery.summaryCharacterLimit))
   }
 
   private static func utcTimestamp(_ date: Date) -> String {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -37,6 +37,17 @@ struct ContextDeliveryAttempt: Equatable, Sendable {
   let reason: ContextDeliveryGateReason
 }
 
+/// A successfully presented director notification for one bucket, used only as
+/// bounded prompt context. This is a signal to the model, not a delivery gate.
+struct ContextBucketRecentDelivery: Equatable, Sendable, Decodable, FetchableRecord {
+  static let promptCap = 3
+  static let summaryCharacterLimit = 120
+
+  let decisionType: String
+  let message: String?
+  let deliveredAt: Date
+}
+
 enum ContextDeliveryLifecycle {
   /// Nonterminal ledger states that may still advance. Terminal
   /// `failed`/`suppressed`/`delivered` rows are immutable.
@@ -269,6 +280,35 @@ extension ContextBucketStore {
         timestampColumn: timestampColumn,
         now: now)
     }
+  }
+
+  /// Newest successfully presented notifications for this bucket. Bounded so
+  /// the director prompt cannot grow without limit. Failed/suppressed rows are
+  /// excluded: the model should see what the user actually received.
+  func recentDeliveredForBucket(
+    bucketID: String,
+    now: Date = Date(),
+    limit: Int = ContextBucketRecentDelivery.promptCap
+  ) async -> [ContextBucketRecentDelivery] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    let cap = max(0, min(limit, ContextBucketRecentDelivery.promptCap))
+    guard cap > 0 else { return [] }
+    return
+      (try? await pool.read { db in
+        try ContextBucketRecentDelivery.fetchAll(
+          db,
+          sql: """
+            SELECT decisionType, message, deliveredAt FROM proactive_deliveries
+            WHERE bucketID = ?
+              AND lifecycleState = 'delivered'
+              AND deliveredAt IS NOT NULL
+              AND expiresAt > ?
+            ORDER BY deliveredAt DESC
+            LIMIT ?
+            """,
+          arguments: [bucketID, now, cap])
+      }) ?? []
   }
 
   func deliveryProvenance(id: String, now: Date = Date()) async -> String? {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -302,9 +302,9 @@ actor ContextProactivityEngine {
       }
       // Durable canonical candidates must exist before an interactive
       // task_candidate notification can be queued or tapped.
-      var graduationSucceeded = true
+      var graduation = CandidateGraduationReason.graduated
       if decision.decision == "task_candidate" {
-        graduationSucceeded = await CandidateSink.shared.graduateValidatedFacts(
+        graduation = await CandidateSink.shared.graduateValidatedFacts(
           deliveryID: deliveryID,
           factIDs: factIDs,
           authorizationSnapshot: authorizationSnapshot)
@@ -312,15 +312,14 @@ actor ContextProactivityEngine {
       guard
         CandidateSinkDeliveryGate.mayPresentInteractively(
           decisionType: decision.decision,
-          graduationSucceeded: graduationSucceeded)
+          graduation: graduation)
       else {
-        log("Context director suppressed before presentation: candidate_graduation_failed")
-        try await store.completeDelivery(
-          id: deliveryID,
-          decisionType: "silence",
-          provenanceJSON: "{\"failure\":\"candidate_graduation_failed\"}",
+        await recordGraduationFailure(
+          deliveryID: deliveryID,
+          decisionType: decision.decision,
+          provenanceJSON: provenanceJSON,
           message: decision.message,
-          state: "failed")
+          reason: graduation)
         return
       }
       // Graduation and system-surface preflight can both await. Rebuild every
@@ -383,6 +382,25 @@ actor ContextProactivityEngine {
       await recordDirectorFailure(deliveryID: deliveryID, error: error)
       // Network and model failures stay user-silent; provenance carries the class.
     }
+  }
+
+  func recordGraduationFailure(
+    deliveryID: String,
+    decisionType: String,
+    provenanceJSON: String,
+    message: String?,
+    reason: CandidateGraduationReason
+  ) async {
+    log(
+      "Context director suppressed before presentation: candidate_graduation_failed reason=\(reason.rawValue)"
+    )
+    _ = try? await store.completeDelivery(
+      id: deliveryID,
+      decisionType: decisionType,
+      provenanceJSON: CandidateGraduationProvenance.mergingFailure(
+        into: provenanceJSON, reason: reason),
+      message: message,
+      state: "failed")
   }
 
   func recordDirectorFailure(deliveryID: String, error: Error) async {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -175,10 +175,13 @@ actor ContextProactivityEngine {
         from: TasksStore.shared.incompleteTasks,
         now: currentFrame.captureTime)
     }
+    let recentDeliveries = await store.recentDeliveredForBucket(
+      bucketID: snapshot.bucketID, now: currentFrame.captureTime)
     let prompt = ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot)
     let uncachedPrompt = ContextProactivityPromptBuilder.directorVolatilePrompt(
       tasks: taskContext,
-      frame: currentFrame)
+      frame: currentFrame,
+      recentDeliveries: recentDeliveries)
     guard
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
       await store.activeFenceIsValid(fence)

--- a/desktop/macos/Desktop/Tests/CandidateSinkDeliveryGateTests.swift
+++ b/desktop/macos/Desktop/Tests/CandidateSinkDeliveryGateTests.swift
@@ -7,11 +7,15 @@ final class CandidateSinkDeliveryGateTests: XCTestCase {
     XCTAssertFalse(
       CandidateSinkDeliveryGate.mayPresentInteractively(
         decisionType: "task_candidate",
-        graduationSucceeded: false))
+        graduation: .stale))
+    XCTAssertFalse(
+      CandidateSinkDeliveryGate.mayPresentInteractively(
+        decisionType: "task_candidate",
+        graduation: .noFactIDs))
     XCTAssertTrue(
       CandidateSinkDeliveryGate.mayPresentInteractively(
         decisionType: "task_candidate",
-        graduationSucceeded: true))
+        graduation: .graduated))
   }
 
   func testNonTaskDecisionsDoNotRequireGraduationBeforePresent() {
@@ -19,7 +23,7 @@ final class CandidateSinkDeliveryGateTests: XCTestCase {
       XCTAssertTrue(
         CandidateSinkDeliveryGate.mayPresentInteractively(
           decisionType: decision,
-          graduationSucceeded: false),
+          graduation: .stale),
         decision)
     }
   }

--- a/desktop/macos/Desktop/Tests/CandidateSinkGraduationTests.swift
+++ b/desktop/macos/Desktop/Tests/CandidateSinkGraduationTests.swift
@@ -1,0 +1,174 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class CandidateSinkGraduationTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+  private var previousOwnerID: String?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "candidate-graduation")
+    previousOwnerID = RuntimeOwnerIdentity.currentOwnerId()
+    await transitionOwner(to: fixture?.testUserId)
+  }
+
+  override func tearDown() async throws {
+    await transitionOwner(to: previousOwnerID)
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testGraduationReasonsDistinguishEmptyFactsFromStaleFacts() async throws {
+    let snapshot = try XCTUnwrap(RuntimeOwnerIdentity.captureAuthorizationSnapshot())
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let empty = await CandidateSink.shared.graduateValidatedFacts(
+      deliveryID: "unused",
+      factIDs: [],
+      authorizationSnapshot: snapshot,
+      now: now)
+    XCTAssertEqual(empty, .noFactIDs)
+
+    let seeded = try await seedDelivery(factDisposition: "candidate_pending", now: now)
+    let stale = await CandidateSink.shared.graduateValidatedFacts(
+      deliveryID: seeded.deliveryID,
+      factIDs: ["current", "missing"],
+      authorizationSnapshot: snapshot,
+      now: now)
+    XCTAssertEqual(stale, .stale)
+    XCTAssertNotEqual(empty.rawValue, stale.rawValue)
+
+    let emptyProvenance = CandidateGraduationProvenance.mergingFailure(
+      into: #"{"bucket_id":"bucket"}"#, reason: empty)
+    let staleProvenance = CandidateGraduationProvenance.mergingFailure(
+      into: #"{"bucket_id":"bucket"}"#, reason: stale)
+    XCTAssertEqual(
+      try provenanceObject(emptyProvenance)["graduation_reason"] as? String, "no_fact_ids")
+    XCTAssertEqual(try provenanceObject(staleProvenance)["graduation_reason"] as? String, "stale")
+  }
+
+  func testAlreadyPendingFactsGraduateWithoutChangingDisposition() async throws {
+    let snapshot = try XCTUnwrap(RuntimeOwnerIdentity.captureAuthorizationSnapshot())
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let seeded = try await seedDelivery(factDisposition: "candidate_pending", now: now)
+
+    let reason = await CandidateSink.shared.graduateValidatedFacts(
+      deliveryID: seeded.deliveryID,
+      factIDs: ["current"],
+      authorizationSnapshot: snapshot,
+      now: now)
+
+    XCTAssertEqual(reason, .graduated)
+    XCTAssertTrue(
+      CandidateSinkDeliveryGate.mayPresentInteractively(
+        decisionType: "task_candidate", graduation: reason))
+    let (database, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    let disposition = try await pool.read { db in
+      try String.fetchOne(
+        db, sql: "SELECT dispositionState FROM bucket_facts WHERE id = 'current'")
+    }
+    XCTAssertEqual(disposition, "candidate_pending")
+  }
+
+  private struct SeededDelivery {
+    let deliveryID: String
+  }
+
+  private func seedDelivery(factDisposition: String, now: Date) async throws -> SeededDelivery {
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    let versionID = try await pool.write { db -> Int64 in
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+          VALUES ('bucket', 'task', 'graduation-test', ?, ?)
+          """,
+        arguments: [now, now])
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_versions (bucketID, version, header, frozenRankedSegment, createdAt)
+          VALUES ('bucket', 1, 'header', ?, ?)
+          """,
+        arguments: [Data(), now])
+      try db.execute(
+        sql: """
+          INSERT INTO context_visits
+            (id, contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+             normalizedContextKey, referenceHash, startedAt, outcome, createdAt, updatedAt)
+          VALUES (1, 1, ?, 'bucket', 'Graduation', 'raw', 'normalized', 'reference', ?, 'active', ?, ?)
+          """,
+        arguments: [poolEpoch, now, now, now])
+      let versionID =
+        try Int64.fetchOne(
+          db,
+          sql: "SELECT id FROM bucket_versions WHERE bucketID = 'bucket' AND version = 1")
+        ?? 0
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_entries
+            (id, bucketID, visitID, bucketVersionID, appName, rawContextKey,
+             normalizedContextKey, narrative, evidenceRefsJson, tokenCount, createdAt)
+          VALUES ('entry-current', 'bucket', 1, ?, 'Graduation', 'raw', 'normalized', 'narrative', '[]', 1, ?)
+          """,
+        arguments: [versionID, now])
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_facts
+            (id, bucketID, entryID, appName, statement, identifiersJson, evidenceText,
+             evidenceRefsJson, validityState, dispositionState, confidence,
+             notifyWorthiness, createdAt, updatedAt)
+          VALUES ('current', 'bucket', 'entry-current', 'Graduation', 'statement', '[]', 'evidence',
+                  '[]', 'validated', ?, 1, 1, ?, ?)
+          """,
+        arguments: [factDisposition, now, now])
+      return versionID
+    }
+    let attempt = try await ContextBucketStore.shared.beginDeliveryAttempt(
+      fence: ContextVisitFence(
+        visitID: 1, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket", startedAt: now),
+      snapshot: ContextBucketSnapshot(
+        bucketID: "bucket",
+        versionID: versionID,
+        version: 1,
+        header: "header",
+        frozenRankedSegment: Data(),
+        tail: ["entry:current"],
+        validatedFacts: ["fact:current statement"],
+        notifyWorthiness: 1),
+      gate: ContextDeliveryGateInput(
+        masterEnabled: true,
+        frequencyLevel: 5,
+        paywalled: false,
+        cooldownSeconds: 0),
+      now: now)
+    return SeededDelivery(deliveryID: try XCTUnwrap(attempt.id))
+  }
+
+  private func provenanceObject(_ json: String) throws -> [String: Any] {
+    let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+    return try XCTUnwrap(object as? [String: Any])
+  }
+
+  private func transitionOwner(to ownerID: String?) async {
+    do {
+      _ = try await RuntimeOwnerIdentity.performEffectiveOwnerTransition(
+        plannedNextOwner: { _, _ in ownerID },
+        quiesceVoice: { _, _ in },
+        retargetLocalStorage: { _, _ in },
+        ownerDidChange: {},
+        { defaults in
+          defaults.removeObject(forKey: .automationOwnerOverride)
+          if let ownerID {
+            defaults.set(ownerID, forKey: .authUserId)
+          } else {
+            defaults.removeObject(forKey: .authUserId)
+          }
+        })
+    } catch {
+      XCTFail("owner transition failed: \(error)")
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -77,6 +77,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "update, recommendation, or useful follow-up without an explicit commitment, promise, or",
       "request is insight or suggest; never infer an owner or due date and never create a task",
       "candidate from actionability alone.",
+      "Do not re-deliver a point already delivered for this bucket unless the validated facts",
+      "add something materially new. Prefer silence over restating.",
       "",
       bucket,
       "",
@@ -94,6 +96,100 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertTrue(prompt.contains("== FROZEN RANKED CONTEXT ==\nfrozen:entry-1"))
     XCTAssertTrue(prompt.contains("== RECENT TAIL ==\ntail:entry-2"))
     XCTAssertTrue(prompt.contains("== VALIDATED FACTS ==\nfact:PR-123"))
+    XCTAssertFalse(prompt.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
+  }
+
+  func testDirectorPromptIncludesBoundedRecentDeliveriesForThisBucket() {
+    let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket", versionID: 1, version: 1, header: "header",
+      frozenRankedSegment: Data(), tail: [], validatedFacts: ["fact"], notifyWorthiness: 1)
+    let frame = CapturedFrame(
+      jpegData: Data(), appName: "Notes", frameNumber: 10, captureTime: capturedAt)
+    let prompt = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot,
+      tasks: [],
+      frame: frame,
+      recentDeliveries: [
+        ContextBucketRecentDelivery(
+          decisionType: "resurface",
+          message: "Keep the investigation open",
+          deliveredAt: capturedAt.addingTimeInterval(-65)),
+        ContextBucketRecentDelivery(
+          decisionType: "insight",
+          message: "Status changed",
+          deliveredAt: capturedAt.addingTimeInterval(-26 * 60)),
+      ])
+    let bucket = String(data: ContextBucketPromptAssembler.assemble(snapshot), encoding: .utf8) ?? ""
+    let expected = [
+      ScreenDerivedContent.untrustedPreamble,
+      "Decide whether interrupting now adds concrete value. Return silence unless the validated",
+      "facts support a specific, timely action. Use only supplied bucket-entry refs.",
+      "Never announce that meeting notes, a transcript, or a call summary are ready. The",
+      "conversation-finalization lane owns that claim and attaches the exact conversation link.",
+      "Use resurface or suggest for an actionable open task supplied below. Entries marked",
+      "reference-only are identity context: do not notify about or recreate them yet. Use",
+      "task_candidate only when a validated fact explicitly records a new commitment, promise,",
+      "or request with an accountable action that the user personally made or accepted (first",
+      "person), and that commitment is absent from the supplied task list. A commitment made by",
+      "another person is never a task candidate, however explicit or well-dated it is; if it",
+      "genuinely bears on the user's tracked work it may at most be insight, and a commitment",
+      "between other parties that does not involve the user is silence. A material change, status",
+      "update, recommendation, or useful follow-up without an explicit commitment, promise, or",
+      "request is insight or suggest; never infer an owner or due date and never create a task",
+      "candidate from actionability alone.",
+      "Do not re-deliver a point already delivered for this bucket unless the validated facts",
+      "add something materially new. Prefer silence over restating.",
+      "",
+      bucket,
+      "",
+      "== OPEN OR OVERDUE TASKS ==",
+      "",
+      "",
+      "== CURRENT FRAME METADATA ==",
+      "App: Notes",
+      "Window: ",
+      "Captured at (UTC): 2023-11-14T22:13:20.000Z",
+      "",
+      "== RECENTLY DELIVERED FOR THIS BUCKET ==",
+      "- resurface (1m ago): Keep the investigation open",
+      "- insight (26m ago): Status changed",
+    ].joined(separator: "\n")
+
+    XCTAssertEqual(prompt, expected)
+  }
+
+  func testDirectorPromptCapsRecentDeliveriesAndOmitsTheSectionWhenEmpty() {
+    let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket", versionID: 1, version: 1, header: "header",
+      frozenRankedSegment: Data(), tail: [], validatedFacts: ["fact"], notifyWorthiness: 1)
+    let frame = CapturedFrame(
+      jpegData: Data(), appName: "Notes", frameNumber: 10, captureTime: capturedAt)
+    let empty = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: [])
+    XCTAssertFalse(empty.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
+
+    let overflow = (0..<5).map { index in
+      ContextBucketRecentDelivery(
+        decisionType: "resurface",
+        message: "nudge-\(index)",
+        deliveredAt: capturedAt.addingTimeInterval(TimeInterval(-60 * (index + 1))))
+    }
+    let capped = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: overflow)
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.recentDeliveriesSection(overflow, now: capturedAt),
+      """
+      == RECENTLY DELIVERED FOR THIS BUCKET ==
+      - resurface (1m ago): nudge-0
+      - resurface (2m ago): nudge-1
+      - resurface (3m ago): nudge-2
+      """)
+    XCTAssertTrue(capped.contains("- resurface (1m ago): nudge-0"))
+    XCTAssertTrue(capped.contains("- resurface (3m ago): nudge-2"))
+    XCTAssertFalse(capped.contains("nudge-3"))
+    XCTAssertFalse(capped.contains("nudge-4"))
   }
 
   func testDirectorTaskContextBoundsDescription() {

--- a/desktop/macos/Desktop/Tests/ContextBucketRecentDeliveryTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketRecentDeliveryTests.swift
@@ -1,0 +1,190 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class ContextBucketRecentDeliveryTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "recent-delivery-prompt")
+  }
+
+  override func tearDown() async throws {
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testAssembledPromptIncludesRecentDeliveriesFromTheLedger() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let versionID = try await seedBucket(now: now)
+    try await seedDelivered(
+      id: "first",
+      visitID: 1,
+      versionID: versionID,
+      decisionType: "resurface",
+      message: "Keep the investigation open",
+      deliveredAt: now.addingTimeInterval(-65),
+      now: now)
+    try await seedDelivered(
+      id: "second",
+      visitID: 2,
+      versionID: versionID,
+      decisionType: "insight",
+      message: "Status changed",
+      deliveredAt: now.addingTimeInterval(-26 * 60),
+      now: now)
+
+    let recent = await ContextBucketStore.shared.recentDeliveredForBucket(
+      bucketID: "bucket", now: now)
+    let prompt = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot(versionID: versionID),
+      tasks: [],
+      frame: CapturedFrame(jpegData: Data(), appName: "Notes", frameNumber: 1, captureTime: now),
+      recentDeliveries: recent)
+
+    XCTAssertEqual(recent.map(\.decisionType), ["resurface", "insight"])
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now),
+      """
+      == RECENTLY DELIVERED FOR THIS BUCKET ==
+      - resurface (1m ago): Keep the investigation open
+      - insight (26m ago): Status changed
+      """)
+    XCTAssertTrue(
+      prompt.hasSuffix(
+        """
+        == RECENTLY DELIVERED FOR THIS BUCKET ==
+        - resurface (1m ago): Keep the investigation open
+        - insight (26m ago): Status changed
+        """))
+  }
+
+  func testAssembledPromptOmitsRecentSectionWhenLedgerHasNone() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let versionID = try await seedBucket(now: now)
+    let recent = await ContextBucketStore.shared.recentDeliveredForBucket(
+      bucketID: "bucket", now: now)
+    let prompt = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot(versionID: versionID),
+      tasks: [],
+      frame: CapturedFrame(jpegData: Data(), appName: "Notes", frameNumber: 1, captureTime: now),
+      recentDeliveries: recent)
+
+    XCTAssertEqual(recent, [])
+    XCTAssertNil(ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now))
+    XCTAssertFalse(prompt.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
+  }
+
+  func testAssembledPromptCapsRecentDeliveriesAtThree() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let versionID = try await seedBucket(now: now)
+    for index in 0..<5 {
+      try await seedDelivered(
+        id: "nudge-\(index)",
+        visitID: Int64(index + 1),
+        versionID: versionID,
+        decisionType: "resurface",
+        message: "nudge-\(index)",
+        deliveredAt: now.addingTimeInterval(TimeInterval(-60 * (index + 1))),
+        now: now)
+    }
+
+    let recent = await ContextBucketStore.shared.recentDeliveredForBucket(
+      bucketID: "bucket", now: now)
+    let prompt = ContextProactivityPromptBuilder.directorPrompt(
+      snapshot: snapshot(versionID: versionID),
+      tasks: [],
+      frame: CapturedFrame(jpegData: Data(), appName: "Notes", frameNumber: 1, captureTime: now),
+      recentDeliveries: recent)
+
+    XCTAssertEqual(recent.map(\.message), ["nudge-0", "nudge-1", "nudge-2"])
+    XCTAssertEqual(recent.count, ContextBucketRecentDelivery.promptCap)
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now),
+      """
+      == RECENTLY DELIVERED FOR THIS BUCKET ==
+      - resurface (1m ago): nudge-0
+      - resurface (2m ago): nudge-1
+      - resurface (3m ago): nudge-2
+      """)
+    XCTAssertFalse(prompt.contains("nudge-3"))
+    XCTAssertFalse(prompt.contains("nudge-4"))
+  }
+
+  private func snapshot(versionID: Int64) -> ContextBucketSnapshot {
+    ContextBucketSnapshot(
+      bucketID: "bucket",
+      versionID: versionID,
+      version: 1,
+      header: "header",
+      frozenRankedSegment: Data(),
+      tail: [],
+      validatedFacts: ["fact"],
+      notifyWorthiness: 1)
+  }
+
+  private func seedBucket(now: Date) async throws -> Int64 {
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    return try await pool.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+          VALUES ('bucket', 'task', 'recent-delivery', ?, ?)
+          """,
+        arguments: [now, now])
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_versions (bucketID, version, header, frozenRankedSegment, createdAt)
+          VALUES ('bucket', 1, 'header', ?, ?)
+          """,
+        arguments: [Data(), now])
+      for visitID in 1...5 {
+        try db.execute(
+          sql: """
+            INSERT INTO context_visits
+              (id, contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+               normalizedContextKey, referenceHash, startedAt, outcome, createdAt, updatedAt)
+            VALUES (?, 1, ?, 'bucket', 'Notes', ?, ?, ?, ?, 'completed', ?, ?)
+            """,
+          arguments: [
+            visitID, poolEpoch, "raw-\(visitID)", "normalized-\(visitID)", "ref-\(visitID)", now, now,
+            now,
+          ])
+      }
+      return try Int64.fetchOne(
+        db,
+        sql: "SELECT id FROM bucket_versions WHERE bucketID = 'bucket' AND version = 1")
+        ?? 0
+    }
+  }
+
+  private func seedDelivered(
+    id: String,
+    visitID: Int64,
+    versionID: Int64,
+    decisionType: String,
+    message: String,
+    deliveredAt: Date,
+    now: Date
+  ) async throws {
+    let (database, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    try await pool.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO proactive_deliveries
+            (id, visitID, bucketID, bucketVersionID, decisionType, lifecycleState,
+             provenanceJson, message, attemptedAt, deliveredAt, expiresAt, createdAt)
+          VALUES (?, ?, 'bucket', ?, ?, 'delivered', '{}', ?, ?, ?, ?, ?)
+          """,
+        arguments: [
+          id, visitID, versionID, decisionType, message, deliveredAt, deliveredAt,
+          now.addingTimeInterval(30 * 24 * 60 * 60), deliveredAt,
+        ])
+    }
+  }
+}

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -456,6 +456,52 @@ final class ContextProactivityDirectorFailureTests: XCTestCase {
     XCTAssertNil(provenance["status"])
   }
 
+  func testGraduationFailureKeepsDirectorDecisionAndBucketProvenance() async throws {
+    let deliveryID = try await seedAttemptedDelivery()
+    let versionID = try await fetchDelivery(id: deliveryID)["bucketVersionID"] as Int64
+    let provenanceJSON =
+      String(
+        data: try JSONSerialization.data(
+          withJSONObject: [
+            "bucket_entry_refs": ["entry:one"],
+            "bucket_id": "bucket",
+            "bucket_version_id": versionID,
+            "fact_ids": ["fact:one"],
+          ],
+          options: [.sortedKeys]),
+        encoding: .utf8) ?? "{}"
+    let store = ContextBucketStore.shared
+    let advanced = try await store.completeDelivery(
+      id: deliveryID,
+      decisionType: "task_candidate",
+      provenanceJSON: provenanceJSON,
+      message: "commitment",
+      state: "policy_approved")
+    XCTAssertTrue(advanced)
+    let engine = ContextProactivityEngine(
+      client: ProactiveLaneClient(authorization: { "Bearer test" }),
+      store: store,
+      dwellNanoseconds: 0)
+
+    await engine.recordGraduationFailure(
+      deliveryID: deliveryID,
+      decisionType: "task_candidate",
+      provenanceJSON: provenanceJSON,
+      message: "commitment",
+      reason: .stale)
+
+    let row = try await fetchDelivery(id: deliveryID)
+    XCTAssertEqual(row["decisionType"] as String?, "task_candidate")
+    XCTAssertEqual(row["lifecycleState"] as String?, "failed")
+    let provenance = try provenanceObject(try XCTUnwrap(row["provenanceJson"] as String?))
+    XCTAssertEqual(provenance["failure"] as? String, "candidate_graduation_failed")
+    XCTAssertEqual(provenance["graduation_reason"] as? String, "stale")
+    XCTAssertEqual(provenance["bucket_id"] as? String, "bucket")
+    XCTAssertEqual((provenance["bucket_version_id"] as? NSNumber)?.int64Value, versionID)
+    XCTAssertEqual(provenance["bucket_entry_refs"] as? [String], ["entry:one"])
+    XCTAssertEqual(provenance["fact_ids"] as? [String], ["fact:one"])
+  }
+
   private func seedAttemptedDelivery() async throws -> String {
     let now = Date(timeIntervalSince1970: 1_800_000_000)
     let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()

--- a/desktop/macos/changelog/unreleased/20260814-director-recent-delivery-context.json
+++ b/desktop/macos/changelog/unreleased/20260814-director-recent-delivery-context.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fewer repeated nudges for the same app context when notification frequency is at Maximum"
+}


### PR DESCRIPTION
## What changed and why

Two dogfood defects in the desktop context-director delivery path, found on Omi Beta 0.12.171 and backed by rows in a live profile DB. Neither change is user-visible for a successful delivery; B reduces repeats at Maximum by giving the model an honest signal.

### Defect A — graduation failure discarded the director's decision and provenance

`contextEntered` recorded a failed `task_candidate` graduation as `decisionType='silence'` with provenance `{"failure":"candidate_graduation_failed"}`, throwing away the real decision and bucket refs. Its three sibling post-decision paths already keep `decision.decision` and the full provenance JSON.

**Live evidence (today, 06:12:08 UTC):** one ledger row with `decisionType='silence'`, `lifecycleState='failed'`, and both `modelCompletedAt` and `policyApprovedAt` set. A first-person commitment was detected and policy-approved, then dropped with no user-visible signal and no retry. The eight graduation guards (empty fact ids, owner change, missing pool, incomplete fact set, workflow not readable, ineligible disposition, staleness, plus the same owner check twice) had collapsed into one opaque string.

**Fix:** keep `decisionType: decision.decision` and merge `"failure":"candidate_graduation_failed"` plus a bounded `"graduation_reason"` into the existing provenance. `CandidateSink.graduateValidatedFacts` now returns a small enum instead of `Bool`. Terminal state stays `failed` and non-user-visible.

### Defect B — the director never saw what it just delivered, so it repeated itself

The director prompt has the bucket snapshot, open tasks, and current frame, but no record of recent deliveries for this bucket. `lastDeliveredAt` is only a cooldown input. At Maximum, cooldown is 0 and `NotificationService.minInterval` is nil, so nothing stops a re-notify about the same bucket; the unique index on `(visitID, bucketVersionID)` only stops double-writes for one version.

**Live evidence (today, same profile):**
- One bucket delivered three `resurface` notifications in 8 minutes (06:03:35, 06:04:40, 06:11:01 UTC — two of them 65 s apart), restating the same open investigation.
- Another bucket delivered two `insight` notifications 26 minutes apart (05:19, 05:45 UTC).

**Fix:** supply a bounded `== RECENTLY DELIVERED FOR THIS BUCKET ==` section (cap 3, truncated summaries, relative age from an injected clock) read from the existing delivery ledger, plus prompt guidance to prefer silence over restating unless the validated facts add something materially new. This is a signal to the model, not a new hard per-bucket cooldown — Maximum still means back-to-back nudges (`20260814-maximum-level-fast-nudges`).

Do not describe any user's actual notification content; the live rows contain personal data.

## Product invariants affected

none

## How it was verified

Hermetic behavioural tests calling production APIs (injected clocks, no wall-clock sleeps). Not exercised on a named bundle against the live profile; the user-facing path for A is "stay silent" (unchanged) and for B is a model-prompt signal.

```
cd desktop/macos && ./scripts/dev-feedback.py --once swift \
  'CandidateSinkDeliveryGateTests|CandidateSinkGraduationTests|ContextProactivityDirectorFailureTests|ContextProactivityEngineTests'
```

Iteration 1: PASS in 23.77s — 27 tests, 0 failures. Includes `testGraduationFailureKeepsDirectorDecisionAndBucketProvenance` (stored row keeps `decisionType == "task_candidate"`, bucket refs, and `graduation_reason=stale`), `testGraduationReasonsDistinguishEmptyFactsFromStaleFacts`, and `testAlreadyPendingFactsGraduateWithoutChangingDisposition`.

```
cd desktop/macos && ./scripts/dev-feedback.py --once swift \
  'ContextBucketPromptAssemblerTests|ContextBucketRecentDeliveryTests|ContextBucketDirectorProbeTests'
```

Iteration 1: PASS in 41.58s — 26 tests, 0 failures. Includes full-equality director prompt (section omitted when empty), ledger-backed recent-delivery section, and cap at 3 when 5 delivered rows are recorded.

```
cd desktop/macos && python3 scripts/check_desktop_test_quality.py
```

OK: desktop test-quality debt at or below baseline.

## Tests

- A: `CandidateSinkGraduationTests` — empty fact IDs vs stale/incomplete facts produce distinct bounded reasons; already-pending facts still graduate.
- A: `ContextProactivityDirectorFailureTests.testGraduationFailureKeepsDirectorDecisionAndBucketProvenance` — store-backed row keeps `task_candidate`, bucket refs, and `graduation_reason`.
- A: `CandidateSinkDeliveryGateTests` — any non-`.graduated` reason still blocks interactive presentation.
- B: `ContextBucketPromptAssemblerTests` — exact director prompt equality, including the new guidance; recent-delivery section present/capped/omitted.
- B: `ContextBucketRecentDeliveryTests` — ledger → assembled prompt, omit when none, cap at 3.

## Failure class (fixes)

Failure-Class: FC-typed-failure-collapsed-to-generic

Recurrence of the registered class: a typed graduation failure was collapsed to generic `silence` + an opaque `candidate_graduation_failed` token. The reusable guard is the bounded `CandidateGraduationReason` enum persisted into provenance JSON, with store-backed contract tests. Artifact paths on the class definition now include `CandidateSink.swift` and `CandidateSinkGraduationTests.swift`.

Defect B is a missing prompt signal, not a typed-failure collapse; it does not mint a second class.

## Failure-class transition narrative

Not a registry lifecycle change. This is an ordinary instance fix that reuses `FC-typed-failure-collapsed-to-generic` and extends `canonical_prevention_artifact` only.

🤖 Generated with Cursor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

