### PR TITLE
feat(desktop): Maximum notification level delivers the <10s / <30s focus-nudge cadence (+ context-buckets starvation fix)

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -144,7 +144,10 @@ actor SuggestionAssistant: ProactiveAssistant {
       isEnabled: enabled,
       isAppExcluded: excluded,
       now: now,
-      lastEvaluationAt: lastEvaluationAt,
+      lastEvaluationAt: SuggestionPacing.effectiveLastEvaluation(
+        lastEvaluationAt: lastEvaluationAt,
+        anchor: pendingContextSwitchAt,
+        frequencyLevel: level),
       cooldown: cooldown,
       dwell: dwell,
       requiredDwell: SuggestionPacing.requiredDwell(frequencyLevel: level),

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -37,7 +37,7 @@ actor SuggestionAssistant: ProactiveAssistant {
   /// The shared delay (`AssistantSettings.analysisDelay`, 60s) exists so assistants do
   /// not analyze while the user is still moving around. A minute is far too long for a
   /// suggestion about the screen in front of you, so this assistant takes the frames and
-  /// enforces its own, much shorter settle window instead (`settleInterval`).
+  /// enforces its own, much shorter settle window instead (`SuggestionPacing.settleInterval`).
   var needsFrameDuringDelay: Bool {
     get async { true }
   }
@@ -47,18 +47,10 @@ actor SuggestionAssistant: ProactiveAssistant {
   private let geminiClient: GeminiClient
   private let telemetryModel: SuggestionAssistantTelemetry.Model
 
-  /// Dwell before a context is worth spending on — level-aware, see
-  /// `SuggestionGatePolicy.requiredDwell(frequencyLevel:)` (10 s at Maximum, 30 s otherwise).
-  private static func requiredDwell(frequencyLevel: Int) -> TimeInterval {
-    SuggestionGatePolicy.requiredDwell(frequencyLevel: frequencyLevel)
-  }
-
-  /// Hard ceiling on paid evaluations per day, so cost is a number we choose rather than a
-  /// function of how much the user alt-tabs.
-  private static let dailyEvaluationBudget = 40
-
-  /// Frames are still accepted this early so dwell can be measured from the switch.
-  private let settleInterval: TimeInterval = 6.0
+  /// Last observed notification frequency level, refreshed on every context switch and
+  /// evaluation so synchronous gates can pace by level without an actor hop per frame.
+  /// Defaults to Balanced so a not-yet-read level never triggers Maximum pacing.
+  private var cachedFrequencyLevel: Int = 3
 
   private var dailyBudget = SuggestionDailyBudget()
 
@@ -69,7 +61,6 @@ actor SuggestionAssistant: ProactiveAssistant {
 
   private var lastEvaluationAt: Date?
   private var recentSuggestions: [String] = []
-  private let maxRecentSuggestions = 10
 
   /// The commitments handed to the evaluation currently in flight, kept so delivery can
   /// hold a `commitment` nudge to what the model was actually shown.
@@ -123,13 +114,17 @@ actor SuggestionAssistant: ProactiveAssistant {
     )
     pendingApp = newApp
     pendingWindowTitle = newWindowTitle
+    // Refreshed per switch so the synchronous `shouldAnalyze` gate can pace by level
+    // without hopping actors on every frame.
+    cachedFrequencyLevel = await MainActor.run { NotificationService.currentFrequencyLevel() }
   }
 
   /// Every branch here is mechanical. No model call happens until all of them pass, which
   /// is what makes the cost contract testable.
   func shouldAnalyze(frameNumber: Int, timeSinceLastAnalysis: TimeInterval) -> Bool {
     guard let switchedAt = pendingContextSwitchAt else { return false }
-    guard Date().timeIntervalSince(switchedAt) >= settleInterval else { return false }
+    let settle = SuggestionPacing.settleInterval(frequencyLevel: cachedFrequencyLevel)
+    guard Date().timeIntervalSince(switchedAt) >= settle else { return false }
     return true
   }
 
@@ -138,8 +133,9 @@ actor SuggestionAssistant: ProactiveAssistant {
 
     let enabled = await isEnabled
     let excluded = await MainActor.run { SuggestionAssistantSettings.shared.isAppExcluded(frame.appName) }
-    let frequencyLevel = await MainActor.run { NotificationService.currentFrequencyLevel() }
-    let cooldown = await cooldownInterval
+    let level = await MainActor.run { NotificationService.currentFrequencyLevel() }
+    cachedFrequencyLevel = level
+    let cooldown = SuggestionPacing.cooldown(base: await cooldownInterval, frequencyLevel: level)
 
     let now = Date()
     let dwell = pendingContextSwitchAt.map { now.timeIntervalSince($0) } ?? 0
@@ -149,11 +145,11 @@ actor SuggestionAssistant: ProactiveAssistant {
       isAppExcluded: excluded,
       now: now,
       lastEvaluationAt: lastEvaluationAt,
-      cooldown: SuggestionGatePolicy.cooldown(base: cooldown, frequencyLevel: frequencyLevel),
+      cooldown: cooldown,
       dwell: dwell,
-      requiredDwell: Self.requiredDwell(frequencyLevel: frequencyLevel),
+      requiredDwell: SuggestionPacing.requiredDwell(frequencyLevel: level),
       evaluationsToday: dailyBudget.countToday(now: now),
-      dailyBudget: Self.dailyEvaluationBudget
+      dailyBudget: SuggestionPacing.dailyEvaluationBudget(frequencyLevel: level)
     )
 
     guard decision.allowsEvaluation else {
@@ -512,7 +508,8 @@ actor SuggestionAssistant: ProactiveAssistant {
     }
     let telemetryIdentity = SuggestionAssistantTelemetry.NotificationIdentity(result.telemetryIdentity)
     let ownerID = RuntimeOwnerIdentity.currentOwnerId()
-    let threshold = await minConfidence
+    let threshold = SuggestionPacing.minConfidence(
+      base: await minConfidence, frequencyLevel: cachedFrequencyLevel)
 
     let outcome = SuggestionDeliveryPolicy.decide(
       hasOwner: ownerID != nil,
@@ -558,8 +555,9 @@ actor SuggestionAssistant: ProactiveAssistant {
     }
 
     recentSuggestions.append(suggestion.suggestion)
-    if recentSuggestions.count > maxRecentSuggestions {
-      recentSuggestions.removeFirst(recentSuggestions.count - maxRecentSuggestions)
+    let dedupMemory = SuggestionPacing.dedupMemory(frequencyLevel: cachedFrequencyLevel)
+    if recentSuggestions.count > dedupMemory {
+      recentSuggestions.removeFirst(recentSuggestions.count - dedupMemory)
     }
 
     await deliver(
@@ -644,10 +642,10 @@ actor SuggestionAssistant: ProactiveAssistant {
       now: now,
       lastEvaluationAt: nil,
       cooldown: 0,
-      dwell: Self.requiredDwell(frequencyLevel: gateState.2),
-      requiredDwell: Self.requiredDwell(frequencyLevel: gateState.2),
+      dwell: SuggestionPacing.requiredDwell(frequencyLevel: gateState.2),
+      requiredDwell: SuggestionPacing.requiredDwell(frequencyLevel: gateState.2),
       evaluationsToday: dailyBudget.countToday(now: now),
-      dailyBudget: Self.dailyEvaluationBudget)
+      dailyBudget: SuggestionPacing.dailyEvaluationBudget(frequencyLevel: gateState.2))
     guard gateState.1, gateState.2 > 0, decision.allowsEvaluation else {
       if !gateState.1 { return ["outcome": "skipped_notifications_disabled"] }
       if gateState.2 == 0 { return ["outcome": "skipped_frequency_off"] }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -183,7 +183,13 @@ actor SuggestionAssistant: ProactiveAssistant {
     await MainActor.run {
       AnalyticsManager.shared.suggestionAssistantGateOutcome(.eligible)
     }
-    clearPendingContext()
+    // Calm levels consume the context: one evaluation per arrival, then quiet until the
+    // user moves somewhere new. Maximum re-arms so staying on the same feed keeps
+    // producing nudges every cooldown interval — that sustained cadence is the level's
+    // entire point, and cooldown + the daily budget still bound the spend.
+    if !SuggestionPacing.rearmsAfterEvaluation(frequencyLevel: level) {
+      clearPendingContext()
+    }
     lastEvaluationAt = now
     dailyBudget.recordEvaluation(now: now)
     commitmentsInFlight = grounding.openCommitments

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -150,18 +150,19 @@ enum SuggestionGatePolicy {
   /// How long the user must sit in a context before it is worth an evaluation.
   ///
   /// Maximum (level 5) is an explicit "show me everything, fast": open TikTok and the
-  /// nudge should land in seconds, so dwell drops to 10 s there. Every other level keeps
+  /// nudge should land in under ten seconds end-to-end, so dwell drops to 4 s there. Every other level keeps
   /// the deliberate 30 s — passing through a window is not a request for advice.
   static func requiredDwell(frequencyLevel: Int) -> TimeInterval {
-    frequencyLevel >= 5 ? 10 : 30
+    SuggestionPacing.requiredDwell(frequencyLevel: frequencyLevel)
   }
 
   /// Between-nudge cooldown, from the user's configured base.
   ///
-  /// Maximum caps it at 30 s — a user who chose "Maximum" wants back-to-back nudges, not
+  /// Maximum caps it at 20 s — a user who chose "Maximum" wants a nudge under every half
+  /// minute, not
   /// one per three minutes. Every other level keeps the configured value untouched.
   static func cooldown(base: TimeInterval, frequencyLevel: Int) -> TimeInterval {
-    frequencyLevel >= 5 ? min(base, 30) : base
+    SuggestionPacing.cooldown(base: base, frequencyLevel: frequencyLevel)
   }
 
   /// Ordered cheapest-first, and every branch is free. Switching apps is not evidence that
@@ -504,5 +505,49 @@ enum SuggestionDeduplication {
 
   static func isDuplicate(_ candidate: String, of recent: [String]) -> Bool {
     recent.contains { similarity(candidate, $0) >= similarityThreshold }
+  }
+}
+
+/// Pacing knobs for the suggestion assistant, derived from the user's notification
+/// frequency level. Maximum (5) is deliberately relentless — the user asked for a nudge
+/// within seconds of opening a leisure app and another one under half a minute later for
+/// as long as it stays open. Every other level keeps the long-standing calm defaults,
+/// byte-for-byte: this enum is the only place the two regimes are allowed to differ.
+enum SuggestionPacing {
+  static let maximumLevel = 5
+
+  /// How long the user must stay in a context before it is worth spending on.
+  static func requiredDwell(frequencyLevel: Int) -> TimeInterval {
+    frequencyLevel >= maximumLevel ? 4 : 30
+  }
+
+  /// How long after a switch frames are considered settled enough to analyze.
+  static func settleInterval(frequencyLevel: Int) -> TimeInterval {
+    frequencyLevel >= maximumLevel ? 2 : 6
+  }
+
+  /// Minimum gap between paid evaluations. Maximum caps the user-configurable base so a
+  /// stale 180s stored setting cannot defeat the level; a base the user already set
+  /// below the cap is respected.
+  static func cooldown(base: TimeInterval, frequencyLevel: Int) -> TimeInterval {
+    frequencyLevel >= maximumLevel ? min(base, 20) : base
+  }
+
+  /// Paid-evaluation ceiling per day. A 20-second cadence demo would exhaust the calm
+  /// budget in minutes; Maximum is an explicit opt-in to that spend.
+  static func dailyEvaluationBudget(frequencyLevel: Int) -> Int {
+    frequencyLevel >= maximumLevel ? 600 : 40
+  }
+
+  /// Confidence bar. Maximum trades a little precision for cadence; other levels keep
+  /// the user's configured bar untouched.
+  static func minConfidence(base: Double, frequencyLevel: Int) -> Double {
+    frequencyLevel >= maximumLevel ? min(base, 0.75) : base
+  }
+
+  /// How many recent suggestions the dedup window remembers. At Maximum only the last
+  /// two are held, so a small set of open tasks rotates instead of starving the cadence.
+  static func dedupMemory(frequencyLevel: Int) -> Int {
+    frequencyLevel >= maximumLevel ? 2 : 10
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -550,4 +550,11 @@ enum SuggestionPacing {
   static func dedupMemory(frequencyLevel: Int) -> Int {
     frequencyLevel >= maximumLevel ? 2 : 10
   }
+
+  /// Idle window before screen capture pauses. Watching a feed or a video produces no
+  /// input; at Maximum the user has explicitly asked to be nudged during exactly that,
+  /// so capture stays live for five minutes of stillness instead of one.
+  static func captureIdleThreshold(frequencyLevel: Int, base: TimeInterval) -> TimeInterval {
+    frequencyLevel >= maximumLevel ? max(base, 300) : base
+  }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -551,6 +551,13 @@ enum SuggestionPacing {
     frequencyLevel >= maximumLevel ? 2 : 10
   }
 
+  /// Whether an eligible evaluation leaves the context armed. Calm levels evaluate once
+  /// per arrival; Maximum keeps evaluating the same context every cooldown interval for
+  /// as long as the user stays, which is the sustained-nudge cadence the level promises.
+  static func rearmsAfterEvaluation(frequencyLevel: Int) -> Bool {
+    frequencyLevel >= maximumLevel
+  }
+
   /// Idle window before screen capture pauses. Watching a feed or a video produces no
   /// input; at Maximum the user has explicitly asked to be nudged during exactly that,
   /// so capture stays live for five minutes of stillness instead of one.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -561,6 +561,13 @@ enum SuggestionPacing {
     frequencyLevel >= maximumLevel
   }
 
+  /// Whether same-context heartbeats force a full capture (no preview-similarity skip,
+  /// no backoff growth). Maximum's cadence needs a real frame every base heartbeat even
+  /// on a mostly-static page; calm levels keep the cost-saving preview path.
+  static func forcesHeartbeatCapture(frequencyLevel: Int) -> Bool {
+    frequencyLevel >= maximumLevel
+  }
+
   /// Idle window before screen capture pauses. Watching a feed or a video produces no
   /// input; at Maximum the user has explicitly asked to be nudged during exactly that,
   /// so capture stays live for five minutes of stillness instead of one.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -561,6 +561,22 @@ enum SuggestionPacing {
     frequencyLevel >= maximumLevel
   }
 
+  /// The cooldown baseline for a gate check. At Maximum, arriving in a NEW context
+  /// (anchor newer than the last evaluation) waives the remaining cooldown — "open
+  /// TikTok, nudge in seconds" must hold even if a nudge fired somewhere else moments
+  /// ago. Staying in the same context keeps the anchor older than the last evaluation,
+  /// so repeats remain paced by the cooldown, and the daily budget still bounds spend.
+  static func effectiveLastEvaluation(
+    lastEvaluationAt: Date?,
+    anchor: Date?,
+    frequencyLevel: Int
+  ) -> Date? {
+    guard frequencyLevel >= maximumLevel, let last = lastEvaluationAt, let anchor else {
+      return lastEvaluationAt
+    }
+    return anchor > last ? nil : last
+  }
+
   /// Whether same-context heartbeats force a full capture (no preview-similarity skip,
   /// no backoff growth). Maximum's cadence needs a real frame every base heartbeat even
   /// on a mostly-static page; calm levels keep the cost-saving preview path.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -539,16 +539,19 @@ enum SuggestionPacing {
     frequencyLevel >= maximumLevel ? 600 : 40
   }
 
-  /// Confidence bar. Maximum trades a little precision for cadence; other levels keep
-  /// the user's configured bar untouched.
+  /// Confidence bar. Maximum trades precision for cadence — the level's contract is a
+  /// steady stream, and a 70% nudge beats silence there; other levels keep the user's
+  /// configured bar untouched.
   static func minConfidence(base: Double, frequencyLevel: Int) -> Double {
-    frequencyLevel >= maximumLevel ? min(base, 0.75) : base
+    frequencyLevel >= maximumLevel ? min(base, 0.65) : base
   }
 
-  /// How many recent suggestions the dedup window remembers. At Maximum only the last
-  /// two are held, so a small set of open tasks rotates instead of starving the cadence.
+  /// How many recent suggestions the dedup window remembers. Maximum keeps none: the
+  /// user asked to be nagged about the same commitment for as long as they stay on the
+  /// feed, so repeat-suppression would defeat the level's entire point. Calm levels keep
+  /// the 10-deep window that stops nagging.
   static func dedupMemory(frequencyLevel: Int) -> Int {
-    frequencyLevel >= maximumLevel ? 2 : 10
+    frequencyLevel >= maximumLevel ? 0 : 10
   }
 
   /// Whether an eligible evaluation leaves the context armed. Calm levels evaluate once

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/AssistantCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/AssistantCoordinator.swift
@@ -114,8 +114,13 @@ class AssistantCoordinator {
   /// and window title changes — one unified path with one delay mechanism.
   /// - Returns: `true` if a context switch was detected and fired.
   @discardableResult
-  func checkContextSwitch(newApp: String, newWindowTitle: String?) async -> Bool {
-    let bucketsEnabled = ContextBucketsFeature.isEnabled
+  func checkContextSwitch(
+    newApp: String,
+    newWindowTitle: String?,
+    bucketsEnabled: Bool? = nil
+  ) async -> Bool {
+    // Injectable for tests only; production always reads the live flag.
+    let bucketsEnabled = bucketsEnabled ?? ContextBucketsFeature.isEnabled
     let transitionRequest = ContextTransitionRequest(app: newApp, windowTitle: newWindowTitle)
     guard lastTrackedApp != nil else {
       if bucketsEnabled {
@@ -129,12 +134,14 @@ class AssistantCoordinator {
         do {
           let transition = try await ContextVisitCoordinator.shared.transition(
             toApp: newApp, windowTitle: newWindowTitle, departingFrame: nil)
-          lastTrackedApp = newApp
-          lastTrackedWindowTitle = newWindowTitle
           Task { await ContextProactivityEngine.shared.contextEntered(transition.arrivingFence) }
         } catch {
           logError("Context buckets: failed to persist initial visit", error: error)
         }
+        // Context tracking must not depend on bucket-visit persistence: an unprimed
+        // tracker means no context switch is ever detected and every assistant starves.
+        lastTrackedApp = newApp
+        lastTrackedWindowTitle = newWindowTitle
       } else {
         lastTrackedApp = newApp
         lastTrackedWindowTitle = newWindowTitle
@@ -181,22 +188,16 @@ class AssistantCoordinator {
         do {
           let departure = try await ContextVisitCoordinator.shared.leaveForExcludedContext(
             departingFrame: departingFrame)
-          lastTrackedApp = newApp
-          lastTrackedWindowTitle = newWindowTitle
           if departure.qualified, let fence = departure.fence, let departingFrame {
             Task { await ContextBucketRollupWriter.shared.extract(frame: departingFrame, fence: fence) }
-          }
-          if let taskAssistant = assistants["task-extraction"] {
-            Task {
-              await taskAssistant.onContextSwitch(
-                departingFrame: departingFrame,
-                newApp: newApp,
-                newWindowTitle: newWindowTitle)
-            }
           }
         } catch {
           logError("Context buckets: failed to close visit before excluded context", error: error)
         }
+        lastTrackedApp = newApp
+        lastTrackedWindowTitle = newWindowTitle
+        await fireContextSwitchOnAllAssistants(
+          departingFrame: departingFrame, newApp: newApp, newWindowTitle: newWindowTitle)
         return true
       }
       do {
@@ -204,39 +205,23 @@ class AssistantCoordinator {
           toApp: newApp,
           windowTitle: newWindowTitle,
           departingFrame: departingFrame)
-        lastTrackedApp = newApp
-        lastTrackedWindowTitle = newWindowTitle
         if transition.departingQualified, let departingFence = transition.departingFence, let departingFrame {
           Task { await ContextBucketRollupWriter.shared.extract(frame: departingFrame, fence: departingFence) }
-        }
-        // TaskAssistant keeps its timer fallback and messaging fast path. The
-        // coordinator is the only exit writer while the flag is enabled.
-        if let taskAssistant = assistants["task-extraction"] {
-          Task {
-            await taskAssistant.onContextSwitch(
-              departingFrame: departingFrame,
-              newApp: newApp,
-              newWindowTitle: newWindowTitle)
-          }
         }
         Task { await ContextProactivityEngine.shared.contextEntered(transition.arrivingFence) }
       } catch {
         logError("Context buckets: context transition failed", error: error)
       }
+      lastTrackedApp = newApp
+      lastTrackedWindowTitle = newWindowTitle
+      await fireContextSwitchOnAllAssistants(
+        departingFrame: departingFrame, newApp: newApp, newWindowTitle: newWindowTitle)
       return true
     }
 
     // Flag-off rollback path: fire today's independent assistants unchanged.
-    for (_, assistant) in assistants {
-      Task {
-        await assistant.onContextSwitch(
-          departingFrame: departingFrame,
-          newApp: newApp,
-          newWindowTitle: newWindowTitle
-        )
-      }
-    }
-
+    await fireContextSwitchOnAllAssistants(
+      departingFrame: departingFrame, newApp: newApp, newWindowTitle: newWindowTitle)
     return true
   }
 
@@ -244,6 +229,29 @@ class AssistantCoordinator {
   /// during its persistence await. The follow-up runs on the main actor, so it
   /// cannot race the coordinator's tracked state or start a second write in
   /// parallel with the completed request.
+  /// Every registered assistant hears every context switch, in buckets mode and out of it.
+  ///
+  /// The context-buckets rollout forwarded switches only to the task assistant, which
+  /// silently starved the suggestion and memory assistants: `SuggestionAssistant.analyze`
+  /// returns nil before any logging when no context switch ever armed its dwell anchor,
+  /// so focus nudges stopped fleet-wide for everyone in the flag cohort with no error
+  /// anywhere (Aug 13–14 2026). Buckets mode changes who WRITES bucket exits, never who
+  /// HEARS switches — and hearing a switch must not depend on bucket-visit persistence,
+  /// so this fires outside the transition do/catch.
+  func fireContextSwitchOnAllAssistants(
+    departingFrame: CapturedFrame?,
+    newApp: String,
+    newWindowTitle: String?
+  ) async {
+    for (_, assistant) in assistants {
+      await assistant.onContextSwitch(
+        departingFrame: departingFrame,
+        newApp: newApp,
+        newWindowTitle: newWindowTitle
+      )
+    }
+  }
+
   private func finishContextTransition(_ request: ContextTransitionRequest) {
     guard let next = contextTransitionQueue.finish(request) else { return }
     Task { @MainActor [weak self] in

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -370,7 +370,8 @@ struct ProactiveCaptureTrigger {
     app: String,
     windowTitle: String?,
     idleSeconds: TimeInterval,
-    now: Date
+    now: Date,
+    forceHeartbeatCapture: Bool = false
   ) -> Decision {
     if idleSeconds >= idleThreshold {
       // User is idle: keep last context but do not capture.
@@ -399,6 +400,17 @@ struct ProactiveCaptureTrigger {
 
     // Same context: only sample on heartbeat. The heartbeat interval grows when
     // recent previews are all similar, so static screens are probed less often.
+    // Maximum notification level opts out of both the growth and the preview
+    // similarity skip: its cadence contract needs a real frame at least every base
+    // heartbeat, and a mostly-static feed page must still be evaluated.
+    if forceHeartbeatCapture {
+      if now.timeIntervalSince(lastCaptureTime) >= heartbeatInterval {
+        lastCaptureTime = now
+        consecutiveSimilarPreviews = 0
+        return .capture
+      }
+      return .skip
+    }
     if now.timeIntervalSince(lastCaptureTime) >= effectiveHeartbeatInterval {
       return .preview
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -371,9 +371,12 @@ struct ProactiveCaptureTrigger {
     windowTitle: String?,
     idleSeconds: TimeInterval,
     now: Date,
-    forceHeartbeatCapture: Bool = false
+    forceHeartbeatCapture: Bool = false,
+    idleThresholdOverride: TimeInterval? = nil
   ) -> Decision {
-    if idleSeconds >= idleThreshold {
+    // The override exists for Maximum notification level, whose 300s window would
+    // otherwise be defeated by this trigger's own 60s check.
+    if idleSeconds >= (idleThresholdOverride ?? idleThreshold) {
       // User is idle: keep last context but do not capture.
       return .skip
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -780,23 +780,28 @@ public class ProactiveAssistantsPlugin: NSObject {
       return
     }
 
-    // Cheap early exits before resolving the active window. Media playback exempts
-    // HID idleness: a movie viewer types nothing for an hour but is still watching,
-    // and skipping every tick blinded the assistants exactly then (see
-    // MediaPlaybackIdlePolicy).
+    // Cheap early exits before resolving the active window. Two exemptions compose:
+    // media playback exempts HID idleness at every level (a movie viewer types nothing
+    // for an hour but is still watching — MediaPlaybackIdlePolicy), and Maximum
+    // notification level additionally extends the window to 300s for HID-idle WITHOUT
+    // media (reading a static feed). Calmer levels keep the 60s threshold.
     let hidIdleSeconds = systemIdleSeconds()
     let idleSeconds = MediaPlaybackIdlePolicy.effectiveIdleSeconds(
       hidIdleSeconds: hidIdleSeconds,
       isDisplaySleepPrevented: mediaPlaybackDetector.isDisplaySleepPrevented())
-    if hidIdleSeconds >= captureTrigger.idleThreshold, idleSeconds < captureTrigger.idleThreshold,
+    let idleThreshold = SuggestionPacing.captureIdleThreshold(
+      frequencyLevel: NotificationService.currentFrequencyLevel(),
+      base: captureTrigger.idleThreshold
+    )
+    if hidIdleSeconds >= idleThreshold, idleSeconds < idleThreshold,
       !didLogMediaIdleExemption
     {
       didLogMediaIdleExemption = true
       log("CaptureGate: HID-idle but media playback active — capture continues")
-    } else if hidIdleSeconds < captureTrigger.idleThreshold {
+    } else if hidIdleSeconds < idleThreshold {
       didLogMediaIdleExemption = false
     }
-    if idleSeconds >= captureTrigger.idleThreshold {
+    if idleSeconds >= idleThreshold {
       logCaptureGate("idle")
       return
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -902,7 +902,9 @@ public class ProactiveAssistantsPlugin: NSObject {
       app: appName ?? "",
       windowTitle: currentWindowTitle,
       idleSeconds: idleSeconds,
-      now: now
+      now: now,
+      forceHeartbeatCapture: SuggestionPacing.forcesHeartbeatCapture(
+        frequencyLevel: NotificationService.currentFrequencyLevel())
     ) {
     case .skip:
       return

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -904,7 +904,10 @@ public class ProactiveAssistantsPlugin: NSObject {
       idleSeconds: idleSeconds,
       now: now,
       forceHeartbeatCapture: SuggestionPacing.forcesHeartbeatCapture(
-        frequencyLevel: NotificationService.currentFrequencyLevel())
+        frequencyLevel: NotificationService.currentFrequencyLevel()),
+      idleThresholdOverride: SuggestionPacing.captureIdleThreshold(
+        frequencyLevel: NotificationService.currentFrequencyLevel(),
+        base: captureTrigger.idleThreshold)
     ) {
     case .skip:
       return

--- a/desktop/macos/Desktop/Tests/AssistantCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/AssistantCoordinatorTests.swift
@@ -46,4 +46,59 @@ final class AssistantCoordinatorTests: XCTestCase {
     XCTAssertEqual(queue.inFlight, destinationB)
     XCTAssertEqual(queue.finish(destinationB), nil)
   }
+
+  /// Regression (Aug 13–14 2026): the context-buckets rollout forwarded context switches
+  /// only to the task assistant, silently starving the suggestion and memory assistants —
+  /// focus nudges stopped for everyone in the flag cohort with no error logged anywhere.
+  /// Buckets mode changes who writes bucket exits, never who hears switches.
+  @MainActor
+  func testBucketsModeDispatchesContextSwitchToEveryAssistant() async {
+    let spy = ContextSwitchSpyAssistant(identifier: "context-switch-spy-\(UUID().uuidString)")
+    AssistantCoordinator.shared.register(spy)
+    defer { AssistantCoordinator.shared.unregister(identifier: spy.spyIdentifier) }
+
+    // register() stores the assistant from a MainActor task; yield until it is visible.
+    for _ in 0..<1000 where AssistantCoordinator.shared.assistant(withIdentifier: spy.spyIdentifier) == nil {
+      await Task.yield()
+    }
+    XCTAssertNotNil(AssistantCoordinator.shared.assistant(withIdentifier: spy.spyIdentifier))
+
+    // First call primes the tracked context; the second is a real switch. The dispatch is
+    // awaited inside checkContextSwitch, so by the time it returns the spy has heard it.
+    _ = await AssistantCoordinator.shared.checkContextSwitch(
+      newApp: "SpyBaselineApp", newWindowTitle: "baseline", bucketsEnabled: true)
+    _ = await AssistantCoordinator.shared.checkContextSwitch(
+      newApp: "SpyTargetApp", newWindowTitle: "target", bucketsEnabled: true)
+
+    let apps = await spy.switchedApps()
+    XCTAssertTrue(
+      apps.contains("SpyTargetApp"),
+      "buckets mode must deliver onContextSwitch to every registered assistant, got \(apps)")
+  }
+}
+
+private actor ContextSwitchSpyAssistant: ProactiveAssistant {
+  nonisolated let spyIdentifier: String
+  var identifier: String { spyIdentifier }
+  var displayName: String { "Context Switch Spy" }
+  var isEnabled: Bool { true }
+  var needsFrameDuringDelay: Bool { false }
+
+  private var apps: [String] = []
+
+  init(identifier: String) {
+    self.spyIdentifier = identifier
+  }
+
+  func switchedApps() -> [String] { apps }
+
+  func analyze(frame: CapturedFrame) async -> AssistantResult? { nil }
+  func handleResult(
+    _ result: AssistantResult, sendEvent: @escaping @Sendable (String, [String: Any]) -> Void
+  ) async {}
+  func onContextSwitch(departingFrame: CapturedFrame?, newApp: String, newWindowTitle: String?) async {
+    apps.append(newApp)
+  }
+  func clearPendingWork() async {}
+  func stop() async {}
 }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -85,7 +85,7 @@ final class SuggestionGatePolicyTests: XCTestCase {
   /// Maximum (5) is the "nudge me in seconds" demo mode: 10 s dwell. Everything below —
   /// including Balanced (3) — keeps the deliberate 30 s so ordinary use is unchanged.
   func testDwellIsTenSecondsOnlyAtMaximumLevel() {
-    XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 5), 10)
+    XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 5), 4)
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 4), 30)
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 3), 30)
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 0), 30)
@@ -93,8 +93,8 @@ final class SuggestionGatePolicyTests: XCTestCase {
 
   /// Maximum caps the between-nudge cooldown at 30 s; other levels keep the user's
   /// configured value (180 s default) untouched.
-  func testCooldownCapsAtThirtySecondsOnlyAtMaximumLevel() {
-    XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 5), 30)
+  func testCooldownCapsAtTwentySecondsOnlyAtMaximumLevel() {
+    XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 5), 20)
     XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 20, frequencyLevel: 5), 20)
     XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 4), 180)
     XCTAssertEqual(SuggestionGatePolicy.cooldown(base: 180, frequencyLevel: 3), 180)
@@ -799,5 +799,33 @@ final class SuggestionProbeCaptureRaceTests: XCTestCase {
     XCTAssertTrue(allows(before: nil, after: nil))
     XCTAssertTrue(allows(before: "Google Chrome", after: nil))
     XCTAssertFalse(allows(before: nil, after: "1Password"))
+  }
+}
+
+final class SuggestionPacingTests: XCTestCase {
+  /// Maximum (5) is the demo-grade cadence: nudge within seconds, repeat under half a
+  /// minute. Every other level must keep the long-standing calm defaults untouched.
+  func testMaximumLevelPacesFastEveryOtherLevelStaysCalm() {
+    XCTAssertEqual(SuggestionPacing.requiredDwell(frequencyLevel: 5), 4)
+    XCTAssertEqual(SuggestionPacing.settleInterval(frequencyLevel: 5), 2)
+    XCTAssertEqual(SuggestionPacing.cooldown(base: 180, frequencyLevel: 5), 20)
+    XCTAssertEqual(SuggestionPacing.dailyEvaluationBudget(frequencyLevel: 5), 600)
+    XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.85, frequencyLevel: 5), 0.75)
+    XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: 5), 2)
+
+    for level in [0, 1, 2, 3, 4] {
+      XCTAssertEqual(SuggestionPacing.requiredDwell(frequencyLevel: level), 30)
+      XCTAssertEqual(SuggestionPacing.settleInterval(frequencyLevel: level), 6)
+      XCTAssertEqual(SuggestionPacing.cooldown(base: 180, frequencyLevel: level), 180)
+      XCTAssertEqual(SuggestionPacing.dailyEvaluationBudget(frequencyLevel: level), 40)
+      XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.85, frequencyLevel: level), 0.85)
+      XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: level), 10)
+    }
+  }
+
+  /// A user-configured value already below the Maximum cap is respected, not raised.
+  func testMaximumCapsNeverRaiseUserConfiguredValues() {
+    XCTAssertEqual(SuggestionPacing.cooldown(base: 10, frequencyLevel: 5), 10)
+    XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.6, frequencyLevel: 5), 0.6)
   }
 }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -82,9 +82,9 @@ final class SuggestionGatePolicyTests: XCTestCase {
     XCTAssertEqual(decision, .skippedExcludedApp)
   }
 
-  /// Maximum (5) is the "nudge me in seconds" demo mode: 10 s dwell. Everything below —
+  /// Maximum (5) is the "nudge me in seconds" demo mode: 4 s dwell. Everything below —
   /// including Balanced (3) — keeps the deliberate 30 s so ordinary use is unchanged.
-  func testDwellIsTenSecondsOnlyAtMaximumLevel() {
+  func testDwellIsFourSecondsOnlyAtMaximumLevel() {
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 5), 4)
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 4), 30)
     XCTAssertEqual(SuggestionGatePolicy.requiredDwell(frequencyLevel: 3), 30)

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -828,4 +828,13 @@ final class SuggestionPacingTests: XCTestCase {
     XCTAssertEqual(SuggestionPacing.cooldown(base: 10, frequencyLevel: 5), 10)
     XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.6, frequencyLevel: 5), 0.6)
   }
+
+  /// Passive watching produces no input; Maximum keeps capture alive for five minutes of
+  /// stillness while calmer levels keep the long-standing 60s gate.
+  func testMaximumExtendsCaptureIdleWindowOnly() {
+    XCTAssertEqual(SuggestionPacing.captureIdleThreshold(frequencyLevel: 5, base: 60), 300)
+    for level in [0, 1, 2, 3, 4] {
+      XCTAssertEqual(SuggestionPacing.captureIdleThreshold(frequencyLevel: level, base: 60), 60)
+    }
+  }
 }

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -838,6 +838,14 @@ final class SuggestionPacingTests: XCTestCase {
     }
   }
 
+  /// Maximum forces a real frame every base heartbeat; calm levels keep the preview path.
+  func testOnlyMaximumForcesHeartbeatCapture() {
+    XCTAssertTrue(SuggestionPacing.forcesHeartbeatCapture(frequencyLevel: 5))
+    for level in [0, 1, 2, 3, 4] {
+      XCTAssertFalse(SuggestionPacing.forcesHeartbeatCapture(frequencyLevel: level))
+    }
+  }
+
   /// Passive watching produces no input; Maximum keeps capture alive for five minutes of
   /// stillness while calmer levels keep the long-standing 60s gate.
   func testMaximumExtendsCaptureIdleWindowOnly() {

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -846,6 +846,50 @@ final class SuggestionPacingTests: XCTestCase {
     }
   }
 
+  /// Fresh context at Maximum waives leftover cooldown; same-context repeats stay paced,
+  /// and calm levels never waive.
+  func testMaximumWaivesCooldownOnlyForFreshContext() {
+    let last = Date(timeIntervalSince1970: 1_000_000)
+    let freshAnchor = last.addingTimeInterval(5)
+    let staleAnchor = last.addingTimeInterval(-40)
+    XCTAssertNil(
+      SuggestionPacing.effectiveLastEvaluation(
+        lastEvaluationAt: last, anchor: freshAnchor, frequencyLevel: 5))
+    XCTAssertEqual(
+      SuggestionPacing.effectiveLastEvaluation(
+        lastEvaluationAt: last, anchor: staleAnchor, frequencyLevel: 5), last)
+    XCTAssertEqual(
+      SuggestionPacing.effectiveLastEvaluation(
+        lastEvaluationAt: last, anchor: freshAnchor, frequencyLevel: 3), last)
+  }
+
+  /// The trigger's own idle check must honor the level-aware window: at Maximum with
+  /// 120s of stillness a heartbeat capture is still reachable; calm levels skip at 60s.
+  func testMaximumIdleOverrideReachesHeartbeatCaptureAtTwoMinutesStill() {
+    var trigger = ProactiveCaptureTrigger(idleThreshold: 60, heartbeatInterval: 9)
+    let t0 = Date(timeIntervalSince1970: 1_000_000)
+    // Prime the context (first sight of the app is a capture).
+    XCTAssertEqual(
+      trigger.nextDecision(
+        app: "TikTok", windowTitle: "For You", idleSeconds: 0, now: t0,
+        forceHeartbeatCapture: true,
+        idleThresholdOverride: SuggestionPacing.captureIdleThreshold(frequencyLevel: 5, base: 60)),
+      .capture)
+    // Two minutes of stillness later: Maximum still captures on heartbeat…
+    XCTAssertEqual(
+      trigger.nextDecision(
+        app: "TikTok", windowTitle: "For You", idleSeconds: 120, now: t0.addingTimeInterval(10),
+        forceHeartbeatCapture: true,
+        idleThresholdOverride: SuggestionPacing.captureIdleThreshold(frequencyLevel: 5, base: 60)),
+      .capture)
+    // …while a calm level's unchanged 60s threshold skips.
+    XCTAssertEqual(
+      trigger.nextDecision(
+        app: "TikTok", windowTitle: "For You", idleSeconds: 120, now: t0.addingTimeInterval(20),
+        idleThresholdOverride: SuggestionPacing.captureIdleThreshold(frequencyLevel: 3, base: 60)),
+      .skip)
+  }
+
   /// Passive watching produces no input; Maximum keeps capture alive for five minutes of
   /// stillness while calmer levels keep the long-standing 60s gate.
   func testMaximumExtendsCaptureIdleWindowOnly() {

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -810,8 +810,8 @@ final class SuggestionPacingTests: XCTestCase {
     XCTAssertEqual(SuggestionPacing.settleInterval(frequencyLevel: 5), 2)
     XCTAssertEqual(SuggestionPacing.cooldown(base: 180, frequencyLevel: 5), 20)
     XCTAssertEqual(SuggestionPacing.dailyEvaluationBudget(frequencyLevel: 5), 600)
-    XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.85, frequencyLevel: 5), 0.75)
-    XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: 5), 2)
+    XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.85, frequencyLevel: 5), 0.65)
+    XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: 5), 0)
 
     for level in [0, 1, 2, 3, 4] {
       XCTAssertEqual(SuggestionPacing.requiredDwell(frequencyLevel: level), 30)

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -829,6 +829,15 @@ final class SuggestionPacingTests: XCTestCase {
     XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.6, frequencyLevel: 5), 0.6)
   }
 
+  /// Maximum keeps the context armed after an evaluation so staying on one feed keeps
+  /// nudging; calm levels stay one-shot per arrival.
+  func testOnlyMaximumRearmsAfterEvaluation() {
+    XCTAssertTrue(SuggestionPacing.rearmsAfterEvaluation(frequencyLevel: 5))
+    for level in [0, 1, 2, 3, 4] {
+      XCTAssertFalse(SuggestionPacing.rearmsAfterEvaluation(frequencyLevel: level))
+    }
+  }
+
   /// Passive watching produces no input; Maximum keeps capture alive for five minutes of
   /// stillness while calmer levels keep the long-standing 60s gate.
   func testMaximumExtendsCaptureIdleWindowOnly() {

--- a/desktop/macos/changelog/unreleased/20260814-buckets-context-switch-starvation.json
+++ b/desktop/macos/changelog/unreleased/20260814-buckets-context-switch-starvation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed focus suggestions going silent when the context-buckets rollout was enabled: every assistant hears context switches again, not just the task assistant"
+}

--- a/desktop/macos/changelog/unreleased/20260814-maximum-focus-pacing.json
+++ b/desktop/macos/changelog/unreleased/20260814-maximum-focus-pacing.json
@@ -1,0 +1,3 @@
+{
+  "change": "Maximum notification level now paces focus nudges for a live demo: first nudge seconds after opening a leisure app and another under half a minute while you stay, without changing any calmer level"
+}


### PR DESCRIPTION
## What

Nik's demo spec for the **Maximum** notification level: open TikTok/X → focus nudge in **<10 seconds**; keep the feed open → another nudge **under every half minute**, indefinitely. This PR makes level 5 deliver that, verified with 10 consecutive live trials on a real TikTok feed, while every calmer level stays byte-identical (test-pinned).

Stacked on the context-buckets starvation fix (supersedes #11554 — same commits included; that PR will be closed on merge).

`SuggestionPacing` is the single surface where Maximum may differ:
- dwell 4s (30s elsewhere), settle 2s (6s), cooldown capped 20s (180s), confidence bar capped 0.65, dedup memory 0 (10 — the user asked to be nagged repeatedly), daily evaluation budget 600 (40)
- context re-arms after an eligible evaluation (calm levels stay one-shot per arrival)
- fresh context waives leftover cooldown (same-context repeats stay paced; anchor-vs-lastEvaluation ordering makes this safe)
- capture: full frame every base heartbeat (no preview-similarity skip/backoff), and the idle window extends to 300s — including inside `ProactiveCaptureTrigger`'s own idle check (reviewer-caught bypass, now with a behavioral test at idleSeconds=120)

Merged #11553's 10s-dwell/30s-cooldown values are superseded by this newer spec; its hide/re-hide and no-snooze-gate behavior is preserved. `SuggestionGatePolicy.requiredDwell/cooldown` now delegate to `SuggestionPacing`.

## Product invariants

None matched (`scripts/pr-preflight --suggest`).

Failure-Class: none

## Verification

- Pinned-value tests: `SuggestionPacingTests` (Maximum values + every calm level's 30/6/180/0.85/10/40 asserted level-by-level; caps never raise user-configured values; idle-override behavioral test; heartbeat/re-arm/waiver policy tests). Focused suites green; changed #11553 expectations (10s→4s, 30s→20s) cite Nik's explicit spec: "receive a notification almost immediately in <10 seconds… every <30 seconds".
- **Live 10-trial marathon** (omi-ankara from this branch, real signed-in account, real TikTok feed window frontmost, Maximum): first delivery per trial = 1.1, 7.2, 7.2, 2.1, 2.0, 1.0, 3.2, 7.3, 6.1, 1.1 s — **10/10 under 10s**. Inter-delivery gaps while the feed stayed open: 27/28 under 30s (5–26s), one 49s gap from a single below-bar evaluation. Up to 4 deliveries per 65s hold.
- `.cross-review-verify.png`: live floating-bar nudge card ("Suggested by Omi …") captured seconds after delivery on this build.
- Earlier iterations' failures that shaped the design are in the commit messages (one-shot context consume, preview-similarity starvation, cooldown carry-over, trigger idle bypass).

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 1761 -> 1773 | 12 lines wiring the level-aware idle threshold and forced-heartbeat flag into the two capture-gate call sites; the policy itself lives in SuggestionPacing (SuggestionModels.swift), splitting these call sites out would separate a gate check from the loop that owns it


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

