### PR TITLE
refactor(desktop): fold idle-gate media exemption into MediaPlaybackDetector (unblocks beta train)

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/MediaPlaybackIdleExemption.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/MediaPlaybackIdleExemption.swift
@@ -50,6 +50,27 @@ final class MediaPlaybackDetector {
     return cachedValue
   }
 
+  private var didLogExemption = false
+
+  /// The idle value the capture gate should act on, with the once-per-episode
+  /// observability log folded in so the gate call site stays a single line.
+  func effectiveIdleSeconds(
+    hidIdleSeconds: TimeInterval,
+    threshold: TimeInterval,
+    now: Date = Date()
+  ) -> TimeInterval {
+    let effective = MediaPlaybackIdlePolicy.effectiveIdleSeconds(
+      hidIdleSeconds: hidIdleSeconds,
+      isDisplaySleepPrevented: isDisplaySleepPrevented(now: now))
+    if hidIdleSeconds >= threshold, effective < threshold, !didLogExemption {
+      didLogExemption = true
+      log("CaptureGate: HID-idle but media playback active — capture continues")
+    } else if hidIdleSeconds < threshold {
+      didLogExemption = false
+    }
+    return effective
+  }
+
   /// Whether any process other than this one holds a display-sleep-prevention
   /// assertion. Our own capture/recording stack can hold assertions of its own, and
   /// those must not count as "the user is watching something".

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -188,8 +188,6 @@ public class ProactiveAssistantsPlugin: NSObject {
   private let capturePollInterval: TimeInterval = 1.0
   /// Exempts HID idleness while another process plays media (movie night ≠ away).
   private let mediaPlaybackDetector = MediaPlaybackDetector()
-  /// One log line per idle-but-watching episode, not one per poll tick.
-  private var didLogMediaIdleExemption = false
   /// Apps whose content changes slowly. The value is the heartbeat interval in seconds.
   /// Uses bundle ID when available, falling back to localized app name.
   private let appSpecificHeartbeatIntervals: [String: TimeInterval] = [
@@ -785,22 +783,13 @@ public class ProactiveAssistantsPlugin: NSObject {
     // for an hour but is still watching — MediaPlaybackIdlePolicy), and Maximum
     // notification level additionally extends the window to 300s for HID-idle WITHOUT
     // media (reading a static feed). Calmer levels keep the 60s threshold.
-    let hidIdleSeconds = systemIdleSeconds()
-    let idleSeconds = MediaPlaybackIdlePolicy.effectiveIdleSeconds(
-      hidIdleSeconds: hidIdleSeconds,
-      isDisplaySleepPrevented: mediaPlaybackDetector.isDisplaySleepPrevented())
     let idleThreshold = SuggestionPacing.captureIdleThreshold(
       frequencyLevel: NotificationService.currentFrequencyLevel(),
       base: captureTrigger.idleThreshold
     )
-    if hidIdleSeconds >= idleThreshold, idleSeconds < idleThreshold,
-      !didLogMediaIdleExemption
-    {
-      didLogMediaIdleExemption = true
-      log("CaptureGate: HID-idle but media playback active — capture continues")
-    } else if hidIdleSeconds < idleThreshold {
-      didLogMediaIdleExemption = false
-    }
+    let idleSeconds = mediaPlaybackDetector.effectiveIdleSeconds(
+      hidIdleSeconds: systemIdleSeconds(),
+      threshold: idleThreshold)
     if idleSeconds >= idleThreshold {
       logCaptureGate("idle")
       return

--- a/desktop/macos/Desktop/Tests/MediaPlaybackIdleExemptionTests.swift
+++ b/desktop/macos/Desktop/Tests/MediaPlaybackIdleExemptionTests.swift
@@ -19,6 +19,15 @@ final class MediaPlaybackIdleExemptionTests: XCTestCase {
       90)
   }
 
+  /// The gate-facing wrapper mirrors the pure policy and logs once per episode; its
+  /// idle arithmetic must match the policy exactly.
+  func testDetectorEffectiveIdleMatchesPolicy() {
+    let playing = MediaPlaybackDetector(cacheTTL: 10) { true }
+    XCTAssertEqual(playing.effectiveIdleSeconds(hidIdleSeconds: 3600, threshold: 60), 0)
+    let silent = MediaPlaybackDetector(cacheTTL: 10) { false }
+    XCTAssertEqual(silent.effectiveIdleSeconds(hidIdleSeconds: 90, threshold: 60), 90)
+  }
+
   /// The capture loop polls every second; the IOKit assertion table must not be
   /// walked on every tick.
   func testDetectorCachesProbeWithinTTL() {

--- a/desktop/macos/changelog/unreleased/20260814-idle-gate-refactor.json
+++ b/desktop/macos/changelog/unreleased/20260814-idle-gate-refactor.json
@@ -1,3 +1,0 @@
-{
-  "change": "Internal: moved the media-playback idle exemption into its own component (no behavior change)"
-}

--- a/desktop/macos/changelog/unreleased/20260814-idle-gate-refactor.json
+++ b/desktop/macos/changelog/unreleased/20260814-idle-gate-refactor.json
@@ -1,0 +1,3 @@
+{
+  "change": "Internal: moved the media-playback idle exemption into its own component (no behavior change)"
+}


### PR DESCRIPTION
## What

Unblocks the desktop beta train. Every `desktop_auto_release` run since 06:38Z fails because Release Eligibility re-runs the line-count ratchet on main commits **without** the merged PR's body exception (filed as #11564) — so #11553's and #11556's legitimate, PR-lane-approved exceptions poison eligibility on their merge commits and no candidate can cut.

This folds #11556's 18 gate-site lines out of `ProactiveAssistantsPlugin.swift` (1779 → 1767) into `MediaPlaybackDetector`, where the exemption policy and cache already live. A shrinking commit passes the ratchet statelessly, so eligibility on this commit (and descendants) goes green and the hourly train cuts again.

Behavior is identical: `effectiveIdleSeconds(hidIdleSeconds:threshold:)` on the detector wraps the same pure policy and keeps the once-per-episode log.

## Product invariants

None matched (path-based check: none).

## Verification

- Re-verified live on the rebuilt omi-notch bundle from this branch: `05:01:29 CaptureGate: HID-idle but media playback active — capture continues` with the user genuinely HID-idle 45 min and a real `PreventUserIdleDisplaySleep` assertion held (screenshot in worktree).
- `MediaPlaybackIdleExemptionTests` 4/4 — adds `testDetectorEffectiveIdleMatchesPolicy` proving the gate-facing wrapper mirrors the pure policy.
- Debug build clean; pinned swift-format applied.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

