### PR TITLE
fix(dev-harness): detect prerequisites that are present but unusable

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -283,6 +283,27 @@ def _python_importable(module: str) -> bool:
     )
 
 
+def _java_runtime_present() -> bool:
+    """Report whether a usable JVM exists, not merely whether `java` is on PATH.
+
+    macOS ships a stub at /usr/bin/java that is always present and exits 1 with
+    "Unable to locate a Java Runtime" when no JDK is installed, so a PATH lookup
+    passes on every Mac. Running the binary is the only check that distinguishes
+    the stub from a real runtime.
+    """
+    if not _which("java"):
+        return False
+    try:
+        return (
+            subprocess.run(
+                ["java", "-version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def prerequisite_report(cfg: config.HarnessConfig) -> tuple[list[str], list[str]]:
     missing: list[str] = []
     warnings: list[str] = []
@@ -292,8 +313,11 @@ def prerequisite_report(cfg: config.HarnessConfig) -> tuple[list[str], list[str]
         missing.append(
             "firebase-tools CLI or npx (install with npm install, npm install -g firebase-tools, or use npx)"
         )
-    if not _which("java"):
-        missing.append("java runtime (required by Firestore emulator)")
+    if not _java_runtime_present():
+        missing.append(
+            "java runtime (required by the Firestore and Auth emulators; "
+            "install one with `brew install --cask temurin` or from https://adoptium.net)"
+        )
     if not _which("redis-server"):
         missing.append("redis-server (required for local Redis on loopback)")
     runtime = typesense_runtime()
@@ -586,7 +610,11 @@ def _firebase_command(cfg: config.HarnessConfig) -> list[str]:
     firestore["rules"] = str(cfg.repo_root / "firestore.rules")
     firestore["indexes"] = str(cfg.repo_root / "firestore.indexes.json")
     _write_json(config_path, payload)
-    base = ["firebase"] if _which("firebase") else ["npx", "firebase-tools"]
+    # `--yes` is required: the emulator runs detached with its output redirected to a
+    # log file, so npx's "Need to install the following packages / Ok to proceed? (y)"
+    # prompt has no terminal to answer it and the process blocks there forever. The
+    # health check then fails on a timeout that says nothing about the real cause.
+    base = ["firebase"] if _which("firebase") else ["npx", "--yes", "firebase-tools"]
     return [
         *base,
         "emulators:start",

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -65,6 +65,55 @@ def test_real_check_lists_provider_credentials(monkeypatch: pytest.MonkeyPatch, 
     assert any("DEEPGRAM_API_KEY" in item for item in missing)
 
 
+def test_java_stub_that_exits_nonzero_is_not_a_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """macOS ships /usr/bin/java as a stub that is always on PATH but has no JVM behind it.
+
+    A PATH lookup therefore passes on every Mac, and the missing runtime only surfaces
+    ~135s later as an unexplained firestore/auth health-check timeout.
+    """
+    monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
+    monkeypatch.setattr(cli.subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 1))
+
+    assert cli._java_runtime_present() is False
+
+
+def test_java_present_when_the_binary_reports_a_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "_which", lambda _name: "/usr/bin/java")
+    monkeypatch.setattr(cli.subprocess, "run", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0))
+
+    assert cli._java_runtime_present() is True
+
+
+def test_missing_java_runtime_is_reported_as_a_prerequisite(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_java_runtime_present", lambda: False)
+    cfg = config.load_config(REPO_ROOT)
+
+    missing, _warnings = cli.prerequisite_report(cfg)
+
+    assert any("java runtime" in item for item in missing)
+
+
+def test_npx_firebase_tools_does_not_wait_on_an_install_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without --yes, npx asks "Ok to proceed? (y)" on a pipe nothing can answer.
+
+    The emulator runs detached with stdout redirected to a log file, so the prompt
+    blocks forever and the failure presents as a health-check timeout instead.
+    """
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setattr(cli, "_which", lambda name: None if name == "firebase" else f"/usr/bin/{name}")
+    cfg = config.load_config(REPO_ROOT, create_layout=True)
+
+    command = cli._firebase_command(cfg)
+
+    assert command[:3] == ["npx", "--yes", "firebase-tools"]
+
+
 def test_firebase_command_writes_the_configured_emulator_ports(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
     monkeypatch.setenv("OMI_HARNESS_PORT_OFFSET", "321")


### PR DESCRIPTION
## Problem

Getting the local dev harness up on a clean Mac took about an hour, and both blockers presented as the *same* misleading failure — a 135-second wait ending in:

```
Health checks failed:
  - firestore: not healthy after 45s at http://127.0.0.1:8085/
  - auth: not healthy after 90s at http://127.0.0.1:9099/
```

Neither emulator was the problem. The message names the wrong components, so the natural next step is to go debugging Firestore.

## Two fixes

**1. `npx firebase-tools` blocked forever on an install prompt.** `_firebase_command()` built `["npx", "firebase-tools"]`. On a machine without firebase-tools, npx asks `Need to install the following packages: firebase-tools@15.27.0 / Ok to proceed? (y)` — but the emulator runs detached with stdout redirected to a log file, so nothing can answer and it blocks indefinitely. The entire `firebase-emulators.log` was that prompt, printed twice, with no other output. Fixed by passing `--yes`.

**2. The java preflight passed on every Mac.** The check was `_which("java")`. macOS ships a stub at `/usr/bin/java` that is always present and exits 1 with "Unable to locate a Java Runtime" when no JDK is installed:

```
$ ls -la /usr/bin/java     -> exists, 135376 bytes
$ java -version            -> "Unable to locate a Java Runtime", exit 1
$ shutil.which("java")     -> /usr/bin/java          <- false pass
```

So the preflight always passed on the platform the harness primarily targets, and the missing JVM surfaced 135 seconds later as the health-check timeout above. Replaced with `_java_runtime_present()`, which runs `java -version` and checks the exit code.

## Verification

```
$ bash scripts/dev-harness/run-tests.sh
85 passed, 9 skipped
```

Four new tests cover both fixes: the macOS stub exiting non-zero is not a runtime, a real runtime is, the missing runtime is reported as a prerequisite, and the npx invocation carries `--yes`.

Exercised the real path, not just the tests:

- **Before:** on a Mac with no JDK, `make dev-up` waited 135s and blamed firestore/auth.
- **After:** it names the real blocker in ~2s — `java runtime (required by the Firestore and Auth emulators; install one with 'brew install --cask temurin' ...)`. Installed Temurin, re-ran, and the harness came up.
- The `--yes` path is the one actually taken on this machine (`which firebase` -> not found), and `firebase-emulators.log` went from containing *only* `Ok to proceed? (y)` to showing a started Emulator Hub on port 4400.

## Notes

`--yes` converts the hang into a silent first-run download of `firebase-tools@15.27.0`. That is a deliberate trade — a slow first run beats an infinite hang — but worth stating, since `prerequisite_report` accepts `_which("npx")` without checking firebase-tools is actually installed.

Related contributor-onboarding issues found on the same path: #11533 (`make dev-init` fails in a git worktree) and #11534.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

