### PR TITLE
wip(ios): adopt the UIScene lifecycle so the app can launch on iOS 26+

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -253,6 +253,22 @@ final class QuickActionsIconPatcher: NSObject {
     // Register Phone Calls plugin
     OmiPhoneCallsPlugin.register(with: registry.registrar(forPlugin: "OmiPhoneCallsPlugin")!)
 
+    // applicationWillEnterForeground never fires under the UIScene lifecycle (measured
+    // 0/4 on iPhone 17 Pro / iOS 27.0 across two background->kill cycles) — Apple's
+    // scene-based apps get sceneWillEnterForeground instead. The app-level notification
+    // fires reliably (4/4) and works whether or not multi-scene support is enabled, so
+    // reconnectStalePeripherals() is anchored to that rather than to a scene delegate.
+    // See #11568.
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(handleWillEnterForeground),
+      name: UIApplication.willEnterForegroundNotification,
+      object: nil
+    )
+  }
+
+  @objc private func handleWillEnterForeground() {
+    OmiBleManager.shared.reconnectStalePeripherals()
   }
 
   override func application(
@@ -385,11 +401,6 @@ final class QuickActionsIconPatcher: NSObject {
       }
 
       completionHandler(exportedMappings.isEmpty ? .noData : .newData)
-  }
-
-  override func applicationWillEnterForeground(_ application: UIApplication) {
-    super.applicationWillEnterForeground(application)
-    OmiBleManager.shared.reconnectStalePeripherals()
   }
 
   override func applicationWillTerminate(_ application: UIApplication) {

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -81,7 +81,7 @@ final class QuickActionsIconPatcher: NSObject {
 }
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private static let unusedForegroundTaskRefreshIdentifier = "com.pravera.flutter_foreground_task.refresh"
   private var methodChannel: FlutterMethodChannel?
   private var appleRemindersChannel: FlutterMethodChannel?
@@ -99,12 +99,21 @@ final class QuickActionsIconPatcher: NSObject {
   private var nextExpectedChunkIndex: Int = 0
   private var isRecordingActive: Bool = false // Track recording state to handle app restarts
 
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    QuickActionsIconPatcher.shared.startObserving()
+  // UIScene lifecycle (#11568). Plugins and every application-level channel are
+  // registered here rather than in didFinishLaunching, because under the UIScene
+  // lifecycle the app delegate owns no window at launch — window?.rootViewController
+  // is nil — and registering plugins against the app delegate as the registry is
+  // itself fatal. Both the registry and the binary messenger therefore come from
+  // the implicit engine. Measured on iPhone 17 Pro / iOS 27.0; see #11568.
+  //
+  // Incidental fix: previously a launch carrying a deep link hit an early
+  // `return true` in didFinishLaunching and skipped ALL of this channel setup.
+  // Registration no longer shares a code path with link handling.
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    let registry = engineBridge.pluginRegistry
+    let messenger = engineBridge.applicationRegistrar.messenger()
+
+    GeneratedPluginRegistrant.register(with: registry)
       
       
       if WCSession.isSupported() {
@@ -112,30 +121,26 @@ final class QuickActionsIconPatcher: NSObject {
           session?.delegate = self
           session?.activate();
 
-          let controller = window?.rootViewController as? FlutterViewController
-            flutterWatchAPI = WatchRecorderFlutterAPI(binaryMessenger: controller!.binaryMessenger)
+            flutterWatchAPI = WatchRecorderFlutterAPI(binaryMessenger: messenger)
             let api: WatchRecorderHostAPI = RecorderHostApiImpl(session: session!, flutterWatchAPI: flutterWatchAPI)
 
-            WatchRecorderHostAPISetup.setUp(binaryMessenger: controller!.binaryMessenger, api: api)
+            WatchRecorderHostAPISetup.setUp(binaryMessenger: messenger, api: api)
       }
 
       // Native BLE module — register Pigeon APIs
       NSLog("[OmiBle] Registering BLE Pigeon APIs")
-      let bleController = window?.rootViewController as? FlutterViewController
-      if let messenger = bleController?.binaryMessenger {
+      do {
           let bleFlutterApi = BleFlutterApi(binaryMessenger: messenger)
           OmiBleManager.shared.setFlutterApi(bleFlutterApi)
           let bleHostApi = BleHostApiImpl(bleManager: OmiBleManager.shared)
           BleHostApiSetup.setUp(binaryMessenger: messenger, api: bleHostApi)
           NSLog("[OmiBle] BLE Pigeon APIs registered successfully")
-      } else {
-          NSLog("[OmiBle] ERROR: Could not get FlutterBinaryMessenger")
       }
 
       // Ray-Ban Meta (Meta Wearables DAT camera + Bluetooth HFP mic) — Pigeon APIs.
       // Registered unconditionally; the impl reports availability mode based on
       // whether the DAT SDK is linked into this build.
-      if let messenger = (window?.rootViewController as? FlutterViewController)?.binaryMessenger {
+      do {
           let rayBanFlutterApi = RayBanMetaFlutterAPI(binaryMessenger: messenger)
           let rayBanApi = RayBanMetaHostApiImpl(flutterAPI: rayBanFlutterApi)
           rayBanMetaHostApi = rayBanApi
@@ -145,47 +150,40 @@ final class QuickActionsIconPatcher: NSObject {
       // Native phone-mic capture (conversation recording) — Pigeon APIs.
       // Self-healing AVAudioEngine capture; interruption/route recovery is
       // handled natively, Dart only mirrors the state.
-      if let messenger = (window?.rootViewController as? FlutterViewController)?.binaryMessenger {
+      do {
           let phoneMicFlutterApi = PhoneMicFlutterApi(binaryMessenger: messenger)
           let controller = PhoneMicController(flutterApi: phoneMicFlutterApi)
           phoneMicController = controller
           PhoneMicHostApiSetup.setUp(binaryMessenger: messenger, api: PhoneMicHostApiImpl(controller: controller))
       }
 
-      // Retrieve the link from parameters
-    if let url = AppLinks.shared.getLink(launchOptions: launchOptions) {
-      // We have a link, propagate it to your Flutter app or not
-      AppLinks.shared.handleLink(url: url)
-      return true // Returning true will stop the propagation to other packages
-    }
     //Creates a method channel to handle notifications on kill
-    let controller = window?.rootViewController as? FlutterViewController
-    methodChannel = FlutterMethodChannel(name: "com.friend.ios/notifyOnKill", binaryMessenger: controller!.binaryMessenger)
+    methodChannel = FlutterMethodChannel(name: "com.friend.ios/notifyOnKill", binaryMessenger: messenger)
     methodChannel?.setMethodCallHandler { [weak self] (call, result) in
       self?.handleMethodCall(call, result: result)
     }
     
     // Create Apple Reminders method channel
-    appleRemindersChannel = FlutterMethodChannel(name: "com.omi.apple_reminders", binaryMessenger: controller!.binaryMessenger)
+    appleRemindersChannel = FlutterMethodChannel(name: "com.omi.apple_reminders", binaryMessenger: messenger)
     appleRemindersChannel?.setMethodCallHandler { [weak self] (call, result) in
       self?.handleAppleRemindersCall(call, result: result)
     }
 
     // Create Apple Health method channel
-    appleHealthChannel = FlutterMethodChannel(name: "com.omi.apple_health", binaryMessenger: controller!.binaryMessenger)
+    appleHealthChannel = FlutterMethodChannel(name: "com.omi.apple_health", binaryMessenger: messenger)
     appleHealthChannel?.setMethodCallHandler { [weak self] (call, result) in
       self?.handleAppleHealthCall(call, result: result)
     }
 
     // Create Speech Recognition method channel
-    let speechChannel = FlutterMethodChannel(name: "com.omi.ios/speech", binaryMessenger: controller!.binaryMessenger)
+    let speechChannel = FlutterMethodChannel(name: "com.omi.ios/speech", binaryMessenger: messenger)
     let speechHandler = SpeechRecognitionHandler()
     speechChannel.setMethodCallHandler { (call, result) in
         speechHandler.handle(call, result: result)
     }
 
     // TestFlight environment detection
-    let envChannel = FlutterMethodChannel(name: "com.omi/environment", binaryMessenger: controller!.binaryMessenger)
+    let envChannel = FlutterMethodChannel(name: "com.omi/environment", binaryMessenger: messenger)
     envChannel.setMethodCallHandler { (call, result) in
         if call.method == "isTestFlight" {
             let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
@@ -196,7 +194,7 @@ final class QuickActionsIconPatcher: NSObject {
     }
 
     // Audio session configuration for Bluetooth microphone support
-    let audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: controller!.binaryMessenger)
+    let audioSessionChannel = FlutterMethodChannel(name: "com.omi.ios/audioSession", binaryMessenger: messenger)
     audioSessionChannel.setMethodCallHandler { (call, result) in
         if call.method == "configureForBluetooth" {
             let audioSession = AVAudioSession.sharedInstance()
@@ -217,11 +215,11 @@ final class QuickActionsIconPatcher: NSObject {
     }
 
     // Create WiFi Network plugin for device AP connection
-    _ = WifiNetworkPlugin(messenger: controller!.binaryMessenger)
+    _ = WifiNetworkPlugin(messenger: messenger)
 
     // Battery widget channel — writes Omi device battery to the shared App Group
     // so the WidgetKit extension can read it.
-    let batteryWidgetChannel = FlutterMethodChannel(name: "com.omi.battery_widget", binaryMessenger: controller!.binaryMessenger)
+    let batteryWidgetChannel = FlutterMethodChannel(name: "com.omi.battery_widget", binaryMessenger: messenger)
     batteryWidgetChannel.setMethodCallHandler { (call, result) in
       let defaults = UserDefaults(suiteName: "group.com.friend-app-with-wearable.ios12")
       guard let args = call.arguments as? [String: Any] else {
@@ -253,8 +251,21 @@ final class QuickActionsIconPatcher: NSObject {
     }
 
     // Register Phone Calls plugin
-    OmiPhoneCallsPlugin.register(with: self.registrar(forPlugin: "OmiPhoneCallsPlugin")!)
+    OmiPhoneCallsPlugin.register(with: registry.registrar(forPlugin: "OmiPhoneCallsPlugin")!)
 
+  }
+
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    QuickActionsIconPatcher.shared.startObserving()
+      // Retrieve the link from parameters
+    if let url = AppLinks.shared.getLink(launchOptions: launchOptions) {
+      // We have a link, propagate it to your Flutter app or not
+      AppLinks.shared.handleLink(url: url)
+      return true // Returning true will stop the propagation to other packages
+    }
     // here, Without this code the task will not work.
     SwiftFlutterForegroundTaskPlugin.setPluginRegistrantCallback { registry in
       GeneratedPluginRegistrant.register(with: registry)

--- a/app/ios/Runner/Info-Dev.plist
+++ b/app/ios/Runner/Info-Dev.plist
@@ -176,6 +176,25 @@
 	<string>We use speech recognition to convert your speech to text for processing on your device.</string>
 	<key>PermissionGroupNotification</key>
 	<string>You need to enable notifications to receive your pro-active feedback.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/app/ios/Runner/Info-Dev.plist
+++ b/app/ios/Runner/Info-Dev.plist
@@ -191,6 +191,8 @@
 					<string>flutter</string>
 					<key>UISceneDelegateClassName</key>
 					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/app/ios/Runner/Info-Dev.plist
+++ b/app/ios/Runner/Info-Dev.plist
@@ -213,8 +213,6 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIStatusBarHidden</key>

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -178,6 +178,8 @@
 					<string>flutter</string>
 					<key>UISceneDelegateClassName</key>
 					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -163,6 +163,25 @@
 	<string>We use speech recognition to convert your speech to text for processing on your device.</string>
 	<key>PermissionGroupNotification</key>
 	<string>You need to enable notifications to receive your pro-active feedback.</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -200,8 +200,6 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UIStatusBarHidden</key>


### PR DESCRIPTION
> **Draft, updated.** All 6 commits are now on this branch, including a correction to a false
> premise in commit 1 (see commit 6 and the correction note below). `didInitializeImplicitFlutterEngine`
> — where all the migrated plugin/channel registration lives — is now confirmed to actually fire
> on hardware, which it was not before commit 6. Still draft: the 11 migrated channels, swipe-kill,
> and the foreground BLE-reconnect path are only proven to register/fire, not exercised
> end-to-end. See "What's left."

## Why

Apps built against the iOS 26+ SDK must adopt the UIScene lifecycle. Omi's `app/ios/Runner/Info.plist` had no `UIApplicationSceneManifest`, so UIKit trapped during scene setup **before the Dart VM started** — the app installed and signed fine, showed the launch storyboard, and stayed there permanently with no crash dialog, no UI, and no Dart code executed. Full diagnosis in #11568.

iOS 27 ships publicly in about two months, so this is a deadline rather than a hypothetical.

## Correction — commit 1's premise was wrong, and it hid a real bug for hours

Commit 1 omitted `UISceneStoryboardFile` from the manifest because "this project has no `Main.storyboard`." **That was never true.** `app/ios/Runner/Base.lproj/Main.storyboard` exists, is a completely standard stock `FlutterViewController` scene, and is correctly wired into `Runner.xcodeproj`'s resource build phases for both the prod and dev targets. The false claim traces to running `ls ios/Runner/*.storyboard`, which doesn't recurse into the `.lproj` subdirectory Xcode puts localized storyboards in — an easy, mechanical mistake, and one worth flagging so it isn't repeated: prefer `find ios/Runner -iname '*.storyboard'` when checking whether an Xcode resource exists.

**Consequence:** without `UISceneStoryboardFile`, UIKit never auto-instantiates a root view controller when the scene connects, so no `FlutterViewController` is ever created — and since the implicit Flutter engine is created lazily when that happens, `didInitializeImplicitFlutterEngine` (where commit 3's entire plugin/channel migration lives) **never fired.** The result was a silent blank screen, not a crash.

This went undetected through the "MILESTONE" verification recorded against commits 1-3 (process alive N seconds after launch, no termination error) because that testing used `devicectl device process launch` directly, and **debug-mode Flutter builds refuse to create an engine at all outside Xcode or `flutter run`** (`"Cannot create a FlutterEngine instance in debug mode without Flutter tooling or Xcode... profile and release mode apps can be launched from the home screen"`). So the app never even attempted engine creation under that test — "process alive, no crash" was true, but proved nothing about whether the app was rendering anything. It happened to look identical to success.

Found and fixed by rebuilding `--profile` instead of `--debug` (profile mode *can* launch from a bare `devicectl` launch, unlike debug), which surfaced the real state: blank screen, confirmed via a temporary log probe that `didInitializeImplicitFlutterEngine` was not firing. Restoring `UISceneStoryboardFile = Main` fixed it — the same probe now fires. The app then reaches an unrelated crash (see below), which is itself further proof of forward progress: it wasn't reachable before this fix.

## What this PR does now (6 commits)

1. **`05b3312416`** — adds `UIApplicationSceneManifest` to `Info.plist`. Clears the native launch trap: the Dart VM Service becomes discoverable and `DartWorker`/`AudioSession` threads come up. The app then SIGABRTs, because `window?.rootViewController` is nil under scenes and `AppDelegate.swift` force-unwraps it in nine places. **Its `UISceneStoryboardFile` omission was later found to be wrong — see commit 6.**
2. **`69b1d80958`** — carries the same manifest into the tracked `Info-Dev.plist`, which the dev/raybanDat xcconfigs actually build against. Without this, a plain Xcode dev build used the stale tracked copy and still crashed.
3. **`4e766a7b13`** — the AppDelegate migration itself. `AppDelegate` now conforms to `FlutterImplicitEngineDelegate`; every plugin-registration and `binaryMessenger` consumer (`GeneratedPluginRegistrant`, `OmiPhoneCallsPlugin`, the Watch/BLE/Ray-Ban/phone-mic Pigeon APIs, and all seven method channels plus `WifiNetworkPlugin`) moved into `didInitializeImplicitFlutterEngine(_:)`, sourcing the registry from `engineBridge.pluginRegistry` and the messenger from `engineBridge.applicationRegistrar.messenger()`. No `window?.rootViewController` reference remains and all nine force unwraps are gone. Incidental fix bundled in: a launch carrying a deep link previously hit an early `return true` in `didFinishLaunchingWithOptions` and skipped **all** channel setup — registration no longer shares a code path with link handling.
4. **`2fe5d7e43a`** — `applicationWillEnterForeground` never fires under the UIScene lifecycle (measured 0/4 across two full background→reopen→swipe-kill cycles on iPhone 17 Pro / iOS 27.0), so the `OmiBleManager.shared.reconnectStalePeripherals()` call inside it was silently dead — no crash, no log, BLE peripherals just never reconnect on foreground. Relocated the call to a `NotificationCenter` observer on `UIApplication.willEnterForegroundNotification`, which fired 4/4 in the same measurement, registered in `didInitializeImplicitFlutterEngine` (not in `didFinishLaunchingWithOptions`, for the same deep-link-early-return reason as above). `applicationWillTerminate` was left alone — measured 2/2, already correct, so `notifyOnKill` and `disconnectAllPeripherals()` still work.
5. **`019861ddfc`** — removes the dangling `UIMainStoryboardFile = Main` key from both plists (the old, pre-scene equivalent of `UISceneStoryboardFile` — also dangling because `window?.rootViewController` was populated by `FlutterAppDelegate`'s own code path, not storyboard auto-instantiation, under the old lifecycle).
6. **`239c357`** — restores `UISceneStoryboardFile = Main`, correcting commit 1. See above.

## Verification

Compiling proves nothing here — the whole failure class is runtime, which is why hardware verification is load-bearing for this PR specifically. Two different launch mechanisms were used and they are **not** equally trustworthy:

| Mechanism | What it can prove | What it can't |
|---|---|---|
| `flutter run` (lldb-attached) | Full Dart/engine correctness — this is how the original SIGABRT fix (commits 1-3) was measured (Dart VM Service discovered, `DartWorker`/`AudioSession` threads live, first frame reached) | Currently broken on this machine for an unrelated reason (Xcode/LLDB debug-symbol issue), so unavailable for commits 4-6 |
| Bare `devicectl device process launch`, **debug** build | Process-level survival only | **Nothing about the Flutter engine** — debug builds refuse to create one outside Xcode/Flutter tooling, so "no crash" is not evidence the app is doing anything |
| Bare `devicectl device process launch`, **profile** build | Real engine creation and app logic, since profile builds *can* launch this way | Still not identical to a release build; good enough for this bug class |

Given the middle row, the "alive N seconds, no termination error" evidence recorded for commits 3-5 during today's earlier debug-build testing should be read as **inconclusive, not confirming** — it's consistent with both "works" and "silently never started," and turned out to be the latter until commit 6. The profile-mode test after commit 6 is the first devicectl-based test in this PR that actually proves engine-level behavior:

| | Before commit 6 | After |
|---|---|---|
| `didFinishLaunchingWithOptions` probe | Fires | Fires (unchanged) |
| `didInitializeImplicitFlutterEngine` probe | **Never fires** | **Fires** |
| Screen state | Blank (silently) | Progresses past engine init |
| Outcome | No crash, no UI, no error — looked identical to a working launch under debug-mode devicectl testing | Crashes on an invalid placeholder `GOOGLE_APP_ID` in the dev flavor's local `GoogleService-Info.plist` — an untracked, pre-existing community-build config placeholder, unrelated to this PR |

The `flutter run`-based measurements for commits 1-3 (SIGABRT fix, first frame reached) remain trustworthy — that mechanism doesn't have the debug-mode gap described above.

## Answers to the original open questions

1. **How should the WCSession/Watch bridge obtain a messenger without `window?.rootViewController`?** `engineBridge.applicationRegistrar.messenger()` — confirmed against the Flutter 3.44.9 engine headers and now in commit 3. No `FlutterViewController` is needed anywhere in this file.
2. **Is `UIApplicationSupportsMultipleScenes = false` the intended posture?** Kept off; nothing in this migration required enabling it, and `FlutterSceneLifeCycleEngineRegistration` documents that manual scene/engine registration is only needed when multi-scene is on.
3. **Should the dangling `UIMainStoryboardFile = Main` be removed?** Yes — done in commit 5, but this is now superseded context: that key was the *old* (pre-scene) equivalent of `UISceneStoryboardFile`, and unlike the scene one, it really was safe to drop — `FlutterAppDelegate`'s own pre-scene code populated `window`/`rootViewController` programmatically, so nothing depended on it. The *new* scene-based key needed the opposite treatment — see commit 6.

## What's left before this is ready to merge

Everything below needs physical interaction with a device and has not been done from this side yet. It also needs a real (non-placeholder) Firebase config for the dev flavor to get past the crash described above — out of scope for this PR, tracked separately as a community-build config gap:

- Exercise each of the 11 migrated channels at least once: Watch, BLE, Ray-Ban, phone-mic, reminders, health, speech, environment, audio session, wifi, battery widget. So far they are only proven to *register* without crashing (via `flutter run`, for the reasons above).
- Swipe-to-kill: confirm the `notifyOnKill` notification still arrives and BLE peripherals disconnect.
- Background → foreground: confirm `reconnectStalePeripherals()` actually runs via the new observer (the notification firing was measured with a temporary probe, not through this exact code path, and not via a debug-build devicectl launch for the reasons above).
- Battery widget still updates after a real device reports battery.
- Ideally, re-run the full channel exercise via `flutter run` once the local Xcode/LLDB debug-symbol issue is resolved, since that's the only mechanism proven trustworthy for this bug class.

Failure-Class: none

