### PR TITLE
fix(desktop): unblock the red Swift test lane — 77 failures across 4 suites (#11563)

### DIFF
--- a/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
@@ -70,12 +70,27 @@ package final class InkGlassHitRegionView: NSView {
 
 /// SwiftUI mount for the marker. Attach as a `.background` so it spans exactly the surface that
 /// should own the pointer.
-package struct InkGlassHitRegionReporter: NSViewRepresentable {
+///
+/// Mounted at zero opacity, which is load-bearing rather than decorative. The marker paints nothing
+/// on screen, but `ImageRenderer` cannot rasterise an `NSViewRepresentable` and substitutes an
+/// opaque placeholder for it — so a marker at full opacity reads as *painted content covering its
+/// whole host* to every pixel-truth test of a surface that mounts one, which is a claim about the
+/// app that is not true. At zero opacity the placeholder contributes no pixels while the AppKit view
+/// stays mounted, unhidden and registered — SwiftUI applies the opacity to the host layer, not to the
+/// view's own `alphaValue`, which is what `InkGlassHitRegions.containsPoint` reads.
+/// `InkGlassHitRegionReporterTests` holds both halves.
+package struct InkGlassHitRegionReporter: View {
   package init() {}
 
-  package func makeNSView(context: Context) -> InkGlassHitRegionView {
+  package var body: some View {
+    InkGlassHitRegionMarker().opacity(0)
+  }
+}
+
+private struct InkGlassHitRegionMarker: NSViewRepresentable {
+  func makeNSView(context: Context) -> InkGlassHitRegionView {
     InkGlassHitRegionView(frame: .zero)
   }
 
-  package func updateNSView(_ view: InkGlassHitRegionView, context: Context) {}
+  func updateNSView(_ view: InkGlassHitRegionView, context: Context) {}
 }

--- a/desktop/macos/Desktop/Tests/ChatCitationTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatCitationTests.swift
@@ -291,6 +291,14 @@ final class ChatCitationTests: XCTestCase {
 
   @MainActor
   func testRewindCitationFocusIsOneShotAndPreservesExactScreenshotID() {
+    // The handoff is owner-scoped, and it reads two owner sources that are ambient here:
+    // `auth_userId` is a persistent UserDefaults value that outlives every suite process on a
+    // CI runner, while `RewindDatabase.currentUserId` starts nil in each one. Pin them to the
+    // same owner so this asserts the one-shot contract, not the runner's leftover defaults.
+    let previousUserID = RewindDatabase.currentUserId
+    defer { RewindDatabase.currentUserId = previousUserID }
+    RewindDatabase.currentUserId = RuntimeOwnerIdentity.currentOwnerId()
+
     RewindCitationFocusState.shared.request(42)
     XCTAssertEqual(RewindCitationFocusState.shared.consume(), 42)
     XCTAssertNil(RewindCitationFocusState.shared.consume())

--- a/desktop/macos/Desktop/Tests/InkGlassHitRegionReporterTests.swift
+++ b/desktop/macos/Desktop/Tests/InkGlassHitRegionReporterTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression: `InkGlassHitRegionReporter` is a marker for the pointer, and it has to be *both*
+/// things at once — invisible to anything that measures paint, and live to `InkGlassHitRegions`.
+///
+/// It arrived mounted opaquely (PR #11552, `15a51fb985`) and took the desktop test lane down with
+/// 75 failures across `ShellModalScrimTests` and `GlassSurfaceReviewRegressionTests`: `ImageRenderer`
+/// cannot rasterise an `NSViewRepresentable`, so it drew an opaque placeholder over the marker's
+/// whole host and every "the dim never reaches the window's edge" assertion read the placeholder as
+/// the dim. Neither half of the pair is provable from the other — dropping the reporter would satisfy
+/// the paint half and silently return the shell to passing clicks through its own modals — so both
+/// are held here.
+@MainActor
+final class InkGlassHitRegionReporterTests: XCTestCase {
+
+  /// The marker contributes no pixels to what the app draws.
+  func testTheReporterPaintsNothing() {
+    let size = CGSize(width: 60, height: 60)
+    let renderer = ImageRenderer(
+      content: Color.clear
+        .background(InkGlassHitRegionReporter())
+        .frame(width: size.width, height: size.height))
+    renderer.scale = 1
+
+    guard let image = renderer.cgImage else { return }
+    let width = image.width
+    let height = image.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    guard
+      let context = CGContext(
+        data: &pixels,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+    else { return XCTFail("could not read the rendered marker") }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    let painted = stride(from: 3, to: pixels.count, by: 4).contains { pixels[$0] > 0 }
+    XCTAssertFalse(
+      painted,
+      "the hit-region marker painted into the app's render tree: every surface that mounts one now "
+        + "measures as covering its whole host")
+  }
+
+  /// …and it still owns the pointer, which is the only reason it exists.
+  func testTheReporterStillRegistersItsExtent() {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 200, height: 200),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false)
+    let host = NSHostingView(
+      rootView: Color.clear
+        .background(InkGlassHitRegionReporter())
+        .frame(width: 200, height: 200))
+    host.frame = NSRect(x: 0, y: 0, width: 200, height: 200)
+    window.contentView = host
+    host.layoutSubtreeIfNeeded()
+
+    XCTAssertTrue(
+      InkGlassHitRegions.shared.containsPoint(NSPoint(x: 100, y: 100), in: window),
+      "a surface mounting the marker no longer owns the pointer, so the shell's click-through sync "
+        + "would pass clicks on it straight to the app behind the window")
+  }
+}

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -275,32 +275,48 @@ final class ProactiveLaneClientTests: XCTestCase {
     try await complete(operation: ModelQoS.Proactivity.reasoningOperation, prompt: "reason", on: client)
   }
 
+  /// Two 429s for the same operation, the second carrying a much shorter `Retry-After`, must leave
+  /// the longer deadline standing.
+  ///
+  /// They have to be genuinely **in flight together**: an armed cooldown short-circuits the network
+  /// before the request is built (`testExtractionSkipsNetworkDuringQuotaCooldown…` above), so a
+  /// second window can only ever be observed by a request that was already past the gate when the
+  /// first one armed. Issuing them one after the other never reaches the code this is about — the
+  /// second call returns from the cooldown and no second `Retry-After` is ever parsed. The rendezvous
+  /// holds both inside `complete` until both are past the gate, so the overlap is a fact of the test
+  /// rather than a race it happens to win.
   func testLaterShorterRetryWindowDoesNotShortenActiveCooldown() async throws {
     ProactiveLaneURLStub.reset()
     let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
+    let bothPastTheGate = RequestRendezvous(count: 2)
     let client = ProactiveLaneClient(
       session: makeStubSession(),
       baseURL: { "https://proactive.test" },
-      authorization: { "Bearer test" },
+      authorization: {
+        await bothPastTheGate.arrive()
+        return "Bearer test"
+      },
       now: { clock.now })
 
-    // First 429 arms a long cooldown (300s).
     ProactiveLaneURLStub.enqueue(
       statusCode: 429, body: Data(), headers: ["Retry-After": "300"])
-    do {
-      _ = try await completeExtraction(on: client)
-      XCTFail("expected 429")
-    } catch ProactiveLaneClientError.http(_, _) {}
-
-    // A second overlapping 429 with a much shorter window must not shorten it.
     ProactiveLaneURLStub.enqueue(
       statusCode: 429, body: Data(), headers: ["Retry-After": "60"])
-    do {
-      _ = try await completeExtraction(on: client)
-      XCTFail("expected quota cooldown")
-    } catch ProactiveLaneClientError.quotaCooldown(_) {}
 
-    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 2)
+    async let first = overlappingExtractionOutcome(on: client)
+    async let second = overlappingExtractionOutcome(on: client)
+    for outcome in await [first, second] {
+      guard case ProactiveLaneClientError.http(let status, _)? = outcome else {
+        return XCTFail(
+          "both overlapping requests must reach the server and throw 429, got "
+            + String(describing: outcome))
+      }
+      XCTAssertEqual(status, 429)
+    }
+
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestCount, 2,
+      "both overlapping requests must have reached the server, or the shorter window was never seen")
 
     // Advance 70s — past the short window but inside the long one.
     clock.advance(by: 70)
@@ -342,6 +358,40 @@ final class ProactiveLaneClientTests: XCTestCase {
     configuration.protocolClasses = [ProactiveLaneURLStub.self]
     configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
     return URLSession(configuration: configuration)
+  }
+}
+
+/// One extraction attempt, run outside the test's isolation so a pair of them can overlap in
+/// `async let`. Returns what it threw rather than asserting, so the assertions stay in the test body.
+private func overlappingExtractionOutcome(on client: ProactiveLaneClient) async -> Error? {
+  do {
+    _ = try await client.complete(
+      operation: ModelQoS.Proactivity.extractionOperation,
+      prompt: "extract",
+      jsonSchema: ["type": "object"])
+    return nil
+  } catch {
+    return error
+  }
+}
+
+/// Holds every caller until `count` of them have arrived, then releases them together.
+private actor RequestRendezvous {
+  private let count: Int
+  private var waiting: [CheckedContinuation<Void, Never>] = []
+
+  init(count: Int) {
+    self.count = count
+  }
+
+  func arrive() async {
+    guard waiting.count + 1 < count else {
+      let released = waiting
+      waiting = []
+      for continuation in released { continuation.resume() }
+      return
+    }
+    await withCheckedContinuation { waiting.append($0) }
   }
 }
 


### PR DESCRIPTION
## Bug

`Desktop Swift Static & Test Contracts` has been red on **every** desktop PR since `15a51fb985` (2026-08-14 02:10 EDT), so no desktop change could reach `main` and the release train had no qualification signal. `main` reads green only because the lane is path-filtered: `Detect Desktop Swift Changes` skips the test job on every commit that does not touch `desktop/macos/**`, so the red only appears on desktop PRs. Filed as #11563.

| Suite | Failures |
|---|---|
| `ShellModalScrimTests` | 74 |
| `GlassSurfaceReviewRegressionTests` | 1 |
| `ProactiveLaneClientTests` | 2 |
| `ChatCitationTests` | 1 |

## Root causes

**1. 75 of the 77 — the hit-region marker paints.** `InkGlassHitRegionReporter` mounts a zero-drawing AppKit marker so a transparent window can tell visible content from air. `ImageRenderer` cannot rasterise an `NSViewRepresentable` and substitutes an **opaque placeholder** for it, so every pixel-truth test of a surface that mounts one measured the placeholder covering the marker's whole host: the modal dim read as painting to the window's edge — which on this window is the user's wallpaper — and the glass panel's rounded corner read as filled. Measured directly: `Color.clear.background(InkGlassHitRegionReporter())` rendered at 40×40 came back fully opaque (centre RGBA `255,56,60,255`), where `Color.clear` alone is `0,0,0,0`.

Fix: mount the marker at **zero opacity**. The placeholder contributes no pixels while the AppKit view stays mounted, unhidden and registered — SwiftUI applies opacity to the host layer, not to the view's own `alphaValue`, which is what `InkGlassHitRegions.containsPoint` reads. `InkGlassHitRegionReporterTests` pins **both** halves, because simply dropping the reporter would satisfy the paint half and silently return the shell to passing clicks through its own modals.

**2. The 2 in `ProactiveLaneClientTests`.** `testLaterShorterRetryWindowDoesNotShortenActiveCooldown` (`ff974901b6`) asserted a request count an armed cooldown makes unreachable: the two 429s were issued sequentially, but the cooldown short-circuits the network before the second request is built, so the shorter `Retry-After` was never parsed. The two attempts now overlap on a rendezvous — the only way a second window is ever observed — so the max-deadline preservation the test is named for is actually exercised.

**3. The 1 in `ChatCitationTests` — a fourth failure #11563 did not record.** `testRewindCitationFocusIsOneShotAndPreservesExactScreenshotID` has failed on every CI run of this lane since #11519 landed, and passes locally.

`RewindCaptureOwnerSnapshot` resolves an owner id two different ways: `capture()` prefers the authorization snapshot's owner (from the persistent `auth_userId` default), while `isCurrent()` compares against `RewindDatabase.currentUserId ?? "anonymous"`, which is in-memory and starts nil in a fresh process. `swift-test-suites.sh` runs each suite in its own process, but UserDefaults is on disk and outlives all of them — so on a runner where an earlier suite left `auth_userId` set, the focus request captured owner `"X"` and `consume()` compared it against `"anonymous"` and refused.

Fix: pin the two owner sources together for the duration of the test. The assertion is about the one-shot handoff contract, not owner plumbing.

## What I tested

- **Reproduced the CI failure locally**, which is what previous attempts were missing: setting `auth_userId` in the test process before the unmodified test turns it red with CI's exact message — `XCTAssertEqual failed: ("nil") is not equal to ("Optional(42)")`. With the fix and that default still set: 18/18 green. With it cleared: 18/18 green.
- `xcrun swift test --filter` on all four suites the lane reports, **77 failures → 0**:
  - `ChatCitationTests` 18/18
  - `ShellModalScrimTests` 7/7
  - `GlassSurfaceReviewRegressionTests` 3/3
  - `ProactiveLaneClientTests` 11/11
  - `InkGlassHitRegionReporterTests` 2/2 (new)
- `scripts/pre-push` bounded gate passed.

## Follow-up, deliberately not in this PR

The divergence between the two owner sources in `RewindCaptureOwnerSnapshot` is a real product defect — any snapshot captured before `RewindDatabase.currentUserId` is resolved at launch can never validate, so frames and citation handoffs are silently dropped in that window. Narrowing a fail-closed ownership fence is not a change to make alongside a CI unblock; filed as #11572.

🤖 automated by hourly watchdog — tested and merged

Failure-Class: none
