### PR TITLE
fix(release): keep the desktop planner's source gate inside the App token's 60-minute life

### DIFF
--- a/.github/scripts/plan-desktop-release.py
+++ b/.github/scripts/plan-desktop-release.py
@@ -20,10 +20,16 @@ REQUIRED_SOURCE_CHECK_NAMES = (
     "Desktop Swift Release Compile",
 )
 RECENT_TAG_WITHOUT_CHECK_SECONDS = 10 * 60
-# Desktop Swift CI can consume the full 90-minute job budget. Keep the planner's
-# exact-SHA wait aligned so healthy builds are not timed out while still running. Override
-# via CI_GATE_TIMEOUT_SECONDS or --source-check-wait-seconds.
-SOURCE_CHECK_WAIT_SECONDS = 90 * 60
+# The planner's GH_TOKEN is a GitHub App installation token minted once at job
+# start, and those expire after 60 minutes. Every poll after expiry — including
+# the blocked-path fallback scan — fails with "gh: Bad credentials (401)", which
+# both kills the newest-green fallback and reports a misleading credentials
+# error instead of the real gate state (Aug 14 2026: every hourly run red;
+# issue #11574). So the wait must stay safely inside the token's life; a Swift
+# CI run that needs longer simply defers to the next hourly train tick, which
+# re-evaluates the finished checks instantly.
+TOKEN_SAFE_WAIT_CEILING_SECONDS = 45 * 60
+SOURCE_CHECK_WAIT_SECONDS = TOKEN_SAFE_WAIT_CEILING_SECONDS
 SOURCE_CHECK_POLL_SECONDS = 30
 MAX_SOURCE_STATUS_POLLS = 20
 CI_GATE_TIMEOUT_ENV = "CI_GATE_TIMEOUT_SECONDS"
@@ -279,6 +285,23 @@ def required_source_checks_gate(repository: str, sha: str) -> SourceCheckGate:
     return SourceCheckGate("ready")
 
 
+def clamp_source_check_wait_seconds(value: int) -> int:
+    """Cap any requested wait to the installation-token-safe ceiling.
+
+    Applied to every source of the value (default, env override, CLI flag): the
+    token constraint is a fact about the credential, not about the caller's
+    intent, so no configuration may exceed it.
+    """
+    if value > TOKEN_SAFE_WAIT_CEILING_SECONDS:
+        print(
+            f"Clamping source-check wait from {value}s to {TOKEN_SAFE_WAIT_CEILING_SECONDS}s: "
+            "the GitHub App installation token expires after 60 minutes and every later "
+            "poll (and the newest-green fallback scan) would fail with 401."
+        )
+        return TOKEN_SAFE_WAIT_CEILING_SECONDS
+    return value
+
+
 def default_source_check_wait_seconds() -> int:
     """Resolve the CI gate wait budget from CI_GATE_TIMEOUT_SECONDS or the default."""
     raw = os.environ.get(CI_GATE_TIMEOUT_ENV)
@@ -515,6 +538,7 @@ def main() -> int:
     )
     if source_check_wait_seconds < 0:
         parser.error("--source-check-wait-seconds must be non-negative")
+    source_check_wait_seconds = clamp_source_check_wait_seconds(source_check_wait_seconds)
     if args.source_check_poll_seconds <= 0:
         parser.error("--source-check-poll-seconds must be positive")
     if args.watch_source_sha:

--- a/.github/scripts/test_plan_desktop_release.py
+++ b/.github/scripts/test_plan_desktop_release.py
@@ -354,6 +354,19 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         with patch.dict(os.environ, {planner.CI_GATE_TIMEOUT_ENV: ""}, clear=False):
             self.assertEqual(planner.default_source_check_wait_seconds(), planner.SOURCE_CHECK_WAIT_SECONDS)
 
+    def test_source_check_wait_is_clamped_to_the_installation_token_life(self) -> None:
+        # Aug 14 2026 (issue #11574): the 90-minute gate outlived the 60-minute
+        # Omi Bot installation token, so late polls AND the newest-green
+        # fallback scan all returned "gh: Bad credentials (401)" and every
+        # hourly run went red. No configuration source may exceed the ceiling.
+        self.assertEqual(
+            planner.clamp_source_check_wait_seconds(90 * 60),
+            planner.TOKEN_SAFE_WAIT_CEILING_SECONDS,
+        )
+        self.assertEqual(planner.clamp_source_check_wait_seconds(600), 600)
+        self.assertLessEqual(planner.SOURCE_CHECK_WAIT_SECONDS, planner.TOKEN_SAFE_WAIT_CEILING_SECONDS)
+        self.assertLess(planner.TOKEN_SAFE_WAIT_CEILING_SECONDS, 60 * 60)
+
     def test_extended_wait_admits_observed_late_exact_sha_success(self) -> None:
         # Run 30179919353 timed out at the former 12-minute boundary, then its
         # final exact-SHA aggregate completed successfully 5m40s later. Model
@@ -506,14 +519,14 @@ class DesktopCandidateSourceCheckTests(unittest.TestCase):
         self.assertNotIn("break_glass", workflow)
         self.assertIn("source_sha: ${{ steps.plan.outputs.source_sha }}", workflow)
         self.assertIn("ref: ${{ steps.recheck.outputs.source_sha }}", workflow)
-        self.assertEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 90 * 60)
+        self.assertEqual(planner.SOURCE_CHECK_WAIT_SECONDS, 45 * 60)
         self.assertEqual(workflow.count('--source-check-wait-seconds "${CI_GATE_TIMEOUT_SECONDS}"'), 2)
         self.assertEqual(workflow.count('--source-check-wait-seconds "${requested_timeout}"'), 1)
         self.assertEqual(workflow.count("--source-check-poll-seconds 30"), 3)
         self.assertIn("CI_GATE_TIMEOUT_SECONDS:", workflow)
         self.assertIn("vars.DESKTOP_CI_GATE_TIMEOUT_SECONDS || '5400'", workflow)
         self.assertIn("timeout-minutes: 105", workflow)
-        self.assertIn("if (( requested_timeout > 5400 )); then", workflow)
+        self.assertIn("if (( requested_timeout > 2700 )); then", workflow)
         self.assertIn("Surface planner non-release decision", workflow)
         self.assertIn("::error::Desktop release planner blocked:", workflow)
         self.assertIn("::warning::Desktop release planner skipped tagging:", workflow)

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -47,17 +47,20 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Keep the planner's internal wait below the 105-minute job ceiling,
-          # preserving 15 minutes for checkout/token/planner overhead even when
-          # a repository variable is accidentally configured higher.
+          # Keep the planner's internal wait inside the Omi Bot installation
+          # token's 60-minute life: polls past expiry — including the
+          # newest-green fallback scan — fail with 401 and wedge the train
+          # (issue #11574). The planner clamps too; this keeps the log honest
+          # when a repository variable is configured higher. A Swift CI run
+          # that needs longer defers to the next hourly tick.
           requested_timeout="${CI_GATE_TIMEOUT_SECONDS}"
           if ! [[ "${requested_timeout}" =~ ^[0-9]+$ ]]; then
             echo "Invalid DESKTOP_CI_GATE_TIMEOUT_SECONDS=${requested_timeout}" >&2
             exit 1
           fi
-          if (( requested_timeout > 5400 )); then
-            echo "Clamping source-check wait from ${requested_timeout}s to 5400s for the 105m job ceiling"
-            requested_timeout=5400
+          if (( requested_timeout > 2700 )); then
+            echo "Clamping source-check wait from ${requested_timeout}s to 2700s for the 60m token life"
+            requested_timeout=2700
           fi
           python3 .github/scripts/plan-desktop-release.py \
             --repository "${{ github.repository }}" \


### PR DESCRIPTION
## Problem

Every scheduled desktop auto-release run on Aug 14 2026 went red and no beta candidates were cut. Two stacked causes:

1. Desktop PRs merged during the morning window when the check workflows were disabled carry **no** "Release Eligibility"/"Desktop Swift" check-runs on their merge commits, ever. The planner requires those checks on the newest desktop SHA.
2. The planner's source gate waited up to 90 minutes on a GitHub App installation token minted once at job start — those expire after **60 minutes**. Every poll past expiry failed with `gh: Bad credentials (401)`, which (a) reported a misleading credentials error instead of the real gate state, and (b) **killed the newest-green fallback scan** that exists precisely to route around a blocked newest SHA. The 90-minute waits also overlapped the next hourly tick, getting runs cancelled by concurrency.

## Fix

Clamp the source-gate wait to 45 minutes at every configuration source (planner default, `CI_GATE_TIMEOUT_SECONDS`, CLI flag) via `clamp_source_check_wait_seconds`, and mirror the clamp in the workflow shell so logs stay honest. A Swift CI run that needs longer defers to the next hourly train tick, which re-reads the finished checks instantly.

Release cadence guarantees after this fix (per Nik's ask):
- **Every desktop update ships**: the hourly train picks the newest desktop SHA; if it is blocked, the (now-functional) fallback releases the newest green SHA, and the blocked commits ride in the first green successor.
- **Never more than once per hour**: unchanged — scheduled runs pass `--min-tag-interval-seconds 3300`, keyed to the last candidate's publication time, plus the hourly cron.

Failure-Class: FC-assumed-credential-lifetime

## Verification

- `.github/scripts/test_plan_desktop_release.py`: 26 tests pass, including the new `test_source_check_wait_is_clamped_to_the_installation_token_life` regression test.
- Clamp exercised against the real script: `CI_GATE_TIMEOUT_SECONDS=5400` resolves to 2700 with the explanatory log line.
- Live incident evidence: run 31805589817 (`PLAN_REASON: ... gh: Bad credentials (HTTP 401)` after 5400s). Tracking issue: #11574.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

