### PR TITLE
fix(ios): salvage incidental BLE cleanups from reverted keepalive

### DIFF
--- a/app/ios/Runner/Ble/BleHostApiImpl.swift
+++ b/app/ios/Runner/Ble/BleHostApiImpl.swift
@@ -84,11 +84,11 @@ final class BleHostApiImpl: BleHostApi {
     // ── Diagnostics ──
 
     func startRssiStreaming(uuid: String) throws {
-        bleManager.isRssiStreamingEnabled = true
+        bleManager.setRssiStreamingEnabled(true, uuid: uuid)
     }
 
     func stopRssiStreaming(uuid: String) throws {
-        bleManager.isRssiStreamingEnabled = false
+        bleManager.setRssiStreamingEnabled(false, uuid: uuid)
     }
 
     func getDeviceDiagnostics(uuid: String, completion: @escaping (Result<BleDeviceDiagnostics, Error>) -> Void) {

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -503,7 +503,25 @@ final class OmiBleManager: NSObject {
 
     private static func batteryHistoryKey(_ uuid: String) -> String { "\(batteryHistoryKeyPrefix)\(uuid)" }
 
+    /// The in-memory throttle baseline is lost on process restart; restore it
+    /// from the newest persisted history entry so the first battery
+    /// notification after a relaunch cannot bypass the throttle.
+    private func rehydrateBatteryBaseline(uuid: String) {
+        guard let history = UserDefaults.standard.array(forKey: OmiBleManager.batteryHistoryKey(uuid)) as? [[String: Any]],
+              let last = history.last,
+              let ts = last["ts"] as? Int64,
+              let level = last["level"] as? Int
+        else { return }
+        lastPersistedBatteryLevel[uuid] = level
+        lastPersistedBatteryAtMs[uuid] = ts
+    }
+
     private func shouldPersistBatteryReading(uuid: String, level: Int, nowMs: Int64) -> Bool {
+        // Rehydrate the throttle baseline after a process restart so the first
+        // notification is checked against the last persisted sample.
+        if lastPersistedBatteryLevel[uuid] == nil || lastPersistedBatteryAtMs[uuid] == nil {
+            rehydrateBatteryBaseline(uuid: uuid)
+        }
         guard let previousLevel = lastPersistedBatteryLevel[uuid],
               let lastPersistedAtMs = lastPersistedBatteryAtMs[uuid]
         else {

--- a/app/ios/Runner/Ble/OmiBleManager.swift
+++ b/app/ios/Runner/Ble/OmiBleManager.swift
@@ -31,8 +31,13 @@ final class OmiBleManager: NSObject {
     /// Whether the user explicitly disconnected (suppress auto-reconnect).
     private var manuallyDisconnected: Set<String> = []
 
-    /// RSSI keep-alive timer — periodic reads prevent connection supervision timeout.
+    /// Diagnostics RSSI poll — only while the diagnostics graph is subscribed.
+    /// Not a connection keep-alive; a 3s timer does not prevent `connection_timeout`.
     private var rssiTimer: Timer?
+
+    /// Last battery sample actually written to the plist ring, per peripheral.
+    private var lastPersistedBatteryLevel: [String: Int] = [:]
+    private var lastPersistedBatteryAtMs: [String: Int64] = [:]
 
     /// When true, RSSI reads are forwarded to Flutter for the diagnostics graph.
     var isRssiStreamingEnabled = false
@@ -253,20 +258,30 @@ final class OmiBleManager: NSObject {
         }
     }
 
-    // MARK: - RSSI Keep-Alive
+    // MARK: - RSSI diagnostics polling
 
-    private func startRssiKeepAlive(for peripheral: CBPeripheral) {
-        stopRssiKeepAlive()
+    func setRssiStreamingEnabled(_ enabled: Bool, uuid: String) {
+        isRssiStreamingEnabled = enabled
+        if enabled, let peripheral = peripherals[uuid], peripheral.state == .connected {
+            startRssiPolling(for: peripheral)
+        } else {
+            stopRssiPolling()
+        }
+    }
+
+    private func startRssiPolling(for peripheral: CBPeripheral) {
+        stopRssiPolling()
         rssiTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self, weak peripheral] _ in
             guard let peripheral = peripheral, peripheral.state == .connected else {
-                self?.stopRssiKeepAlive()
+                self?.stopRssiPolling()
                 return
             }
             peripheral.readRSSI()
         }
+        peripheral.readRSSI()
     }
 
-    private func stopRssiKeepAlive() {
+    private func stopRssiPolling() {
         rssiTimer?.invalidate()
         rssiTimer = nil
     }
@@ -307,6 +322,9 @@ final class OmiBleManager: NSObject {
     private static let batteryHistoryKeyPrefix = "battery_history_"
     private static let maxBatteryHistoryEntries = 2000
     private static let batteryHistoryRetentionMs: Int64 = 7 * 24 * 3600 * 1000
+    private static let batteryMinDeltaPercent = 5
+    private static let batteryMinIntervalMs: Int64 = 15 * 60 * 1_000
+    private static let batteryLowThresholdPercent = 20
 
     private static let batteryLevelCharUuid = CBUUID(string: "2A19")
 
@@ -485,16 +503,34 @@ final class OmiBleManager: NSObject {
 
     private static func batteryHistoryKey(_ uuid: String) -> String { "\(batteryHistoryKeyPrefix)\(uuid)" }
 
+    private func shouldPersistBatteryReading(uuid: String, level: Int, nowMs: Int64) -> Bool {
+        guard let previousLevel = lastPersistedBatteryLevel[uuid],
+              let lastPersistedAtMs = lastPersistedBatteryAtMs[uuid]
+        else {
+            return true
+        }
+        let delta = abs(previousLevel - level)
+        let elapsed = nowMs - lastPersistedAtMs
+        let crossedLow =
+            (level < OmiBleManager.batteryLowThresholdPercent && previousLevel >= OmiBleManager.batteryLowThresholdPercent) ||
+            (level >= OmiBleManager.batteryLowThresholdPercent && previousLevel < OmiBleManager.batteryLowThresholdPercent)
+        return delta >= OmiBleManager.batteryMinDeltaPercent || elapsed >= OmiBleManager.batteryMinIntervalMs || crossedLow
+    }
+
     private func persistBatteryReading(uuid: String, level: Int) {
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        guard shouldPersistBatteryReading(uuid: uuid, level: level, nowMs: now) else { return }
+
         let defaults = UserDefaults.standard
         let key = OmiBleManager.batteryHistoryKey(uuid)
         var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
 
-        let now = Int64(Date().timeIntervalSince1970 * 1000)
         let cutoff = now - OmiBleManager.batteryHistoryRetentionMs
         history.removeAll { ($0["ts"] as? Int64 ?? 0) < cutoff }
 
         history.append(["ts": now, "level": level])
+        lastPersistedBatteryLevel[uuid] = level
+        lastPersistedBatteryAtMs[uuid] = now
 
         if history.count > OmiBleManager.maxBatteryHistoryEntries {
             history = Array(history.suffix(OmiBleManager.maxBatteryHistoryEntries))
@@ -520,7 +556,7 @@ final class OmiBleManager: NSObject {
     // MARK: - Audio Batch Helpers
 
     private func cleanupPeripheral(_ peripheralUuid: String) {
-        stopRssiKeepAlive()
+        stopRssiPolling()
         discoveredServices.removeValue(forKey: peripheralUuid)
 
         // Clean up pending completions
@@ -561,6 +597,10 @@ extension OmiBleManager: CBCentralManagerDelegate {
                 let uuid = peripheralUuidString(peripheral)
                 peripheral.delegate = self
                 peripherals[uuid] = peripheral
+                // State-restored peripherals have already connected in a prior
+                // process lifetime; mark them so reconnectStalePeripherals will
+                // re-issue connect instead of treating them as scan strangers.
+                everConnected.insert(uuid)
                 uuids.append(uuid)
 
                 // Re-establish connection if not already connected
@@ -713,7 +753,9 @@ extension OmiBleManager: CBPeripheralDelegate {
             
             flutterApi?.onDeviceReady(peripheralUuid: uuid, services: bleServices) { _ in }
             LimitlessFlashDrainEngine.shared.onDeviceReady(uuid)
-            startRssiKeepAlive(for: peripheral)
+            if isRssiStreamingEnabled {
+                startRssiPolling(for: peripheral)
+            }
         }
     }
 

--- a/app/lib/services/devices/connectors/bee_connection.dart
+++ b/app/lib/services/devices/connectors/bee_connection.dart
@@ -20,7 +20,7 @@ class BeeDeviceConnection extends CustomDeviceConnection {
   String get controlCharacteristicUuid => "05e1f93c-d8d0-5ed8-dd88-379e4c1a3e3e";
 
   @override
-  String get audioCharacteristicUuid => "b189a505-a86c-11ee-a5fb-8f2089a49e7e";
+  String get audioCharacteristicUuid => beeAudioCharacteristicUuid;
 
   @override
   int get unmuteCommandCode => 0xC006;

--- a/app/lib/services/devices/connectors/fieldy_connection.dart
+++ b/app/lib/services/devices/connectors/fieldy_connection.dart
@@ -15,7 +15,7 @@ class FieldyDeviceConnection extends CustomDeviceConnection {
   String get controlCharacteristicUuid => "82a48422-3ca9-4156-ae67-4170f58666e0";
 
   @override
-  String get audioCharacteristicUuid => "82a48422-3ca9-4156-ae67-4170f58666e0";
+  String get audioCharacteristicUuid => fieldyAudioCharacteristicUuid;
 
   @override
   BleAudioCodec get audioCodec => BleAudioCodec.opusFS320;

--- a/app/lib/services/devices/models.dart
+++ b/app/lib/services/devices/models.dart
@@ -49,8 +49,10 @@ const String plaudWriteCharUuid = "00002bb1-0000-1000-8000-00805f9b34fb";
 const String plaudNotifyCharUuid = "00002bb0-0000-1000-8000-00805f9b34fb";
 
 const String beeServiceUuid = "03d5d5c4-a86c-11ee-9d89-8f2089a49e7e";
+const String beeAudioCharacteristicUuid = "b189a505-a86c-11ee-a5fb-8f2089a49e7e";
 
 const String fieldyServiceUuid = "4fafc201-1fb5-459e-8fcc-c5c9c331914b";
+const String fieldyAudioCharacteristicUuid = "82a48422-3ca9-4156-ae67-4170f58666e0";
 
 const String friendPendantServiceUuid = "1a3fd0e7-b1f3-ac9e-2e49-b647b2c4f8da";
 const String friendPendantAudioCharacteristicUuid = "01000000-1111-1111-1111-111111111111";
@@ -58,6 +60,19 @@ const String friendPendantAudioCharacteristicUuid = "01000000-1111-1111-1111-111
 const String limitlessServiceUuid = "632de001-604c-446b-a80f-7963e950f3fb";
 const String limitlessTxCharUuid = "632de002-604c-446b-a80f-7963e950f3fb";
 const String limitlessRxCharUuid = "632de003-604c-446b-a80f-7963e950f3fb";
+
+/// Audio notify characteristics used by NativeBleTransport's post-reconnect
+/// CCCD liveness watch. Lives next to the UUID constants so there is no
+/// comment-synced copy in Swift.
+bool isBleAudioCharacteristicUuid(String characteristicUuid) {
+  final c = characteristicUuid.toLowerCase();
+  return c == audioDataStreamCharacteristicUuid.toLowerCase() ||
+      c == friendPendantAudioCharacteristicUuid.toLowerCase() ||
+      c == limitlessRxCharUuid.toLowerCase() ||
+      c == beeAudioCharacteristicUuid.toLowerCase() ||
+      c == fieldyAudioCharacteristicUuid.toLowerCase() ||
+      c == plaudNotifyCharUuid.toLowerCase();
+}
 
 // OmiGlass OTA Service UUIDs
 const String omiGlassOtaServiceUuid = "19b10010-e8f2-537e-4f6c-d104768a1214";

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -4,8 +4,13 @@ import 'dart:typed_data';
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
 import 'package:omi/services/devices/bluetooth_readiness.dart';
+import 'package:omi/services/devices/models.dart';
 import 'package:omi/utils/logger.dart';
 import 'device_transport.dart';
+
+/// After reconnect, one CCCD re-subscribe is allowed if no audio bytes arrive.
+const _captureAudioLivenessWindow = Duration(seconds: 4);
+const _captureAudioSilenceResubscribeLimit = 1;
 
 /// BLE transport backed by native platform APIs via Pigeon.
 /// Uses the intent-based manageDevice/unmanageDevice API.
@@ -27,6 +32,8 @@ class NativeBleTransport extends DeviceTransport {
   Completer<List<BleService>>? _deviceReadyCompleter;
 
   DeviceTransportState _state = DeviceTransportState.disconnected;
+  Timer? _audioLivenessTimer;
+  int _audioSilenceResubscribes = 0;
 
   NativeBleTransport(this._peripheralUuid, {this.requiresBond = false, BleHostApi? hostApi})
       : _hostApi = hostApi ?? BleHostApi() {
@@ -157,9 +164,9 @@ class NativeBleTransport extends DeviceTransport {
     return _streamControllers[key]!.stream;
   }
 
-  Future<void> _subscribeCharacteristic(String serviceUuid, String characteristicUuid) async {
+  Future<void> _subscribeCharacteristic(String serviceUuid, String characteristicUuid, {bool force = false}) async {
     final key = '${serviceUuid.toLowerCase()}:${characteristicUuid.toLowerCase()}';
-    if (_subscribedSubscriptionKeys.contains(key)) return;
+    if (!force && _subscribedSubscriptionKeys.contains(key)) return;
     _subscribedSubscriptionKeys.add(key);
     try {
       await _hostApi.subscribeCharacteristic(_peripheralUuid, serviceUuid, characteristicUuid);
@@ -210,6 +217,7 @@ class NativeBleTransport extends DeviceTransport {
 
   @override
   Future<void> dispose() async {
+    _audioLivenessTimer?.cancel();
     BleBridge.instance.unregisterPeripheral(_peripheralUuid);
     _activeSubscriptionKeys.clear();
     _subscribedSubscriptionKeys.clear();
@@ -259,6 +267,8 @@ class NativeBleTransport extends DeviceTransport {
       }
 
       _subscribedSubscriptionKeys.clear();
+      _audioLivenessTimer?.cancel();
+      _audioSilenceResubscribes = 0;
       _services = [];
       _updateState(DeviceTransportState.disconnected);
 
@@ -314,6 +324,8 @@ class NativeBleTransport extends DeviceTransport {
       }
 
       _updateState(DeviceTransportState.connected);
+      _audioSilenceResubscribes = 0;
+      _armAudioLivenessWatch();
     } catch (e) {
       Logger.debug('[NativeBleTransport] Failed to re-subscribe after reconnect: $e');
       _updateState(DeviceTransportState.disconnected);
@@ -323,6 +335,42 @@ class NativeBleTransport extends DeviceTransport {
   }
 
   void _handleCharacteristicValue(String serviceUuid, String characteristicUuid, Uint8List value) {
+    if (isBleAudioCharacteristicUuid(characteristicUuid) && value.isNotEmpty) {
+      _audioSilenceResubscribes = 0;
+      _audioLivenessTimer?.cancel();
+    }
     _addToStream(serviceUuid, characteristicUuid, value);
+  }
+
+  bool get _hasAudioSubscription {
+    return _activeSubscriptionKeys.any((key) {
+      final parts = key.split(':');
+      return parts.length == 2 && isBleAudioCharacteristicUuid(parts[1]);
+    });
+  }
+
+  void _armAudioLivenessWatch() {
+    _audioLivenessTimer?.cancel();
+    if (_state != DeviceTransportState.connected || !_hasAudioSubscription) {
+      return;
+    }
+    _audioLivenessTimer = Timer(_captureAudioLivenessWindow, _onAudioLivenessTimeout);
+  }
+
+  void _onAudioLivenessTimeout() {
+    if (_state != DeviceTransportState.connected) return;
+    if (_audioSilenceResubscribes < _captureAudioSilenceResubscribeLimit) {
+      _audioSilenceResubscribes++;
+      Logger.debug('[NativeBleTransport] no audio after reconnect, retrying CCCD subscribe once');
+      for (final key in _activeSubscriptionKeys) {
+        final parts = key.split(':');
+        if (parts.length == 2 && isBleAudioCharacteristicUuid(parts[1]) && _hasCharacteristic(parts[0], parts[1])) {
+          unawaited(_subscribeCharacteristic(parts[0], parts[1], force: true));
+        }
+      }
+      _armAudioLivenessWatch();
+      return;
+    }
+    Logger.debug('[NativeBleTransport] audio path silent after reconnect — GATT connected is not capturing');
   }
 }

--- a/app/lib/services/devices/transports/native_ble_transport.dart
+++ b/app/lib/services/devices/transports/native_ble_transport.dart
@@ -93,6 +93,11 @@ class NativeBleTransport extends DeviceTransport {
   Future<void> disconnect() async {
     if (_state == DeviceTransportState.disconnected && _streamControllers.isEmpty) return;
 
+    // A liveness watch pending from a prior connection must not fire into a
+    // subsequent one and force a spurious CCCD re-subscribe.
+    _audioLivenessTimer?.cancel();
+    _audioSilenceResubscribes = 0;
+
     _updateState(DeviceTransportState.disconnecting);
 
     // Unsubscribe all active streams

--- a/app/test/unit/native_ble_transport_resync_test.dart
+++ b/app/test/unit/native_ble_transport_resync_test.dart
@@ -1,9 +1,11 @@
 import 'dart:typed_data';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:omi/gen/pigeon_communicator.g.dart';
 import 'package:omi/services/bridges/ble_bridge.dart';
+import 'package:omi/services/devices/models.dart';
 import 'package:omi/services/devices/transports/device_transport.dart';
 import 'package:omi/services/devices/transports/native_ble_transport.dart';
 
@@ -58,7 +60,7 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(received, [
-      [1, 2, 3]
+      [1, 2, 3],
     ]);
   });
 
@@ -74,5 +76,85 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(states, [DeviceTransportState.disconnected, DeviceTransportState.connected]);
+  });
+
+  test('isBleAudioCharacteristicUuid covers wearable audio notify chars', () {
+    expect(isBleAudioCharacteristicUuid(audioDataStreamCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(friendPendantAudioCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(limitlessRxCharUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(beeAudioCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(fieldyAudioCharacteristicUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(plaudNotifyCharUuid), isTrue);
+    expect(isBleAudioCharacteristicUuid(batteryLevelCharacteristicUuid), isFalse);
+    expect(isBleAudioCharacteristicUuid(plaudWriteCharUuid), isFalse);
+  });
+
+  test('after reconnect, silent audio CCCD is retried once then left dead', () {
+    fakeAsync((async) {
+      transport.dispose();
+      final hostApi = _FakeBleHostApi();
+      transport = NativeBleTransport(uuid, hostApi: hostApi);
+
+      const audioChar = '19b10001-e8f2-537e-4f6c-d104768a1214';
+      final audioServices = [
+        BleService(uuid: serviceUuid, characteristicUuids: [audioChar]),
+      ];
+
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      transport.getCharacteristicStream(serviceUuid, audioChar).listen((_) {});
+      async.flushMicrotasks();
+
+      BleBridge.instance.onPeripheralDisconnected(uuid, null);
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      async.flushMicrotasks();
+
+      final subscribesBeforeWatch = hostApi.subscribed.where((s) => s.contains(audioChar)).length;
+      expect(subscribesBeforeWatch, greaterThanOrEqualTo(1));
+
+      async.elapse(const Duration(seconds: 4));
+      async.flushMicrotasks();
+      final afterFirstSilence = hostApi.subscribed.where((s) => s.contains(audioChar)).length;
+      expect(afterFirstSilence, subscribesBeforeWatch + 1, reason: 'one CCCD resubscribe on silence');
+
+      async.elapse(const Duration(seconds: 4));
+      async.flushMicrotasks();
+      expect(
+        hostApi.subscribed.where((s) => s.contains(audioChar)).length,
+        afterFirstSilence,
+        reason: 'do not tight-loop resubscribe after the single retry',
+      );
+    });
+  });
+
+  test('Bee audio UUID silence after reconnect still schedules one CCCD retry', () {
+    fakeAsync((async) {
+      transport.dispose();
+      final hostApi = _FakeBleHostApi();
+      transport = NativeBleTransport(uuid, hostApi: hostApi);
+
+      final audioServices = [
+        BleService(uuid: beeServiceUuid, characteristicUuids: [beeAudioCharacteristicUuid]),
+      ];
+
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      transport.getCharacteristicStream(beeServiceUuid, beeAudioCharacteristicUuid).listen((_) {});
+      async.flushMicrotasks();
+
+      BleBridge.instance.onPeripheralDisconnected(uuid, null);
+      BleBridge.instance.onDeviceReady(uuid, audioServices);
+      async.flushMicrotasks();
+
+      final subscribesBeforeWatch =
+          hostApi.subscribed.where((s) => s.toLowerCase().contains(beeAudioCharacteristicUuid.toLowerCase())).length;
+      expect(subscribesBeforeWatch, greaterThanOrEqualTo(1));
+
+      async.elapse(const Duration(seconds: 4));
+      async.flushMicrotasks();
+      expect(
+        hostApi.subscribed.where((s) => s.toLowerCase().contains(beeAudioCharacteristicUuid.toLowerCase())).length,
+        subscribesBeforeWatch + 1,
+        reason: 'Bee audio UUID must be recognized so CCCD retry arms',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Salvages the independently verifiable pieces [@mdmohsin7](https://github.com/mdmohsin7) named in the #11547 revert (#11567): stop the 3s `readRSSI` keep-alive (poll only while diagnostics is subscribed), mark CoreBluetooth-restored peripherals as `everConnected`, throttle battery-history writes, and one CCCD re-subscribe if audio is silent for 4s after reconnect.
- Audio notify UUIDs (Omi, Friend, Limitless, Bee, Fieldy, Plaud) live next to the constants in `models.dart` for the Dart transport watch. There is no `ble_reconnect_policy.dart` and no comment-synced Swift copy. Android RSSI keep-alive is untouched.
- Not in this PR (intentionally, per #11567): frame-gated `flutter_foreground_task`, 200ms→60s BLE backoff, `configureForBluetooth` deactivate, or removing the 5-minute Geolocator poll.

Related: #11547 (reverted), #11567 (revert), #10573 (draft; RSSI-on-demand overlap inside a much larger DFU/GATT rewrite — not a substitute for this salvage). Related: #5491, #6570. Not a fix for #11307.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

## Test plan
- [x] `cd app && bash test.sh test/unit/native_ble_transport_resync_test.dart test/services/devices/transports/native_ble_transport_test.dart` — 6 passed (silent CCCD retried once then left dead; Bee UUID arms the watch; existing resubscribe tests)
- [ ] Diagnostics screen: RSSI graph still updates; leaving the screen stops the 3s poll
- [ ] Idle connected wearable: no 3s `readRSSI` keep-alive
- [ ] Kill/relaunch with a restored peripheral: `reconnectStalePeripherals` will re-issue connect
- [ ] Battery history: small fluctuations do not write every notification


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

