### PR TITLE
fix(desktop): context buckets reach the whole beta channel and all dev builds

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,36 @@
+## Problem
+
+`ContextBucketsFeature.isEnabled` gated non-production bundles on `OMI_FORCE_CONTEXT_BUCKETS=1`, read from `ProcessInfo.processInfo.environment` at runtime. That only survives a launch that goes through `run.sh`.
+
+Any other launch path drops it — opening the bundle from Finder, or macOS restoring the app after the user grants Screen Recording. `isEnabled` then falls through to the PostHog `context_buckets` flag, which does not resolve true for dev bundles. The result is the worst possible shape: screen capture keeps running normally (`is_monitoring: true`, `capture_gate: flowing`) while the bucket pipeline is off and records nothing.
+
+Observed today on a QA bundle during dogfood, immediately after granting Screen Recording:
+
+```
+has_screen_recording_permission: true
+is_monitoring: true
+capture_gate: flowing
+context_buckets_enabled: false   <-- silently off
+```
+
+Zero `context_visits` rows accumulated. This is indistinguishable from "the feature never fires," and cost real debugging time before the environment was inspected with `ps eww`.
+
+## Change
+
+Non-production bundles no longer consult PostHog and default to **on**. The environment variable is kept as an escape hatch to force the pipeline *off*:
+
+```
+OMI_FORCE_CONTEXT_BUCKETS=0
+```
+
+Dev and QA bundles exist to exercise this pipeline, so "on" is the correct default and the failure mode becomes loud rather than silent.
+
+## Production behavior is unchanged
+
+`AppBuild.isNonProduction` is false for every production-family bundle, so stable and beta still resolve through the PostHog flag and still fail closed when it is unavailable or uninitialized.
+
+## Testing
+
+Not covered by a unit test: `isEnabled` reads the `AppBuild.isNonProduction` global and `PostHogManager.shared`, neither of which has an injection seam today. Adding one would be a wider refactor than this fix warrants. Verified behaviorally instead — a dev bundle relaunched without the variable now reports `context_buckets_enabled: true` and accumulates visits.
+
+Failure-Class: none

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
@@ -5,13 +5,28 @@ enum ContextBucketsFeature {
   private static let localQAOverrideName = "OMI_FORCE_CONTEXT_BUCKETS"
 
   /// PostHog feature flags fail closed while unavailable or uninitialized, so the
-  /// default is exactly today's behavior.
+  /// production default is exactly today's behavior.
+  ///
+  /// Non-production bundles do not consult PostHog at all. They used to require
+  /// `OMI_FORCE_CONTEXT_BUCKETS=1` in the launch environment, but that is read from
+  /// `ProcessInfo` at runtime, so any relaunch that does not go through `run.sh` —
+  /// opening the bundle from Finder, or macOS restoring it after a permission grant —
+  /// silently dropped it. Capture kept running with the bucket pipeline disabled, which
+  /// is indistinguishable from the feature simply never firing. Dev bundles exist to
+  /// exercise this pipeline, so they default to on and the variable now only turns it off.
   @MainActor static var isEnabled: Bool {
-    if AppBuild.isNonProduction,
-      ProcessInfo.processInfo.environment[localQAOverrideName] == "1"
-    {
-      return true
+    if AppBuild.isNonProduction {
+      return ProcessInfo.processInfo.environment[localQAOverrideName] != "0"
     }
+    // The bucket pipeline is a beta-channel surface; stable stays on the fallback
+    // assistants. That split is enforced here, on bundle identity, rather than through
+    // a PostHog release condition on `update_channel`. The channel reaches PostHog as a
+    // super property via `register(...)`, so it rides events but only lands on the person
+    // record when `identify` runs — measured across 14 days of macOS clients, 215 of ~260
+    // beta installs had a null person-side channel and 11 reported `stable`, so
+    // person-property targeting resolved for roughly a sixth of the channel. Bundle
+    // identity is exact and available before any network call.
+    guard AppBuild.isBetaProductionBundle else { return false }
     return PostHogManager.shared.isFeatureEnabled(flagName)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260814-dev-bundles-default-context-buckets.json
+++ b/desktop/macos/changelog/unreleased/20260814-dev-bundles-default-context-buckets.json
@@ -1,0 +1,3 @@
+{
+  "change": "Context-bucket notifications reach the whole beta channel and every development build, instead of depending on analytics targeting that resolved for only part of it"
+}


### PR DESCRIPTION
Two gaps kept the context-bucket pipeline off for users who should have had it.

## 1. Development bundles

`ContextBucketsFeature.isEnabled` gated non-production bundles on `OMI_FORCE_CONTEXT_BUCKETS=1`, read from `ProcessInfo.processInfo.environment` at runtime. That only survives a launch through `run.sh`. Any other path drops it — opening the bundle from Finder, or macOS restoring the app after the user grants Screen Recording — and `isEnabled` then falls through to the PostHog flag, which does not resolve true for dev bundles.

The result is the worst possible shape: capture keeps running normally while the bucket pipeline is off and records nothing. Observed on a QA bundle immediately after granting Screen Recording:

```
has_screen_recording_permission: true
is_monitoring: true
capture_gate: flowing
context_buckets_enabled: false   <-- silently off
```

Zero `context_visits` accumulated. Indistinguishable from "the feature never fires."

Non-production bundles now default to on. The variable is kept as an escape hatch to force the pipeline *off* (`OMI_FORCE_CONTEXT_BUCKETS=0`).

## 2. The beta channel

The beta/stable split was expressed as a PostHog release condition on the person property `update_channel`. That property reaches PostHog through `PostHogSDK.shared.register(...)` — a super property. It rides events, but only lands on the person record when `identify` runs.

Measured across 14 days of macOS clients, grouped by event-side vs person-side channel:

| event `update_channel` | person `update_channel` | users |
| --- | --- | --- |
| beta | (null) | 215 |
| beta | beta | 34 |
| beta | stable | 11 |

Roughly 260 clients were running beta; the person-property condition resolved for about 43 of them. The intended audience was receiving the feature at approximately one sixth coverage, and the shortfall is invisible from the flag UI.

The split now keys on `AppBuild.isBetaProductionBundle` — exact, and available before any network call.

## Effect on stable

Unchanged in practice, and now unconditionally excluded in code rather than by analytics targeting, which matches the flag's stated contract ("stable remains on fallback").

One deliberate consequence: rolling buckets out to stable becomes a code change rather than a flag flip. Given the flag governs user-visible notifications, tying that audience to bundle identity rather than to a property that silently fails open seems the right trade. The `context_buckets` flag remains the remote kill switch for the beta channel.

## Testing

Not covered by a unit test: `isEnabled` reads the `AppBuild` globals and `PostHogManager.shared`, neither of which has an injection seam today, and adding one is a wider refactor than this fix warrants. Verified behaviorally — a dev bundle relaunched without the variable reports `context_buckets_enabled: true` and accumulates visits, buckets, and deliveries.

Failure-Class: none
