### PR TITLE
fix(desktop): hug the summoned shell window to the glass

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -65,7 +65,7 @@ struct ChatFirstShell: View {
       destination
         .id(navigation.route.stableName)
     }
-    // The hidden title bar puts the traffic lights over the content view.
+    // The top bar occupies the hidden title-bar band; the window's top edge is the glass.
     .padding(.top, GlassShell.titlebarClearance)
     .environmentObject(navigation)
     .onAppear {

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1381,7 +1381,7 @@ struct DesktopHomeView: View {
       }
     }
     .onEscapeKey(priority: .navigation) { navigateHomeOnEscapeIfNeeded() }
-    // The hidden title bar puts the traffic lights over the content view.
+    // The top bar occupies the hidden title-bar band; the window's top edge is the glass.
     .padding(.top, GlassShell.titlebarClearance)
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -483,41 +483,25 @@ struct DesktopHomeView: View {
   }
 
   private func enforceMainWindowMinimumSize() {
-    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
     DispatchQueue.main.async {
       // Appearance belongs to `WindowGlass.wear(_:as:)`; stamping one here unpinned the glass.
       for window in NSApp.windows where window.title.lowercased().hasPrefix("omi") {
-        window.contentMinSize = minimumContentSize
-        window.minSize = window.frameRect(forContentRect: NSRect(origin: .zero, size: minimumContentSize)).size
-
-        let currentContentSize = window.contentView?.bounds.size ?? window.contentLayoutRect.size
-        let widthDelta = max(0, minimumContentSize.width - currentContentSize.width)
-        let heightDelta = max(0, minimumContentSize.height - currentContentSize.height)
-        if widthDelta > 0 || heightDelta > 0 {
-          var frame = window.frame
-          frame.size.width += widthDelta
-          frame.size.height += heightDelta
-          frame.origin.y -= heightDelta
-          window.setFrame(frame, display: true, animate: false)
-        }
-
-        // Remove .minSize from hosting view's sizingOptions.
-        // Search contentView itself + all descendants.
+        Self.pinShellWindowSizeLimits(window)
         Self.disableMinSizeComputation(in: window)
       }
     }
   }
 
-  /// Re-pin the window minimum on every live resize. SwiftUI's `.automatic` window
+  /// Re-pin the window min and max on every live resize. SwiftUI's `.automatic` window
   /// resizability periodically recomputes content-size extrema and overwrites the
   /// one-shot pin from `enforceMainWindowMinimumSize()`, after which the window can be
-  /// dragged small enough to hide content. Observing `didResize` and re-pinning keeps
-  /// AppKit clamping the live drag at the minimum. Installed once for the app's lifetime.
+  /// dragged small enough to hide content or wide enough to recreate the invisible
+  /// click border. Observing `didResize` and re-pinning keeps AppKit clamping the live
+  /// drag. Installed once for the app's lifetime.
   private static var minimumSizeGuardInstalled = false
   private func installMinimumSizeGuardIfNeeded() {
     guard !Self.minimumSizeGuardInstalled else { return }
     Self.minimumSizeGuardInstalled = true
-    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
     NotificationCenter.default.addObserver(
       forName: NSWindow.didResizeNotification, object: nil, queue: .main
     ) { notification in
@@ -526,12 +510,48 @@ struct DesktopHomeView: View {
         guard let window = objectBox.value as? NSWindow,
           window.title.lowercased().hasPrefix("omi")
         else { return }
-        let frameMin = window.frameRect(
-          forContentRect: NSRect(origin: .zero, size: minimumContentSize)
-        ).size
-        if window.contentMinSize != minimumContentSize { window.contentMinSize = minimumContentSize }
-        if window.minSize != frameMin { window.minSize = frameMin }
+        Self.pinShellWindowSizeLimits(window, resizeFrame: false)
       }
+    }
+  }
+
+  /// Pins the hugged glass: not smaller than the destinations, not wider than the
+  /// readable lane plus its page margins. Height stays display-limited.
+  private static func pinShellWindowSizeLimits(_ window: NSWindow, resizeFrame: Bool = true) {
+    let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
+    let maximumContentSize = NSSize(
+      width: DesktopWindowLayoutPolicy.maximumContentWidth,
+      height: 10_000)
+    window.contentMinSize = minimumContentSize
+    window.minSize = window.frameRect(forContentRect: NSRect(origin: .zero, size: minimumContentSize)).size
+    window.contentMaxSize = maximumContentSize
+    window.maxSize = window.frameRect(forContentRect: NSRect(origin: .zero, size: maximumContentSize)).size
+
+    guard resizeFrame else { return }
+    let currentContentSize = window.contentView?.bounds.size ?? window.contentLayoutRect.size
+    var frame = window.frame
+    var changed = false
+    let widthDelta = max(0, minimumContentSize.width - currentContentSize.width)
+    let heightDelta = max(0, minimumContentSize.height - currentContentSize.height)
+    if widthDelta > 0 || heightDelta > 0 {
+      frame.size.width += widthDelta
+      frame.size.height += heightDelta
+      frame.origin.y -= heightDelta
+      changed = true
+    }
+    let maxFrameWidth = window.frameRect(
+      forContentRect: NSRect(
+        origin: .zero,
+        size: NSSize(width: maximumContentSize.width, height: currentContentSize.height))
+    ).width
+    if frame.size.width > maxFrameWidth {
+      let extra = frame.size.width - maxFrameWidth
+      frame.origin.x += extra / 2
+      frame.size.width = maxFrameWidth
+      changed = true
+    }
+    if changed {
+      window.setFrame(frame, display: true, animate: false)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -97,7 +97,8 @@ struct DesktopTopBar: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .frame(height: TopNavigationLayoutMetrics.barHeight)
-    .padding(.vertical, OmiSpacing.sm)
+    // Gap below the bar only: padding above it would put the top resize handle on empty air.
+    .padding(.bottom, OmiSpacing.sm)
     // The compact fallback's menu is the one surface here that draws outside the bar. Elevation
     // belongs to the shared top-bar component so every shell and exported preview paints it above the
     // destination sibling rather than relying on each call site to remember (INV-NAV-1).
@@ -170,9 +171,9 @@ enum TopNavigationLayoutMetrics {
   /// `PageGlassLaneLayout.laneWidth` both delegate here, so the bar and whatever is under it cannot
   /// drift apart.
   ///
-  /// The lane **fills the window** minus the resize-rim inset on each side. The 900 pt readable
-  /// cap is a window-max (`DesktopWindowLayoutPolicy.maximumContentWidth`), not an internal inset:
-  /// capping here inside a larger window is what drew the invisible click border around the glass.
+  /// The lane fills the window. The 900 pt readable cap is a window-max
+  /// (`DesktopWindowLayoutPolicy.maximumContentWidth`), not an internal inset: capping here
+  /// inside a larger window is what drew the invisible click border around the glass.
   static func contentLaneWidth(for availableWidth: CGFloat) -> CGFloat {
     max(0, availableWidth - (DesktopWindowLayoutPolicy.windowInset * 2))
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -169,14 +169,12 @@ enum TopNavigationLayoutMetrics {
   /// It is the **source** of that lane rather than a copy of it: `QueryShellLayout.laneWidth` and
   /// `PageGlassLaneLayout.laneWidth` both delegate here, so the bar and whatever is under it cannot
   /// drift apart.
+  ///
+  /// The lane **fills the window** minus one page margin on each side. The 900 pt readable cap is
+  /// a window-max (`DesktopWindowLayoutPolicy.maximumContentWidth`), not an internal inset: capping
+  /// here inside a larger window is what drew the invisible click border around the glass.
   static func contentLaneWidth(for availableWidth: CGFloat) -> CGFloat {
-    max(
-      0,
-      min(
-        ChatComposerLayout.contentLaneMaxWidth,
-        availableWidth - (ChatComposerLayout.pageMargin * 2)
-      )
-    )
+    max(0, availableWidth - (ChatComposerLayout.pageMargin * 2))
   }
 
   /// The bar's own height.

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -170,11 +170,11 @@ enum TopNavigationLayoutMetrics {
   /// `PageGlassLaneLayout.laneWidth` both delegate here, so the bar and whatever is under it cannot
   /// drift apart.
   ///
-  /// The lane **fills the window** minus one page margin on each side. The 900 pt readable cap is
-  /// a window-max (`DesktopWindowLayoutPolicy.maximumContentWidth`), not an internal inset: capping
-  /// here inside a larger window is what drew the invisible click border around the glass.
+  /// The lane **fills the window** minus the resize-rim inset on each side. The 900 pt readable
+  /// cap is a window-max (`DesktopWindowLayoutPolicy.maximumContentWidth`), not an internal inset:
+  /// capping here inside a larger window is what drew the invisible click border around the glass.
   static func contentLaneWidth(for availableWidth: CGFloat) -> CGFloat {
-    max(0, availableWidth - (ChatComposerLayout.pageMargin * 2))
+    max(0, availableWidth - (DesktopWindowLayoutPolicy.windowInset * 2))
   }
 
   /// The bar's own height.

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
@@ -7,4 +7,12 @@ enum DesktopWindowLayoutPolicy {
   static let width: CGFloat = 800
   static let height: CGFloat = 680
   static let minimumContentSize = NSSize(width: width, height: height)
+
+  /// Readable lane plus the page margin on each side, in points — never pixels.
+  ///
+  /// Extra width beyond this is empty wallpaper that still belongs to the window
+  /// (the invisible click border). Height stays display-limited: a taller panel
+  /// is still hugged glass, not a gutter.
+  static let maximumContentWidth =
+    ChatComposerLayout.contentLaneMaxWidth + ChatComposerLayout.pageMargin * 2
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
@@ -8,17 +8,15 @@ enum DesktopWindowLayoutPolicy {
   static let height: CGFloat = 680
   static let minimumContentSize = NSSize(width: width, height: height)
 
-  /// Air between the window frame and the glass, in points — never pixels.
-  ///
-  /// Matches the resize rim so AppKit's edge-resize sits on the visible silhouette,
-  /// not on an outer invisible frame. Chat's own `pageMargin` is interior layout
-  /// and is not this inset.
-  static let windowInset: CGFloat = ShellClickThroughPolicy.resizeRim
+  /// Air between the window frame and the glass. Zero: the visible panel edge *is* the
+  /// window edge, so AppKit's resize rim sits on the glass rather than on an invisible
+  /// gutter. Chat's own `pageMargin` is interior layout and is not this inset.
+  static let windowInset: CGFloat = 0
 
   /// Readable lane plus `windowInset` on each side.
   ///
   /// Extra width beyond this is empty wallpaper that still belongs to the window
-  /// (the invisible click border). Height stays display-limited: a taller panel
+  /// until AppKit clamps the frame. Height stays display-limited: a taller panel
   /// is still hugged glass, not a gutter.
   static let maximumContentWidth =
     ChatComposerLayout.contentLaneMaxWidth + windowInset * 2

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
@@ -8,11 +8,18 @@ enum DesktopWindowLayoutPolicy {
   static let height: CGFloat = 680
   static let minimumContentSize = NSSize(width: width, height: height)
 
-  /// Readable lane plus the page margin on each side, in points — never pixels.
+  /// Air between the window frame and the glass, in points — never pixels.
+  ///
+  /// Matches the resize rim so AppKit's edge-resize sits on the visible silhouette,
+  /// not on an outer invisible frame. Chat's own `pageMargin` is interior layout
+  /// and is not this inset.
+  static let windowInset: CGFloat = ShellClickThroughPolicy.resizeRim
+
+  /// Readable lane plus `windowInset` on each side.
   ///
   /// Extra width beyond this is empty wallpaper that still belongs to the window
   /// (the invisible click border). Height stays display-limited: a taller panel
   /// is still hugged glass, not a gutter.
   static let maximumContentWidth =
-    ChatComposerLayout.contentLaneMaxWidth + ChatComposerLayout.pageMargin * 2
+    ChatComposerLayout.contentLaneMaxWidth + windowInset * 2
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/GlassShellChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/GlassShellChrome.swift
@@ -6,7 +6,7 @@
 //  - `Components/GlassContentChrome.swift` owns what a **page hosted inside the panel** may draw on
 //    it: the card, the row, the chip, the field, the scroll fade. Every one of those is a wash on the
 //    ground rather than a surface of its own.
-//  - **This file owns the shell's own terms** — the clearance the hidden title bar demands — plus the
+//  - **This file owns the shell's own terms** — window-specific clearance, plus the
 //    nav pill / icon button the top bar and the sidebar are built out of. The window itself has no
 //    ground at all: `ShellWindowChrome` makes it transparent and every surface grounds itself, so what
 //    is behind a panel is the user's wallpaper. See that file.
@@ -33,24 +33,10 @@ import SwiftUI
 enum GlassShell {
   /// Vertical clearance the content keeps under a hidden title bar.
   ///
-  /// `.hiddenTitleBar` gives the window `fullSizeContentView`, which lays a real — if transparent —
-  /// title bar *over* the content view. 32 pt is the height AppKit adds to a content rect to make a
-  /// titled window's frame rect, which is exactly that band — a **measurement**, checked against
-  /// `NSWindow.frameRect(forContentRect:styleMask:)` by `ShellGlassChromeTests`, so the guard fails
-  /// rather than the layout if a future macOS changes it.
-  ///
-  /// It used to be the band the traffic lights sat in. `ShellWindowChrome` hides those, and the band
-  /// still has to stay empty for a better reason: **it is the window's drag handle.** A title bar,
-  /// even an invisible one, takes the mouse before the content under it does — so a control drawn up
-  /// there is a control that cannot be clicked, and a bar drawn up there is a window that cannot be
-  /// dragged from the one place every macOS user reaches for first.
-  ///
-  /// It is a *reserved band* and not a leading inset: the top bar centres its lane, so a leading
-  /// inset moves the whole bar off centre and still collides at the minimum window width.
-  ///
-  /// A stored constant rather than the live measurement because `NSWindow.frameRect` is main-actor
-  /// isolated and this is read while laying out — the test does the asking.
-  static let titlebarClearance: CGFloat = 32
+  /// Zero: the top bar is drawn in that band (`fullSizeContentView` + a transparent
+  /// title bar), so the window's top edge is the nav bar's top edge. Drag lives on
+  /// the visible top bar (`ShellWindowDragHandle`).
+  static let titlebarClearance: CGFloat = 0
 
   /// A pill of shell chrome: nothing at rest, a wash under the pointer, the heavier wash when
   /// selected.

--- a/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
@@ -82,9 +82,9 @@ enum PageGlassLaneLayout {
   /// having jumped on navigation.
   static let topGap: CGFloat = OmiSpacing.sm
 
-  /// …and the same margin under it, so the panel reads as a floating object with a bottom edge rather
-  /// than as a sheet that runs out of window.
-  static var bottomGap: CGFloat { topGap }
+  /// Flush with the window's bottom edge so the resize handle sits on the visible panel, not on
+  /// an invisible gutter under it.
+  static let bottomGap: CGFloat = 0
 }
 
 // MARK: - The panel

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -27,7 +27,9 @@ import OmiTheme
 /// Pure policy: which points of the shell window own the pointer.
 enum ShellClickThroughPolicy {
   /// Interactive band kept along the window's frame edge so the chrome-less, resizable window can
-  /// still be resized by grabbing its (invisible) edge. Matches AppKit's effective resize zone.
+  /// still be resized by grabbing its visible silhouette. The glass is inset by this same amount
+  /// (`DesktopWindowLayoutPolicy.windowInset`), so the grab is the panel edge, not an outer
+  /// invisible frame. Matches AppKit's effective resize zone.
   static let resizeRim: CGFloat = 8
 
   static func acceptsMouseHit(

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -1,23 +1,19 @@
 //
 //  ShellClickThrough.swift — the transparent shell window stops swallowing the desktop's clicks.
 //
-//  `ShellWindowChrome` made the main window a transparent rectangle noticeably larger than the
-//  panels floating inside it. The window server routes every click to the window under the cursor
-//  no matter what is drawn there, so all of that air — the reserved title-bar band, the margins
-//  beside the lane, the gaps between panels — was an invisible click sink: clicks aimed at another
-//  app landed on Omi, the other app never activated, and Omi never receded. Same failure class as
-//  the notch panel's dead zone (PR #11372), on the shell window.
+//  `ShellWindowChrome` makes the main window a transparent rectangle the size of the
+//  glass. Leftover air — the rounded-corner triangles, the gaps between stacked panels — would
+//  still be an invisible click sink: the window server routes every click to the window under the
+//  cursor no matter what is drawn there. Same failure class as the notch panel's dead zone
+//  (PR #11372), on the shell window.
 //
 //  Same mechanism, too: a view-level `hitTest` nil cannot make a window click-through, so the
 //  window-level `ignoresMouseEvents` is kept in sync with the pointer — ignored over air,
 //  interactive over content. "Content" is answered by `InkGlassHitRegions`: every glass surface
 //  registers its live extent, and a modal barrier registers the whole host while it is up.
 //
-//  What is deliberately given up: dragging the window from the *invisible* title-bar band above
-//  the top bar. The visible top bar still drags (`ShellWindowDragHandle`), and a band the user
-//  cannot see is exactly where they expect clicks to reach the app behind — that expectation is
-//  the bug report this file exists to fix. Resizing survives via an interactive rim along the
-//  window's frame edge.
+//  Drag lives on the visible top bar (`ShellWindowDragHandle`). Resizing survives via an
+//  interactive rim along the window's frame edge, which is the visible panel edge.
 //
 
 import AppKit
@@ -27,9 +23,8 @@ import OmiTheme
 /// Pure policy: which points of the shell window own the pointer.
 enum ShellClickThroughPolicy {
   /// Interactive band kept along the window's frame edge so the chrome-less, resizable window can
-  /// still be resized by grabbing its visible silhouette. The glass is inset by this same amount
-  /// (`DesktopWindowLayoutPolicy.windowInset`), so the grab is the panel edge, not an outer
-  /// invisible frame. Matches AppKit's effective resize zone.
+  /// still be resized. The glass fills the window (`DesktopWindowLayoutPolicy.windowInset` is 0),
+  /// so this rim *is* the visible panel edge. Matches AppKit's effective resize zone.
   static let resizeRim: CGFloat = 8
 
   static func acceptsMouseHit(

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellModalScrim.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellModalScrim.swift
@@ -58,9 +58,8 @@ import SwiftUI
 /// a fact about where the modal is, not a judgement someone had to make.
 enum ShellModalScrimBounds: Equatable, Sendable, CaseIterable {
   /// Mounted over the whole shell window (`DesktopHomeView`'s overlays), or over any surface that is
-  /// not one of the two below. The window's own extent is invisible, so the dim takes the lane
-  /// instead, starting under the transparent drag band the shell reserves
-  /// (`GlassShell.titlebarClearance`) and ending at the page panel's bottom margin.
+  /// not one of the two below. The lane fills the window, so the dim does too — ending at the page
+  /// panel's bottom margin so it does not paint the air under the stack.
   ///
   /// The default, and deliberately the *conservative* one: an unknown surface is treated as one whose
   /// edges cannot be trusted, which fails towards a dim that is too small rather than one that paints
@@ -130,8 +129,8 @@ enum ShellModalScrimLayout {
   static func topInset(_ bounds: ShellModalScrimBounds) -> CGFloat {
     switch bounds {
     case .wholeShell:
-      // The window's drag band. Painting into it would put a dark strip on the desktop *above* the
-      // top bar, which is the defect drawn a little smaller.
+      // The window is flush with the glass; the top bar is the top edge. Zero here lets the dim
+      // cover the bar. A leftover title-bar band would leave an undimmed strip above it.
       return GlassShell.titlebarClearance
     case .contentArea:
       return PageGlassLaneLayout.topGap
@@ -172,8 +171,8 @@ enum ShellModalScrimLayout {
 
 // MARK: - The dim
 
-/// A modal dim: an invisible barrier at the host's full size, and a painted surface that never
-/// reaches the window's edge.
+/// A modal dim: an invisible barrier at the host's full size, and a painted surface that follows
+/// the glass rather than the leftover air between panels.
 ///
 /// Use it for every modal dim in the shell. A caller that reaches for a bare
 /// `Color.black.opacity(…).ignoresSafeArea()` is drawing a rectangle on the wallpaper.

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -49,24 +49,27 @@ enum ShellSummonPlacement {
   /// The size a shell that has never been placed on this display arrives at.
   ///
   /// Deliberately smaller than the old managed-window default: a surface you summon over your work
-  /// should read as a panel you called up, not as an application you switched to. It stays above
-  /// `DesktopWindowLayoutPolicy.minimumContentSize`, which is the floor the destinations lay out to.
-  static let defaultSize = NSSize(width: 960, height: 700)
+  /// should read as a panel you called up, not as an application you switched to. Width is the
+  /// hugged glass (readable lane + page margins), so a 5K display still gets a panel, not a sheet.
+  /// It stays above `DesktopWindowLayoutPolicy.minimumContentSize`, which is the floor the
+  /// destinations lay out to.
+  static let defaultSize = NSSize(
+    width: DesktopWindowLayoutPolicy.maximumContentWidth, height: 700)
 
   /// Where the shell lands on a given display.
   ///
   /// A remembered frame wins, shrunk and nudged until it fits — a display can get smaller (resolution
   /// change, a scaled mode, a menu bar appearing) and a frame restored past the edge is a shell with
-  /// its query field off-screen. With nothing remembered it is centred, which is where a summoned
-  /// surface belongs the first time you ask for it.
+  /// its query field off-screen. Width is also clamped to the hug max so a frame remembered from the
+  /// pre-hug oversized window cannot restore the invisible border. With nothing remembered it is
+  /// centred, which is where a summoned surface belongs the first time you ask for it.
   static func frame(remembered: NSRect?, visibleFrame: NSRect, defaultSize: NSSize = defaultSize) -> NSRect {
     guard let remembered, remembered.width > 1, remembered.height > 1 else {
       return centered(defaultSize, in: visibleFrame)
     }
-    let size = NSSize(
-      width: min(remembered.width, visibleFrame.width),
-      height: min(remembered.height, visibleFrame.height))
-    return clamped(NSRect(origin: remembered.origin, size: size), into: visibleFrame)
+    return clamped(
+      NSRect(origin: remembered.origin, size: fitted(remembered.size, in: visibleFrame)),
+      into: visibleFrame)
   }
 
   /// The least of a shell a person can actually use: enough visible surface to read the panel and
@@ -108,14 +111,23 @@ enum ShellSummonPlacement {
   }
 
   static func centered(_ size: NSSize, in visibleFrame: NSRect) -> NSRect {
-    let fitted = NSSize(
-      width: min(size.width, visibleFrame.width),
-      height: min(size.height, visibleFrame.height))
+    let fittedSize = fitted(size, in: visibleFrame)
     return NSRect(
-      x: visibleFrame.midX - fitted.width / 2,
-      y: visibleFrame.midY - fitted.height / 2,
-      width: fitted.width,
-      height: fitted.height)
+      x: visibleFrame.midX - fittedSize.width / 2,
+      y: visibleFrame.midY - fittedSize.height / 2,
+      width: fittedSize.width,
+      height: fittedSize.height)
+  }
+
+  /// Points, not pixels: `visibleFrame` is already in points, and Retina scale must not change this.
+  static func fitted(
+    _ size: NSSize,
+    in visibleFrame: NSRect,
+    maxWidth: CGFloat = DesktopWindowLayoutPolicy.maximumContentWidth
+  ) -> NSSize {
+    NSSize(
+      width: min(size.width, visibleFrame.width, maxWidth),
+      height: min(size.height, visibleFrame.height))
   }
 
   private static func clamped(_ rect: NSRect, into visibleFrame: NSRect) -> NSRect {

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
@@ -28,13 +28,14 @@
 //    AppKit from `.closable` / `.miniaturizable`; hiding `standardWindowButton(_:)` hides a view and
 //    changes no behaviour. `dress` re-asserts both bits so a future window-construction change cannot
 //    strand a user in a window with no visible close control *and* no keyboard one.
-//  - **Moving has two handles, deliberately.** `.hiddenTitleBar` keeps a real (transparent) title bar
-//    over the top band, which still drags — that band is why the shell reserves
-//    `GlassShell.titlebarClearance` and draws nothing in it. A simultaneous SwiftUI drag gesture is
-//    confined to the visible top bar. The native `isMovableByWindowBackground` switch cannot do that safely:
-//    AppKit sees a SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background,
-//    and steals its click. A root SwiftUI gesture also competes with every Button, Menu, search field,
-//    and filter in the shell. The top-bar-only simultaneous gesture preserves those child controls.
+//  - **Moving has one handle.** The hidden title bar is occupied by the visible
+//    top bar (`GlassShell.titlebarClearance` is 0), so there is no empty band to
+//    drag from above the glass. The visible top bar still drags (`ShellWindowDragHandle`).
+//    The native `isMovableByWindowBackground` switch cannot do that safely: AppKit sees a
+//    SwiftUI `Button` as its transparent `NSHostingView`, classifies it as background, and
+//    steals its click. A root SwiftUI gesture also competes with every Button, Menu, search
+//    field, and filter in the shell. The top-bar-only simultaneous gesture preserves those
+//    child controls.
 //
 //  ## It is still an ordinary application window
 //
@@ -103,11 +104,9 @@ enum ShellWindowChrome {
   /// panel's edge, so AppKit's window shadow is the correct one and the only one.
   ///
   /// The ground is gone. In **both** presentations the window is now a transparent rectangle
-  /// noticeably larger than the panels floating inside it, which is precisely the case
-  /// `WindowGlass.Kind.summoned` was written for — AppKit's shadow traces empty air. On the first-run
-  /// window it did, and it is the most visible thing on the screen: a large rounded rectangle hanging
-  /// on the wallpaper around a 540 × 640 onboarding card, reading as a second sheet of glass that the
-  /// desktop is supposed to show through untouched.
+  /// the size of the glass (`DesktopWindowLayoutPolicy.windowInset` is 0). AppKit's shadow
+  /// would still trace the rectangular frame, including the squircle's leftover corner
+  /// triangles, so it stays off. The panels draw their own ambient lift.
   ///
   /// A constant rather than a function of the presentation, because that parameter had one job and no
   /// longer has it. `Presentation` is behavioural — level, Spaces, whether the window survives losing

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -137,7 +137,7 @@ struct OMIApp: App {
           log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
         }
     }
-    .windowStyle(.hiddenTitleBar)  // fullSizeContentView: the glass runs under the title bar.
+    .windowStyle(.hiddenTitleBar)  // fullSizeContentView: the top bar occupies the title-bar band.
     .defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)
     .commands {
       CommandGroup(after: .textFormatting) {

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -359,10 +359,11 @@ package enum InkGlass {
 
 /// The broad ambient shadow under a floating panel.
 ///
-/// Not a drop shadow. The floating quality comes almost entirely from a wide, diffuse, low-opacity
-/// shadow — a tight 1 pt one reads as a sticker. It is one value for every panel size for the same
-/// reason the corner is: two floating objects on the same desktop with different shadows read as two
-/// different materials.
+/// Not a drop shadow. The floating quality comes from a soft, low-opacity lift — a 1 pt
+/// contact shadow reads as a sticker, and a 34 pt halo into a hugged window's 8 pt inset
+/// clips into a thick black band. It is one value for every panel size for the same
+/// reason the corner is: two floating objects on the same desktop with different shadows
+/// read as two different materials.
 package struct InkGlassShadow: Equatable, Sendable {
   package var radius: CGFloat
   package var opacity: Float
@@ -377,11 +378,13 @@ package struct InkGlassShadow: Equatable, Sendable {
   /// How much clear margin the panel needs *inside its window* for this shadow to render.
   ///
   /// A borderless window clips at its own bounds, so a panel drawn edge to edge has nowhere to cast
-  /// into. Callers size their window to the panel plus twice this.
-  package var padding: CGFloat { radius + abs(offsetY) + 12 }
+  /// into. Callers size their window to the panel plus twice this. Extra fudge beyond radius+offset
+  /// is what turned a lift into a clipped black band around the hugged shell.
+  package var padding: CGFloat { radius + abs(offsetY) }
 
-  /// The one shadow.
-  package static let ambient = InkGlassShadow(radius: 34, opacity: 0.24, offsetY: -10)
+  /// The one shadow. A lift, not a halo: radius 34 at 0.24 into a hugged window's 8–16 pt
+  /// inset clips into a thick black band around the glass.
+  package static let ambient = InkGlassShadow(radius: 8, opacity: 0.10, offsetY: -2)
 }
 
 // MARK: - The style

--- a/desktop/macos/Desktop/Sources/Theme/WindowGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/WindowGlass.swift
@@ -41,15 +41,10 @@ package enum WindowGlass {
     /// An ordinary titled window whose *inside* is glass (`InkGlassStyle.fullBleed`). The window frame
     /// already owns the corner and the shadow.
     case titled
-    /// A **summoned** surface: the shell. It is the only kind that is both — a titled window (⌘W and
-    /// ⌘M route from the style mask, and the transparent title bar is one of the shell's two drag
-    /// handles) whose inside is *not* one slab of glass but several panels floating with the desktop
-    /// between them.
-    ///
-    /// That combination is why it cannot reuse `.titled`. A titled window's frame *is* the panel's
-    /// edge, so AppKit's shadow is the right one. The shell's frame is a transparent rectangle
-    /// noticeably larger than anything drawn inside it, so AppKit's shadow traces empty air — the
-    /// same defect `.floating` exists to avoid, arriving by a different route.
+    /// A **summoned** surface: the shell. Transparent, with several panels floating over
+    /// the desktop. It still uses a hidden title bar so SwiftUI's scene and `⌘W` / `⌘M`
+    /// keep working; the visible top bar occupies that band (`GlassShell.titlebarClearance`
+    /// is 0) so the top resize handle sits on the glass rather than on empty air above it.
     case summoned
   }
 

--- a/desktop/macos/Desktop/Tests/ChatSurfaceBoundsTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatSurfaceBoundsTests.swift
@@ -149,10 +149,17 @@ final class ChatSurfaceBoundsTests: XCTestCase {
         let composer = restingComposerHeight(mode: mode)
         let body = QueryShellLayout.panelBodyHeight(
           availableHeight: page, composerHeight: composer, mode: mode)
-        XCTAssertEqual(
-          surfaceHeight(bodyHeight: body, composerHeight: composer, mode: mode), page,
-          accuracy: 0.5,
-          "the \(mode) surface leaves part of a \(page) pt page unspent")
+        let surface = surfaceHeight(bodyHeight: body, composerHeight: composer, mode: mode)
+        if body < QueryShellLayout.maximumBodyHeight {
+          XCTAssertEqual(
+            surface, page, accuracy: 0.5,
+            "the \(mode) surface leaves part of a \(page) pt page unspent")
+        } else {
+          XCTAssertEqual(body, QueryShellLayout.maximumBodyHeight)
+          XCTAssertLessThanOrEqual(
+            surface, page,
+            "the \(mode) panel still runs off a \(page) pt page")
+        }
       }
     }
   }
@@ -248,11 +255,11 @@ final class ChatSurfaceBoundsTests: XCTestCase {
       QueryShellLayout.panelChromeHeight(mode: .results, composerHeight: 0))
   }
 
-  /// What Home's `GeometryReader` is actually handed: the window's content height less the traffic
-  /// lights' clearance and the floating top bar above the page.
+  /// What Home's `GeometryReader` is actually handed: the window's content height less the
+  /// floating top bar and the gap beneath it.
   private func pageHeights(windowHeights: [CGFloat]) -> [CGFloat] {
     let chrome =
-      GlassShell.titlebarClearance + TopNavigationLayoutMetrics.barHeight + (OmiSpacing.sm * 2)
+      GlassShell.titlebarClearance + TopNavigationLayoutMetrics.barHeight + OmiSpacing.sm
     return windowHeights.map { $0 - chrome }
   }
 

--- a/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
+++ b/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
@@ -152,10 +152,10 @@ final class PageGlassLaneTests: XCTestCase {
           "at \(size) the panel reaches the \(edge) edge: that is a ground spanning the window, not a "
             + "panel floating on the desktop")
       }
-      // The horizontal margin is the page's own, never smaller — a panel one point inside the frame
+      // The horizontal margin is the window inset, never smaller — a panel one point inside the frame
       // is a full-bleed sheet with a rounding error, not a floating object.
-      XCTAssertGreaterThanOrEqual(leading, ChatComposerLayout.pageMargin - 0.5)
-      XCTAssertGreaterThanOrEqual(trailing, ChatComposerLayout.pageMargin - 0.5)
+      XCTAssertGreaterThanOrEqual(leading, DesktopWindowLayoutPolicy.windowInset - 0.5)
+      XCTAssertGreaterThanOrEqual(trailing, DesktopWindowLayoutPolicy.windowInset - 0.5)
       // …and it is centred, so neither side is the one that got the desktop.
       XCTAssertEqual(leading, trailing, accuracy: 0.5, "the panel drifted off the window's axis")
     }

--- a/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
+++ b/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
@@ -72,11 +72,11 @@ final class PageGlassLaneTests: XCTestCase {
     XCTAssertEqual(PageGlassLaneLayout.cornerRadius, RewindSearchLayout.panelCornerRadius)
   }
 
-  /// The panel opens at the same distance under the top bar as Home's query bar does, and closes the
-  /// same distance above the window's bottom edge.
-  func testThePanelKeepsHomesGapAboveItAndTheSameMarginBelow() {
+  /// The panel opens at the same distance under the top bar as Home's query bar does, and sits on
+  /// the window's bottom edge so resize is on the glass rather than on an invisible gutter.
+  func testThePanelKeepsHomesGapAboveItAndSitsOnTheWindowBottom() {
     XCTAssertEqual(PageGlassLaneLayout.topGap, OmiSpacing.sm)
-    XCTAssertEqual(PageGlassLaneLayout.bottomGap, PageGlassLaneLayout.topGap)
+    XCTAssertEqual(PageGlassLaneLayout.bottomGap, 0)
   }
 
   // MARK: - What the mounted view actually does
@@ -108,17 +108,9 @@ final class PageGlassLaneTests: XCTestCase {
       "one tall panel: the page fills the window and scrolls inside itself")
   }
 
-  /// **The desktop survives on all four sides of the panel, at every window size.**
-  ///
-  /// This is the claim the two cases around it exist to serve, and the one they cannot make. Both
-  /// assert the panel *matches* `laneWidth` and the gaps — which stays true if `contentLaneWidth` is
-  /// ever changed to return the whole window, or if the gaps go to zero. Either change turns the
-  /// lane back into a full-bleed sheet of glass behind the UI, renders identically to the window
-  /// ground `ShellWindowChrome` deleted, and logs nothing.
-  ///
-  /// Measured off a real layout pass rather than recomputed: the recorded frame is in the hosting
-  /// view's own coordinates, so the four margins are the wallpaper the user actually keeps.
-  func testTheLanesGlassNeverReachesAnyEdgeOfTheWindow() {
+  /// The lane fills the window horizontally. Vertical air between the top bar and the page remains
+  /// (`topGap`) so a page is not a full-bleed sheet behind the top bar; the bottom is flush.
+  func testTheLanesGlassFillsTheWindowWidthAndKeepsVerticalGaps() {
     let sizes: [CGSize] = [
       CGSize(width: DesktopWindowLayoutPolicy.width, height: DesktopWindowLayoutPolicy.height),
       CGSize(width: 900, height: 600),
@@ -143,21 +135,14 @@ final class PageGlassLaneTests: XCTestCase {
 
       let leading = placed.minX
       let trailing = size.width - placed.maxX
-      let top = placed.minY
-      let bottom = size.height - placed.maxY
-
-      for (edge, margin) in [("leading", leading), ("trailing", trailing), ("top", top), ("bottom", bottom)] {
-        XCTAssertGreaterThan(
-          margin, 0,
-          "at \(size) the panel reaches the \(edge) edge: that is a ground spanning the window, not a "
-            + "panel floating on the desktop")
-      }
-      // The horizontal margin is the window inset, never smaller — a panel one point inside the frame
-      // is a full-bleed sheet with a rounding error, not a floating object.
-      XCTAssertGreaterThanOrEqual(leading, DesktopWindowLayoutPolicy.windowInset - 0.5)
-      XCTAssertGreaterThanOrEqual(trailing, DesktopWindowLayoutPolicy.windowInset - 0.5)
-      // …and it is centred, so neither side is the one that got the desktop.
-      XCTAssertEqual(leading, trailing, accuracy: 0.5, "the panel drifted off the window's axis")
+      XCTAssertEqual(leading, 0, accuracy: 0.5, "at \(size) the lane must fill the window")
+      XCTAssertEqual(trailing, 0, accuracy: 0.5, "at \(size) the lane must fill the window")
+      XCTAssertGreaterThan(
+        placed.minY, 0,
+        "at \(size) the panel reaches the top edge: that stacks it into the top bar")
+      XCTAssertEqual(
+        size.height - placed.maxY, 0, accuracy: 0.5,
+        "at \(size) the panel must sit on the window's bottom edge")
     }
   }
 
@@ -185,17 +170,17 @@ final class PageGlassLaneTests: XCTestCase {
 
 // MARK: - The modal dim
 
-/// **A modal dim may darken a surface. It may not darken the window.**
+/// **A modal dim may darken a surface. It follows the glass, not leftover air.**
 ///
-/// The same claim as `testTheLanesGlassNeverReachesAnyEdgeOfTheWindow`, one layer up, and it is held
+/// The same claim as `testTheLanesGlassFillsTheWindowWidthAndKeepsVerticalGaps`, one layer up, and it is held
 /// the same way — off a real render at four window sizes rather than off the arithmetic under test.
 /// It is measured on the **pixels** rather than on a placed frame, because the thing that went wrong
 /// is not where a view was laid out: `Color.black.opacity(0.3).ignoresSafeArea()` is a paint, and a
 /// dim that is inset in layout but bleeds in the render is exactly the bug read backwards.
 ///
-/// Both directions are held. A dim that reaches the window's edge fails, and so does a dim that stops
-/// painting altogether — deleting every scrim would trade this visual bug for a usability one, so the
-/// guard has to be able to tell "bounded" from "gone".
+/// Both directions are held. A dim that leaves a gutter of undimmed glass fails, and so does a dim
+/// that stops painting altogether — deleting every scrim would trade this visual bug for a usability
+/// one, so the guard has to be able to tell "bounded" from "gone".
 @MainActor
 final class ShellModalScrimTests: XCTestCase {
 
@@ -206,27 +191,27 @@ final class ShellModalScrimTests: XCTestCase {
     CGSize(width: 3_440, height: 1_440),
   ]
 
-  /// The dim mounted over the whole shell, and the dim mounted in the content area under the top bar,
-  /// both keep desktop on all four sides at every window size.
-  func testTheDimNeverPaintsToAnyEdgeOfTheWindow() throws {
-    for bounds in [ShellModalScrimBounds.wholeShell, .contentArea] {
-      for size in Self.windowSizes {
-        let painted = try XCTUnwrap(
-          PaintedExtent.of(ShellModalScrim().shellModalScrimBounds(bounds), in: size),
-          "\(bounds) at \(size) painted nothing — a modal with no dim does not read as modal")
+  /// The dim fills the glass. Horizontal flush is the product (`windowInset` is 0); the top bar
+  /// occupies the title-bar band, so a whole-shell dim starts at the window's top edge.
+  func testTheDimFillsTheGlass() throws {
+    XCTAssertEqual(ShellModalScrimLayout.topInset(.wholeShell), 0)
+    XCTAssertEqual(ShellModalScrimLayout.bottomInset(.wholeShell), 0)
+    XCTAssertEqual(ShellModalScrimLayout.topInset(.contentArea), PageGlassLaneLayout.topGap)
+    XCTAssertEqual(ShellModalScrimLayout.bottomInset(.contentArea), 0)
 
-        for (edge, margin) in [
-          ("leading", painted.minX),
-          ("trailing", size.width - painted.maxX),
-          ("top", painted.minY),
-          ("bottom", size.height - painted.maxY),
-        ] {
-          XCTAssertGreaterThan(
-            margin, 0,
-            "\(bounds) at \(size) painted to the \(edge) edge: that is a dark rectangle on the "
-              + "user's wallpaper, not a dimmed app")
-        }
-      }
+    for size in Self.windowSizes {
+      let painted = try XCTUnwrap(
+        PaintedExtent.of(ShellModalScrim(), in: size),
+        "at \(size) painted nothing — a modal with no dim does not read as modal")
+
+      XCTAssertEqual(painted.minX, 0, accuracy: 0.5, "at \(size) left an undimmed leading gutter")
+      XCTAssertEqual(
+        size.width - painted.maxX, 0, accuracy: 0.5,
+        "at \(size) left an undimmed trailing gutter")
+      XCTAssertEqual(painted.minY, 0, accuracy: 0.5, "at \(size) left an undimmed band above the top bar")
+      XCTAssertEqual(
+        size.height - painted.maxY, 0, accuracy: 0.5,
+        "at \(size) left an undimmed gutter under the glass")
     }
   }
 
@@ -236,7 +221,7 @@ final class ShellModalScrimTests: XCTestCase {
   /// This is the case that must *not* be lane-clamped a second time: a page riding on
   /// `PageGlassLane` is already the lane, so clamping again would leave an undimmed 24 pt border of
   /// glass and the modal would read as sitting under the page. That the panel itself keeps desktop on
-  /// all four sides is `testTheLanesGlassNeverReachesAnyEdgeOfTheWindow` above; the two compose into
+  /// all four sides is `testTheLanesGlassFillsTheWindowWidthAndKeepsVerticalGaps` above; the two compose into
   /// the window-scale claim, and neither is provable from the other.
   func testAPagesOwnDimFillsThePanelItSitsOnAndNoMore() throws {
     for size in Self.windowSizes {
@@ -300,7 +285,7 @@ final class ShellModalScrimTests: XCTestCase {
       size.height - ShellModalScrimLayout.topInset(.wholeShell)
         - ShellModalScrimLayout.bottomInset(.wholeShell),
       accuracy: 1.5,
-      "the dim does not reach from under the drag band to the panel's bottom margin")
+      "the dim does not reach from the top bar through to the window's bottom edge")
   }
 
   // MARK: - The confirmation that used to be a system alert
@@ -325,17 +310,15 @@ final class ShellModalScrimTests: XCTestCase {
           "\(bounds) at \(size): the confirmation painted nothing into the app. A modal presented by "
             + "the system draws its backdrop on the window instead — which is the desktop here")
 
-        for (edge, margin) in [
-          ("leading", painted.minX),
-          ("trailing", size.width - painted.maxX),
-          ("top", painted.minY),
-          ("bottom", size.height - painted.maxY),
-        ] {
-          XCTAssertGreaterThan(
-            margin, 0,
-            "\(bounds) at \(size): the confirmation painted to the \(edge) edge, which on this "
-              + "window is the user's wallpaper")
-        }
+        XCTAssertEqual(
+          painted.minX, 0, accuracy: 0.5,
+          "\(bounds) at \(size): the confirmation left an undimmed leading gutter")
+        XCTAssertEqual(
+          size.width - painted.maxX, 0, accuracy: 0.5,
+          "\(bounds) at \(size): the confirmation left an undimmed trailing gutter")
+        XCTAssertEqual(
+          size.height - painted.maxY, 0, accuracy: 0.5,
+          "\(bounds) at \(size): the confirmation left an undimmed gutter under the glass")
 
         // …and it is still a modal. A card floating on an undimmed app would keep every margin
         // above and say nothing about the app being unavailable, so the dim's own extent is asserted

--- a/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
@@ -1,3 +1,4 @@
+import OmiTheme
 import XCTest
 
 @testable import Omi_Computer
@@ -43,6 +44,12 @@ final class ShellClickThroughPolicyTests: XCTestCase {
   }
 
   func testResizableWindowKeepsAnInteractiveEdgeRim() {
+    XCTAssertEqual(
+      DesktopWindowLayoutPolicy.windowInset, ShellClickThroughPolicy.resizeRim,
+      "the glass must sit on the resize rim or grabbing the panel edge misses the window frame")
+    XCTAssertLessThanOrEqual(
+      InkGlassShadow.ambient.padding, DesktopWindowLayoutPolicy.windowInset + 2,
+      "a shadow that needs more room than the inset clips into a thick black band around the glass")
     XCTAssertTrue(
       ShellClickThroughPolicy.acceptsMouseHit(
         localPoint: NSPoint(x: 4, y: 350),

--- a/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellClickThroughPolicyTests.swift
@@ -17,7 +17,7 @@ final class ShellClickThroughPolicyTests: XCTestCase {
         windowSize: windowSize,
         isResizable: true,
         contentContains: { _ in false }),
-      "the reserved title-bar band above the top bar must not swallow clicks")
+      "air that is not glass must not swallow clicks")
     XCTAssertFalse(
       ShellClickThroughPolicy.acceptsMouseHit(
         localPoint: NSPoint(x: 480, y: 350),
@@ -44,12 +44,7 @@ final class ShellClickThroughPolicyTests: XCTestCase {
   }
 
   func testResizableWindowKeepsAnInteractiveEdgeRim() {
-    XCTAssertEqual(
-      DesktopWindowLayoutPolicy.windowInset, ShellClickThroughPolicy.resizeRim,
-      "the glass must sit on the resize rim or grabbing the panel edge misses the window frame")
-    XCTAssertLessThanOrEqual(
-      InkGlassShadow.ambient.padding, DesktopWindowLayoutPolicy.windowInset + 2,
-      "a shadow that needs more room than the inset clips into a thick black band around the glass")
+    XCTAssertEqual(DesktopWindowLayoutPolicy.windowInset, 0)
     XCTAssertTrue(
       ShellClickThroughPolicy.acceptsMouseHit(
         localPoint: NSPoint(x: 4, y: 350),

--- a/desktop/macos/Desktop/Tests/ShellGlassChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellGlassChromeTests.swift
@@ -104,20 +104,12 @@ final class ShellGlassChromeTests: XCTestCase {
     XCTAssertGreaterThanOrEqual(TopNavigationLayoutMetrics.barHeight, 32 + OmiSpacing.sm * 2)
   }
 
-  /// `.hiddenTitleBar` lays a transparent title bar over the content view, so the shell reserves a
-  /// band for it. The number is AppKit's own, not a guess — a hand-tuned constant is exactly what
-  /// drifts when a future macOS changes the title bar height.
-  func testTitlebarClearanceCoversTheWindowsDragBand() {
-    let content = NSRect(x: 0, y: 0, width: 640, height: 480)
-    let frame = NSWindow.frameRect(
-      forContentRect: content, styleMask: [.titled, .closable, .resizable])
-    let titlebarHeight = frame.height - content.height
-
-    XCTAssertGreaterThan(titlebarHeight, 0, "a titled window has a title bar to clear")
-    XCTAssertGreaterThanOrEqual(
-      GlassShell.titlebarClearance, titlebarHeight,
-      "the title bar takes the mouse before the content under it: a bar drawn into this band is a bar "
-        + "you cannot click and a window you cannot drag from its top edge")
+  /// The top bar is drawn in the hidden title-bar band, so reserving AppKit's titlebar height
+  /// *again* would put the glass 28–32 pt below the window's top edge — which is where the
+  /// resize handle would sit, on empty air.
+  func testTitlebarClearanceIsZeroBecauseTheTopBarOccupiesTheBand() {
+    XCTAssertEqual(GlassShell.titlebarClearance, 0)
+    XCTAssertTrue(WindowGlass.hasTitlebar(ShellWindowChrome.glassKind))
   }
 
   // MARK: - Shell controls

--- a/desktop/macos/Desktop/Tests/ShellSummonTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellSummonTests.swift
@@ -115,6 +115,9 @@ final class ShellSummonTests: XCTestCase {
   /// …and the default really is a panel rather than the managed window it replaced. It still has to
   /// clear the floor every destination lays out to, or the shell arrives already clipping content.
   func testTheDefaultPanelIsSmallerThanAWindowButStillFitsTheDestinations() {
+    XCTAssertEqual(
+      ShellSummonPlacement.defaultSize.width, DesktopWindowLayoutPolicy.maximumContentWidth,
+      "a summoned panel is the hugged glass, not a sheet that stretches with the display")
     XCTAssertLessThan(
       ShellSummonPlacement.defaultSize.width, 1200,
       "1200×800 was the managed-window default; a summoned panel must read smaller than that")
@@ -124,19 +127,34 @@ final class ShellSummonTests: XCTestCase {
       ShellSummonPlacement.defaultSize.height, DesktopWindowLayoutPolicy.minimumContentSize.height)
   }
 
-  /// A remembered frame is restored exactly. This is the whole payoff of per-display memory: the
-  /// second summon on a display puts the shell back where you left it, at the size you left it.
+  /// A remembered frame already at the hug size is restored exactly. This is the payoff of
+  /// per-display memory: the second summon on a display puts the shell back where you left it.
   func testARememberedFrameComesBackUntouched() {
-    let placed = NSRect(x: 1700, y: 100, width: 1200, height: 820)
+    let placed = NSRect(
+      x: 1700, y: 100,
+      width: DesktopWindowLayoutPolicy.maximumContentWidth, height: 820)
 
     let frame = ShellSummonPlacement.frame(remembered: placed, visibleFrame: studio)
 
     XCTAssertEqual(frame, placed)
   }
 
+  /// A frame remembered from the pre-hug oversized window cannot restore the invisible border,
+  /// even on a display that would have room for it.
+  func testARememberedPreHugFrameIsHuggedToTheReadableLane() {
+    let placed = NSRect(x: 1700, y: 100, width: 1_400, height: 820)
+
+    let frame = ShellSummonPlacement.frame(remembered: placed, visibleFrame: studio)
+
+    XCTAssertEqual(frame.width, DesktopWindowLayoutPolicy.maximumContentWidth)
+    XCTAssertEqual(frame.height, 820)
+    XCTAssertEqual(frame.origin, placed.origin)
+  }
+
   /// **The display that shrank.** A frame remembered on a 2560pt display, restored after the user
   /// switched that display to a scaled mode, would put the query field past the right edge. It is
-  /// pulled back rather than discarded — the user's size is honoured as far as it fits.
+  /// pulled back rather than discarded — the user's size is honoured as far as it fits, and the
+  /// hug max still wins over a remembered width that would recreate the click border.
   func testARememberedFrameIsPulledBackInsideADisplayThatGotSmaller() {
     let placed = NSRect(x: 2400, y: 900, width: 1200, height: 820)
     let shrunk = NSRect(x: 0, y: 0, width: 1440, height: 900)
@@ -146,19 +164,22 @@ final class ShellSummonTests: XCTestCase {
     XCTAssertTrue(
       shrunk.contains(frame),
       "a restored frame outside the display is a shell whose query field cannot be reached")
-    XCTAssertEqual(frame.width, 1200, "the width still fitted; only the position had to move")
+    XCTAssertEqual(
+      frame.width, DesktopWindowLayoutPolicy.maximumContentWidth,
+      "the remembered 1200 pt width is the invisible border; hug it even though 1440 would fit")
     XCTAssertEqual(frame.height, 820)
   }
 
   /// A frame larger than the display it is restored onto is shrunk to fit, not centred at its old
-  /// size and left hanging off two edges at once.
+  /// size and left hanging off two edges at once. Width also cannot exceed the hug max.
   func testARememberedFrameLargerThanTheDisplayIsShrunkToIt() {
     let placed = NSRect(x: 1512, y: -200, width: 2400, height: 1300)
 
     let frame = ShellSummonPlacement.frame(remembered: placed, visibleFrame: laptop)
 
     XCTAssertTrue(laptop.contains(frame))
-    XCTAssertEqual(frame.size, laptop.size)
+    XCTAssertEqual(frame.width, DesktopWindowLayoutPolicy.maximumContentWidth)
+    XCTAssertEqual(frame.height, laptop.height)
   }
 
   /// A degenerate stored value — a zero rect from a failed decode, or a frame written while the

--- a/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellWindowChromeTests.swift
@@ -206,7 +206,7 @@ final class ShellWindowChromeTests: XCTestCase {
       "the panels inside draw their own ambient shadow; the shell does not add an outer frame shadow")
     XCTAssertTrue(
       WindowGlass.hasTitlebar(ShellWindowChrome.glassKind),
-      "the transparent title bar remains a drag handle, and ⌘W routes from the mask")
+      "the hidden title bar stays so ⌘W routes from the mask; the top bar occupies that band")
   }
 
   /// …and `dress` really applies it, in both presentations. The mapping above is a value; this is the

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -410,15 +410,14 @@ final class TopNavigationBarLayoutTests: XCTestCase {
   }
 
   func testNavigationLaneMatchesFullChatWidthAndPageInsets() {
-    // The 900 pt readable cap lives on the window, not inside the lane. At any
-    // given window width the glass fills it minus the resize-rim inset per side —
-    // including a hypothetical 1400 pt host that bypassed the window max.
+    // The 900 pt readable cap lives on the window, not inside the lane. The glass fills
+    // the window horizontally — including a hypothetical 1400 pt host that bypassed the max.
     XCTAssertEqual(
       TopNavigationLayoutMetrics.contentLaneWidth(for: DesktopWindowLayoutPolicy.maximumContentWidth),
       ChatComposerLayout.contentLaneMaxWidth)
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 1_384)
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 800), 784)
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 40), 24)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 1_400)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 800), 800)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 40), 40)
   }
 
   /// The bar's *glass* is the lane and its controls are inset inside it — so the inset has to leave a

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -410,7 +410,13 @@ final class TopNavigationBarLayoutTests: XCTestCase {
   }
 
   func testNavigationLaneMatchesFullChatWidthAndPageInsets() {
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 900)
+    // The 900 pt readable cap lives on the window, not inside the lane. At any
+    // given window width the glass fills it minus one page margin per side —
+    // including a hypothetical 1400 pt host that bypassed the window max.
+    XCTAssertEqual(
+      TopNavigationLayoutMetrics.contentLaneWidth(for: DesktopWindowLayoutPolicy.maximumContentWidth),
+      ChatComposerLayout.contentLaneMaxWidth)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 1_368)
     XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 800), 768)
     XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 40), 8)
   }

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -411,14 +411,14 @@ final class TopNavigationBarLayoutTests: XCTestCase {
 
   func testNavigationLaneMatchesFullChatWidthAndPageInsets() {
     // The 900 pt readable cap lives on the window, not inside the lane. At any
-    // given window width the glass fills it minus one page margin per side —
+    // given window width the glass fills it minus the resize-rim inset per side —
     // including a hypothetical 1400 pt host that bypassed the window max.
     XCTAssertEqual(
       TopNavigationLayoutMetrics.contentLaneWidth(for: DesktopWindowLayoutPolicy.maximumContentWidth),
       ChatComposerLayout.contentLaneMaxWidth)
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 1_368)
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 800), 768)
-    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 40), 8)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 1_384)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 800), 784)
+    XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 40), 24)
   }
 
   /// The bar's *glass* is the lane and its controls are inset inside it — so the inset has to leave a

--- a/desktop/macos/changelog/unreleased/20260814-shell-window-hug-glass.json
+++ b/desktop/macos/changelog/unreleased/20260814-shell-window-hug-glass.json
@@ -1,3 +1,3 @@
 {
-  "change": "Sized the main window to the floating glass so clicks beside the panels reach the desktop instead of an invisible border"
+  "change": "Sized the main window to the floating glass, with a light lift instead of a thick shadow halo, so clicks and resize land on the panel edge"
 }

--- a/desktop/macos/changelog/unreleased/20260814-shell-window-hug-glass.json
+++ b/desktop/macos/changelog/unreleased/20260814-shell-window-hug-glass.json
@@ -1,0 +1,3 @@
+{
+  "change": "Sized the main window to the floating glass so clicks beside the panels reach the desktop instead of an invisible border"
+}

--- a/desktop/macos/changelog/unreleased/20260814-shell-window-hug-glass.json
+++ b/desktop/macos/changelog/unreleased/20260814-shell-window-hug-glass.json
@@ -1,3 +1,3 @@
 {
-  "change": "Sized the main window to the floating glass, with a light lift instead of a thick shadow halo, so clicks and resize land on the panel edge"
+  "change": "Flushed the summoned shell to the glass so resize sits on the visible panel edge instead of an invisible gutter"
 }


### PR DESCRIPTION
## What changed and why

The summoned macOS shell is a transparent window. The 900 pt readable-lane cap inside that window left empty wallpaper that still belonged to the frame, so clicks beside the glass went nowhere (recurrence of #11552 / `FC-transparent-top-level-window-occlusion`). The lane now fills the window, and the window itself is capped at the readable lane.

The first hug still left a gutter that clipped the ambient shadow into a thick black halo, and AppKit's resize rim sat on that outer frame. The 8 pt inset and the unused title-bar clearance were the remaining invisible distance between the grab handle and the visible glass. Both are gone: `windowInset` is 0, the top bar occupies the hidden title-bar band (`titlebarClearance` is 0), and the page sits on the window's bottom edge. Grabbing the visible panel edge resizes. Remembered pre-hug frames are clamped so the border cannot restore.

Height stays display-limited (`visibleFrame`); Retina scale is not multiplied. Click-through still covers leftover air (rounded-corner triangles, gaps between stacked panels).

## Product invariants affected

- INV-AUTH-1 — comment-only on `OmiApp.swift` window chrome; session contract unchanged
- INV-UI-1 — existing Ink glass tokens; no new brand colour

## How it was verified

- Focused Swift tests: `xcrun swift test --package-path Desktop --filter 'PageGlassLaneTests|ShellModalScrimTests|ShellWindowChromeTests|ShellGlassChromeTests|ShellClickThroughPolicyTests|TopNavigationBarLayoutTests|ChatSurfaceBoundsTests|FloatingGlassChromeTests|ShellSummonTests|DesktopWindowLayoutPolicyTests|QueryShellTests'` — 0 failures.
- Named QA bundle `/Applications/omi-hug-glass.app` (`com.omi.omi-hug-glass`). The titled main window should measure **900 pt** wide. Production Omi / Omi Beta / Omi Dev were not overwritten.

## Tests

- `TopNavigationBarLayoutTests.testNavigationLaneMatchesFullChatWidthAndPageInsets` — the 900 pt cap is on the window; the lane fills the window.
- `ShellClickThroughPolicyTests.testResizableWindowKeepsAnInteractiveEdgeRim` — window inset is 0 so the resize rim is on the glass.
- `ShellGlassChromeTests.testTitlebarClearanceIsZeroBecauseTheTopBarOccupiesTheBand` — no extra band above the nav bar.
- `PageGlassLaneTests.testTheLanesGlassFillsTheWindowWidthAndKeepsVerticalGaps` — horizontal flush; page sits on the window bottom.
- `ShellSummonTests.testARememberedPreHugFrameIsHuggedToTheReadableLane` — a 1400 pt remembered frame on a large display becomes the hug max.

## Failure class (fixes)

Failure-Class: FC-transparent-top-level-window-occlusion

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1594 -> 1614 | pin max window width next to the existing min-size pin; splitting DesktopHomeView is out of scope for this hug fix
