### PR TITLE
fix(backend): admit the shipped task-extraction prompt into settings sync (#11481)

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1975,12 +1975,24 @@ class FocusAssistantSettings(BaseModel):
     excluded_apps: list[str] | None = None
 
 
+# Analysis prompts are user-editable, and the desktop client ships a default for each
+# assistant. A bound below an assistant's own shipped default silently disables settings
+# sync for every user still on that default: `SettingsSyncManager.promptForSync` omits an
+# oversized prompt from the PATCH rather than truncating it, so the prompt never reaches
+# the server (issue #11481). Each bound must therefore clear the prompt its assistant
+# actually ships; `test_backend_bounds_admit_every_shipped_desktop_prompt` enforces that
+# against the real Swift sources.
 ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH = 10000
+
+# Task extraction is the one shipped default that outgrew the shared bound: 13,120 code
+# points at 66fe4673ce, and between 13k and 15k since 2026-06. The headroom above it is
+# for user edits, which are the same field.
+TASK_ANALYSIS_PROMPT_MAX_LENGTH = 20000
 
 
 class TaskAssistantSettings(BaseModel):
     enabled: bool | None = None
-    analysis_prompt: str | None = Field(None, max_length=ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH)
+    analysis_prompt: str | None = Field(None, max_length=TASK_ANALYSIS_PROMPT_MAX_LENGTH)
     extraction_interval: float | None = None
     min_confidence: float | None = Field(None, ge=0.0, le=1.0)
     notifications_enabled: bool | None = None

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1967,27 +1967,21 @@ class SharedAssistantSettings(BaseModel):
     screen_analysis_enabled: bool | None = None
 
 
+# Each bound must clear its own assistant's shipped desktop default. An oversized prompt is
+# omitted from the settings PATCH by `SettingsSyncManager.promptForSync` rather than
+# rejected, so a bound under the shipped default unsyncs that prompt silently (#11481);
+# `test_backend_bounds_admit_every_shipped_desktop_prompt` guards this against the Swift source.
+ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH = 10000
+# Task ships the only default over 10k: 13,120 code points, and 13k-15k since 2026-06.
+TASK_ANALYSIS_PROMPT_MAX_LENGTH = 20000
+
+
 class FocusAssistantSettings(BaseModel):
     enabled: bool | None = None
-    analysis_prompt: str | None = Field(None, max_length=10000)
+    analysis_prompt: str | None = Field(None, max_length=ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH)
     cooldown_interval: int | None = None
     notifications_enabled: bool | None = None
     excluded_apps: list[str] | None = None
-
-
-# Analysis prompts are user-editable, and the desktop client ships a default for each
-# assistant. A bound below an assistant's own shipped default silently disables settings
-# sync for every user still on that default: `SettingsSyncManager.promptForSync` omits an
-# oversized prompt from the PATCH rather than truncating it, so the prompt never reaches
-# the server (issue #11481). Each bound must therefore clear the prompt its assistant
-# actually ships; `test_backend_bounds_admit_every_shipped_desktop_prompt` enforces that
-# against the real Swift sources.
-ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH = 10000
-
-# Task extraction is the one shipped default that outgrew the shared bound: 13,120 code
-# points at 66fe4673ce, and between 13k and 15k since 2026-06. The headroom above it is
-# for user edits, which are the same field.
-TASK_ANALYSIS_PROMPT_MAX_LENGTH = 20000
 
 
 class TaskAssistantSettings(BaseModel):
@@ -2002,7 +1996,7 @@ class TaskAssistantSettings(BaseModel):
 
 class AdviceAssistantSettings(BaseModel):
     enabled: bool | None = None
-    analysis_prompt: str | None = Field(None, max_length=10000)
+    analysis_prompt: str | None = Field(None, max_length=ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH)
     extraction_interval: float | None = None
     min_confidence: float | None = Field(None, ge=0.0, le=1.0)
     notifications_enabled: bool | None = None
@@ -2011,7 +2005,7 @@ class AdviceAssistantSettings(BaseModel):
 
 class MemoryAssistantSettings(BaseModel):
     enabled: bool | None = None
-    analysis_prompt: str | None = Field(None, max_length=10000)
+    analysis_prompt: str | None = Field(None, max_length=ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH)
     extraction_interval: float | None = None
     min_confidence: float | None = Field(None, ge=0.0, le=1.0)
     notifications_enabled: bool | None = None

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +10,19 @@ from fastapi.testclient import TestClient
 
 from routers import users as users_router
 from services.users import data_export
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+DESKTOP_SOURCES_DIR = ROOT_DIR / 'desktop' / 'macos' / 'Desktop' / 'Sources' / 'ProactiveAssistants' / 'Assistants'
+
+# Wire section name -> the Swift file declaring that assistant's shipped default prompt.
+# `advice` is the wire key the desktop client encodes its `insight` assistant under
+# (AssistantSettingsResponse.CodingKeys). Focus ships no default prompt, and the
+# suggestion assistant has one but no synced section, so neither is under this contract.
+SHIPPED_DEFAULT_PROMPT_SOURCES = {
+    'task': 'TaskExtraction/TaskAssistantSettings.swift',
+    'advice': 'Insight/InsightAssistantSettings.swift',
+    'memory': 'MemoryExtraction/MemoryAssistantSettings.swift',
+}
 
 
 class _FakeRequest:
@@ -430,23 +444,54 @@ def test_export_all_user_data_returns_500_before_streaming_headers_when_memory_p
     assert 'content-disposition' not in response.headers
 
 
-def test_task_assistant_prompt_contract_accepts_shipped_default_size_and_rejects_oversize():
+def _shipped_default_analysis_prompt(swift_path: Path) -> str:
+    """Return the `static let defaultAnalysisPrompt` literal the desktop client ships.
+
+    These literals carry no escapes and no `\\(...)` interpolation, so the only Swift rule
+    that affects their value is that a multiline literal strips the closing delimiter's
+    indentation from every content line.
+    """
+    assert swift_path.is_file(), f'shipped prompt source moved: {swift_path}. Update SHIPPED_DEFAULT_PROMPT_SOURCES.'
+    lines = swift_path.read_text(encoding='utf-8').splitlines()
+
+    opening = next(i for i, line in enumerate(lines) if 'static let defaultAnalysisPrompt = """' in line)
+    closing = next(i for i in range(opening + 1, len(lines)) if lines[i].strip() == '"""')
+    indent = len(lines[closing]) - len(lines[closing].lstrip())
+
+    return '\n'.join(line[indent:] if len(line) >= indent else line.lstrip() for line in lines[opening + 1 : closing])
+
+
+@pytest.mark.parametrize('section,swift_relative_path', sorted(SHIPPED_DEFAULT_PROMPT_SOURCES.items()))
+def test_backend_bounds_admit_every_shipped_desktop_prompt(section, swift_relative_path):
+    # An oversized prompt does not 422 in practice: SettingsSyncManager.promptForSync omits
+    # it from the PATCH to keep partial semantics, so a bound below an assistant's own
+    # shipped default silently makes that prompt unsyncable rather than loudly rejecting
+    # it. That is how the task prompt went unsynced from 2026-06 until #11481. Validating
+    # the real Swift literal through the real request model is what closes that gap.
+    prompt = _shipped_default_analysis_prompt(DESKTOP_SOURCES_DIR / swift_relative_path)
+
+    request = users_router.UpdateAssistantSettingsRequest(**{section: {'analysis_prompt': prompt}})
+
+    assert getattr(request, section).analysis_prompt == prompt
+
+
+def test_task_assistant_prompt_contract_accepts_bound_size_and_rejects_oversize():
     accepted = users_router.UpdateAssistantSettingsRequest(
-        task={'analysis_prompt': 'x' * users_router.ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH}
+        task={'analysis_prompt': 'x' * users_router.TASK_ANALYSIS_PROMPT_MAX_LENGTH}
     )
 
-    assert len(accepted.task.analysis_prompt) == users_router.ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH
+    assert len(accepted.task.analysis_prompt) == users_router.TASK_ANALYSIS_PROMPT_MAX_LENGTH
     with pytest.raises(ValueError):
         users_router.UpdateAssistantSettingsRequest(
-            task={'analysis_prompt': 'x' * (users_router.ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH + 1)}
+            task={'analysis_prompt': 'x' * (users_router.TASK_ANALYSIS_PROMPT_MAX_LENGTH + 1)}
         )
 
 
 def test_task_assistant_prompt_contract_counts_unicode_code_points():
     flag = '🇺🇸'
-    prompt = flag * (users_router.ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH // len(flag) + 1)
+    prompt = flag * (users_router.TASK_ANALYSIS_PROMPT_MAX_LENGTH // len(flag) + 1)
 
-    assert len(prompt) == users_router.ASSISTANT_ANALYSIS_PROMPT_MAX_LENGTH + 2
+    assert len(prompt) == users_router.TASK_ANALYSIS_PROMPT_MAX_LENGTH + 2
     with pytest.raises(ValueError):
         users_router.UpdateAssistantSettingsRequest(task={'analysis_prompt': prompt})
 

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -20525,7 +20525,7 @@
           "analysis_prompt": {
             "anyOf": [
               {
-                "maxLength": 10000,
+                "maxLength": 20000,
                 "type": "string"
               },
               {


### PR DESCRIPTION
## What

`TaskAssistantSettings.analysis_prompt` was bounded at 10,000 code points while the desktop client's shipped default task prompt is **13,120**. That prompt has therefore never synced — and never will on any deployed build — because the mismatch is silent by construction.

This is the backend half of #11481, and backend-only on purpose.

## Why it is silent

An oversized prompt does not 422. `SettingsSyncManager.promptForSync` omits it from the settings PATCH to preserve partial-update semantics, so the field simply never arrives:

```swift
// desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift:212
let length = prompt.unicodeScalars.count
guard length <= maximumLength else { ... return nil }
```

For every user still on the default task prompt, the server has held no `analysis_prompt` at all since at least 2026-06.

## Why task gets its own bound

Task is the only shipped default that outgrew 10k. Measured at `66fe4673ce` by extracting each `defaultAnalysisPrompt` literal and counting code points:

| assistant | shipped default | bound |
|---|---:|---:|
| task | 13,120 | **20,000** |
| memory | 6,262 | 10,000 |
| insight (wire key `advice`) | 3,576 | 10,000 |
| focus | ships no default | 10,000 |

This mirrors the client, which already carries a task-specific `TaskAssistantSettings.maximumSyncedAnalysisPromptLength`. The headroom above 13,120 is for user edits, which write the same field.

## Sequencing

Order matters and this PR is deliberately step 1 of 3:

1. **this change** — backend accepts up to 20k
2. prod backend deploy
3. client constant raised in a desktop release

Raising the client constant first would make every user on the default start sending a 13.1k `analysis_prompt` that the deployed backend still 422s, breaking assistant-settings sync wholesale for that build. The desktop tests that pin the client at 10k (`testShippedTaskPromptExceedsBackendBoundAndIsOmittedFromSync`, `testEachAssistantPromptUsesItsBackendBound`) are untouched and stay green.

Raising a `max_length` is backward compatible: every payload valid before is still valid.

## The regression test

The existing backend test was named `..._accepts_shipped_default_size_...` but only compared the bound against itself, so it passed at any value — which is why the defect survived. Each side asserted against its own constant and nothing asserted the contract between them.

`test_backend_bounds_admit_every_shipped_desktop_prompt` now parses each assistant's real `defaultAnalysisPrompt` literal out of the Swift sources and validates it through the real `UpdateAssistantSettingsRequest` model. It is behavioral — real Pydantic validation on the real shipped text — not a source scrape.

## Verification

```
$ cd backend && python -m pytest tests/routers/test_users.py -q
25 passed

$ python -m pytest tests/unit/test_app_client_openapi_compatibility.py tests/routers/test_users.py -q
45 passed
```

Proof the new test catches the reported defect — with the bound reverted to 10000, it fails on task **only**:

```
E  String should have at most 10000 characters [type=string_too_long,
   input_value='You are a task commitmen...l_system / project_tool']
FAILED tests/routers/test_users.py::test_backend_bounds_admit_every_shipped_desktop_prompt[task-...]
1 failed, 2 passed
```

Effective bounds read off `model_fields` after the change, confirming the other three are untouched:

```
FocusAssistantSettings     max_length=10000
TaskAssistantSettings      max_length=20000
AdviceAssistantSettings    max_length=10000
MemoryAssistantSettings    max_length=10000
```

## Note on the OpenAPI spec

`docs/api-reference/app-client-openapi.json` carries the single exported bound that changed. It was hand-patched rather than regenerated: `scripts/export_openapi.py` on this machine also rewrites `format: binary` to `contentMediaType` and adds `ctx`/`input` to `ValidationError`, which is local pydantic/fastapi version drift unrelated to this change. Worth a maintainer regenerating on the pinned toolchain if you'd rather have the generated artifact.

Line-Count-Exception: backend/routers/users.py | 2174 -> 2180 | two named bounds replacing a duplicated literal, plus the contract comment explaining why a bound may not sit under its assistant's shipped default

Refs: #11481
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

