### PR TITLE
feat(desktop): index recent work by URL and file handles

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
@@ -663,13 +663,15 @@ enum ScreenContextWorkContextBuilder {
         "Prefer visits[].handles to identify the document, URL, or file the user means, then open or read that source. The screenshot timeline is fallback evidence only. This is recent historical activity, not proof of the current visible screen.",
     ]
     if let queue = await RewindDatabase.shared.getDatabaseQueue() {
+      let excluded = RewindSettings.shared.excludedApps
       let visits =
         (try? await queue.read { db in
-          try WorkHistoryIndex.fetchRecentVisits(in: db, from: start, to: now, limit: 20)
+          try WorkHistoryIndex.fetchRecentVisits(
+            in: db, from: start, to: now, limit: 20, excludedApps: excluded)
         }) ?? []
       let briefs =
         (try? await queue.read { db in
-          try WorkHistoryIndex.fetchBriefs(in: db, limit: 5)
+          try WorkHistoryIndex.fetchBriefs(in: db, limit: 5, excludedApps: excluded)
         }) ?? []
       payload["visits"] = visits.map { $0.jsonObject(clock: clock) }
       payload["briefs"] = briefs.map { $0.jsonObject() }

--- a/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ScreenContextTelemetry.swift
@@ -660,8 +660,20 @@ enum ScreenContextWorkContextBuilder {
       "timeline": timeline,
       "memories_hint": "For the user's operating principles/preferences, also call search_memories (omi-memory).",
       "guidance":
-        "This is recent historical on-screen activity, not proof of the current visible screen. Use it for history; for a direct current-screen question, obtain a live capture instead of answering from this payload.",
+        "Prefer visits[].handles to identify the document, URL, or file the user means, then open or read that source. The screenshot timeline is fallback evidence only. This is recent historical activity, not proof of the current visible screen.",
     ]
+    if let queue = await RewindDatabase.shared.getDatabaseQueue() {
+      let visits =
+        (try? await queue.read { db in
+          try WorkHistoryIndex.fetchRecentVisits(in: db, from: start, to: now, limit: 20)
+        }) ?? []
+      let briefs =
+        (try? await queue.read { db in
+          try WorkHistoryIndex.fetchBriefs(in: db, limit: 5)
+        }) ?? []
+      payload["visits"] = visits.map { $0.jsonObject(clock: clock) }
+      payload["briefs"] = briefs.map { $0.jsonObject() }
+    }
     if let failureCode {
       payload["failure_code"] = failureCode.rawValue
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
@@ -84,6 +84,18 @@ enum ContextBucketSchema {
           """,
         arguments: [migrationName, effectiveOwnerID, sourceOwnerID, legacyBindings.count, Date()])
     }
+    migrator.registerMigration("addContextVisitHandles") { db in
+      try db.alter(table: "context_visits") { table in
+        table.add(column: "primaryHandleType", .text)
+        table.add(column: "primaryHandleValue", .text)
+        table.add(column: "handlesJson", .text)
+        table.add(column: "bundleID", .text)
+      }
+      try db.create(
+        index: "idx_context_visits_handle",
+        on: "context_visits",
+        columns: ["primaryHandleType", "primaryHandleValue"])
+    }
   }
 
   static func removeMigratedLegacyDefaults(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -178,21 +178,6 @@ enum ContextBucketVisitResolver {
       arguments: [
         lookupHash, resolvedBucketID, subjectKind, subjectID, confidence, source, startedAt, startedAt,
       ])
-    if handleIdentity != nil, referenceHash != lookupHash, !referenceHash.hasPrefix("ephemeral:") {
-      try db.execute(
-        sql: """
-          INSERT INTO subject_bindings
-            (referenceHash, bucketID, subjectKind, subjectID, confidence, source,
-             occurrenceCount, createdAt, updatedAt)
-          VALUES (?, ?, ?, ?, 0.6, 'title_cooccurrence', 1, ?, ?)
-          ON CONFLICT(referenceHash) DO UPDATE SET
-            bucketID = excluded.bucketID,
-            updatedAt = excluded.updatedAt
-          """,
-        arguments: [
-          referenceHash, resolvedBucketID, subjectKind, subjectID, startedAt, startedAt,
-        ])
-    }
     return resolvedBucketID
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -83,17 +83,20 @@ enum ContextBucketVisitResolver {
     in db: Database,
     referenceHash: String,
     normalizedTitle: String?,
-    startedAt: Date
+    startedAt: Date,
+    primaryHandle: WorkHistoryHandle? = nil
   ) throws -> String? {
+    let handleIdentity = primaryHandle?.isDurable == true ? primaryHandle : nil
+    let lookupHash = handleIdentity?.identityKey ?? referenceHash
     let binding = try Row.fetchOne(
       db,
       sql: "SELECT * FROM subject_bindings WHERE referenceHash = ?",
-      arguments: [referenceHash])
-    let subjectKind: String = binding?["subjectKind"] ?? "context"
-    let subjectID: String = binding?["subjectID"] ?? referenceHash
+      arguments: [lookupHash])
+    let subjectKind: String = binding?["subjectKind"] ?? handleIdentity?.kind.rawValue ?? "context"
+    let subjectID: String = binding?["subjectID"] ?? handleIdentity?.value ?? referenceHash
     let workstreamID: String? = binding?["workstreamID"]
-    let confidence: Double = binding?["confidence"] ?? 0.5
-    let source: String = binding?["source"] ?? "repeat_cooccurrence"
+    let confidence: Double = binding?["confidence"] ?? (handleIdentity == nil ? 0.5 : 0.8)
+    let source: String = binding?["source"] ?? (handleIdentity == nil ? "repeat_cooccurrence" : "source_handle")
 
     if let existing: String = binding?["bucketID"] {
       let consistent =
@@ -111,17 +114,30 @@ enum ContextBucketVisitResolver {
       // subject. Fall through and re-resolve for the binding's current subject.
     }
 
-    guard normalizedTitle != nil else { return nil }
+    guard normalizedTitle != nil || handleIdentity != nil else { return nil }
     // A subject binding (including explicit_open) already owns this identity, so
     // do not require a prior completed visit before attaching the subject bucket.
     if binding == nil {
       let recentCutoff = startedAt.addingTimeInterval(-7 * 24 * 60 * 60)
-      let previousVisits =
-        try Int.fetchOne(
-          db,
-          sql:
-            "SELECT COUNT(*) FROM context_visits WHERE referenceHash = ? AND outcome = 'completed' AND startedAt >= ?",
-          arguments: [referenceHash, recentCutoff]) ?? 0
+      let previousVisits: Int
+      if let handleIdentity, try db.columns(in: "context_visits").map(\.name).contains("primaryHandleValue") {
+        previousVisits =
+          try Int.fetchOne(
+            db,
+            sql: """
+              SELECT COUNT(*) FROM context_visits
+              WHERE primaryHandleType = ? AND primaryHandleValue = ?
+                AND outcome = 'completed' AND startedAt >= ?
+              """,
+            arguments: [handleIdentity.kind.rawValue, handleIdentity.value, recentCutoff]) ?? 0
+      } else {
+        previousVisits =
+          try Int.fetchOne(
+            db,
+            sql:
+              "SELECT COUNT(*) FROM context_visits WHERE referenceHash = ? AND outcome = 'completed' AND startedAt >= ?",
+            arguments: [referenceHash, recentCutoff]) ?? 0
+      }
       guard previousVisits >= 1 else { return nil }
     }
 
@@ -141,9 +157,12 @@ enum ContextBucketVisitResolver {
           INSERT INTO context_buckets
             (id, subjectKind, subjectID, workstreamID, displayLabel, visitCount,
              lastVisitedAt, createdAt, updatedAt)
-          VALUES (?, ?, ?, ?, NULL, 0, ?, ?, ?)
+          VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?)
           """,
-        arguments: [resolvedBucketID, subjectKind, subjectID, workstreamID, startedAt, startedAt, startedAt])
+        arguments: [
+          resolvedBucketID, subjectKind, subjectID, workstreamID,
+          handleIdentity?.value ?? normalizedTitle, startedAt, startedAt, startedAt,
+        ])
     }
     try db.execute(
       sql: """
@@ -157,8 +176,23 @@ enum ContextBucketVisitResolver {
           updatedAt = excluded.updatedAt
         """,
       arguments: [
-        referenceHash, resolvedBucketID, subjectKind, subjectID, confidence, source, startedAt, startedAt,
+        lookupHash, resolvedBucketID, subjectKind, subjectID, confidence, source, startedAt, startedAt,
       ])
+    if handleIdentity != nil, referenceHash != lookupHash, !referenceHash.hasPrefix("ephemeral:") {
+      try db.execute(
+        sql: """
+          INSERT INTO subject_bindings
+            (referenceHash, bucketID, subjectKind, subjectID, confidence, source,
+             occurrenceCount, createdAt, updatedAt)
+          VALUES (?, ?, ?, ?, 0.6, 'title_cooccurrence', 1, ?, ?)
+          ON CONFLICT(referenceHash) DO UPDATE SET
+            bucketID = excluded.bucketID,
+            updatedAt = excluded.updatedAt
+          """,
+        arguments: [
+          referenceHash, resolvedBucketID, subjectKind, subjectID, startedAt, startedAt,
+        ])
+    }
     return resolvedBucketID
   }
 }
@@ -172,7 +206,9 @@ actor ContextBucketStore {
     appName: String,
     windowTitle: String?,
     contextGeneration: Int64,
-    startedAt: Date = Date()
+    startedAt: Date = Date(),
+    handles: [WorkHistoryHandle] = [],
+    bundleID: String? = nil
   ) async throws -> ContextVisitFence {
     let (pool, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
     guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
@@ -183,25 +219,35 @@ actor ContextBucketStore {
     // hashes keep visit rows unique and skip durable binding/bucket lookup.
     let referenceHash =
       normalizedKey.map(Self.referenceHash) ?? "ephemeral:\(UUID().uuidString.lowercased())"
+    let resolvedHandles =
+      handles.isEmpty
+      ? WorkHistoryHandleExtractor.handles(
+        from: WorkHistoryFrontmostSnapshot(appName: appName, windowTitle: windowTitle, bundleID: bundleID))
+      : handles
+    let primaryHandle = WorkHistoryHandle.primary(in: resolvedHandles)
     let bucketID = try await pool.write { db -> String? in
-      guard normalizedKey != nil else { return nil }
+      guard normalizedKey != nil || primaryHandle?.isDurable == true else { return nil }
       return try ContextBucketVisitResolver.resolveBucketID(
         in: db,
         referenceHash: referenceHash,
         normalizedTitle: normalizedTitle,
-        startedAt: startedAt)
+        startedAt: startedAt,
+        primaryHandle: primaryHandle)
     }
     let visitID = try await pool.write { db -> Int64 in
       try db.execute(
         sql: """
           INSERT INTO context_visits
             (contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
-             normalizedContextKey, referenceHash, startedAt, outcome, createdAt, updatedAt)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+             normalizedContextKey, referenceHash, startedAt, outcome, createdAt, updatedAt,
+             primaryHandleType, primaryHandleValue, handlesJson, bundleID)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?)
           """,
         arguments: [
           contextGeneration, poolEpoch, bucketID, appName, rawKey, normalizedKey ?? "",
           referenceHash, startedAt, startedAt, startedAt,
+          primaryHandle?.kind.rawValue, primaryHandle?.value, WorkHistoryHandle.encodeList(resolvedHandles),
+          bundleID,
         ])
       return db.lastInsertedRowID
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextVisitCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextVisitCoordinator.swift
@@ -83,6 +83,8 @@ actor ContextVisitCoordinator {
     handles: [WorkHistoryHandle] = [],
     bundleID: String? = nil
   ) async throws -> Transition {
+    let arrivingIdentity = Self.resolvedVisitIdentity(
+      appName: appName, windowTitle: windowTitle, handles: handles, bundleID: bundleID)
     ensureOwnerChangeObserver()
     await waitForTransitionTurn()
     defer { releaseTransitionTurn() }
@@ -99,8 +101,6 @@ actor ContextVisitCoordinator {
     // arriving visit so the abandoned row is not left live indefinitely.
     try await ensureReconciled(now: now)
     let nextGeneration = state.generation + 1
-    let arrivingIdentity = Self.resolvedVisitIdentity(
-      appName: appName, windowTitle: windowTitle, handles: handles, bundleID: bundleID)
     let arriving = try await store.startVisit(
       appName: appName,
       windowTitle: windowTitle,
@@ -163,6 +163,8 @@ actor ContextVisitCoordinator {
     handles: [WorkHistoryHandle] = [],
     bundleID: String? = nil
   ) async throws -> ContextVisitFence {
+    let arrivingIdentity = Self.resolvedVisitIdentity(
+      appName: appName, windowTitle: windowTitle, handles: handles, bundleID: bundleID)
     ensureOwnerChangeObserver()
     await waitForTransitionTurn()
     defer { releaseTransitionTurn() }
@@ -182,8 +184,6 @@ actor ContextVisitCoordinator {
     }
     try await ensureReconciled(now: now)
     let nextGeneration = state.generation + 1
-    let arrivingIdentity = Self.resolvedVisitIdentity(
-      appName: appName, windowTitle: windowTitle, handles: handles, bundleID: bundleID)
     let arriving = try await store.startVisit(
       appName: appName,
       windowTitle: windowTitle,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextVisitCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextVisitCoordinator.swift
@@ -79,7 +79,9 @@ actor ContextVisitCoordinator {
     toApp appName: String,
     windowTitle: String?,
     departingFrame: CapturedFrame?,
-    now: Date = Date()
+    now: Date = Date(),
+    handles: [WorkHistoryHandle] = [],
+    bundleID: String? = nil
   ) async throws -> Transition {
     ensureOwnerChangeObserver()
     await waitForTransitionTurn()
@@ -97,11 +99,15 @@ actor ContextVisitCoordinator {
     // arriving visit so the abandoned row is not left live indefinitely.
     try await ensureReconciled(now: now)
     let nextGeneration = state.generation + 1
+    let arrivingIdentity = Self.resolvedVisitIdentity(
+      appName: appName, windowTitle: windowTitle, handles: handles, bundleID: bundleID)
     let arriving = try await store.startVisit(
       appName: appName,
       windowTitle: windowTitle,
       contextGeneration: nextGeneration,
-      startedAt: now)
+      startedAt: now,
+      handles: arrivingIdentity.handles,
+      bundleID: arrivingIdentity.bundleID)
     state.begin(arriving)
     return Transition(
       departingFence: departure.fence,
@@ -153,7 +159,9 @@ actor ContextVisitCoordinator {
   func rearmAfterSystemResume(
     appName: String,
     windowTitle: String?,
-    now: Date = Date()
+    now: Date = Date(),
+    handles: [WorkHistoryHandle] = [],
+    bundleID: String? = nil
   ) async throws -> ContextVisitFence {
     ensureOwnerChangeObserver()
     await waitForTransitionTurn()
@@ -174,11 +182,15 @@ actor ContextVisitCoordinator {
     }
     try await ensureReconciled(now: now)
     let nextGeneration = state.generation + 1
+    let arrivingIdentity = Self.resolvedVisitIdentity(
+      appName: appName, windowTitle: windowTitle, handles: handles, bundleID: bundleID)
     let arriving = try await store.startVisit(
       appName: appName,
       windowTitle: windowTitle,
       contextGeneration: nextGeneration,
-      startedAt: now)
+      startedAt: now,
+      handles: arrivingIdentity.handles,
+      bundleID: arrivingIdentity.bundleID)
     state.begin(arriving)
     return arriving
   }
@@ -196,6 +208,19 @@ actor ContextVisitCoordinator {
 
   func beginForTesting(_ fence: ContextVisitFence) {
     state.begin(fence)
+  }
+
+  private static func resolvedVisitIdentity(
+    appName: String,
+    windowTitle: String?,
+    handles: [WorkHistoryHandle],
+    bundleID: String?
+  ) -> (handles: [WorkHistoryHandle], bundleID: String?) {
+    if !handles.isEmpty {
+      return (handles, bundleID)
+    }
+    let snapshot = WorkHistoryHandleExtractor.liveSnapshot(appName: appName, windowTitle: windowTitle)
+    return (WorkHistoryHandleExtractor.handles(from: snapshot), snapshot.bundleID)
   }
 
   private func finalizeActive(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
@@ -69,11 +69,21 @@ struct WorkHistoryHandle: Equatable, Hashable, Codable, Sendable {
       path.removeLast()
     }
     components.percentEncodedPath = path.isEmpty ? "/" : path
-    if let query = url.query, !query.isEmpty {
-      components.query = query
+    if let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems {
+      let kept = items.filter { item in
+        let name = item.name.lowercased()
+        return !Self.droppedQueryNames.contains(name) && !name.hasPrefix("utm_")
+      }
+      if !kept.isEmpty {
+        components.queryItems = kept
+      }
     }
     return components.string
   }
+
+  private static let droppedQueryNames: Set<String> = [
+    "usp", "sid", "authuser", "tab", "pli", "hl", "gclid", "fbclid", "igshid",
+  ]
 
   static func canonicalizeFile(_ raw: String) -> String? {
     let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
@@ -15,7 +15,12 @@ struct WorkHistoryHandle: Equatable, Hashable, Codable, Sendable {
   var isDurable: Bool { kind == .url || kind == .file }
 
   func jsonObject() -> [String: String] {
-    ["kind": kind.rawValue, "value": value]
+    ["kind": kind.rawValue, "value": redactedValue]
+  }
+
+  var redactedValue: String {
+    guard kind == .url else { return value }
+    return Self.canonicalizeURL(value) ?? value
   }
 
   static func url(_ raw: String) -> WorkHistoryHandle? {
@@ -64,25 +69,38 @@ struct WorkHistoryHandle: Equatable, Hashable, Codable, Sendable {
     if let port = url.port, !((scheme == "http" && port == 80) || (scheme == "https" && port == 443)) {
       components.port = port
     }
-    var path = url.path
+    let parsed = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    var path = parsed?.percentEncodedPath ?? url.path
     if path.count > 1, path.hasSuffix("/") {
       path.removeLast()
     }
     components.percentEncodedPath = path.isEmpty ? "/" : path
-    if let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems {
-      let kept = items.filter { item in
-        let name = item.name.lowercased()
-        return !Self.droppedQueryNames.contains(name) && !name.hasPrefix("utm_")
+    if let encodedQuery = parsed?.percentEncodedQuery, !encodedQuery.isEmpty {
+      let kept = encodedQuery.split(separator: "&").filter { pair in
+        let name =
+          pair.split(separator: "=", maxSplits: 1).first
+          .map(String.init)?
+          .removingPercentEncoding?
+          .lowercased() ?? ""
+        return !shouldDropQueryName(name)
       }
       if !kept.isEmpty {
-        components.queryItems = kept
+        components.percentEncodedQuery = kept.joined(separator: "&")
       }
     }
     return components.string
   }
 
+  private static func shouldDropQueryName(_ name: String) -> Bool {
+    if droppedQueryNames.contains(name) || name.hasPrefix("utm_") { return true }
+    return name.contains("token") || name.contains("secret") || name.contains("password")
+      || name.contains("passwd") || name.contains("session") || name.hasSuffix("sig")
+  }
+
   private static let droppedQueryNames: Set<String> = [
     "usp", "sid", "authuser", "tab", "pli", "hl", "gclid", "fbclid", "igshid",
+    "code", "state", "access_token", "refresh_token", "id_token", "oauth_token",
+    "api_key", "apikey", "authorization", "bearer", "jwt", "client_secret",
   ]
 
   static func canonicalizeFile(_ raw: String) -> String? {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum WorkHistoryHandleKind: String, Codable, Sendable {
+  case url
+  case file
+  case appWindow = "app_window"
+}
+
+struct WorkHistoryHandle: Equatable, Hashable, Codable, Sendable {
+  var kind: WorkHistoryHandleKind
+  var value: String
+
+  var identityKey: String { "\(kind.rawValue)::\(value)" }
+
+  var isDurable: Bool { kind == .url || kind == .file }
+
+  func jsonObject() -> [String: String] {
+    ["kind": kind.rawValue, "value": value]
+  }
+
+  static func url(_ raw: String) -> WorkHistoryHandle? {
+    guard let canonical = canonicalizeURL(raw) else { return nil }
+    return WorkHistoryHandle(kind: .url, value: canonical)
+  }
+
+  static func file(_ raw: String) -> WorkHistoryHandle? {
+    guard let canonical = canonicalizeFile(raw) else { return nil }
+    return WorkHistoryHandle(kind: .file, value: canonical)
+  }
+
+  static func appWindow(appName: String, title: String) -> WorkHistoryHandle? {
+    let app = appName.trimmingCharacters(in: .whitespacesAndNewlines)
+    let cleaned = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !app.isEmpty, !cleaned.isEmpty else { return nil }
+    return WorkHistoryHandle(kind: .appWindow, value: "\(app)\n\(cleaned)")
+  }
+
+  static func decodeList(from json: String?) -> [WorkHistoryHandle] {
+    guard let json, let data = json.data(using: .utf8),
+      let objects = try? JSONDecoder().decode([WorkHistoryHandle].self, from: data)
+    else { return [] }
+    return objects
+  }
+
+  static func encodeList(_ handles: [WorkHistoryHandle]) -> String {
+    guard let data = try? JSONEncoder().encode(handles),
+      let text = String(data: data, encoding: .utf8)
+    else { return "[]" }
+    return text
+  }
+
+  static func primary(in handles: [WorkHistoryHandle]) -> WorkHistoryHandle? {
+    handles.first(where: { $0.isDurable }) ?? handles.first
+  }
+
+  static func canonicalizeURL(_ raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() else { return nil }
+    guard scheme == "http" || scheme == "https" else { return nil }
+    guard let host = url.host?.lowercased(), !host.isEmpty else { return nil }
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = host
+    if let port = url.port, !((scheme == "http" && port == 80) || (scheme == "https" && port == 443)) {
+      components.port = port
+    }
+    var path = url.path
+    if path.count > 1, path.hasSuffix("/") {
+      path.removeLast()
+    }
+    components.percentEncodedPath = path.isEmpty ? "/" : path
+    if let query = url.query, !query.isEmpty {
+      components.query = query
+    }
+    return components.string
+  }
+
+  static func canonicalizeFile(_ raw: String) -> String? {
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+    let url = URL(fileURLWithPath: trimmed.hasPrefix("file:") ? URL(string: trimmed)?.path ?? trimmed : trimmed)
+    let path = url.standardizedFileURL.path
+    guard !path.isEmpty, path != "/" else { return nil }
+    return path
+  }
+}
+
+struct WorkHistoryFrontmostSnapshot: Equatable, Sendable {
+  var appName: String
+  var windowTitle: String?
+  var bundleID: String?
+  var documentURL: URL?
+  var browserURL: URL?
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandleExtractor.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandleExtractor.swift
@@ -20,7 +20,8 @@ enum WorkHistoryHandleExtractor {
 
   static func handles(from snapshot: WorkHistoryFrontmostSnapshot) -> [WorkHistoryHandle] {
     var result: [WorkHistoryHandle] = []
-    if isBrowser(snapshot.appName), let url = snapshot.browserURL ?? httpURL(from: snapshot.documentURL),
+    if isBrowser(snapshot),
+      let url = httpURL(from: snapshot.documentURL) ?? snapshot.browserURL,
       let handle = WorkHistoryHandle.url(url.absoluteString)
     {
       result.append(handle)
@@ -40,29 +41,55 @@ enum WorkHistoryHandleExtractor {
     return uniqued(result)
   }
 
-  static func liveSnapshot(appName: String, windowTitle: String?) -> WorkHistoryFrontmostSnapshot {
+  static func liveSnapshot(appName: String, windowTitle: String?, expectedBundleID: String? = nil)
+    -> WorkHistoryFrontmostSnapshot
+  {
     var snapshot = WorkHistoryFrontmostSnapshot(
       appName: appName,
       windowTitle: windowTitle,
-      bundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+      bundleID: expectedBundleID ?? NSWorkspace.shared.frontmostApplication?.bundleIdentifier
     )
     guard AXIsProcessTrusted() else { return snapshot }
-    guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else { return snapshot }
-    let app = AXUIElementCreateApplication(pid)
+    guard let front = NSWorkspace.shared.frontmostApplication else { return snapshot }
+    let nameMatches = front.localizedName == appName
+    let bundleMatches = expectedBundleID.map { $0 == front.bundleIdentifier } ?? false
+    guard nameMatches || bundleMatches else { return snapshot }
+    snapshot.bundleID = front.bundleIdentifier
+    let app = AXUIElementCreateApplication(front.processIdentifier)
     guard let window = copyElement(app, attribute: kAXFocusedWindowAttribute) else { return snapshot }
 
     if let document = copyString(window, attribute: kAXDocumentAttribute) {
       snapshot.documentURL = URL(string: document) ?? URL(fileURLWithPath: document)
     }
-    if let url = firstURL(in: window, remaining: 24) {
+    if httpURL(from: snapshot.documentURL) == nil, let url = firstURL(in: window, remaining: 24) {
       snapshot.browserURL = url
     }
     return snapshot
   }
 
-  static func isBrowser(_ appName: String) -> Bool {
-    browserApps.contains(appName)
+  static func isBrowser(_ snapshot: WorkHistoryFrontmostSnapshot) -> Bool {
+    isBrowser(appName: snapshot.appName, bundleID: snapshot.bundleID)
   }
+
+  static func isBrowser(appName: String, bundleID: String? = nil) -> Bool {
+    if browserApps.contains(appName) { return true }
+    guard let bundleID else { return false }
+    return browserBundles.contains(bundleID)
+  }
+
+  private static let browserBundles: Set<String> = [
+    "com.google.Chrome",
+    "com.google.Chrome.canary",
+    "company.thebrowser.Browser",
+    "com.apple.Safari",
+    "org.mozilla.firefox",
+    "com.microsoft.edgemac",
+    "com.brave.Browser",
+    "com.operasoftware.Opera",
+    "org.chromium.Chromium",
+    "com.vivaldi.Vivaldi",
+    "com.kagi.kagimacOS",
+  ]
 
   private static func fileHandle(from url: URL?) -> WorkHistoryHandle? {
     guard let url else { return nil }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandleExtractor.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandleExtractor.swift
@@ -1,0 +1,128 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum WorkHistoryHandleExtractor {
+  private static let browserApps: Set<String> = [
+    "Google Chrome",
+    "Arc",
+    "Safari",
+    "Firefox",
+    "Microsoft Edge",
+    "Brave Browser",
+    "Opera",
+    "Chromium",
+    "Vivaldi",
+    "Orion",
+    "Dia",
+    "Comet",
+  ]
+
+  static func handles(from snapshot: WorkHistoryFrontmostSnapshot) -> [WorkHistoryHandle] {
+    var result: [WorkHistoryHandle] = []
+    if isBrowser(snapshot.appName), let url = snapshot.browserURL ?? httpURL(from: snapshot.documentURL),
+      let handle = WorkHistoryHandle.url(url.absoluteString)
+    {
+      result.append(handle)
+    } else if let fileHandle = fileHandle(from: snapshot.documentURL) {
+      result.append(fileHandle)
+    } else if let url = snapshot.browserURL, let handle = WorkHistoryHandle.url(url.absoluteString) {
+      result.append(handle)
+    }
+
+    if let windowHandle = WorkHistoryHandle.appWindow(
+      appName: snapshot.appName,
+      title: ContextTitleNormalizer.normalize(snapshot.windowTitle, appName: snapshot.appName)
+        ?? snapshot.windowTitle ?? "")
+    {
+      result.append(windowHandle)
+    }
+    return uniqued(result)
+  }
+
+  static func liveSnapshot(appName: String, windowTitle: String?) -> WorkHistoryFrontmostSnapshot {
+    var snapshot = WorkHistoryFrontmostSnapshot(
+      appName: appName,
+      windowTitle: windowTitle,
+      bundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    )
+    guard AXIsProcessTrusted() else { return snapshot }
+    guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else { return snapshot }
+    let app = AXUIElementCreateApplication(pid)
+    guard let window = copyElement(app, attribute: kAXFocusedWindowAttribute) else { return snapshot }
+
+    if let document = copyString(window, attribute: kAXDocumentAttribute) {
+      snapshot.documentURL = URL(string: document) ?? URL(fileURLWithPath: document)
+    }
+    if let url = firstURL(in: window, remaining: 24) {
+      snapshot.browserURL = url
+    }
+    return snapshot
+  }
+
+  static func isBrowser(_ appName: String) -> Bool {
+    browserApps.contains(appName)
+  }
+
+  private static func fileHandle(from url: URL?) -> WorkHistoryHandle? {
+    guard let url else { return nil }
+    if url.isFileURL {
+      return WorkHistoryHandle.file(url.path)
+    }
+    if url.scheme == nil {
+      return WorkHistoryHandle.file(url.path)
+    }
+    return nil
+  }
+
+  private static func httpURL(from url: URL?) -> URL? {
+    guard let url, let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+      return nil
+    }
+    return url
+  }
+
+  private static func uniqued(_ handles: [WorkHistoryHandle]) -> [WorkHistoryHandle] {
+    var seen = Set<WorkHistoryHandle>()
+    return handles.filter { seen.insert($0).inserted }
+  }
+
+  private static func copyElement(_ element: AXUIElement, attribute: String) -> AXUIElement? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
+      let value,
+      CFGetTypeID(value) == AXUIElementGetTypeID()
+    else { return nil }
+    return unsafeDowncast(value, to: AXUIElement.self)
+  }
+
+  private static func copyString(_ element: AXUIElement, attribute: String) -> String? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else { return nil }
+    if let string = value as? String { return string }
+    if let url = value as? URL { return url.absoluteString }
+    return nil
+  }
+
+  private static func firstURL(in element: AXUIElement, remaining: Int) -> URL? {
+    guard remaining > 0 else { return nil }
+    if let raw = copyString(element, attribute: "AXURL"),
+      let url = URL(string: raw),
+      let scheme = url.scheme?.lowercased(),
+      scheme == "http" || scheme == "https"
+    {
+      return url
+    }
+    var children: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &children) == .success,
+      let list = children as? [AXUIElement]
+    else { return nil }
+    var budget = remaining - 1
+    for child in list.prefix(8) {
+      if let url = firstURL(in: child, remaining: budget) { return url }
+      budget -= 1
+      if budget <= 0 { break }
+    }
+    return nil
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
@@ -1,0 +1,189 @@
+import Foundation
+@preconcurrency import GRDB
+
+struct WorkHistoryVisitRecord: Equatable, Sendable {
+  var startedAt: Date
+  var endedAt: Date?
+  var appName: String
+  var title: String
+  var handles: [WorkHistoryHandle]
+  var bucketID: String?
+  var outcome: String
+
+  func jsonObject(clock: (Date) -> String) -> [String: Any] {
+    var object: [String: Any] = [
+      "start": clock(startedAt),
+      "end": clock(endedAt ?? startedAt),
+      "app": appName,
+      "title": title,
+      "handles": handles.map { $0.jsonObject() },
+      "outcome": outcome,
+    ]
+    if let bucketID {
+      object["bucket_id"] = bucketID
+    }
+    return object
+  }
+}
+
+struct WorkstreamBrief: Equatable, Sendable {
+  var bucketID: String
+  var name: String
+  var lastVisitAt: Date?
+  var handles: [WorkHistoryHandle]
+  var facts: [String]
+
+  func jsonObject() -> [String: Any] {
+    var object: [String: Any] = [
+      "bucket_id": bucketID,
+      "name": name,
+      "handles": handles.map { $0.jsonObject() },
+      "facts": facts,
+    ]
+    if let lastVisitAt {
+      object["last_visit"] = ISO8601DateFormatter().string(from: lastVisitAt)
+    }
+    return object
+  }
+
+  func recapLine() -> String {
+    let handleText =
+      handles.first(where: \.isDurable).map(\.value)
+      ?? handles.first?.value.split(separator: "\n").last.map(String.init)
+      ?? name
+    return "- \(name): \(handleText)"
+  }
+}
+
+enum WorkHistoryIndex {
+  static func decodeVisits(from rows: [Row]) -> [WorkHistoryVisitRecord] {
+    rows.compactMap { row in
+      guard let startedAt = row["startedAt"] as Date?,
+        let appName = row["appName"] as String?
+      else { return nil }
+      let rawKey = row["rawContextKey"] as String? ?? ""
+      let title = rawKey.split(separator: "\n", maxSplits: 1).dropFirst().first.map(String.init) ?? rawKey
+      return WorkHistoryVisitRecord(
+        startedAt: startedAt,
+        endedAt: row["endedAt"] as Date?,
+        appName: appName,
+        title: title,
+        handles: WorkHistoryHandle.decodeList(from: row["handlesJson"] as String?),
+        bucketID: row["bucketID"] as String?,
+        outcome: row["outcome"] as String? ?? "completed"
+      )
+    }
+  }
+
+  static func fetchRecentVisits(
+    in db: Database,
+    from start: Date,
+    to end: Date,
+    limit: Int
+  ) throws -> [WorkHistoryVisitRecord] {
+    guard try db.tableExists("context_visits") else { return [] }
+    let columns = try db.columns(in: "context_visits").map(\.name)
+    guard columns.contains("handlesJson") else { return [] }
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT startedAt, endedAt, appName, rawContextKey, handlesJson, bucketID, outcome
+        FROM context_visits
+        WHERE startedAt >= ? AND startedAt <= ?
+          AND outcome IN ('completed', 'interrupted', 'active')
+        ORDER BY startedAt DESC
+        LIMIT ?
+        """,
+      arguments: [start, end, max(1, limit)])
+    return decodeVisits(from: rows)
+  }
+
+  static func fetchBriefs(in db: Database, limit: Int) throws -> [WorkstreamBrief] {
+    guard try db.tableExists("context_buckets") else { return [] }
+    let buckets = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT id, displayLabel, subjectKind, subjectID, lastVisitedAt
+        FROM context_buckets
+        ORDER BY COALESCE(lastVisitedAt, updatedAt) DESC
+        LIMIT ?
+        """,
+      arguments: [max(1, limit)])
+    return try buckets.compactMap { row -> WorkstreamBrief? in
+      guard let id = row["id"] as String? else { return nil }
+      let subjectKind = row["subjectKind"] as String? ?? "context"
+      let subjectID = row["subjectID"] as String? ?? id
+      let display = row["displayLabel"] as String?
+      let name = (display?.isEmpty == false ? display : nil) ?? defaultName(kind: subjectKind, subjectID: subjectID)
+      let handles = try handles(forBucket: id, subjectKind: subjectKind, subjectID: subjectID, in: db)
+      let facts = try String.fetchAll(
+        db,
+        sql: """
+          SELECT statement FROM bucket_facts
+          WHERE bucketID = ? AND validityState = 'validated'
+          ORDER BY updatedAt DESC
+          LIMIT 5
+          """,
+        arguments: [id])
+      return WorkstreamBrief(
+        bucketID: id,
+        name: name,
+        lastVisitAt: row["lastVisitedAt"] as Date?,
+        handles: handles,
+        facts: facts
+      )
+    }
+  }
+
+  static func recapSection(from briefs: [WorkstreamBrief]) -> String {
+    guard !briefs.isEmpty else { return "" }
+    var out = "\n## Workstreams (\(briefs.count))\n"
+    for brief in briefs.prefix(8) {
+      out += brief.recapLine() + "\n"
+    }
+    return out
+  }
+
+  private static func handles(
+    forBucket id: String,
+    subjectKind: String,
+    subjectID: String,
+    in db: Database
+  ) throws -> [WorkHistoryHandle] {
+    var handles: [WorkHistoryHandle] = []
+    if subjectKind == WorkHistoryHandleKind.url.rawValue, let handle = WorkHistoryHandle.url(subjectID) {
+      handles.append(handle)
+    } else if subjectKind == WorkHistoryHandleKind.file.rawValue, let handle = WorkHistoryHandle.file(subjectID) {
+      handles.append(handle)
+    }
+    if try db.columns(in: "context_visits").map(\.name).contains("handlesJson") {
+      let encoded = try String.fetchAll(
+        db,
+        sql: """
+          SELECT handlesJson FROM context_visits
+          WHERE bucketID = ? AND handlesJson IS NOT NULL AND handlesJson != '[]'
+          ORDER BY startedAt DESC
+          LIMIT 5
+          """,
+        arguments: [id])
+      for json in encoded {
+        handles.append(contentsOf: WorkHistoryHandle.decodeList(from: json))
+      }
+    }
+    var seen = Set<WorkHistoryHandle>()
+    return handles.filter { seen.insert($0).inserted }
+  }
+
+  private static func defaultName(kind: String, subjectID: String) -> String {
+    if kind == WorkHistoryHandleKind.url.rawValue, let url = URL(string: subjectID) {
+      return url.host.map { "\($0)\(url.path)" } ?? subjectID
+    }
+    if kind == WorkHistoryHandleKind.file.rawValue {
+      return URL(fileURLWithPath: subjectID).lastPathComponent
+    }
+    if let title = subjectID.split(separator: "\n").last, !title.isEmpty {
+      return String(title)
+    }
+    return "Workstream"
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
@@ -79,7 +79,8 @@ enum WorkHistoryIndex {
     in db: Database,
     from start: Date,
     to end: Date,
-    limit: Int
+    limit: Int,
+    excludedApps: Set<String> = []
   ) throws -> [WorkHistoryVisitRecord] {
     guard try db.tableExists("context_visits") else { return [] }
     let columns = try db.columns(in: "context_visits").map(\.name)
@@ -95,10 +96,12 @@ enum WorkHistoryIndex {
         LIMIT ?
         """,
       arguments: [start, end, max(1, limit)])
-    return decodeVisits(from: rows)
+    let visits = decodeVisits(from: rows)
+    if excludedApps.isEmpty { return visits }
+    return visits.filter { !excludedApps.contains($0.appName) }
   }
 
-  static func fetchBriefs(in db: Database, limit: Int) throws -> [WorkstreamBrief] {
+  static func fetchBriefs(in db: Database, limit: Int, excludedApps: Set<String> = []) throws -> [WorkstreamBrief] {
     guard try db.tableExists("context_buckets") else { return [] }
     let buckets = try Row.fetchAll(
       db,
@@ -111,6 +114,15 @@ enum WorkHistoryIndex {
       arguments: [max(1, limit)])
     return try buckets.compactMap { row -> WorkstreamBrief? in
       guard let id = row["id"] as String? else { return nil }
+      if !excludedApps.isEmpty {
+        let visitApps = try String.fetchAll(
+          db,
+          sql: "SELECT DISTINCT appName FROM context_visits WHERE bucketID = ?",
+          arguments: [id])
+        if !visitApps.isEmpty, visitApps.allSatisfy({ excludedApps.contains($0) }) {
+          return nil
+        }
+      }
       let subjectKind = row["subjectKind"] as String? ?? "context"
       let subjectID = row["subjectID"] as String? ?? id
       let display = row["displayLabel"] as String?

--- a/desktop/macos/Desktop/Tests/WorkHistoryHandleTests.swift
+++ b/desktop/macos/Desktop/Tests/WorkHistoryHandleTests.swift
@@ -18,6 +18,18 @@ final class WorkHistoryHandleTests: XCTestCase {
     XCTAssertEqual(shared, clean)
   }
 
+  func testCredentialQueryIsDroppedFromIdentityAndOutboundJSON() {
+    let handle = WorkHistoryHandle.url(
+      "https://docs.google.com/document/d/abc?access_token=secret&q=proposal")
+    XCTAssertEqual(handle?.value, "https://docs.google.com/document/d/abc?q=proposal")
+    XCTAssertEqual(handle?.jsonObject()["value"], "https://docs.google.com/document/d/abc?q=proposal")
+  }
+
+  func testPreservesPercentEncodedPathIdentity() {
+    let handle = WorkHistoryHandle.url("https://example.com/a%2Fb/?utm_source=x")
+    XCTAssertEqual(handle?.value, "https://example.com/a%2Fb")
+  }
+
   func testBrowserPrefersDocumentURLOverChildAXURL() {
     let snapshot = WorkHistoryFrontmostSnapshot(
       appName: "Safari",

--- a/desktop/macos/Desktop/Tests/WorkHistoryHandleTests.swift
+++ b/desktop/macos/Desktop/Tests/WorkHistoryHandleTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class WorkHistoryHandleTests: XCTestCase {
+  func testCanonicalizesHttpURLAndDropsFragmentUserinfoAndDefaultPort() {
+    let handle = WorkHistoryHandle.url(
+      "HTTPS://User:secret@Docs.Google.COM:443/document/d/abc/?usp=sharing#heading")
+    XCTAssertEqual(handle?.kind, .url)
+    XCTAssertEqual(handle?.value, "https://docs.google.com/document/d/abc?usp=sharing")
+  }
+
+  func testRejectsNonHttpSchemesAndAboutBlank() {
+    XCTAssertNil(WorkHistoryHandle.url("about:blank"))
+    XCTAssertNil(WorkHistoryHandle.url("javascript:alert(1)"))
+    XCTAssertNil(WorkHistoryHandle.url("file:///tmp/notes.md"))
+  }
+
+  func testCanonicalizesFilePaths() {
+    XCTAssertEqual(WorkHistoryHandle.file("file:///Users/ada/Notes.md")?.value, "/Users/ada/Notes.md")
+    XCTAssertEqual(WorkHistoryHandle.file("/Users/ada/./Notes.md")?.value, "/Users/ada/Notes.md")
+    XCTAssertNil(WorkHistoryHandle.file("/"))
+  }
+
+  func testExtractorPrefersBrowserURLOverWindowTitle() {
+    let snapshot = WorkHistoryFrontmostSnapshot(
+      appName: "Google Chrome",
+      windowTitle: "Proposal - Google Docs",
+      bundleID: "com.google.Chrome",
+      documentURL: nil,
+      browserURL: URL(string: "https://docs.google.com/document/d/abc")
+    )
+    let handles = WorkHistoryHandleExtractor.handles(from: snapshot)
+    XCTAssertEqual(handles.first?.kind, .url)
+    XCTAssertEqual(handles.first?.value, "https://docs.google.com/document/d/abc")
+    XCTAssertTrue(handles.contains(where: { $0.kind == .appWindow }))
+  }
+
+  func testExtractorUsesAXDocumentAsFileHandleForEditors() {
+    let snapshot = WorkHistoryFrontmostSnapshot(
+      appName: "Cursor",
+      windowTitle: "WorkHistoryHandle.swift — omi",
+      bundleID: "com.todesktop.230313mzl4w4u92",
+      documentURL: URL(fileURLWithPath: "/Users/ada/omi/WorkHistoryHandle.swift"),
+      browserURL: nil
+    )
+    let handles = WorkHistoryHandleExtractor.handles(from: snapshot)
+    XCTAssertEqual(handles.first?.kind, .file)
+    XCTAssertEqual(handles.first?.value, "/Users/ada/omi/WorkHistoryHandle.swift")
+  }
+
+  func testSameCanonicalURLIsPrimaryAcrossApps() {
+    let chrome = WorkHistoryHandleExtractor.handles(
+      from: WorkHistoryFrontmostSnapshot(
+        appName: "Google Chrome",
+        windowTitle: "PR 12",
+        browserURL: URL(string: "https://github.com/BasedHardware/omi/pull/12/")
+      ))
+    let arc = WorkHistoryHandleExtractor.handles(
+      from: WorkHistoryFrontmostSnapshot(
+        appName: "Arc",
+        windowTitle: "Different title",
+        browserURL: URL(string: "https://github.com/BasedHardware/omi/pull/12")
+      ))
+    XCTAssertEqual(WorkHistoryHandle.primary(in: chrome), WorkHistoryHandle.primary(in: arc))
+  }
+}
+
+final class WorkHistoryIndexTests: XCTestCase {
+  func testSecondURLVisitCreatesHandleBucketNotTitleHash() throws {
+    let queue = try migratedQueue()
+    let url = try XCTUnwrap(WorkHistoryHandle.url("https://docs.google.com/document/d/abc"))
+    let firstStart = Date(timeIntervalSince1970: 1_725_000_000)
+
+    try queue.write { db in
+      XCTAssertNil(
+        try ContextBucketVisitResolver.resolveBucketID(
+          in: db,
+          referenceHash: "sha256:chrome-title",
+          normalizedTitle: "Proposal",
+          startedAt: firstStart,
+          primaryHandle: url))
+      _ = try insertVisit(
+        in: db,
+        appName: "Google Chrome",
+        windowTitle: "Proposal",
+        handle: url,
+        referenceHash: "sha256:chrome-title",
+        startedAt: firstStart,
+        endedAt: firstStart.addingTimeInterval(4),
+        outcome: "completed")
+
+      let second = try XCTUnwrap(
+        ContextBucketVisitResolver.resolveBucketID(
+          in: db,
+          referenceHash: "sha256:arc-title",
+          normalizedTitle: "Other tab title",
+          startedAt: firstStart.addingTimeInterval(60),
+          primaryHandle: url))
+      XCTAssertEqual(
+        try String.fetchOne(db, sql: "SELECT subjectKind FROM context_buckets WHERE id = ?", arguments: [second]),
+        "url")
+      XCTAssertEqual(
+        try String.fetchOne(db, sql: "SELECT subjectID FROM context_buckets WHERE id = ?", arguments: [second]),
+        url.value)
+    }
+  }
+
+  func testTitleOnlyFirstVisitStaysUnbucketed() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      XCTAssertNil(
+        try ContextBucketVisitResolver.resolveBucketID(
+          in: db,
+          referenceHash: "sha256:only-title",
+          normalizedTitle: "Notes",
+          startedAt: Date(timeIntervalSince1970: 1_725_000_000),
+          primaryHandle: nil))
+    }
+  }
+
+  func testWorkContextVisitsAndBriefsComeFromHandleIndex() throws {
+    let queue = try migratedQueue()
+    let url = try XCTUnwrap(WorkHistoryHandle.url("https://docs.google.com/document/d/abc"))
+    let start = Date(timeIntervalSince1970: 1_725_000_000)
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets
+            (id, subjectKind, subjectID, displayLabel, visitCount, lastVisitedAt, createdAt, updatedAt)
+          VALUES ('bucket-1', 'url', ?, 'Pricing proposal', 2, ?, ?, ?)
+          """,
+        arguments: [url.value, start, start, start])
+      _ = try insertVisit(
+        in: db,
+        appName: "Arc",
+        windowTitle: "Pricing proposal",
+        handle: url,
+        referenceHash: url.identityKey,
+        bucketID: "bucket-1",
+        startedAt: start,
+        endedAt: start.addingTimeInterval(30),
+        outcome: "completed")
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_entries
+            (id, bucketID, visitID, appName, rawContextKey, normalizedContextKey,
+             narrative, evidenceRefsJson, tokenCount, createdAt)
+          VALUES ('entry-1', 'bucket-1', 1, 'Arc', 'Arc\nPricing', 'arc::pricing',
+                  'Working the pricing doc', '[]', 10, ?)
+          """,
+        arguments: [start])
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_facts
+            (id, bucketID, entryID, appName, statement, identifiersJson, evidenceText,
+             evidenceRefsJson, validityState, dispositionState, confidence,
+             notifyWorthiness, createdAt, updatedAt)
+          VALUES ('fact-1', 'bucket-1', 'entry-1', 'Arc', 'Pricing doc is the source of truth',
+                  ?, 'Pricing doc', '["visit:1"]', 'validated', 'none', 0.9, 0.2, ?, ?)
+          """,
+        arguments: [WorkHistoryHandle.encodeList([url]), start, start])
+
+      let visits = try WorkHistoryIndex.fetchRecentVisits(
+        in: db, from: start.addingTimeInterval(-60), to: start.addingTimeInterval(60), limit: 10)
+      XCTAssertEqual(visits.count, 1)
+      XCTAssertEqual(visits.first?.handles.first?.value, url.value)
+
+      let briefs = try WorkHistoryIndex.fetchBriefs(in: db, limit: 5)
+      XCTAssertEqual(briefs.first?.bucketID, "bucket-1")
+      XCTAssertEqual(briefs.first?.handles.first?.kind, .url)
+      XCTAssertTrue(WorkHistoryIndex.recapSection(from: briefs).contains("Pricing proposal"))
+    }
+  }
+
+  private func migratedQueue() throws -> DatabaseQueue {
+    let queue = try DatabaseQueue()
+    try queue.write { db in
+      try db.create(table: "screenshots") { table in
+        table.autoIncrementedPrimaryKey("id")
+        table.column("timestamp", .datetime).notNull()
+        table.column("appName", .text).notNull()
+      }
+    }
+    var migrator = DatabaseMigrator()
+    let defaults = try XCTUnwrap(
+      UserDefaults(suiteName: "WorkHistoryIndexTests.\(UUID().uuidString)"))
+    ContextBucketSchema.registerMigration(on: &migrator, defaults: defaults, ownerID: "owner")
+    try migrator.migrate(queue)
+    return queue
+  }
+
+  @discardableResult
+  private func insertVisit(
+    in db: Database,
+    appName: String,
+    windowTitle: String,
+    handle: WorkHistoryHandle?,
+    referenceHash: String,
+    bucketID: String? = nil,
+    startedAt: Date,
+    endedAt: Date? = nil,
+    outcome: String
+  ) throws -> Int64 {
+    let handles = handle.map { [$0] } ?? []
+    try db.execute(
+      sql: """
+        INSERT INTO context_visits
+          (contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+           normalizedContextKey, referenceHash, startedAt, outcome, endedAt, createdAt, updatedAt,
+           primaryHandleType, primaryHandleValue, handlesJson)
+        VALUES (1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        bucketID, appName, "\(appName)\n\(windowTitle)", "\(appName.lowercased())::\(windowTitle.lowercased())",
+        referenceHash, startedAt, outcome, endedAt, startedAt, endedAt ?? startedAt,
+        handle?.kind.rawValue, handle?.value, WorkHistoryHandle.encodeList(handles),
+      ])
+    return db.lastInsertedRowID
+  }
+}

--- a/desktop/macos/Desktop/Tests/WorkHistoryHandleTests.swift
+++ b/desktop/macos/Desktop/Tests/WorkHistoryHandleTests.swift
@@ -9,7 +9,26 @@ final class WorkHistoryHandleTests: XCTestCase {
     let handle = WorkHistoryHandle.url(
       "HTTPS://User:secret@Docs.Google.COM:443/document/d/abc/?usp=sharing#heading")
     XCTAssertEqual(handle?.kind, .url)
-    XCTAssertEqual(handle?.value, "https://docs.google.com/document/d/abc?usp=sharing")
+    XCTAssertEqual(handle?.value, "https://docs.google.com/document/d/abc")
+  }
+
+  func testTrackingQueryDoesNotSplitIdentity() {
+    let shared = WorkHistoryHandle.url("https://docs.google.com/document/d/abc?usp=sharing")
+    let clean = WorkHistoryHandle.url("https://docs.google.com/document/d/abc")
+    XCTAssertEqual(shared, clean)
+  }
+
+  func testBrowserPrefersDocumentURLOverChildAXURL() {
+    let snapshot = WorkHistoryFrontmostSnapshot(
+      appName: "Safari",
+      windowTitle: "Proposal",
+      bundleID: "com.apple.Safari",
+      documentURL: URL(string: "https://docs.google.com/document/d/abc"),
+      browserURL: URL(string: "https://example.com/favicon.ico")
+    )
+    XCTAssertEqual(
+      WorkHistoryHandleExtractor.handles(from: snapshot).first?.value,
+      "https://docs.google.com/document/d/abc")
   }
 
   func testRejectsNonHttpSchemesAndAboutBlank() {

--- a/desktop/macos/changelog/unreleased/20260814-work-history-handles.json
+++ b/desktop/macos/changelog/unreleased/20260814-work-history-handles.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat can now find recent work by the document, URL, or file you were in, not only by a screenshot of the tab"
+}

--- a/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
+++ b/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
@@ -24,6 +24,9 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextSubjectBindingService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextTitleNormalizer.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextVisitCoordinator.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandle.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandleExtractor.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/InsightSQLPrivacy.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindCaptureExclusion.swift

--- a/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
+++ b/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
@@ -82,6 +82,14 @@ steps:
       binding, delivery, or candidate from the prior authorization session appears.
 
   - id: S6
+    name: Ask chat for the document by handle
+    do: >
+      After revisiting one of the numbered documents from S1, ask chat where that document
+      is. Confirm get_work_context returns a visit or workstream brief whose handle is the
+      document URL or file path, not only a Rewind screenshot. Switching browsers on the
+      same URL must stay one workstream.
+
+  - id: S7
     name: Logs are clean
     log.expect:
       absent:


### PR DESCRIPTION
## Product invariants affected

- INV-CHAT-1

## Summary
- Persist durable source handles (browser URL, file path, app+window fallback) on context visits at the switch edge.
- Prefer those handles for context-bucket identity so the same Google Doc in Chrome and Arc is one workstream.
- `get_work_context` now returns visit handles and workstream briefs first; the screenshot timeline stays as fallback.

## Test Plan
- [x] `xcrun swift test -c debug --package-path Desktop --filter 'WorkHistoryHandleTests|WorkHistoryIndexTests|ContextBucketVisitResolverTests|ContextVisitCoordinatorTests'` (19 passed)
- [ ] Dogfood: switch between two browsers on the same URL twice and ask chat where that doc is.

## Verification
Focused Swift suites above passed after a real compile. Live AX URL capture was not exercised in a named bundle in this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

