### PR TITLE
fix(desktop): new beta installs run context buckets without waiting on targeting

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,36 +1,48 @@
+Follow-up to #11577. That change made the beta/stable split exact by keying it on `AppBuild.isBetaProductionBundle`, which fixed *stable* leakage. This one fixes the other half: which beta users actually get the feature.
+
 ## Problem
 
-`ContextBucketsFeature.isEnabled` gated non-production bundles on `OMI_FORCE_CONTEXT_BUCKETS=1`, read from `ProcessInfo.processInfo.environment` at runtime. That only survives a launch that goes through `run.sh`.
+After #11577, a beta client still asks PostHog whether `context_buckets` is on. That flag's audience can only be described two ways, and both fail for a **newly installed** beta client:
 
-Any other launch path drops it — opening the bundle from Finder, or macOS restoring the app after the user grants Screen Recording. `isEnabled` then falls through to the PostHog `context_buckets` flag, which does not resolve true for dev bundles. The result is the worst possible shape: screen capture keeps running normally (`is_monitoring: true`, `capture_gate: flowing`) while the bucket pipeline is off and records nothing.
+- **The person property `update_channel`.** Registered as a super property at init, so it rides events — but the person record is only written by `identify`, which returns early when nobody is signed in. Across 14 days of macOS clients, 215 of ~260 beta installs had a null person-side channel and 11 reported `stable`. It resolved for roughly a sixth of the channel.
+- **A static cohort.** Describes only the users who existed when it was built. A new install is not in it.
 
-Observed today on a QA bundle during dogfood, immediately after granting Screen Recording:
+Behavioral cohorts would solve this, since they recalculate — but PostHog refuses them in flag targeting:
 
 ```
-has_screen_recording_permission: true
-is_monitoring: true
-capture_gate: flowing
-context_buckets_enabled: false   <-- silently off
+Cohort 'macOS beta channel (auto-updating)' has an event-based condition on
+'App Launched' (performed_event) and cannot be used in feature flags.
 ```
 
-Zero `context_visits` rows accumulated. This is indistinguishable from "the feature never fires," and cost real debugging time before the environment was inspected with `ps eww`.
+So there is no server-side expression of "is running the beta build" that stays correct as users arrive. A new beta user matches nothing and silently gets no notifications — the same class of silent-off failure #11577 was opened to remove, one layer up.
 
 ## Change
 
-Non-production bundles no longer consult PostHog and default to **on**. The environment variable is kept as an escape hatch to force the pipeline *off*:
+Bundle identity already answers "is this the beta build" exactly, offline, before any network call. So beta enablement no longer consults `context_buckets` at all.
 
+What is still worth having remotely is the ability to **stop** the pipeline, so beta reads a dedicated kill switch instead:
+
+```swift
+guard AppBuild.isBetaProductionBundle else { return false }
+return !PostHogManager.shared.isFeatureEnabled(killSwitchFlagName)
 ```
-OMI_FORCE_CONTEXT_BUCKETS=0
-```
 
-Dev and QA bundles exist to exercise this pipeline, so "on" is the correct default and the failure mode becomes loud rather than silent.
+`context_buckets_kill` is inverted deliberately. `isFeatureEnabled` returns false when PostHog is unavailable or uninitialized, so absent, unresolved, and false all mean "run the pipeline"; only an explicit true stops it. An unreachable PostHog cannot switch the dogfood channel off by accident.
 
-## Production behavior is unchanged
+The flag exists and is currently **off**, so this ships enabled: https://us.posthog.com/project/302298/feature_flags/821229
 
-`AppBuild.isNonProduction` is false for every production-family bundle, so stable and beta still resolve through the PostHog flag and still fail closed when it is unavailable or uninitialized.
+## Blast radius
+
+Stable is gated out one line above and never reaches this branch, so the fail-open default cannot touch it. The audience is the beta channel — roughly 337 macOS clients.
+
+`context_buckets` is left in place and still governs clients built before #11577, which continue to read it.
+
+## Trade-off worth naming
+
+Fail-open is the right default for a dogfood channel that is currently failing *closed* by accident, but it does mean a PostHog outage leaves notifications running rather than pausing them. Given stable is untouchable here and the kill switch is one toggle, that seems the correct side to err on. Worth a second opinion.
 
 ## Testing
 
-Not covered by a unit test: `isEnabled` reads the `AppBuild.isNonProduction` global and `PostHogManager.shared`, neither of which has an injection seam today. Adding one would be a wider refactor than this fix warrants. Verified behaviorally instead — a dev bundle relaunched without the variable now reports `context_buckets_enabled: true` and accumulates visits.
+Not covered by a unit test: `isEnabled` reads `AppBuild` globals and `PostHogManager.shared`, neither of which has an injection seam today. Verified behaviorally — a bundle carrying #11577 and no environment overrides reports `context_buckets_enabled: true` and accumulated 75 visits, 9 buckets, 143 facts and 20 deliveries.
 
 Failure-Class: none

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum ContextBucketsFeature {
   static let flagName = "context_buckets"
+  /// Remote stop for the beta channel. Inverted on purpose: absent, unresolved, and false
+  /// all mean "run the pipeline", so only an explicit true switches it off.
+  static let killSwitchFlagName = "context_buckets_kill"
   private static let localQAOverrideName = "OMI_FORCE_CONTEXT_BUCKETS"
 
   /// PostHog feature flags fail closed while unavailable or uninitialized, so the
@@ -26,7 +29,19 @@ enum ContextBucketsFeature {
     // beta installs had a null person-side channel and 11 reported `stable`, so
     // person-property targeting resolved for roughly a sixth of the channel. Bundle
     // identity is exact and available before any network call.
+    //
+    // Enablement does not consult `context_buckets` either, because that flag inherits the
+    // same problem from the other side: its audience can only be described with a static
+    // cohort or the unreliable person property, so a *newly installed* beta client matches
+    // neither and would silently get nothing. PostHog rejects behavioral cohorts in flag
+    // targeting, so there is no server-side expression of "is running the beta build" that
+    // stays correct as users arrive. Bundle identity already answers that question exactly.
+    //
+    // What remains useful remotely is the ability to stop the pipeline, so beta reads only
+    // the kill switch, and reads it fail-open: an unreachable or uninitialized PostHog must
+    // not switch the dogfood channel off by accident. Stable is gated out above, so this
+    // default cannot reach it.
     guard AppBuild.isBetaProductionBundle else { return false }
-    return PostHogManager.shared.isFeatureEnabled(flagName)
+    return !PostHogManager.shared.isFeatureEnabled(killSwitchFlagName)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260814-beta-context-buckets-default.json
+++ b/desktop/macos/changelog/unreleased/20260814-beta-context-buckets-default.json
@@ -1,0 +1,3 @@
+{
+  "change": "New beta installs get context-bucket notifications immediately instead of waiting to be picked up by analytics targeting"
+}


### PR DESCRIPTION
Follow-up to #11577. That change made the beta/stable split exact by keying it on `AppBuild.isBetaProductionBundle`, which fixed *stable* leakage. This one fixes the other half: which beta users actually get the feature.

## Problem

After #11577, a beta client still asks PostHog whether `context_buckets` is on. That flag's audience can only be described two ways, and both fail for a **newly installed** beta client:

- **The person property `update_channel`.** Registered as a super property at init, so it rides events — but the person record is only written by `identify`, which returns early when nobody is signed in. Across 14 days of macOS clients, 215 of ~260 beta installs had a null person-side channel and 11 reported `stable`. It resolved for roughly a sixth of the channel.
- **A static cohort.** Describes only the users who existed when it was built. A new install is not in it.

Behavioral cohorts would solve this, since they recalculate — but PostHog refuses them in flag targeting:

```
Cohort 'macOS beta channel (auto-updating)' has an event-based condition on
'App Launched' (performed_event) and cannot be used in feature flags.
```

So there is no server-side expression of "is running the beta build" that stays correct as users arrive. A new beta user matches nothing and silently gets no notifications — the same class of silent-off failure #11577 was opened to remove, one layer up.

## Change

Bundle identity already answers "is this the beta build" exactly, offline, before any network call. So beta enablement no longer consults `context_buckets` at all.

What is still worth having remotely is the ability to **stop** the pipeline, so beta reads a dedicated kill switch instead:

```swift
guard AppBuild.isBetaProductionBundle else { return false }
return !PostHogManager.shared.isFeatureEnabled(killSwitchFlagName)
```

`context_buckets_kill` is inverted deliberately. `isFeatureEnabled` returns false when PostHog is unavailable or uninitialized, so absent, unresolved, and false all mean "run the pipeline"; only an explicit true stops it. An unreachable PostHog cannot switch the dogfood channel off by accident.

The flag exists and is currently **off**, so this ships enabled: https://us.posthog.com/project/302298/feature_flags/821229

## Blast radius

Stable is gated out one line above and never reaches this branch, so the fail-open default cannot touch it. The audience is the beta channel — roughly 337 macOS clients.

`context_buckets` is left in place and still governs clients built before #11577, which continue to read it.

## Trade-off worth naming

Fail-open is the right default for a dogfood channel that is currently failing *closed* by accident, but it does mean a PostHog outage leaves notifications running rather than pausing them. Given stable is untouchable here and the kill switch is one toggle, that seems the correct side to err on. Worth a second opinion.

## Testing

Not covered by a unit test: `isEnabled` reads `AppBuild` globals and `PostHogManager.shared`, neither of which has an injection seam today. Verified behaviorally — a bundle carrying #11577 and no environment overrides reports `context_buckets_enabled: true` and accumulated 75 visits, 9 buckets, 143 facts and 20 deliveries.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

