### PR TITLE
feat(desktop): one-click Today in the task composer; priority moves to task details

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -3291,24 +3291,45 @@ class TasksViewModel: ObservableObject {
     let cal = Calendar.current
     let startOfToday = cal.startOfDay(for: Date())
     switch category {
-    case .today: return cal.date(bySettingHour: 23, minute: 59, second: 0, of: Date())
+    case .today: return Self.todayDueAt()
     case .tomorrow: return cal.date(byAdding: .day, value: 1, to: startOfToday)
     case .later: return cal.date(byAdding: .day, value: 7, to: startOfToday)
     case .noDeadline: return nil
     }
   }
 
+  /// Due date assigned by the composer's "Today" button: end of the current day.
+  static func todayDueAt(now: Date = Date(), calendar: Calendar = .current) -> Date? {
+    calendar.date(bySettingHour: 23, minute: 59, second: 0, of: now)
+  }
+
   /// Create an inline task below the specified task
-  func createInlineTask(description: String, afterTaskId: String?) async {
+  func createInlineTask(description: String, afterTaskId: String?, forceToday: Bool = false) async {
     let context = contextForInlineCreate()
     let created = await store.createTask(
       description: description,
-      dueAt: context.dueAt,
+      dueAt: forceToday ? Self.todayDueAt() : context.dueAt,
       priority: nil,
       tags: context.tags.isEmpty ? nil : context.tags
     )
 
     if let created = created {
+      if forceToday {
+        // "Today" button: the task belongs to the Today section regardless of
+        // where the composer was opened. Position after the anchor task when it
+        // is already in Today, otherwise surface at the top of Today.
+        if let afterId = afterTaskId,
+          let afterIndex = getOrderedTasks(for: .today).firstIndex(where: { $0.id == afterId })
+        {
+          moveTask(created, toIndex: afterIndex + 1, inCategory: .today)
+        } else {
+          moveTask(created, toIndex: 0, inCategory: .today)
+        }
+        keyboardSelectedTaskId = created.id
+        isInlineCreating = false
+        inlineCreateAfterTaskId = nil
+        return
+      }
       if let afterId = afterTaskId {
         // Position the new task after afterTaskId in category order
         for category in TaskCategory.allCases {
@@ -3473,7 +3494,12 @@ struct TasksPage: View {
           onDelete: {
             closeTaskDetailPanel()
             Task { await viewModel.deleteTaskWithUndo(taskDetailTask) }
-          }
+          },
+          onPriorityChange: taskDetailTask.completed
+            ? nil
+            : { newPriority in
+              Task { await viewModel.updateTaskDetails(taskDetailTask, priority: newPriority) }
+            }
         )
         .frame(width: 360)
         .transition(.move(edge: .trailing).combined(with: .opacity))
@@ -3799,7 +3825,7 @@ struct TasksPage: View {
     inlineCreateFocused = false
   }
 
-  private func commitInlineCreate() {
+  private func commitInlineCreate(forToday: Bool = false) {
     let text = inlineCreateText.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else {
       cancelInlineCreate()
@@ -3809,7 +3835,7 @@ struct TasksPage: View {
     inlineCreateText = ""
     inlineCreateFocused = false
     Task {
-      await viewModel.createInlineTask(description: text, afterTaskId: afterId)
+      await viewModel.createInlineTask(description: text, afterTaskId: afterId, forceToday: forToday)
     }
   }
 
@@ -4286,7 +4312,8 @@ struct TasksPage: View {
                 text: $inlineCreateText,
                 isFocused: $inlineCreateFocused,
                 onCommit: { _ in commitInlineCreate() },
-                onCancel: { cancelInlineCreate() }
+                onCancel: { cancelInlineCreate() },
+                onCommitToday: { _ in commitInlineCreate(forToday: true) }
               )
               .id("inline-create-top")
             }
@@ -4370,7 +4397,8 @@ struct TasksPage: View {
                   inlineCreateText: $inlineCreateText,
                   inlineCreateFocused: $inlineCreateFocused,
                   onInlineCommit: { commitInlineCreate() },
-                  onInlineCancel: { cancelInlineCreate() }
+                  onInlineCancel: { cancelInlineCreate() },
+                  onInlineCommitToday: { commitInlineCreate(forToday: true) }
                 )
               }
             }
@@ -4381,7 +4409,8 @@ struct TasksPage: View {
                 text: $inlineCreateText,
                 isFocused: $inlineCreateFocused,
                 onCommit: { _ in commitInlineCreate() },
-                onCancel: { cancelInlineCreate() }
+                onCancel: { cancelInlineCreate() },
+                onCommitToday: { _ in commitInlineCreate(forToday: true) }
               )
               .id("inline-create-top-flat")
             }
@@ -4641,6 +4670,7 @@ struct TaskCategorySection: View {
   @FocusState.Binding var inlineCreateFocused: Bool
   var onInlineCommit: (() -> Void)?
   var onInlineCancel: (() -> Void)?
+  var onInlineCommitToday: (() -> Void)?
 
   @State private var isTopDropTargeted = false
 
@@ -4805,7 +4835,8 @@ struct TaskCategorySection: View {
                   text: $inlineCreateText,
                   isFocused: $inlineCreateFocused,
                   onCommit: { _ in onInlineCommit?() },
-                  onCancel: { onInlineCancel?() }
+                  onCancel: { onInlineCancel?() },
+                  onCommitToday: { _ in onInlineCommitToday?() }
                 )
                 .padding(.top, OmiSpacing.xxs)
               }
@@ -5209,7 +5240,6 @@ struct TaskRow: View {
   @State private var showRepeatPicker = false
   @State private var editRecurrenceRule: String = ""
   @State private var showTagPicker = false
-  @State private var showPriorityPicker = false
 
   // Swipe gesture state
   @State private var swipeOffset: CGFloat = 0
@@ -5704,7 +5734,6 @@ struct TaskRow: View {
       // Hover actions overlaid on trailing edge (no layout shift)
       if TaskDetailPanelPresentationPolicy.showsHoverActions(
         isRowHovering: isHovering,
-        isPriorityPickerPresented: showPriorityPicker,
         isMultiSelectMode: isMultiSelectMode,
         isDeletedTask: isDeletedTask,
         isTextFieldFocused: isTextFieldFocused,
@@ -5746,19 +5775,6 @@ struct TaskRow: View {
             }
             .buttonStyle(.plain)
             .help("Add due date")
-          }
-
-          // Priority button
-          if !task.completed {
-            PriorityBadgeInteractive(
-              priority: task.priority,
-              isCompleted: task.completed,
-              isHovering: isHovering,
-              showPriorityPicker: $showPriorityPicker,
-              onPriorityChange: { newPriority in
-                Task { await onUpdateDetails?(task, nil, nil, newPriority, nil) }
-              }
-            )
           }
 
           // Outdent button (decrease indent)
@@ -6124,99 +6140,6 @@ struct DueDateBadgeInteractive: View {
     .buttonStyle(.plain)
     .onHover { hovering in
       isHovering = hovering
-    }
-  }
-}
-
-struct PriorityBadgeInteractive: View {
-  let priority: String?
-  let isCompleted: Bool
-  let isHovering: Bool  // Row hover state
-  @Binding var showPriorityPicker: Bool
-  let onPriorityChange: (String) -> Void
-
-  @State private var badgeHovering = false
-
-  private var badgeColor: Color {
-    switch priority {
-    case "high": return Ink.primary
-    case "medium": return Ink.secondary
-    case "low": return Ink.secondary
-    default: return Ink.secondary
-    }
-  }
-
-  private var label: String {
-    priority?.capitalized ?? "Priority"
-  }
-
-  var body: some View {
-    // Show if task has a priority, or show "add priority" on hover/popover
-    if priority != nil || ((isHovering || showPriorityPicker) && !isCompleted) {
-      Button {
-        showPriorityPicker = true
-      } label: {
-        HStack(spacing: OmiSpacing.hairline) {
-          if priority != nil {
-            Image(systemName: priority == "high" ? "flag.fill" : "flag")
-              .scaledFont(size: 8)
-          } else {
-            Image(systemName: "plus")
-              .scaledFont(size: 8)
-          }
-          Text(label)
-            .scaledFont(size: OmiType.micro, weight: .medium)
-          if badgeHovering && priority != nil {
-            Image(systemName: "pencil")
-              .scaledFont(size: 7)
-          }
-        }
-        .foregroundColor(
-          badgeHovering ? badgeColor : (priority != nil ? Ink.primary : Ink.secondary))
-      }
-      .buttonStyle(.plain)
-      .onHover { hovering in
-        badgeHovering = hovering
-      }
-      .popover(isPresented: $showPriorityPicker) {
-        VStack(spacing: OmiSpacing.xxs) {
-          ForEach(["high", "medium", "low"], id: \.self) { value in
-            let color: Color =
-              value == "high"
-              ? Ink.errorRed : value == "medium" ? PageGlass.warning : Ink.secondary
-            let isSelected = priority == value
-
-            Button {
-              showPriorityPicker = false
-              onPriorityChange(value)
-            } label: {
-              HStack {
-                Image(systemName: value == "high" ? "flag.fill" : "flag")
-                  .scaledFont(size: OmiType.caption)
-                  .foregroundColor(color)
-                  .frame(width: 20)
-                Text(value.capitalized)
-                  .scaledFont(size: OmiType.body)
-                  .foregroundColor(Ink.primary)
-                Spacer()
-                if isSelected {
-                  Image(systemName: "checkmark")
-                    .scaledFont(size: OmiType.caption, weight: .medium)
-                    .foregroundColor(color)
-                }
-              }
-              .padding(.horizontal, OmiSpacing.md)
-              .padding(.vertical, OmiSpacing.sm)
-              .background(isSelected ? color.opacity(0.1) : Color.clear)
-              .cornerRadius(OmiChrome.badgeRadius)
-              .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-          }
-        }
-        .padding(OmiSpacing.sm)
-        .frame(width: 180)
-      }
     }
   }
 }
@@ -6633,6 +6556,11 @@ struct InlineTaskCreationRow: View {
   @FocusState.Binding var isFocused: Bool
   let onCommit: (String) -> Void
   let onCancel: () -> Void
+  var onCommitToday: ((String) -> Void)? = nil
+
+  private var isTextEmpty: Bool {
+    text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
 
   var body: some View {
     HStack(alignment: .center, spacing: OmiSpacing.md) {
@@ -6656,6 +6584,27 @@ struct InlineTaskCreationRow: View {
         }
 
       Spacer()
+
+      if let onCommitToday {
+        Button {
+          onCommitToday(text)
+        } label: {
+          HStack(spacing: OmiSpacing.xs) {
+            Image(systemName: "sun.max")
+              .scaledFont(size: OmiType.caption)
+            Text("Today")
+              .scaledFont(size: OmiType.caption, weight: .medium)
+          }
+          .foregroundColor(Ink.primary)
+          .padding(.horizontal, OmiSpacing.sm)
+          .padding(.vertical, OmiSpacing.xxs)
+          .background(Capsule().fill(Ink.rowFillHover))
+        }
+        .buttonStyle(.plain)
+        .disabled(isTextEmpty)
+        .opacity(isTextEmpty ? 0.4 : 1)
+        .help("Create task due today")
+      }
     }
     .padding(.trailing, OmiSpacing.md)
     .padding(.vertical, OmiSpacing.xs)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift
@@ -505,6 +505,10 @@ class TasksViewModel: ObservableObject {
   @Published var isInlineCreating = false
   @Published var inlineCreateAfterTaskId: String?
   @Published var editingTaskId: String?
+  /// Task whose detail panel is open. Owned here rather than in the page so the
+  /// panel re-reads the live task after an edit, and so the automation bridge can
+  /// open it the same way a row click does.
+  @Published var detailPanelTaskID: String?
   var hoveredTaskId: String?
   @Published var animateToggleTaskId: String?
   @Published var isAnyTaskEditing = false
@@ -2830,6 +2834,21 @@ class TasksViewModel: ObservableObject {
     }
 
     registry.register(
+      name: "open_task_details",
+      summary: "Open a task's detail panel by id — the same panel a row click opens. Omit the id to close it.",
+      params: ["id"]
+    ) { [weak self] params in
+      guard let self else { return ["error": "tasks view model deallocated"] }
+      guard let id = params["id"], !id.isEmpty else {
+        self.detailPanelTaskID = nil
+        return ["open": "false"]
+      }
+      guard let task = self.findTask(id) else { return ["error": "task not found: \(id)"] }
+      self.detailPanelTaskID = task.id
+      return ["open": "true", "id": task.id, "priority": task.priority ?? ""]
+    }
+
+    registry.register(
       name: "seed_tasks",
       summary:
         "Create N tasks for reorder/stress testing; waits for backend ids so they are reorder-persistable; returns synced count + ids",
@@ -3374,7 +3393,9 @@ struct TasksPage: View {
   /// highlight the correct item without observing the full coordinator.
   @State private var activeChatTaskId: String? = nil
   @State private var showChatPanel = false
-  @State private var taskDetailTask: TaskActionItem?
+  private var taskDetailTask: TaskActionItem? {
+    viewModel.detailPanelTaskID.flatMap { viewModel.findTask($0) }
+  }
   @AppStorage("tasksChatPanelWidth") private var chatPanelWidth: Double = 400
   /// The window width before the chat panel was opened, so we can restore it exactly.
   /// Persisted so we can restore on app relaunch if the user quit with chat open.
@@ -3568,13 +3589,11 @@ struct TasksPage: View {
     }
     .onReceive(viewModel.$displayTasks) { tasks in
       chatCoordinator.ingestTaskMappings(tasks)
-      guard let taskDetailTask else { return }
-      self.taskDetailTask = tasks.first(where: { $0.id == taskDetailTask.id })
     }
     .onReceive(chatCoordinator.$isPanelOpen.removeDuplicates()) { isOpen in
       guard isOpen != showChatPanel else { return }
       if isOpen {
-        taskDetailTask = nil
+        viewModel.detailPanelTaskID = nil
         adjustWindowWidth(expand: true)
         OmiMotion.withGated(.easeInOut(duration: 0.25)) {
           showChatPanel = true
@@ -3603,7 +3622,7 @@ struct TasksPage: View {
     log(
       "TaskChat: openChatForTask called for task \(task.id) (deleted=\(task.deleted ?? false), completed=\(task.completed))"
     )
-    taskDetailTask = nil
+    viewModel.detailPanelTaskID = nil
     if !showChatPanel {
       // First open: expand window and reveal the panel together
       adjustWindowWidth(expand: true)
@@ -3628,7 +3647,7 @@ struct TasksPage: View {
   }
 
   private func closeTaskDetailPanel() {
-    taskDetailTask = nil
+    viewModel.detailPanelTaskID = nil
   }
 
   private func openTaskDetailPanel(for task: TaskActionItem) {
@@ -3637,7 +3656,7 @@ struct TasksPage: View {
       closeChatPanel()
       showChatPanel = false
     }
-    taskDetailTask = task
+    viewModel.detailPanelTaskID = task.id
   }
 
   private func handleEscapeKey() -> Bool {

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/TaskDetailPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/TaskDetailPanel.swift
@@ -14,6 +14,7 @@ struct TaskDetailPanel: View {
   let onIncrementIndent: (() -> Void)?
   let onDecrementIndent: (() -> Void)?
   let onDelete: () -> Void
+  let onPriorityChange: ((String) -> Void)?
 
   @State private var isCopyingLink = false
   @State private var copyStatus: String?
@@ -31,7 +32,8 @@ struct TaskDetailPanel: View {
     onOpenChat: (() -> Void)? = nil,
     onIncrementIndent: (() -> Void)? = nil,
     onDecrementIndent: (() -> Void)? = nil,
-    onDelete: @escaping () -> Void
+    onDelete: @escaping () -> Void,
+    onPriorityChange: ((String) -> Void)? = nil
   ) {
     self.task = task
     self.onDismiss = onDismiss
@@ -42,6 +44,7 @@ struct TaskDetailPanel: View {
     self.onIncrementIndent = onIncrementIndent
     self.onDecrementIndent = onDecrementIndent
     self.onDelete = onDelete
+    self.onPriorityChange = onPriorityChange
   }
 
   var body: some View {
@@ -52,6 +55,7 @@ struct TaskDetailPanel: View {
       ScrollView {
         VStack(alignment: .leading, spacing: OmiSpacing.xl) {
           descriptionSection
+          prioritySection
           whySection
           linkedSourcesSection
           detailsSection
@@ -96,6 +100,43 @@ struct TaskDetailPanel: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
+
+  /// Priority lives here rather than on the task row: it is a rarely-changed
+  /// attribute, and the row's hover strip is reserved for per-task actions.
+  @ViewBuilder
+  private var prioritySection: some View {
+    if let onPriorityChange {
+      VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+        sectionTitle("Priority")
+        HStack(spacing: OmiSpacing.xs) {
+          ForEach(TaskDetailPanel.priorityOptions, id: \.value) { option in
+            let isSelected = task.priority?.lowercased() == option.value
+            Button {
+              guard !isSelected else { return }
+              onPriorityChange(option.value)
+            } label: {
+              Text(option.label)
+                .scaledFont(size: OmiType.caption, weight: isSelected ? .semibold : .regular)
+                .foregroundColor(isSelected ? Ink.surface : Ink.primary)
+                .padding(.horizontal, OmiSpacing.md)
+                .padding(.vertical, OmiSpacing.xs)
+                .background(
+                  Capsule().fill(isSelected ? Ink.primary : Ink.rowFillHover)
+                )
+                .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .help("Set \(option.label.lowercased()) priority")
+            .accessibilityIdentifier("task-detail-priority-\(option.value)")
+          }
+        }
+      }
+    }
+  }
+
+  private static let priorityOptions: [(value: String, label: String)] = [
+    ("low", "Low"), ("medium", "Medium"), ("high", "High"),
+  ]
 
   private var whySection: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.sm) {

--- a/desktop/macos/Desktop/Sources/MainWindow/Tasks/TaskDetailPanelPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Tasks/TaskDetailPanelPolicy.swift
@@ -79,14 +79,13 @@ struct TaskDetailPanelState: Equatable {
 enum TaskDetailPanelPresentationPolicy {
   static func showsHoverActions(
     isRowHovering: Bool,
-    isPriorityPickerPresented: Bool,
     isMultiSelectMode: Bool,
     isDeletedTask: Bool,
     isTextFieldFocused: Bool,
     isDetailPanelPresented: Bool
   ) -> Bool {
     guard !isDetailPanelPresented else { return false }
-    return (isRowHovering || isPriorityPickerPresented)
+    return isRowHovering
       && !isMultiSelectMode
       && !isDeletedTask
       && !isTextFieldFocused
@@ -233,9 +232,7 @@ enum TaskDetailSourceLinkPolicy {
     if !task.tags.isEmpty {
       fields.append(TaskDetailField(label: "Tags", value: task.tags.joined(separator: ", ")))
     }
-    if let priority = task.priority, !priority.isEmpty {
-      fields.append(TaskDetailField(label: "Priority", value: priority.capitalized))
-    }
+    // Priority is not a read-only field here — the panel edits it directly.
     if let source = task.source, !source.isEmpty {
       fields.append(TaskDetailField(label: "Source", value: "\(task.sourceLabel) (\(source))"))
     }

--- a/desktop/macos/Desktop/Tests/InlineTaskTodayButtonTests.swift
+++ b/desktop/macos/Desktop/Tests/InlineTaskTodayButtonTests.swift
@@ -13,7 +13,7 @@ final class InlineTaskTodayButtonTests: XCTestCase {
 
   func testTodayDueAtIsEndOfCurrentDay() throws {
     var calendar = Calendar(identifier: .gregorian)
-    calendar.timeZone = TimeZone(identifier: "America/New_York")!
+    calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let now = Date(timeIntervalSince1970: 1_755_100_000)  // fixed instant, not wall clock
 
     let dueAt = TasksViewModel.todayDueAt(now: now, calendar: calendar)

--- a/desktop/macos/Desktop/Tests/InlineTaskTodayButtonTests.swift
+++ b/desktop/macos/Desktop/Tests/InlineTaskTodayButtonTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// The composer's "Today" button assigns a due date that lands the task in the
+/// Today section — end of the current day, so it never rolls into Tomorrow.
+@MainActor
+final class InlineTaskTodayButtonTests: XCTestCase {
+
+  override func tearDown() async throws {
+    TasksStore.shared.resetSessionState()
+  }
+
+  func testTodayDueAtIsEndOfCurrentDay() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "America/New_York")!
+    let now = Date(timeIntervalSince1970: 1_755_100_000)  // fixed instant, not wall clock
+
+    let dueAt = TasksViewModel.todayDueAt(now: now, calendar: calendar)
+
+    let due = try XCTUnwrap(dueAt)
+    XCTAssertTrue(calendar.isDate(due, inSameDayAs: now), "due date must stay on the same day")
+    let components = calendar.dateComponents([.hour, .minute], from: due)
+    XCTAssertEqual(components.hour, 23)
+    XCTAssertEqual(components.minute, 59)
+  }
+
+  func testTaskWithTodayDueAtAppearsInTodayCategory() {
+    let store = TasksStore.shared
+    store.resetSessionState()
+    let todayTask = TaskActionItem(
+      id: "today-button-task",
+      description: "created via Today button",
+      completed: false,
+      createdAt: Date(),
+      dueAt: TasksViewModel.todayDueAt()
+    )
+    let undatedTask = TaskActionItem(
+      id: "undated-task",
+      description: "no due date",
+      completed: false,
+      createdAt: Date()
+    )
+    store.incompleteTasks = [todayTask, undatedTask]
+
+    let vm = TasksViewModel()
+    vm.selectedTags = [.todo]
+
+    XCTAssertEqual(vm.getOrderedTasks(for: .today).map(\.id), ["today-button-task"])
+    XCTAssertEqual(vm.getOrderedTasks(for: .noDeadline).map(\.id), ["undated-task"])
+  }
+}

--- a/desktop/macos/Desktop/Tests/TaskDetailPanelTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskDetailPanelTests.swift
@@ -130,7 +130,6 @@ final class TaskDetailPanelTests: XCTestCase {
     XCTAssertFalse(
       TaskDetailPanelPresentationPolicy.showsHoverActions(
         isRowHovering: true,
-        isPriorityPickerPresented: false,
         isMultiSelectMode: false,
         isDeletedTask: false,
         isTextFieldFocused: false,
@@ -140,7 +139,6 @@ final class TaskDetailPanelTests: XCTestCase {
     XCTAssertTrue(
       TaskDetailPanelPresentationPolicy.showsHoverActions(
         isRowHovering: true,
-        isPriorityPickerPresented: false,
         isMultiSelectMode: false,
         isDeletedTask: false,
         isTextFieldFocused: false,
@@ -150,13 +148,30 @@ final class TaskDetailPanelTests: XCTestCase {
     XCTAssertFalse(
       TaskDetailPanelPresentationPolicy.showsHoverActions(
         isRowHovering: true,
-        isPriorityPickerPresented: false,
         isMultiSelectMode: true,
         isDeletedTask: false,
         isTextFieldFocused: false,
         isDetailPanelPresented: false
       )
     )
+  }
+
+  /// Priority moved off the task row's hover strip into the detail panel, where
+  /// it is an editable control rather than a duplicated read-only field.
+  func testPriorityIsNotDuplicatedAsAReadOnlyDetailField() {
+    let task = TaskActionItem(
+      id: "task-priority",
+      description: "Ship the build",
+      completed: false,
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+      priority: "high"
+    )
+
+    let fields = TaskDetailPanelContent.make(for: task).fields
+
+    XCTAssertFalse(
+      fields.contains { $0.label == "Priority" },
+      "the panel edits priority directly, so it must not also list it as a read-only field")
   }
 
   private func makeTask(

--- a/desktop/macos/changelog/unreleased/20260814-inline-task-today-button.json
+++ b/desktop/macos/changelog/unreleased/20260814-inline-task-today-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added a Today button to the new-task composer that creates the task due today in one click"
+}


### PR DESCRIPTION
## What

Two changes to the desktop Tasks page, both from direct user feedback:

1. **A `Today` button in the new-task composer.** Creating a task due today
   took four steps: create, click the date icon, pick today, save. The inline
   creation row now carries a Today button that assigns end-of-day and creates
   in one click, placing the task in the Today section regardless of which
   section the composer was opened from. Plain Enter is unchanged.
2. **Priority moved off the row's hover strip into the task detail panel.**
   Priority is a rarely-changed attribute that held permanent space in the
   hover actions next to Execute/date/indent/share/delete. It is now an
   editable Low/Medium/High control in the detail panel, replacing the
   read-only Priority field that duplicated it there.

Supporting change: detail-panel selection moved from a page-local `@State`
copy to `TasksViewModel.detailPanelTaskID`, so the panel re-reads the live
task after an edit instead of rendering a stale snapshot, and the automation
bridge gained `open_task_details` — the seam that let the new priority control
be exercised without touching the cursor.

## Product invariants affected

none

## Verification

Built and ran a named bundle (`omi-today-btn`, dev backend) and exercised the
real UI through the accessibility API and the automation bridge — no synthetic
input into the view model.

- **Today button:** Cmd+N opened the composer, typed "QA today button", pressed
  the Today button via AXPress. The Today section went 13 → 14 with the new task
  at the top; the detail panel shows `Due: Aug 14, 2026 at 11:59 PM`.
- **Second path (control):** same composer, typed "QA plain enter path", pressed
  Return. Task was created but the Today count stayed at 14 — the plain-Enter
  path still does not assign a due date.
- **Priority control:** opened the detail panel via `open_task_details`, pressed
  High via AXPress; the capsule became selected and the store read back
  `priority: high`, proving both the write and the panel's live re-read.
- Test tasks were deleted afterwards.

Not visually re-exercised: the row's hover strip itself, because triggering
SwiftUI hover requires moving the physical cursor. The removal is a deletion —
`PriorityBadgeInteractive` no longer exists in the tree, the render site is
gone, and the now-unused `isPriorityPickerPresented` input was removed from
`showsHoverActions` and its tests.

Commands run: `xcrun swift build -c debug`, `xcrun swift test --filter
"InlineTaskTodayButtonTests|TaskDetailPanelTests|TasksViewModel"` (27 tests, 0
failures), `make preflight`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

