### PR TITLE
fix(backend): default MEMORY_MODE=write so memory intake is on

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -175,7 +175,7 @@ env:
         name: dev-omi-backend-secrets
         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: MEMORY_MODE
-    value: "off"
+    value: "write"
   - name: MEMORY_V3_GET_ENABLED
     value: "false"
   - name: MEMORY_CANONICAL_MAINTENANCE_ENABLED

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -145,7 +145,7 @@ env:
         name: prod-omi-backend-secrets
         key: OMI_LLM_GATEWAY_SERVICE_TOKEN
   - name: MEMORY_MODE
-    value: "off"
+    value: "write"
   - name: MEMORY_V3_GET_ENABLED
     value: "false"
   - name: MEMORY_V3_CURSOR_SECRET

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -132,7 +132,7 @@ environments:
               key: TWILIO_ACCOUNT_SID
           MEMORY_MODE:
             category: memory_rollout
-            value: 'off'
+            value: write
           MEMORY_TYPESENSE_COLLECTION:
             value: canonical_memory_atoms
             category: memory_rollout
@@ -429,7 +429,7 @@ environments:
               category: rollout
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
               category: memory_rollout
@@ -571,7 +571,7 @@ environments:
               category: rollout
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             SYNC_BACKFILL_GLOBAL_DAILY_HOURS:
               provisional: true
               value: '555'
@@ -710,7 +710,7 @@ environments:
               category: rollout
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             SYNC_BACKFILL_GLOBAL_DAILY_HOURS:
               provisional: true
               value: '555'
@@ -815,7 +815,7 @@ environments:
               category: reliability
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             PUBLIC_SHARED_CONVERSATION_CHAT_MODE:
               value: 'off'
               category: rollout
@@ -955,7 +955,7 @@ environments:
               value: memories-backend-dev
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
               category: memory_rollout
@@ -1109,7 +1109,7 @@ environments:
               key: TWILIO_ACCOUNT_SID
           MEMORY_MODE:
             category: memory_rollout
-            value: 'off'
+            value: write
           MEMORY_TYPESENSE_COLLECTION:
             value: canonical_memory_atoms
             category: memory_rollout
@@ -1335,7 +1335,7 @@ environments:
               category: rollout
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
               category: memory_rollout
@@ -1494,7 +1494,7 @@ environments:
               category: rollout
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             SYNC_BACKFILL_GLOBAL_DAILY_HOURS:
               provisional: true
               value: '555'
@@ -1634,7 +1634,7 @@ environments:
               category: rollout
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             SYNC_BACKFILL_GLOBAL_DAILY_HOURS:
               provisional: true
               value: '555'
@@ -1740,7 +1740,7 @@ environments:
               category: reliability
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             PUBLIC_SHARED_CONVERSATION_CHAT_MODE:
               value: 'off'
               category: rollout
@@ -1862,7 +1862,7 @@ environments:
               value: memories-backend
             MEMORY_MODE:
               category: memory_rollout
-              value: 'off'
+              value: write
             MEMORY_TYPESENSE_COLLECTION:
               value: canonical_memory_atoms
               category: memory_rollout

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -137,6 +137,7 @@ environment_shared:
             key: TWILIO_ACCOUNT_SID
         MEMORY_MODE:
           category: memory_rollout
+          value: 'write'
         MEMORY_TYPESENSE_COLLECTION:
           value: canonical_memory_atoms
           category: memory_rollout
@@ -202,6 +203,7 @@ environment_shared:
             category: reliability
           MEMORY_MODE:
             category: memory_rollout
+            value: 'write'
           PUBLIC_SHARED_CONVERSATION_CHAT_MODE:
             value: 'off'
             category: rollout
@@ -296,6 +298,7 @@ environment_shared:
             category: rollout
           MEMORY_MODE:
             category: memory_rollout
+            value: 'write'
           MEMORY_TYPESENSE_COLLECTION:
             value: canonical_memory_atoms
             category: memory_rollout
@@ -385,6 +388,7 @@ environment_shared:
             category: rollout
           MEMORY_MODE:
             category: memory_rollout
+            value: 'write'
           SYNC_BACKFILL_GLOBAL_DAILY_HOURS:
             provisional: true
             value: '555'
@@ -482,6 +486,7 @@ environment_shared:
             category: rollout
           MEMORY_MODE:
             category: memory_rollout
+            value: 'write'
           SYNC_BACKFILL_GLOBAL_DAILY_HOURS:
             provisional: true
             value: '555'
@@ -565,6 +570,7 @@ environment_shared:
             category: memory_rollout
           MEMORY_MODE:
             category: memory_rollout
+            value: 'write'
           MEMORY_TYPESENSE_COLLECTION:
             value: canonical_memory_atoms
             category: memory_rollout

--- a/backend/deploy/runtime_env/dev.overlay.yaml
+++ b/backend/deploy/runtime_env/dev.overlay.yaml
@@ -31,7 +31,7 @@ overlay:
           value: '1.0'
           category: rollout
         MEMORY_MODE:
-          value: 'off'
+          value: 'write'
         MEMORY_V3_GET_ENABLED:
           value: 'false'
     pusher:
@@ -251,7 +251,7 @@ overlay:
             value: '1.0'
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
           # `/v3/memories` and the canonical graph use signed cursors even for
@@ -310,7 +310,7 @@ overlay:
             value: '1.0'
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
         forbidden_env:
@@ -362,7 +362,7 @@ overlay:
             value: '1.0'
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
         forbidden_env:
@@ -414,7 +414,7 @@ overlay:
             value: '1.0'
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
         forbidden_env:
@@ -444,7 +444,7 @@ overlay:
           GOOGLE_CLOUD_PROJECT:
             value: based-hardware
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
           MEMORY_CANONICAL_MAINTENANCE_ENABLED:

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -59,7 +59,7 @@ overlay:
           value: gateway
           category: rollout
         MEMORY_MODE:
-          value: 'off'
+          value: 'write'
         MEMORY_V3_GET_ENABLED:
           value: 'false'
         # Canonical graph and /v3/memories first-page cursors fail closed without this HMAC.
@@ -196,7 +196,7 @@ overlay:
             value: gateway
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
           # `/v1/knowledge-graph` and signed memory cursors fail closed until this binding is present.
@@ -277,7 +277,7 @@ overlay:
             value: gateway
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
       backend-sync-backfill:
@@ -332,7 +332,7 @@ overlay:
             value: gateway
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
       backend-integration:
@@ -369,7 +369,7 @@ overlay:
             value: gateway
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
     jobs:
@@ -386,7 +386,7 @@ overlay:
             value: gateway
             category: rollout
           MEMORY_MODE:
-            value: 'off'
+            value: 'write'
           MEMORY_V3_GET_ENABLED:
             value: 'false'
           MEMORY_CANONICAL_MAINTENANCE_ENABLED:

--- a/backend/scripts/runtime_env_validation/manifest.py
+++ b/backend/scripts/runtime_env_validation/manifest.py
@@ -182,9 +182,9 @@ def _validate_manifest_shape(env_config: ConfigDict, env: str) -> list[Validatio
 def _validate_memory_maintenance_job_contract(env: str, env_config: ConfigDict) -> list[ValidationError]:
     """Require memory-maintenance-job to track the global memory safety mode.
 
-    Prod may keep MEMORY_MODE=off with cron disabled. Enabling MEMORY_MODE=read on any
-    request-path surface without enabling the dedicated maintenance job fails validation
-    so Gate 3 cannot forget ST→LT hosting.
+    ``off`` pauses product writes. ``write`` is default-on intake for every UID
+    (no allowlist, ST→LT cron not required). ``read`` still requires the
+    dedicated maintenance job so Gate 3 cannot forget ST→LT hosting.
 
     Also rejects:
     - canonical maintenance env/secrets on notifications-job (its workflow
@@ -353,17 +353,45 @@ def _validate_memory_maintenance_job_contract(env: str, env_config: ConfigDict) 
                 )
             )
         for surface_scope, _surface_env, surface_mode in read_surfaces:
+            if surface_mode == 'write':
+                errors.append(
+                    ValidationError(
+                        scope,
+                        f'{surface_scope} MEMORY_MODE=write requires memory-maintenance-job MEMORY_MODE=write',
+                    )
+                )
+            else:
+                errors.append(
+                    ValidationError(
+                        scope,
+                        f'{surface_scope} MEMORY_MODE={surface_mode!r} requires memory-maintenance-job '
+                        'MEMORY_MODE=read and MEMORY_CANONICAL_MAINTENANCE_ENABLED=true '
+                        '(ST→LT is not hosted by notifications-job)',
+                    )
+                )
+        return errors
+
+    if job_mode == 'write':
+        # Default-on intake. ST→LT cron stays off until an explicit read cutover.
+        if job_cron == 'true':
             errors.append(
                 ValidationError(
                     scope,
-                    f'{surface_scope} MEMORY_MODE={surface_mode!r} requires memory-maintenance-job '
-                    'MEMORY_MODE=read and MEMORY_CANONICAL_MAINTENANCE_ENABLED=true '
-                    '(ST→LT is not hosted by notifications-job)',
+                    'MEMORY_CANONICAL_MAINTENANCE_ENABLED must be false while MEMORY_MODE is write',
                 )
             )
+        for surface_scope, _surface_env, surface_mode in read_surfaces:
+            if surface_mode != 'write':
+                errors.append(
+                    ValidationError(
+                        scope,
+                        f'{surface_scope} MEMORY_MODE={surface_mode!r} must match '
+                        'memory-maintenance-job MEMORY_MODE=write',
+                    )
+                )
         return errors
 
-    # Canonical request-path is on somewhere — maintenance job must be fully enabled.
+    # MEMORY_MODE=read — maintenance job must be fully enabled.
     if job_mode != 'read':
         errors.append(
             ValidationError(scope, f'MEMORY_MODE must be read when enabling canonical memory (got {job_mode!r})')
@@ -372,7 +400,7 @@ def _validate_memory_maintenance_job_contract(env: str, env_config: ConfigDict) 
         errors.append(
             ValidationError(
                 scope,
-                'MEMORY_CANONICAL_MAINTENANCE_ENABLED must be true when MEMORY_MODE is not off '
+                'MEMORY_CANONICAL_MAINTENANCE_ENABLED must be true when MEMORY_MODE is read '
                 '(ST→LT maintenance is hosted by memory-maintenance-job, not notifications-job)',
             )
         )

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -54,7 +54,7 @@ def with_memory_env(payload: str) -> str:
         {"name": "GOOGLE_CLIENT_ID", "value": "fake-public-client-id"},
         {"name": "GOOGLE_CLIENT_SECRET", "valueFrom": {"secretKeyRef": {"name": "GOOGLE_CLIENT_SECRET", "key": "latest"}}},
         {"name": "POSTHOG_PROJECT_API_KEY", "valueFrom": {"secretKeyRef": {"name": "POSTHOG_PROJECT_API_KEY", "key": "latest"}}},
-        {"name": "MEMORY_MODE", "value": "off"},
+        {"name": "MEMORY_MODE", "value": "write"},
         {"name": "MEMORY_V3_GET_ENABLED", "value": "false"},
         {"name": "MEMORY_V3_CURSOR_SECRET_VERSION", "value": "dev-v1"},
         {"name": "MEMORY_CANONICAL_MAINTENANCE_ENABLED", "value": "false"},
@@ -1944,6 +1944,15 @@ def test_memory_maintenance_job_contract_rejects_read_mode_without_job_cron(tmp_
     errors = validator.validate_runtime_env(env='prod', manifest_path=path)
     messages = [error.message for error in errors]
     assert any('requires memory-maintenance-job' in message for message in messages)
+
+
+def test_memory_maintenance_job_contract_allows_write_without_job_cron():
+    validator = load_validator()
+    errors = validator._validate_memory_maintenance_job_contract(
+        'prod',
+        validator._load_yaml(ROOT / 'deploy/runtime_env.yaml')['environments']['prod'],
+    )
+    assert errors == []
 
 
 def test_memory_maintenance_job_contract_rejects_missing_job(tmp_path):

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -112,7 +112,7 @@ def test_render_dev_emits_memory_maintenance_job_outputs():
     assert 'MEMORY_CANONICAL_MAINTENANCE_ENABLED=false' in memory_env
     assert 'MEMORY_CANONICAL_CONSOLIDATION_ENABLED=true' in memory_env
     assert 'MEMORY_ENABLED_USERS' not in memory_env
-    assert 'MEMORY_MODE=off' in memory_env
+    assert 'MEMORY_MODE=write' in memory_env
     assert 'MEMORY_CANONICAL_GRAPH_BACKFILL_ENABLED=false' in memory_env
     assert 'TYPESENSE_HOST_PORT=443' in memory_env
 
@@ -190,7 +190,7 @@ def test_render_prod_keeps_memory_maintenance_job_promotion_off(capsys, monkeypa
     assert rc == 0
     out = capsys.readouterr().out
     job_env = _job_env_block(out, 'memory_maintenance_job')
-    assert 'MEMORY_MODE=off' in job_env
+    assert 'MEMORY_MODE=write' in job_env
     assert 'MEMORY_CANONICAL_MAINTENANCE_ENABLED=false' in job_env
     assert 'MEMORY_ENABLED_USERS' not in job_env
 


### PR DESCRIPTION
## Summary
After #11447, `MEMORY_MODE=off` is a fleet write pause (`503 Memory writes are globally paused`). Source still pinned `off` as a Gate 3 dark-deploy leftover, so every auto-deploy re-pauses intake.

Pin default-on **intake** as `MEMORY_MODE=write` for every UID (no allowlist). ST→LT `read` + maintenance cron stay a separate Gate 3 cutover.

## Failure-Class
Failure-Class: none

## Test plan
- [x] `validate-backend-runtime-env.py --env dev` and `--env prod`
- [x] focused runtime-env validator + render tests
- [ ] Dev auto-deploy after merge: serving `MEMORY_MODE=write`
- [ ] POST `/v3/memories` is not `Memory writes are globally paused`
- [ ] No production live flip in this change; prod source is write for the next approved prod deploy


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

