### PR TITLE
ci(desktop): allow manual dispatch of Desktop Swift CI

### DIFF
--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: main
     types: [opened, synchronize, reopened, closed]
+  # Recovery hatch. `plan-desktop-release.py` requires this workflow's checks on the
+  # exact source SHA, so any interruption — the workflow being disabled, a run cancelled
+  # by concurrency, an infrastructure blip — leaves that SHA permanently unreleasable:
+  # push events do not replay, and neither a force-push nor a PR close/reopen produces a
+  # run for a commit already on main. Manual dispatch is the only way to re-mint the
+  # evidence without an unrelated commit.
+  workflow_dispatch:
 
 concurrency:
   # Supersede stale revisions of the same PR, but never let a later main push

--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,48 +1,29 @@
-Follow-up to #11577. That change made the beta/stable split exact by keying it on `AppBuild.isBetaProductionBundle`, which fixed *stable* leakage. This one fixes the other half: which beta users actually get the feature.
-
 ## Problem
 
-After #11577, a beta client still asks PostHog whether `context_buckets` is on. That flag's audience can only be described two ways, and both fail for a **newly installed** beta client:
+`plan-desktop-release.py` gates every desktop release on this workflow's checks existing for the **exact** source SHA:
 
-- **The person property `update_channel`.** Registered as a super property at init, so it rides events — but the person record is only written by `identify`, which returns early when nobody is signed in. Across 14 days of macOS clients, 215 of ~260 beta installs had a null person-side channel and 11 reported `stable`. It resolved for roughly a sixth of the channel.
-- **A static cohort.** Describes only the users who existed when it was built. A new install is not in it.
-
-Behavioral cohorts would solve this, since they recalculate — but PostHog refuses them in flag targeting:
-
-```
-Cohort 'macOS beta channel (auto-updating)' has an event-based condition on
-'App Launched' (performed_event) and cannot be used in feature flags.
+```python
+REQUIRED_SOURCE_CHECK_NAMES = (
+    RELEASE_ELIGIBILITY_CHECK_NAME,
+    "Desktop Swift Build & Tests",
+    "Desktop Swift Release Compile",
+)
 ```
 
-So there is no server-side expression of "is running the beta build" that stays correct as users arrive. A new beta user matches nothing and silently gets no notifications — the same class of silent-off failure #11577 was opened to remove, one layer up.
+Until today this workflow had no manual trigger, only `push` and `pull_request`. That makes the gate unrecoverable whenever a run does not happen: push events cannot be replayed, and for a commit already on `main` neither a force-push nor a PR close/reopen produces one. The SHA stays permanently unreleasable, and the only remedy is to land an unrelated commit purely to move `main` forward.
+
+That is not hypothetical. This workflow was disabled manually for part of today. During that window several changes merged to `main` with no checks, so the planner could not resolve a releasable SHA. It polls every 30s for up to 5400s and then fails — two release runs burned the full window and ended `cancelled` with `tag-release` skipped. Re-enabling the workflow did not fix it, because enabling does not retroactively create runs for commits that already merged.
+
+Meanwhile the release train looked healthy: builds were dispatched, PRs showed `mergeStateStatus: CLEAN`, and no check reported failure. A required check that is *absent* is materially different from one that fails, and only the second is visible.
 
 ## Change
 
-Bundle identity already answers "is this the beta build" exactly, offline, before any network call. So beta enablement no longer consults `context_buckets` at all.
+Adds `workflow_dispatch` so the evidence can be re-minted for any SHA without inventing a commit.
 
-What is still worth having remotely is the ability to **stop** the pipeline, so beta reads a dedicated kill switch instead:
+No job logic changes. The `changes` job already tolerates the dispatch event: `github.event.pull_request.base.sha` is empty, so `DIFF_BASE` falls through to the existing `git rev-parse HEAD^` fallback, and `github.event.action` is empty so the `!= 'closed'` guard passes.
 
-```swift
-guard AppBuild.isBetaProductionBundle else { return false }
-return !PostHogManager.shared.isFeatureEnabled(killSwitchFlagName)
-```
+## Verification
 
-`context_buckets_kill` is inverted deliberately. `isFeatureEnabled` returns false when PostHog is unavailable or uninitialized, so absent, unresolved, and false all mean "run the pipeline"; only an explicit true stops it. An unreachable PostHog cannot switch the dogfood channel off by accident.
-
-The flag exists and is currently **off**, so this ships enabled: https://us.posthog.com/project/302298/feature_flags/821229
-
-## Blast radius
-
-Stable is gated out one line above and never reaches this branch, so the fail-open default cannot touch it. The audience is the beta channel — roughly 337 macOS clients.
-
-`context_buckets` is left in place and still governs clients built before #11577, which continue to read it.
-
-## Trade-off worth naming
-
-Fail-open is the right default for a dogfood channel that is currently failing *closed* by accident, but it does mean a PostHog outage leaves notifications running rather than pausing them. Given stable is untouchable here and the kill switch is one toggle, that seems the correct side to err on. Worth a second opinion.
-
-## Testing
-
-Not covered by a unit test: `isEnabled` reads `AppBuild` globals and `PostHogManager.shared`, neither of which has an injection seam today. Verified behaviorally — a bundle carrying #11577 and no environment overrides reports `context_buckets_enabled: true` and accumulated 75 visits, 9 buckets, 143 facts and 20 deliveries.
+Merging this is itself the test: it pushes `main`, which must produce `Desktop Swift Build & Tests` and `Desktop Swift Release Compile` for the new SHA and unblock the planner. After that the trigger can be exercised directly with `gh workflow run desktop-swift-ci.yml`.
 
 Failure-Class: none


### PR DESCRIPTION
## Problem

`plan-desktop-release.py` gates every desktop release on this workflow's checks existing for the **exact** source SHA:

```python
REQUIRED_SOURCE_CHECK_NAMES = (
    RELEASE_ELIGIBILITY_CHECK_NAME,
    "Desktop Swift Build & Tests",
    "Desktop Swift Release Compile",
)
```

Until today this workflow had no manual trigger, only `push` and `pull_request`. That makes the gate unrecoverable whenever a run does not happen: push events cannot be replayed, and for a commit already on `main` neither a force-push nor a PR close/reopen produces one. The SHA stays permanently unreleasable, and the only remedy is to land an unrelated commit purely to move `main` forward.

That is not hypothetical. This workflow was disabled manually for part of today. During that window several changes merged to `main` with no checks, so the planner could not resolve a releasable SHA. It polls every 30s for up to 5400s and then fails — two release runs burned the full window and ended `cancelled` with `tag-release` skipped. Re-enabling the workflow did not fix it, because enabling does not retroactively create runs for commits that already merged.

Meanwhile the release train looked healthy: builds were dispatched, PRs showed `mergeStateStatus: CLEAN`, and no check reported failure. A required check that is *absent* is materially different from one that fails, and only the second is visible.

## Change

Adds `workflow_dispatch` so the evidence can be re-minted for any SHA without inventing a commit.

No job logic changes. The `changes` job already tolerates the dispatch event: `github.event.pull_request.base.sha` is empty, so `DIFF_BASE` falls through to the existing `git rev-parse HEAD^` fallback, and `github.event.action` is empty so the `!= 'closed'` guard passes.

## Verification

Merging this is itself the test: it pushes `main`, which must produce `Desktop Swift Build & Tests` and `Desktop Swift Release Compile` for the new SHA and unblock the planner. After that the trigger can be exercised directly with `gh workflow run desktop-swift-ci.yml`.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

