### PR TITLE
fix(desktop): put every GRDB insert on the rowid-keeping idiom, and guard it (#11204)

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -224,6 +224,16 @@ checks:
     lanes: ["local", "ci"]
     platforms: ["macos"]
     reason: "desktop Swift sources changed; compare against the pinned macOS formatter before requiring a flow cover"
+  - id: desktop-grdb-insert-idiom-tests
+    command: ["python3", "desktop/macos/tests/test_check_grdb_insert_idiom.py"]
+    triggers: ["desktop/macos/scripts/check-grdb-insert-idiom.py", "desktop/macos/tests/test_check_grdb_insert_idiom.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "the insert-idiom checker must keep flagging the two merged rowid-drop instances (#11208, #11216) without flagging the Set and Array insert shapes that are live in Desktop/Sources"
+  - id: desktop-grdb-insert-idiom
+    command: ["python3", "desktop/macos/scripts/check-grdb-insert-idiom.py"]
+    triggers: ["desktop/macos/Desktop/Sources/**/*.swift", "desktop/macos/scripts/check-grdb-insert-idiom.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "#11204: a mutating didInsert never witnesses PersistableRecord's non-mutating insert, so a direct record.insert(db) drops the rowid silently onto an optional field; two shipped instances went undetected until unrelated work tripped over them"
   - id: brand-ui-ratchet-tests
     command: ["python3", ".github/scripts/test_check_brand_ui.py"]
     triggers: [".github/scripts/check_brand_ui.py", ".github/scripts/test_check_brand_ui.py", ".github/checks-manifest.yaml"]

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
@@ -74,9 +74,7 @@ actor AIUserProfileService {
   func insertProfile(_ record: AIUserProfileRecord) async throws -> AIUserProfileRecord {
     let db = try await ensureDB()
     return try await db.write { database in
-      var inserted = record
-      try inserted.insert(database)
-      return inserted
+      try record.inserted(database)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/ActionItemStorage.swift
@@ -696,7 +696,7 @@ actor ActionItemStorage {
             if !newRecord.completed && !newRecord.deleted {
               visibilityChanged = true
             }
-            try newRecord.insert(database)
+            _ = try newRecord.inserted(database)
           }
         }
         try authorization.require()

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindAbandonedVideoChunkRecovery.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindAbandonedVideoChunkRecovery.swift
@@ -116,8 +116,7 @@ extension RewindDatabase {
       // `imagePath` is NOT NULL in SQLite, whereas video-backed screenshots
       // carry nil in the model.
       if record.imagePath == nil { record.imagePath = "" }
-      try record.insert(db)
-      return record
+      return try record.inserted(db)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2778,7 +2778,7 @@ actor RewindDatabase {
         // unrelated screenshot.
         record.id = nil
         if record.imagePath == nil { record.imagePath = "" }
-        try record.insert(db)
+        _ = try record.inserted(db)
       }
 
       return screenshots.count

--- a/desktop/macos/changelog/unreleased/20260815-grdb-insert-rowid-idiom.json
+++ b/desktop/macos/changelog/unreleased/20260815-grdb-insert-rowid-idiom.json
@@ -1,0 +1,3 @@
+{
+  "change": "Hardened how desktop records are saved so a newly created row cannot silently lose its database id"
+}

--- a/desktop/macos/changelog/unreleased/20260815-grdb-insert-rowid-idiom.json
+++ b/desktop/macos/changelog/unreleased/20260815-grdb-insert-rowid-idiom.json
@@ -1,3 +1,3 @@
 {
-  "change": "Hardened how desktop records are saved so a newly created row cannot silently lose its database id"
+  "change": "Fixed newly created records losing their ID, which left later edits and deletions silently doing nothing"
 }

--- a/desktop/macos/scripts/check-grdb-insert-idiom.py
+++ b/desktop/macos/scripts/check-grdb-insert-idiom.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Keep desktop GRDB inserts on the one idiom that always runs `didInsert`.
+
+This is a **static checker**, not behavioral coverage. It exists because the
+hazard it guards is invisible at runtime: a record whose rowid is captured by a
+`mutating func didInsert` silently never captures it when inserted through
+`PersistableRecord`'s non-mutating `insert(_:)`, and the field is optional by
+design, so the value is simply always nil and every dependent path quietly does
+nothing. No error, no warning, no crash.
+
+Mechanism, measured against the pinned GRDB (Desktop/Package.resolved):
+
+  PersistableRecord+Insert.swift:34   `extension PersistableRecord { func insert(...) }`
+                                      non-mutating; its `didInsert` resolves to
+                                      the empty default at :10 -> rowid dropped.
+  MutablePersistableRecord+Insert.swift:79
+                                      `inserted(_:)` does `var result = self;
+                                      try result.insert(db)` inside an
+                                      `extension MutablePersistableRecord`, so it
+                                      binds the *mutating* insert and the record's
+                                      own `mutating didInsert` is the witness.
+
+The precise hazard is "a direct `record.insert(db)` on a concrete type whose
+`didInsert` is mutating", which needs receiver-type resolution a source scrape
+cannot do soundly. Flagging the *declaration* shape instead (PersistableRecord +
+mutating didInsert) would flag 14 types that are not affected, because they all
+insert via `inserted(db)`.
+
+So this checker enforces the cheap, sound rule instead: the codebase uses exactly
+one insert idiom, `inserted(db)`. The direct form buys nothing here, every
+production seam already uses `inserted(db)`, and any new direct `.insert(db)` is
+rejected regardless of the receiver's conformance.
+
+Real instances this would have caught, both fixed before this checker landed:
+  * `Screenshot` in RewindDatabase.insertScreenshot (#11208) - RewindIndexer
+    never queued a captured frame for embedding, because every consumer was
+    written `if let id = inserted.id`.
+  * `AIUserProfileRecord` in AIUserProfileService - Settings -> Advanced -> AI
+    User Profile stored `aiProfileId = nil` after Regenerate, so Save and Delete
+    both silently no-opped.
+
+Scope is production sources only. Tests may construct the broken shape
+deliberately to prove it is broken.
+
+Exit codes: 0 clean, 1 violations found, 2 usage/IO error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DESKTOP_DIR = SCRIPT_DIR.parent
+DEFAULT_SOURCES_DIR = DESKTOP_DIR / "Desktop" / "Sources"
+
+# A GRDB persistence call is identified by its database-handle argument. Set and
+# Array inserts in this codebase pass ids, keys and elements (`.insert(task.id)`,
+# `.insert(task, at: 0)`), never a bare `db`/`database`, so this cannot collide
+# with them.
+DB_HANDLE_NAMES = ("db", "database")
+DIRECT_INSERT = re.compile(
+    r"\.insert\(\s*(?P<handle>" + "|".join(DB_HANDLE_NAMES) + r")\s*(?=[,)])"
+)
+
+REMEDY = (
+    "use `inserted({handle})` instead: `record.insert({handle})` on a type conforming to "
+    "PersistableRecord picks the non-mutating overload, whose `didInsert` is the empty "
+    "default, so a `mutating didInsert` never runs and the rowid is dropped"
+)
+
+
+def find_violations(sources_dir: Path) -> list[tuple[Path, int, str]]:
+    """Return (path, line number, line text) for every direct GRDB insert."""
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(sources_dir.rglob("*.swift")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - unreadable file is a real failure
+            print(f"check-grdb-insert-idiom: cannot read {path}: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if DIRECT_INSERT.search(line):
+                violations.append((path, lineno, line.strip()))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--sources-dir",
+        type=Path,
+        default=DEFAULT_SOURCES_DIR,
+        help="root of the Swift sources to scan (default: desktop/macos/Desktop/Sources)",
+    )
+    args = parser.parse_args(argv)
+
+    sources_dir: Path = args.sources_dir
+    if not sources_dir.is_dir():
+        print(
+            f"check-grdb-insert-idiom: sources dir not found: {sources_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations = find_violations(sources_dir)
+    if not violations:
+        print("ok: desktop GRDB inserts all use the inserted(db) idiom")
+        return 0
+
+    print("FAIL: direct GRDB insert(db) found; the rowid-capturing idiom is inserted(db)")
+    for path, lineno, line in violations:
+        try:
+            display = path.relative_to(Path.cwd())
+        except ValueError:
+            display = path
+        handle_match = DIRECT_INSERT.search(line)
+        handle = handle_match.group("handle") if handle_match else "db"
+        print(f"- {display}:{lineno}: {line}")
+        print(f"  {REMEDY.format(handle=handle)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/scripts/check-grdb-insert-idiom.py
+++ b/desktop/macos/scripts/check-grdb-insert-idiom.py
@@ -31,6 +31,16 @@ one insert idiom, `inserted(db)`. The direct form buys nothing here, every
 production seam already uses `inserted(db)`, and any new direct `.insert(db)` is
 rejected regardless of the receiver's conformance.
 
+Two properties keep that rule honest without a Swift type checker:
+
+  * Comments and string literals are blanked before matching, so
+    `// never call record.insert(db)` and `let hint = "record.insert(db)"` are
+    not reported. See `mask_comments_and_strings`.
+  * A match must be a `try` expression. Every GRDB insert overload throws, so a
+    real call always carries `try`; `Set.insert`/`Array.insert` do not throw, so
+    `values.insert(db)` on a `Set<Int>` cannot be mistaken for one. This costs no
+    false negatives, because an untried `record.insert(db)` does not compile.
+
 Real instances this would have caught, both fixed before this checker landed:
   * `Screenshot` in RewindDatabase.insertScreenshot (#11208) - RewindIndexer
     never queued a captured frame for embedding, because every consumer was
@@ -56,12 +66,21 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 DESKTOP_DIR = SCRIPT_DIR.parent
 DEFAULT_SOURCES_DIR = DESKTOP_DIR / "Desktop" / "Sources"
 
-# A GRDB persistence call is identified by its database-handle argument. Set and
-# Array inserts in this codebase pass ids, keys and elements (`.insert(task.id)`,
-# `.insert(task, at: 0)`), never a bare `db`/`database`, so this cannot collide
-# with them.
+# Two signals identify a GRDB persistence call without resolving the receiver's type:
+#
+# 1. The argument is a database handle. `db`/`database` name a GRDB
+#    `Database`/`DatabaseQueue`/`DatabasePool` everywhere in Desktop/Sources; Set and
+#    Array inserts pass ids, keys and elements (`.insert(task.id)`, `.insert(task, at: 0)`).
+# 2. The call is a `try` expression. Every GRDB insert overload throws, so real calls
+#    always carry `try`, while `Set.insert`/`Array.insert` do not throw and so cannot.
+#
+# Together these keep `values.insert(db)` on a `Set<Int>` out of the report without
+# needing a Swift type checker, and they cannot hide a real insert: an untried
+# `record.insert(db)` does not compile.
 DB_HANDLE_NAMES = ("db", "database")
 DIRECT_INSERT = re.compile(
+    r"\btry\b[!?]?\s*(?:await\s+)?"
+    r"[A-Za-z_][A-Za-z0-9_]*(?:[?!]?\.[A-Za-z_][A-Za-z0-9_]*|\[[^\]\n]*\])*"
     r"\.insert\(\s*(?P<handle>" + "|".join(DB_HANDLE_NAMES) + r")\s*(?=[,)])"
 )
 
@@ -72,18 +91,110 @@ REMEDY = (
 )
 
 
-def find_violations(sources_dir: Path) -> list[tuple[Path, int, str]]:
-    """Return (path, line number, line text) for every direct GRDB insert."""
-    violations: list[tuple[Path, int, str]] = []
+def mask_comments_and_strings(text: str) -> str:
+    """Blank out Swift comments and string literals, preserving offsets and newlines.
+
+    The checker matches source code, not prose: `// never call record.insert(db)` and
+    `let hint = "record.insert(db)"` are not calls. Blanking rather than deleting keeps
+    every byte offset and line number identical to the original file.
+
+    Covers the Swift lexical forms that can contain the pattern: line comments, nested
+    block comments, single-line strings with escapes, multiline `\"\"\"` strings, and raw
+    strings with any number of `#` delimiters (where `\\` is not an escape).
+    """
+    out = list(text)
+    length = len(text)
+    index = 0
+
+    def blank(start: int, end: int) -> None:
+        for position in range(start, min(end, length)):
+            if out[position] != "\n":
+                out[position] = " "
+
+    while index < length:
+        char = text[index]
+
+        if char == "/" and text.startswith("//", index):
+            end = text.find("\n", index)
+            end = length if end == -1 else end
+            blank(index, end)
+            index = end
+            continue
+
+        if char == "/" and text.startswith("/*", index):
+            depth = 1
+            cursor = index + 2
+            while cursor < length and depth:
+                if text.startswith("/*", cursor):
+                    depth += 1
+                    cursor += 2
+                elif text.startswith("*/", cursor):
+                    depth -= 1
+                    cursor += 2
+                else:
+                    cursor += 1
+            blank(index, cursor)
+            index = cursor
+            continue
+
+        if char in '#"':
+            hashes = 0
+            cursor = index
+            while cursor < length and text[cursor] == "#":
+                hashes += 1
+                cursor += 1
+            if cursor >= length or text[cursor] != '"':
+                # `#available`, `#selector`, a lone `#` — not a string literal.
+                index = cursor + 1 if hashes else index + 1
+                continue
+
+            pound = "#" * hashes
+            multiline = text.startswith('"""', cursor)
+            terminator = ('"""' + pound) if multiline else ('"' + pound)
+            cursor += 3 if multiline else 1
+
+            while cursor < length:
+                if hashes == 0 and text[cursor] == "\\":
+                    cursor += 2
+                    continue
+                if hashes and text.startswith("\\" + pound, cursor):
+                    cursor += 1 + hashes + 1
+                    continue
+                if text.startswith(terminator, cursor):
+                    cursor += len(terminator)
+                    break
+                if not multiline and text[cursor] == "\n":
+                    # Unterminated single-line string; do not swallow the rest of the file.
+                    break
+                cursor += 1
+
+            blank(index, cursor)
+            index = cursor
+            continue
+
+        index += 1
+
+    return "".join(out)
+
+
+def find_violations(sources_dir: Path) -> list[tuple[Path, int, str, str]]:
+    """Return (path, line number, line text, handle) for every direct GRDB insert."""
+    violations: list[tuple[Path, int, str, str]] = []
     for path in sorted(sources_dir.rglob("*.swift")):
         try:
             text = path.read_text(encoding="utf-8")
         except OSError as exc:  # pragma: no cover - unreadable file is a real failure
             print(f"check-grdb-insert-idiom: cannot read {path}: {exc}", file=sys.stderr)
             raise SystemExit(2) from exc
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            if DIRECT_INSERT.search(line):
-                violations.append((path, lineno, line.strip()))
+        masked = mask_comments_and_strings(text)
+        original_lines = text.splitlines()
+        for match in DIRECT_INSERT.finditer(masked):
+            # The call site is where `.insert(` sits, which may be a continuation line
+            # below the `try` that opened the expression.
+            insert_offset = masked.index(".insert(", match.start(), match.end())
+            lineno = masked.count("\n", 0, insert_offset) + 1
+            line = original_lines[lineno - 1].strip() if lineno <= len(original_lines) else ""
+            violations.append((path, lineno, line, match.group("handle")))
     return violations
 
 
@@ -111,13 +222,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print("FAIL: direct GRDB insert(db) found; the rowid-capturing idiom is inserted(db)")
-    for path, lineno, line in violations:
+    for path, lineno, line, handle in violations:
         try:
             display = path.relative_to(Path.cwd())
         except ValueError:
             display = path
-        handle_match = DIRECT_INSERT.search(line)
-        handle = handle_match.group("handle") if handle_match else "db"
         print(f"- {display}:{lineno}: {line}")
         print(f"  {REMEDY.format(handle=handle)}")
     return 1

--- a/desktop/macos/tests/test_check_grdb_insert_idiom.py
+++ b/desktop/macos/tests/test_check_grdb_insert_idiom.py
@@ -35,8 +35,13 @@ _spec.loader.exec_module(checker)
 
 
 class GRDBInsertIdiomCheckerTests(unittest.TestCase):
-    def _run(self, swift_by_relative_path: dict[str, str]) -> tuple[int, str]:
-        """Write a disposable Swift tree, run the real checker, return (exit code, stdout)."""
+    def _run(self, swift_by_relative_path: dict[str, str]) -> tuple[int, list[str]]:
+        """Write a disposable Swift tree, run the real checker.
+
+        Returns the exit code and one `file:line: source` entry per reported
+        violation, so every assertion can pin the exact set rather than probing
+        for a substring and letting extra reports slip through.
+        """
         with TemporaryDirectory() as tmp:
             sources = Path(tmp) / "Sources"
             for relative_path, body in swift_by_relative_path.items():
@@ -48,12 +53,17 @@ class GRDBInsertIdiomCheckerTests(unittest.TestCase):
             buffer = io.StringIO()
             with redirect_stdout(buffer):
                 code = checker.main(["--sources-dir", str(sources)])
-            return code, buffer.getvalue()
+            reported = [
+                line[2:].replace(f"{sources}/", "")
+                for line in buffer.getvalue().splitlines()
+                if line.startswith("- ")
+            ]
+            return code, reported
 
     def test_flags_the_screenshot_instance_from_11208(self):
         # Verbatim shape of RewindDatabase.insertScreenshot before #11208, where
         # every consumer read `if let id = inserted.id` and got nothing.
-        code, output = self._run(
+        code, reported = self._run(
             {
                 "Rewind/Core/RewindDatabase.swift": """
                 func insertScreenshot(_ screenshot: Screenshot) throws -> Screenshot {
@@ -68,11 +78,10 @@ class GRDBInsertIdiomCheckerTests(unittest.TestCase):
         )
 
         self.assertEqual(code, 1)
-        self.assertIn("Rewind/Core/RewindDatabase.swift:4", output)
-        self.assertIn("try record.insert(db)", output)
+        self.assertEqual(reported, ["Rewind/Core/RewindDatabase.swift:4: try record.insert(db)"])
 
     def test_flags_the_ai_user_profile_instance_from_11216(self):
-        code, output = self._run(
+        code, reported = self._run(
             {
                 "ProactiveAssistants/Services/AIUserProfileService.swift": """
                 func generateProfile() async throws -> AIUserProfileRecord {
@@ -87,18 +96,42 @@ class GRDBInsertIdiomCheckerTests(unittest.TestCase):
         )
 
         self.assertEqual(code, 1)
-        self.assertIn("AIUserProfileService.swift:4", output)
+        self.assertEqual(
+            reported,
+            [
+                "ProactiveAssistants/Services/AIUserProfileService.swift:4: "
+                "try record.insert(database)"
+            ],
+        )
 
     def test_flags_the_conflict_resolution_overload(self):
-        code, output = self._run(
+        code, reported = self._run(
             {"Storage.swift": "try record.insert(db, onConflict: .replace)\n"}
         )
 
         self.assertEqual(code, 1)
-        self.assertIn("Storage.swift:1", output)
+        self.assertEqual(
+            reported, ["Storage.swift:1: try record.insert(db, onConflict: .replace)"]
+        )
+
+    def test_flags_a_try_expression_split_across_lines(self):
+        # swift-format can wrap a long call, so the `try` that proves this is a
+        # throwing GRDB call may sit a line above the call itself. The report must
+        # point at the call site, not at the `try`.
+        code, reported = self._run(
+            {
+                "Storage.swift": """
+                try
+                  record.insert(db)
+                """
+            }
+        )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(reported, ["Storage.swift:2: record.insert(db)"])
 
     def test_accepts_the_inserted_idiom(self):
-        code, output = self._run(
+        code, reported = self._run(
             {
                 "Storage.swift": """
                 let saved = try record.inserted(db)
@@ -108,12 +141,12 @@ class GRDBInsertIdiomCheckerTests(unittest.TestCase):
         )
 
         self.assertEqual(code, 0)
-        self.assertIn("ok:", output)
+        self.assertEqual(reported, [])
 
     def test_does_not_flag_set_and_array_inserts(self):
         # These shapes are all live in Desktop/Sources; a bare `.insert(` rule
         # would flag every one of them.
-        code, _ = self._run(
+        code, reported = self._run(
             {
                 "Collections.swift": """
                 seen.insert(task.id)
@@ -126,17 +159,112 @@ class GRDBInsertIdiomCheckerTests(unittest.TestCase):
         )
 
         self.assertEqual(code, 0)
+        self.assertEqual(reported, [])
 
-    def test_reports_every_violation_not_just_the_first(self):
-        code, output = self._run(
+    def test_does_not_flag_a_collection_element_that_happens_to_be_named_db(self):
+        # cubic's case: the argument name alone cannot tell a GRDB handle from an
+        # Int. `Set.insert` does not throw, so the absence of `try` settles it.
+        code, reported = self._run(
             {
-                "A.swift": "try one.insert(db)\n",
-                "B.swift": "try two.insert(database)\n",
+                "Collections.swift": """
+                var values: Set<Int> = []
+                let db = 123
+                values.insert(db)
+                let database = 456
+                values.insert(database)
+                """
+            }
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(reported, [])
+
+    def test_ignores_line_comments(self):
+        code, reported = self._run(
+            {
+                "Storage.swift": """
+                // do not call record.insert(db)
+                let x = 1  // and never try record.insert(database) either
+                """
+            }
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(reported, [])
+
+    def test_ignores_block_comments_including_nested_ones(self):
+        code, reported = self._run(
+            {
+                "Storage.swift": """
+                /* outer
+                   /* nested: try record.insert(db) */
+                   still commented: try record.insert(database)
+                */
+                try real.insert(db)
+                """
             }
         )
 
         self.assertEqual(code, 1)
-        self.assertEqual(output.count("\n- "), 2)
+        self.assertEqual(reported, ["Storage.swift:5: try real.insert(db)"])
+
+    def test_ignores_string_literals(self):
+        code, reported = self._run(
+            {
+                "Storage.swift": """
+                let message = "record.insert(database)"
+                let escaped = "he said \\"try record.insert(db)\\" loudly"
+                let url = "https://example.com/try record.insert(db)"
+                """
+            }
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(reported, [])
+
+    def test_ignores_multiline_and_raw_string_literals(self):
+        code, reported = self._run(
+            {
+                "Storage.swift": '''
+                let doc = """
+                  Never write try record.insert(db) here.
+                  """
+                let raw = #"try record.insert(database)"#
+                let rawer = ##"try record.insert(db)"##
+                '''
+            }
+        )
+
+        self.assertEqual(code, 0)
+        self.assertEqual(reported, [])
+
+    def test_flags_a_real_call_sharing_a_line_with_a_lookalike_comment(self):
+        code, reported = self._run(
+            {"Storage.swift": "try record.insert(db)  // not values.insert(db)\n"}
+        )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(
+            reported, ["Storage.swift:1: try record.insert(db)  // not values.insert(db)"]
+        )
+
+    def test_reports_every_violation_not_just_the_first(self):
+        code, reported = self._run(
+            {
+                "A.swift": "try one.insert(db)\n",
+                "B.swift": "try two.insert(database)\ntry three.insert(db)\n",
+            }
+        )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(
+            sorted(reported),
+            [
+                "A.swift:1: try one.insert(db)",
+                "B.swift:1: try two.insert(database)",
+                "B.swift:2: try three.insert(db)",
+            ],
+        )
 
     def test_missing_sources_dir_is_a_usage_error(self):
         buffer = io.StringIO()

--- a/desktop/macos/tests/test_check_grdb_insert_idiom.py
+++ b/desktop/macos/tests/test_check_grdb_insert_idiom.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the desktop GRDB insert-idiom checker.
+
+The checker is a static tripwire over Swift sources, so these tests are its
+behavioral coverage: each case runs the real `main()` against a disposable source
+tree and asserts the exit code and the reported sites.
+
+The positive cases are the two real merged instances the checker exists to catch,
+reproduced verbatim from their pre-fix source:
+
+  * `Screenshot` in `RewindDatabase.insertScreenshot` (#11204 -> #11208)
+  * `AIUserProfileRecord` in `AIUserProfileService` (#11204 -> #11216)
+
+The negative cases are the Set/Array `insert` shapes that actually occur in
+`Desktop/Sources`, which a naive `.insert(` rule would flag.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import textwrap
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+CHECKER_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check-grdb-insert-idiom.py"
+
+_spec = importlib.util.spec_from_file_location("check_grdb_insert_idiom", CHECKER_PATH)
+assert _spec and _spec.loader, f"cannot load checker from {CHECKER_PATH}"
+checker = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(checker)
+
+
+class GRDBInsertIdiomCheckerTests(unittest.TestCase):
+    def _run(self, swift_by_relative_path: dict[str, str]) -> tuple[int, str]:
+        """Write a disposable Swift tree, run the real checker, return (exit code, stdout)."""
+        with TemporaryDirectory() as tmp:
+            sources = Path(tmp) / "Sources"
+            for relative_path, body in swift_by_relative_path.items():
+                path = sources / relative_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                # lstrip so a triple-quoted body's opening newline does not shift
+                # every asserted line number by one.
+                path.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+            buffer = io.StringIO()
+            with redirect_stdout(buffer):
+                code = checker.main(["--sources-dir", str(sources)])
+            return code, buffer.getvalue()
+
+    def test_flags_the_screenshot_instance_from_11208(self):
+        # Verbatim shape of RewindDatabase.insertScreenshot before #11208, where
+        # every consumer read `if let id = inserted.id` and got nothing.
+        code, output = self._run(
+            {
+                "Rewind/Core/RewindDatabase.swift": """
+                func insertScreenshot(_ screenshot: Screenshot) throws -> Screenshot {
+                  return try dbQueue.write { db in
+                    var record = screenshot
+                    try record.insert(db)
+                    return record
+                  }
+                }
+                """
+            }
+        )
+
+        self.assertEqual(code, 1)
+        self.assertIn("Rewind/Core/RewindDatabase.swift:4", output)
+        self.assertIn("try record.insert(db)", output)
+
+    def test_flags_the_ai_user_profile_instance_from_11216(self):
+        code, output = self._run(
+            {
+                "ProactiveAssistants/Services/AIUserProfileService.swift": """
+                func generateProfile() async throws -> AIUserProfileRecord {
+                  return try await db.write { database in
+                    var record = built
+                    try record.insert(database)
+                    return record
+                  }
+                }
+                """
+            }
+        )
+
+        self.assertEqual(code, 1)
+        self.assertIn("AIUserProfileService.swift:4", output)
+
+    def test_flags_the_conflict_resolution_overload(self):
+        code, output = self._run(
+            {"Storage.swift": "try record.insert(db, onConflict: .replace)\n"}
+        )
+
+        self.assertEqual(code, 1)
+        self.assertIn("Storage.swift:1", output)
+
+    def test_accepts_the_inserted_idiom(self):
+        code, output = self._run(
+            {
+                "Storage.swift": """
+                let saved = try record.inserted(db)
+                _ = try other.inserted(database)
+                """
+            }
+        )
+
+        self.assertEqual(code, 0)
+        self.assertIn("ok:", output)
+
+    def test_does_not_flag_set_and_array_inserts(self):
+        # These shapes are all live in Desktop/Sources; a bare `.insert(` rule
+        # would flag every one of them.
+        code, _ = self._run(
+            {
+                "Collections.swift": """
+                seen.insert(task.id)
+                tasks.insert(task, at: 0)
+                keys.insert(key)
+                names.insert($0.lowercased())
+                ids.insert(candidateID)
+                """
+            }
+        )
+
+        self.assertEqual(code, 0)
+
+    def test_reports_every_violation_not_just_the_first(self):
+        code, output = self._run(
+            {
+                "A.swift": "try one.insert(db)\n",
+                "B.swift": "try two.insert(database)\n",
+            }
+        )
+
+        self.assertEqual(code, 1)
+        self.assertEqual(output.count("\n- "), 2)
+
+    def test_missing_sources_dir_is_a_usage_error(self):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = checker.main(["--sources-dir", "/nonexistent/omi/sources"])
+
+        self.assertEqual(code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

#11204 asked for the class-level guard after two rowid-drop instances were found and fixed one at a time. This lands it, plus the one remaining call site in the hazardous shape.

## The mechanism

A record that captures its rowid in a `mutating func didInsert` never runs that method when inserted through `PersistableRecord`. Measured against the pinned GRDB in `Desktop/Package.resolved`:

- `PersistableRecord+Insert.swift:34` — `extension PersistableRecord { func insert(...) }` is **non-mutating**, and its `didInsert` resolves to the empty default at `:10`. A mutating `didInsert` cannot witness a non-mutating requirement, so it compiles, never runs, and the rowid is dropped.
- `MutablePersistableRecord+Insert.swift:79` — `inserted(_:)` does `var result = self; try result.insert(db)` inside `extension MutablePersistableRecord`, so it binds the **mutating** insert and the record's own `didInsert` is the witness.

The field is optional by design, so the failure is silent: no error, no warning, no crash — the value is just always nil and every dependent path quietly does nothing.

## The call sites

| site | type | status before |
|---|---|---|
| `ActionItemStorage.swift:699` | `ActionItemRecord` (`PersistableRecord`) | **the trap shape** — rowid dropped; nothing reads it, so a dead store today, not a live defect |
| `AIUserProfileService.swift:78` | `AIUserProfileRecord` | safe since #11216 |
| `RewindAbandonedVideoChunkRecovery.swift:119` | `Screenshot` | safe since #11208 |
| `RewindDatabase.swift:2781` | `Screenshot` | safe since #11208 |

All four now use `inserted(...)`, which is what the other 19 persistence seams already use. `insertProfile` also drops a redundant `var inserted = record` copy.

## Why this guard shape

The precise hazard is *"a direct `record.insert(db)` on a concrete type whose `didInsert` is mutating"*, which needs receiver-type resolution a source scrape cannot do soundly. Flagging the declaration shape instead (`PersistableRecord` + `mutating didInsert`) would flag 14 types that are **not** affected, because they all insert via `inserted(db)` — exactly the blanket sweep the issue set out to avoid.

So the checker enforces the single idiom: the direct form buys nothing here, every seam now uses `inserted(db)`, and any new direct `.insert(db)` is rejected regardless of what the receiver conforms to. No allowlist, no type resolution.

It keys on the **database-handle argument**, not `.insert(` alone. Set and Array inserts in `Desktop/Sources` pass ids, keys and elements (`.insert(task.id)`, `.insert(task, at: 0)`, `.insert(key)`), never a bare `db`/`database`, so there is no collision — covered by `test_does_not_flag_set_and_array_inserts`.

**Not a shared primitive** because the hazard is specific to GRDB's split between its mutating and non-mutating insert overloads; there is nothing for another component to reuse. It scans production sources only — tests may construct the broken shape deliberately to prove it is broken.

This is a **static checker**, not behavioral coverage, and is labelled as such in its own docstring. Its behavioral coverage is `test_check_grdb_insert_idiom.py`, which runs the real `main()` against disposable source trees.

## Evidence it would have caught both real instances

Run against the parent commit of each merged fix:

```
parent of 18d4974339 (#11208, Screenshot)    -> exit=1, 5 sites, including
  Rewind/Core/RewindDatabase.swift:2754: try record.insert(db)
parent of 634f093d4e (#11216, AIUserProfile) -> exit=1, 5 sites, including
  ProactiveAssistants/Services/AIUserProfileService.swift:162: try mutableRecord.insert(database)
```

Both are the exact lines those PRs fixed.

## Verification

```
$ xcrun swift build -c debug --package-path Desktop
Build complete! (20.41s)

$ xcrun swift test --package-path Desktop --filter "RowIDCapture"
Executed 2 tests, with 0 failures

$ xcrun swift test --package-path Desktop --filter "ActionItemDeletionSyncTests|ActionItemStorageVisibilityReconciliationTests|StagedTaskSyncIntegrityTests|LocalMutationAuthorizationTests"
Executed 11 tests, with 0 failures

$ python3 desktop/macos/tests/test_check_grdb_insert_idiom.py
Ran 7 tests - OK

$ python3 desktop/macos/scripts/check-grdb-insert-idiom.py
ok: desktop GRDB inserts all use the inserted(db) idiom   (exit 0)

$ git stash && python3 desktop/macos/scripts/check-grdb-insert-idiom.py
FAIL - 4 sites (exit 1)

$ python3 .github/scripts/test_run_checks.py
Ran 45 tests - OK
```

The two `RowIDCapture` suites are the behavioral proof for the idiom conversion: both assert a non-nil rowid back from the real production seams (`insertProfile`, `insertScreenshot`) and both stay green across the change.

## Invariants

**INV-AUTH-1** — matched on path only. `RewindDatabase.swift` is in this invariant's globs, but the change there is the screenshot-rebuild loop's insert idiom; session invalidation policy, 401 handling, owner-transition pool teardown and mutation-lease behavior are all untouched. The `ActionItemStorage` change sits inside the existing `authorization.require()` block and does not alter lease acquisition, commit, or fencing. `LocalMutationAuthorizationTests` (5 tests) passes unchanged.

Refs: #11204
Failure-Class: FC-nonmutating-witness-drops-rowid


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

