### PR TITLE
fix(app): persist Apple Health connect state across restarts

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -375,6 +375,9 @@ class _AppShellState extends State<AppShell> {
       context.read<MessageProvider>().refreshMessages();
       context.read<UsageProvider>().fetchSubscription();
       context.read<TaskIntegrationProvider>().loadFromBackend();
+      // Same fire-and-forget as task integrations: chat/settings must not
+      // treat an empty in-memory map as "not connected" after process death.
+      context.read<IntegrationProvider>().loadFromBackend();
 
       NotificationService.instance.saveNotificationToken();
     } else {

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -188,6 +188,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     final appleHealthService = AppleHealthService();
     if (appleHealthService.isAvailable) {
       final integrationProvider = context.read<IntegrationProvider>();
+      await integrationProvider.ensureLoaded();
+      if (!mounted) return;
       if (integrationProvider.isAppConnected(IntegrationApp.appleHealth)) {
         debugPrint('🍎 [Apple Health] Starting auto-sync on chat open...');
         final success = await appleHealthService.syncHealthDataToBackend(days: 7);

--- a/app/lib/providers/integration_provider.dart
+++ b/app/lib/providers/integration_provider.dart
@@ -5,7 +5,27 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/pages/settings/integrations_page.dart';
 import 'package:omi/utils/logger.dart';
 
+typedef IntegrationStatusFetcher = Future<IntegrationResponse?> Function(String appKey);
+typedef IntegrationSaver = Future<bool> Function(String appKey, Map<String, dynamic> details);
+typedef IntegrationDeleter = Future<bool> Function(String appKey);
+typedef IntegrationPrefWriter = Future<void> Function(String key, bool value);
+
 class IntegrationProvider extends ChangeNotifier {
+  IntegrationProvider({
+    IntegrationStatusFetcher? fetchStatus,
+    IntegrationSaver? saveStatus,
+    IntegrationDeleter? deleteStatus,
+    IntegrationPrefWriter? persistPref,
+  })  : _fetchStatus = fetchStatus ?? getIntegration,
+        _saveStatus = saveStatus ?? saveIntegration,
+        _deleteStatus = deleteStatus ?? deleteIntegration,
+        _persistPref = persistPref ?? _defaultPersistPref;
+
+  final IntegrationStatusFetcher _fetchStatus;
+  final IntegrationSaver _saveStatus;
+  final IntegrationDeleter _deleteStatus;
+  final IntegrationPrefWriter _persistPref;
+
   final Map<String, bool> _integrations = {};
   bool _isLoading = false;
   bool _hasLoaded = false;
@@ -15,24 +35,29 @@ class IntegrationProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
   bool get hasLoaded => _hasLoaded;
 
+  static List<String> get trackedAppKeys => IntegrationApp.values.map((app) => app.key).toList(growable: false);
+
+  static Future<void> _defaultPersistPref(String key, bool value) {
+    return SharedPreferencesUtil().saveBool(key, value);
+  }
+
+  static String prefKeyFor(String appKey) => '${appKey}_connected';
+
   Future<void> loadFromBackend() async {
     final generation = _sessionGeneration;
     _isLoading = true;
     notifyListeners();
 
     try {
-      final responses = await Future.wait([getIntegration('google_calendar'), getIntegration('gmail')]);
+      final keys = trackedAppKeys;
+      final responses = await Future.wait(keys.map(_fetchStatus));
       if (generation != _sessionGeneration) return;
 
-      _integrations['google_calendar'] = responses[0]?.connected ?? false;
-      // Gmail shares the Google grant; the backend reports it connected only when
-      // that grant carries the Gmail scope.
-      _integrations['gmail'] = responses[1]?.connected ?? false;
-
-      // Sync SharedPreferences for backward compatibility with services
-      // This ensures services that read from SharedPreferences stay in sync
-      await SharedPreferencesUtil().saveBool('google_calendar_connected', _integrations['google_calendar'] ?? false);
-      await SharedPreferencesUtil().saveBool('gmail_connected', _integrations['gmail'] ?? false);
+      for (var i = 0; i < keys.length; i++) {
+        final connected = responses[i]?.connected ?? false;
+        _integrations[keys[i]] = connected;
+        await _persistPref(prefKeyFor(keys[i]), connected);
+      }
 
       _hasLoaded = true;
     } catch (e) {
@@ -46,13 +71,19 @@ class IntegrationProvider extends ChangeNotifier {
     }
   }
 
+  Future<void> ensureLoaded() async {
+    if (_hasLoaded) return;
+    await loadFromBackend();
+  }
+
   Future<bool> saveConnection(String appKey, Map<String, dynamic> details) async {
     final generation = _sessionGeneration;
     try {
-      final success = await saveIntegration(appKey, details);
+      final success = await _saveStatus(appKey, details);
       if (generation != _sessionGeneration) return false;
       if (success) {
         _integrations[appKey] = true;
+        await _persistPref(prefKeyFor(appKey), true);
         notifyListeners();
       }
       return success;
@@ -65,10 +96,11 @@ class IntegrationProvider extends ChangeNotifier {
   Future<bool> deleteConnection(String appKey) async {
     final generation = _sessionGeneration;
     try {
-      final success = await deleteIntegration(appKey);
+      final success = await _deleteStatus(appKey);
       if (generation != _sessionGeneration) return false;
       if (success) {
         _integrations[appKey] = false;
+        await _persistPref(prefKeyFor(appKey), false);
         notifyListeners();
       }
       return success;
@@ -78,24 +110,16 @@ class IntegrationProvider extends ChangeNotifier {
     }
   }
 
-  bool isAppConnected(IntegrationApp app) {
-    switch (app) {
-      case IntegrationApp.googleCalendar:
-        return _integrations['google_calendar'] ?? false;
-      case IntegrationApp.appleHealth:
-        return _integrations['apple_health'] ?? false;
-      case IntegrationApp.gmail:
-        return _integrations['gmail'] ?? false;
-    }
-  }
+  bool isAppConnected(IntegrationApp app) => _integrations[app.key] ?? false;
 
   void clearUserData() {
     _sessionGeneration++;
     _integrations.clear();
     _isLoading = false;
     _hasLoaded = false;
-    SharedPreferencesUtil().saveBool('google_calendar_connected', false);
-    SharedPreferencesUtil().saveBool('gmail_connected', false);
+    for (final key in trackedAppKeys) {
+      _persistPref(prefKeyFor(key), false);
+    }
     notifyListeners();
   }
 }

--- a/app/lib/providers/integration_provider.dart
+++ b/app/lib/providers/integration_provider.dart
@@ -30,6 +30,7 @@ class IntegrationProvider extends ChangeNotifier {
   bool _isLoading = false;
   bool _hasLoaded = false;
   int _sessionGeneration = 0;
+  Future<void>? _inFlightLoad;
 
   Map<String, bool> get integrations => _integrations;
   bool get isLoading => _isLoading;
@@ -43,7 +44,20 @@ class IntegrationProvider extends ChangeNotifier {
 
   static String prefKeyFor(String appKey) => '${appKey}_connected';
 
-  Future<void> loadFromBackend() async {
+  bool _isCurrent(int generation) => generation == _sessionGeneration;
+
+  Future<void> loadFromBackend() {
+    final existing = _inFlightLoad;
+    if (existing != null) return existing;
+    late final Future<void> started;
+    started = _loadFromBackendBody().whenComplete(() {
+      if (identical(_inFlightLoad, started)) _inFlightLoad = null;
+    });
+    _inFlightLoad = started;
+    return started;
+  }
+
+  Future<void> _loadFromBackendBody() async {
     final generation = _sessionGeneration;
     _isLoading = true;
     notifyListeners();
@@ -51,20 +65,22 @@ class IntegrationProvider extends ChangeNotifier {
     try {
       final keys = trackedAppKeys;
       final responses = await Future.wait(keys.map(_fetchStatus));
-      if (generation != _sessionGeneration) return;
+      if (!_isCurrent(generation)) return;
 
       for (var i = 0; i < keys.length; i++) {
         final connected = responses[i]?.connected ?? false;
         _integrations[keys[i]] = connected;
         await _persistPref(prefKeyFor(keys[i]), connected);
+        if (!_isCurrent(generation)) return;
       }
 
+      if (!_isCurrent(generation)) return;
       _hasLoaded = true;
     } catch (e) {
-      if (generation != _sessionGeneration) return;
+      if (!_isCurrent(generation)) return;
       Logger.debug('Error loading integrations from backend: $e');
     } finally {
-      if (generation == _sessionGeneration) {
+      if (_isCurrent(generation)) {
         _isLoading = false;
         notifyListeners();
       }
@@ -80,10 +96,11 @@ class IntegrationProvider extends ChangeNotifier {
     final generation = _sessionGeneration;
     try {
       final success = await _saveStatus(appKey, details);
-      if (generation != _sessionGeneration) return false;
+      if (!_isCurrent(generation)) return false;
       if (success) {
         _integrations[appKey] = true;
         await _persistPref(prefKeyFor(appKey), true);
+        if (!_isCurrent(generation)) return false;
         notifyListeners();
       }
       return success;
@@ -97,10 +114,11 @@ class IntegrationProvider extends ChangeNotifier {
     final generation = _sessionGeneration;
     try {
       final success = await _deleteStatus(appKey);
-      if (generation != _sessionGeneration) return false;
+      if (!_isCurrent(generation)) return false;
       if (success) {
         _integrations[appKey] = false;
         await _persistPref(prefKeyFor(appKey), false);
+        if (!_isCurrent(generation)) return false;
         notifyListeners();
       }
       return success;
@@ -114,6 +132,7 @@ class IntegrationProvider extends ChangeNotifier {
 
   void clearUserData() {
     _sessionGeneration++;
+    _inFlightLoad = null;
     _integrations.clear();
     _isLoading = false;
     _hasLoaded = false;

--- a/app/test/providers/integration_provider_reload_test.dart
+++ b/app/test/providers/integration_provider_reload_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/http/api/integrations.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/pages/settings/integrations_page.dart';
+import 'package:omi/providers/integration_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  IntegrationProvider providerWith(Map<String, bool> backend, {Map<String, bool>? prefs}) {
+    return IntegrationProvider(
+      fetchStatus: (appKey) async {
+        if (!backend.containsKey(appKey)) return null;
+        return IntegrationResponse(connected: backend[appKey]!, appKey: appKey);
+      },
+      saveStatus: (appKey, _) async {
+        backend[appKey] = true;
+        return true;
+      },
+      deleteStatus: (appKey) async {
+        backend[appKey] = false;
+        return true;
+      },
+      persistPref: (key, value) async {
+        prefs?[key] = value;
+        await SharedPreferencesUtil().saveBool(key, value);
+      },
+    );
+  }
+
+  test('cold start restores Apple Health after a previous successful connect', () async {
+    final backend = <String, bool>{
+      'google_calendar': false,
+      'gmail': false,
+      'apple_health': true,
+    };
+    final prefs = <String, bool>{};
+
+    final first = providerWith(backend, prefs: prefs);
+    addTearDown(first.dispose);
+    await first.saveConnection(IntegrationApp.appleHealth.key, {});
+    expect(first.isAppConnected(IntegrationApp.appleHealth), isTrue);
+
+    // Process death: a new provider with empty memory must reload from backend.
+    final restarted = providerWith(backend, prefs: prefs);
+    addTearDown(restarted.dispose);
+    expect(restarted.isAppConnected(IntegrationApp.appleHealth), isFalse);
+
+    await restarted.loadFromBackend();
+
+    expect(restarted.isAppConnected(IntegrationApp.appleHealth), isTrue);
+    expect(prefs['apple_health_connected'], isTrue);
+  });
+
+  test('loadFromBackend fetches every surfaced IntegrationApp, not a hardcoded subset', () async {
+    final requested = <String>[];
+    final provider = IntegrationProvider(
+      fetchStatus: (appKey) async {
+        requested.add(appKey);
+        return IntegrationResponse(connected: appKey == IntegrationApp.appleHealth.key, appKey: appKey);
+      },
+      persistPref: (_, __) async {},
+    );
+    addTearDown(provider.dispose);
+
+    await provider.loadFromBackend();
+
+    expect(
+      requested.toSet(),
+      equals(IntegrationApp.values.map((app) => app.key).toSet()),
+    );
+    for (final app in IntegrationApp.values) {
+      expect(
+        provider.isAppConnected(app),
+        app == IntegrationApp.appleHealth,
+        reason: '${app.key} should reflect the backend row after reload',
+      );
+    }
+  });
+
+  test('ensureLoaded hydrates once so chat can trust isAppConnected after restart', () async {
+    var fetches = 0;
+    final provider = IntegrationProvider(
+      fetchStatus: (appKey) async {
+        fetches++;
+        return IntegrationResponse(connected: appKey == 'apple_health', appKey: appKey);
+      },
+      persistPref: (_, __) async {},
+    );
+    addTearDown(provider.dispose);
+
+    expect(provider.hasLoaded, isFalse);
+    await provider.ensureLoaded();
+    expect(provider.hasLoaded, isTrue);
+    expect(provider.isAppConnected(IntegrationApp.appleHealth), isTrue);
+
+    final before = fetches;
+    await provider.ensureLoaded();
+    expect(fetches, before);
+  });
+
+  test('clearUserData forgets Apple Health as well as Google rows', () async {
+    final prefs = <String, bool>{};
+    final provider = providerWith({
+      'google_calendar': true,
+      'gmail': true,
+      'apple_health': true,
+    }, prefs: prefs);
+    addTearDown(provider.dispose);
+
+    await provider.loadFromBackend();
+    expect(provider.isAppConnected(IntegrationApp.appleHealth), isTrue);
+
+    provider.clearUserData();
+
+    expect(provider.isAppConnected(IntegrationApp.appleHealth), isFalse);
+    expect(provider.hasLoaded, isFalse);
+    expect(prefs['apple_health_connected'], isFalse);
+    expect(prefs['google_calendar_connected'], isFalse);
+    expect(prefs['gmail_connected'], isFalse);
+  });
+}

--- a/app/test/providers/integration_provider_reload_test.dart
+++ b/app/test/providers/integration_provider_reload_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -125,5 +127,36 @@ void main() {
     expect(prefs['apple_health_connected'], isFalse);
     expect(prefs['google_calendar_connected'], isFalse);
     expect(prefs['gmail_connected'], isFalse);
+  });
+
+  test('clearUserData mid-load does not resurrect the previous user', () async {
+    final prefs = <String, bool>{};
+    final persistStarted = Completer<void>();
+    final releasePersist = Completer<void>();
+
+    final provider = IntegrationProvider(
+      fetchStatus: (appKey) async => IntegrationResponse(connected: true, appKey: appKey),
+      persistPref: (key, value) async {
+        prefs[key] = value;
+        if (value) {
+          if (!persistStarted.isCompleted) persistStarted.complete();
+          await releasePersist.future;
+        }
+      },
+    );
+    addTearDown(provider.dispose);
+
+    final load = provider.loadFromBackend();
+    await persistStarted.future;
+    provider.clearUserData();
+    releasePersist.complete();
+    await load;
+
+    expect(provider.hasLoaded, isFalse);
+    expect(provider.isLoading, isFalse);
+    for (final app in IntegrationApp.values) {
+      expect(provider.isAppConnected(app), isFalse, reason: '${app.key} leaked after logout');
+      expect(prefs[IntegrationProvider.prefKeyFor(app.key)], isFalse);
+    }
   });
 }

--- a/app/test/unit/integration_provider_startup_hydration_test.dart
+++ b/app/test/unit/integration_provider_startup_hydration_test.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // Static tripwire, not behavioral coverage: signed-in startup must hydrate
+  // IntegrationProvider the same way it hydrates TaskIntegrationProvider.
+  test('signed-in startup loads IntegrationProvider (static tripwire)', () {
+    final source = File('lib/core/app_shell.dart').readAsStringSync();
+    expect(
+      source.contains('context.read<IntegrationProvider>().loadFromBackend();'),
+      isTrue,
+    );
+    expect(
+      source.contains('context.read<TaskIntegrationProvider>().loadFromBackend();'),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
## Bug Description

Apple Health stays authorized in HealthKit and the backend stores `apple_health.connected=true`, but Settings → Integrations always shows **Connect** after the app is killed. Tapping Connect works until the next cold start.

This is on the live App Store build and was still present on `origin/main`.

## Root Cause

`IntegrationProvider.loadFromBackend()` only fetched `google_calendar` and `gmail`. `isAppConnected(appleHealth)` is an in-memory map lookup that defaults to `false`, so process death forgot Health even though `PUT /v1/integrations/apple-health/sync` and `saveConnection('apple_health')` had persisted it.

Two related footguns on the same path:

1. Signed-in startup hydrated `TaskIntegrationProvider` but never `IntegrationProvider`, so chat auto-sync also treated Health as disconnected after restart.
2. Logout only cleared Google prefs, so a leftover Health pref could have leaked across accounts if we started persisting one.

## Fix

- Reload **every** `IntegrationApp` key from the backend (no hardcoded subset).
- Persist `*_connected` prefs for every surfaced integration, including `apple_health`.
- Hydrate `IntegrationProvider` at signed-in startup.
- Chat calls `ensureLoaded()` before deciding whether to auto-sync Health.
- `clearUserData()` forgets every tracked integration, not just Google.

## How to Verify

1. On an iPhone with Health already authorized, open Settings → Integrations and tap Connect on Apple Health. Confirm it flips to Disconnect.
2. Force-quit Omi and reopen Integrations. Apple Health must still show Disconnect, not Connect.
3. Open chat and ask a health question. Auto-sync should run without reconnecting.

## Test Plan

- [x] Added regression tests: cold-start Health restore, enum-wide fetch (guards the next missing key), `ensureLoaded` once, logout clears Health prefs
- [x] Static tripwire: signed-in startup loads `IntegrationProvider`
- [x] `flutter test test/providers` and `app/scripts/analyze_ratchet.sh` passed locally
- [ ] Manual verification of the live iOS path (HealthKit) — not exercised on this Mac

## Risk Assessment

Low — client-only status reload. Extra `GET /v1/integrations/apple_health` on startup/settings. Existing Calendar/Gmail behavior unchanged except they now load at app start instead of only when Integrations opens.

## Invariants

None of the `docs/product/invariants/` globs apply (this is Flutter Settings integrations, not desktop INV-INT-1).

## Failure-Class

Failure-Class: none

First instance of a missing-key integration reload. The enum-wide fetch test is the guard. After merge we can register `FC-partial-integration-status-reload` with this PR as `evidence_prs`.

## Verification evidence

```
flutter test test/providers/integration_provider_reload_test.dart \
  test/unit/integration_provider_startup_hydration_test.dart
# 5 passed

flutter test test/providers
# all passed

bash scripts/analyze_ratchet.sh
# Analyzer ratchet passed
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

