### PR TITLE
ci(desktop): surface crash reports for signal-killed Swift suites (#11573)

### DIFF
--- a/desktop/macos/scripts/swift-test-suites.sh
+++ b/desktop/macos/scripts/swift-test-suites.sh
@@ -29,10 +29,38 @@ PREBUILD="${OMI_SWIFT_TEST_PREBUILD:-1}"
 # a clean main while CI (300s, see .github/workflows/desktop-swift-ci.yml) was
 # green. Keep this in sync with that workflow — the check below proves it.
 SUITE_TIMEOUT_SECONDS="${OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS:-300}"
+# A suite killed by a signal writes nothing but SwiftPM's one-line "Exited with
+# unexpected signal code N" into its log — no frames. The system crash reporter
+# holds the backtrace, and on a hosted runner it is discarded with the machine,
+# so a crasher that only reproduces on CI is undebuggable from the log alone
+# (#11573). Print the reports this run produced next to the failing suites.
+CRASH_REPORT_DIR="${OMI_SWIFT_TEST_CRASH_REPORT_DIR:-$HOME/Library/Logs/DiagnosticReports}"
+CRASH_REPORT_LIMIT="${OMI_SWIFT_TEST_CRASH_REPORT_LIMIT:-6}"
 
 fail() {
   echo "FAIL: $*" >&2
   exit 1
+}
+
+dump_crash_reports() {
+  local marker="$1"
+  if [ ! -d "$CRASH_REPORT_DIR" ]; then
+    echo "No crash reports: $CRASH_REPORT_DIR does not exist."
+    return
+  fi
+  local reports
+  reports="$(find "$CRASH_REPORT_DIR" -maxdepth 1 -type f -name '*.ips' -newer "$marker" 2>/dev/null \
+    | sort | head -n "$CRASH_REPORT_LIMIT")"
+  if [ -z "$reports" ]; then
+    echo "No crash reports newer than this run in $CRASH_REPORT_DIR."
+    return
+  fi
+  local report
+  while IFS= read -r report; do
+    echo "--- CRASH REPORT: $report ---"
+    cat "$report"
+    echo
+  done <<<"$reports"
 }
 
 terminate_process_tree() {
@@ -237,6 +265,7 @@ suite_log_dir="$(mktemp -d)"
 suite_worker_dir="$(mktemp -d)"
 trap 'rm -rf "$suite_log_dir" "$suite_worker_dir"' EXIT
 failed_suites=""
+crashed_suites=""
 suite_count="${#suites[@]}"
 worker_count=0
 
@@ -250,6 +279,11 @@ if [ "$PREBUILD" = "1" ] && [ "$suite_count" -gt 0 ]; then
   echo "Prebuilding Swift test bundle before parallel suite execution..."
   xcrun swift build --package-path "$PACKAGE_PATH" --build-tests
 fi
+
+# Only reports written after this point belong to the suite run; the prebuild
+# and anything the runner did earlier must not be attributed to a crasher.
+crash_marker="$suite_worker_dir/run-start"
+touch "$crash_marker"
 
 parallel_suite_count="${#parallel_suites[@]}"
 if [ "$parallel_suite_count" -gt 0 ]; then
@@ -323,8 +357,16 @@ for suite in "${suites[@]}"; do
     failed_suites="$failed_suites $suite"
     echo "--- FAILED: $suite ---"
     cat "$suite_log_dir/$suite.log"
+    if grep -q "Exited with unexpected signal" "$suite_log_dir/$suite.log"; then
+      crashed_suites="$crashed_suites $suite"
+    fi
   fi
 done
+
+if [ -n "$crashed_suites" ]; then
+  echo "Signal-killed Swift suites:$crashed_suites"
+  dump_crash_reports "$crash_marker"
+fi
 
 echo "Ran $suite_count Swift suites in isolation with $worker_count worker(s), ${SUITE_TIMEOUT_SECONDS}s per-suite budget."
 

--- a/desktop/macos/tests/test-swift-test-suites.sh
+++ b/desktop/macos/tests/test-swift-test-suites.sh
@@ -141,6 +141,18 @@ if [ "$suite" = "AlphaTests" ]; then
   exit 42
 fi
 
+if [ "$suite" = "CrasherTests" ]; then
+  # What SwiftPM actually emits when the xctest host dies on a signal: the
+  # signal line and nothing else. The crash reporter writes the frames.
+  if [ -z "${FAKE_XCRUN_SKIP_CRASH_REPORT:-}" ]; then
+    mkdir -p "$OMI_SWIFT_TEST_CRASH_REPORT_DIR"
+    printf 'fixture crash report for %s\nThread 0 Crashed: SwiftUI layout frame\n' "$suite" \
+      >"$OMI_SWIFT_TEST_CRASH_REPORT_DIR/xctest-fixture.ips"
+  fi
+  echo "error: Exited with unexpected signal code 11"
+  exit 1
+fi
+
 if [ -n "${FAKE_XCRUN_HANG_SUITE:-}" ] && [ "$FAKE_XCRUN_HANG_SUITE" = "$suite" ]; then
   sleep 30 &
   child_pid=$!
@@ -166,6 +178,7 @@ export FAKE_XCRUN_SCRATCH_LOG="$TMPDIR/xcrun-scratch.log"
 export FAKE_XCRUN_SYNC_DIR="$TMPDIR/xcrun-sync"
 export OMI_SWIFT_TEST_DISCOVERY_ROOT="$TMPDIR/tests"
 export OMI_SWIFT_TEST_PACKAGE_PATH="$TMPDIR/package"
+export OMI_SWIFT_TEST_CRASH_REPORT_DIR="$TMPDIR/crash-reports"
 export OMI_SWIFT_TEST_SUITE_WORKERS=2
 export OMI_SWIFT_TEST_SERIAL_SUITES="AuthRefreshResilienceTests AuthTokenStorageTests"
 mkdir -p "$FAKE_XCRUN_SYNC_DIR"
@@ -276,6 +289,46 @@ export FAKE_XCRUN_LOCKWAIT_SECONDS=5
 "$RUNNER" >"$TMPDIR/lockwait-runner.out" 2>"$TMPDIR/lockwait-runner.err" || true
 if grep -q -- "--- FAILED: BetaTests ---" "$TMPDIR/lockwait-runner.out"; then
   fail "runner charged SwiftPM build-lock wait against the per-suite run budget"
+fi
+
+# A suite killed by a signal leaves no frames in SwiftPM's log, and the hosted
+# runner's crash reports die with the machine. The runner must surface them
+# next to the failing suite or a CI-only crasher stays undiagnosable (#11573).
+unset FAKE_XCRUN_LOCKWAIT_SUITE FAKE_XCRUN_LOCKWAIT_SECONDS
+unset OMI_SWIFT_TEST_SUITE_TIMEOUT_SECONDS
+cat >"$TMPDIR/tests/CrasherTests.swift" <<'SWIFT'
+import XCTest
+final class CrasherTests: XCTestCase {
+    func testOne() {}
+}
+SWIFT
+if "$RUNNER" >"$TMPDIR/crash-runner.out" 2>"$TMPDIR/crash-runner.err"; then
+  fail "crash fixture unexpectedly succeeded"
+fi
+if ! grep -q "Signal-killed Swift suites: CrasherTests" "$TMPDIR/crash-runner.out"; then
+  fail "runner did not name the signal-killed suite"
+fi
+if ! grep -q -- "--- CRASH REPORT: " "$TMPDIR/crash-runner.out"; then
+  fail "runner did not surface the crash report for a signal-killed suite"
+fi
+if ! grep -q "Thread 0 Crashed: SwiftUI layout frame" "$TMPDIR/crash-runner.out"; then
+  fail "runner did not print the crash report's contents"
+fi
+
+# A report predating the run belongs to some earlier process; attributing it to
+# this run's crasher would send the next reader after the wrong backtrace.
+rm -f "$OMI_SWIFT_TEST_CRASH_REPORT_DIR/xctest-fixture.ips"
+printf 'stale report\n' >"$OMI_SWIFT_TEST_CRASH_REPORT_DIR/xctest-stale.ips"
+touch -t 202001010000 "$OMI_SWIFT_TEST_CRASH_REPORT_DIR/xctest-stale.ips"
+export FAKE_XCRUN_SKIP_CRASH_REPORT=1
+if "$RUNNER" >"$TMPDIR/stale-crash-runner.out" 2>"$TMPDIR/stale-crash-runner.err"; then
+  fail "stale-report fixture unexpectedly succeeded"
+fi
+if grep -q "stale report" "$TMPDIR/stale-crash-runner.out"; then
+  fail "runner attributed a pre-run crash report to this run"
+fi
+if ! grep -q "No crash reports newer than this run" "$TMPDIR/stale-crash-runner.out"; then
+  fail "runner did not report the absence of a fresh crash report"
 fi
 
 echo "swift-test-suites tests passed"


### PR DESCRIPTION
## Bug

`Desktop Swift Static & Test Contracts` has been red on `main` since `15a51fb985`, and three of its seven failing suites die with `error: Exited with unexpected signal code 11` (#11573): `AgentPillLifecycleTests`, `ChatTimelineContinuityTests`, `MarkdownNestedScrollTests`.

That one line is *all* SwiftPM emits for a signal death — no frames, no exception type, no faulting thread. The system crash report that does carry the backtrace is written to the runner's `~/Library/Logs/DiagnosticReports` and discarded with the machine when the job ends. None of the three suites reproduce on either available maintainer machine (macOS 26.4 / Xcode 26.4 vs CI's macOS 15 / Xcode 16.4), so CI is the only environment that can produce the evidence — and CI was throwing it away. The crashers have been undiagnosable for two days for exactly this reason, and #11573 asks for this capture by name.

## Fix

`desktop/macos/scripts/swift-test-suites.sh`:

- stamps a marker file immediately before suite execution (after the prebuild, so prebuild-era reports are not attributed to a suite),
- when a failing suite's log carries `Exited with unexpected signal`, records it,
- after the failure summary, prints `Signal-killed Swift suites: …` and `cat`s every `.ips` written after the marker (capped, `OMI_SWIFT_TEST_CRASH_REPORT_LIMIT`, default 6).

The report directory and cap are overridable (`OMI_SWIFT_TEST_CRASH_REPORT_DIR`) so the runner's own harness can drive this hermetically. The whole path is inert unless a suite dies on a signal; on a green lane it adds nothing and costs nothing.

## What I tested

- **Regression test** — `desktop/macos/tests/test-swift-test-suites.sh` gains a signal-death fixture. On the unmodified runner it fails (`runner did not name the signal-killed suite`); with the change it passes. It asserts both directions: a report written during the run is printed, and a report predating the run is *not* attributed to it (`No crash reports newer than this run`), because sending the next reader after the wrong backtrace is worse than printing nothing.

  ```
  $ bash desktop/macos/tests/test-swift-test-suites.sh
  swift-test-suites tests passed
  $ git stash push -- desktop/macos/scripts/swift-test-suites.sh && bash desktop/macos/tests/test-swift-test-suites.sh
  FAIL: runner did not name the signal-killed suite
  ```

- **Real mechanism, not just the fixture** — on macOS 26.4 a deliberate `SIGSEGV` process (`exit=139`) wrote `~/Library/Logs/DiagnosticReports/segv-2026-08-14-171402.ips`; `find -newer <marker>` selected it, and the report carried `EXC_BAD_ACCESS` / `SIGSEGV` / `KERN_INVALID_ADDRESS`, the faulting thread, and symbolicated frames. That is precisely the payload #11573 is missing.

- `shellcheck -S warning` clean on both files.
- `run_checks.py --lane local --skip-changelog`: 13/13 pass. Changelog gate is satisfied by the `no-changelog-needed` label — this is CI diagnostics, nothing a user sees.

## Note on the lane

The Desktop Swift lane is red on `main` independently of this change (7 pre-existing failing suites: the 3 crashers above plus `GlassSurfaceReviewRegressionTests`, `ProactiveLaneClientTests`, `RewindSurfaceLayoutTests`, `ShellModalScrimDismissTests`). This PR does not fix them — it makes the 3 crashers diagnosable. It is merged only if its lane run shows no failure beyond that known set.

Closes nothing; feeds #11573.

🤖 automated by the hourly desktop watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

