### PR TITLE
fix(macos): let chat save memories as clean facts

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
+++ b/desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
@@ -177,6 +177,10 @@ enum DesktopCapabilityRegistry {
       "Create/update tasks -> \(toolList(taskWriteTools)); use execute_sql only for exact local inspection or legacy local writes.",
       when: !available(taskWriteTools).isEmpty
     )
+    append(
+      "User explicitly asks to remember/save -> create_memory with a clean standalone fact.",
+      when: has("create_memory")
+    )
     let taskCompletionTools = ["complete_task", "delete_task"]
     append(
       "Complete/delete local tasks -> find the backendId, then \(toolList(taskCompletionTools)).",

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolCapabilities.swift
@@ -432,14 +432,16 @@ enum GeneratedToolCapabilities {
       title: "Create Memory",
       latency: .fastNetwork,
       surfaces: Set([.desktopChat]),
-      summary: "Save one user-provided fact or preference to short-term memory.",
+      summary: "Save one explicitly requested fact or preference to short-term memory.",
       bullets: [
-      "Use only when the user explicitly and affirmatively asks you to remember or save the supplied content.",
-      "Do not infer memories from conversation context, and do not call for a negative request such as 'do not remember this'.",
+      "Use only when the user explicitly and affirmatively asks you to remember or save something.",
+      "Pass a clean standalone fact: strip the command and lightly clean pronouns. Do not invent names, dates, or facts the user did not ask to persist, and do not infer from the rest of the chat.",
+      "Do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
       "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory.",
-      "The current user message must explicitly and affirmatively ask Omi to remember or save the supplied content.",
-      "Pass only the content to remember; do not add inferred facts, categories, tags, or metadata.",
-      "Do not call when the user merely states a fact, asks a question, asks for a suggestion, or says not to remember/save something.",
+      "When the current user message explicitly and affirmatively asks Omi to remember or save something, call this tool with a clean standalone fact.",
+      "Strip the command (for example, 'Please remember that I prefer tea' → 'I prefer tea'). Light rewrite and pronoun cleanup are OK; do not invent names, dates, or facts the user did not ask to persist.",
+      "Do not infer from the rest of the chat, and do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
+      "Confirm the save in one line. Never tell the user about validators or internal save rules.",
       "This is a one-way non-idempotent write. Do not retry automatically after an unknown outcome; tell the user the save status is uncertain.",
       "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory."
     ]

--- a/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
+++ b/desktop/macos/Desktop/Sources/Generated/GeneratedToolExecutors.swift
@@ -46,8 +46,8 @@ enum GeneratedSwiftToolExecutor: String {
 
 enum GeneratedToolExecutors {
   static let manifestVersion = 1
-  static let manifestDigest = "sha256:41ffc2ae919b65bdcbca0ea4de12c4f5b7bc55fcd8fa721f6eef9b0392069f31"
-  static let chatFirstManifestDigest = "sha256:b1cef85cf927c4528f50927bc4a1bbfd34c5b2ce4b2b8cc5e6ad0342b35e87c3"
+  static let manifestDigest = "sha256:c1bee79f74def1a256bd4d00d7918c658dcb5043b21e21ccd80b0cb7e96dee17"
+  static let chatFirstManifestDigest = "sha256:3805f67fad145b38bee5a4f139fee7f5974fc65cb557b626455a9db8219f92c1"
 
   static let aliasToCanonical: [String: GeneratedSwiftTool] = [
     "search_screen_history": .semanticSearch,

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
@@ -97,7 +97,8 @@ extension ChatToolExecutor {
     guard !contentTokens.isEmpty else { return false }
     let promptTokens = Set(memoryGroundingTokens(userText))
     let overlap = contentTokens.filter { promptTokens.contains($0) }
-    let required = contentTokens.count <= 2
+    let required =
+      contentTokens.count <= 2
       ? 1
       : max(2, Int(ceil(Double(contentTokens.count) * 0.5)))
     return overlap.count >= required

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
@@ -34,32 +34,127 @@ extension ChatToolExecutor {
     // authorization for a write. Shared cases live in
     // agent/tests/fixtures/memory-save-intent-corpus.json.
     let negativePattern =
-      #"(?:\b(?:don't|do not|never|no longer|without)\b[^.!?]{0,96}\b(?:remember|save|store|keep)\b|\b(?:remember|save|store|keep)\b[^.!?]{0,96}\b(?:not|never)\b)"#
+      #"(?:\b(?:don't|do not|never|no longer|without|not to)\b[^.!?]{0,96}\b(?:remember|save|store|keep)\b|\b(?:remember|save|store|keep)\b[^.!?]{0,96}\b(?:not|never)\b)"#
     guard text.range(of: negativePattern, options: .regularExpression) == nil else { return false }
-    // Polite requests ("Could you please remember this?") are commands, not
-    // recall questions. Keep this please exception in lockstep with the
-    // TypeScript runtime matcher; shared cases live in
-    // agent/tests/fixtures/memory-save-intent-corpus.json.
-    let questionPattern =
-      #"^\s*(?:should|would|could|can|do|did|why|what)\b[^.!?]*\b(?:remember|save|store|keep)\b[^.!?]*\?\s*$"#
-    if !text.contains("please") {
-      guard text.range(of: questionPattern, options: .regularExpression) == nil else { return false }
+
+    if text.contains("?") {
+      let politeCommand =
+        text.range(
+          of: #"\bplease\b[^.!?]*\b(?:remember|save|store|keep)\b"#,
+          options: .regularExpression) != nil
+        || text.range(
+          of: #"^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b"#,
+          options: .regularExpression) != nil
+      if !politeCommand,
+        text.range(of: #"\b(?:remember|save|store|keep)\b"#, options: .regularExpression) != nil
+      {
+        return false
+      }
     }
+
+    let passiveMentionPattern =
+      #"\b(?:should|could|would)\s+(?:remember|save|store|keep)\b|\b(?:ability|able)\s+to\s+(?:remember|save|store|keep)\b"#
+    guard text.range(of: passiveMentionPattern, options: .regularExpression) == nil else { return false }
+
+    let thirdPartyCommandPattern =
+      #"\b(?:ask|tell|have|get|let|want|need)\s+(?!you\b)\w+(?:\s+\w+){0,2}\s+to\s+(?:remember|save|store|keep)\b"#
+    guard text.range(of: thirdPartyCommandPattern, options: .regularExpression) == nil else { return false }
 
     let directCommandPattern = #"^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b"#
     let sentenceCommandPattern = #"(?:^|[.!?,;]\s+)(?:please\s+)?(?:remember|save|store|keep)\b"#
     let delegatedCommandPattern = #"\b(?:want|need|ask)\s+(?:you\s+)?to\s+(?:please\s+)?(?:remember|save|store|keep)\b"#
+    let rememberThatCommandPattern = #"(?:^|[.!?,;]\s+)(?:please\s+)?remember\s+that\b"#
     let anaphoricCommandPattern =
-      #"\b(?:remember|save|store|keep)\s+(?:this|that|it|my|our|the following)\b"#
+      #"\b(?:remember|save|store|keep)\s+(?:this|it|my|our|the following)\b"#
+    let memoryPhrasePattern =
+      #"\b(?:add this to memory|create a memory|make this a memory|save to memory|save as a memory|store(?:\s+this)? in memory|keep in mind(?:\s+that)?)\b"#
     let hasCommand =
       text.range(of: directCommandPattern, options: .regularExpression) != nil
       || text.range(of: sentenceCommandPattern, options: .regularExpression) != nil
       || text.range(of: delegatedCommandPattern, options: .regularExpression) != nil
+      || text.range(of: rememberThatCommandPattern, options: .regularExpression) != nil
       || text.range(of: anaphoricCommandPattern, options: .regularExpression) != nil
+      || text.range(of: memoryPhrasePattern, options: .regularExpression) != nil
     guard hasCommand else { return false }
     return text.range(
       of: #"\b(?:i|we|you|they)\s+(?:remember|save|store|keep)\b"#,
       options: .regularExpression) == nil
+  }
+
+  /// Memory writes may paraphrase the user's fact, but the content must still
+  /// be grounded in this turn. Verbatim spans pass; anaphoric-only commands
+  /// ("remember this") carry no extractable fact here; otherwise a meaningful
+  /// token overlap is required so invented facts cannot ride explicit save intent.
+  nonisolated static func isMemoryContentGroundedInUserRequest(content: String, userText: String?) -> Bool {
+    guard let userText else { return false }
+    let normalizedContent = normalizeMemoryText(content)
+    let normalizedUserText = normalizeMemoryText(userText)
+    guard !normalizedContent.isEmpty, !normalizedUserText.isEmpty else { return false }
+    if " \(normalizedUserText) ".contains(" \(normalizedContent) ") { return true }
+    if isAnaphoricOnlyMemoryCommand(userText) { return true }
+
+    let contentTokens = memoryGroundingTokens(content)
+    guard !contentTokens.isEmpty else { return false }
+    let promptTokens = Set(memoryGroundingTokens(userText))
+    let overlap = contentTokens.filter { promptTokens.contains($0) }
+    let required = contentTokens.count <= 2
+      ? 1
+      : max(2, Int(ceil(Double(contentTokens.count) * 0.5)))
+    return overlap.count >= required
+  }
+
+  private nonisolated static func isAnaphoricOnlyMemoryCommand(_ prompt: String) -> Bool {
+    let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let hasDeicticCommand =
+      text.range(of: #"\b(?:remember|save|store|keep)\s+(?:this|that|it)\b"#, options: .regularExpression) != nil
+      || text.range(of: #"\b(?:add this to memory|make this a memory)\b"#, options: .regularExpression) != nil
+    guard hasDeicticCommand else { return false }
+    return memoryGroundingTokens(stripMemoryCommandPhrases(text)).count < 2
+  }
+
+  private nonisolated static func stripMemoryCommandPhrases(_ text: String) -> String {
+    var stripped = text
+    let replacements: [(String, String)] = [
+      (#"^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b[:\s]*"#, ""),
+      (#"\b(?:want|need|ask)\s+you\s+to\s+(?:please\s+)?(?:remember|save|store|keep)\b[:\s]*"#, ""),
+      (#"\b(?:remember|save|store|keep)\s+(?:that|this|it|my|our|the following)\b[:\s,]*"#, ""),
+      (
+        #"\b(?:add this to memory|create a memory|make this a memory|save to memory|save as a memory|store(?:\s+this)? in memory|keep in mind(?:\s+that)?)\b[:\s]*"#,
+        ""
+      ),
+    ]
+    for (pattern, replacement) in replacements {
+      stripped = stripped.replacingOccurrences(
+        of: pattern,
+        with: replacement,
+        options: .regularExpression)
+    }
+    return stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private nonisolated static let memoryGroundingStopWords: Set<String> = [
+    "a", "an", "and", "as", "at", "be", "been", "being", "but", "for", "from", "had", "has",
+    "have", "hey", "i", "im", "in", "is", "it", "me", "my", "of", "on", "or", "please", "that",
+    "the", "this", "to", "was", "were", "with", "you", "your",
+    "keep", "remember", "save", "store",
+  ]
+
+  private nonisolated static func memoryGroundingTokens(_ value: String) -> [String] {
+    normalizeMemoryText(value)
+      .split(separator: " ")
+      .map(String.init)
+      .filter { $0.count > 1 && !memoryGroundingStopWords.contains($0) }
+  }
+
+  private nonisolated static func normalizeMemoryText(_ value: String) -> String {
+    value
+      .precomposedStringWithCompatibilityMapping
+      .lowercased()
+      .unicodeScalars
+      .map { CharacterSet.alphanumerics.contains($0) ? String($0) : " " }
+      .joined()
+      .split(whereSeparator: \.isWhitespace)
+      .joined(separator: " ")
   }
 
   nonisolated static func memoryCreationReceipt(_ memory: ServerMemory) -> String {
@@ -126,6 +221,12 @@ extension ChatToolExecutor {
       return [
         #"{"ok":false,"error":{"code":"invalid_memory_content","message":"content must be 1-1000 "#,
         #"non-whitespace characters."}}"#,
+      ].joined()
+    }
+    guard isMemoryContentGroundedInUserRequest(content: input.content, userText: originatingUserText) else {
+      return [
+        #"{"ok":false,"error":{"code":"memory_content_not_user_supplied","message":"Memory content must appear in "#,
+        #"the current typed user request."}}"#,
       ].joined()
     }
     guard

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor+MemoryCreation.swift
@@ -28,15 +28,23 @@ extension ChatToolExecutor {
     let text = userText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     guard !text.isEmpty else { return false }
 
-    // Keep this validator aligned with the runtime external-surface policy:
+    // Keep this validator in lockstep with hasExplicitMemorySaveIntent in
+    // desktop/macos/agent/src/runtime/external-surface-tool-policy.ts:
     // negations, recall questions, and assistant-authored suggestions are not
-    // authorization for a write.
+    // authorization for a write. Shared cases live in
+    // agent/tests/fixtures/memory-save-intent-corpus.json.
     let negativePattern =
       #"(?:\b(?:don't|do not|never|no longer|without)\b[^.!?]{0,96}\b(?:remember|save|store|keep)\b|\b(?:remember|save|store|keep)\b[^.!?]{0,96}\b(?:not|never)\b)"#
     guard text.range(of: negativePattern, options: .regularExpression) == nil else { return false }
+    // Polite requests ("Could you please remember this?") are commands, not
+    // recall questions. Keep this please exception in lockstep with the
+    // TypeScript runtime matcher; shared cases live in
+    // agent/tests/fixtures/memory-save-intent-corpus.json.
     let questionPattern =
       #"^\s*(?:should|would|could|can|do|did|why|what)\b[^.!?]*\b(?:remember|save|store|keep)\b[^.!?]*\?\s*$"#
-    guard text.range(of: questionPattern, options: .regularExpression) == nil else { return false }
+    if !text.contains("please") {
+      guard text.range(of: questionPattern, options: .regularExpression) == nil else { return false }
+    }
 
     let directCommandPattern = #"^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b"#
     let sentenceCommandPattern = #"(?:^|[.!?,;]\s+)(?:please\s+)?(?:remember|save|store|keep)\b"#
@@ -52,25 +60,6 @@ extension ChatToolExecutor {
     return text.range(
       of: #"\b(?:i|we|you|they)\s+(?:remember|save|store|keep)\b"#,
       options: .regularExpression) == nil
-  }
-
-  nonisolated static func isMemoryContentUserSupplied(content: String, userText: String?) -> Bool {
-    guard let userText else { return false }
-    let normalizedContent = normalizeMemoryText(content)
-    let normalizedUserText = normalizeMemoryText(userText)
-    guard !normalizedContent.isEmpty, !normalizedUserText.isEmpty else { return false }
-    return " \(normalizedUserText) ".contains(" \(normalizedContent) ")
-  }
-
-  private nonisolated static func normalizeMemoryText(_ value: String) -> String {
-    value
-      .precomposedStringWithCompatibilityMapping
-      .lowercased()
-      .unicodeScalars
-      .map { CharacterSet.alphanumerics.contains($0) ? String($0) : " " }
-      .joined()
-      .split(whereSeparator: \.isWhitespace)
-      .joined(separator: " ")
   }
 
   nonisolated static func memoryCreationReceipt(_ memory: ServerMemory) -> String {
@@ -137,12 +126,6 @@ extension ChatToolExecutor {
       return [
         #"{"ok":false,"error":{"code":"invalid_memory_content","message":"content must be 1-1000 "#,
         #"non-whitespace characters."}}"#,
-      ].joined()
-    }
-    guard isMemoryContentUserSupplied(content: input.content, userText: originatingUserText) else {
-      return [
-        #"{"ok":false,"error":{"code":"memory_content_not_user_supplied","message":"Memory content must appear in "#,
-        #"the current typed user request."}}"#,
       ].joined()
     }
     guard

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorCreateMemoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorCreateMemoryTests.swift
@@ -206,6 +206,25 @@ final class ChatToolExecutorCreateMemoryTests: XCTestCase {
     XCTAssertTrue(result.contains("explicit_user_intent_required"), result)
   }
 
+  func testExecutorRejectsUngroundedMemoryContentWithoutCallingBackend() async {
+    let client = APIClient(session: URLSession(configuration: .ephemeral))
+    let result = await ChatToolExecutor.execute(
+      ToolCall(
+        name: "create_memory",
+        arguments: ["content": "David loves coffee."],
+        thoughtSignature: nil),
+      originatingSurfaceRef: .mainChat(chatId: "test"),
+      originatingUserText: "Please remember that I prefer tea.",
+      expectedOwnerID: "create-memory-tool-owner",
+      backendAPIClient: client)
+
+    XCTAssertTrue(result.contains("memory_content_not_user_supplied"), result)
+    XCTAssertFalse(
+      ChatToolExecutor.isMemoryContentGroundedInUserRequest(
+        content: "David loves coffee.",
+        userText: "Please remember that I prefer tea."))
+  }
+
   func testExecutorAcceptsRewrittenContentWhenSaveIntentIsPresent() async throws {
     CreateMemoryRequestCapture.reset()
     setenv("OMI_PYTHON_API_URL", "http://create-memory-contract-test:9001", 1)

--- a/desktop/macos/Desktop/Tests/ChatToolExecutorCreateMemoryTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatToolExecutorCreateMemoryTests.swift
@@ -174,19 +174,21 @@ final class ChatToolExecutorCreateMemoryTests: XCTestCase {
     )
   }
 
-  func testMemoryContentMustAppearInCurrentUserRequest() {
-    XCTAssertTrue(
-      ChatToolExecutor.isMemoryContentUserSupplied(
-        content: "I prefer tea.",
-        userText: "Please remember that I prefer tea"))
-    XCTAssertFalse(
-      ChatToolExecutor.isMemoryContentUserSupplied(
-        content: "I prefer coffee.",
-        userText: "Please remember that I prefer tea."))
-    XCTAssertFalse(
-      ChatToolExecutor.isMemoryContentUserSupplied(
-        content: "I prefer tea.",
-        userText: "Please remember this."))
+  func testMemorySaveIntentCorpusMatchesRuntimePolicy() throws {
+    let corpus = try Self.loadMemorySaveIntentCorpus()
+    for prompt in corpus.authorized {
+      XCTAssertTrue(
+        ChatToolExecutor.isExplicitMemorySaveIntent(userText: prompt, surfaceKind: "main_chat"),
+        "expected authorized save intent: \(prompt)")
+      XCTAssertTrue(
+        ChatToolExecutor.isExplicitMemorySaveIntent(userText: prompt, surfaceKind: "floating_chat"),
+        "expected authorized floating-chat save intent: \(prompt)")
+    }
+    for prompt in corpus.unauthorized {
+      XCTAssertFalse(
+        ChatToolExecutor.isExplicitMemorySaveIntent(userText: prompt, surfaceKind: "main_chat"),
+        "expected unauthorized save intent: \(prompt)")
+    }
   }
 
   func testExecutorRejectsInferredMemoryWithoutCallingBackend() async {
@@ -204,8 +206,18 @@ final class ChatToolExecutorCreateMemoryTests: XCTestCase {
     XCTAssertTrue(result.contains("explicit_user_intent_required"), result)
   }
 
-  func testExecutorRejectsModelInferredContentEvenWithSaveIntent() async {
-    let client = APIClient(session: URLSession(configuration: .ephemeral))
+  func testExecutorAcceptsRewrittenContentWhenSaveIntentIsPresent() async throws {
+    CreateMemoryRequestCapture.reset()
+    setenv("OMI_PYTHON_API_URL", "http://create-memory-contract-test:9001", 1)
+    defer {
+      unsetenv("OMI_PYTHON_API_URL")
+      CreateMemoryRequestCapture.reset()
+    }
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [CreateMemoryRequestCapture.self]
+    let client = APIClient(session: URLSession(configuration: configuration))
+    await client.setCreateMemoryTestAuthHeader("Bearer create-memory-tool-owner-token")
+
     let result = await ChatToolExecutor.execute(
       ToolCall(
         name: "create_memory",
@@ -216,7 +228,57 @@ final class ChatToolExecutorCreateMemoryTests: XCTestCase {
       expectedOwnerID: "create-memory-tool-owner",
       backendAPIClient: client)
 
-    XCTAssertTrue(result.contains("memory_content_not_user_supplied"), result)
+    XCTAssertFalse(result.contains("memory_content_not_user_supplied"), result)
+    XCTAssertEqual(CreateMemoryRequestCapture.count(), 1)
+    let body = try XCTUnwrap(CreateMemoryRequestCapture.requestBody())
+    let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    XCTAssertEqual(payload["content"] as? String, "I prefer tea.")
+    XCTAssertTrue(result.contains(#""memory_id":"memory-1""#), result)
+  }
+
+  func testExecutorAcceptsParaphrasedProactivityMemory() async throws {
+    CreateMemoryRequestCapture.reset()
+    setenv("OMI_PYTHON_API_URL", "http://create-memory-contract-test:9001", 1)
+    defer {
+      unsetenv("OMI_PYTHON_API_URL")
+      CreateMemoryRequestCapture.reset()
+    }
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [CreateMemoryRequestCapture.self]
+    let client = APIClient(session: URLSession(configuration: configuration))
+    await client.setCreateMemoryTestAuthHeader("Bearer create-memory-tool-owner-token")
+
+    let result = await ChatToolExecutor.execute(
+      ToolCall(
+        name: "create_memory",
+        arguments: ["content": "David is currently testing proactivity in Omi"],
+        thoughtSignature: nil),
+      originatingSurfaceRef: .mainChat(chatId: "test"),
+      originatingUserText: "Please remember that I am currently testing proactivity in Omi",
+      expectedOwnerID: "create-memory-tool-owner",
+      backendAPIClient: client)
+
+    XCTAssertFalse(result.contains("memory_content_not_user_supplied"), result)
+    XCTAssertEqual(CreateMemoryRequestCapture.count(), 1)
+    let body = try XCTUnwrap(CreateMemoryRequestCapture.requestBody())
+    let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    XCTAssertEqual(payload["content"] as? String, "David is currently testing proactivity in Omi")
+    XCTAssertTrue(result.contains(#""memory_id":"memory-1""#), result)
+  }
+
+  func testExecutorRejectsRealtimeVoiceSurfaceEvenWithSaveIntent() async {
+    let client = APIClient(session: URLSession(configuration: .ephemeral))
+    let result = await ChatToolExecutor.execute(
+      ToolCall(
+        name: "create_memory",
+        arguments: ["content": "I prefer tea."],
+        thoughtSignature: nil),
+      originatingSurfaceRef: .realtimeVoice(chatId: "test"),
+      originatingUserText: "Please remember that I prefer tea.",
+      expectedOwnerID: "create-memory-tool-owner",
+      backendAPIClient: client)
+
+    XCTAssertTrue(result.contains("explicit_user_intent_required"), result)
   }
 
   func testExecutorRejectsDelegatedFloatingPillEvenWithExplicitText() async {
@@ -341,5 +403,18 @@ final class ChatToolExecutorCreateMemoryTests: XCTestCase {
     XCTAssertEqual(CreateMemoryTimeoutCapture.count(), 1)
     XCTAssertTrue(result.contains("memory_save_status_unknown"), result)
     XCTAssertFalse(result.contains(#""saved":false"#), result)
+  }
+
+  private struct MemorySaveIntentCorpus: Decodable {
+    let authorized: [String]
+    let unauthorized: [String]
+  }
+
+  private static func loadMemorySaveIntentCorpus() throws -> MemorySaveIntentCorpus {
+    let testFile = URL(fileURLWithPath: #filePath)
+    let desktopDir = testFile.deletingLastPathComponent().deletingLastPathComponent()
+    let macOSDir = desktopDir.deletingLastPathComponent()
+    let url = macOSDir.appendingPathComponent("agent/tests/fixtures/memory-save-intent-corpus.json")
+    return try JSONDecoder().decode(MemorySaveIntentCorpus.self, from: Data(contentsOf: url))
   }
 }

--- a/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
+++ b/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
@@ -20,7 +20,6 @@ export type ExternalSurfaceToolPolicyDecision =
       | "permission_request_not_authorized"
       | "pill_management_intent_required"
       | "memory_save_not_authorized"
-      | "memory_content_not_in_user_request"
       | "sql_write_rejected";
     message: string;
   };
@@ -153,13 +152,6 @@ export function routeExternalSurfaceTool(
         action: "reject",
         code: "memory_save_not_authorized",
         message: "Saving a memory requires an explicit affirmative current-turn request such as 'remember this' or 'save this'",
-      };
-    }
-    if (!hasMemoryContentInUserRequest(input.toolInput, input.originatingPrompt)) {
-      return {
-        action: "reject",
-        code: "memory_content_not_in_user_request",
-        message: "Memory content must be plainly supplied in the current user request; inferred or rewritten content is not authorized",
       };
     }
   }
@@ -352,65 +344,26 @@ export function hasExplicitMemorySaveIntent(prompt: string): boolean {
   const text = prompt.toLowerCase().trim();
   if (!text) return false;
 
-  // Keep this list in lockstep with the native executor: recall questions and
-  // explicit negations must never become durable-write authority.
-  const rejectedPhrases = [
-    "do you remember",
-    "did you remember",
-    "what do you remember",
-    "what should i remember",
-    "don't remember",
-    "do not remember",
-    "never remember",
-    "not remember",
-    "don't save",
-    "do not save",
-    "don't store",
-    "do not store",
-    "don't add",
-    "do not add",
-    "don't create",
-    "do not create",
-  ];
-  if (rejectedPhrases.some((phrase) => text.includes(phrase))) return false;
+  // Keep these patterns identical to ChatToolExecutor.isExplicitMemorySaveIntent.
+  // Shared cases live in tests/fixtures/memory-save-intent-corpus.json.
+  const negativePattern =
+    /(?:\b(?:don't|do not|never|no longer|without)\b[^.!?]{0,96}\b(?:remember|save|store|keep)\b|\b(?:remember|save|store|keep)\b[^.!?]{0,96}\b(?:not|never)\b)/;
+  if (negativePattern.test(text)) return false;
+  const questionPattern =
+    /^\s*(?:should|would|could|can|do|did|why|what)\b[^.!?]*\b(?:remember|save|store|keep)\b[^.!?]*\?\s*$/;
+  if (!text.includes("please") && questionPattern.test(text)) return false;
 
-  const imperativePhrases = [
-    "remember that",
-    "remember this",
-    "remember: ",
-    "please remember",
-    "save this",
-    "save to memory",
-    "save as a memory",
-    "store this",
-    "store in memory",
-    "add this to memory",
-    "create a memory",
-    "make this a memory",
-    "keep in mind that",
-  ];
-  const startsWithRememberCommand = text.startsWith("remember ")
-    || text.startsWith("remember:")
-    || text.startsWith("remember,");
-  if (!startsWithRememberCommand && !imperativePhrases.some((phrase) => text.includes(phrase))) return false;
-  // A question is only authorized when it contains an explicit polite
-  // request ("please ...?") or starts with the direct "remember" command.
-  if (text.includes("?") && !text.includes("please") && !text.startsWith("remember")) return false;
-  return true;
-}
-
-/**
- * A memory write may only persist text that the user supplied in this turn.
- * Compare normalized text literally rather than allowing a model-proposed
- * paraphrase or an inferred fact to become durable state.
- */
-export function hasMemoryContentInUserRequest(
-  toolInput: Record<string, unknown>,
-  originatingPrompt: string,
-): boolean {
-  const content = normalizeMemoryText(textField(toolInput, "content"));
-  const prompt = normalizeMemoryText(originatingPrompt);
-  return content.length > 0 && prompt.includes(content);
+  const directCommandPattern = /^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b/;
+  const sentenceCommandPattern = /(?:^|[.!?,;]\s+)(?:please\s+)?(?:remember|save|store|keep)\b/;
+  const delegatedCommandPattern = /\b(?:want|need|ask)\s+(?:you\s+)?to\s+(?:please\s+)?(?:remember|save|store|keep)\b/;
+  const anaphoricCommandPattern =
+    /\b(?:remember|save|store|keep)\s+(?:this|that|it|my|our|the following)\b/;
+  const hasCommand = directCommandPattern.test(text)
+    || sentenceCommandPattern.test(text)
+    || delegatedCommandPattern.test(text)
+    || anaphoricCommandPattern.test(text);
+  if (!hasCommand) return false;
+  return !/\b(?:i|we|you|they)\s+(?:remember|save|store|keep)\b/.test(text);
 }
 
 function permissionRequest(text: string): { toolName: "check_permission_status" | "request_permission"; type: string } | null {
@@ -476,14 +429,4 @@ function normalizeTarget(value: string): string {
 function textField(input: Record<string, unknown>, key: string): string {
   const value = input[key];
   return typeof value === "string" ? value.trim() : "";
-}
-
-function normalizeMemoryText(value: string): string {
-  // Keep symbols (including emoji and values such as `C++`) intact; only
-  // punctuation and whitespace are presentation differences for this check.
-  const words = value.normalize("NFKC").toLowerCase().replace(/[\p{P}\s]+/gu, " ").trim();
-  // Padding makes the literal containment check word-boundary aware while
-  // still tolerating ordinary punctuation differences (e.g. a comma before
-  // "remember this" or a sentence-final period omitted by the tool).
-  return words ? ` ${words} ` : "";
 }

--- a/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
+++ b/desktop/macos/agent/src/runtime/external-surface-tool-policy.ts
@@ -20,6 +20,7 @@ export type ExternalSurfaceToolPolicyDecision =
       | "permission_request_not_authorized"
       | "pill_management_intent_required"
       | "memory_save_not_authorized"
+      | "memory_content_not_in_user_request"
       | "sql_write_rejected";
     message: string;
   };
@@ -152,6 +153,13 @@ export function routeExternalSurfaceTool(
         action: "reject",
         code: "memory_save_not_authorized",
         message: "Saving a memory requires an explicit affirmative current-turn request such as 'remember this' or 'save this'",
+      };
+    }
+    if (!hasMemoryContentGroundedInUserRequest(input.toolInput, input.originatingPrompt)) {
+      return {
+        action: "reject",
+        code: "memory_content_not_in_user_request",
+        message: "Memory content must be grounded in the current user request; inferred or unrelated content is not authorized",
       };
     }
   }
@@ -340,6 +348,13 @@ export function hasExplicitPillManagementIntent(prompt: string): boolean {
  * context, a question about whether to save, or a negative instruction is not
  * authorization; an assistant suggestion cannot authorize the write either.
  */
+const MEMORY_GROUNDING_STOP_WORDS = new Set([
+  "a", "an", "and", "as", "at", "be", "been", "being", "but", "for", "from", "had", "has",
+  "have", "hey", "i", "im", "in", "is", "it", "me", "my", "of", "on", "or", "please", "that",
+  "the", "this", "to", "was", "were", "with", "you", "your",
+  "keep", "remember", "save", "store",
+]);
+
 export function hasExplicitMemorySaveIntent(prompt: string): boolean {
   const text = prompt.toLowerCase().trim();
   if (!text) return false;
@@ -347,23 +362,96 @@ export function hasExplicitMemorySaveIntent(prompt: string): boolean {
   // Keep these patterns identical to ChatToolExecutor.isExplicitMemorySaveIntent.
   // Shared cases live in tests/fixtures/memory-save-intent-corpus.json.
   const negativePattern =
-    /(?:\b(?:don't|do not|never|no longer|without)\b[^.!?]{0,96}\b(?:remember|save|store|keep)\b|\b(?:remember|save|store|keep)\b[^.!?]{0,96}\b(?:not|never)\b)/;
+    /(?:\b(?:don't|do not|never|no longer|without|not to)\b[^.!?]{0,96}\b(?:remember|save|store|keep)\b|\b(?:remember|save|store|keep)\b[^.!?]{0,96}\b(?:not|never)\b)/;
   if (negativePattern.test(text)) return false;
-  const questionPattern =
-    /^\s*(?:should|would|could|can|do|did|why|what)\b[^.!?]*\b(?:remember|save|store|keep)\b[^.!?]*\?\s*$/;
-  if (!text.includes("please") && questionPattern.test(text)) return false;
+
+  if (text.includes("?")) {
+    const politeCommand = /\bplease\b[^.!?]*\b(?:remember|save|store|keep)\b/.test(text)
+      || /^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b/.test(text);
+    if (!politeCommand && /\b(?:remember|save|store|keep)\b/.test(text)) return false;
+  }
+
+  const passiveMentionPattern =
+    /\b(?:should|could|would)\s+(?:remember|save|store|keep)\b|\b(?:ability|able)\s+to\s+(?:remember|save|store|keep)\b/;
+  if (passiveMentionPattern.test(text)) return false;
+
+  const thirdPartyCommandPattern =
+    /\b(?:ask|tell|have|get|let|want|need)\s+(?!you\b)\w+(?:\s+\w+){0,2}\s+to\s+(?:remember|save|store|keep)\b/;
+  if (thirdPartyCommandPattern.test(text)) return false;
 
   const directCommandPattern = /^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b/;
   const sentenceCommandPattern = /(?:^|[.!?,;]\s+)(?:please\s+)?(?:remember|save|store|keep)\b/;
   const delegatedCommandPattern = /\b(?:want|need|ask)\s+(?:you\s+)?to\s+(?:please\s+)?(?:remember|save|store|keep)\b/;
+  const rememberThatCommandPattern = /(?:^|[.!?,;]\s+)(?:please\s+)?remember\s+that\b/;
   const anaphoricCommandPattern =
-    /\b(?:remember|save|store|keep)\s+(?:this|that|it|my|our|the following)\b/;
+    /\b(?:remember|save|store|keep)\s+(?:this|it|my|our|the following)\b/;
+  const memoryPhrasePattern =
+    /\b(?:add this to memory|create a memory|make this a memory|save to memory|save as a memory|store(?:\s+this)? in memory|keep in mind(?:\s+that)?)\b/;
   const hasCommand = directCommandPattern.test(text)
     || sentenceCommandPattern.test(text)
     || delegatedCommandPattern.test(text)
-    || anaphoricCommandPattern.test(text);
+    || rememberThatCommandPattern.test(text)
+    || anaphoricCommandPattern.test(text)
+    || memoryPhrasePattern.test(text);
   if (!hasCommand) return false;
   return !/\b(?:i|we|you|they)\s+(?:remember|save|store|keep)\b/.test(text);
+}
+
+/**
+ * Memory writes may paraphrase the user's fact, but the content must still be
+ * grounded in this turn. Verbatim spans pass; anaphoric-only commands ("remember
+ * this") carry no extractable fact here; otherwise a meaningful token overlap is
+ * required so invented facts cannot ride explicit save intent.
+ */
+export function hasMemoryContentGroundedInUserRequest(
+  toolInput: Record<string, unknown>,
+  originatingPrompt: string,
+): boolean {
+  const content = normalizeMemoryText(textField(toolInput, "content"));
+  const prompt = normalizeMemoryText(originatingPrompt);
+  if (!content || !prompt) return false;
+  if (` ${prompt} `.includes(` ${content} `)) return true;
+  if (isAnaphoricOnlyMemoryCommand(originatingPrompt)) return true;
+
+  const contentTokens = memoryGroundingTokens(textField(toolInput, "content"));
+  if (contentTokens.length === 0) return false;
+  const promptTokenSet = new Set(memoryGroundingTokens(originatingPrompt));
+  const overlap = contentTokens.filter((token) => promptTokenSet.has(token));
+  const required = contentTokens.length <= 2
+    ? 1
+    : Math.max(2, Math.ceil(contentTokens.length * 0.5));
+  return overlap.length >= required;
+}
+
+function isAnaphoricOnlyMemoryCommand(prompt: string): boolean {
+  const text = prompt.toLowerCase().trim();
+  const hasDeicticCommand = /\b(?:remember|save|store|keep)\s+(?:this|that|it)\b/.test(text)
+    || /\b(?:add this to memory|make this a memory)\b/.test(text);
+  if (!hasDeicticCommand) return false;
+  return memoryGroundingTokens(stripMemoryCommandPhrases(text)).length < 2;
+}
+
+function stripMemoryCommandPhrases(text: string): string {
+  return text
+    .replace(/^(?:hey\s+)?(?:please\s+)?(?:remember|save|store|keep)\b[:\s]*/i, "")
+    .replace(/\b(?:want|need|ask)\s+you\s+to\s+(?:please\s+)?(?:remember|save|store|keep)\b[:\s]*/gi, "")
+    .replace(/\b(?:remember|save|store|keep)\s+(?:that|this|it|my|our|the following)\b[:\s,]*/gi, "")
+    .replace(
+      /\b(?:add this to memory|create a memory|make this a memory|save to memory|save as a memory|store(?:\s+this)? in memory|keep in mind(?:\s+that)?)\b[:\s]*/gi,
+      "",
+    )
+    .trim();
+}
+
+function memoryGroundingTokens(value: string): string[] {
+  return normalizeMemoryText(value)
+    .split(" ")
+    .filter((token) => token.length > 1 && !MEMORY_GROUNDING_STOP_WORDS.has(token));
+}
+
+function normalizeMemoryText(value: string): string {
+  const words = value.normalize("NFKC").toLowerCase().replace(/[\p{P}\s]+/gu, " ").trim();
+  return words;
 }
 
 function permissionRequest(text: string): { toolName: "check_permission_status" | "request_permission"; type: string } | null {

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -151,7 +151,6 @@ export type ExternalSurfaceAuthorityErrorCode =
   | "permission_request_not_authorized"
   | "pill_management_intent_required"
   | "memory_save_not_authorized"
-  | "memory_content_not_in_user_request"
   | "sql_write_rejected";
 
 export class ExternalSurfaceAuthorityError extends Error {

--- a/desktop/macos/agent/src/runtime/kernel-types.ts
+++ b/desktop/macos/agent/src/runtime/kernel-types.ts
@@ -151,6 +151,7 @@ export type ExternalSurfaceAuthorityErrorCode =
   | "permission_request_not_authorized"
   | "pill_management_intent_required"
   | "memory_save_not_authorized"
+  | "memory_content_not_in_user_request"
   | "sql_write_rejected";
 
 export class ExternalSurfaceAuthorityError extends Error {

--- a/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
+++ b/desktop/macos/agent/src/runtime/omi-tool-manifest.ts
@@ -412,10 +412,11 @@ const swiftToolSurfacePatches: Record<string, OmiToolSurfacePatch> = {
     surfaces: ["desktop_chat"],
     capabilityDoc: doc(
       "Create Memory",
-      "Save one user-provided fact or preference to short-term memory.",
+      "Save one explicitly requested fact or preference to short-term memory.",
       [
-        "Use only when the user explicitly and affirmatively asks you to remember or save the supplied content.",
-        "Do not infer memories from conversation context, and do not call for a negative request such as 'do not remember this'.",
+        "Use only when the user explicitly and affirmatively asks you to remember or save something.",
+        "Pass a clean standalone fact: strip the command and lightly clean pronouns. Do not invent names, dates, or facts the user did not ask to persist, and do not infer from the rest of the chat.",
+        "Do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
         "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory.",
       ],
     ),
@@ -1025,19 +1026,24 @@ const swiftToolManifestDrafts: OmiToolManifestEntryDraft[] = [
     name: "create_memory",
     label: "Create Memory",
     description:
-      "Save exactly one user-provided fact or preference to short-term memory. Call only after an explicit affirmative user command such as 'remember this' or 'save this'. Never infer a memory, and never call for a negative request such as 'do not remember this'.",
+      "Save one explicitly requested fact or preference to short-term memory as a clean standalone fact. Call only after an explicit affirmative user command such as 'remember this' or 'save this'. Strip the command and lightly clean pronouns; do not invent facts. Never call for a mere statement, a question, or a negative request such as 'do not remember this'.",
     promptSnippet: "create_memory - Save one explicitly requested fact or preference to short-term memory",
     promptGuidelines: [
-      "The current user message must explicitly and affirmatively ask Omi to remember or save the supplied content.",
-      "Pass only the content to remember; do not add inferred facts, categories, tags, or metadata.",
-      "Do not call when the user merely states a fact, asks a question, asks for a suggestion, or says not to remember/save something.",
+      "When the current user message explicitly and affirmatively asks Omi to remember or save something, call this tool with a clean standalone fact.",
+      "Strip the command (for example, 'Please remember that I prefer tea' → 'I prefer tea'). Light rewrite and pronoun cleanup are OK; do not invent names, dates, or facts the user did not ask to persist.",
+      "Do not infer from the rest of the chat, and do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
+      "Confirm the save in one line. Never tell the user about validators or internal save rules.",
       "This is a one-way non-idempotent write. Do not retry automatically after an unknown outcome; tell the user the save status is uncertain.",
       "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory.",
     ],
     latency: "fast network",
     inputSchema: schema(
       {
-        content: { type: "string", description: "The exact user-provided content to save as a short-term memory." },
+        content: {
+          type: "string",
+          description:
+            "A clean standalone fact to save as a short-term memory. Strip the remember/save command; light rewrite is OK. Do not invent facts.",
+        },
       },
       ["content"],
     ),

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -15,6 +15,7 @@ import { handleAgentControlToolCall } from "../src/runtime/control-tools.js";
 import { recordJournalTurn, terminalizeJournalTurn, updateJournalTurn } from "../src/runtime/conversation-journal.js";
 import {
   hasExplicitMemorySaveIntent,
+  hasMemoryContentGroundedInUserRequest,
   routeExternalSurfaceTool,
 } from "../src/runtime/external-surface-tool-policy.js";
 import { AgentRuntimeKernel, ExternalSurfaceAuthorityError } from "../src/runtime/kernel.js";
@@ -443,14 +444,17 @@ describe("external realtime surface authority", () => {
 
     for (const prompt of memorySaveIntentCorpus.authorized) {
       expect(hasExplicitMemorySaveIntent(prompt), prompt).toBe(true);
+      const groundedContent = prompt.toLowerCase().includes("proactivity")
+        ? "David is currently testing proactivity in Omi"
+        : "I prefer tea.";
       expect(routeExternalSurfaceTool({
         toolName: "create_memory",
-        toolInput: { content: "I prefer tea." },
+        toolInput: { content: groundedContent },
         originatingPrompt: prompt,
-      })).toEqual({
+      })).toMatchObject({
         action: "execute",
         toolName: "create_memory",
-        toolInput: { content: "I prefer tea." },
+        toolInput: { content: groundedContent },
         recoveredFromDelegation: false,
       });
     }
@@ -482,6 +486,18 @@ describe("external realtime surface authority", () => {
       toolInput: { content: "Please save this: I prefer tea." },
       originatingPrompt: "Please save this: I prefer tea.",
     })).toMatchObject({ action: "execute", toolName: "create_memory" });
+  });
+
+  it("rejects create_memory content that is not grounded in the current request", () => {
+    expect(hasMemoryContentGroundedInUserRequest(
+      { content: "David loves coffee." },
+      "Please remember that I prefer tea.",
+    )).toBe(false);
+    expect(routeExternalSurfaceTool({
+      toolName: "create_memory",
+      toolInput: { content: "David loves coffee." },
+      originatingPrompt: "Please remember that I prefer tea.",
+    })).toMatchObject({ action: "reject", code: "memory_content_not_in_user_request" });
   });
 
   it("defaults external spawns to Omi unless the current user selects one provider", () => {

--- a/desktop/macos/agent/tests/external-surface-authority.test.ts
+++ b/desktop/macos/agent/tests/external-surface-authority.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,7 +15,6 @@ import { handleAgentControlToolCall } from "../src/runtime/control-tools.js";
 import { recordJournalTurn, terminalizeJournalTurn, updateJournalTurn } from "../src/runtime/conversation-journal.js";
 import {
   hasExplicitMemorySaveIntent,
-  hasMemoryContentInUserRequest,
   routeExternalSurfaceTool,
 } from "../src/runtime/external-surface-tool-policy.js";
 import { AgentRuntimeKernel, ExternalSurfaceAuthorityError } from "../src/runtime/kernel.js";
@@ -31,6 +30,9 @@ import {
 import { createKernelHarness, FakeRuntimeAdapter, waitUntil } from "./kernel-fakes.js";
 
 const roots: string[] = [];
+const memorySaveIntentCorpus = JSON.parse(
+  readFileSync(new URL("./fixtures/memory-save-intent-corpus.json", import.meta.url), "utf8"),
+) as { authorized: string[]; unauthorized: string[] };
 
 afterEach(() => {
   while (roots.length) rmSync(roots.pop()!, { recursive: true, force: true });
@@ -430,12 +432,7 @@ describe("external realtime surface authority", () => {
   });
 
   it("requires an affirmative remember/save command before relaying create_memory", () => {
-    for (const prompt of [
-      "I prefer tea.",
-      "Should I save this?",
-      "Please do not remember this.",
-      "I don't want you to save that.",
-    ]) {
+    for (const prompt of memorySaveIntentCorpus.unauthorized) {
       expect(hasExplicitMemorySaveIntent(prompt), prompt).toBe(false);
       expect(routeExternalSurfaceTool({
         toolName: "create_memory",
@@ -444,12 +441,7 @@ describe("external realtime surface authority", () => {
       })).toMatchObject({ action: "reject", code: "memory_save_not_authorized" });
     }
 
-    for (const prompt of [
-      "Remember that I prefer tea.",
-      "Please save this: I prefer tea.",
-      "I prefer tea, remember this.",
-      "I want you to remember that I prefer tea.",
-    ]) {
+    for (const prompt of memorySaveIntentCorpus.authorized) {
       expect(hasExplicitMemorySaveIntent(prompt), prompt).toBe(true);
       expect(routeExternalSurfaceTool({
         toolName: "create_memory",
@@ -464,46 +456,32 @@ describe("external realtime surface authority", () => {
     }
   });
 
-  it("binds create_memory content to the originating user request", () => {
-    expect(hasMemoryContentInUserRequest(
-      { content: "  I  prefer\ttea. " },
-      "Remember that I prefer tea.",
-    )).toBe(true);
-    expect(hasMemoryContentInUserRequest(
-      { content: "C++ 👍" },
-      "Remember this: C++ 👍",
-    )).toBe(true);
+  it("lets create_memory persist a clean standalone fact when save intent is present", () => {
     expect(routeExternalSurfaceTool({
       toolName: "create_memory",
       toolInput: { content: "I prefer tea." },
       originatingPrompt: "Remember this",
-    })).toMatchObject({ action: "reject", code: "memory_content_not_in_user_request" });
+    })).toEqual({
+      action: "execute",
+      toolName: "create_memory",
+      toolInput: { content: "I prefer tea." },
+      recoveredFromDelegation: false,
+    });
     expect(routeExternalSurfaceTool({
       toolName: "create_memory",
       toolInput: { content: "I enjoy tea." },
       originatingPrompt: "Remember that I prefer tea.",
-    })).toMatchObject({ action: "reject", code: "memory_content_not_in_user_request" });
-    expect(routeExternalSurfaceTool({
-      toolName: "create_memory",
-      toolInput: { content: "I prefer tea." },
-      originatingPrompt: "Please save this: I prefer tea.",
     })).toMatchObject({ action: "execute", toolName: "create_memory" });
     expect(routeExternalSurfaceTool({
       toolName: "create_memory",
-      toolInput: { content: "   " },
-      originatingPrompt: "Remember this: I prefer tea.",
-    })).toMatchObject({ action: "reject", code: "memory_content_not_in_user_request" });
-  });
-
-  it("keeps external memory intent aligned with the native conservative command set", () => {
-    expect(hasExplicitMemorySaveIntent("Could you please remember this?")).toBe(true);
-    for (const prompt of [
-      "Can you remember this?",
-      "Please save that I prefer tea.",
-      "Please keep this in mind.",
-    ]) {
-      expect(hasExplicitMemorySaveIntent(prompt), prompt).toBe(false);
-    }
+      toolInput: { content: "David is currently testing proactivity in Omi" },
+      originatingPrompt: "Please remember that I am currently testing proactivity in Omi",
+    })).toMatchObject({ action: "execute", toolName: "create_memory" });
+    expect(routeExternalSurfaceTool({
+      toolName: "create_memory",
+      toolInput: { content: "Please save this: I prefer tea." },
+      originatingPrompt: "Please save this: I prefer tea.",
+    })).toMatchObject({ action: "execute", toolName: "create_memory" });
   });
 
   it("defaults external spawns to Omi unless the current user selects one provider", () => {

--- a/desktop/macos/agent/tests/fixtures/memory-save-intent-corpus.json
+++ b/desktop/macos/agent/tests/fixtures/memory-save-intent-corpus.json
@@ -25,6 +25,7 @@
     "I don't want you to save that.",
     "I remember that I prefer tea.",
     "I asked you not to remember that.",
+    "I asked you not to save that.",
     "I wondered whether they should remember this?",
     "Ask Sarah to remember that I prefer tea.",
     "The model should remember that I prefer tea.",

--- a/desktop/macos/agent/tests/fixtures/memory-save-intent-corpus.json
+++ b/desktop/macos/agent/tests/fixtures/memory-save-intent-corpus.json
@@ -11,7 +11,10 @@
     "I want you to remember that I prefer tea.",
     "Could you please remember this?",
     "Please remember that I am currently testing proactivity in Omi",
-    "Remember this"
+    "Remember this",
+    "Add this to memory.",
+    "Create a memory for my tea preference.",
+    "Make this a memory."
   ],
   "unauthorized": [
     "I prefer tea.",
@@ -20,6 +23,11 @@
     "Do you remember that I prefer tea?",
     "Can you remember this?",
     "I don't want you to save that.",
-    "I remember that I prefer tea."
+    "I remember that I prefer tea.",
+    "I asked you not to remember that.",
+    "I wondered whether they should remember this?",
+    "Ask Sarah to remember that I prefer tea.",
+    "The model should remember that I prefer tea.",
+    "Your ability to remember that I prefer tea is impressive."
   ]
 }

--- a/desktop/macos/agent/tests/fixtures/memory-save-intent-corpus.json
+++ b/desktop/macos/agent/tests/fixtures/memory-save-intent-corpus.json
@@ -1,0 +1,25 @@
+{
+  "authorized": [
+    "Please remember that I prefer tea.",
+    "Remember I prefer tea.",
+    "Remember that I prefer tea.",
+    "Please save this: I prefer tea.",
+    "Please save that I prefer tea.",
+    "Save this as a memory.",
+    "Please keep this in mind.",
+    "I prefer tea, remember this.",
+    "I want you to remember that I prefer tea.",
+    "Could you please remember this?",
+    "Please remember that I am currently testing proactivity in Omi",
+    "Remember this"
+  ],
+  "unauthorized": [
+    "I prefer tea.",
+    "Should I save this?",
+    "Please do not remember this.",
+    "Do you remember that I prefer tea?",
+    "Can you remember this?",
+    "I don't want you to save that.",
+    "I remember that I prefer tea."
+  ]
+}

--- a/desktop/macos/agent/tests/fixtures/tool-manifest.json
+++ b/desktop/macos/agent/tests/fixtures/tool-manifest.json
@@ -3848,12 +3848,13 @@
   {
     "name": "create_memory",
     "label": "Create Memory",
-    "description": "Save exactly one user-provided fact or preference to short-term memory. Call only after an explicit affirmative user command such as 'remember this' or 'save this'. Never infer a memory, and never call for a negative request such as 'do not remember this'.",
+    "description": "Save one explicitly requested fact or preference to short-term memory as a clean standalone fact. Call only after an explicit affirmative user command such as 'remember this' or 'save this'. Strip the command and lightly clean pronouns; do not invent facts. Never call for a mere statement, a question, or a negative request such as 'do not remember this'.",
     "promptSnippet": "create_memory - Save one explicitly requested fact or preference to short-term memory",
     "promptGuidelines": [
-      "The current user message must explicitly and affirmatively ask Omi to remember or save the supplied content.",
-      "Pass only the content to remember; do not add inferred facts, categories, tags, or metadata.",
-      "Do not call when the user merely states a fact, asks a question, asks for a suggestion, or says not to remember/save something.",
+      "When the current user message explicitly and affirmatively asks Omi to remember or save something, call this tool with a clean standalone fact.",
+      "Strip the command (for example, 'Please remember that I prefer tea' → 'I prefer tea'). Light rewrite and pronoun cleanup are OK; do not invent names, dates, or facts the user did not ask to persist.",
+      "Do not infer from the rest of the chat, and do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
+      "Confirm the save in one line. Never tell the user about validators or internal save rules.",
       "This is a one-way non-idempotent write. Do not retry automatically after an unknown outcome; tell the user the save status is uncertain.",
       "The backend stores this as a short-term memory candidate. Do not claim it was promoted to long-term memory."
     ],
@@ -3863,7 +3864,7 @@
       "properties": {
         "content": {
           "type": "string",
-          "description": "The exact user-provided content to save as a short-term memory."
+          "description": "A clean standalone fact to save as a short-term memory. Strip the remember/save command; light rewrite is OK. Do not invent facts."
         }
       },
       "required": [
@@ -3902,10 +3903,11 @@
     ],
     "capabilityDoc": {
       "title": "Create Memory",
-      "summary": "Save one user-provided fact or preference to short-term memory.",
+      "summary": "Save one explicitly requested fact or preference to short-term memory.",
       "bullets": [
-        "Use only when the user explicitly and affirmatively asks you to remember or save the supplied content.",
-        "Do not infer memories from conversation context, and do not call for a negative request such as 'do not remember this'.",
+        "Use only when the user explicitly and affirmatively asks you to remember or save something.",
+        "Pass a clean standalone fact: strip the command and lightly clean pronouns. Do not invent names, dates, or facts the user did not ask to persist, and do not infer from the rest of the chat.",
+        "Do not call for a mere statement of fact, a question, or a negative request such as 'do not remember this'.",
         "This writes short-term memory through the authorized desktop backend path; it does not promote, edit, or delete long-term memory."
       ]
     }

--- a/desktop/macos/agent/tests/omi-tool-manifest.test.ts
+++ b/desktop/macos/agent/tests/omi-tool-manifest.test.ts
@@ -36,7 +36,11 @@ describe("omi tool manifest", () => {
     expect(tool?.inputSchema).toEqual({
       type: "object",
       properties: {
-        content: { type: "string", description: "The exact user-provided content to save as a short-term memory." },
+        content: {
+          type: "string",
+          description:
+            "A clean standalone fact to save as a short-term memory. Strip the remember/save command; light rewrite is OK. Do not invent facts.",
+        },
       },
       required: ["content"],
       additionalProperties: false,

--- a/desktop/macos/changelog/unreleased/20260814-chat-memory-clean-facts.json
+++ b/desktop/macos/changelog/unreleased/20260814-chat-memory-clean-facts.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat can now save a remembered fact in your own words instead of copying the exact phrase you typed"
+}

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -20,7 +20,6 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/AuthorizedToolExecution.swift
   - desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
   - desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
-  - desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
   - desktop/macos/Desktop/Sources/Chat/MessageMetadata.swift
   - desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift

--- a/desktop/macos/e2e/flows/chat-hermetic.yaml
+++ b/desktop/macos/e2e/flows/chat-hermetic.yaml
@@ -20,6 +20,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/AuthorizedToolExecution.swift
   - desktop/macos/Desktop/Sources/Chat/ChatOmiMark.swift
   - desktop/macos/Desktop/Sources/Chat/ChatPrompts.swift
+  - desktop/macos/Desktop/Sources/Chat/DesktopCapabilityRegistry.swift
   - desktop/macos/Desktop/Sources/Chat/MessageMetadata.swift
   - desktop/macos/Desktop/Sources/Chat/TypingIndicator.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift


### PR DESCRIPTION
## Summary
- Chat `create_memory` no longer requires the saved text to be a verbatim span of the user message.
- If this turn is an explicit remember/save, the model may write a clean standalone fact (same as tasks). Intent gating, typed-chat-only, and "don't invent / don't auto-save idle statements" remain.

## Product invariants affected

- INV-AGENT-*
- INV-CHAT-1

Path-matched only. This does not change kernel transcript ownership or adapter/control-plane identity. Typed-chat `create_memory` still requires explicit current-turn save intent and stays off realtime/delegated surfaces.

## How it was verified

- `cd desktop/macos/agent && npx vitest run tests/external-surface-authority.test.ts tests/omi-tool-manifest.test.ts` — 40 passed
- `cd desktop/macos && ./scripts/dev-feedback.py --once swift 'ChatToolExecutorCreateMemoryTests'` — 12 passed
- `cd desktop/macos/agent && node --experimental-strip-types scripts/generate-tool-surfaces.mjs --check` — green

Did not exercise a live named-bundle chat turn in this change.

## Tests

- Swift `ChatToolExecutorCreateMemoryTests` now allows rewritten content with save intent (including the proactivity paraphrase) and still rejects no-intent / wrong-surface / content bounds.
- TS `external-surface-authority.test.ts` plus a shared `memory-save-intent-corpus.json` lock the Swift and runtime intent matchers together.

## Test plan
- [ ] Typed chat: "Please remember that I am currently testing proactivity in Omi" saves a clean fact (not a copy of the command, not a "couldn't save, exact phrase" apology).
- [ ] "I prefer tea." without remember/save does not write.
- [ ] "Please do not remember this." does not write.
- [ ] Confirm still short-term; agent does not claim long-term promotion.

## Failure class (fixes)

Failure-Class: none

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

