### PR TITLE
fix(backend): fall back to offset read when canonical list scan 503s

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -585,7 +585,15 @@ def get_memories(
                 include_archive=include_archive,
             )
         except HTTPException as exc:
-            if exc.status_code != 503 or exc.detail != "Memory cursor unavailable":
+            # First page must succeed whenever the legacy offset read can serve
+            # it. The cursor path 503s on a missing cursor secret
+            # ("Memory cursor unavailable"); the canonical keyset scan wraps any
+            # underlying failure as "Canonical memory unavailable". Both fall
+            # back to read(); unrelated errors (4xx, other 503s) propagate.
+            if exc.status_code != 503 or exc.detail not in (
+                "Memory cursor unavailable",
+                "Canonical memory unavailable",
+            ):
                 raise
         else:
             if page.next_cursor:

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -180,3 +180,76 @@ def test_blank_cursor_falls_back_to_offset_read_when_cursor_secret_missing():
         )
     service.read.assert_called_once()
     service.read_page.assert_called_once()
+
+
+def _get_first_page(service):
+    scope_request = types.SimpleNamespace(device_scope='all', client_device_id=None)
+    with (
+        patch.object(mem_mod, 'MemoryService', return_value=service),
+        patch.object(mem_mod, '_resolve_get_memories_device_scope', return_value=scope_request),
+        patch.object(mem_mod, '_validate_device_scope_request'),
+        patch.object(mem_mod, 'memory_list_response', side_effect=lambda memories, _exposure, headers=None: memories),
+    ):
+        return mem_mod.get_memories(
+            response=MagicMock(),
+            limit=100,
+            offset=0,
+            cursor=None,
+            uid='uid1',
+            device_scope='all',
+            client_device_id=None,
+            x_app_platform=None,
+            x_device_id_hash=None,
+        )
+
+
+def test_first_page_falls_back_to_offset_read_when_canonical_scan_unavailable():
+    """GET 503: canonical keyset scan wraps any failure as this detail.
+
+    The offset ``read`` path does not use the scan, so the first page must be
+    served from ``read`` instead of failing the whole list endpoint.
+    """
+    from fastapi import HTTPException
+
+    service = MagicMock()
+    service.read_page.side_effect = HTTPException(status_code=503, detail="Canonical memory unavailable")
+    service.read.return_value = ['memory-from-offset-read']
+
+    result = _get_first_page(service)
+
+    assert result == ['memory-from-offset-read']
+    service.read_page.assert_called_once()
+    service.read.assert_called_once()
+
+
+def test_first_page_propagates_unrelated_503_detail():
+    from fastapi import HTTPException
+
+    import pytest
+
+    service = MagicMock()
+    service.read_page.side_effect = HTTPException(status_code=503, detail="Some other degradation")
+
+    with pytest.raises(HTTPException) as exc_info:
+        _get_first_page(service)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Some other degradation"
+    service.read.assert_not_called()
+
+
+def test_first_page_propagates_non_503_errors():
+    from fastapi import HTTPException
+
+    import pytest
+
+    service = MagicMock()
+    service.read_page.side_effect = HTTPException(
+        status_code=402, detail="A paid plan is required to access this memory."
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _get_first_page(service)
+
+    assert exc_info.value.status_code == 402
+    service.read.assert_not_called()

--- a/backend/tests/unit/test_universal_memory_list_cursor.py
+++ b/backend/tests/unit/test_universal_memory_list_cursor.py
@@ -1242,3 +1242,37 @@ def test_read_canonical_scan_page_uses_keyset_order_and_filters(monkeypatch):
     )
     assert next_exhausted is True
     assert [memory.id if memory else None for memory, _ in next_slots] == ["visible-2"]
+
+
+def test_canonical_scan_failure_logs_underlying_exception_and_503s(service_mod, caplog):
+    """The opaque 503 wrap must leave the underlying failure in logs.
+
+    A Firestore FAILED_PRECONDITION (missing composite) and a uid/cursor
+    ValueError must be distinguishable in logs even though the client always
+    sees ``Canonical memory unavailable``.
+    """
+    import logging
+
+    from fastapi import HTTPException
+
+    service = service_mod.MemoryService(db_client=_Db())
+    service_mod.read_canonical_scan_page = MagicMock(
+        side_effect=RuntimeError("FAILED_PRECONDITION: The query requires an index")
+    )
+    service_mod.read_canonical_memories = MagicMock(
+        side_effect=AssertionError("read_page must not full-fetch canonical memories")
+    )
+    service.history.read_updated_scan_page = MagicMock(return_value=([], True))
+    service.history.read_created_scan_page = MagicMock(return_value=([], True))
+    service.canonical_statuses = MagicMock(return_value={})
+
+    with caplog.at_level(logging.ERROR, logger=service_mod.__name__):
+        with pytest.raises(HTTPException) as exc_info:
+            service.read_page("uid-test", limit=2, cursor=None)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Canonical memory unavailable"
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "canonical list scan page failed" in caplog.text
+    assert "RuntimeError" in caplog.text
+    assert "FAILED_PRECONDITION" in caplog.text

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -1115,6 +1115,14 @@ class _CanonicalCursorStream:
         except HTTPException:
             raise
         except Exception as exc:
+            # Surface the underlying failure class/message so a Firestore
+            # FAILED_PRECONDITION (missing composite) is distinguishable from a
+            # uid/cursor ValueError in logs. No uid or memory content here.
+            logger.exception(
+                "canonical list scan page failed: %s: %s",
+                type(exc).__name__,
+                exc,
+            )
             raise HTTPException(status_code=503, detail="Canonical memory unavailable") from exc
         self._slots = [
             (


### PR DESCRIPTION
## What changed and why

`GET /v3/memories` first page failed with 503 `Canonical memory unavailable` even though the legacy offset `read()` path was healthy. The first-page fallback added in #11590 only matched the detail `Memory cursor unavailable`; every failure the canonical keyset scan wraps as `Canonical memory unavailable` (Firestore `FAILED_PRECONDITION`, cursor/uid `ValueError`, anything else) bypassed it and failed the whole list endpoint. The fallback now accepts both 503 details, and the scan wrapper (`_CanonicalCursorStream._ensure_slots`) logs the underlying exception class/message via `logger.exception` before raising the opaque 503, so an index miss is distinguishable from a uid mismatch in dev/prod logs. POST was unaffected because writes do not use the scan.

Multica issue: SCA-311.

## Product invariants affected

- INV-MEM-3 (universal memory authority fails closed): the first-page fallback target is `MemoryService.read()` — the universal offset read that merges canonical and historical rows through the same suppression/authority checks (`_canonical_read` + adaptive historical scan), not a direct legacy reader. A canonical-check failure inside `read()` itself still fails closed; only the cursor-paging transport degradation (503 cursor/canonical-scan detail) falls back to the offset shape. Same pattern #11590 already shipped for the cursor-secret detail.
- INV-MEM-1 (memory tiers): path-match only; no tier vocabulary changed.

## How it was verified

- `backend/.venv/bin/python -m pytest tests/unit/test_memories_pagination_clamp.py` — 7 passed (4 existing + 3 new).
- `backend/.venv/bin/python -m pytest tests/unit/test_universal_memory_list_cursor.py` — 15 passed (14 existing + 1 new).
- `backend/.venv/bin/python -m pytest tests/unit/test_universal_memory_system.py tests/unit/test_memory_service_parity.py tests/unit/test_firestore_indexes.py tests/unit/test_memory_contracts.py tests/unit/test_dev_api_memories_pagination.py` — 27 passed.
- No other test references the old narrow detail match (checked).

Not verified here: the live dev 503 itself — that needs the deploy plus a real GET once this lands. The new `logger.exception` will identify the underlying exception class (Firestore `FAILED_PRECONDITION` vs uid/cursor `ValueError`) the first time the scan path is exercised in dev.

## Tests

Regression tests that would have caught the bug:

- `tests/unit/test_memories_pagination_clamp.py::test_first_page_falls_back_to_offset_read_when_canonical_scan_unavailable` — `read_page` raising 503 `Canonical memory unavailable` now yields the `read()` result instead of a 503 (this is exactly the live failure).
- `tests/unit/test_memories_pagination_clamp.py::test_first_page_propagates_unrelated_503_detail` — an unrelated 503 detail still propagates; no fallback.
- `tests/unit/test_memories_pagination_clamp.py::test_first_page_propagates_non_503_errors` — non-503 errors (e.g. 402) still propagate; no fallback.
- `tests/unit/test_universal_memory_list_cursor.py::test_canonical_scan_failure_logs_underlying_exception_and_503s` — the wrap logs the original exception (class + message) and chains it as `__cause__` on the 503.

## Failure class (fixes)

Failure-Class: none

No registry class matches the incident shape: a serving fallback that already existed but was keyed to a single sibling 503 detail string, so a same-class degradation failed closed. `FC-undeclared-serving-query-index` was considered and rejected: `UNIVERSAL_CANONICAL_LIST_SCAN_QUERY` is deliberately manifest-exempt under the registry's one-non-`__name__`-field rule (Firestore-managed single-field index + document-ID ordering; same shape as the two `memories` historical scans), it is registered in the query inventory contract, and the underlying live exception has not yet been identified — asserting an index class here would be unverified. The new `logger.exception` makes that determination possible from dev logs; if it shows `FAILED_PRECONDITION` on the scan, a follow-up can declare the class with evidence.

## Scoped cleanups (optional)

none

Line-Count-Exception: backend/utils/memory/memory_service.py | 2487 -> 2495 | Failure-diagnosis logging (8 lines) at the opaque canonical-scan 503 wrap required by the incident; splitting the 2.5k-line service file is out of scope for this incident fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

