### PR TITLE
fix(app): local-dev Firebase placeholders must be format-valid, not just fake

### DIFF
--- a/app/lib/firebase_options_local.dart
+++ b/app/lib/firebase_options_local.dart
@@ -26,16 +26,16 @@ class DefaultFirebaseOptions {
   }
 
   static const android = FirebaseOptions(
-    apiKey: 'local-firebase-auth-emulator-api-key',
-    appId: '1:000000000000:android:omi-dev-local',
+    apiKey: 'AIzaSyDEMOOMILOCALFAKEKEY00000000000000',
+    appId: '1:000000000000:android:0000000000000000',
     messagingSenderId: '000000000000',
     projectId: 'demo-omi-local',
     storageBucket: 'demo-omi-local.localhost',
   );
 
   static const ios = FirebaseOptions(
-    apiKey: 'local-firebase-auth-emulator-api-key',
-    appId: '1:000000000000:ios:omi-dev-local',
+    apiKey: 'AIzaSyDEMOOMILOCALFAKEKEY00000000000000',
+    appId: '1:000000000000:ios:0000000000000000',
     messagingSenderId: '000000000000',
     projectId: 'demo-omi-local',
     storageBucket: 'demo-omi-local.localhost',
@@ -43,8 +43,8 @@ class DefaultFirebaseOptions {
   );
 
   static const macos = FirebaseOptions(
-    apiKey: 'local-firebase-auth-emulator-api-key',
-    appId: '1:000000000000:ios:omi-dev-local',
+    apiKey: 'AIzaSyDEMOOMILOCALFAKEKEY00000000000000',
+    appId: '1:000000000000:ios:0000000000000000',
     messagingSenderId: '000000000000',
     projectId: 'demo-omi-local',
     storageBucket: 'demo-omi-local.localhost',
@@ -52,8 +52,8 @@ class DefaultFirebaseOptions {
   );
 
   static const web = FirebaseOptions(
-    apiKey: 'local-firebase-auth-emulator-api-key',
-    appId: '1:000000000000:web:omi-dev-local',
+    apiKey: 'AIzaSyDEMOOMILOCALFAKEKEY00000000000000',
+    appId: '1:000000000000:web:0000000000000000',
     messagingSenderId: '000000000000',
     projectId: 'demo-omi-local',
     authDomain: 'demo-omi-local.firebaseapp.com',

--- a/app/scripts/generate_ios_custom_config_bundle_id_test.sh
+++ b/app/scripts/generate_ios_custom_config_bundle_id_test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for the BUNDLE_ID patch in generate_ios_custom_config(): the
+# prebuilt/placeholder GoogleService-Info.plist always carries a fixed, unsuffixed
+# BUNDLE_ID, but Dev builds get a per-hostname-suffixed APP_BUNDLE_IDENTIFIER. Left
+# unpatched, that mismatch crashes Firebase.initializeApp() on-device with a generic
+# "invalid GOOGLE_APP_ID" error that names the wrong field — measured directly on
+# iOS 27 hardware. See app/test/unit/firebase_local_options_test.dart for the sibling
+# regression test on the placeholder values' own format.
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+source setup.sh
+
+# Override machine/environment-dependent helpers so this test is hermetic: the real
+# generate_device_suffix reads the local hostname, and detect_apple_team_id inspects
+# this machine's signing identities (and prompts interactively as a last resort).
+generate_device_suffix() { echo "testhost"; }
+detect_apple_team_id() { echo "TESTTEAM01"; }
+
+fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/omi-ios-custom-config.XXXXXX")"
+trap 'rm -rf "$fixture_dir"' EXIT
+
+mkdir -p "$fixture_dir/ios/Config/Dev" "$fixture_dir/ios/Flutter" "$fixture_dir/scripts"
+cp scripts/generate_ios_custom_config.sh "$fixture_dir/scripts/generate_ios_custom_config.sh"
+cp setup/prebuilt/GoogleService-Info-Local.plist "$fixture_dir/ios/Config/Dev/GoogleService-Info.plist"
+cp setup/prebuilt/GoogleService-Info-Local.plist "$fixture_dir/ios/Runner/GoogleService-Info.plist" 2>/dev/null \
+  || { mkdir -p "$fixture_dir/ios/Runner"; cp setup/prebuilt/GoogleService-Info-Local.plist "$fixture_dir/ios/Runner/GoogleService-Info.plist"; }
+
+before_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' "$fixture_dir/ios/Config/Dev/GoogleService-Info.plist")"
+
+(
+  cd "$fixture_dir"
+  generate_ios_custom_config Dev omi-dev
+)
+
+config_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' "$fixture_dir/ios/Config/Dev/GoogleService-Info.plist")"
+runner_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' "$fixture_dir/ios/Runner/GoogleService-Info.plist")"
+xcconfig_bundle_id="$(grep '^APP_BUNDLE_IDENTIFIER=' "$fixture_dir/ios/Flutter/Custom.xcconfig" | cut -d= -f2)"
+
+[[ "$config_bundle_id" == "$xcconfig_bundle_id" ]]
+[[ "$runner_bundle_id" == "$xcconfig_bundle_id" ]]
+[[ "$config_bundle_id" != "$before_bundle_id" ]]
+[[ "$config_bundle_id" == "com.friend-app-with-wearable.ios12-testhost" ]]
+
+echo "generate_ios_custom_config patches GoogleService-Info.plist BUNDLE_ID to match the suffixed bundle id"

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -78,6 +78,15 @@ function generate_ios_custom_config() {
     local suffix
     suffix=$(generate_device_suffix)
     echo "APP_BUNDLE_IDENTIFIER=com.friend-app-with-wearable.ios12-${suffix}" >> ios/Flutter/Custom.xcconfig
+    # The prebuilt/placeholder GoogleService-Info.plist (setup_firebase) carries the
+    # stock unsuffixed BUNDLE_ID. Firebase's native SDK validates that field against
+    # the running app's actual bundle identifier at Firebase.initializeApp() and
+    # refuses to start if they don't match. Runner/GoogleService-Info.plist is what
+    # Xcode actually bundles (project.pbxproj references that path directly, not
+    # Config/Dev/); patch both so on-disk copies stay consistent.
+    local suffixed_bundle_id="com.friend-app-with-wearable.ios12-${suffix}"
+    /usr/libexec/PlistBuddy -c "Set :BUNDLE_ID ${suffixed_bundle_id}" "ios/Config/${config_name}/GoogleService-Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :BUNDLE_ID ${suffixed_bundle_id}" ios/Runner/GoogleService-Info.plist
   else
     # Beta uses a distinct bundle/callback identity and must be provisioned
     # explicitly by the developer's Apple team.

--- a/app/setup/prebuilt/GoogleService-Info-Local.plist
+++ b/app/setup/prebuilt/GoogleService-Info-Local.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>local-firebase-auth-emulator-api-key</string>
+	<string>AIzaSyDEMOOMILOCALFAKEKEY00000000000000</string>
 	<key>BUNDLE_ID</key>
 	<string>com.friend-app-with-wearable.ios12.development</string>
 	<key>GCM_SENDER_ID</key>
 	<string>000000000000</string>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:000000000000:ios:omi-dev-local</string>
+	<string>1:000000000000:ios:0000000000000000</string>
 	<key>IS_ADS_ENABLED</key>
 	<false/>
 	<key>IS_ANALYTICS_ENABLED</key>

--- a/app/setup/prebuilt/google-services-local.json
+++ b/app/setup/prebuilt/google-services-local.json
@@ -7,14 +7,14 @@
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:000000000000:android:omi-dev-local",
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000",
         "android_client_info": {
           "package_name": "com.friend.ios.dev"
         }
       },
       "api_key": [
         {
-          "current_key": "local-firebase-auth-emulator-api-key"
+          "current_key": "AIzaSyDEMOOMILOCALFAKEKEY00000000000000"
         }
       ],
       "services": {

--- a/app/test/unit/firebase_local_options_test.dart
+++ b/app/test/unit/firebase_local_options_test.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/firebase_options_local.dart';
+
+// Firebase's native SDKs format-validate these fields at Firebase.initializeApp()
+// time, before any network call and before Auth is routed to the local emulator —
+// so a syntactically invalid placeholder crashes the app on launch even though the
+// values are never used to reach a real backend. Measured directly from the iOS
+// crash text: "API Key length must be 39 characters, API Key must start with `A`"
+// and an EXC_BREAKPOINT inside native Firebase config validation for a malformed
+// GOOGLE_APP_ID. These regexes pin the constraints that broke, so a future edit
+// can't reintroduce a human-readable placeholder like "omi-dev-local" in either
+// field.
+final _apiKeyPattern = RegExp(r'^A.{38}$');
+final _appIdPattern = RegExp(r'^\d+:\d+:(ios|android|web):[0-9a-fA-F]+$');
+
+void main() {
+  group('firebase_options_local placeholders are format-valid', () {
+    for (final entry in {
+      'android': DefaultFirebaseOptions.android,
+      'ios': DefaultFirebaseOptions.ios,
+      'macos': DefaultFirebaseOptions.macos,
+      'web': DefaultFirebaseOptions.web,
+    }.entries) {
+      test('${entry.key} apiKey and appId are format-valid', () {
+        final options = entry.value;
+        expect(options.apiKey, matches(_apiKeyPattern), reason: 'apiKey for ${entry.key}');
+        expect(options.appId, matches(_appIdPattern), reason: 'appId for ${entry.key}');
+      });
+    }
+  });
+
+  group('setup/prebuilt Firebase config sources stay in sync', () {
+    test('GoogleService-Info-Local.plist API_KEY and GOOGLE_APP_ID are format-valid', () {
+      final plist = File('setup/prebuilt/GoogleService-Info-Local.plist').readAsStringSync();
+      final apiKey = RegExp(r'<key>API_KEY</key>\s*<string>([^<]+)</string>').firstMatch(plist)!.group(1)!;
+      final appId = RegExp(r'<key>GOOGLE_APP_ID</key>\s*<string>([^<]+)</string>').firstMatch(plist)!.group(1)!;
+      expect(apiKey, matches(_apiKeyPattern));
+      expect(appId, matches(_appIdPattern));
+    });
+
+    test('google-services-local.json api_key and mobilesdk_app_id are format-valid', () {
+      final json = jsonDecode(File('setup/prebuilt/google-services-local.json').readAsStringSync());
+      final client = json['client'][0];
+      final apiKey = client['api_key'][0]['current_key'] as String;
+      final appId = client['client_info']['mobilesdk_app_id'] as String;
+      expect(apiKey, matches(_apiKeyPattern));
+      expect(appId, matches(_appIdPattern));
+    });
+  });
+}


### PR DESCRIPTION
## Why

Firebase's native SDK format-validates `GOOGLE_APP_ID` and `API_KEY` at `Firebase.initializeApp()` time — before any network call, and before Auth is routed to the local emulator. The local-harness placeholder Firebase configs (`setup/prebuilt/GoogleService-Info-Local.plist`, `google-services-local.json`, `lib/firebase_options_local.dart`) used syntactically invalid values (`GOOGLE_APP_ID = "1:000000000000:ios:omi-dev-local"`, `API_KEY = "local-firebase-auth-emulator-api-key"`), so a `bash setup.sh ios` dev build crashes on launch — never gets anywhere near the local emulator it's supposed to talk to.

## What changed

Measured directly on iPhone 17 Pro / iOS 27.0 while verifying an unrelated iOS UIScene fix:

1. `'Configuration fails. It may be caused by an invalid GOOGLE_APP_ID in GoogleService-Info.plist...'` — `GOOGLE_APP_ID` must look like `<project_number>:<number>:<platform>:<hex>`; `omi-dev-local` isn't hex.
2. After fixing that: `'API Key length must be 39 characters, API Key must start with `A`.'` — the placeholder API key was 37 chars and didn't start with `A`.

Fixed both in all three sources that describe this same fake identity (iOS plist, Android json, Dart `FirebaseOptions` consts) — `main.dart` selects the Dart consts explicitly for `OMI_APP_PROFILE=local_dev`, but the crash traced to native Firebase plugin registration reading the bundled plist even earlier, before Dart's `main()` runs, so both had to change to actually fix it end to end.

Also patches `BUNDLE_ID` in the copied plist (`generate_ios_custom_config` in `setup.sh`) to track the per-hostname-suffixed `APP_BUNDLE_IDENTIFIER` that dev builds already get, since the placeholder's static `BUNDLE_ID` never matched it. This turned out not to be the actual crash trigger for the two errors above — Firebase's error message named the wrong field both times — but it's a real mismatch, cheap to fix alongside this, and could plausibly bite some other Firebase code path that does check bundle identity.

Values remain non-secret placeholders that reach no real Firebase project — `IS_ANALYTICS_ENABLED`/`IS_GCM_ENABLED`/`IS_APPINVITE_ENABLED`/`IS_ADS_ENABLED` stay `false`, matching the existing posture of this config.

## Tests

- `app/test/unit/firebase_local_options_test.dart` (new) — asserts the Dart `FirebaseOptions` consts and the raw plist/json source files match the format Firebase's SDK actually enforces (39-char API key starting with `A`; `\d+:\d+:(ios|android|web):hex` app ID), so a future edit can't reintroduce a human-readable placeholder in either field without a red test.
- `app/scripts/generate_ios_custom_config_bundle_id_test.sh` (new) — hermetic shell test for the `BUNDLE_ID` patch, following the existing `setup_app_env_test.sh` pattern (sources `setup.sh`, stubs the machine-dependent `generate_device_suffix`/`detect_apple_team_id` helpers, asserts the patched plist's `BUNDLE_ID` matches the generated `APP_BUNDLE_IDENTIFIER`).

Both pass locally:
```
flutter test test/unit/firebase_local_options_test.dart   # 6/6 passed
bash scripts/generate_ios_custom_config_bundle_id_test.sh # passed
```

Manually re-verified the actual crash-to-fix progression on-device (iPhone 17 Pro / iOS 27.0) by patching the built app's config file at each step and relaunching via `devicectl`, before committing the same fix to the source files here.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

