### PR TITLE
fix(app): migrate flutter_contacts to 2.x — 1.x crashes under UIScene

### DIFF
--- a/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
@@ -75,7 +75,8 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
     });
 
     // Request contacts permission using flutter_contacts' own method
-    final permissionGranted = await FlutterContacts.requestPermission();
+    final status = await FlutterContacts.permissions.request(PermissionType.readWrite);
+    final permissionGranted = status == PermissionStatus.granted || status == PermissionStatus.limited;
 
     if (!permissionGranted) {
       if (!mounted) return;
@@ -89,17 +90,18 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
 
     try {
       // Fetch contacts with phone numbers
-      final contacts = await FlutterContacts.getContacts(withProperties: true, withPhoto: false);
+      final contacts = await FlutterContacts.getAll(properties: {ContactProperty.phone});
 
       // Filter contacts that have phone numbers and create ShareableContact list
       final shareableContacts = <ShareableContact>[];
       for (final contact in contacts) {
         for (final phone in contact.phones) {
           if (phone.number.isNotEmpty) {
+            final displayName = contact.displayName;
             shareableContacts.add(
               ShareableContact(
                 id: '${contact.id}_${phone.number}',
-                displayName: contact.displayName.isNotEmpty ? contact.displayName : phone.number,
+                displayName: displayName != null && displayName.isNotEmpty ? displayName : phone.number,
                 phoneNumber: _cleanPhoneNumber(phone.number),
               ),
             );

--- a/app/lib/pages/phone_calls/phone_calls_page.dart
+++ b/app/lib/pages/phone_calls/phone_calls_page.dart
@@ -2,7 +2,9 @@ import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
-import 'package:permission_handler/permission_handler.dart';
+// hide PermissionStatus: flutter_contacts has its own PermissionStatus enum, and this
+// file never spells out permission_handler's version by name (only inferred via `var`).
+import 'package:permission_handler/permission_handler.dart' hide PermissionStatus;
 import 'package:intl_country_data/intl_country_data.dart';
 import 'package:provider/provider.dart';
 
@@ -52,9 +54,9 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
 
   Future<void> _loadContacts() async {
     try {
-      bool hasPermission = await FlutterContacts.requestPermission(readonly: true);
+      final status = await FlutterContacts.permissions.request(PermissionType.read);
       if (!mounted) return;
-      if (!hasPermission) {
+      if (status != PermissionStatus.granted && status != PermissionStatus.limited) {
         setState(() {
           _permissionDenied = true;
           _loadingContacts = false;
@@ -62,9 +64,9 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
         return;
       }
 
-      var contacts = await FlutterContacts.getContacts(withProperties: true, withPhoto: false);
+      var contacts = await FlutterContacts.getAll(properties: {ContactProperty.phone});
       contacts = contacts.where((c) => c.phones.isNotEmpty).toList();
-      contacts.sort((a, b) => a.displayName.compareTo(b.displayName));
+      contacts.sort((a, b) => (a.displayName ?? '').compareTo(b.displayName ?? ''));
 
       if (mounted) {
         setState(() {
@@ -89,7 +91,7 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
         _filteredContacts = _contacts;
       } else {
         _filteredContacts = _contacts.where((c) {
-          return c.displayName.toLowerCase().contains(query.toLowerCase()) ||
+          return (c.displayName ?? '').toLowerCase().contains(query.toLowerCase()) ||
               c.phones.any((p) => p.number.contains(query));
         }).toList();
       }
@@ -220,7 +222,7 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
                   if (status.isPermanentlyDenied || status.isDenied) {
                     await openAppSettings();
                   } else {
-                    await FlutterContacts.requestPermission(readonly: true);
+                    await FlutterContacts.permissions.request(PermissionType.read);
                   }
                   _loadContacts();
                 },
@@ -276,11 +278,12 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
                   itemBuilder: (context, index) {
                     var contact = _filteredContacts[index];
                     var phone = contact.phones.first;
+                    var name = contact.displayName ?? '';
                     return _ContactRow(
-                      name: contact.displayName,
-                      phone: '${phone.label.name} ${phone.number}',
-                      initial: contact.displayName.isNotEmpty ? contact.displayName[0].toUpperCase() : '?',
-                      onCall: () => _makeCall(phone.number, contactName: contact.displayName),
+                      name: name,
+                      phone: '${phone.label.label.name} ${phone.number}',
+                      initial: name.isNotEmpty ? name[0].toUpperCase() : '?',
+                      onCall: () => _makeCall(phone.number, contactName: name),
                     );
                   },
                 ),

--- a/app/lib/providers/phone_call_provider.dart
+++ b/app/lib/providers/phone_call_provider.dart
@@ -5,7 +5,9 @@ import 'dart:typed_data';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
-import 'package:permission_handler/permission_handler.dart';
+// hide PermissionStatus: flutter_contacts has its own PermissionStatus enum, and this
+// file never spells out permission_handler's version by name (only inferred via `var`).
+import 'package:permission_handler/permission_handler.dart' hide PermissionStatus;
 import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -611,10 +613,10 @@ class PhoneCallProvider extends ChangeNotifier {
 
   Future<String?> _resolveContactName(String phoneNumber) async {
     try {
-      bool hasPermission = await FlutterContacts.requestPermission(readonly: true);
-      if (!hasPermission) return null;
+      final status = await FlutterContacts.permissions.request(PermissionType.read);
+      if (status != PermissionStatus.granted && status != PermissionStatus.limited) return null;
 
-      var contacts = await FlutterContacts.getContacts(withProperties: true, withPhoto: false);
+      var contacts = await FlutterContacts.getAll(properties: {ContactProperty.phone});
       var cleaned = _cleanPhoneNumber(phoneNumber);
 
       for (var contact in contacts) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -650,10 +650,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_contacts
-      sha256: "388d32cd33f16640ee169570128c933b45f3259bddbfae7a100bb49e5ffea9ae"
+      sha256: "3a018a04ffc88f8555068f86b7750c7cbc758e9ebccafa985f91353bcb6df496"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.9+2"
+    version: "2.3.1"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -1369,10 +1369,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2129,10 +2129,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   time:
     dependency: transitive
     description:
@@ -2511,5 +2511,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -62,7 +62,12 @@ dependencies:
   pdf: ^3.11.0
   intl: ^0.20.2
   permission_handler: ^12.0.0+1
-  flutter_contacts: ^1.1.9+2
+  # Must stay >=2.0.0 — 1.x's iOS registration force-unwraps
+  # UIApplication.shared.delegate!.window!!.rootViewController!, which is nil under the
+  # UIScene lifecycle and crashes on launch (EXC_BREAKPOINT), taking every alphabetically
+  # later plugin down with it since GeneratedPluginRegistrant registers synchronously.
+  # 2.x's rewritten registration doesn't touch window at all. See #11568.
+  flutter_contacts: ^2.3.1
   intl_country_data:
     git:
       url: https://github.com/mdmohsin7/intl_country_data.git


### PR DESCRIPTION
## Why

`flutter_contacts` 1.1.9+2's iOS registration force-unwraps `UIApplication.shared.delegate!.window!!.rootViewController!`, which is nil under the UIScene lifecycle (#11568) and crashes with `EXC_BREAKPOINT` on launch. Plugin registration is alphabetical and synchronous (`GeneratedPluginRegistrant.m`), so this crash takes down every alphabetically later plugin too — `SharedPreferences`, `Sqflite`, `PermissionHandler`, `Geolocator`, `WebView`, ~27 in total. Confirmed via full crash backtrace on iPhone 17 Pro / iOS 27.0 while verifying the UIScene migration.

## What changed

No 1.x patch exists past 1.1.9+2 — checked the full pub.dev version list. The fix only landed in 2.x, a complete Dart-API rewrite. Migrated the 3 call sites:

- `requestPermission({readonly})` → `bool` becomes `permissions.request(PermissionType.read|readWrite)` → `PermissionStatus` (`granted`/`limited` stand in for the old `true`).
- `getContacts(withProperties: true, withPhoto: false)` becomes `getAll(properties: {ContactProperty.phone})` — narrower and cheaper, since these call sites only ever read phones/displayName, and those two are always fetched regardless of the requested property set.
- `Contact.displayName`: non-null `String` → nullable `String?` in 2.x.
- `Phone.label`: bare `PhoneLabel` enum → `Label<PhoneLabel>` wrapper; `phone.label.name` → `phone.label.label.name`.

`phone_calls_page.dart` and `phone_call_provider.dart` both already import `permission_handler`, which also exports a type named `PermissionStatus` — writing `flutter_contacts`' bare `PermissionStatus` in either file is an ambiguous-import error. Fixed with `hide PermissionStatus` on the `permission_handler` import in both files; neither file spells that package's own `PermissionStatus` by name anywhere, so nothing else changes.

Bonus: 2.3.1 ships a `Package.swift`, so `flutter_contacts` drops off the "doesn't support Swift Package Manager" warning Flutter prints on every iOS build.

## Verification

`flutter analyze`: 0 errors on the 3 changed files (1 pre-existing unrelated lint), 0 new errors project-wide. Combined with the UIScene migration (#11570) and a Firebase local-config fix (separate PR) on a throwaway community-build test, the app reached the sign-in screen on iPhone 17 Pro / iOS 27.0, confirmed visually — the first time this plugin registration chain has completed under UIScene on this project.

No dedicated regression test: there's no way to unit-test a native UIScene-launch crash without device access. The version constraint itself (commented in `pubspec.yaml`) is the guard — a downgrade to 1.x would silently reintroduce the crash.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

