### PR TITLE
fix(desktop): break the OmiMarkdown citation view-type cycle crashing the macos-15 Swift lane (#11573)

### DIFF
--- a/.github/failure-classes/FC-recursive-view-type-graph.json
+++ b/.github/failure-classes/FC-recursive-view-type-graph.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-recursive-view-type-graph",
+  "violated_contract": "A SwiftUI view's body must not reach its own type again through concrete (non-erased) view types. SwiftUI resolves View._viewListCount(inputs:) statically, from types alone, without evaluating a body, so a cycle in the view-type graph recurses unbounded regardless of runtime values -- even when the branch closing the cycle never executes. The main thread writes past its stack guard page and the process dies with SIGSEGV.",
+  "canonical_prevention": "Break the cycle at its back-edge with a type-erasing wrapper (AnyView), which resolves its list count dynamically and terminates the static walk. Cover the repair with a test that mounts the view inside the container that forces a static count -- a ScrollView or LazyVStack host driven through AppKit layout -- since an unerased cycle kills the test process rather than failing an assertion.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift",
+    "desktop/macos/Desktop/Tests/OmiMarkdownCitationInteractionTests.swift"
+  ],
+  "evidence_prs": [11519],
+  "scope_hints": ["desktop/macos/Desktop/Sources/**"],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
@@ -1014,7 +1014,14 @@ private struct OmiMarkdownCitationContent: View {
         }
       }
     } else {
-      OmiMarkdownContent(text: text, style: style, fontScale: fontScale)
+      // Type-erased on purpose (#11573). `OmiMarkdownContent.body` reaches this view through
+      // `textView` and `OmiMarkdownTableView`, so naming `OmiMarkdownContent` here closes a cycle
+      // in the *static* view-type graph. SwiftUI's `View._viewListCount(inputs:)` walks that graph
+      // by type, never evaluating a body, so no value-level guard bounds it: on macOS 15 a
+      // `ScrollView`/`LazyVStack` host recursed until the main thread wrote past its stack guard
+      // page and died with SIGSEGV. `AnyView` is the terminator — it resolves its count
+      // dynamically, which cuts both cycles here and leaves the graph acyclic.
+      AnyView(OmiMarkdownContent(text: text, style: style, fontScale: fontScale))
     }
   }
 }

--- a/desktop/macos/Desktop/Tests/OmiMarkdownCitationInteractionTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiMarkdownCitationInteractionTests.swift
@@ -1,9 +1,49 @@
+import AppKit
+import SwiftUI
 import XCTest
 
 @testable import Omi_Computer
 
 @MainActor
 final class OmiMarkdownCitationInteractionTests: XCTestCase {
+  /// #11573 — a cited answer inside a `ScrollView`/`LazyVStack` host made SwiftUI walk the static
+  /// view-type graph (`View._viewListCount(inputs:)`). That walk is driven by types, not values,
+  /// so the `OmiMarkdownContent` <-> `OmiMarkdownCitationContent` cycle recursed until the main
+  /// thread wrote past its stack guard page: SIGSEGV on macOS 15, where this container asks for
+  /// the count. Measuring the host is what forces the walk; an unerased cycle crashes the process
+  /// rather than failing an assertion.
+  func testCitedAnswerInAScrollingTranscriptMeasuresWithoutRecursingOnTheViewTypeGraph() {
+    let citations = (1...3).map {
+      ChatCitationReference(
+        ordinal: $0, kind: .memory, sourceID: "memory-\($0)", title: "Source \($0)")
+    }
+    let messages = (0..<12).map { index in
+      """
+      Completed answer \(index) cites its provenance inline [1], keeps `inline code` copyable [2],
+      and wraps across enough prose to exercise the flow layout [3].
+      """
+    }
+
+    let host = NSHostingView(
+      rootView: ScrollView {
+        LazyVStack(alignment: .leading, spacing: 8) {
+          ForEach(messages.indices, id: \.self) { index in
+            OmiMarkdown(text: messages[index], sender: .ai, citations: citations)
+          }
+        }
+      }
+    )
+
+    for width in [620.0, 980.0, 620.0] {
+      host.frame = NSRect(x: 0, y: 0, width: width, height: 720)
+      host.layoutSubtreeIfNeeded()
+
+      let size = host.fittingSize
+      XCTAssertTrue(size.height.isFinite, "cited transcript height must remain finite")
+      XCTAssertGreaterThan(size.height, 0, "cited messages must remain visible")
+    }
+  }
+
   func testCitationProjectionPreservesInlineCodeAsCopyableUnit() throws {
     let reference = ChatCitationReference(
       ordinal: 1,

--- a/desktop/macos/changelog/unreleased/20260815-markdown-citation-crash.json
+++ b/desktop/macos/changelog/unreleased/20260815-markdown-citation-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash on macOS 15 when a chat answer with source citations was shown in the transcript"
+}


### PR DESCRIPTION
## Bug

Three Swift suites have died with `SIGSEGV` on the `macos-15` CI runner since 2026-08-14, leaving **Desktop Swift Static & Test Contracts red on every run that actually executes desktop tests** (#11573): `AgentPillLifecycleTests`, `ChatTimelineContinuityTests`, `MarkdownNestedScrollTests`. The green runs in between only look green because `Detect Desktop Swift Changes` skipped the job.

## Root cause

The crash report surfaced by #11589 settles it. It is a **stack overflow, not a bad pointer**: the faulting address `0x16b043fe0` sits 31 bytes below the bottom of thread 0's stack, inside the `STACK GUARD` region, with `KERN_PROTECTION_FAILURE` (write to a protected page).

The backtrace (511 frames, recovered from the raw log archive — `gh run view --log` truncates it) is one repeating unit:

```
OmiMarkdownContent -> _ConditionalContent -> OmiMarkdownCitationContent
  -> _ConditionalContent -> Group -> ... -> OmiMarkdownContent -> ...
```

Every frame is `View._viewListCount(inputs:)`. That is a **static** walk: SwiftUI resolves it from view *types* alone and never evaluates a body. So the cycle is in the type graph, not in any value:

- `OmiMarkdownContent.body` reaches `OmiMarkdownCitationContent` via `textView(_:)` **and** via `OmiMarkdownTableView`.
- `OmiMarkdownCitationContent`'s mask-failure fallback named `OmiMarkdownContent`.

That single back-edge closed **two** cycles. Because the walk is type-driven, it recurses whether or not the fallback branch ever executes at runtime — which is exactly why this looked value-dependent and resisted diagnosis for two days, and why `OmiMarkdownLineSpacingTests` (same `NSHostingView`/`fittingSize` measurement, no `ScrollView`) kept passing. The container is what forces the static count.

Introduced by `00cc9ed9d6` — "feat(desktop): add clickable source citations (#11519)" (David Zhang, 2026-08-13) — which added `OmiMarkdownCitationContent` and its fallback.

## Fix

Erase the one back-edge with `AnyView`. `AnyView` resolves its list count dynamically, so it terminates the static walk; the graph becomes acyclic and both cycles are cut. One line plus the comment explaining why it must not be "simplified" back.

## Not CI-only

The production transcript hosts the same tree — `ChatMessagesView.scrollContent` -> `ScrollView` -> `VStack` -> `ChatBubble` -> `OmiMarkdown(citations:)` — so a macOS 15 user on a build carrying #11519 hits the same recursion. Changelog entry added.

## Verification

- `desktop/macos/scripts/swift-test-suites.sh`, full run, **608 suites**, twice: once with this fix and once with the fix stashed on the same commit.
  - **Failure sets are identical** — the same 7 suites fail both ways (`AgentPillLifecycleTests`, `ChatCitationTests`, `GlassSurfaceReviewRegressionTests`, `KnowledgeGraphPaginationTests`, `ProactiveLaneClientTests`, `RewindSurfaceLayoutTests`, `ShellModalScrimDismissTests`), all pre-existing on macOS 26 at `9a4213ad00` and unrelated to markdown rendering (e.g. `ChatCitationTests` fails on `testRewindCitationFocusIsOneShotAndPreservesExactScreenshotID`, a focus-state assertion). **Zero regressions introduced.**
  - `ChatTimelineContinuityTests`, `MarkdownNestedScrollTests`, `OmiMarkdownLineSpacingTests` and the new test all pass.
- New regression test `testCitedAnswerInAScrollingTranscriptMeasuresWithoutRecursingOnTheViewTypeGraph` measures a cited answer inside a `ScrollView`/`LazyVStack` host — the container that forces the static count. Pre-fix that shape kills the process rather than failing an assertion, so the suite surviving on the `macos-15` runner *is* the assertion.
- **The macos-15 lane is the authority here.** The crash does not reproduce on macOS 26 (both maintainer machines), so lane-green on this PR is the proof, and it is the check this PR exists to restore.

Failure-Class: new

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift | 1636 -> 1643 | Seven lines are the comment explaining why the `AnyView` at the cycle's back-edge is load-bearing; without it the next reader deletes the fix as a redundant wrapper. Splitting this file is not in scope for a crash fix.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

