### PR TITLE
fix(ci): stop PR-body-only checks from failing Release Eligibility on main

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -100,6 +100,7 @@ checks:
     command: ["python3", ".github/scripts/check_product_file_line_count_ratchet.py", "--changed-files", "{changed_files}", "--base", "{target_base}", "--head", "{head}", "--pr-body-file", "{pr_body_file}"]
     triggers: ["backend/**/*.py", "desktop/macos/**/*.swift", "desktop/macos/**/*.rs", ".github/scripts/check_product_file_line_count_ratchet.py"]
     lanes: ["local", "ci"]
+    requires_pr_body: true
     reason: "#9838 freezes oversized product files against the target branch without a shared metadata ledger; exact PR-body exceptions preserve reviewability without unrelated merge conflicts"
   - id: product-file-line-count-ratchet-tests
     command: ["python3", ".github/scripts/test_check_product_file_line_count_ratchet.py"]
@@ -209,6 +210,7 @@ checks:
     command: ["python3", ".github/scripts/check_failure_class_guard_ratchet.py", "--pr-body-file", "{pr_body_file}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
+    requires_pr_body: true
     reason: "FC-split-mutation-authority was declared on 30 first-parent integration changes in the 90 days to Jul 24 2026 while its definition still listed evidence_prs [9365, 9597] and named no guard artifact; a recurring class must produce a reusable guard surface, not more paperwork"
   - id: failure-class-guard-artifact-ratchet-tests
     command: ["python3", ".github/scripts/test_check_failure_class_guard_ratchet.py"]

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -577,11 +577,22 @@ esac
         self.assertNotIn("failure-class-protocol", selected)
         self.assertIn("diff-hygiene", selected)
 
+    def test_every_pr_body_consuming_check_is_excluded_from_post_merge_runs(self) -> None:
+        # Post-merge runs have no PR body, so a check whose escape hatch lives
+        # there would fail on main forever.
+        manifest = load_manifest(MANIFEST_PATH)
+        for check in manifest.checks:
+            if "{pr_body_file}" in check.command:
+                self.assertTrue(
+                    check.requires_pr_body,
+                    f"{check.id} consumes the PR body, so it must declare requires_pr_body: true",
+                )
+
     def test_line_count_ratchet_receives_pr_body_metadata(self) -> None:
         manifest = load_manifest(MANIFEST_PATH)
         check = next(check for check in manifest.checks if check.id == "product-file-line-count-ratchet")
 
-        self.assertFalse(check.requires_pr_body)
+        self.assertTrue(check.requires_pr_body)
         self.assertIn("{pr_body_file}", check.command)
         self.assertIn("{target_base}", check.command)
         self.assertIn("{head}", check.command)
@@ -591,7 +602,8 @@ esac
             "ci",
             include_pr_body_checks=False,
         )
-        self.assertIn(check, selected)
+        self.assertNotIn(check, selected)
+        self.assertIn(check, resolve_checks(manifest, ["backend/routers/example.py"], "ci"))
 
         command = command_for_check(
             check,


### PR DESCRIPTION
## Problem

No desktop candidate cut for ~9 hours (v0.12.172 at 17:16Z, five desktop merges since), with hourly `desktop_auto_release` runs failing:

```
PLAN_REASON: Desktop candidate source gate blocked: required check
Desktop Swift Build & Tests ... / Release Eligibility ... completed with failure.
```

`Release Eligibility` — a required exact-SHA check for the release planner — runs the canonical post-merge lane with `--skip-pr-body-checks` and an empty body. That flag excludes **only** checks declaring `requires_pr_body`. Two checks consume `{pr_body_file}` without declaring it:

- `product-file-line-count-ratchet`
- `failure-class-guard-artifact-ratchet`

So any merge that legitimately carried a `Line-Count-Exception` fails Release Eligibility on `main` — permanently, since a push has no authoritative PR body. #11596 grew `OmiMarkdown.swift` 1636 → 1643 with an approved exception; main went red and the train wedged behind it.

## Fix

Declare `requires_pr_body: true` on both checks (the manifest header already states this rule: *"Checks that consume PR metadata declare `requires_pr_body: true`; post-merge push runs exclude only that category"*), plus a manifest-wide contract test asserting every `{pr_body_file}` consumer declares it, so a third one cannot reintroduce the wedge.

PR-lane authority is unchanged — both checks still run on every PR, where the exception text is readable and reviewable. This does not relax the ratchet; it stops applying it where its escape hatch cannot exist.

Failure-Class: none

## Verification

- Replayed the canonical post-merge lane against the exact wedged commit: `run_checks.py --lane ci --base 68e869c900 --head 9f87c2f24b --skip-pr-body-checks --pr-body-file <empty>` → **18 checks pass**, where CI reported `FAIL product-file-line-count-ratchet`.
- `test_run_checks.py`: 45 passed, including the new `test_every_pr_body_consuming_check_is_excluded_from_post_merge_runs`. (One unrelated `DeferredMarkerTests` failure is pre-existing — reproduced on clean `main` with my changes stashed.)
- `test_check_release_eligibility.py` + `test_preflight_runner.py`: 34 passed, 6 skipped.

Note: the segfaulting Swift suite (`Desktop Swift Build & Tests`, signal 11) is the separate blocker tracked as #11573 and is not addressed here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

