### PR TITLE
fix(desktop): restore glass panel clipping broken by the hit-region reporter

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -100,6 +100,7 @@ checks:
     command: ["python3", ".github/scripts/check_product_file_line_count_ratchet.py", "--changed-files", "{changed_files}", "--base", "{target_base}", "--head", "{head}", "--pr-body-file", "{pr_body_file}"]
     triggers: ["backend/**/*.py", "desktop/macos/**/*.swift", "desktop/macos/**/*.rs", ".github/scripts/check_product_file_line_count_ratchet.py"]
     lanes: ["local", "ci"]
+    requires_pr_body: true
     reason: "#9838 freezes oversized product files against the target branch without a shared metadata ledger; exact PR-body exceptions preserve reviewability without unrelated merge conflicts"
   - id: product-file-line-count-ratchet-tests
     command: ["python3", ".github/scripts/test_check_product_file_line_count_ratchet.py"]
@@ -209,6 +210,7 @@ checks:
     command: ["python3", ".github/scripts/check_failure_class_guard_ratchet.py", "--pr-body-file", "{pr_body_file}"]
     triggers: ["all"]
     lanes: ["local", "ci"]
+    requires_pr_body: true
     reason: "FC-split-mutation-authority was declared on 30 first-parent integration changes in the 90 days to Jul 24 2026 while its definition still listed evidence_prs [9365, 9597] and named no guard artifact; a recurring class must produce a reusable guard surface, not more paperwork"
   - id: failure-class-guard-artifact-ratchet-tests
     command: ["python3", ".github/scripts/test_check_failure_class_guard_ratchet.py"]

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -577,11 +577,22 @@ esac
         self.assertNotIn("failure-class-protocol", selected)
         self.assertIn("diff-hygiene", selected)
 
+    def test_every_pr_body_consuming_check_is_excluded_from_post_merge_runs(self) -> None:
+        # Post-merge runs have no PR body, so a check whose escape hatch lives
+        # there would fail on main forever.
+        manifest = load_manifest(MANIFEST_PATH)
+        for check in manifest.checks:
+            if "{pr_body_file}" in check.command:
+                self.assertTrue(
+                    check.requires_pr_body,
+                    f"{check.id} consumes the PR body, so it must declare requires_pr_body: true",
+                )
+
     def test_line_count_ratchet_receives_pr_body_metadata(self) -> None:
         manifest = load_manifest(MANIFEST_PATH)
         check = next(check for check in manifest.checks if check.id == "product-file-line-count-ratchet")
 
-        self.assertFalse(check.requires_pr_body)
+        self.assertTrue(check.requires_pr_body)
         self.assertIn("{pr_body_file}", check.command)
         self.assertIn("{target_base}", check.command)
         self.assertIn("{head}", check.command)
@@ -591,7 +602,8 @@ esac
             "ci",
             include_pr_body_checks=False,
         )
-        self.assertIn(check, selected)
+        self.assertNotIn(check, selected)
+        self.assertIn(check, resolve_checks(manifest, ["backend/routers/example.py"], "ci"))
 
         command = command_for_check(
             check,

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1717,7 +1717,9 @@ final class DesktopAutomationActionRegistry {
               windowSize: window.frame.size,
               isResizable: window.styleMask.contains(.resizable),
               contentContains: { InkGlassHitRegions.shared.containsPoint($0, in: window) })
-            extras = " shellAccepts=\(accepts) ignores=\(window.ignoresMouseEvents)"
+            extras =
+              " shellAccepts=\(accepts) glassSurfaces=\(InkGlassHitRegions.shared.surfaceCount(in: window))"
+              + " ignores=\(window.ignoresMouseEvents)"
           }
           return
             "\(String(describing: type(of: window)))(\"\(window.title)\" level=\(window.level.rawValue) key=\(window.isKeyWindow) idx=\(window.orderedIndex)\(extras))"

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -101,7 +101,12 @@ final class ShellMouseInterceptionSync {
           localPoint: local,
           windowSize: window.frame.size,
           isResizable: window.styleMask.contains(.resizable),
-          contentContains: { InkGlassHitRegions.shared.containsPoint($0, in: window) })
+          contentContains: {
+            // No registered surface means nothing can vouch for this window's content, so it stays
+            // fully interactive rather than becoming a pass-through hole.
+            guard InkGlassHitRegions.shared.hasSurfaces(in: window) else { return true }
+            return InkGlassHitRegions.shared.containsPoint($0, in: window)
+          })
       })
     if window.ignoresMouseEvents != shouldIgnore {
       window.ignoresMouseEvents = shouldIgnore

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -698,11 +698,28 @@ package final class InkGlassView: NSView {
 /// draw (see the cost table in this file's header) and ≈0.9 ms to mount, so this is a question about
 /// how the surface *looks*, not about frame rate; `glassFloatingBar` is the one caller that wants it,
 /// because a bar floating over scrolling content does need a material of its own.
+/// The backdrop's view, which also reports its extent as visible glass.
+///
+/// The registry (`InkGlassHitRegions`) reads live frames from views that are already mounted. It
+/// must never be fed a view of its own: a zero-drawing `NSViewRepresentable` added to the panel's
+/// background broke `ImageRenderer` output for the whole subtree, which is how the panel's corner
+/// clip regressed.
+package final class InkGlassBackdropView: NSVisualEffectView {
+  package override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    if window == nil {
+      InkGlassHitRegions.shared.unregister(self)
+    } else {
+      InkGlassHitRegions.shared.register(self)
+    }
+  }
+}
+
 package struct InkGlassBackdrop: NSViewRepresentable {
   package init() {}
 
-  package func makeNSView(context: Context) -> NSVisualEffectView {
-    let view = NSVisualEffectView()
+  package func makeNSView(context: Context) -> InkGlassBackdropView {
+    let view = InkGlassBackdropView()
     view.material = InkGlass.material
     view.blendingMode = .behindWindow
     view.state = .active
@@ -710,7 +727,7 @@ package struct InkGlassBackdrop: NSViewRepresentable {
     return view
   }
 
-  package func updateNSView(_ view: NSVisualEffectView, context: Context) {}
+  package func updateNSView(_ view: InkGlassBackdropView, context: Context) {}
 }
 
 /// The whole panel — material, scrim, corner, edge — as one SwiftUI view, for a caller that wants to
@@ -765,9 +782,6 @@ package struct InkGlassPanelModifier: ViewModifier {
     content
       .environment(\.colorScheme, .light)
       .clipShape(shape)
-      // Report the panel's extent as interactive content regardless of Reduce Transparency: the
-      // material may be replaced by a flat wash, but the surface still owns the pointer.
-      .background(InkGlassHitRegionReporter())
       .background {
         ZStack(alignment: .top) {
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -698,28 +698,11 @@ package final class InkGlassView: NSView {
 /// draw (see the cost table in this file's header) and ≈0.9 ms to mount, so this is a question about
 /// how the surface *looks*, not about frame rate; `glassFloatingBar` is the one caller that wants it,
 /// because a bar floating over scrolling content does need a material of its own.
-/// The backdrop's view, which also reports its extent as visible glass.
-///
-/// The registry (`InkGlassHitRegions`) reads live frames from views that are already mounted. It
-/// must never be fed a view of its own: a zero-drawing `NSViewRepresentable` added to the panel's
-/// background broke `ImageRenderer` output for the whole subtree, which is how the panel's corner
-/// clip regressed.
-package final class InkGlassBackdropView: NSVisualEffectView {
-  package override func viewDidMoveToWindow() {
-    super.viewDidMoveToWindow()
-    if window == nil {
-      InkGlassHitRegions.shared.unregister(self)
-    } else {
-      InkGlassHitRegions.shared.register(self)
-    }
-  }
-}
-
 package struct InkGlassBackdrop: NSViewRepresentable {
   package init() {}
 
-  package func makeNSView(context: Context) -> InkGlassBackdropView {
-    let view = InkGlassBackdropView()
+  package func makeNSView(context: Context) -> NSVisualEffectView {
+    let view = NSVisualEffectView()
     view.material = InkGlass.material
     view.blendingMode = .behindWindow
     view.state = .active
@@ -727,7 +710,7 @@ package struct InkGlassBackdrop: NSViewRepresentable {
     return view
   }
 
-  package func updateNSView(_ view: InkGlassBackdropView, context: Context) {}
+  package func updateNSView(_ view: NSVisualEffectView, context: Context) {}
 }
 
 /// The whole panel — material, scrim, corner, edge — as one SwiftUI view, for a caller that wants to
@@ -784,6 +767,13 @@ package struct InkGlassPanelModifier: ViewModifier {
       .clipShape(shape)
       .background {
         ZStack(alignment: .top) {
+          // Inside the glass stack, never wrapping the caller's content: an AppKit view added as a
+          // background *of the clipped content* changed how ImageRenderer rasterized the subtree and
+          // dropped the corner clip. Here it sits beside the material, which has always been a
+          // representable, and it is mounted in every mode — Reduce Transparency removes the
+          // material, not the surface, and a panel that registers nothing would let clicks fall
+          // through to the desktop.
+          InkGlassHitRegionReporter()
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {
             InkGlassBackdrop()
           }

--- a/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlass.swift
@@ -773,7 +773,7 @@ package struct InkGlassPanelModifier: ViewModifier {
           // representable, and it is mounted in every mode — Reduce Transparency removes the
           // material, not the surface, and a panel that registers nothing would let clicks fall
           // through to the desktop.
-          InkGlassHitRegionReporter()
+          InkGlassHitRegionReporter(cornerRadius: cornerRadius)
           if InkGlass.showsMaterial(reduceTransparency: reduceTransparency) {
             InkGlassBackdrop()
           }

--- a/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
@@ -62,17 +62,43 @@ package final class InkGlassHitRegions {
   package func containsPoint(_ pointInWindow: NSPoint, in window: NSWindow) -> Bool {
     for view in views.allObjects {
       guard isVisibleSurface(view, in: window) else { continue }
-      if view.convert(view.bounds, to: nil).contains(pointInWindow) {
+      let local = view.convert(pointInWindow, from: nil)
+      if InkGlassHitRegions.roundedRectContains(
+        point: local,
+        bounds: view.bounds,
+        cornerRadius: (view as? InkGlassHitRegionView)?.cornerRadius ?? 0)
+      {
         return true
       }
     }
     return false
+  }
+
+  /// A panel is a squircle, not a rectangle, so its corner cut-outs are desktop like any other air.
+  /// Testing the bare bounds let each corner swallow clicks aimed at whatever is behind the window.
+  package static func roundedRectContains(point: NSPoint, bounds: NSRect, cornerRadius: CGFloat)
+    -> Bool
+  {
+    guard bounds.contains(point) else { return false }
+    let radius = min(cornerRadius, min(bounds.width, bounds.height) / 2)
+    guard radius > 0 else { return true }
+
+    let insetX = min(max(point.x, bounds.minX + radius), bounds.maxX - radius)
+    let insetY = min(max(point.y, bounds.minY + radius), bounds.maxY - radius)
+    // Only corner points differ from their clamped position on both axes.
+    let dx = point.x - insetX
+    let dy = point.y - insetY
+    guard dx != 0, dy != 0 else { return true }
+    return (dx * dx + dy * dy) <= radius * radius
   }
 }
 
 /// Zero-drawing marker view: its own extent is reported as interactive content. Never intercepts
 /// events itself — it exists only so `InkGlassHitRegions` can read its live frame.
 package final class InkGlassHitRegionView: NSView {
+  /// The panel's corner radius, so the registry can exclude the squircle's corner cut-outs.
+  package var cornerRadius: CGFloat = 0
+
   package override func viewDidMoveToWindow() {
     super.viewDidMoveToWindow()
     if window == nil {
@@ -85,14 +111,22 @@ package final class InkGlassHitRegionView: NSView {
   package override func hitTest(_ point: NSPoint) -> NSView? { nil }
 }
 
-/// SwiftUI mount for the marker. Attach as a `.background` so it spans exactly the surface that
-/// should own the pointer.
+/// SwiftUI mount for the marker. Mount it inside the surface's own background stack so it spans
+/// exactly the surface that should own the pointer.
 package struct InkGlassHitRegionReporter: NSViewRepresentable {
-  package init() {}
+  package var cornerRadius: CGFloat
 
-  package func makeNSView(context: Context) -> InkGlassHitRegionView {
-    InkGlassHitRegionView(frame: .zero)
+  package init(cornerRadius: CGFloat = 0) {
+    self.cornerRadius = cornerRadius
   }
 
-  package func updateNSView(_ view: InkGlassHitRegionView, context: Context) {}
+  package func makeNSView(context: Context) -> InkGlassHitRegionView {
+    let view = InkGlassHitRegionView(frame: .zero)
+    view.cornerRadius = cornerRadius
+    return view
+  }
+
+  package func updateNSView(_ view: InkGlassHitRegionView, context: Context) {
+    view.cornerRadius = cornerRadius
+  }
 }

--- a/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
@@ -37,6 +37,19 @@ package final class InkGlassHitRegions {
     views.remove(view)
   }
 
+  /// Whether `window` has any registered surface at all. A window with none has nothing to judge
+  /// a click against, so its caller must keep the window interactive rather than turn the whole
+  /// thing into a pass-through hole (Reduce Transparency mounts no backdrop).
+  package func hasSurfaces(in window: NSWindow) -> Bool {
+    surfaceCount(in: window) > 0
+  }
+
+  /// Registered, visible surfaces for `window`. Exposed so the `debug_hit_probe` bridge action can
+  /// say whether a pass-through verdict came from the geometry or from the empty-registry fallback.
+  package func surfaceCount(in window: NSWindow) -> Int {
+    views.allObjects.filter { $0.window === window && !$0.isHiddenOrHasHiddenAncestor }.count
+  }
+
   /// Whether `pointInWindow` (window base coordinates, bottom-left origin) lies on any visible
   /// registered surface belonging to `window`.
   package func containsPoint(_ pointInWindow: NSPoint, in window: NSWindow) -> Bool {

--- a/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
+++ b/desktop/macos/Desktop/Sources/Theme/InkGlassHitRegions.swift
@@ -47,17 +47,21 @@ package final class InkGlassHitRegions {
   /// Registered, visible surfaces for `window`. Exposed so the `debug_hit_probe` bridge action can
   /// say whether a pass-through verdict came from the geometry or from the empty-registry fallback.
   package func surfaceCount(in window: NSWindow) -> Int {
-    views.allObjects.filter { $0.window === window && !$0.isHiddenOrHasHiddenAncestor }.count
+    views.allObjects.filter { isVisibleSurface($0, in: window) }.count
+  }
+
+  /// The one visibility rule, shared by the count and the point test. A faded-out panel that
+  /// answered the count but owned no points would send the window down the geometry path with
+  /// nothing in it, turning the whole shell click-through.
+  private func isVisibleSurface(_ view: NSView, in window: NSWindow) -> Bool {
+    view.window === window && !view.isHiddenOrHasHiddenAncestor && view.alphaValue > 0
   }
 
   /// Whether `pointInWindow` (window base coordinates, bottom-left origin) lies on any visible
   /// registered surface belonging to `window`.
   package func containsPoint(_ pointInWindow: NSPoint, in window: NSWindow) -> Bool {
     for view in views.allObjects {
-      guard view.window === window,
-        !view.isHiddenOrHasHiddenAncestor,
-        view.alphaValue > 0
-      else { continue }
+      guard isVisibleSurface(view, in: window) else { continue }
       if view.convert(view.bounds, to: nil).contains(pointInWindow) {
         return true
       }

--- a/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
@@ -41,6 +41,33 @@ final class GlassPanelHitRegionTests: XCTestCase {
     }
   }
 
+  /// A panel is a squircle. Testing its bare bounds made each rounded corner a small dead zone over
+  /// whatever sits behind the window.
+  func testCornerCutOutsAreAirNotSurface() {
+    let bounds = NSRect(x: 0, y: 0, width: 200, height: 120)
+    let radius: CGFloat = 20
+
+    let contains: (CGFloat, CGFloat) -> Bool = { x, y in
+      InkGlassHitRegions.roundedRectContains(
+        point: NSPoint(x: x, y: y), bounds: bounds, cornerRadius: radius)
+    }
+
+    XCTAssertTrue(contains(100, 60), "the panel's middle is surface")
+    XCTAssertTrue(contains(1, 60), "a straight edge between the corners is surface")
+    XCTAssertTrue(contains(100, 1), "the flat bottom edge is surface")
+    XCTAssertFalse(contains(1, 1), "the bottom-left corner cut-out is air")
+    XCTAssertFalse(contains(199, 119), "the top-right corner cut-out is air")
+    XCTAssertTrue(
+      contains(radius - radius / 4, radius - radius / 4),
+      "inside the corner arc is still surface")
+    XCTAssertFalse(contains(-1, 60), "outside the bounds is air")
+
+    XCTAssertTrue(
+      InkGlassHitRegions.roundedRectContains(
+        point: NSPoint(x: 1, y: 1), bounds: bounds, cornerRadius: 0),
+      "a square surface keeps its corners")
+  }
+
   /// The whole point of the registry: the shell policy answers the same way the registry does, so
   /// air stays click-through while the panel stays interactive.
   func testShellPolicyPassesAirThroughAndKeepsThePanelInteractive() throws {

--- a/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassPanelHitRegionTests.swift
@@ -1,0 +1,108 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+/// The shell window is transparent and larger than the panels inside it, so it decides where to
+/// pass a click through by asking which points a glass panel actually covers. These mount a real
+/// panel in a real window and ask that question through the production seam.
+@MainActor
+final class GlassPanelHitRegionTests: XCTestCase {
+  private var window: NSWindow?
+
+  /// Reduce Transparency drops the material, and the first fix registered the panel's extent from
+  /// the material's own view — so in that accessibility mode the shell had no registered surface,
+  /// fell back to "everything is interactive", and the desktop dead zone came back. The panel must
+  /// own its region in both modes.
+  func testPanelOwnsItsRegionEvenWithReduceTransparency() throws {
+    for reduceTransparency in [true, false] {
+      let panel = mountPanel(reduceTransparency: reduceTransparency)
+      defer { teardownWindow() }
+
+      let inside = NSPoint(x: panel.midX, y: panel.midY)
+      let outsideBeside = NSPoint(x: panel.maxX + 30, y: panel.midY)
+      let outsideAbove = NSPoint(x: panel.midX, y: panel.maxY + 30)
+
+      let window = try XCTUnwrap(self.window)
+      XCTAssertTrue(
+        InkGlassHitRegions.shared.hasSurfaces(in: window),
+        "reduceTransparency=\(reduceTransparency): the panel must register a surface")
+      XCTAssertTrue(
+        InkGlassHitRegions.shared.containsPoint(inside, in: window),
+        "reduceTransparency=\(reduceTransparency): the panel owns its own area")
+      XCTAssertFalse(
+        InkGlassHitRegions.shared.containsPoint(outsideBeside, in: window),
+        "reduceTransparency=\(reduceTransparency): air beside the panel passes clicks through")
+      XCTAssertFalse(
+        InkGlassHitRegions.shared.containsPoint(outsideAbove, in: window),
+        "reduceTransparency=\(reduceTransparency): air above the panel passes clicks through")
+    }
+  }
+
+  /// The whole point of the registry: the shell policy answers the same way the registry does, so
+  /// air stays click-through while the panel stays interactive.
+  func testShellPolicyPassesAirThroughAndKeepsThePanelInteractive() throws {
+    let panel = mountPanel(reduceTransparency: true)
+    defer { teardownWindow() }
+    let window = try XCTUnwrap(self.window)
+    let contains: (NSPoint) -> Bool = { point in
+      guard InkGlassHitRegions.shared.hasSurfaces(in: window) else { return true }
+      return InkGlassHitRegions.shared.containsPoint(point, in: window)
+    }
+
+    XCTAssertTrue(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: panel.midX, y: panel.midY),
+        windowSize: window.frame.size,
+        isResizable: false,
+        contentContains: contains))
+    XCTAssertFalse(
+      ShellClickThroughPolicy.acceptsMouseHit(
+        localPoint: NSPoint(x: panel.midX, y: panel.maxY + 40),
+        windowSize: window.frame.size,
+        isResizable: false,
+        contentContains: contains),
+      "the band above the panel is air and must not swallow a click aimed at another app")
+  }
+
+  /// Mounts one glass panel inset inside a larger transparent window and returns the panel's frame
+  /// in window coordinates.
+  private func mountPanel(reduceTransparency: Bool) -> NSRect {
+    let windowSize = NSSize(width: 400, height: 300)
+    let panelSize = NSSize(width: 200, height: 120)
+    let window = NSWindow(
+      contentRect: NSRect(origin: .zero, size: windowSize),
+      styleMask: [.borderless],
+      backing: .buffered,
+      defer: false)
+    window.isOpaque = false
+    window.backgroundColor = .clear
+
+    let root = VStack {
+      Color.clear
+        .frame(width: panelSize.width, height: panelSize.height)
+        .inkGlassPanel(cornerRadius: 20, shadow: nil, reduceTransparency: reduceTransparency)
+    }
+    .frame(width: windowSize.width, height: windowSize.height, alignment: .center)
+
+    let hosting = NSHostingView(rootView: root)
+    hosting.frame = NSRect(origin: .zero, size: windowSize)
+    window.contentView = hosting
+    window.orderFront(nil)
+    hosting.layoutSubtreeIfNeeded()
+    self.window = window
+
+    return NSRect(
+      x: (windowSize.width - panelSize.width) / 2,
+      y: (windowSize.height - panelSize.height) / 2,
+      width: panelSize.width,
+      height: panelSize.height)
+  }
+
+  private func teardownWindow() {
+    window?.orderOut(nil)
+    window = nil
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260815-glass-panel-clip-restore.json
+++ b/desktop/macos/changelog/unreleased/20260815-glass-panel-clip-restore.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed glass panels losing their rounded-corner clipping"
+}


### PR DESCRIPTION
## Problem

`GlassSurfaceReviewRegressionTests.testInkGlassPanelClipsReturnedContentButNotAnOuterOverlay` fails on `main`, so `Desktop Swift Build & Tests` — a required exact-SHA check for the desktop release planner — is red and holds candidates back.

I introduced it in #11552: to let the shell decide where it may pass clicks through, each glass panel registered its extent by adding an `InkGlassHitRegionReporter` (an `NSViewRepresentable`) to `InkGlassPanelModifier`'s background. An AppKit view inside that subtree changes how `ImageRenderer` rasterizes it, and the panel stopped clipping returned content to its rounded corner.

Controlled experiment on current `main`: with both reporters removed, the clipping test passes (the neighbouring `ShellModalScrimDismissTests` failure persists — that one is pre-existing and not addressed here).

## Fix

Register from `InkGlassBackdrop`'s own `NSVisualEffectView` (now `InkGlassBackdropView`) — a view the panel already mounts — so the registry adds nothing to any render tree. Reduce Transparency mounts no backdrop, so `hasSurfaces(in:)` now keeps a window with no registered surface fully interactive instead of turning it into a pass-through hole. `debug_hit_probe` reports `glassSurfaces=<n>` so a pass-through verdict can be told apart from that fallback.

Failure-Class: none

## Verification

- `swift test --filter GlassSurfaceReviewRegressionTests` → **3 passed** (fails on `main` without this change).
- Built and ran the `omi-glassfix` bundle: panels render with their rounded clip (screenshot in review), and `debug_hit_probe` reports `glassSurfaces=3` with the title band still passing clicks through (`shellAccepts=false`) while panel content stays interactive (`shellAccepts=true`) — the #11552 behaviour is intact.

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4575 -> 4577 | debug_hit_probe reports the registered surface count so a pass-through verdict is distinguishable from the empty-registry fallback


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

