### PR TITLE
fix(desktop): give notification cards one size per display mode

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1699,7 +1699,13 @@ final class DesktopAutomationActionRegistry {
           assistantId: "suggestion"
         )
       )
-      return ["shown": "true", "frame": NSStringFromRect(window.frame)]
+      return [
+        "shown": "true",
+        "frame": NSStringFromRect(window.frame),
+        "hasNotification": window.state.currentNotification == nil ? "false" : "true",
+        "showingAIConversation": window.state.showingAIConversation ? "true" : "false",
+        "isVisible": window.isVisible ? "true" : "false",
+      ]
     }
 
     // Cursor-free click diagnosis: report which window (any app's) is topmost at a screen point,

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1676,6 +1676,32 @@ final class DesktopAutomationActionRegistry {
       return ["shown": "true"]
     }
 
+    // The suggestion card is the most-seen proactive surface and the one whose geometry regressed
+    // (four call sites sized it differently). The real delivery path needs a live model verdict, so
+    // rendering it was unverifiable offline; this presents the same card through the same
+    // presenter. Non-prod bridge only.
+    register(
+      name: "debug_suggestion_card",
+      summary: "Show a sample 'Suggested by Omi' card on the bar for visual/geometry verification",
+      params: ["message"]
+    ) { params in
+      let mgr = FloatingControlBarManager.shared
+      guard let window = mgr.window else { return ["error": "no bar window"] }
+      if !mgr.isVisible { mgr.show() }
+      let message =
+        params["message"].flatMap { $0.isEmpty ? nil : $0 }
+        ?? "Film and post 'what did we ship' video with Chase From mark today"
+      window.showNotification(
+        FloatingBarNotification(
+          ownerID: RuntimeOwnerIdentity.currentOwnerId() ?? "",
+          title: "Suggested by Omi",
+          message: message,
+          assistantId: "suggestion"
+        )
+      )
+      return ["shown": "true", "frame": NSStringFromRect(window.frame)]
+    }
+
     // Cursor-free click diagnosis: report which window (any app's) is topmost at a screen point,
     // and — when it is one of ours — the exact view AppKit hit-tests there. Exists because "I
     // click X and nothing happens" is otherwise undiagnosable without synthesizing real clicks.

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1682,30 +1682,28 @@ final class DesktopAutomationActionRegistry {
     // presenter. Non-prod bridge only.
     register(
       name: "debug_suggestion_card",
-      summary: "Show a sample 'Suggested by Omi' card on the bar for visual/geometry verification",
+      summary: "Show a sample 'Suggested by Omi' card through the real notification service",
       params: ["message"]
     ) { params in
       let mgr = FloatingControlBarManager.shared
-      guard let window = mgr.window else { return ["error": "no bar window"] }
+      guard mgr.barState != nil else { return ["error": "no bar state"] }
       if !mgr.isVisible { mgr.show() }
       let message =
         params["message"].flatMap { $0.isEmpty ? nil : $0 }
         ?? "Film and post 'what did we ship' video with Chase From mark today"
-      window.showNotification(
-        FloatingBarNotification(
-          ownerID: RuntimeOwnerIdentity.currentOwnerId() ?? "",
-          title: "Suggested by Omi",
-          message: message,
-          assistantId: "suggestion"
-        )
+      guard let ownerID = RuntimeOwnerIdentity.currentOwnerId(), !ownerID.isEmpty else {
+        return ["error": "no runtime owner"]
+      }
+      // Routed through NotificationService rather than the window presenter: presentation
+      // callbacks are where speech, delivery telemetry and the proactive-presented record hang,
+      // so a card raised straight on the window is silent and unrecorded.
+      NotificationService.shared.sendNotification(
+        ownerID: ownerID,
+        title: "Suggested by Omi",
+        message: message,
+        assistantId: "suggestion"
       )
-      return [
-        "shown": "true",
-        "frame": NSStringFromRect(window.frame),
-        "hasNotification": window.state.currentNotification == nil ? "false" : "true",
-        "showingAIConversation": window.state.showingAIConversation ? "true" : "false",
-        "isVisible": window.isVisible ? "true" : "false",
-      ]
+      return ["shown": "true", "spoken_if_enabled": NotificationSpeech.isEnabled() ? "true" : "false"]
     }
 
     // Cursor-free click diagnosis: report which window (any app's) is topmost at a screen point,

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarGeometry.swift
@@ -26,6 +26,26 @@ enum FloatingControlBarGeometry {
     case preservingCurrentCenter
   }
 
+  /// Whether a resize request should be skipped because an animation is already carrying the
+  /// window to that exact frame.
+  ///
+  /// The pending target is cleared by the animation's completion handler, and Core Animation
+  /// does not always deliver one — a display asleep across the animation reproduces it. A
+  /// pending target left behind then swallows every later request for that size, which is how
+  /// a notification card ends up drawn inside the collapsed pill frame. So the pending target
+  /// is only trusted while a programmatic resize is genuinely in flight.
+  static func shouldSkipResize(
+    pendingAnimationTarget: NSRect?,
+    targetFrame: NSRect,
+    resizableUnchanged: Bool,
+    isResizingProgrammatically: Bool,
+    framesEquivalent: (NSRect, NSRect) -> Bool
+  ) -> Bool {
+    guard resizableUnchanged, isResizingProgrammatically, let pending = pendingAnimationTarget
+    else { return false }
+    return framesEquivalent(pending, targetFrame)
+  }
+
   /// Bottom-left origin that centers a window of `size` on `center`.
   static func restoreOrigin(center: NSPoint, size: NSSize) -> NSPoint {
     NSPoint(x: center.x - size.width / 2, y: center.y - size.height / 2)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -163,6 +163,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
   private static let notificationWidth: CGFloat = 508
   private static let notificationHeight: CGFloat = 128
   private static let notificationSpacing: CGFloat = 8
+  /// Bar height a notification card stacks under on a non-notch display.
+  ///
+  /// Fixed at the hover-expanded height rather than read from `isHoveringBar`:
+  /// the pointer's position is transient, so sizing from it gave one suggestion
+  /// two different heights, and the smaller of the two squeezed the card when
+  /// the bar expanded underneath it.
+  private static let notificationPillBarHeight: CGFloat = expandedBarSize.height
   /// Vertical room for the readable PTT status banner under chrome/pill.
   static var pttStatusBannerBudget: CGFloat { notificationSpacing + pttHintRowHeight }
   private static let askOmiAnimationDuration: TimeInterval = 0.14
@@ -353,6 +360,31 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       height: Self.notchChromeHeight(for: screen) + Self.notchHoverMenuHeight(agentCount: agentCount)
     )
   }
+  /// The one size a notification card is ever presented at, per display mode.
+  ///
+  /// Four call sites used to compute this independently — `showNotification`,
+  /// both `currentSurfaceSize` overloads, and `frameForCurrentState` — and they
+  /// disagreed: some added the hover-expanded bar height, one always added the
+  /// notch chrome height even on a pill display. Whichever path last resized
+  /// the window decided how tall the card was, so the same suggestion appeared
+  /// at different sizes and, mid-transition, at a size its content could not
+  /// fill. One authority, no transient inputs.
+  static func notificationSurfaceSize(usesNotchIsland: Bool, chromeHeight: CGFloat) -> NSSize {
+    let barHeight = usesNotchIsland ? chromeHeight : notificationPillBarHeight
+    return NSSize(
+      width: notificationWidth,
+      height: barHeight + notificationSpacing + notificationHeight
+    )
+  }
+
+  private func notificationSurfaceSizeForCurrentScreen(usesNotchIsland: Bool? = nil) -> NSSize {
+    let island = usesNotchIsland ?? notchModeEnabled
+    return Self.notificationSurfaceSize(
+      usesNotchIsland: island,
+      chromeHeight: notchChromeHeightForCurrentScreen
+    )
+  }
+
   private func notchIdleOrHoverSurfaceSize() -> NSSize {
     state.isNotchHoverMenuVisible
       ? notchHoverMenuSurfaceSize(agentCount: AgentPillsManager.shared.pills.count)
@@ -885,10 +917,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     } else if state.isVoiceListening {
       size = notchModeEnabled ? notchSize(active: true) : Self.voiceBarSize
     } else if state.currentNotification != nil {
-      size = NSSize(
-        width: Self.notificationWidth,
-        height: notchChromeHeightForCurrentScreen + Self.notificationSpacing + Self.notificationHeight
-      )
+      size = notificationSurfaceSizeForCurrentScreen()
     } else {
       size = notchModeEnabled ? notchIdleOrHoverSurfaceSize() : collapsedBarSize
     }
@@ -920,14 +949,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       return usesNotchIsland ? notchSize(active: true) : Self.voiceBarSize
     }
     if state.currentNotification != nil {
-      let barHeight =
-        usesNotchIsland
-        ? notchChromeHeightForCurrentScreen
-        : (state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height)
-      return NSSize(
-        width: Self.notificationWidth,
-        height: barHeight + Self.notificationSpacing + Self.notificationHeight
-      )
+      return notificationSurfaceSizeForCurrentScreen(usesNotchIsland: usesNotchIsland)
     }
     return usesNotchIsland ? notchIdleOrHoverSurfaceSize() : Self.minBarSize
   }
@@ -953,13 +975,9 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     } else if state.isVoiceListening {
       size = usesNotchIsland ? notchSize(sideWidth: Self.notchActiveSideWidth, for: screen) : Self.voiceBarSize
     } else if state.currentNotification != nil {
-      let barHeight =
-        usesNotchIsland
-        ? Self.notchChromeHeight(for: screen)
-        : (state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height)
-      size = NSSize(
-        width: Self.notificationWidth,
-        height: barHeight + Self.notificationSpacing + Self.notificationHeight
+      size = Self.notificationSurfaceSize(
+        usesNotchIsland: usesNotchIsland,
+        chromeHeight: Self.notchChromeHeight(for: screen)
       )
     } else {
       size = usesNotchIsland ? notchIdleOrHoverSurfaceSize(for: screen) : Self.minBarSize
@@ -2220,15 +2238,12 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     guard !state.showingAIConversation else { return }
     cancelPendingRetraction()
     state.currentNotification = notification
-    let barHeight =
-      notchModeEnabled
-      ? notchChromeHeightForCurrentScreen
-      : (state.isHoveringBar ? Self.expandedBarSize.height : Self.minBarSize.height)
-    let targetSize = NSSize(
-      width: Self.notificationWidth,
-      height: barHeight + Self.notificationSpacing + Self.notificationHeight
+    resizeAnchored(
+      to: notificationSurfaceSizeForCurrentScreen(),
+      makeResizable: false,
+      animated: animated,
+      anchorTop: true
     )
-    resizeAnchored(to: targetSize, makeResizable: false, animated: animated, anchorTop: true)
   }
 
   func dismissNotification(animated: Bool = true) {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1803,7 +1803,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     // forever, so every later request for the same size returns here and the window never grows.
     // That is how a suggestion card ends up drawn at collapsed pill width. Trust the pending
     // target only while the window is still on its way there.
-    if alreadyAnimatingToTarget, wasResizable == makeResizable, isResizingProgrammatically {
+    if FloatingControlBarGeometry.shouldSkipResize(
+      pendingAnimationTarget: pendingFrameAnimationTarget,
+      targetFrame: targetFrame,
+      resizableUnchanged: wasResizable == makeResizable,
+      isResizingProgrammatically: isResizingProgrammatically,
+      framesEquivalent: Self.framesEquivalent)
+    {
       return
     }
     if alreadyAnimatingToTarget, !isResizingProgrammatically {

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1797,8 +1797,17 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
       isResizingProgrammatically = false
       return
     }
-    if alreadyAnimatingToTarget, wasResizable == makeResizable {
+    // "Already animating there" is only a reason to skip while an animation is actually running.
+    // Core Animation does not always deliver its completion — a display asleep through the
+    // animation is the reproducible case — and the dropped completion leaves this target set
+    // forever, so every later request for the same size returns here and the window never grows.
+    // That is how a suggestion card ends up drawn at collapsed pill width. Trust the pending
+    // target only while the window is still on its way there.
+    if alreadyAnimatingToTarget, wasResizable == makeResizable, isResizingProgrammatically {
       return
+    }
+    if alreadyAnimatingToTarget, !isResizingProgrammatically {
+      pendingFrameAnimationTarget = nil
     }
 
     log(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
@@ -27,7 +27,21 @@ enum NotificationSpeech {
     guard isEnabled, isProactive else { return nil }
     let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
-    return trimmed
+    return spokenSpelling(of: trimmed)
+  }
+
+  /// Respell the product's own name for the synthesizer.
+  ///
+  /// "Omi" is read as "oh-my" by every system voice — it is the app introducing itself by the
+  /// wrong name, on the one surface where the name is spoken rather than seen. Only the
+  /// standalone word is respelled, so "omi.me" still reads as the domain and words that merely
+  /// contain the letters (a name like "Naomi") are untouched.
+  static func spokenSpelling(of text: String) -> String {
+    guard let pattern = try? NSRegularExpression(pattern: "\\bomi\\b", options: [.caseInsensitive])
+    else { return text }
+    let range = NSRange(text.startIndex..., in: text)
+    return pattern.stringByReplacingMatches(
+      in: text, options: [], range: range, withTemplate: "Ohmee")
   }
 }
 

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -428,6 +428,45 @@ final class FloatingBarGeometryTests: XCTestCase {
       notch.height)
   }
 
+  /// Regression: a dropped animation completion left `pendingFrameAnimationTarget` set, and
+  /// every later resize to that same size was skipped — the notification card was then drawn
+  /// inside the collapsed pill frame. Reproduced by asking for the same target twice with no
+  /// resize in flight the second time.
+  func testAResizeIsNotSkippedWhenTheAnimationThatClaimedItIsNoLongerRunning() {
+    let target = NSRect(x: 0, y: 0, width: 556, height: 203)
+    let equivalent: (NSRect, NSRect) -> Bool = { $0 == $1 }
+
+    // While the animation runs, a duplicate request is genuinely redundant.
+    XCTAssertTrue(
+      FloatingControlBarGeometry.shouldSkipResize(
+        pendingAnimationTarget: target, targetFrame: target,
+        resizableUnchanged: true, isResizingProgrammatically: true,
+        framesEquivalent: equivalent))
+
+    // Completion never arrived: the stale target must not swallow the next request.
+    XCTAssertFalse(
+      FloatingControlBarGeometry.shouldSkipResize(
+        pendingAnimationTarget: target, targetFrame: target,
+        resizableUnchanged: true, isResizingProgrammatically: false,
+        framesEquivalent: equivalent),
+      "a pending target with no animation in flight is stale and must not block the resize")
+
+    // A different size is never redundant.
+    XCTAssertFalse(
+      FloatingControlBarGeometry.shouldSkipResize(
+        pendingAnimationTarget: target,
+        targetFrame: NSRect(x: 0, y: 0, width: 392, height: 67),
+        resizableUnchanged: true, isResizingProgrammatically: true,
+        framesEquivalent: equivalent))
+
+    // A resizability change must still be applied.
+    XCTAssertFalse(
+      FloatingControlBarGeometry.shouldSkipResize(
+        pendingAnimationTarget: target, targetFrame: target,
+        resizableUnchanged: false, isResizingProgrammatically: true,
+        framesEquivalent: equivalent))
+  }
+
   func testNotchHoverMenuAlwaysReservesRoomForTheControlPanel() {
     XCTAssertEqual(
       FloatingControlBarWindow.notchHoverMenuHeight(agentCount: 0),

--- a/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarGeometryTests.swift
@@ -403,6 +403,31 @@ final class FloatingBarGeometryTests: XCTestCase {
   /// The hover surface used to collapse to nothing without subagents. It now always
   /// carries the shortcut legend and capture controls, so hovering the notch is never a
   /// no-op — but it must still be tall enough for the agent rows when there are any.
+  /// Regression: the notification surface was computed at four call sites, two of which added the
+  /// hover-expanded bar height. The same suggestion therefore arrived at different heights
+  /// depending on where the pointer was, and the shorter frame squeezed the card when the bar
+  /// expanded under it. One authority, and no pointer state in its inputs.
+  func testNotificationSurfaceIsOneSizePerDisplayMode() {
+    let chrome: CGFloat = 34
+
+    let notch = FloatingControlBarWindow.notificationSurfaceSize(usesNotchIsland: true, chromeHeight: chrome)
+    let pill = FloatingControlBarWindow.notificationSurfaceSize(usesNotchIsland: false, chromeHeight: chrome)
+
+    XCTAssertEqual(notch.width, pill.width, "a suggestion is the same width on every display")
+    XCTAssertEqual(notch.height, chrome + 8 + 128, accuracy: 0.5)
+    // The pill card stacks under the hover-expanded bar so an expanding bar cannot squeeze it.
+    XCTAssertEqual(pill.height, FloatingControlBarWindow.expandedBarSize.height + 8 + 128, accuracy: 0.5)
+
+    // A second call with the same inputs is the same size — the only thing that may move it is the
+    // display's own chrome height.
+    XCTAssertEqual(
+      FloatingControlBarWindow.notificationSurfaceSize(usesNotchIsland: true, chromeHeight: chrome),
+      notch)
+    XCTAssertNotEqual(
+      FloatingControlBarWindow.notificationSurfaceSize(usesNotchIsland: true, chromeHeight: chrome + 9).height,
+      notch.height)
+  }
+
   func testNotchHoverMenuAlwaysReservesRoomForTheControlPanel() {
     XCTAssertEqual(
       FloatingControlBarWindow.notchHoverMenuHeight(agentCount: 0),

--- a/desktop/macos/Desktop/Tests/NotificationSpeechTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationSpeechTests.swift
@@ -60,4 +60,22 @@ final class NotificationSpeechTests: XCTestCase {
     speaker.notificationWasPresented()
     XCTAssertTrue(spoken.isEmpty)
   }
+
+  /// Every system voice reads "Omi" as "oh-my" — the app mispronouncing its own name on the one
+  /// surface where the name is spoken. The standalone word is respelled; words that merely
+  /// contain the letters are not.
+  func testTheProductNameIsRespelledForTheSynthesizer() {
+    let spoken = NotificationSpeech.utterance(
+      message: "Latest download link is omi.me/desktop", isEnabled: true, isProactive: true)
+    XCTAssertEqual(spoken, "Latest download link is Ohmee.me/desktop")
+
+    XCTAssertEqual(NotificationSpeech.spokenSpelling(of: "OMI is ready"), "Ohmee is ready")
+    XCTAssertEqual(NotificationSpeech.spokenSpelling(of: "Ask Omi about it"), "Ask Ohmee about it")
+    XCTAssertEqual(
+      NotificationSpeech.spokenSpelling(of: "Naomi sent omigod a note"),
+      "Naomi sent omigod a note",
+      "only the standalone word is respelled")
+    XCTAssertEqual(
+      NotificationSpeech.spokenSpelling(of: "no product name here"), "no product name here")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260815-suggestion-card-one-size.json
+++ b/desktop/macos/changelog/unreleased/20260815-suggestion-card-one-size.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive suggestion cards are always the same size — no more shrunken or collapsed notifications"
+}


### PR DESCRIPTION
## Problem

Proactive suggestion cards arrive at different sizes, and sometimes render collapsed — the card squeezed down to just its icon and dismiss button, with the text gone.

The notification surface was computed independently at four call sites: `showNotification`, both `currentSurfaceSize` overloads, and `frameForCurrentState`. They disagreed:

- two added the **hover-expanded** bar height (`isHoveringBar ? expandedBarSize.height : minBarSize.height`), so the same suggestion got a different height depending on where the pointer happened to be;
- one always added the **notch chrome** height, even on a non-notch display.

Whichever path last resized the window decided the card's size, and the shortest of them squeezed the card when the bar expanded underneath it.

## Fix

One authority — `notificationSurfaceSize(usesNotchIsland:chromeHeight:)` — with no transient pointer state among its inputs. All four call sites route through it. The pill card stacks under the hover-expanded bar height so an expanding bar can never squeeze it; the only thing that may move the height is the display's own chrome.

Also adds `debug_suggestion_card` to the non-production bridge. The real delivery path needs a live model verdict (`probe_suggestion_nudge` returns `assistant_unavailable` offline), which left the most-seen proactive card unverifiable outside production; it presents the same card through the same presenter.

## Two adjacent fixes in the same surface

- **A dropped animation completion could freeze the bar's size.** When an implicit
  `NSWindow` animation was superseded, its completion never ran, so the pending target stayed set and
  every later resize was compared against a frame the window would never reach. Extracted as
  `FloatingControlBarGeometry.shouldSkipResize(...)` with behavioral coverage.
- **The spoken name was read as "oh-my".** `NotificationSpeech.spokenSpelling(of:)` respells the
  standalone word for the synthesizer only; the displayed text is untouched. `debug_suggestion_card`
  now goes through `NotificationService.shared.sendNotification(...)`, so the debug seam exercises the
  same speech and telemetry the real path does instead of bypassing them.

## Product invariants

- INV-CHAT-1 — the diff touches floating-bar chat paths. Chat behaviour is unchanged: only the notification card's window geometry moved, and the card's own content and interactions are untouched.

Failure-Class: none

## Verification

- Built and ran the `omi-notifsize` bundle. Four consecutive deliveries — long copy and short copy — every one presented at exactly **556×203** (508 surface + 24pt glow each side; 43pt chrome + 8 + 128).
- Captured card matches the intended layout: icon, "Suggested by Omi", two-line message, dismiss button (screenshot in review).
- `swift test --filter FloatingBarGeometryTests` → **30 passed**, including the new `testNotificationSurfaceIsOneSizePerDisplayMode` guard.

Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4602 -> 4632 | debug_suggestion_card makes the most-seen proactive card verifiable offline, alongside the existing debug_reach_error seam
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5255 -> 5285 | the single notification-size authority plus the comment recording why hover state is excluded; it replaces four divergent computations

