### PR TITLE
test(desktop): repair five deterministically failing desktop Swift suites

### DIFF
--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -1164,10 +1164,20 @@ import XCTest
     )
     XCTAssertFalse(source.contains("viewportResizeDetector"))
     XCTAssertFalse(source.contains("handleViewportSizeChange"))
-    // omi-test-quality: source-inspection -- static contract: geometry inside
-    // the LazyVStack must not feed transcript layout values back into state;
-    // the behavioral scroll coverage lives in ChatScrollLiveEdgeTests.
-    XCTAssertFalse(source.contains(".onGeometryChange(for: "))
+    // omi-test-quality: source-inspection -- static contract: measured transcript geometry must
+    // not re-enter this view's observed state; the behavioral scroll coverage lives in
+    // ChatScrollLiveEdgeTests and the rail's in ChatPromptTimelineTests.
+    //
+    // The claim is that geometry never re-enters *this view's* state, not that the transcript
+    // never measures itself. A blanket ban on `.onGeometryChange` stood in for that while the
+    // prompt rail was deleted; the rail is back and measures rows again, but it writes into
+    // `ChatTranscriptGeometry`, which this view holds as a plain `@State` reference and therefore
+    // does not observe — only the rail overlay does. Assert the facts that actually close the
+    // layout loop rather than the mechanism that happened to be absent.
+    XCTAssertFalse(source.contains(".onGeometryChange(for: ChatTranscriptContentFrame.self)"))
+    XCTAssertTrue(source.contains("@State private var transcriptGeometry = ChatTranscriptGeometry()"))
+    XCTAssertFalse(source.contains("@StateObject private var transcriptGeometry"))
+    XCTAssertFalse(source.contains("@ObservedObject private var transcriptGeometry"))
     // omi-test-quality: source-inspection -- static contract: a local send may
     // enter follow mode, but must never clear the reader's in-flight gesture
     // latch to do it; the behavioral coverage is in

--- a/desktop/macos/Desktop/Tests/GlassSurfaceReviewRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/GlassSurfaceReviewRegressionTests.swift
@@ -57,15 +57,20 @@ final class GlassSurfaceReviewRegressionTests: XCTestCase {
       panel
     }
 
+    // Inside the corner's curve the returned content is on the panel. This is the control: without
+    // it a harness that rendered nothing at all would sail through the clip assertion below.
+    let insideTheCorner = try renderedColor(canvas, size: canvasSize, at: CGPoint(x: 90, y: 90))
+    XCTAssertTrue(
+      isReturnedRedContent(insideTheCorner),
+      "the returned red content must paint inside the panel's rounded corner")
+
+    // …and eight points further out, past the curve, the same rectangle must be gone. Asserted as
+    // "not the returned red" rather than as a colour: what is left there is the panel's own glass,
+    // whose lightness belongs to the appearance and is not a fact this test may depend on.
     let clippedCorner = try renderedColor(canvas, size: canvasSize, at: CGPoint(x: 98, y: 98))
-    XCTAssertLessThan(
-      clippedCorner.greenComponent,
-      0.5,
+    XCTAssertFalse(
+      isReturnedRedContent(clippedCorner),
       "the returned red content must not paint through the panel's rounded corner")
-    XCTAssertLessThan(
-      clippedCorner.redComponent - clippedCorner.greenComponent,
-      0.25,
-      "the clipped corner should be the glass/background, not the returned red overlay")
 
     let outerOverlay = try renderedColor(canvas, size: canvasSize, at: CGPoint(x: 108, y: 108))
     XCTAssertGreaterThan(outerOverlay.blueComponent, 0.6)
@@ -87,11 +92,36 @@ final class GlassSurfaceReviewRegressionTests: XCTestCase {
     }
   }
 
+  /// Whether a pixel is the test's red rectangle rather than glass, the blue overlay, or nothing.
+  ///
+  /// A channel comparison instead of an absolute level: `inkGlassPanel` pins its own colour scheme
+  /// and its ground is a system colour, so "how light is the glass" is not something this test may
+  /// assert — but "is this pixel dominated by red" is true of the rectangle under any appearance
+  /// and false of every neutral.
+  private func isReturnedRedContent(_ color: NSColor) -> Bool {
+    color.alphaComponent > 0.5
+      && color.redComponent - color.greenComponent > 0.25
+      && color.redComponent - color.blueComponent > 0.25
+  }
+
+  /// Renders through a real `NSHostingView` rather than through `ImageRenderer`.
+  ///
+  /// `inkGlassPanel` mounts `InkGlassHitRegionReporter`, an `NSViewRepresentable`, so the panel
+  /// keeps the pointer inside the window's ownership. `ImageRenderer` cannot draw a representable:
+  /// it substitutes a placeholder graphic for the whole panel, and every pixel read back then
+  /// describes the placeholder instead of the glass — which is silent, because a placeholder still
+  /// has colours to assert against. An AppKit view hierarchy draws the real surface.
   private func renderedColor(_ view: some View, size: CGSize, at point: CGPoint) throws -> NSColor {
-    let renderer = ImageRenderer(content: view.frame(width: size.width, height: size.height))
-    renderer.scale = 1
-    guard let image = renderer.cgImage else {
-      throw XCTSkip("ImageRenderer did not produce an image for the SwiftUI glass surface")
+    let host = NSHostingView(rootView: view.frame(width: size.width, height: size.height))
+    host.frame = NSRect(origin: .zero, size: size)
+    host.layoutSubtreeIfNeeded()
+
+    guard let representation = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+      throw XCTSkip("AppKit did not vend a bitmap for the SwiftUI glass surface")
+    }
+    host.cacheDisplay(in: host.bounds, to: representation)
+    guard let image = representation.cgImage else {
+      throw XCTSkip("The cached glass surface bitmap carried no image")
     }
 
     var pixels = [UInt8](repeating: 0, count: image.width * image.height * 4)
@@ -108,10 +138,15 @@ final class GlassSurfaceReviewRegressionTests: XCTestCase {
     else {
       throw XCTSkip("Could not create an image inspection context")
     }
-    context.draw(image, in: CGRect(origin: .zero, size: size))
+    context.draw(
+      image,
+      in: CGRect(origin: .zero, size: CGSize(width: image.width, height: image.height)))
 
-    let x = min(max(Int(point.x), 0), image.width - 1)
-    let y = min(max(Int(point.y), 0), image.height - 1)
+    // The bitmap comes back at the display's backing scale, which is not this test's to choose, so
+    // the probe point stays in points and is converted here.
+    let scale = CGFloat(image.width) / size.width
+    let x = min(max(Int(point.x * scale), 0), image.width - 1)
+    let y = min(max(Int(point.y * scale), 0), image.height - 1)
     let offset = (y * image.width + x) * 4
     return NSColor(
       srgbRed: CGFloat(pixels[offset]) / 255,

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -275,6 +275,18 @@ final class ProactiveLaneClientTests: XCTestCase {
     try await complete(operation: ModelQoS.Proactivity.reasoningOperation, prompt: "reason", on: client)
   }
 
+  /// Two 429s that were already in flight together must leave the *longer* window armed.
+  ///
+  /// Both attempts have to reach the network for the shorter window to be able to shorten
+  /// anything, and once a cooldown is armed the client refuses the next attempt before it sends —
+  /// so a second *sequential* attempt could never carry a competing Retry-After. Overlapping calls
+  /// are the only way the two windows race, which is exactly the reentrancy `armQuotaCooldown`
+  /// guards: `complete` suspends at the request, letting a second call past the cooldown check
+  /// before the first has armed anything.
+  ///
+  /// Held open deterministically rather than by hoping the two calls interleave: the stub parks
+  /// every request until both are in flight, so both are guaranteed past the cooldown check before
+  /// either response — and therefore either `armQuotaCooldown` — is delivered.
   func testLaterShorterRetryWindowDoesNotShortenActiveCooldown() async throws {
     ProactiveLaneURLStub.reset()
     let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))
@@ -284,30 +296,54 @@ final class ProactiveLaneClientTests: XCTestCase {
       authorization: { "Bearer test" },
       now: { clock.now })
 
-    // First 429 arms a long cooldown (300s).
+    // A long window (300s) and a much shorter one (60s), racing on the same operation.
     ProactiveLaneURLStub.enqueue(
       statusCode: 429, body: Data(), headers: ["Retry-After": "300"])
-    do {
-      _ = try await completeExtraction(on: client)
-      XCTFail("expected 429")
-    } catch ProactiveLaneClientError.http(_, _) {}
-
-    // A second overlapping 429 with a much shorter window must not shorten it.
     ProactiveLaneURLStub.enqueue(
       statusCode: 429, body: Data(), headers: ["Retry-After": "60"])
-    do {
-      _ = try await completeExtraction(on: client)
-      XCTFail("expected quota cooldown")
-    } catch ProactiveLaneClientError.quotaCooldown(_) {}
+    let bothInFlight = expectation(description: "both extraction attempts reached the network")
+    ProactiveLaneURLStub.holdRequests(until: 2, reaching: bothInFlight)
 
-    XCTAssertEqual(ProactiveLaneURLStub.requestCount, 2)
+    // Captures only the client, never the test case: an `async let` may not send a non-Sendable
+    // XCTestCase across the concurrency boundary, so the outcomes come back as values.
+    @Sendable func attemptExtraction() async -> Error? {
+      do {
+        _ = try await client.complete(
+          operation: ModelQoS.Proactivity.extractionOperation,
+          prompt: "extract",
+          jsonSchema: ["type": "object"])
+        return nil
+      } catch {
+        return error
+      }
+    }
+
+    async let first = attemptExtraction()
+    async let second = attemptExtraction()
+    await fulfillment(of: [bothInFlight], timeout: 5)
+    ProactiveLaneURLStub.releaseHeldRequests()
+    for outcome in await [first, second] {
+      guard case ProactiveLaneClientError.http(let status, _)? = outcome else {
+        XCTFail("expected both overlapping attempts to see the server's 429, got \(String(describing: outcome))")
+        continue
+      }
+      XCTAssertEqual(status, 429)
+    }
+
+    XCTAssertEqual(
+      ProactiveLaneURLStub.requestCount, 2,
+      "both overlapping attempts must have reached the network, or nothing raced")
 
     // Advance 70s — past the short window but inside the long one.
     clock.advance(by: 70)
     do {
       _ = try await completeExtraction(on: client)
       XCTFail("expected quota cooldown — longer deadline must be preserved")
-    } catch ProactiveLaneClientError.quotaCooldown(_) {}
+    } catch ProactiveLaneClientError.quotaCooldown(_) {
+      // Still inside the 300s window the first response asked for.
+    } catch {
+      XCTFail("the shorter window won: extraction left cooldown early with \(error)")
+    }
 
     XCTAssertEqual(
       ProactiveLaneURLStub.requestCount, 2,
@@ -377,6 +413,11 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
   private nonisolated(unsafe) static var responses: [StubResponse] = []
   private nonisolated(unsafe) static var served = 0
   private nonisolated(unsafe) static var operations: [String] = []
+  /// How many requests must be in flight before any of them is answered, if the caller asked for
+  /// that. Nil is the ordinary case: answer each request as it arrives.
+  private nonisolated(unsafe) static var holdThreshold: Int?
+  private nonisolated(unsafe) static var holdReached: XCTestExpectation?
+  private nonisolated(unsafe) static var held: [() -> Void] = []
 
   static var requestCount: Int {
     lock.lock()
@@ -395,7 +436,32 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     responses = []
     served = 0
     operations = []
+    holdThreshold = nil
+    holdReached = nil
+    held = []
     lock.unlock()
+  }
+
+  /// Park every request instead of answering it until `count` of them have been issued, then
+  /// fulfill `expectation`. This is a synchronisation point, not a wait: it makes "these calls
+  /// overlapped" a fact the test establishes rather than one it hopes for.
+  static func holdRequests(until count: Int, reaching expectation: XCTestExpectation) {
+    lock.lock()
+    holdThreshold = count
+    holdReached = expectation
+    held = []
+    lock.unlock()
+  }
+
+  /// Answer everything parked by `holdRequests`, and stop parking.
+  static func releaseHeldRequests() {
+    lock.lock()
+    let pending = held
+    held = []
+    holdThreshold = nil
+    holdReached = nil
+    lock.unlock()
+    for deliver in pending { deliver() }
   }
 
   static func enqueue(statusCode: Int, body: Data, headers: [String: String] = [:]) {
@@ -417,7 +483,19 @@ private final class ProactiveLaneURLStub: URLProtocol, @unchecked Sendable {
     Self.operations.append(operation)
     let stub = Self.responses.isEmpty ? nil : Self.responses.removeFirst()
     Self.served += 1
+    let deliver = { self.deliver(stub, for: url) }
+    let isHeld = Self.holdThreshold != nil
+    if isHeld { Self.held.append(deliver) }
+    let reached = Self.holdThreshold.map { Self.served >= $0 } ?? false
+    let holdReached = reached ? Self.holdReached : nil
+    if reached { Self.holdReached = nil }
     Self.lock.unlock()
+
+    holdReached?.fulfill()
+    if !isHeld { deliver() }
+  }
+
+  private func deliver(_ stub: StubResponse?, for url: URL) {
     guard let stub else {
       client?.urlProtocol(self, didFailWithError: URLError(.cannotConnectToHost))
       return

--- a/desktop/macos/Desktop/Tests/RewindSurfaceLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindSurfaceLayoutTests.swift
@@ -63,7 +63,11 @@ final class RewindSurfaceLayoutTests: XCTestCase {
     XCTAssertEqual(RewindSurfaceLayout.panelGap, QueryShellLayout.panelGap)
     XCTAssertEqual(RewindSurfaceLayout.panelCornerRadius, InkGlass.cornerRadius)
     XCTAssertEqual(RewindSurfaceLayout.topGap, PageGlassLaneLayout.topGap)
-    XCTAssertEqual(RewindSurfaceLayout.bottomGap, RewindSurfaceLayout.topGap)
+    // Delegated, not mirrored. The two gaps were the same number until the shell was flushed to its
+    // glass and `PageGlassLaneLayout.bottomGap` became 0 so the resize handle sits on the visible
+    // panel; restating "bottom equals top" here would make Rewind hold its own opinion again, which
+    // is the one thing this section forbids.
+    XCTAssertEqual(RewindSurfaceLayout.bottomGap, PageGlassLaneLayout.bottomGap)
   }
 
   // MARK: - What the mounted panels actually do

--- a/desktop/macos/Desktop/Tests/ShellModalScrimDismissTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellModalScrimDismissTests.swift
@@ -31,34 +31,72 @@ final class ShellModalScrimDismissTests: XCTestCase {
 
   /// **The click that dismisses lands where nothing was painted.**
   ///
-  /// The dim is clamped to the shell's lane, so at any real window width there is a band of
-  /// undimmed desktop-backed glass on either side of it. A barrier clamped to the same lane would
-  /// leave that band inert: the modal would look modal and refuse to close when you clicked beside
-  /// it. Asserted at the far corner *and* in the middle so a barrier that shrank to the paint fails
-  /// on the first while the second still proves the harness can see a tap at all.
+  /// The paint is inset from its host; the barrier is not. A barrier that shrank to the paint would
+  /// leave the inset band inert: the modal would look modal and refuse to close when you clicked in
+  /// it. Probed in every undimmed band the surface actually has *and* in the middle, so a barrier
+  /// that shrank to the paint fails on the first while the second still proves the harness can see
+  /// a tap at all.
+  ///
+  /// Which band exists is the surface's own arithmetic, not a constant restated here: since the
+  /// shell was flushed to its glass the lane fills the window, so `.wholeShell` has no undimmed
+  /// side band left, while a `.contentArea` surface still leaves the page's top gap above the dim.
+  /// Deriving the probes from `ShellModalScrimLayout` keeps this exercising whichever bands the
+  /// product has rather than the ones it had when this was written.
   func testAClickOutsideThePaintedDimStillRunsTheDismiss() throws {
     let size = Self.hostSize
-    let laneWidth = ShellModalScrimLayout.laneWidth(for: size.width)
-    let sideBand = (size.width - laneWidth) / 2
-    XCTAssertGreaterThan(
-      sideBand, 1,
-      "precondition: the dim is clamped to the lane, so there is undimmed glass beside it")
+    var probed = 0
 
-    for (label, point) in [
-      ("beside the dim", CGPoint(x: sideBand / 2, y: size.height / 2)),
-      ("above the dim", CGPoint(x: size.width / 2, y: size.height - 2)),
-      ("on the dim", CGPoint(x: size.width / 2, y: size.height / 2)),
-    ] {
-      let dismissals = Counter()
+    for bounds in ShellModalScrimBounds.allCases {
+      for (label, point) in undimmedProbes(for: bounds, in: size) {
+        probed += 1
+        let dismissals = Counter()
+        click(
+          at: point,
+          on: ShellModalScrim(onTap: { dismissals.increment() })
+            .shellModalScrimBounds(bounds))
+
+        XCTAssertEqual(
+          dismissals.count, 1,
+          "a click \(label) of a \(bounds) dim must still dismiss the modal — modality covers the "
+            + "host, only the paint is bounded to the surface")
+      }
+
+      let onTheDim = Counter()
       click(
-        at: point,
-        on: ShellModalScrim(onTap: { dismissals.increment() }))
-
+        at: CGPoint(x: size.width / 2, y: size.height / 2),
+        on: ShellModalScrim(onTap: { onTheDim.increment() })
+          .shellModalScrimBounds(bounds))
       XCTAssertEqual(
-        dismissals.count, 1,
-        "a click \(label) must still dismiss the modal — modality covers the host, only the paint "
-          + "is bounded to the surface")
+        onTheDim.count, 1, "a click on a \(bounds) dim must dismiss the modal")
     }
+
+    XCTAssertGreaterThan(
+      probed, 0,
+      "precondition: at least one surface still insets its paint, so there is undimmed host to "
+        + "click; if this ever reaches zero the barrier's extra extent is no longer observable here")
+  }
+
+  /// Points inside `bounds`' host that the dim does **not** paint, derived from the layout itself.
+  private func undimmedProbes(
+    for bounds: ShellModalScrimBounds,
+    in size: CGSize
+  ) -> [(String, CGPoint)] {
+    let sideBand = (size.width - ShellModalScrimLayout.paintedWidth(bounds, in: size.width)) / 2
+    let topBand = ShellModalScrimLayout.topInset(bounds)
+    let bottomBand = ShellModalScrimLayout.bottomInset(bounds)
+
+    var probes: [(String, CGPoint)] = []
+    if sideBand > 1 {
+      probes.append(("beside the dim", CGPoint(x: sideBand / 2, y: size.height / 2)))
+    }
+    // AppKit's origin is bottom-left, so the paint's *top* inset is the band at the high end of y.
+    if topBand > 1 {
+      probes.append(("above the dim", CGPoint(x: size.width / 2, y: size.height - topBand / 2)))
+    }
+    if bottomBand > 1 {
+      probes.append(("below the dim", CGPoint(x: size.width / 2, y: bottomBand / 2)))
+    }
+    return probes
   }
 
   /// …and a dim that is pure decoration must not take the click at all.


### PR DESCRIPTION
## These are not flakes

Five desktop Swift tests were reported as intermittent. They are not: every one of them fails
**100% of the time**, including when its suite is run alone in its own process, so ordering,
parallelism and shared process state are all ruled out.

Measured on `c2458931bf` before this change:

| suite (run alone, `--filter Suite/`) | pass | fail |
| --- | --- | --- |
| `GlassSurfaceReviewRegressionTests` | 0 | 3 |
| `RewindSurfaceLayoutTests` | 0 | 3 |
| `ShellModalScrimDismissTests` | 0 | 3 |
| `ProactiveLaneClientTests` | 0 | 3 |
| `AgentPillLifecycleTests` | 0 | 3 |
| all five together (the reported repro) | 0 | 5 |

The evidence that suggested a flake was a green **Desktop Swift Static & Test Contracts** on
`c2458931bf` 17 minutes after a red one. That run never ran a Swift test: `c2458931bf` touches only
`.github/**`, so `should_run_tests` was false and the `Test desktop Swift app` step is recorded as
`skipped`. The green is real but vacuous, and `main` has in fact been red for these suites since the
commits below landed.

## What actually broke each one

Each failure is a test that outlived the product decision it was written against, or a harness that
silently stopped rendering what it claims to measure.

1. **`RewindSurfaceLayoutTests.testTheGapCornerAndMarginsAreTheProductsOwn`** — asserted
   `bottomGap == topGap`. `1fcb920616` flushed the shell to its glass and set
   `PageGlassLaneLayout.bottomGap` to 0 so AppKit's resize rim sits on the visible panel. The
   section's claim is *delegation*, not equality, so it now asserts `bottomGap` is
   `PageGlassLaneLayout`'s — which is what stops Rewind holding its own opinion about the margin.

2. **`ShellModalScrimDismissTests.testAClickOutsideThePaintedDimStillRunsTheDismiss`** — its
   precondition was that the dim is clamped to a lane narrower than the window. The same commit set
   `DesktopWindowLayoutPolicy.windowInset` to 0, so the lane fills the window and the side band it
   clicked in no longer exists. The claim — *modality is host scale while only the paint is
   bounded* — is still true and still worth holding, so the probes are now derived from
   `ShellModalScrimLayout` itself and run over every `ShellModalScrimBounds`. Today that exercises
   the `.contentArea` top gap; if a lane clamp ever returns, the side band comes back with it for
   free. A guard fails the test if no surface insets its paint at all, so this cannot decay into
   asserting nothing.

3. **`GlassSurfaceReviewRegressionTests.testInkGlassPanelClipsReturnedContentButNotAnOuterOverlay`**
   — the interesting one. `15a51fb985` added `InkGlassHitRegionReporter`, an `NSViewRepresentable`,
   inside `inkGlassPanel` so a glass surface keeps the pointer inside the window. `ImageRenderer`
   cannot draw a representable: it substitutes a placeholder graphic for the **entire panel**, and
   every pixel this test read back described that placeholder rather than the glass. The test was
   not measuring the clip at all — and would not have measured it even had it passed. It now
   renders through a real `NSHostingView` + `cacheDisplay`, converts the probe point at the bitmap's
   backing scale, and asserts the invariant rather than a colour: the returned red rectangle paints
   *inside* the corner's curve (a control, so a harness that renders nothing fails) and is gone 8 pt
   further out. The old `greenComponent < 0.5` assertion was an absolute-lightness proxy that the
   panel's pinned colour scheme makes untrue regardless of the renderer.

4. **`AgentPillLifecycleTests.testSharedChatMessagesOpenAndSendFollowLatest`** — a static contract
   that banned any `.onGeometryChange(for:` in `ChatMessagesView.swift`. That started life
   (`22327060b2`) as the precise pair "no `ChatTranscriptContentFrame` read, no
   `transcriptGeometry.setRowOffset`" and was broadened to the blanket form while the prompt rail was
   deleted. `9294191a61` restored the rail, which measures rows again — but writes into
   `ChatTranscriptGeometry`, which the view holds as a plain `@State` reference and therefore does
   **not** observe; only the rail overlay does. The guard now asserts the facts that actually close
   the `FC-selection-overlay-layout-loop`: no content-frame read back through the transcript's
   layout, and the geometry object is held off the view's observed state (`@State`, never
   `@StateObject`/`@ObservedObject`).

5. **`ProactiveLaneClientTests.testLaterShorterRetryWindowDoesNotShortenActiveCooldown`** — asserted
   that two sequential 429s both reach the network. They cannot: `complete()` checks the cooldown
   *before* it sends, so once the first 429 arms a window the second attempt never leaves the
   process and no competing `Retry-After` can arrive. The guard it means to test
   (`armQuotaCooldown` keeping the later of two deadlines) is only reachable through actor
   reentrancy — two calls already in flight when the responses land. The test now drives exactly
   that, deterministically: the URL stub parks every request until both are in flight, so both are
   guaranteed past the cooldown check before either response is delivered. Verified by mutation —
   deleting the `existing > newDeadline` guard from `ProactiveLaneClient` makes it fail.

**No product behaviour changed.** Every edit is under `desktop/macos/Desktop/Tests/`; the one
product file touched during investigation (`ProactiveLaneClient.swift`, for the mutation check) was
restored byte-for-byte.

## Proof

After the change, on this branch:

| run | pass | fail |
| --- | --- | --- |
| reported combined repro, via `dev-feedback.py --once` | 15 | 0 |
| `ProactiveLaneClientTests\|AgentPillLifecycleTests\|ShellModalScrimDismissTests` | 10 | 0 |
| `RewindSurfaceLayoutTests\|GlassSurfaceReviewRegressionTests` | 10 | 0 |
| `ShellModalScrimDismissTests\|RewindSurfaceLayoutTests\|GlassSurfaceReviewRegressionTests` | 10 | 0 |
| `ProactiveLaneClientTests` alone | 10 | 0 |
| `Glass\|Shell\|Rewind\|Proactive` | 10 | 0 |

Also green: the proactive/desktop gate (`ContextBucket|ContextProactivity|ContextDelivery|
ContextVisit|ContextDestination|ContextSubject|ContextTitle|CandidateSink`) at **148 tests, 0
failures**; `check_desktop_test_quality.py` with debt unchanged at its baseline (54 source-reading
files / 147 sites / 16 waits); `check-main-actor-xctest-hooks.py`; and `pr-preflight` at 18/18.

`OMI_SWIFT_TEST_SUITE_WORKERS=4 ./scripts/swift-test-suites.sh` ran **616 suites** with exactly one
failure, described below. All five suites this PR repairs pass there.

## One unrelated failure the full run surfaced — a real flake, left out of scope

`ChatCitationTests.testRewindCitationFocusIsOneShotAndPreservesExactScreenshotID` fails in the
4-worker run and passes 6/6 alone (real preferences home and a fresh `CFFIXED_USER_HOME`/`TMPDIR`
alike). It is untouched by this diff and predates it.

Unlike the five above it is genuinely non-deterministic: `RewindCitationFocusState.request` silently
*clears* instead of storing whenever `RewindCaptureOwnerSnapshot.capture()` returns nil, and that
happens while the process-global `RewindCaptureOwnerGeneration.transitionActive` flag is set. The
test establishes no owner state and fences nothing, so it depends on whatever the process happens to
be doing. Fixing it means giving it explicit owner setup — which also moves the suite into the
runner's derived sequential cluster — so it belongs in its own change rather than bolted onto a
test-hygiene PR.

## Changelog

No fragment: this is test-only. `desktop/macos/Desktop/Tests/` is an explicit path exemption in
`.github/scripts/check-desktop-changelog.py`, and `changelog/README.md` scopes fragments to
user-facing PRs.

## Follow-up worth doing separately (not in this PR)

`main` carried five deterministically-failing suites without a red required check, because the
`Desktop Swift Static & Test Contracts` job skips the Swift suite whenever a push touches no Swift
paths. A `.github`-only or backend-only commit therefore publishes a green exact-SHA verdict that
says nothing about the tests, and release planning consumes it.

Failure-Class: none
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

