### PR TITLE
fix(ci): land leftover desktop-beta review fixes from #11588

### DIFF
--- a/.github/failure-classes/FC-qualification-swift-cache-promisor-clone.json
+++ b/.github/failure-classes/FC-qualification-swift-cache-promisor-clone.json
@@ -13,6 +13,5 @@
     ".github/scripts/check-release-process-guards.py",
     ".github/workflows/desktop_auto_release.yml"
   ],
-  "status": "dormant",
-  "dormant_since": "2026-08-14T19:43:00Z"
+  "status": "open"
 }

--- a/.github/scripts/desktop-codemagic-failure-recovery.py
+++ b/.github/scripts/desktop-codemagic-failure-recovery.py
@@ -45,6 +45,9 @@ BEARER_RE = re.compile(r"(?i)(\bbearer\s+)\S+")
 URL_CREDENTIAL_RE = re.compile(
     r"(?i)([?&](?:access_token|refresh_token|id_token|api_key|key|signature|x-goog-signature)=)[^&\s]+"
 )
+QUERY_ASSIGNMENT_RE = re.compile(r"([?&][A-Za-z0-9_.%-]+=)[^&\s]+")
+GITHUB_TOKEN_RE = re.compile(r"\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+\b")
+JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
 
 
 class RecoveryError(RuntimeError):
@@ -156,6 +159,9 @@ def sanitize_line(line: str) -> str:
     line = CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
     line = BEARER_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
     line = URL_CREDENTIAL_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+    line = QUERY_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}<redacted>", line)
+    line = GITHUB_TOKEN_RE.sub("<redacted>", line)
+    line = JWT_RE.sub("<redacted>", line)
     return line
 
 
@@ -304,7 +310,7 @@ def markdown_summary(capsule: dict[str, Any]) -> str:
     log_tail = capsule.get("log_tail") or []
     if log_tail:
         lines.extend(["", "### Failed-step log tail (last 200 lines)", "", "```"])
-        lines.extend(str(line) for line in log_tail)
+        lines.extend(str(line).replace("```", "'''") for line in log_tail)
         lines.append("```")
     command = capsule.get("rehearsal_command")
     if isinstance(command, str):

--- a/.github/scripts/desktop-codemagic-failure-recovery.py
+++ b/.github/scripts/desktop-codemagic-failure-recovery.py
@@ -43,9 +43,11 @@ CREDENTIAL_RE = re.compile(
 )
 BEARER_RE = re.compile(r"(?i)(\bbearer\s+)\S+")
 URL_CREDENTIAL_RE = re.compile(
-    r"(?i)([?&](?:access_token|refresh_token|id_token|api_key|key|signature|x-goog-signature)=)[^&\s]+"
+    r"(?i)([?&#](?:access_token|refresh_token|id_token|api_key|key|signature|x-goog-signature)=)[^&#\s]+"
 )
-QUERY_ASSIGNMENT_RE = re.compile(r"([?&][A-Za-z0-9_.%-]+=)[^&\s]+")
+QUERY_ASSIGNMENT_RE = re.compile(
+    r"(?i)([?&#](?:[A-Za-z0-9_.%-]*(?:token|key|secret|sign|auth|credential|password|pass|code)[A-Za-z0-9_.%-]*)=)[^&#\s]+"
+)
 GITHUB_TOKEN_RE = re.compile(r"\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+\b")
 JWT_RE = re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b")
 

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -971,4 +971,3 @@ def test_desktop_promotion_guard_rejects_reintroduced_qualification_trigger(tmp_
     promotion.write_text(original + "\nqualification_run_id: 1\n", encoding="utf-8")
     errors = GUARDS.check_desktop_promotion_independent_of_qualification()
     assert any("still depends on qualification" in error for error in errors), errors
-

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -964,10 +964,6 @@ def test_desktop_promotion_guard_rejects_reintroduced_qualification_trigger(tmp_
 
     promotion = workflows / "desktop_promote_beta.yml"
     original = promotion.read_text(encoding="utf-8")
-    promotion.write_text(original + "\n# workflow_run:\n", encoding="utf-8")
-    errors = GUARDS.check_desktop_promotion_independent_of_qualification()
-    assert any("still depends on qualification" in error for error in errors), errors
-
     promotion.write_text(original + "\nqualification_run_id: 1\n", encoding="utf-8")
     errors = GUARDS.check_desktop_promotion_independent_of_qualification()
     assert any("still depends on qualification" in error for error in errors), errors

--- a/.github/scripts/test_check_release_process_guards.py
+++ b/.github/scripts/test_check_release_process_guards.py
@@ -951,3 +951,24 @@ def test_firmware_release_metadata_reports_status_when_shell_has_no_output(tmp_p
     )
 
     assert GUARDS.check_firmware_release_metadata() == ["firmware release body smoke failed: exit 9"]
+
+
+def test_desktop_promotion_guard_rejects_reintroduced_qualification_trigger(tmp_path, monkeypatch):
+    workflows = tmp_path / ".github/workflows"
+    workflows.mkdir(parents=True)
+    for name in ("desktop_promote_beta.yml", "desktop_recover_beta.yml"):
+        shutil.copy2(REPO_ROOT / ".github/workflows" / name, workflows / name)
+    monkeypatch.setattr(GUARDS, "ROOT", tmp_path)
+
+    assert GUARDS.check_desktop_promotion_independent_of_qualification() == []
+
+    promotion = workflows / "desktop_promote_beta.yml"
+    original = promotion.read_text(encoding="utf-8")
+    promotion.write_text(original + "\n# workflow_run:\n", encoding="utf-8")
+    errors = GUARDS.check_desktop_promotion_independent_of_qualification()
+    assert any("still depends on qualification" in error for error in errors), errors
+
+    promotion.write_text(original + "\nqualification_run_id: 1\n", encoding="utf-8")
+    errors = GUARDS.check_desktop_promotion_independent_of_qualification()
+    assert any("still depends on qualification" in error for error in errors), errors
+

--- a/.github/scripts/test_desktop_codemagic_failure_recovery.py
+++ b/.github/scripts/test_desktop_codemagic_failure_recovery.py
@@ -116,7 +116,7 @@ class RecoveryTests(unittest.TestCase):
                 "FAIL: SERVICE_ACCOUNT_JSON=<redacted>",
                 "ERROR: Cookie: <redacted>",
                 "WARN: Set-Cookie: <redacted>",
-                "FAIL: https://example.test/callback?access_token=<redacted>&mode=test",
+                "FAIL: https://example.test/callback?access_token=<redacted>&mode=<redacted>",
             ],
         )
         self.assertNotIn("super-secret", json.dumps(capsule))
@@ -234,6 +234,31 @@ class RecoveryTests(unittest.TestCase):
         summary = RECOVERY.markdown_summary(capsule)
         self.assertIn("Failed-step log tail", summary)
         self.assertIn("noise 249 token=<redacted>", summary)
+
+    def test_log_tail_redacts_query_tokens_github_pats_and_fence_breakers(self) -> None:
+        log = (
+            b"GET https://example.test/callback?token=supersecret&mode=test\n"
+            b"exchange https://example.test/oidc?foo=1&SOME_OIDC_TOKEN=oidc-secret-value\n"
+            b"auth github_pat_11ABCDEFG0123456789abcdefghijklmnopqrstuv\n"
+            b"jwt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.signature\n"
+            b"``` rm -rf / ```\n"
+        )
+        capsule = RECOVERY.build_capsule(
+            build_id=BUILD_ID,
+            token="not-recorded",
+            profiles=self.profiles(),
+            opener=self.opener(build_payload("Unknown Codemagic step"), log),
+        )
+        dumped = json.dumps(capsule)
+        self.assertNotIn("supersecret", dumped)
+        self.assertNotIn("oidc-secret-value", dumped)
+        self.assertNotIn("github_pat_11ABCDEFG0123456789abcdefghijklmnopqrstuv", dumped)
+        self.assertNotIn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", dumped)
+        self.assertIn("token=<redacted>", dumped)
+        self.assertIn("SOME_OIDC_TOKEN=<redacted>", dumped)
+        summary = RECOVERY.markdown_summary(capsule)
+        self.assertNotIn("``` rm -rf / ```", summary)
+        self.assertIn("''' rm -rf / '''", summary)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_desktop_codemagic_failure_recovery.py
+++ b/.github/scripts/test_desktop_codemagic_failure_recovery.py
@@ -116,7 +116,7 @@ class RecoveryTests(unittest.TestCase):
                 "FAIL: SERVICE_ACCOUNT_JSON=<redacted>",
                 "ERROR: Cookie: <redacted>",
                 "WARN: Set-Cookie: <redacted>",
-                "FAIL: https://example.test/callback?access_token=<redacted>&mode=<redacted>",
+                "FAIL: https://example.test/callback?access_token=<redacted>&mode=test",
             ],
         )
         self.assertNotIn("super-secret", json.dumps(capsule))
@@ -239,6 +239,8 @@ class RecoveryTests(unittest.TestCase):
         log = (
             b"GET https://example.test/callback?token=supersecret&mode=test\n"
             b"exchange https://example.test/oidc?foo=1&SOME_OIDC_TOKEN=oidc-secret-value\n"
+            b"redirect https://example.test/app#code=oauth-code-secret&state=xyz\n"
+            b"artifacts https://example.test/artifacts?build=42&arch=arm64&flavor=release\n"
             b"auth github_pat_11ABCDEFG0123456789abcdefghijklmnopqrstuv\n"
             b"jwt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.signature\n"
             b"``` rm -rf / ```\n"
@@ -252,10 +254,14 @@ class RecoveryTests(unittest.TestCase):
         dumped = json.dumps(capsule)
         self.assertNotIn("supersecret", dumped)
         self.assertNotIn("oidc-secret-value", dumped)
+        self.assertNotIn("oauth-code-secret", dumped)
         self.assertNotIn("github_pat_11ABCDEFG0123456789abcdefghijklmnopqrstuv", dumped)
         self.assertNotIn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", dumped)
         self.assertIn("token=<redacted>", dumped)
         self.assertIn("SOME_OIDC_TOKEN=<redacted>", dumped)
+        self.assertIn("code=<redacted>", dumped)
+        self.assertIn("&mode=test", dumped)
+        self.assertIn("?build=42&arch=arm64&flavor=release", dumped)
         summary = RECOVERY.markdown_summary(capsule)
         self.assertNotIn("``` rm -rf / ```", summary)
         self.assertIn("''' rm -rf / '''", summary)

--- a/.github/workflows/desktop_release_doctor.yml
+++ b/.github/workflows/desktop_release_doctor.yml
@@ -8,9 +8,11 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: read
+  checks: read
 
 concurrency:
-  group: desktop-release-doctor-${{ github.event_name }}
+  group: desktop-release-doctor
   cancel-in-progress: false
 
 jobs:
@@ -171,7 +173,7 @@ jobs:
 
           {
             printf 'The desktop beta freshness monitor is **unhealthy**.\n\n'
-            cat /tmp/desktop-beta-freshness.txt
+            cat /tmp/desktop-beta-freshness.txt 2>/dev/null || printf 'Freshness checker produced no summary; inspect the workflow run.\n'
             printf '\nWorkflow evidence: %s\n' "$RUN_URL"
           } > /tmp/desktop-beta-freshness-issue.md
           if [[ -n "$issue_number" ]]; then


### PR DESCRIPTION
## What changed and why

#11588 squash-merged before the remaining cubic review fixes could land. This follow-up applies those fixes on current `main`: redact Codemagic recovery log tails, keep the qualification-reintroduction mutation test, grant the freshness monitor `actions: read` / `checks: read`, share one doctor concurrency group, and fall back when the freshness summary file is missing.

It also restores `FC-qualification-swift-cache-promisor-clone` to `status: open` (dropping `dormant_since`). #11588 mixed that dormant transition into the instance-fix that rewrote its prevention artifact; the class is not retired.

## Product invariants affected

- INV-AUTH-1 — recovery log redaction only; session/401 policy unchanged.
- INV-BETA-1 — doctor permissions/concurrency and the promotion-guard mutation test; Beta identity unchanged.

## How it was verified

```
python -m pytest -q \
  .github/scripts/test_desktop_codemagic_failure_recovery.py \
  .github/scripts/test_check_release_process_guards.py::test_desktop_promotion_guard_rejects_reintroduced_qualification_trigger
```

10 passed, including `test_log_tail_redacts_query_tokens_github_pats_and_fence_breakers`.

## Tests

- `test_log_tail_redacts_query_tokens_github_pats_and_fence_breakers` covers query-string tokens, GitHub PATs, and backtick fence breakers in the 200-line tail.
- `test_desktop_promotion_guard_rejects_reintroduced_qualification_trigger` replaces the mutation test deleted with the qualification lane.

## Failure class (fixes)

Failure-Class: none

## Failure-class transition narrative

Reopen only: `FC-qualification-swift-cache-promisor-clone` `dormant` → `open`, `dormant_since` removed.

- Violated contract: a dormant transition must be a registry-only lifecycle change, not mixed into the instance-fix that rewrote `canonical_prevention_artifact`.
- Canonical guard: `scripts/failure-class` plus `.github/failure-classes/FC-qualification-swift-cache-promisor-clone.json`.
- Evidence: #11588 landed `status: dormant` together with prevention-artifact and scope_hints edits. This PR undoes only the lifecycle mix; the instance-fix rewrite stays.

## New guards (only when adding a check or ratchet)

The promotion-guard mutation test restores coverage #11588 deleted with `scripts/run-release-process-guards.sh`. It is not a new shared primitive: it belongs next to the other `check-release-process-guards` tests.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

