### PR TITLE
fix(desktop): same task nudge no longer re-fires at Maximum frequency

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -60,7 +60,7 @@ actor SuggestionAssistant: ProactiveAssistant {
   private var pendingWindowTitle: String?
 
   private var lastEvaluationAt: Date?
-  private var recentSuggestions: [String] = []
+  private var recentSuggestions: [SuggestionDeduplication.Remembered] = []
 
   /// The commitments handed to the evaluation currently in flight, kept so delivery can
   /// hold a `commitment` nudge to what the model was actually shown.
@@ -456,7 +456,7 @@ actor SuggestionAssistant: ProactiveAssistant {
     if !recentSuggestions.isEmpty {
       sections.append(
         "== RECENT SUGGESTIONS (do not repeat these) ==\n"
-          + recentSuggestions.joined(separator: "\n")
+          + recentSuggestions.map(\.text).joined(separator: "\n")
       )
     }
 
@@ -524,7 +524,8 @@ actor SuggestionAssistant: ProactiveAssistant {
       hasOwner: ownerID != nil,
       confidence: suggestion.confidence,
       threshold: threshold,
-      isDuplicate: SuggestionDeduplication.isDuplicate(suggestion.suggestion, of: recentSuggestions),
+      isDuplicate: SuggestionDeduplication.isDuplicate(
+        suggestion.suggestion, of: recentSuggestions.map(\.text)),
       isGroundedCommitment: SuggestionCommitmentGuard.isGrounded(
         suggestion: suggestion.suggestion,
         category: suggestion.category,
@@ -563,11 +564,11 @@ actor SuggestionAssistant: ProactiveAssistant {
       return .rejectedOwner
     }
 
-    recentSuggestions.append(suggestion.suggestion)
-    let dedupMemory = SuggestionPacing.dedupMemory(frequencyLevel: cachedFrequencyLevel)
-    if recentSuggestions.count > dedupMemory {
-      recentSuggestions.removeFirst(recentSuggestions.count - dedupMemory)
-    }
+    recentSuggestions = SuggestionDeduplication.remembering(
+      .init(text: suggestion.suggestion, category: suggestion.category),
+      in: recentSuggestions,
+      frequencyLevel: cachedFrequencyLevel
+    )
 
     await deliver(
       suggestion,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionModels.swift
@@ -482,6 +482,39 @@ enum SuggestionDeduplication {
   /// Jaccard overlap at or above this is treated as the same suggestion.
   static let similarityThreshold = 0.6
 
+  /// A delivered suggestion, remembered with its category so trimming can retain task
+  /// nudges at levels whose screen-nudge window is deliberately empty.
+  struct Remembered: Equatable, Sendable {
+    let text: String
+    let category: SuggestionCategory
+  }
+
+  /// The dedup window after remembering a delivery, trimmed per category.
+  ///
+  /// Trimming the whole window to one level-wide depth is how beta 0.12.172 delivered the
+  /// same due-today task three times in quick succession: at Maximum that depth is 0 by
+  /// design (staying on a feed is meant to keep producing fresh screen nudges), so the
+  /// just-delivered task nudge was forgotten before the next evaluation and `isDuplicate`
+  /// had nothing to compare against. Each category keeps its own depth instead, so the
+  /// empty screen-nudge window can never evict a remembered task.
+  static func remembering(
+    _ delivered: Remembered,
+    in window: [Remembered],
+    frequencyLevel: Int
+  ) -> [Remembered] {
+    var kept: [Remembered] = []
+    var counts: [SuggestionCategory: Int] = [:]
+    for entry in (window + [delivered]).reversed() {
+      let depth = SuggestionPacing.dedupMemory(
+        frequencyLevel: frequencyLevel, category: entry.category)
+      if counts[entry.category, default: 0] < depth {
+        kept.append(entry)
+        counts[entry.category, default: 0] += 1
+      }
+    }
+    return kept.reversed()
+  }
+
   static func normalize(_ text: String) -> Set<String> {
     let lowered = text.lowercased()
     let stripped = lowered.map { $0.isLetter || $0.isNumber || $0 == " " ? $0 : " " }
@@ -546,12 +579,16 @@ enum SuggestionPacing {
     frequencyLevel >= maximumLevel ? min(base, 0.65) : base
   }
 
-  /// How many recent suggestions the dedup window remembers. Maximum keeps none: the
-  /// user asked to be nagged about the same commitment for as long as they stay on the
-  /// feed, so repeat-suppression would defeat the level's entire point. Calm levels keep
-  /// the 10-deep window that stops nagging.
-  static func dedupMemory(frequencyLevel: Int) -> Int {
-    frequencyLevel >= maximumLevel ? 0 : 10
+  /// How many recent suggestions the dedup window remembers, per category. Maximum keeps
+  /// none for screen nudges: the user asked to be nagged off the feed for as long as they
+  /// stay on it, so repeat-suppression there would defeat the level's entire point. But a
+  /// commitment nudge is about a task, not the screen, and re-firing the identical task
+  /// every cooldown is a broken record, not the promised cadence — 0.12.172 shipped one
+  /// due-today task three times in a row this way. Commitment nudges therefore keep the
+  /// calm 10-deep window at every level; calm levels keep 10 for everything.
+  static func dedupMemory(frequencyLevel: Int, category: SuggestionCategory) -> Int {
+    if category == .commitment { return 10 }
+    return frequencyLevel >= maximumLevel ? 0 : 10
   }
 
   /// Whether an eligible evaluation leaves the context armed. Calm levels evaluate once

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTests.swift
@@ -274,6 +274,100 @@ final class SuggestionDeduplicationTests: XCTestCase {
   }
 }
 
+/// Field regression, beta 0.12.172: "Lead the call for Nik Shevchenko — it's due today"
+/// was delivered three times in quick succession at Maximum frequency. Dedup ran every
+/// time, but the window it compared against had been trimmed to Maximum's zero screen-nudge
+/// depth right after each delivery, so the identical task nudge escaped as "novel" on every
+/// cycle. These tests drive the same deliver → remember → compare loop the assistant runs.
+final class SuggestionDedupWindowTests: XCTestCase {
+  private let taskNudge = "Lead the call for Nik Shevchenko — it's due today"
+
+  /// One pass of the delivery loop: fire if not a duplicate, then remember what fired.
+  private func deliver(
+    _ text: String,
+    category: SuggestionCategory,
+    window: inout [SuggestionDeduplication.Remembered],
+    level: Int
+  ) -> Bool {
+    guard !SuggestionDeduplication.isDuplicate(text, of: window.map(\.text)) else { return false }
+    window = SuggestionDeduplication.remembering(
+      .init(text: text, category: category), in: window, frequencyLevel: level)
+    return true
+  }
+
+  /// The reproduction: three identical due-today task nudges, ~30s apart, at Maximum.
+  /// Before category-aware retention every one of them fired.
+  func testIdenticalTaskNudgeFiresOnlyOnceAtMaximum() {
+    var window: [SuggestionDeduplication.Remembered] = []
+    var fired = 0
+    for _ in 0..<3 where deliver(taskNudge, category: .commitment, window: &window, level: 5) {
+      fired += 1
+    }
+    XCTAssertEqual(fired, 1, "the same task must not re-fire within its dedup window")
+  }
+
+  /// A genuinely different task is not collateral damage of the repeat suppression.
+  func testDifferentTaskNudgeStillFiresAtMaximum() {
+    var window: [SuggestionDeduplication.Remembered] = []
+    XCTAssertTrue(deliver(taskNudge, category: .commitment, window: &window, level: 5))
+    XCTAssertTrue(
+      deliver(
+        "Send the budget review draft to Adam — due tomorrow",
+        category: .commitment, window: &window, level: 5))
+  }
+
+  /// Maximum's screen-nudge cadence is by design: staying on the feed keeps producing
+  /// repeats, so screen nudges must stay unremembered there — even delivered right after
+  /// a task nudge, which must itself stay remembered.
+  func testMaximumStillRepeatsScreenNudgesAndKeepsTaskMemoryIntact() {
+    var window: [SuggestionDeduplication.Remembered] = []
+    XCTAssertTrue(deliver(taskNudge, category: .commitment, window: &window, level: 5))
+    let screenNudge = "Twenty minutes on the feed — the launch doc is still open"
+    XCTAssertTrue(deliver(screenNudge, category: .opportunity, window: &window, level: 5))
+    XCTAssertTrue(
+      deliver(screenNudge, category: .opportunity, window: &window, level: 5),
+      "Maximum's repeat cadence for screen nudges is the level's contract")
+    XCTAssertFalse(
+      deliver(taskNudge, category: .commitment, window: &window, level: 5),
+      "screen-nudge deliveries must not evict the remembered task")
+  }
+
+  /// Calm levels keep the long-standing 10-deep window for every category.
+  func testCalmLevelsRememberEveryCategory() {
+    for level in [0, 1, 2, 3, 4] {
+      var window: [SuggestionDeduplication.Remembered] = []
+      XCTAssertTrue(deliver(taskNudge, category: .commitment, window: &window, level: level))
+      XCTAssertFalse(deliver(taskNudge, category: .commitment, window: &window, level: level))
+      let screenNudge = "Twenty minutes on the feed — the launch doc is still open"
+      XCTAssertTrue(deliver(screenNudge, category: .opportunity, window: &window, level: level))
+      XCTAssertFalse(deliver(screenNudge, category: .opportunity, window: &window, level: level))
+    }
+  }
+
+  /// The task window is still a window: the eleventh distinct task evicts the first.
+  func testCommitmentMemoryStaysBounded() {
+    var window: [SuggestionDeduplication.Remembered] = []
+    XCTAssertTrue(deliver(taskNudge, category: .commitment, window: &window, level: 5))
+    let distinctTasks = [
+      "Review the quarterly budget spreadsheet before finance sync",
+      "Email Sarah the onboarding checklist",
+      "Renew the office wifi router contract",
+      "Book flights for the Denver conference",
+      "Fix the login crash on older phones",
+      "Water the plants and clean the desk",
+      "Draft a blog post about privacy features",
+      "Schedule the dentist appointment for Thursday",
+      "Upload the podcast episode artwork",
+      "Pay the contractor invoice from July",
+    ]
+    for task in distinctTasks {
+      XCTAssertTrue(deliver(task, category: .commitment, window: &window, level: 5))
+    }
+    XCTAssertEqual(window.count, 10)
+    XCTAssertFalse(window.contains(.init(text: taskNudge, category: .commitment)))
+  }
+}
+
 /// Regression: a live run against a Safari window titled `Start Page (Private Browsing)`
 /// raised `fts5: syntax error near "("` and silently dropped screen-history grounding.
 /// `RewindDatabase.search` does not sanitize its query, so the caller must.
@@ -811,7 +905,10 @@ final class SuggestionPacingTests: XCTestCase {
     XCTAssertEqual(SuggestionPacing.cooldown(base: 180, frequencyLevel: 5), 20)
     XCTAssertEqual(SuggestionPacing.dailyEvaluationBudget(frequencyLevel: 5), 600)
     XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.85, frequencyLevel: 5), 0.65)
-    XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: 5), 0)
+    // Maximum forgets screen nudges instantly (sustained repeats are the level's point)
+    // but never task nudges — the same task re-firing every cooldown is the 0.12.172 bug.
+    XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: 5, category: .opportunity), 0)
+    XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: 5, category: .commitment), 10)
 
     for level in [0, 1, 2, 3, 4] {
       XCTAssertEqual(SuggestionPacing.requiredDwell(frequencyLevel: level), 30)
@@ -819,7 +916,8 @@ final class SuggestionPacingTests: XCTestCase {
       XCTAssertEqual(SuggestionPacing.cooldown(base: 180, frequencyLevel: level), 180)
       XCTAssertEqual(SuggestionPacing.dailyEvaluationBudget(frequencyLevel: level), 40)
       XCTAssertEqual(SuggestionPacing.minConfidence(base: 0.85, frequencyLevel: level), 0.85)
-      XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: level), 10)
+      XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: level, category: .opportunity), 10)
+      XCTAssertEqual(SuggestionPacing.dedupMemory(frequencyLevel: level, category: .commitment), 10)
     }
   }
 

--- a/desktop/macos/changelog/unreleased/20260815-suggestion-task-dedup-repeat.json
+++ b/desktop/macos/changelog/unreleased/20260815-suggestion-task-dedup-repeat.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the same due-task nudge being delivered repeatedly in quick succession at Maximum notification frequency"
+}


### PR DESCRIPTION
<!-- Keep this short and honest. Reviewers read the Verification section first. -->

## What changed and why

Field regression on beta 0.12.172: the task-suggestion surface delivered the identical nudge ("Lead the call for Nik Shevchenko — it's due today") three times in quick succession while the user was composing an email in Gmail, at Maximum notification frequency.

Root cause: `SuggestionPacing.dedupMemory(frequencyLevel:)` returns 0 at Maximum (introduced in 409158becb so screen/focus nudges keep repeating on a feed — the level's demo cadence). But the trim runs on the *whole* `recentSuggestions` window, so a just-delivered task nudge is forgotten before the next evaluation: `SuggestionDeduplication.isDuplicate` (which scores the identical string 1.0, well over the 0.6 Jaccard bar) has nothing to compare against, and the prompt's "RECENT SUGGESTIONS (do not repeat these)" section is empty. With Maximum's re-arm + 20s cooldown the same task re-fires every cycle.

Fix: the dedup window is now trimmed per category. Commitment (task) nudges keep the calm 10-deep window at every level; every other category keeps the existing level behavior — Maximum still forgets screen nudges instantly, so its sustained repeat cadence for focus nudges is untouched. No new settings, no pacing changes.

Note for review: this deliberately narrows 409158becb, which dropped *all* dedup at Maximum after a TikTok trial where repeats were eaten by the duplicate filter. Screen-nudge repeats stay allowed; only the identical task is suppressed until it leaves the 10-deep task window. If the demo cadence needs a small set of open tasks to rotate at Maximum, the task-window depth is a one-line knob in `SuggestionPacing.dedupMemory`.

## Product invariants affected

none

## How it was verified

- `swift test --filter 'Suggestion'` in `desktop/macos/Desktop`: 124 test cases, 0 failures (all Suggestion* suites, including the new `SuggestionDedupWindowTests`).
- Reproduction run: with the pre-fix policy temporarily restored (`dedupMemory` ignoring category), `SuggestionDedupWindowTests` fails exactly as the field bug predicts — `testIdenticalTaskNudgeFiresOnlyOnceAtMaximum`: `XCTAssertEqual failed: ("3") is not equal to ("1")` (three deliveries of the identical nudge), and the task entry is evicted from the window by design-cadence screen deliveries. Restoring the category-aware policy turns the same suite green.
- `scripts/pr-preflight --pr-body-file <this body>`: passed, 20 checks (lane=ci) including failure-class-protocol, desktop-changelog-entry, desktop-e2e-flow-coverage, desktop-test-quality.

Not verified live: I could not reproduce the triple-fire on a real machine in this session (needs a Maximum-frequency install with a due-today task and ~1 minute of dwell); the reproduction is the unit test above, which drives the exact deliver → remember → compare loop `resolveDelivery` runs.

## Tests

- `SuggestionDedupWindowTests.testIdenticalTaskNudgeFiresOnlyOnceAtMaximum` — the reproduction; fails with 3 deliveries under the pre-fix policy (run captured below), passes with 1 after it.
- `testDifferentTaskNudgeStillFiresAtMaximum` — a genuinely different task is not collateral damage.
- `testMaximumStillRepeatsScreenNudgesAndKeepsTaskMemoryIntact` — Maximum's screen-nudge repeat cadence is unchanged and screen deliveries cannot evict the remembered task.
- `testCalmLevelsRememberEveryCategory`, `testCommitmentMemoryStaysBounded` — calm levels unchanged; the task window is still a bounded window.
- `SuggestionPacingTests` updated for the category-aware `dedupMemory` signature.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

