### PR TITLE
fix(desktop): stop task-capture outbox retrying 422-rejected candidates forever

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/ScreenCandidateAdapter.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/ScreenCandidateAdapter.swift
@@ -390,9 +390,86 @@ struct CanonicalScreenCandidateDelivery {
   }
 }
 
+/// Retry classification for canonical capture outbox delivery failures.
+///
+/// Transport failures and server-side conditions (5xx, 401 auth refresh, 409
+/// generation mismatch, 429 throttling) are transient: the same payload can
+/// succeed later, so the outbox row must stay retryable. Validation-class
+/// rejections (400/413/415/422) are deterministic — the payload itself can
+/// never succeed — so retrying them forever only wedges the queue behind
+/// permanently rejected rows.
+enum CandidateOutboxRetryPolicy {
+  /// Permanent validation rejections tolerated before a row is poisoned.
+  /// More than one attempt guards against a backend contract briefly rejecting
+  /// a valid payload mid-deploy; three failures on a deterministic 4xx is
+  /// conclusive.
+  static let maxPermanentRejections = 3
+
+  static func isPermanentRejection(statusCode: Int) -> Bool {
+    switch statusCode {
+    case 400, 413, 415, 422: return true
+    default: return false
+    }
+  }
+
+  static func isPermanentRejection(_ error: Error) -> Bool {
+    guard case APIError.httpError(let statusCode, _) = error else { return false }
+    return isPermanentRejection(statusCode: statusCode)
+  }
+
+  /// Transient failures stay retryable forever; validation-class rejections
+  /// are counted per row and the row is poisoned after a small number of
+  /// attempts so a permanently rejected capture cannot wedge the outbox drain.
+  static func handleDeliveryFailure(_ error: Error, localID: Int64) async {
+    guard isPermanentRejection(error),
+      let outcome = try? await StagedTaskStorage.shared.recordCanonicalOutboxRejection(id: localID)
+    else {
+      logError("Task: Candidate outbox delivery failed; will retry", error: error)
+      return
+    }
+    switch outcome {
+    case .willRetry(let rejections):
+      logError(
+        "Task: Candidate outbox delivery rejected by validation (attempt \(rejections)/\(maxPermanentRejections)); will retry",
+        error: error
+      )
+    case .poisoned(let rejections):
+      logError(
+        "Task: Candidate outbox delivery rejected by validation \(rejections) times; poisoned row \(localID) and stopped retrying",
+        error: error
+      )
+    }
+  }
+}
+
 enum ScreenCandidateAdapter {
   static func idempotencyKey(deviceID: String, localID: Int64) -> String {
     "screen:\(deviceID):\(localID)"
+  }
+
+  /// Canonical task references must be backend StableIds
+  /// (`^[A-Za-z0-9][A-Za-z0-9._:-]*$`, 1–128 chars; keep in sync with
+  /// `backend/models/task_intelligence.py`). The extraction model is asked for
+  /// a task id in `duplicate_of`/`refines_task` but sometimes echoes the
+  /// task's *title* instead. Forwarding that string as `task_id` makes
+  /// POST /v1/candidates fail Pydantic validation (HTTP 422) on every outbox
+  /// retry, forever. Treat any non-conforming reference as absent so the
+  /// capture policy decides create/complete/ignore without a bogus target.
+  static func canonicalTaskReference(_ raw: String?) -> String? {
+    guard let raw, !raw.isEmpty, raw.count <= 128 else { return nil }
+    for (index, scalar) in raw.unicodeScalars.enumerated() {
+      let isAlphanumeric =
+        (scalar >= "A" && scalar <= "Z")
+        || (scalar >= "a" && scalar <= "z")
+        || (scalar >= "0" && scalar <= "9")
+      if index == 0 {
+        guard isAlphanumeric else { return nil }
+      } else {
+        guard isAlphanumeric || scalar == "." || scalar == "_" || scalar == ":" || scalar == "-"
+        else { return nil }
+      }
+    }
+    return raw
   }
 
   static func facts(for task: ExtractedTask) -> ScreenCaptureFacts {
@@ -407,8 +484,8 @@ enum ScreenCandidateAdapter {
       publicBroadcast: task.publicBroadcast ?? false,
       directMention: task.directMention ?? false,
       alreadyDone: task.alreadyDone ?? (kind == "already_done"),
-      duplicateOf: task.duplicateOf,
-      refinesTask: task.refinesTask,
+      duplicateOf: canonicalTaskReference(task.duplicateOf),
+      refinesTask: canonicalTaskReference(task.refinesTask),
       captureConfidence: task.confidence,
       ownershipConfidence: task.ownershipConfidence ?? 0.5
     )

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -758,7 +758,7 @@ actor TaskAssistant: ProactiveAssistant {
         await TaskPromotionService.shared.promoteIfNeeded()
       }
     } catch {
-      logError("Task: Candidate outbox delivery failed; will retry", error: error)
+      await CandidateOutboxRetryPolicy.handleDeliveryFailure(error, localID: localID)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift
@@ -532,6 +532,43 @@ actor StagedTaskStorage {
     }
   }
 
+  enum CanonicalOutboxRejectionOutcome: Equatable {
+    case willRetry(rejections: Int)
+    case poisoned(rejections: Int)
+  }
+
+  /// Records one permanent (validation-class) delivery rejection for an outbox
+  /// row. The count is persisted in the row's metadata so it survives restarts.
+  /// Once the count reaches `limit`, the row is poisoned: marked deleted so
+  /// `getUnsyncedCanonicalOutbox` stops returning it, with a metadata marker
+  /// distinguishing this terminal state from a user delete. A permanently
+  /// rejected payload can never succeed, so retrying it forever only wedges the
+  /// outbox and burns quota on deterministic 4xx responses.
+  func recordCanonicalOutboxRejection(
+    id: Int64,
+    limit: Int = CandidateOutboxRetryPolicy.maxPermanentRejections
+  ) async throws -> CanonicalOutboxRejectionOutcome {
+    let db = try await ensureInitialized()
+    return try await db.write { database in
+      guard var record = try StagedTaskRecord.fetchOne(database, key: id) else {
+        throw ActionItemStorageError.recordNotFound
+      }
+      var metadata = record.metadata ?? [:]
+      let rejections = ((metadata["outbox_permanent_rejections"] as? Int) ?? 0) + 1
+      metadata["outbox_permanent_rejections"] = rejections
+      let poisoned = rejections >= limit
+      if poisoned {
+        metadata["outbox_poisoned"] = true
+        record.completed = true
+        record.deleted = true
+      }
+      record.setMetadata(metadata)
+      record.updatedAt = Date()
+      try record.update(database)
+      return poisoned ? .poisoned(rejections: rejections) : .willRetry(rejections: rejections)
+    }
+  }
+
   func getUnsyncedCanonicalOutbox(limit: Int? = nil) async throws -> [StagedTaskRecord] {
     let db = try await ensureInitialized()
     return try await db.read { database in

--- a/desktop/macos/Desktop/Tests/CandidateOutboxValidationPoisonTests.swift
+++ b/desktop/macos/Desktop/Tests/CandidateOutboxValidationPoisonTests.swift
@@ -1,0 +1,247 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the canonical capture outbox 422 wedge.
+///
+/// The extraction model is asked for a canonical task id in
+/// `duplicate_of`/`refines_task` but sometimes echoes the referenced task's
+/// *title*. The adapter forwarded that string verbatim as `task_id`, the
+/// backend's StableId pattern (`^[A-Za-z0-9][A-Za-z0-9._:-]*$`) rejected it
+/// with HTTP 422, and the outbox drain retried the identical payload forever —
+/// six permanently rejected rows produced a burst of six 422s on every drain.
+/// These tests pin both halves of the fix: non-conforming task references are
+/// treated as absent, and validation-class rejections poison the row after a
+/// bounded number of attempts instead of retrying indefinitely.
+final class CandidateOutboxValidationPoisonTests: XCTestCase {
+
+  // MARK: - Task reference sanitization
+
+  func testCanonicalTaskReferenceRejectsTaskTitles() {
+    // Real values observed wedged in a field outbox: titles, not ids.
+    XCTAssertNil(
+      ScreenCandidateAdapter.canonicalTaskReference(
+        "Fix Omi Windows app time context issue for Schlemosel"))
+    XCTAssertNil(
+      ScreenCandidateAdapter.canonicalTaskReference(
+        "Help Aida implement Apple login option on Omi Windows app"))
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference("Review Omi PR #11580"))
+  }
+
+  func testCanonicalTaskReferenceAcceptsStableIds() {
+    XCTAssertEqual(ScreenCandidateAdapter.canonicalTaskReference("task-budget"), "task-budget")
+    XCTAssertEqual(
+      ScreenCandidateAdapter.canonicalTaskReference("cand_f5777d77f4c68185543a9f12d444af6a"),
+      "cand_f5777d77f4c68185543a9f12d444af6a")
+    XCTAssertEqual(ScreenCandidateAdapter.canonicalTaskReference("screen:dev:42"), "screen:dev:42")
+    XCTAssertEqual(ScreenCandidateAdapter.canonicalTaskReference("a.b-c_d:e"), "a.b-c_d:e")
+  }
+
+  func testCanonicalTaskReferenceEnforcesStableIdShape() {
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference(nil))
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference(""))
+    // First character must be alphanumeric.
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference("-task"))
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference(".hidden"))
+    // Non-ASCII and whitespace are outside the backend pattern.
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference("tâche-1"))
+    XCTAssertNil(ScreenCandidateAdapter.canonicalTaskReference("task 1"))
+    // Backend StableId caps at 128 characters.
+    XCTAssertNil(
+      ScreenCandidateAdapter.canonicalTaskReference(String(repeating: "a", count: 129)))
+    XCTAssertNotNil(
+      ScreenCandidateAdapter.canonicalTaskReference(String(repeating: "a", count: 128)))
+  }
+
+  // MARK: - Adapter behavior with unusable references
+
+  private func makeTask(
+    captureKind: String,
+    alreadyDone: Bool = false,
+    duplicateOf: String? = nil,
+    refinesTask: String? = nil
+  ) -> ExtractedTask {
+    ExtractedTask(
+      title: "Fix Omi Windows app time context issue for Schlemosel",
+      description: nil,
+      priority: .high,
+      sourceApp: "Telegram",
+      inferredDeadline: nil,
+      confidence: 0.9,
+      tags: [],
+      sourceCategory: "direct_request",
+      sourceSubcategory: "commitment",
+      captureKind: captureKind,
+      owner: "user",
+      concreteDeliverable: true,
+      publicBroadcast: false,
+      directMention: true,
+      alreadyDone: alreadyDone,
+      duplicateOf: duplicateOf,
+      refinesTask: refinesTask,
+      ownershipConfidence: 0.95
+    )
+  }
+
+  func testCompletionAgainstTitleReferenceProducesNoCandidate() throws {
+    // already_done + a title-valued refines_task used to build a
+    // TaskCompleteCandidate whose task_id could never validate (HTTP 422).
+    // With the reference treated as absent there is no completion target, so
+    // the adapter must return no candidate; the outbox drain then discards the
+    // row instead of retrying a doomed payload.
+    let decision = ScreenCandidateAdapter.adapt(
+      task: makeTask(
+        captureKind: "already_done",
+        alreadyDone: true,
+        refinesTask: "Fix Omi Windows app time context issue for Schlemosel"),
+      dueAt: nil,
+      localEvidenceID: "screen-2391",
+      deviceID: "macos_device"
+    )
+    XCTAssertEqual(decision.outcome, .proposeCompletion)
+    XCTAssertNil(decision.candidate)
+  }
+
+  func testDuplicateWithTitleReferenceFallsBackToCreateCandidate() throws {
+    // A duplicate_of that is not a StableId cannot target an update; the
+    // capture must fall back to the create policy instead of emitting a
+    // TaskUpdateCandidate the backend deterministically rejects.
+    let decision = ScreenCandidateAdapter.adapt(
+      task: makeTask(
+        captureKind: "direct_request",
+        duplicateOf: "Help Aida implement Apple login option on Omi Windows app"),
+      dueAt: nil,
+      localEvidenceID: "screen-2389",
+      deviceID: "macos_device"
+    )
+    guard case .taskCreate = try XCTUnwrap(decision.candidate) else {
+      return XCTFail("Unusable duplicate reference must fall back to a create Candidate")
+    }
+  }
+
+  func testValidDuplicateReferenceStillProposesEnrichment() throws {
+    // Sanitization must not swallow genuine StableId references.
+    let decision = ScreenCandidateAdapter.adapt(
+      task: makeTask(captureKind: "direct_request", duplicateOf: "task-existing-42"),
+      dueAt: nil,
+      localEvidenceID: "screen-7",
+      deviceID: "macos_device"
+    )
+    XCTAssertEqual(decision.outcome, .proposeEnrichment)
+    guard case .taskUpdate(let candidate) = try XCTUnwrap(decision.candidate) else {
+      return XCTFail("A valid duplicate reference must still propose an update Candidate")
+    }
+    XCTAssertEqual(candidate.taskId, "task-existing-42")
+  }
+
+  // MARK: - Retry classification
+
+  func testValidationRejectionsArePermanent() {
+    XCTAssertTrue(
+      CandidateOutboxRetryPolicy.isPermanentRejection(APIError.httpError(statusCode: 422)))
+    XCTAssertTrue(
+      CandidateOutboxRetryPolicy.isPermanentRejection(APIError.httpError(statusCode: 400)))
+  }
+
+  func testTransientFailuresRemainRetryable() {
+    XCTAssertFalse(
+      CandidateOutboxRetryPolicy.isPermanentRejection(APIError.httpError(statusCode: 401)))
+    XCTAssertFalse(
+      CandidateOutboxRetryPolicy.isPermanentRejection(APIError.httpError(statusCode: 409)))
+    XCTAssertFalse(
+      CandidateOutboxRetryPolicy.isPermanentRejection(APIError.httpError(statusCode: 429)))
+    XCTAssertFalse(
+      CandidateOutboxRetryPolicy.isPermanentRejection(APIError.httpError(statusCode: 500)))
+    XCTAssertFalse(
+      CandidateOutboxRetryPolicy.isPermanentRejection(URLError(.notConnectedToInternet)))
+    XCTAssertFalse(CandidateOutboxRetryPolicy.isPermanentRejection(APIError.invalidResponse))
+  }
+}
+
+/// Storage-level poisoning contract: a bounded number of permanent rejections
+/// removes the row from the retry drain without erasing the evidence.
+final class CanonicalOutboxRejectionStorageTests: XCTestCase {
+  private var testUserId = ""
+  private var userDir: URL?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserId = "outbox-poison-test-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await StagedTaskStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = testUserId
+    await RewindDatabase.shared.configure(userId: testUserId)
+    try await RewindDatabase.shared.initialize()
+
+    let appSupport = try XCTUnwrap(
+      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
+    userDir =
+      appSupport
+      .appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserId, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await RewindDatabase.shared.close()
+    await StagedTaskStorage.shared.invalidateCache()
+    RewindDatabase.currentUserId = nil
+    if let userDir { try? FileManager.default.removeItem(at: userDir) }
+    try await super.tearDown()
+  }
+
+  private func insertOutboxRow() async throws -> Int64 {
+    let record = try await StagedTaskStorage.shared.insertLocalStagedTask(
+      StagedTaskRecord(
+        backendSynced: false,
+        description: "Fix Omi Windows app time context issue for Schlemosel",
+        source: "candidate_outbox",
+        createdAt: Date(),
+        updatedAt: Date()))
+    return try XCTUnwrap(record.id)
+  }
+
+  func testRejectionCountPersistsAndRowStaysRetryableBelowLimit() async throws {
+    let id = try await insertOutboxRow()
+
+    let first = try await StagedTaskStorage.shared.recordCanonicalOutboxRejection(id: id)
+    XCTAssertEqual(first, .willRetry(rejections: 1))
+    let second = try await StagedTaskStorage.shared.recordCanonicalOutboxRejection(id: id)
+    XCTAssertEqual(second, .willRetry(rejections: 2))
+
+    let pending = try await StagedTaskStorage.shared.getUnsyncedCanonicalOutbox()
+    XCTAssertTrue(
+      pending.contains { $0.id == id },
+      "Below the poison limit the row must remain in the retry drain")
+
+    // The count is durable (metadata), so attempts survive an app restart.
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return XCTFail("database should be initialized")
+    }
+    let record = try await dbQueue.read { try StagedTaskRecord.fetchOne($0, key: id) }
+    XCTAssertEqual(record?.metadata?["outbox_permanent_rejections"] as? Int, 2)
+  }
+
+  func testThirdValidationRejectionPoisonsRowOutOfRetryDrain() async throws {
+    let id = try await insertOutboxRow()
+
+    _ = try await StagedTaskStorage.shared.recordCanonicalOutboxRejection(id: id)
+    _ = try await StagedTaskStorage.shared.recordCanonicalOutboxRejection(id: id)
+    let third = try await StagedTaskStorage.shared.recordCanonicalOutboxRejection(id: id)
+    XCTAssertEqual(third, .poisoned(rejections: 3))
+
+    let pending = try await StagedTaskStorage.shared.getUnsyncedCanonicalOutbox()
+    XCTAssertFalse(
+      pending.contains { $0.id == id },
+      "A poisoned row must never re-enter the retry drain")
+
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return XCTFail("database should be initialized")
+    }
+    let record = try await dbQueue.read { try StagedTaskRecord.fetchOne($0, key: id) }
+    XCTAssertEqual(record?.deleted, true)
+    XCTAssertEqual(record?.metadata?["outbox_poisoned"] as? Bool, true)
+    XCTAssertEqual(record?.metadata?["outbox_permanent_rejections"] as? Int, 3)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260815-task-capture-outbox-422.json
+++ b/desktop/macos/changelog/unreleased/20260815-task-capture-outbox-422.json
@@ -1,0 +1,1 @@
+{"change": "Screen task capture no longer retries permanently rejected sync payloads forever; unusable duplicate-task references now fall back to a new suggestion instead of failing delivery"}


### PR DESCRIPTION
## Symptom

Dev-bundle logs show recurring bursts of `Task: Candidate outbox delivery failed; will retry: HTTP error: 422` — exactly 6 per burst, on every outbox drain (each extraction trigger). The QA-profile DB carries the wedged rows; the released Beta profile shows the same pattern.

## Root cause (proven)

The client runs in canonical `read` workflow mode, so outbox delivery goes to `POST /v1/candidates` (not `/v1/staged-tasks`). The QA DB has exactly **6** unsynced, non-deleted `candidate_outbox` rows — the same 6 that fail on every drain — and **every one of them carries a task *title* in `duplicate_of`/`refines_task`** (e.g. `refines_task = "Fix Omi Windows app time context issue for Schlemosel"`).

The extraction tool schema asks the model for an "Existing canonical task id", but the model sometimes echoes the referenced task's title. `ScreenCandidateAdapter.adapt` forwarded that string verbatim as `task_id` on `TaskUpdateCandidate`/`TaskCompleteCandidate`. The backend's `StableId` (`backend/models/task_intelligence.py`) requires `^[A-Za-z0-9][A-Za-z0-9._:-]*$`, so Pydantic rejects the payload with 422 — deterministically, forever.

Replayed against the repo's own contract models:

```
1 validation error for CandidateCreate
task.complete.task_id
  String should match pattern '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
  [input_value='Fix Omi Windows app time...xt issue for Schlemosel']
```

The identical envelope with a well-formed id validates cleanly. The retry drain (`retryCanonicalOutbox`) replays these rows on every trigger with no failure classification, so a permanently rejected payload wedges the queue for good — 6 rows × every drain = the observed bursts.

(`desktop_deprecated.py`'s 410 for `/v1/staged-tasks` is mounted only on `desktop_backend.py`, not the main API app, and is unrelated: the failing endpoint is `/v1/candidates`.)

## Fix (client-only, two independent guards)

1. **Payload**: `ScreenCandidateAdapter.canonicalTaskReference` mirrors the backend `StableId` shape and is applied in `facts(for:)`, the choke point both the fresh-capture and outbox-retry paths flow through. A title-valued reference is treated as absent: `already_done` with no usable target produces no candidate (row is discarded, as a completion of an unknown task is meaningless), and duplicate/refinement captures fall back to the create policy — the capture is not lost, and the backend's own semantic coalescing still applies.
2. **Retry policy**: `CandidateOutboxRetryPolicy` classifies validation-class rejections (400/413/415/422) as permanent. `TaskAssistant` counts them per row (persisted in row metadata, survives restarts) and poisons the row after 3 attempts via `StagedTaskStorage.recordCanonicalOutboxRejection` — marked deleted with an `outbox_poisoned` metadata marker so it leaves the drain without erasing evidence. Transient failures (network, 401/409/429, 5xx) retry forever as before.

The 6 wedged rows drain on the next retry pass: five become valid create candidates, one (already-done) is discarded; any other latent permanent rejection is bounded by guard 2.

## Tests

- `CandidateOutboxValidationPoisonTests`: StableId shape acceptance/rejection (including the exact field values that wedged), adapter fallback behavior (no candidate for untargeted completion; create fallback for title-valued duplicates; valid ids still propose enrichment), and retry classification.
- `CanonicalOutboxRejectionStorageTests`: rejection count persists in metadata below the limit and the row stays in the drain; the third rejection poisons it out of `getUnsyncedCanonicalOutbox`.

Failure-Class: FC-permanent-write-rejection-retried-forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)
