### PR TITLE
fix(desktop): hand the settled director decision to the main actor

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -421,27 +421,32 @@ actor ContextProactivityEngine {
           message: decision.message, state: "suppressed")
         return
       }
+      // The bounded hop is the last writer of `decision`, so hand the main actor
+      // the settled value rather than this actor's mutable binding: the callbacks
+      // below outlive the handoff, and capturing the variable makes their reads
+      // race with any later write to it.
+      let presentedDecision = decision
       let presentation = await MainActor.run {
         let context = FloatingBarNotificationContext(
-          sourceTitle: decision.title,
+          sourceTitle: presentedDecision.title,
           assistantId: "context-director",
-          contextSummary: decision.reasoning,
+          contextSummary: presentedDecision.reasoning,
           detail: (entryRefs + retrievedRefs).joined(separator: ", "),
           provenanceRef: deliveryID)
         return NotificationService.shared.presentContextDirectorNotification(
           ownerID: ownerID,
-          title: decision.title,
-          message: decision.message,
-          decisionType: decision.decision,
+          title: presentedDecision.title,
+          message: presentedDecision.message,
+          decisionType: presentedDecision.decision,
           context: context,
           onPresented: { [weak self] in
             guard let self else { return }
             Task {
               await self.completePresentedDelivery(
                 deliveryID: deliveryID,
-                decisionType: decision.decision,
+                decisionType: presentedDecision.decision,
                 provenanceJSON: provenanceJSON,
-                message: decision.message,
+                message: presentedDecision.message,
                 authorizationSnapshot: authorizationSnapshot)
             }
           },


### PR DESCRIPTION
## Problem

`Omi Computer` does not compile on a current Xcode. On `main` (`7bec0901`), `swift build --target "Omi Computer"` under Xcode 26.4 / Swift 6.3 fails:

```
Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift:442:31: error: sending 'decision' risks causing data races [#SendingRisksDataRace]
  note: 'self'-isolated 'decision' is captured by a main actor-isolated closure.
        main actor-isolated uses in closure may race against later main actor-isolated uses
```

It is the only error in the target. CI pins Xcode 16.4, whose older `sending` analysis accepts it, so the lane is green while every local build, every `scripts/pre-push` desktop debug compile, and every local Swift suite is broken on `main` for anyone on a current Xcode.

## Root cause

#11597 made `decision` a `var` so the bounded retrieval hop could replace it (`ContextProactivityEngine.swift:259,281`). The notification handoff below still captures that binding, so the `MainActor.run` closure and the `onPresented` callback read the delivery decision out of this actor's mutable box instead of out of a value.

## Fix

Bind the settled value once the hop has run — the hop is its last writer — and let the handoff closures capture that. `ContextDirectorDecision` is a `Sendable` struct, so this is a value copy: same fields, same order, no behaviour change.

## Verification

- `swift build --package-path Desktop --target "Omi Computer"` on Xcode 26.4 / Swift 6.3: **clean** (129s). Fails on `main` without this change.
- `swift test` over the suites owning the changed path — `ContextProactivityEngineTests` (16), `ContextProactivityRetrievalHopTests` (16), `ContextBucketDirectorProbeTests` (7), `GlassSurfaceReviewRegressionTests` (3): **42 tests, 0 failures**.
- `make preflight` green.
- Desktop Swift CI on this PR is the proof that the pinned Xcode 16.4 toolchain still accepts the change.

No regression test is added: the regression is a compile error, and the build that would catch it is a second toolchain in `.github/workflows/desktop-swift-ci.yml` — out of scope for this fix. Worth a follow-up: nothing in CI notices when `main` stops building on the Xcode contributors actually have.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

