### PR TITLE
feat(desktop): recommend open action items when meeting notes are ready

### DIFF
--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -375,6 +375,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
     // This ensures notifications display properly when app is in foreground
     _ = NotificationService.shared
+    // Observe meeting completions app-wide so the action-item banner also fires
+    // while the main window is closed or backgrounded.
+    MeetingActionItemBannerService.shared.activate()
     // Notification registration repair is deliberately user-triggered from
     // Settings. Launch must not restart usernoted/NotificationCenter or alter
     // notification registration as a passive side effect.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingActionItemBannerService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingActionItemBannerService.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Pure decision logic for the meeting action-item completion banner, kept
+/// static and value-typed so filtering, formatting, and dedup are unit-testable
+/// without a backend or notification center.
+enum MeetingActionItemBannerPolicy {
+  static let bannerTitle = "Meeting notes ready"
+  static let assistantID = "meeting-notes"
+  static let maxBodyLength = 120
+
+  /// The `capture_owner` value that marks an extracted item as the user's own
+  /// commitment (as opposed to someone else's follow-up captured in passing).
+  static let userCaptureOwner = "user"
+
+  /// Items worth recommending when a meeting's notes finish processing: the
+  /// user's own, still-open commitments. Legacy items without a capture owner
+  /// are excluded rather than guessed at.
+  static func recommendedItems(from items: [ActionItem]) -> [ActionItem] {
+    items.filter { $0.captureOwner == userCaptureOwner && !$0.completed && !$0.deleted }
+  }
+
+  /// Banner body: conversation title plus the first recommended item, with an
+  /// "and N more" tail when more exist. Returns nil for zero items — the
+  /// caller must then change nothing about today's behavior. Truncation always
+  /// preserves the tail so the item count survives a long title/description.
+  static func bannerBody(
+    conversationTitle: String,
+    recommendedItems: [ActionItem],
+    maxLength: Int = maxBodyLength
+  ) -> String? {
+    guard let first = recommendedItems.first else { return nil }
+    let additionalCount = recommendedItems.count - 1
+    let suffix = additionalCount > 0 ? " and \(additionalCount) more" : ""
+    let base = "\(conversationTitle): \(first.description)"
+    if base.count + suffix.count <= maxLength {
+      return base + suffix
+    }
+    let budget = max(1, maxLength - suffix.count - 1)
+    return String(base.prefix(budget)) + "…" + suffix
+  }
+}
+
+/// Posts a system banner recommending a completed meeting's open action items,
+/// deep-linking back into the chat surface that carries the meeting-notes card.
+///
+/// Strictly additive to the existing completion flow: it only observes the
+/// already-coalesced `.desktopMeetingConversationDidComplete` signal, never
+/// blocks or reorders the Chat materialization path, and any fetch/decode
+/// failure or zero-item result degrades silently to today's behavior.
+@MainActor
+final class MeetingActionItemBannerService {
+  static let shared = MeetingActionItemBannerService()
+
+  typealias ConversationFetcher = @Sendable (_ conversationID: String) async throws -> ServerConversation
+  typealias BannerPresenter = @MainActor (_ title: String, _ body: String) -> Void
+
+  private let fetchConversation: ConversationFetcher
+  private let presentBanner: BannerPresenter
+
+  /// Conversations already handled this process, in insertion order. The
+  /// finalization service can legitimately re-signal one conversation (e.g. a
+  /// deferred projection poll racing a crash-recovery retry), so the banner
+  /// dedupes by conversation ID before any async work starts.
+  private var handledConversationIDs: Set<String> = []
+  private var handledConversationIDOrder: [String] = []
+  private static let maxHandledConversationIDs = 512
+
+  private var completionObserver: NSObjectProtocol?
+
+  /// Tracks in-flight fetches so tests can await quiescence. Entries remove
+  /// themselves on completion, so production never accumulates finished tasks.
+  private var inflightTasks: [UUID: Task<Void, Never>] = [:]
+
+  init(
+    fetchConversation: ConversationFetcher? = nil,
+    presentBanner: BannerPresenter? = nil
+  ) {
+    self.fetchConversation =
+      fetchConversation ?? { conversationID in
+        try await APIClient.shared.getConversation(id: conversationID)
+      }
+    self.presentBanner =
+      presentBanner ?? { title, body in
+        // Same owner-provenance and delivery gates as the other proactive
+        // banners: master Notifications toggle, frequency throttle, and the
+        // floating-bar preview policy all remain authoritative inside
+        // `sendNotification`. `deliverSystemBanner: true` because this banner's
+        // whole purpose is to reach a user who is away from the app.
+        guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
+        NotificationService.shared.sendNotification(
+          ownerID: snapshot.ownerID,
+          title: title,
+          message: body,
+          assistantId: MeetingActionItemBannerPolicy.assistantID,
+          deliverSystemBanner: true,
+          authorizationSnapshot: snapshot
+        )
+      }
+  }
+
+  /// Install the completion observer. Idempotent; called once at launch so the
+  /// banner works regardless of which window (if any) is open.
+  func activate() {
+    guard completionObserver == nil else { return }
+    completionObserver = NotificationCenter.default.addObserver(
+      forName: .desktopMeetingConversationDidComplete,
+      object: nil,
+      queue: .main
+    ) { notification in
+      guard let completion = notification.object as? MeetingCompletionNotification else { return }
+      MainActor.assumeIsolated {
+        MeetingActionItemBannerService.shared.handleMeetingCompletion(completion)
+      }
+    }
+  }
+
+  func handleMeetingCompletion(_ completion: MeetingCompletionNotification) {
+    for conversationID in completion.conversationIDs {
+      guard markHandled(conversationID) else { continue }
+      let taskID = UUID()
+      inflightTasks[taskID] = Task { [weak self] in
+        await self?.recommendActionItems(conversationID: conversationID)
+        self?.inflightTasks.removeValue(forKey: taskID)
+      }
+    }
+  }
+
+  /// Await all fetches started so far. Test seam; production never blocks on it.
+  func waitForPendingRecommendations() async {
+    while let task = inflightTasks.values.first {
+      await task.value
+    }
+  }
+
+  /// Returns false when the conversation was already handled. Marking happens
+  /// before the fetch starts, so a duplicate completion signal for the same
+  /// conversation can never race its way into a second banner.
+  private func markHandled(_ conversationID: String) -> Bool {
+    guard handledConversationIDs.insert(conversationID).inserted else { return false }
+    handledConversationIDOrder.append(conversationID)
+    if handledConversationIDOrder.count > Self.maxHandledConversationIDs {
+      let removeCount = handledConversationIDOrder.count - Self.maxHandledConversationIDs
+      for id in handledConversationIDOrder.prefix(removeCount) {
+        handledConversationIDs.remove(id)
+      }
+      handledConversationIDOrder.removeFirst(removeCount)
+    }
+    return true
+  }
+
+  private func recommendActionItems(conversationID: String) async {
+    do {
+      let conversation = try await fetchConversation(conversationID)
+      let items = MeetingActionItemBannerPolicy.recommendedItems(
+        from: conversation.structured.actionItems)
+      guard
+        let body = MeetingActionItemBannerPolicy.bannerBody(
+          conversationTitle: conversation.title,
+          recommendedItems: items
+        )
+      else { return }
+      presentBanner(MeetingActionItemBannerPolicy.bannerTitle, body)
+    } catch {
+      // Silent by design: the meeting-notes card in Chat is the durable
+      // surface; the banner is an opportunistic recommendation on top.
+      log("MeetingActionItemBanner: skipped for \(conversationID) (fetch failed)")
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -276,6 +276,11 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         switch Self.openAction(assistantId: assistantId, title: title) {
         case .resetScreenCapture:
           self.handleScreenCaptureResetAction(source: "notification_click")
+        case .openMainChat:
+          // The same reveal-and-land-on-chat path the floating bar's
+          // "Continue in Omi" affordance uses; the chat transcript there
+          // carries the meeting-notes card with the conversation link.
+          AppDelegate.summonWindowTarget()?.openMainAppChat()
         case .none:
           break
         }
@@ -324,6 +329,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     case none
     /// The screen-recording repair, which is an action rather than a page.
     case resetScreenCapture
+    /// The main-window chat surface, where the meeting-notes card (with its
+    /// conversation link) was materialized.
+    case openMainChat
   }
 
   /// Resolve the tap destination from the notification's provenance.
@@ -333,6 +341,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// change with its own suppression-state migration.
   static func openAction(assistantId: String, title: String) -> OpenAction {
     if title == screenCaptureResetTitle { return .resetScreenCapture }
+    if assistantId == MeetingActionItemBannerPolicy.assistantID { return .openMainChat }
     return .none
   }
 

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
@@ -386,7 +386,8 @@ struct Structured: Codable, Equatable {
   func encode(to encoder: Encoder) throws {
     let actionItemsWire = actionItems.map {
       OmiAPI.ActionItem(
-        candidateAction: nil, captureConfidence: nil, captureKind: nil, captureOwner: nil, completed: $0.completed,
+        candidateAction: nil, captureConfidence: nil, captureKind: nil, captureOwner: $0.captureOwner,
+        completed: $0.completed,
         completedAt: nil, concreteDeliverable: nil, conversationId: nil, createdAt: nil, description_: $0.description,
         dueAt: nil, ownershipConfidence: nil, sourceSegmentIds: $0.sourceSegmentIDs,
         targetTaskId: $0.targetTaskID, updatedAt: nil)
@@ -434,6 +435,10 @@ struct ActionItem: Codable, Identifiable, Equatable {
   let description: String
   let completed: Bool
   let deleted: Bool
+  /// Extraction ownership from the backend (`capture_owner`), e.g. "user" when
+  /// the item is the user's own commitment. Optional: legacy captures and
+  /// locally cached rows predate the field.
+  let captureOwner: String?
   /// Canonical task linkage is optional on legacy captures. When present, the
   /// chat-first archive uses this opaque ID for a typed deep link rather than
   /// inferring a task from the description.
@@ -444,12 +449,14 @@ struct ActionItem: Codable, Identifiable, Equatable {
     description: String,
     completed: Bool,
     deleted: Bool,
+    captureOwner: String? = nil,
     targetTaskID: String? = nil,
     sourceSegmentIDs: [String] = []
   ) {
     self.description = description
     self.completed = completed
     self.deleted = deleted
+    self.captureOwner = captureOwner
     self.targetTaskID = targetTaskID
     self.sourceSegmentIDs = sourceSegmentIDs
   }
@@ -461,6 +468,7 @@ struct ActionItem: Codable, Identifiable, Equatable {
     self.description = wire.description_
     self.completed = wire.completed ?? false
     self.deleted = false
+    self.captureOwner = wire.captureOwner
     self.targetTaskID = wire.targetTaskId
     self.sourceSegmentIDs = wire.sourceSegmentIds ?? []
   }
@@ -470,6 +478,7 @@ struct ActionItem: Codable, Identifiable, Equatable {
     self.description = wire.description_
     self.completed = wire.completed ?? false
     self.deleted = false
+    self.captureOwner = wire.captureOwner
     self.targetTaskID = wire.targetTaskId
     self.sourceSegmentIDs = wire.sourceSegmentIds ?? []
   }
@@ -479,7 +488,7 @@ struct ActionItem: Codable, Identifiable, Equatable {
       candidateAction: nil,
       captureConfidence: nil,
       captureKind: nil,
-      captureOwner: nil,
+      captureOwner: captureOwner,
       completed: completed,
       completedAt: nil,
       concreteDeliverable: nil,

--- a/desktop/macos/Desktop/Tests/MeetingActionItemBannerServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingActionItemBannerServiceTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MeetingActionItemBannerServiceTests: XCTestCase {
+  // MARK: - Item filtering
+
+  func testRecommendedItemsKeepOnlyOpenUserOwnedItems() {
+    let items = [
+      MeetingActionItemBannerServiceTests.item("Send the deck to Alex", owner: "user"),
+      MeetingActionItemBannerServiceTests.item("Alex reviews the deck", owner: "other"),
+      MeetingActionItemBannerServiceTests.item("Legacy item without owner", owner: nil),
+      MeetingActionItemBannerServiceTests.item("Already done", owner: "user", completed: true),
+      MeetingActionItemBannerServiceTests.item("Deleted locally", owner: "user", deleted: true),
+      MeetingActionItemBannerServiceTests.item("Book the follow-up", owner: "user"),
+    ]
+
+    let recommended = MeetingActionItemBannerPolicy.recommendedItems(from: items)
+
+    XCTAssertEqual(
+      recommended.map(\.description),
+      ["Send the deck to Alex", "Book the follow-up"]
+    )
+  }
+
+  // MARK: - Body formatting
+
+  func testBannerBodyForSingleItemHasNoCountTail() {
+    let body = MeetingActionItemBannerPolicy.bannerBody(
+      conversationTitle: "Weekly sync",
+      recommendedItems: [Self.item("Send the deck to Alex", owner: "user")]
+    )
+    XCTAssertEqual(body, "Weekly sync: Send the deck to Alex")
+  }
+
+  func testBannerBodyCountsAdditionalItems() {
+    let body = MeetingActionItemBannerPolicy.bannerBody(
+      conversationTitle: "Weekly sync",
+      recommendedItems: [
+        Self.item("Send the deck to Alex", owner: "user"),
+        Self.item("Book the follow-up", owner: "user"),
+        Self.item("File the expense report", owner: "user"),
+      ]
+    )
+    XCTAssertEqual(body, "Weekly sync: Send the deck to Alex and 2 more")
+  }
+
+  func testBannerBodyTruncatesButPreservesCountTail() throws {
+    let longDescription = String(repeating: "plan ", count: 40)
+    let body = MeetingActionItemBannerPolicy.bannerBody(
+      conversationTitle: "Quarterly planning marathon",
+      recommendedItems: [
+        Self.item(longDescription, owner: "user"),
+        Self.item("Second item", owner: "user"),
+      ]
+    )
+
+    let unwrapped = try XCTUnwrap(body)
+    XCTAssertLessThanOrEqual(unwrapped.count, MeetingActionItemBannerPolicy.maxBodyLength)
+    XCTAssertTrue(unwrapped.hasSuffix(" and 1 more"))
+    XCTAssertTrue(unwrapped.contains("…"))
+    XCTAssertTrue(unwrapped.hasPrefix("Quarterly planning marathon: "))
+  }
+
+  func testBannerBodyIsNilForZeroItems() {
+    XCTAssertNil(
+      MeetingActionItemBannerPolicy.bannerBody(
+        conversationTitle: "Weekly sync",
+        recommendedItems: []
+      )
+    )
+  }
+
+  // MARK: - Service behavior
+
+  @MainActor
+  func testCompletionWithUserItemsPresentsOneBanner() async {
+    var presented: [(title: String, body: String)] = []
+    let service = MeetingActionItemBannerService(
+      fetchConversation: { id in
+        Self.conversation(
+          id: id,
+          title: "Weekly sync",
+          items: [
+            Self.item("Send the deck to Alex", owner: "user"),
+            Self.item("Alex reviews the deck", owner: "other"),
+          ]
+        )
+      },
+      presentBanner: { title, body in
+        presented.append((title, body))
+      }
+    )
+
+    service.handleMeetingCompletion(MeetingCompletionNotification(conversationIDs: ["conv-1"]))
+    await service.waitForPendingRecommendations()
+
+    XCTAssertEqual(presented.count, 1)
+    XCTAssertEqual(presented.first?.title, "Meeting notes ready")
+    XCTAssertEqual(presented.first?.body, "Weekly sync: Send the deck to Alex")
+  }
+
+  @MainActor
+  func testZeroOpenUserItemsPresentsNothing() async {
+    var presentedCount = 0
+    let service = MeetingActionItemBannerService(
+      fetchConversation: { id in
+        Self.conversation(
+          id: id,
+          title: "Weekly sync",
+          items: [
+            Self.item("Alex reviews the deck", owner: "other"),
+            Self.item("Already done", owner: "user", completed: true),
+          ]
+        )
+      },
+      presentBanner: { _, _ in presentedCount += 1 }
+    )
+
+    service.handleMeetingCompletion(MeetingCompletionNotification(conversationIDs: ["conv-1"]))
+    await service.waitForPendingRecommendations()
+
+    XCTAssertEqual(presentedCount, 0)
+  }
+
+  @MainActor
+  func testFetchFailurePresentsNothing() async {
+    var presentedCount = 0
+    let service = MeetingActionItemBannerService(
+      fetchConversation: { _ in throw URLError(.notConnectedToInternet) },
+      presentBanner: { _, _ in presentedCount += 1 }
+    )
+
+    service.handleMeetingCompletion(MeetingCompletionNotification(conversationIDs: ["conv-1"]))
+    await service.waitForPendingRecommendations()
+
+    XCTAssertEqual(presentedCount, 0)
+  }
+
+  @MainActor
+  func testDuplicateCompletionSignalsPresentOneBannerPerConversation() async {
+    var presentedCount = 0
+    let service = MeetingActionItemBannerService(
+      fetchConversation: { id in
+        Self.conversation(
+          id: id,
+          title: "Weekly sync",
+          items: [Self.item("Send the deck to Alex", owner: "user")]
+        )
+      },
+      presentBanner: { _, _ in presentedCount += 1 }
+    )
+
+    // A finalization retry can re-signal the same conversation, including
+    // within one coalesced flush and again from a later projection poll.
+    service.handleMeetingCompletion(
+      MeetingCompletionNotification(conversationIDs: ["conv-1", "conv-2"]))
+    service.handleMeetingCompletion(MeetingCompletionNotification(conversationIDs: ["conv-1"]))
+    await service.waitForPendingRecommendations()
+    service.handleMeetingCompletion(MeetingCompletionNotification(conversationIDs: ["conv-2"]))
+    await service.waitForPendingRecommendations()
+
+    XCTAssertEqual(presentedCount, 2)
+  }
+
+  // MARK: - Click routing
+
+  @MainActor
+  func testMeetingBannerClickOpensMainChat() {
+    XCTAssertEqual(
+      NotificationService.openAction(
+        assistantId: MeetingActionItemBannerPolicy.assistantID,
+        title: MeetingActionItemBannerPolicy.bannerTitle
+      ),
+      .openMainChat
+    )
+    XCTAssertEqual(
+      NotificationService.openAction(assistantId: "default", title: "Anything else"),
+      .none
+    )
+  }
+
+  // MARK: - Fixtures
+
+  private static func item(
+    _ description: String,
+    owner: String?,
+    completed: Bool = false,
+    deleted: Bool = false
+  ) -> ActionItem {
+    ActionItem(
+      description: description,
+      completed: completed,
+      deleted: deleted,
+      captureOwner: owner
+    )
+  }
+
+  private static func conversation(
+    id: String,
+    title: String,
+    items: [ActionItem]
+  ) -> ServerConversation {
+    ServerConversation(
+      id: id,
+      createdAt: Date(timeIntervalSinceReferenceDate: 700_000_000),
+      startedAt: nil,
+      finishedAt: nil,
+      structured: Structured(
+        title: title,
+        overview: "",
+        emoji: "",
+        category: "other",
+        actionItems: items,
+        events: []
+      ),
+      transcriptSegments: [],
+      transcriptSegmentsIncluded: false,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: .desktop,
+      language: nil,
+      status: .completed,
+      discarded: false,
+      deleted: false,
+      isLocked: false,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260815-meeting-action-item-banner.json
+++ b/desktop/macos/changelog/unreleased/20260815-meeting-action-item-banner.json
@@ -1,0 +1,3 @@
+{
+  "change": "When meeting notes finish processing, a notification now recommends your open action items from the meeting and clicking it takes you to the conversation"
+}

--- a/desktop/macos/e2e/flows/notifications-settings.yaml
+++ b/desktop/macos/e2e/flows/notifications-settings.yaml
@@ -11,6 +11,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingActionItemBannerService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSpeech.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
   - desktop/macos/Desktop/Sources/AnalyticsManager.swift


### PR DESCRIPTION
When a meeting conversation finishes processing, the desktop app now posts one system banner recommending the user's own open action items from that meeting, deep-linking back to the chat surface that carries the meeting-notes card. Zero matching items, any fetch/decode failure, or a suppressed notification gate all degrade to exactly today's behavior.

## Design

- **Signal**: observes the already-coalesced `.desktopMeetingConversationDidComplete` (posted by `ConversationFinalizationService` after its projection wait), installed app-wide at launch in `AppDelegate.applicationDidFinishLaunching`, so the banner fires while the main window is closed or backgrounded and never touches the Chat materialization path.
- **Idempotency**: the finalization service can legitimately re-signal one conversation (deferred projection poll racing a crash-recovery retry). `MeetingActionItemBannerService` dedupes by conversation ID *before* any async work starts, with a bounded (512) insertion-ordered set. The retry surface is in-process (projection polls + coalesced flush), so in-process dedupe is the correct scope; a conversation finalized in a previous app run is not re-signaled after relaunch.
- **Filtering**: `capture_owner == "user" && !completed && !deleted`. Legacy items without a capture owner are excluded rather than guessed at. `ActionItem` now carries the wire `capture_owner` (optional, so cached legacy rows decode unchanged) and round-trips it on encode.
- **Body**: `<title>: <first item>` plus `and N more`, truncated to <= 120 chars with the count tail always preserved.
- **Gates**: delivery goes through the existing `NotificationService.sendNotification` with `respectFrequency: true`, so the master Notifications toggle, the frequency throttle, owner-authorization snapshot checks, and the floating-bar preview policy all remain authoritative. No new settings.
- **Click routing**: `openAction` resolves the banner's assistantId to `.openMainChat`, reusing the floating bar's "Continue in Omi" seam (`openMainAppChat()`), which fronts the app and lands on the chat timeline where the meeting-notes card opens the conversation.

## Tests

`MeetingActionItemBannerServiceTests` (10 tests): filtering, body formatting/truncation, zero-item nil, one banner per completion, silent no-op on fetch failure, duplicate completion signals produce one banner per conversation (double-fire idempotency), and click routing. Surrounding suites: `--filter Notification` (100 tests) and the finalization/conversation-model suites (78 tests) pass.

## Product invariants affected

- INV-AUTH-1 — `OmiApp.swift` is a locked auth-session path; this PR only adds the launch-time observer install (`MeetingActionItemBannerService.shared.activate()`). Owner authority is respected downstream: every banner captures a `RuntimeOwnerIdentity.captureAuthorizationSnapshot()` and `sendNotification` re-validates it before delivery, so a stale owner can never publish a banner.

## Review

A cursor grok review via agentctl was attempted twice and returned no result both times (agentctl failed at journal open before launching the reviewer — the shared journal is held by a concurrent agentctl dogfood session on this machine). Self-review was performed against the intended axes instead:

- **Retry-idempotency**: completion handling is `@MainActor`-serialized; `markHandled` inserts the conversation ID synchronously before any async fetch starts, so a duplicate signal (coalesced flush + later projection poll) can never race into a second banner. Covered by `testDuplicateCompletionSignalsPresentOneBannerPerConversation`. A fetch failure marks the conversation handled and does not retry — intentional, since failure is specified as a silent no-op.
- **Notification gates**: delivery uses `sendNotification(..., respectFrequency: true)`, the same path as other proactive banners: master Notifications toggle, global + per-assistant frequency throttle (keyed by plain string, safe for the new `meeting-notes` id — verified no assistantId collision), owner-authorization snapshot captured before send and re-validated inside, floating-bar preview policy downstream.
- **Meeting-notes card flow**: `ChatFirstShell` observes the same notification independently; the banner service only observes and never blocks or reorders Chat materialization. `ActionItem.captureOwner` is optional, so cached legacy rows decode unchanged; encode now round-trips the field instead of dropping it (previously hardcoded `nil`). `openAction` matches the screen-capture-reset title first, then the new assistantId — no change for existing notifications.

Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1590 -> 1593 | app-wide banner observer must be installed at launch in applicationDidFinishLaunching; 3 lines (1 call + 2-line comment), splitting OmiApp is out of scope

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

