### PR TITLE
fix(desktop): director prompts feed local times so notifications stop saying UTC

### DIFF
--- a/.github/failure-classes/FC-machine-timezone-timestamp-in-prompt.json
+++ b/.github/failure-classes/FC-machine-timezone-timestamp-in-prompt.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-machine-timezone-timestamp-in-prompt",
+  "violated_contract": "A timestamp rendered into a model prompt whose output reaches the user verbatim is user-facing text, not wire format. Serializing it in UTC (ISO8601 or otherwise) makes the model quote machine time into notifications and misjudge urgency for every user whose local day differs from the UTC day.",
+  "canonical_prevention": "At the point a date enters prompt text, format it in an injected user TimeZone (or as relative phrasing) and tell the model timestamps are already local; pin the zone in tests to a non-UTC identifier so a CI runner in UTC cannot keep a machine-zone regression green.",
+  "evidence_prs": [11392],
+  "scope_hints": ["desktop/macos/Desktop/Sources/ProactiveAssistants/**"],
+  "status": "open",
+  "canonical_prevention_artifact": ["desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift"]
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -185,12 +185,14 @@ enum ContextProactivityPromptBuilder {
     snapshot: ContextBucketSnapshot,
     tasks: [ContextDirectorTaskContext],
     frame: CapturedFrame,
-    recentDeliveries: [ContextBucketRecentDelivery] = []
+    recentDeliveries: [ContextBucketRecentDelivery] = [],
+    timeZone: TimeZone = .current
   ) -> String {
     """
     \(directorStablePrompt(snapshot: snapshot))
 
-    \(directorVolatilePrompt(tasks: tasks, frame: frame, recentDeliveries: recentDeliveries))
+    \(directorVolatilePrompt(
+      tasks: tasks, frame: frame, recentDeliveries: recentDeliveries, timeZone: timeZone))
     """
   }
 
@@ -244,7 +246,9 @@ enum ContextProactivityPromptBuilder {
       request is insight or suggest; never infer an owner or due date and never create a task
       candidate from actionability alone.
       Do not re-deliver a point already delivered for this bucket unless the validated facts
-      add something materially new. Prefer silence over restating.\(lookup)
+      add something materially new. Prefer silence over restating.
+      Timestamps supplied below are already in the user's local time zone. When a message
+      mentions a date or time, use that local form as written; never convert to or mention UTC.\(lookup)
 
       \(stableBucket)
       """
@@ -253,7 +257,8 @@ enum ContextProactivityPromptBuilder {
   static func directorVolatilePrompt(
     tasks: [ContextDirectorTaskContext],
     frame: CapturedFrame,
-    recentDeliveries: [ContextBucketRecentDelivery] = []
+    recentDeliveries: [ContextBucketRecentDelivery] = [],
+    timeZone: TimeZone = .current
   ) -> String {
     let actionableCutoff = frame.captureTime.addingTimeInterval(
       ContextDirectorTaskSelection.futureHorizon)
@@ -261,9 +266,9 @@ enum ContextProactivityPromptBuilder {
       guard let dueAt = task.dueAt else { return "- \(task.description)" }
       if dueAt > actionableCutoff {
         return
-          "- \(task.description)\n  Due at (UTC): \(utcTimestamp(dueAt))\n  Reference only: already exists; do not resurface or create it yet."
+          "- \(task.description)\n  Due at: \(localTimestamp(dueAt, timeZone: timeZone))\n  Reference only: already exists; do not resurface or create it yet."
       }
-      return "- \(task.description)\n  Due at (UTC): \(utcTimestamp(dueAt))"
+      return "- \(task.description)\n  Due at: \(localTimestamp(dueAt, timeZone: timeZone))"
     }
     let taskContext = taskLines.joined(separator: "\n")
     var prompt = """
@@ -273,7 +278,7 @@ enum ContextProactivityPromptBuilder {
       == CURRENT FRAME METADATA ==
       App: \(frame.appName)
       Window: \(frame.windowTitle ?? "")
-      Captured at (UTC): \(utcTimestamp(frame.captureTime))
+      Captured at: \(localTimestamp(frame.captureTime, timeZone: timeZone))
       """
     if let recent = recentDeliveriesSection(recentDeliveries, now: frame.captureTime) {
       prompt += "\n\n\(recent)"
@@ -320,10 +325,16 @@ enum ContextProactivityPromptBuilder {
     return String(collapsed.prefix(ContextBucketRecentDelivery.summaryCharacterLimit))
   }
 
-  private static func utcTimestamp(_ date: Date) -> String {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+  /// Times shown to the director are the user's wall-clock times: the model quotes
+  /// supplied timestamps verbatim into user-visible messages, and a user should
+  /// never read "04:00 UTC" for their own midnight deadline. Single format
+  /// authority for every timestamp a director prompt carries; the retrieval-hop
+  /// section reuses it so retrieved rows cannot reintroduce UTC.
+  static func localTimestamp(_ date: Date, timeZone: TimeZone) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = timeZone
+    formatter.dateFormat = "yyyy-MM-dd HH:mm zzz"
     return formatter.string(from: date)
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDirectorRetrieval.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDirectorRetrieval.swift
@@ -76,11 +76,15 @@ enum ContextDirectorRetrievalHop {
   /// sits below `ScreenDerivedContent.untrustedPreamble` at the top of the
   /// stable prompt. The static instruction lines come first so no retrieved
   /// byte can precede the label that frames it as quoted data.
-  static func promptSection(query: String, items: [ContextRetrievedItem]) -> String? {
+  static func promptSection(
+    query: String, items: [ContextRetrievedItem], timeZone: TimeZone = .current
+  ) -> String? {
     guard !items.isEmpty else { return nil }
     let lines = items.prefix(perSourceResultLimit * retrievedNamespaces.count).map { item -> String in
       var line = "- \(item.ref)"
-      if let createdAt = item.createdAt, !createdAt.isEmpty { line += " (\(createdAt))" }
+      if let createdAt = item.createdAt, !createdAt.isEmpty {
+        line += " (\(localizedCreatedAt(createdAt, timeZone: timeZone)))"
+      }
       if !item.title.isEmpty { line += " \(item.title):" }
       return line + " \(item.preview)"
     }
@@ -92,6 +96,22 @@ enum ContextDirectorRetrievalHop {
       Lookup query: \(query)
       \(lines.joined(separator: "\n"))
       """
+  }
+
+  /// Backend `createdAt` arrives as UTC ISO-8601. The stable prompt promises the
+  /// model that every timestamp below it is already local, so a retrieved row must
+  /// not smuggle a `...Z` instant back in; parseable values are re-rendered through
+  /// the director's one timestamp format. An unparseable string passes through
+  /// verbatim — it was never a machine timestamp the model could misread as one.
+  private static func localizedCreatedAt(_ createdAt: String, timeZone: TimeZone) -> String {
+    let withFractional = ISO8601DateFormatter()
+    withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let plain = ISO8601DateFormatter()
+    plain.formatOptions = [.withInternetDateTime]
+    guard let date = withFractional.date(from: createdAt) ?? plain.date(from: createdAt) else {
+      return createdAt
+    }
+    return ContextProactivityPromptBuilder.localTimestamp(date, timeZone: timeZone)
   }
 
   static func isRetrievedNamespaceRef(_ ref: String) -> Bool {

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -48,7 +48,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertFalse(prompt.contains("page-group"))
   }
 
-  func testDirectorPromptContainsSafetyPreambleBucketTasksAndFrameMetadata() {
+  func testDirectorPromptContainsSafetyPreambleBucketTasksAndFrameMetadata() throws {
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
     let dueAt = Date(timeIntervalSince1970: 1_700_003_600)
     let snapshot = ContextBucketSnapshot(
@@ -66,7 +67,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
         ContextDirectorTaskContext(description: "Review PR-123", dueAt: dueAt),
         ContextDirectorTaskContext(description: "Send release notes", dueAt: nil),
       ],
-      frame: frame)
+      frame: frame,
+      timeZone: timeZone)
     let bucket = String(data: ContextBucketPromptAssembler.assemble(snapshot), encoding: .utf8) ?? ""
     let expected = [
       ScreenDerivedContent.untrustedPreamble,
@@ -87,16 +89,18 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "candidate from actionability alone.",
       "Do not re-deliver a point already delivered for this bucket unless the validated facts",
       "add something materially new. Prefer silence over restating.",
+      "Timestamps supplied below are already in the user's local time zone. When a message",
+      "mentions a date or time, use that local form as written; never convert to or mention UTC.",
       "",
       bucket,
       "",
       "== OPEN OR OVERDUE TASKS ==",
-      "- Review PR-123\n  Due at (UTC): 2023-11-14T23:13:20.000Z\n- Send release notes",
+      "- Review PR-123\n  Due at: 2023-11-14 18:13 EST\n- Send release notes",
       "",
       "== CURRENT FRAME METADATA ==",
       "App: Terminal",
       "Window: deploy.sh",
-      "Captured at (UTC): 2023-11-14T22:13:20.000Z",
+      "Captured at: 2023-11-14 17:13 EST",
     ].joined(separator: "\n")
 
     XCTAssertEqual(prompt, expected)
@@ -107,7 +111,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertFalse(prompt.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
   }
 
-  func testDirectorPromptIncludesBoundedRecentDeliveriesForThisBucket() {
+  func testDirectorPromptIncludesBoundedRecentDeliveriesForThisBucket() throws {
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
     let snapshot = ContextBucketSnapshot(
       bucketID: "bucket", versionID: 1, version: 1, header: "header",
@@ -127,7 +132,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
           decisionType: "insight",
           message: "Status changed",
           deliveredAt: capturedAt.addingTimeInterval(-26 * 60)),
-      ])
+      ],
+      timeZone: timeZone)
     let bucket = String(data: ContextBucketPromptAssembler.assemble(snapshot), encoding: .utf8) ?? ""
     let expected = [
       ScreenDerivedContent.untrustedPreamble,
@@ -148,6 +154,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "candidate from actionability alone.",
       "Do not re-deliver a point already delivered for this bucket unless the validated facts",
       "add something materially new. Prefer silence over restating.",
+      "Timestamps supplied below are already in the user's local time zone. When a message",
+      "mentions a date or time, use that local form as written; never convert to or mention UTC.",
       "",
       bucket,
       "",
@@ -157,7 +165,7 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "== CURRENT FRAME METADATA ==",
       "App: Notes",
       "Window: ",
-      "Captured at (UTC): 2023-11-14T22:13:20.000Z",
+      "Captured at: 2023-11-14 17:13 EST",
       "",
       "== RECENTLY DELIVERED FOR THIS BUCKET ==",
       "- resurface (1m ago): Keep the investigation open",
@@ -165,6 +173,22 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     ].joined(separator: "\n")
 
     XCTAssertEqual(prompt, expected)
+  }
+
+  func testDirectorPromptKeepsLocalDateWhenUTCHasAlreadyRolledToTheNextDay() throws {
+    // 2026-08-11T03:59:00Z is 2026-08-10 23:59 in New York (DST on). This is the
+    // #11392 failure shape: a due-tonight task whose UTC date reads as tomorrow.
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let dueAt = Date(timeIntervalSince1970: 1_786_420_740)
+    let frame = CapturedFrame(
+      jpegData: Data(), appName: "Notes", frameNumber: 1,
+      captureTime: dueAt.addingTimeInterval(-600))
+    let prompt = ContextProactivityPromptBuilder.directorVolatilePrompt(
+      tasks: [ContextDirectorTaskContext(description: "File the report", dueAt: dueAt)],
+      frame: frame,
+      timeZone: timeZone)
+    XCTAssertTrue(prompt.contains("Due at: 2026-08-10 23:59 EDT"), prompt)
+    XCTAssertFalse(prompt.contains("2026-08-11"))
   }
 
   func testDirectorPromptCapsRecentDeliveriesAndOmitsTheSectionWhenEmpty() {

--- a/desktop/macos/Desktop/Tests/ContextProactivityRetrievalHopTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityRetrievalHopTests.swift
@@ -187,6 +187,30 @@ final class ContextProactivityRetrievalHopTests: XCTestCase {
       "static instruction lines precede retrieved content, never the reverse")
   }
 
+  func testPromptSectionRendersCreatedAtInTheUsersLocalZoneNeverUTC() throws {
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let items = ContextDirectorRetrievalHop.items(fromSources: [source()], kind: "conversation")
+    let section = try XCTUnwrap(
+      ContextDirectorRetrievalHop.promptSection(
+        query: "last omi release", items: items, timeZone: timeZone))
+    // The stable prompt promises every timestamp below it is already local, so
+    // the backend's UTC instant must be re-rendered, not quoted with its Z.
+    XCTAssertTrue(section.contains("(2026-08-01 06:00 EDT)"), section)
+    XCTAssertFalse(section.contains("2026-08-01T10:00:00Z"))
+  }
+
+  func testPromptSectionPassesUnparseableCreatedAtThroughVerbatim() throws {
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let items = [
+      ContextRetrievedItem(
+        ref: "conversation:conv-1", title: "Release chat", preview: "beta live",
+        createdAt: "yesterday afternoon")
+    ]
+    let section = try XCTUnwrap(
+      ContextDirectorRetrievalHop.promptSection(query: "q", items: items, timeZone: timeZone))
+    XCTAssertTrue(section.contains("(yesterday afternoon)"))
+  }
+
   func testRetrievedSectionStaysBelowTheUntrustedPreambleAndOutOfTheCachedPrefix() throws {
     let snapshot = makeSnapshot()
     let stable = ContextProactivityPromptBuilder.directorStablePrompt(

--- a/desktop/macos/changelog/unreleased/20260815-director-local-time-prompts.json
+++ b/desktop/macos/changelog/unreleased/20260815-director-local-time-prompts.json
@@ -1,0 +1,1 @@
+{"change": "Notifications now say times in your local time zone instead of UTC"}


### PR DESCRIPTION
## Summary

The context director's prompts stamped every timestamp as `Due at (UTC): <ISO8601>` / `Captured at (UTC): <ISO8601>`, and the model did exactly what the prompt taught: it quoted machine time into user-visible notifications ("overdue as of 04:00 UTC today"). For anyone not living in UTC that reads as gibberish and can misstate the day entirely.

- `ContextProactivityPromptBuilder` now formats prompt timestamps with `localTimestamp(_:timeZone:)` (`yyyy-MM-dd HH:mm zzz`, `en_US_POSIX`); `directorPrompt` / `directorVolatilePrompt` accept `timeZone: TimeZone = .current`, and the `(UTC)` labels are gone.
- The stable prompt gains two lines telling the model timestamps are already local and never to convert to or mention UTC, so the fix survives model paraphrase.
- Full-prompt tests inject `America/New_York` (via `XCTUnwrap`, matching the repo's test pattern) and pin `Due at: 2023-11-14 18:13 EST` / `Captured at: 2023-11-14 17:13 EST`, so a UTC CI runner cannot keep a machine-zone regression green.
- Retrieval hop (from review): the stable prompt's "already local" promise also has to hold for the second director call, where backend `createdAt` arrives as UTC ISO-8601. `ContextDirectorRetrievalHop.promptSection` now re-renders parseable `createdAt` values through the same `localTimestamp` authority (unparseable strings pass through verbatim), with tests pinning `(2026-08-01 06:00 EDT)` for the `2026-08-01T10:00:00Z` fixture.
- Boundary test (from review): `2026-08-11T03:59Z` pins as `2026-08-10 23:59 EDT` — the exact #11392 failure shape (UTC date rolled to tomorrow while the local day hasn't), and a DST-on rendering.

## Suggestion surface

Checked `ProactiveAssistants/Assistants/Suggestions/` for the same mechanical bug: it is structurally different and already correct. #11392 hit the identical class there (raw `ISO8601DateFormatter` in UTC made due-today tasks score as due-tomorrow) and fixed it with relative phrasing — `SuggestionDueDescription` does local-calendar day arithmetic and `describeScreen` formats in the local zone. No change needed on that surface.

## Failure class

Two same-cause instances (suggestions in #11392, director here), so this PR registers `FC-machine-timezone-timestamp-in-prompt`: a timestamp rendered into a prompt whose output reaches the user verbatim is user-facing text, not wire format. Canonical prevention is an injected user `TimeZone` (or relative phrasing) at the point the date enters prompt text, plus tests pinned to a non-UTC zone.

Failure-Class: new

## Pre-PR review (cursor grok-4.6-high via agentctl)

- **Addressed**: retrieval-hop `createdAt` contradicted the new stable-prompt promise (UTC `Z` instants under a prefix that says everything is local) — fixed above. Missing UTC-next-day/local-same-day + DST-on coverage — boundary test added.
- **Confirmed, no change needed**: cache placement is correct. The two new sentences sit only in the cached stable prefix; `Due at`/`Captured at` stay volatile, so EST↔EDT flips never rewrite the prefix. `cache_key` maps to OpenAI `prompt_cache_key`, a routing hint over exact-prefix-match caching — the wording change is a one-time cold miss per bucket (~30m TTL), never a stale-prefix hit.
- **Noted, deliberately not taken**: reviewer suggested the chat-prompt format (`ISO8601 with numeric offset + IANA id`) over `zzz` abbreviations, since abbreviations are non-unique across zones (EST/IST) and some zones render as `GMT+9`. Kept `yyyy-MM-dd HH:mm zzz` as specified for this surface: the string is quoted verbatim into human-facing notification copy, where "18:13 EST" reads naturally and "2023-11-14T18:13:00-05:00 (America/New_York)" does not. `en_US_POSIX` pins the rendering; if Apple's tz abbreviation data ever shifts, the pinned tests catch it loudly.

## Notes

- Verified `swift test --filter Context`: 319 tests, 0 failures. `scripts/pr-preflight`: all 21 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

