### PR TITLE
fix(desktop): stop silent director evaluations from spending the daily notification budget

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -226,10 +226,18 @@ extension ContextBucketStore {
           cooldownSeconds: gate.cooldownSeconds)
       else { return ContextDeliveryAttempt(id: nil, reason: .cooldown) }
       let windowStart = ContextDeliveryBudget.dailyWindowStart(now: now)
+      // The daily budget caps user-visible interruptions. Evaluations that resolved
+      // to silence or failed never reached the user, so they must not spend it — a
+      // day of heavy screen activity would otherwise exhaust the budget on invisible
+      // decisions and read as a dead feature. In-flight attempts still count until
+      // they resolve, so a burst cannot over-reserve past the cap.
       let attemptedInWindow =
         try Int.fetchOne(
           db,
-          sql: "SELECT COUNT(*) FROM proactive_deliveries WHERE attemptedAt >= ?",
+          sql: """
+            SELECT COUNT(*) FROM proactive_deliveries
+            WHERE attemptedAt >= ? AND lifecycleState NOT IN ('suppressed', 'failed')
+            """,
           arguments: [windowStart]) ?? 0
       guard attemptedInWindow < gate.dailyLimit else {
         return ContextDeliveryAttempt(id: nil, reason: .dailyBudget)

--- a/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
@@ -176,6 +176,77 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
     XCTAssertEqual(result, ContextDeliveryAttempt(id: nil, reason: .cooldown))
   }
 
+  func testDailyBudgetIgnoresInvisibleOutcomesButCountsVisibleSpend() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    let versionID = try await seedBucketAndVisit(in: pool, poolEpoch: poolEpoch, now: now)
+    let gate = ContextDeliveryGateInput(
+      masterEnabled: true,
+      frequencyLevel: 1,
+      paywalled: false,
+      cooldownSeconds: 0)
+    let limit = gate.dailyLimit
+    try await pool.write { db in
+      for index in 0..<(limit + 2) {
+        try db.execute(
+          sql: """
+            INSERT INTO proactive_deliveries
+              (id, visitID, bucketID, bucketVersionID, decisionType, lifecycleState,
+               provenanceJson, attemptedAt, expiresAt, createdAt)
+            VALUES (?, NULL, 'bucket', ?, 'silence', 'suppressed', '{}', ?, ?, ?)
+            """,
+          arguments: [
+            "silence-\(index)", versionID,
+            now.addingTimeInterval(-3_600), now.addingTimeInterval(3_600),
+            now.addingTimeInterval(-3_600),
+          ])
+      }
+    }
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket",
+      versionID: versionID,
+      version: 1,
+      header: "header",
+      frozenRankedSegment: Data(),
+      tail: [],
+      validatedFacts: ["fact:one statement"],
+      notifyWorthiness: 1)
+
+    let afterSilences = try await ContextBucketStore.shared.beginDeliveryAttempt(
+      fence: ContextVisitFence(
+        visitID: 1, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket",
+        startedAt: now),
+      snapshot: snapshot, gate: gate, now: now)
+    XCTAssertEqual(
+      afterSilences.reason, .allowed,
+      "silent evaluations never reached the user, so they must not spend the daily budget")
+
+    try await pool.write { db in
+      for index in 0..<limit {
+        try db.execute(
+          sql: """
+            INSERT INTO proactive_deliveries
+              (id, visitID, bucketID, bucketVersionID, decisionType, lifecycleState,
+               provenanceJson, attemptedAt, deliveredAt, expiresAt, createdAt)
+            VALUES (?, NULL, 'bucket', ?, 'insight', 'delivered', '{}', ?, ?, ?, ?)
+            """,
+          arguments: [
+            "visible-\(index)", versionID,
+            now.addingTimeInterval(-7_200), now.addingTimeInterval(-7_200),
+            now.addingTimeInterval(3_600), now.addingTimeInterval(-7_200),
+          ])
+      }
+    }
+
+    let afterVisible = try await ContextBucketStore.shared.beginDeliveryAttempt(
+      fence: ContextVisitFence(
+        visitID: 2, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket",
+        startedAt: now),
+      snapshot: snapshot, gate: gate, now: now)
+    XCTAssertEqual(afterVisible, ContextDeliveryAttempt(id: nil, reason: .dailyBudget))
+  }
+
   private func allowedGate() -> ContextDeliveryGateInput {
     ContextDeliveryGateInput(
       masterEnabled: true,

--- a/desktop/macos/changelog/unreleased/20260815-daily-budget-excludes-silences.json
+++ b/desktop/macos/changelog/unreleased/20260815-daily-budget-excludes-silences.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive notifications no longer go quiet after a busy day: silent background evaluations stopped counting against the daily notification budget"
+}


### PR DESCRIPTION
## Why

The context director's daily budget counts every evaluation in the rolling 24h window — including the ones that resolved to silence. On a real machine today: 124 attempts in-window against a level-4 cap of 60, with the majority being invisible silence decisions. Result: the director stops evaluating entirely for hours, which reads as a dead feature. The budget is a user-visible interruption cap, not a cost cap (server-side quota already meters model calls), so invisible outcomes must not spend it.

## What

`beginDeliveryAttempt` now excludes `lifecycleState IN ('suppressed', 'failed')` from the daily-window count. In-flight attempts still count until they resolve, so a burst cannot over-reserve past the cap. Per-bucket cooldowns are unchanged and still pace evaluation frequency.

## Proof

- New `testDailyBudgetIgnoresInvisibleOutcomesButCountsVisibleSpend`: seeds limit+2 suppressed silences (attempt still allowed) then limit delivered rows (attempt rejected with `.dailyBudget`).
- `ContextDelivery*` + `ContextProactivityEngine` suites: 78 tests, 0 failures.

Failure-Class: none

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

