### PR TITLE
feat(desktop): user-facing copy-share-link for conversations

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstAnalytics.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstAnalytics.swift
@@ -42,6 +42,7 @@ enum ChatFirstAnalyticsEvent: Equatable, Sendable {
     case open
     case toggle
     case select
+    case copyLink = "copy_link"
   }
 
   enum QuestionLifecycle: String, CaseIterable, Sendable {

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
@@ -1,3 +1,4 @@
+import AppKit
 import OmiTheme
 import SwiftUI
 
@@ -455,6 +456,9 @@ struct ConversationLinkView: View {
 
   @State private var isOpening = false
   @State private var isUnavailable = false
+  @State private var isCopyingLink = false
+  @State private var shareLinkFeedback: ConversationShareLinkFeedback?
+  @State private var shareLinkFeedbackGeneration = 0
 
   var body: some View {
     Group {
@@ -467,16 +471,57 @@ struct ConversationLinkView: View {
           summary: summary,
           actionTitle: "Open conversation",
           isOpening: isOpening,
-          accessibilityID: "chat-first-conversation-\(conversationID)-open"
-        ) {
-          openConversation()
-        }
+          accessibilityID: "chat-first-conversation-\(conversationID)-open",
+          action: { openConversation() },
+          secondaryActionTitle: "Copy share link",
+          secondaryActionSystemImage: "link",
+          isSecondaryBusy: isCopyingLink,
+          secondaryAccessibilityID: "chat-first-conversation-\(conversationID)-copy-link",
+          secondaryHelp: "Copy share link — anyone with the link can view",
+          secondaryAction: { copyShareLink() },
+          statusMessage: shareLinkFeedback?.message,
+          statusSystemImage: shareLinkFeedback?.systemImage,
+          statusColor: shareLinkFeedback == .copied ? Ink.listeningGreen : Ink.errorRed
+        )
       }
     }
     .onAppear {
       AnalyticsManager.shared.chatFirst(
         .richBlock(kind: .conversationLink, outcome: .rendered, action: .none)
       )
+    }
+  }
+
+  /// Copies a public share link for the conversation. Minting the link flips
+  /// the conversation's visibility to shared, so the confirmation discloses
+  /// the audience. A failure here never touches `isUnavailable` — copy
+  /// problems must not block "Open conversation".
+  private func copyShareLink() {
+    guard !isCopyingLink else { return }
+    isCopyingLink = true
+    Task { @MainActor in
+      defer { isCopyingLink = false }
+      let feedback = await ConversationShareLinkAction.run(
+        mintLink: { try await APIClient.shared.getConversationShareLink(id: conversationID) },
+        copyToPasteboard: { link in
+          NSPasteboard.general.clearContents()
+          return NSPasteboard.general.setString(link, forType: .string)
+        }
+      )
+      AnalyticsManager.shared.chatFirst(
+        .richBlock(
+          kind: .conversationLink,
+          outcome: feedback == .copied ? .acted : .rejected,
+          action: .copyLink
+        )
+      )
+      shareLinkFeedback = feedback
+      shareLinkFeedbackGeneration += 1
+      let generation = shareLinkFeedbackGeneration
+      DispatchQueue.main.asyncAfter(deadline: .now() + ConversationShareLinkFeedback.displaySeconds) {
+        guard shareLinkFeedbackGeneration == generation else { return }
+        shareLinkFeedback = nil
+      }
     }
   }
 
@@ -563,6 +608,19 @@ private struct ChatFirstLinkBlockView: View {
   let isOpening: Bool
   let accessibilityID: String
   let action: () -> Void
+  // Optional secondary chip rendered beside the primary destination chip
+  // (e.g. "Copy share link" beside "Open conversation"). The transient
+  // status renders on its own caption line under the chips so a long
+  // confirmation never stretches or clips the chip row.
+  var secondaryActionTitle: String? = nil
+  var secondaryActionSystemImage: String = "link"
+  var isSecondaryBusy: Bool = false
+  var secondaryAccessibilityID: String = ""
+  var secondaryHelp: String? = nil
+  var secondaryAction: (() -> Void)? = nil
+  var statusMessage: String? = nil
+  var statusSystemImage: String? = nil
+  var statusColor: Color = Ink.secondary
 
   var body: some View {
     VStack(alignment: .leading, spacing: OmiSpacing.sm) {
@@ -575,25 +633,57 @@ private struct ChatFirstLinkBlockView: View {
         .foregroundStyle(Ink.primary)
         .fixedSize(horizontal: false, vertical: true)
 
-      Button(action: action) {
-        HStack(spacing: OmiSpacing.xs) {
-          if isOpening {
-            ProgressView()
-              .controlSize(.small)
+      HStack(spacing: OmiSpacing.sm) {
+        Button(action: action) {
+          HStack(spacing: OmiSpacing.xs) {
+            if isOpening {
+              ProgressView()
+                .controlSize(.small)
+            }
+            Text(actionTitle)
+            Image(systemName: "arrow.up.right")
           }
-          Text(actionTitle)
-          Image(systemName: "arrow.up.right")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundStyle(Ink.primary)
+          .padding(.horizontal, OmiSpacing.sm)
+          .padding(.vertical, OmiSpacing.xs)
+          .glassChip()
         }
-        .scaledFont(size: OmiType.caption, weight: .semibold)
-        .foregroundStyle(Ink.primary)
-        .padding(.horizontal, OmiSpacing.sm)
-        .padding(.vertical, OmiSpacing.xs)
-        .glassChip()
+        .buttonStyle(.plain)
+        .disabled(isOpening)
+        .accessibilityLabel(actionTitle)
+        .accessibilityIdentifier(accessibilityID)
+
+        if let secondaryActionTitle, let secondaryAction {
+          Button(action: secondaryAction) {
+            HStack(spacing: OmiSpacing.xs) {
+              if isSecondaryBusy {
+                ProgressView()
+                  .controlSize(.small)
+              }
+              Text(secondaryActionTitle)
+              Image(systemName: secondaryActionSystemImage)
+            }
+            .scaledFont(size: OmiType.caption, weight: .semibold)
+            .foregroundStyle(Ink.primary)
+            .padding(.horizontal, OmiSpacing.sm)
+            .padding(.vertical, OmiSpacing.xs)
+            .glassChip()
+          }
+          .buttonStyle(.plain)
+          .disabled(isSecondaryBusy)
+          .help(secondaryHelp ?? secondaryActionTitle)
+          .accessibilityLabel(secondaryHelp ?? secondaryActionTitle)
+          .accessibilityIdentifier(secondaryAccessibilityID)
+        }
       }
-      .buttonStyle(.plain)
-      .disabled(isOpening)
-      .accessibilityLabel(actionTitle)
-      .accessibilityIdentifier(accessibilityID)
+
+      if let statusMessage {
+        Label(statusMessage, systemImage: statusSystemImage ?? "checkmark")
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundStyle(statusColor)
+          .fixedSize(horizontal: false, vertical: true)
+      }
     }
     .padding(.horizontal, OmiSpacing.md)
     .padding(.vertical, OmiSpacing.sm)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -125,29 +125,23 @@ struct ConversationRowView: View {
   private func copyLink() async {
     guard !isCopyingLink else { return }
     isCopyingLink = true
+    defer { isCopyingLink = false }
 
-    do {
-      // First, make the conversation public/shared so the link works
-      try await APIClient.shared.setConversationVisibility(
-        id: conversation.id, visibility: "shared")
-
-      // Then copy the link
-      let link = DesktopBackendEnvironment.conversationShareURL(id: conversation.id)
-      let pasteboard = NSPasteboard.general
-      pasteboard.clearContents()
-      pasteboard.setString(link, forType: .string)
-      log("Copied conversation link to clipboard (visibility set to shared)")
-    } catch {
-      log("Failed to set conversation visibility: \(error)")
-      // Still copy the link even if visibility fails - user might have shared it before
-      let link = DesktopBackendEnvironment.conversationShareURL(id: conversation.id)
-      let pasteboard = NSPasteboard.general
-      pasteboard.clearContents()
-      pasteboard.setString(link, forType: .string)
-      log("Copied conversation link to clipboard (visibility API failed)")
+    // Same contract as the detail view and the meeting-notes card: the
+    // visibility mutation is what makes the URL resolve, so a failed mint
+    // copies nothing instead of handing out a link that may 404.
+    let feedback = await ConversationShareLinkAction.run(
+      mintLink: { try await APIClient.shared.getConversationShareLink(id: conversation.id) },
+      copyToPasteboard: { link in
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        return pasteboard.setString(link, forType: .string)
+      },
+      onFailure: { log("Failed to get share link: \($0)") }
+    )
+    if feedback == .copied {
+      log("Copied conversation share link to clipboard (visibility set to shared)")
     }
-
-    isCopyingLink = false
   }
 
   private func deleteConversation() async {
@@ -199,7 +193,7 @@ struct ConversationRowView: View {
       }
       .buttonStyle(.plain)
       .disabled(isCopyingLink)
-      .help("Copy link")
+      .help("Copy share link — anyone with the link can view")
 
       // Move to folder (if folders exist)
       if !folders.isEmpty {
@@ -433,10 +427,11 @@ struct ConversationRowView: View {
 
       Button(action: { Task { await copyLink() } }) {
         Label(
-          isCopyingLink ? "Generating Link..." : "Copy Link",
+          isCopyingLink ? "Generating Link..." : "Copy Share Link",
           systemImage: isCopyingLink ? "arrow.triangle.2.circlepath" : "link")
       }
       .disabled(isCopyingLink)
+      .help("Anyone with the link can view")
 
       Divider()
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationShareLink.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationShareLink.swift
@@ -1,0 +1,162 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+
+/// Transient user-facing feedback for the "copy share link" affordance.
+///
+/// Minting a conversation share link is not a plain read: the backend flips the
+/// conversation's visibility to "shared" before the `https://h.omi.me` URL
+/// resolves (`APIClient.getConversationShareLink`). The copied confirmation
+/// therefore has to disclose who can open the link. The wording lives here so
+/// every surface (conversation detail, meeting-notes chat card) discloses the
+/// same thing.
+enum ConversationShareLinkFeedback: Equatable {
+  case copied
+  case failed
+
+  var message: String {
+    switch self {
+    case .copied: return "Link copied — anyone with the link can view"
+    case .failed: return "Couldn't create link"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .copied: return "checkmark"
+    case .failed: return "exclamationmark.triangle"
+    }
+  }
+
+  /// How long the transient confirmation stays visible.
+  static let displaySeconds: TimeInterval = 4
+}
+
+enum ConversationShareLinkAction {
+  /// Mints a share link and copies it to the pasteboard.
+  ///
+  /// The URL is copied only when minting succeeded: the mint call is the
+  /// visibility mutation that makes the URL resolve, so copying after a
+  /// failure would hand the user a link that may 404 while the UI reads as
+  /// success. The pasteboard write's own result is honored too — "Link
+  /// copied" is never shown for a write NSPasteboard rejected. Failure
+  /// feedback is non-blocking; callers keep every other affordance (like
+  /// opening the conversation) available.
+  @MainActor
+  static func run(
+    mintLink: () async throws -> String,
+    copyToPasteboard: (String) -> Bool,
+    onFailure: (Error) -> Void = { _ in }
+  ) async -> ConversationShareLinkFeedback {
+    do {
+      let link = try await mintLink()
+      return copyToPasteboard(link) ? .copied : .failed
+    } catch {
+      onFailure(error)
+      return .failed
+    }
+  }
+}
+
+/// The 28pt header-toolbar control for copying a conversation share link.
+///
+/// Minting the link sets the conversation's visibility to shared, so the
+/// transient confirmation says who can open it instead of reading as a plain
+/// copy. The message renders as an overlay anchored under the glyph so the
+/// header row never reflows and neighboring titles are never crushed while
+/// feedback shows.
+struct ConversationShareLinkButton: View {
+  let conversationId: String
+  var canShare: Bool = true
+  var onCopied: (() -> Void)? = nil
+
+  @State private var isCopyingLink = false
+  @State private var feedback: ConversationShareLinkFeedback?
+  @State private var feedbackGeneration = 0
+
+  var body: some View {
+    Button(action: { Task { await copyLink() } }) {
+      Image(systemName: icon)
+        .scaledFont(size: OmiType.body)
+        .foregroundColor(color)
+        .frame(width: 28, height: 28)
+        .background(
+          Circle()
+            .fill(Ink.rowFillHover)
+        )
+    }
+    .buttonStyle(.plain)
+    .disabled(isCopyingLink || !canShare)
+    .help(
+      canShare
+        ? "Copy share link — anyone with the link can view"
+        : "Sharing is unavailable while the transcript is locked"
+    )
+    .accessibilityLabel(feedback?.message ?? "Copy share link")
+    .overlay(alignment: .trailing) {
+      if let feedback {
+        Text(feedback.message)
+          .scaledFont(size: OmiType.caption, weight: .medium)
+          .foregroundColor(color)
+          .padding(.horizontal, OmiSpacing.md)
+          .padding(.vertical, OmiSpacing.xs)
+          .background(
+            Capsule()
+              .fill(Ink.surface)
+          )
+          .overlay(
+            Capsule()
+              .stroke(Ink.glassEdge, lineWidth: 1)
+          )
+          .fixedSize()
+          .offset(y: 34)
+          .allowsHitTesting(false)
+          .zIndex(1)
+      }
+    }
+  }
+
+  private var icon: String {
+    if isCopyingLink { return "arrow.triangle.2.circlepath" }
+    return feedback?.systemImage ?? "link"
+  }
+
+  private var color: Color {
+    switch feedback {
+    case .copied: return Ink.listeningGreen
+    case .failed: return Ink.errorRed
+    case nil: return Ink.secondary
+    }
+  }
+
+  private func copyLink() async {
+    guard !isCopyingLink, canShare else { return }
+    isCopyingLink = true
+    defer { isCopyingLink = false }
+
+    let outcome = await ConversationShareLinkAction.run(
+      mintLink: { try await APIClient.shared.getConversationShareLink(id: conversationId) },
+      copyToPasteboard: { link in
+        NSPasteboard.general.clearContents()
+        return NSPasteboard.general.setString(link, forType: .string)
+      },
+      onFailure: { logError("Failed to get share link", error: $0) }
+    )
+
+    if outcome == .copied {
+      onCopied?()
+    }
+    show(outcome)
+  }
+
+  private func show(_ outcome: ConversationShareLinkFeedback) {
+    feedback = outcome
+    feedbackGeneration += 1
+    let generation = feedbackGeneration
+    DispatchQueue.main.asyncAfter(deadline: .now() + ConversationShareLinkFeedback.displaySeconds) {
+      // A newer click owns the confirmation; only the latest one clears it.
+      guard feedbackGeneration == generation else { return }
+      feedback = nil
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -46,7 +46,6 @@ struct ConversationDetailView: View {
   @State private var showEditDialog = false
   @State private var editedTitle = ""
   @State private var isUpdatingTitle = false
-  @State private var isCopyingLink = false
   @State private var isDeleting = false
 
   // Speaker naming state
@@ -409,20 +408,16 @@ struct ConversationDetailView: View {
 
   private var inlineActionButtons: some View {
     HStack(spacing: OmiSpacing.sm) {
-      // Copy link button
-      Button(action: { Task { await copyLink() } }) {
-        Image(systemName: isCopyingLink ? "arrow.triangle.2.circlepath" : "link")
-          .scaledFont(size: OmiType.body)
-          .foregroundColor(Ink.secondary)
-          .frame(width: 28, height: 28)
-          .background(
-            Circle()
-              .fill(Ink.rowFillHover)
-          )
-      }
-      .buttonStyle(.plain)
-      .disabled(isCopyingLink)
-      .help("Copy link")
+      // Copy share link (minting flips visibility to shared; the control
+      // discloses and confirms that itself).
+      ConversationShareLinkButton(
+        conversationId: conversation.id,
+        canShare: canShareConversation,
+        onCopied: {
+          AnalyticsManager.shared.shareAction(
+            category: "conversation", properties: ["conversation_id": conversation.id])
+        }
+      )
 
       // Copy transcript button
       Button(action: copyTranscript) {
@@ -503,6 +498,14 @@ struct ConversationDetailView: View {
     displayConversation.transcriptPresenceState != .lockedOrRedacted
   }
 
+  /// Sharing publishes the conversation (visibility flips to "shared"), so it
+  /// honors the same lock/redaction gate as copying the transcript: content
+  /// this surface refuses to put on the pasteboard must not be publishable to
+  /// an unauthenticated share URL from the same toolbar.
+  private var canShareConversation: Bool {
+    canCopyTranscript
+  }
+
   // MARK: - Actions
 
   private func copyTranscript() {
@@ -523,22 +526,6 @@ struct ConversationDetailView: View {
 
     NSPasteboard.general.clearContents()
     NSPasteboard.general.setString(transcript, forType: .string)
-  }
-
-  private func copyLink() async {
-    isCopyingLink = true
-    defer { isCopyingLink = false }
-
-    do {
-      let shareableUrl = try await APIClient.shared.getConversationShareLink(id: conversation.id)
-      await MainActor.run {
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(shareableUrl, forType: .string)
-      }
-      AnalyticsManager.shared.shareAction(category: "conversation", properties: ["conversation_id": conversation.id])
-    } catch {
-      logError("Failed to get share link", error: error)
-    }
   }
 
   private func updateTitle() async {

--- a/desktop/macos/Desktop/Tests/ConversationShareLinkActionTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationShareLinkActionTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ConversationShareLinkActionTests: XCTestCase {
+  @MainActor
+  func testSuccessfulMintCopiesTheMintedLinkExactly() async {
+    var copied: [String] = []
+    let feedback = await ConversationShareLinkAction.run(
+      mintLink: { "https://h.omi.me/conversations/abc" },
+      copyToPasteboard: { link in
+        copied.append(link)
+        return true
+      }
+    )
+    XCTAssertEqual(feedback, .copied)
+    XCTAssertEqual(copied, ["https://h.omi.me/conversations/abc"])
+  }
+
+  @MainActor
+  func testRejectedPasteboardWriteIsNotReportedAsCopied() async {
+    let feedback = await ConversationShareLinkAction.run(
+      mintLink: { "https://h.omi.me/conversations/abc" },
+      copyToPasteboard: { _ in false }
+    )
+    XCTAssertEqual(feedback, .failed)
+  }
+
+  @MainActor
+  func testFailedMintCopiesNothingAndReportsTheError() async {
+    struct MintError: Error {}
+    var copied: [String] = []
+    var reportedErrors = 0
+    let feedback = await ConversationShareLinkAction.run(
+      mintLink: { throw MintError() },
+      copyToPasteboard: { link in
+        copied.append(link)
+        return true
+      },
+      onFailure: { _ in reportedErrors += 1 }
+    )
+    XCTAssertEqual(feedback, .failed)
+    // Minting is the visibility mutation that makes the URL work; after a
+    // failure the user must not be handed a link presented as usable.
+    XCTAssertTrue(copied.isEmpty)
+    XCTAssertEqual(reportedErrors, 1)
+  }
+
+  func testCopiedConfirmationDisclosesTheLinkAudience() {
+    // getConversationShareLink flips the conversation's visibility to
+    // "shared" before returning the URL, so the confirmation must disclose
+    // the audience instead of reading as a plain clipboard copy.
+    XCTAssertTrue(ConversationShareLinkFeedback.copied.message.contains("anyone with the link"))
+    XCTAssertEqual(ConversationShareLinkFeedback.failed.message, "Couldn't create link")
+  }
+
+  func testCopyLinkRichBlockActionStaysInsideTheClosedSchema() {
+    XCTAssertEqual(ChatFirstAnalyticsEvent.RichBlockAction.copyLink.rawValue, "copy_link")
+    let payload = ChatFirstAnalyticsEvent.richBlock(
+      kind: .conversationLink,
+      outcome: .acted,
+      action: .copyLink
+    ).analyticsPayload
+    XCTAssertEqual(payload.eventName, "chat_first_rich_block")
+    XCTAssertEqual(payload.properties["action"], "copy_link")
+    XCTAssertEqual(
+      Set(payload.properties.keys),
+      ["kind", "outcome", "action", "telemetry_schema_version"]
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260815-conversation-copy-share-link.json
+++ b/desktop/macos/changelog/unreleased/20260815-conversation-copy-share-link.json
@@ -1,0 +1,1 @@
+{"change": "Conversation detail and meeting-notes chat cards can copy a public share link, with confirmation that anyone with the link can view"}

--- a/desktop/macos/e2e/flows/conversation-sharing.yaml
+++ b/desktop/macos/e2e/flows/conversation-sharing.yaml
@@ -5,6 +5,7 @@ description: Hermetic conversation share affordance probe (clipboard/native shar
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ConversationShareLink.swift
   - desktop/macos/Desktop/Sources/APIClient.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ChatSessions.swift
   - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift


### PR DESCRIPTION
Adds a user-facing "Copy share link" affordance for conversations on the two desktop surfaces that show them:

- **Conversation detail** — the existing link glyph in the header toolbar now gives real feedback: while the transient confirmation shows, the glyph circle expands into the header's capsule idiom with "Link copied — anyone with the link can view" (green check) or "Couldn't create link" (red warning). The tooltip discloses the audience before the click.
- **Meeting-notes chat card** (`ConversationLinkView`) — a secondary "Copy share link" chip beside "Open conversation", in the same glass-chip style. Its title swaps to the confirmation/failure message for a few seconds (the `TaskDetailPanel` copy-link idiom).

## Visibility semantics — deliberate and disclosed

`APIClient.getConversationShareLink(id:)` is **not a read**: it first `PATCH`es `v1/conversations/<id>/visibility?value=shared`, then returns `https://h.omi.me/conversations/<id>`. Copying a share link therefore makes the conversation viewable by anyone with the link.

- The mutation only runs on the user's explicit click of a control labeled "Copy share link".
- The confirmation wording is centralized in `ConversationShareLinkFeedback` so both surfaces disclose the same thing: "Link copied — anyone with the link can view".
- On a failed mint the URL is **not** copied (the mint is what makes the URL resolve) and the non-blocking "Couldn't create link" message shows; opening the conversation is never blocked, and the chat card's unavailable state is untouched by copy failures.
- The conversation-row surface (`ConversationRowView`, hover glyph + context menu) is aligned to the same contract: it previously copied the URL even when the visibility PATCH failed; it now uses the shared helper, and its labels/tooltips disclose the audience.
- Detail-view share honors the same gate as copy-transcript: a `lockedOrRedacted` transcript cannot be published to the unauthenticated share URL from the same toolbar that refuses to copy it.
- Known residue (pre-existing): a failed mint after the backend already applied the PATCH, or a rejected pasteboard write after a successful mint, leaves the conversation shared while the UI reports failure. The desktop has no unshare affordance on these surfaces; visibility can be reverted from the mobile app.

## Implementation

- `MainWindow/Components/ConversationShareLink.swift` (new): feedback model, `ConversationShareLinkAction.run(mintLink:copyToPasteboard:onFailure:)` carrying the copy-only-on-success rule, and the self-contained `ConversationShareLinkButton` used by the detail header (keeps `ConversationDetailView` under its line-count freeze); registered in `conversation-sharing.yaml` covers.
- `ChatFirstLinkBlockView` gains optional secondary-chip parameters (defaults keep the goal/capture/memory cards unchanged).
- Chat-first analytics stays a closed schema: new `RichBlockAction.copyLink` (`copy_link`); the card logs `acted`/`rejected` with it. The detail view keeps its existing `shareAction` event.
- Logic tests in `ConversationShareLinkActionTests`: exact-URL copy on success, no copy + error report on failure, audience-disclosure wording, closed analytics schema.
- Changelog fragment `20260815-conversation-copy-share-link.json`.

## Product invariants affected

INV-CHAT-1 — touched `MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift`, but only the rich-card presentation layer: a secondary clipboard chip and a closed-schema analytics case. No transcript, session, or continuity state is read or written; the copy action's only mutation is the backend visibility PATCH and the pasteboard.

## Verification

- `xcrun swift build -c debug` clean; `swift test --filter "ConversationShareLinkActionTests|ChatFirstAnalyticsTests|ShareLinksEnvironmentTests|ChatFirstRichBlockTests"` green
- swift-format lint + SwiftLint scope clean; `check-e2e-flow-coverage.py --strict` 0 uncovered; `check_desktop_test_quality.py` at baseline
- `scripts/pr-preflight --lane local` run pre-push
- Reviewed by cursor-agent (Grok 4.6) before push; addressed its findings: pre-click audience disclosure on all three surfaces, share gated on locked/redacted transcripts, `ConversationRowView` contract alignment, `NSPasteboard.setString`'s Bool honored (no "Link copied" on a rejected write), and confirmation text moved out of the chip/header flow so long messages never clip or crush the title

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

