### PR TITLE
fix(desktop): skip ScreenCaptureKit until Screen Recording is live

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -232,6 +232,10 @@ extension SBOnboardingModel {
   /// (the exact spot users hit it). See `ScreenCaptureService.primeCaptureConsent`.
   func primeScreenCaptureConsentIfNeeded() {
     guard !didPrimeScreenCapture else { return }
+    guard
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+        grantedAtLaunch: appState.screenRecordingGrantedAtLaunch)
+    else { return }
     didPrimeScreenCapture = true
     if #available(macOS 14.0, *) {
       Task.detached { await ScreenCaptureService.primeCaptureConsent() }

--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -51,12 +51,19 @@ final class ScreenCaptureService: Sendable {
   /// for up to `sharedContentTTL` seconds; refresh on demand when a target window isn't
   /// present in the cache.
   private static let sharedContentLock = NSLock()
-  nonisolated(unsafe) private static var cachedSharedContent: Any?  // SCShareableContent, typed Any so this decl predates macOS 14 gate
+  // SCShareableContent, typed Any so this decl predates the macOS 14 gate.
+  nonisolated(unsafe) private static var cachedSharedContent: Any?
   nonisolated(unsafe) private static var sharedContentCachedAt: Date?
   private static let sharedContentTTL: TimeInterval = 5.0
 
   @available(macOS 14.0, *)
   private static func sharedContent(forceRefresh: Bool = false) async throws -> SCShareableContent {
+    guard
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+        grantedAtLaunch: grantedAtProcessStart)
+    else {
+      throw ScreenCaptureKitUnavailable.grantNotLiveInThisProcess
+    }
     if !forceRefresh,
       !UserDefaults.standard.bool(forKey: .rewindDisableContentCache)
     {
@@ -83,6 +90,16 @@ final class ScreenCaptureService: Sendable {
 
   init() {}
 
+  /// TCC as observed the first time this snapshot is read. AppState init is the
+  /// first production caller (`checkPermission()`), which is before any
+  /// onboarding grant. Later `CGPreflightScreenCaptureAccess` can flip to true
+  /// without the window-server connection picking up the grant.
+  static let grantedAtProcessStart: Bool = CGPreflightScreenCaptureAccess()
+
+  private enum ScreenCaptureKitUnavailable: Error {
+    case grantNotLiveInThisProcess
+  }
+
   /// Check whether macOS TCC says this app has Screen Recording permission.
   ///
   /// Do not spawn `/usr/sbin/screencapture` here. That helper process can fail
@@ -90,6 +107,7 @@ final class ScreenCaptureService: Sendable {
   /// "Screen Recording disabled" state while System Settings correctly showed
   /// the app as allowed.
   static func checkPermission(forceActualTestIfPreflightDenied: Bool = false) -> Bool {
+    _ = grantedAtProcessStart
     let preflightGranted = CGPreflightScreenCaptureAccess()
 
     if !preflightGranted {
@@ -169,6 +187,22 @@ final class ScreenCaptureService: Sendable {
     }
   }
 
+  /// ScreenCaptureKit talks to the window-server connection opened at launch.
+  /// A first-in-session TCC grant is visible to preflight and dead to SCK;
+  /// calling SCK in that window aborts on some Macs instead of throwing.
+  @available(macOS 14.0, *)
+  static func requestScreenCaptureKitPermissionIfUsableInThisProcess() async -> Bool {
+    _ = grantedAtProcessStart
+    guard
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+        grantedAtLaunch: grantedAtProcessStart)
+    else {
+      log("ScreenCaptureKit: this process launched before the grant; skipping until relaunch")
+      return false
+    }
+    return await requestScreenCaptureKitPermission()
+  }
+
   /// Force re-register this app with Launch Services to ensure it's the authoritative version
   /// This fixes issues where multiple app bundles with the same bundle ID confuse macOS
   /// about which app to grant permissions to.
@@ -237,12 +271,15 @@ final class ScreenCaptureService: Sendable {
     // Screen Recording list (PERM-02). This mirrors requestMicrophonePermission,
     // which activates before requesting and reliably creates its TCC row.
     NSApp.activate()
+    _ = grantedAtProcessStart
     CGRequestScreenCaptureAccess()
 
-    // 2. Request ScreenCaptureKit permission (macOS 14+)
+    // 2. Request ScreenCaptureKit permission (macOS 14+) only when this
+    // process's window-server connection already carries the grant. Calling
+    // SCK immediately after the first TCC dialog returns aborts on some Macs.
     if #available(macOS 14.0, *) {
       Task {
-        _ = await requestScreenCaptureKitPermission()
+        _ = await requestScreenCaptureKitPermissionIfUsableInThisProcess()
       }
     }
 
@@ -257,9 +294,10 @@ final class ScreenCaptureService: Sendable {
   static func requestAllScreenCapturePermissionsAwaitingScreenCaptureKit() async -> Bool {
     ensureLaunchServicesRegistration()
     NSApp.activate()
+    _ = grantedAtProcessStart
     let tccGranted = CGRequestScreenCaptureAccess()
     if #available(macOS 14.0, *) {
-      _ = await requestScreenCaptureKitPermission()
+      _ = await requestScreenCaptureKitPermissionIfUsableInThisProcess()
     }
     return tccGranted || checkPermission()
   }
@@ -296,6 +334,13 @@ final class ScreenCaptureService: Sendable {
   /// swallowed so this never blocks or disrupts onboarding.
   @available(macOS 14.0, *)
   static func primeCaptureConsent() async {
+    guard
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+        grantedAtLaunch: grantedAtProcessStart)
+    else {
+      log("primeCaptureConsent skipped: Screen Recording is not live in this process until relaunch")
+      return
+    }
     do {
       let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
       guard let display = content.displays.first else { return }
@@ -314,6 +359,12 @@ final class ScreenCaptureService: Sendable {
   /// Returns true if ScreenCaptureKit consent is granted, false if declined
   @available(macOS 14.0, *)
   static func testScreenCaptureKitPermission() async -> Bool {
+    guard
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+        grantedAtLaunch: grantedAtProcessStart)
+    else {
+      return false
+    }
     do {
       _ = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
       return true
@@ -331,6 +382,12 @@ final class ScreenCaptureService: Sendable {
     let tccGranted = CGPreflightScreenCaptureAccess()
     if !tccGranted {
       return false  // Not broken, just not granted
+    }
+    guard
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+        grantedAtLaunch: grantedAtProcessStart)
+    else {
+      return false  // Grant isn't live in this process; relaunch, don't probe SCK
     }
 
     let sckGranted = await testScreenCaptureKitPermission()
@@ -350,6 +407,13 @@ final class ScreenCaptureService: Sendable {
     // 2. Re-request ScreenCaptureKit consent (macOS 14+)
     //    This can fix the "TCC says yes but SCK says no" broken state
     if #available(macOS 14.0, *) {
+      guard
+        ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(
+          grantedAtLaunch: grantedAtProcessStart)
+      else {
+        log("Screen capture: Soft recovery skipped SCK; grant is not live until relaunch")
+        return false
+      }
       let sckGranted = await requestScreenCaptureKitPermission()
       if sckGranted {
         log("Screen capture: Soft recovery succeeded (SCK re-consent granted)")
@@ -406,7 +470,7 @@ final class ScreenCaptureService: Sendable {
 
       // Re-request ScreenCaptureKit consent
       if #available(macOS 14.0, *) {
-        _ = await requestScreenCaptureKitPermission()
+        _ = await requestScreenCaptureKitPermissionIfUsableInThisProcess()
       }
 
       await MainActor.run {

--- a/desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
@@ -18,4 +18,13 @@ enum ScreenRecordingPermissionPolicy {
   static func needsRelaunchToApply(grantedNow: Bool, grantedAtLaunch: Bool) -> Bool {
     grantedNow && !grantedAtLaunch
   }
+
+  /// ScreenCaptureKit talks to the window-server connection opened at launch.
+  /// A TCC grant that landed after that connection was created is visible to
+  /// `CGPreflightScreenCaptureAccess` and dead to SCK; calling
+  /// `SCShareableContent` / `SCScreenshotManager` in that window aborts instead
+  /// of throwing. Only invoke SCK when this process launched with the grant.
+  static func shouldInvokeScreenCaptureKit(grantedAtLaunch: Bool) -> Bool {
+    grantedAtLaunch
+  }
 }

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -294,6 +294,59 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
       "revoked while running → a relaunch can't help; the grant flow handles it")
   }
 
+  func testScreenCaptureKitInvokedOnlyWhenGrantWasLiveAtLaunch() {
+    XCTAssertTrue(
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(grantedAtLaunch: true),
+      "SCK is usable when this process launched with Screen Recording already granted")
+    XCTAssertFalse(
+      ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit(grantedAtLaunch: false),
+      "an in-session first grant is not live on this window-server connection")
+  }
+
+  func testFirstGrantPathsDoNotCallScreenCaptureKitUntilRelaunch() throws {
+    // omi-test-quality: source-inspection -- static contract: SCK abort after an
+    // in-session first grant is not reproducible in XCTest without a WindowServer
+    // connection that predates TCC; every SCK entry must consult the policy gate.
+    let src = try sourceFile("Sources/ScreenCaptureService.swift")
+    XCTAssertTrue(src.contains("requestScreenCaptureKitPermissionIfUsableInThisProcess()"))
+    XCTAssertTrue(
+      src.contains("ScreenRecordingPermissionPolicy.shouldInvokeScreenCaptureKit("),
+      "ScreenCaptureService must consult the launch-time SCK gate")
+
+    guard let rfn = src.range(of: "static func requestAllScreenCapturePermissions() {"),
+      let rend = src.range(of: "\n  }", range: rfn.upperBound..<src.endIndex)?.lowerBound
+    else { return XCTFail("requestAllScreenCapturePermissions must exist") }
+    let rbody = String(src[rfn.upperBound..<rend])
+    XCTAssertTrue(
+      rbody.contains("requestScreenCaptureKitPermissionIfUsableInThisProcess()"),
+      "requestAll must not call SCK until the grant is live in this process")
+    XCTAssertFalse(
+      rbody.contains("await requestScreenCaptureKitPermission()"),
+      "requestAll must not call raw SCK after the first TCC dialog")
+
+    guard
+      let pfn = src.range(of: "static func primeCaptureConsent() async {"),
+      let pend = src.range(of: "\n  }", range: pfn.upperBound..<src.endIndex)?.lowerBound
+    else { return XCTFail("primeCaptureConsent must exist") }
+    let pbody = String(src[pfn.upperBound..<pend])
+    XCTAssertTrue(
+      pbody.contains("shouldInvokeScreenCaptureKit"),
+      "primeCaptureConsent must skip SCK when the grant arrived after launch")
+
+    let onboarding = try sourceFile("Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift")
+    guard let ofn = onboarding.range(of: "func primeScreenCaptureConsentIfNeeded() {"),
+      let oend = onboarding.range(of: "\n  }", range: ofn.upperBound..<onboarding.endIndex)?
+        .lowerBound
+    else { return XCTFail("primeScreenCaptureConsentIfNeeded must exist") }
+    let obody = String(onboarding[ofn.upperBound..<oend])
+    XCTAssertTrue(
+      obody.contains("shouldInvokeScreenCaptureKit"),
+      "onboarding must not prime SCK until a relaunch makes the grant live")
+    XCTAssertTrue(
+      obody.contains("screenRecordingGrantedAtLaunch"),
+      "onboarding must use AppState's launch-time snapshot, not a post-grant preflight")
+  }
+
   func testScreenCaptureRestartsUseSharedRelaunchCommand() throws {
     let src = try sourceFile("Sources/ScreenCaptureService.swift")
     XCTAssertTrue(src.contains("static func screenCaptureRelaunchCommand(appPath: String) -> String"))

--- a/desktop/macos/changelog/unreleased/20260815-onboarding-sck-first-grant-crash.json
+++ b/desktop/macos/changelog/unreleased/20260815-onboarding-sck-first-grant-crash.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a crash when granting Screen Recording for the first time during onboarding"
+}


### PR DESCRIPTION
## What changed and why

Granting Screen Recording for the first time during onboarding immediately called ScreenCaptureKit in a process whose window-server connection still predates the grant. TCC preflight already reports allowed, but SCK talks to that launch-time connection and aborts on some Macs instead of throwing. Skip SCK until this process launched with the grant already live; the existing Reopen Omi offer remains the way to make capture work.

## Product invariants affected

none

## How it was verified

Dev GCP logs have no client crash stream (no Crashlytics-like payload). PostHog `Permission Requested` for macOS is dominated by `screen_recording`. The tree already encoded `needsRelaunchToApply(grantedNow && !grantedAtLaunch)` but still invoked `SCShareableContent` / `SCScreenshotManager` immediately after the first TCC dialog.

Could not exercise the real first-grant abort here without a process that launched before TCC flipped. Regression coverage is the policy gate plus source tripwires on every SCK entry used by onboarding.

```
./scripts/dev-feedback.py --once swift 'ScreenRecordingPermissionPolicyTests'
```

20 tests passed, including `testScreenCaptureKitInvokedOnlyWhenGrantWasLiveAtLaunch` and `testFirstGrantPathsDoNotCallScreenCaptureKitUntilRelaunch`.

```
python3 scripts/check_desktop_test_quality.py
```

OK.

## Tests

`ScreenRecordingPermissionPolicyTests.testScreenCaptureKitInvokedOnlyWhenGrantWasLiveAtLaunch` asserts SCK is invoked only when `grantedAtLaunch` is true. `testFirstGrantPathsDoNotCallScreenCaptureKitUntilRelaunch` is a labeled source tripwire that the onboarding prime path and `requestAllScreenCapturePermissions` consult that gate instead of calling SCK after the first TCC dialog.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

