### PR TITLE
fix(desktop): let the context director run to completion after a context switch

### DIFF
--- a/.github/failure-classes/FC-active-only-guard-aborts-owed-delivery.json
+++ b/.github/failure-classes/FC-active-only-guard-aborts-owed-delivery.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-active-only-guard-aborts-owed-delivery",
+  "violated_contract": "An in-flight proactive evaluation that has settled and reserved budget owes the user its outcome. A staleness guard on that pipeline may abort it only when the outcome is no longer safely deliverable \u2014 a discarded or interrupted visit, or a departure older than the delivery validity window \u2014 never merely because the visit's outcome flipped from 'active' to 'completed'. Requiring 'active' at every stage conflates the user's continued presence with the work still being owed, so any fast context switch silently spends quota and delivers nothing.",
+  "canonical_prevention": "Guard every stage of an in-flight director evaluation with ContextBucketStore.visitFreshness, which stays fresh for a completed visit within ContextDeliveryBudget.deliveryValidityWindowSeconds of departure and fails closed for discarded/interrupted outcomes, and bound evidence lookups to the visit's own window (AssistantCoordinator.trackedFrameForDirector notAfter:) so a departed visit can never ground on the next context's screen. Regression tests replay the settle-then-depart timeline.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift",
+    "desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift"
+  ],
+  "evidence_prs": [
+    11616
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/AssistantCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/AssistantCoordinator.swift
@@ -40,6 +40,17 @@ struct ContextTransitionQueue: Sendable {
   }
 }
 
+/// A frame candidate for grounding a director evaluation, paired with the
+/// moment it entered the tracker. On the switch tick the next context's frame
+/// is *captured* before the departing visit's `endedAt` is written, but only
+/// *stored* here after the transition persisted the departure — so
+/// `storedAt <= endedAt` holds exactly for frames belonging to the departed
+/// visit's own context.
+struct TrackedDirectorFrame: Sendable {
+  let frame: CapturedFrame
+  let storedAt: Date
+}
+
 /// Coordinates all proactive assistants, distributing frames and managing lifecycle
 @MainActor
 class AssistantCoordinator {
@@ -55,6 +66,7 @@ class AssistantCoordinator {
   private var lastTrackedApp: String?
   private var lastTrackedWindowTitle: String?
   private var lastTrackedFrame: CapturedFrame?
+  private var lastTrackedFrameStoredAt: Date?
   private var contextTransitionQueue = ContextTransitionQueue()
 
   /// Backpressure: track which assistants are currently analyzing a frame.
@@ -265,11 +277,45 @@ class AssistantCoordinator {
   /// Keep the latest frame reference fresh (call on every capture, even during delay).
   func trackFrame(_ frame: CapturedFrame) {
     lastTrackedFrame = frame
+    lastTrackedFrameStoredAt = Date()
   }
 
-  func trackedFrameForDirector(startedAt: Date) -> CapturedFrame? {
-    guard let frame = lastTrackedFrame, frame.captureTime >= startedAt else { return nil }
-    return frame
+  /// The latest tracked frame as a director grounding candidate. Only frames
+  /// captured at or after the visit began qualify here; the departed-visit
+  /// bound is applied by the caller with `frameMayGroundDirector` AFTER
+  /// re-reading visit freshness, because a bound computed from a pre-lookup
+  /// freshness read races the context switch — the switch can land between
+  /// that read and this lookup, leaving the lookup unbounded exactly when it
+  /// must not be.
+  func trackedFrameForDirector(startedAt: Date) -> TrackedDirectorFrame? {
+    guard
+      let frame = lastTrackedFrame,
+      let storedAt = lastTrackedFrameStoredAt,
+      frame.captureTime >= startedAt
+    else { return nil }
+    return TrackedDirectorFrame(frame: frame, storedAt: storedAt)
+  }
+
+  /// Whether a sampled frame may ground a director evaluation for a visit
+  /// whose freshness was read AFTER the frame was sampled.
+  ///
+  /// Active visit (`endedAt == nil`): any frame captured at or after
+  /// `startedAt`, today's behavior. Departed visit: the frame must also have
+  /// entered the tracker no later than the departure (`storedAt <= endedAt`).
+  /// Capture time alone cannot exclude the next context's screen on the switch
+  /// tick — that frame is *captured* before the transition writes `endedAt` —
+  /// but it is only *stored* after `checkContextSwitch` (which persists the
+  /// departure) returns, so the stored-at bound separates the two exactly. The
+  /// capture-time epsilon additionally keeps the frame near the visit's own
+  /// window under clock skew.
+  nonisolated static func frameMayGroundDirector(
+    captureTime: Date, storedAt: Date, startedAt: Date, endedAt: Date?
+  ) -> Bool {
+    guard captureTime >= startedAt else { return false }
+    guard let endedAt else { return true }
+    return storedAt <= endedAt
+      && captureTime
+        <= endedAt.addingTimeInterval(ContextDeliveryBudget.departedFrameCaptureEpsilonSeconds)
   }
 
   /// Distribute a captured frame to all enabled assistants

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -10,6 +10,18 @@ struct ContextVisitFence: Equatable, Sendable {
   let startedAt: Date
 }
 
+/// Whether an in-flight director evaluation may still act for a visit, plus the
+/// visit's departure time once it has one. A visit is fresh while `active`, and
+/// stays fresh for `ContextDeliveryBudget.deliveryValidityWindowSeconds` after a
+/// `completed` departure so an evaluation the user already paid for can run to
+/// completion. `discarded` and `interrupted` outcomes are never fresh.
+struct ContextVisitFreshness: Equatable, Sendable {
+  let fresh: Bool
+  let endedAt: Date?
+
+  static let stale = ContextVisitFreshness(fresh: false, endedAt: nil)
+}
+
 struct ContextBucketSnapshot: Equatable, Sendable {
   let bucketID: String
   let versionID: Int64
@@ -64,6 +76,12 @@ enum ContextBucketGarbageCollection {
 /// Resolves the durable bucket for a visit identity. Extracted so subject/bucket
 /// consistency after explicit rebinding is testable without the singleton store.
 enum ContextBucketVisitResolver {
+  /// The durable bucket identity this visit persisted, guarding against a
+  /// mid-visit destination rebinding. Liveness is deliberately not enforced
+  /// here — that is `ContextBucketStore.visitFreshness`'s job — so a visit that
+  /// completed moments ago can still resolve its bucket while an in-flight
+  /// evaluation runs to completion. Discarded and interrupted visits stay
+  /// unresolvable.
   static func persistedBucketID(
     in db: Database,
     visitID: Int64,
@@ -74,7 +92,8 @@ enum ContextBucketVisitResolver {
       db,
       sql: """
         SELECT bucketID FROM context_visits
-        WHERE id = ? AND contextGeneration = ? AND poolEpoch = ? AND outcome = 'active'
+        WHERE id = ? AND contextGeneration = ? AND poolEpoch = ?
+          AND outcome IN ('active', 'completed')
         """,
       arguments: [visitID, contextGeneration, poolEpoch])
   }
@@ -362,6 +381,49 @@ actor ContextBucketStore {
       }
     } catch {
       return false
+    }
+  }
+
+  /// Run-to-completion admission for the director pipeline: fresh while the
+  /// visit is active, and for a bounded window after a completed departure.
+  /// Every stage of an in-flight evaluation re-checks this, so an evaluation
+  /// that drags past the window after departure still dies at its next guard.
+  static func visitFreshness(
+    in db: Database, fence: ContextVisitFence, now: Date
+  ) throws -> ContextVisitFreshness {
+    guard
+      let row = try Row.fetchOne(
+        db,
+        sql: """
+          SELECT outcome, endedAt FROM context_visits
+          WHERE id = ? AND contextGeneration = ? AND poolEpoch = ?
+          """,
+        arguments: [fence.visitID, fence.contextGeneration, fence.poolEpoch])
+    else { return .stale }
+    let outcome: String = row["outcome"]
+    let endedAt: Date? = row["endedAt"]
+    switch outcome {
+    case "active":
+      return ContextVisitFreshness(fresh: true, endedAt: endedAt)
+    case "completed":
+      let cutoff = now.addingTimeInterval(-ContextDeliveryBudget.deliveryValidityWindowSeconds)
+      let withinWindow = endedAt.map { $0 >= cutoff } ?? false
+      return ContextVisitFreshness(fresh: withinWindow, endedAt: endedAt)
+    default:
+      // discarded/interrupted: the visit never earned a delivery, however recent.
+      return ContextVisitFreshness(fresh: false, endedAt: endedAt)
+    }
+  }
+
+  func fenceFreshness(_ fence: ContextVisitFence, now: Date = Date()) async -> ContextVisitFreshness {
+    let (pool, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool, poolEpoch == fence.poolEpoch else { return .stale }
+    do {
+      return try await pool.read { db in
+        try Self.visitFreshness(in: db, fence: fence, now: now)
+      }
+    } catch {
+      return .stale
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -112,6 +112,20 @@ enum ContextDeliveryBudget {
   /// 24-hour Redis window (`_QUOTA_WINDOW_SECONDS`), not local midnight.
   static let dailyWindowSeconds: TimeInterval = 24 * 60 * 60
 
+  /// How long after a visit ends its in-flight director evaluation may still
+  /// run to completion and deliver. Requiring `outcome = 'active'` at every
+  /// stage meant any context switch killed the evaluation mid-flight — quota
+  /// spent, nothing delivered — so users who task-switch fast could never
+  /// receive a delivery. Notifications are context-free banners, so a recent
+  /// departure does not invalidate the outcome; each stage re-checks freshness,
+  /// which bounds how stale a departed visit's delivery can be.
+  static let deliveryValidityWindowSeconds: TimeInterval = 60
+
+  /// A departed visit's evaluation must ground on a frame from that visit, not
+  /// the next context's screen. Frames captured at most this long after the
+  /// visit ended still count as the visit's own capture.
+  static let departedFrameCaptureEpsilonSeconds: TimeInterval = 2
+
   static func dailyLimit(frequencyLevel: Int, planMultiplier: Int = 1) -> Int {
     let base = [0, 10, 20, 40, 60, 100][max(0, min(5, frequencyLevel))]
     return base * max(1, planMultiplier)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -74,28 +74,6 @@ enum ContextDirectorTaskSelection {
   }
 }
 
-extension ContextBucketStore {
-  func activeFenceIsValid(_ fence: ContextVisitFence) async -> Bool {
-    let (pool, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
-    guard let pool, poolEpoch == fence.poolEpoch else { return false }
-    do {
-      return try await pool.read { db in
-        try Bool.fetchOne(
-          db,
-          sql: """
-            SELECT EXISTS(
-              SELECT 1 FROM context_visits
-              WHERE id = ? AND contextGeneration = ? AND poolEpoch = ? AND outcome = 'active'
-            )
-            """,
-          arguments: [fence.visitID, fence.contextGeneration, fence.poolEpoch]) ?? false
-      }
-    } catch {
-      return false
-    }
-  }
-}
-
 actor ContextProactivityEngine {
   static let shared = ContextProactivityEngine(client: .shared, store: .shared)
   private let client: ProactiveLaneClient
@@ -143,19 +121,41 @@ actor ContextProactivityEngine {
       log("Context director suppressed before preparation: \(preflightReason.rawValue)")
       return
     }
+    // Run-to-completion: a settled visit's evaluation survives a context switch
+    // for a bounded window (the visit stays "fresh" while active or briefly
+    // after a completed departure), so fast task-switchers can still receive
+    // what their quota already paid for. Every later stage re-checks freshness.
+    let freshness = await store.fenceFreshness(fence)
     guard
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
-      await store.activeFenceIsValid(fence),
+      freshness.fresh,
       let snapshot = await store.snapshot(for: fence)
     else { return }
     // Facts are the only source of notification worthiness. A bucket containing
     // ambient narrative alone cannot purchase a frontier-model call.
     guard ContextDirectorEligibility.permitsEvaluation(of: snapshot) else { return }
+    // After a departure the latest tracked frame can be the NEXT context's
+    // screen. Sample the frame first, then re-read freshness and bound the
+    // sample against it: the transition persists `endedAt` before the next
+    // context's frame is tracked, so a bound applied to a post-sampling
+    // freshness read cannot admit the wrong screen — while a bound computed
+    // from the pre-snapshot read above could, when the switch lands between
+    // that read and this lookup.
     guard
-      let currentFrame = await MainActor.run(body: {
+      let frameSample = await MainActor.run(body: {
         AssistantCoordinator.shared.trackedFrameForDirector(startedAt: fence.startedAt)
       })
     else { return }
+    let frameFreshness = await store.fenceFreshness(fence)
+    guard
+      frameFreshness.fresh,
+      AssistantCoordinator.frameMayGroundDirector(
+        captureTime: frameSample.frame.captureTime,
+        storedAt: frameSample.storedAt,
+        startedAt: fence.startedAt,
+        endedAt: frameFreshness.endedAt)
+    else { return }
+    let currentFrame = frameSample.frame
 
     guard let ownerID = await MainActor.run(body: { RuntimeOwnerIdentity.currentOwnerId() }) else { return }
     let attemptPreflight = await presentationPreflight(ownerID)
@@ -207,7 +207,7 @@ actor ContextProactivityEngine {
       recentDeliveries: recentDeliveries)
     guard
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
-      await store.activeFenceIsValid(fence)
+      await store.fenceFreshness(fence).fresh
     else {
       await terminalize(
         deliveryID: deliveryID,
@@ -244,7 +244,7 @@ actor ContextProactivityEngine {
       await ContextProactivityTelemetry.record(result)
       guard
         RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
-        await store.activeFenceIsValid(fence)
+        await store.fenceFreshness(fence).fresh
       else {
         await terminalize(
           deliveryID: deliveryID,
@@ -292,7 +292,7 @@ actor ContextProactivityEngine {
         // staleness, so a future failure path cannot quietly bypass it.
         guard
           RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
-          await store.activeFenceIsValid(fence)
+          await store.fenceFreshness(fence).fresh
         else {
           await terminalize(
             deliveryID: deliveryID,
@@ -357,7 +357,7 @@ actor ContextProactivityEngine {
         message: decision.message, state: "policy_approved")
       guard
         RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
-        await store.activeFenceIsValid(fence),
+        await store.fenceFreshness(fence).fresh,
         let ownerID = await MainActor.run(body: { RuntimeOwnerIdentity.currentOwnerId() })
       else {
         await terminalize(
@@ -516,7 +516,7 @@ actor ContextProactivityEngine {
     }
     guard
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
-      await store.activeFenceIsValid(fence)
+      await store.fenceFreshness(fence).fresh
     else { return abandoned(items, failure: "stale_visit") }
     // Retrieval awaited the network; rebuild the free gate before the second
     // paid call so disabling notifications, snoozing, or becoming paywalled

--- a/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryLifecycleTests.swift
@@ -247,6 +247,75 @@ final class ContextDeliveryLifecycleTests: XCTestCase {
     XCTAssertEqual(afterVisible, ContextDeliveryAttempt(id: nil, reason: .dailyBudget))
   }
 
+  /// The rehearsal replay of the measured field failure: a 13-second revisit
+  /// settles at +8s, the user leaves at +13s, and the in-flight evaluation used
+  /// to die at the next active-only guard — quota spent, nothing delivered.
+  /// With run-to-completion freshness the departed-but-recent visit still
+  /// assembles its snapshot and reserves a delivery attempt.
+  func testVisitThatCompletedFiveSecondsAgoStillReservesADeliveryAttempt() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    let versionID = try await seedBucketAndVisit(in: pool, poolEpoch: poolEpoch, now: now)
+    try await pool.write { db in
+      try db.execute(
+        sql: "UPDATE context_visits SET outcome = 'completed', endedAt = ? WHERE id = 1",
+        arguments: [now.addingTimeInterval(-5)])
+    }
+    let fence = ContextVisitFence(
+      visitID: 1,
+      contextGeneration: 1,
+      poolEpoch: poolEpoch,
+      bucketID: "bucket",
+      startedAt: now.addingTimeInterval(-18))
+
+    let freshness = await ContextBucketStore.shared.fenceFreshness(fence, now: now)
+    XCTAssertEqual(
+      freshness, ContextVisitFreshness(fresh: true, endedAt: now.addingTimeInterval(-5)))
+
+    let snapshot = await ContextBucketStore.shared.snapshot(for: fence)
+    XCTAssertNotNil(
+      snapshot, "the snapshot path must resolve a completed visit's bucket, not only an active one")
+
+    let attempt = try await ContextBucketStore.shared.beginDeliveryAttempt(
+      fence: fence,
+      snapshot: try XCTUnwrap(snapshot),
+      gate: allowedGate(),
+      now: now)
+    XCTAssertEqual(attempt.reason, .allowed)
+    XCTAssertNotNil(attempt.id)
+
+    let rowCount = try await pool.read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM proactive_deliveries WHERE visitID = 1 AND bucketVersionID = ?",
+        arguments: [versionID])
+    }
+    XCTAssertEqual(rowCount, 1, "run-to-completion must create the reservation row")
+  }
+
+  func testVisitThatCompletedTwoMinutesAgoIsStaleAtTheNextGuard() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    _ = try await seedBucketAndVisit(in: pool, poolEpoch: poolEpoch, now: now)
+    try await pool.write { db in
+      try db.execute(
+        sql: "UPDATE context_visits SET outcome = 'completed', endedAt = ? WHERE id = 1",
+        arguments: [now.addingTimeInterval(-120)])
+    }
+    let fence = ContextVisitFence(
+      visitID: 1,
+      contextGeneration: 1,
+      poolEpoch: poolEpoch,
+      bucketID: "bucket",
+      startedAt: now.addingTimeInterval(-133))
+
+    let freshness = await ContextBucketStore.shared.fenceFreshness(fence, now: now)
+    XCTAssertEqual(
+      freshness, ContextVisitFreshness(fresh: false, endedAt: now.addingTimeInterval(-120)))
+  }
+
   private func allowedGate() -> ContextDeliveryGateInput {
     ContextDeliveryGateInput(
       masterEnabled: true,

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -275,6 +275,155 @@ final class ContextProactivityEngineTests: XCTestCase {
     XCTAssertEqual(json["error_type"] as? String, "timed_out")
   }
 
+  func testVisitFreshnessRunsToCompletionOnlyWithinTheDeliveryValidityWindow() throws {
+    let queue = try contextBucketDatabase()
+    let now = Date(timeIntervalSince1970: 1_725_000_000)
+    let fence = ContextVisitFence(
+      visitID: 1, contextGeneration: 1, poolEpoch: 1, bucketID: "bucket-a", startedAt: now)
+
+    try queue.write { db in
+      try db.execute(
+        sql: "UPDATE context_visits SET outcome = 'active', endedAt = NULL WHERE id = 1")
+      XCTAssertEqual(
+        try ContextBucketStore.visitFreshness(in: db, fence: fence, now: now),
+        ContextVisitFreshness(fresh: true, endedAt: nil),
+        "an active visit is always fresh")
+
+      try db.execute(
+        sql: "UPDATE context_visits SET outcome = 'completed', endedAt = ? WHERE id = 1",
+        arguments: [now.addingTimeInterval(-5)])
+      XCTAssertEqual(
+        try ContextBucketStore.visitFreshness(in: db, fence: fence, now: now),
+        ContextVisitFreshness(fresh: true, endedAt: now.addingTimeInterval(-5)),
+        "a departure five seconds ago must not kill the in-flight evaluation")
+
+      try db.execute(
+        sql: "UPDATE context_visits SET endedAt = ? WHERE id = 1",
+        arguments: [now.addingTimeInterval(-ContextDeliveryBudget.deliveryValidityWindowSeconds)])
+      XCTAssertTrue(
+        try ContextBucketStore.visitFreshness(in: db, fence: fence, now: now).fresh,
+        "the validity window boundary is inclusive")
+
+      try db.execute(
+        sql: "UPDATE context_visits SET endedAt = ? WHERE id = 1",
+        arguments: [now.addingTimeInterval(-120)])
+      XCTAssertEqual(
+        try ContextBucketStore.visitFreshness(in: db, fence: fence, now: now),
+        ContextVisitFreshness(fresh: false, endedAt: now.addingTimeInterval(-120)),
+        "an evaluation that drags past the window after departure dies at its next guard")
+
+      try db.execute(
+        sql: "UPDATE context_visits SET endedAt = NULL WHERE id = 1")
+      XCTAssertFalse(
+        try ContextBucketStore.visitFreshness(in: db, fence: fence, now: now).fresh,
+        "a completed visit with no recorded departure time fails closed")
+    }
+  }
+
+  func testVisitFreshnessRejectsDiscardedAndInterruptedOutcomesHoweverRecent() throws {
+    let queue = try contextBucketDatabase()
+    let now = Date(timeIntervalSince1970: 1_725_000_000)
+    let fence = ContextVisitFence(
+      visitID: 1, contextGeneration: 1, poolEpoch: 1, bucketID: "bucket-a", startedAt: now)
+
+    try queue.write { db in
+      for outcome in ["discarded", "interrupted"] {
+        try db.execute(
+          sql: "UPDATE context_visits SET outcome = ?, endedAt = ? WHERE id = 1",
+          arguments: [outcome, now.addingTimeInterval(-1)])
+        XCTAssertFalse(
+          try ContextBucketStore.visitFreshness(in: db, fence: fence, now: now).fresh,
+          "a \(outcome) visit never earned a delivery, however recent")
+      }
+    }
+  }
+
+  func testVisitFreshnessFailsClosedWhenTheFenceIdentityDoesNotMatch() throws {
+    let queue = try contextBucketDatabase()
+    let now = Date(timeIntervalSince1970: 1_725_000_000)
+
+    try queue.read { db in
+      XCTAssertEqual(
+        try ContextBucketStore.visitFreshness(
+          in: db,
+          fence: ContextVisitFence(
+            visitID: 1, contextGeneration: 99, poolEpoch: 1, bucketID: "bucket-a", startedAt: now),
+          now: now),
+        .stale)
+      XCTAssertEqual(
+        try ContextBucketStore.visitFreshness(
+          in: db,
+          fence: ContextVisitFence(
+            visitID: 999, contextGeneration: 1, poolEpoch: 1, bucketID: "bucket-a", startedAt: now),
+          now: now),
+        .stale)
+    }
+  }
+
+  func testSnapshotBucketResolutionSurvivesACompletedVisitButNotADiscardedOne() throws {
+    let queue = try contextBucketDatabase()
+
+    try queue.write { db in
+      // The fixture seeds visit 1 as completed: the snapshot path must still
+      // resolve its bucket so a run-to-completion evaluation can assemble.
+      XCTAssertEqual(
+        try ContextBucketVisitResolver.persistedBucketID(
+          in: db, visitID: 1, contextGeneration: 1, poolEpoch: 1),
+        "bucket-a")
+
+      try db.execute(sql: "UPDATE context_visits SET outcome = 'discarded' WHERE id = 1")
+      XCTAssertNil(
+        try ContextBucketVisitResolver.persistedBucketID(
+          in: db, visitID: 1, contextGeneration: 1, poolEpoch: 1))
+    }
+  }
+
+  func testDirectorFrameBoundRejectsTheNextContextsScreenAfterDeparture() {
+    let startedAt = Date(timeIntervalSince1970: 1_725_000_000)
+    let endedAt = startedAt.addingTimeInterval(13)
+
+    XCTAssertFalse(
+      AssistantCoordinator.frameMayGroundDirector(
+        captureTime: startedAt.addingTimeInterval(-1),
+        storedAt: startedAt,
+        startedAt: startedAt,
+        endedAt: nil),
+      "a frame captured before the visit began never grounds it")
+    XCTAssertTrue(
+      AssistantCoordinator.frameMayGroundDirector(
+        captureTime: startedAt.addingTimeInterval(30),
+        storedAt: startedAt.addingTimeInterval(30),
+        startedAt: startedAt,
+        endedAt: nil),
+      "an active visit keeps today's behavior: any frame at or after startedAt")
+    XCTAssertTrue(
+      AssistantCoordinator.frameMayGroundDirector(
+        captureTime: startedAt.addingTimeInterval(10),
+        storedAt: startedAt.addingTimeInterval(10),
+        startedAt: startedAt,
+        endedAt: endedAt),
+      "a frame captured and tracked during the visit grounds its departed evaluation")
+    // The switch tick: the next context's frame is CAPTURED milliseconds before
+    // the transition writes endedAt, so capture time cannot exclude it — but it
+    // is only STORED after the transition persisted the departure.
+    XCTAssertFalse(
+      AssistantCoordinator.frameMayGroundDirector(
+        captureTime: endedAt.addingTimeInterval(-0.005),
+        storedAt: endedAt.addingTimeInterval(0.010),
+        startedAt: startedAt,
+        endedAt: endedAt),
+      "the next context's frame on the switch tick must not ground the departed visit")
+    XCTAssertFalse(
+      AssistantCoordinator.frameMayGroundDirector(
+        captureTime: endedAt.addingTimeInterval(
+          ContextDeliveryBudget.departedFrameCaptureEpsilonSeconds + 1),
+        storedAt: endedAt.addingTimeInterval(
+          ContextDeliveryBudget.departedFrameCaptureEpsilonSeconds + 1),
+        startedAt: startedAt,
+        endedAt: endedAt),
+      "a frame captured after departure plus epsilon is the next context's screen")
+  }
+
   private func provenanceObject(_ json: String) throws -> [String: Any] {
     let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
     return try XCTUnwrap(object as? [String: Any])

--- a/desktop/macos/changelog/unreleased/20260815-director-run-to-completion.json
+++ b/desktop/macos/changelog/unreleased/20260815-director-run-to-completion.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive answers now arrive even if you switch away while Omi is still thinking"
+}


### PR DESCRIPTION
## Problem

Measured on a real machine last night: `ContextProactivityEngine.contextEntered` starts a director evaluation after the 8s dwell settle, but six `await store.activeFenceIsValid(fence)` guards require `outcome = 'active'` at every stage. The moment the user switches contexts the visit's outcome flips to `completed` and the next guard kills the in-flight evaluation.

Observed pattern: a 13-second revisit settles at +8s, the user leaves at +13s, and the evaluation dies silently at its next guard — quota spent, nothing delivered. Users who task-switch fast can never receive a delivery.

## Fix: run-to-completion delivery

- `ContextBucketStore.fenceFreshness(_:now:)` (testable core: `visitFreshness(in:fence:now:)`) replaces `activeFenceIsValid` at all six guard sites. A visit is *fresh* while `active`, and for `ContextDeliveryBudget.deliveryValidityWindowSeconds` (60s) after a `completed` departure. `discarded`/`interrupted` are never fresh; `completed` with no recorded `endedAt` fails closed. Each stage re-checks freshness, so an evaluation that drags past the window after departure still dies at its next guard — that bounded staleness is the design.
- **Frame correctness**: after a switch, `AssistantCoordinator.lastTrackedFrame` is the NEXT context's screen — and on the exact switch tick that frame is *captured* before the transition writes `endedAt`, so a capture-time bound alone cannot exclude it (review finding, see below). The coordinator now records when each frame entered the tracker (`TrackedDirectorFrame.storedAt`); the engine samples the frame first, then re-reads freshness and bounds the sample with `frameMayGroundDirector`: `captureTime >= startedAt`, and for a departed visit `storedAt <= endedAt` (frames are stored only after `checkContextSwitch` persisted the departure) plus a 2s capture epsilon. Sampling before the freshness read also closes the race where a departure lands between an early freshness read and the lookup, which would have left the lookup unbounded. Active visits keep today's behavior; if no frame qualifies, the engine bails as today.
- `ContextBucketVisitResolver.persistedBucketID` (the snapshot path's bucket-identity check) now accepts `completed` alongside `active`: its job is guarding against mid-visit destination rebinding, not liveness — liveness belongs to the freshness guard. Without this, any run-to-completion evaluation would die at a hidden seventh active-only check.

No gate weakened: budget, cooldown (in-flight anchoring included), dedup (`visitID` + `bucketVersionID`), presentation preflight, free-gate rebuilds, and grounding all run unchanged; delivery presentation is untouched (notifications are context-free banners). Dwell length, settle semantics, gate reasons, the retrieval hop, and extraction are untouched.

Known bounded-staleness nuance (unchanged from main): the last freshness guard sits before the presentation-preflight/graduation awaits, so a delivery passing it at T+59s can paint slightly after T+60s — same shape as main, where a queued card can legitimately paint after its source visit ends (`completePresentedDelivery` documents this).

Failure-Class: new

## Review

One `cursor-agent` (grok-4.6-high) review via agentctl ran against this diff. It confirmed all six guard sites carry the same 60s inclusive predicate and that no budget/cooldown/dedup/grounding gate was weakened, and surfaced two real frame-bound defects that are fixed in this PR: (1) the next context's frame on the switch tick is captured before `endedAt` is written, so the originally-proposed `captureTime <= endedAt + 2s` bound admitted the wrong screen — fixed with the stored-at bound; (2) the bound was computed from a freshness value read before the lookup, leaving the lookup unbounded when a departure lands in between — fixed by sampling the frame first and re-validating against a post-sampling freshness read. Its third note (no freshness re-check at the final handoff) is main's existing, documented semantics and is deliberately unchanged.

## Verification

- New logic tests: freshness window semantics (active / completed-recent / inclusive boundary / stale / discarded / interrupted / fence mismatch / NULL `endedAt` fails closed), frame bound (during-visit accepted, switch-tick frame rejected via stored-at, post-epsilon rejected, active-visit behavior preserved), completed-visit bucket resolution, and the rehearsal replay of the measured failure (visit completed 5s ago → fresh → snapshot resolves → `beginDeliveryAttempt` reserves a row; 120s ago → stale).
- `swift test --filter 'ContextDelivery|ContextProactivityEngine|ContextBucket'` → 84 tests, 0 failures.
- `scripts/pr-preflight` green (20 checks).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

