### PR TITLE
feat(desktop): cumulative-dwell shortening and departure-triggered director evaluation

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -350,7 +350,16 @@ enum ContextBucketCompactionPolicy {
   }
 }
 
+/// What a departure extraction just persisted, beyond the published version:
+/// the highest notify-worthiness among the facts it newly validated, which is
+/// the departure-evaluation policy's admission signal.
+struct BucketExtractionWriteResult: Equatable, Sendable {
+  let versionID: Int64
+  let maximumValidatedWorthiness: Double
+}
+
 extension ContextBucketStore {
+  @discardableResult
   func writeExtraction(
     _ extraction: BucketExtraction,
     for fence: ContextVisitFence,
@@ -358,125 +367,130 @@ extension ContextBucketStore {
     rawContextKey: String,
     normalizedContextKey: String,
     now: Date = Date()
-  ) async throws -> Int64? {
+  ) async throws -> BucketExtractionWriteResult? {
     guard let bucketID = fence.bucketID else { return nil }
     let pool = try await poolForRollup(fence)
     let evidenceEncoder = JSONEncoder()
     let safeNarrative = String(extraction.narrative.prefix(2_400))
-    let result: (versionID: Int64, paraphraseObserved: Bool) = try await pool.write { db in
-      guard
-        let visit = try Row.fetchOne(
-          db,
-          sql: """
-            SELECT lastScreenshotID FROM context_visits
-            WHERE id = ? AND contextGeneration = ? AND poolEpoch = ? AND outcome = 'completed'
-            """,
-          arguments: [fence.visitID, fence.contextGeneration, fence.poolEpoch])
-      else { throw ContextBucketStoreError.staleFence }
-
-      var allowedEvidenceRefs: Set<String> = ["visit:\(fence.visitID)"]
-      if let screenshotID: Int64 = visit["lastScreenshotID"] {
-        allowedEvidenceRefs.insert("screenshot:\(screenshotID)")
-      }
-
-      let entryID = UUID().uuidString.lowercased()
-      let entryRefs = Array(
-        extraction.facts.prefix(20)
-          .flatMap { BucketFactValidator.resolvableEvidenceRefs($0.evidenceRefs, allowed: allowedEvidenceRefs) }
-          .prefix(40))
-      try db.execute(
-        sql: """
-          INSERT INTO bucket_entries
-            (id, bucketID, visitID, appName, rawContextKey, normalizedContextKey,
-             narrative, evidenceRefsJson, tokenCount, createdAt)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-          """,
-        arguments: [
-          entryID, bucketID, fence.visitID, appName, rawContextKey, normalizedContextKey,
-          safeNarrative,
-          String(data: try evidenceEncoder.encode(entryRefs), encoding: .utf8) ?? "[]",
-          ContextBucketPromptAssembler.estimatedTokens(safeNarrative), now,
-        ])
-
-      var maximumWorthiness = 0.0
-      var paraphraseObserved = false
-      var existingFactIdentities = try Row.fetchAll(
-        db,
-        sql: """
-          SELECT statement, identifiersJson FROM bucket_facts
-          WHERE bucketID = ? AND validityState = 'validated'
-            AND (expiresAt IS NULL OR expiresAt > ?)
-          ORDER BY id DESC LIMIT 250
-          """,
-        arguments: [bucketID, now]
-      ).compactMap { row -> BucketFactValidator.ExistingFactIdentity? in
+    let result: (versionID: Int64, paraphraseObserved: Bool, maximumWorthiness: Double) =
+      try await pool.write { db in
         guard
-          let existingStatement = row["statement"] as String?,
-          let encodedIdentifiers = row["identifiersJson"] as String?,
-          let data = encodedIdentifiers.data(using: .utf8),
-          let existingIdentifiers = try? JSONDecoder().decode([String].self, from: data)
-        else { return nil }
-        return BucketFactValidator.ExistingFactIdentity(
-          statement: existingStatement, identifiers: existingIdentifiers)
-      }
-      for fact in extraction.facts.prefix(20) {
-        let statement = String(fact.statement.prefix(500))
-        let evidenceText = String(fact.evidenceText.prefix(1_000))
-        let evidenceRefs = BucketFactValidator.resolvableEvidenceRefs(
-          Array(fact.evidenceRefs.prefix(10)), allowed: allowedEvidenceRefs)
-        let identifiers = fact.identifiers.prefix(8).map {
-          String($0.prefix(200)).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        .filter { !$0.isEmpty }
-        paraphraseObserved =
-          paraphraseObserved
-          || BucketFactValidator.hasParaphraseMatch(
-            statement: statement, identifiers: identifiers, existingFacts: existingFactIdentities)
-        let duplicate =
-          try Bool.fetchOne(
+          let visit = try Row.fetchOne(
             db,
-            sql: "SELECT EXISTS(SELECT 1 FROM bucket_facts WHERE bucketID = ? AND statement = ?)",
-            arguments: [bucketID, statement]) ?? false
-        let validity = BucketFactValidator.validity(
-          identifiers: identifiers,
-          evidenceText: evidenceText,
-          evidenceRefs: evidenceRefs,
-          duplicate: duplicate)
-        let worthiness = validity == .validated ? min(max(fact.notifyWorthiness, 0), 1) : 0
-        maximumWorthiness = max(maximumWorthiness, worthiness)
+            sql: """
+              SELECT lastScreenshotID FROM context_visits
+              WHERE id = ? AND contextGeneration = ? AND poolEpoch = ? AND outcome = 'completed'
+              """,
+            arguments: [fence.visitID, fence.contextGeneration, fence.poolEpoch])
+        else { throw ContextBucketStoreError.staleFence }
+
+        var allowedEvidenceRefs: Set<String> = ["visit:\(fence.visitID)"]
+        if let screenshotID: Int64 = visit["lastScreenshotID"] {
+          allowedEvidenceRefs.insert("screenshot:\(screenshotID)")
+        }
+
+        let entryID = UUID().uuidString.lowercased()
+        let entryRefs = Array(
+          extraction.facts.prefix(20)
+            .flatMap { BucketFactValidator.resolvableEvidenceRefs($0.evidenceRefs, allowed: allowedEvidenceRefs) }
+            .prefix(40))
         try db.execute(
           sql: """
-            INSERT INTO bucket_facts
-              (id, bucketID, entryID, appName, statement, identifiersJson, evidenceText,
-               evidenceRefsJson, validityState, dispositionState, confidence,
-               notifyWorthiness, createdAt, updatedAt)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?)
+            INSERT INTO bucket_entries
+              (id, bucketID, visitID, appName, rawContextKey, normalizedContextKey,
+               narrative, evidenceRefsJson, tokenCount, createdAt)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
           arguments: [
-            UUID().uuidString.lowercased(), bucketID, entryID, appName, statement,
-            String(data: try evidenceEncoder.encode(identifiers), encoding: .utf8) ?? "[]",
-            evidenceText,
-            String(data: try evidenceEncoder.encode(evidenceRefs), encoding: .utf8) ?? "[]",
-            validity.rawValue, min(max(fact.confidence, 0), 1), worthiness, now, now,
+            entryID, bucketID, fence.visitID, appName, rawContextKey, normalizedContextKey,
+            safeNarrative,
+            String(data: try evidenceEncoder.encode(entryRefs), encoding: .utf8) ?? "[]",
+            ContextBucketPromptAssembler.estimatedTokens(safeNarrative), now,
           ])
-        if validity == .validated {
-          existingFactIdentities.append(
-            BucketFactValidator.ExistingFactIdentity(statement: statement, identifiers: identifiers))
+
+        var maximumWorthiness = 0.0
+        var paraphraseObserved = false
+        var existingFactIdentities = try Row.fetchAll(
+          db,
+          sql: """
+            SELECT statement, identifiersJson FROM bucket_facts
+            WHERE bucketID = ? AND validityState = 'validated'
+              AND (expiresAt IS NULL OR expiresAt > ?)
+            ORDER BY id DESC LIMIT 250
+            """,
+          arguments: [bucketID, now]
+        ).compactMap { row -> BucketFactValidator.ExistingFactIdentity? in
+          guard
+            let existingStatement = row["statement"] as String?,
+            let encodedIdentifiers = row["identifiersJson"] as String?,
+            let data = encodedIdentifiers.data(using: .utf8),
+            let existingIdentifiers = try? JSONDecoder().decode([String].self, from: data)
+          else { return nil }
+          return BucketFactValidator.ExistingFactIdentity(
+            statement: existingStatement, identifiers: existingIdentifiers)
         }
+        for fact in extraction.facts.prefix(20) {
+          let statement = String(fact.statement.prefix(500))
+          let evidenceText = String(fact.evidenceText.prefix(1_000))
+          let evidenceRefs = BucketFactValidator.resolvableEvidenceRefs(
+            Array(fact.evidenceRefs.prefix(10)), allowed: allowedEvidenceRefs)
+          let identifiers = fact.identifiers.prefix(8).map {
+            String($0.prefix(200)).trimmingCharacters(in: .whitespacesAndNewlines)
+          }
+          .filter { !$0.isEmpty }
+          paraphraseObserved =
+            paraphraseObserved
+            || BucketFactValidator.hasParaphraseMatch(
+              statement: statement, identifiers: identifiers, existingFacts: existingFactIdentities)
+          let duplicate =
+            try Bool.fetchOne(
+              db,
+              sql: "SELECT EXISTS(SELECT 1 FROM bucket_facts WHERE bucketID = ? AND statement = ?)",
+              arguments: [bucketID, statement]) ?? false
+          let validity = BucketFactValidator.validity(
+            identifiers: identifiers,
+            evidenceText: evidenceText,
+            evidenceRefs: evidenceRefs,
+            duplicate: duplicate)
+          let worthiness = validity == .validated ? min(max(fact.notifyWorthiness, 0), 1) : 0
+          maximumWorthiness = max(maximumWorthiness, worthiness)
+          try db.execute(
+            sql: """
+              INSERT INTO bucket_facts
+                (id, bucketID, entryID, appName, statement, identifiersJson, evidenceText,
+                 evidenceRefsJson, validityState, dispositionState, confidence,
+                 notifyWorthiness, createdAt, updatedAt)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?)
+              """,
+            arguments: [
+              UUID().uuidString.lowercased(), bucketID, entryID, appName, statement,
+              String(data: try evidenceEncoder.encode(identifiers), encoding: .utf8) ?? "[]",
+              evidenceText,
+              String(data: try evidenceEncoder.encode(evidenceRefs), encoding: .utf8) ?? "[]",
+              validity.rawValue, min(max(fact.confidence, 0), 1), worthiness, now, now,
+            ])
+          if validity == .validated {
+            existingFactIdentities.append(
+              BucketFactValidator.ExistingFactIdentity(statement: statement, identifiers: identifiers))
+          }
+        }
+        try db.execute(
+          sql: "UPDATE context_buckets SET notifyWorthiness = MAX(notifyWorthiness, ?), updatedAt = ? WHERE id = ?",
+          arguments: [maximumWorthiness, now, bucketID])
+        let versionID = try Self.publishVersion(in: db, bucketID: bucketID, now: now)
+        try db.execute(
+          sql: "UPDATE bucket_entries SET bucketVersionID = ? WHERE id = ?",
+          arguments: [versionID, entryID])
+        return (
+          versionID: versionID, paraphraseObserved: paraphraseObserved,
+          maximumWorthiness: maximumWorthiness
+        )
       }
-      try db.execute(
-        sql: "UPDATE context_buckets SET notifyWorthiness = MAX(notifyWorthiness, ?), updatedAt = ? WHERE id = ?",
-        arguments: [maximumWorthiness, now, bucketID])
-      let versionID = try Self.publishVersion(in: db, bucketID: bucketID, now: now)
-      try db.execute(
-        sql: "UPDATE bucket_entries SET bucketVersionID = ? WHERE id = ?",
-        arguments: [versionID, entryID])
-      return (versionID: versionID, paraphraseObserved: paraphraseObserved)
-    }
     if result.paraphraseObserved {
       await ContextProactivityTelemetry.recordFactIdentityShadow()
     }
-    return result.versionID
+    return BucketExtractionWriteResult(
+      versionID: result.versionID, maximumValidatedWorthiness: result.maximumWorthiness)
   }
 
   func purgeExcludedApp(_ appName: String, now: Date = Date()) async throws -> Set<String> {
@@ -751,7 +765,7 @@ actor ContextBucketRollupWriter {
         await ContextProactivityTelemetry.recordExtractionOutcome(.staleContext)
         return
       }
-      _ = try await store.writeExtraction(
+      let writeResult = try await store.writeExtraction(
         extraction,
         for: fence,
         appName: frame.appName,
@@ -760,6 +774,19 @@ actor ContextBucketRollupWriter {
           appName: frame.appName, windowTitle: frame.windowTitle) ?? "")
       await ContextProactivityTelemetry.recordExtractionOutcome(.success)
       await applyDestinationIfEligible(extraction: extraction, frame: frame, fence: fence)
+      // Departure-triggered evaluation: only a fact this extraction newly
+      // validated at or above the worthiness threshold buys an immediate
+      // director look at the departed bucket, grounded on the same departing
+      // frame this extraction used. The engine re-runs every delivery gate and
+      // the freshness window bounds how long after departure it can act.
+      if let writeResult,
+        ContextDepartureEvaluationPolicy.triggers(
+          maximumValidatedWorthiness: writeResult.maximumValidatedWorthiness,
+          flagEnabled: await MainActor.run(body: { ContextBucketsFeature.isDepartureEvaluationEnabled }))
+      {
+        await ContextProactivityEngine.shared.evaluateAfterDeparture(
+          fence: fence, departingFrame: frame)
+      }
     } catch {
       switch error as? ProactiveLaneClientError {
       case .http(let status, _) where status == 429:

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -427,6 +427,33 @@ actor ContextBucketStore {
     }
   }
 
+  /// Completed-visit engagement for one bucket inside the dwell policy's
+  /// rolling window. Read-only and advisory: any failure reports zero
+  /// engagement, which falls back to the standard dwell.
+  func recentEngagementSeconds(bucketID: String, now: Date = Date()) async -> TimeInterval {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return 0 }
+    let lookbackStart = now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds)
+    let intervals: [(startedAt: Date, endedAt: Date)] =
+      (try? await pool.read { db in
+        try Row.fetchAll(
+          db,
+          sql: """
+            SELECT startedAt, endedAt FROM context_visits
+            WHERE bucketID = ? AND outcome = 'completed'
+              AND endedAt IS NOT NULL AND endedAt >= ?
+            """,
+          arguments: [bucketID, lookbackStart]
+        ).compactMap { row -> (startedAt: Date, endedAt: Date)? in
+          guard let startedAt: Date = row["startedAt"], let endedAt: Date = row["endedAt"] else {
+            return nil
+          }
+          return (startedAt: startedAt, endedAt: endedAt)
+        }
+      }) ?? []
+    return ContextDwellPolicy.cumulativeEngagementSeconds(visitIntervals: intervals, now: now)
+  }
+
   func markVisitSettled(_ fence: ContextVisitFence, at date: Date = Date()) async throws {
     let pool = try await pool(for: fence)
     try await pool.write { db in

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
@@ -82,4 +82,23 @@ enum ContextBucketsFeature {
 
   static let retrievalKillSwitchFlagName = "context_buckets_retrieval_kill"
   private static let localRetrievalOverrideName = "OMI_FORCE_BUCKET_RETRIEVAL"
+
+  /// Evaluates a departed bucket immediately when its departure extraction just
+  /// validated a notify-worthy fact, grounded on the departing frame, instead
+  /// of waiting for the next revisit's dwell.
+  ///
+  /// Non-production dogfood defaults to on with the same inverted env override
+  /// as the pipeline flag (`OMI_FORCE_DEPARTURE_EVALUATION=0` turns it off).
+  /// Production and beta stay off until the departure path is validated in
+  /// dogfood — unlike the surfaces above there is deliberately no remote stop
+  /// yet, because nothing ships dark to users this way.
+  @MainActor static var isDepartureEvaluationEnabled: Bool {
+    guard isEnabled else { return false }
+    if AppBuild.isNonProduction {
+      return ProcessInfo.processInfo.environment[localDepartureEvaluationOverrideName] != "0"
+    }
+    return false
+  }
+
+  private static let localDepartureEvaluationOverrideName = "OMI_FORCE_DEPARTURE_EVALUATION"
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -109,7 +109,8 @@ actor ContextProactivityEngine {
     guard let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
     guard dwellAdmission.begin(visitID: fence.visitID) else { return }
     defer { dwellAdmission.finish(visitID: fence.visitID) }
-    do { try await Task.sleep(nanoseconds: dwellNanoseconds) } catch { return }
+    let dwell = await resolvedDwellNanoseconds(for: fence)
+    do { try await Task.sleep(nanoseconds: dwell) } catch { return }
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
     do { try await store.markVisitSettled(fence) } catch { return }
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
@@ -156,8 +157,68 @@ actor ContextProactivityEngine {
         startedAt: fence.startedAt,
         endedAt: frameFreshness.endedAt)
     else { return }
-    let currentFrame = frameSample.frame
+    await evaluateAndDeliver(
+      fence: fence,
+      snapshot: snapshot,
+      currentFrame: frameSample.frame,
+      authorizationSnapshot: authorizationSnapshot)
+  }
 
+  /// Departure-triggered evaluation: a departure extraction that just validated
+  /// a notify-worthy fact evaluates the departed bucket immediately, grounded
+  /// on the departing frame the extraction already holds, instead of waiting
+  /// for the next revisit's dwell. Callers gate on
+  /// `ContextDepartureEvaluationPolicy`; every delivery gate below and the
+  /// freshness window still apply, so a departure older than the validity
+  /// window dies exactly like any other stale evaluation. The dwell admission
+  /// set serializes this against a still-running `contextEntered` evaluation of
+  /// the same visit.
+  func evaluateAfterDeparture(fence: ContextVisitFence, departingFrame: CapturedFrame) async {
+    guard fence.bucketID != nil else { return }
+    guard let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
+    guard dwellAdmission.begin(visitID: fence.visitID) else { return }
+    defer { dwellAdmission.finish(visitID: fence.visitID) }
+    let gate = await MainActor.run { Self.liveDeliveryGateInput() }
+    let preflightReason = ContextDeliveryBudget.freeGate(input: gate)
+    guard preflightReason == .allowed else {
+      log("Context director suppressed before departure evaluation: \(preflightReason.rawValue)")
+      return
+    }
+    let freshness = await store.fenceFreshness(fence)
+    guard
+      RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
+      freshness.fresh,
+      let snapshot = await store.snapshot(for: fence)
+    else { return }
+    guard ContextDirectorEligibility.permitsEvaluation(of: snapshot) else { return }
+    await evaluateAndDeliver(
+      fence: fence,
+      snapshot: snapshot,
+      currentFrame: departingFrame,
+      authorizationSnapshot: authorizationSnapshot)
+  }
+
+  /// A bucket the user keeps returning to has already proven engagement, so the
+  /// settle wait shrinks (never disappears) once recent completed-visit time in
+  /// this bucket crosses the policy threshold.
+  private func resolvedDwellNanoseconds(for fence: ContextVisitFence) async -> UInt64 {
+    guard let bucketID = fence.bucketID else { return dwellNanoseconds }
+    let engagement = await store.recentEngagementSeconds(bucketID: bucketID)
+    return ContextDwellPolicy.dwellNanoseconds(
+      base: dwellNanoseconds, cumulativeEngagementSeconds: engagement)
+  }
+
+  /// The shared post-settle tail of the director pipeline: presentation
+  /// preflight, gate rebuilds, budget reservation, the model call (plus the
+  /// bounded retrieval hop), grounding validation, and the presentation
+  /// handoff. `contextEntered` reaches it after dwell/settle/frame lookup;
+  /// `evaluateAfterDeparture` reaches it with the departing frame.
+  private func evaluateAndDeliver(
+    fence: ContextVisitFence,
+    snapshot: ContextBucketSnapshot,
+    currentFrame: CapturedFrame,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot
+  ) async {
     guard let ownerID = await MainActor.run(body: { RuntimeOwnerIdentity.currentOwnerId() }) else { return }
     let attemptPreflight = await presentationPreflight(ownerID)
     guard Self.presentationSurfaceAvailable(attemptPreflight) else {
@@ -692,6 +753,52 @@ actor ContextProactivityEngine {
       "required": required,
       "additionalProperties": false,
     ]
+  }
+}
+
+/// Shortens (never skips) the dwell settle for a bucket the user demonstrably
+/// keeps returning to. A run of short revisits proves engagement that a single
+/// 8-second dwell was designed to establish, so the wait shrinks once recent
+/// per-bucket engagement crosses a threshold. Settle semantics are untouched:
+/// the visit still settles after the (shorter) sleep, on the same path.
+enum ContextDwellPolicy {
+  /// Rolling window over which completed-visit engagement accumulates.
+  static let engagementLookbackSeconds: TimeInterval = 180
+  /// Cumulative engaged seconds at which the dwell shortens.
+  static let engagedCumulativeSeconds: TimeInterval = 20
+  static let shortenedDwellNanoseconds: UInt64 = 2_000_000_000
+
+  static func dwellNanoseconds(base: UInt64, cumulativeEngagementSeconds: TimeInterval) -> UInt64 {
+    guard cumulativeEngagementSeconds >= engagedCumulativeSeconds else { return base }
+    // min: a caller-configured dwell shorter than the shortened value (tests
+    // use zero) must never be lengthened by an engagement bonus.
+    return min(base, shortenedDwellNanoseconds)
+  }
+
+  /// Sum of completed-visit durations clipped to the lookback window ending at
+  /// `now`. Computable from `context_visits` alone — no new table.
+  static func cumulativeEngagementSeconds(
+    visitIntervals: [(startedAt: Date, endedAt: Date)], now: Date
+  ) -> TimeInterval {
+    let lookbackStart = now.addingTimeInterval(-engagementLookbackSeconds)
+    return visitIntervals.reduce(0.0) { total, interval in
+      let start = max(interval.startedAt, lookbackStart)
+      let end = min(interval.endedAt, now)
+      guard end > start else { return total }
+      return total + end.timeIntervalSince(start)
+    }
+  }
+}
+
+/// Admission for the departure-triggered director evaluation: only a departure
+/// extraction that just validated a fact at or above the worthiness threshold,
+/// with the feature flag on, buys an immediate evaluation of the departed
+/// bucket. Everything else waits for the next revisit's dwell as before.
+enum ContextDepartureEvaluationPolicy {
+  static let worthinessThreshold = 0.6
+
+  static func triggers(maximumValidatedWorthiness: Double, flagEnabled: Bool) -> Bool {
+    flagEnabled && maximumValidatedWorthiness >= worthinessThreshold
   }
 }
 

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -378,6 +378,80 @@ final class ContextProactivityEngineTests: XCTestCase {
     }
   }
 
+  func testCumulativeEngagementShortensDwellForARepeatedlyRevisitedBucket() {
+    let now = Date(timeIntervalSince1970: 1_725_000_000)
+    // Five 10-second visits within the last three minutes: 50s of engagement.
+    let engaged = (0..<5).map { index -> (startedAt: Date, endedAt: Date) in
+      let end = now.addingTimeInterval(TimeInterval(-20 * index) - 5)
+      return (startedAt: end.addingTimeInterval(-10), endedAt: end)
+    }
+    let engagedSeconds = ContextDwellPolicy.cumulativeEngagementSeconds(
+      visitIntervals: engaged, now: now)
+    XCTAssertEqual(engagedSeconds, 50, accuracy: 0.001)
+    XCTAssertEqual(
+      ContextDwellPolicy.dwellNanoseconds(
+        base: 8_000_000_000, cumulativeEngagementSeconds: engagedSeconds),
+      ContextDwellPolicy.shortenedDwellNanoseconds,
+      "a bucket the user keeps returning to earns the shortened dwell")
+
+    // Two sparse 5-second visits: 10s of engagement keeps the standard dwell.
+    let sparse = [0, 100].map { offset -> (startedAt: Date, endedAt: Date) in
+      let end = now.addingTimeInterval(TimeInterval(-offset) - 5)
+      return (startedAt: end.addingTimeInterval(-5), endedAt: end)
+    }
+    let sparseSeconds = ContextDwellPolicy.cumulativeEngagementSeconds(
+      visitIntervals: sparse, now: now)
+    XCTAssertEqual(sparseSeconds, 10, accuracy: 0.001)
+    XCTAssertEqual(
+      ContextDwellPolicy.dwellNanoseconds(
+        base: 8_000_000_000, cumulativeEngagementSeconds: sparseSeconds),
+      8_000_000_000)
+  }
+
+  func testCumulativeEngagementClipsToTheRollingWindowAndNeverLengthensTheDwell() {
+    let now = Date(timeIntervalSince1970: 1_725_000_000)
+    // A long visit that ended before the window contributes nothing; one that
+    // straddles the window start counts only its in-window portion.
+    let outside = [
+      (
+        startedAt: now.addingTimeInterval(-400),
+        endedAt: now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds - 1)
+      )
+    ]
+    XCTAssertEqual(
+      ContextDwellPolicy.cumulativeEngagementSeconds(visitIntervals: outside, now: now), 0)
+
+    let straddling = [
+      (
+        startedAt: now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds - 100),
+        endedAt: now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds + 8)
+      )
+    ]
+    XCTAssertEqual(
+      ContextDwellPolicy.cumulativeEngagementSeconds(visitIntervals: straddling, now: now),
+      8, accuracy: 0.001)
+
+    // The engagement bonus can only shorten: a caller-configured dwell below
+    // the shortened value (tests use zero) is never raised, and settle is
+    // never skipped outright by policy.
+    XCTAssertEqual(
+      ContextDwellPolicy.dwellNanoseconds(base: 0, cumulativeEngagementSeconds: 500), 0)
+    XCTAssertGreaterThan(ContextDwellPolicy.shortenedDwellNanoseconds, 0)
+  }
+
+  func testDepartureEvaluationTriggersOnlyAtTheWorthinessThresholdWithTheFlagOn() {
+    XCTAssertFalse(
+      ContextDepartureEvaluationPolicy.triggers(
+        maximumValidatedWorthiness: 0.59, flagEnabled: true))
+    XCTAssertTrue(
+      ContextDepartureEvaluationPolicy.triggers(
+        maximumValidatedWorthiness: 0.6, flagEnabled: true))
+    XCTAssertFalse(
+      ContextDepartureEvaluationPolicy.triggers(
+        maximumValidatedWorthiness: 1.0, flagEnabled: false),
+      "the feature flag gates the departure path entirely")
+  }
+
   func testDirectorFrameBoundRejectsTheNextContextsScreenAfterDeparture() {
     let startedAt = Date(timeIntervalSince1970: 1_725_000_000)
     let endedAt = startedAt.addingTimeInterval(13)
@@ -714,5 +788,148 @@ final class ContextProactivityDirectorFailureTests: XCTestCase {
   private func provenanceObject(_ json: String) throws -> [String: Any] {
     let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
     return try XCTUnwrap(object as? [String: Any])
+  }
+}
+
+final class ContextDepartureEvaluationStoreTests: XCTestCase {
+  private var fixture: RewindStorageTestIsolation.Fixture?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    fixture = try await RewindStorageTestIsolation.setUp(userIdPrefix: "departure-evaluation-store")
+  }
+
+  override func tearDown() async throws {
+    await RewindStorageTestIsolation.tearDown(userDir: fixture?.userDir)
+    fixture = nil
+    try await super.tearDown()
+  }
+
+  func testRecentEngagementSumsOnlyCompletedVisitsInsideTheRollingWindow() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    try await seedBucket(in: pool, now: now)
+    try await pool.write { db in
+      // Five 10-second completed visits within three minutes, one stale
+      // completed visit outside the window, one recent discarded visit.
+      for index in 0..<5 {
+        let end = now.addingTimeInterval(TimeInterval(-20 * index) - 5)
+        try Self.insertVisit(
+          db, id: Int64(index + 1), poolEpoch: poolEpoch, outcome: "completed",
+          startedAt: end.addingTimeInterval(-10), endedAt: end)
+      }
+      try Self.insertVisit(
+        db, id: 6, poolEpoch: poolEpoch, outcome: "completed",
+        startedAt: now.addingTimeInterval(-400), endedAt: now.addingTimeInterval(-390))
+      try Self.insertVisit(
+        db, id: 7, poolEpoch: poolEpoch, outcome: "discarded",
+        startedAt: now.addingTimeInterval(-30), endedAt: now.addingTimeInterval(-1))
+    }
+
+    let engagement = await ContextBucketStore.shared.recentEngagementSeconds(
+      bucketID: "bucket", now: now)
+    XCTAssertEqual(engagement, 50, accuracy: 0.001)
+    XCTAssertEqual(
+      ContextDwellPolicy.dwellNanoseconds(
+        base: 8_000_000_000, cumulativeEngagementSeconds: engagement),
+      ContextDwellPolicy.shortenedDwellNanoseconds)
+  }
+
+  func testWriteExtractionReportsTheMaximumWorthinessOfNewlyValidatedFactsOnly() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    try await seedBucket(in: pool, now: now)
+    try await pool.write { db in
+      try Self.insertVisit(
+        db, id: 1, poolEpoch: poolEpoch, outcome: "completed",
+        startedAt: now.addingTimeInterval(-13), endedAt: now)
+    }
+    let fence = ContextVisitFence(
+      visitID: 1,
+      contextGeneration: 1,
+      poolEpoch: poolEpoch,
+      bucketID: "bucket",
+      startedAt: now.addingTimeInterval(-13))
+
+    let result = try await ContextBucketStore.shared.writeExtraction(
+      BucketExtraction(
+        narrative: "narrative",
+        facts: [
+          BucketExtraction.Fact(
+            statement: "validated commitment",
+            identifiers: ["deadline"],
+            evidenceText: "evidence",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 0.6),
+          // Higher worthiness, but no identifier: needs_review, so it must not
+          // count toward the departure-evaluation admission signal.
+          BucketExtraction.Fact(
+            statement: "unidentified claim",
+            identifiers: [],
+            evidenceText: "evidence",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 0.9),
+        ]),
+      for: fence,
+      appName: "Test App",
+      rawContextKey: "raw",
+      normalizedContextKey: "normalized",
+      now: now)
+
+    let writeResult = try XCTUnwrap(result)
+    XCTAssertEqual(writeResult.maximumValidatedWorthiness, 0.6, accuracy: 0.000_001)
+    XCTAssertTrue(
+      ContextDepartureEvaluationPolicy.triggers(
+        maximumValidatedWorthiness: writeResult.maximumValidatedWorthiness, flagEnabled: true))
+
+    let below = try await ContextBucketStore.shared.writeExtraction(
+      BucketExtraction(
+        narrative: "narrative two",
+        facts: [
+          BucketExtraction.Fact(
+            statement: "mild update",
+            identifiers: ["status"],
+            evidenceText: "evidence",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 0.59)
+        ]),
+      for: fence,
+      appName: "Test App",
+      rawContextKey: "raw",
+      normalizedContextKey: "normalized",
+      now: now.addingTimeInterval(1))
+    let belowResult = try XCTUnwrap(below)
+    XCTAssertFalse(
+      ContextDepartureEvaluationPolicy.triggers(
+        maximumValidatedWorthiness: belowResult.maximumValidatedWorthiness, flagEnabled: true))
+  }
+
+  private func seedBucket(in pool: DatabasePool, now: Date) async throws {
+    try await pool.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+          VALUES ('bucket', 'task', 'departure-evaluation', ?, ?)
+          """,
+        arguments: [now, now])
+    }
+  }
+
+  private static func insertVisit(
+    _ db: Database, id: Int64, poolEpoch: Int, outcome: String, startedAt: Date, endedAt: Date?
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO context_visits
+          (id, contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+           normalizedContextKey, referenceHash, startedAt, endedAt, outcome, createdAt, updatedAt)
+        VALUES (?, 1, ?, 'bucket', 'Test App', 'raw', 'normalized', ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [id, poolEpoch, "reference-\(id)", startedAt, endedAt, outcome, startedAt, startedAt])
   }
 }

--- a/desktop/macos/changelog/unreleased/20260815-director-dwell-departure.json
+++ b/desktop/macos/changelog/unreleased/20260815-director-dwell-departure.json
@@ -1,0 +1,3 @@
+{
+  "change": "Omi responds faster on work you keep returning to and can follow up right after you switch away"
+}


### PR DESCRIPTION
## Stacked on #11616

Depends on #11616 (run-to-completion delivery, `feat/director-run-to-completion`). This PR targets that branch; retarget to `main` if it merges first — the dependency is real: the departure path relies on the freshness window and the completed-visit snapshot resolution introduced there.

## B. Cumulative dwell

A bucket the user keeps returning to has already proven the engagement the 8-second dwell exists to establish. `ContextDwellPolicy` sums completed-visit durations for the bucket over a rolling 180s window (computed from `context_visits` — no new table, read via `ContextBucketStore.recentEngagementSeconds`). At >= 20 cumulative engaged seconds the settle sleep shortens to 2s.

- Settle is never skipped: the visit still settles after the (shorter) sleep on the same path.
- The policy can only shorten, never lengthen, the configured dwell (`min(base, shortened)`), so test engines configured with a zero dwell are untouched.

## C. Departure-triggered evaluation (flag-gated)

When a departure extraction newly **validates** a fact with `notifyWorthiness >= 0.6` (`ContextDepartureEvaluationPolicy.worthinessThreshold`; needs_review facts don't count) and the flag is on, `ContextBucketRollupWriter` invokes `ContextProactivityEngine.evaluateAfterDeparture` for that bucket, grounded on the same departing frame the extraction already used, instead of waiting for the next revisit.

- `contextEntered`'s post-settle tail is factored into a private `evaluateAndDeliver`, so both entries run the identical sequence: presentation preflight, free-gate rebuilds, budget/cooldown/dedup reservation, model call + bounded retrieval hop, grounding, presentation handoff. No gate is bypassed.
- The freshness window from the base PR naturally bounds how long after departure it can act (60s), and the dwell-admission set serializes it against a still-running `contextEntered` evaluation of the same visit.
- `writeExtraction` now returns `BucketExtractionWriteResult` (versionID + max newly-validated worthiness) as the admission signal.

**Flag**: `ContextBucketsFeature.isDepartureEvaluationEnabled` — default **ON for non-production** builds (inverted env override `OMI_FORCE_DEPARTURE_EVALUATION=0` turns it off, same pattern as the other bucket flags), **OFF for production and beta** until validated in dogfood.

Failure-Class: none

## Verification

- New logic tests: five 10s visits within 3 min → shortened dwell; sparse short visits → standard 8s; window clipping; shorten-only bound; worthiness 0.59 does not trigger, 0.6 does, flag off never triggers; `recentEngagementSeconds` counts only completed in-window visits; `writeExtraction` reports max worthiness of newly *validated* facts only.
- `swift test --filter 'ContextDelivery|ContextProactivityEngine|ContextBucket|ContextDeparture'` → 89 tests, 0 failures.
- `scripts/pr-preflight` green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

