### PR TITLE
fix(desktop): heal notification-settings drift with a durable sync coordinator

### DIFF
--- a/desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/AuthSessionCoordinator.swift
@@ -5,6 +5,9 @@ extension Notification.Name {
   /// without a user-initiated sign-out. Observers should stop auth-dependent work
   /// (e.g. agent bridge) but must NOT wipe onboarding or stop capture.
   static let sessionDidInvalidate = Notification.Name("com.omi.desktop.sessionDidInvalidate")
+  /// Posted after a session is restored or a sign-in commits. Notification
+  /// settings sync uses this so a pending PATCH is retried without opening Settings.
+  static let sessionDidAuthenticate = Notification.Name("com.omi.desktop.sessionDidAuthenticate")
 }
 
 // MARK: - Session phase
@@ -209,5 +212,6 @@ final class AuthSessionCoordinator {
     refreshFlightAttempt = nil
     lastProactiveValidation = nil
     AuthState.shared.transition(to: .authenticated)
+    NotificationCenter.default.post(name: .sessionDidAuthenticate, object: nil)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+BillingHelpers.swift
@@ -731,16 +731,12 @@ extension SettingsContentView {
     vocabularyList = AssistantSettings.shared.transcriptionVocabulary
     let transcriptionVocabularyRevisionAtLoadStart =
       AssistantSettings.shared.transcriptionVocabularyRevision
-    let notificationSettingsRevisionAtLoadStart = UserDefaults.standard.integer(
-      forKey: NotificationService.settingsSyncRevisionDefaultsKey)
-    let notificationSettingsPendingAtLoadStart =
-      NotificationService.hasPendingNotificationSettingsSync()
     vadGateEnabled = AssistantSettings.shared.vadGateEnabled
     Task {
       do {
         // Load all settings in parallel
         async let dailySummaryTask = APIClient.shared.getDailySummarySettings()
-        async let notificationsTask = APIClient.shared.getNotificationSettings()
+        async let notificationsReconcile: Void = NotificationSettingsSyncCoordinator.shared.reconcile()
         async let languageTask = APIClient.shared.getUserLanguage()
         async let recordingTask = APIClient.shared.getRecordingPermission()
         async let cloudSyncTask = APIClient.shared.getPrivateCloudSync()
@@ -749,9 +745,9 @@ extension SettingsContentView {
         // Sync assistant settings from server in parallel
         async let assistantSyncTask: () = SettingsSyncManager.shared.syncFromServer()
 
-        let (dailySummary, notifications, language, recording, cloudSync, transcription, _) = try await (
+        let (dailySummary, _, language, recording, cloudSync, transcription, _) = try await (
           dailySummaryTask,
-          notificationsTask,
+          notificationsReconcile,
           languageTask,
           recordingTask,
           cloudSyncTask,
@@ -764,36 +760,9 @@ extension SettingsContentView {
           dailySummaryHour = dailySummary.hour
           dailySummaryTime = SettingsControlMetrics.dailySummaryDate(
             forHour: dailySummary.hour, referenceDate: Date())
-          let notificationSettingsRevisionNow = UserDefaults.standard.integer(
-            forKey: NotificationService.settingsSyncRevisionDefaultsKey)
-          let notificationSettingsPendingNow =
-            NotificationService.hasPendingNotificationSettingsSync()
-          if NotificationService.shouldPreserveLocalNotificationSettings(
-            revisionAtLoadStart: notificationSettingsRevisionAtLoadStart,
-            currentRevision: notificationSettingsRevisionNow,
-            pendingAtLoadStart: notificationSettingsPendingAtLoadStart,
-            pendingNow: notificationSettingsPendingNow)
-          {
-            // A newer local change may have raced this GET, or the app may have
-            // quit before its previous PATCH completed. Preserve the local
-            // mirror and retry the complete pair instead of hydrating stale
-            // server values over the user's choice.
-            notificationsEnabled = NotificationService.areNotificationsEnabled()
-            notificationFrequency = NotificationService.currentFrequencyLevel()
-            if notificationSettingsPendingNow {
-              let retryEnabled = notificationsEnabled
-              let retryFrequency = notificationFrequency
-              updateNotificationSettings(enabled: retryEnabled, frequency: retryFrequency)
-            }
-          } else {
-            notificationsEnabled = notifications.enabled
-            notificationFrequency = notifications.frequency
-            // Mirror to UserDefaults so NotificationService can gate/throttle without a backend roundtrip.
-            UserDefaults.standard.set(
-              notifications.enabled, forKey: NotificationService.masterEnabledDefaultsKey)
-            UserDefaults.standard.set(
-              notifications.frequency, forKey: NotificationService.frequencyDefaultsKey)
-          }
+          // Local UserDefaults remain the gate. The coordinator owns GET/hydrate/retry.
+          notificationsEnabled = NotificationService.areNotificationsEnabled()
+          notificationFrequency = NotificationService.currentFrequencyLevel()
           userLanguage = language.language
           recordingPermissionEnabled = recording.enabled
           privateCloudSyncEnabled = cloudSync.enabled

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Components/SettingsContentView+SettingsUpdates.swift
@@ -48,7 +48,7 @@ extension SettingsContentView {
     // Preserve request order and always send the complete locally desired state.
     // If an earlier partial mutation fails, a later successful mutation must also
     // repair that field before it is allowed to clear the pending-sync journal.
-    NotificationSettingsSyncQueue.shared.enqueue(
+    NotificationSettingsSyncCoordinator.shared.enqueue(
       enabled: NotificationService.areNotificationsEnabled(),
       frequency: NotificationService.currentFrequencyLevel(),
       revision: syncRevision)

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -378,6 +378,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // Observe meeting completions app-wide so the action-item banner also fires
     // while the main window is closed or backgrounded.
     MeetingActionItemBannerService.shared.activate()
+    NotificationSettingsSyncCoordinator.shared.start()
     // Notification registration repair is deliberately user-triggered from
     // Settings. Launch must not restart usernoted/NotificationCenter or alter
     // notification registration as a passive side effect.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -747,7 +747,10 @@ actor ContextBucketRollupWriter {
       guard
         RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
         await store.fenceIsValid(fence)
-      else { return }
+      else {
+        await ContextProactivityTelemetry.recordExtractionOutcome(.staleContext)
+        return
+      }
       _ = try await store.writeExtraction(
         extraction,
         for: fence,
@@ -755,15 +758,19 @@ actor ContextBucketRollupWriter {
         rawContextKey: "\(frame.appName)\n\(frame.windowTitle ?? "")",
         normalizedContextKey: ContextTitleNormalizer.identityKey(
           appName: frame.appName, windowTitle: frame.windowTitle) ?? "")
+      await ContextProactivityTelemetry.recordExtractionOutcome(.success)
       await applyDestinationIfEligible(extraction: extraction, frame: frame, fence: fence)
     } catch {
       switch error as? ProactiveLaneClientError {
       case .http(let status, _) where status == 429:
+        await ContextProactivityTelemetry.recordExtractionOutcome(.quotaSkip)
         return
       case .quotaCooldown(_):
+        await ContextProactivityTelemetry.recordExtractionOutcome(.quotaSkip)
         return
       default:
         log("Context bucket extraction failed silently: \(error.localizedDescription)")
+        await ContextProactivityTelemetry.recordExtractionOutcome(.failure)
       }
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -141,6 +141,7 @@ actor ContextProactivityEngine {
     let preflightReason = ContextDeliveryBudget.freeGate(input: gate)
     guard preflightReason == .allowed else {
       log("Context director suppressed before preparation: \(preflightReason.rawValue)")
+      await ContextProactivityTelemetry.recordGateRejection(reason: preflightReason, stage: .preflight)
       return
     }
     guard
@@ -168,6 +169,7 @@ actor ContextProactivityEngine {
     let attemptReason = ContextDeliveryBudget.freeGate(input: attemptGate)
     guard attemptReason == .allowed else {
       log("Context director suppressed before attempt: \(attemptReason.rawValue)")
+      await ContextProactivityTelemetry.recordGateRejection(reason: attemptReason, stage: .attempt)
       return
     }
 
@@ -177,6 +179,7 @@ actor ContextProactivityEngine {
     } catch { return }
     guard attempt.reason == .allowed, let deliveryID = attempt.id else {
       log("Context director suppressed: \(attempt.reason.rawValue)")
+      await ContextProactivityTelemetry.recordGateRejection(reason: attempt.reason, stage: .reservation)
       return
     }
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else {
@@ -223,6 +226,7 @@ actor ContextProactivityEngine {
     let evaluationReason = ContextDeliveryBudget.freeGate(input: evaluationGate)
     guard evaluationReason == .allowed else {
       log("Context director suppressed before model: \(evaluationReason.rawValue)")
+      await ContextProactivityTelemetry.recordGateRejection(reason: evaluationReason, stage: .preModel)
       await terminalize(
         deliveryID: deliveryID,
         decisionType: "silence",
@@ -336,6 +340,7 @@ actor ContextProactivityEngine {
       try await store.completeDelivery(
         id: deliveryID, decisionType: decision.decision, provenanceJSON: provenanceJSON,
         message: decision.message, state: "model_completed")
+      await ContextProactivityTelemetry.recordDirectorDecision(decision.decision)
       if decision.decision == "silence" {
         try await store.completeDelivery(
           id: deliveryID, decisionType: decision.decision, provenanceJSON: provenanceJSON,
@@ -373,6 +378,8 @@ actor ContextProactivityEngine {
       let presentationReason = ContextDeliveryBudget.freeGate(input: presentationGate)
       guard presentationReason == .allowed else {
         log("Context director suppressed before presentation: \(presentationReason.rawValue)")
+        await ContextProactivityTelemetry.recordGateRejection(
+          reason: presentationReason, stage: .presentation)
         try await store.completeDelivery(
           id: deliveryID, decisionType: decision.decision, provenanceJSON: provenanceJSON,
           message: decision.message, state: "suppressed")
@@ -415,7 +422,9 @@ actor ContextProactivityEngine {
       // free gate once more at the actual handoff so master-off, snooze, paywall,
       // or another proactive presentation wins the race.
       let handoffGate = await MainActor.run { Self.liveDeliveryGateInput() }
-      guard ContextDeliveryBudget.freeGate(input: handoffGate) == .allowed else {
+      let handoffReason = ContextDeliveryBudget.freeGate(input: handoffGate)
+      guard handoffReason == .allowed else {
+        await ContextProactivityTelemetry.recordGateRejection(reason: handoffReason, stage: .handoff)
         try await store.completeDelivery(
           id: deliveryID, decisionType: decision.decision, provenanceJSON: provenanceJSON,
           message: decision.message, state: "suppressed")
@@ -522,7 +531,9 @@ actor ContextProactivityEngine {
     // paid call so disabling notifications, snoozing, or becoming paywalled
     // mid-hop never spends more director budget.
     let hopGate = await MainActor.run { Self.liveDeliveryGateInput() }
-    guard ContextDeliveryBudget.freeGate(input: hopGate) == .allowed else {
+    let hopReason = ContextDeliveryBudget.freeGate(input: hopGate)
+    guard hopReason == .allowed else {
+      await ContextProactivityTelemetry.recordGateRejection(reason: hopReason, stage: .retrievalHop)
       return abandoned(items, failure: "pre_model_gate")
     }
     do {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -346,4 +346,87 @@ enum ContextProactivityTelemetry {
         ])
     }
   }
+
+  /// Bounded terminal outcome of one screen extraction attempt. Attempts are the
+  /// sum over outcomes; quota skips and successes are subsets. The event carries
+  /// outcome only — no app, title, bucket, narrative, or fact data.
+  static func recordExtractionOutcome(_ outcome: ExtractionOutcome) async {
+    await MainActor.run {
+      PostHogManager.shared.track(
+        "context_bucket_extraction",
+        properties: ["outcome": outcome.rawValue])
+    }
+  }
+
+  enum ExtractionOutcome: String, Sendable {
+    case success
+    case quotaSkip = "quota_skip"
+    case staleContext = "stale_context"
+    case failure
+  }
+
+  /// Director decisions come from model output, so they pass through this
+  /// allowlist before entering telemetry: only the schema's enum values are
+  /// reportable, anything else collapses to "other".
+  static func boundedDirectorDecision(_ value: String) -> String {
+    switch value {
+    case "suggest", "insight", "task_candidate", "resurface", "silence": value
+    default: "other"
+    }
+  }
+
+  /// One event per settled director evaluation. Decision type only — title,
+  /// message, reasoning, refs, and fact IDs never enter telemetry.
+  static func recordDirectorDecision(_ decision: String) async {
+    await MainActor.run {
+      PostHogManager.shared.track(
+        "context_director_decision",
+        properties: ["decision": boundedDirectorDecision(decision)])
+    }
+  }
+
+  /// The engine's fixed free-gate sites. An enum rather than a call-site string
+  /// so a future caller cannot ship unbounded text as a stage.
+  enum GateStage: String, Sendable {
+    case preflight
+    case attempt
+    case reservation
+    case preModel = "pre_model"
+    case presentation
+    case handoff
+    case retrievalHop = "retrieval_hop"
+  }
+
+  /// A free-gate rejection at one of the engine's fixed gate sites. Both values
+  /// are bounded enums — no bucket, owner, or content data.
+  static func recordGateRejection(reason: ContextDeliveryGateReason, stage: GateStage) async {
+    await MainActor.run {
+      PostHogManager.shared.track(
+        "context_delivery_gate_rejected",
+        properties: ["reason": reason.rawValue, "stage": stage.rawValue])
+    }
+  }
+
+  /// Notification-settings drift between the local gate (authoritative) and the
+  /// server mirror, observed by the sync coordinator. Metadata only: two bools,
+  /// two clamped frequency levels, and the pending-sync flag — no identifiers.
+  static func recordSettingsDrift(
+    localEnabled: Bool,
+    serverEnabled: Bool,
+    localFrequency: Int,
+    serverFrequency: Int,
+    pendingSync: Bool
+  ) async {
+    await MainActor.run {
+      PostHogManager.shared.track(
+        "notification_settings_drift",
+        properties: [
+          "local_enabled": localEnabled,
+          "server_enabled": serverEnabled,
+          "local_frequency": min(max(localFrequency, 0), 5),
+          "server_frequency": min(max(serverFrequency, 0), 5),
+          "pending_sync": pendingSync,
+        ])
+    }
+  }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -10,33 +10,6 @@ private struct UNCompletionHandlerBox: @unchecked Sendable {
   init(_ value: @escaping (UNNotificationPresentationOptions) -> Void) { self.value = value }
 }
 
-/// Serializes notification-settings PATCHes so every mutation — user slider/toggle
-/// changes and the launch migration alike — reaches the backend in request order.
-/// An unordered send could let an earlier mutation land last and clear the
-/// pending-sync journal against a state the server never stored.
-@MainActor
-final class NotificationSettingsSyncQueue {
-  static let shared = NotificationSettingsSyncQueue()
-
-  private var tail: Task<Void, Never>?
-
-  /// `enabled: nil` leaves the master toggle untouched server-side (used by the
-  /// launch migration, which only moves the frequency).
-  func enqueue(enabled: Bool?, frequency: Int, revision: Int) {
-    let previous = tail
-    tail = Task {
-      await previous?.value
-      do {
-        _ = try await APIClient.shared.updateNotificationSettings(
-          enabled: enabled, frequency: frequency)
-        NotificationService.completeNotificationSettingsSync(revision: revision)
-      } catch {
-        logError("Failed to update notification settings", error: error)
-      }
-    }
-  }
-}
-
 /// Sound options for notifications
 enum NotificationSound {
   case `default`
@@ -77,8 +50,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
   /// UserDefaults key mirroring the user's `notification_frequency` setting from the backend.
   /// 0=Off (default), 1=Minimal, 2=Low, 3=Balanced, 4=High, 5=Maximum.
-  /// The Settings page writes this on load and on slider change; `sendNotification`
-  /// reads it synchronously to throttle proactive notifications.
+  /// `NotificationSettingsSyncCoordinator` writes this on hydrate and on slider change;
+  /// `sendNotification` reads it synchronously to throttle proactive notifications.
   nonisolated static let frequencyDefaultsKey = "notification_frequency"
   static let settingsPendingSyncDefaultsKey = "notification_settings_pending_sync"
   static let settingsSyncRevisionDefaultsKey = "notification_settings_sync_revision"
@@ -92,10 +65,11 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   nonisolated static let balancedFrequencyLevel = 3
 
   /// UserDefaults key mirroring the master `notifications_enabled` toggle from the backend.
-  /// The Settings page writes it on load and on toggle change; `sendNotification` reads it
-  /// synchronously so proactive notifications are suppressed the moment the user turns the
-  /// master Notifications switch off — without waiting for a backend round-trip. Defaults to
-  /// `true` when the key is absent (first run before the Settings page hydrates).
+  /// `NotificationSettingsSyncCoordinator` writes it on hydrate and on toggle change;
+  /// `sendNotification` reads it synchronously so proactive notifications are suppressed
+  /// the moment the user turns the master Notifications switch off — without waiting for
+  /// a backend round-trip. Defaults to `true` when the key is absent (first run before
+  /// the coordinator hydrates).
   static let masterEnabledDefaultsKey = "notifications_enabled"
 
   /// Default level used when the key has never been written (e.g. first run before
@@ -947,13 +921,14 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   static func migrateToBalancedDefaultIfNeeded() {
     guard let target = applyBalancedDefaultMigration(defaults: .standard) else { return }
     log("NotificationService: applied balanced-by-default migration (frequency=\(target))")
-    // Route the backend push through the pending-sync journal and the shared send
-    // queue: a failed push (offline, signed out during onboarding) is retried by the
-    // next Settings load instead of the stale server value hydrating back over the
-    // local re-enable, and a slow launch push can never land after — and overwrite —
-    // a frequency change the user makes right after startup.
+    // Route the backend push through the pending-sync journal and the durable
+    // coordinator: a failed push is retried with bounded backoff until the server
+    // confirms, instead of waiting for a Settings load, and a slow launch push can
+    // never land after — and overwrite — a frequency change the user makes right
+    // after startup.
     let revision = beginNotificationSettingsSync()
-    NotificationSettingsSyncQueue.shared.enqueue(enabled: nil, frequency: target, revision: revision)
+    NotificationSettingsSyncCoordinator.shared.enqueue(
+      enabled: nil, frequency: target, revision: revision)
   }
 
   /// Local half of the balanced-by-default migration, split from the backend push so the
@@ -977,7 +952,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
   /// Whether the master Notifications toggle is on. Reads the mirrored UserDefaults key,
   /// defaulting to `true` when absent so notifications are not accidentally suppressed
-  /// before the Settings page has hydrated from the backend.
+  /// before the coordinator has hydrated from the backend. The delivery gate never
+  /// consults the network.
   static func areNotificationsEnabled(defaults: UserDefaults = .standard) -> Bool {
     guard defaults.object(forKey: Self.masterEnabledDefaultsKey) != nil else {
       return true

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSettingsSyncCoordinator.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSettingsSyncCoordinator.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+/// Network seam for notification-settings GET/PATCH so the durable sync can be
+/// exercised without a live backend.
+protocol NotificationSettingsRemote: Sendable {
+  func get() async throws -> NotificationSettingsResponse
+  func update(enabled: Bool?, frequency: Int?) async throws -> NotificationSettingsResponse
+}
+
+struct LiveNotificationSettingsRemote: NotificationSettingsRemote {
+  func get() async throws -> NotificationSettingsResponse {
+    try await APIClient.shared.getNotificationSettings()
+  }
+
+  func update(enabled: Bool?, frequency: Int?) async throws -> NotificationSettingsResponse {
+    try await APIClient.shared.updateNotificationSettings(enabled: enabled, frequency: frequency)
+  }
+}
+
+enum NotificationSettingsSyncBackoff {
+  static let initialNanoseconds: UInt64 = 1_000_000_000
+  static let maxNanoseconds: UInt64 = 900_000_000_000
+
+  /// Exponential delay capped at `maxNanoseconds` (15 minutes), so a client that
+  /// stays offline settles at one PATCH attempt per 15 minutes instead of a
+  /// retry storm. `attempt` is zero-based.
+  static func delayNanoseconds(attempt: Int) -> UInt64 {
+    let shift = min(max(attempt, 0), 10)
+    let raw = initialNanoseconds &<< UInt64(shift)
+    return min(raw, maxNanoseconds)
+  }
+}
+
+/// Durable owner of notification-settings GET/PATCH. Local UserDefaults stay
+/// authoritative for the delivery gate; this type only mirrors them to the
+/// server and hydrates when no local mutation is in flight.
+@MainActor
+final class NotificationSettingsSyncCoordinator {
+  static let shared = NotificationSettingsSyncCoordinator()
+
+  typealias Sleeper = @Sendable (UInt64) async throws -> Void
+
+  private let remote: NotificationSettingsRemote
+  private let defaults: UserDefaults
+  private let sleeper: Sleeper
+  private let isSignedIn: () -> Bool
+
+  private var pushTail: Task<Void, Never>?
+  private var retryTask: Task<Void, Never>?
+  private var reconcileTail: Task<Void, Never>?
+  private var retryAttempt = 0
+  private var authObserver: NSObjectProtocol?
+  private var started = false
+  /// True after a reconcile saw the server mirror disagree with the local pair.
+  /// Cleared (with a heal log line) once they agree again — via hydration or a
+  /// confirmed PATCH — so drift episodes are visible in published logs.
+  private var driftObserved = false
+
+  init(
+    remote: NotificationSettingsRemote = LiveNotificationSettingsRemote(),
+    defaults: UserDefaults = .standard,
+    sleeper: @escaping Sleeper = { try await Task.sleep(nanoseconds: $0) },
+    isSignedIn: @escaping () -> Bool = { AuthState.shared.isSignedIn }
+  ) {
+    self.remote = remote
+    self.defaults = defaults
+    self.sleeper = sleeper
+    self.isSignedIn = isSignedIn
+  }
+
+  /// Launch entry point. Also listens for later sign-in so a pending PATCH is
+  /// retried without opening Settings. Does not touch capture plugins.
+  func start() {
+    if !started {
+      started = true
+      authObserver = NotificationCenter.default.addObserver(
+        forName: .sessionDidAuthenticate,
+        object: nil,
+        queue: nil
+      ) { [weak self] _ in
+        Task { @MainActor in
+          self?.enqueueReconcile()
+        }
+      }
+    }
+    enqueueReconcile()
+  }
+
+  func cancel() {
+    retryTask?.cancel()
+    retryTask = nil
+    pushTail?.cancel()
+    pushTail = nil
+    reconcileTail?.cancel()
+    reconcileTail = nil
+    if let authObserver {
+      NotificationCenter.default.removeObserver(authObserver)
+      self.authObserver = nil
+    }
+    started = false
+  }
+
+  private func enqueueReconcile() {
+    let previous = reconcileTail
+    reconcileTail = Task { [weak self] in
+      await previous?.value
+      await self?.reconcileOnce()
+    }
+  }
+
+  /// Serial PATCH of the desired pair. Failures leave the pending journal set and
+  /// arm bounded backoff until a later attempt completes the matching revision.
+  func enqueue(enabled: Bool?, frequency: Int, revision: Int) {
+    let previous = pushTail
+    pushTail = Task { [weak self] in
+      await previous?.value
+      await self?.pushOnce(enabled: enabled, frequency: frequency, revision: revision)
+    }
+  }
+
+  /// Serialized GET/hydrate entry point: concurrent callers (launch, sign-in,
+  /// a Settings load) coalesce onto one tail so two GETs never race each other
+  /// or interleave their hydrate decisions.
+  func reconcile() async {
+    let previous = reconcileTail
+    let current = Task { [weak self] in
+      await previous?.value
+      await self?.reconcileOnce()
+    }
+    reconcileTail = current
+    await current.value
+  }
+
+  /// GET then either hydrate UserDefaults or preserve local and retry PATCH.
+  /// Uses `shouldPreserveLocalNotificationSettings` unchanged. The whole
+  /// snapshot/decide/write sequence after the GET is synchronous on the main
+  /// actor — no `await` may sit between the pending/revision snapshot and the
+  /// hydrate write, or a local mutation in that window would be overwritten by
+  /// the stale server pair. Telemetry is therefore recorded only afterwards.
+  private func reconcileOnce() async {
+    guard isSignedIn() else { return }
+    let revisionAtStart = defaults.integer(forKey: NotificationService.settingsSyncRevisionDefaultsKey)
+    let pendingAtStart = NotificationService.hasPendingNotificationSettingsSync(defaults: defaults)
+    do {
+      let server = try await remote.get()
+      let revisionNow = defaults.integer(forKey: NotificationService.settingsSyncRevisionDefaultsKey)
+      let pendingNow = NotificationService.hasPendingNotificationSettingsSync(defaults: defaults)
+      let localEnabled = NotificationService.areNotificationsEnabled(defaults: defaults)
+      let localFrequency = NotificationService.currentFrequencyLevel(defaults: defaults)
+      let drifted = localEnabled != server.enabled || localFrequency != server.frequency
+      var driftNewlyDetected = false
+      if drifted, !driftObserved {
+        driftObserved = true
+        driftNewlyDetected = true
+        log(
+          "NotificationSettingsSync: drift detected — local enabled=\(localEnabled) "
+            + "frequency=\(localFrequency), server enabled=\(server.enabled) "
+            + "frequency=\(server.frequency), pendingSync=\(pendingNow)")
+      } else if !drifted, driftObserved {
+        driftObserved = false
+        log("NotificationSettingsSync: drift healed — local and server mirror agree")
+      }
+      if NotificationService.shouldPreserveLocalNotificationSettings(
+        revisionAtLoadStart: revisionAtStart,
+        currentRevision: revisionNow,
+        pendingAtLoadStart: pendingAtStart,
+        pendingNow: pendingNow)
+      {
+        if pendingNow {
+          enqueue(
+            enabled: locallyDecidedEnabledForPatch(),
+            frequency: localFrequency,
+            revision: revisionNow)
+        }
+      } else {
+        defaults.set(server.enabled, forKey: NotificationService.masterEnabledDefaultsKey)
+        defaults.set(server.frequency, forKey: NotificationService.frequencyDefaultsKey)
+        if driftObserved {
+          driftObserved = false
+          log("NotificationSettingsSync: drift healed — hydrated local mirror from server")
+        }
+      }
+      if driftNewlyDetected {
+        await ContextProactivityTelemetry.recordSettingsDrift(
+          localEnabled: localEnabled,
+          serverEnabled: server.enabled,
+          localFrequency: localFrequency,
+          serverFrequency: server.frequency,
+          pendingSync: pendingNow)
+      }
+    } catch {
+      logError("Failed to reconcile notification settings", error: error)
+      if NotificationService.hasPendingNotificationSettingsSync(defaults: defaults) {
+        scheduleRetry()
+      }
+    }
+  }
+
+  /// The master toggle to send when retrying a pending PATCH. Only a value the
+  /// user (or a hydrate) actually wrote locally may be pushed: before the key
+  /// exists — first launch, where only the frequency migration is pending — the
+  /// PATCH sends nil so the server keeps a toggle another client may have set,
+  /// instead of overwriting it with the absent-key default of `true`.
+  private func locallyDecidedEnabledForPatch() -> Bool? {
+    guard defaults.object(forKey: NotificationService.masterEnabledDefaultsKey) != nil else {
+      return nil
+    }
+    return NotificationService.areNotificationsEnabled(defaults: defaults)
+  }
+
+  func waitUntilIdleForTesting() async {
+    await reconcileTail?.value
+    await pushTail?.value
+    await retryTask?.value
+  }
+
+  private func pushOnce(enabled: Bool?, frequency: Int, revision: Int) async {
+    guard isSignedIn() else {
+      scheduleRetry()
+      return
+    }
+    do {
+      _ = try await remote.update(enabled: enabled, frequency: frequency)
+      NotificationService.completeNotificationSettingsSync(revision: revision, defaults: defaults)
+      if !NotificationService.hasPendingNotificationSettingsSync(defaults: defaults) {
+        retryAttempt = 0
+        retryTask?.cancel()
+        retryTask = nil
+        if driftObserved {
+          driftObserved = false
+          log("NotificationSettingsSync: drift healed — server confirmed the local pair")
+        }
+      }
+    } catch {
+      logError("Failed to update notification settings", error: error)
+      scheduleRetry()
+    }
+  }
+
+  private func scheduleRetry() {
+    guard retryTask == nil else { return }
+    retryTask = Task { [weak self] in
+      await self?.retryPendingUntilConfirmed()
+    }
+  }
+
+  private func retryPendingUntilConfirmed() async {
+    while !Task.isCancelled {
+      guard NotificationService.hasPendingNotificationSettingsSync(defaults: defaults) else {
+        retryAttempt = 0
+        retryTask = nil
+        return
+      }
+      let delay = NotificationSettingsSyncBackoff.delayNanoseconds(attempt: retryAttempt)
+      retryAttempt = min(retryAttempt + 1, 10)
+      do {
+        try await sleeper(delay)
+      } catch {
+        retryTask = nil
+        return
+      }
+      guard !Task.isCancelled else {
+        retryTask = nil
+        return
+      }
+      guard NotificationService.hasPendingNotificationSettingsSync(defaults: defaults) else {
+        retryAttempt = 0
+        retryTask = nil
+        return
+      }
+      let revision = defaults.integer(forKey: NotificationService.settingsSyncRevisionDefaultsKey)
+      enqueue(
+        enabled: locallyDecidedEnabledForPatch(),
+        frequency: NotificationService.currentFrequencyLevel(defaults: defaults),
+        revision: revision)
+      await pushTail?.value
+    }
+    retryTask = nil
+  }
+}

--- a/desktop/macos/Desktop/Tests/NotificationSettingsSyncCoordinatorTests.swift
+++ b/desktop/macos/Desktop/Tests/NotificationSettingsSyncCoordinatorTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+
+@testable import Omi_Computer
+
+private final class SleepLog: @unchecked Sendable {
+  var values: [UInt64] = []
+}
+
+private struct FakeNotificationSettingsError: Error {}
+
+private final class FakeNotificationSettingsRemote: NotificationSettingsRemote, @unchecked Sendable {
+  var getResult: Result<NotificationSettingsResponse, Error> = .success(
+    NotificationSettingsResponse(enabled: false, frequency: 0))
+  var updateResults: [Result<NotificationSettingsResponse, Error>] = []
+  var getCount = 0
+  var updates: [(enabled: Bool?, frequency: Int?)] = []
+  var beforeGet: (() async -> Void)?
+
+  func get() async throws -> NotificationSettingsResponse {
+    getCount += 1
+    if let beforeGet {
+      await beforeGet()
+    }
+    return try getResult.get()
+  }
+
+  func update(enabled: Bool?, frequency: Int?) async throws -> NotificationSettingsResponse {
+    updates.append((enabled, frequency))
+    if updateResults.isEmpty {
+      return NotificationSettingsResponse(enabled: enabled ?? true, frequency: frequency ?? 0)
+    }
+    return try updateResults.removeFirst().get()
+  }
+}
+
+@MainActor
+private struct Fixture {
+  let suiteName: String
+  let defaults: UserDefaults
+  let remote: FakeNotificationSettingsRemote
+  let coordinator: NotificationSettingsSyncCoordinator
+  let sleepLog: SleepLog
+  var sleeps: [UInt64] { sleepLog.values }
+
+  func tearDown() {
+    coordinator.cancel()
+    defaults.removePersistentDomain(forName: suiteName)
+  }
+}
+
+@MainActor
+final class NotificationSettingsSyncCoordinatorTests: XCTestCase {
+  private func makeFixture() throws -> Fixture {
+    let suiteName = "NotificationSettingsSyncCoordinatorTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    let remote = FakeNotificationSettingsRemote()
+    let sleepLog = SleepLog()
+    let coordinator = NotificationSettingsSyncCoordinator(
+      remote: remote,
+      defaults: defaults,
+      sleeper: { [sleepLog] nanoseconds in
+        sleepLog.values.append(nanoseconds)
+      },
+      isSignedIn: { true })
+    return Fixture(
+      suiteName: suiteName,
+      defaults: defaults,
+      remote: remote,
+      coordinator: coordinator,
+      sleepLog: sleepLog)
+  }
+
+  func testBackoffDelayIsBounded() {
+    XCTAssertEqual(NotificationSettingsSyncBackoff.delayNanoseconds(attempt: 0), 1_000_000_000)
+    XCTAssertEqual(NotificationSettingsSyncBackoff.delayNanoseconds(attempt: 1), 2_000_000_000)
+    XCTAssertEqual(
+      NotificationSettingsSyncBackoff.delayNanoseconds(attempt: 10),
+      NotificationSettingsSyncBackoff.maxNanoseconds)
+    XCTAssertEqual(
+      NotificationSettingsSyncBackoff.delayNanoseconds(attempt: 100),
+      NotificationSettingsSyncBackoff.maxNanoseconds)
+  }
+
+  func testFailedPatchIsRetriedUntilServerConfirmsWithoutReopeningSettings() async throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    fixture.defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    fixture.defaults.set(3, forKey: NotificationService.frequencyDefaultsKey)
+    fixture.remote.updateResults = [
+      .failure(FakeNotificationSettingsError()),
+      .success(NotificationSettingsResponse(enabled: true, frequency: 3)),
+    ]
+
+    let revision = NotificationService.beginNotificationSettingsSync(defaults: fixture.defaults)
+    fixture.coordinator.enqueue(enabled: true, frequency: 3, revision: revision)
+    await fixture.coordinator.waitUntilIdleForTesting()
+
+    XCTAssertEqual(fixture.remote.updates.count, 2)
+    XCTAssertEqual(fixture.remote.updates[0].enabled, true)
+    XCTAssertEqual(fixture.remote.updates[0].frequency, 3)
+    XCTAssertEqual(fixture.remote.updates[1].enabled, true)
+    XCTAssertEqual(fixture.remote.updates[1].frequency, 3)
+    XCTAssertFalse(
+      NotificationService.hasPendingNotificationSettingsSync(defaults: fixture.defaults),
+      "a successful retry must clear the pending journal")
+    XCTAssertEqual(fixture.sleeps.first, NotificationSettingsSyncBackoff.delayNanoseconds(attempt: 0))
+    XCTAssertTrue(NotificationService.areNotificationsEnabled(defaults: fixture.defaults))
+    XCTAssertEqual(NotificationService.currentFrequencyLevel(defaults: fixture.defaults), 3)
+  }
+
+  func testRetryWithoutLocallyWrittenMasterKeySendsNilEnabled() async throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    // First launch: only the frequency migration is pending and the master key
+    // was never written locally. The retry must not push the absent-key default
+    // of `true` over a toggle another client may have set server-side.
+    fixture.defaults.set(3, forKey: NotificationService.frequencyDefaultsKey)
+    fixture.remote.updateResults = [
+      .failure(FakeNotificationSettingsError()),
+      .success(NotificationSettingsResponse(enabled: false, frequency: 3)),
+    ]
+
+    let revision = NotificationService.beginNotificationSettingsSync(defaults: fixture.defaults)
+    fixture.coordinator.enqueue(enabled: nil, frequency: 3, revision: revision)
+    await fixture.coordinator.waitUntilIdleForTesting()
+
+    XCTAssertEqual(fixture.remote.updates.count, 2)
+    XCTAssertNil(fixture.remote.updates[0].enabled)
+    XCTAssertNil(
+      fixture.remote.updates[1].enabled,
+      "a retry must not invent a master-toggle value the user never chose")
+    XCTAssertEqual(fixture.remote.updates[1].frequency, 3)
+    XCTAssertFalse(NotificationService.hasPendingNotificationSettingsSync(defaults: fixture.defaults))
+  }
+
+  func testHydrationAppliesServerValuesWhenNoLocalChangeIsPending() async throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    fixture.defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    fixture.defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
+    fixture.remote.getResult = .success(NotificationSettingsResponse(enabled: false, frequency: 2))
+
+    await fixture.coordinator.reconcile()
+
+    XCTAssertTrue(fixture.remote.updates.isEmpty, "idle hydration must not PATCH")
+    XCTAssertFalse(NotificationService.areNotificationsEnabled(defaults: fixture.defaults))
+    XCTAssertEqual(NotificationService.currentFrequencyLevel(defaults: fixture.defaults), 2)
+  }
+
+  func testPendingLocalChangeIsPreservedAndPatchedInsteadOfHydrated() async throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    fixture.defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    fixture.defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
+    _ = NotificationService.beginNotificationSettingsSync(defaults: fixture.defaults)
+    fixture.remote.getResult = .success(NotificationSettingsResponse(enabled: false, frequency: 0))
+    fixture.remote.updateResults = [
+      .success(NotificationSettingsResponse(enabled: true, frequency: 5))
+    ]
+
+    await fixture.coordinator.reconcile()
+    await fixture.coordinator.waitUntilIdleForTesting()
+
+    XCTAssertTrue(
+      NotificationService.areNotificationsEnabled(defaults: fixture.defaults),
+      "local remains authoritative while a PATCH is pending")
+    XCTAssertEqual(NotificationService.currentFrequencyLevel(defaults: fixture.defaults), 5)
+    XCTAssertEqual(fixture.remote.updates.count, 1)
+    XCTAssertEqual(fixture.remote.updates[0].enabled, true)
+    XCTAssertEqual(fixture.remote.updates[0].frequency, 5)
+    XCTAssertFalse(NotificationService.hasPendingNotificationSettingsSync(defaults: fixture.defaults))
+  }
+
+  func testRevisionRaceDuringGetPreservesLocalAndDoesNotHydrate() async throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    let defaults = fixture.defaults
+    defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    defaults.set(4, forKey: NotificationService.frequencyDefaultsKey)
+    fixture.remote.getResult = .success(NotificationSettingsResponse(enabled: false, frequency: 0))
+    fixture.remote.beforeGet = {
+      _ = NotificationService.beginNotificationSettingsSync(defaults: defaults)
+      defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+      defaults.set(4, forKey: NotificationService.frequencyDefaultsKey)
+    }
+
+    await fixture.coordinator.reconcile()
+    await fixture.coordinator.waitUntilIdleForTesting()
+
+    XCTAssertTrue(NotificationService.areNotificationsEnabled(defaults: defaults))
+    XCTAssertEqual(NotificationService.currentFrequencyLevel(defaults: defaults), 4)
+    XCTAssertFalse(
+      defaults.bool(forKey: NotificationService.masterEnabledDefaultsKey) == false,
+      "a GET that raced a local mutation must not hydrate the stale server pair")
+  }
+
+  func testDeliveryGateStillReadsOnlyLocalDefaults() throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    fixture.defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    fixture.remote.getResult = .success(NotificationSettingsResponse(enabled: false, frequency: 0))
+    XCTAssertTrue(NotificationService.areNotificationsEnabled(defaults: fixture.defaults))
+    XCTAssertEqual(fixture.remote.getCount, 0)
+    XCTAssertTrue(fixture.remote.updates.isEmpty)
+  }
+
+  func testStartReconcilesWhenSignedIn() async throws {
+    let fixture = try makeFixture()
+    defer { fixture.tearDown() }
+    fixture.remote.getResult = .success(NotificationSettingsResponse(enabled: false, frequency: 2))
+    fixture.coordinator.start()
+    await fixture.coordinator.waitUntilIdleForTesting()
+    XCTAssertEqual(fixture.remote.getCount, 1)
+    XCTAssertFalse(NotificationService.areNotificationsEnabled(defaults: fixture.defaults))
+    XCTAssertEqual(NotificationService.currentFrequencyLevel(defaults: fixture.defaults), 2)
+
+    fixture.remote.getResult = .success(NotificationSettingsResponse(enabled: true, frequency: 4))
+    NotificationCenter.default.post(name: .sessionDidAuthenticate, object: nil)
+    await Task { @MainActor in }.value
+    await fixture.coordinator.waitUntilIdleForTesting()
+    XCTAssertEqual(fixture.remote.getCount, 2)
+    XCTAssertTrue(NotificationService.areNotificationsEnabled(defaults: fixture.defaults))
+    XCTAssertEqual(NotificationService.currentFrequencyLevel(defaults: fixture.defaults), 4)
+  }
+}

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -24,6 +24,15 @@ final class ProactiveLaneClientTests: XCTestCase {
     XCTAssertEqual(ContextProactivityTelemetry.boundedProviderModel("attacker-controlled-model"), "other")
   }
 
+  func testTelemetryDirectorDecisionIsBounded() {
+    for allowed in ["suggest", "insight", "task_candidate", "resurface", "silence"] {
+      XCTAssertEqual(ContextProactivityTelemetry.boundedDirectorDecision(allowed), allowed)
+    }
+    XCTAssertEqual(
+      ContextProactivityTelemetry.boundedDirectorDecision("model-invented-decision"), "other",
+      "decision strings come from model output and must collapse to a bounded set")
+  }
+
   func testClientErrorsExposeOnlyStableSafeClassifications() {
     XCTAssertEqual(ProactiveLaneClientError.invalidResponse.localizedDescription, "proactive_invalid_response")
     XCTAssertEqual(

--- a/desktop/macos/changelog/unreleased/20260815-notification-settings-sync.json
+++ b/desktop/macos/changelog/unreleased/20260815-notification-settings-sync.json
@@ -1,0 +1,3 @@
+{
+  "change": "Notification settings now keep syncing in the background after a failed save, so the toggle you see stays aligned with the server"
+}

--- a/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
+++ b/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
@@ -30,6 +30,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryHandleExtractor.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/WorkHistoryIndex.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/InsightSQLPrivacy.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationSettingsSyncCoordinator.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/TaskContextualResurfacingService.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/RewindCaptureExclusion.swift
   - desktop/macos/Desktop/Sources/Rewind/Core/StagedTaskStorage.swift


### PR DESCRIPTION
## What changed and why

The Settings page, an ad-hoc send queue (`NotificationSettingsSyncQueue`), and the launch migration were competing writers of the server's notification-settings mirror, and a failed PATCH was only retried on the next Settings-view load — so the local gate and the Firestore mirror could disagree indefinitely. This converges GET/hydrate/PATCH/retry behind a single `NotificationSettingsSyncCoordinator`: local UserDefaults remain the delivery-gating authority (the gate never consults the network), the server mirror converges durably with bounded backoff (1s doubling to a 15-minute ceiling, so an offline client settles at one attempt per 15 minutes instead of a retry storm), pending PATCHes resume at launch and on sign-in, and drift-detected/drift-healed transitions are logged.

It also adds metadata-only proactivity telemetry on the existing `ContextProactivityTelemetry` PostHog surface: extraction outcomes (`success` / `quota_skip` / `stale_context` / `failure`; attempts are the sum over outcomes), director decisions passed through a bounded allowlist (`suggest`/`insight`/`task_candidate`/`resurface`/`silence`, else `other`), free-gate rejections by bounded reason and call-site stage, and a `notification_settings_drift` event carrying only two booleans, two clamped frequency levels, and the pending-sync flag. No identifiers, titles, message bodies, reasoning text, or bucket data enter any event. `DesktopDiagnosticsManager` is untouched.

## Product invariants affected

INV-AUTH-1 — touched, not altered: `AuthSessionCoordinator` gains a content-free `sessionDidAuthenticate` NotificationCenter post after `commitAuthenticated()` completes its existing transition, so the sync coordinator can retry a pending PATCH without opening Settings. Session ownership, invalidation, and teardown ordering are unchanged; the observer does no auth work and never blocks the transition.

## How it was verified

- `swift build --build-tests` in `desktop/macos/Desktop`: clean.
- `swift test --filter 'NotificationSettings|Notification|ContextProactivity'`: 148 tests, 0 failures.
- `swift test --filter 'ProactiveLaneClient|NotificationSettingsSyncCoordinator'`: 19 tests, 0 failures.
- `scripts/pr-preflight`: all 21 checks pass.
- Independent model review (Grok 4.6 via agentctl/cursor) on the diff, axes: metadata-only privacy, retry-storm risk, local-stays-authoritative. Its findings were addressed: the drift-telemetry `await` no longer sits between the pending/revision snapshot and the hydrate write (the window where a local mutation could be overwritten); a first-launch retry sends `enabled: nil` instead of the absent-key default `true`, so a toggle set by another client is not overwritten; `reconcile()` is serialized so launch/sign-in/Settings-load callers cannot race two GETs; the gate-rejection `stage` is a bounded enum, not a string. One Low finding intentionally not taken: while signed out with a pending sync, the retry loop wakes every 15 minutes but makes no network call (`pushOnce` guards `isSignedIn` before any request).
- Not verified against a live backend: the retry/backoff and drift paths are exercised through the injected `NotificationSettingsRemote` seam, not real network failures.

## Tests

- `NotificationSettingsSyncCoordinatorTests` — regression coverage for the drift bug: a failed PATCH is retried with backoff until the server confirms without reopening Settings; idle hydration applies server values; a pending or racing local change is preserved and PATCHed instead of hydrated; the delivery gate reads only local defaults; `start()` reconciles at launch and again on sign-in.
- `ProactiveLaneClientTests.testTelemetryDirectorDecisionIsBounded` — model-supplied decision strings collapse to the bounded set before entering telemetry.

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

## Ratchet exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1593 -> 1594 | one-line launch hook starting the notification-settings sync coordinator


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

