### PR TITLE
test(desktop): pin manual download tests to the sidecar identity contract

### DIFF
--- a/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
+++ b/desktop/macos/Desktop/Tests/UpdateFailureDiagnosticsTests.swift
@@ -17,12 +17,21 @@ final class UpdateFailureDiagnosticsTests: XCTestCase {
     )
   }
 
-  func testManualDownloadURLPreservesBetaChannel() {
+  func testManualDownloadURLIgnoresLegacyChannelDefault() {
+    // The sidecar design pins the channel to bundle identity; the old
+    // update_channel default must no longer steer a stable install to beta.
     UserDefaults.standard.set("beta", forKey: "update_channel")
 
     XCTAssertEqual(
       AppBuild.manualDownloadURL.absoluteString,
-      "https://api.omi.me/v2/desktop/download/latest?channel=beta"
+      "https://api.omi.me/v2/desktop/download/latest?channel=stable"
+    )
+  }
+
+  func testOmiBetaInstallURLRequestsBetaIdentity() {
+    XCTAssertEqual(
+      AppBuild.omiBetaInstallURL.absoluteString,
+      "https://api.omi.me/v2/desktop/download/latest?channel=beta&identity=beta"
     )
   }
 


### PR DESCRIPTION
## Why

#11614 pinned the update channel to bundle identity (sidecar beta design), deliberately removing the `update_channel` UserDefault as a channel switch. `UpdateFailureDiagnosticsTests.testManualDownloadURLPreservesBetaChannel` still pinned the removed mechanism and now fails deterministically on main, blocking the release train.

## What

Replace the stale test with two that pin the new contract: the legacy default no longer steers a stable install to beta, and `omiBetaInstallURL` requests `channel=beta&identity=beta`. Test-only; no product change.

Failure-Class: none

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

