### PR TITLE
Break the database.users import cycle with utils.subscription and honor the dev goals limit

### DIFF
--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -342,27 +342,18 @@ def get_all_goals(
 ) -> List[Dict[str, Any]]:
     """Fetch a user's goals, newest first.
 
-    ``limit`` bounds the read at the query instead of in Python, so a caller that only needs a
-    page cannot stream the whole collection. It is opt-in: every existing caller omits it and
-    keeps the fetch-everything behaviour they rely on.
+    ``limit`` bounds the returned page after the in-Python newest-first sort. It is opt-in:
+    every existing caller omits it and keeps the full-list behaviour they rely on.
 
-    The query orders by ``created_at`` descending so the bounded page is the newest ``limit``
-    goals rather than an arbitrary slice that only looks sorted after the in-Python sort below.
-
-    ``limit`` is only supported together with ``include_inactive=True``. That shape carries no
-    equality filter, so ordering by ``created_at`` is served by Firestore's automatic
-    single-field index. Combining a limit with the ``is_active`` filter would need a composite
-    index that this project does not declare, and Firestore answers a missing composite index
-    with an opaque 500, so the unsupported combination is rejected here rather than in
-    production.
+    The bound is deliberately NOT pushed into the Firestore query: ``order_by('created_at')``
+    excludes documents that lack the field entirely, and legacy or manually created goals can
+    lack ``created_at`` — a query-level order+limit would silently drop them. Instead the full
+    stream is sorted here (goals without ``created_at`` coerce to ``datetime.min`` and sort
+    last) and the page is sliced, so the bound caps the response payload while dateless legacy
+    goals still appear once dated goals run out.
     """
-    if limit is not None and not include_inactive:
-        raise ValueError('get_all_goals(limit=...) is only supported with include_inactive=True')
-
     collection = _get_db(firestore_client).collection(users_collection).document(uid).collection(goals_collection)
     query = collection if include_inactive else collection.where(filter=FieldFilter('is_active', '==', True))
-    if limit is not None:
-        query = query.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
     goals = [normalize_goal_storage(_goal_dict(doc), goal_id=doc.id) for doc in query.stream()]
     if not include_inactive:
         goals = [goal for goal in goals if goal['is_active']]

--- a/backend/database/goals.py
+++ b/backend/database/goals.py
@@ -337,15 +337,37 @@ def get_all_goals(
     uid: str,
     include_inactive: bool = False,
     *,
+    limit: Optional[int] = None,
     firestore_client: Any = None,
 ) -> List[Dict[str, Any]]:
+    """Fetch a user's goals, newest first.
+
+    ``limit`` bounds the read at the query instead of in Python, so a caller that only needs a
+    page cannot stream the whole collection. It is opt-in: every existing caller omits it and
+    keeps the fetch-everything behaviour they rely on.
+
+    The query orders by ``created_at`` descending so the bounded page is the newest ``limit``
+    goals rather than an arbitrary slice that only looks sorted after the in-Python sort below.
+
+    ``limit`` is only supported together with ``include_inactive=True``. That shape carries no
+    equality filter, so ordering by ``created_at`` is served by Firestore's automatic
+    single-field index. Combining a limit with the ``is_active`` filter would need a composite
+    index that this project does not declare, and Firestore answers a missing composite index
+    with an opaque 500, so the unsupported combination is rejected here rather than in
+    production.
+    """
+    if limit is not None and not include_inactive:
+        raise ValueError('get_all_goals(limit=...) is only supported with include_inactive=True')
+
     collection = _get_db(firestore_client).collection(users_collection).document(uid).collection(goals_collection)
     query = collection if include_inactive else collection.where(filter=FieldFilter('is_active', '==', True))
+    if limit is not None:
+        query = query.order_by('created_at', direction=firestore.Query.DESCENDING).limit(limit)
     goals = [normalize_goal_storage(_goal_dict(doc), goal_id=doc.id) for doc in query.stream()]
     if not include_inactive:
         goals = [goal for goal in goals if goal['is_active']]
     goals.sort(key=_goal_created_at_sort_key, reverse=True)
-    return goals
+    return goals if limit is None else goals[:limit]
 
 
 def create_goal(

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -29,7 +29,6 @@ from models.users import (
     SubscriptionStatus,
 )
 from models.other import Person
-from utils.subscription import get_default_basic_subscription
 import logging
 
 logger = logging.getLogger(__name__)
@@ -1547,6 +1546,11 @@ def get_user_subscription(uid: str, *, firestore_client: Any | None = None) -> S
             return subscription
 
     # If subscription doesn't exist for the user, create and return a default free plan.
+    # Imported here, not at module scope: utils.subscription imports this module, so a
+    # module-level import makes utils.subscription unimportable on its own (see
+    # get_user_valid_subscription, which defers the same import for the same reason).
+    from utils.subscription import get_default_basic_subscription
+
     default_subscription = get_default_basic_subscription()
     # Strip dynamic fields before storing
     sub_to_store = default_subscription.model_dump()
@@ -1678,6 +1682,11 @@ def get_user_valid_subscription(
     quota must use that mode against the customer Firestore so a miss cannot
     stamp ``plan: basic`` onto a paying user.
     """
+    # Imported here, not at module scope: utils.subscription imports this module, and a
+    # module-level import back into it forms a cycle that makes utils.subscription raise
+    # ImportError whenever it is the first of the pair to be imported.
+    from utils.subscription import get_default_basic_subscription
+
     if provision:
         subscription = get_user_subscription(uid, firestore_client=firestore_client)
     else:

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1942,9 +1942,10 @@ def get_goals(
     # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
     limit = max(1, min(limit, 1000))
     if include_inactive:
-        # Pass the clamp down so Firestore returns at most `limit` documents. Slicing the
-        # result here instead would bound the payload but still stream the whole collection,
-        # which is the cost the clamp above exists to prevent.
+        # Pass the clamp down so the response honours the documented limit. The bound is
+        # applied after the in-Python newest-first sort rather than at the query, because a
+        # Firestore order_by('created_at') would silently exclude legacy goals that lack the
+        # field; see get_all_goals.
         goals = goals_db.get_all_goals(uid, include_inactive=True, limit=limit)
     else:
         goals = goals_db.get_user_goals(uid, limit=limit)

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -1942,7 +1942,10 @@ def get_goals(
     # oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
     limit = max(1, min(limit, 1000))
     if include_inactive:
-        goals = goals_db.get_all_goals(uid, include_inactive=True)
+        # Pass the clamp down so Firestore returns at most `limit` documents. Slicing the
+        # result here instead would bound the payload but still stream the whole collection,
+        # which is the cost the clamp above exists to prevent.
+        goals = goals_db.get_all_goals(uid, include_inactive=True, limit=limit)
     else:
         goals = goals_db.get_user_goals(uid, limit=limit)
 

--- a/backend/tests/unit/test_dev_goals_limit_include_inactive.py
+++ b/backend/tests/unit/test_dev_goals_limit_include_inactive.py
@@ -1,0 +1,182 @@
+"""Regression test: GET /v1/dev/user/goals must honour `limit` when include_inactive=true.
+
+routers.developer.get_goals clamps `limit` to [1, 1000] and then branches. The default branch
+calls goals_db.get_user_goals(uid, limit=limit), which is bounded. The include_inactive=True
+branch called goals_db.get_all_goals(uid, include_inactive=True), which had no limit parameter
+and streamed the whole goals collection, so the clamp was dead code on that branch and the
+endpoint returned every goal the user had ever created -- ignoring its own documented
+"**limit**: Maximum number of goals to return".
+
+The clamp is now passed down to the query rather than applied to the result. Slicing the
+returned list would fix the payload length but still stream every historical goal first, which
+is exactly the cost the clamp's own comment says it prevents ("an oversized limit cannot stream
+the whole collection"). So these tests assert the bounded path is *taken*, not only that the
+final list is short.
+
+get_all_goals stays fetch-everything by default for its other callers
+(/v1/dev/user/goals/{goal_id}, routers/goals.py::get_all_goals, and the MCP goal reads); the
+limit is opt-in and only this route passes it.
+"""
+
+import pytest
+
+import database.goals as goals_db_module
+import routers.developer as developer
+
+
+def _fake_goals(count):
+    return [{'id': f'g{index}', 'title': f'goal {index}'} for index in range(count)]
+
+
+# --- router: the clamp reaches the helper -----------------------------------------------
+
+
+def test_include_inactive_passes_the_clamp_down_to_the_query(monkeypatch):
+    captured = {}
+
+    def get_all_goals(uid, include_inactive=False, *, limit=None):
+        captured.update(uid=uid, include_inactive=include_inactive, limit=limit)
+        return _fake_goals(min(limit, 25))
+
+    monkeypatch.setattr(developer.goals_db, 'get_all_goals', get_all_goals)
+
+    result = developer.get_goals(uid='u1', limit=5, include_inactive=True)
+
+    # The bound is delegated, not applied after the fact.
+    assert captured == {'uid': 'u1', 'include_inactive': True, 'limit': 5}
+    assert len(result) == 5
+
+
+def test_include_inactive_delegates_the_clamp_ceiling(monkeypatch):
+    captured = {}
+
+    def get_all_goals(uid, include_inactive=False, *, limit=None):
+        captured.update(limit=limit)
+        return _fake_goals(limit)
+
+    monkeypatch.setattr(developer.goals_db, 'get_all_goals', get_all_goals)
+
+    result = developer.get_goals(uid='u1', limit=99999, include_inactive=True)
+
+    assert captured == {'limit': 1000}
+    assert len(result) == 1000
+
+
+def test_active_only_branch_still_delegates_the_limit(monkeypatch):
+    captured = {}
+
+    def get_user_goals(uid, limit):
+        captured.update(uid=uid, limit=limit)
+        return _fake_goals(3)
+
+    monkeypatch.setattr(developer.goals_db, 'get_user_goals', get_user_goals)
+
+    result = developer.get_goals(uid='u1', limit=3, include_inactive=False)
+
+    assert captured == {'uid': 'u1', 'limit': 3}
+    assert len(result) == 3
+
+
+# --- database: the query itself is bounded ----------------------------------------------
+
+
+class _FakeDoc:
+    def __init__(self, doc_id, payload):
+        self.id = doc_id
+        self._payload = payload
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _FakeQuery:
+    """Records the query builder calls so the test can assert what Firestore was asked for."""
+
+    def __init__(self, docs, calls):
+        self._docs = docs
+        self.calls = calls
+
+    def where(self, **kwargs):
+        self.calls.append(('where', kwargs))
+        return self
+
+    def order_by(self, field, direction=None):
+        self.calls.append(('order_by', field, direction))
+        return self
+
+    def limit(self, count):
+        self.calls.append(('limit', count))
+        return _FakeQuery(self._docs[:count], self.calls)
+
+    def stream(self):
+        return iter(self._docs)
+
+
+class _FakeClient:
+    def __init__(self, docs, calls):
+        self._docs = docs
+        self._calls = calls
+
+    def collection(self, _name):
+        return self
+
+    def document(self, _name):
+        return self
+
+    def where(self, **kwargs):
+        return _FakeQuery(self._docs, self._calls).where(**kwargs)
+
+    def order_by(self, field, direction=None):
+        return _FakeQuery(self._docs, self._calls).order_by(field, direction)
+
+    def limit(self, count):
+        return _FakeQuery(self._docs, self._calls).limit(count)
+
+    def stream(self):
+        return iter(self._docs)
+
+
+def _docs(count):
+    from datetime import datetime, timedelta, timezone
+
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return [
+        _FakeDoc(
+            f'g{index}',
+            {'created_at': base + timedelta(days=index), 'is_active': True, 'status': 'background'},
+        )
+        for index in range(count)
+    ]
+
+
+def test_get_all_goals_bounds_the_query_when_limit_is_given():
+    calls = []
+    client = _FakeClient(_docs(50), calls)
+
+    result = goals_db_module.get_all_goals('u1', include_inactive=True, limit=5, firestore_client=client)
+
+    # The read itself is bounded, and ordered so the bounded page is the newest goals rather
+    # than an arbitrary slice that only looks sorted after the in-Python sort.
+    assert ('limit', 5) in calls
+    assert any(call[0] == 'order_by' and call[1] == 'created_at' for call in calls)
+    assert len(result) == 5
+
+
+def test_get_all_goals_stays_unbounded_for_existing_callers():
+    calls = []
+    client = _FakeClient(_docs(50), calls)
+
+    result = goals_db_module.get_all_goals('u1', include_inactive=True, firestore_client=client)
+
+    # No limit and no ordering pushed into the query: the other callers still fetch everything.
+    assert not any(call[0] == 'limit' for call in calls)
+    assert not any(call[0] == 'order_by' for call in calls)
+    assert len(result) == 50
+
+
+def test_get_all_goals_rejects_a_limit_it_cannot_serve():
+    # A limit alongside the is_active filter would need a composite index this project does not
+    # declare, and Firestore answers a missing composite index with an opaque 500. Fail loudly
+    # here instead.
+    with pytest.raises(ValueError):
+        goals_db_module.get_all_goals('u1', include_inactive=False, limit=5, firestore_client=_FakeClient([], []))

--- a/backend/tests/unit/test_dev_goals_limit_include_inactive.py
+++ b/backend/tests/unit/test_dev_goals_limit_include_inactive.py
@@ -7,11 +7,11 @@ and streamed the whole goals collection, so the clamp was dead code on that bran
 endpoint returned every goal the user had ever created -- ignoring its own documented
 "**limit**: Maximum number of goals to return".
 
-The clamp is now passed down to the query rather than applied to the result. Slicing the
-returned list would fix the payload length but still stream every historical goal first, which
-is exactly the cost the clamp's own comment says it prevents ("an oversized limit cannot stream
-the whole collection"). So these tests assert the bounded path is *taken*, not only that the
-final list is short.
+The clamp is now passed down and applied after the in-Python newest-first sort. The bound is
+deliberately not pushed into the Firestore query: order_by('created_at') excludes documents
+missing the field, and legacy goals can lack created_at, so a query-level bound would silently
+drop them. These tests assert the bounded page is the NEWEST goals, that dateless legacy goals
+survive bounding (sorting last), and that the bounded path is taken by the route.
 
 get_all_goals stays fetch-everything by default for its other callers
 (/v1/dev/user/goals/{goal_id}, routers/goals.py::get_all_goals, and the MCP goal reads); the
@@ -77,7 +77,7 @@ def test_active_only_branch_still_delegates_the_limit(monkeypatch):
     assert len(result) == 3
 
 
-# --- database: the query itself is bounded ----------------------------------------------
+# --- database: the page is the newest goals and legacy goals survive ---------------------
 
 
 class _FakeDoc:
@@ -89,12 +89,19 @@ class _FakeDoc:
         return dict(self._payload)
 
 
-class _FakeQuery:
-    """Records the query builder calls so the test can assert what Firestore was asked for."""
+class _FakeCollection:
+    """Streams the given docs; records whether a query-level order/limit was pushed down
+    (it must NOT be — that is the legacy-goal-dropping shape this fix avoids)."""
 
     def __init__(self, docs, calls):
         self._docs = docs
         self.calls = calls
+
+    def collection(self, _name):
+        return self
+
+    def document(self, _name):
+        return self
 
     def where(self, **kwargs):
         self.calls.append(('where', kwargs))
@@ -106,31 +113,7 @@ class _FakeQuery:
 
     def limit(self, count):
         self.calls.append(('limit', count))
-        return _FakeQuery(self._docs[:count], self.calls)
-
-    def stream(self):
-        return iter(self._docs)
-
-
-class _FakeClient:
-    def __init__(self, docs, calls):
-        self._docs = docs
-        self._calls = calls
-
-    def collection(self, _name):
         return self
-
-    def document(self, _name):
-        return self
-
-    def where(self, **kwargs):
-        return _FakeQuery(self._docs, self._calls).where(**kwargs)
-
-    def order_by(self, field, direction=None):
-        return _FakeQuery(self._docs, self._calls).order_by(field, direction)
-
-    def limit(self, count):
-        return _FakeQuery(self._docs, self._calls).limit(count)
 
     def stream(self):
         return iter(self._docs)
@@ -149,34 +132,47 @@ def _docs(count):
     ]
 
 
-def test_get_all_goals_bounds_the_query_when_limit_is_given():
+def test_get_all_goals_bounded_page_is_the_newest_goals():
     calls = []
-    client = _FakeClient(_docs(50), calls)
+    client = _FakeCollection(_docs(50), calls)
 
     result = goals_db_module.get_all_goals('u1', include_inactive=True, limit=5, firestore_client=client)
 
-    # The read itself is bounded, and ordered so the bounded page is the newest goals rather
-    # than an arbitrary slice that only looks sorted after the in-Python sort.
-    assert ('limit', 5) in calls
-    assert any(call[0] == 'order_by' and call[1] == 'created_at' for call in calls)
-    assert len(result) == 5
+    # Newest first: the docs were streamed oldest-first, so the page must be the LAST five
+    # ids in reverse creation order — proving the sort ran before the slice.
+    assert [g['id'] for g in result] == ['g49', 'g48', 'g47', 'g46', 'g45']
+    # And the bound was never pushed into the query, where order_by('created_at') would
+    # exclude legacy goals lacking the field.
+    assert not any(call[0] in ('order_by', 'limit') for call in calls)
+
+
+def test_get_all_goals_keeps_legacy_goals_without_created_at():
+    calls = []
+    dated = _docs(3)
+    legacy = _FakeDoc('legacy', {'is_active': True, 'status': 'background'})  # no created_at
+    client = _FakeCollection(dated + [legacy], calls)
+
+    result = goals_db_module.get_all_goals('u1', include_inactive=True, limit=10, firestore_client=client)
+
+    # The dateless legacy goal is retained (a query-level order_by would have dropped it)
+    # and sorts deterministically last.
+    assert [g['id'] for g in result] == ['g2', 'g1', 'g0', 'legacy']
+
+
+def test_get_all_goals_bounds_still_apply_over_legacy_goals():
+    client = _FakeCollection(_docs(2) + [_FakeDoc('legacy', {'is_active': True, 'status': 'background'})], [])
+
+    result = goals_db_module.get_all_goals('u1', include_inactive=True, limit=2, firestore_client=client)
+
+    # Dated goals fill the page first; the dateless one only appears when room remains.
+    assert [g['id'] for g in result] == ['g1', 'g0']
 
 
 def test_get_all_goals_stays_unbounded_for_existing_callers():
     calls = []
-    client = _FakeClient(_docs(50), calls)
+    client = _FakeCollection(_docs(50), calls)
 
     result = goals_db_module.get_all_goals('u1', include_inactive=True, firestore_client=client)
 
-    # No limit and no ordering pushed into the query: the other callers still fetch everything.
-    assert not any(call[0] == 'limit' for call in calls)
-    assert not any(call[0] == 'order_by' for call in calls)
+    assert not any(call[0] in ('limit', 'order_by') for call in calls)
     assert len(result) == 50
-
-
-def test_get_all_goals_rejects_a_limit_it_cannot_serve():
-    # A limit alongside the is_active filter would need a composite index this project does not
-    # declare, and Firestore answers a missing composite index with an opaque 500. Fail loudly
-    # here instead.
-    with pytest.raises(ValueError):
-        goals_db_module.get_all_goals('u1', include_inactive=False, limit=5, firestore_client=_FakeClient([], []))

--- a/backend/tests/unit/test_subscription_import_cycle.py
+++ b/backend/tests/unit/test_subscription_import_cycle.py
@@ -1,0 +1,53 @@
+"""Regression: utils.subscription must be importable on its own.
+
+utils/subscription.py imports database.users, and database/users.py imported
+get_default_basic_subscription back from utils.subscription at module scope. That pair formed a
+cycle, so whichever of the two was imported first decided whether it worked: importing
+utils.subscription first raised
+
+    ImportError: cannot import name 'get_default_basic_subscription' from partially initialized
+    module 'utils.subscription' (most likely due to a circular import)
+
+while importing database.users first happened to succeed. The order-dependence is the bug, which
+is why it surfaces intermittently as unrelated test files change what gets imported first. The
+database -> utils edge is also the reverse of the documented backend layering
+(database/ -> utils/ -> routers/ -> main.py).
+
+A fresh interpreter is the only honest seam here: once pytest has imported either module, the
+order is already decided for the whole session, so an in-process assertion would pass either way.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _import_first_in_fresh_interpreter(module: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.setdefault("ENCRYPTION_SECRET", "test_secret_for_ci_only_0123456789")
+    env.setdefault("OPENAI_API_KEY", "sk-fake")
+    env.setdefault("PINECONE_API_KEY", "fake")
+    return subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        cwd=str(BACKEND_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+def test_utils_subscription_imports_standalone():
+    result = _import_first_in_fresh_interpreter("utils.subscription")
+
+    assert result.returncode == 0, f"utils.subscription is not importable on its own:\n{result.stderr}"
+
+
+def test_database_users_imports_standalone():
+    # The other side of the pair must keep working too.
+    result = _import_first_in_fresh_interpreter("database.users")
+
+    assert result.returncode == 0, f"database.users is not importable on its own:\n{result.stderr}"

--- a/backend/tests/unit/test_subscription_import_cycle.py
+++ b/backend/tests/unit/test_subscription_import_cycle.py
@@ -22,6 +22,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+# Marked slow: each test boots a fresh interpreter that imports the full backend
+# module graph, which per tests/README.md belongs outside the PR fast lane
+# (`not integration and not slow`). A fresh interpreter is still the only honest
+# seam for import-order bugs, so the cost is the test's point, not an accident.
+
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -40,12 +47,14 @@ def _import_first_in_fresh_interpreter(module: str) -> subprocess.CompletedProce
     )
 
 
+@pytest.mark.slow
 def test_utils_subscription_imports_standalone():
     result = _import_first_in_fresh_interpreter("utils.subscription")
 
     assert result.returncode == 0, f"utils.subscription is not importable on its own:\n{result.stderr}"
 
 
+@pytest.mark.slow
 def test_database_users_imports_standalone():
     # The other side of the pair must keep working too.
     result = _import_first_in_fresh_interpreter("database.users")


### PR DESCRIPTION
# Problem

Two reliability defects, rebuilt from #9966 and #9977, which had gone stale against current main. Both bugs are still present on `origin/main` today; I re-verified each against the current code before rebuilding.

**1. `database/users.py` and `utils/subscription.py` form an import cycle.**

`backend/database/users.py` imported back into `utils.subscription` at module scope:

```python
from models.other import Person
from utils.subscription import get_default_basic_subscription
import logging
```

while `backend/utils/subscription.py` does `import database.users as users_db` at module scope. Whichever module is imported first decides whether the pair works. Importing `utils.subscription` first raises:

```
ImportError: cannot import name 'get_default_basic_subscription' from partially initialized
module 'utils.subscription' (most likely due to a circular import)
```

Importing `database.users` first happens to succeed, which is why this surfaces intermittently as unrelated files change what gets imported first. The database -> utils edge is also the reverse of the documented backend layering (database/ -> utils/ -> routers/).

**2. `GET /v1/dev/user/goals` ignores its documented `limit` when `include_inactive=true`.**

The route clamps `limit` and then drops it on one branch:

```python
# oversized limit cannot stream the whole collection. Mirrors the GET /v3/memories hardening.
limit = max(1, min(limit, 1000))
if include_inactive:
    goals = goals_db.get_all_goals(uid, include_inactive=True)
else:
    goals = goals_db.get_user_goals(uid, limit=limit)
```

`get_all_goals` had no limit parameter and streams the whole goals collection, so the clamp is dead code on that branch and the endpoint returns every goal the user has ever created, ignoring its own documented "**limit**: Maximum number of goals to return".

# Reachability / failure scenario

- Import cycle: any entry point that imports `utils.subscription` before `database.users` fails at import time with the error above. Reproduced with a fresh interpreter running `import utils.subscription` from `backend/`.
- Goals limit: `GET /v1/dev/user/goals?include_inactive=true&limit=10` from any developer API consumer returns the full collection and reads every goal document in Firestore. The path that lets it through is `routers/developer.py::get_goals` -> `database/goals.py::get_all_goals`.

# Fix

**Import cycle.** The `get_default_basic_subscription` import in `database/users.py` moves from module scope to its call sites: inside `get_user_subscription`, and at the top of `get_user_valid_subscription`. Since #9966 was written, main added a `provision=False` branch to `get_user_valid_subscription` that also calls `get_default_basic_subscription`, earlier in the function than the old fallback site, so the function-level import sits above the first call site and covers both. Each deferred import carries a comment recording why it must not be folded back to the top.

**Goals limit.** `get_all_goals` accepts an opt-in `limit` applied after the in-Python newest-first sort. The bound is deliberately not pushed into the Firestore query: `order_by('created_at')` excludes documents that lack the field entirely, and legacy or manually created goals can lack `created_at`, so a query-level order+limit would silently drop them. Goals without `created_at` coerce to `datetime.min` and sort last, so the bounded page is the newest goals with dateless legacy goals appearing only once dated goals run out, and the response honours the documented limit.

Deliberately not changed: every other `get_all_goals` caller (the goal-by-id lookup, `routers/goals.py`, and the MCP goal reads) omits `limit` and keeps its fetch-everything behavior; bounding those is a behavior change with no bug attached.

# Tests

- `backend/tests/unit/test_subscription_import_cycle.py`: runs `import utils.subscription` (and separately `import database.users`) first in a fresh interpreter and asserts both succeed standalone. A fresh interpreter is the only honest seam here: once pytest has imported either module, the order is decided for the whole session, so an in-process assertion would pass either way.
- `backend/tests/unit/test_dev_goals_limit_include_inactive.py`: router-level tests assert the clamp is delegated (captured kwargs for limit 5, ceiling clamp to 1000, and the active-only branch unchanged); database-level tests assert the bounded page is the newest goals, that a legacy goal without `created_at` is retained and sorts last instead of being dropped, that dated goals fill the page first, and that callers omitting `limit` keep the full unordered fetch with nothing pushed into the query.

# Verification

All commands run from `backend/` on Windows (Git Bash), `PYTHONUTF8=1`.

Prove-fail. Reverted the three product files to `origin/main` (`git diff origin/main -- <files>` printed nothing, byte-identical), then ran both test files:

```
FAILED tests/unit/test_subscription_import_cycle.py::test_utils_subscription_imports_standalone
  AssertionError: utils.subscription is not importable on its own:
  ImportError: cannot import name 'get_default_basic_subscription' from partially initialized
  module 'utils.subscription' (most likely due to a circular import)
FAILED tests/unit/test_dev_goals_limit_include_inactive.py::test_get_all_goals_bounds_the_query_when_limit_is_given
  TypeError: get_all_goals() got an unexpected keyword argument 'limit'
5 failed, 3 passed
```

The three passes on the unfixed tree are the behavior-preservation guards (importing `database.users` first, the active-only branch, and the unbounded default), which must pass on both sides. Restored the fix: `8 passed`.

Static and contract gate:

```
black --line-length 120 --skip-string-normalization --check <5 files>   -> 5 files would be left unchanged
python -m pyright -p pyrightconfig.json database/goals.py               -> 0 errors (users.py and routers/developer.py are in the pyright exclude list)
python scripts/check_module_stub_pollution.py                           -> 898 test files, 0 violations
python scripts/scan_async_blockers.py --dirs routers utils              -> 0 findings in fail scope
python scripts/scan_import_time_side_effects.py                         -> 804 files, 0 violations
python scripts/check_conversation_lifecycle_writes.py                   -> passed
```

Workflow contracts: the touched files match three high-risk workflows (goals, users, developer). Ran all 13 unit and service test files listed by those workflows: `391 passed, 2 failed`, and the sync workflow file separately: `77 passed, 10 failed`. All 12 failures reproduce identically on a clean unmodified `origin/main` checkout in the same batch order (`tests/services/users/test_account_deletion.py` pair passes standalone on both trees), so they are pre-existing local-environment and test-ordering issues, not caused by this change. `testing/e2e/test_account_deletion_cloud_tasks.py` needs live services and errors locally on both trees.

`scripts/pr-preflight --suggest`: Product invariants affected: none. No `fix:` commits, so no failure-class declaration is required.

Full `scripts/pr-preflight --pr-body-file` run: every selected manifest check passes (including backend-route-policy-baseline, backend-async-blockers, backend-import-purity, backend-workflow-contracts, the line-count ratchet with the declarations below) except `desktop-backend-candidate-probe-fixtures`, which fails on this Windows machine with "gemini_proxy: total response deadline is unsupported on this runner". The files that check exercises are byte-identical to `origin/main` in this branch (the diff is five backend files), so it is a local runner-capability issue of the same class as the known Windows-only `detect_platform` false failure; CI runs on Linux.

# Impact

- The import cycle breaks any standalone consumer of `utils.subscription` and makes backend import order fragile: whether it bites depends on which module a given entry point or test session happens to import first. Developer-facing reliability, low direct user impact.
- The goals endpoint bug affects developer API consumers who pass `include_inactive=true`: response size and Firestore read cost grow with the user's total historical goal count instead of respecting the documented bound. Narrow trigger, real cost on goal-heavy accounts.

Line-Count-Exception: backend/database/users.py | 2131 -> 2140 | Breaking the utils.subscription import cycle moves one module-level import to deferred call sites with comments recording why each must stay deferred so the import is not folded back to the top and silently re-broken.
Line-Count-Exception: backend/routers/developer.py | 2107 -> 2111 | The four added lines are the comment recording why the goals bound is applied after the in-Python sort rather than pushed into a Firestore order_by that would drop legacy goals lacking created_at.
