### PR TITLE
fix(backend): serve the legacy graph when the canonical read is unavailable

### DIFF
--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, s
 from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Callable, Optional, cast
 
+from database import knowledge_graph as kg_db
 from database.auth import get_user_name
 from utils.memory import canonical_graph as canonical_graph_service
 from utils.executors import db_executor, llm_executor, run_blocking
@@ -91,6 +92,22 @@ class ExtractKnowledgeGraphResponse(BaseModel):
     edges: List[Dict[str, Any]]
 
 
+def _legacy_knowledge_graph_response(uid: str) -> "KnowledgeGraphResponse":
+    """Bounded read of the pre-canonical graph, used when canonical is unavailable."""
+    graph = kg_db.get_knowledge_graph(uid)
+    nodes = graph.get('nodes', [])
+    edges = graph.get('edges', [])
+    return KnowledgeGraphResponse(
+        nodes=nodes,
+        edges=edges,
+        truncated=bool(graph.get('truncated', False)),
+        node_count=graph.get('node_count', len(nodes)),
+        edge_count=graph.get('edge_count', len(edges)),
+        node_limit=graph.get('node_limit'),
+        edge_limit=graph.get('edge_limit'),
+    )
+
+
 @router.get(
     "/v1/knowledge-graph",
     tags=["knowledge_graph"],
@@ -119,8 +136,12 @@ def get_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
         truncated = (
             bool(page.has_more) or len(page.nodes) > page_limit or len(page.edges) > page_limit or dropped_edges > 0
         )
-    except canonical_graph_service.CanonicalGraphReadUnavailable as exc:
-        raise HTTPException(status_code=503, detail="knowledge_graph_unavailable") from exc
+    except canonical_graph_service.CanonicalGraphReadUnavailable:
+        # Canonical intake is fenced off in production (MEMORY_MODE), so most
+        # accounts have no memory_state/head and the canonical read is
+        # permanently unavailable for them. Their graph still exists in the
+        # legacy store, so serve that instead of failing the feature outright.
+        return _legacy_knowledge_graph_response(uid)
     return KnowledgeGraphResponse(
         nodes=nodes,
         edges=edges,

--- a/backend/tests/unit/test_knowledge_graph_legacy_fallback.py
+++ b/backend/tests/unit/test_knowledge_graph_legacy_fallback.py
@@ -1,0 +1,105 @@
+"""GET /v1/knowledge-graph must not fail when the canonical read is unavailable.
+
+#11617 follow-up: `5724a10084` repointed this route at the canonical (v3) graph
+and deleted the legacy read in the same commit. Production fences canonical
+intake (`MEMORY_MODE=off`), so `users/{uid}/memory_state/head` is never written
+and the canonical read raises for essentially every account — the route returned
+503 `knowledge_graph_unavailable` to all of them for two days while their graph
+sat intact in the legacy store.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from database import knowledge_graph as kg_db
+from routers import knowledge_graph as kg_router
+from utils.memory import canonical_graph as kg
+from utils.other import endpoints as auth
+
+UID = "uid-kg-fallback"
+
+LEGACY_GRAPH = {
+    "nodes": [{"id": "n1", "label": "Ada"}, {"id": "n2", "label": "Lovelace"}],
+    "edges": [{"source_id": "n1", "target_id": "n2", "label": "knows"}],
+    "truncated": False,
+    "node_count": 2,
+    "edge_count": 1,
+    "node_limit": 500,
+    "edge_limit": 500,
+}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(kg_router.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: UID
+    return TestClient(app)
+
+
+def _canonical_unavailable(*_args, **_kwargs):
+    raise kg.CanonicalGraphReadUnavailable("missing_state_head")
+
+
+def test_serves_the_legacy_graph_when_canonical_is_unavailable(client, monkeypatch):
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    monkeypatch.setattr(kg_db, "get_knowledge_graph", lambda uid: dict(LEGACY_GRAPH))
+
+    response = client.get("/v1/knowledge-graph")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [node["id"] for node in body["nodes"]] == ["n1", "n2"]
+    assert body["edge_count"] == 1
+    assert body["node_count"] == 2
+
+
+def test_an_account_with_no_legacy_graph_gets_an_empty_graph_not_a_503(client, monkeypatch):
+    # A user who genuinely has no graph must see an empty one, never an error.
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    monkeypatch.setattr(
+        kg_db,
+        "get_knowledge_graph",
+        lambda uid: {"nodes": [], "edges": [], "truncated": False},
+    )
+
+    response = client.get("/v1/knowledge-graph")
+
+    assert response.status_code == 200
+    assert response.json()["nodes"] == []
+    assert response.json()["edges"] == []
+
+
+def test_canonical_still_wins_when_it_is_available(client, monkeypatch):
+    # The fallback must not shadow a working canonical read.
+    class _Page:
+        nodes = [{"id": "c1"}]
+        edges = []
+        has_more = False
+        next_cursor = None
+
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", lambda *a, **k: _Page())
+
+    def _must_not_be_called(uid):  # pragma: no cover - asserts absence
+        raise AssertionError("legacy reader called while canonical was available")
+
+    monkeypatch.setattr(kg_db, "get_knowledge_graph", _must_not_be_called)
+
+    response = client.get("/v1/knowledge-graph")
+
+    assert response.status_code == 200
+    assert [node["id"] for node in response.json()["nodes"]] == ["c1"]
+
+
+def test_the_explicit_canonical_route_still_reports_unavailable(client, monkeypatch):
+    # /canonical is the caller asking for canonical specifically; silently
+    # serving legacy there would misrepresent which store answered.
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+
+    response = client.get("/v1/knowledge-graph/canonical")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "canonical_graph_unavailable"


### PR DESCRIPTION
## Summary

`GET /v1/knowledge-graph` has returned `503 knowledge_graph_unavailable` to essentially every user since **13 Aug 05:33 UTC**. This restores a fallback so the route serves the legacy graph when the canonical read is unavailable.

## Root cause

`5724a10084` ("feat: converge universal memory and task authority") repointed the route at the canonical (v3) graph and **deleted the legacy read in the same commit**, leaving nothing to fall back to:

```diff
-from database import knowledge_graph as kg_db
+        page = canonical_graph_service.get_canonical_knowledge_graph(...)
+    except canonical_graph_service.CanonicalGraphReadUnavailable as exc:
+        raise HTTPException(status_code=503, detail='knowledge_graph_unavailable')
```

The canonical read requires `users/{uid}/memory_state/head`. That document is only written by canonical intake in `memory_apply_store`, which is fenced by `_require_canonical_intake_enabled()` whenever `MEMORY_MODE` is not `write`/`read`. **Production runs `MEMORY_MODE=off`**, so the head is never written — 6 of 7 sampled accounts have none, and the read raises `MISSING_STATE_HEAD`.

The route was pointed at a store production deliberately does not populate.

## Impact

- **~96% of requests failing** — 314 × 503 against 13 × 200 in a sampled hour, the same shape every hour since 13 Aug.
- Worst for long-standing users: their graphs were built through the legacy path, which the commit stopped reading.
- No new user gets one either, since intake is fenced — the feature is dark in both directions.
- **Nothing was lost.** The graphs sit intact in the legacy store; this was a visibility outage.

Timeline: commit merged 11 Aug 17:18 → first revision carrying it (`backend-strip-meu-0509`, containing `0c36d94`) deployed 13 Aug 05:09 → first 503 at 05:33, 24 minutes later. Confirmed `1947a53` and `9dfcf0d` do not contain the commit; `0c36d94` and `66fe467` do.

## Change

`get_knowledge_graph` catches `CanonicalGraphReadUnavailable` and serves `kg_db.get_knowledge_graph(uid)`. An account with no graph gets an empty graph, never an error.

`/v1/knowledge-graph/canonical` is **deliberately unchanged** — a caller asking for canonical specifically should be told it is unavailable rather than silently handed legacy data.

## Deliberately not done

Flipping `MEMORY_MODE` to `write`. It would un-fence canonical intake globally, only help after each user's *next* memory write, and do nothing for the graphs users have today. Too wide a blast radius for a read bug.

## Verification

```
pytest tests/unit/test_knowledge_graph_legacy_fallback.py    -> 4 passed
  reverted the fix, re-ran                                   -> 2 of 4 FAIL (tests do catch it)
pytest (5 knowledge-graph test files)                        -> 30 passed
pytest (5 memory-state / memory-apply test files)            -> 49 passed
black --line-length 120 --skip-string-normalization          -> unchanged
```

Not verified against prod. The canonical-unavailable path is covered by unit tests with the real router; I have not exercised the deployed endpoint.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

