### PR TITLE
fix(desktop): stop dashboard navigation from opening a retired task (#11518)

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -580,7 +580,10 @@ private struct ChatFirstRestoredTasksHost: View {
     if let task = tasksStore.tasks.first(where: { $0.id == id && $0.deleted != true }) {
       return task
     }
-    if let task = try? await APIClient.shared.getActionItem(id: id), task.deleted != true {
+    // Straight off the wire, so legacy `deleted` may be absent and retirement
+    // only stated through canonical lifecycle status. Cache reads above and
+    // below are already normalized (`ActionItemRecord.from` stores `isRetired`).
+    if let task = try? await APIClient.shared.getActionItem(id: id), !task.isRetired {
       return task
     }
     await tasksStore.loadCompletedTasks()

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/DashboardIntelligenceStore.swift
@@ -400,7 +400,10 @@ final class DashboardIntelligenceStore: ObservableObject {
     do {
       let task = try await client.getActionItem(id: taskID)
       guard requireCurrentOwner(ownerScope) else { return nil }
-      guard task.id == taskID else {
+      // The detail response is the freshest word on retirement, and it projects
+      // it through canonical lifecycle status — a recommendation minted before
+      // the task was cancelled/superseded/deleted must not open it as live.
+      guard task.id == taskID, !task.isRetired else {
         error = "This task is no longer available."
         return nil
       }

--- a/desktop/macos/Desktop/Tests/DashboardIntelligenceStoreTests.swift
+++ b/desktop/macos/Desktop/Tests/DashboardIntelligenceStoreTests.swift
@@ -300,6 +300,49 @@ final class DashboardIntelligenceStoreTests: XCTestCase {
     XCTAssertEqual(task?.id, "old-task")
   }
 
+  /// A recommendation can outlive its task: the projection is minted before the
+  /// task is cancelled/superseded/deleted. `TaskActionItem.isRetired` is the
+  /// projection that reads canonical lifecycle status, because detail responses
+  /// may omit legacy `deleted` entirely — so a raw `deleted` read (or, as here,
+  /// no retirement check at all) hands a retired task back as a live route.
+  func testRetiredTaskIsNotOpenedByNavigation() async {
+    for status in ["cancelled", "superseded"] {
+      let api = FakeDashboardIntelligenceClient()
+      api.exactTask = TaskActionItem(
+        id: "retired-task",
+        description: "Retired server-side after the recommendation was minted",
+        completed: false,
+        createdAt: Date(timeIntervalSince1970: 0),
+        deleted: nil,
+        taskStatus: status
+      )
+      let store = DashboardIntelligenceStore(client: api, outboxStore: MemoryDashboardOutbox())
+
+      let task = await store.taskForNavigation(taskID: "retired-task")
+
+      XCTAssertNil(task, "a \(status) task must not open as a live navigation target")
+      XCTAssertEqual(store.error, "This task is no longer available.")
+    }
+  }
+
+  /// The legacy marker still retires a task on backends that send it.
+  func testLegacyDeletedTaskIsNotOpenedByNavigation() async {
+    let api = FakeDashboardIntelligenceClient()
+    api.exactTask = TaskActionItem(
+      id: "deleted-task",
+      description: "Deleted server-side",
+      completed: false,
+      createdAt: Date(timeIntervalSince1970: 0),
+      deleted: true
+    )
+    let store = DashboardIntelligenceStore(client: api, outboxStore: MemoryDashboardOutbox())
+
+    let task = await store.taskForNavigation(taskID: "deleted-task")
+
+    XCTAssertNil(task)
+    XCTAssertEqual(store.error, "This task is no longer available.")
+  }
+
   func testWriteSidecarModeDoesNotExposeDashboardIntelligence() async {
     let api = FakeDashboardIntelligenceClient()
     api.workflowMode = .write

--- a/desktop/macos/changelog/unreleased/20260815-retired-task-navigation.json
+++ b/desktop/macos/changelog/unreleased/20260815-retired-task-navigation.json
@@ -1,0 +1,3 @@
+{
+  "change": "Opening a task from the dashboard that was already cancelled or deleted now says it is no longer available, instead of switching to Tasks and selecting nothing"
+}


### PR DESCRIPTION
## Bug

`DashboardIntelligenceStore.taskForNavigation(taskID:)` fetched the task detail and returned it with **no retirement check at all**, so a "What matters now" recommendation minted before its task was cancelled, superseded, or deleted still routed the user to that task.

The user-visible symptom is a silent dead end rather than a stale card: every live Tasks lane filters retired rows out, so the `TaskNavigationRequestStore` request `openRecommendation` enqueues can never be consumed — the dashboard switches to the Tasks tab and selects nothing, with no explanation.

Its sibling in the same file, `candidateForNavigation`, already gates on `SuggestedTasksStore.canPresentForNavigation(candidate)` and reports "This Suggested item is no longer available." The task path had no equivalent.

## Root cause

Retirement is re-derived by each reader instead of being asked of the one authority. `TaskActionItem.isRetired` exists precisely for this, and its doc comment records why:

```swift
/// Server list/detail responses project soft retirement through canonical
/// lifecycle status and may omit the legacy `deleted` field. Keep that
/// projection here so every local cache and surface applies the same rule.
var isRetired: Bool {
  deleted == true || taskStatus == "cancelled" || taskStatus == "superseded"
}
```

So a raw `deleted` read is not sufficient on anything straight off the wire, and `taskForNavigation` did not even do that much.

This is mostly invisible on cache paths because every writer normalizes: `ActionItemRecord.from` persists `deleted: item.isRetired`. It is observable only on objects read directly from an API response.

## Fix

- `DashboardIntelligenceStore.taskForNavigation` now requires `!task.isRetired` alongside the existing id match, and surfaces the same "This task is no longer available." error the Suggested path uses.
- `ChatFirstShell.taskForFocus` — the only other site that tests an API response directly rather than a cache row — moves from `task.deleted != true` to `!task.isRetired` (#11518).

Cache reads elsewhere are left alone: they are already normalized, and #11518 explicitly warns that `deleted` is a field on unrelated types, so a blind sweep is not the fix.

## Tested

```
cd desktop/macos
./scripts/dev-feedback.py --once swift 'DashboardIntelligenceStoreTests'
  → Executed 30 tests, with 0 failures  (PASS in 593.66s)
```

The two new tests execute production behavior through the injected `DashboardIntelligenceClient` seam, not a source scrape. To prove they are load-bearing, the `!task.isRetired` guard alone was reverted and they were re-run:

```
testLegacyDeletedTaskIsNotOpenedByNavigation  failed — deleted: true opened as live
testRetiredTaskIsNotOpenedByNavigation        failed — cancelled and superseded both opened as live
  → Executed 2 tests, with 6 failures
```

The guard was then restored and the suite re-run green (above).

Not exercised live: reproducing it in the running app needs a server-side task retired between projection mint and click. The seam the fix sits behind is the same one `taskForNavigation`'s existing coverage uses.

## Product invariants

None matched — `scripts/pr-preflight --suggest` reports no invariant citations required for these paths.

Fixes part of #11518.

🤖 automated by hourly watchdog — tested and merged

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

