### PR TITLE
fix(backend): unbreak conversation merge and cascade delete behind the canonical fence

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -48,6 +48,7 @@ from utils.conversations.process_conversation import process_conversation, retri
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, llm_executor, postprocess_executor, run_blocking, submit_with_context
 from utils.memory.memory_service import MemoryService
+from utils.memory.retraction_scope import retraction_can_be_skipped
 from utils import byok
 from utils.conversations.search import (
     ConversationSearchUnavailableError,
@@ -785,7 +786,13 @@ def delete_conversation(
         # Delete associated memories and action items before removing the conversation doc
         # so a partial failure cannot orphan derived data.
         db_client = getattr(db_client_module, 'db', None)
-        MemoryService(db_client=db_client).retract_conversation_memories(uid, conversation_id)
+        memory_service = MemoryService(db_client=db_client)
+        # Retraction is fenced with canonical intake (MEMORY_MODE). Skipping it
+        # when there is provably nothing to retract keeps delete working while
+        # the fence is closed; anything real still raises rather than orphaning
+        # live memories against a deleted conversation.
+        if not retraction_can_be_skipped(uid, conversation_id, memory_service=memory_service, db_client=db_client):
+            memory_service.retract_conversation_memories(uid, conversation_id)
 
         action_items_db.delete_action_items_for_conversation(uid, conversation_id)
         background_tasks.add_task(delete_conversation_audio_files, uid, conversation_id)

--- a/backend/tests/unit/test_delete_conversation_cascade_retraction_fence.py
+++ b/backend/tests/unit/test_delete_conversation_cascade_retraction_fence.py
@@ -1,0 +1,60 @@
+"""Cascade delete must consult the retraction-skip guard.
+
+`DELETE /v1/conversations/{id}?cascade=true` is the app's only delete path
+(`app/lib/backend/http/api/conversations.dart:136`). It called
+`MemoryService.retract_conversation_memories` with no error handling, and that
+runs through the canonical replace boundary fenced by
+`_require_canonical_intake_enabled()` whenever `MEMORY_MODE` is not write/read.
+
+Production runs `off`, so every cascade delete raised and returned 500 — 100% of
+sampled requests from 13 Aug onward. It was never reported; it was found while
+fixing the merge failure that shares the same cause.
+
+This is a **static checker, not behavioural coverage**: it reads the endpoint's
+source rather than exercising the route, because importing `routers.conversations`
+into a unit-test session pulls in enough global state to break neighbouring
+import-isolated suites. The behaviour it protects — when the skip is allowed and
+when retraction must still run — is covered against the real helper in
+test_merge_skips_retraction_without_canonical_memories.py.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROUTER = pathlib.Path(__file__).resolve().parents[2] / "routers" / "conversations.py"
+
+
+def _delete_conversation_source() -> str:
+    source = ROUTER.read_text()
+    start = source.index("def delete_conversation(")
+    end = source.index("\n@router.", start)
+    return source[start:end]
+
+
+def test_the_cascade_branch_guards_retraction_behind_the_skip_helper():
+    body = _delete_conversation_source()
+    assert "retract_conversation_memories" in body, "expected the cascade branch to still retract"
+    assert "retraction_can_be_skipped" in body, (
+        "cascade delete must consult retraction_can_be_skipped; without it the canonical "
+        "fence turns every delete into a 500"
+    )
+
+
+def test_the_guard_precedes_the_retraction_call():
+    body = _delete_conversation_source()
+    assert body.index("retraction_can_be_skipped") < body.index(
+        "retract_conversation_memories"
+    ), "the guard must run before the retraction it protects"
+
+
+def test_the_retraction_call_is_inside_the_guard():
+    # `if not retraction_can_be_skipped(...)` — a guard that does not actually
+    # gate the call would satisfy the ordering check above but fix nothing.
+    body = _delete_conversation_source()
+    guarded = re.search(
+        r"if not retraction_can_be_skipped\([^)]*\):\s*\n\s+memory_service\.retract_conversation_memories\(",
+        body,
+    )
+    assert guarded, "retraction must be inside the `if not retraction_can_be_skipped(...)` branch"

--- a/backend/tests/unit/test_merge_conversations_canonical_delete.py
+++ b/backend/tests/unit/test_merge_conversations_canonical_delete.py
@@ -69,7 +69,7 @@ def _source_has_memories_to_retract():
     See test_merge_skips_retraction_without_canonical_memories.py.
     """
     with patch(
-        "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+        "utils.conversations.merge_conversations.retraction_can_be_skipped",
         return_value=False,
     ):
         yield

--- a/backend/tests/unit/test_merge_conversations_canonical_delete.py
+++ b/backend/tests/unit/test_merge_conversations_canonical_delete.py
@@ -21,9 +21,35 @@ from tests.unit.memory_import_isolation import (
     snapshot_sys_modules,
 )
 
+_ORIGINAL_ATTRS: dict[tuple[str, str], object] = {}
+_STUBBED_ATTRS = (
+    ("database.conversations", "delete_conversation"),
+    ("database.conversations", "delete_conversation_photos"),
+    ("database.action_items", "delete_action_items_for_conversation"),
+)
+
+
+def _remember_original_attrs() -> None:
+    for module_name, attr in _STUBBED_ATTRS:
+        key = (module_name, attr)
+        if key in _ORIGINAL_ATTRS:
+            continue
+        module = sys.modules.get(module_name)
+        if module is not None and hasattr(module, attr):
+            _ORIGINAL_ATTRS[key] = getattr(module, attr)
+
+
+def _restore_original_attrs() -> None:
+    for module_name, attr in _STUBBED_ATTRS:
+        module = sys.modules.get(module_name)
+        original = _ORIGINAL_ATTRS.get((module_name, attr))
+        if module is not None and original is not None:
+            setattr(module, attr, original)
+
 
 def _install_merge_conversations_stubs() -> list[str]:
     touched = install_ws_i_heavy_import_stubs()
+    _remember_original_attrs()
     conversations_mod = sys.modules["database.conversations"]
     conversations_mod.delete_conversation = MagicMock()
     conversations_mod.delete_conversation_photos = MagicMock()
@@ -52,6 +78,11 @@ def _merge_conversations_import_isolation():
 
     globals()["_delete_conversation_and_related_data"] = _delete_conversation_and_related_data
     yield
+    # These stubs replace *attributes* on real modules; restore_sys_modules
+    # cannot undo that, so without this any later suite calling the real
+    # database.conversations helpers fails. CI only escapes it because
+    # collection is alphabetical and this file sorts after them.
+    _restore_original_attrs()
     restore_sys_modules(saved)
 
 

--- a/backend/tests/unit/test_merge_conversations_canonical_delete.py
+++ b/backend/tests/unit/test_merge_conversations_canonical_delete.py
@@ -69,8 +69,8 @@ def _source_has_memories_to_retract():
     See test_merge_skips_retraction_without_canonical_memories.py.
     """
     with patch(
-        "utils.conversations.merge_conversations._source_has_canonical_memories",
-        return_value=True,
+        "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+        return_value=False,
     ):
         yield
 

--- a/backend/tests/unit/test_merge_conversations_canonical_delete.py
+++ b/backend/tests/unit/test_merge_conversations_canonical_delete.py
@@ -60,6 +60,21 @@ def _reinstall_merge_conversations_stubs():
     _install_merge_conversations_stubs()
 
 
+@pytest.fixture(autouse=True)
+def _source_has_memories_to_retract():
+    """These cases all describe a source that *has* canonical memories.
+
+    Retraction is skipped when a source has none (nothing can dangle), so the
+    precondition is stated here rather than rewriting each assertion below.
+    See test_merge_skips_retraction_without_canonical_memories.py.
+    """
+    with patch(
+        "utils.conversations.merge_conversations._source_has_canonical_memories",
+        return_value=True,
+    ):
+        yield
+
+
 def test_delete_conversation_related_data_always_retracts_through_universal_service():
     service = MagicMock()
 

--- a/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
+++ b/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
@@ -1,0 +1,154 @@
+"""Merge cleanup must not abort on a source that has no canonical memories.
+
+Reported symptom: merging two conversations leaves the UI on "merging" until the
+app is restarted, and afterwards the merged conversation *and* both originals
+are all listed.
+
+Cause: `_delete_conversation_and_related_data` retracts each source's canonical
+memories and re-raises if that fails. Retraction runs through the canonical
+replace boundary, which `_require_canonical_intake_enabled()` fences whenever
+`MEMORY_MODE` is not write/read — production runs `off`. So every merge built
+its merged conversation, then raised on the first source, unwound into
+`_handle_merge_failure`, and reset the sources to `completed`. Step 10 — the FCM
+that tells the app the merge finished — was never reached, which is why the UI
+sat on "merging".
+
+The fence closes *intake*, so a conversation ingested while it was closed has no
+canonical memories to retract. Reading the source cohort first (an unfenced
+read) distinguishes "nothing to retract" from "retraction is broken".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+from tests.unit.memory_import_isolation import (
+    AutoMockModule,
+    install_database_client_stub,
+    install_ws_i_heavy_import_stubs,
+    restore_sys_modules,
+    snapshot_sys_modules,
+)
+
+
+def _install_merge_conversations_stubs() -> list[str]:
+    touched = install_ws_i_heavy_import_stubs()
+    conversations_mod = sys.modules["database.conversations"]
+    conversations_mod.delete_conversation = MagicMock()
+    conversations_mod.delete_conversation_photos = MagicMock()
+    action_items_mod = sys.modules["database.action_items"]
+    action_items_mod.delete_action_items_for_conversation = MagicMock()
+
+    sys.modules["utils.other.storage"] = AutoMockModule("utils.other.storage")
+    touched.append("utils.other.storage")
+
+    for _modname in ["utils.conversations", "utils.conversations.merge_conversations"]:
+        _existing = sys.modules.get(_modname)
+        if _existing is not None and not getattr(_existing, "__file__", None):
+            del sys.modules[_modname]
+    return list(dict.fromkeys(touched))
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _merge_conversations_import_isolation():
+    saved = snapshot_sys_modules(["database._client"])
+    install_database_client_stub()
+    touched = _install_merge_conversations_stubs()
+    saved.update(snapshot_sys_modules(touched))
+    from utils.conversations.merge_conversations import _delete_conversation_and_related_data
+
+    globals()["_delete_conversation_and_related_data"] = _delete_conversation_and_related_data
+    yield
+    restore_sys_modules(saved)
+
+
+@pytest.fixture(autouse=True)
+def _reinstall_stubs():
+    _install_merge_conversations_stubs()
+
+
+def _fenced_service() -> MagicMock:
+    """A MemoryService whose retraction raises the way the closed fence does."""
+    service = MagicMock()
+    service.retract_conversation_memories.side_effect = RuntimeError("canonical memory intake is globally paused")
+    return service
+
+
+def test_source_with_no_canonical_memories_is_deleted_despite_the_closed_fence():
+    service = _fenced_service()
+    delete_conversation = sys.modules["database.conversations"].delete_conversation
+    delete_conversation.reset_mock()
+
+    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+        with patch(
+            "utils.conversations.merge_conversations._source_has_canonical_memories",
+            return_value=False,
+        ):
+            _delete_conversation_and_related_data("uid-any", "conv-1")
+
+    service.retract_conversation_memories.assert_not_called()
+    delete_conversation.assert_called_once()
+
+
+def test_the_fence_is_still_advanced_so_failure_handling_keeps_the_merged_target():
+    # Everything after retraction still destroys source state, so a later
+    # failure must not be treated as "source untouched".
+    service = _fenced_service()
+    advanced = False
+
+    def mark_started():
+        nonlocal advanced
+        advanced = True
+
+    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+        with patch(
+            "utils.conversations.merge_conversations._source_has_canonical_memories",
+            return_value=False,
+        ):
+            _delete_conversation_and_related_data("uid-any", "conv-1", on_authoritative_retraction=mark_started)
+
+    assert advanced is True
+
+
+def test_a_source_that_does_have_memories_still_aborts_when_retraction_fails():
+    # The safety invariant is unchanged: never delete a source whose memories
+    # would be left pointing at it.
+    service = _fenced_service()
+    delete_conversation = sys.modules["database.conversations"].delete_conversation
+    delete_conversation.reset_mock()
+
+    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+        with patch(
+            "utils.conversations.merge_conversations._source_has_canonical_memories",
+            return_value=True,
+        ):
+            with pytest.raises(RuntimeError, match="globally paused"):
+                _delete_conversation_and_related_data("uid-any", "conv-1")
+
+    delete_conversation.assert_not_called()
+
+
+def test_a_failing_cohort_read_aborts_rather_than_assuming_there_is_nothing_to_retract():
+    # If we cannot tell whether evidence exists, fail closed.
+    service = _fenced_service()
+    delete_conversation = sys.modules["database.conversations"].delete_conversation
+    delete_conversation.reset_mock()
+
+    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+        with patch(
+            "utils.conversations.merge_conversations._source_has_canonical_memories",
+            side_effect=RuntimeError("firestore unavailable"),
+        ):
+            with pytest.raises(RuntimeError, match="firestore unavailable"):
+                _delete_conversation_and_related_data("uid-any", "conv-1")
+
+    delete_conversation.assert_not_called()

--- a/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
+++ b/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
@@ -92,11 +92,11 @@ def test_source_with_no_canonical_memories_is_deleted_despite_the_closed_fence()
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
-    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+    with patch("utils.memory.retraction_scope.canonical_intake_is_fenced", return_value=True), patch(
         "utils.conversations.merge_conversations.MemoryService", return_value=service
     ):
         with patch(
-            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            "utils.conversations.merge_conversations.retraction_can_be_skipped",
             return_value=True,
         ):
             _delete_conversation_and_related_data("uid-any", "conv-1")
@@ -115,11 +115,11 @@ def test_the_fence_is_still_advanced_so_failure_handling_keeps_the_merged_target
         nonlocal advanced
         advanced = True
 
-    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+    with patch("utils.memory.retraction_scope.canonical_intake_is_fenced", return_value=True), patch(
         "utils.conversations.merge_conversations.MemoryService", return_value=service
     ):
         with patch(
-            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            "utils.conversations.merge_conversations.retraction_can_be_skipped",
             return_value=True,
         ):
             _delete_conversation_and_related_data("uid-any", "conv-1", on_authoritative_retraction=mark_started)
@@ -134,11 +134,11 @@ def test_a_source_that_does_have_memories_still_aborts_when_retraction_fails():
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
-    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+    with patch("utils.memory.retraction_scope.canonical_intake_is_fenced", return_value=True), patch(
         "utils.conversations.merge_conversations.MemoryService", return_value=service
     ):
         with patch(
-            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            "utils.conversations.merge_conversations.retraction_can_be_skipped",
             return_value=False,
         ):
             with pytest.raises(RuntimeError, match="globally paused"):
@@ -153,11 +153,11 @@ def test_a_failing_cohort_read_aborts_rather_than_assuming_there_is_nothing_to_r
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
-    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+    with patch("utils.memory.retraction_scope.canonical_intake_is_fenced", return_value=True), patch(
         "utils.conversations.merge_conversations.MemoryService", return_value=service
     ):
         with patch(
-            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            "utils.conversations.merge_conversations.retraction_can_be_skipped",
             side_effect=RuntimeError("firestore unavailable"),
         ):
             with pytest.raises(RuntimeError, match="firestore unavailable"):
@@ -166,20 +166,28 @@ def test_a_failing_cohort_read_aborts_rather_than_assuming_there_is_nothing_to_r
     delete_conversation.assert_not_called()
 
 
-def test_intake_enabled_always_retracts_even_for_an_apparently_empty_source():
+def test_intake_enabled_never_reaches_the_history_scan():
     # With the fence open, retraction works and a source write can land between
-    # the check and the delete. Skipping there would race; always retract.
-    service = MagicMock()
-    noop_probe = MagicMock(return_value=True)
+    # the check and the delete. Skipping there would race, so the scan must not
+    # even be consulted.
+    from utils.memory import retraction_scope as rs
 
-    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=False), patch(
+    service = MagicMock()
+    with patch.object(rs, "canonical_intake_is_fenced", return_value=False):
+        with patch.object(rs, "source_retraction_is_a_noop") as probe:
+            assert rs.retraction_can_be_skipped("uid-any", "conv-1", memory_service=service, db_client=None) is False
+            probe.assert_not_called()
+
+
+def test_intake_enabled_always_retracts_even_for_an_apparently_empty_source():
+    service = MagicMock()
+
+    with patch("utils.conversations.merge_conversations.retraction_can_be_skipped", return_value=False), patch(
         "utils.conversations.merge_conversations.MemoryService", return_value=service
     ):
-        with patch("utils.conversations.merge_conversations._source_retraction_is_a_noop", noop_probe):
-            _delete_conversation_and_related_data("uid-any", "conv-1")
+        _delete_conversation_and_related_data("uid-any", "conv-1")
 
     service.retract_conversation_memories.assert_called_once_with("uid-any", "conv-1")
-    noop_probe.assert_not_called()
 
 
 def _record(conversation_id=None, evidence=()):
@@ -212,24 +220,25 @@ def _evidence(source_type, source_id):
 def test_historical_records_referencing_the_source_are_not_a_noop(records, expected_noop):
     # retract_conversation_memories also tombstones historical live rows, so a
     # source with those still has evidence that would be left dangling.
-    from utils.conversations import merge_conversations as mc
+    from utils.memory import retraction_scope as rs
 
     service = MagicMock()
-    service.history.all_live.return_value = records
+    service.history.iter_all_live.return_value = iter(records)
 
-    with patch.object(mc, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
-        with patch.object(mc, "MemoryService", return_value=service):
-            assert mc._source_retraction_is_a_noop("uid-any", "conv-1") is expected_noop
+    with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
+        assert (
+            rs.source_retraction_is_a_noop("uid-any", "conv-1", memory_service=service, db_client=None) is expected_noop
+        )
 
 
 def test_an_active_canonical_item_is_never_a_noop():
-    from utils.conversations import merge_conversations as mc
+    from utils.memory import retraction_scope as rs
 
     item = MagicMock()
     item.status = "active"
     service = MagicMock()
-    service.history.all_live.return_value = []
+    service.history.iter_all_live.return_value = iter([])
 
-    with patch.object(mc, "fetch_authoritative_product_memory_items_for_source", return_value=[item]):
-        with patch.object(mc, "MemoryService", return_value=service):
-            assert mc._source_retraction_is_a_noop("uid-any", "conv-1") is False
+    with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[item]):
+        assert rs.source_retraction_is_a_noop("uid-any", "conv-1", memory_service=service, db_client=None) is False
+        service.history.iter_all_live.assert_not_called()

--- a/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
+++ b/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
@@ -14,8 +14,12 @@ that tells the app the merge finished — was never reached, which is why the UI
 sat on "merging".
 
 The fence closes *intake*, so a conversation ingested while it was closed has no
-canonical memories to retract. Reading the source cohort first (an unfenced
-read) distinguishes "nothing to retract" from "retraction is broken".
+canonical memories to retract. Reading the retraction scope first (unfenced
+reads) distinguishes "nothing to retract" from "retraction is broken".
+
+The skip is deliberately narrow: it applies only while the fence is closed, and
+only when the *full* retraction scope is empty — the canonical source cohort and
+the historical live records that `retract_conversation_memories` also tombstones.
 """
 
 from __future__ import annotations
@@ -88,10 +92,12 @@ def test_source_with_no_canonical_memories_is_deleted_despite_the_closed_fence()
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
-    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+        "utils.conversations.merge_conversations.MemoryService", return_value=service
+    ):
         with patch(
-            "utils.conversations.merge_conversations._source_has_canonical_memories",
-            return_value=False,
+            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            return_value=True,
         ):
             _delete_conversation_and_related_data("uid-any", "conv-1")
 
@@ -109,10 +115,12 @@ def test_the_fence_is_still_advanced_so_failure_handling_keeps_the_merged_target
         nonlocal advanced
         advanced = True
 
-    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+        "utils.conversations.merge_conversations.MemoryService", return_value=service
+    ):
         with patch(
-            "utils.conversations.merge_conversations._source_has_canonical_memories",
-            return_value=False,
+            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            return_value=True,
         ):
             _delete_conversation_and_related_data("uid-any", "conv-1", on_authoritative_retraction=mark_started)
 
@@ -126,10 +134,12 @@ def test_a_source_that_does_have_memories_still_aborts_when_retraction_fails():
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
-    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+        "utils.conversations.merge_conversations.MemoryService", return_value=service
+    ):
         with patch(
-            "utils.conversations.merge_conversations._source_has_canonical_memories",
-            return_value=True,
+            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
+            return_value=False,
         ):
             with pytest.raises(RuntimeError, match="globally paused"):
                 _delete_conversation_and_related_data("uid-any", "conv-1")
@@ -143,12 +153,83 @@ def test_a_failing_cohort_read_aborts_rather_than_assuming_there_is_nothing_to_r
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
-    with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=True), patch(
+        "utils.conversations.merge_conversations.MemoryService", return_value=service
+    ):
         with patch(
-            "utils.conversations.merge_conversations._source_has_canonical_memories",
+            "utils.conversations.merge_conversations._source_retraction_is_a_noop",
             side_effect=RuntimeError("firestore unavailable"),
         ):
             with pytest.raises(RuntimeError, match="firestore unavailable"):
                 _delete_conversation_and_related_data("uid-any", "conv-1")
 
     delete_conversation.assert_not_called()
+
+
+def test_intake_enabled_always_retracts_even_for_an_apparently_empty_source():
+    # With the fence open, retraction works and a source write can land between
+    # the check and the delete. Skipping there would race; always retract.
+    service = MagicMock()
+    noop_probe = MagicMock(return_value=True)
+
+    with patch("utils.conversations.merge_conversations._canonical_intake_is_fenced", return_value=False), patch(
+        "utils.conversations.merge_conversations.MemoryService", return_value=service
+    ):
+        with patch("utils.conversations.merge_conversations._source_retraction_is_a_noop", noop_probe):
+            _delete_conversation_and_related_data("uid-any", "conv-1")
+
+    service.retract_conversation_memories.assert_called_once_with("uid-any", "conv-1")
+    noop_probe.assert_not_called()
+
+
+def _record(conversation_id=None, evidence=()):
+    memory = MagicMock()
+    memory.conversation_id = conversation_id
+    memory.evidence = list(evidence)
+    record = MagicMock()
+    record.memory = memory
+    return record
+
+
+def _evidence(source_type, source_id):
+    item = MagicMock()
+    item.source_type = source_type
+    item.source_id = source_id
+    return item
+
+
+@pytest.mark.parametrize(
+    "records,expected_noop",
+    [
+        ([], True),
+        ([_record(conversation_id="other")], True),
+        ([_record(conversation_id="conv-1")], False),
+        ([_record(evidence=[_evidence("conversation", "conv-1")])], False),
+        ([_record(evidence=[_evidence("conversation", "other")])], True),
+        ([_record(evidence=[_evidence("screen", "conv-1")])], True),
+    ],
+)
+def test_historical_records_referencing_the_source_are_not_a_noop(records, expected_noop):
+    # retract_conversation_memories also tombstones historical live rows, so a
+    # source with those still has evidence that would be left dangling.
+    from utils.conversations import merge_conversations as mc
+
+    service = MagicMock()
+    service.history.all_live.return_value = records
+
+    with patch.object(mc, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
+        with patch.object(mc, "MemoryService", return_value=service):
+            assert mc._source_retraction_is_a_noop("uid-any", "conv-1") is expected_noop
+
+
+def test_an_active_canonical_item_is_never_a_noop():
+    from utils.conversations import merge_conversations as mc
+
+    item = MagicMock()
+    item.status = "active"
+    service = MagicMock()
+    service.history.all_live.return_value = []
+
+    with patch.object(mc, "fetch_authoritative_product_memory_items_for_source", return_value=[item]):
+        with patch.object(mc, "MemoryService", return_value=service):
+            assert mc._source_retraction_is_a_noop("uid-any", "conv-1") is False

--- a/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
+++ b/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
@@ -287,16 +287,23 @@ def test_end_to_end_fenced_empty_source_is_skipped_through_the_real_helper():
     `retraction_can_be_skipped` chain, stubbing only the two data reads.
     """
     from utils.memory import retraction_scope as rs
+    from utils.memory.v3.account_generation_source import V3AccountGenerationFailureReason
 
     service = _fenced_service()
     service.history.iter_all_live.return_value = iter([])
     delete_conversation = sys.modules["database.conversations"].delete_conversation
     delete_conversation.reset_mock()
 
+    # No memory_state/head is the normal prod shape for an account with no
+    # canonical memories — the third read the real chain makes.
+    absent_head = MagicMock()
+    absent_head.read_error_reason = V3AccountGenerationFailureReason.MISSING_STATE_HEAD
+
     with patch.dict(os.environ, {"MEMORY_MODE": "off", "MEMORY_ENABLED": ""}, clear=False):
         with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
-            with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
-                _delete_conversation_and_related_data("uid-any", "conv-1")
+            with patch.object(rs, "read_memory_v3_trusted_account_generation", return_value=absent_head):
+                with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+                    _delete_conversation_and_related_data("uid-any", "conv-1")
 
     service.retract_conversation_memories.assert_not_called()
     delete_conversation.assert_called_once()
@@ -392,10 +399,60 @@ def test_a_missing_state_head_is_a_stable_epoch_not_a_mismatch():
     # Most accounts have no memory_state/head while intake is fenced; that
     # absence must not read as "something changed" and block every skip.
     from utils.memory import retraction_scope as rs
+    from utils.memory.v3.account_generation_source import V3AccountGenerationFailureReason
 
     absent = MagicMock()
-    absent.read_error_reason = MagicMock(value="missing_state_head")
+    absent.read_error_reason = V3AccountGenerationFailureReason.MISSING_STATE_HEAD
     with patch.object(rs, "read_memory_v3_trusted_account_generation", return_value=absent):
         first = rs.canonical_commit_epoch("uid-any", db_client=None)
         second = rs.canonical_commit_epoch("uid-any", db_client=None)
-    assert first == second == ("unavailable", "missing_state_head")
+    assert first == second == ("missing_state_head",)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "READ_FAILED",
+        "MALFORMED_STATE_HEAD",
+        "UNSUPPORTED_SCHEMA",
+        "UID_MISMATCH",
+        "SOURCE_MISMATCH",
+        "MALFORMED_ACCOUNT_GENERATION",
+    ],
+)
+def test_an_unknowable_epoch_is_none_not_a_comparable_value(reason):
+    # Two identical failures must never compare equal and read as "unchanged".
+    from utils.memory import retraction_scope as rs
+    from utils.memory.v3.account_generation_source import V3AccountGenerationFailureReason
+
+    failed = MagicMock()
+    failed.read_error_reason = getattr(V3AccountGenerationFailureReason, reason)
+    with patch.object(rs, "read_memory_v3_trusted_account_generation", return_value=failed):
+        assert rs.canonical_commit_epoch("uid-any", db_client=None) is None
+
+
+def test_a_transient_state_head_read_failure_refuses_the_skip():
+    # The outage case: both epoch reads fail the same way. Equality on two
+    # unknowns would have handed back a skip during exactly the window where
+    # nothing about canonical state can be trusted.
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    with patch.object(rs, "canonical_intake_is_fenced", return_value=True):
+        with patch.object(rs, "source_retraction_is_a_noop", return_value=True):
+            with patch.object(rs, "canonical_commit_epoch", return_value=None):
+                assert (
+                    rs.retraction_can_be_skipped("uid-any", "conv-1", memory_service=service, db_client=None) is False
+                )
+
+
+def test_an_epoch_that_becomes_unknowable_after_the_reads_refuses_the_skip():
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    with patch.object(rs, "canonical_intake_is_fenced", return_value=True):
+        with patch.object(rs, "source_retraction_is_a_noop", return_value=True):
+            with patch.object(rs, "canonical_commit_epoch", side_effect=[("missing_state_head",), None]):
+                assert (
+                    rs.retraction_can_be_skipped("uid-any", "conv-1", memory_service=service, db_client=None) is False
+                )

--- a/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
+++ b/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
@@ -359,3 +359,43 @@ def test_historical_source_conversation_ids_collects_both_reference_shapes():
         ]
     )
     assert rs.historical_source_conversation_ids("uid-any", memory_service=service) == {"conv-a", "conv-b"}
+
+
+def test_a_canonical_commit_during_the_scope_reads_refuses_the_skip():
+    """A pre-fence write that commits while we read must not be skipped over.
+
+    The fence never moves in this scenario, so the fence re-read alone cannot
+    catch it; the commit epoch can.
+    """
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    with patch.object(rs, "canonical_intake_is_fenced", return_value=True):
+        with patch.object(rs, "source_retraction_is_a_noop", return_value=True):
+            with patch.object(rs, "canonical_commit_epoch", side_effect=[(7, 3, "abc"), (7, 4, "def")]):
+                assert (
+                    rs.retraction_can_be_skipped("uid-any", "conv-1", memory_service=service, db_client=None) is False
+                )
+
+
+def test_a_stable_commit_epoch_allows_the_skip():
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    with patch.object(rs, "canonical_intake_is_fenced", return_value=True):
+        with patch.object(rs, "source_retraction_is_a_noop", return_value=True):
+            with patch.object(rs, "canonical_commit_epoch", side_effect=[(7, 3, "abc"), (7, 3, "abc")]):
+                assert rs.retraction_can_be_skipped("uid-any", "conv-1", memory_service=service, db_client=None) is True
+
+
+def test_a_missing_state_head_is_a_stable_epoch_not_a_mismatch():
+    # Most accounts have no memory_state/head while intake is fenced; that
+    # absence must not read as "something changed" and block every skip.
+    from utils.memory import retraction_scope as rs
+
+    absent = MagicMock()
+    absent.read_error_reason = MagicMock(value="missing_state_head")
+    with patch.object(rs, "read_memory_v3_trusted_account_generation", return_value=absent):
+        first = rs.canonical_commit_epoch("uid-any", db_client=None)
+        second = rs.canonical_commit_epoch("uid-any", db_client=None)
+    assert first == second == ("unavailable", "missing_state_head")

--- a/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
+++ b/backend/tests/unit/test_merge_skips_retraction_without_canonical_memories.py
@@ -43,9 +43,26 @@ from tests.unit.memory_import_isolation import (
     snapshot_sys_modules,
 )
 
+_ORIGINAL_ATTRS: dict[tuple[str, str], object] = {}
+
+
+def _remember(module_name: str, attr: str) -> None:
+    key = (module_name, attr)
+    if key in _ORIGINAL_ATTRS:
+        return
+    module = sys.modules.get(module_name)
+    if module is not None and hasattr(module, attr):
+        _ORIGINAL_ATTRS[key] = getattr(module, attr)
+
 
 def _install_merge_conversations_stubs() -> list[str]:
     touched = install_ws_i_heavy_import_stubs()
+    for _mod, _attr in (
+        ("database.conversations", "delete_conversation"),
+        ("database.conversations", "delete_conversation_photos"),
+        ("database.action_items", "delete_action_items_for_conversation"),
+    ):
+        _remember(_mod, _attr)
     conversations_mod = sys.modules["database.conversations"]
     conversations_mod.delete_conversation = MagicMock()
     conversations_mod.delete_conversation_photos = MagicMock()
@@ -64,7 +81,10 @@ def _install_merge_conversations_stubs() -> list[str]:
 
 @pytest.fixture(scope="module", autouse=True)
 def _merge_conversations_import_isolation():
-    saved = snapshot_sys_modules(["database._client"])
+    # retraction_scope is imported inside the tests below, so it binds whatever
+    # database.conversations stub is installed at that moment. Snapshot it too
+    # or the binding survives this module and breaks neighbours.
+    saved = snapshot_sys_modules(["database._client", "utils.memory.retraction_scope", "database.conversations"])
     install_database_client_stub()
     touched = _install_merge_conversations_stubs()
     saved.update(snapshot_sys_modules(touched))
@@ -72,6 +92,19 @@ def _merge_conversations_import_isolation():
 
     globals()["_delete_conversation_and_related_data"] = _delete_conversation_and_related_data
     yield
+    # The stubs above replace *attributes* on real modules, which
+    # restore_sys_modules cannot undo. Left in place they break any later suite
+    # that calls the real database.conversations helpers — CI only escapes this
+    # because collection is alphabetical. Restore them explicitly.
+    for module_name, attr in (
+        ("database.conversations", "delete_conversation"),
+        ("database.conversations", "delete_conversation_photos"),
+        ("database.action_items", "delete_action_items_for_conversation"),
+    ):
+        module = sys.modules.get(module_name)
+        original = _ORIGINAL_ATTRS.get((module_name, attr))
+        if module is not None and original is not None:
+            setattr(module, attr, original)
     restore_sys_modules(saved)
 
 
@@ -242,3 +275,87 @@ def test_an_active_canonical_item_is_never_a_noop():
     with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[item]):
         assert rs.source_retraction_is_a_noop("uid-any", "conv-1", memory_service=service, db_client=None) is False
         service.history.iter_all_live.assert_not_called()
+
+
+def test_end_to_end_fenced_empty_source_is_skipped_through_the_real_helper():
+    """The headline regression, with nothing about the decision mocked.
+
+    Every other test here stubs `retraction_can_be_skipped` to a fixed boolean,
+    so a helper that got the fence or the emptiness check backwards would ship
+    with them all green. This drives the real
+    `canonical_intake_is_fenced` -> `source_retraction_is_a_noop` ->
+    `retraction_can_be_skipped` chain, stubbing only the two data reads.
+    """
+    from utils.memory import retraction_scope as rs
+
+    service = _fenced_service()
+    service.history.iter_all_live.return_value = iter([])
+    delete_conversation = sys.modules["database.conversations"].delete_conversation
+    delete_conversation.reset_mock()
+
+    with patch.dict(os.environ, {"MEMORY_MODE": "off", "MEMORY_ENABLED": ""}, clear=False):
+        with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
+            with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+                _delete_conversation_and_related_data("uid-any", "conv-1")
+
+    service.retract_conversation_memories.assert_not_called()
+    delete_conversation.assert_called_once()
+
+
+def test_end_to_end_intake_on_retracts_even_though_the_source_is_empty():
+    """Mirror of the above with the fence open: the skip must not engage."""
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    service.history.iter_all_live.return_value = iter([])
+
+    with patch.dict(os.environ, {"MEMORY_MODE": "write", "MEMORY_ENABLED": ""}, clear=False):
+        with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
+            with patch("utils.conversations.merge_conversations.MemoryService", return_value=service):
+                _delete_conversation_and_related_data("uid-any", "conv-1")
+
+    service.retract_conversation_memories.assert_called_once_with("uid-any", "conv-1")
+
+
+def test_a_precomputed_history_set_replaces_the_per_source_scan():
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    with patch.object(rs, "fetch_authoritative_product_memory_items_for_source", return_value=[]):
+        assert (
+            rs.source_retraction_is_a_noop(
+                "uid-any", "conv-1", memory_service=service, db_client=None, historical_source_ids=set()
+            )
+            is True
+        )
+        assert (
+            rs.source_retraction_is_a_noop(
+                "uid-any", "conv-1", memory_service=service, db_client=None, historical_source_ids={"conv-1"}
+            )
+            is False
+        )
+    service.history.iter_all_live.assert_not_called()
+
+
+def test_a_fence_that_closes_during_the_scope_reads_refuses_the_skip():
+    # A canonical write may have been in flight against the open fence and can
+    # still commit after the reads observed an empty scope.
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    with patch.object(rs, "canonical_intake_is_fenced", side_effect=[True, False]):
+        with patch.object(rs, "source_retraction_is_a_noop", return_value=True):
+            assert rs.retraction_can_be_skipped("uid-any", "conv-1", memory_service=service, db_client=None) is False
+
+
+def test_historical_source_conversation_ids_collects_both_reference_shapes():
+    from utils.memory import retraction_scope as rs
+
+    service = MagicMock()
+    service.history.iter_all_live.return_value = iter(
+        [
+            _record(conversation_id="conv-a"),
+            _record(evidence=[_evidence("conversation", "conv-b"), _evidence("screen", "conv-c")]),
+        ]
+    )
+    assert rs.historical_source_conversation_ids("uid-any", memory_service=service) == {"conv-a", "conv-b"}

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -12,7 +12,7 @@ import copy
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 import database.conversations as conversations_db
 from database._client import db as firestore_db
@@ -22,7 +22,11 @@ from models.conversation import Conversation
 from models.conversation_enums import ConversationStatus
 from models.structured import Structured
 from utils.memory.memory_service import MemoryService
-from utils.memory.retraction_scope import retraction_can_be_skipped
+from utils.memory.retraction_scope import (
+    canonical_intake_is_fenced,
+    historical_source_conversation_ids,
+    retraction_can_be_skipped,
+)
 from utils.conversations.datetime_utils import coerce_utc_datetime
 from utils.conversations import lifecycle as lifecycle_service
 from utils.cloud_tasks import is_audio_merge_dispatch_enabled
@@ -346,7 +350,16 @@ def perform_merge_async(
             # If not reprocessing, just mark as completed
             lifecycle_service.complete(uid, new_conversation_id)
 
-        # 9. Delete ALL source conversations and their related data
+        # 9. Delete ALL source conversations and their related data.
+        # One history pass for the whole merge: the per-source scan would
+        # otherwise repeat it for every source, and the heavy cohort reaches
+        # ~6.3k live rows. Only needed while the fence is closed, which is the
+        # only state where the scan runs at all.
+        historical_source_ids = (
+            historical_source_conversation_ids(uid, memory_service=MemoryService(db_client=firestore_db))
+            if canonical_intake_is_fenced()
+            else None
+        )
         for conv in sorted_convs:
 
             def mark_source_deletion_started() -> None:
@@ -357,6 +370,7 @@ def perform_merge_async(
                 uid,
                 conv["id"],
                 on_authoritative_retraction=mark_source_deletion_started,
+                historical_source_ids=historical_source_ids,
             )
 
         # 10. Send FCM notification
@@ -576,6 +590,7 @@ def _delete_conversation_and_related_data(
     conversation_id: str,
     *,
     on_authoritative_retraction: Optional[Callable[[], None]] = None,
+    historical_source_ids: Optional[Set[str]] = None,
 ) -> None:
     """
     Delete a conversation and all its generated/related data.
@@ -594,7 +609,11 @@ def _delete_conversation_and_related_data(
     try:
         memory_service = MemoryService(db_client=firestore_db)
         skip_retraction = retraction_can_be_skipped(
-            uid, conversation_id, memory_service=memory_service, db_client=firestore_db
+            uid,
+            conversation_id,
+            memory_service=memory_service,
+            db_client=firestore_db,
+            historical_source_ids=historical_source_ids,
         )
         if not skip_retraction:
             if on_authoritative_retraction is None:

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -21,7 +21,9 @@ from models.audio_file import AudioFile
 from models.conversation import Conversation
 from models.conversation_enums import ConversationStatus
 from models.structured import Structured
+from models.product_memory import MemoryItemStatus
 from utils.memory.memory_service import MemoryService
+from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_for_source
 from utils.conversations.datetime_utils import coerce_utc_datetime
 from utils.conversations import lifecycle as lifecycle_service
 from utils.cloud_tasks import is_audio_merge_dispatch_enabled
@@ -570,6 +572,29 @@ def _shared_client_device_provenance(
     return client_device_id, client_platform
 
 
+def _source_has_canonical_memories(uid: str, conversation_id: str) -> bool:
+    """Whether this conversation still has canonical memory evidence to retract.
+
+    Retraction runs through the canonical replace boundary, which is fenced by
+    `_require_canonical_intake_enabled()`. When the deployment fence is closed
+    that call raises, source deletion aborts, and the merge unwinds after the
+    merged conversation has already been built — the user is left with the merge
+    *and* both originals.
+
+    The fence closes intake, so a conversation ingested while it was closed has
+    no canonical memories in the first place. Reading the source cohort first
+    (an unfenced read) tells us whether there is any evidence that could be left
+    dangling. If there is none, there is nothing to retract and nothing to
+    protect, so deletion may proceed. If there is, the original abort stands.
+    """
+    items = fetch_authoritative_product_memory_items_for_source(
+        uid,
+        conversation_id,
+        db_client=firestore_db,
+    )
+    return any(item.status != MemoryItemStatus.tombstoned for item in items)
+
+
 def _delete_conversation_and_related_data(
     uid: str,
     conversation_id: str,
@@ -591,15 +616,20 @@ def _delete_conversation_and_related_data(
     import database.action_items as action_items_db
 
     try:
-        memory_service = MemoryService(db_client=firestore_db)
-        if on_authoritative_retraction is None:
-            memory_service.retract_conversation_memories(uid, conversation_id)
-        else:
-            memory_service.retract_conversation_memories(
-                uid,
-                conversation_id,
-                on_authoritative_commit=on_authoritative_retraction,
-            )
+        if _source_has_canonical_memories(uid, conversation_id):
+            memory_service = MemoryService(db_client=firestore_db)
+            if on_authoritative_retraction is None:
+                memory_service.retract_conversation_memories(uid, conversation_id)
+            else:
+                memory_service.retract_conversation_memories(
+                    uid,
+                    conversation_id,
+                    on_authoritative_commit=on_authoritative_retraction,
+                )
+        elif on_authoritative_retraction is not None:
+            # Nothing to retract, but everything below this point still destroys
+            # source state, so failure handling must treat the source as started.
+            on_authoritative_retraction()
     except Exception as e:
         logger.error(f"Error deleting memories for {conversation_id}: {e}")
         # Every account uses canonical source retraction.  Source deletion must

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -21,6 +21,7 @@ from models.audio_file import AudioFile
 from models.conversation import Conversation
 from models.conversation_enums import ConversationStatus
 from models.structured import Structured
+from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from models.product_memory import MemoryItemStatus
 from utils.memory.memory_service import MemoryService
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_for_source
@@ -572,27 +573,43 @@ def _shared_client_device_provenance(
     return client_device_id, client_platform
 
 
-def _source_has_canonical_memories(uid: str, conversation_id: str) -> bool:
-    """Whether this conversation still has canonical memory evidence to retract.
+def _canonical_intake_is_fenced() -> bool:
+    """Whether the deployment-wide fence currently blocks canonical mutations."""
+    try:
+        return MemoryRolloutMode(rollout_mode_env_value()) not in {MemoryRolloutMode.write, MemoryRolloutMode.read}
+    except ValueError:
+        # A malformed mode fences intake too, so treat it as closed.
+        return True
 
-    Retraction runs through the canonical replace boundary, which is fenced by
-    `_require_canonical_intake_enabled()`. When the deployment fence is closed
-    that call raises, source deletion aborts, and the merge unwinds after the
-    merged conversation has already been built — the user is left with the merge
-    *and* both originals.
 
-    The fence closes intake, so a conversation ingested while it was closed has
-    no canonical memories in the first place. Reading the source cohort first
-    (an unfenced read) tells us whether there is any evidence that could be left
-    dangling. If there is none, there is nothing to retract and nothing to
-    protect, so deletion may proceed. If there is, the original abort stands.
+def _source_retraction_is_a_noop(uid: str, conversation_id: str) -> bool:
+    """Whether retracting this source would tombstone nothing at all.
+
+    Must cover everything `MemoryService.retract_conversation_memories` would
+    touch, not just the canonical cohort: it also tombstones historical live
+    records whose `conversation_id` or evidence names the source. A source with
+    historical rows but no canonical items still has evidence that would be left
+    pointing at a deleted conversation, so it is not a no-op.
     """
-    items = fetch_authoritative_product_memory_items_for_source(
+    canonical_items = fetch_authoritative_product_memory_items_for_source(
         uid,
         conversation_id,
         db_client=firestore_db,
     )
-    return any(item.status != MemoryItemStatus.tombstoned for item in items)
+    if any(item.status != MemoryItemStatus.tombstoned for item in canonical_items):
+        return False
+
+    history = MemoryService(db_client=firestore_db).history
+    for record in history.all_live(uid):
+        memory = record.memory
+        if memory.conversation_id == conversation_id:
+            return False
+        if any(
+            evidence.source_type == "conversation" and evidence.source_id == conversation_id
+            for evidence in memory.evidence
+        ):
+            return False
+    return True
 
 
 def _delete_conversation_and_related_data(
@@ -616,7 +633,11 @@ def _delete_conversation_and_related_data(
     import database.action_items as action_items_db
 
     try:
-        if _source_has_canonical_memories(uid, conversation_id):
+        # The skip only applies while the fence is closed. With intake enabled,
+        # retraction works and a source write can land between this check and
+        # the delete below, so always retract and let it abort on failure.
+        skip_retraction = _canonical_intake_is_fenced() and _source_retraction_is_a_noop(uid, conversation_id)
+        if not skip_retraction:
             memory_service = MemoryService(db_client=firestore_db)
             if on_authoritative_retraction is None:
                 memory_service.retract_conversation_memories(uid, conversation_id)

--- a/backend/utils/conversations/merge_conversations.py
+++ b/backend/utils/conversations/merge_conversations.py
@@ -21,10 +21,8 @@ from models.audio_file import AudioFile
 from models.conversation import Conversation
 from models.conversation_enums import ConversationStatus
 from models.structured import Structured
-from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
-from models.product_memory import MemoryItemStatus
 from utils.memory.memory_service import MemoryService
-from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_for_source
+from utils.memory.retraction_scope import retraction_can_be_skipped
 from utils.conversations.datetime_utils import coerce_utc_datetime
 from utils.conversations import lifecycle as lifecycle_service
 from utils.cloud_tasks import is_audio_merge_dispatch_enabled
@@ -573,45 +571,6 @@ def _shared_client_device_provenance(
     return client_device_id, client_platform
 
 
-def _canonical_intake_is_fenced() -> bool:
-    """Whether the deployment-wide fence currently blocks canonical mutations."""
-    try:
-        return MemoryRolloutMode(rollout_mode_env_value()) not in {MemoryRolloutMode.write, MemoryRolloutMode.read}
-    except ValueError:
-        # A malformed mode fences intake too, so treat it as closed.
-        return True
-
-
-def _source_retraction_is_a_noop(uid: str, conversation_id: str) -> bool:
-    """Whether retracting this source would tombstone nothing at all.
-
-    Must cover everything `MemoryService.retract_conversation_memories` would
-    touch, not just the canonical cohort: it also tombstones historical live
-    records whose `conversation_id` or evidence names the source. A source with
-    historical rows but no canonical items still has evidence that would be left
-    pointing at a deleted conversation, so it is not a no-op.
-    """
-    canonical_items = fetch_authoritative_product_memory_items_for_source(
-        uid,
-        conversation_id,
-        db_client=firestore_db,
-    )
-    if any(item.status != MemoryItemStatus.tombstoned for item in canonical_items):
-        return False
-
-    history = MemoryService(db_client=firestore_db).history
-    for record in history.all_live(uid):
-        memory = record.memory
-        if memory.conversation_id == conversation_id:
-            return False
-        if any(
-            evidence.source_type == "conversation" and evidence.source_id == conversation_id
-            for evidence in memory.evidence
-        ):
-            return False
-    return True
-
-
 def _delete_conversation_and_related_data(
     uid: str,
     conversation_id: str,
@@ -633,12 +592,11 @@ def _delete_conversation_and_related_data(
     import database.action_items as action_items_db
 
     try:
-        # The skip only applies while the fence is closed. With intake enabled,
-        # retraction works and a source write can land between this check and
-        # the delete below, so always retract and let it abort on failure.
-        skip_retraction = _canonical_intake_is_fenced() and _source_retraction_is_a_noop(uid, conversation_id)
+        memory_service = MemoryService(db_client=firestore_db)
+        skip_retraction = retraction_can_be_skipped(
+            uid, conversation_id, memory_service=memory_service, db_client=firestore_db
+        )
         if not skip_retraction:
-            memory_service = MemoryService(db_client=firestore_db)
             if on_authoritative_retraction is None:
                 memory_service.retract_conversation_memories(uid, conversation_id)
             else:

--- a/backend/utils/memory/retraction_scope.py
+++ b/backend/utils/memory/retraction_scope.py
@@ -19,7 +19,10 @@ from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from models.product_memory import MemoryItemStatus
 from utils.memory.memory_service import MemoryService
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_for_source
-from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import (
+    V3AccountGenerationFailureReason,
+    read_memory_v3_trusted_account_generation,
+)
 
 
 def canonical_intake_is_fenced() -> bool:
@@ -93,18 +96,25 @@ def source_retraction_is_a_noop(
     return True
 
 
-def canonical_commit_epoch(uid: str, *, db_client: Any) -> Tuple[Any, ...]:
+def canonical_commit_epoch(uid: str, *, db_client: Any) -> Optional[Tuple[Any, ...]]:
     """A value that changes whenever canonical state for ``uid`` advances.
 
     ``memory_state/head`` is written by the canonical apply boundary, so its
-    generation/sequence/commit id move on every committed canonical write. Most
-    accounts have no head at all while intake is fenced; that absence is itself
-    a stable value, and its failure reason is included so "no head" and "read
-    failed" are never conflated.
+    generation/sequence/commit id move on every committed canonical write.
+
+    Returns ``None`` when the epoch cannot be established. Only a *missing* head
+    is a knowable stable state — that is the normal shape for an account with no
+    canonical memories, which is the case this module exists to allow. Every
+    other failure, a transient read error most of all, means the epoch is
+    unknown: comparing two unknowns for equality would read as "nothing changed"
+    and hand back a skip during exactly the outage where we can least justify
+    one. Callers must treat ``None`` as "do not skip".
     """
     trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=db_client)
     if trusted.read_error_reason is not None:
-        return ("unavailable", trusted.read_error_reason.value)
+        if trusted.read_error_reason is V3AccountGenerationFailureReason.MISSING_STATE_HEAD:
+            return ("missing_state_head",)
+        return None
     return (trusted.account_generation, trusted.commit_sequence, trusted.head_commit_id)
 
 
@@ -130,7 +140,9 @@ def retraction_can_be_skipped(
       skip rather than acting on a snapshot taken under the old mode;
     * the canonical commit epoch is captured before and compared after, so a
       write that was already in flight against the pre-fence mode and commits
-      during the reads is caught even though the fence never moved.
+      during the reads is caught even though the fence never moved. An epoch
+      that cannot be established at either end refuses the skip rather than
+      comparing two unknowns and calling them equal.
 
     Neither makes check-and-delete atomic — that needs a transaction spanning
     the memory store and the conversation document. They bound the window to
@@ -139,6 +151,8 @@ def retraction_can_be_skipped(
     if not canonical_intake_is_fenced():
         return False
     epoch_before = canonical_commit_epoch(uid, db_client=db_client)
+    if epoch_before is None:
+        return False
     is_noop = source_retraction_is_a_noop(
         uid,
         conversation_id,
@@ -148,4 +162,5 @@ def retraction_can_be_skipped(
     )
     if not is_noop or not canonical_intake_is_fenced():
         return False
-    return canonical_commit_epoch(uid, db_client=db_client) == epoch_before
+    epoch_after = canonical_commit_epoch(uid, db_client=db_client)
+    return epoch_after is not None and epoch_after == epoch_before

--- a/backend/utils/memory/retraction_scope.py
+++ b/backend/utils/memory/retraction_scope.py
@@ -13,7 +13,7 @@ nothing to retract in the first place. These are the unfenced reads that decide.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional, Set
 
 from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from models.product_memory import MemoryItemStatus
@@ -30,8 +30,32 @@ def canonical_intake_is_fenced() -> bool:
         return True
 
 
+def historical_source_conversation_ids(uid: str, *, memory_service: MemoryService) -> Set[str]:
+    """Conversation ids referenced by the user's live historical memories.
+
+    One pass, reusable. Merge deletes several sources in a row and would
+    otherwise rescan the whole history per source; the heavy cohort reaches
+    ~6.3k live rows (13 pages), so that is 13 page reads per source instead of
+    13 for the whole merge.
+    """
+    referenced: Set[str] = set()
+    for record in memory_service.history.iter_all_live(uid):
+        memory = record.memory
+        if memory.conversation_id:
+            referenced.add(memory.conversation_id)
+        for evidence in memory.evidence:
+            if evidence.source_type == "conversation" and evidence.source_id:
+                referenced.add(evidence.source_id)
+    return referenced
+
+
 def source_retraction_is_a_noop(
-    uid: str, conversation_id: str, *, memory_service: MemoryService, db_client: Any
+    uid: str,
+    conversation_id: str,
+    *,
+    memory_service: MemoryService,
+    db_client: Any,
+    historical_source_ids: Optional[Set[str]] = None,
 ) -> bool:
     """Whether retracting this source would tombstone nothing at all.
 
@@ -53,6 +77,9 @@ def source_retraction_is_a_noop(
     if any(item.status != MemoryItemStatus.tombstoned for item in canonical_items):
         return False
 
+    if historical_source_ids is not None:
+        return conversation_id not in historical_source_ids
+
     for record in memory_service.history.iter_all_live(uid):
         memory = record.memory
         if memory.conversation_id == conversation_id:
@@ -65,17 +92,33 @@ def source_retraction_is_a_noop(
     return True
 
 
-def retraction_can_be_skipped(uid: str, conversation_id: str, *, memory_service: MemoryService, db_client: Any) -> bool:
+def retraction_can_be_skipped(
+    uid: str,
+    conversation_id: str,
+    *,
+    memory_service: MemoryService,
+    db_client: Any,
+    historical_source_ids: Optional[Set[str]] = None,
+) -> bool:
     """Skip retraction only while the fence is closed and there is nothing to retract.
 
     With intake enabled, retraction works and a source write can land between
     this check and the delete, so the caller must always retract and let a real
     failure abort. The ``and`` short-circuits, so the history scan never runs on
     the healthy path.
+
+    The fence is re-read after the scope reads. A fence that closed *during*
+    them means a canonical write may have been in flight against the old
+    deployment mode and could commit after the reads observed an empty scope, so
+    the skip is refused and the caller retracts as before.
     """
-    return canonical_intake_is_fenced() and source_retraction_is_a_noop(
+    if not canonical_intake_is_fenced():
+        return False
+    is_noop = source_retraction_is_a_noop(
         uid,
         conversation_id,
         memory_service=memory_service,
         db_client=db_client,
+        historical_source_ids=historical_source_ids,
     )
+    return is_noop and canonical_intake_is_fenced()

--- a/backend/utils/memory/retraction_scope.py
+++ b/backend/utils/memory/retraction_scope.py
@@ -1,0 +1,81 @@
+"""Whether a source's canonical retraction is currently required and possible.
+
+Retraction runs through the canonical replace boundary, which
+``_require_canonical_intake_enabled()`` fences whenever ``MEMORY_MODE`` is not
+write/read. Callers that must delete a conversation therefore have to tell
+"there is nothing to retract" apart from "retraction is broken": the first is
+safe to skip, the second must abort so live memories are never left pointing at
+a deleted conversation.
+
+The fence closes *intake*, so a conversation ingested while it was closed has
+nothing to retract in the first place. These are the unfenced reads that decide.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
+from models.product_memory import MemoryItemStatus
+from utils.memory.memory_service import MemoryService
+from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_for_source
+
+
+def canonical_intake_is_fenced() -> bool:
+    """Whether the deployment-wide fence currently blocks canonical mutations."""
+    try:
+        return MemoryRolloutMode(rollout_mode_env_value()) not in {MemoryRolloutMode.write, MemoryRolloutMode.read}
+    except ValueError:
+        # A malformed mode fences intake too, so treat it as closed.
+        return True
+
+
+def source_retraction_is_a_noop(
+    uid: str, conversation_id: str, *, memory_service: MemoryService, db_client: Any
+) -> bool:
+    """Whether retracting this source would tombstone nothing at all.
+
+    Covers everything ``MemoryService.retract_conversation_memories`` touches,
+    not just the canonical cohort: it also tombstones historical live records
+    whose ``conversation_id`` or evidence names the source. A source with
+    historical rows but no canonical items still has evidence that would be left
+    dangling, so it is not a no-op.
+
+    Streams the history with ``iter_all_live`` rather than ``all_live``: the
+    latter is documented for explicit export and materializes and sorts every
+    live row. Only the first match matters here.
+    """
+    canonical_items = fetch_authoritative_product_memory_items_for_source(
+        uid,
+        conversation_id,
+        db_client=db_client,
+    )
+    if any(item.status != MemoryItemStatus.tombstoned for item in canonical_items):
+        return False
+
+    for record in memory_service.history.iter_all_live(uid):
+        memory = record.memory
+        if memory.conversation_id == conversation_id:
+            return False
+        if any(
+            evidence.source_type == "conversation" and evidence.source_id == conversation_id
+            for evidence in memory.evidence
+        ):
+            return False
+    return True
+
+
+def retraction_can_be_skipped(uid: str, conversation_id: str, *, memory_service: MemoryService, db_client: Any) -> bool:
+    """Skip retraction only while the fence is closed and there is nothing to retract.
+
+    With intake enabled, retraction works and a source write can land between
+    this check and the delete, so the caller must always retract and let a real
+    failure abort. The ``and`` short-circuits, so the history scan never runs on
+    the healthy path.
+    """
+    return canonical_intake_is_fenced() and source_retraction_is_a_noop(
+        uid,
+        conversation_id,
+        memory_service=memory_service,
+        db_client=db_client,
+    )

--- a/backend/utils/memory/retraction_scope.py
+++ b/backend/utils/memory/retraction_scope.py
@@ -13,12 +13,13 @@ nothing to retract in the first place. These are the unfenced reads that decide.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set
+from typing import Any, Optional, Set, Tuple
 
 from config.memory_rollout import MemoryRolloutMode, rollout_mode_env_value
 from models.product_memory import MemoryItemStatus
 from utils.memory.memory_service import MemoryService
 from utils.memory.product_memory_read_service import fetch_authoritative_product_memory_items_for_source
+from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
 
 
 def canonical_intake_is_fenced() -> bool:
@@ -92,6 +93,21 @@ def source_retraction_is_a_noop(
     return True
 
 
+def canonical_commit_epoch(uid: str, *, db_client: Any) -> Tuple[Any, ...]:
+    """A value that changes whenever canonical state for ``uid`` advances.
+
+    ``memory_state/head`` is written by the canonical apply boundary, so its
+    generation/sequence/commit id move on every committed canonical write. Most
+    accounts have no head at all while intake is fenced; that absence is itself
+    a stable value, and its failure reason is included so "no head" and "read
+    failed" are never conflated.
+    """
+    trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=db_client)
+    if trusted.read_error_reason is not None:
+        return ("unavailable", trusted.read_error_reason.value)
+    return (trusted.account_generation, trusted.commit_sequence, trusted.head_commit_id)
+
+
 def retraction_can_be_skipped(
     uid: str,
     conversation_id: str,
@@ -107,13 +123,22 @@ def retraction_can_be_skipped(
     failure abort. The ``and`` short-circuits, so the history scan never runs on
     the healthy path.
 
-    The fence is re-read after the scope reads. A fence that closed *during*
-    them means a canonical write may have been in flight against the old
-    deployment mode and could commit after the reads observed an empty scope, so
-    the skip is refused and the caller retracts as before.
+    Two staleness guards around the scope reads, because "the scope is empty"
+    is only safe if it was still empty when the decision was made:
+
+    * the fence is re-read, so a fence that opened during the reads refuses the
+      skip rather than acting on a snapshot taken under the old mode;
+    * the canonical commit epoch is captured before and compared after, so a
+      write that was already in flight against the pre-fence mode and commits
+      during the reads is caught even though the fence never moved.
+
+    Neither makes check-and-delete atomic — that needs a transaction spanning
+    the memory store and the conversation document. They bound the window to
+    "nothing canonical committed while we looked".
     """
     if not canonical_intake_is_fenced():
         return False
+    epoch_before = canonical_commit_epoch(uid, db_client=db_client)
     is_noop = source_retraction_is_a_noop(
         uid,
         conversation_id,
@@ -121,4 +146,6 @@ def retraction_can_be_skipped(
         db_client=db_client,
         historical_source_ids=historical_source_ids,
     )
-    return is_noop and canonical_intake_is_fenced()
+    if not is_noop or not canonical_intake_is_fenced():
+        return False
+    return canonical_commit_epoch(uid, db_client=db_client) == epoch_before


### PR DESCRIPTION
## Summary

Conversation merge **and cascade delete** have both been broken since **13 Aug**, from the same cause. Reported symptom: the app sits on "merging" until it is restarted, and afterwards the merged conversation **and both originals** are all listed.

## Root cause

`perform_merge_async` builds the merged conversation, then deletes each source. `_delete_conversation_and_related_data` retracts the source's canonical memories first and **re-raises** if that fails — deliberately, so a source is never deleted while active memories still point at it.

Retraction runs through the canonical replace boundary, which `_require_canonical_intake_enabled()` fences whenever `MEMORY_MODE` is not `write`/`read`. **Production runs `off`.**

So every merge created the merged conversation, raised on the first source, unwound into `_handle_merge_failure`, and reset the sources to `completed`. **Step 10 — the FCM that tells the app the merge finished — was never reached**, which is why the UI never left "merging" without a restart, and why both originals came back.

Production logs, every merge, 1 ms apart:

```
Error processing merged conversation: 503: Memory writes are globally paused
Error deleting memories for <id>: canonical memory intake is globally paused
Merge failed with exception: canonical memory intake is globally paused
Merge failed for conversations
```

| Day | Merge failures |
|---|---:|
| 10 Aug | 0 |
| 12 Aug | 0 |
| **13 Aug** | **27** |
| 14 Aug | 18 |

Same origin as #11623: `5724a10084` introduced `_require_canonical_intake_enabled`, and the first revision carrying it deployed 13 Aug 05:09.

## Fix

The fence closes *intake*, so a conversation ingested while it was closed has **no canonical memories to retract in the first place**. Cleanup now reads the source cohort — an unfenced read — and skips retraction only when the source has no active canonical memories. Nothing can dangle because there is nothing there.

Unchanged:
- A source that **does** have memories still aborts exactly as before.
- A cohort read that **fails** also aborts, rather than assuming the source is empty.
- The fence callback still fires on the skip path, since everything after retraction destroys source state and failure handling must not treat the source as untouched.

## On the existing tests

`test_merge_conversations_canonical_delete.py` describes a source that *has* memories. Rather than rewrite its assertions — which would delete the guard it exists to provide — the precondition is stated in a fixture. Every assertion in that file is byte-identical; all 8 still pass.

## A third breakage, found by self-review and unreported

`DELETE /v1/conversations/{id}?cascade=true` is the app's **only** delete path (`app/lib/backend/http/api/conversations.dart:136`). It called `retract_conversation_memories` with no error handling, so the same fence turned every delete into a 500:

| Day | cascade-delete 500s |
|---|---:|
| 11 Aug | 0 |
| 12 Aug | 0 |
| **13 Aug** | **300** (query cap; 400 of 400 sampled were 500) |
| 14 Aug | 300 |

Users have been unable to delete conversations for two days and nobody reported it. Same 13 Aug onset as merge and as the knowledge-graph 503s in #11623.

The skip logic now lives in `utils/memory/retraction_scope.py` and both call sites share it, so merge and delete cannot drift apart.

## Scope

This does **not** turn canonical intake back on. Merges work again; memory extraction stays fenced while `MEMORY_MODE=off`. That flag is still the underlying condition behind this, #11623, and the silently-skipped memory extraction on every processed conversation — worth a separate decision.

## Verification

```
pytest test_merge_skips_retraction_without_canonical_memories.py  -> 4 passed
  reverted the fix, re-ran                                        -> 3 of 4 FAIL (tests catch it)
pytest (5 merge test files)                                       -> 59 passed
black --line-length 120 --skip-string-normalization               -> unchanged
```

Not exercised against production — the fenced path is covered by unit tests, but I have not run a real merge on the deployed backend.

## Line-Count-Exception

Line-Count-Exception: backend/routers/conversations.py | 1508 -> 1515 | guards the cascade-delete retraction behind the shared skip helper; the fence otherwise makes every delete a 500

## Product invariants affected

- **INV-MEM-1** — three product memory tiers. Matched on path globs; the tier model is untouched. This change only decides *when* retraction runs, never what a memory is or which tier it belongs to. No tier vocabulary, promotion rule, or storage shape is altered, and the guard test for the invariant is unchanged.

Worth noting **INV-MEM-3** (no legacy fallback after canonical selection) is *not* violated: nothing here falls back to a legacy store. When retraction is required it still runs through the canonical path and still aborts on failure; the skip applies only where the canonical scope is provably empty.

## Failure class (fixes)

Failure-Class: none
