### PR TITLE
Track the context-director search-chunks route in the desktop REST inventory

### DIFF
--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -181,6 +181,11 @@ KNOWN_MISSING_ROUTES: Set[str] = {
     '/v3/memories/mark-all-read',
     '/v3/memories/visibility',  # backend has /v3/memories/{memory_id}/visibility
     '/v3/memory-imports/batch',  # backend route exists but lacks response_model export
+    # Added by the context-director third retrieval source (#11613): the backend
+    # route exists (routers/tools.py, ToolResponse) but /v1/tools is not part of
+    # the app-client OpenAPI surface. Follow-up: expose the tools search routes
+    # in the app-client contract and remove this entry.
+    '/v1/tools/conversations/search-chunks',
     # These backend routes exist but return unmodeled (loose) responses, so
     # adding them to the app-client surface would regress the strict
     # `unmodeled_success_response_count == 0` gate. They are tracked for a


### PR DESCRIPTION
## Problem

Backend unit suite is red on main: test_desktop_rest_inventory fails with

```
Desktop REST routes hardcoded in APIClient.swift are missing from the app-client OpenAPI spec: ['/v1/tools/conversations/search-chunks']
```

#11613 added the macOS client call (APIClient+Tools.swift, the context-director third retrieval source) but /v1/tools is not part of the app-client OpenAPI surface, so the inventory gate trips on main and on every open PR whose checks merge with main.

## Fix

Record the route in KNOWN_MISSING_ROUTES with a comment citing #11613 and the follow-up (expose the tools search routes in the app-client contract, then remove the entry). This is the same tracked-blocker treatment the sibling entries use. No product code changes.

## Verification

```
python -m pytest tests/unit/test_desktop_rest_inventory.py -q
-> 9 passed  (1 failed, 8 passed before the change, failing on exactly this route)
black --check  -> clean
```

## Impact

Unblocks the Backend unit suite for main and every open PR. The real spec exposure is a follow-up, deliberately kept out of this unblocking change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

