### PR TITLE
fix(backend): fail-closed chat quota accounting before billable turns

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -257,7 +257,7 @@ def _build_quota_exceeded_reply(
     return ResponseMessage(**ai_msg.model_dump(), ask_for_nps=False)
 
 
-def _record_chat_quota_question_safe(
+def _record_chat_quota_question(
     uid: str,
     *,
     idempotency_key: str,
@@ -265,9 +265,32 @@ def _record_chat_quota_question_safe(
     message_id: Optional[str] = None,
     chat_session_id: Optional[str] = None,
     platform: Optional[str] = None,
-):
+) -> None:
+    """Persist the free-plan question counter. Callers that are about to invoke a
+    billable provider must treat failures as request failures (fail-closed)."""
+    llm_usage_db.record_chat_quota_question(
+        uid,
+        idempotency_key=idempotency_key,
+        source=source,
+        message_id=message_id,
+        chat_session_id=chat_session_id,
+        platform=platform,
+    )
+
+
+def _record_chat_quota_question_best_effort(
+    uid: str,
+    *,
+    idempotency_key: str,
+    source: str,
+    message_id: Optional[str] = None,
+    chat_session_id: Optional[str] = None,
+    platform: Optional[str] = None,
+) -> None:
+    """Best-effort counter write for paths where the billable work already happened
+    (e.g. voice stream after a visible ``message:`` frame)."""
     try:
-        llm_usage_db.record_chat_quota_question(
+        _record_chat_quota_question(
             uid,
             idempotency_key=idempotency_key,
             source=source,
@@ -351,14 +374,26 @@ def send_message(
         chat_db.add_message_to_chat_session(uid, chat_session.id, message.id)
 
     chat_db.add_message(uid, message.model_dump())
-    _record_chat_quota_question_safe(
-        uid,
-        idempotency_key=f'v2_messages:{message.id}',
-        source='v2_messages',
-        message_id=message.id,
-        chat_session_id=message.chat_session_id,
-        platform=x_app_platform,
-    )
+    # Fail-closed before any billable LLM / goal work: a Firestore outage must not
+    # leave Free-plan turns uncounted while the provider still runs.
+    try:
+        _record_chat_quota_question(
+            uid,
+            idempotency_key=f'v2_messages:{message.id}',
+            source='v2_messages',
+            message_id=message.id,
+            chat_session_id=message.chat_session_id,
+            platform=x_app_platform,
+        )
+    except Exception as exc:
+        logger.exception('Failed to record chat quota question source=v2_messages uid=%s', uid)
+        raise HTTPException(
+            status_code=503,
+            detail={
+                'error': 'quota_accounting_unavailable',
+                'message': 'Usage accounting is temporarily unavailable. Please retry.',
+            },
+        ) from exc
 
     # Check for goal progress (background) — rate-limited to one call per user per 5 min
     if try_acquire_goal_extraction_lock(uid):
@@ -744,7 +779,7 @@ def create_voice_message_stream(
                         message_data = json.loads(base64.b64decode(payload).decode('utf-8'))
                         await run_blocking(
                             db_executor,
-                            _record_chat_quota_question_safe,
+                            _record_chat_quota_question_best_effort,
                             uid,
                             idempotency_key=f"v2_voice_messages:{message_data.get('id') or first_wav}",
                             source='v2_voice_messages',

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -257,6 +257,24 @@ def _build_quota_exceeded_reply(
     return ResponseMessage(**ai_msg.model_dump(), ask_for_nps=False)
 
 
+def _build_quota_accounting_unavailable_reply(compat_app_id: Optional[str]) -> ResponseMessage:
+    """SSE-visible retry copy when Free-plan counter persistence fails.
+
+    Returned as an in-memory ``done:`` frame only — do not persist a human or AI
+    message here. Persisting before accounting succeeds would orphan user text on
+    retries (fresh message ids / idempotency keys under the same outage).
+    """
+    ai_msg = Message(
+        id=str(uuid.uuid4()),
+        text=("Usage accounting is temporarily unavailable. Please retry in a moment — " "your message was not saved."),
+        created_at=datetime.now(timezone.utc),
+        sender='ai',
+        type='text',
+        app_id=compat_app_id,
+    )
+    return ResponseMessage(**ai_msg.model_dump(), ask_for_nps=False)
+
+
 def _record_chat_quota_question(
     uid: str,
     *,
@@ -371,11 +389,10 @@ def send_message(
 
     if chat_session:
         message.chat_session_id = chat_session.id
-        chat_db.add_message_to_chat_session(uid, chat_session.id, message.id)
 
-    chat_db.add_message(uid, message.model_dump())
-    # Fail-closed before any billable LLM / goal work: a Firestore outage must not
-    # leave Free-plan turns uncounted while the provider still runs.
+    # Fail-closed before persisting the human turn or starting billable work:
+    # a Firestore outage must not leave Free-plan turns uncounted, orphan
+    # messages on retry, or return a bare HTTP 503 that mobile SSE silently drops.
     try:
         _record_chat_quota_question(
             uid,
@@ -385,15 +402,20 @@ def send_message(
             chat_session_id=message.chat_session_id,
             platform=x_app_platform,
         )
-    except Exception as exc:
+    except Exception:
         logger.exception('Failed to record chat quota question source=v2_messages uid=%s', uid)
-        raise HTTPException(
-            status_code=503,
-            detail={
-                'error': 'quota_accounting_unavailable',
-                'message': 'Usage accounting is temporarily unavailable. Please retry.',
-            },
-        ) from exc
+        response_msg = _build_quota_accounting_unavailable_reply(compat_app_id)
+
+        def _quota_accounting_unavailable_stream():
+            encoded = base64.b64encode(bytes(response_msg.model_dump_json(), 'utf-8')).decode('utf-8')
+            yield f"done: {encoded}\n\n"
+
+        return StreamingResponse(_quota_accounting_unavailable_stream(), media_type="text/event-stream")
+
+    if chat_session:
+        chat_db.add_message_to_chat_session(uid, chat_session.id, message.id)
+
+    chat_db.add_message(uid, message.model_dump())
 
     # Check for goal progress (background) — rate-limited to one call per user per 5 min
     if try_acquire_goal_extraction_lock(uid):

--- a/backend/tests/unit/test_chat_quota_counting_router.py
+++ b/backend/tests/unit/test_chat_quota_counting_router.py
@@ -124,7 +124,9 @@ def test_v2_messages_quota_exceeded_reply_does_not_record_quota_question():
 
 
 def test_v2_messages_fails_closed_when_quota_accounting_write_fails():
-    """A Firestore/outage failure recording the Free-plan counter must not start the LLM."""
+    """A Firestore/outage failure recording the Free-plan counter must not start the LLM,
+    must not persist the human turn (retry would otherwise orphan copies), and must emit an
+    SSE ``done:`` frame mobile can render — not a bare HTTP 503."""
     client, module, saved = _make_chat_client()
     try:
         stream_calls = {'n': 0}
@@ -143,11 +145,12 @@ def test_v2_messages_fails_closed_when_quota_accounting_write_fails():
             headers={'X-App-Platform': 'ios'},
         )
 
-        assert response.status_code == 503
-        body = response.json()
-        assert body['detail']['error'] == 'quota_accounting_unavailable'
+        assert response.status_code == 200
+        assert 'done: ' in response.text
         assert stream_calls['n'] == 0
         module.llm_executor.submit.assert_not_called()
+        module.chat_db.add_message.assert_not_called()
+        module.chat_db.add_message_to_chat_session.assert_not_called()
     finally:
         _cleanup(saved)
 

--- a/backend/tests/unit/test_chat_quota_counting_router.py
+++ b/backend/tests/unit/test_chat_quota_counting_router.py
@@ -123,6 +123,35 @@ def test_v2_messages_quota_exceeded_reply_does_not_record_quota_question():
         _cleanup(saved)
 
 
+def test_v2_messages_fails_closed_when_quota_accounting_write_fails():
+    """A Firestore/outage failure recording the Free-plan counter must not start the LLM."""
+    client, module, saved = _make_chat_client()
+    try:
+        stream_calls = {'n': 0}
+
+        async def tracking_stream(*args, **kwargs):
+            stream_calls['n'] += 1
+            kwargs['callback_data']['answer'] = 'should not run'
+            yield ''
+
+        module.execute_chat_stream = tracking_stream
+        module.llm_usage_db.record_chat_quota_question.side_effect = RuntimeError('firestore unavailable')
+
+        response = client.post(
+            '/v2/messages',
+            json={'text': 'hello', 'file_ids': []},
+            headers={'X-App-Platform': 'ios'},
+        )
+
+        assert response.status_code == 503
+        body = response.json()
+        assert body['detail']['error'] == 'quota_accounting_unavailable'
+        assert stream_calls['n'] == 0
+        module.llm_executor.submit.assert_not_called()
+    finally:
+        _cleanup(saved)
+
+
 def test_v2_messages_records_success_when_the_terminal_sse_frame_is_yielded():
     client, module, saved = _make_chat_client()
     try:

--- a/backend/tests/unit/test_desktop_rest_inventory.py
+++ b/backend/tests/unit/test_desktop_rest_inventory.py
@@ -196,6 +196,7 @@ KNOWN_MISSING_ROUTES: Set[str] = {
     '/v1/tools/calendar-events',
     '/v1/tools/conversations',
     '/v1/tools/conversations/search',
+    '/v1/tools/conversations/search-chunks',  # #11613 desktop client; OpenAPI export follow-up
     '/v1/tools/memories',
     '/v1/tools/memories/search',
 }


### PR DESCRIPTION
## Summary
- `/v2/messages` used to swallow `record_chat_quota_question` failures and still run the billable chat stream, so Free-plan question counters could fail open under Firestore outages.
- Recording now happens **before** persisting the human turn / session link. On failure: emit an SSE `done:` canned reply mobile can render (not a bare HTTP 503), and **do not** persist the human message (avoids orphan copies on retry).
- Voice `/v2/voice-messages` keeps best-effort recording after a visible `message:` frame (billable work already started there).
- Allowlists main-wide `#11613` desktop inventory gap (`/v1/tools/conversations/search-chunks`) so tip CI is not poisoned.

## Test plan
- [x] `pytest backend/tests/unit/test_chat_quota_counting_router.py` + `test_desktop_rest_inventory.py` (18 passed)
- [ ] CI backend unit suite on the PR
- Honest gaps: no induced Firestore outage in prod; desktop `/v2/desktop/messages` still best-effort (out of this shrink).

Failure-Class: none

Line-Count-Exception: backend/routers/chat.py | 1734 -> 1791 | Adds fail-closed quota accounting before billable `/v2/messages` turns, with SSE-visible retry copy and no orphan human persistence (#11630).