### PR TITLE
fix(web): wrapped/unlimited Open-in-Omi deep-link parity

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -167,6 +167,15 @@
                 <data
                     android:host="h.omi.me"
                     android:scheme="https"
+                    android:path="/wrapped" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="h.omi.me"
+                    android:scheme="https"
                     android:pathPattern="/tasks/.*" />
             </intent-filter>
         </activity>

--- a/web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs
+++ b/web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs
@@ -62,12 +62,14 @@ describe('wrapped / unlimited acquisition parity contract', () => {
     assert.match(wrappedSource, /getOmiPlatformDeepLink/);
     assert.match(wrappedSource, /Open in Omi/);
     assert.match(wrappedSource, /['"]wrapped['"]/);
+    assert.match(wrappedSource, /apple-itunes-app/);
     assert.doesNotMatch(wrappedSource, /Get the Omi App/);
   });
 
   it('uses platform deep-links on /unlimited instead of iOS-only omi://', () => {
     assert.match(unlimitedSource, /getOmiPlatformDeepLink/);
     assert.match(unlimitedSource, /['"]unlimited['"]/);
+    assert.match(unlimitedSource, /apple-itunes-app/);
     assert.doesNotMatch(unlimitedSource, /omi:\/\/h\.omi\.me\/unlimited/);
   });
 

--- a/web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs
+++ b/web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  getConversationSharePlatformLink,
+  getOmiPlatformDeepLink,
+} from '../lib/conversation-share-platform-link.mjs';
+
+const PLAY_FALLBACK = encodeURIComponent(
+  'https://play.google.com/store/apps/details?id=com.friend.ios',
+);
+const wrappedSource = readFileSync(new URL('../app/wrapped/page.tsx', import.meta.url), 'utf8');
+const unlimitedSource = readFileSync(
+  new URL('../app/unlimited/page.tsx', import.meta.url),
+  'utf8',
+);
+const manifestSource = readFileSync(
+  new URL('../../../../app/android/app/src/main/AndroidManifest.xml', import.meta.url),
+  'utf8',
+);
+
+describe('getOmiPlatformDeepLink (behavioral)', () => {
+  it('returns Android intent:// with Play Store fallback for marketing paths', () => {
+    const href = getOmiPlatformDeepLink(
+      'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36',
+      'unlimited',
+    );
+    assert.equal(
+      href,
+      `intent://h.omi.me/unlimited#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${PLAY_FALLBACK};end`,
+    );
+  });
+
+  it('returns iOS omi:// custom scheme for wrapped', () => {
+    const href = getOmiPlatformDeepLink(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      'wrapped',
+    );
+    assert.equal(href, 'omi://h.omi.me/wrapped');
+  });
+
+  it('returns desktop https://omi.me', () => {
+    const href = getOmiPlatformDeepLink(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15',
+      'unlimited',
+    );
+    assert.equal(href, 'https://omi.me');
+  });
+
+  it('keeps conversation share links on the shared helper', () => {
+    const href = getConversationSharePlatformLink(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      'abc-123',
+    );
+    assert.equal(href, 'omi://h.omi.me/conversations/abc-123');
+  });
+});
+
+describe('wrapped / unlimited acquisition parity contract', () => {
+  it('wires Open in Omi through getOmiPlatformDeepLink on /wrapped', () => {
+    assert.match(wrappedSource, /getOmiPlatformDeepLink/);
+    assert.match(wrappedSource, /Open in Omi/);
+    assert.match(wrappedSource, /['"]wrapped['"]/);
+    assert.doesNotMatch(wrappedSource, /Get the Omi App/);
+  });
+
+  it('uses platform deep-links on /unlimited instead of iOS-only omi://', () => {
+    assert.match(unlimitedSource, /getOmiPlatformDeepLink/);
+    assert.match(unlimitedSource, /['"]unlimited['"]/);
+    assert.doesNotMatch(unlimitedSource, /omi:\/\/h\.omi\.me\/unlimited/);
+  });
+
+  it('registers Android App Link for /wrapped', () => {
+    assert.match(manifestSource, /android:path="\/wrapped"/);
+    assert.match(manifestSource, /android:path="\/unlimited"/);
+  });
+});

--- a/web/frontend/src/app/unlimited/page.tsx
+++ b/web/frontend/src/app/unlimited/page.tsx
@@ -1,5 +1,6 @@
 import { headers } from 'next/headers';
 import { Metadata } from 'next';
+import { getOmiPlatformDeepLink } from '@/src/lib/conversation-share-platform-link.mjs';
 
 export const metadata: Metadata = {
   title: 'Omi Unlimited | Omi',
@@ -27,7 +28,7 @@ export default async function UnlimitedPage() {
   const userAgent = (await headers()).get('user-agent') || '';
   const isMobile = isMobileDevice(userAgent);
   const appStoreLink = getAppStoreLink(userAgent);
-  const deepLink = 'omi://h.omi.me/unlimited';
+  const openInOmiHref = getOmiPlatformDeepLink(userAgent, 'unlimited');
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#0B0F17] px-4 text-center">
@@ -39,7 +40,7 @@ export default async function UnlimitedPage() {
       {isMobile ? (
         <div className="flex flex-col gap-4">
           <a
-            href={deepLink}
+            href={openInOmiHref}
             className="rounded-xl bg-white px-8 py-4 text-lg font-semibold text-[#0B0F17] transition-all duration-300 hover:bg-gray-200"
           >
             Open in App

--- a/web/frontend/src/app/unlimited/page.tsx
+++ b/web/frontend/src/app/unlimited/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'Unlock the full potential with Unlimited.',
     type: 'website',
   },
+  other: {
+    'apple-itunes-app': 'app-id=6502156163',
+    'google-play-app': 'app-id=com.friend.ios',
+  },
 };
 
 function isMobileDevice(userAgent: string): boolean {

--- a/web/frontend/src/app/wrapped/page.tsx
+++ b/web/frontend/src/app/wrapped/page.tsx
@@ -1,5 +1,6 @@
 import { headers } from 'next/headers';
 import { Metadata } from 'next';
+import { getOmiPlatformDeepLink } from '@/src/lib/conversation-share-platform-link.mjs';
 
 export const metadata: Metadata = {
   title: 'Your 2025 Wrapped | Omi',
@@ -27,6 +28,7 @@ export default async function WrappedPage() {
   const userAgent = (await headers()).get('user-agent') || '';
   const isMobile = isMobileDevice(userAgent);
   const appStoreLink = getAppStoreLink(userAgent);
+  const openInOmiHref = getOmiPlatformDeepLink(userAgent, 'wrapped');
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#0B0F17] px-4 text-center">
@@ -36,14 +38,17 @@ export default async function WrappedPage() {
       </p>
 
       {isMobile ? (
-        <>
+        <div className="flex flex-col gap-4">
           <a
-            href={appStoreLink}
-            className="mb-4 rounded-xl bg-white px-8 py-4 text-lg font-semibold text-[#0B0F17] transition-all duration-300 hover:bg-gray-200"
+            href={openInOmiHref}
+            className="rounded-xl bg-white px-8 py-4 text-lg font-semibold text-[#0B0F17] transition-all duration-300 hover:bg-gray-200"
           >
-            Get the Omi App
+            Open in Omi
           </a>
-        </>
+          <a href={appStoreLink} className="text-gray-400 underline hover:text-white">
+            Don&apos;t have the app? Download here
+          </a>
+        </div>
       ) : (
         <>
           <p className="mb-6 text-gray-400">

--- a/web/frontend/src/app/wrapped/page.tsx
+++ b/web/frontend/src/app/wrapped/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     description: 'See your personalized Omi Wrapped for 2025.',
     type: 'website',
   },
+  other: {
+    'apple-itunes-app': 'app-id=6502156163',
+    'google-play-app': 'app-id=com.friend.ios',
+  },
 };
 
 function isMobileDevice(userAgent: string): boolean {

--- a/web/frontend/src/lib/conversation-share-platform-link.mjs
+++ b/web/frontend/src/lib/conversation-share-platform-link.mjs
@@ -1,7 +1,37 @@
 /**
- * Platform deep-link for shared conversation pages (mirrors chat + tasks shares).
+ * Platform deep-links for public Omi web pages (shares, unlimited, wrapped).
  * Kept as plain JS so node:test can import and assert branches without a TS loader.
  */
+
+const PLAY_STORE =
+  'https://play.google.com/store/apps/details?id=com.friend.ios';
+
+/**
+ * @param {string} userAgent
+ * @param {string} path path under h.omi.me without a leading slash (e.g. "unlimited", "conversations/abc")
+ * @returns {string}
+ */
+export function getOmiPlatformDeepLink(userAgent, path) {
+  const normalized = String(path || '')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  if (!normalized) {
+    return 'https://omi.me';
+  }
+
+  const isAndroid = /android/i.test(userAgent);
+  const isIOS = /iphone|ipad|ipod/i.test(userAgent);
+
+  // iOS: custom scheme — Universal Links do not fire for same-domain taps on h.omi.me.
+  // Android: intent:// with Play Store fallback when the app is missing.
+  return isAndroid
+    ? `intent://h.omi.me/${normalized}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
+        PLAY_STORE,
+      )};end`
+    : isIOS
+      ? `omi://h.omi.me/${normalized}`
+      : 'https://omi.me';
+}
 
 /**
  * @param {string} userAgent
@@ -9,16 +39,5 @@
  * @returns {string}
  */
 export function getConversationSharePlatformLink(userAgent, conversationId) {
-  const isAndroid = /android/i.test(userAgent);
-  const isIOS = /iphone|ipad|ipod/i.test(userAgent);
-
-  // iOS: custom scheme — Universal Links do not fire for same-domain taps on h.omi.me.
-  // Android: intent:// with Play Store fallback when the app is missing.
-  return isAndroid
-    ? `intent://h.omi.me/conversations/${conversationId}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
-        'https://play.google.com/store/apps/details?id=com.friend.ios',
-      )};end`
-    : isIOS
-    ? `omi://h.omi.me/conversations/${conversationId}`
-    : 'https://omi.me';
+  return getOmiPlatformDeepLink(userAgent, `conversations/${conversationId}`);
 }


### PR DESCRIPTION
## Summary
- `/wrapped` was store-only on mobile; now uses the same platform deep-link helper as share pages (`Open in Omi` + download fallback).
- `/unlimited` no longer hardcodes iOS-only `omi://` — Android gets `intent://` with Play Store fallback.
- AndroidManifest gains `https://h.omi.me/wrapped` App Link (unlimited already existed).

## Test plan
- [x] `node --test web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs` (+ share CTA suite still green)
- [ ] CI web / Android compile smoke
- Honest gaps: physical / on-device smoke not run (no kit). AASA / Digital Asset Links verification is post-merge.

Failure-Class: none