### PR TITLE
Cross-platform parity contracts: shared fixtures, client conformance suites, and REST route inventories

### DIFF
--- a/.github/scripts/check_agents_md_lean.py
+++ b/.github/scripts/check_agents_md_lean.py
@@ -96,7 +96,9 @@ def main() -> int:
     repo = Path(__file__).resolve().parents[2]
 
     errors: list[str] = []
-    found = {str(p.relative_to(repo)) for p in discover(repo)}
+    # as_posix keeps the keys `/`-separated on Windows too; str() would emit
+    # backslashes there and misreport every budgeted file as both new and gone.
+    found = {p.relative_to(repo).as_posix() for p in discover(repo)}
 
     # Every AGENTS.md must carry a budget, so a new guide cannot land unbounded.
     for rel in sorted(found - BUDGETS.keys()):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ These rules apply to every AI agent working in this repository. This file is **h
 | Desktop macOS (`desktop/macos/`) | `desktop/macos/AGENTS.md` — build/run, named bundles, self-testing, release pipeline, changelog |
 | Firmware (`omi/firmware/`) | `omi/firmware/AGENTS.md` — release workflow |
 | Product behavior | `PRODUCT.md` + `docs/product/invariants/` — locked invariants and guard tests |
+| A rule shared across app/macOS/Windows (buckets, day grouping, wire decode) | `contracts/parity/README.md` — shared fixtures, per-platform conformance suites, divergence register |
 | Fallback/fail-open branches | `docs/agents/fallback-telemetry.md` — when to call `record_fallback` |
 | App flows / E2E | `app/e2e/SKILL.md`, `desktop/macos/e2e/SKILL.md` |
 | Cursor Cloud VM (Linux x86) | `.cursor/cloud-agent-environment.md` — hermetic E2E harness, known failures |

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -26,8 +26,9 @@ This handles: pub get, build_runner, gen-l10n, and flavor configuration.
 
 ### Firebase Config
 Never run `flutterfire configure` — it overwrites prod credentials. Config files:
-- Dev: `ios/Config/Dev/`, `android/app/src/dev/`, `lib/firebase_options_dev.dart`
-- Prod: `ios/Config/Prod/`, `android/app/src/prod/`, `lib/firebase_options_prod.dart`
+- Dev: `android/app/src/dev/`
+- Prod: `android/app/src/prod/`
+- Local emulator: `lib/firebase_options_local.dart`
 
 ## Native Bridge
 

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -532,8 +532,8 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
                   child: provider.isLoading && provider.actionItems.isEmpty
                       ? _buildLoadingState()
                       : categorizedItems.values.every((l) => l.isEmpty)
-                      ? _buildEmptyTasksList()
-                      : _buildTasksList(categorizedItems, provider),
+                          ? _buildEmptyTasksList()
+                          : _buildTasksList(categorizedItems, provider),
                 ),
               ),
               // Hide the purple corner FAB when the empty-state already

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -14,13 +14,12 @@ import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/services/app_review_service.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/debouncer.dart';
+import 'task_categorization.dart';
 import 'widgets/action_item_form_sheet.dart';
 import 'widgets/action_item_shimmer_widget.dart';
 
 // Re-export Goal from goals.dart for use in this file
 export 'package:omi/backend/http/api/goals.dart' show Goal;
-
-enum TaskCategory { today, tomorrow, later, noDeadline, overdue }
 
 class ActionItemsPage extends StatefulWidget {
   final VoidCallback? onAddGoal;
@@ -345,48 +344,9 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     List<ActionItemWithMetadata> items,
     bool showCompleted,
   ) {
-    final now = DateTime.now();
-    final startOfToday = DateTime(now.year, now.month, now.day);
-    final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
-    final startOfDayAfterTomorrow = DateTime(now.year, now.month, now.day + 2);
-    final sevenDaysAgo = now.subtract(const Duration(days: 7));
-
-    final Map<TaskCategory, List<ActionItemWithMetadata>> categorized = {
-      TaskCategory.today: [],
-      TaskCategory.tomorrow: [],
-      TaskCategory.noDeadline: [],
-      TaskCategory.later: [],
-      TaskCategory.overdue: [],
-    };
-
-    for (var item in items) {
-      // Skip completed items unless showing completed
-      if (item.completed && !showCompleted) continue;
-      if (!item.completed && showCompleted) continue;
-
-      if (item.dueAt == null) {
-        // No deadline tasks older than 7 days go to overdue
-        if (!showCompleted && item.createdAt != null && item.createdAt!.isBefore(sevenDaysAgo)) {
-          categorized[TaskCategory.overdue]!.add(item);
-        } else {
-          categorized[TaskCategory.noDeadline]!.add(item);
-        }
-      } else {
-        final dueDate = item.dueAt!;
-        if (!showCompleted && dueDate.isBefore(startOfToday)) {
-          // Due date in the past → overdue
-          categorized[TaskCategory.overdue]!.add(item);
-        } else if (dueDate.isBefore(startOfTomorrow)) {
-          categorized[TaskCategory.today]!.add(item);
-        } else if (dueDate.isBefore(startOfDayAfterTomorrow)) {
-          categorized[TaskCategory.tomorrow]!.add(item);
-        } else {
-          categorized[TaskCategory.later]!.add(item);
-        }
-      }
-    }
-
-    return categorized;
+    // Extracted to task_categorization.dart so the bucketing rule is testable
+    // against the shared contracts/parity fixtures.
+    return categorizeTasks(items, showCompleted);
   }
 
   String _getCategoryTitle(BuildContext context, TaskCategory category) {
@@ -571,8 +531,8 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
                   child: provider.isLoading && provider.actionItems.isEmpty
                       ? _buildLoadingState()
                       : categorizedItems.values.every((l) => l.isEmpty)
-                          ? _buildEmptyTasksList()
-                          : _buildTasksList(categorizedItems, provider),
+                      ? _buildEmptyTasksList()
+                      : _buildTasksList(categorizedItems, provider),
                 ),
               ),
               // Hide the purple corner FAB when the empty-state already

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -14,6 +14,7 @@ import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/services/app_review_service.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/debouncer.dart';
+
 import 'task_categorization.dart';
 import 'widgets/action_item_form_sheet.dart';
 import 'widgets/action_item_shimmer_widget.dart';

--- a/app/lib/pages/action_items/task_categorization.dart
+++ b/app/lib/pages/action_items/task_categorization.dart
@@ -1,0 +1,67 @@
+import 'package:omi/backend/schema/schema.dart';
+
+/// Task list buckets for the action items page.
+///
+/// This is the app's `separate_overdue` model: past-due tasks get their own
+/// Overdue bucket, and tasks with no due date created more than 7 days ago age
+/// into Overdue too. macOS and Windows use the `fold_overdue` model instead
+/// (past-due folds into Today, no aging rule). Both models are pinned per case
+/// by the shared fixtures in `contracts/parity/task_due_buckets.json`; changing
+/// the rule here means editing that fixture in the same PR.
+enum TaskCategory { today, tomorrow, later, noDeadline, overdue }
+
+/// Buckets [items] by due date relative to [now] (defaults to the wall clock;
+/// injectable so the parity conformance test can run the fixture vectors).
+///
+/// Extracted from the action items page state so the rule is unit-testable.
+/// The overdue branches only apply to the open-tasks view: in the completed
+/// view a past-due task shows under Today and a stale dateless one under
+/// No deadline.
+Map<TaskCategory, List<ActionItemWithMetadata>> categorizeTasks(
+  List<ActionItemWithMetadata> items,
+  bool showCompleted, {
+  DateTime? now,
+}) {
+  final current = now ?? DateTime.now();
+  final startOfToday = DateTime(current.year, current.month, current.day);
+  final startOfTomorrow = DateTime(current.year, current.month, current.day + 1);
+  final startOfDayAfterTomorrow = DateTime(current.year, current.month, current.day + 2);
+  final sevenDaysAgo = current.subtract(const Duration(days: 7));
+
+  final Map<TaskCategory, List<ActionItemWithMetadata>> categorized = {
+    TaskCategory.today: [],
+    TaskCategory.tomorrow: [],
+    TaskCategory.noDeadline: [],
+    TaskCategory.later: [],
+    TaskCategory.overdue: [],
+  };
+
+  for (var item in items) {
+    // Skip completed items unless showing completed
+    if (item.completed && !showCompleted) continue;
+    if (!item.completed && showCompleted) continue;
+
+    if (item.dueAt == null) {
+      // No deadline tasks older than 7 days go to overdue
+      if (!showCompleted && item.createdAt != null && item.createdAt!.isBefore(sevenDaysAgo)) {
+        categorized[TaskCategory.overdue]!.add(item);
+      } else {
+        categorized[TaskCategory.noDeadline]!.add(item);
+      }
+    } else {
+      final dueDate = item.dueAt!;
+      if (!showCompleted && dueDate.isBefore(startOfToday)) {
+        // Due date in the past → overdue
+        categorized[TaskCategory.overdue]!.add(item);
+      } else if (dueDate.isBefore(startOfTomorrow)) {
+        categorized[TaskCategory.today]!.add(item);
+      } else if (dueDate.isBefore(startOfDayAfterTomorrow)) {
+        categorized[TaskCategory.tomorrow]!.add(item);
+      } else {
+        categorized[TaskCategory.later]!.add(item);
+      }
+    }
+  }
+
+  return categorized;
+}

--- a/app/test/parity/parity_contracts_test.dart
+++ b/app/test/parity/parity_contracts_test.dart
@@ -125,9 +125,9 @@ String _pad(int n) => n.toString().padLeft(2, '0');
 /// Build the item through the production wire decode so bucket cases exercise
 /// the same path a backend response takes.
 GeneratedActionItemResponse _wireItem({DateTime? due, DateTime? created}) => GeneratedActionItemResponse.fromJson({
-  'id': 'parity',
-  'description': 'parity case',
-  'completed': false,
-  if (created != null) 'created_at': created.toUtc().toIso8601String(),
-  if (due != null) 'due_at': due.toUtc().toIso8601String(),
-});
+      'id': 'parity',
+      'description': 'parity case',
+      'completed': false,
+      if (created != null) 'created_at': created.toUtc().toIso8601String(),
+      if (due != null) 'due_at': due.toUtc().toIso8601String(),
+    });

--- a/app/test/parity/parity_contracts_test.dart
+++ b/app/test/parity/parity_contracts_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/backend/schema/gen/action_items_folders_wire.g.dart';
+import 'package:omi/pages/action_items/task_categorization.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+/// Flutter conformance suite for the shared cross-platform parity contracts
+/// (contracts/parity/README.md). Runs the repo-root fixture vectors through the
+/// REAL production rules: task bucketing (categorizeTasks, this platform's
+/// separate_overdue model), local-day conversation keys
+/// (conversationLocalDayKey, the #10198 contract), and action item wire decode
+/// (GeneratedActionItemResponse.fromJson). Day-key cases execute only when the
+/// fixture covers the runner's zone offset at that instant; offset 0 is always
+/// present so UTC CI runs every case.
+void main() {
+  final root = _repoRoot();
+
+  group('task due buckets (separate_overdue model)', () {
+    final fixture = _fixture(root, 'task_due_buckets.json');
+    const bucketByName = {
+      'today': TaskCategory.today,
+      'tomorrow': TaskCategory.tomorrow,
+      'later': TaskCategory.later,
+      'no_deadline': TaskCategory.noDeadline,
+      'overdue': TaskCategory.overdue,
+    };
+    for (final raw in fixture['cases'] as List<dynamic>) {
+      final c = raw as Map<String, dynamic>;
+      test(c['name'] as String, () {
+        final now = _localFromComponents(c['now'] as List<dynamic>);
+        final due = c['due'] == null ? null : _localFromComponents(c['due'] as List<dynamic>);
+        final created = c['created'] == null ? null : _localFromComponents(c['created'] as List<dynamic>);
+        final item = _wireItem(due: due, created: created);
+
+        final categorized = categorizeTasks([item], false, now: now);
+        final actual = categorized.entries.where((e) => e.value.contains(item)).map((e) => e.key).toList();
+        final expectedName = (c['expected'] as Map<String, dynamic>)['separate_overdue'] as String;
+
+        expect(actual, [bucketByName[expectedName]!]);
+      });
+    }
+  });
+
+  group('local day keys', () {
+    final fixture = _fixture(root, 'day_keys.json');
+    for (final raw in fixture['cases'] as List<dynamic>) {
+      final c = raw as Map<String, dynamic>;
+      final instant = DateTime.parse(c['utc'] as String);
+      final offsetEast = instant.toLocal().timeZoneOffset.inMinutes;
+      final expected = (c['expected_by_offset'] as Map<String, dynamic>)['$offsetEast'] as String?;
+      test('${c['name']} (offset $offsetEast)', () {
+        final key = conversationLocalDayKey(instant);
+        expect('${key.year}-${_pad(key.month)}-${_pad(key.day)}', expected);
+      }, skip: expected == null ? 'fixture does not cover this zone offset' : false);
+    }
+  });
+
+  group('action item wire decode (parity contract)', () {
+    final fixture = _fixture(root, 'wire_action_item.json');
+    for (final raw in fixture['cases'] as List<dynamic>) {
+      final c = raw as Map<String, dynamic>;
+      test(c['name'] as String, () {
+        final expected = c['expected'] as Map<String, dynamic>;
+        final item = GeneratedActionItemResponse.fromJson(c['payload'] as Map<String, dynamic>);
+
+        expect(expected['parses'], isTrue);
+        expect(item.description, expected['description']);
+        expect(item.completed, expected['completed']);
+        final dueUtc = expected['due_utc'] as String?;
+        if (dueUtc == null) {
+          expect(item.dueAt, isNull);
+        } else {
+          expect(item.dueAt?.millisecondsSinceEpoch, DateTime.parse(dueUtc).millisecondsSinceEpoch);
+        }
+      });
+    }
+  });
+}
+
+/// Walk up from the package dir to the repo root (the dir holding
+/// contracts/parity), so the suite works from either the app dir or repo root.
+Directory _repoRoot() {
+  var dir = Directory.current.absolute;
+  for (var i = 0; i < 6; i++) {
+    if (Directory('${dir.path}${Platform.pathSeparator}contracts${Platform.pathSeparator}parity').existsSync()) {
+      return dir;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  throw StateError('contracts/parity not found above ${Directory.current.path}');
+}
+
+Map<String, dynamic> _fixture(Directory root, String name) {
+  final file = File(
+    '${root.path}${Platform.pathSeparator}contracts${Platform.pathSeparator}parity'
+    '${Platform.pathSeparator}$name',
+  );
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+/// Fixture local-time components [year, month, day, hour?, minute?] in the
+/// runner's zone (the contracts are calendar rules, zone-independent).
+DateTime _localFromComponents(List<dynamic> c) =>
+    DateTime(c[0] as int, c[1] as int, c[2] as int, c.length > 3 ? c[3] as int : 0, c.length > 4 ? c[4] as int : 0);
+
+String _pad(int n) => n.toString().padLeft(2, '0');
+
+/// Build the item through the production wire decode so bucket cases exercise
+/// the same path a backend response takes.
+GeneratedActionItemResponse _wireItem({DateTime? due, DateTime? created}) => GeneratedActionItemResponse.fromJson({
+  'id': 'parity',
+  'description': 'parity case',
+  'completed': false,
+  if (created != null) 'created_at': created.toUtc().toIso8601String(),
+  if (due != null) 'due_at': due.toUtc().toIso8601String(),
+});

--- a/app/test/parity/parity_contracts_test.dart
+++ b/app/test/parity/parity_contracts_test.dart
@@ -63,6 +63,18 @@ void main() {
     for (final raw in fixture['cases'] as List<dynamic>) {
       final c = raw as Map<String, dynamic>;
       test(c['name'] as String, () {
+        final byModel = c['expected_by_model'] as Map<String, dynamic>?;
+        if (byModel != null) {
+          // This client is the strict_decode model: a present-but-unparseable
+          // due_at rejects the whole item (see the README divergence register).
+          final strict = byModel['strict_decode'] as Map<String, dynamic>;
+          expect(strict['parses'], isFalse);
+          expect(
+            () => GeneratedActionItemResponse.fromJson(c['payload'] as Map<String, dynamic>),
+            throwsFormatException,
+          );
+          return;
+        }
         final expected = c['expected'] as Map<String, dynamic>;
         final item = GeneratedActionItemResponse.fromJson(c['payload'] as Map<String, dynamic>);
 

--- a/backend/models/action_item.py
+++ b/backend/models/action_item.py
@@ -1,10 +1,10 @@
 """Canonical action-item contracts and legacy compatibility projections."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, model_validator
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from models.task_intelligence import StableId
 
@@ -236,6 +236,17 @@ class ActionItemResponse(BaseModel):
         data.setdefault('source', 'legacy')
         data.setdefault('provenance', [])
         return data
+
+    @field_validator('due_at', 'created_at', 'updated_at', 'completed_at', 'export_date', mode='after')
+    @classmethod
+    def _naive_timestamps_are_utc(cls, value: Optional[datetime]) -> Optional[datetime]:
+        # Firestore timestamps are UTC; a naive one leaking through serializes
+        # without an offset, which Dart/JS decode as LOCAL wall time and Swift's
+        # ISO8601 decoder rejects outright. Stamp UTC so every emitted timestamp
+        # carries an explicit offset (contracts/parity/README.md).
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
 
 
 class ActionItemsResponse(BaseModel):

--- a/backend/models/action_item.py
+++ b/backend/models/action_item.py
@@ -243,8 +243,10 @@ class ActionItemResponse(BaseModel):
         # Firestore timestamps are UTC; a naive one leaking through serializes
         # without an offset, which Dart/JS decode as LOCAL wall time and Swift's
         # ISO8601 decoder rejects outright. Stamp UTC so every emitted timestamp
-        # carries an explicit offset (contracts/parity/README.md).
-        if value is not None and value.tzinfo is None:
+        # carries an explicit offset (contracts/parity/README.md). utcoffset()
+        # rather than tzinfo: a tzinfo whose utcoffset() returns None is still
+        # semantically naive and would serialize offsetless all the same.
+        if value is not None and value.utcoffset() is None:
             return value.replace(tzinfo=timezone.utc)
         return value
 

--- a/backend/tests/unit/test_flutter_rest_inventory.py
+++ b/backend/tests/unit/test_flutter_rest_inventory.py
@@ -26,14 +26,13 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
 FLUTTER_HTTP_ROOT = ROOT_DIR / 'app' / 'lib' / 'backend' / 'http'
 
-# Protocol-level exclusions, mirrored from the desktop inventories where the
-# same surface applies to this client.
-OUT_OF_SCOPE_PREFIXES = (
-    '/v2/messages/',  # SSE streaming
-    '/v2/files',  # multipart upload
-    '/v2/voice-message/transcribe-stream',  # streaming upload
-    '/v4/listen',  # WebSocket transcription socket
-)
+# Unlike the desktop inventories, every route this extractor finds is in scope:
+# the Flutter client reaches its streaming/WebSocket surfaces through other
+# bases than Env.apiBaseUrl, and the REST routes that DO appear (including
+# /v2/messages/{id}/report and /v2/files) are all modeled in the spec. Add a
+# prefix here only with a live extracted route it excludes; a prefix excluding
+# nothing is a blind spot waiting for a call site.
+OUT_OF_SCOPE_PREFIXES: tuple = ()
 
 # Client base-url roots: `dev_api.dart` / `mcp_api.dart` declare
 # `'${Env.apiBaseUrl}v1/dev'`-style prefixes and append subpaths at call sites,

--- a/backend/tests/unit/test_flutter_rest_inventory.py
+++ b/backend/tests/unit/test_flutter_rest_inventory.py
@@ -1,0 +1,124 @@
+"""Inventory + contract test for the Flutter app's Python-backend REST surface.
+
+The Flutter app (`app/lib/backend/http/`) is the primary first-party REST
+consumer of the Python backend; its routes are built as
+`'${Env.apiBaseUrl}vN/...'` string literals. This is the Flutter sibling of
+`test_desktop_rest_inventory.py` (macOS) and `test_windows_rest_inventory.py`,
+added after #11613 shipped a desktop route with no spec entry and broke that
+guard for every open PR: each first-party client needs the same inventory so a
+new client call site cannot drift from backend-owned OpenAPI authority silently.
+
+- Extracts every `${Env.apiBaseUrl}vN/...` route literal under app/lib/backend/http.
+- Normalizes Dart string interpolation (`$id` / `${expr}`) to param placeholders
+  and strips query strings.
+- Excludes out-of-scope protocols (streaming/SSE/multipart/WebSocket) and
+  asserts each in-scope route exists in the app-client OpenAPI spec.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Set
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
+FLUTTER_HTTP_ROOT = ROOT_DIR / 'app' / 'lib' / 'backend' / 'http'
+
+# Protocol-level exclusions, mirrored from the desktop inventories where the
+# same surface applies to this client.
+OUT_OF_SCOPE_PREFIXES = (
+    '/v2/messages/',  # SSE streaming
+    '/v2/files',  # multipart upload
+    '/v2/voice-message/transcribe-stream',  # streaming upload
+    '/v4/listen',  # WebSocket transcription socket
+)
+
+# Client base-url roots: `dev_api.dart` / `mcp_api.dart` declare
+# `'${Env.apiBaseUrl}v1/dev'`-style prefixes and append subpaths at call sites,
+# so the extracted string is a prefix root, not a callable route. Covering the
+# appended subpaths needs call-site-aware extraction and is a tracked extension
+# of this inventory, not silently in scope.
+BASE_URL_ROOTS = {'/v1/dev', '/v1/mcp'}
+
+# Known gaps already tracked with a follow-up owner. Add here ONLY with a note
+# naming the tracking PR/issue, exactly like the desktop inventories.
+KNOWN_MISSING_ROUTES: Set[str] = {
+    # Backend wrapped-2025 routes exist but are not exported to the app-client
+    # spec; same export-scope gap class as #11613's search-chunks incident.
+    '/v1/wrapped/2025',
+    '/v1/wrapped/2025/generate',
+}
+
+# Dart route literals: capture from `${Env.apiBaseUrl}` to the closing quote,
+# then cut at the first `?` (query strings and optional-query ternaries).
+_ROUTE_RE = re.compile(r'\$\{Env\.apiBaseUrl\}(v[0-9]/[^\'"]*)')
+_BRACED_INTERPOLATION_RE = re.compile(r'\$\{[^}]*\}')
+_SIMPLE_INTERPOLATION_RE = re.compile(r'\$[A-Za-z_][A-Za-z0-9_]*')
+_QUERY_RE = re.compile(r'\?.*$')
+
+
+def _extract_routes_from_dart(source: str) -> Set[str]:
+    routes: Set[str] = set()
+    for match in _ROUTE_RE.finditer(source):
+        route = _QUERY_RE.sub('', match.group(1))
+        route = _BRACED_INTERPOLATION_RE.sub('{param}', route)
+        # Drop any trailing unterminated interpolation the quote/query cut left.
+        route = re.sub(r'\$\{.*$', '', route)
+        route = _SIMPLE_INTERPOLATION_RE.sub('{param}', route)
+        route = re.sub(r'//+', '/', route)
+        route = '/' + route
+        if len(route) > 1 and route.endswith('/'):
+            route = route.rstrip('/')
+        routes.add(route)
+    return routes
+
+
+def _load_flutter_sources() -> str:
+    return '\n'.join(path.read_text(encoding='utf-8') for path in sorted(FLUTTER_HTTP_ROOT.rglob('*.dart')))
+
+
+def _in_scope(routes: Set[str]) -> Set[str]:
+    return {r for r in routes if not r.startswith(OUT_OF_SCOPE_PREFIXES) and r not in BASE_URL_ROOTS}
+
+
+def _load_spec_paths() -> Set[str]:
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
+    return set(spec.get('paths', {}).keys())
+
+
+def _normalize_for_match(path: str) -> str:
+    return re.sub(r'\{[^}]+\}', '{param}', path)
+
+
+def test_flutter_sources_exist_and_declare_backend_routes():
+    assert FLUTTER_HTTP_ROOT.is_dir(), 'Flutter backend http tree moved; update FLUTTER_HTTP_ROOT'
+    routes = _extract_routes_from_dart(_load_flutter_sources())
+    assert len(routes) > 20, (
+        f'route extraction found only {len(routes)} routes; the `Env.apiBaseUrl` '
+        'convention or client layout changed and the extraction regex needs updating'
+    )
+
+
+def test_every_in_scope_flutter_rest_route_exists_in_app_client_openapi():
+    routes = _in_scope(_extract_routes_from_dart(_load_flutter_sources()))
+    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
+    missing = sorted(
+        r for r in routes if _normalize_for_match(r) not in spec_normalized and r not in KNOWN_MISSING_ROUTES
+    )
+    assert not missing, (
+        'Flutter REST routes hardcoded under app/lib/backend/http are missing from the '
+        'app-client OpenAPI spec. Either add the backend route + response_model, document '
+        'the route as out of scope in OUT_OF_SCOPE_PREFIXES, or, if it is a known gap '
+        f'already tracked, add it to KNOWN_MISSING_ROUTES with a follow-up owner: {missing}'
+    )
+
+
+def test_known_missing_routes_do_not_rot():
+    """A KNOWN_MISSING entry whose route gained a spec entry (or left the code)
+    must be removed so the allowlist only ever shrinks toward zero."""
+    routes = _in_scope(_extract_routes_from_dart(_load_flutter_sources()))
+    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
+    stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _normalize_for_match(r) in spec_normalized)
+    assert not stale, f'KNOWN_MISSING_ROUTES entries no longer needed, remove them: {stale}'

--- a/backend/tests/unit/test_flutter_rest_inventory.py
+++ b/backend/tests/unit/test_flutter_rest_inventory.py
@@ -44,12 +44,7 @@ BASE_URL_ROOTS = {'/v1/dev', '/v1/mcp'}
 
 # Known gaps already tracked with a follow-up owner. Add here ONLY with a note
 # naming the tracking PR/issue, exactly like the desktop inventories.
-KNOWN_MISSING_ROUTES: Set[str] = {
-    # Backend wrapped-2025 routes exist but are not exported to the app-client
-    # spec; same export-scope gap class as #11613's search-chunks incident.
-    '/v1/wrapped/2025',
-    '/v1/wrapped/2025/generate',
-}
+KNOWN_MISSING_ROUTES: Set[str] = set()
 
 # Dart route literals: capture from `${Env.apiBaseUrl}` to the closing quote,
 # then cut at the first `?` (query strings and optional-query ternaries).
@@ -88,8 +83,19 @@ def _load_spec_paths() -> Set[str]:
     return set(spec.get('paths', {}).keys())
 
 
-def _normalize_for_match(path: str) -> str:
-    return re.sub(r'\{[^}]+\}', '{param}', path)
+def _covered_by_spec(route: str, spec_paths: Set[str]) -> bool:
+    """Segment-wise match where a spec `{param}` segment matches ANY client
+    segment, including a hardcoded literal (`/v1/wrapped/2025` is covered by
+    `/v1/wrapped/{year}` exactly as the HTTP router resolves it). A client
+    `{param}` segment still requires a spec param at that position."""
+    segments = route.split('/')
+    for spec_path in spec_paths:
+        spec_segments = spec_path.split('/')
+        if len(spec_segments) != len(segments):
+            continue
+        if all(s.startswith('{') or s == c for s, c in zip(spec_segments, segments)):
+            return True
+    return False
 
 
 def test_flutter_sources_exist_and_declare_backend_routes():
@@ -103,10 +109,8 @@ def test_flutter_sources_exist_and_declare_backend_routes():
 
 def test_every_in_scope_flutter_rest_route_exists_in_app_client_openapi():
     routes = _in_scope(_extract_routes_from_dart(_load_flutter_sources()))
-    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
-    missing = sorted(
-        r for r in routes if _normalize_for_match(r) not in spec_normalized and r not in KNOWN_MISSING_ROUTES
-    )
+    spec_paths = _load_spec_paths()
+    missing = sorted(r for r in routes if not _covered_by_spec(r, spec_paths) and r not in KNOWN_MISSING_ROUTES)
     assert not missing, (
         'Flutter REST routes hardcoded under app/lib/backend/http are missing from the '
         'app-client OpenAPI spec. Either add the backend route + response_model, document '
@@ -119,6 +123,6 @@ def test_known_missing_routes_do_not_rot():
     """A KNOWN_MISSING entry whose route gained a spec entry (or left the code)
     must be removed so the allowlist only ever shrinks toward zero."""
     routes = _in_scope(_extract_routes_from_dart(_load_flutter_sources()))
-    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
-    stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _normalize_for_match(r) in spec_normalized)
+    spec_paths = _load_spec_paths()
+    stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _covered_by_spec(r, spec_paths))
     assert not stale, f'KNOWN_MISSING_ROUTES entries no longer needed, remove them: {stale}'

--- a/backend/tests/unit/test_parity_contracts.py
+++ b/backend/tests/unit/test_parity_contracts.py
@@ -1,0 +1,149 @@
+"""Conformance + integrity tests for the shared cross-platform parity contracts
+(contracts/parity/README.md).
+
+The backend owns two legs:
+
+- Fixture integrity: every fixture parses, expectations are complete and use the
+  sanctioned vocabulary, and the day-key vectors are arithmetically
+  self-consistent. The client suites all trust these files, so a malformed or
+  self-contradictory fixture would let every platform pass vacuously at once;
+  this suite is the independent check that the vectors themselves are true.
+- The serialization side of the action-item wire contract: ActionItemResponse
+  timestamps always serialize with an explicit UTC offset. Dart and JS interpret
+  a naive ISO string as LOCAL wall time while Swift's ISO8601 decoder rejects it
+  outright, so a naive emission is the one wire form guaranteed to diverge
+  across first-party clients.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from models.action_item import ActionItemResponse
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+PARITY_DIR = ROOT_DIR / 'contracts' / 'parity'
+
+BUCKET_VOCABULARY = {'today', 'tomorrow', 'later', 'no_deadline', 'overdue'}
+# The parseable due_at forms in the wire fixture; the remaining cases exist to
+# pin CLIENT-side tolerance for junk the backend itself refuses to emit.
+CLIENT_ONLY_WIRE_CASES = {'due_empty_string', 'due_unparseable_string'}
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((PARITY_DIR / name).read_text(encoding='utf-8'))
+
+
+def test_bucket_fixture_expectations_are_complete():
+    cases = _fixture('task_due_buckets.json')['cases']
+    assert cases, 'bucket fixture must not be empty'
+    seen = set()
+    for case in cases:
+        assert case['name'] not in seen, f"duplicate case name {case['name']}"
+        seen.add(case['name'])
+        assert 'now' in case and 'due' in case and 'created' in case, case['name']
+        expected = case['expected']
+        # Every case pins BOTH sanctioned models so a platform switching models
+        # is a fixture edit, not silent drift.
+        assert set(expected) == {'fold_overdue', 'separate_overdue'}, case['name']
+        for model, bucket in expected.items():
+            assert bucket in BUCKET_VOCABULARY, f"{case['name']}: {bucket}"
+        # The fold model has no overdue bucket by definition.
+        assert expected['fold_overdue'] != 'overdue', case['name']
+
+
+def test_day_key_fixture_is_arithmetically_consistent():
+    cases = _fixture('day_keys.json')['cases']
+    assert cases, 'day-key fixture must not be empty'
+    for case in cases:
+        instant = datetime.fromisoformat(case['utc'].replace('Z', '+00:00'))
+        offsets = case['expected_by_offset']
+        assert '0' in offsets, f"{case['name']}: offset 0 must be present so UTC CI runs every case"
+        for offset_minutes, expected_day in offsets.items():
+            local = instant + timedelta(minutes=int(offset_minutes))
+            assert local.date().isoformat() == expected_day, (
+                f"{case['name']} offset {offset_minutes}: fixture says {expected_day}, "
+                f"arithmetic says {local.date().isoformat()}"
+            )
+
+
+def test_label_fixture_structure():
+    cases = _fixture('section_labels.json')['cases']
+    assert cases, 'label fixture must not be empty'
+    for case in cases:
+        labels = case['labels']
+        assert set(labels) == {'conversation_section', 'due_badge'}, case['name']
+        for value in labels.values():
+            assert value is None or value in {'Today', 'Yesterday', 'Tomorrow'}, f"{case['name']}: {value}"
+        if 'requires_dst_transition_between' in case:
+            pair = case['requires_dst_transition_between']
+            assert len(pair) == 2, case['name']
+            for day in pair:
+                datetime(day[0], day[1], day[2])  # must be a real calendar day
+
+
+def test_wire_fixture_field_names_exist_on_backend_model():
+    """Guards fixture rot: if the backend renames a serialized field, the wire
+    fixture must move with it instead of silently testing a dead key."""
+    known_fields = set(ActionItemResponse.model_fields)
+    for case in _fixture('wire_action_item.json')['cases']:
+        for key in case['payload']:
+            if key.startswith('parity_probe_'):
+                continue  # the deliberate unknown-field tolerance probe
+            assert key in known_fields, f"{case['name']}: payload key {key} is not an ActionItemResponse field"
+
+
+def test_backend_round_trips_the_parseable_wire_cases():
+    for case in _fixture('wire_action_item.json')['cases']:
+        if case['name'] in CLIENT_ONLY_WIRE_CASES:
+            continue
+        item = ActionItemResponse.model_validate(case['payload'])
+        dumped = item.model_dump(mode='json')
+        expected = case['expected']
+        assert dumped['description'] == expected['description'], case['name']
+        assert dumped['completed'] == expected['completed'], case['name']
+        if expected['due_utc'] is None:
+            assert dumped['due_at'] is None, case['name']
+        else:
+            emitted = datetime.fromisoformat(dumped['due_at'].replace('Z', '+00:00'))
+            target = datetime.fromisoformat(expected['due_utc'].replace('Z', '+00:00'))
+            assert emitted == target, case['name']
+
+
+def test_backend_rejects_the_client_only_junk_forms():
+    """Clients tolerate junk due_at strings defensively; the backend must never
+    accept (and therefore never re-emit) them."""
+    cases = {c['name']: c for c in _fixture('wire_action_item.json')['cases']}
+    for name in CLIENT_ONLY_WIRE_CASES:
+        with pytest.raises(Exception):
+            ActionItemResponse.model_validate(cases[name]['payload'])
+
+
+@pytest.mark.parametrize('field', ['due_at', 'created_at', 'updated_at', 'completed_at'])
+def test_naive_datetimes_serialize_with_an_explicit_utc_offset(field):
+    """Firestore timestamps are UTC; if a naive datetime reaches the response
+    model it must serialize as that UTC instant with an explicit offset, never
+    as an offsetless local-looking string."""
+    naive = datetime(2026, 8, 20, 16, 0, 0)
+    item = ActionItemResponse.model_validate(
+        {'id': 'ai_parity_naive', 'description': 'naive timestamp', 'completed': False, field: naive}
+    )
+    emitted = item.model_dump(mode='json')[field]
+    assert emitted.endswith('Z') or '+00:00' in emitted, (
+        f"{field} serialized without an offset: {emitted!r}; Dart/JS read this as local wall "
+        "time and Swift ISO8601 decoding rejects it (contracts/parity/README.md)"
+    )
+    assert datetime.fromisoformat(emitted.replace('Z', '+00:00')) == naive.replace(tzinfo=timezone.utc)
+
+
+def test_aware_datetimes_keep_their_instant():
+    aware = datetime(2026, 8, 20, 18, 0, 0, tzinfo=timezone(timedelta(hours=2)))
+    item = ActionItemResponse.model_validate(
+        {'id': 'ai_parity_aware', 'description': 'aware timestamp', 'completed': False, 'due_at': aware}
+    )
+    emitted = item.model_dump(mode='json')['due_at']
+    assert datetime.fromisoformat(emitted.replace('Z', '+00:00')) == aware

--- a/backend/tests/unit/test_parity_contracts.py
+++ b/backend/tests/unit/test_parity_contracts.py
@@ -29,9 +29,6 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 PARITY_DIR = ROOT_DIR / 'contracts' / 'parity'
 
 BUCKET_VOCABULARY = {'today', 'tomorrow', 'later', 'no_deadline', 'overdue'}
-# The parseable due_at forms in the wire fixture; the remaining cases exist to
-# pin CLIENT-side tolerance for junk the backend itself refuses to emit.
-CLIENT_ONLY_WIRE_CASES = {'due_empty_string', 'due_unparseable_string'}
 
 
 def _fixture(name: str) -> dict:
@@ -97,10 +94,10 @@ def test_wire_fixture_field_names_exist_on_backend_model():
             assert key in known_fields, f"{case['name']}: payload key {key} is not an ActionItemResponse field"
 
 
-def test_backend_round_trips_the_parseable_wire_cases():
+def test_backend_round_trips_the_agreement_set_wire_cases():
     for case in _fixture('wire_action_item.json')['cases']:
-        if case['name'] in CLIENT_ONLY_WIRE_CASES:
-            continue
+        if 'expected_by_model' in case:
+            continue  # strict-vs-tolerant divergence cases, covered below
         item = ActionItemResponse.model_validate(case['payload'])
         dumped = item.model_dump(mode='json')
         expected = case['expected']
@@ -114,13 +111,18 @@ def test_backend_round_trips_the_parseable_wire_cases():
             assert emitted == target, case['name']
 
 
-def test_backend_rejects_the_client_only_junk_forms():
-    """Clients tolerate junk due_at strings defensively; the backend must never
-    accept (and therefore never re-emit) them."""
-    cases = {c['name']: c for c in _fixture('wire_action_item.json')['cases']}
-    for name in CLIENT_ONLY_WIRE_CASES:
+def test_backend_rejects_the_divergence_case_junk_forms():
+    """The expected_by_model cases pin the strict-vs-tolerant client split on
+    unparseable due_at strings (Dart wire rejects the item, Windows maps it to
+    no-due-date). The backend sits on the strict side: it must never accept,
+    and therefore never re-emit, these forms."""
+    divergence_cases = [c for c in _fixture('wire_action_item.json')['cases'] if 'expected_by_model' in c]
+    assert divergence_cases, 'expected the strict-vs-tolerant wire cases to exist'
+    for case in divergence_cases:
+        assert case['expected_by_model']['strict_decode']['parses'] is False, case['name']
+        assert case['expected_by_model']['tolerant_decode']['parses'] is True, case['name']
         with pytest.raises(Exception):
-            ActionItemResponse.model_validate(cases[name]['payload'])
+            ActionItemResponse.model_validate(case['payload'])
 
 
 @pytest.mark.parametrize('field', ['due_at', 'created_at', 'updated_at', 'completed_at'])

--- a/backend/tests/unit/test_parity_contracts.py
+++ b/backend/tests/unit/test_parity_contracts.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from models.action_item import ActionItemResponse
 
@@ -121,7 +122,9 @@ def test_backend_rejects_the_divergence_case_junk_forms():
     for case in divergence_cases:
         assert case['expected_by_model']['strict_decode']['parses'] is False, case['name']
         assert case['expected_by_model']['tolerant_decode']['parses'] is True, case['name']
-        with pytest.raises(Exception):
+        # ValidationError specifically: a broader except would also swallow a
+        # rotted fixture (missing keys raise KeyError above, loudly).
+        with pytest.raises(ValidationError):
             ActionItemResponse.model_validate(case['payload'])
 
 
@@ -149,3 +152,27 @@ def test_aware_datetimes_keep_their_instant():
     )
     emitted = item.model_dump(mode='json')['due_at']
     assert datetime.fromisoformat(emitted.replace('Z', '+00:00')) == aware
+
+
+def test_semantically_naive_tzinfo_serializes_with_an_explicit_utc_offset():
+    """A tzinfo whose utcoffset() returns None is still naive for serialization
+    purposes; the guard must key off utcoffset(), not tzinfo presence."""
+    import datetime as datetime_module
+
+    class _OffsetlessTzinfo(datetime_module.tzinfo):
+        def utcoffset(self, dt):
+            return None
+
+        def dst(self, dt):
+            return None
+
+        def tzname(self, dt):
+            return 'offsetless'
+
+    semi_naive = datetime(2026, 8, 20, 16, 0, 0, tzinfo=_OffsetlessTzinfo())
+    item = ActionItemResponse.model_validate(
+        {'id': 'ai_parity_semi', 'description': 'semantically naive', 'completed': False, 'due_at': semi_naive}
+    )
+    emitted = item.model_dump(mode='json')['due_at']
+    assert emitted.endswith('Z') or '+00:00' in emitted, f'no offset emitted: {emitted!r}'
+    assert datetime.fromisoformat(emitted.replace('Z', '+00:00')) == semi_naive.replace(tzinfo=timezone.utc)

--- a/backend/tests/unit/test_windows_rest_inventory.py
+++ b/backend/tests/unit/test_windows_rest_inventory.py
@@ -1,0 +1,152 @@
+"""Inventory + contract test for the Windows desktop app's Python-backend REST surface.
+
+The Windows app (`desktop/windows/src/`) is a first-party REST consumer of the
+Python backend: the renderer calls it through the `omiApi` client and the main
+process through `apiFetch`/`net.fetch` (task sync, assistants). Its routes map to
+the same Firebase-auth app-client OpenAPI surface the Flutter and macOS apps use
+(`docs/api-reference/app-client-openapi.json`).
+
+This is the Windows sibling of `test_desktop_rest_inventory.py` (macOS), added
+after #11613 shipped a desktop route with no spec entry and broke that guard for
+every open PR: each first-party client needs the same inventory so a new client
+call site cannot drift from backend-owned OpenAPI authority silently.
+
+- Extracts every `/vN/...` route literal hardcoded under `desktop/windows/src`.
+- Excludes out-of-scope protocols (Rust desktop backend, streaming/SSE,
+  multipart, WebSocket) via the same prefix list the macOS inventory uses.
+- Asserts each in-scope route exists in the app-client OpenAPI spec.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Set
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+SPEC_PATH = ROOT_DIR / 'docs' / 'api-reference' / 'app-client-openapi.json'
+WINDOWS_SOURCE_ROOT = ROOT_DIR / 'desktop' / 'windows' / 'src'
+
+# Route prefixes that belong to other service boundaries / protocols, mirrored
+# from test_desktop_rest_inventory.py (macOS): the Windows app talks to the same
+# Rust desktop backend + streaming surfaces that are out of scope for the
+# Python-backend REST SSoT.
+OUT_OF_SCOPE_PREFIXES = (
+    '/v2/realtime',  # Rust desktop backend
+    '/v2/agent',  # Rust desktop backend / agent VM
+    '/v1/config/api-keys',  # Rust desktop backend
+    '/v1/x/',  # integration OAuth (desktop-mediated)
+    '/v1/tts/synthesize',  # Rust desktop backend
+    '/v2/chat/',  # streaming chat / Rust
+    '/v2/chat-sessions',  # Rust desktop backend
+    '/v2/desktop/',  # Rust desktop backend
+    '/v2/messages/',  # SSE streaming
+    '/v2/files',  # multipart upload
+    '/v2/apps',  # Rust-proxied app routes
+    '/v2/voice-message/transcribe-stream',  # streaming upload; spec models only the non-streaming sibling
+    '/v4/listen',  # WebSocket transcription socket
+)
+
+# Known gaps already tracked with a follow-up owner. Add here ONLY with a note
+# naming the tracking PR/issue, exactly like the macOS inventory's list. These
+# entries mirror test_desktop_rest_inventory.py: the same backend surfaces are
+# consumed by both desktop clients and carry the same follow-up.
+KNOWN_MISSING_ROUTES: Set[str] = {
+    # Backend routers exist (routers/auto_model.py, google-calendar integration)
+    # but the routes are not exported to the app-client spec yet; same
+    # export-scope gap class as #11613's search-chunks incident.
+    '/v1/auto/model-pick',
+    '/v1/integrations/google_calendar',
+    '/v1/integrations/google_calendar/oauth-url',
+    # These backend routes exist but return unmodeled (loose) responses, so
+    # adding them to the app-client surface would regress the strict
+    # `unmodeled_success_response_count == 0` gate (see the macOS inventory's
+    # identical entries). Tracked for the response_model-first follow-up.
+    '/v1/personas',
+    '/v1/staged-tasks',
+    '/v1/staged-tasks/promote',
+    '/v1/tools/conversations',
+    '/v1/tools/conversations/search',
+    '/v1/tools/memories',
+    '/v1/tools/memories/search',
+}
+
+# TS/TSX route literals: '/v1/...' in any quote style including template
+# literals; `${expr}` interpolation becomes an OpenAPI-style param placeholder.
+_ROUTE_RE = re.compile(r'[\'"`](/v[0-9]/[^\'"`\s]*)')
+_TEMPLATE_INTERPOLATION_RE = re.compile(r'\$\{[^}]*\}')
+_QUERY_RE = re.compile(r'\?.*$')
+
+
+def _extract_routes_from_typescript(source: str) -> Set[str]:
+    routes: Set[str] = set()
+    for match in _ROUTE_RE.finditer(source):
+        route = match.group(1)
+        if '*' in route:
+            # Wildcard PATTERNS (route-policy comments/docs), not callable paths.
+            continue
+        route = _TEMPLATE_INTERPOLATION_RE.sub('{param}', route)
+        route = _QUERY_RE.sub('', route)
+        # Drop any trailing unterminated interpolation fragment the quote scan
+        # cut through (e.g. a ternary building an optional query suffix).
+        route = re.sub(r'\$\{.*$', '', route)
+        route = re.sub(r'//+', '/', route)
+        if len(route) > 1 and route.endswith('/'):
+            route = route.rstrip('/')
+        routes.add(route)
+    return routes
+
+
+def _load_windows_sources() -> str:
+    chunks = []
+    for pattern in ('**/*.ts', '**/*.tsx'):
+        for path in sorted(WINDOWS_SOURCE_ROOT.glob(pattern)):
+            if path.name.endswith(('.test.ts', '.test.tsx', '.generated.ts')):
+                # Generated clients mirror the spec by construction; tests may
+                # exercise fixture routes that are not product surface.
+                continue
+            chunks.append(path.read_text(encoding='utf-8'))
+    return '\n'.join(chunks)
+
+
+def _in_scope(routes: Set[str]) -> Set[str]:
+    return {r for r in routes if not r.startswith(OUT_OF_SCOPE_PREFIXES)}
+
+
+def _load_spec_paths() -> Set[str]:
+    spec = json.loads(SPEC_PATH.read_text(encoding='utf-8'))
+    return set(spec.get('paths', {}).keys())
+
+
+def _normalize_for_match(path: str) -> str:
+    return re.sub(r'\{[^}]+\}', '{param}', path)
+
+
+def test_windows_sources_exist_and_declare_backend_routes():
+    assert WINDOWS_SOURCE_ROOT.is_dir(), 'Windows desktop source tree moved; update WINDOWS_SOURCE_ROOT'
+    routes = _extract_routes_from_typescript(_load_windows_sources())
+    assert routes, 'route extraction found nothing; the extraction regex or client layout changed'
+
+
+def test_every_in_scope_windows_rest_route_exists_in_app_client_openapi():
+    routes = _in_scope(_extract_routes_from_typescript(_load_windows_sources()))
+    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
+    missing = sorted(
+        r for r in routes if _normalize_for_match(r) not in spec_normalized and r not in KNOWN_MISSING_ROUTES
+    )
+    assert not missing, (
+        'Windows REST routes hardcoded under desktop/windows/src are missing from the '
+        'app-client OpenAPI spec. Either add the backend route + response_model, document '
+        'the route as out of scope in OUT_OF_SCOPE_PREFIXES, or, if it is a known gap '
+        f'already tracked, add it to KNOWN_MISSING_ROUTES with a follow-up owner: {missing}'
+    )
+
+
+def test_known_missing_routes_do_not_rot():
+    """A KNOWN_MISSING entry whose route gained a spec entry (or left the code)
+    must be removed so the allowlist only ever shrinks toward zero."""
+    routes = _in_scope(_extract_routes_from_typescript(_load_windows_sources()))
+    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
+    stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _normalize_for_match(r) in spec_normalized)
+    assert not stale, f'KNOWN_MISSING_ROUTES entries no longer needed, remove them: {stale}'

--- a/backend/tests/unit/test_windows_rest_inventory.py
+++ b/backend/tests/unit/test_windows_rest_inventory.py
@@ -53,12 +53,10 @@ OUT_OF_SCOPE_PREFIXES = (
 # entries mirror test_desktop_rest_inventory.py: the same backend surfaces are
 # consumed by both desktop clients and carry the same follow-up.
 KNOWN_MISSING_ROUTES: Set[str] = {
-    # Backend routers exist (routers/auto_model.py, google-calendar integration)
-    # but the routes are not exported to the app-client spec yet; same
-    # export-scope gap class as #11613's search-chunks incident.
+    # Backend router exists (routers/auto_model.py) but the route is not
+    # exported to the app-client spec yet; same export-scope gap class as
+    # #11613's search-chunks incident.
     '/v1/auto/model-pick',
-    '/v1/integrations/google_calendar',
-    '/v1/integrations/google_calendar/oauth-url',
     # These backend routes exist but return unmodeled (loose) responses, so
     # adding them to the app-client surface would regress the strict
     # `unmodeled_success_response_count == 0` gate (see the macOS inventory's
@@ -119,22 +117,35 @@ def _load_spec_paths() -> Set[str]:
     return set(spec.get('paths', {}).keys())
 
 
-def _normalize_for_match(path: str) -> str:
-    return re.sub(r'\{[^}]+\}', '{param}', path)
+def _covered_by_spec(route: str, spec_paths: Set[str]) -> bool:
+    """Segment-wise match where a spec `{param}` segment matches ANY client
+    segment, including a hardcoded literal, exactly as the HTTP router resolves
+    the path. A client `{param}` segment still requires a spec param there."""
+    segments = route.split('/')
+    for spec_path in spec_paths:
+        spec_segments = spec_path.split('/')
+        if len(spec_segments) != len(segments):
+            continue
+        if all(s.startswith('{') or s == c for s, c in zip(spec_segments, segments)):
+            return True
+    return False
 
 
 def test_windows_sources_exist_and_declare_backend_routes():
     assert WINDOWS_SOURCE_ROOT.is_dir(), 'Windows desktop source tree moved; update WINDOWS_SOURCE_ROOT'
-    routes = _extract_routes_from_typescript(_load_windows_sources())
-    assert routes, 'route extraction found nothing; the extraction regex or client layout changed'
+    routes = _in_scope(_extract_routes_from_typescript(_load_windows_sources()))
+    # A bare non-empty assertion lets the extractor silently regress to a single
+    # route; the floor keeps the extraction honest (currently ~60 in scope).
+    assert len(routes) >= 20, (
+        f'route extraction found only {len(routes)} in-scope routes; the extraction '
+        'regex or client layout changed and the extractor needs updating'
+    )
 
 
 def test_every_in_scope_windows_rest_route_exists_in_app_client_openapi():
     routes = _in_scope(_extract_routes_from_typescript(_load_windows_sources()))
-    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
-    missing = sorted(
-        r for r in routes if _normalize_for_match(r) not in spec_normalized and r not in KNOWN_MISSING_ROUTES
-    )
+    spec_paths = _load_spec_paths()
+    missing = sorted(r for r in routes if not _covered_by_spec(r, spec_paths) and r not in KNOWN_MISSING_ROUTES)
     assert not missing, (
         'Windows REST routes hardcoded under desktop/windows/src are missing from the '
         'app-client OpenAPI spec. Either add the backend route + response_model, document '
@@ -147,6 +158,6 @@ def test_known_missing_routes_do_not_rot():
     """A KNOWN_MISSING entry whose route gained a spec entry (or left the code)
     must be removed so the allowlist only ever shrinks toward zero."""
     routes = _in_scope(_extract_routes_from_typescript(_load_windows_sources()))
-    spec_normalized = {_normalize_for_match(p) for p in _load_spec_paths()}
-    stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _normalize_for_match(r) in spec_normalized)
+    spec_paths = _load_spec_paths()
+    stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _covered_by_spec(r, spec_paths))
     assert not stale, f'KNOWN_MISSING_ROUTES entries no longer needed, remove them: {stale}'

--- a/backend/tests/unit/test_windows_rest_inventory.py
+++ b/backend/tests/unit/test_windows_rest_inventory.py
@@ -34,14 +34,11 @@ WINDOWS_SOURCE_ROOT = ROOT_DIR / 'desktop' / 'windows' / 'src'
 # Python-backend REST SSoT.
 OUT_OF_SCOPE_PREFIXES = (
     '/v2/realtime',  # Rust desktop backend
-    '/v2/agent',  # Rust desktop backend / agent VM
-    '/v1/config/api-keys',  # Rust desktop backend
     '/v1/x/',  # integration OAuth (desktop-mediated)
     '/v1/tts/synthesize',  # Rust desktop backend
     '/v2/chat/',  # streaming chat / Rust
     '/v2/chat-sessions',  # Rust desktop backend
     '/v2/desktop/',  # Rust desktop backend
-    '/v2/messages/',  # SSE streaming
     '/v2/files',  # multipart upload
     '/v2/apps',  # Rust-proxied app routes
     '/v2/voice-message/transcribe-stream',  # streaming upload; spec models only the non-streaming sibling
@@ -161,3 +158,12 @@ def test_known_missing_routes_do_not_rot():
     spec_paths = _load_spec_paths()
     stale = sorted(r for r in KNOWN_MISSING_ROUTES if r not in routes or _covered_by_spec(r, spec_paths))
     assert not stale, f'KNOWN_MISSING_ROUTES entries no longer needed, remove them: {stale}'
+
+
+def test_out_of_scope_prefixes_match_at_least_one_route():
+    """Mirrors the macOS inventory's rot guard: a prefix excluding nothing is a
+    dead entry that silently widens the blind spot if that surface ever gains a
+    Windows call site."""
+    routes = _extract_routes_from_typescript(_load_windows_sources())
+    dead = sorted(p for p in OUT_OF_SCOPE_PREFIXES if not any(r.startswith(p) for r in routes))
+    assert not dead, f'OUT_OF_SCOPE_PREFIXES entries match no extracted route, remove them: {dead}'

--- a/contracts/parity/README.md
+++ b/contracts/parity/README.md
@@ -29,7 +29,7 @@ cross-platform decision instead of a single-platform drive-by.
 | Backend (fixture integrity + serialization contract) | `backend/tests/unit/test_parity_contracts.py` | `backend/test.sh`, CI Backend unit suite |
 | Flutter app | `app/test/parity/parity_contracts_test.dart` | `app/test.sh`, CI Flutter tests |
 | Windows desktop | `desktop/windows/src/renderer/src/lib/parityContracts.test.ts` | `npm test` in `desktop/windows`, CI Desktop Windows tests |
-| macOS desktop | Adapter pending. The fixtures already encode the macOS model (`fold_overdue`, `categoryFor` in `desktop/macos/Desktop/Sources/TasksPage.swift`); a `ParityContractsTests.swift` reading this directory is the follow-up for a machine that can run the Swift test lane. |
+| macOS desktop | Adapter pending. The fixtures already encode the macOS model (`fold_overdue`, `categoryFor` in `desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift`); a `ParityContractsTests.swift` reading this directory is the follow-up for a machine that can run the Swift test lane. |
 
 The backend suite validates every fixture file structurally (parseable, complete
 expectations, self-consistent day-key arithmetic) so a malformed fixture cannot pass
@@ -48,7 +48,7 @@ in the same PR.
 1. Overdue model. The Flutter app (`app/lib/pages/action_items/task_categorization.dart`)
    uses a separate Overdue bucket: past-due tasks go to Overdue, and tasks with no due
    date created more than 7 days ago age into Overdue. macOS (`categoryFor`,
-   TasksPage.swift) and Windows (`lib/taskBuckets.ts`) fold past-due into Today and have
+   `desktop/macos/Desktop/Sources/MainWindow/Pages/TasksPage.swift`) and Windows (`lib/taskBuckets.ts`) fold past-due into Today and have
    no aging rule. The Windows comment previously claimed the fold model matched the
    Flutter app; it does not, and `task_due_buckets.json` pins BOTH models per case so the
    difference is explicit until product picks one.

--- a/contracts/parity/README.md
+++ b/contracts/parity/README.md
@@ -59,6 +59,15 @@ in the same PR.
 3. Completed view overdue. The Flutter overdue branches are skipped when viewing
    completed tasks (a completed past-due task shows under Today, a completed stale
    dateless task under No deadline). Bucket fixtures therefore model the open-tasks view.
+4. Junk due_at strings (strict vs tolerant decode). A present-but-unparseable
+   due_at ("", "not-a-date") makes the Dart generated wire reject the WHOLE item
+   with a FormatException (its field reader treats a non-null field that reads to
+   null as invalid), while the Windows sync mapper maps it to no-due-date and keeps
+   the item. Found by this fixture set's first CI run: one corrupt timestamp in a
+   list response breaks the app's decode path but not Windows sync. The backend
+   sits on the strict side (it refuses to accept these forms, so it can never
+   re-emit them); the `expected_by_model` cases in `wire_action_item.json` pin
+   both client behaviors until the platforms converge.
 
 ## Adding or changing a case
 

--- a/contracts/parity/README.md
+++ b/contracts/parity/README.md
@@ -1,0 +1,72 @@
+# Cross-platform parity contracts
+
+Omi ships the same product on Flutter (iOS/Android), macOS, and Windows, backed by one
+Python backend. The recurring failure mode is a rule that gets fixed or changed on one
+platform and silently diverges on another: local-day grouping was fixed for the app in
+#10198 and again for macOS in #10980 and #10984, the Windows task bucketing comment
+claims it mirrors the Flutter app while the app actually uses a different model (see
+Divergence register below), and #11613 added a desktop route with no backend spec entry,
+breaking an inventory guard for every open PR.
+
+This directory holds the shared, platform-neutral fixture set for those rules. Each
+platform runs the SAME vectors through its OWN production code in its own test suite.
+A behavior change now requires editing a fixture here, which shows up in review as a
+cross-platform decision instead of a single-platform drive-by.
+
+## Fixture files
+
+| File | Rule under contract |
+|---|---|
+| `task_due_buckets.json` | Task due-date bucketing (Today / Tomorrow / Later / No deadline, and the overdue handling models) |
+| `day_keys.json` | Local-calendar-day identity of a UTC instant (conversation day grouping) |
+| `wire_action_item.json` | Action item wire decode: due_at instant equality across ISO offset forms, and the null / missing / unparseable agreement set |
+| `section_labels.json` | Relative day labels (Today / Yesterday / Tomorrow) as calendar-day relationships, including DST transition days |
+
+## Conformance suites
+
+| Platform | Suite | Runs |
+|---|---|---|
+| Backend (fixture integrity + serialization contract) | `backend/tests/unit/test_parity_contracts.py` | `backend/test.sh`, CI Backend unit suite |
+| Flutter app | `app/test/parity/parity_contracts_test.dart` | `app/test.sh`, CI Flutter tests |
+| Windows desktop | `desktop/windows/src/renderer/src/lib/parityContracts.test.ts` | `npm test` in `desktop/windows`, CI Desktop Windows tests |
+| macOS desktop | Adapter pending. The fixtures already encode the macOS model (`fold_overdue`, `categoryFor` in `desktop/macos/Desktop/Sources/TasksPage.swift`); a `ParityContractsTests.swift` reading this directory is the follow-up for a machine that can run the Swift test lane. |
+
+The backend suite validates every fixture file structurally (parseable, complete
+expectations, self-consistent day-key arithmetic) so a malformed fixture cannot pass
+vacuously on all clients at once, and pins the backend serialization side: due_at is
+always emitted as an ISO-8601 instant with an explicit offset. Naive datetimes are the
+one wire form the clients do NOT agree on (Dart and JS interpret them as local time,
+Swift ISO8601 decoding rejects them), so the backend emitting them is the bug the
+serialization contract exists to catch.
+
+## Divergence register
+
+Divergences that exist in production today. Each is encoded in the fixtures rather than
+papered over; resolving one means changing the losing platform and updating the fixture
+in the same PR.
+
+1. Overdue model. The Flutter app (`app/lib/pages/action_items/task_categorization.dart`)
+   uses a separate Overdue bucket: past-due tasks go to Overdue, and tasks with no due
+   date created more than 7 days ago age into Overdue. macOS (`categoryFor`,
+   TasksPage.swift) and Windows (`lib/taskBuckets.ts`) fold past-due into Today and have
+   no aging rule. The Windows comment previously claimed the fold model matched the
+   Flutter app; it does not, and `task_due_buckets.json` pins BOTH models per case so the
+   difference is explicit until product picks one.
+2. Missing created_at. The Windows sync mapper (`taskSyncEngine.ts` `mapBackendItem`)
+   fills a missing created_at with the sync timestamp because its local store requires
+   one; the Dart wire model keeps it null. Consumers must not treat the Windows value as
+   a backend fact.
+3. Completed view overdue. The Flutter overdue branches are skipped when viewing
+   completed tasks (a completed past-due task shows under Today, a completed stale
+   dateless task under No deadline). Bucket fixtures therefore model the open-tasks view.
+
+## Adding or changing a case
+
+1. Edit the fixture file here. Keep times as local calendar components (or UTC instants
+   with per-offset expectations in `day_keys.json`); never bake one zone's epoch values
+   into a shared expectation.
+2. Run the backend integrity test, then each platform suite. Every adapter loads the
+   fixture by relative path from the repo root, so there is nothing to regenerate.
+3. If a platform legitimately disagrees, add a model column (as `task_due_buckets.json`
+   does) and record it in the Divergence register with the owning files. Do not fork the
+   fixture per platform.

--- a/contracts/parity/day_keys.json
+++ b/contracts/parity/day_keys.json
@@ -1,0 +1,60 @@
+{
+  "$comment": "Local-calendar-day identity for a UTC instant. This is the rule behind conversation day grouping on every platform (Flutter conversationLocalDayKey, Windows startOfLocalDay/groupConversationsByDate) and the class of bug fixed in #10198, #10980 and #10984 (UTC day used where the local day was meant). Because implementations use the runtime's own zone, expectations are keyed by the zone offset IN EFFECT AT THAT INSTANT, in minutes east of UTC (JS: -date.getTimezoneOffset(); Dart: local.timeZoneOffset.inMinutes). An adapter runs each case whose map contains the runtime's offset and counts the rest as skipped; offset 0 is always present so CI (UTC) always exercises every case. Offsets included: 0 (UTC), -420 (US Pacific DST), -480 (US Pacific standard), 120 (central Europe DST), 345 (Nepal).",
+  "cases": [
+    {
+      "name": "early_utc_morning_crosses_backward",
+      "utc": "2026-08-15T03:30:00Z",
+      "expected_by_offset": {
+        "0": "2026-08-15",
+        "-420": "2026-08-14",
+        "-480": "2026-08-14",
+        "120": "2026-08-15",
+        "345": "2026-08-15"
+      }
+    },
+    {
+      "name": "late_utc_evening_crosses_forward",
+      "utc": "2026-08-15T23:30:00Z",
+      "expected_by_offset": {
+        "0": "2026-08-15",
+        "-420": "2026-08-15",
+        "-480": "2026-08-15",
+        "120": "2026-08-16",
+        "345": "2026-08-16"
+      }
+    },
+    {
+      "name": "new_year_boundary",
+      "utc": "2026-01-01T00:30:00Z",
+      "expected_by_offset": {
+        "0": "2026-01-01",
+        "-420": "2025-12-31",
+        "-480": "2025-12-31",
+        "120": "2026-01-01",
+        "345": "2026-01-01"
+      }
+    },
+    {
+      "name": "midday_stable_everywhere",
+      "utc": "2026-08-15T12:00:00Z",
+      "expected_by_offset": {
+        "0": "2026-08-15",
+        "-420": "2026-08-15",
+        "-480": "2026-08-15",
+        "120": "2026-08-15",
+        "345": "2026-08-15"
+      }
+    },
+    {
+      "name": "end_of_february_non_leap",
+      "utc": "2026-03-01T06:59:00Z",
+      "expected_by_offset": {
+        "0": "2026-03-01",
+        "-420": "2026-02-28",
+        "-480": "2026-02-28",
+        "120": "2026-03-01",
+        "345": "2026-03-01"
+      }
+    }
+  ]
+}

--- a/contracts/parity/section_labels.json
+++ b/contracts/parity/section_labels.json
@@ -1,0 +1,57 @@
+{
+  "$comment": "Relative day labels (Today / Yesterday / Tomorrow) as used by the Windows conversation section headers (lib/conversations/filtering.ts sectionLabel) and the Windows task due badge (Tasks.tsx formatDue). The rule under contract: relative labels are a CALENDAR day relationship, never a fixed 24h offset, because on the two DST transition days a local day is 23h or 25h long and a plus or minus DAY_MS comparison silently misses the neighbor day. Cases with requires_dst_transition_between only run when the runtime zone actually changes offset between the two listed local days (they execute on any US zone machine and are counted skips on UTC CI; the non DST cases always run). conversation_section is null when the section shows a formatted date instead of a relative label; due_badge is null when the badge shows a formatted date. now and days are local components [year, month, day, hour, minute] / [year, month, day].",
+  "cases": [
+    {
+      "name": "today_label",
+      "now": [2026, 8, 15, 10, 0],
+      "target_day": [2026, 8, 15],
+      "labels": { "conversation_section": "Today", "due_badge": "Today" }
+    },
+    {
+      "name": "yesterday_label",
+      "now": [2026, 8, 15, 10, 0],
+      "target_day": [2026, 8, 14],
+      "labels": { "conversation_section": "Yesterday", "due_badge": "Yesterday" }
+    },
+    {
+      "name": "tomorrow_label",
+      "now": [2026, 8, 15, 10, 0],
+      "target_day": [2026, 8, 16],
+      "labels": { "conversation_section": null, "due_badge": "Tomorrow" }
+    },
+    {
+      "name": "two_days_ago_is_dated",
+      "now": [2026, 8, 15, 10, 0],
+      "target_day": [2026, 8, 13],
+      "labels": { "conversation_section": null, "due_badge": null }
+    },
+    {
+      "name": "fall_back_yesterday",
+      "now": [2026, 11, 2, 9, 0],
+      "target_day": [2026, 11, 1],
+      "requires_dst_transition_between": [[2026, 11, 1], [2026, 11, 2]],
+      "labels": { "conversation_section": "Yesterday", "due_badge": "Yesterday" }
+    },
+    {
+      "name": "spring_forward_yesterday",
+      "now": [2026, 3, 9, 9, 0],
+      "target_day": [2026, 3, 8],
+      "requires_dst_transition_between": [[2026, 3, 8], [2026, 3, 9]],
+      "labels": { "conversation_section": "Yesterday", "due_badge": "Yesterday" }
+    },
+    {
+      "name": "fall_back_tomorrow",
+      "now": [2026, 11, 1, 9, 0],
+      "target_day": [2026, 11, 2],
+      "requires_dst_transition_between": [[2026, 11, 1], [2026, 11, 2]],
+      "labels": { "conversation_section": null, "due_badge": "Tomorrow" }
+    },
+    {
+      "name": "spring_forward_tomorrow",
+      "now": [2026, 3, 8, 9, 0],
+      "target_day": [2026, 3, 9],
+      "requires_dst_transition_between": [[2026, 3, 8], [2026, 3, 9]],
+      "labels": { "conversation_section": null, "due_badge": "Tomorrow" }
+    }
+  ]
+}

--- a/contracts/parity/task_due_buckets.json
+++ b/contracts/parity/task_due_buckets.json
@@ -1,0 +1,110 @@
+{
+  "$comment": "Cross-platform task due-date bucketing vectors. Times are LOCAL calendar components [year, month, day, hour, minute] so every platform evaluates them in its own local zone with identical results (all implementations bucket by local calendar day). Two sanctioned models exist today: fold_overdue (macOS TasksPage.categoryFor, Windows taskBuckets.bucketOf) folds past-due tasks into today and has no dateless aging rule; separate_overdue (Flutter action_items_page categorizeTasks) has a fifth overdue bucket and moves dateless tasks created more than 7 days (7*24h from now, instant-based) ago into it. Every case pins BOTH models so any platform switching models is a deliberate fixture edit, not silent drift. Cases assume an incomplete task viewed in the open-tasks list (the Flutter overdue branches are skipped in the completed view). Buckets: today | tomorrow | later | no_deadline | overdue.",
+  "cases": [
+    {
+      "name": "no_due_recent",
+      "now": [2026, 8, 15, 10, 0],
+      "due": null,
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "no_deadline", "separate_overdue": "no_deadline" }
+    },
+    {
+      "name": "no_due_stale_two_weeks",
+      "now": [2026, 8, 15, 10, 0],
+      "due": null,
+      "created": [2026, 8, 1, 10, 0],
+      "expected": { "fold_overdue": "no_deadline", "separate_overdue": "overdue" }
+    },
+    {
+      "name": "no_due_just_inside_seven_day_window",
+      "now": [2026, 8, 15, 10, 0],
+      "due": null,
+      "created": [2026, 8, 8, 11, 0],
+      "expected": { "fold_overdue": "no_deadline", "separate_overdue": "no_deadline" }
+    },
+    {
+      "name": "no_due_missing_created",
+      "now": [2026, 8, 15, 10, 0],
+      "due": null,
+      "created": null,
+      "expected": { "fold_overdue": "no_deadline", "separate_overdue": "no_deadline" }
+    },
+    {
+      "name": "due_yesterday",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 14, 17, 0],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "today", "separate_overdue": "overdue" }
+    },
+    {
+      "name": "due_last_month",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 7, 20, 9, 0],
+      "created": [2026, 7, 19, 9, 0],
+      "expected": { "fold_overdue": "today", "separate_overdue": "overdue" }
+    },
+    {
+      "name": "due_today_midnight",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 15, 0, 0],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "today", "separate_overdue": "today" }
+    },
+    {
+      "name": "due_today_earlier_than_now",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 15, 8, 0],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "today", "separate_overdue": "today" }
+    },
+    {
+      "name": "due_today_last_minute",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 15, 23, 59],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "today", "separate_overdue": "today" }
+    },
+    {
+      "name": "due_tomorrow_start",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 16, 0, 0],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "tomorrow", "separate_overdue": "tomorrow" }
+    },
+    {
+      "name": "due_tomorrow_last_minute",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 16, 23, 59],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "tomorrow", "separate_overdue": "tomorrow" }
+    },
+    {
+      "name": "due_day_after_tomorrow",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 8, 17, 0, 0],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "later", "separate_overdue": "later" }
+    },
+    {
+      "name": "due_next_month",
+      "now": [2026, 8, 15, 10, 0],
+      "due": [2026, 9, 2, 12, 0],
+      "created": [2026, 8, 14, 10, 0],
+      "expected": { "fold_overdue": "later", "separate_overdue": "later" }
+    },
+    {
+      "name": "month_boundary_tomorrow",
+      "now": [2026, 8, 31, 10, 0],
+      "due": [2026, 9, 1, 9, 0],
+      "created": [2026, 8, 30, 10, 0],
+      "expected": { "fold_overdue": "tomorrow", "separate_overdue": "tomorrow" }
+    },
+    {
+      "name": "year_boundary_tomorrow",
+      "now": [2026, 12, 31, 10, 0],
+      "due": [2027, 1, 1, 0, 0],
+      "created": [2026, 12, 30, 10, 0],
+      "expected": { "fold_overdue": "tomorrow", "separate_overdue": "tomorrow" }
+    }
+  ]
+}

--- a/contracts/parity/wire_action_item.json
+++ b/contracts/parity/wire_action_item.json
@@ -24,6 +24,28 @@
       "expected": { "parses": true, "description": "Offset form decodes to the same instant", "completed": false, "due_utc": "2026-08-20T16:00:00Z" }
     },
     {
+      "name": "due_with_negative_offset_same_instant",
+      "payload": {
+        "id": "ai_parity_2n",
+        "description": "Negative offset form decodes to the same instant",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "2026-08-20T09:00:00-07:00"
+      },
+      "expected": { "parses": true, "description": "Negative offset form decodes to the same instant", "completed": false, "due_utc": "2026-08-20T16:00:00Z" }
+    },
+    {
+      "name": "due_with_half_hour_offset_same_instant",
+      "payload": {
+        "id": "ai_parity_2h",
+        "description": "Half hour offset form decodes to the same instant",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "2026-08-20T21:30:00+05:30"
+      },
+      "expected": { "parses": true, "description": "Half hour offset form decodes to the same instant", "completed": false, "due_utc": "2026-08-20T16:00:00Z" }
+    },
+    {
       "name": "due_null",
       "payload": {
         "id": "ai_parity_3",

--- a/contracts/parity/wire_action_item.json
+++ b/contracts/parity/wire_action_item.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Action item wire-decode vectors: the exact JSON a backend ActionItemResponse serializes, and what every first-party client must recover from it. Pins the shared agreement set: an ISO-8601 due_at with an explicit offset decodes to the same instant everywhere; null, missing, empty and unparseable due_at all decode to no-due-date rather than an error (Dart DateTime.tryParse returns null, Windows Date.parse returns NaN which maps to null). due_utc in expectations is the canonical instant; adapters compare instants, not string forms. Every payload carries the full required field set of the strictest client (Dart generated wire: id, description, completed). Known asymmetry documented in README.md: the Windows sync mapper fills a missing created_at with sync time because its local store requires one; the Dart wire keeps it null.",
+  "$comment": "Action item wire-decode vectors: the exact JSON a backend ActionItemResponse serializes, and what every first-party client must recover from it. Cases with a flat `expected` are the shared agreement set: an ISO-8601 due_at with an explicit offset decodes to the same instant everywhere, and null or missing due_at decodes to no-due-date. Cases with `expected_by_model` pin a REAL client divergence on present-but-unparseable due_at strings: strict_decode (the Dart generated wire) rejects the whole item with a FormatException because a non-null field that reads to null is invalid, while tolerant_decode (the Windows sync mapper) maps it to no-due-date; the backend refuses to accept these forms at all (strict side, asserted in test_parity_contracts.py). due_utc in expectations is the canonical instant; adapters compare instants, not string forms. Every payload carries the full required field set of the strictest client (Dart generated wire: id, description, completed). Known asymmetry documented in README.md: the Windows sync mapper fills a missing created_at with sync time because its local store requires one; the Dart wire keeps it null.",
   "cases": [
     {
       "name": "due_utc_zulu",
@@ -53,7 +53,10 @@
         "created_at": "2026-08-01T10:00:00Z",
         "due_at": ""
       },
-      "expected": { "parses": true, "description": "Empty string due date", "completed": false, "due_utc": null }
+      "expected_by_model": {
+        "strict_decode": { "parses": false },
+        "tolerant_decode": { "parses": true, "description": "Empty string due date", "completed": false, "due_utc": null }
+      }
     },
     {
       "name": "due_unparseable_string",
@@ -64,7 +67,10 @@
         "created_at": "2026-08-01T10:00:00Z",
         "due_at": "not-a-date"
       },
-      "expected": { "parses": true, "description": "Garbage due date", "completed": false, "due_utc": null }
+      "expected_by_model": {
+        "strict_decode": { "parses": false },
+        "tolerant_decode": { "parses": true, "description": "Garbage due date", "completed": false, "due_utc": null }
+      }
     },
     {
       "name": "completed_with_due",

--- a/contracts/parity/wire_action_item.json
+++ b/contracts/parity/wire_action_item.json
@@ -1,0 +1,93 @@
+{
+  "$comment": "Action item wire-decode vectors: the exact JSON a backend ActionItemResponse serializes, and what every first-party client must recover from it. Pins the shared agreement set: an ISO-8601 due_at with an explicit offset decodes to the same instant everywhere; null, missing, empty and unparseable due_at all decode to no-due-date rather than an error (Dart DateTime.tryParse returns null, Windows Date.parse returns NaN which maps to null). due_utc in expectations is the canonical instant; adapters compare instants, not string forms. Every payload carries the full required field set of the strictest client (Dart generated wire: id, description, completed). Known asymmetry documented in README.md: the Windows sync mapper fills a missing created_at with sync time because its local store requires one; the Dart wire keeps it null.",
+  "cases": [
+    {
+      "name": "due_utc_zulu",
+      "payload": {
+        "id": "ai_parity_1",
+        "description": "Ship the parity contracts",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "2026-08-20T16:00:00Z"
+      },
+      "expected": { "parses": true, "description": "Ship the parity contracts", "completed": false, "due_utc": "2026-08-20T16:00:00Z" }
+    },
+    {
+      "name": "due_with_positive_offset_same_instant",
+      "payload": {
+        "id": "ai_parity_2",
+        "description": "Offset form decodes to the same instant",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "2026-08-20T18:00:00+02:00"
+      },
+      "expected": { "parses": true, "description": "Offset form decodes to the same instant", "completed": false, "due_utc": "2026-08-20T16:00:00Z" }
+    },
+    {
+      "name": "due_null",
+      "payload": {
+        "id": "ai_parity_3",
+        "description": "Null due date",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": null
+      },
+      "expected": { "parses": true, "description": "Null due date", "completed": false, "due_utc": null }
+    },
+    {
+      "name": "due_missing",
+      "payload": {
+        "id": "ai_parity_4",
+        "description": "Missing due date key",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z"
+      },
+      "expected": { "parses": true, "description": "Missing due date key", "completed": false, "due_utc": null }
+    },
+    {
+      "name": "due_empty_string",
+      "payload": {
+        "id": "ai_parity_5",
+        "description": "Empty string due date",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": ""
+      },
+      "expected": { "parses": true, "description": "Empty string due date", "completed": false, "due_utc": null }
+    },
+    {
+      "name": "due_unparseable_string",
+      "payload": {
+        "id": "ai_parity_6",
+        "description": "Garbage due date",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "not-a-date"
+      },
+      "expected": { "parses": true, "description": "Garbage due date", "completed": false, "due_utc": null }
+    },
+    {
+      "name": "completed_with_due",
+      "payload": {
+        "id": "ai_parity_7",
+        "description": "Completed task keeps its due date",
+        "completed": true,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "2026-08-10T09:00:00Z"
+      },
+      "expected": { "parses": true, "description": "Completed task keeps its due date", "completed": true, "due_utc": "2026-08-10T09:00:00Z" }
+    },
+    {
+      "name": "unknown_field_ignored",
+      "payload": {
+        "id": "ai_parity_8",
+        "description": "Unknown fields never break decode",
+        "completed": false,
+        "created_at": "2026-08-01T10:00:00Z",
+        "due_at": "2026-08-20T16:00:00Z",
+        "parity_probe_unknown_field": { "nested": true }
+      },
+      "expected": { "parses": true, "description": "Unknown fields never break decode", "completed": false, "due_utc": "2026-08-20T16:00:00Z" }
+    }
+  ]
+}

--- a/desktop/windows/src/main/tasks/parityWire.test.ts
+++ b/desktop/windows/src/main/tasks/parityWire.test.ts
@@ -1,0 +1,65 @@
+// Windows conformance suite for the shared action-item wire-decode contract
+// (contracts/parity/wire_action_item.json): the sync engine's backend-item
+// mapper must recover the same instant from every sanctioned due_at form and
+// treat null / missing / empty / unparseable ones as no-due-date. The engine
+// module needs the same import-time mocks as taskSyncEngine.test.ts (electron
+// and the native-sqlite storage wrappers cannot load under plain-node vitest);
+// the mapper itself is pure.
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  net: { fetch: vi.fn() },
+  BrowserWindow: {
+    getAllWindows: () => []
+  }
+}))
+
+vi.mock('../ipc/db', () => ({
+  getLocalActionItems: vi.fn(() => []),
+  getFilteredActionItems: vi.fn(() => []),
+  getUnsyncedActionItems: vi.fn(() => []),
+  insertLocalActionItem: vi.fn(),
+  updateCompletionStatus: vi.fn(),
+  updateActionItemFields: vi.fn(),
+  deleteActionItemByBackendId: vi.fn(() => []),
+  markSyncedActionItem: vi.fn(() => ({ merged: false, keptId: 0 })),
+  syncTaskActionItems: vi.fn(() => ({ skipped: 0, adopted: 0, inserted: 0, updated: 0 })),
+  hardDeleteAbsentTasks: vi.fn(() => []),
+  hardDeleteAbsentCompletedTasks: vi.fn(() => []),
+  getAppMeta: vi.fn(() => '1'),
+  setAppMeta: vi.fn()
+}))
+
+vi.mock('../assistants/tasks/create', () => ({ promoteIfNeeded: vi.fn(async () => {}) }))
+
+vi.mock('../observability/backendDegraded', () => ({
+  isBackendDegraded: vi.fn(() => false),
+  noteBackendStatus: vi.fn()
+}))
+
+import { mapBackendItem } from './taskSyncEngine'
+
+type WireCase = {
+  name: string
+  payload: Record<string, unknown>
+  expected: { parses: boolean; description: string; completed: boolean; due_utc: string | null }
+}
+
+// Fixed sync timestamp: the mapper fills a missing created_at with sync time
+// (a documented Windows-only divergence, see contracts/parity/README.md), so the
+// wire expectations only pin description / completed / due instant.
+const SYNC_NOW = Date.parse('2026-08-15T00:00:00Z')
+
+describe('action item wire decode (parity contract)', () => {
+  const path = fileURLToPath(new URL('../../../../../contracts/parity/wire_action_item.json', import.meta.url))
+  const { cases } = JSON.parse(readFileSync(path, 'utf8')) as { cases: WireCase[] }
+  it.each(cases)('$name', (c) => {
+    const mapped = mapBackendItem(c.payload as never, SYNC_NOW)
+    expect(c.expected.parses).toBe(true)
+    expect(mapped.description).toBe(c.expected.description)
+    expect(mapped.completed).toBe(c.expected.completed)
+    expect(mapped.dueAt).toBe(c.expected.due_utc === null ? null : Date.parse(c.expected.due_utc))
+  })
+})

--- a/desktop/windows/src/main/tasks/parityWire.test.ts
+++ b/desktop/windows/src/main/tasks/parityWire.test.ts
@@ -41,10 +41,15 @@ vi.mock('../observability/backendDegraded', () => ({
 
 import { mapBackendItem } from './taskSyncEngine'
 
+type WireExpectation = { parses: boolean; description?: string; completed?: boolean; due_utc?: string | null }
 type WireCase = {
   name: string
   payload: Record<string, unknown>
-  expected: { parses: boolean; description: string; completed: boolean; due_utc: string | null }
+  // Flat `expected` = the cross-client agreement set. `expected_by_model` pins
+  // the strict-vs-tolerant divergence on unparseable due_at strings; this
+  // client is the tolerant_decode model (see the README divergence register).
+  expected?: WireExpectation
+  expected_by_model?: { strict_decode: WireExpectation; tolerant_decode: WireExpectation }
 }
 
 // Fixed sync timestamp: the mapper fills a missing created_at with sync time
@@ -56,10 +61,12 @@ describe('action item wire decode (parity contract)', () => {
   const path = fileURLToPath(new URL('../../../../../contracts/parity/wire_action_item.json', import.meta.url))
   const { cases } = JSON.parse(readFileSync(path, 'utf8')) as { cases: WireCase[] }
   it.each(cases)('$name', (c) => {
+    const expected = c.expected_by_model ? c.expected_by_model.tolerant_decode : c.expected
+    if (!expected) throw new Error(`${c.name}: fixture case has neither expected nor expected_by_model`)
     const mapped = mapBackendItem(c.payload as never, SYNC_NOW)
-    expect(c.expected.parses).toBe(true)
-    expect(mapped.description).toBe(c.expected.description)
-    expect(mapped.completed).toBe(c.expected.completed)
-    expect(mapped.dueAt).toBe(c.expected.due_utc === null ? null : Date.parse(c.expected.due_utc))
+    expect(expected.parses).toBe(true)
+    expect(mapped.description).toBe(expected.description)
+    expect(mapped.completed).toBe(expected.completed)
+    expect(mapped.dueAt).toBe(expected.due_utc == null ? null : Date.parse(expected.due_utc))
   })
 })

--- a/desktop/windows/src/main/tasks/taskSyncEngine.ts
+++ b/desktop/windows/src/main/tasks/taskSyncEngine.ts
@@ -183,8 +183,9 @@ function toEpochMs(iso: string | null | undefined): number | null {
 }
 
 /** Map a backend action item → the storage `SyncActionItem` for syncTaskActionItems.
- *  `now` fills a missing created_at so the required `createdAt` is always present. */
-function mapBackendItem(item: BackendActionItem, now: number): SyncActionItem {
+ *  `now` fills a missing created_at so the required `createdAt` is always present.
+ *  Exported for the contracts/parity wire-decode conformance test. */
+export function mapBackendItem(item: BackendActionItem, now: number): SyncActionItem {
   const createdAt = toEpochMs(item.created_at) ?? now
   const updatedAt = toEpochMs(item.updated_at) ?? createdAt
   return {

--- a/desktop/windows/src/renderer/src/lib/conversations/filtering.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/filtering.ts
@@ -3,6 +3,7 @@
 // the Today/Yesterday/date bucketing are unit-testable without React or the DOM.
 // The Conversations page composes these over its merged cloud+local rows.
 
+import { startOfLocalDay } from '../localDay'
 import type { ConversationRow } from '../pageCache'
 
 /** Windows-ahead type filter: chat threads vs recordings. Cloud conversations are
@@ -132,19 +133,9 @@ export type DateSection = {
   rows: ConversationRow[]
 }
 
-/** Local-midnight epoch ms of the day containing `ms`. */
-export function startOfLocalDay(ms: number): number {
-  const d = new Date(ms)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
-}
-
-/** Inclusive end-of-day (23:59:59.999 local) epoch ms — for date-range upper bounds. */
-export function endOfLocalDay(ms: number): number {
-  const d = new Date(ms)
-  d.setHours(23, 59, 59, 999)
-  return d.getTime()
-}
+// Local-day helpers live in ../localDay (one copy of the local-midnight rule);
+// re-exported here because this module is the historical import site.
+export { startOfLocalDay, endOfLocalDay } from '../localDay'
 
 function sectionLabel(dayStart: number, todayStart: number): string {
   if (dayStart === todayStart) return 'Today'

--- a/desktop/windows/src/renderer/src/lib/conversations/filtering.ts
+++ b/desktop/windows/src/renderer/src/lib/conversations/filtering.ts
@@ -132,8 +132,6 @@ export type DateSection = {
   rows: ConversationRow[]
 }
 
-const DAY_MS = 86_400_000
-
 /** Local-midnight epoch ms of the day containing `ms`. */
 export function startOfLocalDay(ms: number): number {
   const d = new Date(ms)
@@ -150,7 +148,14 @@ export function endOfLocalDay(ms: number): number {
 
 function sectionLabel(dayStart: number, todayStart: number): string {
   if (dayStart === todayStart) return 'Today'
-  if (dayStart === todayStart - DAY_MS) return 'Yesterday'
+  // Yesterday is a calendar-day relationship, not `todayStart - 24h`: on the two
+  // DST-transition days a local day is 23h/25h long, so the fixed offset lands
+  // an hour off the neighbor day's midnight and the label silently degrades to a
+  // date. Pinned by contracts/parity/section_labels.json.
+  const yesterday = new Date(todayStart)
+  yesterday.setDate(yesterday.getDate() - 1)
+  yesterday.setHours(0, 0, 0, 0)
+  if (dayStart === yesterday.getTime()) return 'Yesterday'
   return new Date(dayStart).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',

--- a/desktop/windows/src/renderer/src/lib/localDay.ts
+++ b/desktop/windows/src/renderer/src/lib/localDay.ts
@@ -1,0 +1,28 @@
+// Local-calendar-day helpers shared by the renderer's conversation date
+// grouping and task bucketing. The local day is the product's grouping unit
+// (pinned by contracts/parity/day_keys.json); keep the rule in one place.
+
+/** Local-midnight epoch ms of the day containing `ms`. */
+export function startOfLocalDay(ms: number): number {
+  const d = new Date(ms)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+/** Inclusive end-of-day (23:59:59.999 local) epoch ms — for date-range upper bounds. */
+export function endOfLocalDay(ms: number): number {
+  const d = new Date(ms)
+  d.setHours(23, 59, 59, 999)
+  return d.getTime()
+}
+
+/** Start of the local day a whole number of calendar days away from the day
+ *  containing `ms`. Date.setDate handles DST shifts and month/year boundaries;
+ *  a fixed `± 86_400_000` offset is 23h/25h wrong on the two DST-transition
+ *  days each year, which mis-labels the neighbor day. */
+export function startOfDayOffset(ms: number, days: number): number {
+  const d = new Date(startOfLocalDay(ms))
+  d.setDate(d.getDate() + days)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}

--- a/desktop/windows/src/renderer/src/lib/parityContracts.test.ts
+++ b/desktop/windows/src/renderer/src/lib/parityContracts.test.ts
@@ -1,0 +1,117 @@
+// Windows conformance suite for the shared cross-platform parity contracts
+// (contracts/parity/README.md). Runs the repo-root fixture vectors through the
+// REAL production rules: task due-date bucketing (taskBuckets.bucketOf, the
+// fold_overdue model shared with macOS), local-day conversation grouping
+// (filtering.startOfLocalDay / groupConversationsByDate), and relative day
+// labels (formatDue badge + conversation section headers), including the DST
+// transition-day cases that only execute on runners whose zone observes the
+// transition (counted skips elsewhere; the non-DST cases always run).
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { bucketOf, formatDue, type Bucket } from './taskBuckets'
+import { groupConversationsByDate, startOfLocalDay } from './conversations/filtering'
+import type { ConversationRow } from './pageCache'
+
+function fixture<T>(name: string): T {
+  const path = fileURLToPath(new URL(`../../../../../../contracts/parity/${name}`, import.meta.url))
+  return JSON.parse(readFileSync(path, 'utf8')) as T
+}
+
+/** Fixture local-time components [year, month, day, hour?, minute?] → epoch ms
+ *  in the runner's zone (the contracts are calendar rules, zone-independent). */
+type Components = [number, number, number, number?, number?]
+const localMs = (c: Components): number => new Date(c[0], c[1] - 1, c[2], c[3] ?? 0, c[4] ?? 0).getTime()
+
+const RELATIVE_LABELS = ['Today', 'Tomorrow', 'Yesterday']
+
+describe('task due buckets (fold_overdue model)', () => {
+  type BucketCase = {
+    name: string
+    now: Components
+    due: Components | null
+    created: Components | null
+    expected: { fold_overdue: string; separate_overdue: string }
+  }
+  // Fixture bucket names → this platform's Bucket vocabulary. fold_overdue never
+  // expects 'overdue'; an unmapped name fails loudly rather than passing vacuously.
+  const BUCKET_MAP: Record<string, Bucket> = {
+    today: 'today',
+    tomorrow: 'tomorrow',
+    later: 'later',
+    no_deadline: 'nodate'
+  }
+  const { cases } = fixture<{ cases: BucketCase[] }>('task_due_buckets.json')
+  it.each(cases)('$name', (c) => {
+    const now = localMs(c.now)
+    const dueAt = c.due === null ? null : localMs(c.due)
+    expect(bucketOf({ dueAt }, now)).toBe(BUCKET_MAP[c.expected.fold_overdue])
+  })
+})
+
+describe('local day keys', () => {
+  type DayKeyCase = { name: string; utc: string; expected_by_offset: Record<string, string> }
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  const { cases } = fixture<{ cases: DayKeyCase[] }>('day_keys.json')
+  for (const c of cases) {
+    const instant = Date.parse(c.utc)
+    const offsetEast = -new Date(instant).getTimezoneOffset()
+    const expected = c.expected_by_offset[String(offsetEast)]
+    // Only cases whose fixture covers this runner's zone offset execute; offset 0
+    // is always present so UTC CI runs every case.
+    it.runIf(expected !== undefined)(`${c.name} (offset ${offsetEast})`, () => {
+      const d = new Date(startOfLocalDay(instant))
+      expect(`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`).toBe(expected)
+    })
+  }
+})
+
+describe('relative day labels', () => {
+  type LabelCase = {
+    name: string
+    now: Components
+    target_day: Components
+    requires_dst_transition_between?: [Components, Components]
+    labels: { conversation_section: string | null; due_badge: string | null }
+  }
+  const transitionObserved = (c: LabelCase): boolean => {
+    if (!c.requires_dst_transition_between) return true
+    const [a, b] = c.requires_dst_transition_between
+    return (
+      new Date(a[0], a[1] - 1, a[2]).getTimezoneOffset() !== new Date(b[0], b[1] - 1, b[2]).getTimezoneOffset()
+    )
+  }
+  const { cases } = fixture<{ cases: LabelCase[] }>('section_labels.json')
+  for (const c of cases) {
+    it.runIf(transitionObserved(c))(c.name, () => {
+      const now = localMs(c.now)
+      const targetNoon = localMs([c.target_day[0], c.target_day[1], c.target_day[2], 12, 0])
+
+      const badge = formatDue(targetNoon, now)
+      if (c.labels.due_badge === null) {
+        expect(badge).toBeTruthy()
+        expect(RELATIVE_LABELS).not.toContain(badge)
+      } else {
+        expect(badge).toBe(c.labels.due_badge)
+      }
+
+      const row = {
+        id: 'parity-row',
+        title: 'row',
+        subtitle: '',
+        preview: '',
+        source: 'cloud',
+        sortAt: targetNoon
+      } as unknown as ConversationRow
+      const sections = groupConversationsByDate([row], now)
+      expect(sections).toHaveLength(1)
+      const label = sections[0].label
+      if (c.labels.conversation_section === null) {
+        expect(label).toBeTruthy()
+        expect(RELATIVE_LABELS).not.toContain(label)
+      } else {
+        expect(label).toBe(c.labels.conversation_section)
+      }
+    })
+  }
+})

--- a/desktop/windows/src/renderer/src/lib/taskBuckets.ts
+++ b/desktop/windows/src/renderer/src/lib/taskBuckets.ts
@@ -1,0 +1,52 @@
+// Task due-date bucketing and the due-badge label for the Tasks page. Extracted
+// from pages/Tasks.tsx so the rules are unit-testable against the shared
+// contracts/parity fixtures (see contracts/parity/README.md).
+
+export function startOfDay(ms: number): number {
+  const d = new Date(ms)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+/** Start of the local day a whole number of calendar days away from the day
+ *  containing `ms`. Date.setDate handles DST shifts and month/year boundaries;
+ *  a fixed `± 86_400_000` offset is 23h/25h wrong on the two DST-transition
+ *  days each year, which mis-labels the neighbor day. */
+export function startOfDayOffset(ms: number, days: number): number {
+  const d = new Date(startOfDay(ms))
+  d.setDate(d.getDate() + days)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+export type Bucket = 'today' | 'tomorrow' | 'later' | 'nodate'
+
+// Four due-date buckets, matching Mac's TaskCategory (Today · Tomorrow · Later ·
+// No Deadline). Overdue tasks fold into Today — there is no separate Overdue
+// section — mirroring Mac's `categoryFor` (`dueAt < startOfTomorrow → .today`,
+// TasksPage.swift). The Flutter app uses a different model (a fifth Overdue
+// bucket plus a 7-day aging rule for dateless tasks); both models are pinned in
+// contracts/parity/task_due_buckets.json until the platforms converge.
+export function bucketOf(t: { dueAt: number | null }, now: number = Date.now()): Bucket {
+  if (t.dueAt == null) return 'nodate'
+  const due = startOfDay(t.dueAt)
+  const today = startOfDay(now)
+  if (due <= today) return 'today' // overdue + today
+  if (due === startOfDayOffset(now, 1)) return 'tomorrow'
+  return 'later'
+}
+
+export function formatDue(ms: number, now: number = Date.now()): string {
+  const d = new Date(ms)
+  if (Number.isNaN(d.getTime())) return ''
+  const due = startOfDay(d.getTime())
+  if (due === startOfDay(now)) return 'Today'
+  if (due === startOfDayOffset(now, 1)) return 'Tomorrow'
+  if (due === startOfDayOffset(now, -1)) return 'Yesterday'
+  const sameYear = d.getFullYear() === new Date(now).getFullYear()
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' })
+  })
+}

--- a/desktop/windows/src/renderer/src/lib/taskBuckets.ts
+++ b/desktop/windows/src/renderer/src/lib/taskBuckets.ts
@@ -2,22 +2,13 @@
 // from pages/Tasks.tsx so the rules are unit-testable against the shared
 // contracts/parity fixtures (see contracts/parity/README.md).
 
-export function startOfDay(ms: number): number {
-  const d = new Date(ms)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
-}
+import { startOfLocalDay, startOfDayOffset } from './localDay'
 
-/** Start of the local day a whole number of calendar days away from the day
- *  containing `ms`. Date.setDate handles DST shifts and month/year boundaries;
- *  a fixed `± 86_400_000` offset is 23h/25h wrong on the two DST-transition
- *  days each year, which mis-labels the neighbor day. */
-export function startOfDayOffset(ms: number, days: number): number {
-  const d = new Date(startOfDay(ms))
-  d.setDate(d.getDate() + days)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
-}
+// Re-exported under the Tasks page's existing names; the implementation lives
+// in localDay.ts so the local-midnight rule has one copy.
+export { startOfLocalDay as startOfDay, startOfDayOffset } from './localDay'
+
+const startOfDay = startOfLocalDay
 
 export type Bucket = 'today' | 'tomorrow' | 'later' | 'nodate'
 

--- a/desktop/windows/src/renderer/src/pages/Tasks.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.tsx
@@ -7,6 +7,7 @@ import { PageHeader } from '../components/layout/PageHeader'
 import { TasksGoalsToggle } from '../components/layout/TasksGoalsToggle'
 import { EmptyState } from '../components/ui/EmptyState'
 import { toast } from '../lib/toast'
+import { bucketOf, formatDue, startOfDay, type Bucket } from '../lib/taskBuckets'
 import type { ActionItemRecord } from '../../../shared/types'
 import type { Conversation as CloudConversation } from '../lib/omiApi.generated'
 
@@ -47,14 +48,6 @@ async function fetchConvMeta(): Promise<Record<string, ConvMeta>> {
   return map
 }
 
-const DAY = 86_400_000
-
-function startOfDay(ms: number): number {
-  const d = new Date(ms)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
-}
-
 // Native <input type="date"> works in local YYYY-MM-DD; convert both ways while
 // pinning the time to local noon so the day never slips across time zones. The
 // store speaks epoch-ms, so these bridge ms ↔ the date input's string.
@@ -72,43 +65,6 @@ function dateInputToMs(v: string): number | null {
   if (!v) return null
   const d = new Date(`${v}T12:00:00`)
   return Number.isNaN(d.getTime()) ? null : d.getTime()
-}
-
-function formatDue(ms: number): string {
-  const d = new Date(ms)
-  if (Number.isNaN(d.getTime())) return ''
-  const today = startOfDay(Date.now())
-  const due = startOfDay(d.getTime())
-  if (due === today) return 'Today'
-  if (due === today + DAY) return 'Tomorrow'
-  if (due === today - DAY) return 'Yesterday'
-  const sameYear = d.getFullYear() === new Date().getFullYear()
-  return d.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    ...(sameYear ? {} : { year: 'numeric' })
-  })
-}
-
-type Bucket = 'today' | 'tomorrow' | 'later' | 'nodate'
-
-// Four due-date buckets, matching Mac's TaskCategory (Today · Tomorrow · Later ·
-// No Deadline). Overdue tasks fold into Today — there is no separate Overdue
-// section — mirroring Mac's `categoryFor` (`dueAt < startOfTomorrow → .today`,
-// TasksPage.swift) and the Flutter app's grouping.
-function bucketOf(t: ActionItemRecord): Bucket {
-  if (t.dueAt == null) return 'nodate'
-  const due = startOfDay(t.dueAt)
-  const today = startOfDay(Date.now())
-  if (due <= today) return 'today' // overdue + today
-  // Tomorrow's local start-of-day via Date.setDate (which handles DST shifts and
-  // month/year boundaries). A fixed `today + DAY` offset is 23h/25h wrong on the
-  // two DST-transition days each year, which would mis-bucket a "due tomorrow"
-  // task into Later.
-  const tomorrow = new Date(today)
-  tomorrow.setDate(tomorrow.getDate() + 1)
-  if (due === startOfDay(tomorrow.getTime())) return 'tomorrow'
-  return 'later'
 }
 
 // A task whose due date is before today. Independent of bucketing (overdue rows

--- a/desktop/windows/src/renderer/src/pages/Tasks.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from '../components/layout/PageHeader'
 import { TasksGoalsToggle } from '../components/layout/TasksGoalsToggle'
 import { EmptyState } from '../components/ui/EmptyState'
 import { toast } from '../lib/toast'
-import { bucketOf, formatDue, startOfDay, type Bucket } from '../lib/taskBuckets'
+import { bucketOf, formatDue, startOfDay, startOfDayOffset, type Bucket } from '../lib/taskBuckets'
 import type { ActionItemRecord } from '../../../shared/types'
 import type { Conversation as CloudConversation } from '../lib/omiApi.generated'
 
@@ -273,6 +273,27 @@ export function Tasks(): React.JSX.Element {
 
   // For open/all: group open items by due bucket. For done/all: a flat
   // completed list (newest first), shown after the open buckets.
+  // The bucket grouping reads the clock, so a page left open across local
+  // midnight would keep yesterday's Today/Tomorrow split until something else
+  // re-rendered. Tick the day anchor at each local midnight; bucketOf(t, dayStamp)
+  // is equivalent to bucketOf(t, Date.now()) because the rule only consumes
+  // startOfDay(now).
+  const [dayStamp, setDayStamp] = useState(() => startOfDay(Date.now()))
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>
+    const arm = (): void => {
+      timer = setTimeout(
+        () => {
+          setDayStamp(startOfDay(Date.now()))
+          arm()
+        },
+        Math.max(1000, startOfDayOffset(Date.now(), 1) - Date.now())
+      )
+    }
+    arm()
+    return () => clearTimeout(timer)
+  }, [])
+
   const openGroups = useMemo(() => {
     if (filter === 'done') return []
     const groups: Record<Bucket, ActionItemRecord[]> = {
@@ -283,7 +304,7 @@ export function Tasks(): React.JSX.Element {
     }
     for (const t of items) {
       if (t.completed) continue
-      groups[bucketOf(t)].push(t)
+      groups[bucketOf(t, dayStamp)].push(t)
     }
     for (const b of BUCKET_ORDER) {
       groups[b].sort((a, c) => {
@@ -297,7 +318,7 @@ export function Tasks(): React.JSX.Element {
       bucket: b,
       items: groups[b]
     }))
-  }, [items, filter])
+  }, [items, filter, dayStamp])
 
   const doneItems = useMemo(() => {
     if (filter === 'open') return []


### PR DESCRIPTION
## Summary

Omi ships the same product on Flutter, macOS, and Windows against one backend, and the recurring failure mode is a rule that gets fixed on one platform and silently diverges on another. This PR adds the shared guard surface for that class: a platform-neutral contract fixture set at `contracts/parity/` that every client runs through its own production code, plus per-client REST route inventories so each first-party client is pinned to backend-owned OpenAPI authority the way macOS already is.

Real instances this would have caught, from the merged history:

- #10198 fixed local-day grouping in the app; #10980 and #10984 fixed the same class again on macOS. The day-key fixtures pin the rule once for every platform.
- #11613 added a desktop route with no spec entry, which broke the macOS inventory guard for every open PR (unblocked by #11629). The new Windows and Flutter inventories close the same hole for the other two clients before it happens there.
- The Windows task bucketing comment claimed it mirrors the Flutter app's grouping. It does not: the app has a separate Overdue bucket plus a 7-day aging rule for dateless tasks, macOS and Windows fold overdue into Today. The bucket fixtures pin BOTH live models per case and the README carries a divergence register, so converging is an explicit fixture edit instead of silent drift.
- Two live DST bugs found by writing the label fixtures: Windows `formatDue` and the conversations `sectionLabel` computed Tomorrow and Yesterday as fixed 24h offsets, which degrade relative labels to dated ones on the two DST transition days each year. The neighboring `bucketOf` comment already warned about exactly this hazard. Both fixed to calendar day arithmetic.
- One live backend wire bug found by writing the wire fixtures: a naive datetime reaching `ActionItemResponse` serialized with no UTC offset, the one wire form the clients disagree on (Dart and JS decode it as local wall time, Swift ISO8601 decoding rejects it). The response model now stamps UTC on naive values, with a red-first regression test.
- One more client divergence found by the suite's own first CI run: a present-but-unparseable due_at string makes the Dart generated wire reject the WHOLE item with a FormatException, while the Windows sync mapper maps it to no-due-date and keeps the item. One corrupt timestamp in a list response breaks the app's decode path but not Windows sync. The two junk-due fixture cases now pin both behaviors as an explicit strict versus tolerant model split (divergence register entry 4) with the backend asserted on the strict side.

## What is in here

- `contracts/parity/` fixtures + README: task due buckets (dual model), local day keys (offset-keyed expectations), action item wire decode agreement set, relative day labels including DST transition cases. Times are local calendar components so every platform evaluates them in its own zone with identical results.
- Backend: `test_parity_contracts.py` validates the fixtures structurally and arithmetically (a malformed fixture cannot pass vacuously on every client at once), proves backend round-trip of the parseable wire vectors, rejects the junk forms clients only tolerate defensively, and pins the new naive-timestamp guard.
- Windows: `bucketOf`/`formatDue` extracted from the Tasks page into `lib/taskBuckets.ts` (behavior unchanged, comment corrected), DST fixes, `mapBackendItem` exported, and two conformance suites (28 + 8 cases).
- Flutter: the page-private categorization extracted to `task_categorization.dart` as a pure injectable-now function (behavior unchanged), and a conformance suite covering buckets, `conversationLocalDayKey`, and the generated wire decode.
- Inventories: `test_windows_rest_inventory.py` and `test_flutter_rest_inventory.py`, siblings of the macOS one, with known gaps seeded from the current live surfaces (mirroring the macOS list's follow-up notes) and an anti-rot test that forces allowlist entries out as soon as the spec catches up.
- macOS: no Swift adapter in this PR. The fixtures already encode the macOS model, and the README lists the adapter as the tracked follow-up with exact file pointers; shipping untested Swift from a non-Mac machine into the flaky Swift lane seemed worse than saying so plainly.
- Two small repairs found along the way, each in its own commit: the AGENTS.md lean check compared backslash paths against forward-slash budget keys on Windows (every budgeted file misreported), and the app guide pointed at Firebase config files deleted in e81f1e8572, which fails `agent-doc-references` for any PR touching agent docs.

Why a fixture set instead of per-platform tests: the failing pattern is cross-platform disagreement, not single-platform regression. A shared vector file makes a behavior change reviewable as a cross-platform decision, and the backend integrity test keeps the fixtures themselves honest.

## Verification

- Backend: `python -m pytest tests/unit/test_parity_contracts.py tests/unit/test_windows_rest_inventory.py tests/unit/test_flutter_rest_inventory.py -q` passes 17/17. The naive-timestamp test failed 4 cases before the validator (offsetless emission reproduced) and passes with it. 79 neighboring action item tests pass unchanged.
- Windows: full vitest suite 5199 passed, 18 skipped (546 files). `npm run typecheck` clean on both configs. Mutation check: reintroducing the fixed-offset math fails exactly the 4 DST label cases; restoring the fix returns 28/28. DST cases executed locally on a US Pacific machine; they are counted skips on UTC CI and the non-DST cases always run.
- Flutter: no local Flutter SDK on this machine; the suite is discovered by `app/test.sh` and is CI-verified (the first CI run passed 1031 of 1033 parity-adjacent cases and the two failures were the genuine strict-decode divergence above, now pinned). Dart formatting was aligned with CI exactly: dart 3.12.2 (the flutter 3.44.5 bundled version) with an explicit language version 3.0, verified with set-exit-if-changed. The extraction is a pure move plus a `now` parameter defaulting to the wall clock.
- `make preflight`: 26 checks pass locally; `desktop-backend-candidate-probe-fixtures` fails only because the probe requires `signal.SIGALRM`, which does not exist on Windows runners (untouched by this diff; passes on Linux CI).

Product invariants affected: none

## Notes for review

- The `task_due_buckets.json` dual-model column is deliberate: it documents that the platforms disagree today rather than pretending one of them is authoritative. Whichever way product converges, the change is one fixture edit plus the losing platform's code.
- The inventories' KNOWN_MISSING sets are seeded with the same surfaces and reasons the macOS list already tracks (unmodeled responses, unexported routers), so this PR does not regenerate the app-client spec; the anti-rot test guarantees the lists only shrink.
