### PR TITLE
test(backend): stub utils.memory.retraction_scope in the conversations isolation fixtures

### DIFF
--- a/backend/tests/unit/test_batch_upload_storage.py
+++ b/backend/tests/unit/test_batch_upload_storage.py
@@ -102,6 +102,12 @@ def merge():
     canonical_activation_stub = ModuleType("utils.memory.canonical_activation")
     setattr(canonical_activation_stub, "canonical_write_enabled", MagicMock(return_value=False))
 
+    # The retraction-scope helpers decide whether a source's canonical retraction
+    # can be skipped; only the delete path in perform_merge_async calls them.
+    retraction_scope_stub = ModuleType("utils.memory.retraction_scope")
+    for _name in ["canonical_intake_is_fenced", "historical_source_conversation_ids", "retraction_can_be_skipped"]:
+        setattr(retraction_scope_stub, _name, MagicMock())
+
     # These tests exercise the merge module's audio-copy helper only. Stub the
     # lifecycle boundary so the fixture remains isolated from its unrelated
     # durable-finalization dependencies.
@@ -118,6 +124,7 @@ def merge():
         "utils.memory.memory_service": memory_service_stub,
         "utils.memory.memory_system": memory_system_stub,
         "utils.memory.canonical_activation": canonical_activation_stub,
+        "utils.memory.retraction_scope": retraction_scope_stub,
         "utils.conversations.lifecycle": lifecycle_stub,
     }
     fakes.update(model_stubs)

--- a/backend/tests/unit/test_conversation_events_bounds.py
+++ b/backend/tests/unit/test_conversation_events_bounds.py
@@ -99,6 +99,9 @@ def router():
     memory_service = ModuleType("utils.memory.memory_service")
     memory_service.MemoryService = MagicMock()
 
+    retraction_scope = ModuleType("utils.memory.retraction_scope")
+    setattr(retraction_scope, "retraction_can_be_skipped", MagicMock(return_value=False))
+
     request_validation = ModuleType("utils.request_validation")
     setattr(request_validation, "NonNegativeOffset", int)
     setattr(request_validation, "PositiveLimit", int)
@@ -164,6 +167,7 @@ def router():
         "utils.memory.memory_service": memory_service,
         "utils.memory.memory_system": memory_system,
         "utils.memory.canonical_activation": canonical_activation,
+        "utils.memory.retraction_scope": retraction_scope,
         "utils.retrieval": _pkg("utils.retrieval"),
         "utils.retrieval.tools": _pkg("utils.retrieval.tools"),
         "utils.retrieval.tools.calendar_tools": _pkg("utils.retrieval.tools.calendar_tools"),

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -180,6 +180,10 @@ _canonical_activation_stub = ModuleType('utils.memory.canonical_activation')
 setattr(_canonical_activation_stub, 'canonical_write_enabled', MagicMock(return_value=False))
 _register_module('utils.memory.canonical_activation', _canonical_activation_stub)
 
+_retraction_scope_stub = ModuleType('utils.memory.retraction_scope')
+setattr(_retraction_scope_stub, 'retraction_can_be_skipped', MagicMock(return_value=False))
+_register_module('utils.memory.retraction_scope', _retraction_scope_stub)
+
 _apps_stub = ModuleType('utils.apps')
 setattr(_apps_stub, 'get_available_app_by_id_with_reviews', MagicMock())
 setattr(_apps_stub, 'get_is_user_paid_app', MagicMock(return_value=False))

--- a/backend/tests/unit/test_conversations_date_range_validation.py
+++ b/backend/tests/unit/test_conversations_date_range_validation.py
@@ -72,6 +72,9 @@ def conv():
     canonical_activation_stub = ModuleType("utils.memory.canonical_activation")
     canonical_activation_stub.canonical_write_enabled = MagicMock(return_value=False)
 
+    retraction_scope_stub = ModuleType("utils.memory.retraction_scope")
+    retraction_scope_stub.retraction_can_be_skipped = MagicMock(return_value=False)
+
     # utils.request_validation — route param annotations; plain int keeps the direct-call path simple.
     request_validation_stub = ModuleType("utils.request_validation")
     request_validation_stub.NonNegativeOffset = int
@@ -121,6 +124,7 @@ def conv():
         "utils.memory.memory_service": memory_service_stub,
         "utils.memory.memory_system": memory_system_stub,
         "utils.memory.canonical_activation": canonical_activation_stub,
+        "utils.memory.retraction_scope": retraction_scope_stub,
         # utils.request_validation
         "utils.request_validation": request_validation_stub,
     }

--- a/backend/tests/unit/test_merge_validation.py
+++ b/backend/tests/unit/test_merge_validation.py
@@ -104,6 +104,12 @@ def merge():
     canonical_activation_stub = ModuleType("utils.memory.canonical_activation")
     setattr(canonical_activation_stub, "canonical_write_enabled", MagicMock(return_value=False))
 
+    # The retraction-scope helpers decide whether a source's canonical retraction
+    # can be skipped; only the delete path in perform_merge_async calls them.
+    retraction_scope_stub = ModuleType("utils.memory.retraction_scope")
+    for _name in ["canonical_intake_is_fenced", "historical_source_conversation_ids", "retraction_can_be_skipped"]:
+        setattr(retraction_scope_stub, _name, MagicMock())
+
     fakes: dict[str, ModuleType] = {
         "database": database_pkg,
         "database._client": client_stub,
@@ -118,6 +124,7 @@ def merge():
         "utils.memory.memory_service": memory_service_stub,
         "utils.memory.memory_system": memory_system_stub,
         "utils.memory.canonical_activation": canonical_activation_stub,
+        "utils.memory.retraction_scope": retraction_scope_stub,
     }
     fakes.update(model_stubs)
 


### PR DESCRIPTION
## What

Five backend unit files have been failing on `main` since `6316415534` (merged today, 14:44 UTC) with the same error:

```
ModuleNotFoundError: No module named 'utils.memory.retraction_scope'
```

- `tests/unit/test_batch_upload_storage.py`
- `tests/unit/test_conversation_events_bounds.py`
- `tests/unit/test_conversation_search_date_validation.py`
- `tests/unit/test_conversations_date_range_validation.py`
- `tests/unit/test_merge_validation.py`

Red lane on `main`: [run 31890773063](https://github.com/BasedHardware/omi/actions/runs/31890773063).

## Why

PR #11627 added a new module, `utils/memory/retraction_scope.py`, and imported it from both `utils/conversations/merge_conversations.py:25` and `routers/conversations.py:51`.

All five files load their module under test through the `stub_modules` + `load_module_fresh` isolation seam, and each stubs `utils.memory` as a package with an empty `__path__` plus a hand-listed set of submodules (`memory_service`, `memory_system`, `canonical_activation`). An empty `__path__` means any submodule that is *not* on that list cannot resolve at all — so the new import fails at fixture setup rather than falling through to the real module.

Nothing in these five files exercises retraction; they cover audio-copy helpers, merge validation, event index bounds, and search/date validation. The stubs simply had not caught up with a new import in the graph they load.

## Fix

Register a `utils.memory.retraction_scope` stub in each fixture, in that file's local idiom, exposing only the symbols its importer binds:

- the two `merge_conversations` loaders get `canonical_intake_is_fenced`, `historical_source_conversation_ids`, `retraction_can_be_skipped`
- the three `routers.conversations` loaders get `retraction_can_be_skipped`

Test files only — no production code changes, and no assertion in any of the five was touched.

## On #11531

The issue's original cause (the customer-Firestore split, #11522) was fixed by #11535 and the issue was left open. Verified at `6316415534` that all nine files it named now pass:

```
BACKEND_UNIT_TEST_FILE_LIST=<the 9 files> bash test.sh
-> 34 passed in 23.52s
```

The lane was red again for the unrelated cause above. With this change the lane is green, so the issue's condition is resolved.

## Tested

```
# the 5 failing files, before the fix (reproduced locally at 6316415534)
-> ModuleNotFoundError: No module named 'utils.memory.retraction_scope' in all 5

# after
BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-fail5.txt bash test.sh
-> 40 + 9 + 9 + 23 + 27 = 108 passed

# full backend unit suite
bash test.sh
-> the 5 files pass. 14 other files fail; the identical 14 fail on
   unmodified main (stashed, same runner, same machine), so none are
   attributable to this diff. test_sync_v2.py failed only under
   full-suite parallel load and passes standalone (168 passed) both
   before and after.

black --line-length 120 --skip-string-normalization --check
-> 5 files would be left unchanged

scripts/pr-preflight --pr-body-file <this body>
-> PR preflight passed: 24 checks in 117.98s
   (includes backend-module-isolation, backend-import-purity)
```

Local runner is Python 3.12 / pytest 9.1.1 against CI's 3.11 / 8.4.1, which accounts for some of the 14 pre-existing local failures.

## Follow-up (not in this PR)

This is the second time in two weeks that a new import into the conversations/memory graph broke hand-listed stub sets (#11531 was the same shape). The durable fix is to derive the stub set rather than hand-list it — e.g. letting a stubbed package auto-provide `AutoMockModule` submodules instead of failing on an empty `__path__`. That is a change to the shared `testing/import_isolation.py` seam with a much wider blast radius than a red-lane repair, so it is deliberately left out here.

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

