### PR TITLE
feat(desktop): pool workstream context across buckets and drop the base dwell to 2s

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -9,9 +9,15 @@ struct BucketExtraction: Codable, Equatable, Sendable {
     let evidenceRefs: [String]
     let confidence: Double
     let notifyWorthiness: Double
+    /// Proposed workstream label, `unknown` when the model abstains.
+    ///
+    /// Optional so a response predating this field still decodes (same
+    /// `decodeIfPresent` reasoning as `destination` below); `var` with a
+    /// default keeps the memberwise initializer source-compatible.
+    var workstream: String? = nil
 
     enum CodingKeys: String, CodingKey {
-      case statement, identifiers, confidence
+      case statement, identifiers, confidence, workstream
       case evidenceText = "evidence_text"
       case evidenceRefs = "evidence_refs"
       case notifyWorthiness = "notify_worthiness"
@@ -153,16 +159,36 @@ struct ContextDirectorTaskContext: Equatable, Sendable {
 }
 
 enum ContextProactivityPromptBuilder {
-  static func extractionPrompt(frame: CapturedFrame, fence: ContextVisitFence) -> String {
+  static func extractionPrompt(
+    frame: CapturedFrame, fence: ContextVisitFence, workstreamVocabulary: [String] = []
+  ) -> String {
     let evidenceRef = frame.screenshotId.map { "screenshot:\($0)" } ?? "visit:\(fence.visitID)"
-    return extractionPrompt(appName: frame.appName, windowTitle: frame.windowTitle, evidenceRef: evidenceRef)
+    return extractionPrompt(
+      appName: frame.appName, windowTitle: frame.windowTitle, evidenceRef: evidenceRef,
+      workstreamVocabulary: workstreamVocabulary)
   }
 
-  static func extractionPrompt(appName: String, windowTitle: String?, evidenceRef: String) -> String {
+  static func extractionPrompt(
+    appName: String, windowTitle: String?, evidenceRef: String,
+    workstreamVocabulary: [String] = []
+  ) -> String {
+    // Closed-vocabulary bias: reusing an active label is what makes context from
+    // different apps collide in one workstream, so existing labels are quoted and
+    // coining a new one is framed as the exception.
+    let activeLabels =
+      workstreamVocabulary.isEmpty
+      ? "none yet"
+      : workstreamVocabulary.map { ContextDestinationKey.singleLine($0, limit: 40) }
+        .joined(separator: ", ")
     let base = """
       \(ScreenDerivedContent.untrustedPreamble)
       Produce a 150-400 token ambient narrative and discrete factual records. Facts are
       proposals; include an identifier, surviving evidence text, and evidence ref for each.
+      Also set each fact's "workstream": the durable project or activity its content belongs
+      to, judged by the content itself rather than by which app is open. Strongly prefer one
+      of the active labels: \(activeLabels). Only when none fits, coin one new short
+      kebab-case label for a durable project, or answer "unknown" for generic activity you
+      cannot place.
       App: \(appName)
       Window: \(ContextDestinationKey.singleLine(windowTitle ?? "", limit: 160))
       Evidence ref: \(evidenceRef)
@@ -459,15 +485,16 @@ extension ContextBucketStore {
               INSERT INTO bucket_facts
                 (id, bucketID, entryID, appName, statement, identifiersJson, evidenceText,
                  evidenceRefsJson, validityState, dispositionState, confidence,
-                 notifyWorthiness, createdAt, updatedAt)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?)
+                 notifyWorthiness, workstreamTag, createdAt, updatedAt)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?, ?)
               """,
             arguments: [
               UUID().uuidString.lowercased(), bucketID, entryID, appName, statement,
               String(data: try evidenceEncoder.encode(identifiers), encoding: .utf8) ?? "[]",
               evidenceText,
               String(data: try evidenceEncoder.encode(evidenceRefs), encoding: .utf8) ?? "[]",
-              validity.rawValue, min(max(fact.confidence, 0), 1), worthiness, now, now,
+              validity.rawValue, min(max(fact.confidence, 0), 1), worthiness,
+              ContextWorkstreamTag.sanitize(fact.workstream), now, now,
             ])
           if validity == .validated {
             existingFactIdentities.append(
@@ -747,7 +774,8 @@ actor ContextBucketRollupWriter {
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
       await store.fenceIsValid(fence)
     else { return }
-    let prompt = ContextProactivityPromptBuilder.extractionPrompt(frame: frame, fence: fence)
+    let prompt = ContextProactivityPromptBuilder.extractionPrompt(
+      frame: frame, fence: fence, workstreamVocabulary: await store.activeWorkstreamTags())
     do {
       let result = try await client.complete(
         operation: ModelQoS.Proactivity.extractionOperation,
@@ -838,10 +866,14 @@ actor ContextBucketRollupWriter {
               "evidence_refs": ["type": "array", "items": ["type": "string"]],
               "confidence": ["type": "number"],
               "notify_worthiness": ["type": "number"],
+              "workstream": ["type": "string"],
             ],
+            // Strict structured output requires every declared property listed as
+            // required, so the prompt tells the model to answer "unknown" when it
+            // cannot place a fact in a workstream.
             "required": [
               "statement", "identifiers", "evidence_text", "evidence_refs", "confidence",
-              "notify_worthiness",
+              "notify_worthiness", "workstream",
             ],
             "additionalProperties": false,
           ],

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
@@ -96,6 +96,18 @@ enum ContextBucketSchema {
         on: "context_visits",
         columns: ["primaryHandleType", "primaryHandleValue"])
     }
+    migrator.registerMigration("addBucketFactWorkstreamTag") { db in
+      try db.alter(table: "bucket_facts") { table in
+        // Sanitized workstream label proposed by the extraction model, nil when
+        // it abstained or the proposal failed sanitization. Facts written before
+        // this column exist as nil and simply never pool.
+        table.add(column: "workstreamTag", .text)
+      }
+      try db.create(
+        index: "idx_bucket_facts_workstream",
+        on: "bucket_facts",
+        columns: ["workstreamTag", "createdAt"])
+    }
   }
 
   static func removeMigratedLegacyDefaults(

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -427,31 +427,133 @@ actor ContextBucketStore {
     }
   }
 
-  /// Completed-visit engagement for one bucket inside the dwell policy's
-  /// rolling window. Read-only and advisory: any failure reports zero
-  /// engagement, which falls back to the standard dwell.
-  func recentEngagementSeconds(bucketID: String, now: Date = Date()) async -> TimeInterval {
+  /// Active workstream labels for the extraction prompt's closed vocabulary,
+  /// most recently used first. Read-only and advisory: failure means an empty
+  /// vocabulary, which only weakens label reuse for one extraction.
+  func activeWorkstreamTags(now: Date = Date(), limit: Int = 12) async -> [String] {
     let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
-    guard let pool else { return 0 }
-    let lookbackStart = now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds)
-    let intervals: [(startedAt: Date, endedAt: Date)] =
+    guard let pool else { return [] }
+    return
+      (try? await pool.read { db in
+        try String.fetchAll(
+          db,
+          sql: """
+            SELECT workstreamTag FROM bucket_facts
+            WHERE workstreamTag IS NOT NULL AND validityState = 'validated'
+              AND (expiresAt IS NULL OR expiresAt > ?)
+            GROUP BY workstreamTag ORDER BY MAX(createdAt) DESC LIMIT ?
+            """,
+          arguments: [now, max(0, limit)])
+      }) ?? []
+  }
+
+  /// The workstream to pool for this evaluation: the visit's own validated fact
+  /// tags first, else the bucket's overwhelming-majority tag. Nil (no pooling)
+  /// on any failure or ambiguity — the safe direction.
+  func liveWorkstreamTag(for fence: ContextVisitFence, now: Date = Date()) async -> String? {
+    guard let bucketID = fence.bucketID else { return nil }
+    let (pool, generation) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool, generation == fence.poolEpoch else { return nil }
+    return try? await pool.read { db in
+      let ownRows = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT f.workstreamTag AS tag, COUNT(*) AS n FROM bucket_facts f
+          JOIN bucket_entries e ON f.entryID = e.id
+          WHERE e.visitID = ? AND f.bucketID = ? AND f.validityState = 'validated'
+            AND f.workstreamTag IS NOT NULL
+          GROUP BY f.workstreamTag
+          """,
+        arguments: [fence.visitID, bucketID])
+      let bucketRows = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT workstreamTag AS tag, COUNT(*) AS n FROM bucket_facts
+          WHERE bucketID = ? AND validityState = 'validated' AND workstreamTag IS NOT NULL
+            AND (expiresAt IS NULL OR expiresAt > ?)
+          GROUP BY workstreamTag
+          """,
+        arguments: [bucketID, now])
+      func counts(_ rows: [Row]) -> [String: Int] {
+        rows.reduce(into: [:]) { result, row in
+          if let tag: String = row["tag"] { result[tag] = row["n"] }
+        }
+      }
+      return ContextWorkstreamPooling.liveTag(
+        ownTagCounts: counts(ownRows), bucketTagCounts: counts(bucketRows))
+    } ?? nil
+  }
+
+  /// Candidate facts for the related-workstream section: validated, unexpired,
+  /// same tag, other buckets, above the worthiness floor. Ranking and the
+  /// per-bucket diversity cap happen in `ContextWorkstreamPooling.select`.
+  func workstreamPool(
+    tag: String, excludingBucketID: String, now: Date = Date()
+  ) async -> [ContextWorkstreamPoolItem] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    return
       (try? await pool.read { db in
         try Row.fetchAll(
           db,
           sql: """
-            SELECT startedAt, endedAt FROM context_visits
-            WHERE bucketID = ? AND outcome = 'completed'
-              AND endedAt IS NOT NULL AND endedAt >= ?
+            SELECT id, bucketID, appName, statement, notifyWorthiness, createdAt
+            FROM bucket_facts
+            WHERE workstreamTag = ? AND bucketID <> ? AND validityState = 'validated'
+              AND (expiresAt IS NULL OR expiresAt > ?)
+              AND notifyWorthiness >= ?
+            ORDER BY createdAt DESC LIMIT ?
             """,
-          arguments: [bucketID, lookbackStart]
-        ).compactMap { row -> (startedAt: Date, endedAt: Date)? in
-          guard let startedAt: Date = row["startedAt"], let endedAt: Date = row["endedAt"] else {
-            return nil
-          }
-          return (startedAt: startedAt, endedAt: endedAt)
+          arguments: [
+            tag, excludingBucketID, now, ContextWorkstreamPooling.worthinessFloor,
+            ContextWorkstreamPooling.candidateFetchLimit,
+          ]
+        ).compactMap { row -> ContextWorkstreamPoolItem? in
+          guard
+            let factID: String = row["id"], let bucketID: String = row["bucketID"],
+            let statement: String = row["statement"], let createdAt: Date = row["createdAt"]
+          else { return nil }
+          return ContextWorkstreamPoolItem(
+            factID: factID,
+            bucketID: bucketID,
+            appName: row["appName"] ?? "",
+            statement: statement,
+            notifyWorthiness: row["notifyWorthiness"] ?? 0,
+            createdAt: createdAt)
         }
       }) ?? []
-    return ContextDwellPolicy.cumulativeEngagementSeconds(visitIntervals: intervals, now: now)
+  }
+
+  /// Recent deliveries from sibling buckets of the same workstream. With
+  /// pooling, the same cross-app point is reachable from every bucket carrying
+  /// the tag, so bucket-scoped dedup alone would re-deliver it once per
+  /// entry point.
+  func recentDeliveredForWorkstream(
+    tag: String,
+    excludingBucketID: String,
+    now: Date = Date(),
+    limit: Int = ContextBucketRecentDelivery.promptCap
+  ) async -> [ContextBucketRecentDelivery] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    let cap = max(0, min(limit, ContextBucketRecentDelivery.promptCap))
+    guard cap > 0 else { return [] }
+    return
+      (try? await pool.read { db in
+        try ContextBucketRecentDelivery.fetchAll(
+          db,
+          sql: """
+            SELECT decisionType, message, deliveredAt FROM proactive_deliveries
+            WHERE bucketID <> ?
+              AND bucketID IN (SELECT DISTINCT bucketID FROM bucket_facts WHERE workstreamTag = ?)
+              AND lifecycleState = 'delivered'
+              AND deliveredAt IS NOT NULL
+              AND expiresAt > ?
+            ORDER BY deliveredAt DESC
+            LIMIT ?
+            """,
+          arguments: [excludingBucketID, tag, now, cap])
+      }) ?? []
   }
 
   func markVisitSettled(_ fence: ContextVisitFence, at date: Date = Date()) async throws {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
@@ -101,4 +101,23 @@ enum ContextBucketsFeature {
   }
 
   private static let localDepartureEvaluationOverrideName = "OMI_FORCE_DEPARTURE_EVALUATION"
+
+  /// Quotes quality-gated validated facts from sibling buckets of the visit's
+  /// live workstream into the director's volatile prompt, and widens delivery
+  /// dedup to that workstream.
+  ///
+  /// Non-production dogfood defaults to on with the same inverted env override
+  /// as the flags above (`OMI_FORCE_BUCKET_WORKSTREAMS=0` turns it off).
+  /// Production and beta stay off until pooling is validated in dogfood — like
+  /// departure evaluation there is deliberately no remote stop yet, because
+  /// nothing ships dark to users this way.
+  @MainActor static var isWorkstreamPoolingEnabled: Bool {
+    guard isEnabled else { return false }
+    if AppBuild.isNonProduction {
+      return ProcessInfo.processInfo.environment[localWorkstreamPoolingOverrideName] != "0"
+    }
+    return false
+  }
+
+  private static let localWorkstreamPoolingOverrideName = "OMI_FORCE_BUCKET_WORKSTREAMS"
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -86,7 +86,7 @@ actor ContextProactivityEngine {
   init(
     client: ProactiveLaneClient,
     store: ContextBucketStore,
-    dwellNanoseconds: UInt64 = 8_000_000_000,
+    dwellNanoseconds: UInt64 = 2_000_000_000,
     presentationPreflight: @escaping @Sendable (String) async -> OwnerBoundNotificationPresentationResult = {
       ownerID in
       await NotificationService.shared.contextDirectorPresentationPreflight(ownerID: ownerID)
@@ -109,8 +109,7 @@ actor ContextProactivityEngine {
     guard let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
     guard dwellAdmission.begin(visitID: fence.visitID) else { return }
     defer { dwellAdmission.finish(visitID: fence.visitID) }
-    let dwell = await resolvedDwellNanoseconds(for: fence)
-    do { try await Task.sleep(nanoseconds: dwell) } catch { return }
+    do { try await Task.sleep(nanoseconds: dwellNanoseconds) } catch { return }
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
     do { try await store.markVisitSettled(fence) } catch { return }
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
@@ -198,16 +197,6 @@ actor ContextProactivityEngine {
       authorizationSnapshot: authorizationSnapshot)
   }
 
-  /// A bucket the user keeps returning to has already proven engagement, so the
-  /// settle wait shrinks (never disappears) once recent completed-visit time in
-  /// this bucket crosses the policy threshold.
-  private func resolvedDwellNanoseconds(for fence: ContextVisitFence) async -> UInt64 {
-    guard let bucketID = fence.bucketID else { return dwellNanoseconds }
-    let engagement = await store.recentEngagementSeconds(bucketID: bucketID)
-    return ContextDwellPolicy.dwellNanoseconds(
-      base: dwellNanoseconds, cumulativeEngagementSeconds: engagement)
-  }
-
   /// The shared post-settle tail of the director pipeline: presentation
   /// preflight, gate rebuilds, budget reservation, the model call (plus the
   /// bounded retrieval hop), grounding validation, and the presentation
@@ -257,18 +246,54 @@ actor ContextProactivityEngine {
         from: TasksStore.shared.incompleteTasks,
         now: currentFrame.captureTime)
     }
-    let recentDeliveries = await store.recentDeliveredForBucket(
+    var recentDeliveries = await store.recentDeliveredForBucket(
       bucketID: snapshot.bucketID, now: currentFrame.captureTime)
+    // The related-workstream section: validated facts from sibling buckets of
+    // the visit's live workstream, quality-gated and quoted as non-citable
+    // context. Read the flag once so section, dedup, and provenance agree; with
+    // the flag off (or no live tag) the prompt is byte-identical to today.
+    let workstreamPoolingEnabled = await MainActor.run {
+      ContextBucketsFeature.isWorkstreamPoolingEnabled
+    }
+    var workstreamSection: String? = nil
+    var workstreamProvenance: [String: Any]? = nil
+    if workstreamPoolingEnabled,
+      let liveTag = await store.liveWorkstreamTag(for: fence, now: currentFrame.captureTime)
+    {
+      let selected = ContextWorkstreamPooling.select(
+        await store.workstreamPool(
+          tag: liveTag, excludingBucketID: snapshot.bucketID, now: currentFrame.captureTime),
+        now: currentFrame.captureTime)
+      if !selected.isEmpty {
+        workstreamSection = ContextWorkstreamPooling.promptSection(
+          tag: liveTag, items: selected, now: currentFrame.captureTime)
+        workstreamProvenance = [
+          "tag": liveTag,
+          "pooled_fact_ids": selected.map(\.factID),
+        ]
+      }
+      // Tag-aware dedup: with pooling, the same cross-app point is reachable
+      // from every bucket carrying this tag, so sibling deliveries join the
+      // bucket's own under the same prompt cap.
+      let workstreamDeliveries = await store.recentDeliveredForWorkstream(
+        tag: liveTag, excludingBucketID: snapshot.bucketID, now: currentFrame.captureTime)
+      recentDeliveries = Array(
+        (recentDeliveries + workstreamDeliveries)
+          .sorted { $0.deliveredAt > $1.deliveredAt }
+          .prefix(ContextBucketRecentDelivery.promptCap))
+    }
     // Read once and use for the whole visit: schema, prompt, and hop admission
     // must agree, and a mid-visit flag flip must not desynchronize them. With
     // the flag off, schema and prompt are byte-identical to the pre-hop build.
     let retrievalHopEnabled = await MainActor.run { ContextBucketsFeature.isRetrievalHopEnabled }
     let prompt = ContextProactivityPromptBuilder.directorStablePrompt(
       snapshot: snapshot, allowLookup: retrievalHopEnabled)
-    let uncachedPrompt = ContextProactivityPromptBuilder.directorVolatilePrompt(
-      tasks: taskContext,
-      frame: currentFrame,
-      recentDeliveries: recentDeliveries)
+    let uncachedPrompt =
+      ContextProactivityPromptBuilder.directorVolatilePrompt(
+        tasks: taskContext,
+        frame: currentFrame,
+        recentDeliveries: recentDeliveries)
+      + (workstreamSection.map { "\n\n" + $0 } ?? "")
     guard
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
       await store.fenceFreshness(fence).fresh
@@ -395,6 +420,9 @@ actor ContextProactivityEngine {
       if var hopProvenance = retrievalProvenance {
         hopProvenance["cited_refs"] = retrievedRefs
         provenance["retrieval"] = hopProvenance
+      }
+      if let workstreamProvenance {
+        provenance["workstream"] = workstreamProvenance
       }
       let provenanceData = try JSONSerialization.data(withJSONObject: provenance, options: [.sortedKeys])
       let provenanceJSON = String(data: provenanceData, encoding: .utf8) ?? "{}"
@@ -753,40 +781,6 @@ actor ContextProactivityEngine {
       "required": required,
       "additionalProperties": false,
     ]
-  }
-}
-
-/// Shortens (never skips) the dwell settle for a bucket the user demonstrably
-/// keeps returning to. A run of short revisits proves engagement that a single
-/// 8-second dwell was designed to establish, so the wait shrinks once recent
-/// per-bucket engagement crosses a threshold. Settle semantics are untouched:
-/// the visit still settles after the (shorter) sleep, on the same path.
-enum ContextDwellPolicy {
-  /// Rolling window over which completed-visit engagement accumulates.
-  static let engagementLookbackSeconds: TimeInterval = 180
-  /// Cumulative engaged seconds at which the dwell shortens.
-  static let engagedCumulativeSeconds: TimeInterval = 20
-  static let shortenedDwellNanoseconds: UInt64 = 2_000_000_000
-
-  static func dwellNanoseconds(base: UInt64, cumulativeEngagementSeconds: TimeInterval) -> UInt64 {
-    guard cumulativeEngagementSeconds >= engagedCumulativeSeconds else { return base }
-    // min: a caller-configured dwell shorter than the shortened value (tests
-    // use zero) must never be lengthened by an engagement bonus.
-    return min(base, shortenedDwellNanoseconds)
-  }
-
-  /// Sum of completed-visit durations clipped to the lookback window ending at
-  /// `now`. Computable from `context_visits` alone — no new table.
-  static func cumulativeEngagementSeconds(
-    visitIntervals: [(startedAt: Date, endedAt: Date)], now: Date
-  ) -> TimeInterval {
-    let lookbackStart = now.addingTimeInterval(-engagementLookbackSeconds)
-    return visitIntervals.reduce(0.0) { total, interval in
-      let start = max(interval.startedAt, lookbackStart)
-      let end = min(interval.endedAt, now)
-      guard end > start else { return total }
-      return total + end.timeIntervalSince(start)
-    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// One validated cross-bucket fact quoted into the director's related-workstream
+/// section. Deliberately carries no citable ref: pooled facts are advisory
+/// context, and grounding stays on the visited bucket's own entries and facts.
+struct ContextWorkstreamPoolItem: Equatable, Sendable {
+  let factID: String
+  let bucketID: String
+  let appName: String
+  let statement: String
+  let notifyWorthiness: Double
+  let createdAt: Date
+}
+
+/// Workstream labels are model-proposed once per fact at extraction time and
+/// then behave as durable routing data, so everything stored must survive this
+/// sanitizer. Failing to nil is always the safe direction: an untagged fact
+/// simply never pools, exactly like every fact written before the tag existed.
+enum ContextWorkstreamTag {
+  /// The extraction prompt tells the model to answer this when unsure; it is an
+  /// abstention, not a label.
+  static let abstention = "unknown"
+  static let maximumLength = 32
+
+  static func sanitize(_ proposed: String?) -> String? {
+    guard let proposed else { return nil }
+    let lowered = proposed.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !lowered.isEmpty, lowered != abstention else { return nil }
+    // Kebab-case identity: spaces and underscores collapse to hyphens, anything
+    // outside [a-z0-9-] is dropped, and hyphen runs collapse so near-identical
+    // proposals ("Omi App", "omi_app", "omi-app") converge on one tag.
+    var kebab = ""
+    for scalar in lowered.unicodeScalars {
+      if scalar == " " || scalar == "_" || scalar == "-" {
+        kebab.append("-")
+      } else if (scalar >= "a" && scalar <= "z") || (scalar >= "0" && scalar <= "9") {
+        kebab.append(Character(scalar))
+      }
+    }
+    while kebab.contains("--") { kebab = kebab.replacingOccurrences(of: "--", with: "-") }
+    kebab = kebab.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    guard kebab.count >= 2, kebab.count <= maximumLength else { return nil }
+    guard kebab != abstention else { return nil }
+    return kebab
+  }
+}
+
+/// Pure selection policy for the related-workstream prompt section. Extracted
+/// so the quality gate, live-tag resolution, and section assembly are testable
+/// without the singleton store.
+enum ContextWorkstreamPooling {
+  /// Facts below this worthiness never earn pooled quota; measured against the
+  /// live fact corpus, a recency-only pool surfaces scaffolding and w=0 noise.
+  static let worthinessFloor = 0.3
+  static let maximumItems = 8
+  /// Diversity cap so one chatty sibling bucket cannot fill the section.
+  static let maximumPerBucket = 3
+  static let recencyHalfLifeHours = 6.0
+  /// Bound on candidates fetched from SQL before in-memory scoring.
+  static let candidateFetchLimit = 200
+  /// A bucket majority tag only stands in for a missing own-visit tag when it
+  /// is this dominant among the bucket's tagged facts…
+  static let bucketMajorityShare = 0.8
+  /// …and the bucket has at least this many tagged facts to have a majority of.
+  static let bucketMajorityMinimumFacts = 3
+
+  private static let scaffoldingPrefixes = [
+    "identifier", "ambient narrative", "evidence fragment", "evidence record",
+    "proposed record", "proposal ",
+  ]
+
+  /// Extraction-model scaffolding re-copied into `statement` reads as prose but
+  /// carries no information worth cross-bucket quota.
+  static func isScaffolding(_ statement: String) -> Bool {
+    let lowered = statement.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return scaffoldingPrefixes.contains { lowered.hasPrefix($0) }
+  }
+
+  /// The workstream the director should pool for right now. The visit's own
+  /// freshly extracted facts are the strongest signal; a bucket-majority tag
+  /// stands in only when it is overwhelming, so genuinely multi-topic surfaces
+  /// (a chat app hosting several projects) stay bucket-only rather than pooling
+  /// the wrong project's context.
+  static func liveTag(
+    ownTagCounts: [String: Int], bucketTagCounts: [String: Int]
+  ) -> String? {
+    if let own = ownTagCounts.max(by: { ($0.value, $1.key) < ($1.value, $0.key) }), own.value > 0 {
+      return own.key
+    }
+    let total = bucketTagCounts.values.reduce(0, +)
+    guard total >= bucketMajorityMinimumFacts else { return nil }
+    guard let dominant = bucketTagCounts.max(by: { ($0.value, $1.key) < ($1.value, $0.key) })
+    else { return nil }
+    guard Double(dominant.value) >= bucketMajorityShare * Double(total) else { return nil }
+    return dominant.key
+  }
+
+  /// Quality gate and ranking: worthiness floor, scaffolding filter, then
+  /// worthiness plus a recency half-life, capped per source bucket.
+  static func select(
+    _ candidates: [ContextWorkstreamPoolItem], now: Date
+  ) -> [ContextWorkstreamPoolItem] {
+    let scored =
+      candidates
+      .filter { $0.notifyWorthiness >= worthinessFloor && !isScaffolding($0.statement) }
+      .map { item -> (score: Double, item: ContextWorkstreamPoolItem) in
+        let ageHours = max(0, now.timeIntervalSince(item.createdAt)) / 3600
+        return (item.notifyWorthiness + pow(0.5, ageHours / recencyHalfLifeHours), item)
+      }
+      .sorted { lhs, rhs in
+        if lhs.score != rhs.score { return lhs.score > rhs.score }
+        return lhs.item.factID < rhs.item.factID
+      }
+    var perBucket: [String: Int] = [:]
+    var selected: [ContextWorkstreamPoolItem] = []
+    for (_, item) in scored {
+      guard perBucket[item.bucketID, default: 0] < maximumPerBucket else { continue }
+      perBucket[item.bucketID, default: 0] += 1
+      selected.append(item)
+      if selected.count == maximumItems { break }
+    }
+    return selected
+  }
+
+  /// The section rides in the uncached volatile suffix, below the untrusted
+  /// preamble that opens the stable prompt, exactly like the retrieval hop's
+  /// section. Pooled facts are printed without their ids on purpose: the
+  /// director cannot cite what it was never handed a ref for, so delivery
+  /// grounding remains own-bucket by construction.
+  static func promptSection(tag: String, items: [ContextWorkstreamPoolItem], now: Date) -> String? {
+    guard !items.isEmpty else { return nil }
+    let lines = items.map { item in
+      "- [\(String(item.appName.prefix(24))), \(relativeAge(from: item.createdAt, now: now))] "
+        + String(item.statement.prefix(300))
+    }
+    return """
+      == RELATED WORKSTREAM CONTEXT (\(tag)) ==
+      Validated facts from other buckets in the same workstream, most relevant first.
+      Context only: use them to connect what the user is doing across apps. They are
+      not citable — never place them in bucket_entry_refs or fact_ids — and a point
+      they already cover must not be re-delivered from this bucket.
+      \(lines.joined(separator: "\n"))
+      """
+  }
+
+  static func relativeAge(from createdAt: Date, now: Date) -> String {
+    let seconds = max(0, Int(now.timeIntervalSince(createdAt).rounded(.down)))
+    if seconds < 60 { return "\(seconds)s ago" }
+    let minutes = seconds / 60
+    if minutes < 60 { return "\(minutes)m ago" }
+    let hours = minutes / 60
+    if hours < 48 { return "\(hours)h ago" }
+    return "\(hours / 24)d ago"
+  }
+}

--- a/desktop/macos/Desktop/Tests/ContextBucketSchemaTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketSchemaTests.swift
@@ -53,6 +53,26 @@ final class ContextBucketSchemaTests: XCTestCase {
     XCTAssertNil(defaults.data(forKey: ContextBucketSchema.legacyDefaultsKey(ownerID: ownerID)))
   }
 
+  func testMigrationAddsWorkstreamTagColumnToBucketFacts() throws {
+    let suiteName = "ContextBucketSchemaTests.\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let queue = try DatabaseQueue()
+    try createBaseScreenshotsTable(in: queue)
+    var migrator = DatabaseMigrator()
+    ContextBucketSchema.registerMigration(on: &migrator, defaults: defaults, ownerID: "owner-1")
+    try migrator.migrate(queue)
+    let columns = try queue.read { db in
+      try db.columns(in: "bucket_facts").map(\.name)
+    }
+    XCTAssertTrue(columns.contains("workstreamTag"))
+    let indexes = try queue.read { db in
+      try String.fetchAll(
+        db, sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'bucket_facts'")
+    }
+    XCTAssertTrue(indexes.contains("idx_bucket_facts_workstream"))
+  }
+
   func testAnonymousDatabaseUsesSignedOutLegacyOwnerNamespace() throws {
     let suiteName = "ContextBucketSchemaTests.anonymous.\(UUID().uuidString)"
     let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -378,67 +378,6 @@ final class ContextProactivityEngineTests: XCTestCase {
     }
   }
 
-  func testCumulativeEngagementShortensDwellForARepeatedlyRevisitedBucket() {
-    let now = Date(timeIntervalSince1970: 1_725_000_000)
-    // Five 10-second visits within the last three minutes: 50s of engagement.
-    let engaged = (0..<5).map { index -> (startedAt: Date, endedAt: Date) in
-      let end = now.addingTimeInterval(TimeInterval(-20 * index) - 5)
-      return (startedAt: end.addingTimeInterval(-10), endedAt: end)
-    }
-    let engagedSeconds = ContextDwellPolicy.cumulativeEngagementSeconds(
-      visitIntervals: engaged, now: now)
-    XCTAssertEqual(engagedSeconds, 50, accuracy: 0.001)
-    XCTAssertEqual(
-      ContextDwellPolicy.dwellNanoseconds(
-        base: 8_000_000_000, cumulativeEngagementSeconds: engagedSeconds),
-      ContextDwellPolicy.shortenedDwellNanoseconds,
-      "a bucket the user keeps returning to earns the shortened dwell")
-
-    // Two sparse 5-second visits: 10s of engagement keeps the standard dwell.
-    let sparse = [0, 100].map { offset -> (startedAt: Date, endedAt: Date) in
-      let end = now.addingTimeInterval(TimeInterval(-offset) - 5)
-      return (startedAt: end.addingTimeInterval(-5), endedAt: end)
-    }
-    let sparseSeconds = ContextDwellPolicy.cumulativeEngagementSeconds(
-      visitIntervals: sparse, now: now)
-    XCTAssertEqual(sparseSeconds, 10, accuracy: 0.001)
-    XCTAssertEqual(
-      ContextDwellPolicy.dwellNanoseconds(
-        base: 8_000_000_000, cumulativeEngagementSeconds: sparseSeconds),
-      8_000_000_000)
-  }
-
-  func testCumulativeEngagementClipsToTheRollingWindowAndNeverLengthensTheDwell() {
-    let now = Date(timeIntervalSince1970: 1_725_000_000)
-    // A long visit that ended before the window contributes nothing; one that
-    // straddles the window start counts only its in-window portion.
-    let outside = [
-      (
-        startedAt: now.addingTimeInterval(-400),
-        endedAt: now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds - 1)
-      )
-    ]
-    XCTAssertEqual(
-      ContextDwellPolicy.cumulativeEngagementSeconds(visitIntervals: outside, now: now), 0)
-
-    let straddling = [
-      (
-        startedAt: now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds - 100),
-        endedAt: now.addingTimeInterval(-ContextDwellPolicy.engagementLookbackSeconds + 8)
-      )
-    ]
-    XCTAssertEqual(
-      ContextDwellPolicy.cumulativeEngagementSeconds(visitIntervals: straddling, now: now),
-      8, accuracy: 0.001)
-
-    // The engagement bonus can only shorten: a caller-configured dwell below
-    // the shortened value (tests use zero) is never raised, and settle is
-    // never skipped outright by policy.
-    XCTAssertEqual(
-      ContextDwellPolicy.dwellNanoseconds(base: 0, cumulativeEngagementSeconds: 500), 0)
-    XCTAssertGreaterThan(ContextDwellPolicy.shortenedDwellNanoseconds, 0)
-  }
-
   func testDepartureEvaluationTriggersOnlyAtTheWorthinessThresholdWithTheFlagOn() {
     XCTAssertFalse(
       ContextDepartureEvaluationPolicy.triggers(
@@ -805,35 +744,86 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
     try await super.tearDown()
   }
 
-  func testRecentEngagementSumsOnlyCompletedVisitsInsideTheRollingWindow() async throws {
+  func testWorkstreamTagsPersistPoolAcrossBucketsAndResolveTheLiveTag() async throws {
     let now = Date(timeIntervalSince1970: 1_800_000_000)
     let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
     let pool = try XCTUnwrap(database)
     try await seedBucket(in: pool, now: now)
     try await pool.write { db in
-      // Five 10-second completed visits within three minutes, one stale
-      // completed visit outside the window, one recent discarded visit.
-      for index in 0..<5 {
-        let end = now.addingTimeInterval(TimeInterval(-20 * index) - 5)
-        try Self.insertVisit(
-          db, id: Int64(index + 1), poolEpoch: poolEpoch, outcome: "completed",
-          startedAt: end.addingTimeInterval(-10), endedAt: end)
-      }
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+          VALUES ('bucket-b', 'task', 'workstream-sibling', ?, ?)
+          """,
+        arguments: [now, now])
       try Self.insertVisit(
-        db, id: 6, poolEpoch: poolEpoch, outcome: "completed",
-        startedAt: now.addingTimeInterval(-400), endedAt: now.addingTimeInterval(-390))
-      try Self.insertVisit(
-        db, id: 7, poolEpoch: poolEpoch, outcome: "discarded",
-        startedAt: now.addingTimeInterval(-30), endedAt: now.addingTimeInterval(-1))
+        db, id: 1, poolEpoch: poolEpoch, outcome: "completed",
+        startedAt: now.addingTimeInterval(-13), endedAt: now)
+      try db.execute(
+        sql: """
+          INSERT INTO context_visits
+            (id, contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+             normalizedContextKey, referenceHash, startedAt, endedAt, outcome, createdAt, updatedAt)
+          VALUES (2, 1, ?, 'bucket-b', 'Sibling App', 'raw', 'normalized', 'reference-b', ?, ?,
+                  'completed', ?, ?)
+          """,
+        arguments: [poolEpoch, now.addingTimeInterval(-60), now.addingTimeInterval(-40), now, now])
     }
+    let fence = ContextVisitFence(
+      visitID: 1, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket",
+      startedAt: now.addingTimeInterval(-13))
+    let siblingFence = ContextVisitFence(
+      visitID: 2, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket-b",
+      startedAt: now.addingTimeInterval(-60))
 
-    let engagement = await ContextBucketStore.shared.recentEngagementSeconds(
-      bucketID: "bucket", now: now)
-    XCTAssertEqual(engagement, 50, accuracy: 0.001)
-    XCTAssertEqual(
-      ContextDwellPolicy.dwellNanoseconds(
-        base: 8_000_000_000, cumulativeEngagementSeconds: engagement),
-      ContextDwellPolicy.shortenedDwellNanoseconds)
+    func fact(_ statement: String, workstream: String?, worthiness: Double, visit: Int64)
+      -> BucketExtraction.Fact
+    {
+      BucketExtraction.Fact(
+        statement: statement,
+        identifiers: ["identity"],
+        evidenceText: "evidence",
+        evidenceRefs: ["visit:\(visit)"],
+        confidence: 1,
+        notifyWorthiness: worthiness,
+        workstream: workstream)
+    }
+    // "Omi App" must survive sanitization as "omi-app"; the sibling writes one
+    // poolable fact, one below the worthiness floor, and one scaffolding-shaped
+    // statement that the selector must drop.
+    _ = try await ContextBucketStore.shared.writeExtraction(
+      BucketExtraction(
+        narrative: "own narrative",
+        facts: [fact("own visit fact", workstream: "Omi App", worthiness: 0.7, visit: 1)]),
+      for: fence, appName: "Test App", rawContextKey: "raw", normalizedContextKey: "normalized",
+      now: now)
+    _ = try await ContextBucketStore.shared.writeExtraction(
+      BucketExtraction(
+        narrative: "sibling narrative",
+        facts: [
+          fact("sibling poolable fact", workstream: "omi app", worthiness: 0.8, visit: 2),
+          fact("sibling weak fact", workstream: "omi-app", worthiness: 0.1, visit: 2),
+          fact(
+            "Identifier proposal: visit:2", workstream: "omi-app", worthiness: 0.9, visit: 2),
+        ]),
+      for: siblingFence, appName: "Sibling App", rawContextKey: "raw",
+      normalizedContextKey: "normalized", now: now.addingTimeInterval(-30))
+
+    let liveTag = await ContextBucketStore.shared.liveWorkstreamTag(for: fence, now: now)
+    XCTAssertEqual(liveTag, "omi-app")
+    let activeTags = await ContextBucketStore.shared.activeWorkstreamTags(now: now)
+    XCTAssertEqual(activeTags, ["omi-app"])
+
+    let candidates = await ContextBucketStore.shared.workstreamPool(
+      tag: "omi-app", excludingBucketID: "bucket", now: now)
+    let selected = ContextWorkstreamPooling.select(candidates, now: now)
+    XCTAssertEqual(selected.map(\.statement), ["sibling poolable fact"])
+    XCTAssertEqual(selected.map(\.bucketID), ["bucket-b"])
+    let section = try XCTUnwrap(
+      ContextWorkstreamPooling.promptSection(tag: "omi-app", items: selected, now: now))
+    XCTAssertTrue(section.contains("RELATED WORKSTREAM CONTEXT (omi-app)"))
+    XCTAssertTrue(section.contains("sibling poolable fact"))
+    XCTAssertFalse(section.contains("fact:"), "pooled facts must never expose citable refs")
   }
 
   func testWriteExtractionReportsTheMaximumWorthinessOfNewlyValidatedFactsOnly() async throws {

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamPoolingTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamPoolingTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class ContextWorkstreamPoolingTests: XCTestCase {
+  private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+  private func item(
+    _ factID: String, bucket: String = "bucket-a", worthiness: Double = 0.7,
+    ageMinutes: Double = 5, statement: String = "a concrete fact"
+  ) -> ContextWorkstreamPoolItem {
+    ContextWorkstreamPoolItem(
+      factID: factID,
+      bucketID: bucket,
+      appName: "App",
+      statement: statement,
+      notifyWorthiness: worthiness,
+      createdAt: now.addingTimeInterval(-ageMinutes * 60))
+  }
+
+  func testTagSanitizationConvergesVariantsAndRejectsAbstentionAndNoise() {
+    XCTAssertEqual(ContextWorkstreamTag.sanitize("Omi App"), "omi-app")
+    XCTAssertEqual(ContextWorkstreamTag.sanitize("omi_app"), "omi-app")
+    XCTAssertEqual(ContextWorkstreamTag.sanitize("  OMI--app  "), "omi-app")
+    XCTAssertEqual(ContextWorkstreamTag.sanitize("dtrinity"), "dtrinity")
+    XCTAssertNil(ContextWorkstreamTag.sanitize(nil))
+    XCTAssertNil(ContextWorkstreamTag.sanitize(""))
+    XCTAssertNil(ContextWorkstreamTag.sanitize("unknown"))
+    XCTAssertNil(ContextWorkstreamTag.sanitize("UNKNOWN"))
+    XCTAssertNil(ContextWorkstreamTag.sanitize("x"), "single characters carry no identity")
+    XCTAssertNil(
+      ContextWorkstreamTag.sanitize(String(repeating: "a", count: 40)),
+      "over-length labels are rejected rather than truncated into collisions")
+    XCTAssertNil(ContextWorkstreamTag.sanitize("!!!"), "symbol-only proposals reduce to nothing")
+  }
+
+  func testLiveTagPrefersOwnFactsAndFallsBackOnlyToAnOverwhelmingBucketMajority() {
+    // The visit's own facts win even against a different bucket majority.
+    XCTAssertEqual(
+      ContextWorkstreamPooling.liveTag(
+        ownTagCounts: ["omi": 2, "spudpay": 1], bucketTagCounts: ["spudpay": 40]),
+      "omi")
+    // No own tags: an 80%+ majority with enough tagged facts stands in…
+    XCTAssertEqual(
+      ContextWorkstreamPooling.liveTag(ownTagCounts: [:], bucketTagCounts: ["omi": 8, "agentctl": 2]),
+      "omi")
+    // …a genuinely mixed surface does not pool at all…
+    XCTAssertNil(
+      ContextWorkstreamPooling.liveTag(ownTagCounts: [:], bucketTagCounts: ["omi": 6, "agentctl": 4]))
+    // …and neither does a bucket with too few tagged facts to have a majority.
+    XCTAssertNil(ContextWorkstreamPooling.liveTag(ownTagCounts: [:], bucketTagCounts: ["omi": 2]))
+    XCTAssertNil(ContextWorkstreamPooling.liveTag(ownTagCounts: [:], bucketTagCounts: [:]))
+  }
+
+  func testSelectionEnforcesFloorScaffoldFilterDiversityCapAndSize() {
+    var candidates: [ContextWorkstreamPoolItem] = [
+      item("below-floor", worthiness: 0.2),
+      item("scaffold", statement: "Identifier proposal: visit:18"),
+      item("narrative", statement: "Ambient narrative: a quiet scene unfolds"),
+    ]
+    // Four eligible facts in one bucket: the per-bucket cap keeps three.
+    for index in 0..<4 {
+      candidates.append(item("chatty-\(index)", bucket: "chatty", worthiness: 0.9, ageMinutes: 1))
+    }
+    // Ten other buckets, one eligible fact each, older than the chatty ones.
+    for index in 0..<10 {
+      candidates.append(
+        item("spread-\(index)", bucket: "bucket-\(index)", worthiness: 0.5, ageMinutes: 30))
+    }
+    let selected = ContextWorkstreamPooling.select(candidates, now: now)
+    XCTAssertEqual(selected.count, ContextWorkstreamPooling.maximumItems)
+    XCTAssertFalse(selected.contains { $0.factID == "below-floor" })
+    XCTAssertFalse(selected.contains { $0.factID == "scaffold" })
+    XCTAssertFalse(selected.contains { $0.factID == "narrative" })
+    XCTAssertEqual(
+      selected.filter { $0.bucketID == "chatty" }.count, ContextWorkstreamPooling.maximumPerBucket)
+  }
+
+  func testSelectionRanksWorthinessPlusRecencyDeterministically() {
+    // Equal worthiness: the fresher fact outranks the stale one. Equal
+    // everything: factID breaks the tie so the ranking is stable.
+    let fresh = item("fresh", worthiness: 0.5, ageMinutes: 1)
+    let stale = item("stale", worthiness: 0.5, ageMinutes: 60 * 24)
+    let selected = ContextWorkstreamPooling.select([stale, fresh], now: now)
+    XCTAssertEqual(selected.map(\.factID), ["fresh", "stale"])
+    let tied = ContextWorkstreamPooling.select(
+      [item("b", ageMinutes: 3), item("a", ageMinutes: 3)], now: now)
+    XCTAssertEqual(tied.map(\.factID), ["a", "b"])
+  }
+
+  func testPromptSectionQuotesFactsWithoutCitableRefs() throws {
+    let items = [item("fact-id-1", statement: "Archit is waiting on the crash-report PR")]
+    let section = ContextWorkstreamPooling.promptSection(tag: "omi", items: items, now: now)
+    let unwrapped = try XCTUnwrap(section)
+    XCTAssertTrue(unwrapped.contains("RELATED WORKSTREAM CONTEXT (omi)"))
+    XCTAssertTrue(unwrapped.contains("Archit is waiting"))
+    XCTAssertTrue(unwrapped.contains("not citable"))
+    XCTAssertFalse(unwrapped.contains("fact-id-1"), "ids never reach the model")
+    XCTAssertNil(ContextWorkstreamPooling.promptSection(tag: "omi", items: [], now: now))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260815-workstream-context-pooling.json
+++ b/desktop/macos/changelog/unreleased/20260815-workstream-context-pooling.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive context now connects related work across apps — reading a PR, chatting about it, and drafting an email on the same project share one workstream's context — and reacts after 2 seconds on a page instead of 8"
+}

--- a/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
+++ b/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
@@ -17,6 +17,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDestinationKey.swift


### PR DESCRIPTION
## What

Two locked-in outcomes from the context-buckets dogfood review (offline replay against 2.5 days of live data, 2,127 visits / 200 buckets / 2,945 validated facts):

**1. Workstream pooling (flag-gated, non-prod on / prod+beta off).** Extraction labels every fact with a `workstream` — the durable project its content belongs to, judged by content rather than app, biased toward reusing the active label vocabulary quoted into the prompt. Labels survive `ContextWorkstreamTag.sanitize` into a new `bucket_facts.workstreamTag` column (migration `addBucketFactWorkstreamTag`). At director time, the visit's live tag (own facts first, else a ≥80% bucket majority of ≥3 tagged facts) pulls quality-gated validated facts from sibling buckets of the same workstream into a non-citable `RELATED WORKSTREAM CONTEXT` section of the volatile prompt: worthiness ≥ 0.3, scaffolding filtered, ranked by worthiness + 6h-half-life recency, max 3 per source bucket, top 8 (~300 tokens median in replay). Pooled facts carry no refs, so delivery grounding stays own-bucket by construction. Delivery dedup widens to the workstream's sibling buckets under the same prompt cap, and provenance records the tag plus pooled fact ids.

**2. Base dwell 8s → 2s.** Replay: buckets that ever become notify-eligible 77 → 141; director runs with context 458 → 814; budget gates bound the added volume. With the base now equal to `ContextDwellPolicy`'s shortened floor, the cumulative-engagement policy became a no-op, so the policy, its store query, and its tests are removed rather than left as a dead layer.

Deliberately **not** in this PR: browser destination-identity migration (rewrites stored identities; separate change).

## Why

A single research task fragments across apps — in the replay corpus, one project (omi) spanned ~30 buckets in 6 apps, and each fragment had to independently earn its own second dwell before it could ever notify. Pooling makes the cross-app context collide: in the replayed real sequence (Telegram `omi pr reviews` → GitHub PR list → 26s read of PR #11613), the director's section would have carried the email question about the last Omi macOS release from one minute earlier plus the CI-watch work from the Claude session.

## Verification

- `xcrun swift build -c debug --package-path Desktop` clean.
- Focused suites all pass: `ContextWorkstreamPoolingTests` (5: sanitization, live-tag fallback, floor/scaffold/diversity gates, deterministic ranking, non-citable section), `ContextProactivityEngineTests` (22), `ContextDepartureEvaluationStoreTests` (2, incl. a new integration test proving tags persist through `writeExtraction`, resolve as the live tag, and pool across buckets with the weak/scaffolding facts dropped), `ContextBucketSchemaTests` (8, incl. new migration/column/index assertion).
- Selection thresholds (0.3 floor, top-8, 3/bucket, 6h half-life) were tuned against the live fact corpus in the replay, not guessed.
- Per operator instruction, full `make preflight` and broader suites were deliberately skipped; local pre-push gates (changelog, flow coverage, format/lint, test-quality) all passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

