### PR TITLE
test(desktop): pin the signed-out owner in RealtimeHubSessionHandoffPolicyTests

### DIFF
--- a/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeHubSessionHandoffPolicyTests.swift
@@ -10,6 +10,27 @@ import XCTest
   // notification regression step must compile the bundle without them.
 
   final class RealtimeHubSessionHandoffPolicyTests: XCTestCase {
+    // Every policy here is evaluated against `RealtimeHubOwnerScope.signedOut`,
+    // which is only current while the standard domain holds no `auth_userId`.
+    // Inheriting that domain let a concurrent suite's signed-in owner make
+    // `isOwnerScopeCurrent(.signedOut)` false, so `failoverBargeInReplacement`
+    // returned false and the barge-in test failed on CI only. Pin the owner
+    // (which also moves this suite into the sequential cluster).
+    private var ownerFixture: RuntimeOwnerAuthorityTestFixture?
+
+    override func setUp() async throws {
+      try await super.setUp()
+      let fixture = await RuntimeOwnerAuthorityTestFixture()
+      ownerFixture = fixture
+      await fixture.establish(authOwnerID: nil)
+    }
+
+    override func tearDown() async throws {
+      await ownerFixture?.restore()
+      ownerFixture = nil
+      try await super.tearDown()
+    }
+
     @MainActor
     func testPhysicalReplacementGateDrainsBeforeStartingAndCoalescesDuplicates() async {
       let gate = RealtimeHubTransportReplacementGate()


### PR DESCRIPTION
## Bug

The desktop release train is blocked. `Build Desktop Release Candidate` (run 31894961914, 16:14Z) failed its source gate:

```
required check Desktop Swift Build & Tests for exact source SHA 197e6997cbe3ee3301b4c0609ac065c90efecfc3 completed with failure
```

That SHA's `Desktop Swift CI` run (31890381385) failed one suite — `RealtimeHubSessionHandoffPolicyTests`, in `testBargeInFailoverWaitsForTransportAcknowledgementBeforeSpecializedStart`, at lines 200/203/209/211. The same code passed pre-merge; the diff on that SHA touched `DashboardIntelligenceStore`, not the realtime hub. No desktop candidate can be cut while the newest releasable desktop SHA carries a red required check.

## Root cause

Every policy in the suite is asserted against `RealtimeHubOwnerScope.signedOut`, and `.signedOut` is only *current* while the standard defaults domain holds no `auth_userId` (`RealtimeHubOwnerScope.isCurrent` → `RuntimeOwnerIdentity.currentOwnerId()`). The suite never pinned that owner, so it inherited whatever the process's standard domain held.

`scripts/swift-test-suites.sh` gives each worker its own `CFFIXED_USER_HOME`, but that does not isolate this domain: the xctest process's `UserDefaults.standard` resolves to the shared `com.apple.dt.xctest.tool` domain regardless of the worker home (verified locally — the run's writes land in the real user's `~/Library/Preferences/com.apple.dt.xctest.tool.plist`, never in the worker home). A concurrently running suite that establishes a signed-in owner therefore makes `isOwnerScopeCurrent(.signedOut)` false, `failoverBargeInReplacement` returns `false` at its owner guard, and the four assertions fail exactly as CI reported.

This is the failure class #11511 already documented for `ChatToolExecutorPolicyTests` ("a concurrent suite moving `auth_userId` underneath it"), which the runner mitigates by auto-serializing every suite that drives `RuntimeOwnerAuthorityTestFixture`.

## Fix

Adopt that same fixture in `setUp`/`tearDown` and establish a signed-out owner (`authOwnerID: nil`), restoring the prior owner afterwards. Test-only, +21/-1 in one file. Two effects:

1. The suite's owner is pinned instead of inherited.
2. It joins `swift-test-suites.sh`'s derived sequential cluster (membership is derived by grepping for `RuntimeOwnerAuthorityTestFixture`), so no concurrent suite can move the owner — or the BYOK key the barge-in test seeds — underneath it.

## Verification

Reproduced the CI-only failure deterministically by seeding the leak, then proving the fix removes it:

```
defaults write com.apple.dt.xctest.tool auth_userId "leaked-concurrent-owner"
env CFFIXED_USER_HOME=... xcrun swift test --package-path Desktop --filter 'RealtimeHubSessionHandoffPolicyTests/'
```

| state | result |
|---|---|
| before this commit, leaked owner seeded | 21 tests, **7 failures** — including the exact CI signature at lines 200/203/209/211 |
| after this commit, same leaked owner seeded | 21 tests, 0 failures |
| after this commit, clean domain | 21 tests, 0 failures |

`make preflight` passes (18 checks).

Separately, the failed `Desktop Swift CI` run on `197e6997cb` was re-run to clear the release-train source gate for that SHA; this PR removes the cause so it does not recur.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

