### PR TITLE
fix(desktop+backend): deliver notifications when floating bar is disabled; add proactive quota + delivery observability

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -881,15 +881,21 @@ end
 return {1, current, ttl}
 """)
 
-_RATE_LIMIT_RELEASE_LUA = r.register_script("""
+_RATE_LIMIT_RELEASE_LUA_SOURCE = """
 local key = KEYS[1]
-local current = tonumber(redis.call('GET', key) or '0')
+local current = tonumber(redis.call('GET', key) or '0') or 0
 if current <= 1 then
     redis.call('DEL', key)
     return 0
 end
-return redis.call('DECR', key)
-""")
+local remaining = tonumber(redis.call('DECR', key) or '0') or 0
+if remaining <= 0 then
+    redis.call('DEL', key)
+    return 0
+end
+return remaining
+"""
+_RATE_LIMIT_RELEASE_LUA = r.register_script(_RATE_LIMIT_RELEASE_LUA_SOURCE)
 
 
 def check_rate_limit(key: str, policy: str, max_requests: int, window: int) -> tuple[bool, int, int]:
@@ -913,13 +919,18 @@ def check_rate_limit(key: str, policy: str, max_requests: int, window: int) -> t
 
 
 def reserve_rate_limit(key: str, policy: str, max_requests: int, window: int) -> tuple[bool, int, int]:
-    """Atomically reserve one reversible slot without counting denied attempts."""
+    """Atomically reserve one reversible slot without counting denied attempts.
+
+    Returns ``(allowed, remaining, reset_seconds)``. ``reset_seconds`` is the
+    key TTL on both admit and deny so callers can advertise window reset without
+    a second Redis round-trip. Denied attempts still do not increment the counter.
+    """
     redis_key = f'rl:{policy}:{key}'
     admitted, current, ttl = _RATE_LIMIT_RESERVE_LUA(keys=[redis_key], args=[window, max_requests])
     allowed = bool(admitted)
     remaining = max(0, max_requests - current)
-    retry_after = max(0, ttl) if not allowed else 0
-    return allowed, remaining, retry_after
+    reset_seconds = max(0, int(ttl))
+    return allowed, remaining, reset_seconds
 
 
 def release_rate_limit(key: str, policy: str) -> None:

--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -10,7 +10,7 @@ from typing import Any
 from uuid import uuid4
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from jsonschema import Draft202012Validator, SchemaError, ValidationError
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -62,6 +62,36 @@ class _ProviderRequest:
     headers: dict[str, str]
     payload: dict[str, Any]
     fallback_class: str
+
+
+@dataclass(frozen=True)
+class ProactiveQuotaState:
+    limit: int
+    remaining: int
+    reset_seconds: int
+
+
+_QUOTA_LIMIT_HEADER = "X-Proactive-Quota-Limit"
+_QUOTA_REMAINING_HEADER = "X-Proactive-Quota-Remaining"
+_QUOTA_RESET_HEADER = "X-Proactive-Quota-Reset"
+
+
+def _quota_headers(state: ProactiveQuotaState, *, include_retry_after: bool = False) -> dict[str, str]:
+    headers = {
+        _QUOTA_LIMIT_HEADER: str(state.limit),
+        _QUOTA_REMAINING_HEADER: str(state.remaining),
+        _QUOTA_RESET_HEADER: str(state.reset_seconds),
+    }
+    if include_retry_after:
+        headers["Retry-After"] = str(state.reset_seconds)
+    return headers
+
+
+def _apply_quota_headers(response: Response | None, state: ProactiveQuotaState | None) -> None:
+    if response is None or state is None:
+        return
+    for name, value in _quota_headers(state).items():
+        response.headers[name] = value
 
 
 def _dev_direct_provider_allowed() -> bool:
@@ -197,7 +227,7 @@ def _customer_subscription(uid: str) -> Subscription | None:
     )
 
 
-async def _consume_quota(uid: str, operation: ProactiveOperation) -> None:
+async def _consume_quota(uid: str, operation: ProactiveOperation) -> ProactiveQuotaState:
     operation_value = operation.value
     try:
         subscription = await run_blocking(
@@ -206,7 +236,7 @@ async def _consume_quota(uid: str, operation: ProactiveOperation) -> None:
             uid,
         )
         limit = _quota_limit_for_subscription(operation, subscription)
-        allowed, _, retry_after = await run_blocking(
+        allowed, remaining, reset_seconds = await run_blocking(
             critical_executor,
             redis_db.reserve_rate_limit,
             uid,
@@ -216,12 +246,14 @@ async def _consume_quota(uid: str, operation: ProactiveOperation) -> None:
         )
     except Exception as exc:
         raise HTTPException(status_code=503, detail="Proactive metering is temporarily unavailable") from exc
+    state = ProactiveQuotaState(limit=limit, remaining=remaining, reset_seconds=reset_seconds)
     if not allowed:
         raise HTTPException(
             status_code=429,
             detail="Proactive request limit exceeded",
-            headers={"Retry-After": str(retry_after)},
+            headers=_quota_headers(state, include_retry_after=True),
         )
+    return state
 
 
 async def _release_quota(uid: str, operation: ProactiveOperation) -> None:
@@ -450,6 +482,7 @@ async def _post_provider_completion(
 @router.post("/v1/desktop/proactivity/completions", response_model=ProactiveCompletionEnvelope)
 async def proactive_completion(
     request: ProactiveCompletionRequest,
+    response: Response,
     uid: str = Depends(_authorized_desktop_user),
 ) -> ProactiveCompletionEnvelope:
     operation = request.operation.value
@@ -466,7 +499,8 @@ async def proactive_completion(
             response=response_body,
         )
 
-    await _consume_quota(uid, request.operation)
+    quota = await _consume_quota(uid, request.operation)
+    _apply_quota_headers(response, quota)
     request_id = str(uuid4())
     provider_request: _ProviderRequest | None = None
     direct_extraction_retry_attempted = False

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from fastapi import Response
 
 from routers import desktop_proactivity
 from utils.subscription import NEO_DESKTOP_GRANDFATHER_CUTOFF
@@ -119,7 +120,12 @@ async def test_quota_is_allowed_based_and_fails_closed(monkeypatch):
     with pytest.raises(desktop_proactivity.HTTPException) as exhausted:
         await desktop_proactivity._consume_quota("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)
     assert exhausted.value.status_code == 429
-    assert exhausted.value.headers == {"Retry-After": "19"}
+    assert exhausted.value.headers == {
+        "Retry-After": "19",
+        "X-Proactive-Quota-Limit": "200",
+        "X-Proactive-Quota-Remaining": "0",
+        "X-Proactive-Quota-Reset": "19",
+    }
 
     monkeypatch.setattr(
         desktop_proactivity.redis_db,
@@ -160,6 +166,95 @@ async def test_quota_matches_expanded_director_budget(monkeypatch, operation, ex
     assert observed["key"] == f"desktop_{operation.value}"
     assert observed["limit"] == expected_limit
     assert observed["window_seconds"] == 24 * 60 * 60
+
+
+@pytest.mark.asyncio
+async def test_quota_headers_present_on_success(monkeypatch):
+    async def run_blocking(_, function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(desktop_proactivity, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_proactivity, "get_customer_firestore_client", MagicMock())
+    monkeypatch.setattr(desktop_proactivity.users_db, "get_user_valid_subscription", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        desktop_proactivity.redis_db,
+        "reserve_rate_limit",
+        lambda *_: (True, 12, 3600),
+    )
+
+    state = await desktop_proactivity._consume_quota("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)
+    assert state == desktop_proactivity.ProactiveQuotaState(limit=200, remaining=12, reset_seconds=3600)
+
+    response = Response()
+    desktop_proactivity._apply_quota_headers(response, state)
+    assert response.headers["X-Proactive-Quota-Limit"] == "200"
+    assert response.headers["X-Proactive-Quota-Remaining"] == "12"
+    assert response.headers["X-Proactive-Quota-Reset"] == "3600"
+    assert "retry-after" not in {name.lower() for name in response.headers.keys()}
+
+
+@pytest.mark.asyncio
+async def test_completion_success_attaches_quota_headers(monkeypatch):
+    class GatewayClient:
+        async def post(self, url, *, headers, json):
+            return httpx.Response(
+                200,
+                request=httpx.Request("POST", url),
+                json={
+                    "model": "gpt-5.6-luna",
+                    "choices": [{"message": {"content": '{"summary":"ok"}'}}],
+                    "usage": {"prompt_tokens": 8},
+                },
+            )
+
+    class Semaphore:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return None
+
+    async def consume(*_):
+        return desktop_proactivity.ProactiveQuotaState(limit=200, remaining=12, reset_seconds=3600)
+
+    monkeypatch.setattr(desktop_proactivity, "llm_stub_enabled", lambda: False)
+    monkeypatch.setenv("OMI_LLM_GATEWAY_URL", "http://gateway")
+    monkeypatch.setattr(desktop_proactivity, "_consume_quota", consume)
+    monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", lambda: GatewayClient())
+    monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_semaphore", lambda: Semaphore())
+    monkeypatch.setattr(desktop_proactivity, "llm_gateway_headers", lambda **_: {})
+
+    response = Response()
+    result = await desktop_proactivity.proactive_completion(request(), response, uid="user-1")
+    assert result.provider_model == "gpt-5.6-luna"
+    assert response.headers["X-Proactive-Quota-Limit"] == "200"
+    assert response.headers["X-Proactive-Quota-Remaining"] == "12"
+    assert response.headers["X-Proactive-Quota-Reset"] == "3600"
+
+
+def test_release_after_delete_does_not_go_negative():
+    import fakeredis
+
+    client = fakeredis.FakeRedis()
+    script = client.register_script(desktop_proactivity.redis_db._RATE_LIMIT_RELEASE_LUA_SOURCE)
+    key = "rl:desktop_proactive_extraction:user-1"
+
+    remaining = script(keys=[key], args=[])
+    assert int(remaining) == 0
+    stored = client.get(key)
+    assert stored is None or int(stored) >= 0
+
+    client.set(key, 3)
+    remaining = script(keys=[key], args=[])
+    assert int(remaining) == 2
+    assert int(client.get(key)) == 2
+
+    client.delete(key)
+    remaining = script(keys=[key], args=[])
+    assert int(remaining) == 0
+    stored = client.get(key)
+    if stored is not None:
+        assert int(stored) >= 0
 
 
 @pytest.mark.parametrize(
@@ -212,7 +307,9 @@ async def test_offline_stub_honors_schema_without_gateway_or_quota(monkeypatch):
     monkeypatch.setattr(desktop_proactivity, "_consume_quota", forbidden)
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", forbidden)
 
-    result = await desktop_proactivity.proactive_completion(request("proactive_reasoning"), uid="offline-user")
+    result = await desktop_proactivity.proactive_completion(
+        request("proactive_reasoning"), Response(), uid="offline-user"
+    )
 
     assert result.provider_model == "omi-offline-stub"
     assert result.fallback_class == "offline_stub"
@@ -250,7 +347,7 @@ async def test_gateway_failure_releases_reserved_quota(monkeypatch):
     monkeypatch.setattr(desktop_proactivity, "llm_gateway_headers", lambda **_: {})
 
     with pytest.raises(desktop_proactivity.HTTPException) as unavailable:
-        await desktop_proactivity.proactive_completion(request(), uid="user-1")
+        await desktop_proactivity.proactive_completion(request(), Response(), uid="user-1")
 
     assert unavailable.value.status_code == 502
     assert released == [("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)]
@@ -389,7 +486,7 @@ async def test_direct_extraction_retries_length_once_without_extra_quota_reserva
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_client", lambda: DirectClient())
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_semaphore", lambda: Semaphore())
 
-    result = await desktop_proactivity.proactive_completion(request(), uid="user-1")
+    result = await desktop_proactivity.proactive_completion(request(), Response(), uid="user-1")
 
     assert len(calls) == 2
     assert calls[0][2]["max_completion_tokens"] == 1024
@@ -457,7 +554,7 @@ async def test_direct_extraction_length_retry_releases_quota_once_after_final_fa
     monkeypatch.setattr(desktop_proactivity, "get_llm_gateway_semaphore", lambda: Semaphore())
 
     with pytest.raises(desktop_proactivity.HTTPException) as unavailable:
-        await desktop_proactivity.proactive_completion(request(), uid="user-1")
+        await desktop_proactivity.proactive_completion(request(), Response(), uid="user-1")
 
     assert unavailable.value.status_code == 502
     assert [payload["max_completion_tokens"] for payload in calls] == [1024, 2400]
@@ -493,7 +590,7 @@ async def test_provider_configuration_failure_releases_reserved_quota(monkeypatc
     )
 
     with pytest.raises(desktop_proactivity.HTTPException) as unavailable:
-        await desktop_proactivity.proactive_completion(request(), uid="user-1")
+        await desktop_proactivity.proactive_completion(request(), Response(), uid="user-1")
 
     assert unavailable.value.status_code == 503
     assert released == [("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)]
@@ -541,7 +638,7 @@ async def test_facade_adds_provenance_and_cache_envelope(monkeypatch):
     )
 
     result = await desktop_proactivity.proactive_completion(
-        request("proactive_reasoning", cache_key="bucket-1"), uid="user-1"
+        request("proactive_reasoning", cache_key="bucket-1"), Response(), uid="user-1"
     )
 
     assert seen["json"]["model"] == "omi:auto:desktop-proactive-reasoning"

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -778,7 +778,7 @@ class TestRealCheckRateLimit(unittest.TestCase):
         self.real_module._RATE_LIMIT_RESERVE_LUA = MagicMock(return_value=[1, 3, 3600])
         allowed, remaining, retry = self.real_module.reserve_rate_limit("uid1", "desktop_reasoning", 10, 3600)
         self.assertTrue(allowed)
-        self.assertEqual((remaining, retry), (7, 0))
+        self.assertEqual((remaining, retry), (7, 3600))
         self.real_module._RATE_LIMIT_RESERVE_LUA.assert_called_once_with(
             keys=["rl:desktop_reasoning:uid1"], args=[3600, 10]
         )
@@ -792,6 +792,45 @@ class TestRealCheckRateLimit(unittest.TestCase):
         self.real_module._RATE_LIMIT_RELEASE_LUA = MagicMock(return_value=2)
         self.real_module.release_rate_limit("uid1", "desktop_reasoning")
         self.real_module._RATE_LIMIT_RELEASE_LUA.assert_called_once_with(keys=["rl:desktop_reasoning:uid1"], args=[])
+
+    def _release_lua_source(self) -> str:
+        source = None
+        for lua_source in self.lua_sources:
+            if "DECR" in lua_source and "DEL" in lua_source and "INCR" not in lua_source:
+                source = lua_source
+                break
+        self.assertIsNotNone(source, "release Lua script was not registered")
+        return source
+
+    def test_release_lua_clamps_at_zero_after_delete(self):
+        # The guarded unit runner stubs the redis package, so the script cannot
+        # be executed here. Pin the clamp semantics structurally: a release on a
+        # missing/zeroed counter must DEL and return 0 instead of DECR-ing the
+        # key negative (an operator quota reset deletes keys mid-flight).
+        source = self._release_lua_source()
+        self.assertIn("or '0'", source)
+        self.assertIn("current <= 1", source)
+        self.assertIn("remaining <= 0", source)
+        self.assertEqual(source.count("redis.call('DEL', key)"), 2)
+        for clause in ("current <= 1", "remaining <= 0"):
+            branch = source.split(clause, 1)[1]
+            self.assertIn("return 0", branch.split("end", 1)[0])
+
+    def test_release_lua_clamps_at_zero_after_delete_executes(self):
+        # Full execution against fakeredis, for environments where the real
+        # redis package (and lupa) are importable — bare pytest locally.
+        try:
+            import fakeredis
+
+            client = fakeredis.FakeRedis()
+            script = client.register_script(self._release_lua_source())
+        except Exception:
+            self.skipTest("fakeredis with Lua support unavailable under the guarded runner")
+        key = "rl:desktop_reasoning:uid1"
+        remaining = script(keys=[key], args=[])
+        self.assertEqual(int(remaining), 0)
+        stored = client.get(key)
+        self.assertTrue(stored is None or int(stored) >= 0)
 
 
 if __name__ == '__main__':

--- a/desktop/macos/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/macos/Desktop/Sources/AnalyticsManager.swift
@@ -2,6 +2,15 @@ import AppKit
 import Foundation
 import Sentry
 
+/// Closed reason a presented notification left the screen. Auto-hide and explicit
+/// close must not share a single "dismissed" bucket — that made engagement
+/// unreadable (expiry counted as a user dismiss).
+enum NotificationDismissalKind: String, CaseIterable, Sendable {
+  case user
+  case timeout
+  case replaced
+}
+
 /// Unified analytics manager that sends events to PostHog.
 /// Use this instead of calling PostHogManager directly
 @MainActor
@@ -1061,12 +1070,14 @@ class AnalyticsManager {
   func suggestionAssistantEvaluationFailed(
     identity: SuggestionAssistantTelemetry.Identity,
     shape: SuggestionAssistantTelemetry.EvaluationShape,
-    latency: TimeInterval
+    latency: TimeInterval,
+    reason: SuggestionAssistantTelemetry.EvaluationFailureReason
   ) {
     let payload = SuggestionAssistantTelemetry.evaluationFailedPayload(
       identity: identity,
       shape: shape,
-      latency: latency
+      latency: latency,
+      reason: reason
     )
     captureSuggestionAssistantTelemetryForTests(
       SuggestionAssistantTelemetry.evaluationFailedEventName,
@@ -1075,7 +1086,8 @@ class AnalyticsManager {
     PostHogManager.shared.suggestionAssistantEvaluationFailed(
       identity: identity,
       shape: shape,
-      latency: latency
+      latency: latency,
+      reason: reason
     )
   }
 
@@ -1246,12 +1258,15 @@ class AnalyticsManager {
     title: String,
     assistantId: String,
     surface: String,
+    dismissalKind: NotificationDismissalKind,
     suggestionIdentity: SuggestionAssistantTelemetry.NotificationIdentity? = nil
   ) {
     if let suggestionIdentity {
+      var properties = SuggestionAssistantTelemetry.notificationPayload(suggestionIdentity)
+      properties["dismissal_kind"] = dismissalKind.rawValue
       captureSuggestionAssistantTelemetryForTests(
         "Notification Dismissed",
-        properties: SuggestionAssistantTelemetry.notificationPayload(suggestionIdentity)
+        properties: properties
       )
     }
     PostHogManager.shared.notificationDismissed(
@@ -1259,6 +1274,7 @@ class AnalyticsManager {
       title: title,
       assistantId: assistantId,
       surface: surface,
+      dismissalKind: dismissalKind,
       suggestionIdentity: suggestionIdentity
     )
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3466,9 +3466,13 @@ class FloatingControlBarManager {
   }
 
   func dismissCurrentNotification() {
+    dismissCurrentNotification(kind: .user)
+  }
+
+  func dismissCurrentNotification(kind: NotificationDismissalKind) {
     notificationDismissWorkItem?.cancel()
     notificationDismissWorkItem = nil
-    dismissNotificationAndAdvanceQueue(trackDismissal: true)
+    dismissNotificationAndAdvanceQueue(trackDismissal: true, kind: kind)
   }
 
   func flushQueuedNotificationsIfPossible() {
@@ -4045,7 +4049,7 @@ class FloatingControlBarManager {
 
     notificationDismissWorkItem?.cancel()
     notificationDismissWorkItem = nil
-    dismissNotificationAndAdvanceQueue(trackDismissal: false)
+    dismissNotificationAndAdvanceQueue(trackDismissal: false, kind: .user)
     if case .openWhatMattersNow(let recommendationID) = notification.action {
       ContextualTaskNavigationRouter.shared.request(recommendationID: recommendationID)
       return
@@ -4068,6 +4072,22 @@ class FloatingControlBarManager {
       return false
     }
     persistNotificationMessageIfNeeded(notification)
+
+    if let existing = window.state.currentNotification, existing.id != notification.id {
+      notificationDismissWorkItem?.cancel()
+      notificationDismissWorkItem = nil
+      AnalyticsManager.shared.notificationDismissed(
+        notificationId: existing.id.uuidString,
+        title: existing.title,
+        assistantId: existing.assistantId,
+        surface: "floating_bar",
+        dismissalKind: .replaced,
+        suggestionIdentity: existing.suggestionTelemetryIdentity
+      )
+      notificationPresentationCallbacks.removeValue(forKey: existing.id)?.onDropped()
+      notificationAuthorizationSnapshots.removeValue(forKey: existing.id)
+      window.dismissNotification(animated: false)
+    }
 
     // A live voice session has no eyes. Hand it the card as silent context so a spoken
     // follow-up has a referent; the typed path gets the same thing via
@@ -4111,14 +4131,17 @@ class FloatingControlBarManager {
     )
 
     let dismissWorkItem = DispatchWorkItem { [weak self] in
-      self?.dismissNotificationAndAdvanceQueue(trackDismissal: true)
+      self?.dismissNotificationAndAdvanceQueue(trackDismissal: true, kind: .timeout)
     }
     notificationDismissWorkItem = dismissWorkItem
     DispatchQueue.main.asyncAfter(deadline: .now() + 6.0, execute: dismissWorkItem)
     return true
   }
 
-  private func dismissNotificationAndAdvanceQueue(trackDismissal: Bool) {
+  private func dismissNotificationAndAdvanceQueue(
+    trackDismissal: Bool,
+    kind: NotificationDismissalKind
+  ) {
     guard let window else { return }
 
     let dismissedNotification = window.state.currentNotification
@@ -4134,6 +4157,7 @@ class FloatingControlBarManager {
         title: dismissedNotification.title,
         assistantId: dismissedNotification.assistantId,
         surface: "floating_bar",
+        dismissalKind: kind,
         suggestionIdentity: dismissedNotification.suggestionTelemetryIdentity
       )
     }

--- a/desktop/macos/Desktop/Sources/PostHogManager.swift
+++ b/desktop/macos/Desktop/Sources/PostHogManager.swift
@@ -839,14 +839,16 @@ extension PostHogManager {
   func suggestionAssistantEvaluationFailed(
     identity: SuggestionAssistantTelemetry.Identity,
     shape: SuggestionAssistantTelemetry.EvaluationShape,
-    latency: TimeInterval
+    latency: TimeInterval,
+    reason: SuggestionAssistantTelemetry.EvaluationFailureReason
   ) {
     track(
       SuggestionAssistantTelemetry.evaluationFailedEventName,
       properties: SuggestionAssistantTelemetry.evaluationFailedPayload(
         identity: identity,
         shape: shape,
-        latency: latency
+        latency: latency,
+        reason: reason
       )
     )
   }
@@ -1014,6 +1016,7 @@ extension PostHogManager {
     title: String,
     assistantId: String,
     surface: String,
+    dismissalKind: NotificationDismissalKind,
     suggestionIdentity: SuggestionAssistantTelemetry.NotificationIdentity? = nil
   ) {
     var properties = notificationProperties(
@@ -1022,6 +1025,7 @@ extension PostHogManager {
       assistantId: assistantId,
       surface: surface
     )
+    properties["dismissal_kind"] = dismissalKind.rawValue
     appendSuggestionNotificationIdentity(suggestionIdentity, to: &properties)
     track(
       "Notification Dismissed",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -429,7 +429,8 @@ actor SuggestionAssistant: ProactiveAssistant {
         AnalyticsManager.shared.suggestionAssistantEvaluationFailed(
           identity: identity,
           shape: shape,
-          latency: Date().timeIntervalSince(startedAt)
+          latency: Date().timeIntervalSince(startedAt),
+          reason: SuggestionAssistantTelemetry.EvaluationFailureReason(error)
         )
       }
       throw error

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistantTelemetry.swift
@@ -78,6 +78,79 @@ enum SuggestionAssistantTelemetry {
     case over120Seconds = "120s_plus"
   }
 
+  /// Closed failure class for `Suggestion Assistant Evaluation Failed`.
+  /// Raw error strings, URLs, and user content are never accepted.
+  enum EvaluationFailureReason: String, CaseIterable, Sendable {
+    case network
+    case httpStatus4xx = "http_status_4xx"
+    case httpStatus5xx = "http_status_5xx"
+    case rateLimited = "rate_limited"
+    case decodeFailed = "decode_failed"
+    case timeout
+    case cancelled
+    case other
+
+    init(_ error: Error) {
+      self = Self.classify(error)
+    }
+
+    private static func classify(_ error: Error) -> EvaluationFailureReason {
+      if error is CancellationError { return .cancelled }
+      if error is DecodingError { return .decodeFailed }
+      if let urlError = error as? URLError {
+        switch urlError.code {
+        case .timedOut: return .timeout
+        case .cancelled: return .cancelled
+        default: return .network
+        }
+      }
+      if let geminiError = error as? GeminiClient.GeminiClientError {
+        switch geminiError {
+        case .networkError(let underlying):
+          return classify(underlying)
+        case .invalidResponse:
+          return .decodeFailed
+        case .apiError(let message, _):
+          return classifyAPIMessage(message)
+        case .missingAPIKey:
+          return .other
+        }
+      }
+      let nsError = error as NSError
+      if nsError.domain == NSURLErrorDomain {
+        switch nsError.code {
+        case NSURLErrorTimedOut: return .timeout
+        case NSURLErrorCancelled: return .cancelled
+        default: return .network
+        }
+      }
+      let typeName = String(describing: type(of: error))
+      if typeName.contains("SuggestionEvaluationError") { return .decodeFailed }
+      return .other
+    }
+
+    private static func classifyAPIMessage(_ message: String) -> EvaluationFailureReason {
+      if let status = httpStatus(from: message) {
+        if status == 429 { return .rateLimited }
+        if (400..<500).contains(status) { return .httpStatus4xx }
+        if (500..<600).contains(status) { return .httpStatus5xx }
+      }
+      let lower = message.lowercased()
+      if lower.contains("rate limit") || lower.contains("resource exhausted") || lower.contains("quota") {
+        return .rateLimited
+      }
+      if lower.contains("timeout") || lower.contains("timed out") { return .timeout }
+      return .other
+    }
+
+    private static func httpStatus(from message: String) -> Int? {
+      let prefix = "HTTP "
+      guard message.hasPrefix(prefix) else { return nil }
+      let digits = message.dropFirst(prefix.count).prefix(while: \.isNumber)
+      return Int(digits)
+    }
+  }
+
   /// Terminal state after a decoded model yield asks to interrupt the user.
   /// `delivered` is emitted only after the floating bar presents the card;
   /// the existing `Notification Sent` event shares the same presentation point.
@@ -201,10 +274,12 @@ enum SuggestionAssistantTelemetry {
   static func evaluationFailedPayload(
     identity: Identity,
     shape: EvaluationShape,
-    latency: TimeInterval
+    latency: TimeInterval,
+    reason: EvaluationFailureReason
   ) -> [String: Any] {
     var payload = evaluationPayload(identity: identity, shape: shape)
     payload["latency_bucket"] = latencyBucket(latency).rawValue
+    payload["reason"] = reason.rawValue
     return payload
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -206,7 +206,7 @@ actor GeminiClient {
     )
   }
 
-  enum GeminiClientError: LocalizedError {
+  nonisolated enum GeminiClientError: LocalizedError {
     case missingAPIKey
     case networkError(Error)
     case invalidResponse

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveLaneClient.swift
@@ -213,6 +213,7 @@ actor ProactiveLaneClient {
       }
     }
     guard let http = response as? HTTPURLResponse else { throw ProactiveLaneClientError.invalidResponse }
+    Self.logQuotaIfNeeded(operation: operation, response: http)
     guard (200..<300).contains(http.statusCode) else {
       let retryAfter: Int?
       if http.statusCode == 429 {
@@ -273,6 +274,16 @@ actor ProactiveLaneClient {
     return Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
   }
 
+  static func parseQuotaObservation(from response: HTTPURLResponse) -> ProactiveQuotaObservation? {
+    ProactiveQuotaObservation.parse(from: response)
+  }
+
+  static func logQuotaIfNeeded(operation: String, response: HTTPURLResponse) {
+    let observation = ProactiveQuotaObservation.parse(from: response)
+    guard ProactiveQuotaObservation.shouldLog(observation, statusCode: response.statusCode) else { return }
+    log(ProactiveQuotaObservation.logLine(operation: operation, observation: observation))
+  }
+
   static func parseEnvelope(_ data: Data) throws -> ProactiveLaneResult {
     let object: Any
     do {
@@ -300,6 +311,43 @@ actor ProactiveLaneClient {
       cacheWrite: root["cache_write"] as? Bool ?? false,
       fallbackClass: root["fallback_class"] as? String ?? "unknown",
       content: content)
+  }
+}
+
+struct ProactiveQuotaObservation: Equatable, Sendable {
+  let remaining: Int
+  let limit: Int
+  let resetSeconds: Int
+
+  var isLow: Bool {
+    limit > 0 && remaining * 10 <= limit
+  }
+
+  static func parse(from response: HTTPURLResponse) -> ProactiveQuotaObservation? {
+    guard let remaining = intHeader("X-Proactive-Quota-Remaining", from: response),
+      let limit = intHeader("X-Proactive-Quota-Limit", from: response)
+    else { return nil }
+    let resetSeconds = intHeader("X-Proactive-Quota-Reset", from: response) ?? 0
+    return ProactiveQuotaObservation(remaining: remaining, limit: limit, resetSeconds: resetSeconds)
+  }
+
+  static func shouldLog(_ observation: ProactiveQuotaObservation?, statusCode: Int) -> Bool {
+    if statusCode == 429 { return true }
+    return observation?.isLow == true
+  }
+
+  static func logLine(operation: String, observation: ProactiveQuotaObservation?) -> String {
+    let label = operation.hasPrefix("proactive_") ? String(operation.dropFirst("proactive_".count)) : operation
+    guard let observation else {
+      return "ProactiveLaneClient: quota \(label) remaining=unknown"
+    }
+    return
+      "ProactiveLaneClient: quota \(label) remaining=\(observation.remaining)/\(observation.limit) reset=\(observation.resetSeconds)s"
+  }
+
+  private static func intHeader(_ name: String, from response: HTTPURLResponse) -> Int? {
+    guard let raw = response.value(forHTTPHeaderField: name) else { return nil }
+    return Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
   }
 }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
@@ -1,8 +1,20 @@
 import Foundation
 
 enum FloatingBarNotificationPreviewPolicy {
+  /// In-bar card presentation is independent of the persisted Ask Omi enable
+  /// toggle. That toggle only controls whether the bar stays on screen; the
+  /// Notifications master toggle (and frequency gate) decide whether a
+  /// notification is owed at all.
+  ///
+  /// - Bar enabled + previews on → show the card on the persistent bar.
+  /// - Bar enabled + previews muted → skip the card so #6765 can fall back to a
+  ///   system banner.
+  /// - Bar disabled → still show the card via the existing temp-show path
+  ///   (present, then re-hide). Previews-muted does not silence this path:
+  ///   only the notification toggle decides, and a muted-preview + disabled-bar
+  ///   combination still owes a visible surface.
   static func shouldShowInBarPreview(previewsEnabled: Bool, floatingBarEnabled: Bool) -> Bool {
-    previewsEnabled && floatingBarEnabled
+    previewsEnabled || !floatingBarEnabled
   }
 
   /// The system-banner fallback only fires when the user explicitly muted in-bar
@@ -12,11 +24,9 @@ enum FloatingBarNotificationPreviewPolicy {
   /// Context-director delivery must use this same rule: muting the in-bar preview
   /// cannot silently burn ledger quota with no visible surface.
   ///
-  /// It deliberately does NOT fire just because the Floating Bar itself is
-  /// disabled/hidden: `NotificationService` documents that a bare system banner
-  /// with no conversation context was previously reported as confusing, which is
-  /// why floating-bar-only notifications stay floating-bar-only (i.e. silent)
-  /// when the bar is off, matching pre-existing behavior.
+  /// Disabling the Floating Bar itself does not force a banner. That path
+  /// temp-shows the in-bar card and re-hides afterwards, which keeps conversation
+  /// context instead of a contentless system banner.
   static func shouldDeliverSystemBanner(
     previewsEnabled: Bool, floatingBarEnabled: Bool, deliverSystemBanner: Bool
   ) -> Bool {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -266,7 +266,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
           notificationId: notificationId,
           title: title,
           assistantId: assistantId,
-          surface: "system_notification"
+          surface: "system_notification",
+          dismissalKind: .user
         )
 
       case Self.resetNowActionId:
@@ -329,21 +330,21 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// Send a notification via the floating bar, and optionally as a native macOS system banner.
   ///
   /// `deliverSystemBanner` defaults to `false` because proactive AI notifications are
-  /// floating-bar only by default — users who disabled the floating bar reported clicking
-  /// the top-right system banner and getting no conversation context, which was confusing.
-  /// Functional notifications (screen-recording permission
-  /// prompts with a repair action) must pass `deliverSystemBanner: true` so they
+  /// floating-bar cards by default — a bare top-right system banner with no conversation
+  /// context was previously reported as confusing. Functional notifications (screen-recording
+  /// permission prompts with a repair action) must pass `deliverSystemBanner: true` so they
   /// still surface as a system banner — they either have no floating-bar equivalent
   /// or must reach the user even when the floating bar is hidden/snoozed.
   ///
-  /// That default is no longer absolute: `FloatingBarNotificationPreviewPolicy` forces a
-  /// system banner anyway once the user has explicitly muted in-bar previews
-  /// (`ShortcutSettings.floatingBarNotificationPreviewsEnabled == false`) while the Floating
-  /// Bar is still enabled, so the notification is never fully silenced (#6765). That banner
-  /// still lacks the in-bar conversation context noted above — the tradeoff is accepted only
-  /// for that explicit opt-out, not by default. Disabling the Floating Bar itself does
-  /// *not* force a banner: floating-bar-only notifications stay silent in that case, same
-  /// as before this policy existed, per the contentless-banner confusion noted above.
+  /// Only the Notifications master toggle (and frequency gate) decide whether a
+  /// notification is owed. Disabling the Ask Omi bar (`askOmiBarEnabled`) hides the
+  /// persistent bar UI only: delivery still uses the existing temp-show path, which
+  /// pops the card and re-hides afterwards. `FloatingBarNotificationPreviewPolicy`
+  /// forces a system banner once the user has explicitly muted in-bar previews
+  /// (`ShortcutSettings.floatingBarNotificationPreviewsEnabled == false`) while the
+  /// Floating Bar is still enabled, so that opt-out is never fully silenced (#6765).
+  /// Previews muted *and* the bar disabled still temp-shows the card rather than
+  /// going silent or falling back to a contentless banner.
   /// `insightDeliveryID`, when present, is an opaque Advice correlation key. It records only
   /// bounded delivery outcomes and never carries notification text or window context.
   func sendNotification(
@@ -395,10 +396,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
-    // Hiding the floating bar ("Hide for 2 hours") is a statement about the BAR, not
-    // about notifications: an hour of a movie with the bar hidden must still nudge.
-    // Delivery while hidden goes through the existing temp-show path, which pops the
-    // card and re-hides the bar afterwards. It deliberately does not gate here.
+    // Hiding the floating bar ("Hide for 2 hours") and disabling it are both statements
+    // about the BAR, not about notifications: an hour of a movie with the bar hidden or
+    // off must still nudge. Delivery goes through the existing temp-show path, which pops
+    // the card and re-hides the bar afterwards. It deliberately does not gate here.
 
     // Proactive notifications honor the master Notifications toggle. When the user
     // turns Notifications off in Settings, suppress the floating-bar popup and the
@@ -490,8 +491,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         // later presentation boundary (or a system-banner fallback) can emit the terminal event.
         floatingBarQueued = true
       case .suppressed:
-        // Unreachable today (a hidden bar presents via temp-show instead of suppressing),
-        // kept for the shared result type; label with the surface, not a retired reason.
+        // Unreachable today (a hidden or disabled bar presents via temp-show instead of
+        // suppressing), kept for the shared result type; label with the surface, not a
+        // retired reason.
         recordInsightDeliveryOutcome(insightDeliveryID, outcome: .suppressed, reason: .floatingBarUnavailable)
         return
       case .rejectedOwnerChange:
@@ -506,11 +508,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       }
     }
 
-    // Default path: floating-bar only. Functional callers opt-in via
-    // `deliverSystemBanner: true` (see the parameter doc above). When the user
-    // explicitly muted in-bar previews (bar still enabled), fall back to the
-    // system banner so the notification is never fully silenced. Disabling the
-    // Floating Bar itself does not force a banner — see the parameter doc.
+    // Default path: floating-bar card (including temp-show when the bar is disabled).
+    // Functional callers opt-in via `deliverSystemBanner: true` (see the parameter
+    // doc above). When the user explicitly muted in-bar previews (bar still enabled),
+    // fall back to the system banner so the notification is never fully silenced.
     let shouldDeliverSystemBanner =
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
         previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
@@ -519,10 +520,12 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       )
     guard shouldDeliverSystemBanner else {
       if !floatingBarMayDeliver && !floatingBarQueued {
+        // Genuine no-surface failure (window creation / presentation never started).
+        // Bar-disabled is no longer a suppression reason; that path temp-shows.
         recordInsightDeliveryOutcome(
           insightDeliveryID,
-          outcome: floatingBarPreviewEnabled ? .failed : .suppressed,
-          reason: floatingBarPreviewEnabled ? .floatingBarUnavailable : .noDeliverySurface
+          outcome: .failed,
+          reason: .noDeliverySurface
         )
       }
       return
@@ -574,7 +577,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
   /// Presentation seam for the flag-on context director. Budget/dedup live in the
   /// durable ledger; this method still re-checks floating-preview policy so a muted
-  /// in-bar preview falls back to a system banner instead of burning quota invisibly.
+  /// in-bar preview (bar still enabled) falls back to a system banner, and a
+  /// disabled bar still temp-shows the card, instead of burning quota invisibly.
   @discardableResult
   func contextDirectorPresentationPreflight(ownerID: String) async -> OwnerBoundNotificationPresentationResult {
     guard !ownerID.isEmpty,

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -2,18 +2,15 @@ import XCTest
 
 @testable import Omi_Computer
 
-/// Regression coverage for `FloatingBarNotificationPreviewPolicy` (issue #6765).
+/// Regression coverage for `FloatingBarNotificationPreviewPolicy` (issue #6765
+/// plus the bar-disabled temp-show contract).
 ///
-/// Proactive notifications default to `deliverSystemBanner: false`, so the
-/// Floating Bar in-app preview is their only delivery path today. Muting that
-/// preview without a fallback would silence those notifications entirely.
-/// These tests pin the policy that keeps a notification delivered via the
-/// native system banner only when the user *explicitly* muted in-bar previews
-/// while the Floating Bar stayed enabled. Merely disabling the Floating Bar
-/// must not force a banner: `NotificationService.sendNotification` documents
-/// that a contentless system banner (no conversation context) was previously
-/// reported as confusing, which is why floating-bar-only notifications stay
-/// silent when the bar itself is off — same as before this policy existed.
+/// Only the Notifications master toggle (and frequency gate in
+/// `NotificationService`) decide whether a notification is owed. The Ask Omi
+/// enable toggle controls persistent bar UI only: a disabled bar still presents
+/// via temp-show, then re-hides. Muting in-bar previews while the bar stays
+/// enabled is the one case that falls back to a native system banner so the
+/// notification is never fully silenced.
 final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testPreviewsAndBarEnabledShowsPreviewWithNoForcedBanner() {
     XCTAssertTrue(
@@ -24,13 +21,15 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
         previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: false))
   }
 
-  func testFloatingBarDisabledSkipsPreviewWithNoForcedBanner() {
-    XCTAssertFalse(
+  func testFloatingBarDisabledPresentsViaTempShowWithNoForcedBanner() {
+    XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: true, floatingBarEnabled: false))
+        previewsEnabled: true, floatingBarEnabled: false),
+      "bar disabled + notifications owed must still present the in-bar card via temp-show")
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
-        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false))
+        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false),
+      "disabling the bar must not force a contentless system banner")
   }
 
   func testPreviewsMutedSkipsPreviewAndFallsBackToBanner() {
@@ -42,13 +41,25 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
         previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false))
   }
 
-  func testFloatingBarDisabledStillNoForcedBannerEvenWithPreviewsMuted() {
-    XCTAssertFalse(
+  func testFloatingBarDisabledAndPreviewsMutedStillTempShowsTheCard() {
+    XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: false, floatingBarEnabled: false))
+        previewsEnabled: false, floatingBarEnabled: false),
+      "previews muted + bar disabled must still temp-show the card; only the notification toggle silences")
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
-        previewsEnabled: false, floatingBarEnabled: false, deliverSystemBanner: false))
+        previewsEnabled: false, floatingBarEnabled: false, deliverSystemBanner: false),
+      "the combined muted+disabled case uses the card, not a system banner")
+  }
+
+  func testBarDisabledDoesNotSilenceWhenMasterNotificationsAreOffTheMasterGateDoes() {
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: true, floatingBarEnabled: false))
+    XCTAssertEqual(
+      InsightAssistantTelemetry.Reason.masterNotificationsDisabled.rawValue,
+      "master_notifications_disabled",
+      "bar disabled + notifications off is suppressed by NotificationService's master toggle, not by preview policy")
   }
 
   func testExplicitSystemBannerAlwaysDeliversRegardlessOfPreviewState() {

--- a/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveLaneClientTests.swift
@@ -66,6 +66,64 @@ final class ProactiveLaneClientTests: XCTestCase {
     XCTAssertEqual(ProactiveLaneClient.parseRetryAfterSeconds(from: response), 45)
   }
 
+  func testQuotaHeadersLogWhenRemainingIsLowAndAlwaysOn429() throws {
+    let url = try XCTUnwrap(URL(string: "https://proactive.test/v1/desktop/proactivity/completions"))
+    let low = try XCTUnwrap(
+      HTTPURLResponse(
+        url: url,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: [
+          "X-Proactive-Quota-Limit": "200",
+          "X-Proactive-Quota-Remaining": "12",
+          "X-Proactive-Quota-Reset": "3600",
+        ]))
+    let healthy = try XCTUnwrap(
+      HTTPURLResponse(
+        url: url,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: [
+          "X-Proactive-Quota-Limit": "200",
+          "X-Proactive-Quota-Remaining": "180",
+          "X-Proactive-Quota-Reset": "3600",
+        ]))
+    let rateLimited = try XCTUnwrap(
+      HTTPURLResponse(
+        url: url,
+        statusCode: 429,
+        httpVersion: nil,
+        headerFields: [
+          "X-Proactive-Quota-Limit": "200",
+          "X-Proactive-Quota-Remaining": "0",
+          "X-Proactive-Quota-Reset": "3600",
+        ]))
+    let rateLimitedWithoutHeaders = try XCTUnwrap(
+      HTTPURLResponse(url: url, statusCode: 429, httpVersion: nil, headerFields: [:]))
+
+    let lowObservation = try XCTUnwrap(ProactiveQuotaObservation.parse(from: low))
+    XCTAssertEqual(lowObservation.remaining, 12)
+    XCTAssertEqual(lowObservation.limit, 200)
+    XCTAssertEqual(lowObservation.resetSeconds, 3600)
+    XCTAssertTrue(lowObservation.isLow)
+    XCTAssertTrue(ProactiveQuotaObservation.shouldLog(lowObservation, statusCode: 200))
+    XCTAssertEqual(
+      ProactiveQuotaObservation.logLine(operation: "proactive_extraction", observation: lowObservation),
+      "ProactiveLaneClient: quota extraction remaining=12/200 reset=3600s")
+
+    let healthyObservation = try XCTUnwrap(ProactiveQuotaObservation.parse(from: healthy))
+    XCTAssertFalse(healthyObservation.isLow)
+    XCTAssertFalse(ProactiveQuotaObservation.shouldLog(healthyObservation, statusCode: 200))
+
+    let denied = try XCTUnwrap(ProactiveQuotaObservation.parse(from: rateLimited))
+    XCTAssertTrue(ProactiveQuotaObservation.shouldLog(denied, statusCode: 429))
+    XCTAssertTrue(ProactiveQuotaObservation.shouldLog(nil, statusCode: 429))
+    XCTAssertEqual(
+      ProactiveQuotaObservation.logLine(operation: "proactive_extraction", observation: nil),
+      "ProactiveLaneClient: quota extraction remaining=unknown")
+    XCTAssertNil(ProactiveQuotaObservation.parse(from: rateLimitedWithoutHeaders))
+  }
+
   func testExtractionSkipsNetworkDuringQuotaCooldownThenResumesAfterDeadline() async throws {
     ProactiveLaneURLStub.reset()
     let clock = ManualDateClock(Date(timeIntervalSince1970: 1_800_000_000))

--- a/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
+++ b/desktop/macos/Desktop/Tests/SuggestionAssistantTelemetryTests.swift
@@ -95,7 +95,8 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
     let failed = SuggestionAssistantTelemetry.evaluationFailedPayload(
       identity: identity,
       shape: shape(),
-      latency: 125
+      latency: 125,
+      reason: .timeout
     )
 
     XCTAssertEqual(completed["evaluation_id"] as? String, evaluationID.uuidString)
@@ -104,8 +105,56 @@ final class SuggestionAssistantTelemetryTests: XCTestCase {
     XCTAssertEqual(completed["produced_suggestion"] as? Bool, true)
     XCTAssertEqual(failed["evaluation_id"] as? String, evaluationID.uuidString)
     XCTAssertEqual(failed["latency_bucket"] as? String, "120s_plus")
+    XCTAssertEqual(failed["reason"] as? String, "timeout")
     XCTAssertNil(failed["suggestion_id"])
     XCTAssertNil(failed["produced_suggestion"])
+  }
+
+  func testEvaluationFailureReasonsAreClosedAndNeverCarryRawErrorMaterial() {
+    XCTAssertEqual(
+      Set(SuggestionAssistantTelemetry.EvaluationFailureReason.allCases.map(\.rawValue)),
+      Set([
+        "network", "http_status_4xx", "http_status_5xx", "rate_limited",
+        "decode_failed", "timeout", "cancelled", "other",
+      ])
+    )
+
+    let classified: [(Error, SuggestionAssistantTelemetry.EvaluationFailureReason)] = [
+      (CancellationError(), .cancelled),
+      (URLError(.timedOut), .timeout),
+      (URLError(.notConnectedToInternet), .network),
+      (URLError(.cancelled), .cancelled),
+      (DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "secret payload")), .decodeFailed),
+      (GeminiClient.GeminiClientError.invalidResponse, .decodeFailed),
+      (GeminiClient.GeminiClientError.apiError("HTTP 429: quota-key-xyz", retryable: true), .rateLimited),
+      (GeminiClient.GeminiClientError.apiError("HTTP 503: upstream body", retryable: true), .httpStatus5xx),
+      (GeminiClient.GeminiClientError.apiError("HTTP 400: prompt leaked", retryable: false), .httpStatus4xx),
+      (GeminiClient.GeminiClientError.missingAPIKey, .other),
+    ]
+    for (error, expected) in classified {
+      XCTAssertEqual(SuggestionAssistantTelemetry.EvaluationFailureReason(error), expected, String(describing: error))
+    }
+
+    let payload = SuggestionAssistantTelemetry.evaluationFailedPayload(
+      identity: SuggestionAssistantTelemetry.Identity(),
+      shape: shape(),
+      latency: 1,
+      reason: SuggestionAssistantTelemetry.EvaluationFailureReason(
+        GeminiClient.GeminiClientError.apiError("HTTP 429: user@example.com leaked", retryable: true)
+      )
+    )
+    let serialized = String(describing: payload)
+    XCTAssertEqual(payload["reason"] as? String, "rate_limited")
+    XCTAssertFalse(serialized.contains("user@example.com"))
+    XCTAssertFalse(serialized.contains("leaked"))
+    XCTAssertFalse(serialized.contains("HTTP 429"))
+  }
+
+  func testNotificationDismissalKindIsClosed() {
+    XCTAssertEqual(
+      Set(NotificationDismissalKind.allCases.map(\.rawValue)),
+      Set(["user", "timeout", "replaced"])
+    )
   }
 
   func testNotificationIdentityCarriesOnlyEvaluationAndSuggestionJoinKeys() throws {

--- a/desktop/macos/changelog/unreleased/20260815-floating-bar-notification-delivery.json
+++ b/desktop/macos/changelog/unreleased/20260815-floating-bar-notification-delivery.json
@@ -1,0 +1,3 @@
+{
+  "change": "Notifications now appear even when the Ask Omi floating bar is disabled: the card pops up briefly and the bar hides itself again. Only the Notifications toggle controls whether notifications are shown."
+}


### PR DESCRIPTION
## What

**1. Floating bar disabled must not silence notifications** (product decision)
- Only the Notifications master toggle + frequency gate decide whether a notification is shown. The Ask Omi bar toggle (`askOmiBarEnabled`) now controls the persistent bar UI only.
- With the bar disabled, delivery reuses the existing temp-show path: the card pops, then the bar re-hides (`FloatingControlBarWindow.swift` — temp-show arming now includes `!isEnabled`, re-hide on dismissal likewise). Previews muted + bar disabled also temp-shows (documented in `FloatingBarNotificationPreviewPolicy`). The #6765 previews-muted-while-enabled banner fallback is unchanged.
- Stale doc comments describing the old silent behavior are rewritten.

**2. Proactive quota observability**
- `POST /v1/desktop/proactivity/completions` responds with `X-Proactive-Quota-Limit`, `X-Proactive-Quota-Remaining`, `X-Proactive-Quota-Reset` on success and 429 (plus existing `Retry-After`). `reserve_rate_limit` now returns the window TTL on both admit and deny (it was discarded before); its only caller is this router.
- `ProactiveLaneClient` logs one bounded line when remaining ≤ 10% of limit and always on 429 — remote debugging via /tmp/omi-beta.log.
- Release Lua clamps at zero: an operator quota reset (`DEL` mid-flight) can no longer drive the counter negative.

**3. Telemetry precision**
- `Notification Dismissed` gains `dismissal_kind`: `user` / `timeout` / `replaced` (closed enum; auto-hide no longer masquerades as engagement — a real account showed 527 'dismissed' that were all expiries).
- `Suggestion Assistant Evaluation Failed` gains a closed-enum `reason` (network/http_status_4xx/http_status_5xx/rate_limited/decode_failed/timeout/cancelled/other). No raw error strings.

## Why

Diagnosed today on a real account: total perceived notification silence with a fully healthy pipeline. The floating-bar-disabled path dropped proactive notifications with no fallback by design, and quota/telemetry gaps made remote diagnosis take hours instead of minutes.

## Tests run

- backend: `pytest tests/unit/test_desktop_proactivity.py tests/unit/test_rate_limiting.py` — 99 passed
- desktop: `swift test --filter "FloatingBarNotificationPreviewPolicyTests|ProactiveLaneClientTests|SuggestionAssistantTelemetryTests"` — 30 passed, 0 failures

Implementation by cursor grok-4.6-high via agentctl.

## Failure class (fixes)

Failure-Class: none

## Invariants

INV-CHAT-1: this change touches the floating bar's notification presentation only. It adds no transcript/session state and no per-surface continuity — the temp-show/re-hide path explicitly defers to `window.state.showingAIConversation` so an active shared-transcript conversation is never hidden or forked, and dismissal-kind threading is telemetry-only.

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5207 -> 5231 | dismissal-kind threading and disabled-bar temp-show arming touch the notification presentation path that lives in this file; the additions are 24 lines of existing-pattern code and a split is out of scope for a demo-window fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

