### PR TITLE
test(desktop): update extraction-prompt golden for the workstream instruction

### DIFF
--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -23,6 +23,11 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
         ScreenDerivedContent.untrustedPreamble,
         "Produce a 150-400 token ambient narrative and discrete factual records. Facts are",
         "proposals; include an identifier, surviving evidence text, and evidence ref for each.",
+        "Also set each fact's \"workstream\": the durable project or activity its content belongs",
+        "to, judged by the content itself rather than by which app is open. Strongly prefer one",
+        "of the active labels: none yet. Only when none fits, coin one new short",
+        "kebab-case label for a durable project, or answer \"unknown\" for generic activity you",
+        "cannot place.",
         "App: Xcode",
         "Window: PR-123",
         "Evidence ref: screenshot:42",
@@ -32,6 +37,10 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       + "\n\nSet \"destination\" to \"\(ContextDestinationKey.abstention)\"."
 
     XCTAssertEqual(prompt, expected)
+
+    let withVocabulary = ContextProactivityPromptBuilder.extractionPrompt(
+      frame: frame, fence: fence, workstreamVocabulary: ["omi", "spudpay"])
+    XCTAssertTrue(withVocabulary.contains("of the active labels: omi, spudpay."))
   }
 
   func testExtractionPromptFallsBackToVisitEvidenceRefWithoutScreenshot() {


### PR DESCRIPTION
Unblocks the release train: #11634 changed the extraction prompt (workstream labeling block) but its focused test run missed this strict-equality golden, so `Desktop Swift Build & Tests` is red on main and the auto-release planner cannot tag a candidate.

The golden now mirrors the new prompt exactly (empty-vocabulary `none yet` rendering included) and adds an assertion that a supplied vocabulary renders as `of the active labels: omi, spudpay.`

Verification: `xcrun swift test --filter 'Context'` — all Context suites pass locally including the previously failing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

