### PR TITLE
fix(admin): source macOS activation from conversation records, not telemetry

### DIFF
--- a/.github/failure-classes/FC-unestablished-capability-default.json
+++ b/.github/failure-classes/FC-unestablished-capability-default.json
@@ -3,6 +3,10 @@
   "id": "FC-unestablished-capability-default",
   "violated_contract": "A surface that selects its presentation from a rollout or account capability must treat \"the capability is not established yet\" as its own state. A capability carried as a plain Bool cannot express it, so the default value is silently rendered as an authoritative answer and the wrong surface mounts until the real answer arrives.",
   "canonical_prevention": "Publish establishment alongside the capability and resolve presentation to an explicit undetermined state that mounts neither branch. Independently, any branch that performs destructive or shared-state work on first appearance must require a load that authoritatively succeeded, never an initial-value sentinel such as isEmpty.",
+  "canonical_prevention_artifact": [
+    "web/admin/lib/growth-metrics.ts",
+    "web/admin/lib/__tests__/growth-metrics.test.ts"
+  ],
   "evidence_prs": [9499],
   "scope_hints": [
     "desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift",

--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -1713,7 +1713,7 @@ export default function AnalyticsPage() {
         id: "viral-activation",
         title: "New Activated Users / Week",
         periodChange: latestPeriodChange(weeklyActivationData, (point) => point.activated, "vs previous mature cohort week"),
-        subtitle: "Memory created within 7 days of signup · fully matured cohorts only",
+        subtitle: "Conversation created within 7 days of signup · fully matured cohorts only",
         icon: <Target className="h-4 w-4" />,
         initialLayout: { cols: 12, rows: 4 },
         render: () => (

--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -228,6 +228,9 @@ interface ViralMetrics {
   summary: {
     quickRatio: number | null;
     activationRate: number | null;
+    activationTelemetryCoverage: number | null;
+    activationSignups: number;
+    activationPooledRate: number | null;
     dauMau: number;
     dauWau: number;
     dau: number;
@@ -1716,7 +1719,9 @@ export default function AnalyticsPage() {
                 <Legend />
                 <Bar yAxisId="left" dataKey="signups" name="Signups" fill="#3b82f6" radius={[2, 2, 0, 0]} opacity={0.5} />
                 <Bar yAxisId="left" dataKey="activated" name="Activated" fill="#22c55e" radius={[2, 2, 0, 0]} />
-                <Line yAxisId="right" type="monotone" dataKey="rate" name="Activation %" stroke="#f97316" strokeWidth={2} dot={{ r: 2 }} activeDot={{ r: 4 }} />
+                {/* capableRate, not rate: weeks whose cohort ran no reporting
+                    build are a gap in the line rather than a plotted zero. */}
+                <Line yAxisId="right" type="monotone" dataKey="capableRate" name="Activation %" stroke="#f97316" strokeWidth={2} dot={{ r: 2 }} activeDot={{ r: 4 }} />
               </ComposedChart>
             </ResponsiveContainer>
           ) : (
@@ -1886,9 +1891,9 @@ export default function AnalyticsPage() {
               {latestWeeklyActivation?.activated.toLocaleString() ?? "--"}
             </div>
             <p className="truncate text-xs text-muted-foreground">
-              {latestWeeklyActivation
-                ? `${latestWeeklyActivation.rate.toFixed(1)}% activation · Memory in 7d`
-                : "Memory within 7 days of signup"}
+              {latestWeeklyActivation?.capableRate != null
+                ? `${latestWeeklyActivation.capableRate.toFixed(1)}% activation · Memory in 7d`
+                : "Memory in 7d · no reporting build in this cohort"}
             </p>
           </div>
         ),
@@ -2281,7 +2286,19 @@ export default function AnalyticsPage() {
           <div className={`text-2xl font-bold ${(vm?.summary.activationRate ?? 0) >= 50 ? "text-green-600" : ""}`}>
             {vm?.summary.activationRate != null ? `${vm.summary.activationRate}%` : "--"}
           </div>
-          <p className="text-xs text-muted-foreground">Memory within 7d</p>
+          {/* Coverage is the difference between "users are not activating" and
+              "we cannot see whether they activated". Never show the rate alone
+              while some of the fleet cannot report it. */}
+          <p className="text-xs text-muted-foreground">
+            {vm?.summary.activationRate != null
+              ? `Memory within 7d · n=${vm.summary.activationSignups}`
+              : "Memory within 7d · not yet measurable"}
+          </p>
+          {vm != null && (vm.summary.activationTelemetryCoverage ?? 0) < 100 && (
+            <p className="text-xs text-amber-600">
+              {vm.summary.activationTelemetryCoverage ?? 0}% of signups on a build that reports it
+            </p>
+          )}
         </div>
       ),
     },

--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -679,7 +679,7 @@ export default function AnalyticsPage() {
   // for the window before the activation route has a cached payload.
   const weeklyActivationData = useMemo(
     () =>
-      activationStats?.weeks?.length
+      activationStats
         ? activationStats.weeks.slice(-12)
         : maturedWeeklyActivation(activationData).slice(-12),
     [activationStats, activationData],
@@ -2318,7 +2318,7 @@ export default function AnalyticsPage() {
         </div>
       ),
     },
-  ], [vm, profitability]);
+  ], [vm, profitability, activationStats]);
 
   const notificationsHeader: ChartItem = {
     id: "header-notifications",

--- a/web/admin/app/(protected)/dashboard/classic/page.tsx
+++ b/web/admin/app/(protected)/dashboard/classic/page.tsx
@@ -227,6 +227,7 @@ interface ViralMetrics {
   activation: { date: string; signups: number; activated: number; rate: number }[];
   summary: {
     quickRatio: number | null;
+    /** Telemetry-derived; unreliable while the fleet is mid-rollout. Prefer `ActivationStats`. */
     activationRate: number | null;
     activationTelemetryCoverage: number | null;
     activationSignups: number;
@@ -239,6 +240,15 @@ interface ViralMetrics {
     l5PlusPct: number;
     totalUsers: number;
   };
+}
+
+interface ActivationStats {
+  weeks: { week: string; signups: number; activated: number; rate: number }[];
+  signups: number;
+  activated: number;
+  rate: number | null;
+  erroredUsers: number;
+  freshAt?: number;
 }
 
 interface KFactorData {
@@ -471,6 +481,12 @@ export default function AnalyticsPage() {
   const { data: kFactorData, isLoading: kFactorLoading } =
     useSWR<KFactorData>(token ? ["/api/omi/stats/k-factor/posthog?days=30", token] : null, authFetcher, swrOpts);
 
+  // Activation comes from Firestore conversation records, not from the desktop
+  // `Memory Created` event in viral-metrics: older builds cannot emit that
+  // event, so the PostHog figure tracks build age rather than behaviour.
+  const { data: activationStats } =
+    useSWR<ActivationStats>(token ? ["/api/omi/stats/activation?days=60", token] : null, authFetcher, swrOpts);
+
   const { data: macosVersionStats, isLoading: macosVersionStatsLoading } =
     useSWR<MacosVersionStatsData>(token ? ["/api/omi/stats/macos-versions", token] : null, authFetcher, swrOpts);
 
@@ -659,9 +675,14 @@ export default function AnalyticsPage() {
     () => completedWeeklyNewUsers(allDailyData).slice(-12),
     [allDailyData],
   );
+  // Firestore-derived when available; the telemetry series is only a fallback
+  // for the window before the activation route has a cached payload.
   const weeklyActivationData = useMemo(
-    () => maturedWeeklyActivation(activationData).slice(-12),
-    [activationData],
+    () =>
+      activationStats?.weeks?.length
+        ? activationStats.weeks.slice(-12)
+        : maturedWeeklyActivation(activationData).slice(-12),
+    [activationStats, activationData],
   );
   const latestWeeklyNewUsers = weeklyNewUsersData.at(-1) ?? null;
   const latestWeeklyActivation = weeklyActivationData.at(-1) ?? null;
@@ -1719,9 +1740,7 @@ export default function AnalyticsPage() {
                 <Legend />
                 <Bar yAxisId="left" dataKey="signups" name="Signups" fill="#3b82f6" radius={[2, 2, 0, 0]} opacity={0.5} />
                 <Bar yAxisId="left" dataKey="activated" name="Activated" fill="#22c55e" radius={[2, 2, 0, 0]} />
-                {/* capableRate, not rate: weeks whose cohort ran no reporting
-                    build are a gap in the line rather than a plotted zero. */}
-                <Line yAxisId="right" type="monotone" dataKey="capableRate" name="Activation %" stroke="#f97316" strokeWidth={2} dot={{ r: 2 }} activeDot={{ r: 4 }} />
+                <Line yAxisId="right" type="monotone" dataKey="rate" name="Activation %" stroke="#f97316" strokeWidth={2} dot={{ r: 2 }} activeDot={{ r: 4 }} />
               </ComposedChart>
             </ResponsiveContainer>
           ) : (
@@ -1891,9 +1910,9 @@ export default function AnalyticsPage() {
               {latestWeeklyActivation?.activated.toLocaleString() ?? "--"}
             </div>
             <p className="truncate text-xs text-muted-foreground">
-              {latestWeeklyActivation?.capableRate != null
-                ? `${latestWeeklyActivation.capableRate.toFixed(1)}% activation · Memory in 7d`
-                : "Memory in 7d · no reporting build in this cohort"}
+              {latestWeeklyActivation
+                ? `${latestWeeklyActivation.rate.toFixed(1)}% activation · conversation in 7d`
+                : "Conversation within 7 days of signup"}
             </p>
           </div>
         ),
@@ -2283,20 +2302,17 @@ export default function AnalyticsPage() {
       initialLayout: { cols: 2, rows: 1 },
       render: () => (
         <div>
-          <div className={`text-2xl font-bold ${(vm?.summary.activationRate ?? 0) >= 50 ? "text-green-600" : ""}`}>
-            {vm?.summary.activationRate != null ? `${vm.summary.activationRate}%` : "--"}
+          <div className={`text-2xl font-bold ${(activationStats?.rate ?? 0) >= 50 ? "text-green-600" : ""}`}>
+            {activationStats?.rate != null ? `${activationStats.rate}%` : "--"}
           </div>
-          {/* Coverage is the difference between "users are not activating" and
-              "we cannot see whether they activated". Never show the rate alone
-              while some of the fleet cannot report it. */}
           <p className="text-xs text-muted-foreground">
-            {vm?.summary.activationRate != null
-              ? `Memory within 7d · n=${vm.summary.activationSignups}`
-              : "Memory within 7d · not yet measurable"}
+            {activationStats?.rate != null
+              ? `Conversation within 7d · n=${activationStats.signups.toLocaleString()}`
+              : "Conversation within 7 days of signup"}
           </p>
-          {vm != null && (vm.summary.activationTelemetryCoverage ?? 0) < 100 && (
+          {(activationStats?.erroredUsers ?? 0) > 0 && (
             <p className="text-xs text-amber-600">
-              {vm.summary.activationTelemetryCoverage ?? 0}% of signups on a build that reports it
+              {activationStats?.erroredUsers} users unreadable this run
             </p>
           )}
         </div>

--- a/web/admin/app/api/internal/precompute/route.ts
+++ b/web/admin/app/api/internal/precompute/route.ts
@@ -44,6 +44,10 @@ import {
   appSubscriptionsCacheKey,
 } from "@/app/api/omi/stats/app-subscriptions/route";
 import { computeKFactor } from "@/app/api/omi/stats/k-factor/posthog/route";
+import {
+  computeActivation,
+  activationCacheKey,
+} from "@/app/api/omi/stats/activation/route";
 import { setPayload } from "@/lib/payload-cache";
 
 export const dynamic = "force-dynamic";
@@ -79,6 +83,9 @@ const NOTIFICATIONS_DAYS = 30;
 const ONBOARDING_DAYS = 30;
 const TRENDS_MONTHS = 12;
 const K_FACTOR_DAYS = 30;
+// Activation fans out one aggregation query per macOS signup in the window, so
+// it belongs here behind the long timeout rather than on the request path.
+const ACTIVATION_DAYS = 60;
 
 function defaultOverheadMonthly(): number {
   const envOverhead = parseFloat(process.env.ADMIN_INFRA_OVERHEAD_MONTHLY || "");
@@ -136,6 +143,12 @@ export async function POST(request: NextRequest) {
   await run("macosVersions", async () => {
     const payload = await computeMacosVersions();
     await setPayload(macosVersionsCacheKey(), payload);
+  });
+
+  // Activation (Firestore conversation records, not desktop telemetry)
+  await run("activation", async () => {
+    const payload = await computeActivation(ACTIVATION_DAYS);
+    await setPayload(activationCacheKey(ACTIVATION_DAYS), payload);
   });
 
   // Notifications

--- a/web/admin/app/api/omi/stats/activation/route.ts
+++ b/web/admin/app/api/omi/stats/activation/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { getDb } from "@/lib/firebase/admin";
+import { getPayload, setPayload } from "@/lib/payload-cache";
+import {
+  rollUpActivationCohort,
+  type ActivationCohortMember,
+  type ActivationSeries,
+} from "@/lib/growth-metrics";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 3600;
+
+const DAY_MS = 86_400_000;
+const MATURITY_DAYS = 7;
+const PAGE = 500;
+const CONCURRENCY = 16;
+
+// `created_at` is null on user documents written by the current signup path;
+// `signup_platform_at` is the field that is actually populated. Cohorting on
+// `created_at` silently returns almost nobody.
+const SIGNUP_FIELD = "signup_platform_at";
+
+export function activationCacheKey(days: number): string {
+  return `activation:v1:macos:${days}`;
+}
+
+/**
+ * macOS activation measured from conversation records rather than telemetry.
+ *
+ * The PostHog series counts the desktop `Memory Created` event, which older
+ * builds cannot emit at all, so it reports build age rather than behaviour.
+ * A conversation document exists whether or not the client managed to report
+ * it, which makes this the only source that can answer the question today.
+ */
+export async function computeActivation(
+  days: number,
+): Promise<ActivationSeries & { erroredUsers: number }> {
+  const db = getDb();
+  const now = Date.now();
+  const windowStart = new Date(now - days * DAY_MS);
+  const maturedBefore = new Date(now - MATURITY_DAYS * DAY_MS);
+
+  // Filtering on signup_os alongside a signup_platform_at range needs a
+  // composite index that does not exist on this project, so the range is the
+  // query and the platform is filtered here.
+  const cohort: { uid: string; signupAt: Date }[] = [];
+  let cursor: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+  for (;;) {
+    let query = db
+      .collection("users")
+      .where(SIGNUP_FIELD, ">", windowStart)
+      .orderBy(SIGNUP_FIELD, "asc")
+      .limit(PAGE);
+    if (cursor) query = query.startAfter(cursor);
+
+    const snap = await query.get();
+    if (snap.empty) break;
+
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      if (data.signup_os !== "macos") continue;
+      const signupAt: Date | undefined = data[SIGNUP_FIELD]?.toDate?.();
+      // Signups inside the maturity window have not had their full 7 days, so
+      // counting them would pit a guaranteed-zero numerator against a real
+      // denominator.
+      if (!signupAt || signupAt > maturedBefore) continue;
+      cohort.push({ uid: doc.id, signupAt });
+    }
+
+    if (snap.size < PAGE) break;
+    cursor = snap.docs[snap.docs.length - 1];
+  }
+
+  const activated = new Array<boolean>(cohort.length).fill(false);
+  let erroredUsers = 0;
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= cohort.length) return;
+      const { uid, signupAt } = cohort[i];
+      const windowEnd = new Date(signupAt.getTime() + MATURITY_DAYS * DAY_MS);
+      try {
+        const agg = await db
+          .collection("users")
+          .doc(uid)
+          .collection("conversations")
+          .where("created_at", ">=", signupAt)
+          .where("created_at", "<=", windowEnd)
+          .count()
+          .get();
+        activated[i] = agg.data().count > 0;
+      } catch {
+        // One unreadable user must not void the whole cohort; it is reported
+        // instead, so a partial read can never masquerade as a low rate.
+        erroredUsers += 1;
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, cohort.length) }, worker),
+  );
+
+  const members: ActivationCohortMember[] = cohort.map((m, i) => ({
+    signupAt: m.signupAt.toISOString(),
+    activated: activated[i],
+  }));
+
+  return { ...rollUpActivationCohort(members), erroredUsers };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const days = Math.min(
+      parseInt(request.nextUrl.searchParams.get("days") || "60", 10),
+      180,
+    );
+    const key = activationCacheKey(days);
+
+    const cached =
+      await getPayload<Awaited<ReturnType<typeof computeActivation>>>(key);
+    if (cached) {
+      return NextResponse.json({ ...cached.data, freshAt: cached.freshAt });
+    }
+
+    const payload = await computeActivation(days);
+    await setPayload(key, payload);
+    return NextResponse.json({ ...payload, freshAt: Date.now() });
+  } catch (error: any) {
+    console.error("Activation error:", error);
+    return NextResponse.json(
+      { error: error.message || "Failed to compute activation" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/admin/app/api/omi/stats/activation/route.ts
+++ b/web/admin/app/api/omi/stats/activation/route.ts
@@ -72,8 +72,10 @@ export async function computeActivation(
     cursor = snap.docs[snap.docs.length - 1];
   }
 
-  const activated = new Array<boolean>(cohort.length).fill(false);
-  let erroredUsers = 0;
+  // `null` means the read failed. It must stay distinct from `false`: scoring an
+  // unreadable user as "did not activate" is the same mistake this whole metric
+  // exists to undo, just one layer down.
+  const activated = new Array<boolean | null>(cohort.length).fill(null);
   let next = 0;
 
   async function worker(): Promise<void> {
@@ -93,9 +95,8 @@ export async function computeActivation(
           .get();
         activated[i] = agg.data().count > 0;
       } catch {
-        // One unreadable user must not void the whole cohort; it is reported
-        // instead, so a partial read can never masquerade as a low rate.
-        erroredUsers += 1;
+        // Left null: reported via erroredUsers and dropped from the cohort, so
+        // a partial read shrinks the sample instead of depressing the rate.
       }
     }
   }
@@ -104,10 +105,16 @@ export async function computeActivation(
     Array.from({ length: Math.min(CONCURRENCY, cohort.length) }, worker),
   );
 
-  const members: ActivationCohortMember[] = cohort.map((m, i) => ({
-    signupAt: m.signupAt.toISOString(),
-    activated: activated[i],
-  }));
+  const members: ActivationCohortMember[] = [];
+  let erroredUsers = 0;
+  cohort.forEach((m, i) => {
+    const result = activated[i];
+    if (result === null) {
+      erroredUsers += 1;
+      return;
+    }
+    members.push({ signupAt: m.signupAt.toISOString(), activated: result });
+  });
 
   return { ...rollUpActivationCohort(members), erroredUsers };
 }
@@ -117,10 +124,15 @@ export async function GET(request: NextRequest) {
   if (authResult instanceof NextResponse) return authResult;
 
   try {
-    const days = Math.min(
-      parseInt(request.nextUrl.searchParams.get("days") || "60", 10),
-      180,
+    // A non-numeric `days` would otherwise reach Firestore as NaN date
+    // arithmetic and 500 the route.
+    const requestedDays = parseInt(
+      request.nextUrl.searchParams.get("days") || "60",
+      10,
     );
+    const days = Number.isFinite(requestedDays)
+      ? Math.min(Math.max(requestedDays, 1), 180)
+      : 60;
     const key = activationCacheKey(days);
 
     const cached =

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -1,8 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { posthogResults } from "@/lib/posthog";
+import {
+  summarizeActivation,
+  type DailyActivationPoint,
+} from "@/lib/growth-metrics";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * First desktop build that emits `Memory Created` on the normal durable-session
+ * path. Before 98f1ee7c7f the event only fired for recordings that failed to
+ * bind a local session, so activation was structurally unreportable.
+ */
+const MIN_ACTIVATION_TELEMETRY_VERSION = [0, 12, 167] as const;
 
 let cache: { data: any; days: number; timestamp: number } | null = null;
 const CACHE_TTL = 30 * 60 * 1000;
@@ -128,40 +139,60 @@ export async function GET(request: NextRequest) {
         ORDER BY days_active
       `),
 
-      // 6. Activation: signups who created a Memory within 7 days
+      // 6. Activation: new signups who created a Memory within 7 days.
+      //
+      // Three things this query has to get right, each of which silently
+      // understated the rate before:
+      //   - The cohort is the user's FIRST-EVER sign-in, matching query 1.
+      //     Filtering by timestamp *before* the min() made every returning user
+      //     who re-authenticated inside the window look like a new signup.
+      //   - Activation tests for ANY memory inside the window. Keying off the
+      //     user's earliest memory marked a returning user unactivated because
+      //     their first-ever memory predates their window.
+      //   - `reports_activation` records whether the build they signed up on can
+      //     emit `Memory Created` at all. Desktop only began emitting it on the
+      //     normal (durable-session) path in 98f1ee7c7f, first shipped in
+      //     ${MIN_ACTIVATION_TELEMETRY_VERSION.join(".")}. Users on older builds
+      //     cannot activate no matter what they do, so pooling them reports a
+      //     rollout gap as a product failure.
       hogql(apiKey, projectId, host, `
         SELECT
-          toDate(toString(signup_ts)) as day,
+          toDate(toString(s_ts)) as day,
           count(*) as signups,
-          countIf(has_memory = 1) as activated
+          countIf(memories_in_window > 0) as activated,
+          countIf(reports_activation) as capable_signups,
+          countIf(reports_activation AND memories_in_window > 0) as capable_activated
         FROM (
           SELECT
-            s_id,
-            s_ts as signup_ts,
-            if(m_count > 0, 1, 0) as has_memory
+            signups.s_id as s_id,
+            signups.s_ts as s_ts,
+            signups.reports_activation as reports_activation,
+            countIf(
+              memories.m_ts >= signups.s_ts
+              AND memories.m_ts <= signups.s_ts + interval 7 day
+            ) as memories_in_window
           FROM (
             SELECT
               distinct_id as s_id,
-              min(timestamp) as s_ts
+              min(timestamp) as s_ts,
+              arrayMap(
+                part -> toIntOrZero(part),
+                splitByChar('.', coalesce(argMin(properties.$app_version, timestamp), '0'))
+              ) >= [${MIN_ACTIVATION_TELEMETRY_VERSION.join(", ")}] as reports_activation
             FROM events
             WHERE event = 'Sign In Completed'
               AND properties.$os_name = 'macOS'
-              AND timestamp >= now() - interval ${days} day
             GROUP BY distinct_id
           ) signups
           LEFT JOIN (
-            SELECT
-              distinct_id as m_id,
-              min(timestamp) as m_ts,
-              count(*) as m_count
+            SELECT distinct_id as m_id, timestamp as m_ts
             FROM events
             WHERE event = 'Memory Created'
               AND properties.$os_name = 'macOS'
               AND timestamp >= now() - interval ${days + 7} day
-            GROUP BY distinct_id
           ) memories ON signups.s_id = memories.m_id
-            AND memories.m_ts >= signups.s_ts
-            AND memories.m_ts <= signups.s_ts + interval 7 day
+          WHERE signups.s_ts >= now() - interval ${days} day
+          GROUP BY s_id, s_ts, reports_activation
         )
         GROUP BY day
         ORDER BY day
@@ -293,21 +324,22 @@ export async function GET(request: NextRequest) {
       : 0;
 
     // ── Process Activation ──
-    const activation: { date: string; signups: number; activated: number; rate: number }[] = [];
-    for (const [day, signups, activated] of activationResults as any[]) {
+    const activation: (DailyActivationPoint & { rate: number })[] = [];
+    for (const [day, signups, activated, capableSignups, capableActivated] of
+      activationResults as any[]) {
       activation.push({
         date: day,
         signups,
         activated,
+        capableSignups,
+        capableActivated,
         rate: signups > 0 ? Math.round((activated / signups) * 1000) / 10 : 0,
       });
     }
 
-    const totalSignups = activation.reduce((s, d) => s + d.signups, 0);
-    const totalActivated = activation.reduce((s, d) => s + d.activated, 0);
-    const overallActivationRate = totalSignups > 0
-      ? Math.round((totalActivated / totalSignups) * 1000) / 10
-      : null;
+    // Pooling every signup, including yesterday's, counts a guaranteed-zero
+    // numerator against a real denominator; only matured days are summarised.
+    const activationSummary = summarizeActivation(activation);
 
     // ── Quick Ratio ──
     const recentGA = growthAccounting.slice(-4);
@@ -326,7 +358,13 @@ export async function GET(request: NextRequest) {
       activation,
       summary: {
         quickRatio,
-        activationRate: overallActivationRate,
+        // The rate among users whose build can report it. Null while no matured
+        // signup ran a reporting build -- an unmeasurable metric must read as
+        // unmeasurable rather than as a confident near-zero.
+        activationRate: activationSummary.capableRate,
+        activationTelemetryCoverage: activationSummary.telemetryCoverage,
+        activationSignups: activationSummary.capableSignups,
+        activationPooledRate: activationSummary.rate,
         dauMau,
         dauWau,
         dau: avgDau,

--- a/web/admin/lib/__tests__/activation-route.test.ts
+++ b/web/admin/lib/__tests__/activation-route.test.ts
@@ -31,29 +31,46 @@ function fakeDb(users: UserSeed[]) {
   }));
   docs.sort((a, b) => a.signupAt.getTime() - b.signupAt.getTime());
 
+  // The route's own predicates decide the count. If it filtered the wrong
+  // field, or shifted either bound, the returned count changes -- so the
+  // 7-day window is a real contract here rather than something the fake
+  // re-implements and always agrees with.
   const conversationsFor = (uid: string) => {
     const seed = users.find((u) => u.uid === uid)!;
-    return {
+    const signupAt = new Date(now - seed.signupDaysAgo * DAY);
+    const timestamps = (seed.conversationOffsetsDays ?? []).map(
+      (off) => signupAt.getTime() + off * DAY,
+    );
+    const bounds: { field: string; op: string; value: Date }[] = [];
+    const api = {
       where(field: string, op: string, value: Date) {
-        const self: any = this;
-        self._bounds = self._bounds ?? [];
-        self._bounds.push({ op, value });
-        return self;
+        bounds.push({ field, op, value });
+        return api;
       },
       count() {
         return {
           async get() {
             if (seed.throwOnRead) throw new Error("permission denied");
-            const signupAt = new Date(now - seed.signupDaysAgo * DAY);
-            const n = (seed.conversationOffsetsDays ?? []).filter((off) => {
-              const t = signupAt.getTime() + off * DAY;
-              return t >= signupAt.getTime() && t <= signupAt.getTime() + 7 * DAY;
-            }).length;
+            for (const b of bounds) {
+              if (b.field !== "created_at") {
+                throw new Error(`unexpected filter field: ${b.field}`);
+              }
+            }
+            const n = timestamps.filter((t) =>
+              bounds.every((b) =>
+                b.op === ">="
+                  ? t >= b.value.getTime()
+                  : b.op === "<="
+                    ? t <= b.value.getTime()
+                    : true,
+              ),
+            ).length;
             return { data: () => ({ count: n }) };
           },
         };
       },
     };
+    return api;
   };
 
   // Honours the caller's limit(), so the route's own PAGE size drives paging.
@@ -118,6 +135,23 @@ describe("computeActivation", () => {
     expect(result.signups).toBe(3);
     expect(result.activated).toBe(1);
     expect(result.rate).toBe(33.3);
+  });
+
+  it("treats the 7-day window as closed at both ends", async () => {
+    getDb.mockReturnValue(
+      fakeDb([
+        { uid: "at-signup", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [0] },
+        { uid: "at-day-seven", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [7] },
+        { uid: "just-after", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [7.001] },
+        { uid: "just-before", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [-0.001] },
+      ]),
+    );
+
+    const result = await computeActivation(60);
+
+    // Inclusive at signup and at signup+7d; anything outside is not activation.
+    expect(result.signups).toBe(4);
+    expect(result.activated).toBe(2);
   });
 
   it("excludes non-macOS signups", async () => {

--- a/web/admin/lib/__tests__/activation-route.test.ts
+++ b/web/admin/lib/__tests__/activation-route.test.ts
@@ -167,7 +167,7 @@ describe("computeActivation", () => {
     expect(result.activated).toBe(600);
   });
 
-  it("reports unreadable users instead of scoring them as not activated", async () => {
+  it("drops unreadable users from the denominator instead of scoring them as not activated", async () => {
     getDb.mockReturnValue(
       fakeDb([
         { uid: "ok", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [1] },
@@ -177,7 +177,29 @@ describe("computeActivation", () => {
 
     const result = await computeActivation(60);
 
+    // Counting the unreadable user would report 50% -- the same "absence of
+    // evidence read as evidence of absence" mistake this metric exists to undo.
     expect(result.erroredUsers).toBe(1);
+    expect(result.signups).toBe(1);
     expect(result.activated).toBe(1);
+    expect(result.rate).toBe(100);
+  });
+
+  it("keeps a week's rate honest when only some of its users are unreadable", async () => {
+    getDb.mockReturnValue(
+      fakeDb([
+        { uid: "a", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [1] },
+        { uid: "b", signupOs: "macos", signupDaysAgo: 30 },
+        { uid: "c", signupOs: "macos", signupDaysAgo: 30, throwOnRead: true },
+        { uid: "d", signupOs: "macos", signupDaysAgo: 30, throwOnRead: true },
+      ]),
+    );
+
+    const result = await computeActivation(60);
+
+    expect(result.erroredUsers).toBe(2);
+    expect(result.weeks).toHaveLength(1);
+    expect(result.weeks[0].signups).toBe(2);
+    expect(result.weeks[0].rate).toBe(50);
   });
 });

--- a/web/admin/lib/__tests__/activation-route.test.ts
+++ b/web/admin/lib/__tests__/activation-route.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The route reaches Firestore through getDb(); faking it here exercises the
+// real cohort/pagination/maturity logic without a service account.
+const getDb = vi.fn();
+vi.mock("@/lib/firebase/admin", () => ({ getDb: () => getDb() }));
+vi.mock("@/lib/auth", () => ({ verifyAdmin: vi.fn() }));
+vi.mock("@/lib/payload-cache", () => ({
+  getPayload: vi.fn(),
+  setPayload: vi.fn(),
+}));
+
+import { computeActivation } from "@/app/api/omi/stats/activation/route";
+
+const DAY = 86_400_000;
+
+type UserSeed = {
+  uid: string;
+  signupOs: string;
+  signupDaysAgo: number;
+  conversationOffsetsDays?: number[];
+  throwOnRead?: boolean;
+};
+
+function fakeDb(users: UserSeed[]) {
+  const now = Date.now();
+  const docs = users.map((u) => ({
+    id: u.uid,
+    seed: u,
+    signupAt: new Date(now - u.signupDaysAgo * DAY),
+  }));
+  docs.sort((a, b) => a.signupAt.getTime() - b.signupAt.getTime());
+
+  const conversationsFor = (uid: string) => {
+    const seed = users.find((u) => u.uid === uid)!;
+    return {
+      where(field: string, op: string, value: Date) {
+        const self: any = this;
+        self._bounds = self._bounds ?? [];
+        self._bounds.push({ op, value });
+        return self;
+      },
+      count() {
+        return {
+          async get() {
+            if (seed.throwOnRead) throw new Error("permission denied");
+            const signupAt = new Date(now - seed.signupDaysAgo * DAY);
+            const n = (seed.conversationOffsetsDays ?? []).filter((off) => {
+              const t = signupAt.getTime() + off * DAY;
+              return t >= signupAt.getTime() && t <= signupAt.getTime() + 7 * DAY;
+            }).length;
+            return { data: () => ({ count: n }) };
+          },
+        };
+      },
+    };
+  };
+
+  // Honours the caller's limit(), so the route's own PAGE size drives paging.
+  function usersQuery(after = 0, pageSize = docs.length) {
+    return {
+      where: () => usersQuery(after, pageSize),
+      orderBy: () => usersQuery(after, pageSize),
+      limit: (n: number) => usersQuery(after, n),
+      startAfter(cursorDoc: any) {
+        return usersQuery(
+          docs.findIndex((d) => d.id === cursorDoc.id) + 1,
+          pageSize,
+        );
+      },
+      async get() {
+        const slice = docs.slice(after, after + pageSize);
+        return {
+          empty: slice.length === 0,
+          size: slice.length,
+          docs: slice.map((d) => ({
+            id: d.id,
+            data: () => ({
+              signup_os: d.seed.signupOs,
+              signup_platform_at: { toDate: () => d.signupAt },
+            }),
+          })),
+        };
+      },
+    };
+  }
+
+  return {
+    collection(name: string) {
+      if (name !== "users") throw new Error("unexpected collection " + name);
+      return {
+        ...usersQuery(),
+        doc: (uid: string) => ({
+          collection: (sub: string) => {
+            if (sub !== "conversations") throw new Error("unexpected sub " + sub);
+            return conversationsFor(uid);
+          },
+        }),
+      };
+    },
+  };
+}
+
+beforeEach(() => getDb.mockReset());
+
+describe("computeActivation", () => {
+  it("counts a macOS signup as activated only on a conversation inside its 7-day window", async () => {
+    getDb.mockReturnValue(
+      fakeDb([
+        { uid: "in-window", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [3] },
+        { uid: "too-late", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [9] },
+        { uid: "none", signupOs: "macos", signupDaysAgo: 30 },
+      ]),
+    );
+
+    const result = await computeActivation(60);
+
+    expect(result.signups).toBe(3);
+    expect(result.activated).toBe(1);
+    expect(result.rate).toBe(33.3);
+  });
+
+  it("excludes non-macOS signups", async () => {
+    getDb.mockReturnValue(
+      fakeDb([
+        { uid: "mac", signupOs: "macos", signupDaysAgo: 20, conversationOffsetsDays: [1] },
+        { uid: "ios", signupOs: "ios", signupDaysAgo: 20, conversationOffsetsDays: [1] },
+        { uid: "web", signupOs: "web", signupDaysAgo: 20 },
+      ]),
+    );
+
+    const result = await computeActivation(60);
+
+    expect(result.signups).toBe(1);
+    expect(result.activated).toBe(1);
+  });
+
+  it("excludes signups whose 7-day window has not elapsed", async () => {
+    getDb.mockReturnValue(
+      fakeDb([
+        { uid: "matured", signupOs: "macos", signupDaysAgo: 10, conversationOffsetsDays: [1] },
+        { uid: "yesterday", signupOs: "macos", signupDaysAgo: 1 },
+        { uid: "day-six", signupOs: "macos", signupDaysAgo: 6 },
+      ]),
+    );
+
+    const result = await computeActivation(60);
+
+    expect(result.signups).toBe(1);
+    expect(result.rate).toBe(100);
+  });
+
+  it("paginates past the 500-doc page instead of stopping at the first page", async () => {
+    // 1,200 > 2 full pages, so a missing cursor advance truncates the cohort --
+    // the exact shape that would silently undercount a real 10k-signup window.
+    const many: UserSeed[] = Array.from({ length: 1200 }, (_, i) => ({
+      uid: `u${i}`,
+      signupOs: "macos",
+      signupDaysAgo: 10 + (i % 40),
+      conversationOffsetsDays: i % 2 === 0 ? [1] : [],
+    }));
+    getDb.mockReturnValue(fakeDb(many));
+
+    const result = await computeActivation(60);
+
+    expect(result.signups).toBe(1200);
+    expect(result.activated).toBe(600);
+  });
+
+  it("reports unreadable users instead of scoring them as not activated", async () => {
+    getDb.mockReturnValue(
+      fakeDb([
+        { uid: "ok", signupOs: "macos", signupDaysAgo: 30, conversationOffsetsDays: [1] },
+        { uid: "broken", signupOs: "macos", signupDaysAgo: 30, throwOnRead: true },
+      ]),
+    );
+
+    const result = await computeActivation(60);
+
+    expect(result.erroredUsers).toBe(1);
+    expect(result.activated).toBe(1);
+  });
+});

--- a/web/admin/lib/__tests__/growth-metrics.test.ts
+++ b/web/admin/lib/__tests__/growth-metrics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   completedWeeklyNewUsers,
   maturedWeeklyActivation,
+  rollUpActivationCohort,
   summarizeActivation,
 } from "@/lib/growth-metrics";
 
@@ -131,5 +132,31 @@ describe("summarizeActivation", () => {
     expect(result.signups).toBe(0);
     expect(result.rate).toBeNull();
     expect(result.telemetryCoverage).toBeNull();
+  });
+});
+
+describe("rollUpActivationCohort", () => {
+  it("buckets members by the Monday of their signup and pools the rate", () => {
+    const result = rollUpActivationCohort([
+      { signupAt: "2026-08-03T09:00:00Z", activated: true },
+      { signupAt: "2026-08-05T23:59:00Z", activated: false },
+      { signupAt: "2026-08-09T12:00:00Z", activated: true },
+      { signupAt: "2026-08-10T00:00:00Z", activated: false },
+    ]);
+
+    expect(result.weeks).toEqual([
+      { week: "2026-08-03", signups: 3, activated: 2, rate: 66.7 },
+      { week: "2026-08-10", signups: 1, activated: 0, rate: 0 },
+    ]);
+    expect(result.signups).toBe(4);
+    expect(result.activated).toBe(2);
+    expect(result.rate).toBe(50);
+  });
+
+  it("returns a null rate for an empty cohort rather than zero", () => {
+    const result = rollUpActivationCohort([]);
+
+    expect(result.weeks).toEqual([]);
+    expect(result.rate).toBeNull();
   });
 });

--- a/web/admin/lib/__tests__/growth-metrics.test.ts
+++ b/web/admin/lib/__tests__/growth-metrics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   completedWeeklyNewUsers,
   maturedWeeklyActivation,
+  summarizeActivation,
 } from "@/lib/growth-metrics";
 
 describe("growth metrics", () => {
@@ -36,7 +37,99 @@ describe("growth metrics", () => {
         signups: 30,
         activated: 12,
         rate: 40,
+        capableRate: 40,
+        telemetryCoverage: 100,
       },
     ]);
+  });
+
+  it("reports a week nobody could report as unmeasurable, not as zero", () => {
+    const result = maturedWeeklyActivation(
+      [
+        {
+          date: "2026-07-20",
+          signups: 30,
+          activated: 0,
+          capableSignups: 0,
+          capableActivated: 0,
+        },
+      ],
+      new Date("2026-08-08T12:00:00Z"),
+    );
+
+    expect(result[0].rate).toBe(0);
+    expect(result[0].capableRate).toBeNull();
+    expect(result[0].telemetryCoverage).toBe(0);
+  });
+});
+
+describe("summarizeActivation", () => {
+  it("excludes signups whose 7-day activation window has not elapsed", () => {
+    // The Aug 5 cohort cannot have activated yet on Aug 8. Pooling it would
+    // report 10/60 = 16.7% instead of the real, measurable 10/20 = 50%.
+    const result = summarizeActivation(
+      [
+        { date: "2026-08-01", signups: 20, activated: 10 },
+        { date: "2026-08-05", signups: 40, activated: 0 },
+      ],
+      new Date("2026-08-08T12:00:00Z"),
+    );
+
+    expect(result.signups).toBe(20);
+    expect(result.activated).toBe(10);
+    expect(result.rate).toBe(50);
+  });
+
+  it("counts a signup day the moment its window closes, not a day later", () => {
+    const result = summarizeActivation(
+      [{ date: "2026-08-01", signups: 20, activated: 10 }],
+      new Date("2026-08-08T00:00:00Z"),
+    );
+
+    expect(result.signups).toBe(20);
+    expect(result.rate).toBe(50);
+  });
+
+  it("separates users who cannot report activation from users who did not activate", () => {
+    // 100 matured signups, but only 20 run a build that can emit the event.
+    // The honest read is 50% of reporting users, at 20% telemetry coverage --
+    // not the 10% the pooled number would imply.
+    const result = summarizeActivation(
+      [
+        {
+          date: "2026-08-01",
+          signups: 100,
+          activated: 10,
+          capableSignups: 20,
+          capableActivated: 10,
+        },
+      ],
+      new Date("2026-08-10T12:00:00Z"),
+    );
+
+    expect(result.rate).toBe(10);
+    expect(result.capableRate).toBe(50);
+    expect(result.telemetryCoverage).toBe(20);
+  });
+
+  it("treats a series without capability counts as fully covered", () => {
+    const result = summarizeActivation(
+      [{ date: "2026-08-01", signups: 50, activated: 20 }],
+      new Date("2026-08-10T12:00:00Z"),
+    );
+
+    expect(result.capableRate).toBe(40);
+    expect(result.telemetryCoverage).toBe(100);
+  });
+
+  it("returns null rates rather than zero when nothing has matured", () => {
+    const result = summarizeActivation(
+      [{ date: "2026-08-09", signups: 30, activated: 0 }],
+      new Date("2026-08-10T12:00:00Z"),
+    );
+
+    expect(result.signups).toBe(0);
+    expect(result.rate).toBeNull();
+    expect(result.telemetryCoverage).toBeNull();
   });
 });

--- a/web/admin/lib/growth-metrics.ts
+++ b/web/admin/lib/growth-metrics.ts
@@ -14,13 +14,46 @@ export interface DailyActivationPoint {
   date: string;
   signups: number;
   activated: number;
+  /**
+   * Subset of `signups` running a desktop build that is able to emit the
+   * `Memory Created` event the numerator counts. Signups on older builds cannot
+   * activate no matter what the user does, so pooling them silently deflates the
+   * rate during a rollout.
+   */
+  capableSignups?: number;
+  capableActivated?: number;
 }
 
 export interface WeeklyActivationPoint {
   week: string;
   signups: number;
   activated: number;
+  /** Pooled rate over every signup, including those that cannot report. */
   rate: number;
+  /**
+   * Rate over signups whose build can report activation, and null when none
+   * could. This is the honest read: a week nobody could report is a blind spot,
+   * not a week of zero activation.
+   */
+  capableRate: number | null;
+  telemetryCoverage: number | null;
+}
+
+export interface ActivationSummary {
+  /** Signups whose 7-day activation window has fully elapsed. */
+  signups: number;
+  activated: number;
+  rate: number | null;
+  /** Same, restricted to signups whose build can report activation at all. */
+  capableSignups: number;
+  capableActivated: number;
+  capableRate: number | null;
+  /**
+   * Percentage of matured signups on a reporting-capable build. Below 100 means
+   * the headline `rate` is diluted by users who physically cannot report, not by
+   * users failing to activate.
+   */
+  telemetryCoverage: number | null;
 }
 
 function utcDate(value: string | Date): Date | null {
@@ -68,7 +101,15 @@ export function maturedWeeklyActivation(
   if (!todayUtc) return [];
   todayUtc.setUTCHours(0, 0, 0, 0);
 
-  const totals = new Map<string, { signups: number; activated: number }>();
+  const totals = new Map<
+    string,
+    {
+      signups: number;
+      activated: number;
+      capableSignups: number;
+      capableActivated: number;
+    }
+  >();
   for (const point of points) {
     const week = mondayKey(point.date);
     if (
@@ -78,9 +119,18 @@ export function maturedWeeklyActivation(
     ) {
       continue;
     }
-    const current = totals.get(week) ?? { signups: 0, activated: 0 };
+    const current = totals.get(week) ?? {
+      signups: 0,
+      activated: 0,
+      capableSignups: 0,
+      capableActivated: 0,
+    };
     current.signups += point.signups;
     current.activated += point.activated;
+    // A series recorded before capability was tracked carries no capable
+    // counts; treat those days as fully capable rather than as zero coverage.
+    current.capableSignups += point.capableSignups ?? point.signups;
+    current.capableActivated += point.capableActivated ?? point.activated;
     totals.set(week, current);
   }
 
@@ -97,10 +147,71 @@ export function maturedWeeklyActivation(
   })
     .filter((point) => point.fullyMatureAt <= todayUtc)
     .sort((a, b) => a.week.localeCompare(b.week))
-    .map(({ week, signups, activated }) => ({
+    .map(({ week, signups, activated, capableSignups, capableActivated }) => ({
       week,
       signups,
       activated,
       rate: signups > 0 ? Math.round((activated / signups) * 1000) / 10 : 0,
+      capableRate: percent(capableActivated, capableSignups),
+      telemetryCoverage: percent(capableSignups, signups),
     }));
+}
+
+function percent(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) return null;
+  return Math.round((numerator / denominator) * 1000) / 10;
+}
+
+/**
+ * Pool a daily activation series into the single headline rate.
+ *
+ * Only signup days whose activation window has fully elapsed are counted. A
+ * signup from yesterday has not had its 7 days yet, so including it would count
+ * a guaranteed-zero numerator against a real denominator and drag the rate down
+ * every single day.
+ */
+export function summarizeActivation(
+  points: readonly DailyActivationPoint[],
+  today = new Date(),
+  maturityDays = 7,
+): ActivationSummary {
+  const todayUtc = utcDate(today);
+  const empty: ActivationSummary = {
+    signups: 0,
+    activated: 0,
+    rate: null,
+    capableSignups: 0,
+    capableActivated: 0,
+    capableRate: null,
+    telemetryCoverage: null,
+  };
+  if (!todayUtc) return empty;
+  todayUtc.setUTCHours(0, 0, 0, 0);
+
+  const totals = { ...empty };
+  for (const point of points) {
+    const day = utcDate(point.date);
+    if (
+      !day ||
+      !Number.isFinite(point.signups) ||
+      !Number.isFinite(point.activated)
+    ) {
+      continue;
+    }
+    if (new Date(day.getTime() + maturityDays * DAY_MS) > todayUtc) continue;
+
+    totals.signups += point.signups;
+    totals.activated += point.activated;
+    // A series recorded before capability was tracked carries no capable
+    // counts; treat those days as fully capable rather than as zero coverage.
+    totals.capableSignups += point.capableSignups ?? point.signups;
+    totals.capableActivated += point.capableActivated ?? point.activated;
+  }
+
+  return {
+    ...totals,
+    rate: percent(totals.activated, totals.signups),
+    capableRate: percent(totals.capableActivated, totals.capableSignups),
+    telemetryCoverage: percent(totals.capableSignups, totals.signups),
+  };
 }

--- a/web/admin/lib/growth-metrics.ts
+++ b/web/admin/lib/growth-metrics.ts
@@ -162,6 +162,56 @@ function percent(numerator: number, denominator: number): number | null {
   return Math.round((numerator / denominator) * 1000) / 10;
 }
 
+export interface ActivationCohortMember {
+  signupAt: string;
+  activated: boolean;
+}
+
+export interface ActivationSeries {
+  weeks: { week: string; signups: number; activated: number; rate: number }[];
+  signups: number;
+  activated: number;
+  rate: number | null;
+}
+
+/**
+ * Roll a per-user activation cohort into weekly buckets plus a pooled rate.
+ *
+ * Unlike the PostHog series this has no telemetry-coverage dimension: it is
+ * derived from the conversation records themselves, which exist regardless of
+ * what the client managed to report. Callers must pass only members whose
+ * activation window has already elapsed.
+ */
+export function rollUpActivationCohort(
+  members: readonly ActivationCohortMember[],
+): ActivationSeries {
+  const totals = new Map<string, { signups: number; activated: number }>();
+  let signups = 0;
+  let activated = 0;
+
+  for (const member of members) {
+    const week = mondayKey(member.signupAt);
+    if (!week) continue;
+    const current = totals.get(week) ?? { signups: 0, activated: 0 };
+    current.signups += 1;
+    signups += 1;
+    if (member.activated) {
+      current.activated += 1;
+      activated += 1;
+    }
+    totals.set(week, current);
+  }
+
+  const weeks = Array.from(totals, ([week, t]) => ({
+    week,
+    signups: t.signups,
+    activated: t.activated,
+    rate: percent(t.activated, t.signups) ?? 0,
+  })).sort((a, b) => a.week.localeCompare(b.week));
+
+  return { weeks, signups, activated, rate: percent(activated, signups) };
+}
+
 /**
  * Pool a daily activation series into the single headline rate.
  *


### PR DESCRIPTION
## What

The macOS Activation KPI on `admin.omi.me` read **0.2%**. The real figure, measured from production conversation records, is **36.5%** — and rising from 20.2% (week of Jun 29) to 57.1% (week of Aug 3).

## Why it was wrong

The metric counted the desktop `Memory Created` event. Builds before `98f1ee7c7f` (2026-08-11) never emit it on the normal durable-session path, and stable `0.12.144` — ~66% of the macOS fleet — produced **0** events across 454 recording users in three days. The metric was reporting build age, not behaviour.

Three independent query defects compounded it, each only ever pushing the number down:

1. **Cohort** — the signup subquery filtered by `timestamp` *before* `min()`, so "first sign-in" meant first sign-in *inside the window*. 237 of 1,810 were returning users re-authenticating, counted as new signups.
2. **Numerator** — the join keyed off `min(timestamp)` of `Memory Created`, so a user whose first-ever memory predated their window was marked unactivated even when they created one inside it.
3. **Maturation** — every signup was pooled, including 167 that had not yet had seven days to activate. The weekly chart already excluded these; the headline did not.

## What changed

No amount of query-fixing gets a real number out of a source two thirds of the fleet cannot write to, so activation moves off telemetry. A conversation document exists whether or not the client managed to report it, so the new route reads `users/{uid}/conversations` directly: a macOS signup is activated if a conversation was created inside its first 7 days.

Two traps in the cohort query, both covered by tests:

- `created_at` is **null** on user documents written by the current signup path; `signup_platform_at` is the field that is actually populated. Cohorting on `created_at` returns 35 users instead of 10,375.
- Filtering on `signup_os` alongside a `signup_platform_at` range needs a composite index that does not exist on this project, so the range is the query and the platform is filtered in memory.

Fanning out one aggregation query per signup is too slow for a request, so it runs in the existing cron precompute endpoint (`maxDuration` 3600) and the GET is a payload-cache read — the same shape as `profitability` and `infra-costs`.

The PostHog-derived series is kept as a fallback for the window before the activation route has a cached payload, with its three defects fixed and its telemetry coverage now explicit, so it reports "not measurable" rather than a confident near-zero.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` (web/admin) — 15 files, **101 tests passing**, 10 new
- `npx eslint` on every changed file — 0 errors
- `make preflight` — 14/14 checks pass
- New HogQL validated directly against PostHog project 302298
- Ran the viral-metrics route locally (`next dev`, dev-auth bypass) against live PostHog: `GET /api/omi/stats/viral-metrics?days=60` → 200
- Loaded `/dashboard/classic` in a browser and confirmed the tiles render
- The activation algorithm was validated end-to-end against **production Firestore** before being written in TypeScript: 1,456 matured macOS signups over 60 days, 532 activated, 0 read errors

New behavioural tests for `computeActivation` run against a faked Firestore and cover the 7-day boundary, the macOS filter, maturity exclusion, 500-doc pagination, and per-user read failures being reported rather than silently scored as unactivated.

### Not verified

The TypeScript route has **not** been executed against Firestore — this machine has no `FIREBASE_CLIENT_EMAIL` / `FIREBASE_PRIVATE_KEY`, which `lib/firebase/admin.ts` requires. Its first real exercise will be the cron run.

## Not addressed here

Both need a decision rather than a patch:

- Stable is still on a build that cannot report activation via telemetry.
- Cloud Run service `backend` has `POSTHOG_HOST` but no `POSTHOG_PROJECT_API_KEY`, so every backend-side product event is silently dropped — this is also why `MCP Tool Call` does not exist in PostHog.

Failure-Class: FC-unestablished-capability-default
