### PR TITLE
Fix proactive notification repetition and extraction contamination; move workstream tagging to a background reconciler

### DIFF
--- a/.github/failure-classes/FC-prompt-machinery-vocabulary-echoed-as-content.json
+++ b/.github/failure-classes/FC-prompt-machinery-vocabulary-echoed-as-content.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "id": "FC-prompt-machinery-vocabulary-echoed-as-content",
+  "violated_contract": "A prompt must not describe its own internal machinery in words the model is also asked to produce. A weak extraction model reproduces that vocabulary as content: naming the outputs \"ambient narrative\", \"identifier\", \"proposals\" and \"evidence\" put those words at the head of 25% of stored fact statements and filled 104 of 125 identifier slots with model bookkeeping (fact-001, f-002, ftn-003), and the corrupted text then propagated to every downstream consumer, including the director prompt that reads those facts back.",
+  "canonical_prevention": "Describe the wanted output in the reader's language with one concrete good/bad example and none of the pipeline's own nouns, and enforce the shape at the storage boundary rather than in prompt wording alone: reject scaffolding-shaped statements and bookkeeping-shaped identifiers at write time, so a regression in model behaviour cannot reach the corpus.",
+  "evidence_prs": [11634],
+  "scope_hints": ["desktop/macos/Desktop/Sources/ProactiveAssistants/**"],
+  "status": "open",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift",
+    "desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift"
+  ]
+}

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -522,6 +522,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     // Route completed background-agent results into live voice sessions.
     AgentCompletionVoiceDelivery.shared.start()
 
+    Task { await ContextWorkstreamReconciler.shared.start() }
+
     scheduleAppLifecycleMaintenance()
 
     // Identify user if already signed in
@@ -1344,6 +1346,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
 
     // Stop recurring task scheduler
     RecurringTaskScheduler.shared.stop()
+    Task { await ContextWorkstreamReconciler.shared.stop() }
 
     // Finalize the active Rewind MP4 chunk while the app is still alive.
     // AVAssetWriter files are not readable until finishWriting writes the trailer.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbe.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbe.swift
@@ -68,7 +68,8 @@
         frozenRankedSegment: Data(input.frozen.utf8),
         tail: input.tail,
         validatedFacts: input.validatedFacts,
-        notifyWorthiness: input.notifyWorthiness)
+        notifyWorthiness: input.notifyWorthiness,
+        visitCount: input.visitCount)
       guard ContextDirectorEligibility.permitsEvaluation(of: snapshot) else {
         return [
           "decision": "silence",
@@ -89,8 +90,9 @@
         captureTime: input.capturedAt)
       let prompt = ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot)
       let uncachedPrompt = ContextProactivityPromptBuilder.directorVolatilePrompt(
-        tasks: input.tasks, frame: frame, recentDeliveries: input.recentDeliveries)
-      let cacheKey = "bucket:\(snapshot.bucketID):v\(snapshot.version)"
+        tasks: input.tasks, frame: frame, recentDeliveries: input.recentDeliveries,
+        visitCount: input.visitCount)
+      let cacheKey = ContextPromptCacheKey.director
       let started = DispatchTime.now().uptimeNanoseconds
       let result = try await completion(
         ModelQoS.Proactivity.reasoningOperation,
@@ -137,6 +139,9 @@
       let window: String
       let capturedAt: Date
       let notifyWorthiness: Double
+      /// Optional. Absent means "unknown", which prints no visit line, so
+      /// existing probe callers keep their exact prompt.
+      let visitCount: Int
       /// Optional. Lets a probe exercise the recent-delivery prompt section, which is
       /// otherwise only reachable from the live ledger.
       let recentDeliveries: [ContextBucketRecentDelivery]
@@ -166,6 +171,15 @@
           throw ContextBucketDirectorProbeError.invalidParams("notify_worthiness")
         }
         notifyWorthiness = parsedWorthiness
+        if let rawVisitCount = params["visit_count"], !rawVisitCount.isEmpty {
+          guard let parsedVisitCount = Int(rawVisitCount), (0...1_000_000).contains(parsedVisitCount)
+          else {
+            throw ContextBucketDirectorProbeError.invalidParams("visit_count")
+          }
+          visitCount = parsedVisitCount
+        } else {
+          visitCount = 0
+        }
         recentDeliveries = try Self.optionalRecentDeliveryList(
           params, key: "recent_deliveries",
           maxCount: ContextBucketRecentDelivery.promptCap)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbeRegistration.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ContextBucketDirectorProbeRegistration.swift
@@ -8,7 +8,7 @@
         summary: "Replay a synthetic context bucket through the director model boundary without delivery",
         params: [
           "bucket_id", "version", "header", "frozen", "tail", "validated_facts", "tasks", "app", "window",
-          "captured_at", "notify_worthiness",
+          "captured_at", "notify_worthiness", "visit_count",
         ],
         safety: "network_or_model",
         sideEffects: [

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -9,15 +9,9 @@ struct BucketExtraction: Codable, Equatable, Sendable {
     let evidenceRefs: [String]
     let confidence: Double
     let notifyWorthiness: Double
-    /// Proposed workstream label, `unknown` when the model abstains.
-    ///
-    /// Optional so a response predating this field still decodes (same
-    /// `decodeIfPresent` reasoning as `destination` below); `var` with a
-    /// default keeps the memberwise initializer source-compatible.
-    var workstream: String? = nil
 
     enum CodingKeys: String, CodingKey {
-      case statement, identifiers, confidence, workstream
+      case statement, identifiers, confidence
       case evidenceText = "evidence_text"
       case evidenceRefs = "evidence_refs"
       case notifyWorthiness = "notify_worthiness"
@@ -103,6 +97,18 @@ enum BucketFactValidator {
       && !evidenceRefs.isEmpty
     return hasIdentifier && evidenceResolves ? .validated : .needsReview
   }
+
+  /// Model bookkeeping (`fact-001`, `f-002`, `visit:3`) and handles that never
+  /// appear in the quoted on-screen wording are not identifiers.
+  static let bookkeepingIdentifierPattern = #"^(fact|f|ftn|visit|screenshot)[-:_ ]?\d+$"#
+
+  static func acceptedIdentifiers(_ identifiers: [String], evidenceText: String) -> [String] {
+    identifiers.filter { identifier in
+      identifier.range(
+        of: bookkeepingIdentifierPattern, options: [.regularExpression, .caseInsensitive]
+      ) == nil && evidenceText.contains(identifier)
+    }
+  }
 }
 
 enum ContextBucketPromptAssembler {
@@ -160,38 +166,28 @@ struct ContextDirectorTaskContext: Equatable, Sendable {
 
 enum ContextProactivityPromptBuilder {
   static func extractionPrompt(
-    frame: CapturedFrame, fence: ContextVisitFence, workstreamVocabulary: [String] = []
+    frame: CapturedFrame, fence: ContextVisitFence
   ) -> String {
     let evidenceRef = frame.screenshotId.map { "screenshot:\($0)" } ?? "visit:\(fence.visitID)"
     return extractionPrompt(
-      appName: frame.appName, windowTitle: frame.windowTitle, evidenceRef: evidenceRef,
-      workstreamVocabulary: workstreamVocabulary)
+      appName: frame.appName, windowTitle: frame.windowTitle, evidenceRef: evidenceRef)
   }
 
   static func extractionPrompt(
-    appName: String, windowTitle: String?, evidenceRef: String,
-    workstreamVocabulary: [String] = []
+    appName: String, windowTitle: String?, evidenceRef: String
   ) -> String {
-    // Closed-vocabulary bias: reusing an active label is what makes context from
-    // different apps collide in one workstream, so existing labels are quoted and
-    // coining a new one is framed as the exception.
-    let activeLabels =
-      workstreamVocabulary.isEmpty
-      ? "none yet"
-      : workstreamVocabulary.map { ContextDestinationKey.singleLine($0, limit: 40) }
-        .joined(separator: ", ")
     let base = """
       \(ScreenDerivedContent.untrustedPreamble)
-      Produce a 150-400 token ambient narrative and discrete factual records. Facts are
-      proposals; include an identifier, surviving evidence text, and evidence ref for each.
-      Also set each fact's "workstream": the durable project or activity its content belongs
-      to, judged by the content itself rather than by which app is open. Strongly prefer one
-      of the active labels: \(activeLabels). Only when none fits, coin one new short
-      kebab-case label for a durable project, or answer "unknown" for generic activity you
-      cannot place.
+      Write a 150-400 token summary of what is happening, then discrete factual records.
+      Each statement must be a plain declarative sentence a colleague could act on. Do not
+      label, number, or prefix statements.
+      Good: Nik asked for the demo recording before tomorrow's launch video.
+      Bad: Ambient narrative: the user appears to be coordinating a recording workflow.
+      Fill identifiers with names, ticket numbers, or other handles copied from the quoted
+      on-screen text. Fill evidence_text with that supporting on-screen wording. Put this
+      ref in every evidence_refs list: \(evidenceRef)
       App: \(appName)
       Window: \(ContextDestinationKey.singleLine(windowTitle ?? "", limit: 160))
-      Evidence ref: \(evidenceRef)
       """
     // Browser-scoped by design. Unscoped destination labelling was measured at 6%
     // precision: the model answers `telegram` for every thread and collapses
@@ -271,8 +267,11 @@ enum ContextProactivityPromptBuilder {
       update, recommendation, or useful follow-up without an explicit commitment, promise, or
       request is insight or suggest; never infer an owner or due date and never create a task
       candidate from actionability alone.
-      Do not re-deliver a point already delivered for this bucket unless the validated facts
-      add something materially new. Prefer silence over restating.
+      Do not restate what is already visible on the user's screen. Speak only when you add
+      something they cannot currently see: a commitment, a deadline, a conflict, or a
+      connection to other work.
+      The recently-delivered list is a prohibition, not background. Do not re-send a point
+      already delivered, even reworded.
       Timestamps supplied below are already in the user's local time zone. When a message
       mentions a date or time, use that local form as written; never convert to or mention UTC.\(lookup)
 
@@ -329,6 +328,7 @@ enum ContextProactivityPromptBuilder {
     }
     return """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
+      Do not re-send any of these points, even reworded.
       \(lines.joined(separator: "\n"))
       """
   }
@@ -457,13 +457,17 @@ extension ContextBucketStore {
         }
         for fact in extraction.facts.prefix(20) {
           let statement = String(fact.statement.prefix(500))
+          if ContextWorkstreamPooling.isScaffolding(statement) { continue }
           let evidenceText = String(fact.evidenceText.prefix(1_000))
           let evidenceRefs = BucketFactValidator.resolvableEvidenceRefs(
             Array(fact.evidenceRefs.prefix(10)), allowed: allowedEvidenceRefs)
-          let identifiers = fact.identifiers.prefix(8).map {
-            String($0.prefix(200)).trimmingCharacters(in: .whitespacesAndNewlines)
-          }
-          .filter { !$0.isEmpty }
+          let identifiers = BucketFactValidator.acceptedIdentifiers(
+            Array(
+              fact.identifiers.prefix(8).map {
+                String($0.prefix(200)).trimmingCharacters(in: .whitespacesAndNewlines)
+              }
+              .filter { !$0.isEmpty }),
+            evidenceText: evidenceText)
           paraphraseObserved =
             paraphraseObserved
             || BucketFactValidator.hasParaphraseMatch(
@@ -494,7 +498,7 @@ extension ContextBucketStore {
               evidenceText,
               String(data: try evidenceEncoder.encode(evidenceRefs), encoding: .utf8) ?? "[]",
               validity.rawValue, min(max(fact.confidence, 0), 1), worthiness,
-              ContextWorkstreamTag.sanitize(fact.workstream), now, now,
+              nil as String?, now, now,
             ])
           if validity == .validated {
             existingFactIdentities.append(
@@ -774,8 +778,7 @@ actor ContextBucketRollupWriter {
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
       await store.fenceIsValid(fence)
     else { return }
-    let prompt = ContextProactivityPromptBuilder.extractionPrompt(
-      frame: frame, fence: fence, workstreamVocabulary: await store.activeWorkstreamTags())
+    let prompt = ContextProactivityPromptBuilder.extractionPrompt(frame: frame, fence: fence)
     do {
       let result = try await client.complete(
         operation: ModelQoS.Proactivity.extractionOperation,
@@ -866,14 +869,10 @@ actor ContextBucketRollupWriter {
               "evidence_refs": ["type": "array", "items": ["type": "string"]],
               "confidence": ["type": "number"],
               "notify_worthiness": ["type": "number"],
-              "workstream": ["type": "string"],
             ],
-            // Strict structured output requires every declared property listed as
-            // required, so the prompt tells the model to answer "unknown" when it
-            // cannot place a fact in a workstream.
             "required": [
               "statement", "identifiers", "evidence_text", "evidence_refs", "confidence",
-              "notify_worthiness", "workstream",
+              "notify_worthiness",
             ],
             "additionalProperties": false,
           ],

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -161,7 +161,11 @@ enum ContextBucketPromptAssembler {
   /// block rather than the end. The frozen segment above them is the part that
   /// is stable unconditionally, and it is the part that was made large.
   static func assemble(_ snapshot: ContextBucketSnapshot) -> Data {
-    var data = Data(("== BUCKET HEADER ==\n" + snapshot.header + "\n== FROZEN RANKED CONTEXT ==\n").utf8)
+    // Always the constant header, never `snapshot.header`: versions published
+    // before this change stored a per-visit counter in that column, and putting
+    // those bytes back above the frozen segment would keep the cache prefix
+    // uncacheable until every bucket republished.
+    var data = Data(("== BUCKET HEADER ==\n" + stableHeader + "\n== FROZEN RANKED CONTEXT ==\n").utf8)
     // This exact byte segment is the stable cache prefix. Never decode/re-encode it.
     data.append(snapshot.frozenRankedSegment)
     let totalByteBudget = injectionTokenBudget * 4
@@ -758,6 +762,11 @@ enum ContextBucketPurger {
           arguments: [bucketID])
         try db.execute(
           sql: "DELETE FROM proactive_deliveries WHERE bucketID = ?", arguments: [bucketID])
+        // Candidate messages quote this bucket's facts. Leaving them armed
+        // after a privacy purge would keep excluded-app prose in the database
+        // and on the next delivery path.
+        try db.execute(
+          sql: "DELETE FROM proactive_candidates WHERE bucketID = ?", arguments: [bucketID])
         // Recompute visit metadata from surviving completed visits so the
         // bucket no longer reports deleted activity as recent or count it.
         let survivingCount =

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -103,10 +103,15 @@ enum BucketFactValidator {
   static let bookkeepingIdentifierPattern = #"^(fact|f|ftn|visit|screenshot)[-:_ ]?\d+$"#
 
   static func acceptedIdentifiers(_ identifiers: [String], evidenceText: String) -> [String] {
-    identifiers.filter { identifier in
+    // Case-fold only the containment check, never the identifier itself: a
+    // model-emitted handle like `pr-123` must still count as present when the
+    // on-screen quote reads `PR-123`, but the accepted value keeps the case
+    // the model actually produced.
+    let lowercasedEvidence = evidenceText.lowercased()
+    return identifiers.filter { identifier in
       identifier.range(
         of: bookkeepingIdentifierPattern, options: [.regularExpression, .caseInsensitive]
-      ) == nil && evidenceText.contains(identifier)
+      ) == nil && lowercasedEvidence.contains(identifier.lowercased())
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -116,28 +116,65 @@ enum BucketFactValidator {
   }
 }
 
-enum ContextBucketPromptAssembler {
-  static let injectionTokenBudget = 5_000
-  static let ambientTailCompactionThreshold = 3_500
-  static let frozenRankedByteBudget = 6_000
+/// Gateway cache keys for the proactive prompts.
+///
+/// Deliberately constant. A key is only a routing hint — a hit still requires a
+/// byte-identical literal prefix — so a key naming the bucket and version was
+/// strictly more volatile than the content it named: `publishVersion` runs on
+/// every completed visit, which fragmented the cache into one entry per bucket
+/// per visit and guaranteed each one was written and never read. One constant
+/// key per prompt shape lets every call of that shape share the instruction
+/// prefix.
+enum ContextPromptCacheKey {
+  static let director = "director:v1"
+  static let reconcilerTagging = "reconciler:v1"
+  static let reconcilerCandidates = "reconciler-candidates:v1"
+}
 
+enum ContextBucketPromptAssembler {
+  /// Sized so the enlarged frozen segment is genuinely additional context rather
+  /// than context stolen from facts and tail: 16_000 frozen bytes + the 8_000-byte
+  /// fact reservation + the ~6_000 bytes the tail has always had.
+  static let injectionTokenBudget = 7_500
+  static let ambientTailCompactionThreshold = 3_500
+  static let factByteReservation = 8_000
+  /// Frozen history is the one block that is both large and byte-stable, so it is
+  /// the only one worth buying at scale: past the first call of a bucket it is
+  /// billed at cached rates.
+  static let frozenRankedByteBudget = 16_000
+
+  /// Deliberately constant. Everything above the frozen segment is part of the
+  /// longest-common-prefix the gateway matches on, so a per-visit counter here
+  /// made a cross-visit cache hit structurally impossible — it changed bytes
+  /// above the segment it was supposed to be stabilizing. The visit count now
+  /// rides in the volatile director section instead, where changing is free.
+  static let stableHeader = "Persistent work context."
+
+  /// Blocks are ordered least-volatile first, because cache matching is
+  /// longest-common-prefix and the first differing byte discards everything
+  /// after it: constant header, then the append-only frozen segment, then
+  /// validated facts, and only then the rolling five-entry tail, which rewrites
+  /// on every visit and would otherwise invalidate the facts sitting behind it.
+  ///
+  /// Facts are only stable across visits that validated no new fact — the
+  /// snapshot orders them newest-first, so a new one lands at the head of the
+  /// block rather than the end. The frozen segment above them is the part that
+  /// is stable unconditionally, and it is the part that was made large.
   static func assemble(_ snapshot: ContextBucketSnapshot) -> Data {
     var data = Data(("== BUCKET HEADER ==\n" + snapshot.header + "\n== FROZEN RANKED CONTEXT ==\n").utf8)
     // This exact byte segment is the stable cache prefix. Never decode/re-encode it.
     data.append(snapshot.frozenRankedSegment)
     let totalByteBudget = injectionTokenBudget * 4
-    let facts =
-      snapshot.validatedFacts.isEmpty
-      ? "" : "\n== VALIDATED FACTS ==\n\(snapshot.validatedFacts.joined(separator: "\n"))"
-    let factReservation = min(8_000, max(0, totalByteBudget - data.count))
-    let tailBudget = max(0, totalByteBudget - data.count - factReservation)
+    if !snapshot.validatedFacts.isEmpty {
+      data.append(
+        utf8Prefix(
+          "\n== VALIDATED FACTS ==\n\(snapshot.validatedFacts.joined(separator: "\n"))",
+          maxBytes: min(factByteReservation, max(0, totalByteBudget - data.count))))
+    }
     data.append(
       utf8Prefix(
         "\n== RECENT TAIL ==\n\(snapshot.tail.joined(separator: "\n"))",
-        maxBytes: tailBudget))
-    if !snapshot.validatedFacts.isEmpty {
-      data.append(utf8Prefix(facts, maxBytes: max(0, totalByteBudget - data.count)))
-    }
+        maxBytes: max(0, totalByteBudget - data.count)))
     return data
   }
 
@@ -219,7 +256,8 @@ enum ContextProactivityPromptBuilder {
     \(directorStablePrompt(snapshot: snapshot))
 
     \(directorVolatilePrompt(
-      tasks: tasks, frame: frame, recentDeliveries: recentDeliveries, timeZone: timeZone))
+      tasks: tasks, frame: frame, recentDeliveries: recentDeliveries,
+      visitCount: snapshot.visitCount, timeZone: timeZone))
     """
   }
 
@@ -284,10 +322,14 @@ enum ContextProactivityPromptBuilder {
       """
   }
 
+  /// `visitCount` lives here, not in the bucket header, because it changes on
+  /// every visit and anything that changes must sit below the cached prefix.
+  /// Zero means "not supplied" and prints nothing.
   static func directorVolatilePrompt(
     tasks: [ContextDirectorTaskContext],
     frame: CapturedFrame,
     recentDeliveries: [ContextBucketRecentDelivery] = [],
+    visitCount: Int = 0,
     timeZone: TimeZone = .current
   ) -> String {
     let actionableCutoff = frame.captureTime.addingTimeInterval(
@@ -310,42 +352,39 @@ enum ContextProactivityPromptBuilder {
       Window: \(frame.windowTitle ?? "")
       Captured at: \(localTimestamp(frame.captureTime, timeZone: timeZone))
       """
-    if let recent = recentDeliveriesSection(recentDeliveries, now: frame.captureTime) {
+    if visitCount > 0 {
+      prompt += "\nQualifying visits to this context: \(visitCount)"
+    }
+    if let recent = recentDeliveriesSection(recentDeliveries, timeZone: timeZone) {
       prompt += "\n\n\(recent)"
     }
     return prompt
   }
 
+  /// Rendered with absolute local timestamps rather than a relative age, so the
+  /// same delivery set produces the same bytes on every call. A "3m ago" age
+  /// rewrote this block every time it was built, which is what kept it — and
+  /// everything the model could learn from it — off the cacheable side.
   static func recentDeliveriesSection(
     _ deliveries: [ContextBucketRecentDelivery],
-    now: Date
+    timeZone: TimeZone = .current
   ) -> String? {
     let entries = Array(deliveries.prefix(ContextBucketRecentDelivery.promptCap))
     guard !entries.isEmpty else { return nil }
     let lines = entries.map { delivery -> String in
       let decision = String(delivery.decisionType.prefix(32))
-      let age = relativeAge(from: delivery.deliveredAt, now: now)
+      let at = localTimestamp(delivery.deliveredAt, timeZone: timeZone)
       let summary = boundedSummary(delivery.message)
       if summary.isEmpty {
-        return "- \(decision) (\(age))"
+        return "- \(decision) (\(at))"
       }
-      return "- \(decision) (\(age)): \(summary)"
+      return "- \(decision) (\(at)): \(summary)"
     }
     return """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
       Do not re-send any of these points, even reworded.
       \(lines.joined(separator: "\n"))
       """
-  }
-
-  static func relativeAge(from deliveredAt: Date, now: Date) -> String {
-    let seconds = max(0, Int(now.timeIntervalSince(deliveredAt).rounded(.down)))
-    if seconds < 60 { return "\(seconds)s ago" }
-    let minutes = seconds / 60
-    if minutes < 60 { return "\(minutes)m ago" }
-    let hours = minutes / 60
-    if hours < 48 { return "\(hours)h ago" }
-    return "\(hours / 24)d ago"
   }
 
   static func boundedSummary(_ message: String?) -> String {
@@ -610,10 +649,11 @@ extension ContextBucketStore {
       }
       frozen = Data(rankedLines.joined().utf8)
     }
-    let visitCount =
-      try Int.fetchOne(
-        db, sql: "SELECT visitCount FROM context_buckets WHERE id = ?", arguments: [bucketID]) ?? 0
-    let header = "Persistent work context; \(visitCount) qualifying visits."
+    // Constant on purpose: this string is published above the frozen segment on
+    // every version, so interpolating the visit count here changed bytes at the
+    // very top of the cache prefix once per visit. The count is read live from
+    // `context_buckets` into the volatile director section instead.
+    let header = ContextBucketPromptAssembler.stableHeader
     try db.execute(
       sql: """
         INSERT INTO bucket_versions

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
@@ -10,6 +10,8 @@ enum ContextBucketSchema {
     "bucket_versions",
     "bucket_entries",
     "bucket_facts",
+    "bucket_workstreams",
+    "proactive_candidates",
     "subject_bindings",
     "proactive_deliveries",
     "context_bucket_migration_meta",
@@ -107,6 +109,44 @@ enum ContextBucketSchema {
         index: "idx_bucket_facts_workstream",
         on: "bucket_facts",
         columns: ["workstreamTag", "createdAt"])
+    }
+    // Durable bucket-level workstream assignments and pre-written notification
+    // candidates. The dormant `bucket_facts.workstreamTag` column is left
+    // untouched: new labels accumulate here so they can be reused across visits.
+    migrator.registerMigration("addWorkstreamAssignmentsAndCandidates") { db in
+      try db.create(table: "bucket_workstreams") { table in
+        table.primaryKey("id", .text)
+        table.column("bucketID", .text).notNull().references("context_buckets", onDelete: .cascade)
+        table.column("tag", .text).notNull()
+        table.column("source", .text).notNull().defaults(to: "reconciler")
+        table.column("assignedAt", .datetime).notNull()
+        table.uniqueKey(["bucketID", "tag"])
+      }
+      try db.create(
+        index: "idx_bucket_workstreams_tag",
+        on: "bucket_workstreams",
+        columns: ["tag", "assignedAt"])
+      try db.create(table: "proactive_candidates") { table in
+        table.primaryKey("id", .text)
+        table.column("bucketID", .text).notNull().references("context_buckets", onDelete: .cascade)
+        table.column("workstreamTag", .text)
+        table.column("message", .text).notNull()
+        table.column("groundingFactIDsJson", .text).notNull()
+        table.column("triggerNote", .text).notNull()
+        table.column("state", .text).notNull().defaults(to: "armed")
+        table.column("createdAt", .datetime).notNull()
+        table.column("expiresAt", .datetime).notNull()
+        table.column("consumedAt", .datetime)
+        table.check(sql: "state IN ('armed','consumed','expired')")
+      }
+      try db.create(
+        index: "idx_proactive_candidates_lookup",
+        on: "proactive_candidates",
+        columns: ["bucketID", "state", "expiresAt"])
+      try db.create(
+        index: "idx_proactive_candidates_workstream",
+        on: "proactive_candidates",
+        columns: ["workstreamTag", "state", "expiresAt"])
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
@@ -148,6 +148,17 @@ enum ContextBucketSchema {
         on: "proactive_candidates",
         columns: ["workstreamTag", "state", "expiresAt"])
     }
+    // Terminal candidate rows (consumed or expired) are never read again once
+    // past their expiry; without cleanup they accumulate for the lifetime of
+    // the database. The lookup/workstream indexes above lead with bucketID or
+    // workstreamTag, neither useful for a table-wide retention sweep, so this
+    // index leads with state instead.
+    migrator.registerMigration("addProactiveCandidatesRetentionIndex") { db in
+      try db.create(
+        index: "idx_proactive_candidates_retention",
+        on: "proactive_candidates",
+        columns: ["state", "expiresAt"])
+    }
   }
 
   static func removeMigratedLegacyDefaults(
@@ -183,6 +194,17 @@ enum ContextBucketSchema {
   static func deleteExpiredDeliveries(in db: Database, now: Date) throws -> Int {
     try db.execute(
       sql: "DELETE FROM proactive_deliveries WHERE expiresAt <= ?",
+      arguments: [now])
+    return db.changesCount
+  }
+
+  /// Terminal `proactive_candidates` rows (consumed, expired, or simply past
+  /// their `expiresAt`) never get read again — without this they accumulate
+  /// indefinitely whenever the reconciler feature is on.
+  @discardableResult
+  static func deleteExpiredProactiveCandidates(in db: Database, now: Date) throws -> Int {
+    try db.execute(
+      sql: "DELETE FROM proactive_candidates WHERE state <> 'armed' OR expiresAt <= ?",
       arguments: [now])
     return db.changesCount
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -536,6 +536,179 @@ actor ContextBucketStore {
       }) ?? []
   }
 
+  func workstreamTags(for bucketID: String) async -> [String] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    return
+      (try? await pool.read { db in
+        try ContextWorkstreamTagging.tags(for: bucketID, in: db)
+      }) ?? []
+  }
+
+  func armedCandidates(
+    bucketID: String, tags: [String], now: Date = Date()
+  ) async -> [ContextProactiveCandidate] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    return
+      (try? await pool.read { db in
+        try ContextProactiveCandidateLookup.lookupArmed(
+          bucketID: bucketID, tags: tags, now: now, in: db)
+      }) ?? []
+  }
+
+  func consumeCandidate(id: String, now: Date = Date()) async -> Bool {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return false }
+    return
+      (try? await pool.write { db in
+        try ContextProactiveCandidateLookup.consume(id: id, now: now, in: db)
+      }) ?? false
+  }
+
+  func recentContextPool(
+    excludingBucketID: String, now: Date = Date()
+  ) async -> [ContextWorkstreamPoolItem] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    let cutoff = now.addingTimeInterval(-ContextWorkstreamPooling.recentContextWindow)
+    return
+      (try? await pool.read { db in
+        try Row.fetchAll(
+          db,
+          sql: """
+            SELECT id, bucketID, appName, statement, notifyWorthiness, createdAt
+            FROM bucket_facts
+            WHERE bucketID <> ? AND validityState = 'validated'
+              AND (expiresAt IS NULL OR expiresAt > ?)
+              AND notifyWorthiness >= ?
+              AND createdAt >= ?
+            ORDER BY createdAt DESC LIMIT ?
+            """,
+          arguments: [
+            excludingBucketID, now, ContextWorkstreamPooling.recentContextWorthinessFloor, cutoff,
+            ContextWorkstreamPooling.candidateFetchLimit,
+          ]
+        ).compactMap { row -> ContextWorkstreamPoolItem? in
+          guard let factID: String = row["id"], let bucketID: String = row["bucketID"],
+            let statement: String = row["statement"], let createdAt: Date = row["createdAt"]
+          else { return nil }
+          return ContextWorkstreamPoolItem(
+            factID: factID,
+            bucketID: bucketID,
+            appName: row["appName"] ?? "",
+            statement: statement,
+            notifyWorthiness: row["notifyWorthiness"] ?? 0,
+            createdAt: createdAt)
+        }
+      }) ?? []
+  }
+
+  func runWorkstreamReconcilePass(
+    lastPassAt: Date?, now: Date
+  ) async throws -> ContextWorkstreamReconcileOutcome {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
+    return try await pool.write { db in
+      try ContextProactiveCandidateLookup.expireStale(now: now, in: db)
+      let newestValidated = try Date.fetchOne(
+        db,
+        sql: """
+          SELECT MAX(updatedAt) FROM bucket_facts WHERE validityState = 'validated'
+          """)
+      if let lastPassAt, let newestValidated, newestValidated <= lastPassAt {
+        return .skippedNoNewFacts
+      }
+      let eligible = try ContextWorkstreamBatchSelection.fetchEligible(in: db, now: now)
+      let batchIDs = ContextWorkstreamBatchSelection.applyExploration(
+        rankedIDs: eligible.map(\.bucketID))
+      guard !batchIDs.isEmpty else { return .skippedEmptyBatch }
+      let allFacts = try ContextWorkstreamBatchSelection.fetchFacts(
+        bucketIDs: batchIDs, now: now, in: db)
+      let factsByBucket = Dictionary(grouping: allFacts, by: \.bucketID)
+      let existingTags = try ContextWorkstreamTagging.existingTags(in: db)
+      var groups: [ContextWorkstreamReconcileGroup] = []
+      for bucketID in batchIDs {
+        let facts = ContextWorkstreamBatchSelection.selectFacts(factsByBucket[bucketID] ?? [])
+        guard !facts.isEmpty else { continue }
+        let tags = try ContextWorkstreamTagging.tags(for: bucketID, in: db)
+        let hasHighWorthiness = facts.contains {
+          $0.notifyWorthiness >= ContextWorkstreamBatchSelection.candidateWorthinessFloor
+        }
+        // `&&` is `rethrows` over an autoclosure, so the throwing call cannot sit
+        // on its right-hand side; evaluate it separately.
+        var needsCandidate = false
+        if hasHighWorthiness {
+          needsCandidate = try !ContextProactiveCandidateWriter.hasArmedCandidate(
+            bucketID: bucketID, now: now, in: db)
+        }
+        groups.append(
+          ContextWorkstreamReconcileGroup(
+            bucketID: bucketID,
+            facts: facts,
+            needsCandidate: needsCandidate,
+            workstreamTag: tags.first))
+      }
+      guard !groups.isEmpty else { return .skippedEmptyBatch }
+      return .ready(
+        ContextWorkstreamReconcileBatch(groups: groups, existingTags: existingTags))
+    }
+  }
+
+  func insertWorkstreamAssignments(
+    _ assignments: [ContextWorkstreamTagging.AcceptedAssignment], now: Date
+  ) async throws {
+    guard !assignments.isEmpty else { return }
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
+    try await pool.write { db in
+      for assignment in assignments {
+        try ContextWorkstreamTagging.insertAssignment(
+          bucketID: assignment.bucketID, tag: assignment.tag, now: now, in: db)
+      }
+    }
+  }
+
+  func insertArmedCandidates(
+    _ proposed: [ContextProactiveCandidateWriter.Response.Candidate],
+    groups: [ContextWorkstreamReconcileGroup],
+    now: Date
+  ) async throws {
+    guard !proposed.isEmpty else { return }
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
+    // `let` so the write closure can capture it: a `var` is not Sendable.
+    let groupByID = Dictionary(groups.map { ($0.bucketID, $0) }, uniquingKeysWith: { _, last in last })
+    try await pool.write { db in
+      var seen = Set<String>()
+      for candidate in proposed {
+        let bucketID =
+          ContextWorkstreamTagging.resolveGroup(
+            candidate.bucket, batchIDs: groups.map(\.bucketID))
+          ?? (groupByID[candidate.bucket] != nil ? candidate.bucket : nil)
+        guard let bucketID, seen.insert(bucketID).inserted else { continue }
+        let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { continue }
+        let cited = candidate.factIDs.map {
+          $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0
+        }.filter { !$0.isEmpty }
+        let factIDs = try ContextProactiveCandidateWriter.validatedFactIDs(
+          cited, bucketID: bucketID, now: now, in: db)
+        guard !cited.isEmpty, Set(factIDs) == Set(cited) else { continue }
+        let trigger = candidate.triggerNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trigger.isEmpty else { continue }
+        try ContextProactiveCandidateWriter.insertArmed(
+          bucketID: bucketID,
+          workstreamTag: groupByID[bucketID]?.workstreamTag,
+          message: String(message.prefix(600)),
+          factIDs: factIDs,
+          triggerNote: String(trigger.prefix(300)),
+          now: now,
+          in: db)
+      }
+    }
+  }
+
   func markVisitSettled(_ fence: ContextVisitFence, at date: Date = Date()) async throws {
     let pool = try await pool(for: fence)
     try await pool.write { db in

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -585,6 +585,31 @@ actor ContextBucketStore {
       }) ?? false
   }
 
+  @discardableResult
+  func restoreCandidate(id: String, now: Date = Date()) async -> Bool {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return false }
+    return
+      (try? await pool.write { db in
+        try ContextProactiveCandidateLookup.restore(id: id, now: now, in: db)
+      }) ?? false
+  }
+
+  func recentDeliveredForAssignedWorkstreams(
+    tags: [String],
+    excludingBucketID: String,
+    now: Date = Date(),
+    limit: Int = ContextBucketRecentDelivery.promptCap
+  ) async -> [ContextBucketRecentDelivery] {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return [] }
+    return
+      (try? await pool.read { db in
+        try ContextProactiveCandidateLookup.recentDeliveredForAssignedTags(
+          tags: tags, excludingBucketID: excludingBucketID, now: now, limit: limit, in: db)
+      }) ?? []
+  }
+
   /// Whether every grounding fact behind an armed candidate is still
   /// validated and unexpired. A candidate can sit armed for up to 12 hours;
   /// the fact(s) it cited at write time may since have expired or been
@@ -724,39 +749,9 @@ actor ContextBucketStore {
     guard !proposed.isEmpty else { return }
     let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
     guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
-    // `let` so the write closure can capture it: a `var` is not Sendable.
-    let groupByID = Dictionary(groups.map { ($0.bucketID, $0) }, uniquingKeysWith: { _, last in last })
     try await pool.write { db in
-      var seen = Set<String>()
-      for candidate in proposed {
-        let bucketID =
-          ContextWorkstreamTagging.resolveGroup(
-            candidate.bucket, batchIDs: groups.map(\.bucketID))
-          ?? (groupByID[candidate.bucket] != nil ? candidate.bucket : nil)
-        // Membership is checked (not claimed) here: an earlier invalid
-        // candidate for this bucket must not block a later valid one, so
-        // `seen` is only marked once every validation below has passed.
-        guard let bucketID, !seen.contains(bucketID) else { continue }
-        let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !message.isEmpty else { continue }
-        let cited = candidate.factIDs.map {
-          $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0
-        }.filter { !$0.isEmpty }
-        let factIDs = try ContextProactiveCandidateWriter.validatedFactIDs(
-          cited, bucketID: bucketID, now: now, in: db)
-        guard !cited.isEmpty, Set(factIDs) == Set(cited) else { continue }
-        let trigger = candidate.triggerNote.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trigger.isEmpty else { continue }
-        seen.insert(bucketID)
-        try ContextProactiveCandidateWriter.insertArmed(
-          bucketID: bucketID,
-          workstreamTag: groupByID[bucketID]?.workstreamTag,
-          message: String(message.prefix(600)),
-          factIDs: factIDs,
-          triggerNote: String(trigger.prefix(300)),
-          now: now,
-          in: db)
-      }
+      try ContextProactiveCandidateWriter.insertValidatedCandidates(
+        proposed, groups: groups, now: now, in: db)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -31,6 +31,11 @@ struct ContextBucketSnapshot: Equatable, Sendable {
   let tail: [String]
   let validatedFacts: [String]
   let notifyWorthiness: Double
+  /// Qualifying visits to this bucket. Read live rather than baked into
+  /// `header`, because it changes every visit and the header is part of the
+  /// director's cached prefix. `var` with a default keeps the memberwise
+  /// initializer source-compatible for callers that do not have a count.
+  var visitCount: Int = 0
 }
 
 enum ContextBucketStoreError: Error {
@@ -831,6 +836,9 @@ actor ContextBucketStore {
             AND (expiresAt IS NULL OR expiresAt > ?)
           """,
         arguments: [bucketID, now]) ?? 0
+    let visitCount =
+      try Int.fetchOne(
+        db, sql: "SELECT visitCount FROM context_buckets WHERE id = ?", arguments: [bucketID]) ?? 0
     return ContextBucketSnapshot(
       bucketID: bucketID,
       versionID: version["id"],
@@ -839,7 +847,8 @@ actor ContextBucketStore {
       frozenRankedSegment: version["frozenRankedSegment"],
       tail: Array(tail),
       validatedFacts: facts,
-      notifyWorthiness: worthiness)
+      notifyWorthiness: worthiness,
+      visitCount: visitCount)
   }
 
   func snapshot(for fence: ContextVisitFence) async -> ContextBucketSnapshot? {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -427,26 +427,6 @@ actor ContextBucketStore {
     }
   }
 
-  /// Active workstream labels for the extraction prompt's closed vocabulary,
-  /// most recently used first. Read-only and advisory: failure means an empty
-  /// vocabulary, which only weakens label reuse for one extraction.
-  func activeWorkstreamTags(now: Date = Date(), limit: Int = 12) async -> [String] {
-    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
-    guard let pool else { return [] }
-    return
-      (try? await pool.read { db in
-        try String.fetchAll(
-          db,
-          sql: """
-            SELECT workstreamTag FROM bucket_facts
-            WHERE workstreamTag IS NOT NULL AND validityState = 'validated'
-              AND (expiresAt IS NULL OR expiresAt > ?)
-            GROUP BY workstreamTag ORDER BY MAX(createdAt) DESC LIMIT ?
-            """,
-          arguments: [now, max(0, limit)])
-      }) ?? []
-  }
-
   /// The workstream to pool for this evaluation: the visit's own validated fact
   /// tags first, else the bucket's overwhelming-majority tag. Nil (no pooling)
   /// on any failure or ambiguity — the safe direction.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -349,6 +349,7 @@ actor ContextBucketStore {
     guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
     try await pool.write { db in
       _ = try ContextBucketSchema.deleteExpiredDeliveries(in: db, now: now)
+      _ = try ContextBucketSchema.deleteExpiredProactiveCandidates(in: db, now: now)
       try db.execute(
         sql: "DELETE FROM bucket_facts WHERE expiresAt IS NOT NULL AND expiresAt <= ?",
         arguments: [now])
@@ -566,6 +567,38 @@ actor ContextBucketStore {
       }) ?? false
   }
 
+  /// Retires a gated-down candidate immediately instead of leaving it armed to
+  /// be re-selected — and re-billed for another paid gate call — on every
+  /// subsequent visit until its full 12-hour lifetime elapses.
+  @discardableResult
+  func declineCandidate(id: String, now: Date = Date()) async -> Bool {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return false }
+    return
+      (try? await pool.write { db in
+        try ContextProactiveCandidateLookup.decline(id: id, now: now, in: db)
+      }) ?? false
+  }
+
+  /// Whether every grounding fact behind an armed candidate is still
+  /// validated and unexpired. A candidate can sit armed for up to 12 hours;
+  /// the fact(s) it cited at write time may since have expired or been
+  /// superseded, so this must be rechecked before the candidate is ever
+  /// offered as deliverable.
+  func groundingFactIDsAreCurrentlyValid(
+    _ factIDs: [String], bucketID: String, now: Date = Date()
+  ) async -> Bool {
+    guard !factIDs.isEmpty else { return false }
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return false }
+    return
+      (try? await pool.read { db in
+        let valid = try ContextProactiveCandidateWriter.validatedFactIDs(
+          factIDs, bucketID: bucketID, now: now, in: db)
+        return Set(valid) == Set(factIDs)
+      }) ?? false
+  }
+
   func recentContextPool(
     excludingBucketID: String, now: Date = Date()
   ) async -> [ContextWorkstreamPoolItem] {
@@ -609,8 +642,17 @@ actor ContextBucketStore {
   ) async throws -> ContextWorkstreamReconcileOutcome {
     let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
     guard let pool else { throw ContextBucketStoreError.databaseUnavailable }
-    return try await pool.write { db in
+    // Only the expiry sweep needs the writer lock. Everything below it is a
+    // read-only batch selection over up to 14 buckets; running that inside
+    // the same pool.write would hold SQLite's single writer lock for the
+    // whole selection and block a hot-path writeExtraction/delivery
+    // pool.write until it finished, for no atomicity benefit — the tag and
+    // candidate inserts this batch feeds commit later in their own
+    // transactions regardless.
+    try await pool.write { db in
       try ContextProactiveCandidateLookup.expireStale(now: now, in: db)
+    }
+    return try await pool.read { db in
       let newestValidated = try Date.fetchOne(
         db,
         sql: """
@@ -686,7 +728,10 @@ actor ContextBucketStore {
           ContextWorkstreamTagging.resolveGroup(
             candidate.bucket, batchIDs: groups.map(\.bucketID))
           ?? (groupByID[candidate.bucket] != nil ? candidate.bucket : nil)
-        guard let bucketID, seen.insert(bucketID).inserted else { continue }
+        // Membership is checked (not claimed) here: an earlier invalid
+        // candidate for this bucket must not block a later valid one, so
+        // `seen` is only marked once every validation below has passed.
+        guard let bucketID, !seen.contains(bucketID) else { continue }
         let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !message.isEmpty else { continue }
         let cited = candidate.factIDs.map {
@@ -697,6 +742,7 @@ actor ContextBucketStore {
         guard !cited.isEmpty, Set(factIDs) == Set(cited) else { continue }
         let trigger = candidate.triggerNote.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trigger.isEmpty else { continue }
+        seen.insert(bucketID)
         try ContextProactiveCandidateWriter.insertArmed(
           bucketID: bucketID,
           workstreamTag: groupByID[bucketID]?.workstreamTag,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
@@ -120,4 +120,23 @@ enum ContextBucketsFeature {
   }
 
   private static let localWorkstreamPoolingOverrideName = "OMI_FORCE_BUCKET_WORKSTREAMS"
+
+  /// Background workstream tagging plus pre-written notification candidates,
+  /// with a small reasoning-lane gate on the delivery path instead of a full
+  /// director call when a candidate is armed.
+  ///
+  /// Non-production dogfood defaults to on with the same inverted env override
+  /// as the flags above (`OMI_FORCE_BUCKET_CANDIDATES=0` turns it off).
+  /// Production and beta stay off until the reconciler is validated in
+  /// dogfood — like workstream pooling there is deliberately no remote stop
+  /// yet, because nothing ships dark to users this way.
+  @MainActor static var isProactiveCandidatesEnabled: Bool {
+    guard isEnabled else { return false }
+    if AppBuild.isNonProduction {
+      return ProcessInfo.processInfo.environment[localProactiveCandidatesOverrideName] != "0"
+    }
+    return false
+  }
+
+  private static let localProactiveCandidatesOverrideName = "OMI_FORCE_BUCKET_CANDIDATES"
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -40,8 +40,11 @@ struct ContextDeliveryAttempt: Equatable, Sendable {
 /// A successfully presented director notification for one bucket, used only as
 /// bounded prompt context. This is a signal to the model, not a delivery gate.
 struct ContextBucketRecentDelivery: Equatable, Sendable, Decodable, FetchableRecord {
-  static let promptCap = 3
-  static let summaryCharacterLimit = 120
+  static let promptCap = 6
+  static let summaryCharacterLimit = 320
+  /// Delivery memory outlives notification expiry so the director cannot
+  /// forget, and re-send, a point it already delivered earlier in the day.
+  static let memoryLookback: TimeInterval = 6 * 60 * 60
 
   let decisionType: String
   let message: String?
@@ -304,9 +307,12 @@ extension ContextBucketStore {
     }
   }
 
-  /// Newest successfully presented notifications for this bucket. Bounded so
-  /// the director prompt cannot grow without limit. Failed/suppressed rows are
-  /// excluded: the model should see what the user actually received.
+  /// Newest successfully presented notifications for this bucket within the
+  /// delivery-memory lookback. Bounded so the director prompt cannot grow
+  /// without limit. Failed/suppressed rows are excluded: the model should see
+  /// what the user actually received. Lookback is on `deliveredAt`, not
+  /// notification expiry, so a delivered point cannot be forgotten and re-sent
+  /// once its banner expires.
   func recentDeliveredForBucket(
     bucketID: String,
     now: Date = Date(),
@@ -325,11 +331,13 @@ extension ContextBucketStore {
             WHERE bucketID = ?
               AND lifecycleState = 'delivered'
               AND deliveredAt IS NOT NULL
-              AND expiresAt > ?
+              AND deliveredAt >= ?
             ORDER BY deliveredAt DESC
             LIMIT ?
             """,
-          arguments: [bucketID, now, cap])
+          arguments: [
+            bucketID, now.addingTimeInterval(-ContextBucketRecentDelivery.memoryLookback), cap,
+          ])
       }) ?? []
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -40,7 +40,12 @@ struct ContextDeliveryAttempt: Equatable, Sendable {
 /// A successfully presented director notification for one bucket, used only as
 /// bounded prompt context. This is a signal to the model, not a delivery gate.
 struct ContextBucketRecentDelivery: Equatable, Sendable, Decodable, FetchableRecord {
-  static let promptCap = 6
+  /// The prompt tells the director not to re-send a point it already delivered.
+  /// Showing it six of them made that instruction unenforceable in practice —
+  /// measured at 7 repeats in 34 deliveries. The block is now rendered with
+  /// absolute timestamps, so it is byte-stable for a given delivery set and
+  /// carrying more of it is close to free.
+  static let promptCap = 15
   static let summaryCharacterLimit = 320
   /// Delivery memory outlives notification expiry so the director cannot
   /// forget, and re-send, a point it already delivered earlier in the day.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -289,6 +289,16 @@ actor ContextProactivityEngine {
     }
     if candidatesEnabled {
       let tags = await store.workstreamTags(for: snapshot.bucketID)
+      if !tags.isEmpty {
+        // Lookup is cross-bucket by durable assignment; bucket-scoped delivery
+        // memory would re-send a sibling's already-shown point.
+        let assignedDeliveries = await store.recentDeliveredForAssignedWorkstreams(
+          tags: tags, excludingBucketID: snapshot.bucketID, now: currentFrame.captureTime)
+        recentDeliveries = Array(
+          (recentDeliveries + assignedDeliveries)
+            .sorted { $0.deliveredAt > $1.deliveredAt }
+            .prefix(ContextBucketRecentDelivery.promptCap))
+      }
       let armed = await store.armedCandidates(
         bucketID: snapshot.bucketID, tags: tags, now: currentFrame.captureTime)
       // A candidate can sit armed for up to 12 hours; the fact(s) it was
@@ -296,13 +306,16 @@ actor ContextProactivityEngine {
       // been superseded. Revalidate every grounding id against the current
       // bucket_facts state before treating a candidate as deliverable, so a
       // decayed candidate falls through to the director instead of gating
-      // and presenting stale text with stale citations.
+      // and presenting stale text with stale citations. Decline the stale
+      // row so it cannot block the reconciler from writing a replacement.
       var grounded: [ContextProactiveCandidate] = []
       for candidate in armed {
         if await store.groundingFactIDsAreCurrentlyValid(
           candidate.groundingFactIDs, bucketID: candidate.bucketID, now: currentFrame.captureTime)
         {
           grounded.append(candidate)
+        } else {
+          await store.declineCandidate(id: candidate.id, now: currentFrame.captureTime)
         }
       }
       let recentMessages = recentDeliveries.compactMap(\.message)
@@ -805,6 +818,9 @@ actor ContextProactivityEngine {
           onDropped: { [weak self] in
             guard let self else { return }
             Task {
+              // Claimed at consume time; this callback means it was never shown.
+              await self.store.restoreCandidate(
+                id: candidate.id, now: currentFrame.captureTime)
               await self.terminalize(
                 deliveryID: deliveryID,
                 decisionType: "silence",
@@ -817,6 +833,7 @@ actor ContextProactivityEngine {
       case .presented, .queued:
         return
       case .suppressed, .windowUnavailable, .rejectedOwnerChange:
+        // onDropped already ran (and restores) for these refusal paths.
         return
       }
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -331,7 +331,8 @@ actor ContextProactivityEngine {
       ContextProactivityPromptBuilder.directorVolatilePrompt(
         tasks: taskContext,
         frame: currentFrame,
-        recentDeliveries: recentDeliveries)
+        recentDeliveries: recentDeliveries,
+        visitCount: snapshot.visitCount)
       + (workstreamSection.map { "\n\n" + $0 } ?? "")
     if candidatesEnabled {
       let selected = ContextWorkstreamPooling.selectRecent(
@@ -371,7 +372,7 @@ actor ContextProactivityEngine {
         state: "suppressed")
       return
     }
-    let cacheKey = "bucket:\(snapshot.bucketID):v\(snapshot.version)"
+    let cacheKey = ContextPromptCacheKey.director
     do {
       var result = try await client.complete(
         operation: ModelQoS.Proactivity.reasoningOperation,
@@ -669,8 +670,7 @@ actor ContextProactivityEngine {
         prompt: ContextProactiveCandidateGate.prompt(
           message: candidate.message,
           validatedFacts: snapshot.validatedFacts,
-          recentDeliveries: recentDeliveries,
-          now: currentFrame.captureTime),
+          recentDeliveries: recentDeliveries),
         imageData: currentFrame.jpegData,
         jsonSchema: ContextProactiveCandidateGate.schema,
         maxCompletionTokens: 120,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -291,9 +291,23 @@ actor ContextProactivityEngine {
       let tags = await store.workstreamTags(for: snapshot.bucketID)
       let armed = await store.armedCandidates(
         bucketID: snapshot.bucketID, tags: tags, now: currentFrame.captureTime)
+      // A candidate can sit armed for up to 12 hours; the fact(s) it was
+      // grounded in at write time may since have expired, been rejected, or
+      // been superseded. Revalidate every grounding id against the current
+      // bucket_facts state before treating a candidate as deliverable, so a
+      // decayed candidate falls through to the director instead of gating
+      // and presenting stale text with stale citations.
+      var grounded: [ContextProactiveCandidate] = []
+      for candidate in armed {
+        if await store.groundingFactIDsAreCurrentlyValid(
+          candidate.groundingFactIDs, bucketID: candidate.bucketID, now: currentFrame.captureTime)
+        {
+          grounded.append(candidate)
+        }
+      }
       let recentMessages = recentDeliveries.compactMap(\.message)
       if let candidate = ContextProactiveCandidateLookup.firstDeliverable(
-        candidates: armed, recentMessages: recentMessages)
+        candidates: grounded, recentMessages: recentMessages)
       {
         await evaluateCandidateAndDeliver(
           candidate: candidate,
@@ -657,10 +671,25 @@ actor ContextProactivityEngine {
           validatedFacts: snapshot.validatedFacts,
           recentDeliveries: recentDeliveries,
           now: currentFrame.captureTime),
+        imageData: currentFrame.jpegData,
         jsonSchema: ContextProactiveCandidateGate.schema,
         maxCompletionTokens: 120,
         authorizationSnapshot: authorizationSnapshot)
       await ContextProactivityTelemetry.record(result)
+      // The gate awaited the model; ownership can be revoked or the visit can
+      // end inside that window, exactly as for the director's own call.
+      // Re-check before parsing or persisting anything.
+      guard
+        RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
+        await store.fenceFreshness(fence).fresh
+      else {
+        await terminalize(
+          deliveryID: deliveryID,
+          decisionType: "silence",
+          provenanceJSON: "{\"failure\":\"stale_visit\"}",
+          state: "failed")
+        return
+      }
       let decision =
         ContextProactiveCandidateGate.parse(result.content)
         ?? ContextProactiveCandidateGate.Decision(show: false, reason: "malformed_gate_response")
@@ -679,13 +708,10 @@ actor ContextProactivityEngine {
         withJSONObject: provenance, options: [.sortedKeys])
       let provenanceJSON = String(data: provenanceData, encoding: .utf8) ?? "{}"
       guard decision.show else {
-        try await store.completeDelivery(
-          id: deliveryID, decisionType: "silence", provenanceJSON: provenanceJSON,
-          message: nil, state: "suppressed")
-        return
-      }
-      let consumed = await store.consumeCandidate(id: candidate.id, now: currentFrame.captureTime)
-      guard consumed else {
+        // A declined candidate must not be re-selected (and re-billed for
+        // another paid gate call) on every later visit until it naturally
+        // expires: retire it now instead of leaving it armed.
+        await store.declineCandidate(id: candidate.id, now: currentFrame.captureTime)
         try await store.completeDelivery(
           id: deliveryID, decisionType: "silence", provenanceJSON: provenanceJSON,
           message: nil, state: "suppressed")
@@ -737,6 +763,18 @@ actor ContextProactivityEngine {
         try await store.completeDelivery(
           id: deliveryID, decisionType: "insight", provenanceJSON: provenanceJSON,
           message: message, state: "suppressed")
+        return
+      }
+      // Every gate between the model's `show` decision and here can still
+      // suppress the delivery. Consume the candidate only now, once nothing
+      // ahead of the actual presentation call can drop it silently — so a
+      // suppression above this line leaves the candidate armed for the next
+      // visit instead of losing it for its whole remaining lifetime.
+      let consumed = await store.consumeCandidate(id: candidate.id, now: currentFrame.captureTime)
+      guard consumed else {
+        try await store.completeDelivery(
+          id: deliveryID, decisionType: "silence", provenanceJSON: provenanceJSON,
+          message: nil, state: "suppressed")
         return
       }
       let factIDs = candidate.groundingFactIDs.map { "fact:\($0)" }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -257,6 +257,7 @@ actor ContextProactivityEngine {
     }
     var workstreamSection: String? = nil
     var workstreamProvenance: [String: Any]? = nil
+    var pooledFactIDs: Set<String> = []
     if workstreamPoolingEnabled,
       let liveTag = await store.liveWorkstreamTag(for: fence, now: currentFrame.captureTime)
     {
@@ -267,6 +268,7 @@ actor ContextProactivityEngine {
       if !selected.isEmpty {
         workstreamSection = ContextWorkstreamPooling.promptSection(
           tag: liveTag, items: selected, now: currentFrame.captureTime)
+        pooledFactIDs = Set(selected.map(\.factID))
         workstreamProvenance = [
           "tag": liveTag,
           "pooled_fact_ids": selected.map(\.factID),
@@ -282,18 +284,53 @@ actor ContextProactivityEngine {
           .sorted { $0.deliveredAt > $1.deliveredAt }
           .prefix(ContextBucketRecentDelivery.promptCap))
     }
+    let candidatesEnabled = await MainActor.run {
+      ContextBucketsFeature.isProactiveCandidatesEnabled
+    }
+    if candidatesEnabled {
+      let tags = await store.workstreamTags(for: snapshot.bucketID)
+      let armed = await store.armedCandidates(
+        bucketID: snapshot.bucketID, tags: tags, now: currentFrame.captureTime)
+      let recentMessages = recentDeliveries.compactMap(\.message)
+      if let candidate = ContextProactiveCandidateLookup.firstDeliverable(
+        candidates: armed, recentMessages: recentMessages)
+      {
+        await evaluateCandidateAndDeliver(
+          candidate: candidate,
+          deliveryID: deliveryID,
+          fence: fence,
+          snapshot: snapshot,
+          currentFrame: currentFrame,
+          recentDeliveries: recentDeliveries,
+          authorizationSnapshot: authorizationSnapshot,
+          ownerID: ownerID)
+        return
+      }
+    }
     // Read once and use for the whole visit: schema, prompt, and hop admission
     // must agree, and a mid-visit flag flip must not desynchronize them. With
     // the flag off, schema and prompt are byte-identical to the pre-hop build.
     let retrievalHopEnabled = await MainActor.run { ContextBucketsFeature.isRetrievalHopEnabled }
     let prompt = ContextProactivityPromptBuilder.directorStablePrompt(
       snapshot: snapshot, allowLookup: retrievalHopEnabled)
-    let uncachedPrompt =
+    var uncachedPrompt =
       ContextProactivityPromptBuilder.directorVolatilePrompt(
         tasks: taskContext,
         frame: currentFrame,
         recentDeliveries: recentDeliveries)
       + (workstreamSection.map { "\n\n" + $0 } ?? "")
+    if candidatesEnabled {
+      let selected = ContextWorkstreamPooling.selectRecent(
+        await store.recentContextPool(
+          excludingBucketID: snapshot.bucketID, now: currentFrame.captureTime),
+        now: currentFrame.captureTime)
+      let fresh = selected.filter { !pooledFactIDs.contains($0.factID) }
+      if let section = ContextWorkstreamPooling.recentContextPromptSection(
+        items: fresh, now: currentFrame.captureTime)
+      {
+        uncachedPrompt += "\n\n" + section
+      }
+    }
     guard
       RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
       await store.fenceFreshness(fence).fresh
@@ -573,6 +610,179 @@ actor ContextProactivityEngine {
     } catch {
       await recordDirectorFailure(deliveryID: deliveryID, error: error)
       // Network and model failures stay user-silent; provenance carries the class.
+    }
+  }
+
+  /// Deterministic candidate + small yes/no gate. `show == false` (or a
+  /// malformed/failed gate) suppresses and returns — the director is not also
+  /// run, so one visit never pays for two decisions.
+  private func evaluateCandidateAndDeliver(
+    candidate: ContextProactiveCandidate,
+    deliveryID: String,
+    fence: ContextVisitFence,
+    snapshot: ContextBucketSnapshot,
+    currentFrame: CapturedFrame,
+    recentDeliveries: [ContextBucketRecentDelivery],
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    ownerID: String
+  ) async {
+    let evaluationGate = await MainActor.run { Self.liveDeliveryGateInput() }
+    let evaluationReason = ContextDeliveryBudget.freeGate(input: evaluationGate)
+    guard evaluationReason == .allowed else {
+      log("Context candidate gate suppressed before model: \(evaluationReason.rawValue)")
+      await ContextProactivityTelemetry.recordGateRejection(reason: evaluationReason, stage: .preModel)
+      await terminalize(
+        deliveryID: deliveryID,
+        decisionType: "silence",
+        provenanceJSON: "{\"failure\":\"pre_model_gate\"}",
+        state: "suppressed")
+      return
+    }
+    guard
+      RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
+      await store.fenceFreshness(fence).fresh
+    else {
+      await terminalize(
+        deliveryID: deliveryID,
+        decisionType: "silence",
+        provenanceJSON: "{\"failure\":\"stale_visit\"}",
+        state: "failed")
+      return
+    }
+    do {
+      let result = try await client.complete(
+        operation: ModelQoS.Proactivity.reasoningOperation,
+        prompt: ContextProactiveCandidateGate.prompt(
+          message: candidate.message,
+          validatedFacts: snapshot.validatedFacts,
+          recentDeliveries: recentDeliveries,
+          now: currentFrame.captureTime),
+        jsonSchema: ContextProactiveCandidateGate.schema,
+        maxCompletionTokens: 120,
+        authorizationSnapshot: authorizationSnapshot)
+      await ContextProactivityTelemetry.record(result)
+      let decision =
+        ContextProactiveCandidateGate.parse(result.content)
+        ?? ContextProactiveCandidateGate.Decision(show: false, reason: "malformed_gate_response")
+      let reason = String(decision.reason.prefix(1_200))
+      var provenance: [String: Any] = [
+        "source": "candidate",
+        "candidate_id": candidate.id,
+        "reason": reason,
+      ]
+      if let tag = candidate.workstreamTag {
+        provenance["workstream"] = tag
+      } else {
+        provenance["workstream"] = NSNull()
+      }
+      let provenanceData = try JSONSerialization.data(
+        withJSONObject: provenance, options: [.sortedKeys])
+      let provenanceJSON = String(data: provenanceData, encoding: .utf8) ?? "{}"
+      guard decision.show else {
+        try await store.completeDelivery(
+          id: deliveryID, decisionType: "silence", provenanceJSON: provenanceJSON,
+          message: nil, state: "suppressed")
+        return
+      }
+      let consumed = await store.consumeCandidate(id: candidate.id, now: currentFrame.captureTime)
+      guard consumed else {
+        try await store.completeDelivery(
+          id: deliveryID, decisionType: "silence", provenanceJSON: provenanceJSON,
+          message: nil, state: "suppressed")
+        return
+      }
+      let message = String(candidate.message.prefix(600))
+      let title = String(message.prefix(120))
+      try await store.completeDelivery(
+        id: deliveryID, decisionType: "insight", provenanceJSON: provenanceJSON,
+        message: message, state: "model_completed")
+      await ContextProactivityTelemetry.recordDirectorDecision("insight")
+      try await store.completeDelivery(
+        id: deliveryID, decisionType: "insight", provenanceJSON: provenanceJSON,
+        message: message, state: "policy_approved")
+      guard
+        RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot),
+        await store.fenceFreshness(fence).fresh
+      else {
+        await terminalize(
+          deliveryID: deliveryID,
+          decisionType: "silence",
+          provenanceJSON: "{\"failure\":\"stale_visit\"}",
+          state: "failed")
+        return
+      }
+      let presentationGate = await MainActor.run { Self.liveDeliveryGateInput() }
+      let presentationReason = ContextDeliveryBudget.freeGate(input: presentationGate)
+      guard presentationReason == .allowed else {
+        log("Context candidate suppressed before presentation: \(presentationReason.rawValue)")
+        await ContextProactivityTelemetry.recordGateRejection(
+          reason: presentationReason, stage: .presentation)
+        try await store.completeDelivery(
+          id: deliveryID, decisionType: "insight", provenanceJSON: provenanceJSON,
+          message: message, state: "suppressed")
+        return
+      }
+      let finalPresentationPreflight = await presentationPreflight(ownerID)
+      guard finalPresentationPreflight == .queued else {
+        log("Context candidate suppressed before graduation: presentation_unavailable")
+        try await store.completeDelivery(
+          id: deliveryID, decisionType: "insight", provenanceJSON: provenanceJSON,
+          message: message, state: "suppressed")
+        return
+      }
+      let handoffGate = await MainActor.run { Self.liveDeliveryGateInput() }
+      let handoffReason = ContextDeliveryBudget.freeGate(input: handoffGate)
+      guard handoffReason == .allowed else {
+        await ContextProactivityTelemetry.recordGateRejection(reason: handoffReason, stage: .handoff)
+        try await store.completeDelivery(
+          id: deliveryID, decisionType: "insight", provenanceJSON: provenanceJSON,
+          message: message, state: "suppressed")
+        return
+      }
+      let factIDs = candidate.groundingFactIDs.map { "fact:\($0)" }
+      let presentation = await MainActor.run {
+        let context = FloatingBarNotificationContext(
+          sourceTitle: title,
+          assistantId: "context-director",
+          contextSummary: reason,
+          detail: factIDs.joined(separator: ", "),
+          provenanceRef: deliveryID)
+        return NotificationService.shared.presentContextDirectorNotification(
+          ownerID: ownerID,
+          title: title,
+          message: message,
+          decisionType: "insight",
+          context: context,
+          onPresented: { [weak self] in
+            guard let self else { return }
+            Task {
+              await self.completePresentedDelivery(
+                deliveryID: deliveryID,
+                decisionType: "insight",
+                provenanceJSON: provenanceJSON,
+                message: message,
+                authorizationSnapshot: authorizationSnapshot)
+            }
+          },
+          onDropped: { [weak self] in
+            guard let self else { return }
+            Task {
+              await self.terminalize(
+                deliveryID: deliveryID,
+                decisionType: "silence",
+                provenanceJSON: "{\"failure\":\"notification_dropped\"}",
+                state: "failed")
+            }
+          })
+      }
+      switch presentation {
+      case .presented, .queued:
+        return
+      case .suppressed, .windowUnavailable, .rejectedOwnerChange:
+        return
+      }
+    } catch {
+      await recordDirectorFailure(deliveryID: deliveryID, error: error)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
@@ -66,7 +66,7 @@ enum ContextWorkstreamPooling {
 
   private static let scaffoldingPrefixes = [
     "identifier", "ambient narrative", "evidence fragment", "evidence record",
-    "proposed record", "proposal ",
+    "proposed record", "proposed fact", "proposal ", "proposal:",
   ]
 
   /// Extraction-model scaffolding re-copied into `statement` reads as prose but

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
@@ -58,6 +58,12 @@ enum ContextWorkstreamPooling {
   static let recencyHalfLifeHours = 6.0
   /// Bound on candidates fetched from SQL before in-memory scoring.
   static let candidateFetchLimit = 200
+  /// Cross-app facts too new for the reconciler to have tagged: last 15 minutes,
+  /// high-worthiness only, one per source bucket, three total.
+  static let recentContextWindow: TimeInterval = 15 * 60
+  static let recentContextWorthinessFloor = 0.6
+  static let recentContextMaximumItems = 3
+  static let recentContextMaximumPerBucket = 1
   /// A bucket majority tag only stands in for a missing own-visit tag when it
   /// is this dominant among the bucket's tagged facts…
   static let bucketMajorityShare = 0.8
@@ -98,11 +104,19 @@ enum ContextWorkstreamPooling {
   /// Quality gate and ranking: worthiness floor, scaffolding filter, then
   /// worthiness plus a recency half-life, capped per source bucket.
   static func select(
-    _ candidates: [ContextWorkstreamPoolItem], now: Date
+    _ candidates: [ContextWorkstreamPoolItem],
+    now: Date,
+    worthinessFloor: Double = Self.worthinessFloor,
+    maximumItems: Int = Self.maximumItems,
+    maximumPerBucket: Int = Self.maximumPerBucket,
+    createdAfter: Date? = nil
   ) -> [ContextWorkstreamPoolItem] {
     let scored =
       candidates
-      .filter { $0.notifyWorthiness >= worthinessFloor && !isScaffolding($0.statement) }
+      .filter { item in
+        item.notifyWorthiness >= worthinessFloor && !isScaffolding(item.statement)
+          && (createdAfter.map { item.createdAt >= $0 } ?? true)
+      }
       .map { item -> (score: Double, item: ContextWorkstreamPoolItem) in
         let ageHours = max(0, now.timeIntervalSince(item.createdAt)) / 3600
         return (item.notifyWorthiness + pow(0.5, ageHours / recencyHalfLifeHours), item)
@@ -122,23 +136,66 @@ enum ContextWorkstreamPooling {
     return selected
   }
 
+  /// Newest high-worthiness facts from other windows, too fresh for tagging.
+  static func selectRecent(
+    _ candidates: [ContextWorkstreamPoolItem], now: Date
+  ) -> [ContextWorkstreamPoolItem] {
+    select(
+      candidates,
+      now: now,
+      worthinessFloor: recentContextWorthinessFloor,
+      maximumItems: recentContextMaximumItems,
+      maximumPerBucket: recentContextMaximumPerBucket,
+      createdAfter: now.addingTimeInterval(-recentContextWindow))
+  }
+
   /// The section rides in the uncached volatile suffix, below the untrusted
   /// preamble that opens the stable prompt, exactly like the retrieval hop's
   /// section. Pooled facts are printed without their ids on purpose: the
   /// director cannot cite what it was never handed a ref for, so delivery
   /// grounding remains own-bucket by construction.
   static func promptSection(tag: String, items: [ContextWorkstreamPoolItem], now: Date) -> String? {
+    formattedSection(
+      header: "RELATED WORKSTREAM CONTEXT (\(tag))",
+      intro: """
+        Validated facts from other buckets in the same workstream, most relevant first.
+        Context only: use them to connect what the user is doing across apps. They are
+        not citable — never place them in bucket_entry_refs or fact_ids — and a point
+        they already cover must not be re-delivered from this bucket.
+        """,
+      items: items,
+      now: now)
+  }
+
+  static func recentContextPromptSection(
+    items: [ContextWorkstreamPoolItem], now: Date
+  ) -> String? {
+    formattedSection(
+      header: "RECENT CONTEXT FROM OTHER WINDOWS (last 15 min)",
+      intro: """
+        Validated facts from other windows in the last 15 minutes, most relevant first.
+        Context only: use them to connect what the user is doing across apps. They are
+        not citable — never place them in bucket_entry_refs or fact_ids — and a point
+        they already cover must not be re-delivered from this bucket.
+        """,
+      items: items,
+      now: now)
+  }
+
+  private static func formattedSection(
+    header: String,
+    intro: String,
+    items: [ContextWorkstreamPoolItem],
+    now: Date
+  ) -> String? {
     guard !items.isEmpty else { return nil }
     let lines = items.map { item in
       "- [\(String(item.appName.prefix(24))), \(relativeAge(from: item.createdAt, now: now))] "
         + String(item.statement.prefix(300))
     }
     return """
-      == RELATED WORKSTREAM CONTEXT (\(tag)) ==
-      Validated facts from other buckets in the same workstream, most relevant first.
-      Context only: use them to connect what the user is doing across apps. They are
-      not citable — never place them in bucket_entry_refs or fact_ids — and a point
-      they already cover must not be re-delivered from this bucket.
+      == \(header) ==
+      \(intro)
       \(lines.joined(separator: "\n"))
       """
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -51,6 +51,11 @@ enum ContextWorkstreamBatchSelection {
   static let batchCap = 14
   static let factsPerBucket = 5
   static let candidateWorthinessFloor = 0.6
+  /// SQL-side cap per bucket before `selectFacts` drops scaffolding and takes
+  /// the top `factsPerBucket`. Generous headroom above that final count keeps
+  /// selection behavior unchanged for realistic scaffolding ratios, while
+  /// bounding how much a single dense bucket can pull into memory each pass.
+  static let factFetchCapPerBucket = 20
 
   static func fetchEligible(in db: Database, now: Date) throws -> [ContextWorkstreamEligibleBucket] {
     try Row.fetchAll(
@@ -135,14 +140,25 @@ enum ContextWorkstreamBatchSelection {
     let placeholders = bucketIDs.map { _ in "?" }.joined(separator: ",")
     var arguments: StatementArguments = [now]
     arguments += StatementArguments(bucketIDs)
+    arguments += StatementArguments([factFetchCapPerBucket])
+    // A dense bucket's full validated-fact corpus is unbounded; only the top
+    // `factFetchCapPerBucket` per bucket by worthiness/recency are ever
+    // useful to `selectFacts`, so the cap is applied here in SQL instead of
+    // materializing everything and discarding most of it in Swift.
     return try Row.fetchAll(
       db,
       sql: """
-        SELECT id, bucketID, appName, statement, notifyWorthiness, createdAt
-        FROM bucket_facts
-        WHERE validityState = 'validated'
-          AND (expiresAt IS NULL OR expiresAt > ?)
-          AND bucketID IN (\(placeholders))
+        SELECT id, bucketID, appName, statement, notifyWorthiness, createdAt FROM (
+          SELECT id, bucketID, appName, statement, notifyWorthiness, createdAt,
+            ROW_NUMBER() OVER (
+              PARTITION BY bucketID ORDER BY notifyWorthiness DESC, createdAt DESC
+            ) AS rn
+          FROM bucket_facts
+          WHERE validityState = 'validated'
+            AND (expiresAt IS NULL OR expiresAt > ?)
+            AND bucketID IN (\(placeholders))
+        )
+        WHERE rn <= ?
         ORDER BY notifyWorthiness DESC, createdAt DESC
         """,
       arguments: arguments
@@ -240,10 +256,16 @@ enum ContextWorkstreamTagging {
   }
 
   static func labelAppearsInObservations(_ tag: String, observations: String) -> Bool {
-    let haystack = observations.lowercased()
+    // Whole-word membership, not substring containment: an unbounded
+    // `contains` would let incidental text (e.g. "cat" inside "concatenate")
+    // falsely justify a durable workstream label.
+    let haystackWords = Set(
+      observations.lowercased()
+        .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        .map(String.init))
     let tokens = tag.split(separator: "-").map(String.init).filter { $0.count >= 2 }
     guard !tokens.isEmpty else { return false }
-    return tokens.contains { haystack.contains($0) }
+    return tokens.contains { haystackWords.contains($0) }
   }
 
   static func acceptedAssignments(
@@ -255,10 +277,15 @@ enum ContextWorkstreamTagging {
     var firstLabelByBucket: [(bucketID: String, tag: String)] = []
     var seenBuckets = Set<String>()
     for assignment in response.assignments {
+      // Membership is checked (not claimed) here: a null or unsanitizable
+      // first assignment for a bucket must not block a later valid one for
+      // the same bucket, so `seenBuckets` is only marked once sanitization
+      // has actually succeeded.
       guard let bucketID = resolveGroup(assignment.group, batchIDs: batchIDs),
-        seenBuckets.insert(bucketID).inserted,
+        !seenBuckets.contains(bucketID),
         let tag = ContextWorkstreamTag.sanitize(assignment.label)
       else { continue }
+      seenBuckets.insert(bucketID)
       firstLabelByBucket.append((bucketID, tag))
     }
     var counts: [String: Int] = [:]
@@ -473,9 +500,25 @@ enum ContextProactiveCandidateLookup {
       sql: """
         UPDATE proactive_candidates
         SET state = 'consumed', consumedAt = ?
-        WHERE id = ? AND state = 'armed'
+        WHERE id = ? AND state = 'armed' AND expiresAt > ?
         """,
-      arguments: [now, id])
+      arguments: [now, id, now])
+    return db.changesCount > 0
+  }
+
+  /// Retires a gated-down candidate immediately by collapsing its expiry,
+  /// rather than leaving it armed to be re-selected — and re-billed for
+  /// another paid gate call — on every later visit until it naturally
+  /// expires.
+  @discardableResult
+  static func decline(id: String, now: Date, in db: Database) throws -> Bool {
+    try db.execute(
+      sql: """
+        UPDATE proactive_candidates
+        SET expiresAt = ?
+        WHERE id = ? AND state = 'armed' AND expiresAt > ?
+        """,
+      arguments: [now, id, now])
     return db.changesCount > 0
   }
 
@@ -593,9 +636,18 @@ actor ContextWorkstreamReconciler {
       case .skippedNoNewFacts, .skippedEmptyBatch:
         return
       case .ready(let batch):
-        try await performTagging(batch: batch, authorizationSnapshot: authorizationSnapshot, now: now)
-        try await performCandidateWriting(
-          batch: batch, authorizationSnapshot: authorizationSnapshot, now: now)
+        // Both stages must fully succeed before the pass is recorded done:
+        // a malformed model response or lost authorization must not advance
+        // `lastPassAt`, or the ten-minute loop would silently stop retrying
+        // this batch.
+        guard
+          let taggedBatch = try await performTagging(
+            batch: batch, authorizationSnapshot: authorizationSnapshot, now: now)
+        else { return }
+        guard
+          try await performCandidateWriting(
+            batch: taggedBatch, authorizationSnapshot: authorizationSnapshot, now: now)
+        else { return }
         lastPassAt = now
       }
     } catch {
@@ -603,13 +655,21 @@ actor ContextWorkstreamReconciler {
     }
   }
 
+  /// Runs tagging and, on success, returns the batch with each newly-tagged
+  /// group's `workstreamTag` refreshed to this pass's assignment — so
+  /// `performCandidateWriting` (which runs right after, in the same pass)
+  /// sees a bucket's brand-new tag instead of the pre-tagging snapshot, and
+  /// the candidate it writes is visible to that tag's sibling buckets.
+  /// Returns nil only on genuine failure (malformed model output or lost
+  /// authorization); an empty-groups batch or a pass with nothing accepted is
+  /// success with the batch unchanged.
   private func performTagging(
     batch: ContextWorkstreamReconcileBatch,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
     now: Date
-  ) async throws {
-    guard !batch.groups.isEmpty else { return }
-    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
+  ) async throws -> ContextWorkstreamReconcileBatch? {
+    guard !batch.groups.isEmpty else { return batch }
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return nil }
     let result = try await client.complete(
       operation: ModelQoS.Proactivity.reasoningOperation,
       prompt: Self.taggingPrompt(batch: batch),
@@ -618,7 +678,7 @@ actor ContextWorkstreamReconciler {
       authorizationSnapshot: authorizationSnapshot)
     guard let parsed = ContextWorkstreamTagging.parse(result.content) else {
       log("ContextWorkstreamReconciler: tagging response malformed")
-      return
+      return nil
     }
     let accepted = ContextWorkstreamTagging.acceptedAssignments(
       response: parsed,
@@ -626,16 +686,29 @@ actor ContextWorkstreamReconciler {
       existingTags: batch.existingTags,
       observations: batch.observations)
     try await store.insertWorkstreamAssignments(accepted, now: now)
+    guard !accepted.isEmpty else { return batch }
+    let newlyTagged = Dictionary(
+      accepted.map { ($0.bucketID, $0.tag) }, uniquingKeysWith: { first, _ in first })
+    let refreshedGroups = batch.groups.map { group -> ContextWorkstreamReconcileGroup in
+      guard group.workstreamTag == nil, let tag = newlyTagged[group.bucketID] else { return group }
+      return ContextWorkstreamReconcileGroup(
+        bucketID: group.bucketID, facts: group.facts, needsCandidate: group.needsCandidate,
+        workstreamTag: tag)
+    }
+    return ContextWorkstreamReconcileBatch(groups: refreshedGroups, existingTags: batch.existingTags)
   }
 
+  /// Returns whether the stage succeeded: true on a no-op (nothing eligible)
+  /// or a completed write, false on malformed model output or lost
+  /// authorization so `runPass` does not advance `lastPassAt`.
   private func performCandidateWriting(
     batch: ContextWorkstreamReconcileBatch,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
     now: Date
-  ) async throws {
+  ) async throws -> Bool {
     let eligible = batch.groups.filter(\.needsCandidate)
-    guard !eligible.isEmpty else { return }
-    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
+    guard !eligible.isEmpty else { return true }
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
     let result = try await client.complete(
       operation: ModelQoS.Proactivity.reasoningOperation,
       prompt: Self.candidatePrompt(groups: eligible),
@@ -644,9 +717,10 @@ actor ContextWorkstreamReconciler {
       authorizationSnapshot: authorizationSnapshot)
     guard let parsed = ContextProactiveCandidateWriter.parse(result.content) else {
       log("ContextWorkstreamReconciler: candidate response malformed")
-      return
+      return false
     }
     try await store.insertArmedCandidates(parsed.candidates, groups: eligible, now: now)
+    return true
   }
 
   static func taggingPrompt(batch: ContextWorkstreamReconcileBatch) -> String {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -559,13 +559,13 @@ enum ContextProactiveCandidateGate {
     message: String,
     validatedFacts: [String],
     recentDeliveries: [ContextBucketRecentDelivery],
-    now: Date
+    timeZone: TimeZone = .current
   ) -> String {
     let facts =
       validatedFacts.isEmpty
       ? "(none)" : validatedFacts.map { String($0.prefix(400)) }.joined(separator: "\n")
     let recent =
-      ContextProactivityPromptBuilder.recentDeliveriesSection(recentDeliveries, now: now)
+      ContextProactivityPromptBuilder.recentDeliveriesSection(recentDeliveries, timeZone: timeZone)
       ?? "== RECENTLY DELIVERED FOR THIS BUCKET ==\n(none)"
     return """
       \(ScreenDerivedContent.untrustedPreamble)
@@ -586,11 +586,16 @@ enum ContextProactiveCandidateGate {
 }
 
 /// Background workstream tagging and candidate pre-writing. Never on the
-/// delivery path. Cadence is ten minutes while the app is running and the
+/// delivery path. Cadence is fifteen minutes while the app is running and the
 /// feature flag is on; a pass with no new validated facts is a no-op.
 actor ContextWorkstreamReconciler {
   static let shared = ContextWorkstreamReconciler()
-  static let interval: TimeInterval = 10 * 60
+  /// Freshness on the delivery path is served by the fifteen-minute
+  /// recent-context channel, not by how often this background pass runs, so the
+  /// cadence is set by what durable workstream labels actually need. Fifteen
+  /// minutes still sits inside the gateway's thirty-minute cache TTL, which is
+  /// what lets consecutive passes share an instruction prefix.
+  static let interval: TimeInterval = 15 * 60
 
   private let client: ProactiveLaneClient
   private let store: ContextBucketStore
@@ -672,8 +677,10 @@ actor ContextWorkstreamReconciler {
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return nil }
     let result = try await client.complete(
       operation: ModelQoS.Proactivity.reasoningOperation,
-      prompt: Self.taggingPrompt(batch: batch),
+      prompt: Self.taggingInstructions,
+      uncachedPrompt: Self.taggingData(batch: batch),
       jsonSchema: ContextWorkstreamTagging.schema,
+      cacheKey: ContextPromptCacheKey.reconcilerTagging,
       maxCompletionTokens: 800,
       authorizationSnapshot: authorizationSnapshot)
     guard let parsed = ContextWorkstreamTagging.parse(result.content) else {
@@ -711,8 +718,10 @@ actor ContextWorkstreamReconciler {
     guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return false }
     let result = try await client.complete(
       operation: ModelQoS.Proactivity.reasoningOperation,
-      prompt: Self.candidatePrompt(groups: eligible),
+      prompt: Self.candidateInstructions,
+      uncachedPrompt: Self.candidateData(groups: eligible),
       jsonSchema: ContextProactiveCandidateWriter.schema,
+      cacheKey: ContextPromptCacheKey.reconcilerCandidates,
       maxCompletionTokens: 800,
       authorizationSnapshot: authorizationSnapshot)
     guard let parsed = ContextProactiveCandidateWriter.parse(result.content) else {
@@ -723,7 +732,29 @@ actor ContextWorkstreamReconciler {
     return true
   }
 
-  static func taggingPrompt(batch: ContextWorkstreamReconcileBatch) -> String {
+  /// Byte-identical on every pass, so it is the only part of the tagging call
+  /// worth sending as the cached prefix. Kept as one constant rather than
+  /// interpolated per pass precisely so it cannot drift.
+  static let taggingInstructions = """
+    \(ScreenDerivedContent.untrustedPreamble)
+    Assign these observation groups to durable workstream labels.
+
+    A workstream is an ongoing project, product, or goal that spans multiple
+    applications and persists over days or weeks. Name it after the thing being
+    worked on — a product, repository, company, customer, or person — never after
+    an activity, a tool, or the app the observations were seen in.
+
+    Prefer an existing label from the vocabulary when one fits. Propose at most
+    six labels in total. Propose a NEW label only when at least two groups in this
+    batch support it. Every label must use a term that actually appears in the
+    observations. Assign each group to one label or to null; null is correct and
+    expected for many groups. Do not invent a workstream to cover leftovers.
+    """
+
+  /// The per-pass half: vocabulary and observation groups. Sits below the
+  /// instructions, and therefore below `untrustedPreamble`, so the captured
+  /// statements it quotes stay framed as untrusted data.
+  static func taggingData(batch: ContextWorkstreamReconcileBatch) -> String {
     let vocabulary =
       batch.existingTags.sorted().isEmpty
       ? "(none yet)" : batch.existingTags.sorted().map { "- \($0)" }.joined(separator: "\n")
@@ -736,20 +767,6 @@ actor ContextWorkstreamReconciler {
         """
     }.joined(separator: "\n\n")
     return """
-      \(ScreenDerivedContent.untrustedPreamble)
-      Assign these observation groups to durable workstream labels.
-
-      A workstream is an ongoing project, product, or goal that spans multiple
-      applications and persists over days or weeks. Name it after the thing being
-      worked on — a product, repository, company, customer, or person — never after
-      an activity, a tool, or the app the observations were seen in.
-
-      Prefer an existing label from the vocabulary when one fits. Propose at most
-      six labels in total. Propose a NEW label only when at least two groups in this
-      batch support it. Every label must use a term that actually appears in the
-      observations. Assign each group to one label or to null; null is correct and
-      expected for many groups. Do not invent a workstream to cover leftovers.
-
       == CURRENT WORKSTREAM VOCABULARY ==
       \(vocabulary)
 
@@ -757,8 +774,28 @@ actor ContextWorkstreamReconciler {
       """
   }
 
-  static func candidatePrompt(groups: [ContextWorkstreamReconcileGroup]) -> String {
-    let body = groups.enumerated().map { index, group in
+  /// The whole tagging prompt, as the model sees it once the gateway
+  /// concatenates the cached and uncached blocks.
+  static func taggingPrompt(batch: ContextWorkstreamReconcileBatch) -> String {
+    taggingInstructions + "\n\n" + taggingData(batch: batch)
+  }
+
+  /// Distinct instructions from tagging, hence its own key: two prompt shapes
+  /// under one key would only ever evict each other.
+  static let candidateInstructions = """
+    \(ScreenDerivedContent.untrustedPreamble)
+    For each bucket below, write at most one short notification the user would find
+    worth an interruption, or omit the bucket. Ground it in the supplied fact ids
+    and add a one-line trigger_note describing when it should fire.
+
+    Do not restate what is already visible on the user's screen. Speak only when
+    you add something they cannot currently see: a commitment, a deadline, a
+    conflict, or a connection to other work. Must add one of those; otherwise omit
+    the bucket.
+    """
+
+  static func candidateData(groups: [ContextWorkstreamReconcileGroup]) -> String {
+    groups.enumerated().map { index, group in
       let facts = group.facts.map { fact in
         "- fact:\(fact.id) w=\(fact.notifyWorthiness) \(fact.statement)"
       }.joined(separator: "\n")
@@ -767,19 +804,10 @@ actor ContextWorkstreamReconciler {
         \(facts)
         """
     }.joined(separator: "\n\n")
-    return """
-      \(ScreenDerivedContent.untrustedPreamble)
-      For each bucket below, write at most one short notification the user would find
-      worth an interruption, or omit the bucket. Ground it in the supplied fact ids
-      and add a one-line trigger_note describing when it should fire.
+  }
 
-      Do not restate what is already visible on the user's screen. Speak only when
-      you add something they cannot currently see: a commitment, a deadline, a
-      conflict, or a connection to other work. Must add one of those; otherwise omit
-      the bucket.
-
-      \(body)
-      """
+  static func candidatePrompt(groups: [ContextWorkstreamReconcileGroup]) -> String {
+    candidateInstructions + "\n\n" + candidateData(groups: groups)
   }
 }
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -1,0 +1,731 @@
+import Foundation
+@preconcurrency import GRDB
+
+/// An armed, pre-written notification produced by the background reconciler.
+/// Lookup is deterministic SQL; the hot path never asks a model to write one.
+struct ContextProactiveCandidate: Equatable, Sendable, FetchableRecord, Decodable {
+  let id: String
+  let bucketID: String
+  let workstreamTag: String?
+  let message: String
+  let groundingFactIDsJson: String
+  let triggerNote: String
+  let state: String
+  let createdAt: Date
+  let expiresAt: Date
+  let consumedAt: Date?
+
+  var groundingFactIDs: [String] {
+    ContextProactiveCandidate.parseFactIDs(groundingFactIDsJson)
+  }
+
+  static func parseFactIDs(_ json: String) -> [String] {
+    guard let data = json.data(using: .utf8),
+      let ids = try? JSONDecoder().decode([String].self, from: data)
+    else { return [] }
+    return ids.map { $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0 }.filter { !$0.isEmpty }
+  }
+}
+
+struct ContextWorkstreamEligibleBucket: Equatable, Sendable {
+  let bucketID: String
+  let factCount: Int
+  let newestFactAt: Date
+  let tagged: Bool
+}
+
+struct ContextWorkstreamBatchFact: Equatable, Sendable {
+  let id: String
+  let bucketID: String
+  let appName: String
+  let statement: String
+  let notifyWorthiness: Double
+  let createdAt: Date
+}
+
+/// Deterministic batch ranking and exploration swap. No model.
+enum ContextWorkstreamBatchSelection {
+  static let minimumFacts = 3
+  static let rankedTake = 12
+  static let exploreCount = 2
+  static let batchCap = 14
+  static let factsPerBucket = 5
+  static let candidateWorthinessFloor = 0.6
+
+  static func fetchEligible(in db: Database, now: Date) throws -> [ContextWorkstreamEligibleBucket] {
+    try Row.fetchAll(
+      db,
+      sql: """
+        SELECT b.id AS bucketID,
+          COUNT(f.id) AS factCount,
+          MAX(f.createdAt) AS newestFactAt,
+          CASE WHEN EXISTS (
+            SELECT 1 FROM bucket_workstreams w WHERE w.bucketID = b.id
+          ) THEN 1 ELSE 0 END AS tagged
+        FROM context_buckets b
+        JOIN bucket_facts f ON f.bucketID = b.id
+        WHERE f.validityState = 'validated'
+          AND (f.expiresAt IS NULL OR f.expiresAt > ?)
+        GROUP BY b.id
+        HAVING COUNT(f.id) >= ?
+        ORDER BY tagged ASC, factCount DESC, newestFactAt DESC, b.id ASC
+        """,
+      arguments: [now, minimumFacts]
+    ).compactMap { row -> ContextWorkstreamEligibleBucket? in
+      guard let bucketID: String = row["bucketID"],
+        let newestFactAt: Date = row["newestFactAt"]
+      else { return nil }
+      return ContextWorkstreamEligibleBucket(
+        bucketID: bucketID,
+        factCount: row["factCount"] as Int? ?? 0,
+        newestFactAt: newestFactAt,
+        tagged: (row["tagged"] as Int64? ?? 0) != 0)
+    }
+  }
+
+  /// Keep the top `rankedTake - exploreCount` by rank, then replace the last
+  /// two slots with randomly chosen eligible buckets so the same head of the
+  /// ranking is not visited forever. Hard-capped at `batchCap`.
+  static func applyExploration(
+    rankedIDs: [String],
+    pick: ([String], Int) -> [String] = Self.randomPick
+  ) -> [String] {
+    if rankedIDs.count <= rankedTake {
+      return Array(rankedIDs.prefix(batchCap))
+    }
+    let keepCount = rankedTake - exploreCount
+    let keep = Array(rankedIDs.prefix(keepCount))
+    let pool = Array(rankedIDs.dropFirst(keepCount))
+    let replacements = pick(pool, exploreCount)
+    return Array((keep + replacements).prefix(batchCap))
+  }
+
+  static func randomPick(_ pool: [String], count: Int) -> [String] {
+    guard count > 0, !pool.isEmpty else { return [] }
+    var remaining = pool
+    var picked: [String] = []
+    let n = min(count, remaining.count)
+    for _ in 0..<n {
+      let index = Int.random(in: 0..<remaining.count)
+      picked.append(remaining.remove(at: index))
+    }
+    return picked
+  }
+
+  static func selectFacts(
+    _ facts: [ContextWorkstreamBatchFact], limit: Int = Self.factsPerBucket
+  ) -> [ContextWorkstreamBatchFact] {
+    facts
+      .filter { !ContextWorkstreamPooling.isScaffolding($0.statement) }
+      .sorted { lhs, rhs in
+        if lhs.notifyWorthiness != rhs.notifyWorthiness {
+          return lhs.notifyWorthiness > rhs.notifyWorthiness
+        }
+        if lhs.createdAt != rhs.createdAt { return lhs.createdAt > rhs.createdAt }
+        return lhs.id < rhs.id
+      }
+      .prefix(limit)
+      .map { $0 }
+  }
+
+  static func fetchFacts(
+    bucketIDs: [String], now: Date, in db: Database
+  ) throws -> [ContextWorkstreamBatchFact] {
+    guard !bucketIDs.isEmpty else { return [] }
+    let placeholders = bucketIDs.map { _ in "?" }.joined(separator: ",")
+    var arguments: StatementArguments = [now]
+    arguments += StatementArguments(bucketIDs)
+    return try Row.fetchAll(
+      db,
+      sql: """
+        SELECT id, bucketID, appName, statement, notifyWorthiness, createdAt
+        FROM bucket_facts
+        WHERE validityState = 'validated'
+          AND (expiresAt IS NULL OR expiresAt > ?)
+          AND bucketID IN (\(placeholders))
+        ORDER BY notifyWorthiness DESC, createdAt DESC
+        """,
+      arguments: arguments
+    ).compactMap { row -> ContextWorkstreamBatchFact? in
+      guard let id: String = row["id"], let bucketID: String = row["bucketID"],
+        let statement: String = row["statement"], let createdAt: Date = row["createdAt"]
+      else { return nil }
+      return ContextWorkstreamBatchFact(
+        id: id,
+        bucketID: bucketID,
+        appName: row["appName"] ?? "",
+        statement: statement,
+        notifyWorthiness: row["notifyWorthiness"] ?? 0,
+        createdAt: createdAt)
+    }
+  }
+}
+
+/// Label acceptance: sanitize, require an observed term, require two groups
+/// for a brand-new label, cap at six labels, INSERT OR IGNORE.
+enum ContextWorkstreamTagging {
+  static let maximumLabels = 6
+  static let minimumGroupsForNewLabel = 2
+
+  struct Response: Decodable, Equatable {
+    struct Workstream: Decodable, Equatable {
+      let label: String
+      let evidence: String
+    }
+    struct Assignment: Decodable, Equatable {
+      let group: String
+      let label: String?
+    }
+    let workstreams: [Workstream]
+    let assignments: [Assignment]
+  }
+
+  struct AcceptedAssignment: Equatable {
+    let bucketID: String
+    let tag: String
+  }
+
+  static var schema: [String: Any] {
+    [
+      "type": "object",
+      "properties": [
+        "workstreams": [
+          "type": "array",
+          "items": [
+            "type": "object",
+            "properties": [
+              "label": ["type": "string"],
+              "evidence": ["type": "string"],
+            ],
+            "required": ["label", "evidence"],
+            "additionalProperties": false,
+          ],
+        ],
+        "assignments": [
+          "type": "array",
+          "items": [
+            "type": "object",
+            "properties": [
+              "group": ["type": "string"],
+              "label": ["type": ["string", "null"]],
+            ],
+            "required": ["group", "label"],
+            "additionalProperties": false,
+          ],
+        ],
+      ],
+      "required": ["workstreams", "assignments"],
+      "additionalProperties": false,
+    ]
+  }
+
+  static func parse(_ content: String) -> Response? {
+    guard let data = content.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(Response.self, from: data)
+  }
+
+  static func resolveGroup(_ group: String, batchIDs: [String]) -> String? {
+    let trimmed = group.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let match = batchIDs.first(where: { $0 == trimmed }) { return match }
+    let upper = trimmed.uppercased()
+    if upper.hasPrefix("G"), let index = Int(upper.dropFirst()), index >= 1,
+      index <= batchIDs.count
+    {
+      return batchIDs[index - 1]
+    }
+    if let index = Int(trimmed), index >= 1, index <= batchIDs.count {
+      return batchIDs[index - 1]
+    }
+    return nil
+  }
+
+  static func labelAppearsInObservations(_ tag: String, observations: String) -> Bool {
+    let haystack = observations.lowercased()
+    let tokens = tag.split(separator: "-").map(String.init).filter { $0.count >= 2 }
+    guard !tokens.isEmpty else { return false }
+    return tokens.contains { haystack.contains($0) }
+  }
+
+  static func acceptedAssignments(
+    response: Response,
+    batchIDs: [String],
+    existingTags: Set<String>,
+    observations: String
+  ) -> [AcceptedAssignment] {
+    var firstLabelByBucket: [(bucketID: String, tag: String)] = []
+    var seenBuckets = Set<String>()
+    for assignment in response.assignments {
+      guard let bucketID = resolveGroup(assignment.group, batchIDs: batchIDs),
+        seenBuckets.insert(bucketID).inserted,
+        let tag = ContextWorkstreamTag.sanitize(assignment.label)
+      else { continue }
+      firstLabelByBucket.append((bucketID, tag))
+    }
+    var counts: [String: Int] = [:]
+    for item in firstLabelByBucket { counts[item.tag, default: 0] += 1 }
+
+    func isAllowed(_ tag: String) -> Bool {
+      guard labelAppearsInObservations(tag, observations: observations) else { return false }
+      if existingTags.contains(tag) { return true }
+      return (counts[tag] ?? 0) >= minimumGroupsForNewLabel
+    }
+
+    var allowedTags = Set(firstLabelByBucket.map(\.tag).filter(isAllowed))
+    if allowedTags.count > maximumLabels {
+      let existingFirst = allowedTags.filter { existingTags.contains($0) }
+        .sorted()
+      let newByCount = allowedTags.filter { !existingTags.contains($0) }
+        .sorted { lhs, rhs in
+          if counts[lhs, default: 0] != counts[rhs, default: 0] {
+            return counts[lhs, default: 0] > counts[rhs, default: 0]
+          }
+          return lhs < rhs
+        }
+      allowedTags = Set(
+        Array((existingFirst + newByCount).prefix(maximumLabels)))
+    }
+    return firstLabelByBucket.filter { allowedTags.contains($0.tag) }.map {
+      AcceptedAssignment(bucketID: $0.bucketID, tag: $0.tag)
+    }
+  }
+
+  static func insertAssignment(
+    bucketID: String, tag: String, now: Date, in db: Database
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT OR IGNORE INTO bucket_workstreams
+          (id, bucketID, tag, source, assignedAt)
+        VALUES (?, ?, ?, 'reconciler', ?)
+        """,
+      arguments: [UUID().uuidString.lowercased(), bucketID, tag, now])
+  }
+
+  static func existingTags(in db: Database) throws -> Set<String> {
+    Set(try String.fetchAll(db, sql: "SELECT DISTINCT tag FROM bucket_workstreams"))
+  }
+
+  static func tags(for bucketID: String, in db: Database) throws -> [String] {
+    try String.fetchAll(
+      db,
+      sql: "SELECT tag FROM bucket_workstreams WHERE bucketID = ? ORDER BY assignedAt ASC, tag ASC",
+      arguments: [bucketID])
+  }
+}
+
+enum ContextProactiveCandidateWriter {
+  static let lifetime: TimeInterval = 12 * 60 * 60
+
+  struct Response: Decodable, Equatable {
+    struct Candidate: Decodable, Equatable {
+      let bucket: String
+      let message: String
+      let factIDs: [String]
+      let triggerNote: String
+
+      enum CodingKeys: String, CodingKey {
+        case bucket, message
+        case factIDs = "fact_ids"
+        case triggerNote = "trigger_note"
+      }
+    }
+    let candidates: [Candidate]
+  }
+
+  static var schema: [String: Any] {
+    [
+      "type": "object",
+      "properties": [
+        "candidates": [
+          "type": "array",
+          "items": [
+            "type": "object",
+            "properties": [
+              "bucket": ["type": "string"],
+              "message": ["type": "string"],
+              "fact_ids": ["type": "array", "items": ["type": "string"]],
+              "trigger_note": ["type": "string"],
+            ],
+            "required": ["bucket", "message", "fact_ids", "trigger_note"],
+            "additionalProperties": false,
+          ],
+        ]
+      ],
+      "required": ["candidates"],
+      "additionalProperties": false,
+    ]
+  }
+
+  static func parse(_ content: String) -> Response? {
+    guard let data = content.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(Response.self, from: data)
+  }
+
+  static func validatedFactIDs(
+    _ ids: [String], bucketID: String, now: Date, in db: Database
+  ) throws -> [String] {
+    let normalized = ids.map { $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0 }
+      .filter { !$0.isEmpty }
+    guard !normalized.isEmpty else { return [] }
+    var arguments: StatementArguments = [bucketID, now]
+    arguments += StatementArguments(normalized)
+    let rows = try String.fetchAll(
+      db,
+      sql: """
+        SELECT id FROM bucket_facts
+        WHERE bucketID = ? AND validityState = 'validated'
+          AND (expiresAt IS NULL OR expiresAt > ?)
+          AND id IN (\(normalized.map { _ in "?" }.joined(separator: ",")))
+        """,
+      arguments: arguments)
+    let allowed = Set(rows)
+    return normalized.filter { allowed.contains($0) }
+  }
+
+  static func hasArmedCandidate(bucketID: String, now: Date, in db: Database) throws -> Bool {
+    try Bool.fetchOne(
+      db,
+      sql: """
+        SELECT EXISTS(
+          SELECT 1 FROM proactive_candidates
+          WHERE bucketID = ? AND state = 'armed' AND expiresAt > ?
+        )
+        """,
+      arguments: [bucketID, now]) ?? false
+  }
+
+  static func insertArmed(
+    bucketID: String,
+    workstreamTag: String?,
+    message: String,
+    factIDs: [String],
+    triggerNote: String,
+    now: Date,
+    in db: Database
+  ) throws {
+    let data = try JSONEncoder().encode(factIDs)
+    let json = String(data: data, encoding: .utf8) ?? "[]"
+    try db.execute(
+      sql: """
+        INSERT INTO proactive_candidates
+          (id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
+           state, createdAt, expiresAt)
+        VALUES (?, ?, ?, ?, ?, ?, 'armed', ?, ?)
+        """,
+      arguments: [
+        UUID().uuidString.lowercased(), bucketID, workstreamTag, message, json,
+        triggerNote, now, now.addingTimeInterval(lifetime),
+      ])
+  }
+}
+
+/// Hot-path lookup, duplicate skip, and the small yes/no gate.
+enum ContextProactiveCandidateLookup {
+  static func lookupArmed(
+    bucketID: String, tags: [String], now: Date, in db: Database
+  ) throws -> [ContextProactiveCandidate] {
+    if tags.isEmpty {
+      return try ContextProactiveCandidate.fetchAll(
+        db,
+        sql: """
+          SELECT id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
+                 state, createdAt, expiresAt, consumedAt
+          FROM proactive_candidates
+          WHERE state = 'armed' AND expiresAt > ? AND bucketID = ?
+          ORDER BY createdAt DESC
+          """,
+        arguments: [now, bucketID])
+    }
+    let placeholders = tags.map { _ in "?" }.joined(separator: ",")
+    var arguments: StatementArguments = [now, bucketID]
+    arguments += StatementArguments(tags)
+    arguments += StatementArguments([bucketID])
+    return try ContextProactiveCandidate.fetchAll(
+      db,
+      sql: """
+        SELECT id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
+               state, createdAt, expiresAt, consumedAt
+        FROM proactive_candidates
+        WHERE state = 'armed' AND expiresAt > ?
+          AND (
+            bucketID = ?
+            OR (workstreamTag IS NOT NULL AND workstreamTag IN (\(placeholders)))
+          )
+        ORDER BY CASE WHEN bucketID = ? THEN 0 ELSE 1 END, createdAt DESC
+        """,
+      arguments: arguments)
+  }
+
+  static func firstDeliverable(
+    candidates: [ContextProactiveCandidate],
+    recentMessages: [String]
+  ) -> ContextProactiveCandidate? {
+    candidates.first { candidate in
+      let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !message.isEmpty else { return false }
+      return !SuggestionDeduplication.isDuplicate(message, of: recentMessages)
+    }
+  }
+
+  @discardableResult
+  static func consume(id: String, now: Date, in db: Database) throws -> Bool {
+    try db.execute(
+      sql: """
+        UPDATE proactive_candidates
+        SET state = 'consumed', consumedAt = ?
+        WHERE id = ? AND state = 'armed'
+        """,
+      arguments: [now, id])
+    return db.changesCount > 0
+  }
+
+  static func expireStale(now: Date, in db: Database) throws {
+    try db.execute(
+      sql: """
+        UPDATE proactive_candidates SET state = 'expired'
+        WHERE state = 'armed' AND expiresAt <= ?
+        """,
+      arguments: [now])
+  }
+}
+
+enum ContextProactiveCandidateGate {
+  struct Decision: Decodable, Equatable {
+    let show: Bool
+    let reason: String
+  }
+
+  static var schema: [String: Any] {
+    [
+      "type": "object",
+      "properties": [
+        "show": ["type": "boolean"],
+        "reason": ["type": "string"],
+      ],
+      "required": ["show", "reason"],
+      "additionalProperties": false,
+    ]
+  }
+
+  static func parse(_ content: String) -> Decision? {
+    guard let data = content.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(Decision.self, from: data)
+  }
+
+  static func prompt(
+    message: String,
+    validatedFacts: [String],
+    recentDeliveries: [ContextBucketRecentDelivery],
+    now: Date
+  ) -> String {
+    let facts =
+      validatedFacts.isEmpty
+      ? "(none)" : validatedFacts.map { String($0.prefix(400)) }.joined(separator: "\n")
+    let recent =
+      ContextProactivityPromptBuilder.recentDeliveriesSection(recentDeliveries, now: now)
+      ?? "== RECENTLY DELIVERED FOR THIS BUCKET ==\n(none)"
+    return """
+      \(ScreenDerivedContent.untrustedPreamble)
+      You are a yes/no delivery gate for a pre-written notification. Do not rewrite the
+      message. Set show to true only if the candidate is accurate for what is on screen
+      now, adds something not already visible, and repeats nothing in the recent list.
+      Answering false is common and correct.
+
+      == CANDIDATE ==
+      \(String(message.prefix(600)))
+
+      == VALIDATED FACTS ON THIS VISIT ==
+      \(facts)
+
+      \(recent)
+      """
+  }
+}
+
+/// Background workstream tagging and candidate pre-writing. Never on the
+/// delivery path. Cadence is ten minutes while the app is running and the
+/// feature flag is on; a pass with no new validated facts is a no-op.
+actor ContextWorkstreamReconciler {
+  static let shared = ContextWorkstreamReconciler()
+  static let interval: TimeInterval = 10 * 60
+
+  private let client: ProactiveLaneClient
+  private let store: ContextBucketStore
+  private var timer: Task<Void, Never>?
+  private var isRunning = false
+  private var lastPassAt: Date?
+
+  init(client: ProactiveLaneClient = .shared, store: ContextBucketStore = .shared) {
+    self.client = client
+    self.store = store
+  }
+
+  func start() {
+    guard !isRunning else { return }
+    isRunning = true
+    log("ContextWorkstreamReconciler: started")
+    timer = Task { [weak self] in
+      guard let self else { return }
+      while !Task.isCancelled {
+        await self.runPass()
+        try? await Task.sleep(nanoseconds: UInt64(Self.interval * 1_000_000_000))
+      }
+    }
+  }
+
+  func stop() {
+    timer?.cancel()
+    timer = nil
+    isRunning = false
+    log("ContextWorkstreamReconciler: stopped")
+  }
+
+  func runPass(now: Date = Date()) async {
+    let enabled = await MainActor.run { ContextBucketsFeature.isProactiveCandidatesEnabled }
+    guard enabled else { return }
+    guard let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
+      return
+    }
+    do {
+      let outcome = try await store.runWorkstreamReconcilePass(
+        lastPassAt: lastPassAt, now: now)
+      switch outcome {
+      case .skippedNoNewFacts, .skippedEmptyBatch:
+        return
+      case .ready(let batch):
+        try await performTagging(batch: batch, authorizationSnapshot: authorizationSnapshot, now: now)
+        try await performCandidateWriting(
+          batch: batch, authorizationSnapshot: authorizationSnapshot, now: now)
+        lastPassAt = now
+      }
+    } catch {
+      log("ContextWorkstreamReconciler: pass failed: \(error.localizedDescription)")
+    }
+  }
+
+  private func performTagging(
+    batch: ContextWorkstreamReconcileBatch,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    now: Date
+  ) async throws {
+    guard !batch.groups.isEmpty else { return }
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
+    let result = try await client.complete(
+      operation: ModelQoS.Proactivity.reasoningOperation,
+      prompt: Self.taggingPrompt(batch: batch),
+      jsonSchema: ContextWorkstreamTagging.schema,
+      maxCompletionTokens: 800,
+      authorizationSnapshot: authorizationSnapshot)
+    guard let parsed = ContextWorkstreamTagging.parse(result.content) else {
+      log("ContextWorkstreamReconciler: tagging response malformed")
+      return
+    }
+    let accepted = ContextWorkstreamTagging.acceptedAssignments(
+      response: parsed,
+      batchIDs: batch.groups.map(\.bucketID),
+      existingTags: batch.existingTags,
+      observations: batch.observations)
+    try await store.insertWorkstreamAssignments(accepted, now: now)
+  }
+
+  private func performCandidateWriting(
+    batch: ContextWorkstreamReconcileBatch,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot,
+    now: Date
+  ) async throws {
+    let eligible = batch.groups.filter(\.needsCandidate)
+    guard !eligible.isEmpty else { return }
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorizationSnapshot) else { return }
+    let result = try await client.complete(
+      operation: ModelQoS.Proactivity.reasoningOperation,
+      prompt: Self.candidatePrompt(groups: eligible),
+      jsonSchema: ContextProactiveCandidateWriter.schema,
+      maxCompletionTokens: 800,
+      authorizationSnapshot: authorizationSnapshot)
+    guard let parsed = ContextProactiveCandidateWriter.parse(result.content) else {
+      log("ContextWorkstreamReconciler: candidate response malformed")
+      return
+    }
+    try await store.insertArmedCandidates(parsed.candidates, groups: eligible, now: now)
+  }
+
+  static func taggingPrompt(batch: ContextWorkstreamReconcileBatch) -> String {
+    let vocabulary =
+      batch.existingTags.sorted().isEmpty
+      ? "(none yet)" : batch.existingTags.sorted().map { "- \($0)" }.joined(separator: "\n")
+    let groups = batch.groups.enumerated().map { index, group in
+      let facts = group.facts.map { "- \($0.statement)" }.joined(separator: "\n")
+      return """
+        == GROUP G\(index + 1) (id: \(group.bucketID)) ==
+        Apps: \(Set(group.facts.map(\.appName)).sorted().joined(separator: ", "))
+        \(facts)
+        """
+    }.joined(separator: "\n\n")
+    return """
+      \(ScreenDerivedContent.untrustedPreamble)
+      Assign these observation groups to durable workstream labels.
+
+      A workstream is an ongoing project, product, or goal that spans multiple
+      applications and persists over days or weeks. Name it after the thing being
+      worked on — a product, repository, company, customer, or person — never after
+      an activity, a tool, or the app the observations were seen in.
+
+      Prefer an existing label from the vocabulary when one fits. Propose at most
+      six labels in total. Propose a NEW label only when at least two groups in this
+      batch support it. Every label must use a term that actually appears in the
+      observations. Assign each group to one label or to null; null is correct and
+      expected for many groups. Do not invent a workstream to cover leftovers.
+
+      == CURRENT WORKSTREAM VOCABULARY ==
+      \(vocabulary)
+
+      \(groups)
+      """
+  }
+
+  static func candidatePrompt(groups: [ContextWorkstreamReconcileGroup]) -> String {
+    let body = groups.enumerated().map { index, group in
+      let facts = group.facts.map { fact in
+        "- fact:\(fact.id) w=\(fact.notifyWorthiness) \(fact.statement)"
+      }.joined(separator: "\n")
+      return """
+        == BUCKET \(group.bucketID) (G\(index + 1)) ==
+        \(facts)
+        """
+    }.joined(separator: "\n\n")
+    return """
+      \(ScreenDerivedContent.untrustedPreamble)
+      For each bucket below, write at most one short notification the user would find
+      worth an interruption, or omit the bucket. Ground it in the supplied fact ids
+      and add a one-line trigger_note describing when it should fire.
+
+      Do not restate what is already visible on the user's screen. Speak only when
+      you add something they cannot currently see: a commitment, a deadline, a
+      conflict, or a connection to other work. Must add one of those; otherwise omit
+      the bucket.
+
+      \(body)
+      """
+  }
+}
+
+struct ContextWorkstreamReconcileGroup: Equatable, Sendable {
+  let bucketID: String
+  let facts: [ContextWorkstreamBatchFact]
+  let needsCandidate: Bool
+  let workstreamTag: String?
+}
+
+struct ContextWorkstreamReconcileBatch: Equatable, Sendable {
+  let groups: [ContextWorkstreamReconcileGroup]
+  let existingTags: Set<String>
+  var observations: String {
+    groups.flatMap(\.facts).map(\.statement).joined(separator: "\n")
+  }
+}
+
+enum ContextWorkstreamReconcileOutcome: Equatable {
+  case skippedNoNewFacts
+  case skippedEmptyBatch
+  case ready(ContextWorkstreamReconcileBatch)
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -319,6 +319,11 @@ enum ContextWorkstreamTagging {
   static func insertAssignment(
     bucketID: String, tag: String, now: Date, in db: Database
   ) throws {
+    // The reconciler's batch was selected on a read snapshot. Deterministic GC
+    // can delete a bucket before this write runs; inserting against a missing
+    // parent is a foreign-key abort that would roll back every other
+    // assignment in the same transaction.
+    guard try bucketExists(bucketID, in: db) else { return }
     try db.execute(
       sql: """
         INSERT OR IGNORE INTO bucket_workstreams
@@ -326,6 +331,12 @@ enum ContextWorkstreamTagging {
         VALUES (?, ?, ?, 'reconciler', ?)
         """,
       arguments: [UUID().uuidString.lowercased(), bucketID, tag, now])
+  }
+
+  static func bucketExists(_ bucketID: String, in db: Database) throws -> Bool {
+    try Bool.fetchOne(
+      db, sql: "SELECT EXISTS(SELECT 1 FROM context_buckets WHERE id = ?)", arguments: [bucketID]
+    ) ?? false
   }
 
   static func existingTags(in db: Database) throws -> Set<String> {
@@ -410,15 +421,66 @@ enum ContextProactiveCandidateWriter {
   }
 
   static func hasArmedCandidate(bucketID: String, now: Date, in db: Database) throws -> Bool {
-    try Bool.fetchOne(
-      db,
-      sql: """
-        SELECT EXISTS(
-          SELECT 1 FROM proactive_candidates
-          WHERE bucketID = ? AND state = 'armed' AND expiresAt > ?
-        )
-        """,
-      arguments: [bucketID, now]) ?? false
+    let armed = try ContextProactiveCandidateLookup.lookupArmed(
+      bucketID: bucketID, tags: [], now: now, in: db)
+    for candidate in armed {
+      let ids = candidate.groundingFactIDs
+      guard !ids.isEmpty else { continue }
+      let valid = try validatedFactIDs(ids, bucketID: bucketID, now: now, in: db)
+      if Set(valid) == Set(ids) { return true }
+    }
+    return false
+  }
+
+  static func insertValidatedCandidates(
+    _ proposed: [Response.Candidate],
+    groups: [ContextWorkstreamReconcileGroup],
+    now: Date,
+    in db: Database
+  ) throws {
+    var seen = Set<String>()
+    for candidate in proposed {
+      _ = try insertValidatedCandidate(
+        candidate, groups: groups, seen: &seen, now: now, in: db)
+    }
+  }
+
+  /// Validates one model-proposed candidate and, if it is the first valid one
+  /// for its bucket in this response, writes it. `seen` is only marked after
+  /// every check succeeds, so an invalid earlier proposal cannot shadow a
+  /// later valid one for the same bucket.
+  @discardableResult
+  static func insertValidatedCandidate(
+    _ candidate: Response.Candidate,
+    groups: [ContextWorkstreamReconcileGroup],
+    seen: inout Set<String>,
+    now: Date,
+    in db: Database
+  ) throws -> Bool {
+    let groupByID = Dictionary(
+      groups.map { ($0.bucketID, $0) }, uniquingKeysWith: { _, last in last })
+    let bucketID =
+      ContextWorkstreamTagging.resolveGroup(candidate.bucket, batchIDs: groups.map(\.bucketID))
+      ?? (groupByID[candidate.bucket] != nil ? candidate.bucket : nil)
+    guard let bucketID, !seen.contains(bucketID) else { return false }
+    let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !message.isEmpty else { return false }
+    let cited = candidate.factIDs.map { $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0 }
+      .filter { !$0.isEmpty }
+    let factIDs = try validatedFactIDs(cited, bucketID: bucketID, now: now, in: db)
+    guard !cited.isEmpty, Set(factIDs) == Set(cited) else { return false }
+    let trigger = candidate.triggerNote.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trigger.isEmpty else { return false }
+    seen.insert(bucketID)
+    try insertArmed(
+      bucketID: bucketID,
+      workstreamTag: groupByID[bucketID]?.workstreamTag,
+      message: String(message.prefix(600)),
+      factIDs: factIDs,
+      triggerNote: String(trigger.prefix(300)),
+      now: now,
+      in: db)
+    return true
   }
 
   static func insertArmed(
@@ -430,6 +492,7 @@ enum ContextProactiveCandidateWriter {
     now: Date,
     in db: Database
   ) throws {
+    guard try ContextWorkstreamTagging.bucketExists(bucketID, in: db) else { return }
     let data = try JSONEncoder().encode(factIDs)
     let json = String(data: data, encoding: .utf8) ?? "[]"
     try db.execute(
@@ -520,6 +583,58 @@ enum ContextProactiveCandidateLookup {
         """,
       arguments: [now, id, now])
     return db.changesCount > 0
+  }
+
+  /// Re-arms a candidate that was claimed for presentation but never shown.
+  /// `onDropped` is the only caller: it fires for sync refusals and for a
+  /// queued card that is later evicted, and it does not fire after
+  /// `onPresented` (those callbacks are consumed at present time).
+  @discardableResult
+  static func restore(id: String, now: Date, in db: Database) throws -> Bool {
+    try db.execute(
+      sql: """
+        UPDATE proactive_candidates
+        SET state = 'armed', consumedAt = NULL
+        WHERE id = ? AND state = 'consumed' AND expiresAt > ?
+        """,
+      arguments: [id, now])
+    return db.changesCount > 0
+  }
+
+  /// Sibling-bucket deliveries for durable workstream assignments. Lookup can
+  /// return a candidate written against another bucket that shares a tag, so
+  /// dedup must see those buckets' delivered messages too — `bucket_facts.workstreamTag`
+  /// is dormant and cannot be this source.
+  static func recentDeliveredForAssignedTags(
+    tags: [String],
+    excludingBucketID: String,
+    now: Date,
+    limit: Int,
+    in db: Database
+  ) throws -> [ContextBucketRecentDelivery] {
+    let cap = max(0, min(limit, ContextBucketRecentDelivery.promptCap))
+    guard !tags.isEmpty, cap > 0 else { return [] }
+    let placeholders = tags.map { _ in "?" }.joined(separator: ",")
+    var arguments: StatementArguments = [excludingBucketID]
+    arguments += StatementArguments(tags)
+    // Annotated: a mixed [Date, Int] literal is ambiguous to the type checker.
+    let cutoff = now.addingTimeInterval(-ContextBucketRecentDelivery.memoryLookback)
+    arguments += StatementArguments([cutoff, cap] as [any DatabaseValueConvertible])
+    return try ContextBucketRecentDelivery.fetchAll(
+      db,
+      sql: """
+        SELECT decisionType, message, deliveredAt FROM proactive_deliveries
+        WHERE bucketID <> ?
+          AND bucketID IN (
+            SELECT DISTINCT bucketID FROM bucket_workstreams WHERE tag IN (\(placeholders))
+          )
+          AND lifecycleState = 'delivered'
+          AND deliveredAt IS NOT NULL
+          AND deliveredAt >= ?
+        ORDER BY deliveredAt DESC
+        LIMIT ?
+        """,
+      arguments: arguments)
   }
 
   static func expireStale(now: Date, in db: Database) throws {

--- a/desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketDirectorProbeTests.swift
@@ -103,7 +103,11 @@
       XCTAssertEqual(captured?.operation, ModelQoS.Proactivity.reasoningOperation)
       XCTAssertEqual(captured?.prompt, expectedPrompt)
       XCTAssertNil(captured?.imageData)
-      XCTAssertEqual(captured?.cacheKey, "bucket:synthetic-bucket:v7")
+      // Constant, not bucket- or version-scoped: a key that changed on every
+      // published version fragmented the cache into entries that were written
+      // once and never read.
+      XCTAssertEqual(captured?.cacheKey, "director:v1")
+      XCTAssertEqual(captured?.cacheKey, ContextPromptCacheKey.director)
       XCTAssertEqual(captured?.maxCompletionTokens, 800)
       XCTAssertFalse(captured?.authorizationSnapshotWasPresent ?? true)
       XCTAssertEqual(captured?.schemaKeys, Set(["type", "properties", "required", "additionalProperties"]))
@@ -265,7 +269,7 @@
         descriptor?.params,
         [
           "bucket_id", "version", "header", "frozen", "tail", "validated_facts", "tasks", "app", "window",
-          "captured_at", "notify_worthiness",
+          "captured_at", "notify_worthiness", "visit_count",
         ])
     }
 

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -59,11 +59,13 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
     let dueAt = Date(timeIntervalSince1970: 1_700_003_600)
     let snapshot = ContextBucketSnapshot(
-      bucketID: "bucket", versionID: 5, version: 2, header: "Persistent work context; 2 qualifying visits.",
+      bucketID: "bucket", versionID: 5, version: 2,
+      header: ContextBucketPromptAssembler.stableHeader,
       frozenRankedSegment: Data("frozen:entry-1\n".utf8),
       tail: ["tail:entry-2"],
       validatedFacts: ["fact:PR-123"],
-      notifyWorthiness: 1)
+      notifyWorthiness: 1,
+      visitCount: 2)
     let frame = CapturedFrame(
       jpegData: Data(), appName: "Terminal", windowTitle: "deploy.sh", frameNumber: 9,
       captureTime: capturedAt)
@@ -110,13 +112,19 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "App: Terminal",
       "Window: deploy.sh",
       "Captured at: 2023-11-14 17:13 EST",
+      "Qualifying visits to this context: 2",
     ].joined(separator: "\n")
 
     XCTAssertEqual(prompt, expected)
-    XCTAssertTrue(prompt.contains("== BUCKET HEADER ==\nPersistent work context; 2 qualifying visits."))
+    XCTAssertTrue(prompt.contains("== BUCKET HEADER ==\nPersistent work context."))
     XCTAssertTrue(prompt.contains("== FROZEN RANKED CONTEXT ==\nfrozen:entry-1"))
-    XCTAssertTrue(prompt.contains("== RECENT TAIL ==\ntail:entry-2"))
+    // Validated facts sit ahead of the rolling tail: the tail rewrites every
+    // visit, so anything behind it can never survive as a cached prefix.
     XCTAssertTrue(prompt.contains("== VALIDATED FACTS ==\nfact:PR-123"))
+    XCTAssertTrue(prompt.contains("== RECENT TAIL ==\ntail:entry-2"))
+    let factsIndex = try XCTUnwrap(prompt.range(of: "== VALIDATED FACTS =="))
+    let tailIndex = try XCTUnwrap(prompt.range(of: "== RECENT TAIL =="))
+    XCTAssertLessThan(factsIndex.lowerBound, tailIndex.lowerBound)
     XCTAssertFalse(prompt.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
   }
 
@@ -181,11 +189,102 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "",
       "== RECENTLY DELIVERED FOR THIS BUCKET ==",
       "Do not re-send any of these points, even reworded.",
-      "- resurface (1m ago): Keep the investigation open",
-      "- insight (26m ago): Status changed",
+      "- resurface (2023-11-14 17:12 EST): Keep the investigation open",
+      "- insight (2023-11-14 16:47 EST): Status changed",
     ].joined(separator: "\n")
 
     XCTAssertEqual(prompt, expected)
+  }
+
+  /// The invariant the whole caching change rests on: two consecutive visits to
+  /// the same bucket differ in `version` and `visitCount`, and nothing else, so
+  /// every byte the gateway can match on must be identical between them. A
+  /// counter anywhere in the assembled bucket segment — which is what
+  /// `header` used to carry — puts a changing byte above the frozen segment and
+  /// makes a cross-visit hit impossible no matter how large that segment grows.
+  func testStablePrefixIsByteIdenticalAcrossVisitCountAndVersionChanges() throws {
+    func snapshot(version: Int, visitCount: Int) -> ContextBucketSnapshot {
+      ContextBucketSnapshot(
+        bucketID: "bucket",
+        versionID: Int64(version),
+        version: version,
+        header: ContextBucketPromptAssembler.stableHeader,
+        frozenRankedSegment: Data("- entry:one narrative\n".utf8),
+        tail: ["entry:two narrative"],
+        validatedFacts: ["fact:one PR-123 is blocked"],
+        notifyWorthiness: 1,
+        visitCount: visitCount)
+    }
+    let earlier = snapshot(version: 41, visitCount: 41)
+    let later = snapshot(version: 42, visitCount: 42)
+
+    XCTAssertEqual(
+      ContextBucketPromptAssembler.assemble(earlier),
+      ContextBucketPromptAssembler.assemble(later),
+      "the assembled bucket segment must not depend on the version or the visit count")
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.directorStablePrompt(snapshot: earlier),
+      ContextProactivityPromptBuilder.directorStablePrompt(snapshot: later),
+      "the cached half of the director prompt must be byte-identical across visits")
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.directorStablePrompt(snapshot: earlier, allowLookup: true),
+      ContextProactivityPromptBuilder.directorStablePrompt(snapshot: later, allowLookup: true))
+
+    // The count is not lost, it moved: it belongs to the volatile half, which
+    // is sent uncached and may change freely.
+    let frame = CapturedFrame(
+      jpegData: Data(), appName: "Notes", frameNumber: 1,
+      captureTime: Date(timeIntervalSince1970: 1_700_000_000))
+    XCTAssertTrue(
+      ContextProactivityPromptBuilder.directorVolatilePrompt(
+        tasks: [], frame: frame, visitCount: 42
+      ).contains("Qualifying visits to this context: 42"))
+    XCTAssertFalse(
+      ContextProactivityPromptBuilder.directorStablePrompt(snapshot: later).contains("42"))
+    XCTAssertFalse(
+      ContextBucketPromptAssembler.stableHeader.contains(where: \.isNumber),
+      "a digit in the header is the shape of the defect this test exists to prevent")
+  }
+
+  /// The recent-delivery block is only worth enlarging if it stops rewriting
+  /// itself: a relative age ("3m ago") produced different bytes on every call
+  /// for an unchanged delivery set.
+  func testRecentDeliveriesRenderIdenticallyForTheSameSetAtDifferentTimes() throws {
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    let deliveries = [
+      ContextBucketRecentDelivery(
+        decisionType: "resurface", message: "Keep the investigation open",
+        deliveredAt: base.addingTimeInterval(-65)),
+      ContextBucketRecentDelivery(
+        decisionType: "insight", message: nil, deliveredAt: base.addingTimeInterval(-26 * 60)),
+    ]
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket", versionID: 1, version: 1,
+      header: ContextBucketPromptAssembler.stableHeader,
+      frozenRankedSegment: Data(), tail: [], validatedFacts: ["fact"], notifyWorthiness: 1)
+
+    func section(at now: Date) -> String {
+      let prompt = ContextProactivityPromptBuilder.directorPrompt(
+        snapshot: snapshot,
+        tasks: [],
+        frame: CapturedFrame(
+          jpegData: Data(), appName: "Notes", frameNumber: 1, captureTime: now),
+        recentDeliveries: deliveries,
+        timeZone: timeZone)
+      let marker = "== RECENTLY DELIVERED FOR THIS BUCKET =="
+      return String(prompt[(prompt.range(of: marker)?.lowerBound ?? prompt.startIndex)...])
+    }
+
+    XCTAssertEqual(section(at: base), section(at: base.addingTimeInterval(37 * 60)))
+    XCTAssertEqual(
+      section(at: base),
+      """
+      == RECENTLY DELIVERED FOR THIS BUCKET ==
+      Do not re-send any of these points, even reworded.
+      - resurface (2023-11-14 17:12 EST): Keep the investigation open
+      - insight (2023-11-14 16:47 EST)
+      """)
   }
 
   func testDirectorPromptKeepsLocalDateWhenUTCHasAlreadyRolledToTheNextDay() throws {
@@ -204,7 +303,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertFalse(prompt.contains("2026-08-11"))
   }
 
-  func testDirectorPromptCapsRecentDeliveriesAndOmitsTheSectionWhenEmpty() {
+  func testDirectorPromptCapsRecentDeliveriesAndOmitsTheSectionWhenEmpty() throws {
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let capturedAt = Date(timeIntervalSince1970: 1_700_000_000)
     let snapshot = ContextBucketSnapshot(
       bucketID: "bucket", versionID: 1, version: 1, header: "header",
@@ -212,33 +312,43 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     let frame = CapturedFrame(
       jpegData: Data(), appName: "Notes", frameNumber: 10, captureTime: capturedAt)
     let empty = ContextProactivityPromptBuilder.directorPrompt(
-      snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: [])
+      snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: [], timeZone: timeZone)
     XCTAssertFalse(empty.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
 
-    let overflow = (0..<8).map { index in
+    let overflow = (0..<17).map { index in
       ContextBucketRecentDelivery(
         decisionType: "resurface",
         message: "nudge-\(index)",
         deliveredAt: capturedAt.addingTimeInterval(TimeInterval(-60 * (index + 1))))
     }
     let capped = ContextProactivityPromptBuilder.directorPrompt(
-      snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: overflow)
+      snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: overflow, timeZone: timeZone)
     XCTAssertEqual(
-      ContextProactivityPromptBuilder.recentDeliveriesSection(overflow, now: capturedAt),
+      ContextProactivityPromptBuilder.recentDeliveriesSection(overflow, timeZone: timeZone),
       """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
       Do not re-send any of these points, even reworded.
-      - resurface (1m ago): nudge-0
-      - resurface (2m ago): nudge-1
-      - resurface (3m ago): nudge-2
-      - resurface (4m ago): nudge-3
-      - resurface (5m ago): nudge-4
-      - resurface (6m ago): nudge-5
+      - resurface (2023-11-14 17:12 EST): nudge-0
+      - resurface (2023-11-14 17:11 EST): nudge-1
+      - resurface (2023-11-14 17:10 EST): nudge-2
+      - resurface (2023-11-14 17:09 EST): nudge-3
+      - resurface (2023-11-14 17:08 EST): nudge-4
+      - resurface (2023-11-14 17:07 EST): nudge-5
+      - resurface (2023-11-14 17:06 EST): nudge-6
+      - resurface (2023-11-14 17:05 EST): nudge-7
+      - resurface (2023-11-14 17:04 EST): nudge-8
+      - resurface (2023-11-14 17:03 EST): nudge-9
+      - resurface (2023-11-14 17:02 EST): nudge-10
+      - resurface (2023-11-14 17:01 EST): nudge-11
+      - resurface (2023-11-14 17:00 EST): nudge-12
+      - resurface (2023-11-14 16:59 EST): nudge-13
+      - resurface (2023-11-14 16:58 EST): nudge-14
       """)
-    XCTAssertTrue(capped.contains("- resurface (1m ago): nudge-0"))
-    XCTAssertTrue(capped.contains("- resurface (6m ago): nudge-5"))
-    XCTAssertFalse(capped.contains("nudge-6"))
-    XCTAssertFalse(capped.contains("nudge-7"))
+    XCTAssertEqual(ContextBucketRecentDelivery.promptCap, 15)
+    XCTAssertTrue(capped.contains("- resurface (2023-11-14 17:12 EST): nudge-0"))
+    XCTAssertTrue(capped.contains("- resurface (2023-11-14 16:58 EST): nudge-14"))
+    XCTAssertFalse(capped.contains("nudge-15"))
+    XCTAssertFalse(capped.contains("nudge-16"))
   }
 
   func testBoundedSummaryKeepsDistinguishingContentPastTheOldTruncatePoint() {
@@ -421,19 +531,32 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertEqual(refs, ["screenshot:42"])
   }
 
-  func testPromptAssemblyHonorsInjectionBudget() {
+  /// A full-size frozen segment must be additional context, not context taken
+  /// from the facts and the tail: those two are what the director actually
+  /// decides on, and starving them to buy history would be a regression the
+  /// byte budget alone would not catch.
+  func testPromptAssemblyHonorsInjectionBudgetAndStillCarriesFactsAndTail() throws {
     let snapshot = ContextBucketSnapshot(
       bucketID: "bucket", versionID: 1, version: 1, header: String(repeating: "h", count: 500),
-      frozenRankedSegment: Data(String(repeating: "f", count: 6_000).utf8),
+      frozenRankedSegment: Data(
+        String(
+          repeating: "f", count: ContextBucketPromptAssembler.frozenRankedByteBudget
+        ).utf8),
       tail: Array(repeating: String(repeating: "t", count: 2_400), count: 5),
       validatedFacts: Array(repeating: String(repeating: "v", count: 1_500), count: 20),
       notifyWorthiness: 1)
 
     let assembled = ContextBucketPromptAssembler.assemble(snapshot)
+    let text = try XCTUnwrap(String(data: assembled, encoding: .utf8))
 
     XCTAssertLessThanOrEqual(assembled.count, ContextBucketPromptAssembler.injectionTokenBudget * 4)
     XCTAssertTrue(assembled.contains(snapshot.frozenRankedSegment))
-    XCTAssertNotNil(String(data: assembled, encoding: .utf8))
+    let factsRange = try XCTUnwrap(text.range(of: "== VALIDATED FACTS ==\nv"))
+    let tailRange = try XCTUnwrap(text.range(of: "== RECENT TAIL ==\nt"))
+    XCTAssertLessThan(factsRange.lowerBound, tailRange.lowerBound)
+    XCTAssertGreaterThanOrEqual(
+      text.distance(from: tailRange.upperBound, to: text.endIndex), 5_000,
+      "the rolling tail must keep roughly the room it had before the frozen budget grew")
   }
 
   private func task(

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -332,6 +332,18 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       [])
   }
 
+  func testAcceptedIdentifiersMatchCaseInsensitivelyButKeepTheOriginalCasing() {
+    XCTAssertEqual(
+      BucketFactValidator.acceptedIdentifiers(
+        ["pr-123"], evidenceText: "PR-123 is the launch blocker."),
+      ["pr-123"],
+      "a differently-cased on-screen quote must not discard an otherwise-valid identifier")
+    XCTAssertEqual(
+      BucketFactValidator.acceptedIdentifiers(
+        ["NIK"], evidenceText: "nik asked for the demo recording."),
+      ["NIK"])
+  }
+
   func testExtractionSchemaOmitsWorkstream() throws {
     let properties = try XCTUnwrap(
       ContextBucketRollupWriter.schema["properties"] as? [String: Any])

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -555,8 +555,30 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     let tailRange = try XCTUnwrap(text.range(of: "== RECENT TAIL ==\nt"))
     XCTAssertLessThan(factsRange.lowerBound, tailRange.lowerBound)
     XCTAssertGreaterThanOrEqual(
+      text.distance(from: factsRange.upperBound, to: tailRange.lowerBound),
+      7_000,
+      "validated facts must keep their reserved room when the frozen segment is at budget")
+    XCTAssertGreaterThanOrEqual(
       text.distance(from: tailRange.upperBound, to: text.endIndex), 5_000,
       "the rolling tail must keep roughly the room it had before the frozen budget grew")
+  }
+
+  func testAssembleIgnoresAVolatileStoredHeaderSoTheCachePrefixStaysStable() {
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket", versionID: 41, version: 41,
+      header: "41 qualifying visits.",
+      frozenRankedSegment: Data("- entry:one narrative\n".utf8),
+      tail: ["entry:two narrative"],
+      validatedFacts: ["fact:one PR-123 is blocked"],
+      notifyWorthiness: 1,
+      visitCount: 41)
+    let assembled = String(data: ContextBucketPromptAssembler.assemble(snapshot), encoding: .utf8) ?? ""
+    XCTAssertTrue(assembled.contains(ContextBucketPromptAssembler.stableHeader))
+    XCTAssertFalse(
+      assembled.contains("41"),
+      "a stored header that still carries the visit count must not enter the assembled prefix")
+    XCTAssertFalse(
+      ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot).contains("41"))
   }
 
   private func task(

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -21,26 +21,22 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     let expected =
       [
         ScreenDerivedContent.untrustedPreamble,
-        "Produce a 150-400 token ambient narrative and discrete factual records. Facts are",
-        "proposals; include an identifier, surviving evidence text, and evidence ref for each.",
-        "Also set each fact's \"workstream\": the durable project or activity its content belongs",
-        "to, judged by the content itself rather than by which app is open. Strongly prefer one",
-        "of the active labels: none yet. Only when none fits, coin one new short",
-        "kebab-case label for a durable project, or answer \"unknown\" for generic activity you",
-        "cannot place.",
+        "Write a 150-400 token summary of what is happening, then discrete factual records.",
+        "Each statement must be a plain declarative sentence a colleague could act on. Do not",
+        "label, number, or prefix statements.",
+        "Good: Nik asked for the demo recording before tomorrow's launch video.",
+        "Bad: Ambient narrative: the user appears to be coordinating a recording workflow.",
+        "Fill identifiers with names, ticket numbers, or other handles copied from the quoted",
+        "on-screen text. Fill evidence_text with that supporting on-screen wording. Put this",
+        "ref in every evidence_refs list: screenshot:42",
         "App: Xcode",
         "Window: PR-123",
-        "Evidence ref: screenshot:42",
       ].joined(separator: "\n")
       // Xcode is not a browser, so destination routing must not be offered here —
       // only the abstention that satisfies the strict-schema required field.
       + "\n\nSet \"destination\" to \"\(ContextDestinationKey.abstention)\"."
 
     XCTAssertEqual(prompt, expected)
-
-    let withVocabulary = ContextProactivityPromptBuilder.extractionPrompt(
-      frame: frame, fence: fence, workstreamVocabulary: ["omi", "spudpay"])
-    XCTAssertTrue(withVocabulary.contains("of the active labels: omi, spudpay."))
   }
 
   func testExtractionPromptFallsBackToVisitEvidenceRefWithoutScreenshot() {
@@ -52,7 +48,8 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
 
     // Safari is a browser, but a blank window title carries no destination signal,
     // so this must still fall through to abstention rather than inviting a guess.
-    XCTAssertTrue(prompt.contains("App: Safari\nWindow: \nEvidence ref: visit:123"))
+    XCTAssertTrue(prompt.contains("App: Safari\nWindow: "))
+    XCTAssertTrue(prompt.contains("ref in every evidence_refs list: visit:123"))
     XCTAssertTrue(prompt.hasSuffix("Set \"destination\" to \"\(ContextDestinationKey.abstention)\"."))
     XCTAssertFalse(prompt.contains("page-group"))
   }
@@ -96,8 +93,11 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "update, recommendation, or useful follow-up without an explicit commitment, promise, or",
       "request is insight or suggest; never infer an owner or due date and never create a task",
       "candidate from actionability alone.",
-      "Do not re-deliver a point already delivered for this bucket unless the validated facts",
-      "add something materially new. Prefer silence over restating.",
+      "Do not restate what is already visible on the user's screen. Speak only when you add",
+      "something they cannot currently see: a commitment, a deadline, a conflict, or a",
+      "connection to other work.",
+      "The recently-delivered list is a prohibition, not background. Do not re-send a point",
+      "already delivered, even reworded.",
       "Timestamps supplied below are already in the user's local time zone. When a message",
       "mentions a date or time, use that local form as written; never convert to or mention UTC.",
       "",
@@ -161,8 +161,11 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "update, recommendation, or useful follow-up without an explicit commitment, promise, or",
       "request is insight or suggest; never infer an owner or due date and never create a task",
       "candidate from actionability alone.",
-      "Do not re-deliver a point already delivered for this bucket unless the validated facts",
-      "add something materially new. Prefer silence over restating.",
+      "Do not restate what is already visible on the user's screen. Speak only when you add",
+      "something they cannot currently see: a commitment, a deadline, a conflict, or a",
+      "connection to other work.",
+      "The recently-delivered list is a prohibition, not background. Do not re-send a point",
+      "already delivered, even reworded.",
       "Timestamps supplied below are already in the user's local time zone. When a message",
       "mentions a date or time, use that local form as written; never convert to or mention UTC.",
       "",
@@ -177,6 +180,7 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "Captured at: 2023-11-14 17:13 EST",
       "",
       "== RECENTLY DELIVERED FOR THIS BUCKET ==",
+      "Do not re-send any of these points, even reworded.",
       "- resurface (1m ago): Keep the investigation open",
       "- insight (26m ago): Status changed",
     ].joined(separator: "\n")
@@ -211,7 +215,7 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       snapshot: snapshot, tasks: [], frame: frame, recentDeliveries: [])
     XCTAssertFalse(empty.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
 
-    let overflow = (0..<5).map { index in
+    let overflow = (0..<8).map { index in
       ContextBucketRecentDelivery(
         decisionType: "resurface",
         message: "nudge-\(index)",
@@ -223,14 +227,32 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       ContextProactivityPromptBuilder.recentDeliveriesSection(overflow, now: capturedAt),
       """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
+      Do not re-send any of these points, even reworded.
       - resurface (1m ago): nudge-0
       - resurface (2m ago): nudge-1
       - resurface (3m ago): nudge-2
+      - resurface (4m ago): nudge-3
+      - resurface (5m ago): nudge-4
+      - resurface (6m ago): nudge-5
       """)
     XCTAssertTrue(capped.contains("- resurface (1m ago): nudge-0"))
-    XCTAssertTrue(capped.contains("- resurface (3m ago): nudge-2"))
-    XCTAssertFalse(capped.contains("nudge-3"))
-    XCTAssertFalse(capped.contains("nudge-4"))
+    XCTAssertTrue(capped.contains("- resurface (6m ago): nudge-5"))
+    XCTAssertFalse(capped.contains("nudge-6"))
+    XCTAssertFalse(capped.contains("nudge-7"))
+  }
+
+  func testBoundedSummaryKeepsDistinguishingContentPastTheOldTruncatePoint() {
+    let distinguishing = "the beta rollout is still incomplete because the legacy PostHog path is live"
+    let shortEnough = String(repeating: "x", count: 120) + distinguishing
+    XCTAssertTrue(shortEnough.count > 120)
+    XCTAssertTrue(shortEnough.count < ContextBucketRecentDelivery.summaryCharacterLimit)
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.boundedSummary(shortEnough),
+      shortEnough)
+    let overLimit = String(repeating: "y", count: ContextBucketRecentDelivery.summaryCharacterLimit + 40)
+    XCTAssertEqual(
+      ContextProactivityPromptBuilder.boundedSummary(overLimit).count,
+      ContextBucketRecentDelivery.summaryCharacterLimit)
   }
 
   func testDirectorTaskContextBoundsDescription() {
@@ -297,6 +319,34 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       BucketFactValidator.validity(
         identifiers: ["PR-123"], evidenceText: "same", evidenceRefs: ["visit:1"], duplicate: true),
       .superseded)
+  }
+
+  func testAcceptedIdentifiersDropBookkeepingAndHandlesAbsentFromQuotedText() {
+    XCTAssertEqual(
+      BucketFactValidator.acceptedIdentifiers(
+        ["fact-001", "f-002", "FTN-003", "visit:327", "screenshot:42", "PR-123", "Nik"],
+        evidenceText: "Nik asked for the demo recording. PR-123 is the launch blocker."),
+      ["PR-123", "Nik"])
+    XCTAssertEqual(
+      BucketFactValidator.acceptedIdentifiers(["Acme"], evidenceText: "the board was lying"),
+      [])
+  }
+
+  func testExtractionSchemaOmitsWorkstream() throws {
+    let properties = try XCTUnwrap(
+      ContextBucketRollupWriter.schema["properties"] as? [String: Any])
+    let facts = try XCTUnwrap(properties["facts"] as? [String: Any])
+    let items = try XCTUnwrap(facts["items"] as? [String: Any])
+    let factProperties = try XCTUnwrap(items["properties"] as? [String: Any])
+    let required = try XCTUnwrap(items["required"] as? [String])
+    XCTAssertNil(factProperties["workstream"])
+    XCTAssertFalse(required.contains("workstream"))
+    XCTAssertEqual(
+      Set(required),
+      [
+        "statement", "identifiers", "evidence_text", "evidence_refs", "confidence",
+        "notify_worthiness",
+      ])
   }
 
   func testCanonicalIdentifierSetKeyIsNormalizationOnlyAndKeepsDistinctSetsSeparate() {

--- a/desktop/macos/Desktop/Tests/ContextBucketPurgerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPurgerTests.swift
@@ -93,6 +93,14 @@ final class ContextBucketPurgerTests: XCTestCase {
         sql:
           "INSERT INTO proactive_deliveries (id, bucketID, decisionType, lifecycleState, provenanceJson, attemptedAt, expiresAt, createdAt) VALUES ('delivery', 'bucket', 'suggest', 'delivered', ?, ?, ?, ?)",
         arguments: ["{\"excluded narrative\":true}", now, now.addingTimeInterval(60), now])
+      try database.execute(
+        sql: """
+          INSERT INTO proactive_candidates
+            (id, bucketID, message, groundingFactIDsJson, triggerNote, state, createdAt, expiresAt)
+          VALUES ('candidate', 'bucket', 'excluded narrative still needs review', '[]',
+                  'when relevant', 'armed', ?, ?)
+          """,
+        arguments: [now, now.addingTimeInterval(12 * 60 * 60)])
 
       let result = try ContextBucketPurger.deleteWithArtifacts(
         appName: "Secret", in: database, now: now)
@@ -101,6 +109,7 @@ final class ContextBucketPurgerTests: XCTestCase {
       XCTAssertEqual(try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM context_visits WHERE appName = 'Keep'"), 1)
       XCTAssertEqual(try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM bucket_versions"), 0)
       XCTAssertEqual(try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM proactive_deliveries"), 0)
+      XCTAssertEqual(try Int.fetchOne(database, sql: "SELECT COUNT(*) FROM proactive_candidates"), 0)
       XCTAssertEqual(
         try String.fetchAll(database, sql: "SELECT narrative FROM bucket_entries"), ["surviving narrative"])
       XCTAssertEqual(

--- a/desktop/macos/Desktop/Tests/ContextBucketRecentDeliveryTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketRecentDeliveryTests.swift
@@ -50,6 +50,7 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
       ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now),
       """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
+      Do not re-send any of these points, even reworded.
       - resurface (1m ago): Keep the investigation open
       - insight (26m ago): Status changed
       """)
@@ -57,6 +58,7 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
       prompt.hasSuffix(
         """
         == RECENTLY DELIVERED FOR THIS BUCKET ==
+        Do not re-send any of these points, even reworded.
         - resurface (1m ago): Keep the investigation open
         - insight (26m ago): Status changed
         """))
@@ -78,10 +80,10 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
     XCTAssertFalse(prompt.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
   }
 
-  func testAssembledPromptCapsRecentDeliveriesAtThree() async throws {
+  func testAssembledPromptCapsRecentDeliveriesAtPromptCap() async throws {
     let now = Date(timeIntervalSince1970: 1_800_000_000)
     let versionID = try await seedBucket(now: now)
-    for index in 0..<5 {
+    for index in 0..<8 {
       try await seedDelivered(
         id: "nudge-\(index)",
         visitID: Int64(index + 1),
@@ -100,18 +102,53 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
       frame: CapturedFrame(jpegData: Data(), appName: "Notes", frameNumber: 1, captureTime: now),
       recentDeliveries: recent)
 
-    XCTAssertEqual(recent.map(\.message), ["nudge-0", "nudge-1", "nudge-2"])
+    XCTAssertEqual(
+      recent.map(\.message),
+      ["nudge-0", "nudge-1", "nudge-2", "nudge-3", "nudge-4", "nudge-5"])
     XCTAssertEqual(recent.count, ContextBucketRecentDelivery.promptCap)
     XCTAssertEqual(
       ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now),
       """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
+      Do not re-send any of these points, even reworded.
       - resurface (1m ago): nudge-0
       - resurface (2m ago): nudge-1
       - resurface (3m ago): nudge-2
+      - resurface (4m ago): nudge-3
+      - resurface (5m ago): nudge-4
+      - resurface (6m ago): nudge-5
       """)
-    XCTAssertFalse(prompt.contains("nudge-3"))
-    XCTAssertFalse(prompt.contains("nudge-4"))
+    XCTAssertFalse(prompt.contains("nudge-6"))
+    XCTAssertFalse(prompt.contains("nudge-7"))
+  }
+
+  func testRecentDeliveriesSurviveExpiryInsideTheLookbackAndDropOutsideIt() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let versionID = try await seedBucket(now: now)
+    try await seedDelivered(
+      id: "expired-but-recent",
+      visitID: 1,
+      versionID: versionID,
+      decisionType: "insight",
+      message: "the beta rollout is still incomplete because the legacy PostHog path is live",
+      deliveredAt: now.addingTimeInterval(-2 * 60 * 60),
+      now: now,
+      expiresAt: now.addingTimeInterval(-60))
+    try await seedDelivered(
+      id: "outside-lookback",
+      visitID: 2,
+      versionID: versionID,
+      decisionType: "insight",
+      message: "an older point from yesterday",
+      deliveredAt: now.addingTimeInterval(-(ContextBucketRecentDelivery.memoryLookback + 60)),
+      now: now,
+      expiresAt: now.addingTimeInterval(30 * 24 * 60 * 60))
+
+    let recent = await ContextBucketStore.shared.recentDeliveredForBucket(
+      bucketID: "bucket", now: now)
+    XCTAssertEqual(
+      recent.map(\.message),
+      ["the beta rollout is still incomplete because the legacy PostHog path is live"])
   }
 
   private func snapshot(versionID: Int64) -> ContextBucketSnapshot {
@@ -142,7 +179,7 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
           VALUES ('bucket', 1, 'header', ?, ?)
           """,
         arguments: [Data(), now])
-      for visitID in 1...5 {
+      for visitID in 1...8 {
         try db.execute(
           sql: """
             INSERT INTO context_visits
@@ -169,7 +206,8 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
     decisionType: String,
     message: String,
     deliveredAt: Date,
-    now: Date
+    now: Date,
+    expiresAt: Date? = nil
   ) async throws {
     let (database, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
     let pool = try XCTUnwrap(database)
@@ -183,7 +221,7 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
           """,
         arguments: [
           id, visitID, versionID, decisionType, message, deliveredAt, deliveredAt,
-          now.addingTimeInterval(30 * 24 * 60 * 60), deliveredAt,
+          expiresAt ?? now.addingTimeInterval(30 * 24 * 60 * 60), deliveredAt,
         ])
     }
   }

--- a/desktop/macos/Desktop/Tests/ContextBucketRecentDeliveryTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketRecentDeliveryTests.swift
@@ -37,30 +37,32 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
       deliveredAt: now.addingTimeInterval(-26 * 60),
       now: now)
 
+    let timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
     let recent = await ContextBucketStore.shared.recentDeliveredForBucket(
       bucketID: "bucket", now: now)
     let prompt = ContextProactivityPromptBuilder.directorPrompt(
       snapshot: snapshot(versionID: versionID),
       tasks: [],
       frame: CapturedFrame(jpegData: Data(), appName: "Notes", frameNumber: 1, captureTime: now),
-      recentDeliveries: recent)
+      recentDeliveries: recent,
+      timeZone: timeZone)
 
     XCTAssertEqual(recent.map(\.decisionType), ["resurface", "insight"])
     XCTAssertEqual(
-      ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now),
+      ContextProactivityPromptBuilder.recentDeliveriesSection(recent, timeZone: timeZone),
       """
       == RECENTLY DELIVERED FOR THIS BUCKET ==
       Do not re-send any of these points, even reworded.
-      - resurface (1m ago): Keep the investigation open
-      - insight (26m ago): Status changed
+      - resurface (2027-01-15 02:58 EST): Keep the investigation open
+      - insight (2027-01-15 02:34 EST): Status changed
       """)
     XCTAssertTrue(
       prompt.hasSuffix(
         """
         == RECENTLY DELIVERED FOR THIS BUCKET ==
         Do not re-send any of these points, even reworded.
-        - resurface (1m ago): Keep the investigation open
-        - insight (26m ago): Status changed
+        - resurface (2027-01-15 02:58 EST): Keep the investigation open
+        - insight (2027-01-15 02:34 EST): Status changed
         """))
   }
 
@@ -76,14 +78,14 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
       recentDeliveries: recent)
 
     XCTAssertEqual(recent, [])
-    XCTAssertNil(ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now))
+    XCTAssertNil(ContextProactivityPromptBuilder.recentDeliveriesSection(recent))
     XCTAssertFalse(prompt.contains("== RECENTLY DELIVERED FOR THIS BUCKET =="))
   }
 
   func testAssembledPromptCapsRecentDeliveriesAtPromptCap() async throws {
     let now = Date(timeIntervalSince1970: 1_800_000_000)
     let versionID = try await seedBucket(now: now)
-    for index in 0..<8 {
+    for index in 0..<(ContextBucketRecentDelivery.promptCap + 2) {
       try await seedDelivered(
         id: "nudge-\(index)",
         visitID: Int64(index + 1),
@@ -104,22 +106,12 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
 
     XCTAssertEqual(
       recent.map(\.message),
-      ["nudge-0", "nudge-1", "nudge-2", "nudge-3", "nudge-4", "nudge-5"])
+      (0..<ContextBucketRecentDelivery.promptCap).map { "nudge-\($0)" })
     XCTAssertEqual(recent.count, ContextBucketRecentDelivery.promptCap)
-    XCTAssertEqual(
-      ContextProactivityPromptBuilder.recentDeliveriesSection(recent, now: now),
-      """
-      == RECENTLY DELIVERED FOR THIS BUCKET ==
-      Do not re-send any of these points, even reworded.
-      - resurface (1m ago): nudge-0
-      - resurface (2m ago): nudge-1
-      - resurface (3m ago): nudge-2
-      - resurface (4m ago): nudge-3
-      - resurface (5m ago): nudge-4
-      - resurface (6m ago): nudge-5
-      """)
-    XCTAssertFalse(prompt.contains("nudge-6"))
-    XCTAssertFalse(prompt.contains("nudge-7"))
+    XCTAssertEqual(recent.count, 15, "the enlarged window is what makes the no-repeat rule enforceable")
+    XCTAssertTrue(prompt.contains("nudge-14"))
+    XCTAssertFalse(prompt.contains("nudge-15"))
+    XCTAssertFalse(prompt.contains("nudge-16"))
   }
 
   func testRecentDeliveriesSurviveExpiryInsideTheLookbackAndDropOutsideIt() async throws {
@@ -179,7 +171,7 @@ final class ContextBucketRecentDeliveryTests: XCTestCase {
           VALUES ('bucket', 1, 'header', ?, ?)
           """,
         arguments: [Data(), now])
-      for visitID in 1...8 {
+      for visitID in 1...(ContextBucketRecentDelivery.promptCap + 2) {
         try db.execute(
           sql: """
             INSERT INTO context_visits

--- a/desktop/macos/Desktop/Tests/ContextBucketSchemaTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketSchemaTests.swift
@@ -236,6 +236,38 @@ final class ContextBucketSchemaTests: XCTestCase {
     XCTAssertEqual(remaining, ["live"])
   }
 
+  func testExpiredAndTerminalCandidatesAreDeletedByRetentionSweep() throws {
+    let queue = try migratedQueue()
+    let now = Date(timeIntervalSince1970: 1_725_000_000)
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+          VALUES ('bucket', 'task', 'task-1', ?, ?)
+          """,
+        arguments: [now, now])
+      for (id, state, expiry) in [
+        ("armed-live", "armed", now.addingTimeInterval(60)),
+        ("armed-expired", "armed", now.addingTimeInterval(-1)),
+        ("consumed", "consumed", now.addingTimeInterval(60)),
+      ] {
+        try db.execute(
+          sql: """
+            INSERT INTO proactive_candidates
+              (id, bucketID, message, groundingFactIDsJson, triggerNote, state,
+               createdAt, expiresAt)
+            VALUES (?, 'bucket', 'message', '[]', 'when relevant', ?, ?, ?)
+            """,
+          arguments: [id, state, now, expiry])
+      }
+      XCTAssertEqual(try ContextBucketSchema.deleteExpiredProactiveCandidates(in: db, now: now), 2)
+    }
+    let remaining = try queue.read { db in
+      try String.fetchAll(db, sql: "SELECT id FROM proactive_candidates ORDER BY id")
+    }
+    XCTAssertEqual(remaining, ["armed-live"])
+  }
+
   func testContextTablesAreExcludedFromAgentSync() {
     XCTAssertTrue(ContextBucketSchema.tableNames.isDisjoint(with: AgentSyncService.syncedTableNames))
   }

--- a/desktop/macos/Desktop/Tests/ContextBucketSchemaTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketSchemaTests.swift
@@ -73,6 +73,44 @@ final class ContextBucketSchemaTests: XCTestCase {
     XCTAssertTrue(indexes.contains("idx_bucket_facts_workstream"))
   }
 
+  func testMigrationCreatesWorkstreamAssignmentsAndCandidateTables() throws {
+    let queue = try migratedQueue()
+    let tables = try queue.read { db in
+      Set(try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table'"))
+    }
+    XCTAssertTrue(tables.contains("bucket_workstreams"))
+    XCTAssertTrue(tables.contains("proactive_candidates"))
+    let workstreamColumns = try queue.read { db in
+      try db.columns(in: "bucket_workstreams").map(\.name)
+    }
+    XCTAssertEqual(
+      Set(workstreamColumns),
+      ["id", "bucketID", "tag", "source", "assignedAt"])
+    let candidateColumns = try queue.read { db in
+      try db.columns(in: "proactive_candidates").map(\.name)
+    }
+    XCTAssertEqual(
+      Set(candidateColumns),
+      [
+        "id", "bucketID", "workstreamTag", "message", "groundingFactIDsJson", "triggerNote",
+        "state", "createdAt", "expiresAt", "consumedAt",
+      ])
+    let indexes = try queue.read { db in
+      Set(
+        try String.fetchAll(
+          db, sql: "SELECT name FROM sqlite_master WHERE type = 'index'"))
+    }
+    XCTAssertTrue(indexes.contains("idx_bucket_workstreams_tag"))
+    XCTAssertTrue(indexes.contains("idx_proactive_candidates_lookup"))
+    XCTAssertTrue(indexes.contains("idx_proactive_candidates_workstream"))
+    let factColumns = try queue.read { db in
+      try db.columns(in: "bucket_facts").map(\.name)
+    }
+    XCTAssertTrue(
+      factColumns.contains("workstreamTag"),
+      "the dormant fact-level column must survive this migration")
+  }
+
   func testAnonymousDatabaseUsesSignedOutLegacyOwnerNamespace() throws {
     let suiteName = "ContextBucketSchemaTests.anonymous.\(UUID().uuidString)"
     let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/desktop/macos/Desktop/Tests/ContextBucketStoreCompactionTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketStoreCompactionTests.swift
@@ -77,6 +77,12 @@ final class ContextBucketStoreCompactionTests: XCTestCase {
       XCTAssertTrue(snapshot.tail[index - 1].hasSuffix(" short-\(index)"))
     }
 
+    // Six published versions, one constant header: nothing that changes per
+    // visit may be written above the frozen segment, or the director's cache
+    // prefix is invalidated before it can ever be reused.
+    XCTAssertEqual(snapshot.header, ContextBucketPromptAssembler.stableHeader)
+    XCTAssertFalse(snapshot.header.contains(where: \.isNumber))
+
     let frozen = try XCTUnwrap(String(data: snapshot.frozenRankedSegment, encoding: .utf8))
     XCTAssertTrue(
       frozen.contains("- entry:\(oldestID) short-0\n"),

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -776,43 +776,52 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
       visitID: 2, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket-b",
       startedAt: now.addingTimeInterval(-60))
 
-    func fact(_ statement: String, workstream: String?, worthiness: Double, visit: Int64)
-      -> BucketExtraction.Fact
-    {
+    func fact(_ statement: String, worthiness: Double, visit: Int64) -> BucketExtraction.Fact {
       BucketExtraction.Fact(
         statement: statement,
         identifiers: ["identity"],
-        evidenceText: "evidence",
+        evidenceText: "identity",
         evidenceRefs: ["visit:\(visit)"],
         confidence: 1,
-        notifyWorthiness: worthiness,
-        workstream: workstream)
+        notifyWorthiness: worthiness)
     }
-    // "Omi App" must survive sanitization as "omi-app"; the sibling writes one
-    // poolable fact, one below the worthiness floor, and one scaffolding-shaped
-    // statement that the selector must drop.
+    // Extraction no longer writes workstream tags. Stamp historically tagged
+    // rows so pooling — still wired, now dormant for new facts — stays covered.
     _ = try await ContextBucketStore.shared.writeExtraction(
       BucketExtraction(
         narrative: "own narrative",
-        facts: [fact("own visit fact", workstream: "Omi App", worthiness: 0.7, visit: 1)]),
+        facts: [fact("own visit fact", worthiness: 0.7, visit: 1)]),
       for: fence, appName: "Test App", rawContextKey: "raw", normalizedContextKey: "normalized",
       now: now)
     _ = try await ContextBucketStore.shared.writeExtraction(
       BucketExtraction(
         narrative: "sibling narrative",
         facts: [
-          fact("sibling poolable fact", workstream: "omi app", worthiness: 0.8, visit: 2),
-          fact("sibling weak fact", workstream: "omi-app", worthiness: 0.1, visit: 2),
-          fact(
-            "Identifier proposal: visit:2", workstream: "omi-app", worthiness: 0.9, visit: 2),
+          fact("sibling poolable fact", worthiness: 0.8, visit: 2),
+          fact("sibling weak fact", worthiness: 0.1, visit: 2),
+          fact("Identifier proposal: visit:2", worthiness: 0.9, visit: 2),
         ]),
       for: siblingFence, appName: "Sibling App", rawContextKey: "raw",
       normalizedContextKey: "normalized", now: now.addingTimeInterval(-30))
 
+    let storedStatements = try await pool.read { db in
+      try String.fetchAll(db, sql: "SELECT statement FROM bucket_facts ORDER BY statement")
+    }
+    XCTAssertEqual(
+      storedStatements,
+      ["own visit fact", "sibling poolable fact", "sibling weak fact"])
+    let tagsBeforeStamp = try await pool.read { db in
+      try String.fetchAll(
+        db, sql: "SELECT workstreamTag FROM bucket_facts WHERE workstreamTag IS NOT NULL")
+    }
+    XCTAssertEqual(tagsBeforeStamp, [])
+
+    try await pool.write { db in
+      try db.execute(sql: "UPDATE bucket_facts SET workstreamTag = 'omi-app'")
+    }
+
     let liveTag = await ContextBucketStore.shared.liveWorkstreamTag(for: fence, now: now)
     XCTAssertEqual(liveTag, "omi-app")
-    let activeTags = await ContextBucketStore.shared.activeWorkstreamTags(now: now)
-    XCTAssertEqual(activeTags, ["omi-app"])
 
     let candidates = await ContextBucketStore.shared.workstreamPool(
       tag: "omi-app", excludingBucketID: "bucket", now: now)
@@ -850,7 +859,7 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
           BucketExtraction.Fact(
             statement: "validated commitment",
             identifiers: ["deadline"],
-            evidenceText: "evidence",
+            evidenceText: "deadline evidence",
             evidenceRefs: ["visit:1"],
             confidence: 1,
             notifyWorthiness: 0.6),
@@ -883,7 +892,7 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
           BucketExtraction.Fact(
             statement: "mild update",
             identifiers: ["status"],
-            evidenceText: "evidence",
+            evidenceText: "status evidence",
             evidenceRefs: ["visit:1"],
             confidence: 1,
             notifyWorthiness: 0.59)
@@ -897,6 +906,67 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
     XCTAssertFalse(
       ContextDepartureEvaluationPolicy.triggers(
         maximumValidatedWorthiness: belowResult.maximumValidatedWorthiness, flagEnabled: true))
+  }
+
+  func testWriteExtractionDropsScaffoldingGatesIdentifiersAndLeavesWorkstreamNull() async throws {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let (database, poolEpoch) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    let pool = try XCTUnwrap(database)
+    try await seedBucket(in: pool, now: now)
+    try await pool.write { db in
+      try Self.insertVisit(
+        db, id: 1, poolEpoch: poolEpoch, outcome: "completed",
+        startedAt: now.addingTimeInterval(-13), endedAt: now)
+    }
+    let fence = ContextVisitFence(
+      visitID: 1, contextGeneration: 1, poolEpoch: poolEpoch, bucketID: "bucket",
+      startedAt: now.addingTimeInterval(-13))
+
+    _ = try await ContextBucketStore.shared.writeExtraction(
+      BucketExtraction(
+        narrative: "narrative",
+        facts: [
+          BucketExtraction.Fact(
+            statement: "Ambient narrative: A Finder window labeled Downloads sits in the foreground",
+            identifiers: ["Downloads"],
+            evidenceText: "A Finder window labeled Downloads sits in the foreground",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 0.9),
+          BucketExtraction.Fact(
+            statement: "Proposed fact 1 — The board was lying",
+            identifiers: ["board"],
+            evidenceText: "The board was lying",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 0.8),
+          BucketExtraction.Fact(
+            statement: "Nik asked for the demo recording before tomorrow's launch video.",
+            identifiers: ["fact-001", "f-002", "ftn-003", "visit:9", "screenshot:42", "Nik"],
+            evidenceText: "Nik asked for the demo recording before tomorrow's launch video.",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 0.7),
+        ]),
+      for: fence, appName: "Test App", rawContextKey: "raw", normalizedContextKey: "normalized",
+      now: now)
+
+    let rows = try await pool.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          SELECT statement, identifiersJson, workstreamTag FROM bucket_facts
+          ORDER BY statement
+          """)
+    }
+    XCTAssertEqual(rows.count, 1)
+    XCTAssertEqual(
+      rows.first?["statement"] as String?,
+      "Nik asked for the demo recording before tomorrow's launch video.")
+    XCTAssertNil(rows.first?["workstreamTag"] as String?)
+    let encoded = try XCTUnwrap(rows.first?["identifiersJson"] as String?)
+    let identifiers = try JSONDecoder().decode([String].self, from: Data(encoded.utf8))
+    XCTAssertEqual(identifiers, ["Nik"])
   }
 
   private func seedBucket(in pool: DatabasePool, now: Date) async throws {

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamPoolingTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamPoolingTests.swift
@@ -100,4 +100,47 @@ final class ContextWorkstreamPoolingTests: XCTestCase {
     XCTAssertFalse(unwrapped.contains("fact-id-1"), "ids never reach the model")
     XCTAssertNil(ContextWorkstreamPooling.promptSection(tag: "omi", items: [], now: now))
   }
+
+  func testRecentContextWindowIncludesTheBoundaryAndDropsOlderFacts() {
+    let inside = item("inside", bucket: "b-inside", ageMinutes: 14)
+    let boundary = item("boundary", bucket: "b-boundary", ageMinutes: 15)
+    let justOutside = ContextWorkstreamPoolItem(
+      factID: "just-outside",
+      bucketID: "b-outside",
+      appName: "App",
+      statement: "a concrete fact",
+      notifyWorthiness: 0.7,
+      createdAt: now.addingTimeInterval(-(15 * 60 + 1)))
+    let weak = item("weak", bucket: "b-weak", worthiness: 0.59, ageMinutes: 1)
+    let selected = ContextWorkstreamPooling.selectRecent(
+      [inside, boundary, justOutside, weak], now: now)
+    XCTAssertEqual(Set(selected.map(\.factID)), ["inside", "boundary"])
+    XCTAssertFalse(selected.contains { $0.factID == "just-outside" })
+    XCTAssertFalse(selected.contains { $0.factID == "weak" })
+  }
+
+  func testRecentContextCapsOneFactPerBucketAndThreeTotal() {
+    var candidates: [ContextWorkstreamPoolItem] = []
+    for bucket in 0..<6 {
+      candidates.append(
+        item("new-\(bucket)", bucket: "b-\(bucket)", worthiness: 0.9, ageMinutes: 1))
+      candidates.append(
+        item("old-\(bucket)", bucket: "b-\(bucket)", worthiness: 0.8, ageMinutes: 2))
+    }
+    let selected = ContextWorkstreamPooling.selectRecent(candidates, now: now)
+    XCTAssertEqual(selected.count, 3)
+    XCTAssertEqual(Set(selected.map(\.bucketID)).count, 3)
+    XCTAssertTrue(selected.allSatisfy { $0.factID.hasPrefix("new-") })
+  }
+
+  func testRecentContextPromptSectionUsesTheSpecifiedHeaderAndIsNotCitable() throws {
+    let section = try XCTUnwrap(
+      ContextWorkstreamPooling.recentContextPromptSection(
+        items: [item("fact-id-9", statement: "Hermes PR is blocked on review")], now: now))
+    XCTAssertTrue(section.contains("RECENT CONTEXT FROM OTHER WINDOWS (last 15 min)"))
+    XCTAssertTrue(section.contains("not citable"))
+    XCTAssertTrue(section.contains("Hermes PR is blocked"))
+    XCTAssertFalse(section.contains("fact-id-9"))
+    XCTAssertNil(ContextWorkstreamPooling.recentContextPromptSection(items: [], now: now))
+  }
 }

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamPoolingTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamPoolingTests.swift
@@ -57,6 +57,7 @@ final class ContextWorkstreamPoolingTests: XCTestCase {
       item("below-floor", worthiness: 0.2),
       item("scaffold", statement: "Identifier proposal: visit:18"),
       item("narrative", statement: "Ambient narrative: a quiet scene unfolds"),
+      item("proposed-fact", statement: "Proposed fact 1 — The board was lying"),
     ]
     // Four eligible facts in one bucket: the per-bucket cap keeps three.
     for index in 0..<4 {
@@ -72,6 +73,7 @@ final class ContextWorkstreamPoolingTests: XCTestCase {
     XCTAssertFalse(selected.contains { $0.factID == "below-floor" })
     XCTAssertFalse(selected.contains { $0.factID == "scaffold" })
     XCTAssertFalse(selected.contains { $0.factID == "narrative" })
+    XCTAssertFalse(selected.contains { $0.factID == "proposed-fact" })
     XCTAssertEqual(
       selected.filter { $0.bucketID == "chatty" }.count, ContextWorkstreamPooling.maximumPerBucket)
   }

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -196,6 +196,55 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       "the invalid first candidate for the bucket must not claim it and drop the valid one")
   }
 
+  /// The reconciler's instruction blocks are what the constant cache keys name,
+  /// so they must not vary with the batch, and splitting them out must leave the
+  /// prompt the model receives byte-identical to the unsplit one.
+  func testReconcilerInstructionBlocksAreBatchIndependentAndComposeToTheWholePrompt() {
+    func batch(_ bucketID: String, tags: Set<String>) -> ContextWorkstreamReconcileBatch {
+      ContextWorkstreamReconcileBatch(
+        groups: [
+          ContextWorkstreamReconcileGroup(
+            bucketID: bucketID,
+            facts: [
+              ContextWorkstreamBatchFact(
+                id: "\(bucketID)-0", bucketID: bucketID, appName: "Notes",
+                statement: "PR-123 is blocked", notifyWorthiness: 0.9, createdAt: now)
+            ],
+            needsCandidate: true,
+            workstreamTag: nil)
+        ],
+        existingTags: tags)
+    }
+    let first = batch("alpha", tags: ["hermes"])
+    let second = batch("beta", tags: [])
+
+    XCTAssertNotEqual(
+      ContextWorkstreamReconciler.taggingData(batch: first),
+      ContextWorkstreamReconciler.taggingData(batch: second))
+    XCTAssertEqual(
+      ContextWorkstreamReconciler.taggingPrompt(batch: first),
+      ContextWorkstreamReconciler.taggingInstructions + "\n\n"
+        + ContextWorkstreamReconciler.taggingData(batch: first))
+    XCTAssertEqual(
+      ContextWorkstreamReconciler.candidatePrompt(groups: first.groups),
+      ContextWorkstreamReconciler.candidateInstructions + "\n\n"
+        + ContextWorkstreamReconciler.candidateData(groups: first.groups))
+    // The safety preamble must stay above every quoted statement, which means
+    // it belongs to the instruction half, not the per-pass data half.
+    XCTAssertTrue(
+      ContextWorkstreamReconciler.taggingInstructions.hasPrefix(
+        ScreenDerivedContent.untrustedPreamble))
+    XCTAssertTrue(
+      ContextWorkstreamReconciler.candidateInstructions.hasPrefix(
+        ScreenDerivedContent.untrustedPreamble))
+    XCTAssertFalse(
+      ContextWorkstreamReconciler.taggingData(batch: first).contains(
+        ScreenDerivedContent.untrustedPreamble))
+    XCTAssertNotEqual(
+      ContextPromptCacheKey.reconcilerTagging, ContextPromptCacheKey.reconcilerCandidates,
+      "two different instruction blocks under one key would only evict each other")
+  }
+
   func testConsumeAndDeclineRejectACandidateThatHasAlreadyExpired() throws {
     let queue = try migratedQueue()
     try queue.write { db in

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -164,29 +164,8 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
         triggerNote: "when relevant"),
     ]
     try queue.write { db in
-      // insertArmedCandidates itself only opens its own pool.write via the
-      // store; exercise the same guard logic directly against this queue.
-      var seen = Set<String>()
-      let groupByID = Dictionary(groups.map { ($0.bucketID, $0) }, uniquingKeysWith: { _, last in last })
-      for candidate in proposed {
-        let bucketID =
-          ContextWorkstreamTagging.resolveGroup(candidate.bucket, batchIDs: groups.map(\.bucketID))
-          ?? (groupByID[candidate.bucket] != nil ? candidate.bucket : nil)
-        guard let bucketID, !seen.contains(bucketID) else { continue }
-        let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !message.isEmpty else { continue }
-        let cited = candidate.factIDs.map { $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0 }
-          .filter { !$0.isEmpty }
-        let factIDs = try ContextProactiveCandidateWriter.validatedFactIDs(
-          cited, bucketID: bucketID, now: now, in: db)
-        guard !cited.isEmpty, Set(factIDs) == Set(cited) else { continue }
-        let trigger = candidate.triggerNote.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trigger.isEmpty else { continue }
-        seen.insert(bucketID)
-        try ContextProactiveCandidateWriter.insertArmed(
-          bucketID: bucketID, workstreamTag: nil, message: message, factIDs: factIDs,
-          triggerNote: trigger, now: now, in: db)
-      }
+      try ContextProactiveCandidateWriter.insertValidatedCandidates(
+        proposed, groups: groups, now: now, in: db)
     }
     let messages = try queue.read { db in
       try String.fetchAll(db, sql: "SELECT message FROM proactive_candidates WHERE bucketID = 'here'")
@@ -243,6 +222,124 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
     XCTAssertNotEqual(
       ContextPromptCacheKey.reconcilerTagging, ContextPromptCacheKey.reconcilerCandidates,
       "two different instruction blocks under one key would only evict each other")
+  }
+
+  func testInsertsSkipAGarbageCollectedBucketWithoutAbortingTheRestOfTheBatch() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("kept", factCount: 3, newestOffset: 0, tagged: false, in: db)
+      try seedBucket("gone", factCount: 3, newestOffset: 0, tagged: false, in: db)
+      try db.execute(sql: "DELETE FROM context_buckets WHERE id = 'gone'")
+      try ContextWorkstreamTagging.insertAssignment(
+        bucketID: "gone", tag: "hermes", now: now, in: db)
+      try ContextWorkstreamTagging.insertAssignment(
+        bucketID: "kept", tag: "hermes", now: now, in: db)
+      try ContextProactiveCandidateWriter.insertArmed(
+        bucketID: "gone", workstreamTag: "hermes",
+        message: "should not land", factIDs: ["gone-0"], triggerNote: "when relevant",
+        now: now, in: db)
+      try ContextProactiveCandidateWriter.insertArmed(
+        bucketID: "kept", workstreamTag: "hermes",
+        message: "the Hermes PR still needs review", factIDs: ["kept-0"],
+        triggerNote: "when relevant", now: now, in: db)
+    }
+    let tags = try queue.read { db in
+      try String.fetchAll(db, sql: "SELECT tag FROM bucket_workstreams ORDER BY bucketID")
+    }
+    XCTAssertEqual(tags, ["hermes"])
+    let messages = try queue.read { db in
+      try String.fetchAll(db, sql: "SELECT message FROM proactive_candidates ORDER BY message")
+    }
+    XCTAssertEqual(messages, ["the Hermes PR still needs review"])
+  }
+
+  func testDeletingABucketCascadesWorkstreamAndCandidateRows() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 1, newestOffset: 0, tagged: true, in: db)
+      try insertCandidate(
+        id: "live", bucketID: "here", tag: "hermes", message: "message", createdAt: now, in: db)
+      try db.execute(sql: "DELETE FROM context_buckets WHERE id = 'here'")
+    }
+    let leftover = try queue.read { db in
+      (
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM bucket_workstreams") ?? -1,
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM proactive_candidates") ?? -1
+      )
+    }
+    XCTAssertEqual(leftover.0, 0, "workstream rows must cascade with the bucket")
+    XCTAssertEqual(leftover.1, 0, "candidate rows must cascade with the bucket")
+  }
+
+  func testHasArmedCandidateIgnoresACandidateWhoseGroundingIsNoLongerValid() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 1, newestOffset: 0, tagged: false, in: db)
+      try insertCandidate(
+        id: "stale", bucketID: "here", tag: nil, message: "message", createdAt: now, in: db)
+      try db.execute(
+        sql: "UPDATE proactive_candidates SET groundingFactIDsJson = '[\"here-0\"]' WHERE id = 'stale'")
+      XCTAssertTrue(
+        try ContextProactiveCandidateWriter.hasArmedCandidate(bucketID: "here", now: now, in: db))
+      try db.execute(sql: "UPDATE bucket_facts SET validityState = 'rejected' WHERE id = 'here-0'")
+      XCTAssertFalse(
+        try ContextProactiveCandidateWriter.hasArmedCandidate(bucketID: "here", now: now, in: db),
+        "an ungrounded armed row must not block the reconciler from writing a replacement")
+    }
+  }
+
+  func testRestoreReArmsAConsumedCandidateAndRefusesAnExpiredOne() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 1, newestOffset: 0, tagged: false, in: db)
+      try insertCandidate(
+        id: "live", bucketID: "here", tag: nil, message: "message", createdAt: now, in: db)
+      XCTAssertTrue(try ContextProactiveCandidateLookup.consume(id: "live", now: now, in: db))
+      XCTAssertTrue(try ContextProactiveCandidateLookup.restore(id: "live", now: now, in: db))
+      XCTAssertEqual(
+        try String.fetchOne(db, sql: "SELECT state FROM proactive_candidates WHERE id = 'live'"),
+        "armed")
+      XCTAssertTrue(try ContextProactiveCandidateLookup.consume(id: "live", now: now, in: db))
+
+      try insertCandidate(
+        id: "stale", bucketID: "here", tag: nil, message: "message",
+        createdAt: now.addingTimeInterval(-13 * 60 * 60), in: db)
+      try db.execute(
+        sql: "UPDATE proactive_candidates SET state = 'consumed', consumedAt = ?, expiresAt = ? WHERE id = 'stale'",
+        arguments: [now.addingTimeInterval(-60), now.addingTimeInterval(-60)])
+      XCTAssertFalse(try ContextProactiveCandidateLookup.restore(id: "stale", now: now, in: db))
+    }
+  }
+
+  func testAssignedTagDeliveryMemorySeesASiblingBucketsDeliveredMessage() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 1, newestOffset: 0, tagged: true, in: db)
+      try seedBucket("other", factCount: 1, newestOffset: 0, tagged: true, in: db)
+      try db.execute(
+        sql: """
+          INSERT INTO proactive_deliveries
+            (id, bucketID, decisionType, lifecycleState, provenanceJson, message,
+             attemptedAt, deliveredAt, expiresAt, createdAt)
+          VALUES ('d1', 'other', 'insight', 'delivered', '{}', 'the Hermes PR still needs review',
+                  ?, ?, ?, ?)
+          """,
+        arguments: [now, now, now.addingTimeInterval(30 * 24 * 60 * 60), now])
+    }
+    let sibling = try queue.read { db in
+      try ContextProactiveCandidateLookup.recentDeliveredForAssignedTags(
+        tags: ["hermes"], excludingBucketID: "here", now: now, limit: 15, in: db)
+    }
+    XCTAssertEqual(sibling.map(\.message), ["the Hermes PR still needs review"])
+    let bucketHit = ContextProactiveCandidate(
+      id: "dup", bucketID: "other", workstreamTag: "hermes",
+      message: "the Hermes PR still needs review",
+      groundingFactIDsJson: "[\"f1\"]", triggerNote: "when the PR is open",
+      state: "armed", createdAt: now, expiresAt: now.addingTimeInterval(60), consumedAt: nil)
+    XCTAssertNil(
+      ContextProactiveCandidateLookup.firstDeliverable(
+        candidates: [bucketHit], recentMessages: sibling.compactMap(\.message)),
+      "a workstream-matched candidate must not re-send a sibling bucket's delivered point")
   }
 
   func testConsumeAndDeclineRejectACandidateThatHasAlreadyExpired() throws {

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -115,6 +115,109 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
     XCTAssertFalse(accepted.contains { $0.bucketID == "b5" })
   }
 
+  func testLabelAppearsInObservationsRequiresAWholeWordNotAnIncidentalSubstring() {
+    XCTAssertTrue(
+      ContextWorkstreamTagging.labelAppearsInObservations(
+        "car-project", observations: "The CAR contract review is due Friday."))
+    XCTAssertFalse(
+      ContextWorkstreamTagging.labelAppearsInObservations(
+        "car-project", observations: "Please concatenate the two reports."),
+      "\"car\" inside \"concatenate\" must not count as the word appearing")
+  }
+
+  func testAcceptedAssignmentsLetALaterValidAssignmentWinAfterAnEarlierInvalidOneForTheSameBucket() {
+    let response = ContextWorkstreamTagging.Response(
+      workstreams: [.init(label: "Hermes", evidence: "two groups")],
+      assignments: [
+        // b1's first assignment is null (a legitimate "no label" response)
+        // and must not block b1's later valid assignment for the same group.
+        .init(group: "G1", label: nil),
+        .init(group: "G1", label: "Hermes"),
+        .init(group: "G2", label: "Hermes"),
+      ])
+    let accepted = ContextWorkstreamTagging.acceptedAssignments(
+      response: response,
+      batchIDs: ["b1", "b2"],
+      existingTags: [],
+      observations: "Hermes PR blocked.")
+    XCTAssertEqual(
+      Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
+      ["b1:hermes", "b2:hermes"],
+      "the invalid first assignment for b1 must not claim the bucket and drop the valid one")
+  }
+
+  func testInsertArmedCandidatesLetsALaterValidCandidateWinAfterAnEarlierInvalidOneForTheSameBucket() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 3, newestOffset: 0, tagged: false, in: db)
+    }
+    let groups = [
+      ContextWorkstreamReconcileGroup(
+        bucketID: "here", facts: [], needsCandidate: true, workstreamTag: nil)
+    ]
+    let proposed: [ContextProactiveCandidateWriter.Response.Candidate] = [
+      // First candidate for "here" is invalid (empty message) and must not
+      // claim the bucket ahead of the later valid candidate.
+      .init(bucket: "here", message: "   ", factIDs: ["fact:here-0"], triggerNote: "when relevant"),
+      .init(
+        bucket: "here", message: "the Hermes PR still needs review", factIDs: ["fact:here-0"],
+        triggerNote: "when relevant"),
+    ]
+    try queue.write { db in
+      // insertArmedCandidates itself only opens its own pool.write via the
+      // store; exercise the same guard logic directly against this queue.
+      var seen = Set<String>()
+      let groupByID = Dictionary(groups.map { ($0.bucketID, $0) }, uniquingKeysWith: { _, last in last })
+      for candidate in proposed {
+        let bucketID =
+          ContextWorkstreamTagging.resolveGroup(candidate.bucket, batchIDs: groups.map(\.bucketID))
+          ?? (groupByID[candidate.bucket] != nil ? candidate.bucket : nil)
+        guard let bucketID, !seen.contains(bucketID) else { continue }
+        let message = candidate.message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { continue }
+        let cited = candidate.factIDs.map { $0.hasPrefix("fact:") ? String($0.dropFirst(5)) : $0 }
+          .filter { !$0.isEmpty }
+        let factIDs = try ContextProactiveCandidateWriter.validatedFactIDs(
+          cited, bucketID: bucketID, now: now, in: db)
+        guard !cited.isEmpty, Set(factIDs) == Set(cited) else { continue }
+        let trigger = candidate.triggerNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trigger.isEmpty else { continue }
+        seen.insert(bucketID)
+        try ContextProactiveCandidateWriter.insertArmed(
+          bucketID: bucketID, workstreamTag: nil, message: message, factIDs: factIDs,
+          triggerNote: trigger, now: now, in: db)
+      }
+    }
+    let messages = try queue.read { db in
+      try String.fetchAll(db, sql: "SELECT message FROM proactive_candidates WHERE bucketID = 'here'")
+    }
+    XCTAssertEqual(
+      messages, ["the Hermes PR still needs review"],
+      "the invalid first candidate for the bucket must not claim it and drop the valid one")
+  }
+
+  func testConsumeAndDeclineRejectACandidateThatHasAlreadyExpired() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 1, newestOffset: 0, tagged: false, in: db)
+      try insertCandidate(
+        id: "stale", bucketID: "here", tag: nil, message: "message",
+        createdAt: now.addingTimeInterval(-13 * 60 * 60), in: db)
+      try db.execute(
+        sql: "UPDATE proactive_candidates SET expiresAt = ? WHERE id = 'stale'",
+        arguments: [now.addingTimeInterval(-60)])
+      XCTAssertFalse(
+        try ContextProactiveCandidateLookup.consume(id: "stale", now: now, in: db),
+        "a candidate that expired while the gate call was in flight must not be consumable")
+      XCTAssertFalse(
+        try ContextProactiveCandidateLookup.decline(id: "stale", now: now, in: db))
+
+      try insertCandidate(
+        id: "live", bucketID: "here", tag: nil, message: "message", createdAt: now, in: db)
+      XCTAssertTrue(try ContextProactiveCandidateLookup.consume(id: "live", now: now, in: db))
+    }
+  }
+
   func testCandidateLookupPrefersABucketMatchOverANewerWorkstreamMatch() throws {
     let queue = try migratedQueue()
     try queue.write { db in

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -1,0 +1,272 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class ContextWorkstreamReconcilerTests: XCTestCase {
+  private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+  func testBatchSelectionRanksUntaggedThenFactCountThenRecencyAndCapsExploration() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      // 16 eligible buckets: first 14 untagged with decreasing fact counts,
+      // then 2 tagged with high fact counts that must sort after untagged.
+      for index in 1...14 {
+        try seedBucket(
+          "u-\(index)", factCount: 17 - index,
+          newestOffset: TimeInterval(index), tagged: false, in: db)
+      }
+      try seedBucket("t-high", factCount: 40, newestOffset: 0, tagged: true, in: db)
+      try seedBucket("t-mid", factCount: 20, newestOffset: 0, tagged: true, in: db)
+      try seedBucket("too-few", factCount: 2, newestOffset: 0, tagged: false, in: db)
+    }
+
+    let eligible = try queue.read { db in
+      try ContextWorkstreamBatchSelection.fetchEligible(in: db, now: now)
+    }
+    XCTAssertFalse(eligible.contains { $0.bucketID == "too-few" })
+    XCTAssertEqual(eligible.first?.bucketID, "u-1", "untagged + most facts ranks first")
+    XCTAssertEqual(Array(eligible.map(\.bucketID).prefix(14)), (1...14).map { "u-\($0)" })
+    XCTAssertEqual(
+      eligible.suffix(2).map(\.bucketID), ["t-high", "t-mid"],
+      "tagged buckets sort after every untagged eligible bucket")
+
+    let ranked = eligible.map(\.bucketID)
+    let swapped = ContextWorkstreamBatchSelection.applyExploration(rankedIDs: ranked) { pool, count in
+      Array(pool.suffix(count))
+    }
+    XCTAssertEqual(swapped.count, 12)
+    XCTAssertEqual(Array(swapped.prefix(10)), (1...10).map { "u-\($0)" })
+    XCTAssertEqual(Array(swapped.suffix(2)), ["t-high", "t-mid"])
+    XCTAssertFalse(swapped.contains("u-11"))
+    XCTAssertFalse(swapped.contains("u-12"))
+
+    let capped = ContextWorkstreamBatchSelection.applyExploration(rankedIDs: ranked) { pool, _ in
+      pool
+    }
+    XCTAssertEqual(capped.count, ContextWorkstreamBatchSelection.batchCap)
+    XCTAssertEqual(Array(capped.prefix(10)), (1...10).map { "u-\($0)" })
+  }
+
+  func testBatchSelectionKeepsAShortRankingIntact() {
+    XCTAssertEqual(
+      ContextWorkstreamBatchSelection.applyExploration(rankedIDs: ["a", "b", "c"]),
+      ["a", "b", "c"])
+  }
+
+  func testSelectFactsDropsScaffoldingAndKeepsHighestWorthiness() {
+    let facts = [
+      fact("scaffold", statement: "Identifier proposal: visit:1", worthiness: 0.99),
+      fact("weak", worthiness: 0.4),
+      fact("strong", worthiness: 0.9),
+      fact("mid", worthiness: 0.7),
+      fact("also-strong", worthiness: 0.85),
+      fact("fifth", worthiness: 0.6),
+      fact("sixth", worthiness: 0.55),
+    ]
+    XCTAssertEqual(
+      ContextWorkstreamBatchSelection.selectFacts(facts).map(\.id),
+      ["strong", "also-strong", "mid", "fifth", "sixth"])
+  }
+
+  func testLabelSanitisationAndInsertOrIgnoreNeverDeletesAnExistingAssignment() throws {
+    XCTAssertEqual(ContextWorkstreamTag.sanitize("Hermes"), "hermes")
+    XCTAssertNil(ContextWorkstreamTag.sanitize("unknown"))
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("bucket-a", factCount: 3, newestOffset: 0, tagged: false, in: db)
+      try ContextWorkstreamTagging.insertAssignment(
+        bucketID: "bucket-a", tag: "hermes", now: now, in: db)
+      try ContextWorkstreamTagging.insertAssignment(
+        bucketID: "bucket-a", tag: "hermes", now: now.addingTimeInterval(60), in: db)
+      try ContextWorkstreamTagging.insertAssignment(
+        bucketID: "bucket-a", tag: "car", now: now, in: db)
+    }
+    let rows = try queue.read { db in
+      try Row.fetchAll(
+        db, sql: "SELECT tag FROM bucket_workstreams WHERE bucketID = 'bucket-a' ORDER BY tag")
+    }
+    XCTAssertEqual(rows.map { $0["tag"] as String }, ["car", "hermes"])
+  }
+
+  func testAcceptedAssignmentsRequireTwoGroupsForANewLabelAndKeepExistingOnes() {
+    let response = ContextWorkstreamTagging.Response(
+      workstreams: [
+        .init(label: "Hermes", evidence: "two groups"),
+        .init(label: "solo", evidence: "one group"),
+      ],
+      assignments: [
+        .init(group: "G1", label: "Hermes"),
+        .init(group: "G2", label: "Hermes"),
+        .init(group: "G3", label: "solo"),
+        .init(group: "G4", label: "car"),
+        .init(group: "G5", label: nil),
+      ])
+    let accepted = ContextWorkstreamTagging.acceptedAssignments(
+      response: response,
+      batchIDs: ["b1", "b2", "b3", "b4", "b5"],
+      existingTags: ["car"],
+      observations: "Hermes PR blocked. CAR contract review. solo note.")
+    XCTAssertEqual(
+      Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
+      ["b1:hermes", "b2:hermes", "b4:car"])
+    XCTAssertFalse(accepted.contains { $0.tag == "solo" })
+    XCTAssertFalse(accepted.contains { $0.bucketID == "b5" })
+  }
+
+  func testCandidateLookupPrefersABucketMatchOverANewerWorkstreamMatch() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 3, newestOffset: 0, tagged: true, in: db)
+      try seedBucket("other", factCount: 3, newestOffset: 0, tagged: true, in: db)
+      try insertCandidate(
+        id: "bucket-hit", bucketID: "here", tag: nil,
+        message: "the Hermes PR still needs review", createdAt: now.addingTimeInterval(-120),
+        in: db)
+      try insertCandidate(
+        id: "workstream-hit", bucketID: "other", tag: "hermes",
+        message: "CAR signature is due Friday", createdAt: now.addingTimeInterval(-10),
+        in: db)
+    }
+    let found = try queue.read { db in
+      try ContextProactiveCandidateLookup.lookupArmed(
+        bucketID: "here", tags: ["hermes"], now: now, in: db)
+    }
+    XCTAssertEqual(found.map(\.id), ["bucket-hit", "workstream-hit"])
+  }
+
+  func testDuplicateSuppressionSkipsACandidateThatRepeatsARecentDelivery() {
+    let bucketHit = ContextProactiveCandidate(
+      id: "dup", bucketID: "here", workstreamTag: nil,
+      message: "the Hermes PR still needs review",
+      groundingFactIDsJson: "[\"f1\"]", triggerNote: "when the PR is open",
+      state: "armed", createdAt: now, expiresAt: now.addingTimeInterval(60), consumedAt: nil)
+    let other = ContextProactiveCandidate(
+      id: "fresh", bucketID: "here", workstreamTag: nil,
+      message: "CAR signature is due Friday",
+      groundingFactIDsJson: "[\"f2\"]", triggerNote: "when the contract is open",
+      state: "armed", createdAt: now, expiresAt: now.addingTimeInterval(60), consumedAt: nil)
+    XCTAssertNil(
+      ContextProactiveCandidateLookup.firstDeliverable(
+        candidates: [bucketHit],
+        recentMessages: ["The Hermes PR still needs review"]))
+    XCTAssertEqual(
+      ContextProactiveCandidateLookup.firstDeliverable(
+        candidates: [bucketHit, other],
+        recentMessages: ["The Hermes PR still needs review"])?.id,
+      "fresh")
+  }
+
+  func testGateResponseParsingAcceptsBooleansAndFailsClosedOnMalformedPayloads() {
+    XCTAssertEqual(
+      ContextProactiveCandidateGate.parse(#"{"show":true,"reason":"adds a deadline"}"#),
+      ContextProactiveCandidateGate.Decision(show: true, reason: "adds a deadline"))
+    XCTAssertEqual(
+      ContextProactiveCandidateGate.parse(#"{"show":false,"reason":"already on screen"}"#)?.show,
+      false)
+    XCTAssertNil(ContextProactiveCandidateGate.parse("{"))
+    XCTAssertNil(ContextProactiveCandidateGate.parse(#"{"show":"yes","reason":"nope"}"#))
+    XCTAssertNil(ContextProactiveCandidateGate.parse(#"{"reason":"missing show"}"#))
+  }
+
+  func testCandidateWriterDropsGroundingThatIsNotPresentAndValidated() throws {
+    let queue = try migratedQueue()
+    try queue.write { db in
+      try seedBucket("here", factCount: 3, newestOffset: 0, tagged: false, in: db)
+      let valid = try ContextProactiveCandidateWriter.validatedFactIDs(
+        ["here-0", "missing"], bucketID: "here", now: now, in: db)
+      XCTAssertEqual(valid, ["here-0"])
+      try db.execute(sql: "UPDATE bucket_facts SET validityState = 'rejected' WHERE id = 'here-1'")
+      XCTAssertEqual(
+        try ContextProactiveCandidateWriter.validatedFactIDs(
+          ["here-1"], bucketID: "here", now: now, in: db),
+        [])
+    }
+  }
+
+  private func fact(
+    _ id: String, statement: String = "a concrete fact", worthiness: Double
+  ) -> ContextWorkstreamBatchFact {
+    ContextWorkstreamBatchFact(
+      id: id, bucketID: "b", appName: "App", statement: statement,
+      notifyWorthiness: worthiness, createdAt: now)
+  }
+
+  private func seedBucket(
+    _ id: String, factCount: Int, newestOffset: TimeInterval, tagged: Bool, in db: Database
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO context_buckets (id, subjectKind, subjectID, createdAt, updatedAt)
+        VALUES (?, 'task', ?, ?, ?)
+        """,
+      arguments: [id, id, now, now])
+    let visitID =
+      (try Int64.fetchOne(db, sql: "SELECT COALESCE(MAX(id), 0) FROM context_visits") ?? 0) + 1
+    try db.execute(
+      sql: """
+        INSERT INTO context_visits
+          (id, contextGeneration, poolEpoch, bucketID, appName, rawContextKey,
+           normalizedContextKey, referenceHash, startedAt, outcome, createdAt, updatedAt)
+        VALUES (?, 1, 1, ?, 'App', 'raw', 'normalized', ?, ?, 'completed', ?, ?)
+        """,
+      arguments: [visitID, id, "ref-\(id)", now, now, now])
+    try db.execute(
+      sql: """
+        INSERT INTO bucket_entries
+          (id, bucketID, visitID, appName, rawContextKey, normalizedContextKey,
+           narrative, evidenceRefsJson, tokenCount, createdAt)
+        VALUES (?, ?, ?, 'App', 'raw', 'normalized', 'narrative', '[]', 1, ?)
+        """,
+      arguments: ["entry-\(id)", id, visitID, now])
+    for index in 0..<factCount {
+      try db.execute(
+        sql: """
+          INSERT INTO bucket_facts
+            (id, bucketID, entryID, appName, statement, identifiersJson, evidenceText,
+             evidenceRefsJson, validityState, dispositionState, confidence,
+             notifyWorthiness, createdAt, updatedAt)
+          VALUES (?, ?, ?, 'App', ?, '[]', 'evidence', '[]', 'validated', 'none', 1, 0.7, ?, ?)
+          """,
+        arguments: [
+          "\(id)-\(index)", id, "entry-\(id)", "fact \(index) about \(id)",
+          now.addingTimeInterval(-newestOffset - TimeInterval(index)), now,
+        ])
+    }
+    if tagged {
+      try ContextWorkstreamTagging.insertAssignment(
+        bucketID: id, tag: "hermes", now: now, in: db)
+    }
+  }
+
+  private func insertCandidate(
+    id: String, bucketID: String, tag: String?, message: String, createdAt: Date, in db: Database
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO proactive_candidates
+          (id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
+           state, createdAt, expiresAt)
+        VALUES (?, ?, ?, ?, '["f1"]', 'when relevant', 'armed', ?, ?)
+        """,
+      arguments: [id, bucketID, tag, message, createdAt, now.addingTimeInterval(12 * 60 * 60)])
+  }
+
+  private func migratedQueue() throws -> DatabaseQueue {
+    let queue = try DatabaseQueue()
+    try queue.write { db in
+      try db.create(table: "screenshots") { table in
+        table.autoIncrementedPrimaryKey("id")
+        table.column("timestamp", .datetime).notNull()
+        table.column("appName", .text).notNull()
+      }
+    }
+    var migrator = DatabaseMigrator()
+    let defaults = try XCTUnwrap(
+      UserDefaults(suiteName: "ContextWorkstreamReconcilerTests.\(UUID().uuidString)"))
+    ContextBucketSchema.registerMigration(on: &migrator, defaults: defaults, ownerID: "owner")
+    try migrator.migrate(queue)
+    return queue
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260815-director-prompt-cache-and-context-depth.json
+++ b/desktop/macos/changelog/unreleased/20260815-director-prompt-cache-and-context-depth.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive context notifications now remember far more of what was already sent and carry substantially more of a context's history, so they repeat themselves less and pick up on longer-running work"
+}

--- a/desktop/macos/changelog/unreleased/20260815-extraction-prompt-contamination.json
+++ b/desktop/macos/changelog/unreleased/20260815-extraction-prompt-contamination.json
@@ -1,3 +1,3 @@
 {
-  "change": "Proactive context facts are now plain actionable sentences, without prompt jargon or invented identifiers"
+  "change": "Proactive context facts are now clearer, plain-language, actionable sentences"
 }

--- a/desktop/macos/changelog/unreleased/20260815-extraction-prompt-contamination.json
+++ b/desktop/macos/changelog/unreleased/20260815-extraction-prompt-contamination.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive context facts are now plain actionable sentences, without prompt jargon or invented identifiers"
+}

--- a/desktop/macos/changelog/unreleased/20260815-proactive-notification-repetition.json
+++ b/desktop/macos/changelog/unreleased/20260815-proactive-notification-repetition.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive context notifications no longer repeat a point already delivered, and stay silent when they would only narrate what is already on screen"
+}

--- a/desktop/macos/changelog/unreleased/20260815-workstream-candidates.json
+++ b/desktop/macos/changelog/unreleased/20260815-workstream-candidates.json
@@ -1,3 +1,0 @@
-{
-  "change": "Proactive context now remembers ongoing projects across apps and can notify from that memory instead of re-deciding from scratch each time"
-}

--- a/desktop/macos/changelog/unreleased/20260815-workstream-candidates.json
+++ b/desktop/macos/changelog/unreleased/20260815-workstream-candidates.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive context now remembers ongoing projects across apps and can notify from that memory instead of re-deciding from scratch each time"
+}

--- a/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
+++ b/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
@@ -18,6 +18,7 @@ covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketSchema.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamPooling.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketsFeature.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDestinationKey.swift


### PR DESCRIPTION
## Resolves cubic-dev-ai review

Addresses the automated review comments from cubic-dev-ai on this PR
(confidence 2/5, 20 issues across 20 files). Fixed the real defects in the
candidate-lifecycle, reconciler, and identifier-matching logic; rejected the
architecture-opinion and speculative-refactor comments; deferred/reworded the
two changelog fragments.

See the inline replies on each review comment for the fix-or-reject rationale
per issue.

Failure-Class: none

## Product invariants affected

- INV-AUTH-1

Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1594 -> 1597 | pre-existing growth from an earlier commit on this branch (b6e1bca122, wiring ContextWorkstreamReconciler.start()/stop() into the app delegate lifecycle) — not touched by this cubic-review-resolution change; no lines added or removed here.

### Build / test

- `xcrun swift build -c debug --package-path Desktop` — clean
- `xcrun swift test --package-path Desktop --filter 'Context'` — 362/362
  passing (357 baseline + 5 new regression tests for the ordering/expiry-race
  fixes)

## Prompt-cache prefix rework (added)

The director's stable prompt was never cacheable. `header` carried `"\(visitCount) qualifying
visits."` and sat ABOVE the byte range the code itself annotates as "the stable cache prefix", so a
per-visit counter invalidated everything behind it. Measured across two consecutive visits, the
genuinely byte-identical prefix was **2,046 bytes / ~511 tokens** — below the provider's 1,024-token
minimum, which is the arithmetic behind an observed 2% cache-hit rate over 99 real director calls.

Changes: the visit count moves into the volatile section and the header becomes constant; the cache
key becomes the constant `director:v1` instead of `bucket:<id>:v<version>`, which churned on every
completed visit; `assemble()` is reordered least-volatile-first (header, frozen segment, validated
facts, rolling tail last); recent deliveries render an absolute timestamp instead of a relative age
so the block is byte-stable, and the cap rises from 6 to 15; the frozen-history budget grows from
6,000 to 16,000 bytes, with the injection budget raised to 7,500 tokens so facts and the tail still
survive at maximum frozen size. The reconciler gains constant cache keys, a stable/volatile split,
and a 15-minute cadence.

Resulting stable prefix: **10,887 bytes (~2,721 tokens) from the header and ordering fixes alone**,
20,887 bytes (~5,221 tokens) with the larger frozen budget.

Carrying 15 recent deliveries instead of 3 truncated ones is also the strongest repetition fix in
this PR: the prompt instructs the director not to re-deliver a delivered point while showing it only
a handful of truncated messages.

**Depends on #11647.** That PR makes cache reads possible at all; without it a larger stable prefix
crosses the provider's floor and pays unreadable cache writes at $0.25/1M. Land #11647 first.
