### PR TITLE
Size proactive quota ceilings per desktop access tier

### DIFF
--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -28,6 +28,7 @@ from utils.observability.fallback import record_fallback
 from utils.other.endpoints import get_current_user_uid
 from utils.subscription import (
     DESKTOP_ACCESS_TIER_ARCHITECT,
+    DESKTOP_ACCESS_TIER_FREE,
     DESKTOP_ACCESS_TIER_FULL,
     effective_desktop_access_tier,
     is_desktop_trial_paywalled,
@@ -38,12 +39,17 @@ logger = logging.getLogger(__name__)
 
 _MAX_REQUEST_BYTES = 5 * 1024 * 1024
 _QUOTA_WINDOW_SECONDS = 24 * 60 * 60
-_OPERATION_DAILY_LIMITS = {
-    # Extraction can precede reasoning for several context buckets. Keep its
-    # server ceiling at twice the Maximum client director budget so lower
-    # notification levels remain governed by their device-side frequency gate.
-    "proactive_extraction": 200,
-    "proactive_reasoning": 100,
+# Explicit per-tier ceilings. These are deliberately not a constant multiple of
+# a shared base row: measured desktop dogfooding runs ~37 extraction calls per
+# hour of active use, so the architect extraction ceiling is sized for a genuine
+# 24-hour day (~888 calls) plus burst headroom, while reasoning is sized for a
+# background reconciler that batches ~2 calls per pass on top of the per-visit
+# gate and director calls. Lower tiers are sized for a partial day and stay
+# governed by the device-side frequency gate.
+_TIER_DAILY_LIMITS: dict[str, dict[str, int]] = {
+    DESKTOP_ACCESS_TIER_FREE: {"proactive_extraction": 150, "proactive_reasoning": 60},
+    DESKTOP_ACCESS_TIER_FULL: {"proactive_extraction": 1000, "proactive_reasoning": 500},
+    DESKTOP_ACCESS_TIER_ARCHITECT: {"proactive_extraction": 2000, "proactive_reasoning": 1000},
 }
 _OPERATION_LANES = {
     "proactive_extraction": "omi:auto:desktop-proactive-extraction",
@@ -152,8 +158,10 @@ def _quota_limit_for_subscription(operation: ProactiveOperation, subscription: S
     """Return the server-authoritative proactive ceiling for a verified plan."""
     plan = subscription.plan if subscription is not None else PlanType.basic
     tier = effective_desktop_access_tier(plan, subscription)
-    multiplier = 4 if tier == DESKTOP_ACCESS_TIER_ARCHITECT else 2 if tier == DESKTOP_ACCESS_TIER_FULL else 1
-    return _OPERATION_DAILY_LIMITS[operation.value] * multiplier
+    # Keep the lookup total: an unrecognised tier resolves to the free row
+    # rather than raising, so a new tier string can never 500 the lane.
+    limits = _TIER_DAILY_LIMITS.get(tier, _TIER_DAILY_LIMITS[DESKTOP_ACCESS_TIER_FREE])
+    return limits[operation.value]
 
 
 class ProactiveOperation(str, Enum):

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -9,7 +9,12 @@ import pytest
 from fastapi import Response
 
 from routers import desktop_proactivity
-from utils.subscription import NEO_DESKTOP_GRANDFATHER_CUTOFF
+from utils.subscription import (
+    DESKTOP_ACCESS_TIER_ARCHITECT,
+    DESKTOP_ACCESS_TIER_FREE,
+    DESKTOP_ACCESS_TIER_FULL,
+    NEO_DESKTOP_GRANDFATHER_CUTOFF,
+)
 
 
 def request(operation: str = "proactive_extraction", *, cache_key: str | None = None):
@@ -122,7 +127,7 @@ async def test_quota_is_allowed_based_and_fails_closed(monkeypatch):
     assert exhausted.value.status_code == 429
     assert exhausted.value.headers == {
         "Retry-After": "19",
-        "X-Proactive-Quota-Limit": "200",
+        "X-Proactive-Quota-Limit": "150",
         "X-Proactive-Quota-Remaining": "0",
         "X-Proactive-Quota-Reset": "19",
     }
@@ -141,8 +146,8 @@ async def test_quota_is_allowed_based_and_fails_closed(monkeypatch):
 @pytest.mark.parametrize(
     ("operation", "expected_limit"),
     [
-        (desktop_proactivity.ProactiveOperation.EXTRACTION, 200),
-        (desktop_proactivity.ProactiveOperation.REASONING, 100),
+        (desktop_proactivity.ProactiveOperation.EXTRACTION, 150),
+        (desktop_proactivity.ProactiveOperation.REASONING, 60),
     ],
 )
 async def test_quota_matches_expanded_director_budget(monkeypatch, operation, expected_limit):
@@ -183,11 +188,11 @@ async def test_quota_headers_present_on_success(monkeypatch):
     )
 
     state = await desktop_proactivity._consume_quota("user-1", desktop_proactivity.ProactiveOperation.EXTRACTION)
-    assert state == desktop_proactivity.ProactiveQuotaState(limit=200, remaining=12, reset_seconds=3600)
+    assert state == desktop_proactivity.ProactiveQuotaState(limit=150, remaining=12, reset_seconds=3600)
 
     response = Response()
     desktop_proactivity._apply_quota_headers(response, state)
-    assert response.headers["X-Proactive-Quota-Limit"] == "200"
+    assert response.headers["X-Proactive-Quota-Limit"] == "150"
     assert response.headers["X-Proactive-Quota-Remaining"] == "12"
     assert response.headers["X-Proactive-Quota-Reset"] == "3600"
     assert "retry-after" not in {name.lower() for name in response.headers.keys()}
@@ -258,11 +263,55 @@ def test_release_after_delete_does_not_go_negative():
 
 
 @pytest.mark.parametrize(
+    ("tier", "extraction_limit", "reasoning_limit"),
+    [
+        (DESKTOP_ACCESS_TIER_FREE, 150, 60),
+        (DESKTOP_ACCESS_TIER_FULL, 1000, 500),
+        (DESKTOP_ACCESS_TIER_ARCHITECT, 2000, 1000),
+    ],
+)
+def test_each_tier_resolves_to_its_exact_limit_pair(monkeypatch, tier, extraction_limit, reasoning_limit):
+    monkeypatch.setattr(desktop_proactivity, "effective_desktop_access_tier", lambda *_args, **_kwargs: tier)
+    subscription = SimpleNamespace(plan=desktop_proactivity.PlanType.basic)
+    assert (
+        desktop_proactivity._quota_limit_for_subscription(
+            desktop_proactivity.ProactiveOperation.EXTRACTION, subscription
+        )
+        == extraction_limit
+    )
+    assert (
+        desktop_proactivity._quota_limit_for_subscription(
+            desktop_proactivity.ProactiveOperation.REASONING, subscription
+        )
+        == reasoning_limit
+    )
+
+
+def test_unknown_tier_falls_back_to_free_row_without_raising(monkeypatch):
+    monkeypatch.setattr(
+        desktop_proactivity, "effective_desktop_access_tier", lambda *_args, **_kwargs: "desktop_does_not_exist"
+    )
+    subscription = SimpleNamespace(plan=desktop_proactivity.PlanType.basic)
+    assert (
+        desktop_proactivity._quota_limit_for_subscription(
+            desktop_proactivity.ProactiveOperation.EXTRACTION, subscription
+        )
+        == 150
+    )
+    assert (
+        desktop_proactivity._quota_limit_for_subscription(
+            desktop_proactivity.ProactiveOperation.REASONING, subscription
+        )
+        == 60
+    )
+
+
+@pytest.mark.parametrize(
     ("plan", "reasoning_limit", "extraction_limit"),
     [
-        (desktop_proactivity.PlanType.basic, 100, 200),
-        (desktop_proactivity.PlanType.operator, 200, 400),
-        (desktop_proactivity.PlanType.architect, 400, 800),
+        (desktop_proactivity.PlanType.basic, 60, 150),
+        (desktop_proactivity.PlanType.operator, 500, 1000),
+        (desktop_proactivity.PlanType.architect, 1000, 2000),
     ],
 )
 def test_quota_limit_scales_from_server_verified_subscription(plan, reasoning_limit, extraction_limit):
@@ -288,13 +337,13 @@ def test_post_cutoff_neo_uses_free_quota_while_grandfathered_neo_keeps_full_quot
 
     assert (
         desktop_proactivity._quota_limit_for_subscription(desktop_proactivity.ProactiveOperation.REASONING, post_cutoff)
-        == 100
+        == 60
     )
     assert (
         desktop_proactivity._quota_limit_for_subscription(
             desktop_proactivity.ProactiveOperation.REASONING, grandfathered
         )
-        == 200
+        == 500
     )
 
 

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -150,7 +150,7 @@ async def test_quota_is_allowed_based_and_fails_closed(monkeypatch):
         (desktop_proactivity.ProactiveOperation.REASONING, 60),
     ],
 )
-async def test_quota_matches_expanded_director_budget(monkeypatch, operation, expected_limit):
+async def test_quota_reservation_uses_the_free_row_and_daily_window(monkeypatch, operation, expected_limit):
     observed = {}
 
     async def run_blocking(_, function, *args, **kwargs):


### PR DESCRIPTION
## Why

Desktop dogfooding runs ~37 extraction calls per hour of active use. Today's ceilings come from a
flat base (200 extraction / 100 reasoning) times a tier multiplier (x1 free, x2 full, x4 architect),
giving free 200/100, full 400/200, architect 800/400.

Architect's 800 is about 21 hours at the measured rate, with no headroom for the bursts that follow
a cold start — every context needs a second sighting to promote a bucket, so a fresh profile
generates a spike of extraction demand. A real dogfood session hit exactly 800 and stalled for an
hour behind a quota cooldown, which reads as a dead pipeline rather than a spent budget.

Reasoning needs resizing for a different reason: the background workstream reconciler batches ~2
calls per pass on a 10-15 minute cadence, which alone approaches the old 100/day free ceiling
before any director or gate call.

## What changed

Replaces base-times-multiplier with an explicit per-tier table, because the new ceilings are not a
constant ratio:

| tier | proactive_extraction | proactive_reasoning |
|---|---|---|
| free | 150 | 60 |
| full | 1000 | 500 |
| architect | 2000 | 1000 |

Architect is sized for a genuine 24-hour day (~888 calls at the measured rate) with burst headroom.
The lookup is total: an unrecognised tier resolves to the free row rather than raising.
`ProactiveQuotaState`, the quota headers, reservation/release and the 24h window are unchanged.

## User-visible regression, called out deliberately

Free drops from an effective 200/100 to 150/60 — 25% less extraction, 40% less reasoning. This is
intentional and approved, but it is the one change here that makes an existing tier smaller.

## Validation

`tests/unit/test_desktop_proactivity.py` — 31 passed, including two new tests pinning each tier to
its exact pair and asserting the unknown-tier fallback. Related suites (subscription plans,
subscription restructure, free quota gate wiring, desktop message quota router) — 104 passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

