### PR TITLE
Fix proactive prompt-cache reads: stop discarding the cache breakpoint on the direct path

### DIFF
--- a/backend/routers/desktop_proactivity.py
+++ b/backend/routers/desktop_proactivity.py
@@ -23,6 +23,7 @@ from utils.http_client import get_llm_gateway_client, get_llm_gateway_semaphore
 from utils.llm.desktop_llm_stub import llm_stub_enabled
 from utils.llm.gateway_client import llm_gateway_headers
 from utils.llm.gateway_observability import record_direct_exception_surface
+from utils.llm.prompt_cache import EXPLICIT_CACHE_OPTIONS, has_cacheable_prefix
 from utils.llm.providers import get_openai_api_key
 from utils.observability.fallback import record_fallback
 from utils.other.endpoints import get_current_user_uid
@@ -126,9 +127,14 @@ def _proactive_provider_request(request: "ProactiveCompletionRequest", uid: str,
     # budget on hidden reasoning. Extraction then returns an empty message with
     # finish_reason=length instead of the required strict JSON payload.
     payload["reasoning_effort"] = "minimal" if request.operation == ProactiveOperation.EXTRACTION else "medium"
-    # These are gateway cache extensions, not OpenAI request fields.
-    payload["messages"] = request.messages
-    payload.pop("prompt_cache_key", None)
+    # Keep the breakpointed messages built above. The desktop client packs the stable
+    # bucket prompt, the volatile frame metadata and the screenshot into ONE user
+    # message, and the provider only serves a cache read from a prefix that ends on a
+    # message boundary or on an explicit breakpoint. Replacing these with the raw
+    # request messages removes the only readable boundary in the prompt, which charges
+    # a full cache write on every call and lets no read ever hit.
+    # prompt_cache_options and metadata are gateway extensions, not OpenAI request
+    # fields; prompt_cache_key is a real OpenAI field and is kept.
     payload.pop("prompt_cache_options", None)
     payload.pop("metadata", None)
     record_fallback(
@@ -336,11 +342,29 @@ def _gateway_payload(request: ProactiveCompletionRequest) -> dict[str, Any]:
             "parser_version": "desktop_proactive_json.v1",
         },
     }
-    if request.cache_key is not None:
+    if request.cache_key is not None and has_cacheable_prefix(_stable_prefix_text(request.messages)):
         payload["prompt_cache_key"] = request.cache_key
-        payload["prompt_cache_options"] = {"mode": "explicit", "ttl": "30m"}
+        payload["prompt_cache_options"] = dict(EXPLICIT_CACHE_OPTIONS)
         payload["messages"] = _add_explicit_cache_breakpoint(request.messages)
     return payload
+
+
+def _stable_prefix_text(messages: list[dict[str, Any]]) -> str:
+    """Return the text a breakpoint would mark as cacheable, for a size preflight.
+
+    A prefix under the provider minimum is never served back as a read, so marking
+    it buys nothing. Mirrors the message chosen by ``_add_explicit_cache_breakpoint``.
+    """
+    for message in reversed(messages):
+        content = message.get("content")
+        if isinstance(content, list):
+            first = next((part for part in content if isinstance(part, dict)), None)
+            if first is not None and first.get("type") == "text" and isinstance(first.get("text"), str):
+                return first["text"]
+            return ""
+        if isinstance(content, str):
+            return content
+    return ""
 
 
 def _add_explicit_cache_breakpoint(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -138,6 +138,10 @@ if _conversation_processing_stub is not None and not hasattr(_conversation_proce
 # discard_parser only needs pydantic and langchain_core, so load the real module.
 _load_module_from_file("utils.llm.discard_parser", BACKEND_DIR / "utils" / "llm" / "discard_parser.py")
 
+# prompt_cache only needs tiktoken, so load the real module rather than stub the
+# cache floor the preflight assertions below depend on.
+_load_module_from_file("utils.llm.prompt_cache", BACKEND_DIR / "utils" / "llm" / "prompt_cache.py")
+
 conv_proc = _load_module_from_file(
     "utils.llm.conversation_processing",
     BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",

--- a/backend/tests/unit/test_desktop_proactivity.py
+++ b/backend/tests/unit/test_desktop_proactivity.py
@@ -11,11 +11,20 @@ from fastapi import Response
 from routers import desktop_proactivity
 from utils.subscription import NEO_DESKTOP_GRANDFATHER_CUTOFF
 
+# The provider ignores a cached prefix under 1024 tokens, so any test that expects
+# explicit caching to engage must carry a stable block that clears that floor.
+CACHEABLE_STABLE_PROMPT = "stable bucket instructions for the proactive director. " * 400
 
-def request(operation: str = "proactive_extraction", *, cache_key: str | None = None):
+
+def request(
+    operation: str = "proactive_extraction",
+    *,
+    cache_key: str | None = None,
+    messages: list[dict] | None = None,
+):
     return desktop_proactivity.ProactiveCompletionRequest(
         operation=operation,
-        messages=[{"role": "user", "content": "screen context"}],
+        messages=messages or [{"role": "user", "content": "screen context"}],
         response_format={
             "type": "json_schema",
             "json_schema": {
@@ -35,7 +44,13 @@ def request(operation: str = "proactive_extraction", *, cache_key: str | None = 
 
 def test_operation_pins_lane_and_only_reasoning_enables_explicit_cache():
     extraction = desktop_proactivity._gateway_payload(request())
-    reasoning = desktop_proactivity._gateway_payload(request("proactive_reasoning", cache_key="bucket-7-version-3"))
+    reasoning = desktop_proactivity._gateway_payload(
+        request(
+            "proactive_reasoning",
+            cache_key="bucket-7-version-3",
+            messages=[{"role": "user", "content": CACHEABLE_STABLE_PROMPT}],
+        )
+    )
 
     assert extraction["model"] == "omi:auto:desktop-proactive-extraction"
     assert "prompt_cache_options" not in extraction
@@ -47,6 +62,34 @@ def test_operation_pins_lane_and_only_reasoning_enables_explicit_cache():
     assert parts[1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
 
 
+def test_stable_block_under_provider_minimum_is_not_marked_for_cache():
+    """A prefix the provider will never serve back must not be marked or keyed.
+
+    The write is billed at a premium over fresh input, so paying for one that can
+    never be read is strictly worse than not caching at all.
+    """
+    payload = desktop_proactivity._gateway_payload(
+        request(
+            "proactive_reasoning",
+            cache_key="bucket-7-version-3",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "short stable block"},
+                        {"type": "text", "text": "captured at: 2026-08-15T16:00:00Z"},
+                    ],
+                }
+            ],
+        )
+    )
+
+    assert "prompt_cache_key" not in payload
+    assert "prompt_cache_options" not in payload
+    parts = payload["messages"][0]["content"]
+    assert not any(isinstance(part, dict) and "prompt_cache_breakpoint" in part for part in parts)
+
+
 def test_reasoning_cache_breakpoint_precedes_volatile_text_and_image():
     def parts_for(captured_at: str):
         request_value = request("proactive_reasoning", cache_key="bucket-7-version-3")
@@ -54,7 +97,7 @@ def test_reasoning_cache_breakpoint_precedes_volatile_text_and_image():
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "stable bucket"},
+                    {"type": "text", "text": CACHEABLE_STABLE_PROMPT},
                     {"type": "text", "text": f"captured at: {captured_at}"},
                     {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,"}},
                 ],
@@ -65,7 +108,7 @@ def test_reasoning_cache_breakpoint_precedes_volatile_text_and_image():
     parts = parts_for("2026-08-13T16:00:00Z")
     later_parts = parts_for("2026-08-13T16:00:01Z")
 
-    assert parts[0] == {"type": "text", "text": "stable bucket"}
+    assert parts[0] == {"type": "text", "text": CACHEABLE_STABLE_PROMPT}
     assert parts[1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
     assert parts[2]["text"].startswith("captured at:")
     assert parts[3]["type"] == "image_url"
@@ -377,6 +420,49 @@ def test_dev_direct_provider_fallback_is_scoped_to_proactivity(monkeypatch):
     )
     assert reasoning_provider.payload["model"] == "gpt-5.6-luna"
     assert reasoning_provider.payload["reasoning_effort"] == "medium"
+
+
+def test_dev_direct_keeps_cache_breakpoint_so_reads_can_hit(monkeypatch):
+    """The direct path must not discard the only readable boundary in the prompt.
+
+    The client packs the stable prompt, the volatile frame metadata and the
+    screenshot into one user message. The provider serves a cache read only from a
+    prefix ending on a message boundary or an explicit breakpoint, so dropping the
+    breakpoint charges a full write per call that no later call can ever read.
+    """
+    monkeypatch.delenv("OMI_LLM_GATEWAY_URL", raising=False)
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
+    monkeypatch.setattr(desktop_proactivity, "get_openai_api_key", lambda: "dev-provider-key")
+    monkeypatch.setattr(desktop_proactivity, "record_fallback", lambda **values: None)
+
+    provider = desktop_proactivity._proactive_provider_request(
+        request(
+            "proactive_reasoning",
+            cache_key="bucket-7-version-3",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": CACHEABLE_STABLE_PROMPT},
+                        {"type": "text", "text": "captured at: 2026-08-15T16:00:00Z"},
+                        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,"}},
+                    ],
+                }
+            ],
+        ),
+        "user-1",
+        "request-3",
+    )
+
+    parts = provider.payload["messages"][0]["content"]
+    assert parts[0] == {"type": "text", "text": CACHEABLE_STABLE_PROMPT}
+    assert parts[1]["prompt_cache_breakpoint"] == {"mode": "explicit"}
+    assert parts[2]["text"].startswith("captured at:")
+    # prompt_cache_key is a real OpenAI request field; the options/metadata wrappers
+    # are gateway-only extensions the provider would reject.
+    assert provider.payload["prompt_cache_key"] == "bucket-7-version-3"
+    assert "prompt_cache_options" not in provider.payload
+    assert "metadata" not in provider.payload
 
 
 def test_direct_provider_fallback_fails_closed_outside_dev(monkeypatch):

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -8,7 +8,6 @@ from difflib import SequenceMatcher
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-import tiktoken
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.messages import SystemMessage
 from langchain_core.prompts import ChatPromptTemplate
@@ -26,6 +25,11 @@ from .gateway_error_contract import is_byok_rate_limit_gateway_error
 from utils.byok import has_byok_keys
 from utils.llm.gateway_client import record_chat_extraction_gateway_result
 from utils.llm.gateway_observability import record_gateway_shadow_comparison
+from utils.llm.prompt_cache import (
+    EXPLICIT_CACHE_MINIMUM_TOKENS,
+    EXPLICIT_CACHE_OPTIONS,
+    has_cacheable_prefix,
+)
 
 try:
     from utils.llm.gateway_client import should_route_features_through_gateway
@@ -42,10 +46,10 @@ CONVERSATION_STRUCTURE_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ST
 CONVERSATION_ACTION_ITEMS_SHADOW_FEATURE = 'conversation_action_items.extract.shadow'
 CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_ENABLED'
 CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE_ENV = 'OMI_LLM_GATEWAY_CONVERSATION_ACTION_ITEMS_SHADOW_SAMPLE_RATE'
-GPT56_EXPLICIT_CACHE_OPTIONS = {'mode': 'explicit', 'ttl': '30m'}
+GPT56_EXPLICIT_CACHE_OPTIONS = EXPLICIT_CACHE_OPTIONS
 CONVERSATION_CACHE_BUCKET_COUNT = 4
 CONVERSATION_CACHE_BUCKET_SECONDS = 15
-GPT56_CACHE_MINIMUM_TOKENS = 1024
+GPT56_CACHE_MINIMUM_TOKENS = EXPLICIT_CACHE_MINIMUM_TOKENS
 
 
 def _cache_bucket_key(prefix: str, *, now: float | None = None) -> str:
@@ -73,11 +77,7 @@ def _gpt56_cacheable_system_message(content: str, *, cache_enabled: bool) -> Any
 
 def _has_gpt56_cacheable_static_prefix(content: str) -> bool:
     """Use the model-family tokenizer as a conservative preflight for a cache write."""
-    try:
-        return len(tiktoken.get_encoding('o200k_base').encode(content)) >= GPT56_CACHE_MINIMUM_TOKENS
-    except AttributeError:
-        # Do not make a cache write merely because an optional tokenizer dependency is unavailable.
-        return len(content) >= GPT56_CACHE_MINIMUM_TOKENS * 4
+    return has_cacheable_prefix(content)
 
 
 # =============================================

--- a/backend/utils/llm/prompt_cache.py
+++ b/backend/utils/llm/prompt_cache.py
@@ -15,21 +15,22 @@ nothing, so callers preflight with :func:`has_cacheable_prefix` first.
 
 from __future__ import annotations
 
-import tiktoken
-
 # Below this, the provider never serves a read, so a breakpoint is pure noise.
 EXPLICIT_CACHE_MINIMUM_TOKENS = 1024
+
+# Deliberately a character heuristic rather than a real tokenizer. This runs on
+# the request path, and `tiktoken.get_encoding` fetches its vocabulary from a
+# remote blob on first use: a network failure there would surface as a 500 on a
+# call that only needed to answer "is this block big enough to be worth
+# caching?". Four characters per token is the usual English ratio, and the
+# decision degrades gracefully either way — slightly under-counting skips a
+# marginal cache write, slightly over-counting pays for one.
+EXPLICIT_CACHE_MINIMUM_CHARACTERS = EXPLICIT_CACHE_MINIMUM_TOKENS * 4
 
 EXPLICIT_CACHE_OPTIONS = {'mode': 'explicit', 'ttl': '30m'}
 EXPLICIT_CACHE_BREAKPOINT = {'mode': 'explicit'}
 
 
 def has_cacheable_prefix(content: str) -> bool:
-    """Use the model-family tokenizer as a conservative preflight for a cache write."""
-    if not content:
-        return False
-    try:
-        return len(tiktoken.get_encoding('o200k_base').encode(content)) >= EXPLICIT_CACHE_MINIMUM_TOKENS
-    except AttributeError:
-        # Do not make a cache write merely because an optional tokenizer dependency is unavailable.
-        return len(content) >= EXPLICIT_CACHE_MINIMUM_TOKENS * 4
+    """Conservative preflight: is this block worth marking for a cache write?"""
+    return len(content) >= EXPLICIT_CACHE_MINIMUM_CHARACTERS

--- a/backend/utils/llm/prompt_cache.py
+++ b/backend/utils/llm/prompt_cache.py
@@ -1,0 +1,35 @@
+"""Shared explicit prompt-cache primitives for the GPT-5.6 family.
+
+The provider only serves a cache READ from a prefix that ends on a message
+boundary or on an explicit ``prompt_cache_breakpoint``. A prompt whose stable
+text is packed into the same message as volatile text (a per-frame timestamp,
+a screenshot) therefore has no readable boundary at all: every call is charged
+a full cache WRITE and no call can ever hit. Cache writes are billed at a
+premium over fresh input, so an unreadable write is strictly worse than not
+caching, and the breakpoint is what makes the write worth paying for.
+
+The provider also ignores any cached prefix shorter than
+``EXPLICIT_CACHE_MINIMUM_TOKENS``. Marking a block under that floor buys
+nothing, so callers preflight with :func:`has_cacheable_prefix` first.
+"""
+
+from __future__ import annotations
+
+import tiktoken
+
+# Below this, the provider never serves a read, so a breakpoint is pure noise.
+EXPLICIT_CACHE_MINIMUM_TOKENS = 1024
+
+EXPLICIT_CACHE_OPTIONS = {'mode': 'explicit', 'ttl': '30m'}
+EXPLICIT_CACHE_BREAKPOINT = {'mode': 'explicit'}
+
+
+def has_cacheable_prefix(content: str) -> bool:
+    """Use the model-family tokenizer as a conservative preflight for a cache write."""
+    if not content:
+        return False
+    try:
+        return len(tiktoken.get_encoding('o200k_base').encode(content)) >= EXPLICIT_CACHE_MINIMUM_TOKENS
+    except AttributeError:
+        # Do not make a cache write merely because an optional tokenizer dependency is unavailable.
+        return len(content) >= EXPLICIT_CACHE_MINIMUM_TOKENS * 4


### PR DESCRIPTION
## The defect

Desktop proactivity was paying for a prompt-cache write on every call and never reading one back.
Measured on the live dev path with a byte-identical stable prefix resent seconds apart:

```
call 1   cached_tokens=0   cache_write_tokens=7083
call 2   cached_tokens=0   cache_write_tokens=7083
call 3   cached_tokens=0   cache_write_tokens=7083
```

`gpt-5.6-luna` bills cache writes at $0.25/1M against $0.20/1M for fresh input, so this was a net
loss rather than a missed saving — roughly $5/month per heavy user for nothing.

## Root cause

Ground truth, taken by calling the provider directly with our backend bypassed: the provider serves
a cache read only from a prefix that ends on a **message boundary** or on an explicit
**`prompt_cache_breakpoint`**. The final message is never auto-cached. Ablation confirmed this is
the rule — the stable prefix cached when it sat in its own message or carried a breakpoint, and did
not cache when it sat inside the final user message, with `reasoning_effort`, `response_format` and
`max_completion_tokens` all ruled out.

The desktop client packs the stable bucket prompt, the volatile frame metadata and the screenshot
into a **single** user message, so the breakpoint inserted by `_add_explicit_cache_breakpoint` is the
prompt's only readable boundary. The `dev_direct_openai` branch then overwrote those breakpointed
messages with the raw request messages and dropped `prompt_cache_key`, removing that boundary. Every
request therefore wrote a fresh entry keyed on content that never repeats.

The gateway path was already correct; only the direct path discarded the breakpoint.

## What changed

- Keep the breakpointed messages on the direct path, and keep `prompt_cache_key` — it is a real
  OpenAI request field. Only `prompt_cache_options` and `metadata`, which genuinely are gateway
  extensions, are still dropped.
- Preflight the stable block against the provider's 1,024-token minimum before marking anything, so
  we never request a write that cannot be read.
- New `utils/llm/prompt_cache.py` holds the floor, the options and the tokenizer preflight, shared
  with `conversation_processing.py`, which had the same prior art duplicated.

## Result

Same prefix, changing tail on each call:

```
before   call 1/2/3   cached=0                     write=7083 / 7083 / 7083
after    call 1       cached=0                     write=7084     (cold)
         call 2/3     cached=7070                  write=14 / 14
```

## Sequencing note for reviewers

This makes reads possible; it does not by itself make live director traffic cache. The director's
current stable block is about 613 tokens, under the provider's minimum, so it will keep reading zero
until the client-side prompt composition grows that block past the floor. That change is on the
desktop side and **depends on this landing first** — a larger stable prefix without this fix would
cross the floor and start paying unreadable writes.

## Validation

`tests/unit/test_desktop_proactivity.py` — 29 pass, 2 new. Per-file parity with upstream across 10
related suites.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class (fixes)

Failure-Class: FC-credentialed-dependency-resolved-before-guard

The floor preflight answered "is this block big enough to be worth caching?" by calling
`tiktoken.get_encoding('o200k_base')`, which fetches its vocabulary from a remote blob on first use.
That resolves an external dependency to decide a question the guard could answer locally, on the
request path, where a fetch failure surfaces as a 500 rather than as a skipped cache write. Replaced
with a character-count heuristic.
