### PR TITLE
fix(backend): unbreak Backend Unit Tests on main — load the real prompt_cache module in the action-item date-validation test

### DIFF
--- a/backend/tests/unit/test_action_item_date_validation.py
+++ b/backend/tests/unit/test_action_item_date_validation.py
@@ -316,6 +316,11 @@ update_action_item_tool = action_item_tools.update_action_item_tool
 # discard_parser only needs pydantic and langchain_core, so load the real module.
 _load_module_from_file("utils.llm.discard_parser", BACKEND_DIR / "utils" / "llm" / "discard_parser.py")
 
+# prompt_cache is stdlib-only, so load the real module. utils.llm is stubbed with an
+# empty __path__ above, which leaves conversation_processing's absolute import of it
+# unresolvable.
+_load_module_from_file("utils.llm.prompt_cache", BACKEND_DIR / "utils" / "llm" / "prompt_cache.py")
+
 conversation_processing = _load_module_from_file(
     "utils.llm.conversation_processing",
     BACKEND_DIR / "utils" / "llm" / "conversation_processing.py",


### PR DESCRIPTION
## The defect

`Backend Unit Tests` is red on `main` (a9a78b20b9). The suite fails at collection:

```
ERROR collecting tests/unit/test_action_item_date_validation.py
utils/llm/conversation_processing.py:28: in <module>
    from utils.llm.prompt_cache import (
E   ModuleNotFoundError: No module named 'utils.llm.prompt_cache'
```

## Root cause

#11647 added `utils/llm/prompt_cache.py` and made `conversation_processing.py` import it
absolutely (`from utils.llm.prompt_cache import ...`).

`tests/unit/test_action_item_date_validation.py` replaces `utils.llm` with a stub package
whose `__path__` is empty (`_stub_package("utils.llm")`) and then loads
`conversation_processing.py` straight from disk. With an empty `__path__` the import system
has nowhere to look for the new submodule, so the module under test cannot be imported at
all and the file exits with status 2.

`tests/unit/test_conversation_structure_timezone.py` stubs `utils.llm` the same way and was
already updated in #11647; only this second file was missed.

## What changed

Load the real `utils.llm.prompt_cache` from disk before `conversation_processing`, exactly as
`test_conversation_structure_timezone.py` does. The module is stdlib-only (the tokenizer was
dropped in 2332c75aca), so there is nothing to stub — and the real constants are what the
module under test should bind to.

Test-only change: 5 added lines, no production code touched.

## What I tested

Reproduced and verified with the authoritative runner (`backend/test.sh`), not bare pytest:

- Before, on `a9a78b20b9`: `tests/unit/test_action_item_date_validation.py` fails to collect
  with the exact CI signature above (status 2).
- After: `26 passed`.
- Related files that also load `conversation_processing` — `test_conversation_structure_timezone.py`,
  `test_process_conversation_usage_context.py`, `test_omi_qos_tiers.py`,
  `test_product_capability_synthetics.py` — run green alongside it: `95 passed`.
- Both `utils.llm`-stubbing files in a single pytest process (stub-leak check, #8661): `40 passed`.
- `make preflight`: green.

## Failure class (fixes)
Failure-Class: none

Test-harness repair for one file, no product behaviour involved.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

