### PR TITLE
Stop desktop tests deciding a day in one zone and asserting it in another

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -44,13 +44,30 @@ struct ChatMessageTimestamp: View {
 /// the message and started reading as page furniture. Today says the time; this
 /// year adds the day; only another year is worth naming.
 enum ChatMessageTimestampFormat {
-  static func text(for date: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
-    let time = date.formatted(.dateTime.hour().minute())
+  /// - Parameters:
+  ///   - calendar: decides *and* renders. Which day a message belongs to and which day the stamp
+  ///     says have to be the same question: `Date.FormatStyle` otherwise resolves against
+  ///     `.autoupdatingCurrent`, so a caller passing any other calendar would get "today" decided in
+  ///     one zone and the clock time printed in another — a 1:28 PM stamp on a row the same call
+  ///     just decided was yesterday.
+  ///   - locale: how the stamp is worded; the user's, so the month reads in their language.
+  static func text(
+    for date: Date, now: Date = Date(), calendar: Calendar = .current, locale: Locale = .current
+  ) -> String {
+    func render(_ style: Date.FormatStyle) -> String {
+      var style = style
+      style.calendar = calendar
+      style.timeZone = calendar.timeZone
+      style.locale = locale
+      return date.formatted(style)
+    }
+
+    let time = render(.dateTime.hour().minute())
     if calendar.isDate(date, inSameDayAs: now) { return time }
     if calendar.component(.year, from: date) == calendar.component(.year, from: now) {
-      return "\(date.formatted(.dateTime.month(.abbreviated).day())) · \(time)"
+      return "\(render(.dateTime.month(.abbreviated).day())) · \(time)"
     }
-    return "\(date.formatted(.dateTime.year().month(.abbreviated).day())) · \(time)"
+    return "\(render(.dateTime.year().month(.abbreviated).day())) · \(time)"
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindHistoryReach.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindHistoryReach.swift
@@ -24,12 +24,24 @@ enum RewindHistoryReach {
   /// - Parameters:
   ///   - days: local start-of-day instants that hold capture, newest first.
   ///   - surveyed: whether the walk over the capture database has finished at least once.
-  static func spanLabel(days: [Date], surveyed: Bool, calendar: Calendar = .current) -> String {
+  ///   - calendar: the calendar the days were bucketed in — and, therefore, the one they are named in.
+  ///   - locale: how the resulting dates are worded; the user's, so the label reads in their language.
+  static func spanLabel(
+    days: [Date], surveyed: Bool, calendar: Calendar = .current, locale: Locale = .current
+  ) -> String {
     guard surveyed else { return "Checking how far back your capture goes…" }
     guard let newest = days.first, let oldest = days.last else { return "No screen capture yet" }
 
     let formatter = DateFormatter()
     formatter.calendar = calendar
+    // **A day has to be named in the zone it was bucketed in.** `days` are start-of-day instants
+    // produced by `capturedDayStarts(calendar:)`, so they mean midnight *in that calendar's zone*.
+    // `DateFormatter.timeZone` does not follow `formatter.calendar`: left unset it is the machine's,
+    // and rendering another zone's midnight in the machine's zone prints the day before or the day
+    // after for every caller whose calendar is not `.current` — `SpineStore` already passes its own.
+    // The label would then disagree with the day the popover jumps to, which is the whole contract.
+    formatter.timeZone = calendar.timeZone
+    formatter.locale = locale
     formatter.dateStyle = .medium
     formatter.timeStyle = .none
 

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -114,11 +114,15 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
       "director reservation must share the newest global proactive presentation clock")
   }
 
-  func testDailyBudgetUsesRollingTwentyFourHourWindowNotLocalMidnight() {
+  func testDailyBudgetUsesRollingTwentyFourHourWindowNotLocalMidnight() throws {
     let now = Date(timeIntervalSince1970: 1_725_000_000)
     let windowStart = ContextDeliveryBudget.dailyWindowStart(now: now)
     XCTAssertEqual(windowStart, now.addingTimeInterval(-24 * 60 * 60))
-    XCTAssertNotEqual(windowStart, Calendar.current.startOfDay(for: now))
+    // The contrast is with *a* local midnight, so it is drawn against a pinned zone rather than the
+    // machine's: an assertion that reads `TimeZone.current` states a different thing on every runner.
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/New_York"))
+    XCTAssertNotEqual(windowStart, calendar.startOfDay(for: now))
   }
 
   func testFrequencyCooldownMatchesNotificationSpacingAndMaximumHasNoThrottle() {

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -363,7 +363,19 @@ final class ChatRowPresentationTests: XCTestCase {
 
 /// The stamp under a reply is read to the minute, not to the year.
 final class ChatMessageTimestampFormatTests: XCTestCase {
-  private let calendar = Calendar(identifier: .gregorian)
+  /// Fixtures are built and rendered in one pinned zone, so neither the machine's zone nor its
+  /// language decides whether these assertions hold. `America/New_York` matches what the rest of
+  /// the desktop suite pins; the month and year below are only stable against a pinned `locale`,
+  /// since production deliberately renders in the user's own (`ja_JP` says 6月, not "Jun").
+  private var calendar = Calendar(identifier: .gregorian)
+  private let locale = Locale(identifier: "en_US_POSIX")
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    calendar.timeZone = try XCTUnwrap(
+      TimeZone(identifier: "America/New_York"),
+      "the pinned fixture zone must exist in the system time zone database")
+  }
 
   private func date(_ y: Int, _ m: Int, _ d: Int, _ h: Int, _ min: Int) -> Date {
     var components = DateComponents()
@@ -378,7 +390,8 @@ final class ChatMessageTimestampFormatTests: XCTestCase {
 
   func testTodayIsJustTheTime() {
     let now = date(2026, 8, 6, 17, 0)
-    let text = ChatMessageTimestampFormat.text(for: date(2026, 8, 6, 13, 28), now: now, calendar: calendar)
+    let text = ChatMessageTimestampFormat.text(
+      for: date(2026, 8, 6, 13, 28), now: now, calendar: calendar, locale: locale)
 
     XCTAssertFalse(text.contains("2026"), "the year on a message sent hours ago is chrome")
     XCTAssertFalse(text.contains("Aug"))
@@ -387,7 +400,8 @@ final class ChatMessageTimestampFormatTests: XCTestCase {
 
   func testAnEarlierDayThisYearAddsTheDayButNotTheYear() {
     let now = date(2026, 8, 6, 17, 0)
-    let text = ChatMessageTimestampFormat.text(for: date(2026, 6, 1, 9, 5), now: now, calendar: calendar)
+    let text = ChatMessageTimestampFormat.text(
+      for: date(2026, 6, 1, 9, 5), now: now, calendar: calendar, locale: locale)
 
     XCTAssertTrue(text.contains("Jun"))
     XCTAssertFalse(text.contains("2026"))
@@ -395,7 +409,8 @@ final class ChatMessageTimestampFormatTests: XCTestCase {
 
   func testAnotherYearIsTheOnlyCaseWorthNamingTheYearFor() {
     let now = date(2026, 8, 6, 17, 0)
-    let text = ChatMessageTimestampFormat.text(for: date(2025, 12, 24, 9, 5), now: now, calendar: calendar)
+    let text = ChatMessageTimestampFormat.text(
+      for: date(2025, 12, 24, 9, 5), now: now, calendar: calendar, locale: locale)
 
     XCTAssertTrue(text.contains("2025"))
   }

--- a/desktop/macos/Desktop/Tests/RewindAllTimeSearchTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindAllTimeSearchTests.swift
@@ -79,16 +79,80 @@ final class RewindAllTimeSearchTests: XCTestCase {
     try await super.tearDown()
   }
 
+  // MARK: - One clock, one zone, for both halves of every day-bucket assertion
+
+  /// The zone every local day in this suite is expressed in.
+  ///
+  /// Pinned for the same reason `ContextBucketPromptAssemblerTests` pins it: it is never the CI
+  /// runner's zone, so a regression that goes back to bucketing in `Calendar.current` fails on a
+  /// UTC runner instead of staying green there.
+  private static let seedZoneIdentifier = "America/New_York"
+
+  /// One reading of the clock, in a zone that does not come from the machine.
+  ///
+  /// **Both halves of a day-bucket assertion must come from the same instant and the same zone.**
+  /// Seeding from one `Date()` and deriving the expectation from another lets the two straddle
+  /// local midnight; taking the zone from `Calendar.current` is the same defect in space rather
+  /// than in time, because a UTC runner and a developer at UTC-4 disagree about which local day an
+  /// evening frame belongs to. Everything below is derived from a single `Date()`, read once.
+  private struct SeedClock {
+    let calendar: Calendar
+
+    /// Local noon of the day *before* the run.
+    ///
+    /// Yesterday rather than today because `capturedDayStarts` walks back from the live `Date()`
+    /// and can never see a row seeded into the future — an anchor at today's noon is in the future
+    /// for every run before midday. Noon rather than the current time of day because a within-day
+    /// offset added to a noon anchor cannot reach either midnight.
+    let noon: Date
+
+    /// The anchor shifted back `daysAgo` local days, still at local noon.
+    func instant(daysAgo: Int) throws -> Date {
+      try XCTUnwrap(
+        calendar.date(byAdding: .day, value: -daysAgo, to: noon),
+        "the seeded day must be representable in the pinned calendar")
+    }
+
+    /// Where the local day `daysAgo` days before the anchor begins.
+    func dayStart(daysAgo: Int) throws -> Date {
+      calendar.startOfDay(for: try instant(daysAgo: daysAgo))
+    }
+
+    /// The last instant that still belongs to that local day.
+    ///
+    /// Asked of the calendar rather than computed as `start + 23:59:59`, so a 23-hour spring-forward
+    /// day does not spill the frame into the following day — which is the whole hazard this suite
+    /// exists to pin down, in its other form.
+    func dayEnd(daysAgo: Int) throws -> Date {
+      let start = try dayStart(daysAgo: daysAgo)
+      let next = try XCTUnwrap(
+        calendar.date(byAdding: .day, value: 1, to: start),
+        "the day after a seeded day must be representable in the pinned calendar")
+      return next.addingTimeInterval(-30)
+    }
+  }
+
+  private func makeSeedClock() throws -> SeedClock {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try XCTUnwrap(
+      TimeZone(identifier: Self.seedZoneIdentifier),
+      "the pinned seed zone must exist in the system time zone database")
+    let today = calendar.startOfDay(for: Date())
+    let yesterday = try XCTUnwrap(
+      calendar.date(byAdding: .day, value: -1, to: today),
+      "the day before the run must be representable in the pinned calendar")
+    return SeedClock(calendar: calendar, noon: yesterday.addingTimeInterval(12 * 3600))
+  }
+
   @discardableResult
   private func insert(
-    daysAgo: Int, text: String, appName: String = "AllTimeTest", embedding: Data? = nil
+    at stamp: Date, text: String, appName: String = "AllTimeTest", embedding: Data? = nil
   ) async throws -> Screenshot {
-    let stamp = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()))
     let inserted = try await RewindDatabase.shared.insertScreenshot(
       Screenshot(
         timestamp: stamp,
         appName: appName,
-        videoChunkPath: "alltime/\(daysAgo).mp4",
+        videoChunkPath: "alltime/\(stamp.timeIntervalSince1970).mp4",
         frameOffset: 0,
         ocrText: text,
         isIndexed: true))
@@ -111,7 +175,9 @@ final class RewindAllTimeSearchTests: XCTestCase {
   /// only by the launch backfill, which marks itself complete — after which nothing newly captured
   /// was ever embedded, and a newest-first semantic scan looks at exactly those frames.
   func testInsertedScreenshotCarriesItsRowId() async throws {
-    let inserted = try await insert(daysAgo: 0, text: "a frame the rest of capture must be able to name")
+    let clock = try makeSeedClock()
+    let inserted = try await insert(
+      at: try clock.instant(daysAgo: 0), text: "a frame the rest of capture must be able to name")
     let id = try XCTUnwrap(inserted.id, "insertScreenshot must return the row id it just generated")
 
     let stored = try await RewindDatabase.shared.getScreenshot(id: id)
@@ -123,8 +189,9 @@ final class RewindAllTimeSearchTests: XCTestCase {
   // MARK: - Text search reaches past the day on screen
 
   func testUnclampedSearchFindsAMatchFromAnOlderDay() async throws {
-    try await insert(daysAgo: 0, text: "today the quarterly ledger reconciled")
-    try await insert(daysAgo: 23, text: "the peregrine migration notes were filed")
+    let clock = try makeSeedClock()
+    try await insert(at: try clock.instant(daysAgo: 0), text: "today the quarterly ledger reconciled")
+    try await insert(at: try clock.instant(daysAgo: 23), text: "the peregrine migration notes were filed")
 
     // What the page now asks: no date bounds at all.
     let allTime = try await RewindDatabase.shared.search(query: "peregrine", startDate: nil, endDate: nil)
@@ -132,10 +199,11 @@ final class RewindAllTimeSearchTests: XCTestCase {
     let match = try XCTUnwrap(allTime.first)
     XCTAssertTrue(match.ocrText?.contains("peregrine") == true)
 
-    // What it used to ask, and why the phrase was unfindable.
-    let calendar = Calendar.current
-    let todayStart = calendar.startOfDay(for: Date())
-    let todayEnd = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: todayStart))
+    // What it used to ask, and why the phrase was unfindable. The bound is the seeded day in the
+    // pinned zone, so the window is the one the newer frame actually sits in on any machine.
+    let todayStart = try clock.dayStart(daysAgo: 0)
+    let todayEnd = try XCTUnwrap(
+      clock.calendar.date(byAdding: .day, value: 1, to: todayStart))
     let dayScoped = try await RewindDatabase.shared.search(
       query: "peregrine", startDate: todayStart, endDate: todayEnd)
     XCTAssertTrue(
@@ -146,10 +214,11 @@ final class RewindAllTimeSearchTests: XCTestCase {
   // MARK: - The semantic pass stays bounded once history is unlimited
 
   func testEmbeddingBatchReadsNewestFirstOverAnUnboundedRange() async throws {
+    let clock = try makeSeedClock()
     let blob = Data(repeating: 0, count: 4)
-    try await insert(daysAgo: 40, text: "oldest", embedding: blob)
-    try await insert(daysAgo: 5, text: "middle", embedding: blob)
-    try await insert(daysAgo: 0, text: "newest", embedding: blob)
+    try await insert(at: try clock.instant(daysAgo: 40), text: "oldest", embedding: blob)
+    try await insert(at: try clock.instant(daysAgo: 5), text: "middle", embedding: blob)
+    try await insert(at: try clock.instant(daysAgo: 0), text: "newest", embedding: blob)
 
     // Unbounded range, budget of one row: the caller's budget must buy the *newest* frame.
     let firstPage = try await RewindDatabase.shared.readEmbeddingBatch(
@@ -164,13 +233,13 @@ final class RewindAllTimeSearchTests: XCTestCase {
   }
 
   func testEmbeddingBatchStillHonoursAnExplicitRange() async throws {
+    let clock = try makeSeedClock()
     let blob = Data(repeating: 0, count: 4)
-    try await insert(daysAgo: 40, text: "oldest", embedding: blob)
-    try await insert(daysAgo: 0, text: "newest", embedding: blob)
+    try await insert(at: try clock.instant(daysAgo: 40), text: "oldest", embedding: blob)
+    try await insert(at: try clock.instant(daysAgo: 0), text: "newest", embedding: blob)
 
-    let calendar = Calendar.current
-    let start = try XCTUnwrap(calendar.date(byAdding: .day, value: -60, to: Date()))
-    let end = try XCTUnwrap(calendar.date(byAdding: .day, value: -30, to: Date()))
+    let start = try clock.instant(daysAgo: 60)
+    let end = try clock.instant(daysAgo: 30)
     let windowed = try await RewindDatabase.shared.readEmbeddingBatch(startDate: start, endDate: end)
 
     XCTAssertEqual(windowed.count, 1, "callers that pass a window must still get only that window")
@@ -185,24 +254,30 @@ final class RewindAllTimeSearchTests: XCTestCase {
   /// any. This drives the real seek walk against real rows: the days that hold capture come back
   /// newest-first, the days that hold nothing are absent, and no day is reported twice.
   func testCapturedDayStartsReportsEveryDayThatHoldsCaptureNewestFirst() async throws {
-    let calendar = Calendar.current
-    // Days 0, 2 and 9 back hold capture; days 1 and 3–8 hold nothing at all.
+    let clock = try makeSeedClock()
+    // Days 0, 2 and 9 back from the anchor hold capture; days 1 and 3–8 hold nothing at all.
     let offsets = [0, 2, 9]
     for offset in offsets {
-      try await insert(daysAgo: offset, text: "span \(offset)")
-      // A second frame the same day must not produce a second day.
-      let stamp = try XCTUnwrap(calendar.date(byAdding: .day, value: -offset, to: Date()))
+      // The two frames sit at the two ends of one local day *by construction*, which is the claim
+      // the assertion below rests on. They used to be a live-clock stamp and that stamp plus two
+      // minutes — same-day only if the run did not happen in the last two minutes of a day. On
+      // 2026-08-15 at 23:58 it did: each second frame landed after midnight and reported a day one
+      // newer than the one it was meant to duplicate, so three seeded days came back as five.
+      // Seeding the day's first and last instants also drives the boundary the old fixture never
+      // reached — a day is one day even when its capture touches both of its edges.
+      try await insert(
+        at: try clock.dayStart(daysAgo: offset).addingTimeInterval(30),
+        text: "span \(offset)")
       _ = try await RewindDatabase.shared.insertScreenshot(
         Screenshot(
-          timestamp: stamp.addingTimeInterval(120), appName: "AllTimeTest",
+          timestamp: try clock.dayEnd(daysAgo: offset), appName: "AllTimeTest",
           videoChunkPath: "alltime/\(offset).mp4", frameOffset: 1, isIndexed: true))
     }
 
-    let days = try await RewindDatabase.shared.capturedDayStarts()
+    // The pinned calendar, not the machine's: on a UTC runner these rows straddle two UTC days.
+    let days = try await RewindDatabase.shared.capturedDayStarts(calendar: clock.calendar)
 
-    let expected = try offsets.map {
-      calendar.startOfDay(for: try XCTUnwrap(calendar.date(byAdding: .day, value: -$0, to: Date())))
-    }
+    let expected = try offsets.map { try clock.dayStart(daysAgo: $0) }
     XCTAssertEqual(days, expected, "captured days must be exactly the days that hold rows, newest first")
     XCTAssertEqual(Set(days).count, days.count, "a day with several frames must appear once")
     XCTAssertEqual(days.last, expected.last, "the oldest captured day is what 'all time' reaches back to")
@@ -218,9 +293,10 @@ final class RewindAllTimeSearchTests: XCTestCase {
   // MARK: - The continuous timeline reaches retained history
 
   func testHistorySurveyPublishesGlobalBoundsWithoutReplacingTheVisibleWindow() async throws {
-    let newest = try await insert(daysAgo: 0, text: "newest day")
-    try await insert(daysAgo: 2, text: "middle day")
-    let oldest = try await insert(daysAgo: 9, text: "oldest day")
+    let clock = try makeSeedClock()
+    let newest = try await insert(at: try clock.instant(daysAgo: 0), text: "newest day")
+    try await insert(at: try clock.instant(daysAgo: 2), text: "middle day")
+    let oldest = try await insert(at: try clock.instant(daysAgo: 9), text: "oldest day")
 
     let viewModel = await MainActor.run { RewindViewModel() }
     await viewModel.surveyCapturedHistory(attempts: 1)
@@ -236,9 +312,10 @@ final class RewindAllTimeSearchTests: XCTestCase {
   }
 
   func testPanningReloadsOnlyTheRequestedContinuousWindow() async throws {
-    let newest = try await insert(daysAgo: 0, text: "newest day")
-    let middle = try await insert(daysAgo: 2, text: "middle day")
-    let oldest = try await insert(daysAgo: 9, text: "oldest day")
+    let clock = try makeSeedClock()
+    let newest = try await insert(at: try clock.instant(daysAgo: 0), text: "newest day")
+    let middle = try await insert(at: try clock.instant(daysAgo: 2), text: "middle day")
+    let oldest = try await insert(at: try clock.instant(daysAgo: 9), text: "oldest day")
     let viewModel = await MainActor.run { RewindViewModel() }
     await viewModel.surveyCapturedHistory(attempts: 1)
 
@@ -325,13 +402,12 @@ final class RewindAllTimeSearchTests: XCTestCase {
   }
 
   func testBoundedAllTimeSampleIncludesTheOldestAndNewestCapture() async throws {
+    let clock = try makeSeedClock()
     for offset in (0..<10).reversed() {
-      try await insert(daysAgo: offset, text: "day \(offset)")
+      try await insert(at: try clock.instant(daysAgo: offset), text: "day \(offset)")
     }
-    let calendar = Calendar.current
-    let start = calendar.startOfDay(
-      for: try XCTUnwrap(calendar.date(byAdding: .day, value: -10, to: Date())))
-    let end = try XCTUnwrap(calendar.date(byAdding: .day, value: 1, to: Date()))
+    let start = try clock.dayStart(daysAgo: 10)
+    let end = try clock.instant(daysAgo: -1)
 
     let sample = try await RewindDatabase.shared.getScreenshotsSampled(
       from: start, to: end, targetCount: 3)

--- a/desktop/macos/Desktop/Tests/RewindHistoryReachTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindHistoryReachTests.swift
@@ -13,7 +13,30 @@ import XCTest
 ///     retention setting reads a limit as a fact about themselves.
 final class RewindHistoryReachTests: XCTestCase {
 
-  private let calendar = Calendar(identifier: .gregorian)
+  /// One calendar builds the fixture days *and* names them, so the two can never disagree.
+  ///
+  /// The zone is `Asia/Tokyo` rather than the `America/New_York` the rest of this suite pins,
+  /// because here the zone has to be *east* of UTC to do its job. These fixtures are start-of-day
+  /// instants: Tokyo midnight on the 5th is 15:00 UTC on the **4th**, so a renderer that ignores the
+  /// calendar it was handed and formats in the machine's zone prints "Aug 4" and fails — on the UTC
+  /// CI runner and on a UTC-4 developer's machine alike. Pinning a zone west of UTC would leave
+  /// local midnight on the same UTC calendar day and keep exactly that regression green everywhere.
+  /// Resolved in `setUpWithError` rather than in a property initializer so a zone the system cannot
+  /// resolve fails the test outright instead of quietly falling back to GMT — a GMT fallback would
+  /// put local midnight back on the UTC calendar day and keep the regression above green.
+  private var calendar = Calendar(identifier: .gregorian)
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    calendar.timeZone = try XCTUnwrap(
+      TimeZone(identifier: "Asia/Tokyo"),
+      "the pinned fixture zone must exist in the system time zone database")
+  }
+
+  /// Pinned so the month names and digits asserted below are the ones this test was written against,
+  /// rather than whatever language and numbering system the machine happens to be set to. Production
+  /// deliberately keeps `Locale.current` — the label is read by the user, not by a machine.
+  private let locale = Locale(identifier: "en_US_POSIX")
 
   /// Throws rather than traps: an unresolvable fixture date is this test's own setup failing, and a
   /// trap here takes the whole `xctest` process down with it and hides every result after it.
@@ -22,8 +45,6 @@ final class RewindHistoryReachTests: XCTestCase {
     components.year = year
     components.month = month
     components.day = dayOfMonth
-    var calendar = self.calendar
-    calendar.timeZone = .gmt
     return try XCTUnwrap(
       calendar.date(from: components), "\(year)-\(month)-\(dayOfMonth) must be a real date")
   }
@@ -43,9 +64,12 @@ final class RewindHistoryReachTests: XCTestCase {
     // The flag, not the emptiness, is what distinguishes the two. A populated list while the survey
     // is still running must still read as a real span, not as "checking".
     let label = RewindHistoryReach.spanLabel(
-      days: [try day(2026, 8, 5)], surveyed: true, calendar: calendar)
+      days: [try day(2026, 8, 5)], surveyed: true, calendar: calendar, locale: locale)
 
     XCTAssertTrue(label.hasPrefix("1 day of capture"), "Got: \(label)")
+    XCTAssertTrue(
+      label.contains("Aug 5, 2026"),
+      "the day must be named in the zone it was bucketed in, not the machine's, got: \(label)")
   }
 
   func testSurveyedEmptyHistoryReadsAsNone() {
@@ -60,18 +84,23 @@ final class RewindHistoryReachTests: XCTestCase {
     // Newest first, as the walk produces them.
     let days = [try day(2026, 8, 5), try day(2026, 8, 4), try day(2026, 7, 2)]
 
-    let label = RewindHistoryReach.spanLabel(days: days, surveyed: true, calendar: calendar)
+    let label = RewindHistoryReach.spanLabel(
+      days: days, surveyed: true, calendar: calendar, locale: locale)
 
     XCTAssertTrue(label.hasPrefix("3 days of capture"), "Got: \(label)")
     XCTAssertTrue(label.contains("2026"), "Span must name real dates, got: \(label)")
-    // Oldest end first: the user is reading it as "from … to …".
-    let oldestRange = label.range(of: "Jul")
-    let newestRange = label.range(of: "Aug")
-    if let oldestRange, let newestRange {
-      XCTAssertLessThan(
-        oldestRange.lowerBound, newestRange.lowerBound,
-        "The oldest end of the span must be stated first, got: \(label)")
-    }
+    // Both ends named exactly, in the pinned zone: rendering these Tokyo midnights in the machine's
+    // zone would say "Jul 1" and "Aug 4" instead, which is the day-off defect this pins down.
+    XCTAssertTrue(label.contains("Jul 2, 2026"), "Got: \(label)")
+    XCTAssertTrue(label.contains("Aug 5, 2026"), "Got: \(label)")
+    // Oldest end first: the user is reading it as "from … to …". Unwrapped rather than `if let`,
+    // because a lookup that finds nothing means the label stopped naming months — which is a
+    // failure, not a reason to skip the check.
+    let oldestRange = try XCTUnwrap(label.range(of: "Jul"), "Got: \(label)")
+    let newestRange = try XCTUnwrap(label.range(of: "Aug"), "Got: \(label)")
+    XCTAssertLessThan(
+      oldestRange.lowerBound, newestRange.lowerBound,
+      "The oldest end of the span must be stated first, got: \(label)")
   }
 
   // MARK: - The span names its cause

--- a/desktop/macos/changelog/unreleased/20260815-rewind-span-label-day-naming.json
+++ b/desktop/macos/changelog/unreleased/20260815-rewind-span-label-day-naming.json
@@ -1,0 +1,3 @@
+{
+  "change": "Rewind's capture-span label and chat message timestamps now always show the date of the day they point at, even around midnight and across time zones"
+}


### PR DESCRIPTION
## Summary

Three desktop tests decided a day in one time zone or at one instant and asserted it in another, so their result depended on when and where they ran. One of them blocked a desktop release tonight.

`RewindAllTimeSearchTests.testCapturedDayStartsReportsEveryDayThatHoldsCaptureNewestFirst` seeded a frame at the live time-of-day shifted back N days, plus a duplicate at that stamp `+120s` — same-day only if the run misses the last two minutes of a day. The CI job started 23:40Z on 2026-08-15 and hit that window: each duplicate crossed midnight and reported a day one newer than the one it was meant to duplicate, so three seeded days came back as five.

Replaying the old seeding arithmetic over every minute of a day in four zones fails at 23:58 and 23:59 (and 22:58 on a spring-forward day). The new arithmetic fails at none of 17,280 sampled minutes.

## Which layer

The walk was already correct: `capturedDayStarts(calendar:)` takes its calendar and buckets with `Calendar` rather than in SQL deliberately. The tests never exercised that injection point, so they bucketed in whatever zone the machine had. They now derive every instant from one reading of the clock in one pinned zone, and seed a day's first and last instants rather than a stamp and a stamp `+120s` — which also drives the day-edge case the old fixture could not reach.

Two production paths did have a real defect of the same shape — they took a `calendar` and honoured it for *deciding* a day but not for *naming* one:

- `RewindHistoryReach.spanLabel` set `formatter.calendar` but not `formatter.timeZone`, which does not follow it.
- `ChatMessageTimestampFormat` decided day-ness with the injected calendar while `Date.FormatStyle` rendered against `.autoupdatingCurrent`.

Every shipping caller passes `.current`, so no user sees this today — but `SpineStore` already passes its own calendar to the day walk, and the label would then name a day either side of the one it points at. Reverting the one-line fix now fails three assertions with "Jul 1 – Aug 4" where the days say "Jul 2 – Aug 5".

## Product invariants affected

- INV-CHAT-1

Cited on paths: `ChatBubbleSupport.swift` is matched by the invariant's globs. The change is confined to how an already-rendered message's timestamp is worded — no transcript store, session identity, continuity ring, or ordering behavior is touched, so the invariant's guard behavior is unchanged.

## Failure class (fixes)

Failure-Class: FC-day-bucket-key-recomputed

## Verification

- `xcrun swift build -c debug --package-path Desktop` — exit 0.
- `xcrun swift test --package-path Desktop` — 5329 tests, 1 skipped, 0 failures, exit 0.
- The three suites also pass under `TZ=UTC`, `Asia/Tokyo`, `Pacific/Kiritimati`, `America/Los_Angeles`.
- Negative control: reverting `formatter.timeZone = calendar.timeZone` fails 3 assertions in `RewindHistoryReachTests`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

