### PR TITLE
fix(app): four iOS startup fixes — CGNAT dev endpoints, and hangs that presented as a blank splash

### DIFF
--- a/app/ios/Runner/Info-Dev.plist
+++ b/app/ios/Runner/Info-Dev.plist
@@ -131,7 +131,15 @@
 	</dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsLocalNetworking</key>
+		<!-- Dev-only plist. NSAllowsArbitraryLoads rather than NSAllowsLocalNetworking,
+		     because the latter covers only .local, unqualified hostnames and link-local
+		     addresses — never a Tailscale CGNAT address (100.64.0.0/10), which is what
+		     the local dev harness is reached on.
+
+		     These two keys must not be combined: declaring NSAllowsArbitraryLoads
+		     alongside NSAllowsLocalNetworking makes the former a documented no-op on any
+		     OS that understands the newer key, silently leaving CGNAT hosts blocked. -->
+		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -184,6 +184,12 @@ abstract class Env {
     return first == 10 ||
         (first == 172 && second >= 16 && second <= 31) ||
         (first == 192 && second == 168) ||
+        // 100.64.0.0/10 — RFC 6598 shared address space, the range Tailscale
+        // assigns. Included because a physical device has no other route to a
+        // developer's local harness: the harness binds loopback only by design,
+        // so the device cannot use 127.x, and a plain LAN address does not reach
+        // it either. Bounded to the real /10 — 100.63.x and 100.128.x are public.
+        (first == 100 && second >= 64 && second <= 127) ||
         (first == 127);
   }
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -36,6 +36,7 @@ import 'package:omi/env/prod_env.dart';
 import 'package:omi/firebase_options_local.dart' as local;
 import 'package:omi/firebase_options_prod.dart' as prod;
 import 'package:omi/flavors.dart';
+import 'package:omi/startup_failure_app.dart';
 import 'package:omi/startup_routing.dart';
 import 'package:omi/l10n/app_localizations.dart';
 import 'package:omi/pages/apps/providers/add_app_provider.dart';
@@ -228,7 +229,21 @@ void main() {
       } else {
         WidgetsFlutterBinding.ensureInitialized();
       }
-      await _init();
+      try {
+        await _init();
+      } catch (error, stack) {
+        // Startup failed before the first frame. Without this the launch
+        // storyboard stays on screen forever: runApp() is never reached, and the
+        // zone handler below only calls debugPrint, which goes nowhere in
+        // profile/release builds. A misconfigured OMI_API_BASE_URL cost about a
+        // day of investigation for exactly this reason — the app looked hung
+        // when it had in fact thrown a precise, actionable StateError.
+        if (Firebase.apps.isNotEmpty) {
+          FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+        }
+        runApp(StartupFailureApp(error: error, stack: stack));
+        return;
+      }
       runApp(const MyApp());
     },
     (error, stack) {

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -36,6 +36,7 @@ import 'package:omi/env/prod_env.dart';
 import 'package:omi/firebase_options_local.dart' as local;
 import 'package:omi/firebase_options_prod.dart' as prod;
 import 'package:omi/flavors.dart';
+import 'package:omi/startup_auth.dart';
 import 'package:omi/startup_failure_app.dart';
 import 'package:omi/startup_routing.dart';
 import 'package:omi/l10n/app_localizations.dart';
@@ -175,7 +176,7 @@ Future _init() async {
     Env.isTestFlight = await EnvironmentDetector.isTestFlight();
   }
 
-  bool isAuth = (await AuthService.instance.getIdToken()) != null;
+  bool isAuth = await resolveStartupAuth(() => AuthService.instance.getIdToken());
   if (isAuth) {
     PlatformManager.instance.analytics.identify();
     // Restore onboarding state from server if not already set locally

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -84,6 +84,7 @@ class AuthService {
 
   AuthService._internal()
       : _tokenGateway = _FirebaseAuthTokenGateway(),
+        _refreshAttemptTimeout = _defaultRefreshAttemptTimeout,
         _refreshDelay = _defaultRefreshDelay,
         _recordTelemetry = _recordProductionTelemetry,
         _telemetryContextProvider = _productionTelemetryContext;
@@ -92,14 +93,28 @@ class AuthService {
   AuthService.forTesting({
     required AuthTokenGateway tokenGateway,
     AuthRefreshDelay? refreshDelay,
+    Duration? refreshAttemptTimeout,
     AuthTelemetryRecorder? recordTelemetry,
     AuthTelemetryContextProvider? telemetryContextProvider,
   })  : _tokenGateway = tokenGateway,
+        _refreshAttemptTimeout = refreshAttemptTimeout ?? _defaultRefreshAttemptTimeout,
         _refreshDelay = refreshDelay ?? _defaultRefreshDelay,
         _recordTelemetry = recordTelemetry ?? ((eventName, properties) {}),
         _telemetryContextProvider = telemetryContextProvider ?? (() => const {});
 
   static const int _maxRefreshAttempts = 3;
+
+  /// Per-attempt ceiling on the Firebase forced token refresh.
+  ///
+  /// `forceRefresh()` can hang indefinitely rather than fail: measured on
+  /// iPhone 17 Pro / iOS 27.0 against a Firebase Auth emulator on a non-loopback
+  /// host, it never returned at all. Because `shared.dart` refreshes on the way
+  /// into *every* authenticated request, an unbounded stall here silently freezes
+  /// all backend traffic app-wide — no error, no timeout, nothing to report.
+  ///
+  /// A timed-out attempt is reported as a transient failure, which the retry loop
+  /// below and every existing caller already handle.
+  static const Duration _defaultRefreshAttemptTimeout = Duration(seconds: 8);
   static const List<Duration> _refreshRetryDelays = [Duration(milliseconds: 200), Duration(milliseconds: 500)];
   static const Set<String> _terminalTokenErrorCodes = {
     'invalid-user-token',
@@ -111,6 +126,7 @@ class AuthService {
   static Future<void> _defaultRefreshDelay(Duration duration) => Future<void>.delayed(duration);
 
   final AuthTokenGateway _tokenGateway;
+  final Duration _refreshAttemptTimeout;
   final AuthRefreshDelay _refreshDelay;
   final AuthTelemetryRecorder _recordTelemetry;
   final AuthTelemetryContextProvider _telemetryContextProvider;
@@ -366,7 +382,7 @@ class AuthService {
 
   Future<AuthTokenResult> _refreshIdTokenOnce(int generation, String expectedUid) async {
     try {
-      final refreshed = await _tokenGateway.forceRefresh();
+      final refreshed = await _tokenGateway.forceRefresh().timeout(_refreshAttemptTimeout);
       if (generation != _sessionGeneration || _tokenGateway.currentUser?.uid != expectedUid) {
         return const AuthTokenMissingUser();
       }
@@ -395,6 +411,12 @@ class AuthService {
       }
       _sessionExpired = false;
       return AuthTokenSuccess(token: token, expirationTime: refreshed?.expirationTime);
+    } on TimeoutException {
+      if (generation != _sessionGeneration) return const AuthTokenMissingUser();
+      Logger.debug('refreshIdToken: forceRefresh timed out after $_refreshAttemptTimeout');
+      // Distinct class so a stalled refresh is distinguishable in telemetry from
+      // one that actually failed — they have very different causes.
+      return const AuthTokenTransientFailure(failureClass: 'refresh_timeout');
     } on FirebaseAuthException catch (e) {
       if (generation != _sessionGeneration) return const AuthTokenMissingUser();
       Logger.debug('refreshIdToken: FirebaseAuthException: ${e.code}');

--- a/app/lib/startup_auth.dart
+++ b/app/lib/startup_auth.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+/// How long startup will wait for an id-token refresh before giving up and
+/// continuing unauthenticated. Generous enough not to log out a user on a slow
+/// network, short enough that a stalled refresh cannot hold the first frame.
+const Duration startupAuthTimeout = Duration(seconds: 10);
+
+/// Resolve whether startup has a usable session, without ever blocking forever.
+///
+/// This runs before `runApp()`, so an unbounded stall here leaves the launch
+/// storyboard on screen indefinitely — no crash, no UI, no diagnostic. Measured
+/// on iPhone 17 Pro / iOS 27.0 against a Firebase Auth emulator on a non-loopback
+/// host, FirebaseAuth's forced token refresh never returned at all (not an error,
+/// just silence), and the app could not be launched again until it was deleted,
+/// because the cached session made every start hang on this call.
+///
+/// A timeout is deliberately treated as "not authenticated" rather than as an
+/// error: [getIdToken] already returns null on every failure branch, and startup
+/// already continues to the sign-in screen in that case. So this only makes a
+/// hang behave like the failure it effectively is, and never blocks startup where
+/// the previous code would have proceeded.
+///
+/// Kept in its own library, free of Firebase and generated-env imports, so it is
+/// testable without codegen — the same reason `startup_routing.dart` is separate.
+@visibleForTesting
+Future<bool> resolveStartupAuth(
+  Future<String?> Function() getIdToken, {
+  Duration timeout = startupAuthTimeout,
+}) async {
+  // A race rather than Future.timeout(onTimeout:). `onTimeout` must return the
+  // *concrete* future's type, so if the supplied callback happens to produce a
+  // Future<String> rather than Future<String?>, `() => null` throws a TypeError
+  // at runtime — turning a hang-guard into a new startup crash. Racing sidesteps
+  // the variance entirely.
+  return await Future.any<bool>([
+    getIdToken().then((token) => token != null),
+    Future<bool>.delayed(timeout, () => false),
+  ]);
+}

--- a/app/lib/startup_auth.dart
+++ b/app/lib/startup_auth.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 /// How long startup will wait for an id-token refresh before giving up and
 /// continuing unauthenticated. Generous enough not to log out a user on a slow
 /// network, short enough that a stalled refresh cannot hold the first frame.
@@ -22,7 +20,9 @@ const Duration startupAuthTimeout = Duration(seconds: 10);
 ///
 /// Kept in its own library, free of Firebase and generated-env imports, so it is
 /// testable without codegen — the same reason `startup_routing.dart` is separate.
-@visibleForTesting
+///
+/// Not test-only: called from [main] to gate the first frame, and directly by
+/// startup_auth_timeout_test.dart.
 Future<bool> resolveStartupAuth(
   Future<String?> Function() getIdToken, {
   Duration timeout = startupAuthTimeout,

--- a/app/lib/startup_failure_app.dart
+++ b/app/lib/startup_failure_app.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Shown when `_init()` throws before the app's first frame.
+///
+/// Deliberately self-contained: no providers, no services, no theme lookups and
+/// no localisation. Everything it could depend on is exactly what may have just
+/// failed to initialise, so it must render from nothing but Flutter itself.
+///
+/// Without this the app sits on the launch storyboard indefinitely — `runApp()`
+/// never runs, and `debugPrint` from the zone handler is invisible in profile
+/// and release builds. A startup guard rejecting a misconfigured
+/// `OMI_API_BASE_URL` is a precise, actionable error; presenting it as a blank
+/// splash screen is what made it expensive to diagnose.
+class StartupFailureApp extends StatelessWidget {
+  const StartupFailureApp({super.key, required this.error, this.stack});
+
+  final Object error;
+  final StackTrace? stack;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        backgroundColor: const Color(0xFF000000),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Omi could not start',
+                  style: TextStyle(color: Colors.white, fontSize: 22, fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 12),
+                const Text(
+                  'Startup configuration was rejected before the app could load. '
+                  'This is usually a build-time setting, not a problem with your device.',
+                  style: TextStyle(color: Colors.white70, fontSize: 14),
+                ),
+                const SizedBox(height: 20),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: SelectableText(
+                      // Selectable so the message can be copied off a device
+                      // that has no debugger attached — which is the situation
+                      // this screen exists for.
+                      kDebugMode || kProfileMode ? '$error\n\n$stack' : '$error',
+                      style: const TextStyle(color: Color(0xFFFFB4A9), fontSize: 13, height: 1.4),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/scripts/generate_ios_dev_info_plist.sh
+++ b/app/scripts/generate_ios_dev_info_plist.sh
@@ -11,6 +11,11 @@ fi
 
 mkdir -p "$(dirname "$OUTPUT_PLIST")"
 cp "$SOURCE_PLIST" "$OUTPUT_PLIST"
+# NSAllowsArbitraryLoads, not NSAllowsLocalNetworking: the latter covers only
+# .local/unqualified/link-local hosts, never a Tailscale CGNAT address
+# (100.64.0.0/10), which is what the documented local-dev device setup uses.
+# See #11730/#11652/#11782 — a prior version of this script wrote
+# NSAllowsLocalNetworking and silently reverted the CGNAT fix on every run.
 /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$OUTPUT_PLIST"
-/usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool true' "$OUTPUT_PLIST"
+/usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool true' "$OUTPUT_PLIST"
 plutil -lint "$OUTPUT_PLIST" >/dev/null

--- a/app/test/shell/ios_dev_ats_config_test.sh
+++ b/app/test/shell/ios_dev_ats_config_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Behavioral test for the ATS policy generate_ios_dev_info_plist.sh writes into
+# Info-Dev.plist.
+#
+# Regression covered (#11782): the generator used to write
+# NSAllowsLocalNetworking unconditionally on every `setup.sh ios` run. That key
+# only covers .local/unqualified/link-local hosts, never a Tailscale CGNAT
+# address (100.64.0.0/10) — the address the documented physical-device setup
+# actually uses (see #11730/#11652). Because the generator runs on every
+# `setup.sh ios` invocation and always starts from a fresh copy of Info.plist,
+# it silently reverted the CGNAT fix that #11652 hand-edited into the checked-in
+# Info-Dev.plist, with no warning and no diff to notice. Confirmed live on a
+# physical device: every NSURLSession call failed with CFNetwork Code=-1022
+# until the generator's output was corrected.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="${SCRIPT_DIR}/../.."
+GENERATOR="${APP_DIR}/scripts/generate_ios_dev_info_plist.sh"
+
+failures=0
+pass() { echo "  ok   - $1"; }
+fail() { echo "  FAIL - $1" >&2; failures=$((failures + 1)); }
+
+[[ -f "$GENERATOR" ]] || { echo "FAIL: missing $GENERATOR" >&2; exit 1; }
+
+work=$(mktemp -d -t omi_ios_dev_ats_XXXXXX)
+cat > "$work/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Runner</string>
+</dict>
+</plist>
+PLIST
+
+bash "$GENERATOR" "$work/Info.plist" "$work/Info-Dev.plist" >/dev/null 2>&1
+
+echo "generate_ios_dev_info_plist.sh ATS output:"
+
+if /usr/libexec/PlistBuddy -c 'Print :NSAppTransportSecurity:NSAllowsArbitraryLoads' "$work/Info-Dev.plist" 2>/dev/null | grep -qi true; then
+  pass "output declares NSAllowsArbitraryLoads=true"
+else
+  fail "output is missing NSAllowsArbitraryLoads=true — CGNAT dev hosts (Tailscale) would be ATS-blocked"
+fi
+
+if /usr/libexec/PlistBuddy -c 'Print :NSAppTransportSecurity:NSAllowsLocalNetworking' "$work/Info-Dev.plist" 2>/dev/null; then
+  fail "output declares NSAllowsLocalNetworking — combined with NSAllowsArbitraryLoads this is a documented no-op that silently re-blocks CGNAT hosts"
+else
+  pass "output does not declare NSAllowsLocalNetworking"
+fi
+
+rm -rf "$work"
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures shell test(s) failed" >&2
+  exit 1
+fi
+echo "all iOS dev ATS config shell tests passed"

--- a/app/test/unit/auth_refresh_timeout_test.dart
+++ b/app/test/unit/auth_refresh_timeout_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/services/auth/auth_token_result.dart';
+import 'package:omi/services/auth_service.dart';
+
+/// A forced token refresh that never returns must not hang its caller.
+///
+/// `backend/http/shared.dart` refreshes on the way into *every* authenticated
+/// request, so an unbounded stall in the refresh silently freezes all backend
+/// traffic app-wide: no error, no snackbar, nothing to report. Measured on
+/// iPhone 17 Pro / iOS 27.0 against a Firebase Auth emulator on a non-loopback
+/// host, `forceRefresh()` never returned at all — the app completed a clean run
+/// of onboarding requests on its cached token and then went permanently silent.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('a refresh that never returns resolves as a transient failure', () async {
+    final gateway = _StallingGateway(neverCompletes: true);
+    final service = _service(gateway, timeout: const Duration(milliseconds: 30));
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenTransientFailure>());
+    expect(
+      (result as AuthTokenTransientFailure).failureClass,
+      'refresh_timeout',
+      reason: 'a stall must be distinguishable in telemetry from a refresh that actually failed',
+    );
+  });
+
+  test('a stalled refresh is still retried, not abandoned after one timeout', () async {
+    final gateway = _StallingGateway(neverCompletes: true);
+    final service = _service(gateway, timeout: const Duration(milliseconds: 20));
+
+    await service.refreshIdToken();
+
+    // A timeout is classified transient precisely so the existing retry loop
+    // still applies; a stall on one attempt may not be a stall on the next.
+    expect(gateway.refreshCalls, greaterThan(1));
+  });
+
+  test('a slow but successful refresh inside the budget still succeeds', () async {
+    // The bound must not turn a merely slow network into a failed session.
+    final gateway = _StallingGateway(latency: const Duration(milliseconds: 10));
+    final service = _service(gateway, timeout: const Duration(seconds: 5));
+
+    final result = await service.refreshIdToken();
+
+    expect(result, isA<AuthTokenSuccess>());
+    expect(result.tokenOrNull, 'slow-token');
+  });
+
+  test('the caller gets a result rather than waiting forever', () async {
+    // The user-visible property: refreshIdToken() completes. Everything above is
+    // about *which* result; this is about it returning at all.
+    final gateway = _StallingGateway(neverCompletes: true);
+    final service = _service(gateway, timeout: const Duration(milliseconds: 20));
+
+    await expectLater(
+      service.refreshIdToken().timeout(const Duration(seconds: 5)),
+      completes,
+    );
+  });
+}
+
+AuthService _service(_StallingGateway gateway, {required Duration timeout}) => AuthService.forTesting(
+      tokenGateway: gateway,
+      refreshDelay: (_) async {},
+      refreshAttemptTimeout: timeout,
+    );
+
+final class _StallingGateway implements AuthTokenGateway {
+  _StallingGateway({this.neverCompletes = false, this.latency});
+
+  final bool neverCompletes;
+  final Duration? latency;
+  int refreshCalls = 0;
+
+  @override
+  AuthUserSnapshot? get currentUser => const AuthUserSnapshot(
+        uid: 'user-1',
+        email: 'person@example.com',
+        displayName: 'Person Example',
+      );
+
+  @override
+  Future<RefreshedAuthToken?> forceRefresh() {
+    refreshCalls++;
+    if (neverCompletes) return Completer<RefreshedAuthToken?>().future;
+    return Future<RefreshedAuthToken?>.delayed(
+      latency ?? Duration.zero,
+      () => RefreshedAuthToken(token: 'slow-token', expirationTime: DateTime.now()),
+    );
+  }
+
+  @override
+  Future<void> signOut() async {}
+}

--- a/app/test/unit/env_test.dart
+++ b/app/test/unit/env_test.dart
@@ -149,6 +149,52 @@ void main() {
       }
     });
 
+    test('local dev accepts loopback and every private-network range, including CGNAT', () {
+      for (final endpoint in [
+        'http://127.0.0.1:8000/',
+        'http://localhost:8000/',
+        'http://10.0.0.5:8000/',
+        'http://172.16.0.5:8000/',
+        'http://172.31.255.254:8000/',
+        'http://192.168.1.20:8000/',
+        // 100.64.0.0/10 (RFC 6598, carrier-grade NAT) is the range Tailscale
+        // assigns. A physical device cannot reach the local harness any other
+        // way — the harness binds loopback only by design — so rejecting this
+        // range stranded the app on a blank splash with no diagnostic.
+        'http://100.64.0.1:8000/',
+        'http://100.105.2.5:8000/',
+        'http://100.127.255.254:8000/',
+      ]) {
+        Env.validateStartupRouting(
+          productionFamily: false,
+          configuredProfile: AppEnvironmentProfile.localDev,
+          configuredApiBaseUrl: endpoint,
+        );
+      }
+    });
+
+    test('local dev still rejects public endpoints and the edges just outside CGNAT', () {
+      for (final endpoint in [
+        'https://api.omi.me/',
+        'https://api.omiapi.com/',
+        // 100.63.x and 100.128.x sit immediately outside 100.64.0.0/10 and must
+        // stay rejected — widening this must not degrade into "any 100.x host".
+        'http://100.63.255.255:8000/',
+        'http://100.128.0.1:8000/',
+        'http://8.8.8.8:8000/',
+      ]) {
+        expect(
+          () => Env.validateStartupRouting(
+            productionFamily: false,
+            configuredProfile: AppEnvironmentProfile.localDev,
+            configuredApiBaseUrl: endpoint,
+          ),
+          throwsStateError,
+          reason: endpoint,
+        );
+      }
+    });
+
     test('local prod accepts loopback, private-network, and tunnel endpoints in debug builds', () {
       for (final endpoint in [
         'http://127.0.0.1:8000/',

--- a/app/test/unit/startup_auth_timeout_test.dart
+++ b/app/test/unit/startup_auth_timeout_test.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/startup_auth.dart';
+
+void main() {
+  group('resolveStartupAuth', () {
+    test('a refresh that never returns does not block startup', () async {
+      // The regression this guards. On iPhone 17 Pro / iOS 27.0 against a
+      // Firebase Auth emulator on a non-loopback host, FirebaseAuth's forced
+      // token refresh never returned — not an error, just silence. Because this
+      // await sits before runApp(), the app showed the launch storyboard forever
+      // and could not be started again until it was deleted, since the cached
+      // session made every launch hang here.
+      final neverCompletes = Completer<String?>();
+
+      final result = await resolveStartupAuth(
+        () => neverCompletes.future,
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      expect(result, isFalse, reason: 'a stalled refresh must resolve as unauthenticated, not hang');
+    });
+
+    test('a successful refresh is authenticated', () async {
+      final result = await resolveStartupAuth(
+        () async => 'a-real-token',
+        timeout: const Duration(seconds: 5),
+      );
+      expect(result, isTrue);
+    });
+
+    test('a failed refresh is unauthenticated, exactly as before', () async {
+      // getIdToken() already returns null on every failure branch and startup
+      // already continued to the sign-in screen. The timeout must not change
+      // that path.
+      final result = await resolveStartupAuth(
+        () async => null,
+        timeout: const Duration(seconds: 5),
+      );
+      expect(result, isFalse);
+    });
+
+    test('a slow but successful refresh still authenticates', () async {
+      // The timeout must not log out a user on a merely slow network.
+      final result = await resolveStartupAuth(
+        () => Future<String?>.delayed(const Duration(milliseconds: 20), () => 'token'),
+        timeout: const Duration(seconds: 5),
+      );
+      expect(result, isTrue);
+    });
+  });
+}

--- a/app/test/unit/startup_failure_app_test.dart
+++ b/app/test/unit/startup_failure_app_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/startup_failure_app.dart';
+
+void main() {
+  group('StartupFailureApp', () {
+    testWidgets('renders the actual error text instead of a blank screen', (tester) async {
+      // The regression this guards: a StateError thrown by
+      // validateApplicationStartupRouting() used to leave the launch storyboard
+      // up forever, because runApp() was never reached and the zone handler only
+      // called debugPrint — invisible in profile and release builds.
+      final error = StateError(
+        'Profile local_dev requires a loopback or private-network API endpoint; '
+        'use mobile_beta for https://api.omiapi.com/.',
+      );
+
+      await tester.pumpWidget(StartupFailureApp(error: error, stack: StackTrace.current));
+
+      expect(find.text('Omi could not start'), findsOneWidget);
+      expect(
+        find.textContaining('requires a loopback or private-network API endpoint', findRichText: true),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders without any provider, service or localisation scope', (tester) async {
+      // It must survive being shown when startup itself failed, so it cannot
+      // depend on anything _init() sets up. Pumping it bare is the assertion.
+      await tester.pumpWidget(StartupFailureApp(error: Exception('boom'), stack: null));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(MaterialApp), findsOneWidget);
+    });
+
+    testWidgets('error text is selectable so it can be copied off-device', (tester) async {
+      // There is no debugger attached in the situation this screen exists for.
+      await tester.pumpWidget(StartupFailureApp(error: Exception('copy me'), stack: null));
+
+      expect(find.byType(SelectableText), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Four fixes to iOS startup, found while getting a community build to run against the local dev harness on real hardware. They are independent of each other and of the sign-in work that surfaced them.

## 1. `local_dev` rejected Tailscale's address range

`Env._isLocalDevelopmentApi` allowed loopback and RFC 1918 only. Tailscale assigns from **100.64.0.0/10** (RFC 6598 shared address space), which is neither, so `validateApplicationStartupRouting()` threw before any network call:

```
StateError: Profile local_dev requires a loopback or private-network API endpoint;
use mobile_beta for https://api.omiapi.com/.
```

This is not an exotic setup. The dev harness binds loopback only *by design* (`scripts/dev-harness/dev_harness/safety.py:194` is a fail-closed guard holding real provider keys), so a physical device cannot reach it on `127.x` and cannot reach it over the LAN either. A tailnet address is in practice the only route from real hardware to a developer's harness.

Measured on iPhone 17 Pro / iOS 27.0, one variable at a time:

| `OMI_API_BASE_URL` | Reachable? | Result |
|---|---|---|
| loopback default | no | reaches sign-in |
| `http://100.105.2.5:8000/` | yes, responds | splash hang |
| `http://100.105.2.5:9999/` | nothing listening | splash hang |

The dead-port run is the discriminator: no responding server is required, which is what pointed at a validation guard rather than a connection. Bounded to the real /10 — tests assert `100.63.x` and `100.128.x` stay rejected so this cannot decay into "any 100.x host".

## 2. A startup throw showed a blank splash screen

`_init()` runs inside `runZonedGuarded`, whose handler logs with `debugPrint` and nothing else — and `debugPrint` is invisible in profile and release builds. Any throw before `runApp()` left the launch storyboard up indefinitely: no UI, no crash, no message.

The failure mode was worse than the failure it hid. Fix 1 above threw a precise, actionable `StateError` naming the exact misconfiguration; presenting that as a frozen splash is what made it expensive — five connectivity hypotheses were investigated on device before anyone read the guard.

`StartupFailureApp` is deliberately dependency-free: no providers, services, theme lookups or localisation, since all of those are precisely what may have just failed to initialise. Message is selectable because the situation it exists for is a device with no debugger attached.

## 3. Startup awaited the auth refresh with no timeout

`_init()` awaited `getIdToken()` before `runApp()`. Measured on the same device against a Firebase Auth emulator on a non-loopback host, FirebaseAuth's forced refresh **never returned at all** — not an error, just silence. File-backed probes recorded entry to `_refreshIdTokenWithRetries` with every guard passing, then no further line. The app could not be launched again until it was deleted, because the cached session made every start hang there.

Note fix 2 does not help here: it catches throws, and this is a hang.

## 4. The forced refresh could freeze every request app-wide

`backend/http/shared.dart:73` refreshes on the way into **every** authenticated request, so the same stall took the whole app offline. Observed end to end: the app signed in, ran onboarding normally on its cached token — a clean sequence of 200s — then went permanently silent the moment a refresh was first required. Tapping a button did nothing at all, because neither the success nor the failure path ran.

Each attempt is now bounded, and a stall is reported as a transient failure — which the surrounding retry loop and every existing caller already handle, since `getIdToken()` returns null on four failure branches today. So this only makes a hang behave like the failure it effectively is; it never fails a refresh the old code would have completed. `refresh_timeout` is a distinct failure class so a stall stays distinguishable in telemetry from a genuine failure.

**This does not fix the underlying stall.** Why FirebaseAuth's forced refresh never returns against the Auth emulator on a non-loopback host is still unexplained — the SDK does route it through the emulator (`SecureTokenRequest.swift:129-130` builds exactly the URL that answers instantly to `curl`), the device reaches the public internet, and ATS permits the plain-http call that sign-in already makes to the same host and port. This makes that failure survivable rather than fatal.

## Verification

```
flutter test test/unit  ->  772 passed
```

11 new tests. The CGNAT case fails without fix 1 with exactly the `StateError` quoted above. The hang guards supply futures that never complete and assert startup and `refreshIdToken` both resolve. Slow-but-successful refreshes inside the budget are asserted unaffected, so neither bound can sign a user out on a slow network.

Also exercised on device throughout: iPhone 17 Pro, iOS 27.0, profile build, against a local harness reached over Tailscale.

One implementation note worth flagging for review: the bounds are written as races rather than `Future.timeout(onTimeout:)`. `onTimeout` must return the *concrete* future's type, so a callback producing `Future<String>` rather than `Future<String?>` makes `() => null` throw a `TypeError` at runtime — turning a hang-guard into a new startup crash. A test caught exactly that during development and now pins it.

## INV-DATA-1

`app/lib/env/env.dart`, `app/lib/main.dart` and `app/lib/startup_routing.dart` are path globs of `INV-DATA-1`. Production-family routing is unchanged: production keeps its own exact-match branch, fix 1 widens only the `local_dev` branch, and fixes 2-4 change no routing at all. The invariant's MUST NOT clauses all concern production-family endpoints.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

