### PR TITLE
fix(desktop): keep the system banner for functional notices when the Ask Omi bar is off (#11645)

### DIFF
--- a/.github/failure-classes/FC-broadened-default-surface-absorbs-explicit-delivery.json
+++ b/.github/failure-classes/FC-broadened-default-surface-absorbs-explicit-delivery.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-broadened-default-surface-absorbs-explicit-delivery",
+  "violated_contract": "Widening a default presentation path to cover a state it previously skipped must not consume deliveries whose caller explicitly requested a different, persistent surface. Delivery policies that suppress duplicates treat 'the default surface accepted it' as proof the user was reached, so once the broadened path accepts a functional notice the explicit surface is dropped as a duplicate. A notice sent once per episode has no second chance: the disabled Ask Omi bar's temp-show card auto-dismisses in seconds, and the screen-recording repair prompt's one-shot flag is set at that delivery and cleared only on capture recovery, which cannot happen while capture is broken.",
+  "canonical_prevention": "Pass the caller's explicit surface intent into the policy that selects the presentation, so a broadened default applies only to callers that did not name a surface. FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview takes deliverSystemBanner and yields the card when the bar is disabled and a banner was explicitly requested; the regression tests assert both the widened default and the explicit-intent path.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift"
+  ],
+  "evidence_prs": [
+    11636
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Services/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+NotificationSettings.swift
@@ -49,6 +49,7 @@ struct ProactiveTestNotificationPayload: Sendable {
   private static let supportedKeys = [
     "hours", "count", "title", "message", "assistantId", "sourceApp",
     "windowTitle", "contextSummary", "currentActivity", "reasoning", "detail",
+    "deliverSystemBanner",
   ]
 
   private let values: [String: String]

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -1226,13 +1226,21 @@ public class ProactiveAssistantsPlugin: NSObject {
         detail: payload["detail"]
       )
 
-      log("NotificationTestCLI: Received test trigger (title=\(resolvedTitle), assistantId=\(resolvedAssistantId))")
+      // Functional notices (screen-recording repair, meeting hand-off) opt into a system
+      // banner; the proactive default does not. The CLI carries the flag so both delivery
+      // contracts stay exercisable against a real running bundle.
+      let deliverSystemBanner = payload["deliverSystemBanner"] == "true"
+
+      log(
+        "NotificationTestCLI: Received test trigger (title=\(resolvedTitle), "
+          + "assistantId=\(resolvedAssistantId), deliverSystemBanner=\(deliverSystemBanner))")
       NotificationService.shared.sendNotification(
         ownerID: ownerID,
         title: resolvedTitle,
         message: resolvedMessage,
         assistantId: resolvedAssistantId,
-        context: context
+        context: context,
+        deliverSystemBanner: deliverSystemBanner
       )
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/FloatingBarNotificationPreviewPolicy.swift
@@ -13,8 +13,19 @@ enum FloatingBarNotificationPreviewPolicy {
   ///   (present, then re-hide). Previews-muted does not silence this path:
   ///   only the notification toggle decides, and a muted-preview + disabled-bar
   ///   combination still owes a visible surface.
-  static func shouldShowInBarPreview(previewsEnabled: Bool, floatingBarEnabled: Bool) -> Bool {
-    previewsEnabled || !floatingBarEnabled
+  /// - Bar disabled + an explicit `deliverSystemBanner` caller → skip the card so the
+  ///   banner it asked for is not swallowed. The temp-show path is a card on a bar the
+  ///   user turned off: it auto-dismisses after seconds and leaves nothing behind, which
+  ///   is not a surface for a functional notice that must reach a user away from the app.
+  ///   The screen-recording repair notice is delivered once per broken-capture episode
+  ///   (`screenCaptureResetShownKey`, cleared only on recovery), so a missed card is the
+  ///   whole notice. With the bar enabled the card stays authoritative and the
+  ///   no-duplicate-surface rule is unchanged.
+  static func shouldShowInBarPreview(
+    previewsEnabled: Bool, floatingBarEnabled: Bool, deliverSystemBanner: Bool
+  ) -> Bool {
+    if deliverSystemBanner && !floatingBarEnabled { return false }
+    return previewsEnabled || !floatingBarEnabled
   }
 
   /// The system-banner fallback only fires when the user explicitly muted in-bar

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -344,7 +344,11 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// (`ShortcutSettings.floatingBarNotificationPreviewsEnabled == false`) while the
   /// Floating Bar is still enabled, so that opt-out is never fully silenced (#6765).
   /// Previews muted *and* the bar disabled still temp-shows the card rather than
-  /// going silent or falling back to a contentless banner.
+  /// going silent or falling back to a contentless banner. That temp-show is a
+  /// proactive-notification surface only: a caller passing `deliverSystemBanner: true`
+  /// while the bar is disabled keeps its banner instead, because a card on a bar the
+  /// user turned off auto-dismisses in seconds and cannot carry a functional notice
+  /// (the screen-recording repair prompt is delivered once per broken-capture episode).
   /// `insightDeliveryID`, when present, is an opaque Advice correlation key. It records only
   /// bounded delivery outcomes and never carries notification text or window context.
   func sendNotification(
@@ -464,7 +468,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     let previewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
     let floatingBarEnabled = FloatingControlBarManager.shared.isEnabled
     let floatingBarPreviewEnabled = FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-      previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled
+      previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
+      deliverSystemBanner: deliverSystemBanner
     )
 
     var floatingBarMayDeliver = false
@@ -593,7 +598,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     let floatingBarEnabled = FloatingControlBarManager.shared.isEnabled
     if FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
       previewsEnabled: previewsEnabled,
-      floatingBarEnabled: floatingBarEnabled)
+      floatingBarEnabled: floatingBarEnabled,
+      deliverSystemBanner: false)
     {
       return FloatingControlBarManager.shared.contextNotificationPreflight(
         ownerID: ownerID,
@@ -644,7 +650,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     let previewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
     let floatingBarEnabled = FloatingControlBarManager.shared.isEnabled
     let showInBar = FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-      previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled)
+      previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
+      deliverSystemBanner: false)
     let deliverSystemBanner = FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
       previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled, deliverSystemBanner: false)
 

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -15,7 +15,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testPreviewsAndBarEnabledShowsPreviewWithNoForcedBanner() {
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: true, floatingBarEnabled: true))
+        previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: false))
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
         previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: false))
@@ -24,7 +24,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testFloatingBarDisabledPresentsViaTempShowWithNoForcedBanner() {
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: true, floatingBarEnabled: false),
+        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false),
       "bar disabled + notifications owed must still present the in-bar card via temp-show")
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
@@ -35,7 +35,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testPreviewsMutedSkipsPreviewAndFallsBackToBanner() {
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: false, floatingBarEnabled: true))
+        previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false))
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
         previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false))
@@ -44,7 +44,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testFloatingBarDisabledAndPreviewsMutedStillTempShowsTheCard() {
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: false, floatingBarEnabled: false),
+        previewsEnabled: false, floatingBarEnabled: false, deliverSystemBanner: false),
       "previews muted + bar disabled must still temp-show the card; only the notification toggle silences")
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
@@ -55,7 +55,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   func testBarDisabledDoesNotSilenceWhenMasterNotificationsAreOffTheMasterGateDoes() {
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: true, floatingBarEnabled: false))
+        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false))
     XCTAssertEqual(
       InsightAssistantTelemetry.Reason.masterNotificationsDisabled.rawValue,
       "master_notifications_disabled",
@@ -86,12 +86,71 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
         floatingBarAccepted: false))
   }
 
+  /// A functional caller (`deliverSystemBanner: true`) with the bar disabled must keep the
+  /// persistent banner it asked for. Routing it through the temp-show card marks the
+  /// floating bar as having accepted delivery, which suppresses the banner — and the
+  /// screen-recording repair notice is one-per-episode, so the seconds-long card is the
+  /// only notice the user ever gets while capture stays broken.
+  func testFunctionalBannerWithBarDisabledKeepsItsBannerInsteadOfTheTempShowCard() {
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: true),
+      "a functional notice with the bar disabled must not be swallowed by the temp-show card")
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
+        previewsEnabled: true,
+        floatingBarEnabled: false,
+        deliverSystemBanner: true,
+        floatingBarAccepted: false),
+      "skipping the card must leave the explicit system banner as the delivered surface")
+  }
+
+  /// The muted-previews variant of the same case: still no card, still the banner.
+  func testFunctionalBannerWithBarDisabledAndPreviewsMutedStillDeliversTheBanner() {
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: false, floatingBarEnabled: false, deliverSystemBanner: true))
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
+        previewsEnabled: false,
+        floatingBarEnabled: false,
+        deliverSystemBanner: true,
+        floatingBarAccepted: false))
+  }
+
+  /// The bar-enabled contract is untouched: the card stays authoritative and an explicit
+  /// banner request does not duplicate it.
+  func testFunctionalBannerWithBarEnabledStillPresentsTheCardAndNoDuplicateBanner() {
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: true, floatingBarEnabled: true, deliverSystemBanner: true))
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
+        previewsEnabled: true,
+        floatingBarEnabled: true,
+        deliverSystemBanner: true,
+        floatingBarAccepted: true))
+  }
+
+  /// Proactive delivery with the bar disabled keeps the temp-show card (the #11636 fix).
+  func testProactiveDeliveryWithBarDisabledStillUsesTheTempShowCard() {
+    XCTAssertTrue(
+      FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: true, floatingBarEnabled: false, deliverSystemBanner: false))
+    XCTAssertFalse(
+      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
+        previewsEnabled: true,
+        floatingBarEnabled: false,
+        deliverSystemBanner: false,
+        floatingBarAccepted: true))
+  }
+
   func testDirectorMutedPreviewFallsBackToBannerInsteadOfSilentQuotaBurn() {
     // Context-director presentation must use this policy: muted previews with
     // the floating bar still enabled keep a visible system-banner surface.
     XCTAssertFalse(
       FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-        previewsEnabled: false, floatingBarEnabled: true))
+        previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false))
     XCTAssertTrue(
       FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBanner(
         previewsEnabled: false, floatingBarEnabled: true, deliverSystemBanner: false),

--- a/desktop/macos/changelog/unreleased/20260815-functional-banner-bar-disabled.json
+++ b/desktop/macos/changelog/unreleased/20260815-functional-banner-bar-disabled.json
@@ -1,0 +1,3 @@
+{
+  "change": "With the Ask Omi bar turned off, the \"Screen Recording Needs Reset\" prompt is delivered as a real macOS notification again instead of a card that pops the hidden bar open for a few seconds — that notice is sent only once per broken-capture episode, so a missed card left screen capture off with no further warning"
+}


### PR DESCRIPTION
Fixes #11645.

## Bug

With the **Ask Omi bar turned off**, the screen-recording repair prompt stopped arriving as a macOS notification. It popped the hidden bar open as a card that auto-dismisses after 6s and left nothing behind. That notice is delivered **once per broken-capture episode**, so a missed card is the entire notice — screen capture stays off and the user is never told again.

## Root cause

#11636 (`dd4d06e020`) changed `FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview` from `previewsEnabled && floatingBarEnabled` to `previewsEnabled || !floatingBarEnabled`, so a disabled bar delivers via the temp-show path instead of staying silent. That is right for proactive notifications, but it applied to every caller — including the four that explicitly opt into a system banner with `deliverSystemBanner: true`:

- `ProactiveAssistantsPlugin.swift:1472` — screen-recording permission lost
- `ProactiveAssistantsPlugin.swift:1747`, `:1764` — "Screen Recording Needs Reset"
- `MeetingActionItemBannerService.swift:95` — meeting hand-off

With the bar disabled: `shouldShowInBarPreview` → `true` → card temp-shown → `floatingBarAccepted = true` → `shouldDeliverSystemBannerAfterFloatingBar` returns `false` under its no-duplicate-surface rule → the requested banner is dropped. `NotificationService.swift:392` compounds it: `screenCaptureResetShownKey` is set at delivery and cleared only on capture *recovery* (`AppState+Permissions.swift:353`), which cannot happen while capture is broken.

## Fix

Pass the caller's `deliverSystemBanner` intent into `shouldShowInBarPreview` and skip the card when the bar is disabled, so the explicit banner survives. Everything else is unchanged: proactive delivery with the bar disabled keeps the #11636 temp-show card, the bar-enabled card stays authoritative with no duplicate banner, and the #6765 previews-muted fallback is untouched. The two context-director call sites pass `deliverSystemBanner: false`, matching the value they already pass to `shouldDeliverSystemBanner`.

The notification test CLI also learns the `deliverSystemBanner` key so the functional-notice contract is exercisable against a real running bundle, not just the proactive default.

## Tested

- `swift test --filter FloatingBarNotificationPreviewPolicyTests` — 13/13 pass (full `Desktop` package build).
- Negative control: with only the new guard line removed and everything else identical, exactly the two new regression cases fail (`testFunctionalBannerWithBarDisabledKeepsItsBannerInsteadOfTheTempShowCard`, `testFunctionalBannerWithBarDisabledAndPreviewsMutedStillDeliversTheBanner`) and the other 11 still pass — so the guard is load-bearing and the pre-existing contracts are unchanged.
- Not exercised in a running signed bundle: this machine has no code-signing identity, and ad-hoc signing would invalidate the Screen Recording TCC grant for every Omi app on it. The decision this fix changes is entirely inside the policy seam that the suite covers end-to-end (`shouldShowInBarPreview` → `shouldDeliverSystemBannerAfterFloatingBar`).

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

Adds `FC-broadened-default-surface-absorbs-explicit-delivery`: widening a default presentation path to cover a state it previously skipped must not consume deliveries whose caller explicitly requested a different, persistent surface.

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 1778 -> 1786 | notification test CLI carries the deliverSystemBanner flag so the functional-notice path this PR fixes can be triggered against a running bundle

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

