### PR TITLE
chore(backend): refresh stale query-coverage baseline counts

### DIFF
--- a/backend/scripts/firestore_query_coverage_baseline.json
+++ b/backend/scripts/firestore_query_coverage_baseline.json
@@ -1,5 +1,5 @@
 {
-  "eligible_serving": 47,
+  "eligible_serving": 70,
   "raw_unregistered": [
     "05fdb282df637274",
     "0c75b579eb9f7f04",
@@ -45,7 +45,7 @@
     "fbf6a1e1fdc6920e",
     "fcb4a9e8a36ebd5e"
   ],
-  "registered_serving": 1,
+  "registered_serving": 24,
   "schema_version": 1,
   "unsupported": [
     "4a1b611f6580fc78",


### PR DESCRIPTION
## What

The committed query-coverage baseline reports **47 eligible / 1 registered** serving query shapes. Regenerating from the current registry yields **70 / 24**. The hash lists are byte-identical — this is pure count drift.

## Why it rotted

`check_ratchet` only compares the *shape lists*, never the counts. So query specs got registered over time, the counts never got refreshed, and nothing ever failed. The counts are human-reading surface, and they've been under-reporting registration progress by 23 shapes.

Spotted while adding new queries in #11657; kept separate so that PR's diff stays scoped to its own two shapes.

## Verification

```
backend/tests/unit/test_firestore_query_contract.py    26 passed
```

Regenerated with `scripts/firestore_query_coverage.py --format baseline` — not hand-edited.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Baseline JSON metadata only; no runtime, query, or ratchet logic changes.
> 
> **Overview**
> Updates **`firestore_query_coverage_baseline.json`** so serving coverage totals match the current registry: **`eligible_serving`** 47 → **70** and **`registered_serving`** 1 → **24**. The **`raw_unregistered`** and **`unsupported`** hash lists are unchanged—only the headline counts were stale because **`check_ratchet`** compares shape sets, not count fields, so registration progress never forced a baseline refresh.
> 
> Values were regenerated via **`scripts/firestore_query_coverage.py --format baseline`**, not hand-edited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04483dd3ccbe8a940f0e17b19e6552011224594. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->