### PR TITLE
fix(dev-harness): reap the detached Firestore emulator JVM on dev-down (#11654)

### DIFF
--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -222,6 +222,7 @@ def _stop_single_service(cfg: config.HarnessConfig, record: dict[str, object]) -
     service = str(record.get("service"))
     if not safety.process_exists(pid):
         return
+    descendants = safety.descendant_pids(pid)
     try:
         safety.validate_owned_pid(pid, process_manifest=cfg.layout.process_manifest, service=service)
         _signal_owned_process_group(pid, service)
@@ -238,6 +239,7 @@ def _stop_single_service(cfg: config.HarnessConfig, record: dict[str, object]) -
             os.killpg(pid, signal.SIGTERM)
         except (ProcessLookupError, PermissionError):
             pass
+    _reap_detached_port_holders(record, descendants)
     remaining = [entry for entry in _process_records(cfg) if entry.get("service") != service]
     _save_manifests(cfg, remaining)
 
@@ -1023,8 +1025,51 @@ def _signal_owned_process_group(pid: int, service: str) -> None:
         raise safety.SafetyError(f"Cannot signal process group {pid}: {exc}") from exc
 
 
+def _reap_detached_port_holders(record: dict[str, object], descendants: tuple[int, ...]) -> None:
+    """Stop a detached child that survived the group signal and still owns the service port.
+
+    Ownership is proven twice over: the PID was a descendant of the manifest-validated
+    supervisor before any signal was sent, and it is still holding the port this service
+    recorded. Anything else on the port is left alone.
+    """
+
+    service = str(record.get("service"))
+    port = int(record.get("port", 0) or 0)
+    if port <= 0 or not descendants:
+        return
+    try:
+        holders = safety.listening_pids(port)
+    except safety.SafetyError as exc:
+        print(f"{service}: cannot inspect port {port} after stop: {exc}")
+        return
+    owned = [pid for pid in holders if pid in descendants]
+    for pid in holders:
+        if pid not in descendants:
+            print(f"{service}: port {port} held by unowned pid {pid}; leaving it for safety inspection")
+    for pid in owned:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            print(f"{service}: sent SIGTERM to detached child {pid} still holding port {port}")
+        except (ProcessLookupError, PermissionError) as exc:
+            print(f"{service}: cannot stop detached child {pid} on port {port}: {exc}")
+    deadline = time.time() + 5
+    while time.time() < deadline and any(safety.process_exists(pid) for pid in owned):
+        time.sleep(0.25)
+    for pid in owned:
+        if not safety.process_exists(pid):
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+            print(f"{service}: sent SIGKILL to detached child {pid} still holding port {port}")
+        except (ProcessLookupError, PermissionError) as exc:
+            print(f"{service}: detached child {pid} still holds port {port}: {exc}")
+
+
 def _stop_owned(cfg: config.HarnessConfig) -> None:
     records = _process_records(cfg)
+    # Capture the tree while the supervisors are alive; detached children (the
+    # Firestore emulator JVM) are unreachable through the process group.
+    descendants = {int(record.get("pid", -1)): safety.descendant_pids(int(record.get("pid", -1))) for record in records}
     for record in records:
         pid = int(record.get("pid", -1))
         service = str(record.get("service"))
@@ -1055,6 +1100,7 @@ def _stop_owned(cfg: config.HarnessConfig) -> None:
         pid = int(record.get("pid", -1))
         if safety.process_exists(pid):
             print(f"{record.get('service')}: still running pid={pid}; leaving it for safety inspection")
+        _reap_detached_port_holders(record, descendants.get(pid, ()))
     _save_manifests(cfg, records)
 
 

--- a/scripts/dev-harness/dev_harness/safety.py
+++ b/scripts/dev-harness/dev_harness/safety.py
@@ -518,6 +518,52 @@ def is_descendant_of(pid: int, ancestor_pid: int) -> bool:
     return current == ancestor
 
 
+def descendant_pids(ancestor_pid: int) -> tuple[int, ...]:
+    """Snapshot the live descendants of a supervised PID before it is signalled.
+
+    Emulator CLIs spawn their heavyweight children detached (`firebase
+    emulators:start` gives the Firestore JVM its own session), so a process
+    group signal never reaches them. Once the supervisor dies the survivors are
+    reparented to init and the tree is unrecoverable, so teardown has to capture
+    it first.
+    """
+
+    ancestor = int(ancestor_pid)
+    if ancestor <= 1:
+        return ()
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return ()
+    if result.returncode != 0:
+        return ()
+    children: dict[int, list[int]] = {}
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            pid, parent = int(fields[0]), int(fields[1])
+        except ValueError:
+            continue
+        children.setdefault(parent, []).append(pid)
+    found: set[int] = set()
+    queue = list(children.get(ancestor, ()))
+    while queue:
+        pid = queue.pop()
+        if pid in found or pid == ancestor:
+            continue
+        found.add(pid)
+        queue.extend(children.get(pid, ()))
+    return tuple(sorted(found))
+
+
 def validate_owned_pid(pid: int, *, process_manifest: Path, service: str | None = None) -> dict[str, object]:
     manifest = load_json_file(process_manifest)
     records = manifest.get("processes") if isinstance(manifest, dict) else None

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -277,3 +279,112 @@ def test_session_summary_is_local_emulator_non_activation(tmp_path: Path) -> Non
     assert payload["memory_write_attempt_instrumentation"]["instrumented"] is False
     assert "before_digest" in payload["protected_state_digest"]
     assert any("Not DEV_CLOUD_PROOF" in item for item in payload["non_claims"])
+
+
+_DETACHED_PORT_HOLDER = """
+import socket, sys, time
+
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", {port}))
+sock.listen(8)
+sys.stdout.write("ready\\n")
+sys.stdout.flush()
+time.sleep(300)
+"""
+
+_SUPERVISED_PARENT = """
+import subprocess, sys, time
+
+subprocess.Popen([sys.executable, "-c", {holder!r}], start_new_session=True)
+time.sleep(300)
+"""
+
+# dev-up exits and leaves the supervisors running, so the process under test is an
+# orphan reaped by init — not a child of the caller that would linger as a zombie.
+_ORPHANING_LAUNCHER = """
+import subprocess, sys
+
+proc = subprocess.Popen(sys.argv[1:], start_new_session=True,
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+print(proc.pid)
+"""
+
+
+def _wait_for_listener(port: int, *, timeout: float = 20.0) -> tuple[int, ...]:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        pids = safety.listening_pids(port)
+        if pids:
+            return pids
+        time.sleep(0.1)
+    return ()
+
+
+def test_down_reaps_a_detached_child_still_holding_the_service_port(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The Firestore emulator JVM is spawned detached (its own session), so signalling
+    the supervisor's process group never reaches it and it keeps port 8085."""
+
+    monkeypatch.setenv("PROVIDER_MODE", "offline")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    cfg = config.load_config(REPO_ROOT, create_layout=True)
+    port = cfg.firestore_port
+    if safety.listening_pids(port):
+        pytest.skip(f"port {port} is already in use on this machine")
+
+    env = os.environ.copy()
+    _prepend_dev_harness_pythonpath(env)
+    marker = cli._marker(cfg, "firestore")
+    holder = _DETACHED_PORT_HOLDER.format(port=port)
+    launched = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _ORPHANING_LAUNCHER,
+            sys.executable,
+            "-m",
+            "dev_harness.supervise",
+            "--marker",
+            marker,
+            "--service",
+            "firestore",
+            "--",
+            sys.executable,
+            "-c",
+            _SUPERVISED_PARENT.format(holder=holder),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        timeout=30,
+    )
+    supervisor_pid = int(launched.stdout.strip())
+    try:
+        cli._save_manifests(
+            cfg,
+            [
+                {
+                    "service": "firestore",
+                    "pid": supervisor_pid,
+                    "process_group": supervisor_pid,
+                    "port": port,
+                    "endpoint": f"127.0.0.1:{port}",
+                    "ownership_marker": marker,
+                }
+            ],
+        )
+        assert _wait_for_listener(port), "detached port holder never came up"
+
+        cli._stop_owned(cfg)
+
+        assert safety.listening_pids(port) == (), f"port {port} still held after dev-down"
+        assert not safety.process_exists(supervisor_pid), "supervisor survived dev-down"
+    finally:
+        for pid in safety.listening_pids(port) + (supervisor_pid,):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass


### PR DESCRIPTION
## Bug

`make dev-down` reports success but leaves the Firestore emulator running, so the next `make dev-up` fails:

```
dev-up failed: Port 8085 for firestore is already in use by a foreign process.
```

The "foreign process" is a `java` process the harness itself started. Reported in #11654 with `lsof` evidence; auth (9099) and the emulator hub (4400) are torn down correctly, only 8085 leaks.

## Root cause

`firebase emulators:start` spawns downloadable (Java) emulators with `detached: true` (`firebase-tools/lib/emulator/downloadableEmulators.js:333`), which on POSIX puts the Firestore JVM in **its own session and process group**. Verified live: supervisor pid 88444 → firebase CLI 88447 → `java -jar cloud-firestore-emulator-v1.21.0.jar --port 8085` at pid **88475 with pgid 88475**.

`_stop_owned` only signals the supervisor's process group, so the JVM is never signalled directly. It normally still dies because the firebase CLI handles SIGINT and stops it — but that clean shutdown does `onExit` (export-on-exit) plus a 4s per-emulator kill timeout. When it does not finish inside the harness's 8s window, the harness escalates to SIGTERM on the group, kills the CLI mid-shutdown, and the detached JVM survives forever. The other two emulators are implemented in-process in Node, which is why only 8085 leaks.

## Fix

Teardown now snapshots each supervisor's descendants **before** signalling (once the parent dies the survivors are reparented to init and the tree is unrecoverable), and after the group signals stops any snapshot descendant still listening on that service's recorded port. Ownership is proven twice — descendant of a manifest-validated supervisor before any signal *and* holder of the port this service recorded — so anything else on the port is reported and left alone. `_stop_single_service` (the unhealthy-service restart path) gets the same treatment; it leaks identically today and then trips the port-availability guard on restart.

## What I tested

- **Real emulator, real teardown path.** Started the harness's own `_firebase_command` under the real `dev_harness.supervise` wrapper (orphaned, as `dev-up` leaves it), waited for 8085, then ran the real `_stop_owned`. Clean case: shuts down in 8.3s, 8085 and 9099 both free, reap not needed. Leak case (SIGSTOP on the firebase CLI to reproduce a clean shutdown that does not finish in the window): `firestore: sent SIGTERM to detached child 88475 still holding port 8085` → `8085 listeners after dev-down: ()`. Before this change the identical run leaves the JVM listening.
- **Regression test** `test_down_reaps_a_detached_child_still_holding_the_service_port` — drives `_stop_owned` against a real supervised process whose child detaches into its own session and holds the port. Fails without the fix (`AssertionError: port 8085 still held after dev-down`), passes with it.
- `scripts/dev-harness/tests`: 71 passed, 7 skipped.
- `make preflight` (local lane) green.

## Product invariants

none

Failure-Class: none

The nearest existing class, `FC-self-hosted-qualification-residue` ("residue from an abandoned run can retain processes, ports, containers"), is `dormant` and scoped to the release-gate scripts; per AGENTS.md a dormant class is reopened in its own PR, so this fix does not classify against it.

Fixes #11654

🤖 automated by the hourly desktop bug watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

