### PR TITLE
Windows Home intelligence: the What Matters Now loop, canonical focused goals, personalized suggestions, and a durable feedback outbox

### DIFF
--- a/desktop/windows/docs/mac-parity-audit/track3-ground-truth/_TRACK3-STATUS.md
+++ b/desktop/windows/docs/mac-parity-audit/track3-ground-truth/_TRACK3-STATUS.md
@@ -32,7 +32,7 @@ Mac reference (frozen ground truth): `.worktrees/mac-ref` @ tag `v0.12.72+12072-
 - [ ] **P6 Auto daily goal gen + advice** — goal-completion uses BACKEND contract (C10, Mac wrong).
       Goals nav = GATE G-C.
 - [ ] **P7 Unified connectors** — publish 3 entry points (Memories page / onboarding / Apps hub).
-- [ ] **P8 Home widgets** WhatMattersNowSection + FocusedGoalsSection; delete legacy QuickTask/QuickGoals.
+- [x] **P8 Home widgets** WhatMattersNowSection + FocusedGoalsSection — built as the Home intelligence loop (knows list + canonical goals chips + durable feedback outbox); see gt-home-intelligence-build.md. Legacy HomeGoalsChips retained as the out-of-rollout fallback rather than deleted.
 - [ ] **P9 Page surfaces** to Mac spec: Memories (filters, cards, detail sheet, undo toast, BrainGraph
       mount via props), Tasks (grouped-by-due; NOT rich multi-filter = G-D), Goals (G-C; emoji/gradient/confetti).
 

--- a/desktop/windows/docs/mac-parity-audit/track3-ground-truth/gt-home-intelligence-build.md
+++ b/desktop/windows/docs/mac-parity-audit/track3-ground-truth/gt-home-intelligence-build.md
@@ -1,0 +1,69 @@
+# Home intelligence loop — build note (closes P8)
+
+The Windows port of macOS's What Matters Now recommendation loop, canonical
+goals with focus, and personalized home suggestions. Ground truth extracted from
+`DashboardIntelligenceStore.swift`, `WhatMattersNowSection.swift`,
+`CanonicalGoalsStore.swift`, `HomeSuggestionsStore.swift`, and
+`DashboardPage.swift` (the knows-list composition, rotation, and dismiss rules),
+then verified against the backend contracts in
+`backend/routers/task_recommendations.py` and `backend/routers/goals.py` before
+any TypeScript was written.
+
+## Module map
+
+| Module | Mac source | Owns |
+|---|---|---|
+| `lib/intelligence/wireTypes.ts` | OmiApi.generated.swift structs | Snake_case wire types, lenient enum decode (unknown → `_unknown`, rows dropped later, payload never fails) |
+| `lib/intelligence/feedbackOutbox.ts` | `PendingDashboardFeedback` queue | Durable per-owner outbox: `whatMattersNowFeedbackOutbox.v1.<uid>`, write-ahead, same-key overwrite, one-pass sequential replay, generation purge, pending later/dismiss row suppression |
+| `lib/intelligence/dashboardStore.ts` | `DashboardIntelligenceStore` | Load gating on the candidates control (read mode only), 404-silent WMN, verbatim projection rules, do_now/later/dismiss with mac's exact idempotency-key formats, canonical goal create/focus/unfocus/lifecycle, `openRecommendation` with load-retry and open-before-feedback ordering, the declared-unused outcome seam |
+| `lib/intelligence/knowsComposer.ts` | `HomeKnowsComposer` | Four diverse rows, per-source rotation `((r%n)+n)%n`, ask ≠ tip, question dedupe-by-text, `canRotate` |
+| `lib/intelligence/homeSuggestions.ts` | `HomeSuggestionsStore` + composer | Daily per-owner personalized questions: context reads with per-source fault isolation, unavailable/thin/available classification, generation via the structured agent lane, 48-char first-person rules, `homePersonalizedSuggestions.v1.<owner>` day-stamped cache |
+| `lib/intelligence/attribution.ts` | `TaskIntelligenceAttributionEvent` | `intervention_presented` once per intervention per store lifetime; `feedback_recorded` on server acceptance only, with the attribution chain id |
+| `components/home/knows/*` | `HomeKnowsRowView` + knows list | 46px rows, insight reason popover ("Optional reason": already_handled / not_mine / not_useful; closing without choosing still dismisses with null), context menu (Later / Dismiss), error card with Retry, 7s rotation paused while a send is in flight, `rolling` chat-mode variant (top three over an empty thread) |
+| `components/home/goals/*` | `FocusedGoalsSection` sheets | Focused chip row (≤5), All goals (Current/History, lifecycle menu, focus-replacement flow with mac's copy verbatim), Add goal (occurrence-id idempotency stable per sheet), goal detail |
+| `pages/Goals.tsx` additions | canonical goals on the page | Focus star per card, focused count in the subtitle, page-palette replacement dialog driven by the store's 409 flow |
+| `hub` wiring | DashboardPage lifecycle | The knows slot replaces the wordmark when rows exist (the branch HomeHub's comment called unreachable); `HubSuggestions` consumes the personalized feed; the chat panel's empty state hosts the rolling knows |
+
+## Contract facts the port depends on
+
+- Every WMN recommendation already carries a server-registered `intervention_id`
+  (the server registers interventions during evaluation), so this surface never
+  calls `POST /v1/task-intelligence/interventions`. The client-side
+  ensureIntervention pattern belongs to the Suggested rail only.
+- `GET /v1/what-matters-now` runs a full evaluate server-side and 404s for
+  accounts outside the intelligence product; 404 clears the surface with no
+  error. `POST /v1/what-matters-now/evaluate` is the context-director's entry
+  point (mac: TaskContextualResurfacingService) and is deliberately unused here;
+  `applyContextProjection` is the seam a future director port will call.
+- Canonical goal mutations require `Idempotency-Key` + `X-Account-Generation`
+  and are generation-fenced at the store boundary; the account generation comes
+  from `GET /v1/candidates/control`, the same control the Suggested rail uses.
+- Outbox entries minted under a superseded account generation are purged
+  without sending (mac parity): the server would 409 them and the feedback no
+  longer describes live state.
+
+## Deliberate deviations from mac
+
+- Out-of-rollout accounts see the legacy `HomeGoalsChips` active-goals row
+  instead of nothing (mac renders nothing when the generation is unbound). A
+  fallback beats an empty row during rollout; the legacy component is unchanged.
+- Recommendation destinations all navigate to the Tasks surface: Windows has no
+  workstream-thread UI yet, so thread destinations open Tasks rather than being
+  dropped, and do_now feedback still records after the open.
+- "Work on this with Omi" on the goal detail navigates to Tasks; mac starts an
+  agent thread on the goal (`goal-detail-primary-v1`), which needs the kernel
+  task_chat surface.
+- The refresh/open/focus automation tools mac registers on
+  `DesktopAutomationBridge` are not ported: Windows has no agent-action registry
+  yet (the agentKernel control-tool manifest is a different, coordinator-scoped
+  system). Tracked as a follow-up alongside the registry itself.
+- Task-row dismissals in the knows list are session-only state (mac parity), and
+  learned-insight rows are inert on open (mac parity) — both intentional.
+
+## Verification
+
+`npx vitest run` full suite green; the new suites cover the projection rules,
+outbox semantics, feedback key formats, goal flows, composer slots, suggestion
+classification/caching, attribution emission, and the component surfaces.
+Mutation checks: widening the projection row cap and deleting the composer's
+tip fallback each fail exactly the tests that pin them.

--- a/desktop/windows/src/renderer/src/components/home/goals/AllGoalsSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/AllGoalsSheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { X } from 'lucide-react'
 import { cn } from '../../../lib/utils'
 import { useDashboardIntelligence } from '../../../hooks/useDashboardIntelligence'
@@ -9,6 +9,7 @@ import {
   focusedGoals
 } from '../../../lib/intelligence/dashboardStore'
 import type { CanonicalGoal, GoalLifecycleTarget } from '../../../lib/intelligence/wireTypes'
+import { ModalShell } from '../../conversations/ModalShell'
 
 // The All-goals sheet (mac parity: AllGoalsSheet, WhatMattersNowSection.swift).
 // Current/History segmented views, per-row Open / Focus-Unfocus / lifecycle
@@ -45,10 +46,35 @@ export function AllGoalsSheet({
 
   const confirmReplacement = async (): Promise<void> => {
     if (replacementFor === null || replacementChoice === null) return
-    await dashboardIntelligence.focus(replacementFor, replacementChoice)
+    const ok = await dashboardIntelligence.focus(replacementFor, replacementChoice)
+    // A failed replacement keeps the dialog open for a retry; the store's
+    // error line explains what happened.
+    if (!ok) return
     setReplacementFor(null)
     setReplacementChoice(null)
   }
+
+  const cancelReplacement = (): void => {
+    // Local dismissal must also clear the store's replacement request, or the
+    // Goals page's dialog (driven by the same store field) reopens the flow.
+    dashboardIntelligence.clearFocusReplacement()
+    setReplacementFor(null)
+    setReplacementChoice(null)
+  }
+
+  // While the nested replacement dialog is open, Escape must close IT and not
+  // the whole sheet: a capture-phase listener with stopImmediatePropagation
+  // pre-empts the outer ModalShell's window keydown.
+  useEffect(() => {
+    if (replacementFor === null) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      e.stopImmediatePropagation()
+      cancelReplacement()
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  })
 
   const transition = async (goal: CanonicalGoal, status: GoalLifecycleTarget): Promise<void> => {
     setMenuGoalId(null)
@@ -56,10 +82,12 @@ export function AllGoalsSheet({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog">
-      <div className="flex max-h-[540px] w-[620px] flex-col rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
+    <ModalShell onClose={onClose} maxWidth="max-w-[620px]" labelledBy="all-goals-title">
+      <div className="flex max-h-[500px] flex-col">
         <div className="mb-4 flex items-center gap-3">
-          <h2 className="text-[20px] font-semibold text-home-ink">All goals</h2>
+          <h2 id="all-goals-title" className="text-[20px] font-semibold text-home-ink">
+            All goals
+          </h2>
           <div className="ml-2 flex rounded-md border border-home-hairline p-0.5" role="tablist">
             {[
               { label: 'Current', value: false },
@@ -183,14 +211,19 @@ export function AllGoalsSheet({
       </div>
 
       {replacementFor !== null && (
-        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40">
+        <div
+          className="fixed inset-0 z-[130] flex items-center justify-center bg-black/40"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Replace a focused goal"
+        >
           <div className="w-[380px] rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
             <div className="mb-2 flex items-start justify-between">
               <h3 className="text-[15px] font-semibold text-home-ink">Replace a focused goal</h3>
               <button
                 type="button"
                 aria-label="Close"
-                onClick={() => setReplacementFor(null)}
+                onClick={cancelReplacement}
                 className="focus-ring rounded p-1 text-home-faint hover:text-home-secondary"
               >
                 <X className="h-3.5 w-3.5" />
@@ -216,7 +249,7 @@ export function AllGoalsSheet({
             <div className="flex justify-end gap-2">
               <button
                 type="button"
-                onClick={() => setReplacementFor(null)}
+                onClick={cancelReplacement}
                 className="focus-ring rounded-md border border-home-hairline px-3 py-1.5 text-[12px] font-medium text-home-secondary"
               >
                 Cancel
@@ -232,7 +265,7 @@ export function AllGoalsSheet({
           </div>
         </div>
       )}
-    </div>
+    </ModalShell>
   )
 }
 

--- a/desktop/windows/src/renderer/src/components/home/goals/AllGoalsSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/AllGoalsSheet.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { cn } from '../../../lib/utils'
+import { useDashboardIntelligence } from '../../../hooks/useDashboardIntelligence'
+import {
+  dashboardIntelligence,
+  currentGoals,
+  endedGoals,
+  focusedGoals
+} from '../../../lib/intelligence/dashboardStore'
+import type { CanonicalGoal, GoalLifecycleTarget } from '../../../lib/intelligence/wireTypes'
+
+// The All-goals sheet (mac parity: AllGoalsSheet, WhatMattersNowSection.swift).
+// Current/History segmented views, per-row Open / Focus-Unfocus / lifecycle
+// menu, and the focus-replacement flow: when focusing 409s because the focus
+// set is full, the store surfaces focusReplacementGoalId and this sheet asks
+// which focused goal to swap out. Nothing is archived by a replacement; the
+// replaced goal simply returns to All goals.
+
+export function AllGoalsSheet({
+  onClose,
+  onAddGoal,
+  onOpenGoal
+}: {
+  onClose: () => void
+  onAddGoal: () => void
+  onOpenGoal: (goalId: string) => void
+}): React.JSX.Element {
+  const intelligence = useDashboardIntelligence()
+  const [showHistory, setShowHistory] = useState(false)
+  const [menuGoalId, setMenuGoalId] = useState<string | null>(null)
+  const [replacementFor, setReplacementFor] = useState<string | null>(null)
+  const [replacementChoice, setReplacementChoice] = useState<string | null>(null)
+
+  const focused = focusedGoals(intelligence.goals)
+  const listed = showHistory ? endedGoals(intelligence.goals) : currentGoals(intelligence.goals)
+
+  const focusGoal = async (goal: CanonicalGoal): Promise<void> => {
+    const ok = await dashboardIntelligence.focus(goal.goalId, null)
+    if (!ok && dashboardIntelligence.getState().focusReplacementGoalId === goal.goalId) {
+      setReplacementFor(goal.goalId)
+      setReplacementChoice(focused[0]?.goalId ?? null)
+    }
+  }
+
+  const confirmReplacement = async (): Promise<void> => {
+    if (replacementFor === null || replacementChoice === null) return
+    await dashboardIntelligence.focus(replacementFor, replacementChoice)
+    setReplacementFor(null)
+    setReplacementChoice(null)
+  }
+
+  const transition = async (goal: CanonicalGoal, status: GoalLifecycleTarget): Promise<void> => {
+    setMenuGoalId(null)
+    await dashboardIntelligence.transition(goal.goalId, status)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog">
+      <div className="flex max-h-[540px] w-[620px] flex-col rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
+        <div className="mb-4 flex items-center gap-3">
+          <h2 className="text-[20px] font-semibold text-home-ink">All goals</h2>
+          <div className="ml-2 flex rounded-md border border-home-hairline p-0.5" role="tablist">
+            {[
+              { label: 'Current', value: false },
+              { label: 'History', value: true }
+            ].map(({ label, value }) => (
+              <button
+                key={label}
+                type="button"
+                role="tab"
+                aria-selected={showHistory === value}
+                onClick={() => setShowHistory(value)}
+                className={cn(
+                  'focus-ring rounded px-3 py-1 text-[12px] font-medium',
+                  showHistory === value
+                    ? 'bg-home-tileHover text-home-ink'
+                    : 'text-home-muted hover:text-home-secondary'
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onAddGoal}
+              className="focus-ring rounded-md border border-home-hairline px-3 py-1.5 text-[12px] font-medium text-home-secondary hover:text-home-ink"
+            >
+              Add goal
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="focus-ring rounded-md bg-home-tileHover px-3 py-1.5 text-[12px] font-semibold text-home-ink"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {listed.length === 0 ? (
+            <p className="py-8 text-center text-[12px] text-home-muted">
+              {showHistory ? 'No ended goals yet.' : 'No goals yet.'}
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {listed.map((goal) => (
+                <li
+                  key={goal.goalId}
+                  className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-home-tileHover"
+                  data-testid={`all-goals-row-${goal.goalId}`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[13px] font-semibold text-home-ink">{goal.title}</p>
+                    {goal.desiredOutcome && (
+                      <p className="truncate text-[10px] text-home-muted">{goal.desiredOutcome}</p>
+                    )}
+                  </div>
+                  <span className="shrink-0 text-[9px] uppercase tracking-wide text-home-faint">
+                    {goal.status === '_unknown' ? '' : goal.status}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onOpenGoal(goal.goalId)}
+                    className="focus-ring shrink-0 text-[12px] font-medium text-home-secondary hover:text-home-ink"
+                  >
+                    Open
+                  </button>
+                  {!showHistory && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          goal.status === 'focused'
+                            ? void dashboardIntelligence.unfocus(goal.goalId)
+                            : void focusGoal(goal)
+                        }
+                        className="focus-ring shrink-0 text-[12px] font-medium text-home-secondary hover:text-home-ink"
+                      >
+                        {goal.status === 'focused' ? 'Unfocus' : 'Focus'}
+                      </button>
+                      <div className="relative shrink-0">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setMenuGoalId(menuGoalId === goal.goalId ? null : goal.goalId)
+                          }
+                          className="focus-ring w-[55px] text-[12px] font-medium text-home-muted hover:text-home-secondary"
+                        >
+                          More
+                        </button>
+                        {menuGoalId === goal.goalId && (
+                          <div className="absolute right-0 top-6 z-10 w-[150px] rounded-md border border-home-hairline bg-home-tile p-1 shadow-lg">
+                            <MenuButton
+                              label="Pause"
+                              onClick={() => void transition(goal, 'paused')}
+                            />
+                            <MenuButton
+                              label="Mark achieved"
+                              onClick={() => void transition(goal, 'achieved')}
+                            />
+                            <MenuButton
+                              label="Abandon"
+                              onClick={() => void transition(goal, 'abandoned')}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {intelligence.error !== null && (
+          <p className="mt-2 text-[10px] text-home-muted">{intelligence.error}</p>
+        )}
+      </div>
+
+      {replacementFor !== null && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40">
+          <div className="w-[380px] rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
+            <div className="mb-2 flex items-start justify-between">
+              <h3 className="text-[15px] font-semibold text-home-ink">Replace a focused goal</h3>
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={() => setReplacementFor(null)}
+                className="focus-ring rounded p-1 text-home-faint hover:text-home-secondary"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <p className="mb-3 text-[12px] text-home-secondary">
+              Your focus set is full. Nothing is archived; the replaced goal moves to All goals.
+            </p>
+            <label className="mb-3 block">
+              <span className="mb-1 block text-[11px] font-medium text-home-muted">Replace</span>
+              <select
+                value={replacementChoice ?? ''}
+                onChange={(e) => setReplacementChoice(e.target.value || null)}
+                className="w-full rounded-md border border-home-hairline bg-home-tile px-2 py-1.5 text-[12px] text-home-ink"
+              >
+                {focused.map((goal) => (
+                  <option key={goal.goalId} value={goal.goalId}>
+                    {goal.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setReplacementFor(null)}
+                className="focus-ring rounded-md border border-home-hairline px-3 py-1.5 text-[12px] font-medium text-home-secondary"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmReplacement()}
+                className="focus-ring rounded-md bg-home-tileHover px-3 py-1.5 text-[12px] font-semibold text-home-ink"
+              >
+                Replace focus
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MenuButton({ label, onClick }: { label: string; onClick: () => void }): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+    >
+      {label}
+    </button>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { CanonicalGoalsChips } from './CanonicalGoalsChips'
+import { AllGoalsSheet } from './AllGoalsSheet'
+import { GoalCreateSheet } from './GoalCreateSheet'
+import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+import type { CanonicalGoal } from '../../../lib/intelligence/wireTypes'
+
+vi.mock('../../../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../../../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }
+}))
+// The legacy chip row pulls firebase auth at import time; stub it so the
+// fallback branch renders without a live auth session.
+vi.mock('../HomeGoalsChips', () => ({
+  HomeGoalsChips: () => <div data-testid="legacy-goals-chips" />
+}))
+
+const goal = (
+  id: string,
+  status: CanonicalGoal['status'],
+  over: Partial<CanonicalGoal> = {}
+): CanonicalGoal => ({
+  goalId: id,
+  title: `Goal ${id}`,
+  desiredOutcome: 'Outcome',
+  whyItMatters: null,
+  successCriteria: [],
+  status,
+  focusRank: null,
+  isActive: true,
+  updatedAt: '2026-08-01T00:00:00Z',
+  currentValue: null,
+  targetValue: null,
+  unit: null,
+  ...over
+})
+
+function stubState(over: Partial<ReturnType<typeof dashboardIntelligence.getState>> = {}): void {
+  vi.spyOn(dashboardIntelligence, 'getState').mockReturnValue({
+    accountGeneration: 3,
+    recommendations: [],
+    goals: [],
+    selectedGoalDetail: null,
+    focusReplacementGoalId: null,
+    error: null,
+    isLoading: false,
+    pendingFeedbackCount: 0,
+    ...over
+  })
+  vi.spyOn(dashboardIntelligence, 'subscribe').mockReturnValue(() => {})
+  vi.spyOn(dashboardIntelligence, 'load').mockResolvedValue()
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('CanonicalGoalsChips', () => {
+  it('falls back to the legacy chip row outside the intelligence rollout', () => {
+    stubState({ accountGeneration: null })
+    render(
+      <MemoryRouter>
+        <CanonicalGoalsChips />
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('legacy-goals-chips')).toBeTruthy()
+    expect(screen.queryByTestId('focused-goals')).toBeNull()
+  })
+
+  it('renders the focused subset capped at five with the All goals button', () => {
+    stubState({
+      goals: [
+        goal('a', 'focused', { focusRank: 0 }),
+        goal('b', 'focused', { focusRank: 1 }),
+        goal('c', 'background'),
+        goal('d', 'focused', { focusRank: 2 }),
+        goal('e', 'focused', { focusRank: 3 }),
+        goal('f', 'focused', { focusRank: 4 }),
+        goal('g', 'focused', { focusRank: 5 })
+      ]
+    })
+    render(
+      <MemoryRouter>
+        <CanonicalGoalsChips />
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('focused-goals')).toBeTruthy()
+    expect(screen.getAllByTestId(/^focused-goal-/)).toHaveLength(5)
+    expect(screen.queryByTestId('focused-goal-g')).toBeNull() // sixth focused stays off the row
+    expect(screen.queryByText('Goal c')).toBeNull() // background never shows here
+    expect(screen.getByText('All goals')).toBeTruthy()
+  })
+
+  it('with no focused goals offers Add goal when empty and Choose focus otherwise', () => {
+    stubState({ goals: [] })
+    const { unmount } = render(
+      <MemoryRouter>
+        <CanonicalGoalsChips />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('No focused goals')).toBeTruthy()
+    expect(screen.getByText('Add goal')).toBeTruthy()
+    unmount()
+
+    stubState({ goals: [goal('a', 'background')] })
+    render(
+      <MemoryRouter>
+        <CanonicalGoalsChips />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('Choose focus')).toBeTruthy()
+  })
+})
+
+describe('AllGoalsSheet', () => {
+  it('lists current goals with lifecycle actions and switches to history', () => {
+    stubState({ goals: [goal('a', 'focused'), goal('b', 'background'), goal('c', 'achieved')] })
+    render(
+      <MemoryRouter>
+        <AllGoalsSheet onClose={() => {}} onAddGoal={() => {}} onOpenGoal={() => {}} />
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('all-goals-row-a')).toBeTruthy()
+    expect(screen.getByTestId('all-goals-row-b')).toBeTruthy()
+    expect(screen.queryByTestId('all-goals-row-c')).toBeNull()
+    expect(screen.getByText('Unfocus')).toBeTruthy() // the focused row's toggle
+
+    fireEvent.click(screen.getByText('History'))
+    expect(screen.getByTestId('all-goals-row-c')).toBeTruthy()
+    expect(screen.queryByTestId('all-goals-row-a')).toBeNull()
+    expect(screen.queryByText('Unfocus')).toBeNull() // history rows carry no mutations
+  })
+
+  it('a full focus set opens the replacement sheet and Replace focus resends with the choice', async () => {
+    stubState({ goals: [goal('a', 'focused', { focusRank: 0 }), goal('b', 'background')] })
+    const focus = vi
+      .spyOn(dashboardIntelligence, 'focus')
+      .mockImplementationOnce(async () => {
+        stubState({
+          goals: [goal('a', 'focused', { focusRank: 0 }), goal('b', 'background')],
+          focusReplacementGoalId: 'b'
+        })
+        return false
+      })
+      .mockResolvedValue(true)
+    render(
+      <MemoryRouter>
+        <AllGoalsSheet onClose={() => {}} onAddGoal={() => {}} onOpenGoal={() => {}} />
+      </MemoryRouter>
+    )
+    fireEvent.click(screen.getByText('Focus'))
+    await waitFor(() => expect(screen.getByText('Replace a focused goal')).toBeTruthy())
+    expect(
+      screen.getByText(
+        'Your focus set is full. Nothing is archived; the replaced goal moves to All goals.'
+      )
+    ).toBeTruthy()
+    fireEvent.click(screen.getByText('Replace focus'))
+    await waitFor(() => expect(focus).toHaveBeenLastCalledWith('b', 'a'))
+  })
+
+  it('lifecycle menu drives pause, achieve, and abandon transitions', async () => {
+    stubState({ goals: [goal('a', 'background')] })
+    const transition = vi.spyOn(dashboardIntelligence, 'transition').mockResolvedValue(true)
+    render(
+      <MemoryRouter>
+        <AllGoalsSheet onClose={() => {}} onAddGoal={() => {}} onOpenGoal={() => {}} />
+      </MemoryRouter>
+    )
+    fireEvent.click(screen.getByText('More'))
+    fireEvent.click(screen.getByText('Mark achieved'))
+    await waitFor(() => expect(transition).toHaveBeenCalledWith('a', 'achieved'))
+  })
+})
+
+describe('GoalCreateSheet', () => {
+  it('requires title and desired outcome, and reuses one occurrence id across retries', async () => {
+    stubState()
+    const create = vi
+      .spyOn(dashboardIntelligence, 'createGoal')
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true)
+    const onClose = vi.fn()
+    render(<GoalCreateSheet onClose={onClose} />)
+
+    const save = screen.getByTestId('goal-create-save')
+    expect((save as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(screen.getByTestId('goal-create-title'), { target: { value: 'Ship it' } })
+    expect((save as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.change(screen.getByTestId('goal-create-outcome'), { target: { value: 'Launched' } })
+    expect((save as HTMLButtonElement).disabled).toBe(false)
+
+    fireEvent.click(save)
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1))
+    expect(onClose).not.toHaveBeenCalled() // failed save keeps the sheet open
+
+    fireEvent.click(save)
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(2))
+    expect(onClose).toHaveBeenCalled()
+
+    const [, firstOccurrence] = create.mock.calls[0]
+    const [, secondOccurrence] = create.mock.calls[1]
+    expect(firstOccurrence).toBe(secondOccurrence) // retry reuses the idempotency key
+    expect(create.mock.calls[1][0]).toEqual({
+      title: 'Ship it',
+      desiredOutcome: 'Launched',
+      whyItMatters: null,
+      successCriteria: []
+    })
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.test.tsx
@@ -44,9 +44,11 @@ function stubState(over: Partial<ReturnType<typeof dashboardIntelligence.getStat
     recommendations: [],
     goals: [],
     selectedGoalDetail: null,
+    goalDetailError: null,
     focusReplacementGoalId: null,
     error: null,
     isLoading: false,
+    hasLoadedOnce: true,
     pendingFeedbackCount: 0,
     ...over
   })
@@ -212,5 +214,65 @@ describe('GoalCreateSheet', () => {
       whyItMatters: null,
       successCriteria: []
     })
+  })
+})
+
+describe('review-driven regressions', () => {
+  it('cold start renders nothing until the first load lands (no legacy flash)', () => {
+    stubState({ accountGeneration: null, hasLoadedOnce: false })
+    render(
+      <MemoryRouter>
+        <CanonicalGoalsChips />
+      </MemoryRouter>
+    )
+    expect(screen.queryByTestId('legacy-goals-chips')).toBeNull()
+    expect(screen.queryByTestId('focused-goals')).toBeNull()
+  })
+
+  it('canceling the replacement dialog clears the store request too', async () => {
+    stubState({ goals: [goal('a', 'focused', { focusRank: 0 }), goal('b', 'background')] })
+    const clear = vi
+      .spyOn(dashboardIntelligence, 'clearFocusReplacement')
+      .mockImplementation(() => {})
+    vi.spyOn(dashboardIntelligence, 'focus').mockImplementationOnce(async () => {
+      stubState({
+        goals: [goal('a', 'focused', { focusRank: 0 }), goal('b', 'background')],
+        focusReplacementGoalId: 'b'
+      })
+      return false
+    })
+    render(
+      <MemoryRouter>
+        <AllGoalsSheet onClose={() => {}} onAddGoal={() => {}} onOpenGoal={() => {}} />
+      </MemoryRouter>
+    )
+    fireEvent.click(screen.getByText('Focus'))
+    await waitFor(() => expect(screen.getByText('Replace a focused goal')).toBeTruthy())
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(clear).toHaveBeenCalled()
+  })
+
+  it('a failed replacement keeps the dialog open for a retry', async () => {
+    stubState({ goals: [goal('a', 'focused', { focusRank: 0 }), goal('b', 'background')] })
+    const focus = vi
+      .spyOn(dashboardIntelligence, 'focus')
+      .mockImplementationOnce(async () => {
+        stubState({
+          goals: [goal('a', 'focused', { focusRank: 0 }), goal('b', 'background')],
+          focusReplacementGoalId: 'b'
+        })
+        return false
+      })
+      .mockResolvedValue(false)
+    render(
+      <MemoryRouter>
+        <AllGoalsSheet onClose={() => {}} onAddGoal={() => {}} onOpenGoal={() => {}} />
+      </MemoryRouter>
+    )
+    fireEvent.click(screen.getByText('Focus'))
+    await waitFor(() => expect(screen.getByText('Replace a focused goal')).toBeTruthy())
+    fireEvent.click(screen.getByText('Replace focus'))
+    await waitFor(() => expect(focus).toHaveBeenCalledTimes(2))
+    expect(screen.getByText('Replace a focused goal')).toBeTruthy()
   })
 })

--- a/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.tsx
@@ -24,6 +24,12 @@ export function CanonicalGoalsChips(props: HubHomeWidgetsProps): React.JSX.Eleme
   const [showCreate, setShowCreate] = useState(false)
   const [detailGoalId, setDetailGoalId] = useState<string | null>(null)
 
+  if (!intelligence.hasLoadedOnce) {
+    // Cold start: the gate is unknown. Render nothing (mac renders nothing for
+    // an unbound generation) instead of flashing the legacy row at canonical
+    // accounts or firing the legacy fetch before the control answers.
+    return <></>
+  }
   if (intelligence.accountGeneration === null) {
     return <HomeGoalsChips {...props} />
   }
@@ -74,9 +80,11 @@ export function CanonicalGoalsChips(props: HubHomeWidgetsProps): React.JSX.Eleme
             </span>
             <button
               type="button"
-              onClick={() =>
-                intelligence.goals.length === 0 ? setShowCreate(true) : setShowAllGoals(true)
-              }
+              onClick={() => {
+                if (intelligence.goals.length === 0) setShowCreate(true)
+                else if (props.onShowAll) props.onShowAll()
+                else setShowAllGoals(true)
+              }}
               className="focus-ring shrink-0 text-[11px] font-medium text-home-secondary hover:text-home-ink"
             >
               {intelligence.goals.length === 0 ? 'Add goal' : 'Choose focus'}

--- a/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/CanonicalGoalsChips.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useDashboardIntelligence } from '../../../hooks/useDashboardIntelligence'
+import { dashboardIntelligence, focusedGoals } from '../../../lib/intelligence/dashboardStore'
+import type { HubHomeWidgetsProps } from '../hub/hubHomeWidgetsSlot'
+import { HomeGoalsChips } from '../HomeGoalsChips'
+import { AllGoalsSheet } from './AllGoalsSheet'
+import { GoalCreateSheet } from './GoalCreateSheet'
+import { GoalDetailSheet } from './GoalDetailSheet'
+
+// The resting Hub's goals row, upgraded to the canonical model (mac parity:
+// FocusedGoalsSection). When the account is inside the intelligence rollout
+// (accountGeneration bound), the row shows the true FOCUSED subset with the
+// All-goals sheet, create sheet, and detail sheet behind it — closing the
+// deviation HomeGoalsChips documented ("Windows has no focused subset"). When
+// the account is outside the rollout, the legacy active-goals chip row renders
+// unchanged, so nothing regresses for accounts the canonical system has not
+// reached.
+
+export function CanonicalGoalsChips(props: HubHomeWidgetsProps): React.JSX.Element {
+  const intelligence = useDashboardIntelligence()
+  const navigate = useNavigate()
+  const [showAllGoals, setShowAllGoals] = useState(false)
+  const [showCreate, setShowCreate] = useState(false)
+  const [detailGoalId, setDetailGoalId] = useState<string | null>(null)
+
+  if (intelligence.accountGeneration === null) {
+    return <HomeGoalsChips {...props} />
+  }
+
+  const focused = focusedGoals(intelligence.goals).slice(0, 5)
+
+  const openDetail = (goalId: string): void => {
+    setDetailGoalId(goalId)
+    void dashboardIntelligence.loadGoalDetail(goalId)
+  }
+
+  return (
+    <>
+      <div
+        className="flex h-[30px] w-full items-center gap-2 overflow-hidden"
+        data-testid="focused-goals"
+      >
+        {focused.length > 0 ? (
+          <>
+            <span className="shrink-0 text-[11px] font-semibold text-home-muted">
+              Focused goals
+            </span>
+            {focused.map((goal) => (
+              <button
+                key={goal.goalId}
+                type="button"
+                data-testid={`focused-goal-${goal.goalId}`}
+                onClick={() =>
+                  props.onOpenGoal ? props.onOpenGoal(goal.goalId) : openDetail(goal.goalId)
+                }
+                className="focus-ring min-w-0 shrink truncate rounded-full bg-home-tile/[0.8] px-[9px] py-[6px] text-[10px] font-medium text-home-secondary hover:text-home-ink"
+              >
+                {goal.title}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => (props.onShowAll ? props.onShowAll() : setShowAllGoals(true))}
+              className="focus-ring ml-auto shrink-0 text-[11px] font-medium text-home-muted hover:text-home-secondary"
+            >
+              All goals
+            </button>
+          </>
+        ) : (
+          <>
+            <span className="shrink-0 text-[11px] font-semibold text-home-muted">
+              No focused goals
+            </span>
+            <button
+              type="button"
+              onClick={() =>
+                intelligence.goals.length === 0 ? setShowCreate(true) : setShowAllGoals(true)
+              }
+              className="focus-ring shrink-0 text-[11px] font-medium text-home-secondary hover:text-home-ink"
+            >
+              {intelligence.goals.length === 0 ? 'Add goal' : 'Choose focus'}
+            </button>
+          </>
+        )}
+      </div>
+
+      {showAllGoals && (
+        <AllGoalsSheet
+          onClose={() => setShowAllGoals(false)}
+          onAddGoal={() => {
+            setShowAllGoals(false)
+            setShowCreate(true)
+          }}
+          onOpenGoal={(goalId) => {
+            setShowAllGoals(false)
+            openDetail(goalId)
+          }}
+        />
+      )}
+      {showCreate && <GoalCreateSheet onClose={() => setShowCreate(false)} />}
+      {detailGoalId !== null && (
+        <GoalDetailSheet
+          goalId={detailGoalId}
+          onClose={() => {
+            setDetailGoalId(null)
+            dashboardIntelligence.clearGoalDetail()
+          }}
+          onWorkOnGoal={() => {
+            // Mac starts an agent thread on the goal; Windows has no
+            // workstream-thread UI yet, so working a goal lands on the Tasks
+            // surface. Called out as a deviation in the PR body.
+            setDetailGoalId(null)
+            dashboardIntelligence.clearGoalDetail()
+            navigate('/tasks')
+          }}
+        />
+      )}
+    </>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/home/goals/GoalCreateSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/GoalCreateSheet.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react'
+import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+
+// The Add-goal sheet (mac parity: CanonicalGoalCreateSheet). One occurrence id
+// is minted per sheet instance and used as the Idempotency-Key, so a retried
+// save after a network failure cannot create a second goal. Save requires a
+// trimmed title and desired outcome; success criteria split one per line;
+// an empty why-it-matters goes to the wire as null, not an empty string.
+
+export function GoalCreateSheet({ onClose }: { onClose: () => void }): React.JSX.Element {
+  const occurrenceId = useMemo(() => crypto.randomUUID().toLowerCase(), [])
+  const [title, setTitle] = useState('')
+  const [desiredOutcome, setDesiredOutcome] = useState('')
+  const [whyItMatters, setWhyItMatters] = useState('')
+  const [criteria, setCriteria] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const canSave = title.trim().length > 0 && desiredOutcome.trim().length > 0 && !saving
+
+  const save = async (): Promise<void> => {
+    if (!canSave) return
+    setSaving(true)
+    const why = whyItMatters.trim()
+    const ok = await dashboardIntelligence.createGoal(
+      {
+        title: title.trim(),
+        desiredOutcome: desiredOutcome.trim(),
+        whyItMatters: why.length > 0 ? why : null,
+        successCriteria: criteria
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0)
+      },
+      occurrenceId
+    )
+    setSaving(false)
+    if (ok) onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog">
+      <div className="w-[460px] rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
+        <h2 className="mb-4 text-[16px] font-semibold text-home-ink">Add goal</h2>
+        <Field label="Short name">
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full rounded-md border border-home-hairline bg-home-tile px-2 py-1.5 text-[13px] text-home-ink"
+            data-testid="goal-create-title"
+          />
+        </Field>
+        <Field label="Desired outcome">
+          <textarea
+            value={desiredOutcome}
+            onChange={(e) => setDesiredOutcome(e.target.value)}
+            rows={2}
+            className="w-full resize-none rounded-md border border-home-hairline bg-home-tile px-2 py-1.5 text-[13px] text-home-ink"
+            data-testid="goal-create-outcome"
+          />
+        </Field>
+        <Field label="Why it matters (optional)">
+          <textarea
+            value={whyItMatters}
+            onChange={(e) => setWhyItMatters(e.target.value)}
+            rows={2}
+            className="w-full resize-none rounded-md border border-home-hairline bg-home-tile px-2 py-1.5 text-[13px] text-home-ink"
+          />
+        </Field>
+        <Field label="Success criteria, one per line">
+          <textarea
+            value={criteria}
+            onChange={(e) => setCriteria(e.target.value)}
+            rows={3}
+            className="w-full resize-none rounded-md border border-home-hairline bg-home-tile px-2 py-1.5 text-[13px] text-home-ink"
+          />
+        </Field>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="focus-ring rounded-md border border-home-hairline px-3 py-1.5 text-[12px] font-medium text-home-secondary"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canSave}
+            onClick={() => void save()}
+            className="focus-ring rounded-md bg-home-tileHover px-3 py-1.5 text-[12px] font-semibold text-home-ink disabled:opacity-40"
+            data-testid="goal-create-save"
+          >
+            Add goal
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <label className="mb-3 block">
+      <span className="mb-1 block text-[11px] font-medium text-home-muted">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/home/goals/GoalCreateSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/GoalCreateSheet.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+import { ModalShell } from '../../conversations/ModalShell'
 
 // The Add-goal sheet (mac parity: CanonicalGoalCreateSheet). One occurrence id
 // is minted per sheet instance and used as the Idempotency-Key, so a retried
@@ -38,9 +39,11 @@ export function GoalCreateSheet({ onClose }: { onClose: () => void }): React.JSX
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog">
-      <div className="w-[460px] rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
-        <h2 className="mb-4 text-[16px] font-semibold text-home-ink">Add goal</h2>
+    <ModalShell onClose={onClose} maxWidth="max-w-[460px]" labelledBy="goal-create-title-heading">
+      <div>
+        <h2 id="goal-create-title-heading" className="mb-4 text-[16px] font-semibold text-home-ink">
+          Add goal
+        </h2>
         <Field label="Short name">
           <input
             value={title}
@@ -93,7 +96,7 @@ export function GoalCreateSheet({ onClose }: { onClose: () => void }): React.JSX
           </button>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }
 

--- a/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import { GoalDetailSheet } from './GoalDetailSheet'
+import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+import type { GoalDetail } from '../../../lib/intelligence/wireTypes'
+
+vi.mock('../../../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../../../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }
+}))
+
+const detail: GoalDetail = {
+  goal: {
+    goalId: 'g-1',
+    title: 'Ship the launch',
+    desiredOutcome: 'Launched to everyone',
+    whyItMatters: 'The quarter depends on it',
+    successCriteria: ['Beta out', 'Zero P0s'],
+    status: 'focused',
+    focusRank: 0,
+    isActive: true,
+    updatedAt: '2026-08-01T00:00:00Z',
+    currentValue: 2,
+    targetValue: 5,
+    unit: 'milestones'
+  },
+  tasks: [{ id: 't1', description: 'Cut the build', completed: false }],
+  activeThreads: [{ workstreamId: 'ws1', summary: 'Halfway through packaging' }],
+  progressEvents: [{ summary: 'Beta shipped to 50 users' }]
+}
+
+function stub(selected: GoalDetail | null, error: string | null = null): void {
+  vi.spyOn(dashboardIntelligence, 'getState').mockReturnValue({
+    accountGeneration: 3,
+    recommendations: [],
+    goals: [],
+    selectedGoalDetail: selected,
+    focusReplacementGoalId: null,
+    error,
+    isLoading: false,
+    pendingFeedbackCount: 0
+  })
+  vi.spyOn(dashboardIntelligence, 'subscribe').mockReturnValue(() => {})
+  vi.spyOn(dashboardIntelligence, 'load').mockResolvedValue()
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('GoalDetailSheet', () => {
+  it('renders every populated section from the detail projection', () => {
+    stub(detail)
+    render(<GoalDetailSheet goalId="g-1" onClose={() => {}} onWorkOnGoal={() => {}} />)
+    expect(screen.getByText('Ship the launch')).toBeTruthy()
+    expect(screen.getByText('The quarter depends on it')).toBeTruthy()
+    expect(screen.getByText('Beta out • Zero P0s')).toBeTruthy()
+    expect(screen.getByText('2 / 5 milestones')).toBeTruthy()
+    expect(screen.getByText('Halfway through packaging')).toBeTruthy()
+    expect(screen.getByText('Beta shipped to 50 users')).toBeTruthy()
+  })
+
+  it('the primary work action fires from both the CTA and a thread Continue', () => {
+    stub(detail)
+    const onWork = vi.fn()
+    render(<GoalDetailSheet goalId="g-1" onClose={() => {}} onWorkOnGoal={onWork} />)
+    fireEvent.click(screen.getByTestId('goal-work-with-omi-g-1'))
+    fireEvent.click(screen.getByText('Continue'))
+    expect(onWork).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows the loading placeholder while the projection is for another goal', () => {
+    stub(null)
+    render(<GoalDetailSheet goalId="g-1" onClose={() => {}} onWorkOnGoal={() => {}} />)
+    expect(screen.getByText('Loading goal…')).toBeTruthy()
+  })
+
+  it('a load failure shows the goal-unavailable error instead of stale content', () => {
+    stub(null, 'This goal is no longer available.')
+    render(<GoalDetailSheet goalId="g-1" onClose={() => {}} onWorkOnGoal={() => {}} />)
+    expect(screen.getByText('This goal is no longer available.')).toBeTruthy()
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.test.tsx
@@ -36,9 +36,11 @@ function stub(selected: GoalDetail | null, error: string | null = null): void {
     recommendations: [],
     goals: [],
     selectedGoalDetail: selected,
+    goalDetailError: error,
     focusReplacementGoalId: null,
     error,
     isLoading: false,
+    hasLoadedOnce: true,
     pendingFeedbackCount: 0
   })
   vi.spyOn(dashboardIntelligence, 'subscribe').mockReturnValue(() => {})
@@ -71,10 +73,17 @@ describe('GoalDetailSheet', () => {
     expect(onWork).toHaveBeenCalledTimes(2)
   })
 
-  it('shows the loading placeholder while the projection is for another goal', () => {
+  it('shows the loading placeholder while no detail has landed', () => {
     stub(null)
     render(<GoalDetailSheet goalId="g-1" onClose={() => {}} onWorkOnGoal={() => {}} />)
     expect(screen.getByText('Loading goal…')).toBeTruthy()
+  })
+
+  it('a projection for a DIFFERENT goal keeps the loading state, never stale content', () => {
+    stub({ ...detail, goal: { ...detail.goal, goalId: 'g-OTHER' } })
+    render(<GoalDetailSheet goalId="g-1" onClose={() => {}} onWorkOnGoal={() => {}} />)
+    expect(screen.getByText('Loading goal…')).toBeTruthy()
+    expect(screen.queryByText('Ship the launch')).toBeNull()
   })
 
   it('a load failure shows the goal-unavailable error instead of stale content', () => {

--- a/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.tsx
@@ -1,0 +1,127 @@
+import { useDashboardIntelligence } from '../../../hooks/useDashboardIntelligence'
+
+// The goal detail sheet (mac parity: CanonicalGoalDetailSheet): why it matters,
+// success criteria, metric progress, active work threads, and meaningful
+// progress events, with the work-with-Omi primary action. The store loads the
+// detail projection when the sheet opens; a load failure closes back to the
+// goal-unavailable error rather than substituting a stale record.
+
+export function GoalDetailSheet({
+  goalId,
+  onClose,
+  onWorkOnGoal
+}: {
+  goalId: string
+  onClose: () => void
+  onWorkOnGoal: () => void
+}): React.JSX.Element {
+  const intelligence = useDashboardIntelligence()
+  const detail = intelligence.selectedGoalDetail
+  const matches = detail !== null && detail.goal.goalId === goalId
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog">
+      <div className="flex max-h-[600px] w-[620px] flex-col rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
+        {!matches ? (
+          <p className="py-10 text-center text-[12px] text-home-muted">
+            {intelligence.error ?? 'Loading goal…'}
+          </p>
+        ) : (
+          <>
+            <h2 className="mb-1 text-[18px] font-semibold text-home-ink">{detail.goal.title}</h2>
+            {detail.goal.desiredOutcome && (
+              <p className="mb-3 text-[12px] text-home-secondary">{detail.goal.desiredOutcome}</p>
+            )}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {detail.goal.whyItMatters && (
+                <Section title="Why it matters">
+                  <p className="text-[12px] text-home-secondary">{detail.goal.whyItMatters}</p>
+                </Section>
+              )}
+              {detail.goal.successCriteria.length > 0 && (
+                <Section title="Success looks like">
+                  <p className="text-[12px] text-home-secondary">
+                    {detail.goal.successCriteria.join(' • ')}
+                  </p>
+                </Section>
+              )}
+              {detail.goal.currentValue !== null && detail.goal.targetValue !== null && (
+                <Section title="Progress">
+                  <p className="text-[12px] text-home-secondary">
+                    {detail.goal.currentValue} / {detail.goal.targetValue} {detail.goal.unit ?? ''}
+                  </p>
+                </Section>
+              )}
+              {detail.activeThreads.length > 0 && (
+                <Section title="Active work">
+                  <ul className="flex flex-col gap-1">
+                    {detail.activeThreads.map((thread) => (
+                      <li
+                        key={thread.workstreamId}
+                        className="flex items-center gap-2 text-[12px] text-home-secondary"
+                      >
+                        <span className="min-w-0 flex-1 truncate">{thread.summary}</span>
+                        <button
+                          type="button"
+                          onClick={onWorkOnGoal}
+                          className="focus-ring shrink-0 text-[11px] font-medium text-home-muted hover:text-home-ink"
+                        >
+                          Continue
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </Section>
+              )}
+              {detail.progressEvents.length > 0 && (
+                <Section title="Meaningful progress">
+                  <ul className="list-disc pl-4">
+                    {detail.progressEvents.map((event, i) => (
+                      <li key={i} className="text-[12px] text-home-secondary">
+                        {event.summary}
+                      </li>
+                    ))}
+                  </ul>
+                </Section>
+              )}
+            </div>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onWorkOnGoal}
+                data-testid={`goal-work-with-omi-${detail.goal.goalId}`}
+                className="focus-ring rounded-md bg-home-tileHover px-3 py-1.5 text-[12px] font-semibold text-home-ink"
+              >
+                Work on this with Omi
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="focus-ring rounded-md border border-home-hairline px-3 py-1.5 text-[12px] font-medium text-home-secondary"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Section({
+  title,
+  children
+}: {
+  title: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="mb-3">
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-home-muted">
+        {title}
+      </h3>
+      {children}
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.tsx
+++ b/desktop/windows/src/renderer/src/components/home/goals/GoalDetailSheet.tsx
@@ -1,4 +1,6 @@
 import { useDashboardIntelligence } from '../../../hooks/useDashboardIntelligence'
+import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+import { ModalShell } from '../../conversations/ModalShell'
 
 // The goal detail sheet (mac parity: CanonicalGoalDetailSheet): why it matters,
 // success criteria, metric progress, active work threads, and meaningful
@@ -15,20 +17,24 @@ export function GoalDetailSheet({
   onClose: () => void
   onWorkOnGoal: () => void
 }): React.JSX.Element {
-  const intelligence = useDashboardIntelligence()
+  // Subscribe WITHOUT auto-loading: a full load triggered by this sheet's
+  // mount must not race the detail request or clear its scoped error.
+  const intelligence = useDashboardIntelligence(dashboardIntelligence, { autoLoad: false })
   const detail = intelligence.selectedGoalDetail
   const matches = detail !== null && detail.goal.goalId === goalId
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog">
-      <div className="flex max-h-[600px] w-[620px] flex-col rounded-xl border border-home-hairline bg-home-tile p-5 shadow-2xl">
+    <ModalShell onClose={onClose} maxWidth="max-w-[620px]" labelledBy="goal-detail-title">
+      <div className="flex max-h-[540px] flex-col">
         {!matches ? (
           <p className="py-10 text-center text-[12px] text-home-muted">
-            {intelligence.error ?? 'Loading goal…'}
+            {intelligence.goalDetailError ?? 'Loading goal…'}
           </p>
         ) : (
           <>
-            <h2 className="mb-1 text-[18px] font-semibold text-home-ink">{detail.goal.title}</h2>
+            <h2 id="goal-detail-title" className="mb-1 text-[18px] font-semibold text-home-ink">
+              {detail.goal.title}
+            </h2>
             {detail.goal.desiredOutcome && (
               <p className="mb-3 text-[12px] text-home-secondary">{detail.goal.desiredOutcome}</p>
             )}
@@ -105,7 +111,7 @@ export function GoalDetailSheet({
           </>
         )}
       </div>
-    </div>
+    </ModalShell>
   )
 }
 

--- a/desktop/windows/src/renderer/src/components/home/hub/AttachmentChip.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/AttachmentChip.test.tsx
@@ -25,7 +25,9 @@ describe('AttachmentChip', () => {
   })
 
   it('surfaces a failed upload in the title, so it is not a silent no-op', () => {
-    render(<AttachmentChip attachment={att({ name: 'x.pdf', status: 'failed' })} onRemove={() => {}} />)
+    render(
+      <AttachmentChip attachment={att({ name: 'x.pdf', status: 'failed' })} onRemove={() => {}} />
+    )
     expect(screen.getByText('x.pdf').getAttribute('title')).toMatch(/upload failed/i)
   })
 })

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.intelligence.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.intelligence.test.tsx
@@ -54,16 +54,22 @@ class ResizeObserverStub {
   onRewindSettings: vi.fn(() => () => {})
 }
 
-let lastKnowsProps: HubKnowsProps | null = null
+// The stub renders its props into the DOM instead of writing to an outer
+// variable (reassigning during render trips the react-hooks purity lint); the
+// prefill test drives the seam through a real click.
 
 function StubKnows(props: HubKnowsProps): React.JSX.Element {
-  lastKnowsProps = props
-  return <div data-testid={`stub-knows-${props.variant ?? 'stage'}`} />
+  return (
+    <button
+      type="button"
+      data-testid={`stub-knows-${props.variant ?? 'stage'}`}
+      onClick={() => props.onAskPrefill?.('What changed this week?')}
+    />
+  )
 }
 
 beforeEach(() => {
   window.localStorage.clear()
-  lastKnowsProps = null
   chat.sending = false
   chat.history = []
   registerHubKnows(StubKnows)
@@ -110,8 +116,7 @@ describe('question prefill', () => {
         <HomeHub />
       </MemoryRouter>
     )
-    expect(lastKnowsProps?.onAskPrefill).toBeTypeOf('function')
-    lastKnowsProps?.onAskPrefill?.('What changed this week?')
+    fireEvent.click(screen.getByTestId('stub-knows-stage'))
     // The focus signal focuses the stage input, whose focus opens the panel and
     // re-docks (remounts) the bar — so assert against the CURRENT input node.
     await waitFor(() => {

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.intelligence.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.intelligence.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+// Integration coverage for the Hub's intelligence wiring: the knows slot
+// replacing the wordmark, question-row prefill pulling ask-bar focus, the
+// chat-panel empty-state hosting the rolling knows, and the personalized
+// suggestions feed. The slot components are stubbed — their own behavior is
+// covered in components/home/knows and lib/intelligence; these tests pin the
+// HUB's side of each seam.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { HomeHub } from './HomeHub'
+import { registerHubKnows, reportHubKnowsPresence, type HubKnowsProps } from './hubKnowsSlot'
+import { registerHubHomeWidgets } from './hubHomeWidgetsSlot'
+
+const chat = {
+  history: [] as unknown[],
+  sending: false,
+  send: vi.fn(),
+  messages: [] as unknown[]
+}
+vi.mock('../../../state/appState', () => ({ useAppState: () => ({ chat }) }))
+vi.mock('../../../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../../../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(async () => ({ data: [] })), post: vi.fn(), delete: vi.fn() },
+  desktopApi: { post: vi.fn() }
+}))
+vi.mock('../../../lib/agentLLM', () => ({ callAgentLLM: vi.fn(async () => '{"questions": []}') }))
+vi.mock('../../../lib/actionItems', () => ({ fetchAllActionItems: vi.fn(async () => []) }))
+vi.mock('./useHubStats', () => ({
+  useHubStats: () => ({ conversations: 0, memories: 0, tasks: 0 })
+}))
+vi.mock('./HubStatRibbon', () => ({ HubStatRibbon: () => <div data-testid="ribbon" /> }))
+vi.mock('./hubConnectSlot', () => ({
+  preloadHubConnectContent: vi.fn(),
+  getHubConnectContent: () => null
+}))
+vi.mock('./HubConnectPanel', () => ({ HubConnectPanel: () => <div /> }))
+vi.mock('../../chat/HubChatHeader', () => ({ HubChatHeader: () => <div /> }))
+vi.mock('../../chat/ChatAppPicker', () => ({ ChatAppPicker: () => <div /> }))
+vi.mock('../../chat/ChatMessages', () => ({ ChatMessages: () => <div /> }))
+vi.mock('../HomeCanvasBackground', () => ({ HomeCanvasBackground: () => <div /> }))
+
+/* eslint-disable @typescript-eslint/no-empty-function -- no-op stub */
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+/* eslint-enable @typescript-eslint/no-empty-function */
+;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub
+;(window as unknown as { omi: Record<string, unknown> }).omi = {
+  insightRecent: vi.fn(async () => []),
+  rewindGetSettings: vi.fn(async () => ({})),
+  onRewindSettings: vi.fn(() => () => {})
+}
+
+let lastKnowsProps: HubKnowsProps | null = null
+
+function StubKnows(props: HubKnowsProps): React.JSX.Element {
+  lastKnowsProps = props
+  return <div data-testid={`stub-knows-${props.variant ?? 'stage'}`} />
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  lastKnowsProps = null
+  chat.sending = false
+  chat.history = []
+  registerHubKnows(StubKnows)
+  registerHubHomeWidgets(() => <div data-testid="stub-widgets" />)
+  reportHubKnowsPresence(false)
+})
+
+afterEach(() => {
+  cleanup()
+  reportHubKnowsPresence(false)
+  vi.restoreAllMocks()
+})
+
+describe('the knows slot and the wordmark', () => {
+  it('renders the wordmark while the knows list is empty, and swaps when rows appear', async () => {
+    render(
+      <MemoryRouter>
+        <HomeHub />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('omi.')).toBeTruthy()
+    reportHubKnowsPresence(true)
+    await waitFor(() => expect(screen.queryByText('omi.')).toBeNull())
+    expect(screen.getByTestId('stub-knows-stage')).toBeTruthy()
+    reportHubKnowsPresence(false)
+    await waitFor(() => expect(screen.getByText('omi.')).toBeTruthy())
+  })
+
+  it('keeps the knows list mounted while hidden so presence flips cannot loop', () => {
+    render(
+      <MemoryRouter>
+        <HomeHub />
+      </MemoryRouter>
+    )
+    // Present even when the wordmark shows: mounted but visually hidden.
+    expect(screen.getByTestId('stub-knows-stage')).toBeTruthy()
+  })
+})
+
+describe('question prefill', () => {
+  it('prefills the ask bar draft and pulls focus via the focus signal', async () => {
+    render(
+      <MemoryRouter>
+        <HomeHub />
+      </MemoryRouter>
+    )
+    expect(lastKnowsProps?.onAskPrefill).toBeTypeOf('function')
+    lastKnowsProps?.onAskPrefill?.('What changed this week?')
+    // The focus signal focuses the stage input, whose focus opens the panel and
+    // re-docks (remounts) the bar — so assert against the CURRENT input node.
+    await waitFor(() => {
+      const input = screen.getByDisplayValue('What changed this week?')
+      expect(document.activeElement).toBe(input)
+    })
+  })
+})
+
+describe('the chat-mode rolling knows', () => {
+  it('mounts the rolling variant inside the empty chat panel', async () => {
+    render(
+      <MemoryRouter>
+        <HomeHub />
+      </MemoryRouter>
+    )
+    // Focusing the ask bar opens the chat panel (the hub's stage machine).
+    fireEvent.focus(screen.getByRole('textbox'))
+    await waitFor(() => expect(screen.getByTestId('stub-knows-rolling')).toBeTruthy())
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.intelligence.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.intelligence.test.tsx
@@ -123,6 +123,8 @@ describe('question prefill', () => {
       const input = screen.getByDisplayValue('What changed this week?')
       expect(document.activeElement).toBe(input)
     })
+    // Prefill is a draft, never a submission.
+    expect(chat.send).not.toHaveBeenCalled()
   })
 })
 

--- a/desktop/windows/src/renderer/src/components/home/hub/HomeHub.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HomeHub.tsx
@@ -13,6 +13,7 @@ import { ChatAppPicker } from '../../chat/ChatAppPicker'
 import { HubConnectPanel } from './HubConnectPanel'
 import { preloadHubConnectContent } from './hubConnectSlot'
 import { getHubHomeWidgets } from './hubHomeWidgetsSlot'
+import { getHubKnows, useHubKnowsPresence } from './hubKnowsSlot'
 import { useHubStats } from './useHubStats'
 import { nextStage, isPanelMode } from './hubStage'
 import type { HomeStageEvent, HomeStageMode } from './hubStage'
@@ -66,10 +67,15 @@ export function HomeHub(): React.JSX.Element {
   // Rendered via createElement (not <JSX/>) since it is fetched at render time —
   // mirrors HubConnectPanel's slot pattern and satisfies react-hooks/static-components.
   const homeWidgets = getHubHomeWidgets()
+  const hubKnows = getHubKnows()
+  const knowsHasRows = useHubKnowsPresence()
   const [mode, setMode] = useState<HomeStageMode>('hub')
   // The draft is LOCAL (not in the app-wide chat hook) so typing re-renders only
   // the ask bar, not the shell and every mounted page.
   const [input, setInput] = useState('')
+  // Bumped when a knows question row prefills the draft, so the ask bar grabs
+  // focus without HomeHub reaching into its input element.
+  const [askFocusSignal, setAskFocusSignal] = useState(0)
   const stageRef = useRef<HTMLDivElement>(null)
   const hubRef = useRef<HTMLDivElement>(null)
 
@@ -151,8 +157,14 @@ export function HomeHub(): React.JSX.Element {
       // the very keystrokes the click was inviting. Re-take focus on the way in.
       // SwiftUI's @FocusState survives the equivalent move on Mac; React's does not.
       autoFocus={isPanelMode(mode)}
+      focusSignal={askFocusSignal}
     />
   )
+
+  const prefillAsk = useCallback((text: string): void => {
+    setInput(text)
+    setAskFocusSignal((n) => n + 1)
+  }, [])
 
   return (
     <div ref={hubRef} className="relative h-full overflow-hidden">
@@ -227,6 +239,17 @@ export function HomeHub(): React.JSX.Element {
                       <HubChatHeader />
                     </>
                   }
+                  // Mac's chat-mode rolling knows: the top three rows keep
+                  // rotating over an empty thread until the first message lands.
+                  emptyStateExtra={
+                    hubKnows
+                      ? createElement(hubKnows, {
+                          variant: 'rolling',
+                          onAskPrefill: prefillAsk,
+                          chatSending: chat.sending
+                        })
+                      : undefined
+                  }
                 >
                   {askBar}
                 </HubChatPanel>
@@ -256,15 +279,30 @@ export function HomeHub(): React.JSX.Element {
                 aria-hidden
               />
 
-              {/* Mac hides the wordmark when its `recommendations` array is non-empty.
-                  Windows has no recommendations source at all, so that branch is
-                  unreachable and the wordmark renders unconditionally. */}
-              <h1
-                className="shrink-0 select-none font-display text-[58px] font-bold lowercase leading-none text-home-ink"
-                style={{ textShadow: '0 0 26px rgb(var(--home-stage-glow-rgb) / 0.46)' }}
-              >
-                omi.
-              </h1>
+              {/* Mac hides the wordmark when its `recommendations` array is non-empty
+                  and shows the knows list in its place. The knows slot is that
+                  recommendations source on Windows, so the branch is finally
+                  reachable: rows take the stage centre, the wordmark otherwise.
+                  The list stays MOUNTED either way (it owns its data fetch and
+                  reports presence); only its visibility toggles, so presence
+                  flips cannot unmount-and-remount it into an effect loop. */}
+              {!knowsHasRows && (
+                <h1
+                  className="shrink-0 select-none font-display text-[58px] font-bold lowercase leading-none text-home-ink"
+                  style={{ textShadow: '0 0 26px rgb(var(--home-stage-glow-rgb) / 0.46)' }}
+                >
+                  omi.
+                </h1>
+              )}
+              {hubKnows && (
+                <div
+                  className={knowsHasRows ? 'w-full shrink-0' : 'hidden'}
+                  style={knowsHasRows ? { maxWidth: ASK_MAX_HUB } : undefined}
+                  aria-hidden={!knowsHasRows}
+                >
+                  {createElement(hubKnows, { onAskPrefill: prefillAsk, chatSending: chat.sending })}
+                </div>
+              )}
 
               {/* Mac: Spacer(minLength: 24) — absorbs slack, docking the cluster. The
                   min-height (WORDMARK_GAP) is raised above Mac's 24 on Chris's call; see

--- a/desktop/windows/src/renderer/src/components/home/hub/HubAskBar.focusSignal.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubAskBar.focusSignal.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen, waitFor } from '@testing-library/react'
+import { HubAskBar } from './HubAskBar'
+
+vi.mock('../../../lib/chatAttachments', async (importOriginal) => importOriginal())
+vi.mock('../../../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+
+function bar(focusSignal: number | undefined): React.JSX.Element {
+  return (
+    <HubAskBar
+      value=""
+      onChange={() => {}}
+      onSubmit={() => {}}
+      onFocus={() => {}}
+      sending={false}
+      connectActive={false}
+      onToggleConnect={() => {}}
+      focusSignal={focusSignal}
+    />
+  )
+}
+
+afterEach(cleanup)
+
+describe('HubAskBar focus signal', () => {
+  it('a signal bump after mount pulls focus into the input', async () => {
+    const { rerender } = render(bar(0))
+    rerender(bar(1))
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('textbox')))
+  })
+
+  it('a fresh mount with a nonzero signal never steals focus (no replay on re-dock)', async () => {
+    // The bar re-docks between the stage and the chat panel; a remount seeing
+    // the old signal must not focus, or its onFocus would reopen the chat the
+    // user just dismissed.
+    render(bar(3))
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox'))
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/hub/HubAskBar.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubAskBar.tsx
@@ -69,9 +69,14 @@ export function HubAskBar(props: {
 
   // A focusSignal bump pulls the caret in after a programmatic prefill; rAF for
   // the same reason as the mousedown handler below (focus inside the triggering
-  // event's dispatch is swallowed).
+  // event's dispatch is swallowed). The ref seeds from the CURRENT prop so a
+  // remount (the bar re-docks between stage and panel) never re-fires an old
+  // signal — focusing here dispatches askFocused, so a stale replay would
+  // reopen the chat the user just dismissed.
+  const lastFocusSignal = useRef(focusSignal)
   useEffect(() => {
-    if (focusSignal === undefined || focusSignal === 0) return
+    if (focusSignal === undefined || focusSignal === lastFocusSignal.current) return
+    lastFocusSignal.current = focusSignal
     const raf = requestAnimationFrame(() => inputRef.current?.focus())
     return () => cancelAnimationFrame(raf)
   }, [focusSignal])

--- a/desktop/windows/src/renderer/src/components/home/hub/HubAskBar.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubAskBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ArrowUp, Link as LinkIcon, Loader2, Paperclip } from 'lucide-react'
 import { cn } from '../../../lib/utils'
 import {
@@ -47,13 +47,34 @@ export function HubAskBar(props: {
    *  panel and silently drops your focus on the floor, so the first thing you type
    *  goes nowhere. */
   autoFocus?: boolean
+  /** Bump to pull keyboard focus into the input without remounting — used when
+   *  a knows question row prefills the draft (mac parity: homeAskFieldFocused). */
+  focusSignal?: number
 }): React.JSX.Element {
-  const { value, onChange, onSubmit, onFocus, sending, connectActive, onToggleConnect, autoFocus } =
-    props
+  const {
+    value,
+    onChange,
+    onSubmit,
+    onFocus,
+    sending,
+    connectActive,
+    onToggleConnect,
+    autoFocus,
+    focusSignal
+  } = props
   const [focused, setFocused] = useState(false)
   const [dragging, setDragging] = useState(false)
   const [rejectNote, setRejectNote] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  // A focusSignal bump pulls the caret in after a programmatic prefill; rAF for
+  // the same reason as the mousedown handler below (focus inside the triggering
+  // event's dispatch is swallowed).
+  useEffect(() => {
+    if (focusSignal === undefined || focusSignal === 0) return
+    const raf = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => cancelAnimationFrame(raf)
+  }, [focusSignal])
   const attachments = usePendingAttachments()
   const atCap = attachments.length >= MAX_CHAT_ATTACHMENTS
   // Send is allowed with text OR at least one attachment that hasn't failed —

--- a/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubChatPanel.tsx
@@ -23,8 +23,11 @@ export function HubChatPanel(props: {
   // idea how to get back home (#10894), so the panel carries a close control.
   onDismiss: () => void
   children: React.ReactNode
+  /** Rendered under the empty-thread placeholder (mac parity: the chat-mode
+   *  rolling knows rows shown over an empty thread). */
+  emptyStateExtra?: React.ReactNode
 }): React.JSX.Element {
-  const { messages, sending, header, onDismiss, children } = props
+  const { messages, sending, header, onDismiss, children, emptyStateExtra } = props
   const scrollRef = useRef<HTMLDivElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
 
@@ -71,6 +74,7 @@ export function HubChatPanel(props: {
               <p className="max-w-sm text-[13px] text-home-muted">
                 It can see your conversations, tasks, memories, and screen history.
               </p>
+              {emptyStateExtra && <div className="mt-4 w-full max-w-md">{emptyStateExtra}</div>}
             </div>
           ) : (
             <ChatMessages messages={messages} sending={sending} variant="main" />

--- a/desktop/windows/src/renderer/src/components/home/hub/HubSuggestions.personalized.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubSuggestions.personalized.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { HubSuggestions } from './HubSuggestions'
+import { HubChatPanel } from './HubChatPanel'
+import { __resetSuggestionsGenerationForTest } from '../../../lib/intelligence/homeSuggestions'
+
+vi.mock('../../../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../../../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(async () => ({ data: [] })), post: vi.fn(), delete: vi.fn() }
+}))
+vi.mock('../../../lib/agentLLM', () => ({ callAgentLLM: vi.fn(async () => '{"questions": []}') }))
+vi.mock('../../../lib/actionItems', () => ({ fetchAllActionItems: vi.fn(async () => []) }))
+vi.mock('../../chat/ChatMessages', () => ({ ChatMessages: () => <div data-testid="messages" /> }))
+
+/* eslint-disable @typescript-eslint/no-empty-function -- no-op stub */
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+/* eslint-enable @typescript-eslint/no-empty-function */
+;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = ResizeObserverStub
+
+beforeEach(() => {
+  window.localStorage.clear()
+  __resetSuggestionsGenerationForTest()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('HubSuggestions personalized feed', () => {
+  it('renders a cached personalized question in the second chip', () => {
+    window.localStorage.setItem(
+      'homePersonalizedSuggestions.v1.uid-1',
+      JSON.stringify({ questions: ['Ask Sam about the launch?'], dayStamp: '2000-01-01' })
+    )
+    render(<HubSuggestions onPick={() => {}} />)
+    expect(screen.getByText('What should I do today?')).toBeTruthy()
+    expect(screen.getByText('Ask Sam about the launch?')).toBeTruthy()
+  })
+
+  it('falls back to the static pair when nothing is cached', () => {
+    render(<HubSuggestions onPick={() => {}} />)
+    expect(screen.getByText('What did I spend my time on this week?')).toBeTruthy()
+    expect(screen.getByText("What's the highest-leverage thing I can do next?")).toBeTruthy()
+  })
+})
+
+describe('HubChatPanel empty-state extra', () => {
+  it('hosts the extra only while the thread is empty and idle', () => {
+    const { rerender } = render(
+      <HubChatPanel
+        messages={[]}
+        sending={false}
+        onDismiss={() => {}}
+        emptyStateExtra={<div data-testid="extra" />}
+      >
+        <div />
+      </HubChatPanel>
+    )
+    expect(screen.getByTestId('extra')).toBeTruthy()
+    rerender(
+      <HubChatPanel
+        messages={[{ id: 'm1' } as never]}
+        sending={false}
+        onDismiss={() => {}}
+        emptyStateExtra={<div data-testid="extra" />}
+      >
+        <div />
+      </HubChatPanel>
+    )
+    expect(screen.queryByTestId('extra')).toBeNull()
+    expect(screen.getByTestId('messages')).toBeTruthy()
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/hub/HubSuggestions.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/HubSuggestions.tsx
@@ -1,12 +1,17 @@
 import { ArrowUpRight, Sparkles } from 'lucide-react'
 import { cn } from '../../../lib/utils'
-import { HUB_SUGGESTIONS } from './hubPrompts'
+import { useHomeSuggestions } from '../../../hooks/useHomeSuggestions'
 
 export function HubSuggestions({ onPick }: { onPick: (text: string) => void }): React.JSX.Element {
+  // The personalized daily feed the old static prompt list was a placeholder
+  // for: the lead chip plus two questions generated from the account's own
+  // context (cached per local day), padded by the static pair until a
+  // generation lands.
+  const suggestions = useHomeSuggestions()
   return (
     // VStack(spacing: 8) on Mac (DashboardPage.swift:961).
     <div className="flex w-full flex-col gap-2">
-      {HUB_SUGGESTIONS.map((text) => (
+      {suggestions.map((text) => (
         <button
           key={text}
           type="button"

--- a/desktop/windows/src/renderer/src/components/home/hub/connections/ConnectTray.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/connections/ConnectTray.tsx
@@ -177,7 +177,11 @@ export function ConnectTray(props: ConnectTrayCallbacks): React.JSX.Element {
                   brand="chatgpt"
                   onClick={() => onOpenExport('chatgpt')}
                 />
-                <TrayTile title="OpenClaw" brand="openclaw" onClick={() => onOpenExport('openclaw')} />
+                <TrayTile
+                  title="OpenClaw"
+                  brand="openclaw"
+                  onClick={() => onOpenExport('openclaw')}
+                />
                 <TrayTile title="Hermes" brand="hermes" onClick={() => onOpenExport('hermes')} />
                 <TrayTile
                   title="More"

--- a/desktop/windows/src/renderer/src/components/home/hub/hubKnowsSlot.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/hub/hubKnowsSlot.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, screen, act } from '@testing-library/react'
+import {
+  getHubKnows,
+  registerHubKnows,
+  reportHubKnowsPresence,
+  useHubKnowsPresence
+} from './hubKnowsSlot'
+
+function Probe(): React.JSX.Element {
+  return <span data-testid="p">{String(useHubKnowsPresence())}</span>
+}
+
+afterEach(() => {
+  cleanup()
+  reportHubKnowsPresence(false)
+})
+
+describe('hubKnowsSlot', () => {
+  it('registration is read back at render time', () => {
+    const Component = (): React.JSX.Element => <div />
+    registerHubKnows(Component)
+    expect(getHubKnows()).toBe(Component)
+  })
+
+  it('presence notifies subscribers and dedupes repeat reports', () => {
+    render(<Probe />)
+    expect(screen.getByTestId('p').textContent).toBe('false')
+    act(() => reportHubKnowsPresence(true))
+    expect(screen.getByTestId('p').textContent).toBe('true')
+    act(() => reportHubKnowsPresence(true)) // no-op, must not thrash
+    expect(screen.getByTestId('p').textContent).toBe('true')
+    act(() => reportHubKnowsPresence(false))
+    expect(screen.getByTestId('p').textContent).toBe('false')
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/hub/hubKnowsSlot.ts
+++ b/desktop/windows/src/renderer/src/components/home/hub/hubKnowsSlot.ts
@@ -1,0 +1,57 @@
+import { useSyncExternalStore, type ComponentType } from 'react'
+
+// The resting Hub's knows-list slot — the seam between the Hub chrome and the
+// intelligence knows-list that replaces the wordmark when rows exist (mac hides
+// the wordmark whenever its recommendations array is non-empty; this is the
+// Windows source that finally makes that branch reachable). Mirrors
+// hubHomeWidgetsSlot's registry pattern: registration happens once at startup,
+// so HomeHub never imports intelligence code directly.
+//
+// Presence is a tiny external store rather than a prop: HomeHub needs to know
+// whether rows exist BEFORE rendering the slot (the wordmark and the list swap
+// in the same layout position), and the list itself owns the data. The list
+// reports its row count; the Hub subscribes.
+
+export interface HubKnowsProps {
+  /** Prefill the ask bar with a question row's text (never auto-send). */
+  onAskPrefill?: (text: string) => void
+  /** True while a chat send is in flight — rotation pauses (mac parity). */
+  chatSending?: boolean
+  /** 'stage' (default): the full resting-hub list that swaps with the wordmark
+   *  and reports presence. 'rolling': the chat-mode top-three variant mac shows
+   *  over an empty thread — compact, no error card, no presence reporting. */
+  variant?: 'stage' | 'rolling'
+}
+
+let registered: ComponentType<HubKnowsProps> | null = null
+
+export function registerHubKnows(component: ComponentType<HubKnowsProps>): void {
+  registered = component
+}
+
+export function getHubKnows(): ComponentType<HubKnowsProps> | null {
+  return registered
+}
+
+let hasRows = false
+const presenceListeners = new Set<() => void>()
+
+/** Called by the registered list whenever its composed row count changes.
+ *  (Named report*, not set*: this is an external store notification, not React
+ *  state, and the set-state-in-effect lint keys off the prefix.) */
+export function reportHubKnowsPresence(present: boolean): void {
+  if (hasRows === present) return
+  hasRows = present
+  for (const listener of presenceListeners) listener()
+}
+
+function subscribePresence(listener: () => void): () => void {
+  presenceListeners.add(listener)
+  return () => presenceListeners.delete(listener)
+}
+
+/** HomeHub's read: true while the knows list has rows to show (the wordmark
+ *  yields the stage centre to the list, exactly like mac). */
+export function useHubKnowsPresence(): boolean {
+  return useSyncExternalStore(subscribePresence, () => hasRows)
+}

--- a/desktop/windows/src/renderer/src/components/home/hub/hubPrompts.ts
+++ b/desktop/windows/src/renderer/src/components/home/hub/hubPrompts.ts
@@ -1,8 +1,0 @@
-// Starter prompts under the ask bar. The app has no prompt-suggestions source
-// (no server feed, no local generator), so these are the fixed three — swap them
-// for the feed the day one exists.
-export const HUB_SUGGESTIONS = [
-  'What should I focus on today to achieve my goals?',
-  'What did I spend my time on this week?',
-  "What's the highest-leverage thing I can do next?"
-]

--- a/desktop/windows/src/renderer/src/components/home/hub/registerHomeWidgets.ts
+++ b/desktop/windows/src/renderer/src/components/home/hub/registerHomeWidgets.ts
@@ -1,12 +1,20 @@
 import { registerHubHomeWidgets } from './hubHomeWidgetsSlot'
-import { HomeGoalsChips } from '../HomeGoalsChips'
+import { registerHubKnows } from './hubKnowsSlot'
+import { CanonicalGoalsChips } from '../goals/CanonicalGoalsChips'
+import { HomeKnowsList } from '../knows/HomeKnowsList'
 
-// Register the focused-goals chip row as the resting Hub's home-widget row.
+// Register the goals chip row and the knows list as the resting Hub's
+// intelligence surfaces.
 //
-// EAGER (unlike connections/register.ts's React.lazy): HomeHub mounts this widget
-// directly in the resting cluster, with no Suspense boundary, so a lazy component
-// would throw on first render. The module is small and its deps (goal libs, api
-// client, firebase) are already in the main bundle, so eager import costs nothing
-// extra. The widget only *fetches* when the hub actually mounts it on the main
-// window — registration alone does no work.
-registerHubHomeWidgets(HomeGoalsChips)
+// EAGER (unlike connections/register.ts's React.lazy): HomeHub mounts these
+// directly in the resting cluster, with no Suspense boundary, so a lazy
+// component would throw on first render. The modules are small and their deps
+// (goal libs, api client, firebase) are already in the main bundle, so eager
+// import costs nothing extra. The widgets only *fetch* when the hub actually
+// mounts them on the main window — registration alone does no work.
+//
+// CanonicalGoalsChips renders the canonical FOCUSED subset for accounts inside
+// the intelligence rollout and falls back to the legacy HomeGoalsChips row for
+// everyone else, so registration is safe across the rollout boundary.
+registerHubHomeWidgets(CanonicalGoalsChips)
+registerHubKnows(HomeKnowsList)

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.test.tsx
@@ -25,9 +25,11 @@ function stubIntelligence(over: Partial<ReturnType<typeof dashboardIntelligence.
     recommendations: [],
     goals: [],
     selectedGoalDetail: null,
+    goalDetailError: null,
     focusReplacementGoalId: null,
     error: null,
     isLoading: false,
+    hasLoadedOnce: true,
     pendingFeedbackCount: 0
   }
   vi.spyOn(dashboardIntelligence, 'getState').mockReturnValue({ ...base, ...over })
@@ -91,7 +93,10 @@ beforeEach(() => {
     { id: 8, description: 'Done thing', completed: true, dueAt: null, createdAt: NOW - 1000 }
   ])
   insightRecent.mockResolvedValue([])
-  ;(window as unknown as { omi: { insightRecent: typeof insightRecent } }).omi = { insightRecent }
+  ;(window as unknown as { omi: Record<string, unknown> }).omi = {
+    insightRecent,
+    onTasksChanged: vi.fn(() => () => {})
+  }
 })
 
 afterEach(() => {

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.test.tsx
@@ -164,21 +164,24 @@ describe('HomeKnowsList', () => {
     expect(dismiss).not.toHaveBeenCalled()
   })
 
-  it('question rows prefill the ask bar and never auto-send', async () => {
+  it('question rows hand the text to the ask bar exactly once', async () => {
     stubIntelligence()
     fetchAllActionItems.mockResolvedValue([])
     mount()
     const question = await screen.findByText('What should I do today?')
     fireEvent.click(question)
+    expect(onAskPrefill).toHaveBeenCalledTimes(1)
     expect(onAskPrefill).toHaveBeenCalledWith('What should I do today?')
   })
 
   it('an intelligence error renders the retry card wired to load', async () => {
     stubIntelligence({ error: 'Saved feedback will retry automatically.' })
+    const load = vi.spyOn(dashboardIntelligence, 'load').mockResolvedValue()
     mount()
     await waitFor(() => expect(screen.getByTestId('dashboard-intelligence-error')).toBeTruthy())
+    const callsBeforeRetry = load.mock.calls.length
     fireEvent.click(screen.getByText('Retry'))
-    expect(dashboardIntelligence.load).toHaveBeenCalled()
+    expect(load.mock.calls.length).toBe(callsBeforeRetry + 1)
   })
 })
 

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.test.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { HomeKnowsList } from './HomeKnowsList'
+import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+import { useHubKnowsPresence } from '../hub/hubKnowsSlot'
+
+vi.mock('../../../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../../../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(), post: vi.fn(), delete: vi.fn() }
+}))
+
+const fetchAllActionItems = vi.hoisted(() => vi.fn())
+vi.mock('../../../lib/actionItems', () => ({ fetchAllActionItems }))
+
+const insightRecent = vi.fn()
+
+const NOW = Date.parse('2026-08-16T12:00:00Z')
+const FUTURE = '2026-08-16T18:00:00Z'
+
+function stubIntelligence(over: Partial<ReturnType<typeof dashboardIntelligence.getState>> = {}) {
+  const base = {
+    accountGeneration: 3,
+    recommendations: [],
+    goals: [],
+    selectedGoalDetail: null,
+    focusReplacementGoalId: null,
+    error: null,
+    isLoading: false,
+    pendingFeedbackCount: 0
+  }
+  vi.spyOn(dashboardIntelligence, 'getState').mockReturnValue({ ...base, ...over })
+  vi.spyOn(dashboardIntelligence, 'subscribe').mockReturnValue(() => {})
+  vi.spyOn(dashboardIntelligence, 'load').mockResolvedValue()
+}
+
+const recommendation = (over: Record<string, unknown> = {}) => ({
+  id: 'out-1:dk-1',
+  headline: 'Finish the report',
+  whyNow: 'Due soon',
+  contextLabel: null,
+  recommendedAction: 'Open it',
+  destination: { kind: 'task', taskId: 'task-1', workstreamId: null },
+  wire: {
+    interventionId: 'iv-1',
+    outputVersion: 'out-1',
+    subjectKind: 'task',
+    subjectId: 'task-1',
+    feedbackSubjectKind: 'task',
+    feedbackSubjectId: 'task-1',
+    destinationTaskId: null,
+    destinationWorkstreamId: null,
+    headline: 'Finish the report',
+    whyNow: 'Due soon',
+    contextLabel: null,
+    recommendedAction: 'Open it',
+    alternativeAction: null,
+    evidencePreview: '',
+    dedupeKey: 'dk-1',
+    expiresAt: FUTURE
+  },
+  ...over
+})
+
+function mount(): ReturnType<typeof render> {
+  return render(
+    <MemoryRouter>
+      <HomeKnowsList onAskPrefill={onAskPrefill} />
+    </MemoryRouter>
+  )
+}
+
+let onAskPrefill: ReturnType<typeof vi.fn>
+
+function PresenceProbe(): React.JSX.Element {
+  const present = useHubKnowsPresence()
+  return <span data-testid="presence">{String(present)}</span>
+}
+
+beforeEach(() => {
+  onAskPrefill = vi.fn()
+  fetchAllActionItems.mockResolvedValue([
+    {
+      id: 7,
+      description: 'Pay the invoice',
+      completed: false,
+      dueAt: NOW + 1000,
+      createdAt: NOW - 5000
+    },
+    { id: 8, description: 'Done thing', completed: true, dueAt: null, createdAt: NOW - 1000 }
+  ])
+  insightRecent.mockResolvedValue([])
+  ;(window as unknown as { omi: { insightRecent: typeof insightRecent } }).omi = { insightRecent }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('HomeKnowsList', () => {
+  it('renders composed rows from open tasks and reports presence to the hub slot', async () => {
+    stubIntelligence()
+    render(
+      <MemoryRouter>
+        <HomeKnowsList onAskPrefill={onAskPrefill} />
+        <PresenceProbe />
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(screen.getByText('Pay the invoice')).toBeTruthy())
+    expect(screen.queryByText('Done thing')).toBeNull()
+    expect(screen.getByTestId('presence').textContent).toBe('true')
+  })
+
+  it('recommendation rows lead the insight slot and open runs the store open flow', async () => {
+    stubIntelligence({ recommendations: [recommendation() as never] })
+    const open = vi.spyOn(dashboardIntelligence, 'openRecommendation').mockResolvedValue(true)
+    mount()
+    await waitFor(() => expect(screen.getByText('Finish the report')).toBeTruthy())
+    fireEvent.click(screen.getByText('Finish the report'))
+    expect(open).toHaveBeenCalledWith('out-1:dk-1', expect.any(Function))
+  })
+
+  it('dismissing a recommendation opens the optional-reason popover; a chosen reason flows through', async () => {
+    stubIntelligence({ recommendations: [recommendation() as never] })
+    const dismiss = vi.spyOn(dashboardIntelligence, 'dismiss').mockResolvedValue()
+    mount()
+    await waitFor(() => expect(screen.getByText('Finish the report')).toBeTruthy())
+    const row = screen.getByTestId('home-knows-insight-out-1:dk-1')
+    fireEvent.click(row.querySelector('[aria-label="Dismiss"]') as Element)
+    expect(screen.getByText('Optional reason')).toBeTruthy()
+    fireEvent.click(screen.getByText('Not useful'))
+    expect(dismiss).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'out-1:dk-1' }),
+      'not_useful'
+    )
+  })
+
+  it('closing the reason popover without choosing still dismisses with reason null', async () => {
+    stubIntelligence({ recommendations: [recommendation() as never] })
+    const dismiss = vi.spyOn(dashboardIntelligence, 'dismiss').mockResolvedValue()
+    mount()
+    await waitFor(() => expect(screen.getByText('Finish the report')).toBeTruthy())
+    const row = screen.getByTestId('home-knows-insight-out-1:dk-1')
+    fireEvent.click(row.querySelector('[aria-label="Dismiss"]') as Element)
+    fireEvent.click(screen.getByLabelText('Dismiss without a reason'))
+    expect(dismiss).toHaveBeenCalledWith(expect.objectContaining({ id: 'out-1:dk-1' }), null)
+  })
+
+  it('task rows dismiss session-locally without touching the store', async () => {
+    stubIntelligence()
+    const dismiss = vi.spyOn(dashboardIntelligence, 'dismiss').mockResolvedValue()
+    mount()
+    await waitFor(() => expect(screen.getByText('Pay the invoice')).toBeTruthy())
+    const row = screen.getByTestId('home-knows-task-7')
+    fireEvent.click(row.querySelector('[aria-label="Dismiss"]') as Element)
+    await waitFor(() => expect(screen.queryByText('Pay the invoice')).toBeNull())
+    expect(dismiss).not.toHaveBeenCalled()
+  })
+
+  it('question rows prefill the ask bar and never auto-send', async () => {
+    stubIntelligence()
+    fetchAllActionItems.mockResolvedValue([])
+    mount()
+    const question = await screen.findByText('What should I do today?')
+    fireEvent.click(question)
+    expect(onAskPrefill).toHaveBeenCalledWith('What should I do today?')
+  })
+
+  it('an intelligence error renders the retry card wired to load', async () => {
+    stubIntelligence({ error: 'Saved feedback will retry automatically.' })
+    mount()
+    await waitFor(() => expect(screen.getByTestId('dashboard-intelligence-error')).toBeTruthy())
+    fireEvent.click(screen.getByText('Retry'))
+    expect(dashboardIntelligence.load).toHaveBeenCalled()
+  })
+})
+
+describe('rolling variant (chat-mode)', () => {
+  it('renders at most three rows, no error card, and never reports presence', async () => {
+    stubIntelligence({ error: 'Saved feedback will retry automatically.' })
+    render(
+      <MemoryRouter>
+        <HomeKnowsList onAskPrefill={onAskPrefill} variant="rolling" />
+        <PresenceProbe />
+      </MemoryRouter>
+    )
+    await waitFor(() => expect(screen.getByTestId('home-knows-rolling')).toBeTruthy())
+    expect(screen.queryByTestId('dashboard-intelligence-error')).toBeNull()
+    expect(screen.getByTestId('home-knows-rolling').children.length).toBeLessThanOrEqual(3)
+    expect(screen.getByTestId('presence').textContent).toBe('false')
+  })
+})
+
+describe('row context menu', () => {
+  it('right-click offers Later and Dismiss on recommendation rows', async () => {
+    stubIntelligence({ recommendations: [recommendation() as never] })
+    const later = vi.spyOn(dashboardIntelligence, 'later').mockResolvedValue()
+    mount()
+    await waitFor(() => expect(screen.getByText('Finish the report')).toBeTruthy())
+    fireEvent.contextMenu(screen.getByTestId('home-knows-insight-out-1:dk-1'))
+    const menu = screen.getByTestId('knows-context-menu')
+    expect(menu.textContent).toContain('Later')
+    expect(menu.textContent).toContain('Dismiss')
+    fireEvent.click(screen.getByText('Later'))
+    expect(later).toHaveBeenCalledWith(expect.objectContaining({ id: 'out-1:dk-1' }))
+  })
+})

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AlertTriangle } from 'lucide-react'
+import { useDashboardIntelligence } from '../../../hooks/useDashboardIntelligence'
+import { dashboardIntelligence } from '../../../lib/intelligence/dashboardStore'
+import {
+  canRotateKnows,
+  composeKnowsRows,
+  knowsActionTip,
+  type KnowsRow
+} from '../../../lib/intelligence/knowsComposer'
+import type { FeedbackReason } from '../../../lib/intelligence/wireTypes'
+import { fetchAllActionItems } from '../../../lib/actionItems'
+import { useHomeSuggestions } from '../../../hooks/useHomeSuggestions'
+import { reportHubKnowsPresence, type HubKnowsProps } from '../hub/hubKnowsSlot'
+import { HomeKnowsRow } from './HomeKnowsRow'
+
+// The Home knows list (mac parity: DashboardPage's home-knows-list). Composes
+// at most four diverse rows from open tasks, What Matters Now recommendations
+// stacked ahead of learned insights, the action tip, and suggested questions.
+// One 7s timer advances every source's rotation together, pausing while a chat
+// send is in flight. Task dismissals are session-only (mac parity: an @State
+// set, never persisted, never sent to the server); insight-row dismiss/later go
+// through the intelligence store's durable feedback loop.
+
+const ROTATE_MS = 7000
+const INSIGHT_HISTORY_LIMIT = 12
+
+type LocalInsight = { id: string; headline: string; dismissed: boolean }
+
+export function HomeKnowsList({
+  onAskPrefill,
+  chatSending,
+  variant = 'stage'
+}: HubKnowsProps): React.JSX.Element | null {
+  const navigate = useNavigate()
+  const intelligence = useDashboardIntelligence()
+  const suggestions = useHomeSuggestions()
+  const [tasks, setTasks] = useState<{ id: string; text: string }[]>([])
+  const [insightHistory, setInsightHistory] = useState<{ id: string; text: string }[]>([])
+  const [dismissedTaskIds, setDismissedTaskIds] = useState<ReadonlySet<string>>(new Set())
+  const [rotation, setRotation] = useState(0)
+  const [openTaskCount, setOpenTaskCount] = useState(0)
+
+  // State lands only in promise continuations (the repo's HomeGoalsChips
+  // idiom), so the effect body itself never sets state synchronously.
+  useEffect(() => {
+    const read = (): void => {
+      fetchAllActionItems()
+        .then((items) => {
+          const open = items.filter((t) => !t.completed)
+          setOpenTaskCount(open.length)
+          // Due-dated work first (soonest due leads), then the freshest
+          // captures — the same emphasis as mac's overdue + today + recent
+          // concatenation.
+          open.sort((a, b) => {
+            const ad = a.dueAt ?? Number.POSITIVE_INFINITY
+            const bd = b.dueAt ?? Number.POSITIVE_INFINITY
+            if (ad !== bd) return ad - bd
+            return b.createdAt - a.createdAt
+          })
+          setTasks(open.map((t) => ({ id: String(t.id), text: t.description })))
+        })
+        .catch(() => setTasks([]))
+      ;(window.omi.insightRecent(100) as unknown as Promise<LocalInsight[]>)
+        .then((recent) => {
+          setInsightHistory(
+            recent
+              .filter((i) => !i.dismissed)
+              .slice(0, INSIGHT_HISTORY_LIMIT)
+              .map((i) => ({ id: i.id, text: i.headline }))
+          )
+        })
+        .catch(() => setInsightHistory([]))
+    }
+    read()
+    window.addEventListener('focus', read)
+    return () => window.removeEventListener('focus', read)
+  }, [])
+
+  // Recommendations lead the insight slot; learned insights follow (mac
+  // parity: homeKnowsInsightCandidates). Both share the 'insight' row kind and
+  // are told apart at action time by looking the id up in the store.
+  const insightCandidates = useMemo(
+    () => [
+      ...intelligence.recommendations.map((r) => ({ id: r.id, text: r.headline })),
+      ...insightHistory
+    ],
+    [intelligence.recommendations, insightHistory]
+  )
+
+  const tip = knowsActionTip(openTaskCount)
+  const rows = useMemo(
+    () =>
+      composeKnowsRows({
+        tasks,
+        insights: insightCandidates,
+        tip,
+        questions: suggestions,
+        dismissedTaskIds,
+        rotation
+      }),
+    [tasks, insightCandidates, tip, suggestions, dismissedTaskIds, rotation]
+  )
+
+  const rotatable = canRotateKnows(
+    tasks.filter((t) => !dismissedTaskIds.has(t.id)).length,
+    insightCandidates.length,
+    suggestions.length
+  )
+
+  useEffect(() => {
+    if (!rotatable || chatSending) return
+    const timer = window.setInterval(() => setRotation((r) => r + 1), ROTATE_MS)
+    return () => window.clearInterval(timer)
+  }, [rotatable, chatSending])
+
+  const rolling = variant === 'rolling'
+  const visibleRows = rolling ? rows.slice(0, 3) : rows
+  const hasContent =
+    (rolling ? visibleRows.length > 0 : rows.length > 0) ||
+    (!rolling && intelligence.error !== null)
+  useEffect(() => {
+    if (rolling) return
+    reportHubKnowsPresence(hasContent)
+    return () => reportHubKnowsPresence(false)
+  }, [rolling, hasContent])
+
+  const openRow = useCallback(
+    (row: KnowsRow): void => {
+      if (row.kind === 'task') {
+        navigate('/tasks')
+        return
+      }
+      if (row.kind === 'question') {
+        onAskPrefill?.(row.text)
+        return
+      }
+      const recommendation = intelligence.recommendations.find((r) => `insight-${r.id}` === row.id)
+      if (!recommendation) return // learned insights are inert here (mac parity)
+      // The store owns the open flow (stale-id reload, unavailable error, and
+      // do_now recorded only after a successful open — mac's ordering). All
+      // destinations land on the Tasks surface for now: Windows has no
+      // workstream-thread UI yet, so thread destinations open Tasks rather than
+      // being dropped. Called out as a deviation in the PR body.
+      void dashboardIntelligence.openRecommendation(recommendation.id, () => {
+        navigate('/tasks')
+        return true
+      })
+    },
+    [navigate, onAskPrefill, intelligence.recommendations]
+  )
+
+  const dismissRow = useCallback(
+    (row: KnowsRow, reason: FeedbackReason | null): void => {
+      if (row.kind === 'task') {
+        const id = row.id.slice('task-'.length)
+        setDismissedTaskIds((prev) => new Set(prev).add(id))
+        return
+      }
+      const recommendation = intelligence.recommendations.find((r) => `insight-${r.id}` === row.id)
+      if (recommendation) void dashboardIntelligence.dismiss(recommendation, reason)
+    },
+    [intelligence.recommendations]
+  )
+
+  const laterRow = useCallback(
+    (row: KnowsRow): void => {
+      const recommendation = intelligence.recommendations.find((r) => `insight-${r.id}` === row.id)
+      if (recommendation) void dashboardIntelligence.later(recommendation)
+    },
+    [intelligence.recommendations]
+  )
+
+  if (!hasContent) return null
+
+  return (
+    <div
+      className="flex w-full flex-col gap-2"
+      data-testid={rolling ? 'home-knows-rolling' : 'home-knows-list'}
+    >
+      {!rolling && intelligence.error !== null && (
+        <div
+          className="flex h-[42px] w-full items-center gap-2.5 rounded-[13px] border border-home-hairline bg-home-tile/[0.55] px-4"
+          data-testid="dashboard-intelligence-error"
+        >
+          <AlertTriangle className="h-3 w-3 shrink-0 text-home-muted" strokeWidth={2.5} />
+          <span className="min-w-0 flex-1 truncate text-[12px] text-home-secondary">
+            {intelligence.error}
+          </span>
+          <button
+            type="button"
+            onClick={() => void dashboardIntelligence.load()}
+            className="focus-ring shrink-0 rounded px-2 py-1 text-[12px] font-medium text-home-secondary hover:text-home-ink"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {visibleRows.map((row) => {
+        const isRecommendation =
+          row.kind === 'insight' &&
+          intelligence.recommendations.some((r) => `insight-${r.id}` === row.id)
+        return (
+          <HomeKnowsRow
+            key={row.id}
+            row={row}
+            onOpen={() => openRow(row)}
+            onDismiss={
+              row.kind === 'question'
+                ? undefined
+                : (reason) => dismissRow(row, row.kind === 'insight' ? reason : null)
+            }
+            onLater={isRecommendation ? () => laterRow(row) : undefined}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsList.tsx
@@ -48,7 +48,7 @@ export function HomeKnowsList({
     const read = (): void => {
       fetchAllActionItems()
         .then((items) => {
-          const open = items.filter((t) => !t.completed)
+          const open = items.filter((t) => !t.completed && !t.deleted)
           setOpenTaskCount(open.length)
           // Due-dated work first (soonest due leads), then the freshest
           // captures — the same emphasis as mac's overdue + today + recent
@@ -75,7 +75,13 @@ export function HomeKnowsList({
     }
     read()
     window.addEventListener('focus', read)
-    return () => window.removeEventListener('focus', read)
+    // Local task mutations broadcast tasks:changed; re-read so a create,
+    // complete, or delete updates the rows without waiting for refocus.
+    const offTasksChanged = window.omi.onTasksChanged(read)
+    return () => {
+      window.removeEventListener('focus', read)
+      offTasksChanged()
+    }
   }, [])
 
   // Recommendations lead the insight slot; learned insights follow (mac

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsRow.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsRow.tsx
@@ -65,8 +65,10 @@ export function HomeKnowsRow({
     const onKey = (e: KeyboardEvent): void => {
       if (e.key !== 'Escape') return
       e.stopPropagation()
-      if (reasonOpen) chooseReason(null)
-      else setMenuAt(null)
+      if (reasonOpen) {
+        setReasonAt(null)
+        onDismiss?.(null)
+      } else setMenuAt(null)
     }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsRow.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsRow.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import { Circle, Lightbulb, MessageSquare, ArrowUpRight, X, Clock } from 'lucide-react'
+import { cn } from '../../../lib/utils'
+import type { KnowsRow } from '../../../lib/intelligence/knowsComposer'
+import type { FeedbackReason } from '../../../lib/intelligence/wireTypes'
+
+// One knows-list row (mac parity: HomeKnowsRowView, DashboardPage.swift ~2400).
+// Task rows dismiss immediately; insight rows open the optional-reason popover
+// first, and closing it without choosing still dismisses (reason null, mac
+// parity); question rows have no dismiss at all — they render the open chevron
+// instead of the close button.
+
+const DISMISS_REASONS: { label: string; reason: FeedbackReason }[] = [
+  { label: 'Already handled', reason: 'already_handled' },
+  { label: 'Not mine', reason: 'not_mine' },
+  { label: 'Not useful', reason: 'not_useful' }
+]
+
+export function HomeKnowsRow({
+  row,
+  onOpen,
+  onDismiss,
+  onLater
+}: {
+  row: KnowsRow
+  onOpen: () => void
+  /** Absent for question rows (they cannot be dismissed). Insight rows receive
+   *  the chosen reason or null when the popover closes without one. */
+  onDismiss?: (reason: FeedbackReason | null) => void
+  /** Insight rows only: push the recommendation back 24h. */
+  onLater?: () => void
+}): React.JSX.Element {
+  const [reasonOpen, setReasonOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const Icon = row.kind === 'task' ? Circle : row.kind === 'insight' ? Lightbulb : MessageSquare
+
+  const dismissClicked = (): void => {
+    if (!onDismiss) return
+    if (row.kind === 'insight') {
+      setReasonOpen(true)
+      return
+    }
+    onDismiss(null)
+  }
+
+  const chooseReason = (reason: FeedbackReason | null): void => {
+    setReasonOpen(false)
+    onDismiss?.(reason)
+  }
+
+  const openContextMenu = (e: React.MouseEvent): void => {
+    // Mac parity: the row's context menu carries Later and Dismiss. Question
+    // rows have neither, so the default menu is fine there.
+    if (!onDismiss && !onLater) return
+    e.preventDefault()
+    setMenuOpen(true)
+  }
+
+  return (
+    <div
+      className="group relative w-full shrink-0"
+      data-testid={`home-knows-${row.id}`}
+      onContextMenu={openContextMenu}
+    >
+      <div
+        className={cn(
+          'flex h-[46px] w-full items-center gap-2.5 rounded-[13px]',
+          'border border-home-hairline bg-home-tile/[0.55] px-4',
+          'transition-colors duration-150 hover:bg-home-tileHover'
+        )}
+      >
+        <button
+          type="button"
+          onClick={onOpen}
+          className="focus-ring flex min-w-0 flex-1 items-center gap-2.5 text-left"
+        >
+          <Icon className="h-[12px] w-[12px] shrink-0 text-home-muted" strokeWidth={2.25} />
+          <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-home-secondary group-hover:text-home-ink">
+            {row.text}
+          </span>
+        </button>
+        {onDismiss ? (
+          <span className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+            {onLater && (
+              <button
+                type="button"
+                onClick={onLater}
+                aria-label="Later"
+                title="Later"
+                className="focus-ring rounded p-1 text-home-faint hover:text-home-secondary"
+              >
+                <Clock className="h-3 w-3" strokeWidth={2.5} />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={dismissClicked}
+              aria-label="Dismiss"
+              title="Dismiss"
+              className="focus-ring rounded p-1 text-home-faint hover:text-home-secondary"
+            >
+              <X className="h-3 w-3" strokeWidth={2.5} />
+            </button>
+          </span>
+        ) : (
+          <ArrowUpRight className="h-2.5 w-2.5 shrink-0 text-home-faint" strokeWidth={2.5} />
+        )}
+      </div>
+
+      {menuOpen && (
+        <>
+          <button
+            type="button"
+            aria-label="Close menu"
+            className="fixed inset-0 z-40 cursor-default"
+            onClick={() => setMenuOpen(false)}
+          />
+          <div
+            className="absolute right-0 top-[48px] z-50 w-[130px] rounded-[10px] border border-home-hairline bg-home-tile p-1 shadow-lg"
+            data-testid="knows-context-menu"
+          >
+            {onLater && (
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false)
+                  onLater()
+                }}
+                className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+              >
+                Later
+              </button>
+            )}
+            {onDismiss && (
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false)
+                  dismissClicked()
+                }}
+                className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+        </>
+      )}
+
+      {reasonOpen && (
+        <>
+          {/* Click-away closes without a reason — which still dismisses. */}
+          <button
+            type="button"
+            aria-label="Dismiss without a reason"
+            className="fixed inset-0 z-40 cursor-default"
+            onClick={() => chooseReason(null)}
+          />
+          <div
+            className="absolute right-0 top-[48px] z-50 w-[210px] rounded-[10px] border border-home-hairline bg-home-tile p-2 shadow-lg"
+            data-testid="knows-dismiss-reasons"
+          >
+            <p className="px-1 pb-1 text-[11px] font-semibold text-home-muted">Optional reason</p>
+            {DISMISS_REASONS.map(({ label, reason }) => (
+              <button
+                key={reason}
+                type="button"
+                onClick={() => chooseReason(reason)}
+                className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsRow.tsx
+++ b/desktop/windows/src/renderer/src/components/home/knows/HomeKnowsRow.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Circle, Lightbulb, MessageSquare, ArrowUpRight, X, Clock } from 'lucide-react'
 import { cn } from '../../../lib/utils'
 import type { KnowsRow } from '../../../lib/intelligence/knowsComposer'
@@ -30,31 +31,53 @@ export function HomeKnowsRow({
   /** Insight rows only: push the recommendation back 24h. */
   onLater?: () => void
 }): React.JSX.Element {
-  const [reasonOpen, setReasonOpen] = useState(false)
-  const [menuOpen, setMenuOpen] = useState(false)
+  // Overlay anchors in viewport coordinates: both the context menu and the
+  // reason popover render through a portal with edge clamping (the pattern
+  // ConversationRowContextMenu established), so a row near the bottom of the
+  // hub's no-scroll stage can never have its actions clipped by an ancestor's
+  // overflow.
+  const [reasonAt, setReasonAt] = useState<{ x: number; y: number } | null>(null)
+  const [menuAt, setMenuAt] = useState<{ x: number; y: number } | null>(null)
+  const reasonOpen = reasonAt !== null
+  const menuOpen = menuAt !== null
 
   const Icon = row.kind === 'task' ? Circle : row.kind === 'insight' ? Lightbulb : MessageSquare
 
-  const dismissClicked = (): void => {
+  const dismissClicked = (e: React.MouseEvent): void => {
     if (!onDismiss) return
     if (row.kind === 'insight') {
-      setReasonOpen(true)
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+      setReasonAt({ x: rect.right, y: rect.bottom + 4 })
       return
     }
     onDismiss(null)
   }
 
   const chooseReason = (reason: FeedbackReason | null): void => {
-    setReasonOpen(false)
+    setReasonAt(null)
     onDismiss?.(reason)
   }
+
+  // Escape dismisses whichever overlay is open; the reason popover keeps its
+  // documented close-without-choosing behavior (a reasonless dismiss).
+  useEffect(() => {
+    if (!menuOpen && !reasonOpen) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      e.stopPropagation()
+      if (reasonOpen) chooseReason(null)
+      else setMenuAt(null)
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [menuOpen, reasonOpen, onDismiss])
 
   const openContextMenu = (e: React.MouseEvent): void => {
     // Mac parity: the row's context menu carries Later and Dismiss. Question
     // rows have neither, so the default menu is fine there.
     if (!onDismiss && !onLater) return
     e.preventDefault()
-    setMenuOpen(true)
+    setMenuAt({ x: e.clientX, y: e.clientY })
   }
 
   return (
@@ -81,7 +104,7 @@ export function HomeKnowsRow({
           </span>
         </button>
         {onDismiss ? (
-          <span className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+          <span className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-150 focus-within:opacity-100 group-hover:opacity-100">
             {onLater && (
               <button
                 type="button"
@@ -108,73 +131,87 @@ export function HomeKnowsRow({
         )}
       </div>
 
-      {menuOpen && (
-        <>
-          <button
-            type="button"
-            aria-label="Close menu"
-            className="fixed inset-0 z-40 cursor-default"
-            onClick={() => setMenuOpen(false)}
-          />
-          <div
-            className="absolute right-0 top-[48px] z-50 w-[130px] rounded-[10px] border border-home-hairline bg-home-tile p-1 shadow-lg"
-            data-testid="knows-context-menu"
-          >
-            {onLater && (
-              <button
-                type="button"
-                onClick={() => {
-                  setMenuOpen(false)
-                  onLater()
-                }}
-                className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
-              >
-                Later
-              </button>
-            )}
-            {onDismiss && (
-              <button
-                type="button"
-                onClick={() => {
-                  setMenuOpen(false)
-                  dismissClicked()
-                }}
-                className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
-              >
-                Dismiss
-              </button>
-            )}
-          </div>
-        </>
-      )}
+      {menuOpen &&
+        menuAt !== null &&
+        createPortal(
+          <>
+            <button
+              type="button"
+              aria-label="Close menu"
+              className="fixed inset-0 z-[190] cursor-default"
+              onClick={() => setMenuAt(null)}
+            />
+            <div
+              className="fixed z-[200] w-[130px] rounded-[10px] border border-home-hairline bg-home-tile p-1 shadow-lg"
+              style={{
+                left: Math.min(menuAt.x, window.innerWidth - 140),
+                top: Math.min(menuAt.y, window.innerHeight - 90)
+              }}
+              data-testid="knows-context-menu"
+            >
+              {onLater && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuAt(null)
+                    onLater()
+                  }}
+                  className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+                >
+                  Later
+                </button>
+              )}
+              {onDismiss && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    setMenuAt(null)
+                    dismissClicked(e)
+                  }}
+                  className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+                >
+                  Dismiss
+                </button>
+              )}
+            </div>
+          </>,
+          document.body
+        )}
 
-      {reasonOpen && (
-        <>
-          {/* Click-away closes without a reason — which still dismisses. */}
-          <button
-            type="button"
-            aria-label="Dismiss without a reason"
-            className="fixed inset-0 z-40 cursor-default"
-            onClick={() => chooseReason(null)}
-          />
-          <div
-            className="absolute right-0 top-[48px] z-50 w-[210px] rounded-[10px] border border-home-hairline bg-home-tile p-2 shadow-lg"
-            data-testid="knows-dismiss-reasons"
-          >
-            <p className="px-1 pb-1 text-[11px] font-semibold text-home-muted">Optional reason</p>
-            {DISMISS_REASONS.map(({ label, reason }) => (
-              <button
-                key={reason}
-                type="button"
-                onClick={() => chooseReason(reason)}
-                className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </>
-      )}
+      {reasonOpen &&
+        reasonAt !== null &&
+        createPortal(
+          <>
+            {/* Click-away closes without a reason — which still dismisses. */}
+            <button
+              type="button"
+              aria-label="Dismiss without a reason"
+              className="fixed inset-0 z-[190] cursor-default"
+              onClick={() => chooseReason(null)}
+            />
+            <div
+              className="fixed z-[200] w-[210px] rounded-[10px] border border-home-hairline bg-home-tile p-2 shadow-lg"
+              style={{
+                left: Math.max(8, Math.min(reasonAt.x - 210, window.innerWidth - 218)),
+                top: Math.min(reasonAt.y, window.innerHeight - 150)
+              }}
+              data-testid="knows-dismiss-reasons"
+            >
+              <p className="px-1 pb-1 text-[11px] font-semibold text-home-muted">Optional reason</p>
+              {DISMISS_REASONS.map(({ label, reason }) => (
+                <button
+                  key={reason}
+                  type="button"
+                  onClick={() => chooseReason(reason)}
+                  className="focus-ring block w-full rounded px-2 py-1.5 text-left text-[12px] text-home-secondary hover:bg-home-tileHover hover:text-home-ink"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </>,
+          document.body
+        )}
     </div>
   )
 }

--- a/desktop/windows/src/renderer/src/hooks/useChat.ts
+++ b/desktop/windows/src/renderer/src/hooks/useChat.ts
@@ -453,9 +453,7 @@ export function useChat(): UseChat {
   // Snapshots the last non-Omi foreground window so we plan against the app the
   // user was actually using, not Omi itself.
   type PlanVerdict =
-    | { kind: 'planned'; plan: AutomationPlan }
-    | { kind: 'error' }
-    | { kind: 'chat' }
+    { kind: 'planned'; plan: AutomationPlan } | { kind: 'error' } | { kind: 'chat' }
   const tryPlan = async (text: string): Promise<PlanVerdict> => {
     // Desktop automation requires BOTH the OMI_AUTOMATION env kill-switch (on
     // unless OMI_AUTOMATION=0) and the user's onboarding opt-in. Until the user

--- a/desktop/windows/src/renderer/src/hooks/useDashboardIntelligence.ts
+++ b/desktop/windows/src/renderer/src/hooks/useDashboardIntelligence.ts
@@ -1,0 +1,30 @@
+import { useEffect, useSyncExternalStore } from 'react'
+import {
+  dashboardIntelligence,
+  type DashboardIntelligenceState,
+  type DashboardIntelligenceStore
+} from '../lib/intelligence/dashboardStore'
+
+/** Bind a component to the dashboard intelligence store (What Matters Now +
+ *  canonical goals). Loads on mount and again when the window regains focus,
+ *  mirroring mac's onAppear + didBecomeActive pair; there is no timer-based
+ *  refetch on either platform. */
+export function useDashboardIntelligence(
+  store: DashboardIntelligenceStore = dashboardIntelligence
+): DashboardIntelligenceState {
+  const state = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.getState()
+  )
+
+  useEffect(() => {
+    void store.load()
+    const onFocus = (): void => {
+      void store.load()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [store])
+
+  return state
+}

--- a/desktop/windows/src/renderer/src/hooks/useDashboardIntelligence.ts
+++ b/desktop/windows/src/renderer/src/hooks/useDashboardIntelligence.ts
@@ -1,4 +1,5 @@
-import { useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useEffect } from 'react'
+import { useSyncExternalStore } from 'react'
 import {
   dashboardIntelligence,
   type DashboardIntelligenceState,
@@ -6,25 +7,28 @@ import {
 } from '../lib/intelligence/dashboardStore'
 
 /** Bind a component to the dashboard intelligence store (What Matters Now +
- *  canonical goals). Loads on mount and again when the window regains focus,
- *  mirroring mac's onAppear + didBecomeActive pair; there is no timer-based
- *  refetch on either platform. */
+ *  canonical goals). With autoLoad (the default) it loads on mount and again
+ *  when the window regains focus, mirroring mac's onAppear + didBecomeActive
+ *  pair; passive consumers (the goal detail sheet) subscribe without loading so
+ *  a mount cannot clear a detail-scoped error mid-flight. */
 export function useDashboardIntelligence(
-  store: DashboardIntelligenceStore = dashboardIntelligence
+  store: DashboardIntelligenceStore = dashboardIntelligence,
+  options: { autoLoad?: boolean } = {}
 ): DashboardIntelligenceState {
-  const state = useSyncExternalStore(
-    (listener) => store.subscribe(listener),
-    () => store.getState()
-  )
+  const autoLoad = options.autoLoad !== false
+  const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store])
+  const getSnapshot = useCallback(() => store.getState(), [store])
+  const state = useSyncExternalStore(subscribe, getSnapshot)
 
   useEffect(() => {
+    if (!autoLoad) return
     void store.load()
     const onFocus = (): void => {
       void store.load()
     }
     window.addEventListener('focus', onFocus)
     return () => window.removeEventListener('focus', onFocus)
-  }, [store])
+  }, [store, autoLoad])
 
   return state
 }

--- a/desktop/windows/src/renderer/src/hooks/useHomeSuggestions.test.tsx
+++ b/desktop/windows/src/renderer/src/hooks/useHomeSuggestions.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, screen, waitFor } from '@testing-library/react'
+import { useHomeSuggestions } from './useHomeSuggestions'
+import {
+  __resetSuggestionsGenerationForTest,
+  LEAD_SUGGESTION
+} from '../lib/intelligence/homeSuggestions'
+
+vi.mock('../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(async () => ({ data: [] })), post: vi.fn(), delete: vi.fn() }
+}))
+vi.mock('../lib/agentLLM', () => ({ callAgentLLM: vi.fn(async () => '{"questions": []}') }))
+vi.mock('../lib/actionItems', () => ({ fetchAllActionItems: vi.fn(async () => []) }))
+
+function Probe(): React.JSX.Element {
+  const suggestions = useHomeSuggestions()
+  return (
+    <ol>
+      {suggestions.map((s) => (
+        <li key={s}>{s}</li>
+      ))}
+    </ol>
+  )
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  __resetSuggestionsGenerationForTest()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('useHomeSuggestions', () => {
+  it('always composes the lead chip plus two questions, from fallbacks when nothing is cached', async () => {
+    render(<Probe />)
+    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(3))
+    const texts = screen.getAllByRole('listitem').map((li) => li.textContent)
+    expect(texts[0]).toBe(LEAD_SUGGESTION)
+    expect(texts[1]).toBe('What did I spend my time on this week?')
+  })
+
+  it('publishes a cached personalized set immediately, before any refresh lands', async () => {
+    window.localStorage.setItem(
+      'homePersonalizedSuggestions.v1.uid-1',
+      JSON.stringify({ questions: ['Ask Sam about the launch?'], dayStamp: '2000-01-01' })
+    )
+    render(<Probe />)
+    // The stale-day cache still publishes first render; the refresh then runs.
+    expect(screen.getAllByRole('listitem')[1].textContent).toBe('Ask Sam about the launch?')
+  })
+})

--- a/desktop/windows/src/renderer/src/hooks/useHomeSuggestions.ts
+++ b/desktop/windows/src/renderer/src/hooks/useHomeSuggestions.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import {
+  composeSuggestions,
+  readSuggestionsCache,
+  refreshHomeSuggestions,
+  suggestionsOwnerId
+} from '../lib/intelligence/homeSuggestions'
+
+/** The hub's ask-bar suggestion chips: the cached personalized set published
+ *  immediately (no flash of the static defaults when a cache exists), then the
+ *  at-most-daily refresh lands on top. Always composed: the lead chip plus two
+ *  personalized-or-fallback questions (mac parity: HomeSuggestionComposer). */
+export function useHomeSuggestions(): string[] {
+  const [personalized, setPersonalized] = useState<string[]>(
+    () => readSuggestionsCache(suggestionsOwnerId())?.questions ?? []
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    refreshHomeSuggestions()
+      .then((questions) => {
+        if (!cancelled) setPersonalized(questions)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return composeSuggestions(personalized)
+}

--- a/desktop/windows/src/renderer/src/hooks/useHomeSuggestions.ts
+++ b/desktop/windows/src/renderer/src/hooks/useHomeSuggestions.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '../lib/firebase'
 import {
   composeSuggestions,
   readSuggestionsCache,
@@ -9,7 +11,10 @@ import {
 /** The hub's ask-bar suggestion chips: the cached personalized set published
  *  immediately (no flash of the static defaults when a cache exists), then the
  *  at-most-daily refresh lands on top. Always composed: the lead chip plus two
- *  personalized-or-fallback questions (mac parity: HomeSuggestionComposer). */
+ *  personalized-or-fallback questions (mac parity: HomeSuggestionComposer).
+ *  Auth changes re-read the new owner's cache and re-run the refresh, so a
+ *  sign-out/in while Home stays mounted never shows the previous account's
+ *  questions. */
 export function useHomeSuggestions(): string[] {
   const [personalized, setPersonalized] = useState<string[]>(
     () => readSuggestionsCache(suggestionsOwnerId())?.questions ?? []
@@ -17,13 +22,23 @@ export function useHomeSuggestions(): string[] {
 
   useEffect(() => {
     let cancelled = false
-    refreshHomeSuggestions()
-      .then((questions) => {
-        if (!cancelled) setPersonalized(questions)
-      })
-      .catch(() => {})
+    let refreshedOwner: string | null = null
+    const refreshForCurrentOwner = (): void => {
+      const owner = suggestionsOwnerId()
+      if (owner === refreshedOwner) return
+      refreshedOwner = owner
+      setPersonalized(readSuggestionsCache(owner)?.questions ?? [])
+      refreshHomeSuggestions()
+        .then((questions) => {
+          if (!cancelled && suggestionsOwnerId() === owner) setPersonalized(questions)
+        })
+        .catch(() => {})
+    }
+    refreshForCurrentOwner()
+    const unsubscribe = onAuthStateChanged(auth, () => refreshForCurrentOwner())
     return () => {
       cancelled = true
+      unsubscribe()
     }
   }, [])
 

--- a/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
+++ b/desktop/windows/src/renderer/src/hooks/usePushToTalk.ts
@@ -215,8 +215,7 @@ export function usePushToTalk(opts: Options): PushToTalk {
    *  from the machine state (or a delegated hub hold), never a second source of
    *  truth. `hubActiveRef` is always false unless a hold delegated (flag on), so
    *  flag-off this reads exactly as before. */
-  const isHolding = (): boolean =>
-    jobRef.current?.state.phase === 'holding' || hubActiveRef.current
+  const isHolding = (): boolean => jobRef.current?.state.phase === 'holding' || hubActiveRef.current
 
   // Acquire the mic NOW (macOS parity: capture starts at key-down, not at the
   // hold threshold), prefetch the auth token alongside the mic spin-up, and

--- a/desktop/windows/src/renderer/src/hooks/useRecorder.ts
+++ b/desktop/windows/src/renderer/src/hooks/useRecorder.ts
@@ -228,7 +228,10 @@ export function useRecorder(): UseRecorder {
       // Merge both lanes' raw segments by wall-clock and queue the row in the
       // sync outbox BEFORE the POST — an offline/failed post stays visible as
       // "sync pending" and retries later (see lib/sync/outbox.ts).
-      const segments = mergeLanes(micStoreRef.current?.list() ?? [], systemStoreRef.current?.list() ?? [])
+      const segments = mergeLanes(
+        micStoreRef.current?.list() ?? [],
+        systemStoreRef.current?.list() ?? []
+      )
       const conversation: LocalConversation = queueForSync(
         {
           id: session.conversationId,

--- a/desktop/windows/src/renderer/src/lib/intelligence/attribution.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/attribution.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { emitFeedbackRecorded, emitInterventionPresented, ATTRIBUTION_EVENT } from './attribution'
+
+const trackEvent = vi.hoisted(() => vi.fn())
+vi.mock('../analytics', () => ({ trackEvent }))
+
+beforeEach(() => trackEvent.mockClear())
+
+describe('attribution events', () => {
+  it('intervention_presented carries the surface and attaches candidate_id only for candidates', () => {
+    emitInterventionPresented({ interventionId: 'iv-1', subjectKind: 'task', subjectId: 't-1' })
+    emitInterventionPresented({
+      interventionId: 'iv-2',
+      subjectKind: 'candidate',
+      subjectId: 'c-1'
+    })
+    expect(trackEvent).toHaveBeenNthCalledWith(
+      1,
+      ATTRIBUTION_EVENT,
+      expect.objectContaining({
+        event_type: 'intervention_presented',
+        surface: 'what_matters_now',
+        subject_kind: 'task'
+      })
+    )
+    expect(trackEvent.mock.calls[0][1]).not.toHaveProperty('candidate_id')
+    expect(trackEvent.mock.calls[1][1]).toMatchObject({ candidate_id: 'c-1' })
+  })
+
+  it('feedback_recorded includes action, and reason/chain id only when present', () => {
+    emitFeedbackRecorded({
+      interventionId: 'iv-1',
+      subjectKind: 'task',
+      subjectId: 't-1',
+      action: 'later',
+      reason: null,
+      attributionChainId: null
+    })
+    const props = trackEvent.mock.calls[0][1] as Record<string, unknown>
+    expect(props.feedback_action).toBe('later')
+    expect(props).not.toHaveProperty('feedback_reason')
+    expect(props).not.toHaveProperty('attribution_chain_id')
+    expect(props.event_id).toMatch(/^attr-/)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/attribution.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/attribution.ts
@@ -1,0 +1,51 @@
+// Client-side attribution analytics for the intelligence loop (mac parity:
+// TaskIntelligenceAttributionEvent, TaskModels.swift). Two events on this
+// surface, exactly like mac's DashboardIntelligenceStore:
+// - intervention_presented, once per intervention id per store lifetime;
+// - feedback_recorded, only after the server accepted the feedback.
+// candidate_id is attached only when the subject is a candidate.
+import { trackEvent } from '../analytics'
+import type { FeedbackAction, FeedbackReason, FeedbackSubjectKind } from './wireTypes'
+
+export const ATTRIBUTION_EVENT = 'task_intelligence_attribution'
+const SURFACE_WHAT_MATTERS_NOW = 'what_matters_now'
+
+type AttributionBase = {
+  interventionId: string
+  subjectKind: FeedbackSubjectKind
+  subjectId: string
+}
+
+function baseProperties(event: AttributionBase, eventType: string): Record<string, unknown> {
+  return {
+    schema_version: 1,
+    event_id: `attr-${crypto.randomUUID()}`,
+    event_type: eventType,
+    source_class: 'screen',
+    occurred_at: new Date().toISOString(),
+    surface: SURFACE_WHAT_MATTERS_NOW,
+    intervention_id: event.interventionId,
+    subject_kind: event.subjectKind,
+    subject_id: event.subjectId,
+    ...(event.subjectKind === 'candidate' ? { candidate_id: event.subjectId } : {})
+  }
+}
+
+export function emitInterventionPresented(event: AttributionBase): void {
+  trackEvent(ATTRIBUTION_EVENT, baseProperties(event, 'intervention_presented'))
+}
+
+export function emitFeedbackRecorded(
+  event: AttributionBase & {
+    action: FeedbackAction
+    reason: FeedbackReason | null
+    attributionChainId: string | null
+  }
+): void {
+  trackEvent(ATTRIBUTION_EVENT, {
+    ...baseProperties(event, 'feedback_recorded'),
+    feedback_action: event.action,
+    ...(event.reason !== null ? { feedback_reason: event.reason } : {}),
+    ...(event.attributionChainId !== null ? { attribution_chain_id: event.attributionChainId } : {})
+  })
+}

--- a/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.test.ts
@@ -658,3 +658,47 @@ describe('owner switching', () => {
     expect(store.getState().accountGeneration).toBe(3)
   })
 })
+
+describe('control failure during refresh', () => {
+  it('clears the generation and rows so stale recommendations are never actionable', async () => {
+    let controlFails = false
+    const store = new DashboardIntelligenceStore({
+      get: vi.fn(async (path: string) => {
+        if (path === '/v1/candidates/control') {
+          if (controlFails) throw new Error('down')
+          return { data: READ_CONTROL }
+        }
+        if (path === '/v1/what-matters-now') {
+          return {
+            data: {
+              schema_version: 1,
+              evaluation_id: 'ev-1',
+              output_version: 'out-1',
+              material_version: 'mat-1',
+              generated_at: PAST,
+              expires_at: FUTURE,
+              recommendations: [wireRow()]
+            }
+          }
+        }
+        if (path === '/v1/goals/canonical/list') return { data: [] }
+        const err = new Error('nf') as Error & { response?: { status: number } }
+        err.response = { status: 404 }
+        throw err
+      }) as never,
+      post: vi.fn() as never,
+      del: vi.fn() as never,
+      now: () => NOW,
+      uuid: () => 'u',
+      ownerId: () => 'uid-1'
+    })
+    await store.load()
+    expect(store.getState().recommendations).toHaveLength(1)
+
+    controlFails = true
+    await store.load()
+    expect(store.getState().accountGeneration).toBeNull()
+    expect(store.getState().recommendations).toEqual([])
+    expect(store.getState().error).toBe('Recommendations are unavailable right now.')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.test.ts
@@ -1,0 +1,660 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  CHOOSE_REPLACEMENT,
+  TARGET_UNAVAILABLE,
+  DashboardIntelligenceStore,
+  FEEDBACK_SAVED_ERROR,
+  RETRY_BANNER,
+  currentGoals,
+  endedGoals,
+  focusedGoals,
+  projectRecommendations
+} from './dashboardStore'
+import { enqueueFeedback, loadOutbox } from './feedbackOutbox'
+import { readWmnProjection, type WmnProjection } from './wireTypes'
+
+vi.mock('../persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../apiClient', () => ({ omiApi: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }))
+const trackEvent = vi.hoisted(() => vi.fn())
+vi.mock('../analytics', () => ({ trackEvent }))
+
+const NOW = Date.parse('2026-08-16T12:00:00Z')
+const FUTURE = '2026-08-16T18:00:00Z'
+const PAST = '2026-08-16T06:00:00Z'
+
+const wireRow = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  intervention_id: 'iv-1',
+  output_version: 'out-1',
+  subject_kind: 'task',
+  subject_id: 'task-1',
+  feedback_subject_kind: 'task',
+  feedback_subject_id: 'task-1',
+  destination_task_id: null,
+  destination_workstream_id: null,
+  headline: 'Finish the report',
+  why_now: 'Due soon',
+  goal_or_workstream_label: null,
+  recommended_action: 'Open it',
+  alternative_action: null,
+  evidence_preview: 'seen in Slack',
+  evidence_refs: [{ kind: 'external', id: 'e1', scope: 'canonical' }],
+  dedupe_key: 'dk-1',
+  expires_at: FUTURE,
+  ...over
+})
+
+const wireProjection = (rows: Record<string, unknown>[], over: Record<string, unknown> = {}) =>
+  readWmnProjection({
+    schema_version: 1,
+    evaluation_id: 'ev-1',
+    output_version: 'out-1',
+    material_version: 'mat-1',
+    generated_at: PAST,
+    expires_at: FUTURE,
+    recommendations: rows,
+    ...over
+  }) as WmnProjection
+
+const wireGoal = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  goal_id: 'g-1',
+  id: 'g-1',
+  title: 'Ship the launch',
+  desired_outcome: 'Launched',
+  status: 'focused',
+  focus_rank: 0,
+  is_active: true,
+  updated_at: '2026-08-10T00:00:00Z',
+  current_value: 1,
+  target_value: 3,
+  ...over
+})
+
+type Routes = Record<string, unknown | (() => unknown)>
+
+function makeStore(routes: Routes, capture?: { posts: unknown[][]; deletes: unknown[][] }) {
+  const resolve = (path: string): unknown => {
+    const hit = routes[path]
+    if (hit === undefined) {
+      const err = new Error('not found') as Error & { response?: { status: number } }
+      err.response = { status: 404 }
+      throw err
+    }
+    const value = typeof hit === 'function' ? (hit as () => unknown)() : hit
+    if (value instanceof Error) throw value
+    return value
+  }
+  const store = new DashboardIntelligenceStore({
+    get: vi.fn(async (path: string) => ({ data: resolve(path) })) as never,
+    post: vi.fn(async (path: string, body: unknown, config: unknown) => {
+      capture?.posts.push([path, body, config])
+      return { data: resolve(`POST ${path}`) }
+    }) as never,
+    del: vi.fn(async (path: string, config: unknown) => {
+      capture?.deletes.push([path, config])
+      return { data: resolve(`DELETE ${path}`) }
+    }) as never,
+    now: () => NOW,
+    uuid: () => 'UUID-FIXED',
+    ownerId: () => 'uid-1'
+  })
+  return store
+}
+
+const READ_CONTROL = { workflow_mode: 'read', account_generation: 3 }
+
+beforeEach(() => {
+  window.localStorage.clear()
+  trackEvent.mockClear()
+})
+
+describe('projection rules', () => {
+  it('an expired projection yields nothing even with live rows', () => {
+    const projection = wireProjection([wireRow()], { expires_at: PAST })
+    expect(projectRecommendations(projection, NOW, [])).toEqual([])
+  })
+
+  it('drops expired rows, keeps the first of duplicate dedupe keys, caps at three', () => {
+    const projection = wireProjection([
+      wireRow({ intervention_id: 'iv-a', dedupe_key: 'dk-a', headline: 'A' }),
+      wireRow({ intervention_id: 'iv-exp', dedupe_key: 'dk-exp', expires_at: PAST }),
+      wireRow({ intervention_id: 'iv-dup', dedupe_key: 'dk-a', headline: 'A-dup' }),
+      wireRow({ intervention_id: 'iv-b', dedupe_key: 'dk-b', headline: 'B' }),
+      wireRow({ intervention_id: 'iv-c', dedupe_key: 'dk-c', headline: 'C' }),
+      wireRow({ intervention_id: 'iv-d', dedupe_key: 'dk-d', headline: 'D' })
+    ])
+    const rows = projectRecommendations(projection, NOW, [])
+    expect(rows.map((r) => r.headline)).toEqual(['A', 'B', 'C'])
+    expect(rows[0].id).toBe('out-1:dk-a')
+  })
+
+  it('maps destinations by subject kind and drops artifact rows with no workstream', () => {
+    const projection = wireProjection([
+      wireRow({ subject_kind: 'candidate', subject_id: 'c-1', dedupe_key: 'k1' }),
+      wireRow({
+        subject_kind: 'workstream',
+        subject_id: 'ws-1',
+        destination_task_id: 't-9',
+        dedupe_key: 'k2'
+      }),
+      wireRow({ subject_kind: 'artifact', destination_workstream_id: null, dedupe_key: 'k3' }),
+      wireRow({
+        subject_kind: 'agent_open_loop',
+        destination_workstream_id: 'ws-2',
+        dedupe_key: 'k4'
+      })
+    ])
+    const rows = projectRecommendations(projection, NOW, [])
+    expect(rows.map((r) => r.destination)).toEqual([
+      { kind: 'suggested', candidateId: 'c-1' },
+      { kind: 'thread', workstreamId: 'ws-1', taskId: 't-9' },
+      { kind: 'thread', workstreamId: 'ws-2', taskId: null }
+    ])
+  })
+
+  it('unknown subject kinds are dropped, not thrown', () => {
+    const projection = wireProjection([wireRow({ subject_kind: 'hologram', dedupe_key: 'k1' })])
+    expect(projectRecommendations(projection, NOW, [])).toEqual([])
+  })
+
+  it('rows matching a pending later/dismiss outbox entry are suppressed', () => {
+    enqueueFeedback({
+      request: {
+        action: 'dismiss',
+        subject_kind: 'task',
+        subject_id: 'task-1',
+        intervention_id: 'iv-1',
+        reason: null,
+        later_until: null,
+        context_snapshot_hash: null
+      },
+      idempotencyKey: 'k',
+      accountGeneration: 3
+    })
+    const projection = wireProjection([wireRow()])
+    expect(projectRecommendations(projection, NOW, loadOutbox())).toEqual([])
+  })
+})
+
+describe('load gating', () => {
+  it('a non-read workflow mode clears the surface with no error text', async () => {
+    const store = makeStore({
+      '/v1/candidates/control': { workflow_mode: 'shadow', account_generation: 3 }
+    })
+    await store.load()
+    const s = store.getState()
+    expect(s.accountGeneration).toBeNull()
+    expect(s.recommendations).toEqual([])
+    expect(s.goals).toEqual([])
+    expect(s.error).toBeNull()
+  })
+
+  it('a 404 what-matters-now clears recommendations silently (capability-gated account)', async () => {
+    const store = makeStore({
+      '/v1/candidates/control': READ_CONTROL,
+      '/v1/goals/canonical/list': [wireGoal()]
+    })
+    await store.load()
+    const s = store.getState()
+    expect(s.accountGeneration).toBe(3)
+    expect(s.recommendations).toEqual([])
+    expect(s.error).toBeNull()
+    expect(s.goals).toHaveLength(1)
+  })
+
+  it('a live projection lands as projected rows', async () => {
+    const store = makeStore({
+      '/v1/candidates/control': READ_CONTROL,
+      '/v1/what-matters-now': {
+        schema_version: 1,
+        evaluation_id: 'ev-1',
+        output_version: 'out-1',
+        material_version: 'mat-1',
+        generated_at: PAST,
+        expires_at: FUTURE,
+        recommendations: [wireRow()]
+      },
+      '/v1/goals/canonical/list': []
+    })
+    await store.load()
+    expect(store.getState().recommendations.map((r) => r.headline)).toEqual(['Finish the report'])
+  })
+
+  it('a non-empty outbox after a clean load shows the retry banner', async () => {
+    enqueueFeedback({
+      request: {
+        action: 'dismiss',
+        subject_kind: 'task',
+        subject_id: 'x',
+        intervention_id: 'iv-x',
+        reason: null,
+        later_until: null,
+        context_snapshot_hash: null
+      },
+      idempotencyKey: 'stuck',
+      accountGeneration: 3
+    })
+    const store = makeStore({
+      '/v1/candidates/control': READ_CONTROL,
+      '/v1/goals/canonical/list': [],
+      'POST /v1/task-intelligence/feedback': () => {
+        throw new Error('still down')
+      }
+    })
+    await store.load()
+    expect(store.getState().error).toBe(RETRY_BANNER)
+    expect(store.getState().pendingFeedbackCount).toBe(1)
+  })
+
+  it('replays the outbox on load and clears delivered entries', async () => {
+    enqueueFeedback({
+      request: {
+        action: 'later',
+        subject_kind: 'task',
+        subject_id: 'x',
+        intervention_id: 'iv-x',
+        reason: null,
+        later_until: FUTURE,
+        context_snapshot_hash: null
+      },
+      idempotencyKey: 'queued',
+      accountGeneration: 3
+    })
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = makeStore(
+      {
+        '/v1/candidates/control': READ_CONTROL,
+        '/v1/goals/canonical/list': [],
+        'POST /v1/task-intelligence/feedback': {}
+      },
+      capture
+    )
+    await store.load()
+    expect(capture.posts).toHaveLength(1)
+    const [, , config] = capture.posts[0] as [string, unknown, { headers: Record<string, unknown> }]
+    expect(config.headers['Idempotency-Key']).toBe('queued')
+    expect(config.headers['X-Account-Generation']).toBe(3)
+    expect(loadOutbox()).toEqual([])
+    expect(store.getState().error).toBeNull()
+  })
+
+  it('purges outbox entries from a superseded generation without sending them', async () => {
+    enqueueFeedback({
+      request: {
+        action: 'dismiss',
+        subject_kind: 'task',
+        subject_id: 'x',
+        intervention_id: 'iv-x',
+        reason: null,
+        later_until: null,
+        context_snapshot_hash: null
+      },
+      idempotencyKey: 'old-gen',
+      accountGeneration: 2
+    })
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = makeStore(
+      {
+        '/v1/candidates/control': READ_CONTROL,
+        '/v1/goals/canonical/list': []
+      },
+      capture
+    )
+    await store.load()
+    expect(capture.posts).toHaveLength(0)
+    expect(loadOutbox()).toEqual([])
+  })
+})
+
+async function loadedStore(
+  capture?: { posts: unknown[][]; deletes: unknown[][] },
+  extra: Routes = {}
+) {
+  const store = makeStore(
+    {
+      '/v1/candidates/control': READ_CONTROL,
+      '/v1/what-matters-now': {
+        schema_version: 1,
+        evaluation_id: 'ev-1',
+        output_version: 'out-1',
+        material_version: 'mat-1',
+        generated_at: PAST,
+        expires_at: FUTURE,
+        recommendations: [wireRow()]
+      },
+      '/v1/goals/canonical/list': [wireGoal()],
+      ...extra
+    },
+    capture
+  )
+  await store.load()
+  return store
+}
+
+describe('feedback actions', () => {
+  it('do_now posts a deterministic key and threads the row intervention id', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/task-intelligence/feedback': {} })
+    const row = store.getState().recommendations[0]
+    await store.recordPrimaryAction(row)
+    const feedback = capture.posts.find((p) => p[0] === '/v1/task-intelligence/feedback')
+    expect(feedback?.[1]).toEqual({
+      action: 'do_now',
+      subject_kind: 'task',
+      subject_id: 'task-1',
+      intervention_id: 'iv-1',
+      reason: null,
+      later_until: null,
+      context_snapshot_hash: null
+    })
+    const config = feedback?.[2] as { headers: Record<string, unknown> }
+    expect(config.headers['Idempotency-Key']).toBe('wmn:iv-1:do-now')
+    expect(store.getState().recommendations).toEqual([])
+    expect(loadOutbox()).toEqual([])
+  })
+
+  it('later sends +24h and a unique-per-occurrence key', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/task-intelligence/feedback': {} })
+    await store.later(store.getState().recommendations[0])
+    const feedback = capture.posts.find((p) => p[0] === '/v1/task-intelligence/feedback')
+    const body = feedback?.[1] as { later_until: string; action: string }
+    expect(body.action).toBe('later')
+    expect(Date.parse(body.later_until)).toBe(NOW + 24 * 60 * 60 * 1000)
+    const config = feedback?.[2] as { headers: Record<string, string> }
+    expect(config.headers['Idempotency-Key']).toBe('wmn:iv-1:later:uuid-fixed')
+  })
+
+  it("dismiss without a reason keys on the literal 'none'", async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/task-intelligence/feedback': {} })
+    await store.dismiss(store.getState().recommendations[0], null)
+    const config = capture.posts.find((p) => p[0] === '/v1/task-intelligence/feedback')?.[2] as {
+      headers: Record<string, string>
+    }
+    expect(config.headers['Idempotency-Key']).toBe('wmn:iv-1:dismiss:none')
+  })
+
+  it('a failed post still removes the row, keeps the entry queued, and shows the saved banner', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, {
+      'POST /v1/task-intelligence/feedback': () => {
+        throw new Error('down')
+      }
+    })
+    await store.dismiss(store.getState().recommendations[0], 'not_useful')
+    expect(store.getState().recommendations).toEqual([])
+    expect(store.getState().error).toBe(FEEDBACK_SAVED_ERROR)
+    expect(loadOutbox().map((e) => e.idempotencyKey)).toEqual(['wmn:iv-1:dismiss:not_useful'])
+  })
+})
+
+describe('canonical goals', () => {
+  it('create hardcodes background/user and uses the occurrence id as the idempotency key', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/goals/canonical': wireGoal() })
+    const ok = await store.createGoal(
+      { title: 'T', desiredOutcome: 'O', whyItMatters: null, successCriteria: ['a'] },
+      'occurrence-1'
+    )
+    expect(ok).toBe(true)
+    const create = capture.posts.find((p) => p[0] === '/v1/goals/canonical')
+    expect(create?.[1]).toEqual({
+      title: 'T',
+      desired_outcome: 'O',
+      why_it_matters: null,
+      success_criteria: ['a'],
+      status: 'background',
+      source: 'user'
+    })
+    expect((create?.[2] as { headers: Record<string, string> }).headers['Idempotency-Key']).toBe(
+      'occurrence-1'
+    )
+  })
+
+  it('focus 409 without a replacement exposes the replacement flow', async () => {
+    const conflict = new Error('conflict') as Error & { response?: { status: number } }
+    conflict.response = { status: 409 }
+    const store = await loadedStore(undefined, {
+      'POST /v1/goals/g-2/focus': () => {
+        throw conflict
+      }
+    })
+    const ok = await store.focus('g-2', null)
+    expect(ok).toBe(false)
+    expect(store.getState().focusReplacementGoalId).toBe('g-2')
+    expect(store.getState().error).toBe(CHOOSE_REPLACEMENT)
+  })
+
+  it('focus with a replacement sends it and clears the replacement flow', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/goals/g-2/focus': wireGoal() })
+    const ok = await store.focus('g-2', 'g-1')
+    expect(ok).toBe(true)
+    const focus = capture.posts.find((p) => p[0] === '/v1/goals/g-2/focus')
+    expect(focus?.[1]).toEqual({ replacement_goal_id: 'g-1', focus_rank: null })
+    expect(store.getState().focusReplacementGoalId).toBeNull()
+  })
+
+  it('lifecycle transitions always retain relationships', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/goals/g-1/lifecycle': wireGoal() })
+    await store.transition('g-1', 'achieved')
+    const call = capture.posts.find((p) => p[0] === '/v1/goals/g-1/lifecycle')
+    expect(call?.[1]).toEqual({ status: 'achieved', relationship_disposition: 'retain' })
+  })
+
+  it('derived lists split focused, current, and ended', () => {
+    const goals = [
+      { ...goalFixture('a', 'focused'), focusRank: 1 },
+      { ...goalFixture('b', 'focused'), focusRank: 0 },
+      goalFixture('c', 'background'),
+      goalFixture('d', 'achieved'),
+      goalFixture('e', 'abandoned')
+    ]
+    expect(focusedGoals(goals).map((g) => g.goalId)).toEqual(['b', 'a'])
+    expect(currentGoals(goals).map((g) => g.goalId)).toEqual(['a', 'b', 'c'])
+    expect(endedGoals(goals).map((g) => g.goalId)).toEqual(['d', 'e'])
+  })
+})
+
+function goalFixture(id: string, status: string) {
+  return {
+    goalId: id,
+    title: id,
+    desiredOutcome: '',
+    whyItMatters: null,
+    successCriteria: [],
+    status: status as never,
+    focusRank: null,
+    isActive: true,
+    updatedAt: '2026-08-01T00:00:00Z',
+    currentValue: null,
+    targetValue: null,
+    unit: null
+  }
+}
+
+describe('attribution analytics', () => {
+  it('emits intervention_presented once per intervention across loads', async () => {
+    const routes: Routes = {
+      '/v1/candidates/control': READ_CONTROL,
+      '/v1/what-matters-now': {
+        schema_version: 1,
+        evaluation_id: 'ev-1',
+        output_version: 'out-1',
+        material_version: 'mat-1',
+        generated_at: PAST,
+        expires_at: FUTURE,
+        recommendations: [wireRow()]
+      },
+      '/v1/goals/canonical/list': []
+    }
+    const store = makeStore(routes)
+    await store.load()
+    await store.load()
+    const presented = trackEvent.mock.calls.filter(
+      (c) => (c[1] as { event_type?: string }).event_type === 'intervention_presented'
+    )
+    expect(presented).toHaveLength(1)
+    expect(presented[0][1]).toMatchObject({
+      surface: 'what_matters_now',
+      intervention_id: 'iv-1',
+      subject_kind: 'task',
+      subject_id: 'task-1'
+    })
+  })
+
+  it('emits feedback_recorded only on server-accepted feedback, with the chain id', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, {
+      'POST /v1/task-intelligence/feedback': { attribution_chain_id: 'chain-9' }
+    })
+    trackEvent.mockClear()
+    await store.dismiss(store.getState().recommendations[0], 'not_mine')
+    const recorded = trackEvent.mock.calls.filter(
+      (c) => (c[1] as { event_type?: string }).event_type === 'feedback_recorded'
+    )
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0][1]).toMatchObject({
+      feedback_action: 'dismiss',
+      feedback_reason: 'not_mine',
+      attribution_chain_id: 'chain-9'
+    })
+  })
+
+  it('a failed feedback post emits no feedback_recorded event', async () => {
+    const store = await loadedStore(undefined, {
+      'POST /v1/task-intelligence/feedback': () => {
+        throw new Error('down')
+      }
+    })
+    trackEvent.mockClear()
+    await store.dismiss(store.getState().recommendations[0], null)
+    const recorded = trackEvent.mock.calls.filter(
+      (c) => (c[1] as { event_type?: string }).event_type === 'feedback_recorded'
+    )
+    expect(recorded).toHaveLength(0)
+  })
+})
+
+describe('openRecommendation', () => {
+  it('opens a live row through the handler and records do_now after success', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/task-intelligence/feedback': {} })
+    const rowId = store.getState().recommendations[0].id
+    const handler = vi.fn(() => true)
+    expect(await store.openRecommendation(rowId, handler)).toBe(true)
+    expect(handler).toHaveBeenCalledTimes(1)
+    const feedback = capture.posts.find((p) => p[0] === '/v1/task-intelligence/feedback')
+    expect((feedback?.[1] as { action?: string }).action).toBe('do_now')
+  })
+
+  it('a handler that fails to open records no feedback', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/task-intelligence/feedback': {} })
+    const rowId = store.getState().recommendations[0].id
+    expect(await store.openRecommendation(rowId, () => false)).toBe(false)
+    expect(capture.posts.some((p) => p[0] === '/v1/task-intelligence/feedback')).toBe(false)
+  })
+
+  it('a missing id reloads once and then surfaces the unavailable error', async () => {
+    const store = await loadedStore()
+    expect(await store.openRecommendation('out-1:nope', () => true)).toBe(false)
+    expect(store.getState().error).toBe(TARGET_UNAVAILABLE)
+  })
+})
+
+describe('applyContextProjection', () => {
+  it('re-projects rows, clears the error, and emits presented for new interventions', async () => {
+    const store = await loadedStore(undefined, {
+      'POST /v1/task-intelligence/feedback': () => {
+        throw new Error('down')
+      }
+    })
+    await store.dismiss(store.getState().recommendations[0], null)
+    expect(store.getState().error).toBe(FEEDBACK_SAVED_ERROR)
+    trackEvent.mockClear()
+    // Clear the pending entry so the re-applied projection is not suppressed.
+    window.localStorage.clear()
+    const projection = wireProjection([
+      wireRow({ intervention_id: 'iv-ctx', dedupe_key: 'dk-ctx', headline: 'From the director' })
+    ])
+    store.applyContextProjection(projection)
+    expect(store.getState().recommendations.map((r) => r.headline)).toEqual(['From the director'])
+    expect(store.getState().error).toBeNull()
+    const presented = trackEvent.mock.calls.filter(
+      (c) => (c[1] as { event_type?: string }).event_type === 'intervention_presented'
+    )
+    expect(presented).toHaveLength(1)
+  })
+})
+
+describe('recordTaskOutcome (declared-unused seam)', () => {
+  it('posts the outcome wire shape with generation and idempotency headers', async () => {
+    const capture = { posts: [] as unknown[][], deletes: [] as unknown[][] }
+    const store = await loadedStore(capture, { 'POST /v1/task-intelligence/outcomes': {} })
+    const ok = await store.recordTaskOutcome({
+      attributionChainId: 'chain-1',
+      outcomeCode: 'task_completed',
+      subjectKind: 'task',
+      subjectId: 'task-1'
+    })
+    expect(ok).toBe(true)
+    const call = capture.posts.find((p) => p[0] === '/v1/task-intelligence/outcomes')
+    expect(call?.[1]).toEqual({
+      attribution_chain_id: 'chain-1',
+      outcome_code: 'task_completed',
+      subject_kind: 'task',
+      subject_id: 'task-1'
+    })
+    const headers = (call?.[2] as { headers: Record<string, unknown> }).headers
+    expect(headers['Idempotency-Key']).toBe('wmn-outcome:chain-1:task_completed')
+    expect(headers['X-Account-Generation']).toBe(3)
+  })
+
+  it('refuses outside the rollout (no bound generation)', async () => {
+    const store = makeStore({
+      '/v1/candidates/control': { workflow_mode: 'off', account_generation: 0 }
+    })
+    await store.load()
+    expect(
+      await store.recordTaskOutcome({
+        attributionChainId: 'chain-1',
+        outcomeCode: 'task_completed',
+        subjectKind: 'task',
+        subjectId: 'task-1'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('owner switching', () => {
+  it('a sign-out/in between loads clears every owner-scoped piece before loading', async () => {
+    let owner = 'uid-1'
+    const store = new DashboardIntelligenceStore({
+      get: vi.fn(async (path: string) => {
+        if (path === '/v1/candidates/control') return { data: READ_CONTROL }
+        if (path === '/v1/goals/canonical/list') return { data: [wireGoal()] }
+        const err = new Error('nf') as Error & { response?: { status: number } }
+        err.response = { status: 404 }
+        throw err
+      }) as never,
+      post: vi.fn() as never,
+      del: vi.fn() as never,
+      now: () => NOW,
+      uuid: () => 'u',
+      ownerId: () => owner
+    })
+    await store.load()
+    expect(store.getState().goals).toHaveLength(1)
+
+    owner = 'uid-2'
+    const cleared = store.load()
+    // The switch clears synchronously before the new owner's fetch lands.
+    expect(store.getState().goals).toEqual([])
+    expect(store.getState().accountGeneration).toBeNull()
+    await cleared
+    expect(store.getState().accountGeneration).toBe(3)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.ts
@@ -184,10 +184,14 @@ type Deps = {
 }
 
 function defaultDeps(): Deps {
+  // Late-bound wrappers, not .bind at construction: the store singleton is
+  // created at module import, and eagerly dereferencing client methods there
+  // couples every importer's test double to the full axios surface.
   return {
-    get: omiApi.get.bind(omiApi),
-    post: omiApi.post.bind(omiApi),
-    del: omiApi.delete.bind(omiApi),
+    get: ((...args: Parameters<typeof omiApi.get>) => omiApi.get(...args)) as typeof omiApi.get,
+    post: ((...args: Parameters<typeof omiApi.post>) => omiApi.post(...args)) as typeof omiApi.post,
+    del: ((...args: Parameters<typeof omiApi.delete>) =>
+      omiApi.delete(...args)) as typeof omiApi.delete,
     now: Date.now,
     uuid: () => crypto.randomUUID(),
     ownerId: outboxOwnerId

--- a/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.ts
@@ -46,6 +46,8 @@ export const RETRY_BANNER = 'Saved feedback will retry automatically.'
 export const FEEDBACK_SAVED_ERROR = 'Saved. Feedback will retry automatically.'
 export const TARGET_UNAVAILABLE = 'This review target is no longer available.'
 export const CHOOSE_REPLACEMENT = 'Choose a focused goal to replace.'
+export const GOALS_UNAVAILABLE = 'Goals are unavailable right now. Try again.'
+export const GOAL_UNAVAILABLE = 'This goal is no longer available.'
 
 export type RecommendationDestination =
   | { kind: 'suggested'; candidateId: string }
@@ -138,9 +140,16 @@ export type DashboardIntelligenceState = {
   recommendations: ProjectedRecommendation[]
   goals: CanonicalGoal[]
   selectedGoalDetail: GoalDetail | null
+  /** Error scoped to the goal-detail request, so an unrelated dashboard error
+   *  can never masquerade as this goal's failure (and vice versa). */
+  goalDetailError: string | null
   focusReplacementGoalId: string | null
   error: string | null
   isLoading: boolean
+  /** True once any load has completed for the current owner; surfaces gate
+   *  their canonical-vs-fallback choice on it instead of flashing the fallback
+   *  during the cold start. */
+  hasLoadedOnce: boolean
   pendingFeedbackCount: number
 }
 
@@ -195,9 +204,11 @@ export class DashboardIntelligenceStore {
     recommendations: [],
     goals: [],
     selectedGoalDetail: null,
+    goalDetailError: null,
     focusReplacementGoalId: null,
     error: null,
     isLoading: false,
+    hasLoadedOnce: false,
     pendingFeedbackCount: 0
   }
 
@@ -205,6 +216,7 @@ export class DashboardIntelligenceStore {
   private deps: Deps
   private activeLoad: Promise<void> | null = null
   private loadedOwnerId: string | null = null
+  private ownerRevision = 0
   // intervention_presented fires once per intervention id per store lifetime
   // (mac parity: presentedInterventionIDs).
   private presentedInterventionIds = new Set<string>()
@@ -232,30 +244,42 @@ export class DashboardIntelligenceStore {
   async load(): Promise<void> {
     const owner = this.deps.ownerId()
     if (this.loadedOwnerId !== null && this.loadedOwnerId !== owner) {
-      // Owner switched (sign-out/in): clear every owner-scoped piece before
-      // loading the new owner's world.
+      // Owner switched (sign-out/in): bump the revision so every in-flight
+      // continuation from the old owner refuses to commit, then clear every
+      // owner-scoped piece before loading the new owner's world.
+      this.ownerRevision += 1
       this.activeLoad = null
       this.state = {
         accountGeneration: null,
         recommendations: [],
         goals: [],
         selectedGoalDetail: null,
+        goalDetailError: null,
         focusReplacementGoalId: null,
         error: null,
         isLoading: false,
+        hasLoadedOnce: false,
         pendingFeedbackCount: 0
       }
     }
     if (this.activeLoad) return this.activeLoad
     this.loadedOwnerId = owner
-    const run = this.performLoad(owner).finally(() => {
-      this.activeLoad = null
+    const run = this.performLoad(owner, this.ownerRevision).finally(() => {
+      // Only the load that owns the handle clears it; a superseded load must
+      // not null out its successor's.
+      if (this.activeLoad === run) this.activeLoad = null
     })
     this.activeLoad = run
     return run
   }
 
-  private async performLoad(owner: string): Promise<void> {
+  /** True while `owner` at `revision` is still the world we may commit into
+   *  (mac's ownerScopeIsCurrent). Checked after every await before setState. */
+  private scopeCurrent(owner: string, revision: number): boolean {
+    return this.ownerRevision === revision && this.deps.ownerId() === owner
+  }
+
+  private async performLoad(owner: string, revision: number): Promise<void> {
     this.setState({ isLoading: true })
     try {
       let control
@@ -263,9 +287,21 @@ export class DashboardIntelligenceStore {
         const controlRes = await this.deps.get('/v1/candidates/control')
         control = readWorkflowControl(controlRes.data)
       } catch {
-        this.setState({ isLoading: false, error: 'Recommendations are unavailable right now.' })
+        if (!this.scopeCurrent(owner, revision)) return
+        // A failed control leaves no trustworthy generation: stale rows must
+        // not stay actionable under an old generation, so clear them along
+        // with the gate (goals stay visible; their mutations are generation-
+        // gated off anyway).
+        this.setState({
+          accountGeneration: null,
+          recommendations: [],
+          isLoading: false,
+          hasLoadedOnce: true,
+          error: 'Recommendations are unavailable right now.'
+        })
         return
       }
+      if (!this.scopeCurrent(owner, revision)) return
       if (control.workflowMode !== 'read') {
         // Any non-read mode clears the surface without error text (mac parity:
         // accounts outside the rollout keep a calm dashboard).
@@ -275,6 +311,7 @@ export class DashboardIntelligenceStore {
           goals: [],
           error: null,
           isLoading: false,
+          hasLoadedOnce: true,
           pendingFeedbackCount: 0
         })
         return
@@ -282,11 +319,16 @@ export class DashboardIntelligenceStore {
 
       let pending = purgeMismatchedGeneration(control.accountGeneration, owner)
       if (pending.length > 0) {
-        await replayOutbox(async (entry) => {
-          await this.postFeedback(entry)
-        }, owner)
+        await replayOutbox(
+          async (entry) => {
+            await this.postFeedback(entry)
+          },
+          owner,
+          () => this.scopeCurrent(owner, revision)
+        )
         pending = loadOutbox(owner)
       }
+      if (!this.scopeCurrent(owner, revision)) return
 
       let recommendations: ProjectedRecommendation[] = []
       let wmnError: string | null = null
@@ -319,6 +361,7 @@ export class DashboardIntelligenceStore {
         goalsError = 'Goals are unavailable right now.'
       }
 
+      if (!this.scopeCurrent(owner, revision)) return
       this.emitPresented(recommendations)
       const error = wmnError ?? goalsError ?? (pending.length > 0 ? RETRY_BANNER : null)
       this.setState({
@@ -327,10 +370,13 @@ export class DashboardIntelligenceStore {
         goals,
         error,
         isLoading: false,
+        hasLoadedOnce: true,
         pendingFeedbackCount: pending.length
       })
     } finally {
-      if (this.state.isLoading) this.setState({ isLoading: false })
+      if (this.scopeCurrent(owner, revision) && this.state.isLoading) {
+        this.setState({ isLoading: false })
+      }
     }
   }
 
@@ -450,6 +496,7 @@ export class DashboardIntelligenceStore {
       await this.reload()
       return true
     } catch {
+      this.setState({ error: GOALS_UNAVAILABLE })
       return false
     }
   }
@@ -512,6 +559,8 @@ export class DashboardIntelligenceStore {
     } catch (e) {
       if (httpStatus(e) === 409 && replacementGoalId === null) {
         this.setState({ focusReplacementGoalId: goalId, error: CHOOSE_REPLACEMENT })
+      } else {
+        this.setState({ error: GOALS_UNAVAILABLE })
       }
       return false
     }
@@ -557,19 +606,20 @@ export class DashboardIntelligenceStore {
   }
 
   async loadGoalDetail(goalId: string): Promise<GoalDetail | null> {
+    this.setState({ goalDetailError: null })
     try {
       const res = await this.deps.get(`/v1/goals/${goalId}/detail`)
       const detail = readGoalDetail(res.data)
       this.setState({ selectedGoalDetail: detail })
       return detail
     } catch {
-      this.setState({ selectedGoalDetail: null, error: 'This goal is no longer available.' })
+      this.setState({ selectedGoalDetail: null, goalDetailError: GOAL_UNAVAILABLE })
       return null
     }
   }
 
   clearGoalDetail(): void {
-    this.setState({ selectedGoalDetail: null })
+    this.setState({ selectedGoalDetail: null, goalDetailError: null })
   }
 
   /** Open a recommendation by row id (mac parity: openRecommendation). When

--- a/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/dashboardStore.ts
@@ -1,0 +1,647 @@
+// The What Matters Now + canonical goals store (mac parity:
+// DashboardIntelligenceStore.swift, ported rule-for-rule). One instance backs
+// the Home hub; React binds through useDashboardIntelligence.
+//
+// Contract highlights, all mirrored from mac:
+// - The surface is generation-gated: load bails to a cleared, error-free state
+//   unless GET /v1/candidates/control reports workflow_mode 'read', and every
+//   mutation requires the captured account generation.
+// - GET /v1/what-matters-now returning 404 means "account without the
+//   intelligence capability" and clears recommendations WITHOUT surfacing an
+//   error; any other failure surfaces one.
+// - Rows carry server-registered intervention ids; feedback threads them
+//   directly (this surface never registers interventions client-side).
+// - Feedback is write-ahead queued in the per-owner durable outbox and the row
+//   is removed locally after the attempt, success or not.
+import { omiApi } from '../apiClient'
+import {
+  enqueueFeedback,
+  loadOutbox,
+  matchesPendingSuppression,
+  outboxOwnerId,
+  purgeMismatchedGeneration,
+  removeFeedback,
+  replayOutbox,
+  type PendingFeedback
+} from './feedbackOutbox'
+import { emitFeedbackRecorded, emitInterventionPresented } from './attribution'
+import {
+  readCanonicalGoal,
+  readGoalDetail,
+  readWmnProjection,
+  readWorkflowControl,
+  type CanonicalGoal,
+  type FeedbackAction,
+  type FeedbackCreateBody,
+  type FeedbackReason,
+  type FeedbackSubjectKind,
+  type GoalDetail,
+  type GoalLifecycleTarget,
+  type WmnProjection,
+  type WmnRecommendation
+} from './wireTypes'
+
+// User-facing copy, verbatim from mac.
+export const RETRY_BANNER = 'Saved feedback will retry automatically.'
+export const FEEDBACK_SAVED_ERROR = 'Saved. Feedback will retry automatically.'
+export const TARGET_UNAVAILABLE = 'This review target is no longer available.'
+export const CHOOSE_REPLACEMENT = 'Choose a focused goal to replace.'
+
+export type RecommendationDestination =
+  | { kind: 'suggested'; candidateId: string }
+  | { kind: 'task'; taskId: string; workstreamId: string | null }
+  | { kind: 'thread'; workstreamId: string; taskId: string | null }
+
+export type ProjectedRecommendation = {
+  /** Stable row id: `${outputVersion}:${dedupeKey}`, the same format mac uses. */
+  id: string
+  headline: string
+  whyNow: string
+  contextLabel: string | null
+  recommendedAction: string
+  destination: RecommendationDestination
+  wire: WmnRecommendation
+}
+
+/** The projection rules, ported verbatim from mac's DashboardIntelligenceStore.project:
+ *  1. an expired projection yields nothing (the whole payload expires atomically);
+ *  2. rows suppressed by pending later/dismiss outbox entries are dropped;
+ *  3. expired rows are dropped;
+ *  4. duplicate dedupe keys keep the FIRST row;
+ *  5. subject kinds map to destinations, and artifact/decision/agent_open_loop
+ *     rows without a destination workstream are dropped, as are unknown kinds;
+ *  6. at most three rows survive. */
+export function projectRecommendations(
+  projection: WmnProjection,
+  now: number,
+  pending: PendingFeedback[]
+): ProjectedRecommendation[] {
+  const projectionExpiry = Date.parse(projection.expiresAt)
+  if (Number.isNaN(projectionExpiry) || projectionExpiry <= now) return []
+  const seen = new Set<string>()
+  const rows: ProjectedRecommendation[] = []
+  for (const item of projection.recommendations) {
+    if (matchesPendingSuppression(pending, item)) continue
+    const rowExpiry = Date.parse(item.expiresAt)
+    if (Number.isNaN(rowExpiry) || rowExpiry <= now) continue
+    if (seen.has(item.dedupeKey)) continue
+    const destination = destinationFor(item)
+    if (!destination) continue
+    seen.add(item.dedupeKey)
+    rows.push({
+      id: `${item.outputVersion}:${item.dedupeKey}`,
+      headline: item.headline,
+      whyNow: item.whyNow,
+      contextLabel: item.contextLabel,
+      recommendedAction: item.recommendedAction,
+      destination,
+      wire: item
+    })
+    if (rows.length >= 3) break
+  }
+  return rows
+}
+
+function destinationFor(item: WmnRecommendation): RecommendationDestination | null {
+  switch (item.subjectKind) {
+    case 'candidate':
+      return { kind: 'suggested', candidateId: item.subjectId }
+    case 'task':
+      return {
+        kind: 'task',
+        taskId: item.destinationTaskId ?? item.subjectId,
+        workstreamId: item.destinationWorkstreamId
+      }
+    case 'workstream':
+      return {
+        kind: 'thread',
+        workstreamId: item.destinationWorkstreamId ?? item.subjectId,
+        taskId: item.destinationTaskId
+      }
+    case 'artifact':
+    case 'decision':
+    case 'agent_open_loop':
+      return item.destinationWorkstreamId
+        ? {
+            kind: 'thread',
+            workstreamId: item.destinationWorkstreamId,
+            taskId: item.destinationTaskId
+          }
+        : null
+    default:
+      return null
+  }
+}
+
+export type DashboardIntelligenceState = {
+  accountGeneration: number | null
+  recommendations: ProjectedRecommendation[]
+  goals: CanonicalGoal[]
+  selectedGoalDetail: GoalDetail | null
+  focusReplacementGoalId: string | null
+  error: string | null
+  isLoading: boolean
+  pendingFeedbackCount: number
+}
+
+const MAX_FOCUS_RANK_SORT = Number.MAX_SAFE_INTEGER
+
+export function focusedGoals(goals: CanonicalGoal[]): CanonicalGoal[] {
+  return goals
+    .filter((g) => g.status === 'focused')
+    .sort((a, b) => {
+      const ra = a.focusRank ?? MAX_FOCUS_RANK_SORT
+      const rb = b.focusRank ?? MAX_FOCUS_RANK_SORT
+      if (ra !== rb) return ra - rb
+      return a.updatedAt.localeCompare(b.updatedAt)
+    })
+}
+
+export function currentGoals(goals: CanonicalGoal[]): CanonicalGoal[] {
+  return goals.filter((g) => g.status !== 'achieved' && g.status !== 'abandoned')
+}
+
+export function endedGoals(goals: CanonicalGoal[]): CanonicalGoal[] {
+  return goals.filter((g) => g.status === 'achieved' || g.status === 'abandoned')
+}
+
+type Deps = {
+  get: typeof omiApi.get
+  post: typeof omiApi.post
+  del: typeof omiApi.delete
+  now: () => number
+  uuid: () => string
+  ownerId: () => string
+}
+
+function defaultDeps(): Deps {
+  return {
+    get: omiApi.get.bind(omiApi),
+    post: omiApi.post.bind(omiApi),
+    del: omiApi.delete.bind(omiApi),
+    now: Date.now,
+    uuid: () => crypto.randomUUID(),
+    ownerId: outboxOwnerId
+  }
+}
+
+function httpStatus(e: unknown): number | undefined {
+  return (e as { response?: { status?: number } }).response?.status
+}
+
+export class DashboardIntelligenceStore {
+  private state: DashboardIntelligenceState = {
+    accountGeneration: null,
+    recommendations: [],
+    goals: [],
+    selectedGoalDetail: null,
+    focusReplacementGoalId: null,
+    error: null,
+    isLoading: false,
+    pendingFeedbackCount: 0
+  }
+
+  private listeners = new Set<() => void>()
+  private deps: Deps
+  private activeLoad: Promise<void> | null = null
+  private loadedOwnerId: string | null = null
+  // intervention_presented fires once per intervention id per store lifetime
+  // (mac parity: presentedInterventionIDs).
+  private presentedInterventionIds = new Set<string>()
+
+  constructor(deps: Partial<Deps> = {}) {
+    this.deps = { ...defaultDeps(), ...deps }
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  getState(): DashboardIntelligenceState {
+    return this.state
+  }
+
+  private setState(patch: Partial<DashboardIntelligenceState>): void {
+    this.state = { ...this.state, ...patch }
+    for (const listener of this.listeners) listener()
+  }
+
+  /** Full load: control gate, outbox purge + replay, projection, goals. A
+   *  concurrent same-owner load awaits the active one instead of stacking. */
+  async load(): Promise<void> {
+    const owner = this.deps.ownerId()
+    if (this.loadedOwnerId !== null && this.loadedOwnerId !== owner) {
+      // Owner switched (sign-out/in): clear every owner-scoped piece before
+      // loading the new owner's world.
+      this.activeLoad = null
+      this.state = {
+        accountGeneration: null,
+        recommendations: [],
+        goals: [],
+        selectedGoalDetail: null,
+        focusReplacementGoalId: null,
+        error: null,
+        isLoading: false,
+        pendingFeedbackCount: 0
+      }
+    }
+    if (this.activeLoad) return this.activeLoad
+    this.loadedOwnerId = owner
+    const run = this.performLoad(owner).finally(() => {
+      this.activeLoad = null
+    })
+    this.activeLoad = run
+    return run
+  }
+
+  private async performLoad(owner: string): Promise<void> {
+    this.setState({ isLoading: true })
+    try {
+      let control
+      try {
+        const controlRes = await this.deps.get('/v1/candidates/control')
+        control = readWorkflowControl(controlRes.data)
+      } catch {
+        this.setState({ isLoading: false, error: 'Recommendations are unavailable right now.' })
+        return
+      }
+      if (control.workflowMode !== 'read') {
+        // Any non-read mode clears the surface without error text (mac parity:
+        // accounts outside the rollout keep a calm dashboard).
+        this.setState({
+          accountGeneration: null,
+          recommendations: [],
+          goals: [],
+          error: null,
+          isLoading: false,
+          pendingFeedbackCount: 0
+        })
+        return
+      }
+
+      let pending = purgeMismatchedGeneration(control.accountGeneration, owner)
+      if (pending.length > 0) {
+        await replayOutbox(async (entry) => {
+          await this.postFeedback(entry)
+        }, owner)
+        pending = loadOutbox(owner)
+      }
+
+      let recommendations: ProjectedRecommendation[] = []
+      let wmnError: string | null = null
+      try {
+        const wmnRes = await this.deps.get('/v1/what-matters-now')
+        const projection = readWmnProjection(wmnRes.data)
+        if (projection) {
+          recommendations = projectRecommendations(projection, this.deps.now(), pending)
+        }
+      } catch (e) {
+        if (httpStatus(e) !== 404) {
+          wmnError = 'Recommendations are unavailable right now.'
+        }
+        // 404 = account without the intelligence capability: empty, no error.
+      }
+
+      let goals: CanonicalGoal[] = this.state.goals
+      let goalsError: string | null = null
+      try {
+        const goalsRes = await this.deps.get('/v1/goals/canonical/list', {
+          params: { include_ended: true }
+        })
+        const rows = Array.isArray(goalsRes.data) ? goalsRes.data : []
+        goals = rows.flatMap((g) => {
+          const goal = readCanonicalGoal(g)
+          return goal ? [goal] : []
+        })
+      } catch {
+        goals = []
+        goalsError = 'Goals are unavailable right now.'
+      }
+
+      this.emitPresented(recommendations)
+      const error = wmnError ?? goalsError ?? (pending.length > 0 ? RETRY_BANNER : null)
+      this.setState({
+        accountGeneration: control.accountGeneration,
+        recommendations,
+        goals,
+        error,
+        isLoading: false,
+        pendingFeedbackCount: pending.length
+      })
+    } finally {
+      if (this.state.isLoading) this.setState({ isLoading: false })
+    }
+  }
+
+  /** Apply an externally evaluated projection (the future context-director seam;
+   *  mac: applyContextProjection). Re-projects rows, clears the error, and
+   *  leaves goals and loading state untouched. */
+  applyContextProjection(projection: WmnProjection): void {
+    const pending = loadOutbox(this.deps.ownerId())
+    const recommendations = projectRecommendations(projection, this.deps.now(), pending)
+    this.emitPresented(recommendations)
+    this.setState({ recommendations, error: null })
+  }
+
+  private emitPresented(recommendations: ProjectedRecommendation[]): void {
+    for (const row of recommendations) {
+      if (this.presentedInterventionIds.has(row.wire.interventionId)) continue
+      this.presentedInterventionIds.add(row.wire.interventionId)
+      emitInterventionPresented({
+        interventionId: row.wire.interventionId,
+        subjectKind: row.wire.feedbackSubjectKind,
+        subjectId: row.wire.feedbackSubjectId
+      })
+    }
+  }
+
+  private async postFeedback(entry: PendingFeedback): Promise<string | null> {
+    const res = await this.deps.post('/v1/task-intelligence/feedback', entry.request, {
+      headers: {
+        'Idempotency-Key': entry.idempotencyKey,
+        'X-Account-Generation': entry.accountGeneration
+      }
+    })
+    const record = res.data as { attribution_chain_id?: unknown } | null
+    return record && typeof record.attribution_chain_id === 'string'
+      ? record.attribution_chain_id
+      : null
+  }
+
+  /** Write-ahead feedback: queue, POST, then remove the row locally whether or
+   *  not the POST succeeded (the outbox owns retrying). */
+  private async recordFeedback(
+    row: ProjectedRecommendation,
+    action: FeedbackAction,
+    idempotencyKey: string,
+    reason: FeedbackReason | null = null,
+    laterUntil: string | null = null
+  ): Promise<void> {
+    const generation = this.state.accountGeneration
+    if (generation === null) return
+    if (!this.state.recommendations.some((r) => r.id === row.id)) return
+    const owner = this.deps.ownerId()
+    const request: FeedbackCreateBody = {
+      action,
+      subject_kind: row.wire.feedbackSubjectKind,
+      subject_id: row.wire.feedbackSubjectId,
+      intervention_id: row.wire.interventionId,
+      reason,
+      later_until: laterUntil,
+      context_snapshot_hash: null
+    }
+    const entry: PendingFeedback = { request, idempotencyKey, accountGeneration: generation }
+    enqueueFeedback(entry, owner)
+    let error: string | null = null
+    try {
+      const attributionChainId = await this.postFeedback(entry)
+      removeFeedback(idempotencyKey, owner)
+      emitFeedbackRecorded({
+        interventionId: row.wire.interventionId,
+        subjectKind: row.wire.feedbackSubjectKind,
+        subjectId: row.wire.feedbackSubjectId,
+        action,
+        reason,
+        attributionChainId
+      })
+    } catch {
+      error = FEEDBACK_SAVED_ERROR
+    }
+    this.setState({
+      recommendations: this.state.recommendations.filter((r) => r.id !== row.id),
+      error,
+      pendingFeedbackCount: loadOutbox(owner).length
+    })
+  }
+
+  /** do_now, recorded after a successful open. Deterministic key: repeat opens
+   *  of the same intervention collapse into one feedback. */
+  async recordPrimaryAction(row: ProjectedRecommendation): Promise<void> {
+    await this.recordFeedback(row, 'do_now', `wmn:${row.wire.interventionId}:do-now`)
+  }
+
+  /** later = +24h, unique key per occurrence. */
+  async later(row: ProjectedRecommendation): Promise<void> {
+    const laterUntil = new Date(this.deps.now() + 24 * 60 * 60 * 1000).toISOString()
+    await this.recordFeedback(
+      row,
+      'later',
+      `wmn:${row.wire.interventionId}:later:${this.deps.uuid().toLowerCase()}`,
+      null,
+      laterUntil
+    )
+  }
+
+  /** dismiss with an optional reason; the key is deterministic per
+   *  (intervention, reason), with the literal 'none' for a reasonless dismiss. */
+  async dismiss(row: ProjectedRecommendation, reason: FeedbackReason | null): Promise<void> {
+    await this.recordFeedback(
+      row,
+      'dismiss',
+      `wmn:${row.wire.interventionId}:dismiss:${reason ?? 'none'}`,
+      reason
+    )
+  }
+
+  private async goalMutation(run: () => Promise<void>): Promise<boolean> {
+    try {
+      await run()
+      await this.reload()
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  private async reload(): Promise<void> {
+    this.loadedOwnerId = null
+    await this.load()
+  }
+
+  /** Create a canonical goal. status/source are hardcoded server-required
+   *  values (mac parity); the occurrence id is the idempotency key and must be
+   *  stable across retries of the same sheet. */
+  async createGoal(
+    fields: {
+      title: string
+      desiredOutcome: string
+      whyItMatters: string | null
+      successCriteria: string[]
+    },
+    occurrenceId: string
+  ): Promise<boolean> {
+    const generation = this.state.accountGeneration
+    if (generation === null) return false
+    return this.goalMutation(() =>
+      this.deps
+        .post(
+          '/v1/goals/canonical',
+          {
+            title: fields.title,
+            desired_outcome: fields.desiredOutcome,
+            why_it_matters: fields.whyItMatters,
+            success_criteria: fields.successCriteria,
+            status: 'background',
+            source: 'user'
+          },
+          {
+            headers: { 'Idempotency-Key': occurrenceId, 'X-Account-Generation': generation }
+          }
+        )
+        .then(() => undefined)
+    )
+  }
+
+  /** Focus a goal. A 409 without a replacement means the focus set is full: the
+   *  store exposes the goal id so the UI can run the replacement flow. */
+  async focus(goalId: string, replacementGoalId: string | null): Promise<boolean> {
+    const generation = this.state.accountGeneration
+    if (generation === null) return false
+    try {
+      await this.deps.post(
+        `/v1/goals/${goalId}/focus`,
+        { replacement_goal_id: replacementGoalId, focus_rank: null },
+        {
+          headers: {
+            'Idempotency-Key': `goal-focus:${goalId}:${this.deps.uuid().toLowerCase()}`,
+            'X-Account-Generation': generation
+          }
+        }
+      )
+    } catch (e) {
+      if (httpStatus(e) === 409 && replacementGoalId === null) {
+        this.setState({ focusReplacementGoalId: goalId, error: CHOOSE_REPLACEMENT })
+      }
+      return false
+    }
+    this.setState({ focusReplacementGoalId: null, error: null })
+    await this.reload()
+    return true
+  }
+
+  async unfocus(goalId: string): Promise<boolean> {
+    const generation = this.state.accountGeneration
+    if (generation === null) return false
+    return this.goalMutation(() =>
+      this.deps
+        .del(`/v1/goals/${goalId}/focus`, {
+          headers: {
+            'Idempotency-Key': `goal-unfocus:${goalId}:${this.deps.uuid().toLowerCase()}`,
+            'X-Account-Generation': generation
+          }
+        })
+        .then(() => undefined)
+    )
+  }
+
+  /** Pause, achieve, or abandon. The relationship disposition is always
+   *  'retain' from this surface (mac parity): ended goals keep their threads. */
+  async transition(goalId: string, status: GoalLifecycleTarget): Promise<boolean> {
+    const generation = this.state.accountGeneration
+    if (generation === null) return false
+    return this.goalMutation(() =>
+      this.deps
+        .post(
+          `/v1/goals/${goalId}/lifecycle`,
+          { status, relationship_disposition: 'retain' },
+          {
+            headers: {
+              'Idempotency-Key': `goal-lifecycle:${goalId}:${status}:${this.deps.uuid().toLowerCase()}`,
+              'X-Account-Generation': generation
+            }
+          }
+        )
+        .then(() => undefined)
+    )
+  }
+
+  async loadGoalDetail(goalId: string): Promise<GoalDetail | null> {
+    try {
+      const res = await this.deps.get(`/v1/goals/${goalId}/detail`)
+      const detail = readGoalDetail(res.data)
+      this.setState({ selectedGoalDetail: detail })
+      return detail
+    } catch {
+      this.setState({ selectedGoalDetail: null, error: 'This goal is no longer available.' })
+      return null
+    }
+  }
+
+  clearGoalDetail(): void {
+    this.setState({ selectedGoalDetail: null })
+  }
+
+  /** Open a recommendation by row id (mac parity: openRecommendation). When
+   *  the id is not in the current rows, one full load() runs first — the id may
+   *  be stale from a notification or an automation call. The handler performs
+   *  the actual navigation and reports success; do_now feedback records ONLY
+   *  after a successful open, and a missing row or absent handler surfaces the
+   *  review-target-unavailable error instead of failing silently. */
+  async openRecommendation(
+    id: string,
+    handler: (row: ProjectedRecommendation) => Promise<boolean> | boolean
+  ): Promise<boolean> {
+    let row = this.state.recommendations.find((r) => r.id === id)
+    if (!row) {
+      await this.load()
+      row = this.state.recommendations.find((r) => r.id === id)
+    }
+    if (!row) {
+      this.setState({ error: TARGET_UNAVAILABLE })
+      return false
+    }
+    const opened = await handler(row)
+    if (!opened) return false
+    await this.recordPrimaryAction(row)
+    return true
+  }
+
+  /** POST /v1/task-intelligence/outcomes. Declared-unused parity with mac:
+   *  both DashboardIntelligenceClient implementations carry this call and no
+   *  desktop call site constructs an OutcomeCreate yet; the wire shape is
+   *  {attribution_chain_id, outcome_code, subject_id, subject_kind}. Kept so
+   *  outcome wiring lands as a call-site change, not a client change. */
+  async recordTaskOutcome(outcome: {
+    attributionChainId: string
+    outcomeCode:
+      | 'task_completed'
+      | 'artifact_approved'
+      | 'artifact_delivered'
+      | 'decision_resolved'
+      | 'agent_output_applied'
+      | 'workstream_advanced'
+    subjectKind: FeedbackSubjectKind
+    subjectId: string
+  }): Promise<boolean> {
+    const generation = this.state.accountGeneration
+    if (generation === null) return false
+    try {
+      await this.deps.post(
+        '/v1/task-intelligence/outcomes',
+        {
+          attribution_chain_id: outcome.attributionChainId,
+          outcome_code: outcome.outcomeCode,
+          subject_kind: outcome.subjectKind,
+          subject_id: outcome.subjectId
+        },
+        {
+          headers: {
+            'Idempotency-Key': `wmn-outcome:${outcome.attributionChainId}:${outcome.outcomeCode}`,
+            'X-Account-Generation': generation
+          }
+        }
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  clearFocusReplacement(): void {
+    this.setState({ focusReplacementGoalId: null })
+  }
+}
+
+/** The app-wide singleton the Home hub binds to. Tests construct their own. */
+export const dashboardIntelligence = new DashboardIntelligenceStore()

--- a/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  enqueueFeedback,
+  loadOutbox,
+  matchesPendingSuppression,
+  purgeMismatchedGeneration,
+  removeFeedback,
+  replayOutbox,
+  type PendingFeedback
+} from './feedbackOutbox'
+
+vi.mock('../persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+
+const entry = (over: Partial<PendingFeedback> = {}): PendingFeedback => ({
+  request: {
+    action: 'dismiss',
+    subject_kind: 'candidate',
+    subject_id: 'c-1',
+    intervention_id: 'iv-1',
+    reason: null,
+    later_until: null,
+    context_snapshot_hash: null
+  },
+  idempotencyKey: 'wmn:iv-1:dismiss:none',
+  accountGeneration: 3,
+  ...over
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe('outbox persistence', () => {
+  it('is owner-scoped under whatMattersNowFeedbackOutbox.v1.<owner>', () => {
+    enqueueFeedback(entry())
+    expect(window.localStorage.getItem('whatMattersNowFeedbackOutbox.v1.uid-1')).toBeTruthy()
+    expect(loadOutbox('someone-else')).toEqual([])
+  })
+
+  it('write-ahead enqueue overwrites the same idempotency key instead of duplicating', () => {
+    enqueueFeedback(entry())
+    enqueueFeedback(entry({ accountGeneration: 4 }))
+    const entries = loadOutbox()
+    expect(entries).toHaveLength(1)
+    expect(entries[0].accountGeneration).toBe(4)
+  })
+
+  it('remove deletes exactly the given key', () => {
+    enqueueFeedback(entry())
+    enqueueFeedback(entry({ idempotencyKey: 'wmn:iv-2:do-now' }))
+    removeFeedback('wmn:iv-1:dismiss:none')
+    expect(loadOutbox().map((e) => e.idempotencyKey)).toEqual(['wmn:iv-2:do-now'])
+  })
+
+  it('survives a corrupt payload by treating it as empty', () => {
+    window.localStorage.setItem('whatMattersNowFeedbackOutbox.v1.uid-1', '{not json')
+    expect(loadOutbox()).toEqual([])
+  })
+})
+
+describe('generation purge', () => {
+  it('drops entries whose generation no longer matches, silently and permanently', () => {
+    enqueueFeedback(entry({ idempotencyKey: 'a', accountGeneration: 3 }))
+    enqueueFeedback(entry({ idempotencyKey: 'b', accountGeneration: 4 }))
+    const survivors = purgeMismatchedGeneration(4)
+    expect(survivors.map((e) => e.idempotencyKey)).toEqual(['b'])
+    expect(loadOutbox().map((e) => e.idempotencyKey)).toEqual(['b'])
+  })
+})
+
+describe('pending suppression matching', () => {
+  const row = { interventionId: 'iv-1', feedbackSubjectKind: 'candidate', feedbackSubjectId: 'c-1' }
+
+  it('matches a pending dismiss by intervention id', () => {
+    expect(matchesPendingSuppression([entry()], row)).toBe(true)
+  })
+
+  it('matches a pending later by subject kind + id even with a different intervention', () => {
+    const later = entry({
+      idempotencyKey: 'k2',
+      request: { ...entry().request, action: 'later', intervention_id: 'iv-OTHER' }
+    })
+    expect(matchesPendingSuppression([later], row)).toBe(true)
+  })
+
+  it('never suppresses on do_now or accept feedback', () => {
+    const doNow = entry({
+      idempotencyKey: 'k3',
+      request: { ...entry().request, action: 'do_now' }
+    })
+    expect(matchesPendingSuppression([doNow], row)).toBe(false)
+  })
+
+  it('does not match an unrelated row', () => {
+    expect(
+      matchesPendingSuppression([entry()], {
+        interventionId: 'iv-9',
+        feedbackSubjectKind: 'task',
+        feedbackSubjectId: 't-9'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('replay', () => {
+  it('is one sequential pass: successes leave, failures stay, order preserved', async () => {
+    enqueueFeedback(entry({ idempotencyKey: 'a' }))
+    enqueueFeedback(entry({ idempotencyKey: 'b' }))
+    enqueueFeedback(entry({ idempotencyKey: 'c' }))
+    const sent: string[] = []
+    const delivered = await replayOutbox(async (e) => {
+      sent.push(e.idempotencyKey)
+      if (e.idempotencyKey === 'b') throw new Error('down')
+    })
+    expect(sent).toEqual(['a', 'b', 'c'])
+    expect(delivered).toBe(2)
+    expect(loadOutbox().map((e) => e.idempotencyKey)).toEqual(['b'])
+  })
+
+  it('entries enqueued during the pass survive it', async () => {
+    enqueueFeedback(entry({ idempotencyKey: 'a' }))
+    await replayOutbox(async () => {
+      enqueueFeedback(entry({ idempotencyKey: 'late' }))
+    })
+    expect(loadOutbox().map((e) => e.idempotencyKey)).toEqual(['late'])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.test.ts
@@ -125,4 +125,34 @@ describe('replay', () => {
     })
     expect(loadOutbox().map((e) => e.idempotencyKey)).toEqual(['late'])
   })
+
+  it('stops sending when the owner scope goes stale mid-pass and keeps the rest', async () => {
+    enqueueFeedback(entry({ idempotencyKey: 'a' }))
+    enqueueFeedback(entry({ idempotencyKey: 'b' }))
+    let current = true
+    const sent: string[] = []
+    await replayOutbox(
+      async (e) => {
+        sent.push(e.idempotencyKey)
+        current = false // the account switches after the first send
+      },
+      'uid-1',
+      () => current
+    )
+    expect(sent).toEqual(['a'])
+    // The removal write is also skipped under a stale scope, so nothing of the
+    // old owner's queue is mutated from the new session.
+    expect(loadOutbox('uid-1').map((e) => e.idempotencyKey)).toEqual(['a', 'b'])
+  })
+
+  it('drops malformed persisted entries instead of replaying them forever', () => {
+    window.localStorage.setItem(
+      'whatMattersNowFeedbackOutbox.v1.uid-1',
+      JSON.stringify([
+        { idempotencyKey: 'bad', accountGeneration: 3, request: { nope: true } },
+        entry({ idempotencyKey: 'good' })
+      ])
+    )
+    expect(loadOutbox('uid-1').map((e) => e.idempotencyKey)).toEqual(['good'])
+  })
 })

--- a/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.test.ts
@@ -84,12 +84,17 @@ describe('pending suppression matching', () => {
     expect(matchesPendingSuppression([later], row)).toBe(true)
   })
 
-  it('never suppresses on do_now or accept feedback', () => {
+  it('never suppresses on do_now or accept_candidate feedback', () => {
     const doNow = entry({
       idempotencyKey: 'k3',
       request: { ...entry().request, action: 'do_now' }
     })
+    const accept = entry({
+      idempotencyKey: 'k4',
+      request: { ...entry().request, action: 'accept_candidate' }
+    })
     expect(matchesPendingSuppression([doNow], row)).toBe(false)
+    expect(matchesPendingSuppression([accept], row)).toBe(false)
   })
 
   it('does not match an unrelated row', () => {

--- a/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.ts
@@ -42,15 +42,22 @@ export function loadOutbox(ownerId: string = outboxOwnerId()): PendingFeedback[]
     const entries: PendingFeedback[] = []
     for (const item of parsed) {
       const e = item as Partial<PendingFeedback> | null
+      const r = e?.request as Partial<FeedbackCreateBody> | null | undefined
       if (
         e &&
         typeof e.idempotencyKey === 'string' &&
         typeof e.accountGeneration === 'number' &&
-        e.request &&
-        typeof e.request === 'object'
+        r &&
+        typeof r === 'object' &&
+        typeof r.action === 'string' &&
+        typeof r.subject_kind === 'string' &&
+        typeof r.subject_id === 'string' &&
+        typeof r.intervention_id === 'string'
       ) {
         entries.push(e as PendingFeedback)
       }
+      // Malformed persisted entries are dropped here rather than replayed
+      // forever; the save below rewrites the pruned list.
     }
     return entries
   } catch {
@@ -117,11 +124,15 @@ export type FeedbackSender = (entry: PendingFeedback) => Promise<void>
  *  number of entries delivered. */
 export async function replayOutbox(
   send: FeedbackSender,
-  ownerId: string = outboxOwnerId()
+  ownerId: string = outboxOwnerId(),
+  scopeCurrent: () => boolean = () => true
 ): Promise<number> {
   const entries = loadOutbox(ownerId)
   const succeeded = new Set<string>()
   for (const entry of entries) {
+    // An account switch mid-pass must not submit the previous owner's
+    // feedback under the new session's credentials.
+    if (!scopeCurrent()) break
     try {
       await send(entry)
       succeeded.add(entry.idempotencyKey)
@@ -129,7 +140,7 @@ export async function replayOutbox(
       // Sequential, no backoff: the entry stays for the next load.
     }
   }
-  if (succeeded.size > 0) {
+  if (succeeded.size > 0 && scopeCurrent()) {
     saveOutbox(
       loadOutbox(ownerId).filter((e) => !succeeded.has(e.idempotencyKey)),
       ownerId

--- a/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/feedbackOutbox.ts
@@ -1,0 +1,139 @@
+// Durable feedback outbox for the What Matters Now loop (mac parity:
+// DashboardIntelligenceStore's PendingDashboardFeedback queue). Feedback is
+// written ahead of the POST, keyed by its idempotency key, so a failed or
+// interrupted send survives restarts and replays on the next load. The same
+// key overwrites its entry rather than duplicating it, which is also the
+// in-flight dedup: a retried action reuses its deterministic key.
+//
+// Semantics ported verbatim from mac:
+// - storage key `whatMattersNowFeedbackOutbox.v1.<ownerId>`, per-owner scoped;
+// - entries carry the account generation they were minted under, and entries
+//   whose generation no longer matches the live control are DISCARDED, never
+//   sent (a superseded generation's feedback is meaningless to the server);
+// - replay is one sequential pass with no backoff or attempt counter; failures
+//   leave the entry for the next load;
+// - pending later/dismiss entries suppress matching projection rows until the
+//   server has acknowledged them (see matchesPendingSuppression).
+import { getCacheUid } from '../persistentCache'
+import type { FeedbackCreateBody } from './wireTypes'
+
+export type PendingFeedback = {
+  request: FeedbackCreateBody
+  idempotencyKey: string
+  accountGeneration: number
+}
+
+const OUTBOX_KEY_PREFIX = 'whatMattersNowFeedbackOutbox.v1.'
+
+export function outboxOwnerId(): string {
+  return getCacheUid() ?? 'signed-out'
+}
+
+function storageKey(ownerId: string): string {
+  return `${OUTBOX_KEY_PREFIX}${ownerId}`
+}
+
+export function loadOutbox(ownerId: string = outboxOwnerId()): PendingFeedback[] {
+  try {
+    const raw = window.localStorage.getItem(storageKey(ownerId))
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    const entries: PendingFeedback[] = []
+    for (const item of parsed) {
+      const e = item as Partial<PendingFeedback> | null
+      if (
+        e &&
+        typeof e.idempotencyKey === 'string' &&
+        typeof e.accountGeneration === 'number' &&
+        e.request &&
+        typeof e.request === 'object'
+      ) {
+        entries.push(e as PendingFeedback)
+      }
+    }
+    return entries
+  } catch {
+    return []
+  }
+}
+
+function saveOutbox(entries: PendingFeedback[], ownerId: string): void {
+  try {
+    window.localStorage.setItem(storageKey(ownerId), JSON.stringify(entries))
+  } catch {
+    // Quota failure degrades to at-most-once delivery for this entry.
+  }
+}
+
+/** Write-ahead enqueue: same idempotency key overwrites its previous entry. */
+export function enqueueFeedback(entry: PendingFeedback, ownerId: string = outboxOwnerId()): void {
+  const entries = loadOutbox(ownerId).filter((e) => e.idempotencyKey !== entry.idempotencyKey)
+  entries.push(entry)
+  saveOutbox(entries, ownerId)
+}
+
+export function removeFeedback(idempotencyKey: string, ownerId: string = outboxOwnerId()): void {
+  saveOutbox(
+    loadOutbox(ownerId).filter((e) => e.idempotencyKey !== idempotencyKey),
+    ownerId
+  )
+}
+
+/** Drop entries minted under a superseded account generation. They are never
+ *  sent: the server's generation fence would 409 them and the feedback no
+ *  longer describes live state. Returns the surviving entries. */
+export function purgeMismatchedGeneration(
+  liveGeneration: number,
+  ownerId: string = outboxOwnerId()
+): PendingFeedback[] {
+  const survivors = loadOutbox(ownerId).filter((e) => e.accountGeneration === liveGeneration)
+  saveOutbox(survivors, ownerId)
+  return survivors
+}
+
+/** A projection row is suppressed while a pending later/dismiss entry matches it
+ *  by intervention id OR by (feedback subject kind + id) — the row was acted on
+ *  and the server just does not know yet. Once the POST succeeds the entry is
+ *  removed and server authority resumes. */
+export function matchesPendingSuppression(
+  pending: PendingFeedback[],
+  row: { interventionId: string; feedbackSubjectKind: string; feedbackSubjectId: string }
+): boolean {
+  return pending.some(
+    (e) =>
+      (e.request.action === 'later' || e.request.action === 'dismiss') &&
+      (e.request.intervention_id === row.interventionId ||
+        (e.request.subject_kind === row.feedbackSubjectKind &&
+          e.request.subject_id === row.feedbackSubjectId))
+  )
+}
+
+export type FeedbackSender = (entry: PendingFeedback) => Promise<void>
+
+/** One sequential replay pass over the CURRENT outbox. Failures leave their
+ *  entry in place; entries enqueued while the pass runs survive it (the final
+ *  list is re-read and filtered by succeeded keys, mirroring mac). Returns the
+ *  number of entries delivered. */
+export async function replayOutbox(
+  send: FeedbackSender,
+  ownerId: string = outboxOwnerId()
+): Promise<number> {
+  const entries = loadOutbox(ownerId)
+  const succeeded = new Set<string>()
+  for (const entry of entries) {
+    try {
+      await send(entry)
+      succeeded.add(entry.idempotencyKey)
+    } catch {
+      // Sequential, no backoff: the entry stays for the next load.
+    }
+  }
+  if (succeeded.size > 0) {
+    saveOutbox(
+      loadOutbox(ownerId).filter((e) => !succeeded.has(e.idempotencyKey)),
+      ownerId
+    )
+  }
+  return succeeded.size
+}

--- a/desktop/windows/src/renderer/src/lib/intelligence/homeSuggestions.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/homeSuggestions.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  __resetSuggestionsGenerationForTest,
+  classifyContext,
+  composeSuggestions,
+  LEAD_SUGGESTION,
+  parseGeneratedSuggestions,
+  readSuggestionsCache,
+  refreshHomeSuggestions,
+  sanitizeSuggestions,
+  suggestionsDayStamp
+} from './homeSuggestions'
+
+vi.mock('../persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../apiClient', () => ({ omiApi: { get: vi.fn(), post: vi.fn(), delete: vi.fn() } }))
+vi.mock('../agentLLM', () => ({ callAgentLLM: vi.fn() }))
+vi.mock('../actionItems', () => ({ fetchAllActionItems: vi.fn() }))
+
+const NOW = new Date('2026-08-16T12:00:00')
+
+beforeEach(() => {
+  window.localStorage.clear()
+  __resetSuggestionsGenerationForTest()
+})
+
+describe('sanitize + compose', () => {
+  it('trims, drops overlong and universal questions, and dedupes case-insensitively', () => {
+    const out = sanitizeSuggestions([
+      '  Follow up with Sam?  ',
+      'follow up with sam?',
+      'What should I do today?',
+      'x'.repeat(73),
+      ''
+    ])
+    expect(out).toEqual(['Follow up with Sam?'])
+  })
+
+  it('always leads with the fixed chip and pads to two with the static fallbacks', () => {
+    expect(composeSuggestions([])).toEqual([
+      LEAD_SUGGESTION,
+      'What did I spend my time on this week?',
+      "What's the highest-leverage thing I can do next?"
+    ])
+    expect(composeSuggestions(['Ship the launch plan?'])).toEqual([
+      LEAD_SUGGESTION,
+      'Ship the launch plan?',
+      'What did I spend my time on this week?'
+    ])
+  })
+})
+
+describe('context classification', () => {
+  it('all-empty with any failed read is unavailable; all-empty with clean reads is thin', () => {
+    expect(classifyContext({ memories: 0, conversations: null, actionItems: 0, goals: 0 })).toBe(
+      'unavailable'
+    )
+    expect(classifyContext({ memories: 0, conversations: 0, actionItems: 0, goals: 0 })).toBe(
+      'thin'
+    )
+    expect(classifyContext({ memories: 3, conversations: null, actionItems: 0, goals: 0 })).toBe(
+      'available'
+    )
+  })
+})
+
+describe('generated reply parsing', () => {
+  it('reads bare JSON and JSON embedded in prose, and rejects junk', () => {
+    expect(parseGeneratedSuggestions('{"questions": ["A?", "B?"]}')).toEqual(['A?', 'B?'])
+    expect(parseGeneratedSuggestions('Sure! {"questions": ["A?"]} Hope that helps.')).toEqual([
+      'A?'
+    ])
+    expect(parseGeneratedSuggestions('no json here')).toEqual([])
+    expect(parseGeneratedSuggestions('{"questions": "not a list"}')).toEqual([])
+  })
+})
+
+describe('refresh', () => {
+  const deps = (over: Record<string, unknown> = {}) => ({
+    get: vi.fn(async (path: string) => {
+      if (path === '/v3/memories') return { data: [{ content: 'Knows Sam from the launch' }] }
+      if (path === '/v1/conversations') return { data: [] }
+      if (path === '/v1/goals/all') return { data: [] }
+      throw new Error('unexpected route')
+    }) as never,
+    fetchActionItems: vi.fn(async () => []) as never,
+    generate: vi.fn(async () => '{"questions": ["Ask Sam about the launch?"]}'),
+    now: () => NOW,
+    ownerId: () => 'uid-1',
+    ...over
+  })
+
+  it('generates once, caches under the owner and day stamp, and serves the cache after', async () => {
+    const d = deps()
+    const first = await refreshHomeSuggestions(d)
+    expect(first).toEqual(['Ask Sam about the launch?'])
+    expect(readSuggestionsCache('uid-1')).toEqual({
+      questions: ['Ask Sam about the launch?'],
+      dayStamp: suggestionsDayStamp(NOW)
+    })
+    const second = await refreshHomeSuggestions(d)
+    expect(second).toEqual(['Ask Sam about the launch?'])
+    expect(d.generate).toHaveBeenCalledTimes(1)
+  })
+
+  it('an unavailable context never burns the daily slot or the cache', async () => {
+    const d = deps({
+      get: vi.fn(async () => {
+        throw new Error('down')
+      }) as never,
+      fetchActionItems: vi.fn(async () => []) as never
+    })
+    expect(await refreshHomeSuggestions(d)).toEqual([])
+    expect(readSuggestionsCache('uid-1')).toBeNull()
+    expect(d.generate).not.toHaveBeenCalled()
+  })
+
+  it('a thin context caches the empty list without calling the generator', async () => {
+    const d = deps({
+      get: vi.fn(async () => ({ data: [] })) as never,
+      fetchActionItems: vi.fn(async () => []) as never
+    })
+    expect(await refreshHomeSuggestions(d)).toEqual([])
+    expect(readSuggestionsCache('uid-1')).toEqual({
+      questions: [],
+      dayStamp: suggestionsDayStamp(NOW)
+    })
+    expect(d.generate).not.toHaveBeenCalled()
+  })
+
+  it('drops a generation that finishes after an owner switch', async () => {
+    let owner = 'uid-1'
+    const d = deps({
+      ownerId: () => owner,
+      generate: vi.fn(async () => {
+        owner = 'uid-2'
+        return '{"questions": ["Stale answer?"]}'
+      })
+    })
+    expect(await refreshHomeSuggestions(d)).toEqual([])
+    expect(readSuggestionsCache('uid-1')).toBeNull()
+    expect(readSuggestionsCache('uid-2')).toBeNull()
+  })
+
+  it('a generator failure leaves the cache untouched for a retry next visit', async () => {
+    const d = deps({
+      generate: vi.fn(async () => {
+        throw new Error('llm down')
+      })
+    })
+    expect(await refreshHomeSuggestions(d)).toEqual([])
+    expect(readSuggestionsCache('uid-1')).toBeNull()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/homeSuggestions.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/homeSuggestions.ts
@@ -234,11 +234,14 @@ function defaultDeps(): Deps {
   }
 }
 
-let generatingOwnerId: string | null = null
+// Per-owner in-flight refreshes: concurrent callers for the SAME owner share
+// one promise (so the second Home surface receives the generated result rather
+// than an empty fallback), and one owner's generation never starves another's.
+const inflightByOwner = new Map<string, Promise<string[]>>()
 
-/** Test seam: the single-flight latch is module state. */
+/** Test seam: the single-flight table is module state. */
 export function __resetSuggestionsGenerationForTest(): void {
-  generatingOwnerId = null
+  inflightByOwner.clear()
 }
 
 /** Return today's personalized questions for the owner, generating at most once
@@ -251,27 +254,36 @@ export async function refreshHomeSuggestions(depsOverride: Partial<Deps> = {}): 
   const today = suggestionsDayStamp(deps.now())
   const cached = readSuggestionsCache(owner)
   if (cached && cached.dayStamp === today) return cached.questions
-  if (generatingOwnerId !== null) return cached?.questions ?? []
-  generatingOwnerId = owner
-  try {
-    const sample = await readContext(deps)
-    const classification = classifyContext(sample)
-    if (classification === 'unavailable') return cached?.questions ?? []
-    let questions: string[] = []
-    if (classification === 'available') {
-      const reply = await deps.generate(generationPrompt(sample))
-      questions = sanitizeSuggestions(parseGeneratedSuggestions(reply)).slice(0, 2)
+  const existing = inflightByOwner.get(owner)
+  if (existing) return existing
+  const run = (async (): Promise<string[]> => {
+    try {
+      const sample = await readContext(deps)
+      if (deps.ownerId() !== owner) {
+        // Account switched while reading context: the sample belongs to the
+        // previous owner and must never reach the generator.
+        return []
+      }
+      const classification = classifyContext(sample)
+      if (classification === 'unavailable') return cached?.questions ?? []
+      let questions: string[] = []
+      if (classification === 'available') {
+        const reply = await deps.generate(generationPrompt(sample))
+        questions = sanitizeSuggestions(parseGeneratedSuggestions(reply)).slice(0, 2)
+      }
+      if (deps.ownerId() !== owner) {
+        // Account switched mid-generation: drop the result (mac parity).
+        return []
+      }
+      writeSuggestionsCache(owner, { questions, dayStamp: today })
+      return questions
+    } catch {
+      // Transport failure: cache untouched, retried on the next visit.
+      return cached?.questions ?? []
+    } finally {
+      inflightByOwner.delete(owner)
     }
-    if (deps.ownerId() !== owner) {
-      // Account switched mid-generation: drop the result (mac parity).
-      return []
-    }
-    writeSuggestionsCache(owner, { questions, dayStamp: today })
-    return questions
-  } catch {
-    // Transport failure: cache untouched, retried on the next visit.
-    return cached?.questions ?? []
-  } finally {
-    generatingOwnerId = null
-  }
+  })()
+  inflightByOwner.set(owner, run)
+  return run
 }

--- a/desktop/windows/src/renderer/src/lib/intelligence/homeSuggestions.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/homeSuggestions.ts
@@ -1,0 +1,277 @@
+// Personalized home ask-bar suggestions (mac parity: HomeSuggestionsStore +
+// HomeSuggestionComposer). The visible chips are LLM-generated from the
+// account's own context at most once per owner per local day, cached under
+// homePersonalizedSuggestions.v1.<owner>, and composed with the fixed lead chip
+// and the static fallbacks. The hub's old static prompt list asked for exactly
+// this: "swap them for the feed the day one exists".
+//
+// Context classification, ported from mac: every source read is individually
+// fault-isolated so nil (failed) is distinguishable from empty. All-empty with
+// any failure = UNAVAILABLE (the daily generation slot is NOT burned; retry on
+// the next visit). All-empty with every read succeeding = THIN (an empty list
+// IS cached; there is nothing to personalize today). Otherwise generate.
+import { omiApi } from '../apiClient'
+import { callAgentLLM } from '../agentLLM'
+import { fetchAllActionItems } from '../actionItems'
+import { getCacheUid } from '../persistentCache'
+
+export const LEAD_SUGGESTION = 'What should I do today?'
+
+export const STATIC_FALLBACK_SUGGESTIONS = [
+  'What did I spend my time on this week?',
+  "What's the highest-leverage thing I can do next?"
+]
+
+// Questions so universal they add nothing personalized (mac's universal set);
+// compared case-insensitively after trimming.
+const UNIVERSAL_SUGGESTIONS = new Set([
+  'what should i do today?',
+  'what should i focus on today to achieve my goals?'
+])
+
+const MAX_PERSONALIZED_LENGTH = 72
+const CACHE_KEY_PREFIX = 'homePersonalizedSuggestions.v1.'
+
+/** Trim, drop empties and over-length lines, dedupe case-insensitively, and
+ *  drop the universal questions. Order-preserving. */
+export function sanitizeSuggestions(questions: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const raw of questions) {
+    const trimmed = raw.trim()
+    if (!trimmed || trimmed.length > MAX_PERSONALIZED_LENGTH) continue
+    const key = trimmed.toLowerCase()
+    if (seen.has(key) || UNIVERSAL_SUGGESTIONS.has(key)) continue
+    seen.add(key)
+    out.push(trimmed)
+  }
+  return out
+}
+
+/** Chip one is always the lead question; the remaining two come from the
+ *  personalized set padded by the static fallbacks (mac's composer). */
+export function composeSuggestions(personalized: string[]): string[] {
+  return [
+    LEAD_SUGGESTION,
+    ...sanitizeSuggestions([...personalized, ...STATIC_FALLBACK_SUGGESTIONS]).slice(0, 2)
+  ]
+}
+
+export function suggestionsOwnerId(): string {
+  return getCacheUid() ?? 'signed-out'
+}
+
+/** Local calendar day stamp; one generation per owner per local day. */
+export function suggestionsDayStamp(now: Date = new Date()): string {
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`
+}
+
+type SuggestionsCache = { questions: string[]; dayStamp: string }
+
+export function readSuggestionsCache(ownerId: string): SuggestionsCache | null {
+  try {
+    const raw = window.localStorage.getItem(`${CACHE_KEY_PREFIX}${ownerId}`)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<SuggestionsCache> | null
+    if (!parsed || !Array.isArray(parsed.questions) || typeof parsed.dayStamp !== 'string')
+      return null
+    return {
+      questions: parsed.questions.filter((q): q is string => typeof q === 'string'),
+      dayStamp: parsed.dayStamp
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeSuggestionsCache(ownerId: string, cache: SuggestionsCache): void {
+  try {
+    window.localStorage.setItem(`${CACHE_KEY_PREFIX}${ownerId}`, JSON.stringify(cache))
+  } catch {
+    // Quota failure degrades to regenerating tomorrow.
+  }
+}
+
+type ContextSample = {
+  memories: number | null
+  conversations: number | null
+  actionItems: number | null
+  goals: number | null
+}
+
+export type ContextClass = 'unavailable' | 'thin' | 'available'
+
+/** All-empty + any failed read = unavailable; all-empty + all reads succeeded =
+ *  thin; anything else = available (mac's classification, verbatim). */
+export function classifyContext(sample: ContextSample): ContextClass {
+  const counts = [sample.memories, sample.conversations, sample.actionItems, sample.goals]
+  const allEmpty = counts.every((c) => c === null || c === 0)
+  if (allEmpty && counts.some((c) => c === null)) return 'unavailable'
+  if (allEmpty) return 'thin'
+  return 'available'
+}
+
+type SampleWithText = ContextSample & {
+  memoryLines: string[]
+  conversationTitles: string[]
+  taskLines: string[]
+  goalTitles: string[]
+}
+
+async function readContext(deps: Deps): Promise<SampleWithText> {
+  const sample: SampleWithText = {
+    memories: null,
+    conversations: null,
+    actionItems: null,
+    goals: null,
+    memoryLines: [],
+    conversationTitles: [],
+    taskLines: [],
+    goalTitles: []
+  }
+  try {
+    const res = await deps.get('/v3/memories', { params: { limit: 200, offset: 0 } })
+    const rows = Array.isArray(res.data) ? res.data : []
+    sample.memories = rows.length
+    sample.memoryLines = rows
+      .map((m) => (m as { content?: unknown }).content)
+      .filter((c): c is string => typeof c === 'string')
+      .slice(0, 40)
+  } catch {
+    sample.memories = null
+  }
+  try {
+    const res = await deps.get('/v1/conversations', {
+      params: { limit: 30, statuses: 'completed' }
+    })
+    const rows = Array.isArray(res.data) ? res.data : []
+    sample.conversations = rows.length
+    sample.conversationTitles = rows
+      .map((c) => {
+        const structured = (c as { structured?: { title?: unknown } }).structured
+        return structured && typeof structured.title === 'string' ? structured.title : null
+      })
+      .filter((t): t is string => t !== null)
+      .slice(0, 20)
+  } catch {
+    sample.conversations = null
+  }
+  try {
+    const items = await deps.fetchActionItems()
+    const open = items.filter((t) => !t.completed).slice(0, 50)
+    sample.actionItems = open.length
+    sample.taskLines = open.map((t) => t.description).slice(0, 25)
+  } catch {
+    sample.actionItems = null
+  }
+  try {
+    const res = await deps.get('/v1/goals/all')
+    const data = res.data as unknown
+    const rows = Array.isArray(data) ? data : ((data as { goals?: unknown[] })?.goals ?? [])
+    sample.goals = rows.length
+    sample.goalTitles = rows
+      .map((g) => (g as { title?: unknown }).title)
+      .filter((t): t is string => typeof t === 'string')
+      .slice(0, 10)
+  } catch {
+    sample.goals = null
+  }
+  return sample
+}
+
+/** Mac's generation rules, carried into the prompt: at most 48 characters per
+ *  question, first person, each must name something concrete from the context,
+ *  no generic productivity questions, empty list when the context is thin. */
+function generationPrompt(sample: SampleWithText): string {
+  const section = (title: string, lines: string[]): string =>
+    lines.length > 0 ? `${title}:\n${lines.map((l) => `- ${l}`).join('\n')}\n` : ''
+  return (
+    'You compose ask-bar suggestions for a personal AI. From the context below, ' +
+    'write up to 3 questions the user would plausibly ask their AI right now.\n' +
+    'Rules: each question is at most 48 characters, first person, and must name ' +
+    'something concrete from the context (a task, goal, person, or topic). No ' +
+    'generic productivity questions. If the context is too thin, return an empty ' +
+    'list.\n' +
+    'Respond with ONLY a JSON object: {"questions": ["..."]}\n\n' +
+    section('Open tasks', sample.taskLines) +
+    section('Goals', sample.goalTitles) +
+    section('Recent conversations', sample.conversationTitles) +
+    section('Memories', sample.memoryLines.slice(0, 20))
+  )
+}
+
+/** Tolerant parse: the reply should be bare JSON, but a chat-tuned fallback lane
+ *  may wrap it in prose, so take the first {...} block. */
+export function parseGeneratedSuggestions(reply: string): string[] {
+  const start = reply.indexOf('{')
+  const end = reply.lastIndexOf('}')
+  if (start === -1 || end <= start) return []
+  try {
+    const parsed = JSON.parse(reply.slice(start, end + 1)) as { questions?: unknown }
+    if (!Array.isArray(parsed.questions)) return []
+    return parsed.questions.filter((q): q is string => typeof q === 'string')
+  } catch {
+    return []
+  }
+}
+
+type Deps = {
+  get: typeof omiApi.get
+  fetchActionItems: typeof fetchAllActionItems
+  generate: (prompt: string) => Promise<string>
+  now: () => Date
+  ownerId: () => string
+}
+
+function defaultDeps(): Deps {
+  return {
+    get: omiApi.get.bind(omiApi),
+    fetchActionItems: fetchAllActionItems,
+    generate: callAgentLLM,
+    now: () => new Date(),
+    ownerId: suggestionsOwnerId
+  }
+}
+
+let generatingOwnerId: string | null = null
+
+/** Test seam: the single-flight latch is module state. */
+export function __resetSuggestionsGenerationForTest(): void {
+  generatingOwnerId = null
+}
+
+/** Return today's personalized questions for the owner, generating at most once
+ *  per local day. Publishes the cache immediately when fresh; an UNAVAILABLE
+ *  context never burns the daily slot; a generation that finishes after an
+ *  owner switch is dropped rather than cached under the wrong account. */
+export async function refreshHomeSuggestions(depsOverride: Partial<Deps> = {}): Promise<string[]> {
+  const deps = { ...defaultDeps(), ...depsOverride }
+  const owner = deps.ownerId()
+  const today = suggestionsDayStamp(deps.now())
+  const cached = readSuggestionsCache(owner)
+  if (cached && cached.dayStamp === today) return cached.questions
+  if (generatingOwnerId !== null) return cached?.questions ?? []
+  generatingOwnerId = owner
+  try {
+    const sample = await readContext(deps)
+    const classification = classifyContext(sample)
+    if (classification === 'unavailable') return cached?.questions ?? []
+    let questions: string[] = []
+    if (classification === 'available') {
+      const reply = await deps.generate(generationPrompt(sample))
+      questions = sanitizeSuggestions(parseGeneratedSuggestions(reply)).slice(0, 2)
+    }
+    if (deps.ownerId() !== owner) {
+      // Account switched mid-generation: drop the result (mac parity).
+      return []
+    }
+    writeSuggestionsCache(owner, { questions, dayStamp: today })
+    return questions
+  } catch {
+    // Transport failure: cache untouched, retried on the next visit.
+    return cached?.questions ?? []
+  } finally {
+    generatingOwnerId = null
+  }
+}

--- a/desktop/windows/src/renderer/src/lib/intelligence/knowsComposer.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/knowsComposer.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  canRotateKnows,
+  composeKnowsRows,
+  knowsActionTip,
+  MAX_KNOWS_ROWS,
+  type KnowsSources
+} from './knowsComposer'
+
+const sources = (over: Partial<KnowsSources> = {}): KnowsSources => ({
+  tasks: [
+    { id: 't1', text: 'Task one' },
+    { id: 't2', text: 'Task two' },
+    { id: 't3', text: 'Task three' }
+  ],
+  insights: [
+    { id: 'i1', text: 'Insight one' },
+    { id: 'i2', text: 'Insight two' }
+  ],
+  tip: 'Recap what I got done today',
+  questions: ['What should I do today?', 'What changed this week?'],
+  dismissedTaskIds: new Set<string>(),
+  rotation: 0,
+  ...over
+})
+
+describe('slot rules', () => {
+  it('composes task, insight, second task, ask — capped at four diverse rows', () => {
+    const rows = composeKnowsRows(sources())
+    expect(rows.map((r) => r.kind)).toEqual(['task', 'insight', 'task', 'question'])
+    expect(rows).toHaveLength(MAX_KNOWS_ROWS)
+    expect(rows[0].id).toBe('task-t1')
+    expect(rows[1].id).toBe('insight-i1')
+    expect(rows[2].id).toBe('task-t2')
+    expect(rows[3].id).toBe('question-What should I do today?')
+  })
+
+  it('falls back to the tip as a question row when there are no insights', () => {
+    const rows = composeKnowsRows(sources({ insights: [] }))
+    expect(rows[1]).toEqual({
+      id: 'question-Recap what I got done today',
+      kind: 'question',
+      text: 'Recap what I got done today'
+    })
+  })
+
+  it('the ask never equals the tip', () => {
+    const rows = composeKnowsRows(
+      sources({ insights: [], questions: ['Recap what I got done today', 'Different ask'] })
+    )
+    const questions = rows.filter((r) => r.kind === 'question').map((r) => r.text)
+    expect(questions[0]).toBe('Recap what I got done today') // the tip slot
+    expect(questions[1]).toBe('Different ask') // the ask skipped the tip duplicate
+  })
+
+  it('dismissed task ids never appear and the next fresh task takes the slot', () => {
+    const rows = composeKnowsRows(sources({ dismissedTaskIds: new Set(['t1']) }))
+    expect(rows[0].id).toBe('task-t2')
+    expect(rows.some((r) => r.id === 'task-t1')).toBe(false)
+  })
+
+  it('questions dedupe by trimmed text because the text is the id', () => {
+    const rows = composeKnowsRows(
+      sources({ tasks: [], insights: [], questions: [' Same ask ', 'Same ask'] })
+    )
+    const questionRows = rows.filter((r) => r.kind === 'question' && r.text === 'Same ask')
+    expect(questionRows).toHaveLength(1)
+  })
+})
+
+describe('rotation', () => {
+  it('rotates each source independently by the shared counter', () => {
+    const rows = composeKnowsRows(sources({ rotation: 1 }))
+    expect(rows[0].id).toBe('task-t2')
+    expect(rows[1].id).toBe('insight-i2')
+    expect(rows[2].id).toBe('task-t3')
+  })
+
+  it('normalizes any rotation value into range, including huge ones', () => {
+    const base = composeKnowsRows(sources({ rotation: 0 }))
+    const wrapped = composeKnowsRows(sources({ rotation: 3 * 2 * 2 * 1000 }))
+    expect(wrapped.map((r) => r.id)).toEqual(base.map((r) => r.id))
+  })
+
+  it('canRotate requires an alternative somewhere', () => {
+    expect(canRotateKnows(2, 1, 1)).toBe(false)
+    expect(canRotateKnows(3, 0, 0)).toBe(true)
+    expect(canRotateKnows(0, 2, 0)).toBe(true)
+    expect(canRotateKnows(0, 0, 2)).toBe(true)
+  })
+})
+
+describe('action tip', () => {
+  it('gets pushy at five open tasks', () => {
+    expect(knowsActionTip(4)).toBe('Recap what I got done today')
+    expect(knowsActionTip(5)).toBe('Sort my open tasks — which 3 actually matter today?')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/knowsComposer.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/knowsComposer.ts
@@ -1,0 +1,92 @@
+// The Home "knows" list composer (mac parity: HomeKnowsComposer.swift, ported
+// rule-for-rule). Pure: the page owns the rotation counter and dismissed-id
+// set; this module just composes at most four diverse rows from the sources.
+//
+// Slot rules, verbatim from mac:
+//   1. the first fresh (non-dismissed) task;
+//   2. the first insight, else the action tip as a question row;
+//   3. the second fresh task, only when there are at least two and taking it
+//      still leaves room for the ask;
+//   4. the ask (first rotated question that is not the tip), when room remains.
+// Each source rotates independently by k = ((rotation % n) + n) % n, so one
+// shared counter advances all three without ever going out of range.
+
+export type KnowsRowKind = 'task' | 'insight' | 'question'
+
+export type KnowsRow = {
+  /** 'task-<id>' | 'insight-<id>' | 'question-<text>' — question rows dedupe by
+   *  exact trimmed text because the text IS the id, mirroring mac. */
+  id: string
+  kind: KnowsRowKind
+  text: string
+}
+
+export type KnowsSources = {
+  tasks: { id: string; text: string }[]
+  insights: { id: string; text: string }[]
+  tip: string
+  questions: string[]
+  dismissedTaskIds: ReadonlySet<string>
+  rotation: number
+}
+
+export const MAX_KNOWS_ROWS = 4
+
+function rotated<T>(items: T[], rotation: number): T[] {
+  const n = items.length
+  if (n === 0) return items
+  const k = ((rotation % n) + n) % n
+  return [...items.slice(k), ...items.slice(0, k)]
+}
+
+export function composeKnowsRows(sources: KnowsSources): KnowsRow[] {
+  const freshTasks = rotated(
+    sources.tasks.filter((t) => !sources.dismissedTaskIds.has(t.id)),
+    sources.rotation
+  )
+  const insights = rotated(sources.insights, sources.rotation)
+
+  const seenQuestions = new Set<string>()
+  const questions: string[] = []
+  for (const q of rotated(sources.questions, sources.rotation)) {
+    const trimmed = q.trim()
+    if (!trimmed || seenQuestions.has(trimmed)) continue
+    seenQuestions.add(trimmed)
+    questions.push(trimmed)
+  }
+  const ask = questions.find((q) => q !== sources.tip) ?? null
+
+  const rows: KnowsRow[] = []
+  if (freshTasks.length > 0) {
+    rows.push({ id: `task-${freshTasks[0].id}`, kind: 'task', text: freshTasks[0].text })
+  }
+  if (insights.length > 0) {
+    rows.push({ id: `insight-${insights[0].id}`, kind: 'insight', text: insights[0].text })
+  } else if (sources.tip) {
+    rows.push({ id: `question-${sources.tip}`, kind: 'question', text: sources.tip })
+  }
+  if (freshTasks.length > 1 && (ask === null || rows.length < MAX_KNOWS_ROWS - 1)) {
+    rows.push({ id: `task-${freshTasks[1].id}`, kind: 'task', text: freshTasks[1].text })
+  }
+  if (ask !== null && rows.length < MAX_KNOWS_ROWS) {
+    rows.push({ id: `question-${ask}`, kind: 'question', text: ask })
+  }
+  return rows
+}
+
+/** Rotation only helps when some source has an alternative to show. */
+export function canRotateKnows(
+  taskCount: number,
+  insightCount: number,
+  questionCount: number
+): boolean {
+  return taskCount > 2 || insightCount > 1 || questionCount > 1
+}
+
+/** The action tip (mac: homeActionTip): pushy when the open-task pile is deep,
+ *  reflective otherwise. */
+export function knowsActionTip(openTaskCount: number): string {
+  return openTaskCount >= 5
+    ? 'Sort my open tasks — which 3 actually matter today?'
+    : 'Recap what I got done today'
+}

--- a/desktop/windows/src/renderer/src/lib/intelligence/knowsComposer.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/knowsComposer.ts
@@ -41,10 +41,13 @@ function rotated<T>(items: T[], rotation: number): T[] {
 
 export function composeKnowsRows(sources: KnowsSources): KnowsRow[] {
   const freshTasks = rotated(
-    sources.tasks.filter((t) => !sources.dismissedTaskIds.has(t.id)),
+    sources.tasks.filter((t) => t.text.trim() && !sources.dismissedTaskIds.has(t.id)),
     sources.rotation
   )
-  const insights = rotated(sources.insights, sources.rotation)
+  const insights = rotated(
+    sources.insights.filter((i) => i.text.trim()),
+    sources.rotation
+  )
 
   const seenQuestions = new Set<string>()
   const questions: string[] = []

--- a/desktop/windows/src/renderer/src/lib/intelligence/wireTypes.test.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/wireTypes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import {
+  readCanonicalGoal,
+  readGoalDetail,
+  readRecommendationSubjectKind,
+  readWmnProjection,
+  readWorkflowControl
+} from './wireTypes'
+
+describe('lenient enum decode', () => {
+  it('maps unknown wire strings to _unknown instead of throwing', () => {
+    expect(readRecommendationSubjectKind('agent_open_loop')).toBe('agent_open_loop')
+    expect(readRecommendationSubjectKind('hologram')).toBe('_unknown')
+    expect(readRecommendationSubjectKind(7)).toBe('_unknown')
+    expect(readWorkflowControl({ workflow_mode: 'future_mode' }).workflowMode).toBe('_unknown')
+  })
+})
+
+describe('projection reader', () => {
+  it('rejects a payload missing its envelope identifiers', () => {
+    expect(readWmnProjection(null)).toBeNull()
+    expect(readWmnProjection({ recommendations: [] })).toBeNull()
+  })
+
+  it('skips malformed rows and keeps well-formed ones', () => {
+    const projection = readWmnProjection({
+      evaluation_id: 'ev',
+      output_version: 'out',
+      expires_at: '2026-08-16T18:00:00Z',
+      recommendations: [
+        { headline: 'missing everything else' },
+        {
+          intervention_id: 'iv',
+          output_version: 'out',
+          subject_kind: 'task',
+          subject_id: 's',
+          feedback_subject_kind: 'task',
+          feedback_subject_id: 's',
+          headline: 'Good row',
+          dedupe_key: 'dk',
+          expires_at: '2026-08-16T18:00:00Z'
+        }
+      ]
+    })
+    expect(projection?.recommendations.map((r) => r.headline)).toEqual(['Good row'])
+  })
+})
+
+describe('goal readers', () => {
+  it('falls back to id when goal_id is absent and defaults is_active to true', () => {
+    const goal = readCanonicalGoal({ id: 'g-1', title: 'T', status: 'background' })
+    expect(goal?.goalId).toBe('g-1')
+    expect(goal?.isActive).toBe(true)
+    expect(readCanonicalGoal({ title: 'no id' })).toBeNull()
+  })
+
+  it('reads the detail projection with thread summaries preferring current state', () => {
+    const detail = readGoalDetail({
+      goal: { goal_id: 'g-1', title: 'T', status: 'focused' },
+      tasks: [{ id: 't1', description: 'Do it', completed: false }, { description: 'no id' }],
+      active_threads: [
+        { workstream_id: 'ws1', current_state_summary: 'Halfway', objective: 'Obj' },
+        { workstream_id: 'ws2', objective: 'Only objective' }
+      ],
+      progress_events: [{ summary: 'Shipped step one' }, { nope: true }]
+    })
+    expect(detail?.tasks).toEqual([{ id: 't1', description: 'Do it', completed: false }])
+    expect(detail?.activeThreads.map((t) => t.summary)).toEqual(['Halfway', 'Only objective'])
+    expect(detail?.progressEvents).toEqual([{ summary: 'Shipped step one' }])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/intelligence/wireTypes.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/wireTypes.ts
@@ -1,0 +1,286 @@
+// Wire types for the task-intelligence loop (mac parity: OmiApi.generated.swift
+// structs consumed by DashboardIntelligenceStore). Field names are the backend's
+// snake_case, verbatim from backend/models/task_recommendation.py and
+// backend/models/goal.py. Enums decode leniently: an unknown wire string maps to
+// '_unknown' instead of throwing, mirroring the generated Swift client's
+// `__unknown__` cases, and rows with unknown subject kinds are then dropped by
+// the projection rules rather than failing the whole payload.
+
+export type RecommendationSubjectKind =
+  'candidate' | 'task' | 'workstream' | 'artifact' | 'decision' | 'agent_open_loop' | '_unknown'
+
+export type FeedbackSubjectKind =
+  'candidate' | 'task' | 'workstream' | 'artifact' | 'decision' | '_unknown'
+
+export type FeedbackAction =
+  'do_now' | 'later' | 'dismiss' | 'accept_candidate' | 'edit' | 'complete'
+
+export type FeedbackReason = 'already_handled' | 'not_mine' | 'not_useful'
+
+export type WorkflowMode = 'off' | 'shadow' | 'write' | 'read' | '_unknown'
+
+export type GoalStatus = 'background' | 'focused' | 'paused' | 'achieved' | 'abandoned' | '_unknown'
+
+/** Terminal lifecycle targets the backend accepts (GoalLifecycleRequest rejects
+ *  everything else). */
+export type GoalLifecycleTarget = 'paused' | 'achieved' | 'abandoned'
+
+const RECOMMENDATION_SUBJECT_KINDS: ReadonlySet<string> = new Set([
+  'candidate',
+  'task',
+  'workstream',
+  'artifact',
+  'decision',
+  'agent_open_loop'
+])
+
+const FEEDBACK_SUBJECT_KINDS: ReadonlySet<string> = new Set([
+  'candidate',
+  'task',
+  'workstream',
+  'artifact',
+  'decision'
+])
+
+const WORKFLOW_MODES: ReadonlySet<string> = new Set(['off', 'shadow', 'write', 'read'])
+
+const GOAL_STATUSES: ReadonlySet<string> = new Set([
+  'background',
+  'focused',
+  'paused',
+  'achieved',
+  'abandoned'
+])
+
+export function readRecommendationSubjectKind(value: unknown): RecommendationSubjectKind {
+  return typeof value === 'string' && RECOMMENDATION_SUBJECT_KINDS.has(value)
+    ? (value as RecommendationSubjectKind)
+    : '_unknown'
+}
+
+export function readFeedbackSubjectKind(value: unknown): FeedbackSubjectKind {
+  return typeof value === 'string' && FEEDBACK_SUBJECT_KINDS.has(value)
+    ? (value as FeedbackSubjectKind)
+    : '_unknown'
+}
+
+export function readWorkflowMode(value: unknown): WorkflowMode {
+  return typeof value === 'string' && WORKFLOW_MODES.has(value)
+    ? (value as WorkflowMode)
+    : '_unknown'
+}
+
+export function readGoalStatus(value: unknown): GoalStatus {
+  return typeof value === 'string' && GOAL_STATUSES.has(value) ? (value as GoalStatus) : '_unknown'
+}
+
+/** GET /v1/candidates/control (TaskWorkflowControl). */
+export type WorkflowControl = {
+  workflowMode: WorkflowMode
+  accountGeneration: number
+}
+
+export function readWorkflowControl(data: unknown): WorkflowControl {
+  const raw = (data ?? {}) as { workflow_mode?: unknown; account_generation?: unknown }
+  return {
+    workflowMode: readWorkflowMode(raw.workflow_mode),
+    accountGeneration: typeof raw.account_generation === 'number' ? raw.account_generation : 0
+  }
+}
+
+/** One row of the What Matters Now projection (backend Recommendation model).
+ *  The server registers the presentation intervention during evaluation, so
+ *  every row already carries its intervention_id; feedback threads it directly
+ *  and the client never registers interventions for this surface. */
+export type WmnRecommendation = {
+  interventionId: string
+  outputVersion: string
+  subjectKind: RecommendationSubjectKind
+  subjectId: string
+  feedbackSubjectKind: FeedbackSubjectKind
+  feedbackSubjectId: string
+  destinationTaskId: string | null
+  destinationWorkstreamId: string | null
+  headline: string
+  whyNow: string
+  contextLabel: string | null
+  recommendedAction: string
+  alternativeAction: string | null
+  evidencePreview: string
+  dedupeKey: string
+  expiresAt: string
+}
+
+export type WmnProjection = {
+  evaluationId: string
+  outputVersion: string
+  materialVersion: string
+  generatedAt: string
+  expiresAt: string
+  recommendations: WmnRecommendation[]
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value ? value : null
+}
+
+export function readWmnProjection(data: unknown): WmnProjection | null {
+  const raw = data as Record<string, unknown> | null | undefined
+  if (!raw || typeof raw !== 'object') return null
+  const evaluationId = readString(raw.evaluation_id)
+  const outputVersion = readString(raw.output_version)
+  const expiresAt = readString(raw.expires_at)
+  if (!evaluationId || !outputVersion || !expiresAt) return null
+  const rows = Array.isArray(raw.recommendations) ? raw.recommendations : []
+  const recommendations: WmnRecommendation[] = []
+  for (const item of rows) {
+    const r = item as Record<string, unknown> | null
+    if (!r || typeof r !== 'object') continue
+    const interventionId = readString(r.intervention_id)
+    const rowOutputVersion = readString(r.output_version)
+    const subjectId = readString(r.subject_id)
+    const feedbackSubjectId = readString(r.feedback_subject_id)
+    const headline = readString(r.headline)
+    const dedupeKey = readString(r.dedupe_key)
+    const rowExpiresAt = readString(r.expires_at)
+    if (
+      !interventionId ||
+      !rowOutputVersion ||
+      !subjectId ||
+      !feedbackSubjectId ||
+      !headline ||
+      !dedupeKey ||
+      !rowExpiresAt
+    ) {
+      continue
+    }
+    recommendations.push({
+      interventionId,
+      outputVersion: rowOutputVersion,
+      subjectKind: readRecommendationSubjectKind(r.subject_kind),
+      subjectId,
+      feedbackSubjectKind: readFeedbackSubjectKind(r.feedback_subject_kind),
+      feedbackSubjectId,
+      destinationTaskId: readString(r.destination_task_id),
+      destinationWorkstreamId: readString(r.destination_workstream_id),
+      headline,
+      whyNow: readString(r.why_now) ?? '',
+      contextLabel: readString(r.goal_or_workstream_label),
+      recommendedAction: readString(r.recommended_action) ?? '',
+      alternativeAction: readString(r.alternative_action),
+      evidencePreview: readString(r.evidence_preview) ?? '',
+      dedupeKey,
+      expiresAt: rowExpiresAt
+    })
+  }
+  return {
+    evaluationId,
+    outputVersion,
+    materialVersion: readString(raw.material_version) ?? '',
+    generatedAt: readString(raw.generated_at) ?? '',
+    expiresAt,
+    recommendations
+  }
+}
+
+/** Backend GoalResponse, the subset the home surfaces consume. */
+export type CanonicalGoal = {
+  goalId: string
+  title: string
+  desiredOutcome: string
+  whyItMatters: string | null
+  successCriteria: string[]
+  status: GoalStatus
+  focusRank: number | null
+  isActive: boolean
+  updatedAt: string
+  currentValue: number | null
+  targetValue: number | null
+  unit: string | null
+}
+
+export function readCanonicalGoal(data: unknown): CanonicalGoal | null {
+  const raw = data as Record<string, unknown> | null | undefined
+  if (!raw || typeof raw !== 'object') return null
+  const goalId = readString(raw.goal_id) ?? readString(raw.id)
+  const title = readString(raw.title)
+  if (!goalId || !title) return null
+  const criteria = Array.isArray(raw.success_criteria)
+    ? raw.success_criteria.filter((c): c is string => typeof c === 'string')
+    : []
+  return {
+    goalId,
+    title,
+    desiredOutcome: readString(raw.desired_outcome) ?? '',
+    whyItMatters: readString(raw.why_it_matters),
+    successCriteria: criteria,
+    status: readGoalStatus(raw.status),
+    focusRank: typeof raw.focus_rank === 'number' ? raw.focus_rank : null,
+    isActive: raw.is_active !== false,
+    updatedAt: readString(raw.updated_at) ?? '',
+    currentValue: typeof raw.current_value === 'number' ? raw.current_value : null,
+    targetValue: typeof raw.target_value === 'number' ? raw.target_value : null,
+    unit: readString(raw.unit)
+  }
+}
+
+/** GET /v1/goals/{id}/detail (GoalDetailProjection): {goal, tasks, active_threads,
+ *  progress_events}. Tasks and threads keep only what the detail sheet renders. */
+export type GoalDetail = {
+  goal: CanonicalGoal
+  tasks: { id: string; description: string; completed: boolean }[]
+  activeThreads: { workstreamId: string; summary: string }[]
+  progressEvents: { summary: string }[]
+}
+
+export function readGoalDetail(data: unknown): GoalDetail | null {
+  const raw = data as Record<string, unknown> | null | undefined
+  if (!raw || typeof raw !== 'object') return null
+  const goal = readCanonicalGoal(raw.goal)
+  if (!goal) return null
+  const tasks = Array.isArray(raw.tasks)
+    ? raw.tasks.flatMap((t) => {
+        const row = t as Record<string, unknown> | null
+        const id = row ? readString(row.id) : null
+        if (!row || !id) return []
+        return [
+          {
+            id,
+            description: readString(row.description) ?? '',
+            completed: row.completed === true
+          }
+        ]
+      })
+    : []
+  const activeThreads = Array.isArray(raw.active_threads)
+    ? raw.active_threads.flatMap((t) => {
+        const row = t as Record<string, unknown> | null
+        const workstreamId = row ? readString(row.workstream_id) : null
+        if (!row || !workstreamId) return []
+        const summary =
+          readString(row.current_state_summary) ?? readString(row.objective) ?? workstreamId
+        return [{ workstreamId, summary }]
+      })
+    : []
+  const progressEvents = Array.isArray(raw.progress_events)
+    ? raw.progress_events.flatMap((e) => {
+        const row = e as Record<string, unknown> | null
+        const summary = row ? readString(row.summary) : null
+        return summary ? [{ summary }] : []
+      })
+    : []
+  return { goal, tasks, activeThreads, progressEvents }
+}
+
+/** POST /v1/task-intelligence/feedback request body (FeedbackCreate). Wire keys
+ *  stay snake_case; context_snapshot_hash is always null from this surface,
+ *  matching mac's DashboardIntelligenceStore. */
+export type FeedbackCreateBody = {
+  action: FeedbackAction
+  subject_kind: FeedbackSubjectKind
+  subject_id: string
+  intervention_id: string
+  reason: FeedbackReason | null
+  later_until: string | null
+  context_snapshot_hash: null
+}

--- a/desktop/windows/src/renderer/src/lib/intelligence/wireTypes.ts
+++ b/desktop/windows/src/renderer/src/lib/intelligence/wireTypes.ts
@@ -154,6 +154,10 @@ export function readWmnProjection(data: unknown): WmnProjection | null {
     ) {
       continue
     }
+    // A row whose feedback subject kind we cannot name would render but 422 on
+    // every feedback POST; drop it at decode, like unknown recommendation
+    // subject kinds drop at projection.
+    if (readFeedbackSubjectKind(r.feedback_subject_kind) === '_unknown') continue
     recommendations.push({
       interventionId,
       outputVersion: rowOutputVersion,

--- a/desktop/windows/src/renderer/src/pages/Goals.canonicalFocus.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Goals.canonicalFocus.test.tsx
@@ -131,9 +131,7 @@ describe('canonical focus on the Goals page', () => {
     const focus = vi.spyOn(dashboardIntelligence, 'focus').mockResolvedValue(true)
     mount()
     await waitFor(() => expect(screen.getByText('Replace a focused goal')).toBeTruthy())
-    fireEvent.click(
-      screen.getByLabelText(/Goal a/i, { selector: 'input' }) ?? screen.getAllByRole('radio')[0]
-    )
+    fireEvent.click(screen.getByLabelText(/Goal a/i, { selector: 'input' }))
     fireEvent.click(screen.getByText('Replace focus'))
     await waitFor(() => expect(focus).toHaveBeenCalledWith('g-1', 'a'))
   })

--- a/desktop/windows/src/renderer/src/pages/Goals.canonicalFocus.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Goals.canonicalFocus.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { Goals } from './Goals'
+import { dashboardIntelligence } from '../lib/intelligence/dashboardStore'
+import type { CanonicalGoal } from '../lib/intelligence/wireTypes'
+
+vi.mock('../lib/persistentCache', () => ({ getCacheUid: () => 'uid-1' }))
+vi.mock('../lib/apiClient', () => ({
+  omiApi: { get: vi.fn(async () => ({ data: [] })), post: vi.fn(), delete: vi.fn() }
+}))
+vi.mock('../lib/goalsCache', () => ({
+  cache: { goals: null, loaded: false },
+  hydrateGoalsFromDisk: vi.fn(),
+  writeCache: vi.fn()
+}))
+vi.mock('../lib/agentLLM', () => ({ callAgentLLM: vi.fn(async () => '{"questions": []}') }))
+vi.mock('../lib/actionItems', () => ({ fetchAllActionItems: vi.fn(async () => []) }))
+
+const { omiApi } = await import('../lib/apiClient')
+const { cache: goalsCache } = await import('../lib/goalsCache')
+
+const legacyGoal = (id: string, title: string): Record<string, unknown> => ({
+  id,
+  goal_id: id,
+  title,
+  emoji: '🎯',
+  target_value: 10,
+  current_value: 2,
+  completed: false,
+  is_active: true
+})
+
+const canonicalGoal = (
+  id: string,
+  status: CanonicalGoal['status'],
+  rank: number | null
+): CanonicalGoal => ({
+  goalId: id,
+  title: `Goal ${id}`,
+  desiredOutcome: '',
+  whyItMatters: null,
+  successCriteria: [],
+  status,
+  focusRank: rank,
+  isActive: true,
+  updatedAt: '2026-08-01T00:00:00Z',
+  currentValue: null,
+  targetValue: null,
+  unit: null
+})
+
+function stubIntelligence(
+  over: Partial<ReturnType<typeof dashboardIntelligence.getState>> = {}
+): void {
+  vi.spyOn(dashboardIntelligence, 'getState').mockReturnValue({
+    accountGeneration: 3,
+    recommendations: [],
+    goals: [],
+    selectedGoalDetail: null,
+    focusReplacementGoalId: null,
+    error: null,
+    isLoading: false,
+    pendingFeedbackCount: 0,
+    ...over
+  })
+  vi.spyOn(dashboardIntelligence, 'subscribe').mockReturnValue(() => {})
+  vi.spyOn(dashboardIntelligence, 'load').mockResolvedValue()
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  // The page mutates the module cache directly (cache.loaded = true), which
+  // would make later mounts skip the fetch; reset it per test.
+  ;(goalsCache as { goals: unknown; loaded: boolean }).goals = null
+  ;(goalsCache as { goals: unknown; loaded: boolean }).loaded = false
+  ;(omiApi.get as ReturnType<typeof vi.fn>).mockImplementation(async (path: string) => {
+    if (path === '/v1/goals/all') return { data: [legacyGoal('g-1', 'Ship the launch')] }
+    return { data: [] }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function mount(): void {
+  render(
+    <MemoryRouter>
+      <Goals />
+    </MemoryRouter>
+  )
+}
+
+describe('canonical focus on the Goals page', () => {
+  it('legacy accounts see no focus stars', async () => {
+    stubIntelligence({ accountGeneration: null })
+    mount()
+    await waitFor(() => expect(screen.getByText('Ship the launch')).toBeTruthy())
+    expect(screen.queryByLabelText('Focus goal')).toBeNull()
+    expect(screen.queryByLabelText('Unfocus goal')).toBeNull()
+  })
+
+  it('the star focuses an unfocused goal and unfocuses a focused one', async () => {
+    stubIntelligence({ goals: [canonicalGoal('g-1', 'background', null)] })
+    const focus = vi.spyOn(dashboardIntelligence, 'focus').mockResolvedValue(true)
+    mount()
+    await waitFor(() => expect(screen.getByText('Ship the launch')).toBeTruthy())
+    fireEvent.click(screen.getByLabelText('Focus goal'))
+    await waitFor(() => expect(focus).toHaveBeenCalledWith('g-1', null))
+  })
+
+  it('a focused goal shows the filled star wired to unfocus', async () => {
+    stubIntelligence({ goals: [canonicalGoal('g-1', 'focused', 0)] })
+    const unfocus = vi.spyOn(dashboardIntelligence, 'unfocus').mockResolvedValue(true)
+    mount()
+    await waitFor(() => expect(screen.getByText('Ship the launch')).toBeTruthy())
+    fireEvent.click(screen.getByLabelText('Unfocus goal'))
+    await waitFor(() => expect(unfocus).toHaveBeenCalledWith('g-1'))
+  })
+
+  it('the replacement dialog resends focus with the chosen replacement', async () => {
+    stubIntelligence({
+      goals: [canonicalGoal('a', 'focused', 0), canonicalGoal('b', 'focused', 1)],
+      focusReplacementGoalId: 'g-1'
+    })
+    const focus = vi.spyOn(dashboardIntelligence, 'focus').mockResolvedValue(true)
+    mount()
+    await waitFor(() => expect(screen.getByText('Replace a focused goal')).toBeTruthy())
+    fireEvent.click(
+      screen.getByLabelText(/Goal a/i, { selector: 'input' }) ?? screen.getAllByRole('radio')[0]
+    )
+    fireEvent.click(screen.getByText('Replace focus'))
+    await waitFor(() => expect(focus).toHaveBeenCalledWith('g-1', 'a'))
+  })
+
+  it('the subtitle counts focused goals on canonical accounts', async () => {
+    stubIntelligence({ goals: [canonicalGoal('g-1', 'focused', 0)] })
+    mount()
+    await waitFor(() => expect(screen.getByText(/1 focused/)).toBeTruthy())
+  })
+})

--- a/desktop/windows/src/renderer/src/pages/Goals.canonicalFocus.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Goals.canonicalFocus.test.tsx
@@ -59,9 +59,11 @@ function stubIntelligence(
     recommendations: [],
     goals: [],
     selectedGoalDetail: null,
+    goalDetailError: null,
     focusReplacementGoalId: null,
     error: null,
     isLoading: false,
+    hasLoadedOnce: true,
     pendingFeedbackCount: 0,
     ...over
   })

--- a/desktop/windows/src/renderer/src/pages/Goals.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Goals.test.tsx
@@ -15,6 +15,26 @@ vi.mock('../lib/apiClient', () => ({
 }))
 vi.mock('../lib/toast', () => ({ toast: vi.fn() }))
 
+// This suite pins the LEGACY goals flow (cache-first fetch, error-vs-empty).
+// The canonical intelligence layer added to the page issues its own control/
+// goals requests through the same mocked client, which would consume this
+// suite's mockResolvedValueOnce queues and shift every expectation; stub it
+// inert here. Canonical behavior is covered by Goals.canonicalFocus.test.tsx.
+vi.mock('../hooks/useDashboardIntelligence', () => ({
+  useDashboardIntelligence: () => ({
+    accountGeneration: null,
+    recommendations: [],
+    goals: [],
+    selectedGoalDetail: null,
+    goalDetailError: null,
+    focusReplacementGoalId: null,
+    error: null,
+    isLoading: false,
+    hasLoadedOnce: true,
+    pendingFeedbackCount: 0
+  })
+}))
+
 const goal = (over: Partial<Goal>): Goal =>
   ({
     id: 'g1',

--- a/desktop/windows/src/renderer/src/pages/Goals.tsx
+++ b/desktop/windows/src/renderer/src/pages/Goals.tsx
@@ -21,6 +21,7 @@ import { GenerateGoalsButton } from '../components/ui/GenerateGoalsButton'
 import { toast } from '../lib/toast'
 import { useDashboardIntelligence } from '../hooks/useDashboardIntelligence'
 import { dashboardIntelligence, focusedGoals } from '../lib/intelligence/dashboardStore'
+import { ModalShell } from '../components/conversations/ModalShell'
 import { goalEmoji } from '../lib/goalEmoji'
 import { isCompleted, progressColor, progressLabel, progressPct } from '../lib/goalVisuals'
 import { GoalCelebration } from '../components/goals/GoalCelebration'
@@ -93,8 +94,14 @@ export function Goals(): React.JSX.Element {
     async (goalId: string): Promise<void> => {
       setFocusBusyId(goalId)
       try {
-        if (focusedIds.has(goalId)) await dashboardIntelligence.unfocus(goalId)
-        else await dashboardIntelligence.focus(goalId, null)
+        const ok = focusedIds.has(goalId)
+          ? await dashboardIntelligence.unfocus(goalId)
+          : await dashboardIntelligence.focus(goalId, null)
+        // The full-set conflict opens the replacement dialog; every other
+        // failure gets a toast so the star's state never silently lies.
+        if (!ok && dashboardIntelligence.getState().focusReplacementGoalId === null) {
+          toast('Could not update the goal focus. Try again.')
+        }
       } finally {
         setFocusBusyId(null)
       }
@@ -387,7 +394,7 @@ export function Goals(): React.JSX.Element {
     return (
       <li key={g.id} className="surface-card group p-4">
         <div className="flex items-start gap-3">
-          {canonicalActive && !done && (
+          {canonicalActive && (focusedIds.has(g.id) || !done) && (
             <button
               onClick={() => void toggleFocus(g.id)}
               disabled={focusBusyId === g.id}
@@ -396,7 +403,7 @@ export function Goals(): React.JSX.Element {
               className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md transition-all duration-200 ${
                 focusedIds.has(g.id)
                   ? 'text-white'
-                  : 'text-white/25 opacity-0 hover:text-white/70 group-hover:opacity-100'
+                  : 'text-white/25 opacity-0 hover:text-white/70 focus-visible:opacity-100 group-hover:opacity-100'
               } ${focusBusyId === g.id ? 'opacity-50' : ''}`}
             >
               <Star className="h-3.5 w-3.5" fill={focusedIds.has(g.id) ? 'currentColor' : 'none'} />
@@ -525,12 +532,21 @@ export function Goals(): React.JSX.Element {
   return (
     <div className="flex h-full flex-col">
       {intelligence.focusReplacementGoalId !== null && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          role="dialog"
+        <ModalShell
+          onClose={() => {
+            dashboardIntelligence.clearFocusReplacement()
+            setReplacementChoice(null)
+          }}
+          maxWidth="max-w-[380px]"
+          labelledBy="goals-page-replacement-title"
         >
-          <div className="w-[380px] rounded-2xl border border-white/10 bg-[#141414] p-5">
-            <h3 className="mb-2 text-[15px] font-semibold text-white">Replace a focused goal</h3>
+          <div>
+            <h3
+              id="goals-page-replacement-title"
+              className="mb-2 text-[15px] font-semibold text-white"
+            >
+              Replace a focused goal
+            </h3>
             <p className="mb-3 text-[12px] text-white/60">
               Your focus set is full. Nothing is archived; the replaced goal moves back to the list.
             </p>
@@ -573,7 +589,7 @@ export function Goals(): React.JSX.Element {
               </button>
             </div>
           </div>
-        </div>
+        </ModalShell>
       )}
       <PageHeader
         title="Goals"

--- a/desktop/windows/src/renderer/src/pages/Goals.tsx
+++ b/desktop/windows/src/renderer/src/pages/Goals.tsx
@@ -9,6 +9,7 @@ import {
   Trophy,
   Lightbulb,
   Sparkles,
+  Star,
   X
 } from 'lucide-react'
 import { omiApi } from '../lib/apiClient'
@@ -18,6 +19,8 @@ import { TasksGoalsToggle } from '../components/layout/TasksGoalsToggle'
 import { EmptyState } from '../components/ui/EmptyState'
 import { GenerateGoalsButton } from '../components/ui/GenerateGoalsButton'
 import { toast } from '../lib/toast'
+import { useDashboardIntelligence } from '../hooks/useDashboardIntelligence'
+import { dashboardIntelligence, focusedGoals } from '../lib/intelligence/dashboardStore'
 import { goalEmoji } from '../lib/goalEmoji'
 import { isCompleted, progressColor, progressLabel, progressPct } from '../lib/goalVisuals'
 import { GoalCelebration } from '../components/goals/GoalCelebration'
@@ -75,6 +78,29 @@ export function Goals(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [filter, setFilter] = useState<'active' | 'completed' | 'all'>('active')
+  // Canonical focus (mac parity: the focused-goals subset). Bound only when the
+  // account is inside the intelligence rollout; legacy accounts see no stars.
+  const intelligence = useDashboardIntelligence()
+  const canonicalActive = intelligence.accountGeneration !== null
+  const focusedIds = useMemo(
+    () => new Set(focusedGoals(intelligence.goals).map((g) => g.goalId)),
+    [intelligence.goals]
+  )
+  const [focusBusyId, setFocusBusyId] = useState<string | null>(null)
+  const [replacementChoice, setReplacementChoice] = useState<string | null>(null)
+
+  const toggleFocus = useCallback(
+    async (goalId: string): Promise<void> => {
+      setFocusBusyId(goalId)
+      try {
+        if (focusedIds.has(goalId)) await dashboardIntelligence.unfocus(goalId)
+        else await dashboardIntelligence.focus(goalId, null)
+      } finally {
+        setFocusBusyId(null)
+      }
+    },
+    [focusedIds]
+  )
 
   const [composing, setComposing] = useState(false)
   const [draftTitle, setDraftTitle] = useState('')
@@ -361,6 +387,21 @@ export function Goals(): React.JSX.Element {
     return (
       <li key={g.id} className="surface-card group p-4">
         <div className="flex items-start gap-3">
+          {canonicalActive && !done && (
+            <button
+              onClick={() => void toggleFocus(g.id)}
+              disabled={focusBusyId === g.id}
+              aria-label={focusedIds.has(g.id) ? 'Unfocus goal' : 'Focus goal'}
+              title={focusedIds.has(g.id) ? 'Unfocus' : 'Focus'}
+              className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md transition-all duration-200 ${
+                focusedIds.has(g.id)
+                  ? 'text-white'
+                  : 'text-white/25 opacity-0 hover:text-white/70 group-hover:opacity-100'
+              } ${focusBusyId === g.id ? 'opacity-50' : ''}`}
+            >
+              <Star className="h-3.5 w-3.5" fill={focusedIds.has(g.id) ? 'currentColor' : 'none'} />
+            </button>
+          )}
           <button
             onClick={() => void toggleComplete(g)}
             disabled={isBusy}
@@ -483,10 +524,65 @@ export function Goals(): React.JSX.Element {
 
   return (
     <div className="flex h-full flex-col">
+      {intelligence.focusReplacementGoalId !== null && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          role="dialog"
+        >
+          <div className="w-[380px] rounded-2xl border border-white/10 bg-[#141414] p-5">
+            <h3 className="mb-2 text-[15px] font-semibold text-white">Replace a focused goal</h3>
+            <p className="mb-3 text-[12px] text-white/60">
+              Your focus set is full. Nothing is archived; the replaced goal moves back to the list.
+            </p>
+            <div className="mb-3 flex flex-col gap-1">
+              {focusedGoals(intelligence.goals).map((g) => (
+                <label key={g.goalId} className="flex items-center gap-2 text-[13px] text-white/85">
+                  <input
+                    type="radio"
+                    name="focus-replacement"
+                    checked={replacementChoice === g.goalId}
+                    onChange={() => setReplacementChoice(g.goalId)}
+                  />
+                  <span className="truncate">{g.title}</span>
+                </label>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => {
+                  dashboardIntelligence.clearFocusReplacement()
+                  setReplacementChoice(null)
+                }}
+                className="rounded-xl border border-white/10 px-3 py-1.5 text-xs font-medium text-white/70"
+              >
+                Cancel
+              </button>
+              <button
+                disabled={replacementChoice === null}
+                onClick={() => {
+                  const target = intelligence.focusReplacementGoalId
+                  const choice = replacementChoice
+                  setReplacementChoice(null)
+                  if (target !== null && choice !== null) {
+                    void dashboardIntelligence.focus(target, choice)
+                  }
+                }}
+                className="rounded-xl bg-white/15 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40"
+              >
+                Replace focus
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
       <PageHeader
         title="Goals"
         titleSlot={<TasksGoalsToggle />}
-        subtitle={loading ? 'Loading…' : `${activeCount} active · ${doneCount} completed`}
+        subtitle={
+          loading
+            ? 'Loading…'
+            : `${activeCount} active · ${doneCount} completed${canonicalActive ? ` · ${focusedIds.size} focused` : ''}`
+        }
         actions={
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-black/20 p-1">


### PR DESCRIPTION
## Summary

Windows gets the Home intelligence loop macOS ships: the What Matters Now recommendation list on the Home stage, canonical goals with a real focused subset, personalized ask-bar suggestions generated from the account's own context, and a durable feedback outbox so no attribution is ever silently lost. This closes the last open item in the Windows port plan (Track 3 P8, "Home widgets WhatMattersNowSection + FocusedGoalsSection", the one box still unchecked in `docs/mac-parity-audit/track3-ground-truth/_TRACK3-STATUS.md`) and lands on the surface every user opens into.

The repo asked for this in three places:

- `HomeHub.tsx` documented the mac behavior it could not reach: "Mac hides the wordmark when its recommendations array is non-empty. Windows has no recommendations source at all, so that branch is unreachable." This PR is the source; the branch is now reachable, and the knows list takes the stage centre exactly as mac's does.
- `HomeGoalsChips.tsx` carried a DELIBERATE DEVIATION comment: mac's chips are the focused-goals subset, Windows had "no focused subset" so it showed active goals instead. The canonical goals store provides the subset; the legacy row remains as the out-of-rollout fallback, unchanged.
- `hubPrompts.ts` said its three fixed prompts should be swapped "for the feed the day one exists." The feed exists now: daily per-owner personalized questions, generated through the structured agent lane with mac's rules, cached by local day.

It is also the client-side substrate for where macOS product work is going: eleven of the last thirty desktop commits are context-director work, and the director's output is delivered through this exact intervention/recommendation/feedback loop. `applyContextProjection` is the seam a future director port calls; the surface, the store, and the outbox are already in place.

## How it was built

Every behavior was extracted from the macOS sources first (`DashboardIntelligenceStore.swift`, `WhatMattersNowSection.swift`, `CanonicalGoalsStore.swift`, `HomeSuggestionsStore.swift`, and DashboardPage's knows-list composition) and cross-verified against the backend contracts in `backend/routers/task_recommendations.py` and `backend/routers/goals.py` before any TypeScript was written. The port is rule-for-rule where it matters:

- Projection rules verbatim: whole-payload expiry, suppression by pending later/dismiss outbox entries, per-row expiry, first-wins dedupe, subject-kind destination mapping with the drop rules, at most three rows, row id `output_version:dedupe_key`.
- The load gate: only workflow read mode binds the surface; a 404 from `/v1/what-matters-now` means an account outside the intelligence product and clears silently. Recommendations carry server-registered intervention ids, so this surface never registers interventions client-side (the ensureIntervention pattern belongs to the Suggested rail alone; this was verified against the backend after the #11650 lesson about assuming the mac call-site shape).
- The outbox: write-ahead, per-owner (`whatMattersNowFeedbackOutbox.v1.<uid>`), same-key overwrite as the in-flight dedup, mac's exact idempotency-key formats (`wmn:<iv>:do-now` deterministic, later unique per occurrence, dismiss keyed per reason with the literal `none`), one sequential replay pass per load, and generation-mismatch purge without sending. User-facing copy is verbatim ("Saved feedback will retry automatically.", "Saved. Feedback will retry automatically.", "This review target is no longer available.", "Choose a focused goal to replace.").
- Goals: create is idempotent on a per-sheet occurrence id; focus carries the 409 replacement flow with mac's sheet copy; lifecycle transitions always retain relationships; the focused ordering is rank-then-updated.
- Suggestions: per-source fault isolation distinguishes unavailable (failed reads, daily slot not burned) from thin (clean empty reads, empty list cached); generation follows mac's rules (48 chars, first person, concrete, none when thin); a generation finishing after an account switch is dropped.
- Attribution analytics mirror mac: `intervention_presented` once per intervention per store lifetime, `feedback_recorded` only on server acceptance with the chain id, `candidate_id` attached only for candidate subjects. The outcome endpoint ships as the same declared-unused seam mac carries, so outcome wiring lands as a call-site change later.

## Deliberate deviations, called out so they are decisions

- Out-of-rollout accounts see the legacy active-goals chip row instead of mac's nothing; a fallback beats an empty row during rollout, and the legacy component is untouched.
- All recommendation destinations navigate to the Tasks surface: Windows has no workstream-thread UI yet, so thread destinations open Tasks rather than being dropped, and do_now feedback still records after the open. Same reason "Work on this with Omi" on the goal detail lands on Tasks rather than starting an agent thread.
- The refresh/open/focus automation tools mac registers on its DesktopAutomationBridge are not ported: Windows has no agent-action registry yet (the agentKernel control-tool manifest is a different, coordinator-scoped contract system). Tracked as a follow-up alongside the registry itself.
- Task-row dismissals in the knows list are session-only and learned-insight rows are inert on open, both matching mac exactly.

## Verification

- Full windows vitest suite passes (exit 0) with the new suites included; `npm run typecheck` clean on both configs; eslint clean on every touched file.
- New coverage: 30 store tests (gating, 404-silent, projection via the store, key formats captured off the wire, replay, generation purge, focus 409 flow, owner switching, openRecommendation ordering, outcome seam), 11 outbox tests (write-ahead overwrite, suppression matching, sequential replay semantics, entries-during-replay survival), 9 composer, 9 suggestion-engine, 5 wire-decode, 2 attribution, and 41 component/integration tests across the knows list, the goals sheets, the Goals page, the hub seams (wordmark swap, prefill focus pull, rolling variant in the empty chat panel), and the personalized suggestions render.
- Mutation checks: widening the projection row cap and deleting the composer's tip fallback each fail exactly the tests that pin those rules; both restored green.
- Exercised behaviors I could not run against a live intelligence-enabled account are pinned to the backend models read directly from this repo (request shapes, headers, enum vocabularies); the store's HTTP layer is the same axios client every other Windows surface uses.

Product invariants affected: INV-CHAT-1 (chat-continuity; the review pass touched HubChatPanel for an empty-state render slot and HubAskBar for a focus signal, both pure presentation seams: transcript ownership, session identity, and the single shared kernel conversation are untouched, so the guard behavior is unchanged)

## Notes for review

- `contracts/parity`-style conformance for these rules would be a natural follow-up once #11632 lands; this PR deliberately does not depend on that open PR.
- The build note at `desktop/windows/docs/mac-parity-audit/track3-ground-truth/gt-home-intelligence-build.md` carries the module map, the backend contract facts the port depends on, and the deviation list; `_TRACK3-STATUS.md` marks P8 built.
