### PR TITLE
fix(desktop): bind kind-only chat citations and drop pre-tool commentary

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatCitation.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatCitation.swift
@@ -87,6 +87,49 @@ struct ChatCitationReference: Equatable, Sendable {
     return trimmed.isEmpty ? "Preview unavailable" : trimmed
   }
 
+  static func merging(_ lists: [ChatCitationReference]...) -> [ChatCitationReference] {
+    var result = [ChatCitationReference]()
+    for list in lists {
+      for reference in list {
+        let duplicate = result.contains {
+          $0.ordinal == reference.ordinal && $0.kind == reference.kind && $0.sourceID == reference.sourceID
+        }
+        if !duplicate { result.append(reference) }
+      }
+    }
+    return result
+  }
+
+  /// Adds lookup-only sources (local memories/conversations) without colliding with prompt or tool ordinals.
+  static func appendingLookup(
+    _ extras: [ChatCitationReference],
+    to existing: [ChatCitationReference]
+  ) -> [ChatCitationReference] {
+    var result = existing
+    var seen = Set(existing.map { "\($0.kind.rawValue):\($0.sourceID)" })
+    var nextOrdinal = max(8000, existing.map(\.ordinal).max() ?? 0) + 1
+    for extra in extras {
+      let sourceID = extra.sourceID.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard extra.kind != .unavailable, !sourceID.isEmpty else { continue }
+      let key = "\(extra.kind.rawValue):\(sourceID)"
+      guard seen.insert(key).inserted else { continue }
+      result.append(
+        ChatCitationReference(
+          ordinal: nextOrdinal,
+          kind: extra.kind,
+          sourceID: sourceID,
+          title: extra.title,
+          preview: extra.preview,
+          momentTimestampMs: extra.momentTimestampMs,
+          createdAt: extra.createdAt,
+          appName: extra.appName,
+          url: extra.url
+        ))
+      nextOrdinal += 1
+    }
+    return result
+  }
+
   var canOpen: Bool {
     guard ordinal > 0 else { return false }
     switch kind {
@@ -149,12 +192,23 @@ struct ChatPromptCitationLedger: Equatable, Sendable {
     guard !references.isEmpty else { return nil }
     return
       "Source markers such as [5001] in the supplied context are citations. "
-      + "Copy every relevant marker exactly at the end of each claim grounded in that source. "
+      + "Copy every relevant numeric marker exactly, for example [5001], at the end of each claim grounded in that source. "
+      + "Never write [memory], [conversation], or other kind labels as citations. "
       + "Do not claim to provide citations without emitting the markers, and do not invent markers."
   }
 }
 
 enum ChatCitationMarkup {
+  /// Bare `[20]` or a kind-prefixed copy of the context label (`[memory 5023]`, `[task:12]`).
+  static let numericMarkerPattern =
+    #"\[(?:(?:memory|task|goal|conversation|screenshot|web|source|capture|rewind)[:\s]+)?(\d{1,4})\](?!\()"#
+  /// Same markers, including numeric markdown links the citation mask still has to replace.
+  static let numericMarkerOrMarkdownLinkPattern =
+    #"\[(?:(?:memory|task|goal|conversation|screenshot|web|source|capture|rewind)[:\s]+)?(\d{1,4})\](?:\(https?://[^\s)]+\))?"#
+  /// Kind-only copies such as `[memory]` or `[conversation]` with no ordinal.
+  static let kindOnlyMarkerPattern =
+    #"\[(memory|task|goal|conversation|screenshot|web|source|capture|rewind)\](?![\s:]*\d)"#
+
   static func explicitlyRequestsSources(_ text: String) -> Bool {
     guard
       let expression = try? NSRegularExpression(
@@ -166,18 +220,209 @@ enum ChatCitationMarkup {
   }
 
   /// Numeric citations outside inline-code spans, in reading order. Incomplete streaming markers
-  /// and bracketed prose are left alone.
+  /// and bracketed prose are left alone. Kind-prefixed copies such as `[memory 5023]` still count.
   static func ordinals(in text: String) -> [Int] {
+    markerMatches(in: text, pattern: numericMarkerPattern).map(\.ordinal)
+  }
+
+  static func markerMatches(
+    in text: String,
+    pattern: String
+  ) -> [(range: Range<String.Index>, ordinal: Int)] {
     let codeRanges = OmiMarkdownInlineCode.codeSpanRanges(in: text)
-    let expression = try? NSRegularExpression(pattern: #"\[(\d{1,4})\](?!\()"#)
+    guard
+      let expression = try? NSRegularExpression(
+        pattern: pattern, options: [.caseInsensitive])
+    else { return [] }
     let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
-    return expression?.matches(in: text, range: nsRange).compactMap { match in
+    return expression.matches(in: text, range: nsRange).compactMap { match in
       guard let full = Range(match.range(at: 0), in: text),
         !codeRanges.contains(where: { $0.overlaps(full) }),
-        let digits = Range(match.range(at: 1), in: text)
+        let digits = Range(match.range(at: 1), in: text),
+        let ordinal = Int(text[digits])
       else { return nil }
-      return Int(text[digits])
-    } ?? []
+      return (full, ordinal)
+    }
+  }
+
+  static func containsKindOnlyMarkers(_ text: String) -> Bool {
+    !kindOnlyMatches(in: text).isEmpty
+  }
+
+  /// Replace `[memory]` / `[conversation]` with the numeric marker for the best matching source of
+  /// that kind. Unmatched labels stay inert instead of opening a random row.
+  static func resolvingKindLabels(
+    in text: String,
+    using references: [ChatCitationReference],
+    allowUniqueKindFallback: Bool = true
+  ) -> (text: String, references: [ChatCitationReference]) {
+    let matches = kindOnlyMatches(in: text)
+    guard !matches.isEmpty else { return (text, []) }
+    var pool = [ChatCitationReference.Kind: [ChatCitationReference]]()
+    for reference in references where reference.canOpen {
+      pool[reference.kind, default: []].append(reference)
+    }
+    var used = Set<String>()
+    var replacements = [(range: Range<String.Index>, marker: String, reference: ChatCitationReference)]()
+    for match in matches {
+      guard let kind = kind(fromLabel: match.label),
+        let chosen = pickReference(
+          kind: kind,
+          claim: claimText(before: match.range, in: text),
+          pool: pool[kind] ?? [],
+          used: &used,
+          allowUniqueKindFallback: allowUniqueKindFallback)
+      else { continue }
+      replacements.append((match.range, "[\(chosen.ordinal)]", chosen))
+    }
+    guard !replacements.isEmpty else { return (text, []) }
+    var rewritten = text
+    for replacement in replacements.reversed() {
+      rewritten.replaceSubrange(replacement.range, with: replacement.marker)
+    }
+    var bound = [ChatCitationReference]()
+    var seen = Set<String>()
+    for replacement in replacements {
+      let key = "\(replacement.reference.kind.rawValue):\(replacement.reference.sourceID)"
+      if seen.insert(key).inserted {
+        bound.append(replacement.reference)
+      }
+    }
+    return (rewritten, bound)
+  }
+
+  private static func kindOnlyMatches(
+    in text: String
+  ) -> [(range: Range<String.Index>, label: String)] {
+    let codeRanges = OmiMarkdownInlineCode.codeSpanRanges(in: text)
+    guard
+      let expression = try? NSRegularExpression(
+        pattern: kindOnlyMarkerPattern, options: [.caseInsensitive])
+    else { return [] }
+    let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+    return expression.matches(in: text, range: nsRange).compactMap { match in
+      guard let full = Range(match.range(at: 0), in: text),
+        !codeRanges.contains(where: { $0.overlaps(full) }),
+        let labelRange = Range(match.range(at: 1), in: text)
+      else { return nil }
+      return (full, String(text[labelRange]).lowercased())
+    }
+  }
+
+  private static func kind(fromLabel label: String) -> ChatCitationReference.Kind? {
+    switch label.lowercased() {
+    case "memory": return .memory
+    case "conversation", "capture": return .conversation
+    case "task": return .task
+    case "goal": return .goal
+    case "screenshot", "rewind": return .screenshot
+    case "web": return .web
+    default: return nil
+    }
+  }
+
+  private static func claimText(before range: Range<String.Index>, in text: String) -> String {
+    let prefix = text[text.startIndex..<range.lowerBound]
+    let lineStart = prefix.lastIndex(of: "\n").map { text.index(after: $0) } ?? text.startIndex
+    return String(text[lineStart..<range.lowerBound]).trimmingCharacters(in: .whitespaces)
+  }
+
+  private static func sourceKey(_ reference: ChatCitationReference) -> String {
+    "\(reference.kind.rawValue):\(reference.sourceID)"
+  }
+
+  private static func pickReference(
+    kind: ChatCitationReference.Kind,
+    claim: String,
+    pool: [ChatCitationReference],
+    used: inout Set<String>,
+    allowUniqueKindFallback: Bool
+  ) -> ChatCitationReference? {
+    guard !pool.isEmpty else { return nil }
+    if pool.count == 1 {
+      if allowUniqueKindFallback { return pool[0] }
+      return overlapScore(claim: claim, reference: pool[0]) >= 2 ? pool[0] : nil
+    }
+    let scored = pool.map { ($0, overlapScore(claim: claim, reference: $0)) }
+    let unused = scored.filter { !used.contains(sourceKey($0.0)) }
+    if let best = unused.max(by: { $0.1 < $1.1 }), best.1 >= 2 {
+      used.insert(sourceKey(best.0))
+      return best.0
+    }
+    if let best = scored.max(by: { $0.1 < $1.1 }), best.1 >= 2 {
+      return best.0
+    }
+    return nil
+  }
+
+  static func kindOnlySearchQueries(
+    in text: String
+  ) -> [(kind: ChatCitationReference.Kind, query: String, fallback: String)] {
+    kindOnlyMatches(in: text).compactMap { match in
+      guard let kind = kind(fromLabel: match.label) else { return nil }
+      let claim = claimText(before: match.range, in: text)
+      return (kind, searchQuery(fromClaim: claim), searchFallback(fromClaim: claim))
+    }
+  }
+
+  static func searchQuery(fromClaim claim: String) -> String {
+    let bold = firstBoldPhrase(in: claim)
+    if let bold, bold.count >= 4 { return sanitizeSearchQuery(bold) }
+    return sanitizeSearchQuery(tokenize(claim).sorted { $0.count > $1.count }.prefix(4).joined(separator: " "))
+  }
+
+  private static func searchFallback(fromClaim claim: String) -> String {
+    tokenize(claim).first { $0.count >= 6 }.map(sanitizeSearchQuery) ?? ""
+  }
+
+  private static func overlapScore(claim: String, reference: ChatCitationReference) -> Int {
+    let haystack = (reference.title + " " + reference.preview).lowercased()
+    if let bold = firstBoldPhrase(in: claim), bold.count >= 8, haystack.contains(bold) {
+      return 100
+    }
+    let stripped = strippedClaim(claim)
+    if stripped.count >= 12, haystack.contains(stripped) { return 100 }
+    let haystackWords = Set(tokenize(haystack))
+    return tokenize(claim).filter { haystackWords.contains($0) }.count
+  }
+
+  private static func firstBoldPhrase(in claim: String) -> String? {
+    guard let expression = try? NSRegularExpression(pattern: #"\*\*(.+?)\*\*"#),
+      let match = expression.firstMatch(
+        in: claim, range: NSRange(claim.startIndex..<claim.endIndex, in: claim)),
+      let range = Range(match.range(at: 1), in: claim)
+    else { return nil }
+    let phrase = String(claim[range]).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return phrase.isEmpty ? nil : phrase
+  }
+
+  private static func strippedClaim(_ claim: String) -> String {
+    claim.replacingOccurrences(of: "*", with: "")
+      .replacingOccurrences(of: "`", with: "")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+  }
+
+  private static func tokenize(_ text: String) -> [String] {
+    text.lowercased().split { !$0.isLetter }.map(String.init).filter {
+      $0.count >= 4 && !overlapStopwords.contains($0)
+    }
+  }
+
+  private static let overlapStopwords: Set<String> = [
+    "about", "after", "around", "asked", "been", "being", "could", "from", "have", "into",
+    "issue", "just", "later", "make", "made", "other", "planned", "should", "than", "that",
+    "their", "them", "then", "there", "these", "they", "this", "those", "today", "used",
+    "using", "were", "what", "when", "where", "which", "while", "with", "would", "your",
+  ]
+
+  private static func sanitizeSearchQuery(_ value: String) -> String {
+    let allowed = value.unicodeScalars.filter {
+      CharacterSet.alphanumerics.union(.whitespaces).contains($0)
+    }
+    return String(String.UnicodeScalarView(allowed))
+      .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
   }
 
   /// Resolve only durable, explicit provenance. A visible ordinal and an independently ordered
@@ -246,6 +491,71 @@ enum ChatCitationMarkup {
 extension ChatMessage {
   var inlineCitationReferences: [ChatCitationReference] {
     ChatCitationMarkup.references(text: text, blocks: contentBlocks)
+  }
+
+  var hasKindOnlyCitationMarkers: Bool {
+    if ChatCitationMarkup.containsKindOnlyMarkers(text) { return true }
+    return contentBlocks.contains { block in
+      if case .text(_, let blockText) = block {
+        return ChatCitationMarkup.containsKindOnlyMarkers(blockText)
+      }
+      return false
+    }
+  }
+
+  var hasPersistedCitationBlocks: Bool {
+    contentBlocks.contains { block in
+      if case .citation = block { return true }
+      return false
+    }
+  }
+
+  mutating func bindInlineCitations(
+    using references: [ChatCitationReference],
+    allowUniqueKindFallback: Bool = true
+  ) {
+    rewriteKindOnlyCitations(using: references, allowUniqueKindFallback: allowUniqueKindFallback)
+    persistCitedReferences(from: references)
+  }
+
+  mutating func rewriteKindOnlyCitations(
+    using references: [ChatCitationReference],
+    allowUniqueKindFallback: Bool = true
+  ) {
+    text =
+      ChatCitationMarkup.resolvingKindLabels(
+        in: text, using: references, allowUniqueKindFallback: allowUniqueKindFallback
+      ).text
+    contentBlocks = contentBlocks.map { block in
+      guard case .text(let id, let blockText) = block else { return block }
+      return .text(
+        id: id,
+        text: ChatCitationMarkup.resolvingKindLabels(
+          in: blockText, using: references, allowUniqueKindFallback: allowUniqueKindFallback
+        ).text)
+    }
+  }
+
+  mutating func persistCitedReferences(from references: [ChatCitationReference]) {
+    var cited = Set(ChatCitationMarkup.ordinals(in: text))
+    for block in contentBlocks {
+      if case .text(_, let blockText) = block {
+        cited.formUnion(ChatCitationMarkup.ordinals(in: blockText))
+      }
+    }
+    let existing = Set(
+      contentBlocks.compactMap { block -> Int? in
+        guard case .citation(_, let reference) = block else { return nil }
+        return reference.ordinal
+      })
+    contentBlocks.append(
+      contentsOf: references.filter {
+        cited.contains($0.ordinal) && !existing.contains($0.ordinal)
+      }.map { reference in
+        .citation(
+          id: "citation-\(reference.ordinal)-\(reference.sourceID)",
+          reference: reference)
+      })
   }
 }
 
@@ -349,6 +659,24 @@ actor ChatCitationProvenanceRegistry {
     consumeSnapshot(runID: runID, attemptID: attemptID).references
   }
 
+  /// Non-destructive read. Truncated tool projections drop the citation guide JSON, so the
+  /// in-process ledger is the remaining typed mapping until the turn consumes it.
+  func peekSnapshot(runID: String?, attemptID: String?) -> Snapshot {
+    guard let runID, !runID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+      return Snapshot(references: [], selectedReferences: [])
+    }
+    pruneExpired(now: Date())
+    let attempt = attemptID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if !attempt.isEmpty, let bucket = buckets[Key(runID: runID, attemptID: attempt)] {
+      return snapshot(from: bucket)
+    }
+    let matching = buckets.filter { $0.key.runID == runID }
+    guard matching.count == 1, let (_, bucket) = matching.first else {
+      return Snapshot(references: [], selectedReferences: [])
+    }
+    return snapshot(from: bucket)
+  }
+
   func markSelected(
     _ selections: [(kind: ChatCitationReference.Kind, sourceID: String)],
     runID: String?,
@@ -365,19 +693,60 @@ actor ChatCitationProvenanceRegistry {
   }
 
   func consumeSnapshot(runID: String?, attemptID: String?) -> Snapshot {
-    guard let runID, let attemptID,
-      !runID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-      !attemptID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    else { return Snapshot(references: [], selectedReferences: []) }
-    pruneExpired(now: Date())
-    guard let bucket = buckets.removeValue(forKey: Key(runID: runID, attemptID: attemptID)) else {
+    guard let runID, !runID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
       return Snapshot(references: [], selectedReferences: [])
     }
-    return Snapshot(
+    pruneExpired(now: Date())
+    let attempt = attemptID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    if !attempt.isEmpty, let bucket = buckets.removeValue(forKey: Key(runID: runID, attemptID: attempt)) {
+      return snapshot(from: bucket)
+    }
+    // Host tools authorize against the canonical run, but some adapters finish
+    // the query with a different or empty attempt id. If this run has exactly
+    // one ledger, that is the same provenance the model cited.
+    let matching = buckets.filter { $0.key.runID == runID }
+    guard matching.count == 1, let (key, bucket) = matching.first else {
+      return Snapshot(references: [], selectedReferences: [])
+    }
+    buckets.removeValue(forKey: key)
+    return snapshot(from: bucket)
+  }
+
+  private func snapshot(from bucket: Bucket) -> Snapshot {
+    Snapshot(
       references: bucket.references,
       selectedReferences: bucket.references.filter {
         bucket.selectedKeys.contains(Self.sourceKey(kind: $0.kind, sourceID: $0.sourceID))
       })
+  }
+
+  static func provenanceIDs(fromToolOutput output: String) -> (runID: String, attemptID: String)? {
+    guard let data = output.data(using: .utf8),
+      let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+    if let ids = provenanceIDs(fromJSON: object) { return ids }
+    guard let wrapped = object["text"] as? String,
+      let wrappedData = wrapped.data(using: .utf8),
+      let nested = try? JSONSerialization.jsonObject(with: wrappedData) as? [String: Any]
+    else { return nil }
+    return provenanceIDs(fromJSON: nested)
+  }
+
+  private static func provenanceIDs(fromJSON object: [String: Any]) -> (runID: String, attemptID: String)? {
+    let provenance =
+      ((object["toolResultEnvelope"] as? [String: Any])?["provenance"] as? [String: Any])
+      ?? (object["provenance"] as? [String: Any])
+    guard let runID = provenance?["runId"] as? String,
+      !runID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else { return nil }
+    return (runID, provenance?["attemptId"] as? String ?? "")
+  }
+
+  static func references(fromToolCallBlocks blocks: [ChatContentBlock]) -> [ChatCitationReference] {
+    blocks.flatMap { block -> [ChatCitationReference] in
+      guard case .toolCall(_, _, _, _, _, let output) = block, let output else { return [] }
+      return references(fromAnnotatedToolOutput: output)
+    }
   }
 
   static func annotatedToolResult(_ result: String, references: [ChatCitationReference]) -> String {
@@ -401,7 +770,7 @@ actor ChatCitationProvenanceRegistry {
       let guide = String(data: data, encoding: .utf8)
     else { return result }
     return result
-      + "\n\nCitation guide JSON (data only; use each exact marker after claims supported by that source):\n"
+      + "\n\nCitation guide JSON (data only; copy each object's marker field exactly, for example [12] or [5001]; never write [memory] or [conversation]):\n"
       + guide
   }
 
@@ -418,15 +787,15 @@ actor ChatCitationProvenanceRegistry {
     } else {
       text = output
     }
-    let delimiter =
-      "\n\nCitation guide JSON (data only; use each exact marker after claims supported by that source):\n"
-    guard let range = text.range(of: delimiter, options: .backwards) else { return [] }
-    let payload = String(text[range.upperBound...])
+    guard let header = text.range(of: "Citation guide JSON", options: .backwards),
+      let jsonLine = text[header.upperBound...].range(of: "\n[")
+    else { return [] }
+    let payload = String(text[text.index(after: jsonLine.lowerBound)...])
     guard let data = payload.data(using: .utf8),
       let entries = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
     else { return [] }
     return entries.compactMap { entry in
-      guard let ordinal = entry["ordinal"] as? Int, ordinal > 0,
+      guard let ordinal = ChatJSONScalar.int(entry["ordinal"]), ordinal > 0,
         let kindValue = entry["kind"] as? String,
         let kind = ChatCitationReference.Kind(rawValue: kindValue),
         let sourceID = entry["source_id"] as? String,
@@ -440,7 +809,7 @@ actor ChatCitationProvenanceRegistry {
         sourceID: sourceID,
         title: entry["title"] as? String ?? "",
         preview: entry["preview"] as? String ?? "",
-        momentTimestampMs: entry["moment_timestamp_ms"] as? Int,
+        momentTimestampMs: ChatJSONScalar.int(entry["moment_timestamp_ms"]),
         createdAt: entry["created_at"] as? String,
         appName: entry["app_name"] as? String,
         url: url)

--- a/desktop/macos/Desktop/Sources/Chat/ChatCitation.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatCitation.swift
@@ -345,14 +345,17 @@ enum ChatCitationMarkup {
     }
     let scored = pool.map { ($0, overlapScore(claim: claim, reference: $0)) }
     let unused = scored.filter { !used.contains(sourceKey($0.0)) }
-    if let best = unused.max(by: { $0.1 < $1.1 }), best.1 >= 2 {
-      used.insert(sourceKey(best.0))
+    func uniqueBest(in candidates: [(ChatCitationReference, Int)]) -> ChatCitationReference? {
+      guard let best = candidates.max(by: { $0.1 < $1.1 }), best.1 >= 2 else { return nil }
+      let tied = candidates.filter { $0.1 == best.1 }
+      guard tied.count == 1 else { return nil }
       return best.0
     }
-    if let best = scored.max(by: { $0.1 < $1.1 }), best.1 >= 2 {
-      return best.0
+    if let best = uniqueBest(in: unused) {
+      used.insert(sourceKey(best))
+      return best
     }
-    return nil
+    return uniqueBest(in: scored)
   }
 
   static func kindOnlySearchQueries(
@@ -557,6 +560,53 @@ extension ChatMessage {
           reference: reference)
       })
   }
+
+  mutating func applySelectedSourceFallback(
+    selectedReferences: [ChatCitationReference],
+    requestedSources: Bool,
+    retrievedReferences: [ChatCitationReference],
+    fallbackText: String = ""
+  ) {
+    func apply(_ value: String) -> String {
+      ChatCitationMarkup.appendingSelectedSources(
+        to: value,
+        selectedReferences: selectedReferences,
+        requestedSources: requestedSources,
+        retrievedReferences: retrievedReferences)
+    }
+    if text.isEmpty {
+      text = fallbackText
+    }
+    text = apply(text)
+    guard let index = lastVisibleAnswerTextIndex,
+      case .text(let id, let blockText) = contentBlocks[index]
+    else { return }
+    contentBlocks[index] = .text(id: id, text: apply(blockText))
+  }
+
+  private var lastVisibleAnswerTextIndex: Int? {
+    func lastNonEmptyText(in range: Range<Int>) -> Int? {
+      for index in range.reversed() {
+        if case .text(_, let text) = contentBlocks[index],
+          !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+          return index
+        }
+      }
+      return nil
+    }
+    let lastTool = contentBlocks.lastIndex { block in
+      if case .toolCall = block { return true }
+      return false
+    }
+    if let lastTool {
+      if let after = lastNonEmptyText(in: (lastTool + 1)..<contentBlocks.count) {
+        return after
+      }
+      return lastNonEmptyText(in: contentBlocks.startIndex..<lastTool)
+    }
+    return lastNonEmptyText(in: contentBlocks.indices)
+  }
 }
 
 /// Per-attempt source ledger. Tool output teaches the model the assigned ordinals; the terminal
@@ -670,6 +720,9 @@ actor ChatCitationProvenanceRegistry {
     if !attempt.isEmpty, let bucket = buckets[Key(runID: runID, attemptID: attempt)] {
       return snapshot(from: bucket)
     }
+    guard attempt.isEmpty else {
+      return Snapshot(references: [], selectedReferences: [])
+    }
     let matching = buckets.filter { $0.key.runID == runID }
     guard matching.count == 1, let (_, bucket) = matching.first else {
       return Snapshot(references: [], selectedReferences: [])
@@ -702,8 +755,12 @@ actor ChatCitationProvenanceRegistry {
       return snapshot(from: bucket)
     }
     // Host tools authorize against the canonical run, but some adapters finish
-    // the query with a different or empty attempt id. If this run has exactly
-    // one ledger, that is the same provenance the model cited.
+    // the query with an empty attempt id. If this run has exactly one ledger,
+    // that is the same provenance the model cited. A non-empty mismatch must
+    // not steal another attempt's citations.
+    guard attempt.isEmpty else {
+      return Snapshot(references: [], selectedReferences: [])
+    }
     let matching = buckets.filter { $0.key.runID == runID }
     guard matching.count == 1, let (key, bucket) = matching.first else {
       return Snapshot(references: [], selectedReferences: [])

--- a/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
@@ -231,14 +231,14 @@ enum ChatContentBlockCodec {
     _ blocks: [ChatContentBlock],
     backup: [ChatContentBlock]
   ) -> [ChatContentBlock] {
-    let existing = Set(
+    var seen = Set(
       blocks.compactMap { block -> Int? in
         guard case .citation(_, let reference) = block else { return nil }
         return reference.ordinal
       })
     let recovered = backup.filter { block in
       guard case .citation(_, let reference) = block else { return false }
-      return !existing.contains(reference.ordinal)
+      return seen.insert(reference.ordinal).inserted
     }
     return recovered.isEmpty ? blocks : blocks + recovered
   }

--- a/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
@@ -8,15 +8,16 @@ enum ChatContentBlockCodec {
 
   static func encode(_ blocks: [ChatContentBlock]) -> String? {
     guard !blocks.isEmpty else { return nil }
-    let encoded = blocks.map(persistenceDictionary(for:))
-    guard let data = try? JSONSerialization.data(withJSONObject: encoded),
+    let encoded = encodeArray(blocks)
+    guard !encoded.isEmpty,
+      let data = try? JSONSerialization.data(withJSONObject: encoded),
       let json = String(data: data, encoding: .utf8)
     else { return nil }
     return json
   }
 
   static func encodeArray(_ blocks: [ChatContentBlock]) -> [[String: Any]] {
-    blocks.map(persistenceDictionary(for:))
+    blocks.map(persistenceDictionary(for:)).filter { JSONSerialization.isValidJSONObject($0) }
   }
 
   /// Stable, in-process representation used to compare every persisted
@@ -116,7 +117,8 @@ enum ChatContentBlockCodec {
         }
         blocks.append(
           .captureLink(
-            id: id, conversationId: conversationId, momentTimestampMs: dict["momentTimestampMs"] as? Int,
+            id: id, conversationId: conversationId,
+            momentTimestampMs: ChatJSONScalar.int(dict["momentTimestampMs"]),
             summary: summary))
       case "conversationLink":
         guard let conversationId = dict["conversationId"] as? String, let summary = dict["summary"] as? String else {
@@ -127,10 +129,10 @@ enum ChatContentBlockCodec {
         guard let memoryId = dict["memoryId"] as? String, let summary = dict["summary"] as? String else { continue }
         blocks.append(.memoryLink(id: id, memoryId: memoryId, summary: summary))
       case "citation":
-        guard let ordinal = dict["ordinal"] as? Int,
+        guard let ordinal = ChatJSONScalar.int(dict["ordinal"]),
           let kindValue = dict["kind"] as? String,
           let kind = ChatCitationReference.Kind(rawValue: kindValue),
-          let sourceID = dict["sourceId"] as? String
+          let sourceID = (dict["sourceId"] as? String) ?? (dict["source_id"] as? String)
         else { continue }
         blocks.append(
           .citation(
@@ -141,9 +143,10 @@ enum ChatContentBlockCodec {
               sourceID: sourceID,
               title: dict["title"] as? String ?? "",
               preview: dict["preview"] as? String ?? "",
-              momentTimestampMs: dict["momentTimestampMs"] as? Int,
-              createdAt: dict["createdAt"] as? String,
-              appName: dict["appName"] as? String,
+              momentTimestampMs: ChatJSONScalar.int(dict["momentTimestampMs"])
+                ?? ChatJSONScalar.int(dict["moment_timestamp_ms"]),
+              createdAt: dict["createdAt"] as? String ?? dict["created_at"] as? String,
+              appName: dict["appName"] as? String ?? dict["app_name"] as? String,
               url: (dict["url"] as? String).flatMap(URL.init(string:)))))
       case "agentSpawn":
         guard let sessionId = dict["sessionId"] as? String,
@@ -222,6 +225,29 @@ enum ChatContentBlockCodec {
       let array = root[messageMetadataKey] as? [[String: Any]]
     else { return [] }
     return decode(array)
+  }
+
+  static func mergingCitationBackup(
+    _ blocks: [ChatContentBlock],
+    backup: [ChatContentBlock]
+  ) -> [ChatContentBlock] {
+    let existing = Set(
+      blocks.compactMap { block -> Int? in
+        guard case .citation(_, let reference) = block else { return nil }
+        return reference.ordinal
+      })
+    let recovered = backup.filter { block in
+      guard case .citation(_, let reference) = block else { return false }
+      return !existing.contains(reference.ordinal)
+    }
+    return recovered.isEmpty ? blocks : blocks + recovered
+  }
+
+  static func citationBlocks(in blocks: [ChatContentBlock]) -> [ChatContentBlock] {
+    blocks.filter { block in
+      if case .citation = block { return true }
+      return false
+    }
   }
 
   private static func persistenceDictionary(for block: ChatContentBlock) -> [String: Any] {
@@ -325,5 +351,15 @@ enum ChatContentBlockCodec {
       if let runId { dict["runId"] = runId }
       return dict
     }
+  }
+}
+
+enum ChatJSONScalar {
+  static func int(_ value: Any?) -> Int? {
+    if let value = value as? Int { return value }
+    if let value = value as? Int64 { return Int(value) }
+    if let value = value as? NSNumber { return value.intValue }
+    if let value = value as? String { return Int(value.trimmingCharacters(in: .whitespacesAndNewlines)) }
+    return nil
   }
 }

--- a/desktop/macos/Desktop/Sources/Chat/KernelTurnJournal.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelTurnJournal.swift
@@ -293,7 +293,10 @@ extension KernelJournalTurn {
       sender: role == "user" ? .user : .ai,
       isStreaming: status == .pending || status == .streaming,
       isSynced: remoteId != nil,
-      contentBlocks: ChatContentBlockCodec.decode(contentBlocksJSON) ?? [],
+      contentBlocks: ChatContentBlockCodec.mergingCitationBackup(
+        ChatContentBlockCodec.decode(contentBlocksJSON) ?? [],
+        backup: ChatContentBlockCodec.decodeFromMessageMetadata(metadataJSON)
+      ),
       notificationContext: metadata["notificationContext"] as? String,
       resources: ChatResource.hydrateFileStates(
         ChatResource.decodeResourcesFromPersistence(resourcesJSON)
@@ -331,13 +334,19 @@ extension ChatMessage {
     if let sessionId { metadata["sessionId"] = sessionId }
     if let messageSource { metadata["messageSource"] = messageSource }
     let metadataJSON: String
+    let encodedMetadata: String
     if let data = try? JSONSerialization.data(withJSONObject: metadata),
       let encoded = String(data: data, encoding: .utf8)
     {
-      metadataJSON = encoded
+      encodedMetadata = encoded
     } else {
-      metadataJSON = "{}"
+      encodedMetadata = "{}"
     }
+    metadataJSON =
+      ChatContentBlockCodec.mergeIntoMessageMetadata(
+        encodedMetadata,
+        contentBlocks: ChatContentBlockCodec.citationBlocks(in: contentBlocks)
+      ) ?? encodedMetadata
     return KernelJournalTurnWrite(
       turnId: id,
       role: sender == .user ? "user" : "assistant",

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -195,8 +195,12 @@ struct AIResponseView: View {
       ForEach(grouped) { group in
         switch group {
         case .text(_, let text):
-          OmiMarkdown(text: text, sender: .ai)
+          OmiMarkdown(text: text, sender: .ai, citations: message.inlineCitationReferences)
             .textSelection(.enabled)
+            .environment(\.colorScheme, .dark)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        case .commentary(_, let text):
+          TurnCommentaryRow(text: text)
             .environment(\.colorScheme, .dark)
             .frame(maxWidth: .infinity, alignment: .leading)
         case .toolCalls(_, let calls):
@@ -245,7 +249,7 @@ struct AIResponseView: View {
         }
       }
     } else if !message.text.isEmpty {
-      OmiMarkdown(text: message.text, sender: .ai)
+      OmiMarkdown(text: message.text, sender: .ai, citations: message.inlineCitationReferences)
         .textSelection(.enabled)
         .environment(\.colorScheme, .dark)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -2075,10 +2075,14 @@ private struct AgentMainChatView: View {
           switch group {
           case .text(_, let text):
             if !text.isEmpty {
-              OmiMarkdown(text: text, sender: .ai)
+              OmiMarkdown(text: text, sender: .ai, citations: message.inlineCitationReferences)
                 .environment(\.colorScheme, .dark)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+          case .commentary(_, let text):
+            TurnCommentaryRow(text: text)
+              .environment(\.colorScheme, .dark)
+              .frame(maxWidth: .infinity, alignment: .leading)
           case .toolCalls(_, let calls):
             ToolCallsGroup(calls: calls, compact: true)
               .frame(maxWidth: .infinity, alignment: .leading)
@@ -2121,7 +2125,7 @@ private struct AgentMainChatView: View {
     } else {
       let trimmed = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
       if !trimmed.isEmpty {
-        OmiMarkdown(text: trimmed, sender: .ai)
+        OmiMarkdown(text: trimmed, sender: .ai, citations: message.inlineCitationReferences)
           .textSelection(.enabled)
           .environment(\.fontScale, 0.88)
           .fixedSize(horizontal: false, vertical: true)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -111,16 +111,24 @@ struct ChatBubble: View {
   /// Whether this message should be truncated
   private var shouldTruncate: Bool {
     ChatBubbleTruncation.shouldTruncate(
-      text: message.text,
+      text: bubbleText,
       isStreaming: message.isStreaming,
       isExpanded: isExpanded
     )
   }
 
+  /// Visible answer body. Pre-tool model commentary is not the turn output.
+  private var bubbleText: String {
+    if message.sender == .ai, !message.contentBlocks.isEmpty {
+      return message.visibleAnswerText
+    }
+    return message.text
+  }
+
   /// The text to display (truncated or full) — keeps the start of the message visible
   private var displayText: String {
     ChatBubbleTruncation.displayText(
-      message.text,
+      bubbleText,
       isStreaming: message.isStreaming,
       isExpanded: isExpanded
     )
@@ -240,21 +248,26 @@ struct ChatBubble: View {
         TypingIndicator()
       }
     } else if message.sender == .ai && !message.contentBlocks.isEmpty {
-      if groupedBlocks.isEmpty, !message.text.isEmpty {
-        messageTextBubble(message.text)
-      }
       ForEach(groupedBlocks) { group in
-        groupView(group)
+        if case .text = group {
+          EmptyView()
+        } else {
+          groupView(group)
+        }
+      }
+      if !message.visibleAnswerText.isEmpty {
+        messageTextBubble(displayText)
+        truncationControl
       }
       if message.isStreaming, app != nil {
-        if case .toolCalls(_, let calls) = groupedBlocks.last,
-          calls.contains(where: { block in
+        let hasInFlightTool = groupedBlocks.contains { group in
+          guard case .toolCalls(_, let calls) = group else { return false }
+          return calls.contains { block in
             if case .toolCall(_, _, let status, _, _, _) = block { return status.isInFlight }
             return false
-          })
-        {
-          // Tool group has a running tool — its card already shows a spinner
-        } else {
+          }
+        }
+        if !hasInFlightTool {
           TypingIndicator()
         }
       }
@@ -299,19 +312,7 @@ struct ChatBubble: View {
           messageTextBubble(displayText)
         }
 
-        if backgroundAgentSummary == nil, message.text.count > Self.truncationThreshold {
-          if isExpanded {
-            Button(action: { isExpanded.toggle() }) {
-              // Pairs with `showMoreButton`; left `.white`, it vanished on the light panel.
-              Text("Show less")
-                .scaledFont(size: OmiType.caption)
-                .foregroundColor(Ink.accent)
-            }
-            .buttonStyle(.plain)
-          } else if shouldTruncate {
-            showMoreButton
-          }
-        }
+        truncationControl
 
         if message.sender != .user, let resourceStrip {
           resourceStrip
@@ -380,6 +381,22 @@ struct ChatBubble: View {
     .accessibilityHint("Expand the full message")
   }
 
+  @ViewBuilder
+  private var truncationControl: some View {
+    if backgroundAgentSummary == nil, bubbleText.count > Self.truncationThreshold {
+      if isExpanded {
+        Button(action: { isExpanded.toggle() }) {
+          Text("Show less")
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.accent)
+        }
+        .buttonStyle(.plain)
+      } else if shouldTruncate {
+        showMoreButton
+      }
+    }
+  }
+
   private var agentOpenClosure: ((AgentTimelineRef, @escaping (Bool) -> Void) -> Void)? {
     guard hasAgentOpenAction else { return nil }
     return openAgent(ref:completion:)
@@ -401,6 +418,8 @@ struct ChatBubble: View {
           onOpenCitation: onOpenInlineCitation
         )
         .chatMessageBlock(filled: false))
+    case .commentary(_, let text):
+      return AnyView(TurnCommentaryRow(text: text))
     case .toolCalls(_, let calls):
       return AnyView(
         ToolCallsGroup(
@@ -1120,6 +1139,7 @@ extension ChatBubble: @preconcurrency Equatable {
 /// Groups consecutive tool call blocks into a single collapsible group
 enum ContentBlockGroup: Identifiable {
   case text(id: String, text: String)
+  case commentary(id: String, text: String)
   case toolCalls(id: String, calls: [ChatContentBlock])
   case thinking(id: String, text: String)
   case discoveryCard(id: String, title: String, summary: String, fullText: String)
@@ -1152,6 +1172,7 @@ enum ContentBlockGroup: Identifiable {
   var id: String {
     switch self {
     case .text(let id, _): return id
+    case .commentary(let id, _): return id
     case .toolCalls(let id, _): return id
     case .thinking(let id, _): return id
     case .discoveryCard(let id, _, _, _): return id
@@ -1297,10 +1318,35 @@ enum ContentBlockGroup: Identifiable {
         return trimmedRun.isEmpty ? nil : "run:\(trimmedRun)"
       }
     )
-    return group(blocks, richBlockRenderingEnabled: richBlockRenderingEnabled).compactMap { group in
+    let grouped = group(blocks, richBlockRenderingEnabled: richBlockRenderingEnabled)
+    let lastToolIndex = grouped.lastIndex { group in
+      if case .toolCalls = group { return true }
+      return false
+    }
+    let hasTextAfterLastTool =
+      lastToolIndex.map { toolIndex in
+        grouped[(toolIndex + 1)...].contains { group in
+          if case .text = group { return true }
+          return false
+        }
+      } ?? false
+
+    return grouped.enumerated().compactMap { index, group in
       switch group {
       case .text(_, let text):
-        return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : group
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        if let lastToolIndex, index < lastToolIndex {
+          if isStreaming {
+            return .commentary(id: group.id, text: trimmed)
+          }
+          if hasTextAfterLastTool {
+            return nil
+          }
+        }
+        return group
+      case .commentary:
+        return isStreaming ? group : nil
       case .discoveryCard, .questionCard, .taskCard, .goalLink, .captureLink, .conversationLink, .memoryLink,
         .agentSpawn, .agentCompletion:
         return group
@@ -1487,6 +1533,41 @@ struct ToolCallsGroup: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .fixedSize(horizontal: false, vertical: true)
+  }
+}
+
+/// Live-only model narration that preceded tools. Same rail as tool chips; dropped
+/// when the turn settles so only the final answer remains.
+struct TurnCommentaryRow: View {
+  let text: String
+
+  var body: some View {
+    ToolCallActivityHeadline(name: "commentary", status: .completed) {
+      Text(text)
+        .scaledFont(size: OmiType.body)
+        .foregroundColor(Ink.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .frame(maxWidth: .infinity, minHeight: ToolActivityTimelineLayout.rowMinHeight, alignment: .topLeading)
+    .background(alignment: .topLeading) {
+      GeometryReader { proxy in
+        Rectangle()
+          .fill(Ink.secondary.opacity(0.28))
+          .frame(
+            width: ToolActivityTimelineLayout.connectorWidth,
+            height: max(0, proxy.size.height - ToolActivityTimelineLayout.connectorBottomTrim)
+          )
+          .offset(
+            x: ToolActivityTimelineLayout.connectorOriginX,
+            y: ToolActivityTimelineLayout.connectorTopInset
+          )
+      }
+      .accessibilityHidden(true)
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(text)
+    .accessibilityIdentifier("query-shell-turn-commentary")
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -1326,7 +1326,9 @@ enum ContentBlockGroup: Identifiable {
     let hasTextAfterLastTool =
       lastToolIndex.map { toolIndex in
         grouped[(toolIndex + 1)...].contains { group in
-          if case .text = group { return true }
+          if case .text(_, let text) = group {
+            return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          }
           return false
         }
       } ?? false

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -19,6 +19,49 @@ enum ChatBubbleTruncation {
   }
 }
 
+/// Assistant `text_delta` before the first tool call is commentary, not the answer.
+/// The host still concatenates every delta into `message.text`; this projection is
+/// what the bubble, copy affordance, and truncation must use instead.
+enum ChatAssistantAnswerText {
+  static func visible(
+    contentBlocks: [ChatContentBlock],
+    fallback: String,
+    isStreaming: Bool
+  ) -> String {
+    func texts(in slice: ArraySlice<ChatContentBlock>) -> [String] {
+      slice.compactMap { block in
+        guard case .text(_, let text) = block else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+      }
+    }
+
+    let fallbackText = fallback.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard
+      let lastTool = contentBlocks.lastIndex(where: { block in
+        if case .toolCall = block { return true }
+        return false
+      })
+    else {
+      let fromBlocks = texts(in: contentBlocks[...]).joined(separator: "\n")
+      return fromBlocks.isEmpty ? fallbackText : fromBlocks
+    }
+
+    let afterTools = texts(in: contentBlocks[(lastTool + 1)...])
+    if !afterTools.isEmpty {
+      return afterTools.joined(separator: "\n")
+    }
+    if isStreaming {
+      return ""
+    }
+    let beforeTools = texts(in: contentBlocks[..<lastTool])
+    if !beforeTools.isEmpty {
+      return beforeTools.joined(separator: "\n")
+    }
+    return fallbackText
+  }
+}
+
 /// Shared understated date treatment for a transcript row and its prompt-rail
 /// preview. Keeping this outside the bubble makes the time contextual rather
 /// than part of the message itself.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/OmiMarkdown.swift
@@ -1049,29 +1049,21 @@ enum ChatCitationMask {
   }
 
   static func mask(_ text: String, references: [Int: ChatCitationReference]) -> Masked? {
-    guard !references.isEmpty,
-      let expression = try? NSRegularExpression(
-        pattern: #"\[(\d{1,4})\](?:\(https?://[^\s)]+\))?"#)
-    else { return nil }
-    let codeRanges = OmiMarkdownInlineCode.codeSpanRanges(in: text)
-    let matches = expression.matches(in: text, range: NSRange(text.startIndex..<text.endIndex, in: text))
+    guard !references.isEmpty else { return nil }
     var markdown = ""
     var markers = [Marker]()
     var cursor = text.startIndex
 
-    for match in matches {
-      guard let full = Range(match.range(at: 0), in: text),
-        !codeRanges.contains(where: { $0.overlaps(full) }),
-        let digits = Range(match.range(at: 1), in: text),
-        let ordinal = Int(text[digits]),
-        let reference = references[ordinal]
-      else { continue }
-      markdown += text[cursor..<full.lowerBound]
+    for match in ChatCitationMarkup.markerMatches(
+      in: text, pattern: ChatCitationMarkup.numericMarkerOrMarkdownLinkPattern)
+    {
+      guard let reference = references[match.ordinal] else { continue }
+      markdown += text[cursor..<match.range.lowerBound]
       var placeholder = "omiCitationPlaceholder\(markers.count)"
       while text.contains(placeholder) { placeholder.append("x") }
       markdown += placeholder
       markers.append(Marker(placeholder: placeholder, reference: reference))
-      cursor = full.upperBound
+      cursor = match.range.upperBound
     }
     guard !markers.isEmpty else { return nil }
     markdown += text[cursor...]

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -90,6 +90,7 @@ extension ChatProvider {
     }
     messages = updatedMessages
     flushPendingMessageRatings()
+    Task { await bindKindOnlyCitationsIfNeeded() }
 
     for divergence in divergences {
       DesktopDiagnosticsManager.shared.recordStateAuthoritySignal(
@@ -102,6 +103,188 @@ extension ChatProvider {
 
   func projectJournalTurn(_ turn: KernelJournalTurn) {
     projectJournalTurns([turn])
+  }
+
+  /// Local memories/conversations/tasks used to bind kind-only labels such as `[memory]` when the
+  /// model copied a category name instead of the numeric marker.
+  func kindCitationLookupReferences() async -> [ChatCitationReference] {
+    let formatter = ISO8601DateFormatter()
+    async let memories = (try? await MemoryStorage.shared.getLocalMemories(limit: 200)) ?? []
+    async let conversations =
+      (try? await TranscriptionStorage.shared.getLocalConversations(limit: 80)) ?? []
+    async let tasks =
+      (try? await ActionItemStorage.shared.getLocalActionItems(limit: 20, completed: false)) ?? []
+    let loadedMemories = await memories
+    let loadedConversations = await conversations
+    let loadedTasks = await tasks
+    return lookupReferences(
+      memories: loadedMemories,
+      conversations: loadedConversations,
+      tasks: loadedTasks,
+      formatter: formatter)
+  }
+
+  func applyKindOnlyCitationBinding(to messageId: String, base: [ChatCitationReference]) async {
+    guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return }
+    messages[index].bindInlineCitations(using: base)
+    guard let current = messages.first(where: { $0.id == messageId }),
+      current.hasKindOnlyCitationMarkers
+    else { return }
+    let searched = await searchedMemoryReferences(in: current)
+    guard !searched.isEmpty,
+      let index = messages.firstIndex(where: { $0.id == messageId })
+    else { return }
+    let existing = messages[index].contentBlocks.compactMap { block -> ChatCitationReference? in
+      guard case .citation(_, let reference) = block else { return nil }
+      return reference
+    }
+    messages[index].bindInlineCitations(
+      using: ChatCitationReference.appendingLookup(searched, to: existing),
+      allowUniqueKindFallback: false)
+  }
+
+  func finalizeAssistantMessageCitations(
+    messageId: String,
+    queryText: String,
+    selectedReferences: [ChatCitationReference],
+    requestedSources: Bool,
+    terminalCitationReferences: [ChatCitationReference]
+  ) async -> String {
+    guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return queryText }
+    let durableToolReferences = messages[index].contentBlocks.compactMap {
+      block -> ChatCitationReference? in
+      guard case .citation(_, let reference) = block else { return nil }
+      return reference
+    }
+    let allTerminalCitationReferences = ChatCitationReference.appendingLookup(
+      await kindCitationLookupReferences(),
+      to: ChatCitationReference.merging(
+        terminalCitationReferences,
+        durableToolReferences,
+        ChatCitationProvenanceRegistry.references(
+          fromToolCallBlocks: messages[index].contentBlocks))
+    )
+    guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return queryText }
+    messages[index].text = ChatCitationMarkup.appendingSelectedSources(
+      to: messages[index].text.isEmpty ? queryText : messages[index].text,
+      selectedReferences: selectedReferences,
+      requestedSources: requestedSources,
+      retrievedReferences: allTerminalCitationReferences)
+    messages[index].isStreaming = false
+    await applyKindOnlyCitationBinding(to: messageId, base: allTerminalCitationReferences)
+    guard let current = messages.first(where: { $0.id == messageId }) else { return queryText }
+    let visible = current.visibleAnswerText
+    return visible.isEmpty ? current.text : visible
+  }
+
+  func bindKindOnlyCitationsIfNeeded() async {
+    let needsBind = messages.contains { message in
+      message.sender == .ai && !message.isStreaming && message.hasKindOnlyCitationMarkers
+    }
+    guard needsBind else { return }
+    let lookup = await kindCitationLookupReferences()
+    let ids = messages.compactMap { message -> String? in
+      guard message.sender == .ai, !message.isStreaming, message.hasKindOnlyCitationMarkers else {
+        return nil
+      }
+      return message.id
+    }
+    for id in ids {
+      guard let message = messages.first(where: { $0.id == id }),
+        message.sender == .ai,
+        !message.isStreaming,
+        message.hasKindOnlyCitationMarkers
+      else { continue }
+      let existing = message.contentBlocks.compactMap { block -> ChatCitationReference? in
+        guard case .citation(_, let reference) = block else { return nil }
+        return reference
+      }
+      await applyKindOnlyCitationBinding(
+        to: id,
+        base: ChatCitationReference.appendingLookup(lookup, to: existing))
+    }
+  }
+
+  private func lookupReferences(
+    memories: [ServerMemory],
+    conversations: [ServerConversation],
+    tasks: [TaskActionItem],
+    formatter: ISO8601DateFormatter
+  ) -> [ChatCitationReference] {
+    var result = [ChatCitationReference]()
+    var seen = Set<String>()
+    var ordinal = 1
+    func append(
+      kind: ChatCitationReference.Kind,
+      sourceID: String,
+      title: String,
+      preview: String,
+      createdAt: Date?
+    ) {
+      let trimmed = sourceID.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty, seen.insert("\(kind.rawValue):\(trimmed)").inserted else { return }
+      result.append(
+        ChatCitationReference(
+          ordinal: ordinal,
+          kind: kind,
+          sourceID: trimmed,
+          title: title,
+          preview: preview,
+          createdAt: createdAt.map { formatter.string(from: $0) }))
+      ordinal += 1
+    }
+    for memory in memories {
+      append(
+        kind: .memory,
+        sourceID: memory.id,
+        title: memory.headline ?? "Memory",
+        preview: memory.content,
+        createdAt: memory.createdAt)
+    }
+    for conversation in conversations {
+      append(
+        kind: .conversation,
+        sourceID: conversation.id,
+        title: conversation.structured.title.isEmpty ? "Conversation" : conversation.structured.title,
+        preview: conversation.structured.overview,
+        createdAt: conversation.createdAt)
+    }
+    for task in tasks {
+      append(
+        kind: .task,
+        sourceID: task.id,
+        title: task.description,
+        preview: task.contextSummary ?? task.description,
+        createdAt: task.createdAt)
+    }
+    return result
+  }
+
+  private func searchedMemoryReferences(in message: ChatMessage) async -> [ChatCitationReference] {
+    let corpus =
+      ([message.text]
+      + message.contentBlocks.compactMap { block -> String? in
+        guard case .text(_, let text) = block else { return nil }
+        return text
+      }).joined(separator: "\n")
+    var memories = [ServerMemory]()
+    var seen = Set<String>()
+    for item in ChatCitationMarkup.kindOnlySearchQueries(in: corpus).prefix(16) {
+      guard item.kind == .memory else { continue }
+      for query in [item.query, item.fallback] where !query.isEmpty {
+        let found =
+          (try? await MemoryStorage.shared.searchLocalMemories(query: query, limit: 8)) ?? []
+        for memory in found where seen.insert(memory.id).inserted {
+          memories.append(memory)
+        }
+        if !found.isEmpty { break }
+      }
+    }
+    return lookupReferences(
+      memories: memories,
+      conversations: [],
+      tasks: [],
+      formatter: ISO8601DateFormatter())
   }
 
   /// Compare only journal-owned values. The comparison may inspect content in

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -156,22 +156,26 @@ extension ChatProvider {
       guard case .citation(_, let reference) = block else { return nil }
       return reference
     }
-    let allTerminalCitationReferences = ChatCitationReference.appendingLookup(
-      await kindCitationLookupReferences(),
-      to: ChatCitationReference.merging(
-        terminalCitationReferences,
-        durableToolReferences,
-        ChatCitationProvenanceRegistry.references(
-          fromToolCallBlocks: messages[index].contentBlocks))
-    )
-    guard let index = messages.firstIndex(where: { $0.id == messageId }) else { return queryText }
-    messages[index].text = ChatCitationMarkup.appendingSelectedSources(
-      to: messages[index].text.isEmpty ? queryText : messages[index].text,
+    let turnReferences = ChatCitationReference.merging(
+      terminalCitationReferences,
+      durableToolReferences,
+      ChatCitationProvenanceRegistry.references(
+        fromToolCallBlocks: messages[index].contentBlocks))
+    messages[index].applySelectedSourceFallback(
       selectedReferences: selectedReferences,
       requestedSources: requestedSources,
-      retrievedReferences: allTerminalCitationReferences)
+      retrievedReferences: turnReferences,
+      fallbackText: queryText)
     messages[index].isStreaming = false
-    await applyKindOnlyCitationBinding(to: messageId, base: allTerminalCitationReferences)
+    let bindBase: [ChatCitationReference]
+    if messages[index].hasKindOnlyCitationMarkers {
+      bindBase = ChatCitationReference.appendingLookup(
+        await kindCitationLookupReferences(),
+        to: turnReferences)
+    } else {
+      bindBase = turnReferences
+    }
+    await applyKindOnlyCitationBinding(to: messageId, base: bindBase)
     guard let current = messages.first(where: { $0.id == messageId }) else { return queryText }
     let visible = current.visibleAnswerText
     return visible.isEmpty ? current.text : visible

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -785,23 +785,17 @@ struct ChatQuestionCardContinuation: Sendable {
 }
 
 extension ChatMessage {
+  /// User-visible answer, excluding pre-tool commentary the model streamed before tools.
+  var visibleAnswerText: String {
+    ChatAssistantAnswerText.visible(
+      contentBlocks: contentBlocks,
+      fallback: text,
+      isStreaming: isStreaming
+    )
+  }
+
   var copyableText: String {
-    // A completed assistant turn can contain internal reasoning and transient
-    // tool/lifecycle blocks alongside its user-visible answer. The message
-    // copy affordance promises the answer, so retain only final text blocks.
-    let finalOutput =
-      contentBlocks
-      .compactMap { block -> String? in
-        guard case .text(_, let text) = block else { return nil }
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
-      }
-      .joined(separator: "\n")
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    if !finalOutput.isEmpty {
-      return finalOutput
-    }
-    return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    visibleAnswerText
   }
 
   var displayResources: [ChatResource] {
@@ -2499,7 +2493,8 @@ class ChatProvider: ObservableObject {
     var lines: [String] = ["<user_facts>", "Facts about \(userName):"]
     for memory in cachedMemories.prefix(30) {  // Limit to 30 most relevant
       let marker = citations.marker(kind: .memory, sourceID: memory.id).map { " \($0)" } ?? ""
-      lines.append("- [memory] \(memory.content)\(marker)")
+      // Kind labels in square brackets get copied as fake citations (`[memory]`, `[memory 5023]`).
+      lines.append("- \(memory.content)\(marker)")
     }
     lines.append("</user_facts>")
 
@@ -3479,7 +3474,8 @@ class ChatProvider: ObservableObject {
   /// written to the kernel journal, so `KernelJournalTurn.chatMessage()` cannot
   /// reconstruct them and a journal projection can never be their authority:
   /// `rating` (user-set), `metadata` (model/token/cost stats attached at
-  /// completion, rendered in the message footer) and `notificationScreenshot`.
+  /// completion, rendered in the message footer), `notificationScreenshot`,
+  /// and in-memory kind-only citation rewrites until the journal catches up.
   /// Replacing a row wholesale with the projection would drop them, so carry
   /// them forward from the row being replaced. A field the projection *does*
   /// carry (non-nil) wins, so this stays correct if the journal schema later
@@ -3489,6 +3485,16 @@ class ChatProvider: ObservableObject {
     if merged.rating == nil { merged.rating = existing.rating }
     if merged.metadata == nil { merged.metadata = existing.metadata }
     if merged.notificationScreenshot == nil { merged.notificationScreenshot = existing.notificationScreenshot }
+    // Kind-only binding rewrites markers and appends citation blocks in memory.
+    // A stale journal echo still has `[memory]` and no citation blocks; keep the
+    // already-bound row so chips do not vanish between hydrate and the next bind.
+    if existing.hasPersistedCitationBlocks,
+      !existing.hasKindOnlyCitationMarkers,
+      projected.hasKindOnlyCitationMarkers
+    {
+      merged.text = existing.text
+      merged.contentBlocks = existing.contentBlocks
+    }
     return merged
   }
 
@@ -4806,8 +4812,16 @@ class ChatProvider: ObservableObject {
             )
           }
           self.addToolResult(messageId: aiMessageId, toolUseId: toolUseId, name: name, output: output)
-          let durableReferences = ChatCitationProvenanceRegistry.references(
+          var durableReferences = ChatCitationProvenanceRegistry.references(
             fromAnnotatedToolOutput: output)
+          if durableReferences.isEmpty,
+            let provenance = ChatCitationProvenanceRegistry.provenanceIDs(fromToolOutput: output)
+          {
+            durableReferences = await ChatCitationProvenanceRegistry.shared.peekSnapshot(
+              runID: provenance.runID,
+              attemptID: provenance.attemptID
+            ).references
+          }
           if !durableReferences.isEmpty,
             let messageIndex = self.messages.firstIndex(where: { $0.id == aiMessageId })
           {
@@ -5078,63 +5092,33 @@ class ChatProvider: ObservableObject {
           toolName: "get_work_context"
         )
       }
-      if let index = messages.firstIndex(where: { $0.id == aiMessageId }) {
-        // Message still in memory — update it in-place
-        let durableToolReferences = messages[index].contentBlocks.compactMap {
-          block -> ChatCitationReference? in
-          guard case .citation(_, let reference) = block else { return nil }
-          return reference
-        }
-        let allTerminalCitationReferences =
-          terminalCitationReferences
-          + durableToolReferences.filter { reference in
-            !terminalCitationReferences.contains(where: {
-              $0.ordinal == reference.ordinal && $0.kind == reference.kind
-                && $0.sourceID == reference.sourceID
-            })
-          }
-        let resolvedMessageText = ChatCitationMarkup.appendingSelectedSources(
-          to: messages[index].text.isEmpty ? queryResult.text : messages[index].text,
+      if messages.contains(where: { $0.id == aiMessageId }) {
+        messageText = await finalizeAssistantMessageCitations(
+          messageId: aiMessageId,
+          queryText: queryResult.text,
           selectedReferences: toolCitationSnapshot.selectedReferences,
           requestedSources: ChatCitationMarkup.explicitlyRequestsSources(effectivePrompt),
-          retrievedReferences: allTerminalCitationReferences)
-        messageText = resolvedMessageText
-        messages[index].text = messageText
-        messages[index].isStreaming = false
-        let citedOrdinals = Set(ChatCitationMarkup.ordinals(in: messageText))
-        let citedReferences = allTerminalCitationReferences.filter {
-          citedOrdinals.contains($0.ordinal)
+          terminalCitationReferences: terminalCitationReferences)
+        if let index = messages.firstIndex(where: { $0.id == aiMessageId }) {
+          let deltaResources = queryResult.completionDeltaArtifacts.map(ChatResource.artifact)
+          messages[index].resources = mergedResources(
+            existing: messages[index].resources,
+            adding: queryResult.artifacts.map(ChatResource.artifact) + deltaResources
+          )
+          messages[index].metadata = MessageMetadata.fromCompletedTurn(
+            snapshot: kernelContext.snapshot,
+            profile: kernelContext.session.profile,
+            imageByteCount: effectiveImageData?.count,
+            toolNames: toolTiming.toolNames,
+            sqlRowsReturned: metricsSnapshot.sqlRowsReturned,
+            sqlQueryCount: metricsSnapshot.sqlQueryCount
+          )
+          completeRemainingToolCalls(
+            messageId: aiMessageId,
+            terminalStatus: .completed,
+            scheduleJournal: false
+          )
         }
-        let alreadyPersistedCitationOrdinals = Set(durableToolReferences.map(\.ordinal))
-        messages[index].contentBlocks.append(
-          contentsOf: citedReferences.filter {
-            !alreadyPersistedCitationOrdinals.contains($0.ordinal)
-          }.map { reference in
-            .citation(
-              id: "citation-\(reference.ordinal)-\(UUID().uuidString)",
-              reference: reference)
-          })
-        // Merge the parent agent's own artifacts with any produced by
-        // sub-agents that completed since the last coordinator check, so
-        // a finished sub-agent's file surfaces as a card on this response.
-        let deltaResources = queryResult.completionDeltaArtifacts.map(ChatResource.artifact)
-        messages[index].resources = mergedResources(
-          existing: messages[index].resources,
-          adding: queryResult.artifacts.map(ChatResource.artifact) + deltaResources
-        )
-        messages[index].metadata = MessageMetadata.fromCompletedTurn(
-          snapshot: kernelContext.snapshot,
-          profile: kernelContext.session.profile,
-          imageByteCount: effectiveImageData?.count,
-          toolNames: toolTiming.toolNames,
-          sqlRowsReturned: metricsSnapshot.sqlRowsReturned,
-          sqlQueryCount: metricsSnapshot.sqlQueryCount
-        )
-        completeRemainingToolCalls(
-          messageId: aiMessageId,
-          terminalStatus: .completed,
-          scheduleJournal: false
-        )
       } else {
         // The assistant row this turn owns is gone from the transcript while
         // the turn is still authoritative. A session switch is only one way to

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -3488,10 +3488,7 @@ class ChatProvider: ObservableObject {
     // Kind-only binding rewrites markers and appends citation blocks in memory.
     // A stale journal echo still has `[memory]` and no citation blocks; keep the
     // already-bound row so chips do not vanish between hydrate and the next bind.
-    if existing.hasPersistedCitationBlocks,
-      !existing.hasKindOnlyCitationMarkers,
-      projected.hasKindOnlyCitationMarkers
-    {
+    if existing.hasPersistedCitationBlocks, !projected.hasPersistedCitationBlocks {
       merged.text = existing.text
       merged.contentBlocks = existing.contentBlocks
     }

--- a/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -245,7 +245,11 @@ class ChatToolExecutor {
         expectedOwnerID: expectedOwnerID)
 
     case .getDailyRecap:
-      return await executeDailyRecap(toolCall.arguments, expectedOwnerID: expectedOwnerID)
+      return await executeDailyRecap(
+        toolCall.arguments,
+        runID: originatingRunId,
+        attemptID: originatingAttemptId,
+        expectedOwnerID: expectedOwnerID)
 
     case .searchTasks:
       return await executeSearchTasks(toolCall.arguments, expectedOwnerID: expectedOwnerID)
@@ -1442,6 +1446,8 @@ class ChatToolExecutor {
   /// Get a pre-formatted daily activity recap
   private static func executeDailyRecap(
     _ args: [String: Any],
+    runID: String?,
+    attemptID: String?,
     expectedOwnerID: String?
   ) async -> String {
     guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
@@ -1478,7 +1484,7 @@ class ChatToolExecutor {
         let convos = try Row.fetchAll(
           db,
           sql: """
-            SELECT title, overview, emoji, category, startedAt, finishedAt,
+            SELECT backendId, title, overview, emoji, category, startedAt, finishedAt,
                 ROUND((julianday(finishedAt) - julianday(startedAt)) * 1440, 1) as duration_min
             FROM transcription_sessions
             WHERE startedAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
@@ -1491,7 +1497,7 @@ class ChatToolExecutor {
         let tasks = try Row.fetchAll(
           db,
           sql: """
-            SELECT description, completed, priority, createdAt FROM action_items
+            SELECT backendId, description, completed, priority, createdAt FROM action_items
             WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
                 AND createdAt < \(upperBound)
                 AND deleted = 0
@@ -1512,7 +1518,7 @@ class ChatToolExecutor {
         let memories = try Row.fetchAll(
           db,
           sql: """
-            SELECT content, category, source FROM memories
+            SELECT backendId, content, category, source FROM memories
             WHERE createdAt >= datetime('now', 'start of day', '-\(daysAgo) day', 'localtime')
                 AND createdAt < \(upperBound)
                 AND deleted = 0
@@ -1532,6 +1538,27 @@ class ChatToolExecutor {
 
         // Format compact markdown
         var out = "# \(dateLabel) Recap\n\n"
+        var sources = [APIClient.ToolSource]()
+        func note(
+          kind: ChatCitationReference.Kind,
+          sourceID: String?,
+          title: String,
+          preview: String
+        ) -> String {
+          let trimmed = sourceID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+          guard !trimmed.isEmpty else { return "" }
+          sources.append(
+            APIClient.ToolSource(
+              kind: kind.rawValue,
+              sourceID: trimmed,
+              title: title,
+              preview: preview,
+              createdAt: nil,
+              momentTimestampMs: nil,
+              appName: nil,
+              url: nil))
+          return " {{cite:\(sources.count)}}"
+        }
 
         out += "## Apps (\(apps.count) apps)\n"
         if apps.isEmpty {
@@ -1559,7 +1586,12 @@ class ChatToolExecutor {
             let emoji = convo["emoji"] as? String ?? ""
             let durMin = convo["duration_min"] as? Double ?? 0
             let dur = durMin > 0 ? " (\(durMin) min)" : ""
-            out += "- \(emoji) **\(title)**\(dur): \(overview)\n"
+            let marker = note(
+              kind: .conversation,
+              sourceID: convo["backendId"] as? String,
+              title: title,
+              preview: overview)
+            out += "- \(emoji) **\(title)**\(dur): \(overview)\(marker)\n"
           }
         }
 
@@ -1573,7 +1605,12 @@ class ChatToolExecutor {
             let priority = task["priority"] as? String ?? ""
             let check = completed ? "[x]" : "[ ]"
             let pri = priority.isEmpty ? "" : " (\(priority))"
-            out += "- \(check) \(desc)\(pri)\n"
+            let marker = note(
+              kind: .task,
+              sourceID: task["backendId"] as? String,
+              title: desc,
+              preview: desc)
+            out += "- \(check) \(desc)\(pri)\(marker)\n"
           }
         }
 
@@ -1602,8 +1639,13 @@ class ChatToolExecutor {
           for memory in memories.prefix(10) {
             let content = memory["content"] as? String ?? ""
             let category = memory["category"] as? String ?? ""
-            let catStr = category.isEmpty ? "" : " [\(category)]"
-            out += "- \(content)\(catStr)\n"
+            let catStr = category.isEmpty ? "" : " (\(category))"
+            let marker = note(
+              kind: .memory,
+              sourceID: memory["backendId"] as? String,
+              title: content,
+              preview: content)
+            out += "- \(content)\(catStr)\(marker)\n"
           }
           if memories.count > 10 { out += "- ...and \(memories.count - 10) more\n" }
         }
@@ -1624,10 +1666,25 @@ class ChatToolExecutor {
         log(
           "Tool get_daily_recap: \(apps.count) apps, \(convos.count) convos, \(tasks.count) tasks, \(focusSessions.count) focus, \(memories.count) memories, \(observations.count) observations"
         )
-        return out
+        return (out, sources)
       }
       guard isExpectedOwnerCurrent(expectedOwnerID) else { return authorizedOwnerChangedResult() }
-      return result
+      let references = await ChatCitationProvenanceRegistry.shared.register(
+        result.1, runID: runID, attemptID: attemptID)
+      var recap = result.0
+      if references.isEmpty {
+        recap = recap.replacingOccurrences(
+          of: #" \{\{cite:\d+\}\}"#,
+          with: "",
+          options: .regularExpression)
+      } else {
+        for (index, reference) in references.enumerated() {
+          recap = recap.replacingOccurrences(
+            of: " {{cite:\(index + 1)}}",
+            with: " [\(reference.ordinal)]")
+        }
+      }
+      return ChatCitationProvenanceRegistry.annotatedToolResult(recap, references: references)
     } catch {
       logError("Tool get_daily_recap failed", error: error)
       return "Error: \(error.localizedDescription)"

--- a/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentPillLifecycleTests.swift
@@ -392,7 +392,8 @@ import XCTest
     XCTAssertTrue(source.contains("private func groupedContentBlocks(for message: ChatMessage) -> [ContentBlockGroup]"))
     XCTAssertTrue(source.contains("ToolCallsGroup(calls: calls, compact: true)"))
     XCTAssertTrue(source.contains("ThinkingBlock(text: text)"))
-    XCTAssertTrue(source.contains("OmiMarkdown(text: trimmed, sender: .ai)"))
+    XCTAssertTrue(
+      source.contains("OmiMarkdown(text: trimmed, sender: .ai, citations: message.inlineCitationReferences)"))
     XCTAssertTrue(source.contains(".environment(\\.fontScale, 0.88)"))
     XCTAssertTrue(source.contains(".frame(width: 36, height: 36)"))
     XCTAssertTrue(source.contains(".contentShape(Rectangle())"))

--- a/desktop/macos/Desktop/Tests/ChatCitationTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatCitationTests.swift
@@ -10,6 +10,14 @@ final class ChatCitationTests: XCTestCase {
       [20, 27, 3, 20])
   }
 
+  func testOrdinalParserAcceptsKindPrefixedMarkersAndIgnoresBareKindLabels() {
+    XCTAssertEqual(
+      ChatCitationMarkup.ordinals(
+        in: "Copied label [memory 5023] then [memory:5001] and [TASK 12]. Bare [memory] stays prose."
+      ),
+      [5023, 5001, 12])
+  }
+
   func testOrdinalParserIgnoresInlineCodeAndNumericMarkdownLinks() {
     XCTAssertEqual(
       ChatCitationMarkup.ordinals(
@@ -117,6 +125,7 @@ final class ChatCitationTests: XCTestCase {
     XCTAssertEqual(ledger.marker(kind: .task, sourceID: "task-1"), "[5002]")
     XCTAssertNil(ledger.marker(kind: .goal, sourceID: "goal-1"))
     XCTAssertTrue(ledger.responseInstruction?.contains("Do not claim to provide citations") == true)
+    XCTAssertTrue(ledger.responseInstruction?.contains("Never write [memory]") == true)
   }
 
   func testPromptAndToolReferencesCanCoexistInOneAnswer() {
@@ -294,5 +303,306 @@ final class ChatCitationTests: XCTestCase {
     RewindCitationFocusState.shared.request(42)
     XCTAssertEqual(RewindCitationFocusState.shared.consume(), 42)
     XCTAssertNil(RewindCitationFocusState.shared.consume())
+  }
+
+  func testRegistryConsumeFallsBackToUniqueRunWhenAttemptIdDiffers() async {
+    let runID = UUID().uuidString
+    let sources = [
+      APIClient.ToolSource(
+        kind: "conversation", sourceID: "conversation-20", title: "Planning", preview: "Ship the beta",
+        createdAt: nil, momentTimestampMs: nil, appName: nil, url: nil)
+    ]
+    _ = await ChatCitationProvenanceRegistry.shared.register(
+      sources, runID: runID, attemptID: "tool-attempt")
+
+    let snapshot = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
+      runID: runID, attemptID: "query-attempt")
+
+    XCTAssertEqual(snapshot.references.map(\.sourceID), ["conversation-20"])
+    XCTAssertEqual(snapshot.references.first?.ordinal, 1)
+  }
+
+  func testRegistryConsumeFallsBackWhenTerminalAttemptIdIsEmpty() async {
+    let runID = UUID().uuidString
+    let sources = [
+      APIClient.ToolSource(
+        kind: "memory", sourceID: "memory-9", title: "Preference", preview: "Uses Omi Beta",
+        createdAt: nil, momentTimestampMs: nil, appName: nil, url: nil)
+    ]
+    _ = await ChatCitationProvenanceRegistry.shared.register(
+      sources, runID: runID, attemptID: "tool-attempt")
+
+    let snapshot = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
+      runID: runID, attemptID: "")
+
+    XCTAssertEqual(snapshot.references.map(\.sourceID), ["memory-9"])
+  }
+
+  func testRegistryConsumeDoesNotGuessWhenMultipleAttemptsShareARun() async {
+    let runID = UUID().uuidString
+    let first = [
+      APIClient.ToolSource(
+        kind: "task", sourceID: "task-1", title: "One", preview: "One",
+        createdAt: nil, momentTimestampMs: nil, appName: nil, url: nil)
+    ]
+    let second = [
+      APIClient.ToolSource(
+        kind: "task", sourceID: "task-2", title: "Two", preview: "Two",
+        createdAt: nil, momentTimestampMs: nil, appName: nil, url: nil)
+    ]
+    _ = await ChatCitationProvenanceRegistry.shared.register(
+      first, runID: runID, attemptID: "attempt-a")
+    _ = await ChatCitationProvenanceRegistry.shared.register(
+      second, runID: runID, attemptID: "attempt-b")
+
+    let snapshot = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
+      runID: runID, attemptID: "attempt-missing")
+
+    XCTAssertTrue(snapshot.references.isEmpty)
+    let exact = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
+      runID: runID, attemptID: "attempt-a")
+    XCTAssertEqual(exact.references.map(\.sourceID), ["task-1"])
+  }
+
+  func testCitationEncodeKeepsTypedBlocksWhenASiblingIsNotJSON() throws {
+    let reference = ChatCitationReference(
+      ordinal: 21, kind: .conversation, sourceID: "conversation-21", title: "Demo notes")
+    let encoded = try XCTUnwrap(
+      ChatContentBlockCodec.encode([
+        .citation(id: "citation-21", reference: reference),
+        .questionCard(
+          id: "question-1",
+          questionId: "question-1",
+          text: "Which task?",
+          subjectKind: "task",
+          subjectId: "task-1",
+          options: [["label": Date()]],
+          selectedOptionId: nil),
+      ]))
+    let decoded = try XCTUnwrap(ChatContentBlockCodec.decode(encoded))
+    XCTAssertEqual(decoded.count, 1)
+    guard case .citation(_, let restored) = decoded[0] else {
+      return XCTFail("Expected the citation to survive an unserializable sibling")
+    }
+    XCTAssertEqual(restored, reference)
+  }
+
+  func testCitationCodecDecodesNSNumberOrdinals() throws {
+    let encoded = try JSONSerialization.data(
+      withJSONObject: [
+        [
+          "type": "citation",
+          "id": "citation-3",
+          "ordinal": NSNumber(value: 3),
+          "kind": "conversation",
+          "sourceId": "conversation-3",
+          "title": "Saturday recap",
+          "preview": "Worked on Omi",
+        ]
+      ])
+    let decoded = try XCTUnwrap(
+      ChatContentBlockCodec.decode(String(data: encoded, encoding: .utf8) ?? ""))
+    guard case .citation(_, let restored) = try XCTUnwrap(decoded.first) else {
+      return XCTFail("Expected NSNumber ordinals to decode")
+    }
+    XCTAssertEqual(restored.ordinal, 3)
+    XCTAssertEqual(restored.sourceID, "conversation-3")
+  }
+
+  @MainActor
+  func testJournalHydrateRestoresCitationBackupWhenContentBlocksVanish() throws {
+    let reference = ChatCitationReference(
+      ordinal: 20, kind: .conversation, sourceID: "conversation-20", title: "Planning")
+    let message = ChatMessage(
+      id: "turn-citation-backup",
+      text: "Worked on the launch video [20][21][3].",
+      sender: .ai,
+      contentBlocks: [.citation(id: "citation-20", reference: reference)])
+    let write = message.journalWrite(origin: "legacy", status: .completed)
+    XCTAssertTrue(write.metadataJSON.contains("\"type\":\"citation\""))
+
+    let turn = try XCTUnwrap(
+      KernelJournalTurn(dictionary: [
+        "turnId": "turn-citation-backup",
+        "role": "assistant",
+        "content": message.text,
+        "status": "completed",
+        "contentBlocks": [],
+        "metadataJson": write.metadataJSON,
+        "createdAtMs": 1,
+      ]))
+    let restored = turn.chatMessage()
+    XCTAssertEqual(restored.inlineCitationReferences, [reference])
+  }
+
+  func testToolCallOutputRecoversTypedCitationLedger() {
+    let original = ChatCitationReference(
+      ordinal: 14, kind: .conversation, sourceID: "conversation-14", title: "Backend costs")
+    let annotated = ChatCitationProvenanceRegistry.annotatedToolResult(
+      "Conversation #14: backend costs", references: [original])
+    let recovered = ChatCitationProvenanceRegistry.references(
+      fromToolCallBlocks: [
+        .toolCall(
+          id: "tool-1",
+          name: "get_conversations",
+          status: .completed,
+          toolUseId: "use-1",
+          input: nil,
+          output: annotated)
+      ])
+    XCTAssertEqual(recovered, [original])
+  }
+
+  func testTruncatedEnvelopeExposesRunAndAttemptForLedgerPeek() {
+    let output = """
+      {"ok":false,"error":{"code":"tool_result_projection_exceeded_budget"},\
+      "toolResultEnvelope":{"version":1,"status":"failed","truncated":true,\
+      "provenance":{"runId":"run-truncated","attemptId":"att-truncated","toolName":"get_daily_recap"}}}
+      """
+    let ids = ChatCitationProvenanceRegistry.provenanceIDs(fromToolOutput: output)
+    XCTAssertEqual(ids?.runID, "run-truncated")
+    XCTAssertEqual(ids?.attemptID, "att-truncated")
+  }
+
+  func testKindOnlyLabelsBindByClaimOverlap() {
+    let memory = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1", title: "Launch",
+      preview: "Ship the beta recap on Wednesday")
+    let other = ChatCitationReference(
+      ordinal: 8002, kind: .memory, sourceID: "m2", title: "Unrelated",
+      preview: "Grocery list and milk")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "You shipped the beta recap [memory]",
+      using: [memory, other])
+    XCTAssertEqual(resolved.text, "You shipped the beta recap [8001]")
+    XCTAssertEqual(resolved.references, [memory])
+  }
+
+  func testKindOnlyLabelsBindUniqueSourceOfThatKind() {
+    let conversation = ChatCitationReference(
+      ordinal: 12, kind: .conversation, sourceID: "c1", title: "Standup")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "Catch-up notes [conversation]",
+      using: [conversation])
+    XCTAssertEqual(resolved.text, "Catch-up notes [12]")
+  }
+
+  func testSearchPassDoesNotUniqueBindAOneHitMemory() {
+    let memory = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1",
+      preview: "GLM key has rate limiting issues during live tests")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "PR reliability fix exceeded the expected 10K char limit [memory]",
+      using: [memory],
+      allowUniqueKindFallback: false)
+    XCTAssertEqual(
+      resolved.text, "PR reliability fix exceeded the expected 10K char limit [memory]")
+    XCTAssertTrue(resolved.references.isEmpty)
+  }
+
+  func testKindOnlyLabelsStayInertWithoutOverlap() {
+    let first = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1", preview: "Alpha project timeline")
+    let second = ChatCitationReference(
+      ordinal: 8002, kind: .memory, sourceID: "m2", preview: "Beta grocery list")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "Something vague happened [memory]",
+      using: [first, second])
+    XCTAssertEqual(resolved.text, "Something vague happened [memory]")
+    XCTAssertTrue(resolved.references.isEmpty)
+  }
+
+  func testKindOnlyLabelsDoNotBindOnSharedSubstrings() {
+    let memory = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1",
+      preview: "GLM key has rate limiting issues during live tests")
+    let other = ChatCitationReference(
+      ordinal: 8002, kind: .memory, sourceID: "m2",
+      preview: "Unrelated grocery list and milk run")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "PR reliability fix exceeded the expected 10K char limit [memory]",
+      using: [memory, other])
+    XCTAssertEqual(
+      resolved.text, "PR reliability fix exceeded the expected 10K char limit [memory]")
+    XCTAssertTrue(resolved.references.isEmpty)
+  }
+
+  func testKindOnlyLabelsBindBoldClaimPhrases() {
+    let memory = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1",
+      preview: "The brain map is empty and new memories are not stored")
+    let other = ChatCitationReference(
+      ordinal: 8002, kind: .memory, sourceID: "m2",
+      preview: "Installer onboarding problems on new computers")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "- **Brain map is empty** — flagged as a critical bug [memory]",
+      using: [memory, other])
+    XCTAssertEqual(resolved.text, "- **Brain map is empty** — flagged as a critical bug [8001]")
+    XCTAssertEqual(resolved.references, [memory])
+  }
+
+  func testKindOnlySearchQueryPrefersBoldPhrase() {
+    let queries = ChatCitationMarkup.kindOnlySearchQueries(
+      in: "- **TikTok to X loop** — adapt winners [memory]")
+    XCTAssertEqual(queries.map(\.query), ["tiktok to x loop"])
+  }
+
+  func testKindPrefixedNumericMarkersAreNotRewrittenAsKindOnly() {
+    let memory = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1", preview: "Ship the beta recap")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "Copied label [memory 5023] after the recap.",
+      using: [memory])
+    XCTAssertEqual(resolved.text, "Copied label [memory 5023] after the recap.")
+  }
+
+  func testAppendLookupAssignsDisjointOrdinalsAndDedupes() {
+    let existing = ChatCitationReference(
+      ordinal: 5001, kind: .memory, sourceID: "m1", preview: "Prompt")
+    let extraSame = ChatCitationReference(
+      ordinal: 1, kind: .memory, sourceID: "m1", preview: "Ignored")
+    let extraNew = ChatCitationReference(
+      ordinal: 1, kind: .conversation, sourceID: "c1", title: "Talk")
+    let merged = ChatCitationReference.appendingLookup([extraSame, extraNew], to: [existing])
+    XCTAssertEqual(merged.map(\.ordinal), [5001, 8001])
+    XCTAssertEqual(merged.map(\.sourceID), ["m1", "c1"])
+  }
+
+  func testMessageRewritePersistsBoundCitationBlocks() {
+    var message = ChatMessage(
+      id: "ai-1",
+      text: "Shipped the beta recap [memory]",
+      sender: .ai,
+      contentBlocks: [.text(id: "t1", text: "Shipped the beta recap [memory]")])
+    let memory = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1",
+      preview: "Shipped the beta recap on Wednesday")
+    message.bindInlineCitations(using: [memory])
+    XCTAssertEqual(message.text, "Shipped the beta recap [8001]")
+    guard case .text(_, let blockText) = message.contentBlocks[0] else {
+      return XCTFail("Expected the rewritten text block to remain first")
+    }
+    XCTAssertEqual(blockText, "Shipped the beta recap [8001]")
+    XCTAssertEqual(message.inlineCitationReferences, [memory])
+  }
+
+  func testPeekSnapshotLeavesLedgerForLaterConsume() async {
+    let runID = UUID().uuidString
+    let attemptID = UUID().uuidString
+    let sources = [
+      APIClient.ToolSource(
+        kind: "conversation", sourceID: "conversation-20", title: "Planning", preview: "Ship",
+        createdAt: nil, momentTimestampMs: nil, appName: nil, url: nil)
+    ]
+    _ = await ChatCitationProvenanceRegistry.shared.register(
+      sources, runID: runID, attemptID: attemptID)
+
+    let peeked = await ChatCitationProvenanceRegistry.shared.peekSnapshot(
+      runID: runID, attemptID: attemptID)
+    let consumed = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
+      runID: runID, attemptID: attemptID)
+
+    XCTAssertEqual(peeked.references.map(\.sourceID), ["conversation-20"])
+    XCTAssertEqual(consumed.references.map(\.sourceID), ["conversation-20"])
   }
 }

--- a/desktop/macos/Desktop/Tests/ChatCitationTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatCitationTests.swift
@@ -318,8 +318,12 @@ final class ChatCitationTests: XCTestCase {
     let snapshot = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
       runID: runID, attemptID: "query-attempt")
 
-    XCTAssertEqual(snapshot.references.map(\.sourceID), ["conversation-20"])
-    XCTAssertEqual(snapshot.references.first?.ordinal, 1)
+    XCTAssertTrue(
+      snapshot.references.isEmpty,
+      "a non-empty mismatched attempt must not consume another attempt's ledger")
+    let remaining = await ChatCitationProvenanceRegistry.shared.consumeSnapshot(
+      runID: runID, attemptID: "tool-attempt")
+    XCTAssertEqual(remaining.references.map(\.sourceID), ["conversation-20"])
   }
 
   func testRegistryConsumeFallsBackWhenTerminalAttemptIdIsEmpty() async {
@@ -500,6 +504,18 @@ final class ChatCitationTests: XCTestCase {
     XCTAssertTrue(resolved.references.isEmpty)
   }
 
+  func testKindOnlyLabelsStayInertWhenOverlapTies() {
+    let first = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1", preview: "Shipped the beta recap")
+    let second = ChatCitationReference(
+      ordinal: 8002, kind: .memory, sourceID: "m2", preview: "Shipped the beta recap")
+    let resolved = ChatCitationMarkup.resolvingKindLabels(
+      in: "You shipped the beta recap [memory]",
+      using: [first, second])
+    XCTAssertEqual(resolved.text, "You shipped the beta recap [memory]")
+    XCTAssertTrue(resolved.references.isEmpty)
+  }
+
   func testKindOnlyLabelsStayInertWithoutOverlap() {
     let first = ChatCitationReference(
       ordinal: 8001, kind: .memory, sourceID: "m1", preview: "Alpha project timeline")
@@ -584,6 +600,86 @@ final class ChatCitationTests: XCTestCase {
     }
     XCTAssertEqual(blockText, "Shipped the beta recap [8001]")
     XCTAssertEqual(message.inlineCitationReferences, [memory])
+  }
+
+  func testSelectedSourceFallbackLandsOnVisibleAnswerBlock() {
+    var message = ChatMessage(
+      id: "ai-1",
+      text: "Looking that up.\n\nYou filmed the launch.",
+      sender: .ai,
+      contentBlocks: [
+        .text(id: "commentary", text: "Looking that up."),
+        .toolCall(id: "tool", name: "execute_sql", status: .completed),
+        .text(id: "answer", text: "You filmed the launch."),
+      ])
+    let source = ChatCitationReference(
+      ordinal: 12, kind: .conversation, sourceID: "c1", title: "Launch")
+    message.applySelectedSourceFallback(
+      selectedReferences: [source],
+      requestedSources: true,
+      retrievedReferences: [source])
+    XCTAssertEqual(message.visibleAnswerText, "You filmed the launch.\n\nSources: [12]")
+    XCTAssertTrue(message.text.contains("Sources: [12]"))
+  }
+
+  func testRequestedSourcesRailUsesTurnLedgerNotLookupCorpus() {
+    var message = ChatMessage(
+      id: "ai-1",
+      text: "You filmed the launch.",
+      sender: .ai,
+      contentBlocks: [.text(id: "answer", text: "You filmed the launch.")])
+    let turn = ChatCitationReference(
+      ordinal: 3, kind: .conversation, sourceID: "c1", title: "Launch")
+    message.applySelectedSourceFallback(
+      selectedReferences: [],
+      requestedSources: true,
+      retrievedReferences: [turn])
+    XCTAssertEqual(message.visibleAnswerText, "You filmed the launch.\n\nSources: [3]")
+
+    var unanswered = ChatMessage(
+      id: "ai-2",
+      text: "You filmed the launch.",
+      sender: .ai,
+      contentBlocks: [.text(id: "answer", text: "You filmed the launch.")])
+    unanswered.applySelectedSourceFallback(
+      selectedReferences: [],
+      requestedSources: true,
+      retrievedReferences: [])
+    XCTAssertEqual(unanswered.visibleAnswerText, "You filmed the launch.")
+    XCTAssertFalse(unanswered.visibleAnswerText.contains("[8001]"))
+  }
+
+  func testSelectedSourceFallbackSeedsEmptyRowFromQueryText() {
+    var message = ChatMessage(id: "ai-1", text: "", sender: .ai)
+    let source = ChatCitationReference(
+      ordinal: 4, kind: .memory, sourceID: "m1", title: "Note")
+    message.applySelectedSourceFallback(
+      selectedReferences: [source],
+      requestedSources: false,
+      retrievedReferences: [source],
+      fallbackText: "The note is empty.")
+    XCTAssertEqual(message.visibleAnswerText, "The note is empty.\n\nSources: [4]")
+  }
+
+  func testCitationBackupDropsDuplicateOrdinals() {
+    let first = ChatCitationReference(
+      ordinal: 7, kind: .memory, sourceID: "m1", title: "One")
+    let duplicate = ChatCitationReference(
+      ordinal: 7, kind: .memory, sourceID: "m2", title: "Two")
+    let extra = ChatCitationReference(
+      ordinal: 8, kind: .conversation, sourceID: "c1", title: "Talk")
+    let merged = ChatContentBlockCodec.mergingCitationBackup(
+      [],
+      backup: [
+        .citation(id: "a", reference: first),
+        .citation(id: "b", reference: duplicate),
+        .citation(id: "c", reference: extra),
+      ])
+    let ordinals = merged.compactMap { block -> Int? in
+      guard case .citation(_, let reference) = block else { return nil }
+      return reference.ordinal
+    }
+    XCTAssertEqual(ordinals, [7, 8])
   }
 
   func testPeekSnapshotLeavesLedgerForLaterConsume() async {

--- a/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
@@ -269,6 +269,51 @@ final class ChatJournalWritePathTests: XCTestCase {
     XCTAssertEqual(carried.rating, -1, "A nil projected rating falls back to the local value")
   }
 
+  func testProjectionCarryingHelperKeepsBoundCitationsAcrossKindOnlyJournalEcho() {
+    let bound = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1", preview: "Brain map is empty")
+    var existing = ChatMessage(
+      id: "m",
+      text: "The brain map is empty [8001]",
+      sender: .ai,
+      contentBlocks: [
+        .text(id: "t", text: "The brain map is empty [8001]"),
+        .citation(id: "citation-8001-m1", reference: bound),
+      ])
+    existing.rating = 1
+    let projected = ChatMessage(
+      id: "m",
+      text: "The brain map is empty [memory]",
+      sender: .ai,
+      contentBlocks: [.text(id: "t", text: "The brain map is empty [memory]")])
+
+    let merged = ChatProvider.carryingLocalOnlyFields(projected, from: existing)
+    XCTAssertEqual(merged.text, existing.text)
+    XCTAssertEqual(merged.inlineCitationReferences, [bound])
+    XCTAssertEqual(merged.rating, 1)
+  }
+
+  func testAcceptedTerminalContentUsesVisibleAnswerNotCommentaryConcatenation() {
+    let message = ChatMessage(
+      id: "turn-commentary",
+      text: "Let me look that up.\n\nYou filmed the launch video.",
+      sender: .ai,
+      contentBlocks: [
+        .text(id: "commentary", text: "Let me look that up."),
+        .toolCall(id: "tool", name: "execute_sql", status: .completed),
+        .text(id: "answer", text: "You filmed the launch video."),
+      ])
+    let accepted = message.visibleAnswerText
+    XCTAssertEqual(accepted, "You filmed the launch video.")
+    let blocks = KernelTurnProjection.acceptedTerminalContentBlocks(
+      message: message, acceptedContent: accepted)
+    guard case .text(_, let text) = blocks.first else {
+      return XCTFail("Terminal payload must start with the visible answer")
+    }
+    XCTAssertEqual(text, "You filmed the launch video.")
+    XCTAssertFalse(text.contains("Let me look that up"))
+  }
+
   // MARK: - Helpers
 
   private func makeTurn(

--- a/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatJournalWritePathTests.swift
@@ -293,6 +293,37 @@ final class ChatJournalWritePathTests: XCTestCase {
     XCTAssertEqual(merged.rating, 1)
   }
 
+  func testProjectionCarryingHelperKeepsBoundCitationsWhenCommentaryStillHasKindOnly() {
+    let bound = ChatCitationReference(
+      ordinal: 8001, kind: .memory, sourceID: "m1", preview: "You filmed the launch")
+    var existing = ChatMessage(
+      id: "m",
+      text: "Looking that up [memory]\n\nYou filmed the launch [8001]",
+      sender: .ai,
+      contentBlocks: [
+        .text(id: "commentary", text: "Looking that up [memory]"),
+        .toolCall(id: "tool", name: "execute_sql", status: .completed),
+        .text(id: "answer", text: "You filmed the launch [8001]"),
+        .citation(id: "citation-8001-m1", reference: bound),
+      ])
+    existing.rating = 1
+    let projected = ChatMessage(
+      id: "m",
+      text: "Looking that up [memory]\n\nYou filmed the launch [memory]",
+      sender: .ai,
+      contentBlocks: [
+        .text(id: "commentary", text: "Looking that up [memory]"),
+        .toolCall(id: "tool", name: "execute_sql", status: .completed),
+        .text(id: "answer", text: "You filmed the launch [memory]"),
+      ])
+
+    let merged = ChatProvider.carryingLocalOnlyFields(projected, from: existing)
+    XCTAssertEqual(merged.text, existing.text)
+    XCTAssertEqual(merged.inlineCitationReferences, [bound])
+    XCTAssertEqual(merged.visibleAnswerText, "You filmed the launch [8001]")
+    XCTAssertEqual(merged.rating, 1)
+  }
+
   func testAcceptedTerminalContentUsesVisibleAnswerNotCommentaryConcatenation() {
     let message = ChatMessage(
       id: "turn-commentary",

--- a/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
@@ -83,6 +83,73 @@ final class ChatTimelineContinuityTests: XCTestCase {
     XCTAssertFalse(settled.contains(where: isToolCalls))
   }
 
+  func testContentBlocksPathRendersToolGroupsBeforeTruncatedAnswer() throws {
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    // omi-test-quality: source-inspection -- static contract: SwiftUI ViewBuilder order of live tool chips vs truncated answer cannot be observed without mounting ChatBubble.
+    let source = try String(
+      contentsOf: root.appendingPathComponent("Sources/MainWindow/Components/ChatBubble.swift"),
+      encoding: .utf8
+    )
+
+    guard
+      let functionRange = source.range(
+        of: "private func messageContentView(_ groupedBlocks: [ContentBlockGroup]) -> some View {"
+      )
+    else {
+      return XCTFail("messageContentView must exist")
+    }
+    let functionBody = source[functionRange.upperBound...]
+    guard
+      let contentBlocksRange = functionBody.range(
+        of: "else if message.sender == .ai && !message.contentBlocks.isEmpty {"
+      )
+    else {
+      return XCTFail("content-blocks branch must exist")
+    }
+    let afterContentBlocks = functionBody[contentBlocksRange.upperBound...]
+    guard
+      let nextBranchRange = afterContentBlocks.range(of: "} else if isDuplicate && !isExpanded {")
+    else {
+      return XCTFail("content-blocks branch must be followed by the duplicate-message path")
+    }
+    let contentBlocksBranch = afterContentBlocks[..<nextBranchRange.lowerBound]
+
+    guard let groupsIndex = contentBlocksBranch.range(of: "ForEach(groupedBlocks)")?.lowerBound else {
+      return XCTFail("content-blocks path must iterate groupedBlocks")
+    }
+    guard let groupViewIndex = contentBlocksBranch.range(of: "groupView(group)")?.lowerBound else {
+      return XCTFail("content-blocks path must render non-text groups via groupView")
+    }
+    guard let answerIndex = contentBlocksBranch.range(of: "messageTextBubble(displayText)")?.lowerBound else {
+      return XCTFail("content-blocks path must still render truncated displayText")
+    }
+
+    XCTAssertLessThan(
+      groupsIndex,
+      answerIndex,
+      "tool/rich groups must render above the truncated answer on the content-blocks path"
+    )
+    XCTAssertLessThan(
+      groupViewIndex,
+      answerIndex,
+      "non-text groupView must appear before messageTextBubble(displayText)"
+    )
+    XCTAssertTrue(
+      contentBlocksBranch.contains("if case .text = group"),
+      "duplicate .text groups must stay skipped when the answer bubble already renders"
+    )
+    XCTAssertTrue(
+      contentBlocksBranch.contains("message.visibleAnswerText"),
+      "content-blocks path must render post-tool answer text, not concatenated commentary"
+    )
+    XCTAssertTrue(
+      contentBlocksBranch.contains("truncationControl"),
+      "long answers on the content-blocks path must keep Show more/less"
+    )
+  }
+
   func testCopyableTextIncludesOnlyFinalAssistantOutput() {
     let message = ChatMessage(
       text: "Fallback answer",
@@ -105,6 +172,103 @@ final class ChatTimelineContinuityTests: XCTestCase {
     )
 
     XCTAssertEqual(message.copyableText, "Visible final answer")
+  }
+
+  func testPreToolCommentaryIsNotTheVisibleOrCopyableAnswer() {
+    let preamble = ChatContentBlock.text(id: "preamble", text: "Let me look that up.")
+    let tool = ChatContentBlock.toolCall(
+      id: "tool_1",
+      name: "get_daily_recap",
+      status: .completed,
+      output: "recap"
+    )
+    let answer = ChatContentBlock.text(
+      id: "answer",
+      text: "You filmed the launch video and tested the memory graph."
+    )
+    let concatenated = "Let me look that up.You filmed the launch video and tested the memory graph."
+    let streaming = ChatMessage(
+      text: concatenated,
+      sender: .ai,
+      isStreaming: true,
+      contentBlocks: [preamble, tool, answer]
+    )
+    let settled = ChatMessage(
+      text: concatenated,
+      sender: .ai,
+      isStreaming: false,
+      contentBlocks: [preamble, tool, answer]
+    )
+
+    XCTAssertEqual(streaming.visibleAnswerText, "You filmed the launch video and tested the memory graph.")
+    XCTAssertEqual(settled.copyableText, "You filmed the launch video and tested the memory graph.")
+    XCTAssertEqual(
+      ChatAssistantAnswerText.visible(
+        contentBlocks: [preamble, tool],
+        fallback: concatenated,
+        isStreaming: true
+      ),
+      "",
+      "hide commentary while tools run and no post-tool answer exists yet"
+    )
+
+    let streamingGroups = ContentBlockGroup.visibleChatGroups(
+      [preamble, tool, answer], isStreaming: true)
+    XCTAssertFalse(
+      streamingGroups.contains { group in
+        if case .text(_, let text) = group { return text.contains("look that up") }
+        return false
+      })
+    XCTAssertTrue(
+      streamingGroups.contains { group in
+        if case .commentary(_, let text) = group { return text.contains("look that up") }
+        return false
+      },
+      "pre-tool commentary must render as live progress while the turn is streaming"
+    )
+    XCTAssertTrue(
+      streamingGroups.contains { group in
+        if case .toolCalls = group { return true }
+        return false
+      })
+    XCTAssertTrue(
+      streamingGroups.contains { group in
+        if case .text(_, let text) = group {
+          return text.contains("filmed the launch video")
+        }
+        return false
+      })
+
+    let settledGroups = ContentBlockGroup.visibleChatGroups(
+      [preamble, tool, answer], isStreaming: false)
+    XCTAssertFalse(
+      settledGroups.contains { group in
+        if case .commentary = group { return true }
+        return false
+      })
+    XCTAssertFalse(
+      settledGroups.contains { group in
+        if case .toolCalls = group { return true }
+        return false
+      })
+    XCTAssertEqual(settled.copyableText, "You filmed the launch video and tested the memory graph.")
+  }
+
+  func testSettledPreToolTextRemainsWhenItIsTheOnlyAnswer() {
+    let blocks: [ChatContentBlock] = [
+      .text(id: "text_1", text: "I started a background agent for that."),
+      .toolCall(id: "tool_1", name: "spawn_agent", status: .completed, output: "started"),
+    ]
+    XCTAssertEqual(
+      ChatAssistantAnswerText.visible(
+        contentBlocks: blocks, fallback: "I started a background agent for that.", isStreaming: false),
+      "I started a background agent for that.")
+    let settled = ContentBlockGroup.visibleChatGroups(blocks, isStreaming: false)
+    XCTAssertEqual(settled.count, 1)
+    guard case .text(_, let text) = settled[0] else {
+      return XCTFail("settled pre-tool text must remain when it is the only answer")
+    }
+    XCTAssertEqual(text, "I started a background agent for that.")
   }
 
   func testFloatingResponseCopiesTheSharedFinalOutputProjection() throws {

--- a/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTimelineContinuityTests.swift
@@ -271,6 +271,24 @@ final class ChatTimelineContinuityTests: XCTestCase {
     XCTAssertEqual(text, "I started a background agent for that.")
   }
 
+  func testWhitespaceOnlyPostToolTextDoesNotDropSettledCommentary() {
+    let blocks: [ChatContentBlock] = [
+      .text(id: "text_1", text: "I started a background agent for that."),
+      .toolCall(id: "tool_1", name: "spawn_agent", status: .completed, output: "started"),
+      .text(id: "text_2", text: " \n "),
+    ]
+    XCTAssertEqual(
+      ChatAssistantAnswerText.visible(
+        contentBlocks: blocks, fallback: "I started a background agent for that.", isStreaming: false),
+      "I started a background agent for that.")
+    let settled = ContentBlockGroup.visibleChatGroups(blocks, isStreaming: false)
+    XCTAssertEqual(settled.count, 1)
+    guard case .text(_, let text) = settled[0] else {
+      return XCTFail("whitespace after a tool must not hide the settled pre-tool answer")
+    }
+    XCTAssertEqual(text, "I started a background agent for that.")
+  }
+
   func testFloatingResponseCopiesTheSharedFinalOutputProjection() throws {
     let root = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()

--- a/desktop/macos/Desktop/Tests/OmiMarkdownCitationInteractionTests.swift
+++ b/desktop/macos/Desktop/Tests/OmiMarkdownCitationInteractionTests.swift
@@ -89,4 +89,31 @@ final class OmiMarkdownCitationInteractionTests: XCTestCase {
 
     XCTAssertEqual(table.rows.first?[1], "Build notes [1]")
   }
+
+  func testCitationMaskKeepsAdjacentMarkersOnRecapBullets() throws {
+    let references = [20, 21, 3].map {
+      ChatCitationReference(
+        ordinal: $0, kind: .conversation, sourceID: "conversation-\($0)", title: "Source \($0)")
+    }
+    let mask = try XCTUnwrap(
+      ChatCitationMask.mask(
+        "- Worked on the launch/demo video [20][21][3]",
+        references: Dictionary(uniqueKeysWithValues: references.map { ($0.ordinal, $0) })))
+
+    XCTAssertEqual(mask.markers.map(\.reference.ordinal), [20, 21, 3])
+  }
+
+  func testCitationMaskPromotesKindPrefixedMemoryMarkers() throws {
+    let references = [5023, 5001].map {
+      ChatCitationReference(
+        ordinal: $0, kind: .memory, sourceID: "memory-\($0)", title: "Source \($0)")
+    }
+    let mask = try XCTUnwrap(
+      ChatCitationMask.mask(
+        "- Formalizing the content testing loop [memory 5023][memory:5001]. Bare [memory] stays prose.",
+        references: Dictionary(uniqueKeysWithValues: references.map { ($0.ordinal, $0) })))
+
+    XCTAssertEqual(mask.markers.map(\.reference.ordinal), [5023, 5001])
+    XCTAssertTrue(mask.markdown.contains("Bare [memory] stays prose."))
+  }
 }

--- a/desktop/macos/agent/src/runtime/types.ts
+++ b/desktop/macos/agent/src/runtime/types.ts
@@ -124,6 +124,20 @@ export type ConversationContentBlock =
   | { type: "goalLink"; id: string; goalId: string; summary: string }
   | { type: "captureLink"; id: string; conversationId: string; momentTimestampMs?: number; summary: string }
   | { type: "conversationLink"; id: string; conversationId: string; summary: string }
+  | { type: "memoryLink"; id: string; memoryId: string; summary: string }
+  | {
+      type: "citation";
+      id: string;
+      ordinal: number;
+      kind: string;
+      sourceId: string;
+      title?: string;
+      preview?: string;
+      momentTimestampMs?: number;
+      createdAt?: string;
+      appName?: string;
+      url?: string;
+    }
   | {
       type: "agentSpawn";
       id: string;

--- a/desktop/macos/changelog/unreleased/20260815-chat-pretool-commentary.json
+++ b/desktop/macos/changelog/unreleased/20260815-chat-pretool-commentary.json
@@ -1,0 +1,3 @@
+{
+  "change": "Show the model's pre-tool commentary as live progress on the tool rail, then drop it with the chips so only the final answer remains"
+}

--- a/desktop/macos/changelog/unreleased/20260815-clickable-chat-citations.json
+++ b/desktop/macos/changelog/unreleased/20260815-clickable-chat-citations.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed chat source citations so numbered markers and kind-only labels such as [memory] stay tappable and open the matching conversation, memory, task, or Rewind moment"
+}


### PR DESCRIPTION
## Summary
- Recap answers that copied `[memory]` / `[conversation]` now bind to typed local sources by claim overlap and become tappable chips, including already-settled bubbles after journal hydrate.
- Pre-tool model commentary stays on the tool rail while streaming, then drops so the settled answer, copy text, and journal payload are the visible answer only.
- Search unique-bind, stale message indexes after await, and journal echoes that wiped bound chips are closed.
- Sources rail now lands on the visible answer block (not just concatenated `message.text`), unique-run citation fallback requires an empty attempt ID, and lookup-only local rows are not dumped as “Sources”.

## Invariants
- INV-CHAT-1
- INV-AGENT-*
- INV-AUTH-1

## Failure class
Failure-Class: none

This is a presentation-binding repair (kind-only labels → typed provenance, commentary vs answer) rather than a recurring ownership-class regression.

## Line-count exceptions
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 2704 -> 2708 | Pass citation chips into floating markdown so notch recaps stay tappable
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift | 1988 -> 2071 | Commentary groups, truncation on visible answer, and citation chip wiring stay on the bubble owner
Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatToolExecutor.swift | 3411 -> 3468 | Recap and SQL tools register typed citation provenance at the executor that already owns those results

## Test plan
- [x] `ChatCitationTests`, `ChatJournalWritePathTests`, `ChatTimelineContinuityTests`, `OmiMarkdownCitationInteractionTests` via `desktop/macos/scripts/dev-feedback.py` (102 tests, 0 failures)
- [x] Named QA bundle `/Applications/omi-clickable-citations-fix.app`: Wednesday recap `[memory]`/`[conversation]` labels became numbered chips that matched the right memories and conversations
- [ ] CI Desktop Swift Build & Tests green
