### PR TITLE
fix(gateway): price GPT-5.6 long-context requests at the provider's long-context rate

### DIFF
--- a/backend/llm_gateway/config/cost_rate_cards.yaml
+++ b/backend/llm_gateway/config/cost_rate_cards.yaml
@@ -4,6 +4,16 @@
 # The ledger deliberately marks models without a card as `unpriced`, rather
 # than pretending their COGS are zero. Update cards from the provider's public
 # pricing page and create a new ID when a rate changes.
+#
+# Long-context tier: some providers publish a second, pricier band once a
+# request's total input context (cached + uncached + cache-write tokens)
+# crosses a threshold; the higher rates then apply to the whole request, not
+# just the tokens past the boundary. A card represents this with the
+# `long_context_*` fields alongside its normal (short-context) fields; a card
+# with none of those fields is single-tier and unaffected. This is additive
+# schema, not a rate change to the short-context fields, so it does not by
+# itself require a new rate_card_id — see the OpenAI GPT-5.6 cards below for
+# the reasoning on why their existing ID was kept.
 rate_cards:
   - rate_card_id: openai.gpt-5-nano.2026-07-17
     provider: openai
@@ -19,6 +29,25 @@ rate_cards:
     cached_input_micro_usd_per_million: 20000
     output_micro_usd_per_million: 1250000
 
+  # The GPT-5.6 family (Luna/Sol/Terra) shares one context window and one
+  # long-context boundary: requests whose total input context exceeds
+  # 272,000 tokens bill input, cached input, and cache writes at 2x, and
+  # output at 1.5x, for the entire request. The 272,000-token figure is not
+  # recorded anywhere else in this repo (no gateway config or doc encodes a
+  # GPT-5.6 context threshold) — it comes from the provider's published
+  # pricing, cross-checked across independent pricing trackers on
+  # 2026-08-15: eesel.ai/blog/gpt-5-6-pricing, cometapi.com/gpt-5-6-pricing,
+  # requesty.ai/models/openai-responses/gpt-5.6-luna, and
+  # openrouter.ai/openai/gpt-5.6-terra. All agree on "more than 272K input
+  # tokens" as the boundary (i.e. the short tier covers <=272,000 tokens).
+  #
+  # Luna's long-context fields are added to its existing 2026-07-30 card
+  # rather than a new rate_card_id: the short-context values are unchanged,
+  # and 2026-07-30 was already the effective date of the provider's full
+  # (short + long) GPT-5.6 price list — only this card's short-tier-only
+  # schema was incomplete, not the provider's actual rates on that date. Sol
+  # and Terra are brand-new cards (not previously priced at all), dated to
+  # the same 2026-07-30 price list per the sources above.
   - rate_card_id: openai.gpt-5.6-luna.2026-07-30
     provider: openai
     model: gpt-5.6-luna
@@ -26,6 +55,37 @@ rate_cards:
     cached_input_micro_usd_per_million: 20000
     output_micro_usd_per_million: 1200000
     cache_write_micro_usd_per_million: 250000
+    long_context_threshold_tokens: 272000
+    long_context_input_micro_usd_per_million: 400000
+    long_context_cached_input_micro_usd_per_million: 40000
+    long_context_output_micro_usd_per_million: 1800000
+    long_context_cache_write_micro_usd_per_million: 500000
+
+  - rate_card_id: openai.gpt-5.6-sol.2026-07-30
+    provider: openai
+    model: gpt-5.6-sol
+    input_micro_usd_per_million: 5000000
+    cached_input_micro_usd_per_million: 500000
+    output_micro_usd_per_million: 30000000
+    cache_write_micro_usd_per_million: 6250000
+    long_context_threshold_tokens: 272000
+    long_context_input_micro_usd_per_million: 10000000
+    long_context_cached_input_micro_usd_per_million: 1000000
+    long_context_output_micro_usd_per_million: 45000000
+    long_context_cache_write_micro_usd_per_million: 12500000
+
+  - rate_card_id: openai.gpt-5.6-terra.2026-07-30
+    provider: openai
+    model: gpt-5.6-terra
+    input_micro_usd_per_million: 2000000
+    cached_input_micro_usd_per_million: 200000
+    output_micro_usd_per_million: 12000000
+    cache_write_micro_usd_per_million: 2500000
+    long_context_threshold_tokens: 272000
+    long_context_input_micro_usd_per_million: 4000000
+    long_context_cached_input_micro_usd_per_million: 400000
+    long_context_output_micro_usd_per_million: 18000000
+    long_context_cache_write_micro_usd_per_million: 5000000
 
   - rate_card_id: vertex.gemini-2.5-flash.2026-07-17
     provider: gemini

--- a/backend/llm_gateway/gateway/accounting.py
+++ b/backend/llm_gateway/gateway/accounting.py
@@ -175,6 +175,17 @@ class AccountingContext:
 
 
 @dataclass(frozen=True)
+class RateCardTier:
+    """The four-ish per-token rates that actually apply to one request."""
+
+    input_micro_usd_per_million: int
+    cached_input_micro_usd_per_million: int
+    output_micro_usd_per_million: int
+    cache_write_micro_usd_per_million: int | None
+    cache_write_1h_micro_usd_per_million: int | None
+
+
+@dataclass(frozen=True)
 class RateCard:
     rate_card_id: str
     provider: str
@@ -184,6 +195,44 @@ class RateCard:
     output_micro_usd_per_million: int
     cache_write_micro_usd_per_million: int | None = None
     cache_write_1h_micro_usd_per_million: int | None = None
+    # Some providers publish a second, more expensive price band once a
+    # request's total context crosses a token threshold (e.g. OpenAI's
+    # >272K-input-token band for the GPT-5.6 family). A card with no
+    # `long_context_threshold_tokens` has only the single tier above, and
+    # `effective_rates` always returns it regardless of token count.
+    long_context_threshold_tokens: int | None = None
+    long_context_input_micro_usd_per_million: int | None = None
+    long_context_cached_input_micro_usd_per_million: int | None = None
+    long_context_output_micro_usd_per_million: int | None = None
+    long_context_cache_write_micro_usd_per_million: int | None = None
+    long_context_cache_write_1h_micro_usd_per_million: int | None = None
+
+    def effective_rates(self, total_context_tokens: int) -> RateCardTier:
+        """Pick the short- or long-context tier for a request.
+
+        `total_context_tokens` must be the request's total prompt/input token
+        count (cached + uncached + cache-write) — never output tokens, which
+        do not affect which price band applies.
+        """
+        if (
+            self.long_context_threshold_tokens is not None
+            and total_context_tokens > self.long_context_threshold_tokens
+            and self.long_context_input_micro_usd_per_million is not None
+        ):
+            return RateCardTier(
+                input_micro_usd_per_million=self.long_context_input_micro_usd_per_million,
+                cached_input_micro_usd_per_million=self.long_context_cached_input_micro_usd_per_million or 0,
+                output_micro_usd_per_million=self.long_context_output_micro_usd_per_million or 0,
+                cache_write_micro_usd_per_million=self.long_context_cache_write_micro_usd_per_million,
+                cache_write_1h_micro_usd_per_million=self.long_context_cache_write_1h_micro_usd_per_million,
+            )
+        return RateCardTier(
+            input_micro_usd_per_million=self.input_micro_usd_per_million,
+            cached_input_micro_usd_per_million=self.cached_input_micro_usd_per_million,
+            output_micro_usd_per_million=self.output_micro_usd_per_million,
+            cache_write_micro_usd_per_million=self.cache_write_micro_usd_per_million,
+            cache_write_1h_micro_usd_per_million=self.cache_write_1h_micro_usd_per_million,
+        )
 
 
 @dataclass(frozen=True)
@@ -643,16 +692,27 @@ def _estimate_cost(
     rate_card = _rate_card_for(provider, model)
     if rate_card is None:
         return CostStatus.UNPRICED, None, None, None, 'rate_card_missing'
-    cache_write_rate = rate_card.cache_write_micro_usd_per_million
+    # The tier that applies is decided by total request context — cached,
+    # uncached, and cache-write input tokens together — never by output
+    # tokens, which some providers price at a different multiplier entirely.
+    # Built from the split fields rather than `usage.prompt_tokens` because
+    # that field's relationship to cache-write tokens differs by provider:
+    # OpenAI's raw `prompt_tokens` already includes cache-write tokens, while
+    # Anthropic's `input_tokens` (this codebase's `prompt_tokens`) excludes
+    # `cache_creation_input_tokens`. Summing the three split components is
+    # correct for both.
+    total_context_tokens = usage.uncached_input_tokens + usage.cached_input_tokens + usage.cache_write_tokens
+    rates = rate_card.effective_rates(total_context_tokens)
+    cache_write_rate = rates.cache_write_micro_usd_per_million
     if usage.cache_write_ttl == '1h':
-        cache_write_rate = rate_card.cache_write_1h_micro_usd_per_million
+        cache_write_rate = rates.cache_write_1h_micro_usd_per_million
     if usage.cache_write_tokens and (cache_write_rate is None or usage.cache_write_ttl == 'mixed'):
         return CostStatus.UNPRICED, None, None, rate_card.rate_card_id, 'cache_write_rate_missing_or_mixed_ttl'
 
     numerator = (
-        usage.uncached_input_tokens * rate_card.input_micro_usd_per_million
-        + usage.cached_input_tokens * rate_card.cached_input_micro_usd_per_million
-        + usage.billable_output_tokens * rate_card.output_micro_usd_per_million
+        usage.uncached_input_tokens * rates.input_micro_usd_per_million
+        + usage.cached_input_tokens * rates.cached_input_micro_usd_per_million
+        + usage.billable_output_tokens * rates.output_micro_usd_per_million
     )
     if cache_write_rate is not None:
         numerator += usage.cache_write_tokens * cache_write_rate
@@ -661,14 +721,20 @@ def _estimate_cost(
     # of that prompt-token counterfactual too, so their premium (or discount)
     # is included in the net savings.  This intentionally may be negative for
     # a cache miss whose write has not yet been amortized by a later read.
+    #
+    # "This tier's" is now literal: the counterfactual is priced with the same
+    # `rates` the bill above used, so a long-context request is compared against
+    # the long-context input rate rather than the short-context one.  Reading
+    # them from the card instead would understate the savings on exactly the
+    # requests where caching is worth the most.
     cache_savings_numerator = usage.cached_input_tokens * (
-        rate_card.input_micro_usd_per_million - rate_card.cached_input_micro_usd_per_million
+        rates.input_micro_usd_per_million - rates.cached_input_micro_usd_per_million
     )
     if usage.cache_write_tokens:
         # A missing write rate was rejected above whenever write tokens are
         # present, so this is safe after the guard at the top of this block.
         assert cache_write_rate is not None
-        cache_savings_numerator += usage.cache_write_tokens * (rate_card.input_micro_usd_per_million - cache_write_rate)
+        cache_savings_numerator += usage.cache_write_tokens * (rates.input_micro_usd_per_million - cache_write_rate)
     if provider.strip().lower() == 'openai' and traffic_type == 'flex':
         # OpenAI documents Flex tokens at Batch API rates (50% below the
         # synchronous Standard rates represented by this rate card).
@@ -711,15 +777,25 @@ def _load_rate_cards() -> dict[tuple[str, str], RateCard]:
             input_micro_usd_per_million=_nonnegative_int(item.get('input_micro_usd_per_million')),
             cached_input_micro_usd_per_million=_nonnegative_int(item.get('cached_input_micro_usd_per_million')),
             output_micro_usd_per_million=_nonnegative_int(item.get('output_micro_usd_per_million')),
-            cache_write_micro_usd_per_million=(
-                _nonnegative_int(item['cache_write_micro_usd_per_million'])
-                if item.get('cache_write_micro_usd_per_million') is not None
-                else None
+            cache_write_micro_usd_per_million=_optional_nonnegative_int(item, 'cache_write_micro_usd_per_million'),
+            cache_write_1h_micro_usd_per_million=_optional_nonnegative_int(
+                item, 'cache_write_1h_micro_usd_per_million'
             ),
-            cache_write_1h_micro_usd_per_million=(
-                _nonnegative_int(item['cache_write_1h_micro_usd_per_million'])
-                if item.get('cache_write_1h_micro_usd_per_million') is not None
-                else None
+            long_context_threshold_tokens=_optional_nonnegative_int(item, 'long_context_threshold_tokens'),
+            long_context_input_micro_usd_per_million=_optional_nonnegative_int(
+                item, 'long_context_input_micro_usd_per_million'
+            ),
+            long_context_cached_input_micro_usd_per_million=_optional_nonnegative_int(
+                item, 'long_context_cached_input_micro_usd_per_million'
+            ),
+            long_context_output_micro_usd_per_million=_optional_nonnegative_int(
+                item, 'long_context_output_micro_usd_per_million'
+            ),
+            long_context_cache_write_micro_usd_per_million=_optional_nonnegative_int(
+                item, 'long_context_cache_write_micro_usd_per_million'
+            ),
+            long_context_cache_write_1h_micro_usd_per_million=_optional_nonnegative_int(
+                item, 'long_context_cache_write_1h_micro_usd_per_million'
             ),
         )
         key = (card.provider, card.model)
@@ -789,6 +865,10 @@ def _nonnegative_int(value: object) -> int:
     if isinstance(value, float):
         return max(int(value), 0)
     return 0
+
+
+def _optional_nonnegative_int(item: Mapping[str, Any], key: str) -> int | None:
+    return _nonnegative_int(item[key]) if item.get(key) is not None else None
 
 
 def _string_or_none(value: object) -> str | None:

--- a/backend/tests/unit/test_llm_gateway_accounting.py
+++ b/backend/tests/unit/test_llm_gateway_accounting.py
@@ -131,7 +131,9 @@ def test_openai_flex_tier_is_recorded_and_priced_at_batch_rates() -> None:
     event = build_accounting_event(context, attempt)
 
     assert event.traffic_type == 'flex'
-    assert event.estimated_cost_micro_usd == 700_000
+    # 1M input + 1M output puts this over the 272K long-context boundary:
+    # (1M * $0.40 + 1M * $1.80) halved for Flex = $1.10.
+    assert event.estimated_cost_micro_usd == 1_100_000
     assert event.cost_basis == 'flex_batch_token_rates_excludes_cache_storage'
 
 
@@ -166,7 +168,9 @@ def test_openai_usage_parses_cache_writes_and_prices_luna_write_tokens() -> None
     event = build_accounting_event(_context(), attempt)
 
     assert event.cache_write_tokens == 400_000
-    assert event.estimated_cost_micro_usd == 1_384_000
+    # Long-context tier: 400K * $0.40 + 200K * $0.04 + 1M * $1.80
+    # + 400K * $0.50 = $2.168.
+    assert event.estimated_cost_micro_usd == 2_168_000
     assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-30'
 
 
@@ -191,10 +195,11 @@ def test_cache_write_only_miss_reports_negative_net_cache_savings() -> None:
 
     event = build_accounting_event(_context(), attempt)
 
-    # A write costs $0.25/M while the ordinary input counterfactual costs
-    # $0.20/M, so this first miss is a $0.05/M net loss until it is reused.
-    assert event.estimated_cost_micro_usd == 250_000
-    assert event.estimated_cache_savings_micro_usd == -50_000
+    # 1M of write tokens is past the 272K boundary, so the long-context rates
+    # apply: a write costs $0.50/M while the ordinary input counterfactual
+    # costs $0.40/M, a $0.10/M net loss until this entry is reused.
+    assert event.estimated_cost_micro_usd == 500_000
+    assert event.estimated_cache_savings_micro_usd == -100_000
 
 
 def test_cache_write_and_read_report_net_cache_savings() -> None:
@@ -221,10 +226,12 @@ def test_cache_write_and_read_report_net_cache_savings() -> None:
 
     event = build_accounting_event(_context(), attempt)
 
-    # Counterfactual input bill: 2M * $0.20 = $0.40. Actual input bill is
-    # 1M * $0.02 + 1M * $0.25 = $0.27, for $0.13 net savings.
-    assert event.estimated_cost_micro_usd == 1_470_000
-    assert event.estimated_cache_savings_micro_usd == 130_000
+    # 2M of input context is past the 272K boundary, so this prices at the
+    # long-context tier throughout. Counterfactual input bill: 2M * $0.40 =
+    # $0.80. Actual input bill is 1M * $0.04 + 1M * $0.50 = $0.54, for $0.26
+    # net savings. Output adds 1M * $1.80.
+    assert event.estimated_cost_micro_usd == 2_340_000
+    assert event.estimated_cache_savings_micro_usd == 260_000
 
 
 def test_flex_halves_complete_net_cache_savings_and_total_cost() -> None:
@@ -251,8 +258,9 @@ def test_flex_halves_complete_net_cache_savings_and_total_cost() -> None:
 
     event = build_accounting_event(_context(), attempt)
 
-    assert event.estimated_cost_micro_usd == 735_000
-    assert event.estimated_cache_savings_micro_usd == 65_000
+    # Exactly half of the long-context figures in the test above.
+    assert event.estimated_cost_micro_usd == 1_170_000
+    assert event.estimated_cache_savings_micro_usd == 130_000
 
 
 def test_empty_usage_object_is_unreported_not_a_zero_cost_completion() -> None:
@@ -619,3 +627,102 @@ class _FakeFirestoreClient:
 
     def collection(self, name: str) -> _FakeCollection:
         return _FakeCollection(self.collections.setdefault(name, {}))
+
+
+def test_long_context_threshold_is_pinned_and_exclusive() -> None:
+    # The boundary is "more than 272K input tokens": exactly at 272,000 must
+    # still use the short-context rate, and 272,001 must switch to long.
+    trace = AttemptTrace()
+
+    def _priced_cost(prompt_tokens: int) -> int | None:
+        attempt = trace.record(
+            provider='openai',
+            configured_model='gpt-5.6-luna',
+            route_artifact_id='route.test.001',
+            fallback_reason=None,
+            retry_ordinal=1,
+            outcome='success',
+            error_class='none',
+            metadata=ProviderResponseMetadata(
+                usage=ProviderUsage(
+                    prompt_tokens=prompt_tokens,
+                    uncached_input_tokens=prompt_tokens,
+                    output_tokens=0,
+                    output_tokens_include_reasoning=True,
+                )
+            ),
+        )
+        return build_accounting_event(_context(), attempt).estimated_cost_micro_usd
+
+    at_boundary = _priced_cost(272_000)
+    past_boundary = _priced_cost(272_001)
+
+    # 272,000 * $0.20/M short rate = $54,400 micro-USD.
+    assert at_boundary == 54_400
+    # 272,001 * $0.40/M long rate, rounded = $108,800 micro-USD (rounds down
+    # from 108800.4).
+    assert past_boundary == 108_800
+
+
+def test_model_with_no_long_context_tier_ignores_token_count() -> None:
+    # gpt-5.4-nano has no long_context_* fields in cost_rate_cards.yaml, so
+    # even a huge prompt must keep pricing at its single (short) rate.
+    trace = AttemptTrace()
+    attempt = trace.record(
+        provider='openai',
+        configured_model='gpt-5.4-nano',
+        route_artifact_id='route.test.001',
+        fallback_reason=None,
+        retry_ordinal=1,
+        outcome='success',
+        error_class='none',
+        metadata=ProviderResponseMetadata(
+            usage=ProviderUsage(
+                prompt_tokens=5_000_000,
+                uncached_input_tokens=5_000_000,
+                output_tokens=0,
+                output_tokens_include_reasoning=True,
+            )
+        ),
+    )
+    event = build_accounting_event(_context(), attempt)
+
+    # 5,000,000 * $0.20/M (the only rate this card has) = $1,000,000.
+    assert event.estimated_cost_micro_usd == 1_000_000
+    assert event.rate_card_id == 'openai.gpt-5.4-nano.2026-07-17'
+
+
+def test_short_context_luna_request_uses_short_context_rates() -> None:
+    # Same shape as the long-context test above, scaled down so total input
+    # context (150K) stays under the 272K-token boundary.
+    usage = openai_usage_from_response(
+        {
+            'id': 'chatcmpl-short',
+            'usage': {
+                'prompt_tokens': 150_000,
+                'completion_tokens': 100_000,
+                'prompt_tokens_details': {'cached_tokens': 30_000, 'cache_write_tokens': 60_000},
+            },
+        },
+        cache_requested=True,
+    ).usage
+    assert usage is not None
+    assert usage.uncached_input_tokens == 60_000
+
+    trace = AttemptTrace()
+    attempt = trace.record(
+        provider='openai',
+        configured_model='gpt-5.6-luna',
+        route_artifact_id='route.conv_action_items.model_config.001',
+        fallback_reason=None,
+        retry_ordinal=1,
+        outcome='success',
+        error_class='none',
+        metadata=ProviderResponseMetadata(usage=usage),
+    )
+    event = build_accounting_event(_context(), attempt)
+
+    # Short-context rates: 60K uncached @ $0.20/M + 30K cached @ $0.02/M +
+    # 100K output @ $1.20/M + 60K cache-write @ $0.25/M = $147,600 micro-USD.
+    assert event.estimated_cost_micro_usd == 147_600
+    assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-30'


### PR DESCRIPTION
## Summary

`cost_rate_cards.yaml` carried only the short-context price band for `gpt-5.6-luna`, and no card at
all for `gpt-5.6-sol` / `gpt-5.6-terra`. OpenAI publishes a second, more expensive band for the
GPT-5.6 family once a request's input context crosses 272,000 tokens. Every request over that
threshold was therefore priced at roughly half its real cost, and the two unlisted models were
recorded as `rate_card_missing` — unpriced rather than mispriced.

This adds an optional long-context tier to `RateCard` and the cards for the missing models.

## Which layer

The tier is selected in `_estimate_cost`, from **total request context** — cached + uncached +
cache-write input tokens — never from output tokens, which do not affect which band applies.

The sum is built from the split usage fields rather than `usage.prompt_tokens` because that field's
relationship to cache-write tokens is provider-specific: OpenAI's raw `prompt_tokens` already
includes cache-write tokens, while Anthropic's `input_tokens` excludes
`cache_creation_input_tokens`. Reading the aggregate would have under-counted Anthropic requests
near the boundary and double-counted nothing on OpenAI — a silent, provider-dependent error.

A card with no `long_context_threshold_tokens` has a single tier, and `effective_rates` returns it
for any token count, so every existing card is unaffected.

## Product invariants affected

None. This changes recorded cost attribution only — no routing, admission, quota, or user-visible
behavior. Pricing is read after a request completes.

## Verification

- `pytest backend/tests/unit/test_llm_gateway_accounting.py backend/tests/unit/test_llm_gateway_deploy_contract.py` — 30 passed, exit 0.
- Boundary cases covered in tests: exactly at the threshold (short band), one token over (long
  band), and a card without a long-context tier (unchanged).
- Rebased onto `origin/main` — the deploy-contract test asserts against `.github/workflows/*` and
  failed only because this branch's `.github` had diverged. It passes on the rebased tip.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

