### PR TITLE
chore(failure-classes): add FC-attestation-scoped-to-batch-not-item

### DIFF
--- a/.github/failure-classes/FC-attestation-scoped-to-batch-not-item.json
+++ b/.github/failure-classes/FC-attestation-scoped-to-batch-not-item.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-attestation-scoped-to-batch-not-item",
+  "violated_contract": "When a model proposes a label, tag, or claim for each of several items in one batched request, the evidence check that accepts it must run against the item it is being attached to. Searching the batch's combined text accepts any proposal supported by any item, which is a strictly weaker check than no batching at all: it is satisfied more easily the more items are batched together.",
+  "canonical_prevention": "Carry the per-item evidence alongside the per-item proposal — a map keyed by item id, not one concatenated string — and pass the item's own key into the acceptance predicate. Keep a test in which a label is supported by exactly one item in a multi-item batch and assert the other items in that batch are not given it.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift"
+  ],
+  "evidence_prs": [
+    11665
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift"
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
## Summary

Registry-only PR adding one failure class: `FC-attestation-scoped-to-batch-not-item`.

When several items are sent to a model in one batched request and it proposes a label for each,
the check that decides whether a proposal is supported must run against **the item the label is
being attached to**. Checking the batch's concatenated text instead accepts any proposal supported
by any item in the batch.

The property that makes this worth a class rather than a one-line fix: the check gets *weaker as
batches get larger*. Batching is normally a cost optimisation with no semantic effect, so the
defect appears when someone tunes a batch size, in a component nobody edited.

## Evidence

Measured in the desktop workstream reconciler on live dogfood data: bucket
`1bfc86de-c6e5-4aaf-91ad-3b40fce94e2d` holds 193 facts, none containing the string `stably`, and
was tagged `stably` — a label earned by a different bucket in the same batch.

The instance fix is committed on `fix/workstream-label-attestation` and is blocked on this PR:
`failure-class-protocol` validates a declaration against the merge base, so the definition has to
land before the fix that declares it can be pushed. That PR opens as soon as this one merges.

## Why a new class

The nearest existing classes do not cover it. `FC-unbounded-user-collection-in-prompt` is about
request size, not acceptance scope. `FC-split-mutation-authority` is about who may write a state,
where here a single owner performs a correctly-owned write against the wrong evidence.
`FC-bounded-read-exceeds-request-budget` is a budget contract.

## Guard artifact

Named, not deferred: `ContextWorkstreamReconcilerTests.swift` must hold a case where a label is
supported by exactly one item of a multi-item batch, asserting the other items do not receive it.
That test is written and passing on the instance-fix branch, and lands with it.

## Product invariants affected

None. Registry metadata only — no product code, no workflow, no behavior.
