### PR TITLE
fix(desktop): attest a workstream label against the bucket it labels

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -557,8 +557,9 @@ actor ContextBucketStore {
     let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
     guard let pool else { return [] }
     return
-      (try? await pool.read { db in
-        try ContextProactiveCandidateLookup.lookupArmed(
+      (try? await pool.write { db in
+        try ContextProactiveCandidateLookup.expireStale(now: now, in: db)
+        return try ContextProactiveCandidateLookup.lookupArmed(
           bucketID: bucketID, tags: tags, now: now, in: db)
       }) ?? []
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -316,7 +316,8 @@ enum ContextWorkstreamTagging {
     }
     var counts: [String: Int] = [:]
     for bucketID in bucketOrder {
-      counts[proposalsByBucket[bucketID]!.first!, default: 0] += 1
+      guard let firstProposal = proposalsByBucket[bucketID]?.first else { continue }
+      counts[firstProposal, default: 0] += 1
     }
 
     func isAllowed(_ tag: String, bucketID: String) -> Bool {
@@ -333,7 +334,7 @@ enum ContextWorkstreamTagging {
       // earlier proposals that were sanitizable but unattestable, generic,
       // or below the new-label threshold are skipped, not fatal.
       guard
-        let tag = proposalsByBucket[bucketID]!.first(where: {
+        let tag = proposalsByBucket[bucketID]?.first(where: {
           isAllowed($0, bucketID: bucketID)
         })
       else { continue }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -19,6 +19,13 @@ struct ContextProactiveCandidate: Equatable, Sendable, FetchableRecord, Decodabl
     ContextProactiveCandidate.parseFactIDs(groundingFactIDsJson)
   }
 
+  /// The stored column stays `armed` until the lazy expiry sweep runs. Callers
+  /// that report state must use this so a past `expiresAt` is never still armed.
+  func effectiveState(at now: Date) -> String {
+    if state == "armed", expiresAt <= now { return "expired" }
+    return state
+  }
+
   static func parseFactIDs(_ json: String) -> [String] {
     guard let data = json.data(using: .utf8),
       let ids = try? JSONDecoder().decode([String].self, from: data)
@@ -292,7 +299,7 @@ enum ContextWorkstreamTagging {
     response: Response,
     batchIDs: [String],
     existingTags: Set<String>,
-    observations: String
+    observationsByBucket: [String: String]
   ) -> [AcceptedAssignment] {
     var firstLabelByBucket: [(bucketID: String, tag: String)] = []
     var seenBuckets = Set<String>()
@@ -311,14 +318,16 @@ enum ContextWorkstreamTagging {
     var counts: [String: Int] = [:]
     for item in firstLabelByBucket { counts[item.tag, default: 0] += 1 }
 
-    func isAllowed(_ tag: String) -> Bool {
+    func isAllowed(_ tag: String, bucketID: String) -> Bool {
       guard !isGenericLabel(tag) else { return false }
-      guard labelAppearsInObservations(tag, observations: observations) else { return false }
+      let bucketObservations = observationsByBucket[bucketID] ?? ""
+      guard labelAppearsInObservations(tag, observations: bucketObservations) else { return false }
       if existingTags.contains(tag) { return true }
       return (counts[tag] ?? 0) >= minimumGroupsForNewLabel
     }
 
-    var allowedTags = Set(firstLabelByBucket.map(\.tag).filter(isAllowed))
+    let attested = firstLabelByBucket.filter { isAllowed($0.tag, bucketID: $0.bucketID) }
+    var allowedTags = Set(attested.map(\.tag))
     if allowedTags.count > maximumLabels {
       let existingFirst = allowedTags.filter { existingTags.contains($0) }
         .sorted()
@@ -332,7 +341,7 @@ enum ContextWorkstreamTagging {
       allowedTags = Set(
         Array((existingFirst + newByCount).prefix(maximumLabels)))
     }
-    return firstLabelByBucket.filter { allowedTags.contains($0.tag) }.map {
+    return attested.filter { allowedTags.contains($0.tag) }.map {
       AcceptedAssignment(bucketID: $0.bucketID, tag: $0.tag)
     }
   }
@@ -535,8 +544,9 @@ enum ContextProactiveCandidateLookup {
   static func lookupArmed(
     bucketID: String, tags: [String], now: Date, in db: Database
   ) throws -> [ContextProactiveCandidate] {
+    let rows: [ContextProactiveCandidate]
     if tags.isEmpty {
-      return try ContextProactiveCandidate.fetchAll(
+      rows = try ContextProactiveCandidate.fetchAll(
         db,
         sql: """
           SELECT id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
@@ -546,25 +556,27 @@ enum ContextProactiveCandidateLookup {
           ORDER BY createdAt DESC
           """,
         arguments: [now, bucketID])
+    } else {
+      let placeholders = tags.map { _ in "?" }.joined(separator: ",")
+      var arguments: StatementArguments = [now, bucketID]
+      arguments += StatementArguments(tags)
+      arguments += StatementArguments([bucketID])
+      rows = try ContextProactiveCandidate.fetchAll(
+        db,
+        sql: """
+          SELECT id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
+                 state, createdAt, expiresAt, consumedAt
+          FROM proactive_candidates
+          WHERE state = 'armed' AND expiresAt > ?
+            AND (
+              bucketID = ?
+              OR (workstreamTag IS NOT NULL AND workstreamTag IN (\(placeholders)))
+            )
+          ORDER BY CASE WHEN bucketID = ? THEN 0 ELSE 1 END, createdAt DESC
+          """,
+        arguments: arguments)
     }
-    let placeholders = tags.map { _ in "?" }.joined(separator: ",")
-    var arguments: StatementArguments = [now, bucketID]
-    arguments += StatementArguments(tags)
-    arguments += StatementArguments([bucketID])
-    return try ContextProactiveCandidate.fetchAll(
-      db,
-      sql: """
-        SELECT id, bucketID, workstreamTag, message, groundingFactIDsJson, triggerNote,
-               state, createdAt, expiresAt, consumedAt
-        FROM proactive_candidates
-        WHERE state = 'armed' AND expiresAt > ?
-          AND (
-            bucketID = ?
-            OR (workstreamTag IS NOT NULL AND workstreamTag IN (\(placeholders)))
-          )
-        ORDER BY CASE WHEN bucketID = ? THEN 0 ELSE 1 END, createdAt DESC
-        """,
-      arguments: arguments)
+    return rows.filter { $0.effectiveState(at: now) == "armed" }
   }
 
   static func firstDeliverable(
@@ -827,7 +839,11 @@ actor ContextWorkstreamReconciler {
       response: parsed,
       batchIDs: batch.groups.map(\.bucketID),
       existingTags: batch.existingTags,
-      observations: batch.observations)
+      observationsByBucket: Dictionary(
+        batch.groups.map {
+          ($0.bucketID, $0.facts.map(\.statement).joined(separator: "\n"))
+        },
+        uniquingKeysWith: { first, _ in first }))
     try await store.insertWorkstreamAssignments(accepted, now: now)
     guard !accepted.isEmpty else { return batch }
     let newlyTagged = Dictionary(
@@ -957,9 +973,6 @@ struct ContextWorkstreamReconcileGroup: Equatable, Sendable {
 struct ContextWorkstreamReconcileBatch: Equatable, Sendable {
   let groups: [ContextWorkstreamReconcileGroup]
   let existingTags: Set<String>
-  var observations: String {
-    groups.flatMap(\.facts).map(\.statement).joined(separator: "\n")
-  }
 }
 
 enum ContextWorkstreamReconcileOutcome: Equatable {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -301,22 +301,23 @@ enum ContextWorkstreamTagging {
     existingTags: Set<String>,
     observationsByBucket: [String: String]
   ) -> [AcceptedAssignment] {
-    var firstLabelByBucket: [(bucketID: String, tag: String)] = []
-    var seenBuckets = Set<String>()
+    // Proposals are collected without claiming their bucket: a bucket whose
+    // first proposal is null, unsanitizable, or fails per-bucket attestation
+    // must not block a later valid proposal for the same bucket. A bucket is
+    // only claimed below, once one of its proposals passes all validation.
+    var proposalsByBucket: [String: [String]] = [:]
+    var bucketOrder: [String] = []
     for assignment in response.assignments {
-      // Membership is checked (not claimed) here: a null or unsanitizable
-      // first assignment for a bucket must not block a later valid one for
-      // the same bucket, so `seenBuckets` is only marked once sanitization
-      // has actually succeeded.
       guard let bucketID = resolveGroup(assignment.group, batchIDs: batchIDs),
-        !seenBuckets.contains(bucketID),
         let tag = ContextWorkstreamTag.sanitize(assignment.label)
       else { continue }
-      seenBuckets.insert(bucketID)
-      firstLabelByBucket.append((bucketID, tag))
+      if proposalsByBucket[bucketID] == nil { bucketOrder.append(bucketID) }
+      proposalsByBucket[bucketID, default: []].append(tag)
     }
     var counts: [String: Int] = [:]
-    for item in firstLabelByBucket { counts[item.tag, default: 0] += 1 }
+    for bucketID in bucketOrder {
+      counts[proposalsByBucket[bucketID]!.first!, default: 0] += 1
+    }
 
     func isAllowed(_ tag: String, bucketID: String) -> Bool {
       guard !isGenericLabel(tag) else { return false }
@@ -326,7 +327,19 @@ enum ContextWorkstreamTagging {
       return (counts[tag] ?? 0) >= minimumGroupsForNewLabel
     }
 
-    let attested = firstLabelByBucket.filter { isAllowed($0.tag, bucketID: $0.bucketID) }
+    var firstLabelByBucket: [(bucketID: String, tag: String)] = []
+    for bucketID in bucketOrder {
+      // The first proposal that passes all validation claims the bucket;
+      // earlier proposals that were sanitizable but unattestable, generic,
+      // or below the new-label threshold are skipped, not fatal.
+      guard
+        let tag = proposalsByBucket[bucketID]!.first(where: {
+          isAllowed($0, bucketID: bucketID)
+        })
+      else { continue }
+      firstLabelByBucket.append((bucketID, tag))
+    }
+    let attested = firstLabelByBucket
     var allowedTags = Set(attested.map(\.tag))
     if allowedTags.count > maximumLabels {
       let existingFirst = allowedTags.filter { existingTags.contains($0) }

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -107,7 +107,13 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       response: response,
       batchIDs: ["b1", "b2", "b3", "b4", "b5"],
       existingTags: ["car"],
-      observations: "Hermes PR blocked. CAR contract review. solo note.")
+      observationsByBucket: [
+        "b1": "Hermes PR blocked.",
+        "b2": "Hermes PR blocked.",
+        "b3": "solo note.",
+        "b4": "CAR contract review.",
+        "b5": "",
+      ])
     XCTAssertEqual(
       Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
       ["b1:hermes", "b2:hermes", "b4:car"])
@@ -123,6 +129,30 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       ContextWorkstreamTagging.labelAppearsInObservations(
         "car-project", observations: "Please concatenate the two reports."),
       "\"car\" inside \"concatenate\" must not count as the word appearing")
+  }
+
+  func testAcceptedAssignmentsRejectALabelAbsentFromTheAssignedBucketsFacts() {
+    let response = ContextWorkstreamTagging.Response(
+      workstreams: [.init(label: "stably", evidence: "two groups")],
+      assignments: [
+        .init(group: "G1", label: "stably"),
+        .init(group: "G2", label: "stably"),
+      ])
+    let accepted = ContextWorkstreamTagging.acceptedAssignments(
+      response: response,
+      batchIDs: ["cursor-agents", "github-pr"],
+      existingTags: [],
+      observationsByBucket: [
+        "cursor-agents": "Screen content is from the Cursor app window labeled Cursor Agents.",
+        "github-pr": "The stably deploy is green and the rate-card PR remains parked.",
+      ])
+    XCTAssertEqual(
+      Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
+      ["github-pr:stably"],
+      "a label earned by one bucket must not attach to another bucket in the same batch")
+    XCTAssertFalse(
+      accepted.contains { $0.bucketID == "cursor-agents" },
+      "attestation must use the assigned bucket's own facts, not the rest of the batch")
   }
 
   func testGenericLabelsAreRejectedWhileRealProjectNamesAreAccepted() {
@@ -175,7 +205,15 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       response: response,
       batchIDs: ["b1", "b2", "b3", "b4", "b5", "b6", "b7"],
       existingTags: ["api"],
-      observations: "Omi release blocked on the Hermes PR. API rate limit on /v1/chat.")
+      observationsByBucket: [
+        "b1": "Omi release blocked on the Hermes PR.",
+        "b2": "Omi release blocked on the Hermes PR.",
+        "b3": "API rate limit on /v1/chat.",
+        "b4": "API rate limit on /v1/chat.",
+        "b5": "Omi release blocked on the Hermes PR.",
+        "b6": "Omi release blocked on the Hermes PR.",
+        "b7": "",
+      ])
     XCTAssertEqual(
       Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
       ["b1:omi", "b2:omi", "b5:hermes", "b6:hermes"])
@@ -200,7 +238,10 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       response: response,
       batchIDs: ["b1", "b2"],
       existingTags: [],
-      observations: "Hermes PR blocked.")
+      observationsByBucket: [
+        "b1": "Hermes PR blocked.",
+        "b2": "Hermes PR blocked.",
+      ])
     XCTAssertEqual(
       Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
       ["b1:hermes", "b2:hermes"],
@@ -422,6 +463,44 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       try insertCandidate(
         id: "live", bucketID: "here", tag: nil, message: "message", createdAt: now, in: db)
       XCTAssertTrue(try ContextProactiveCandidateLookup.consume(id: "live", now: now, in: db))
+    }
+  }
+
+  func testExpiredCandidateNeverReportsAsArmed() throws {
+    let queue = try migratedQueue()
+    let overdue = ContextProactiveCandidate(
+      id: "stale", bucketID: "here", workstreamTag: nil, message: "message",
+      groundingFactIDsJson: "[\"f1\"]", triggerNote: "when relevant",
+      state: "armed", createdAt: now.addingTimeInterval(-13 * 60 * 60),
+      expiresAt: now.addingTimeInterval(-60), consumedAt: nil)
+    XCTAssertEqual(
+      overdue.effectiveState(at: now), "expired",
+      "callers that report state must not still call an overdue row armed")
+    XCTAssertEqual(overdue.state, "armed", "the stored column stays armed until the sweep")
+
+    try queue.write { db in
+      try seedBucket("here", factCount: 1, newestOffset: 0, tagged: false, in: db)
+      try insertCandidate(
+        id: "stale", bucketID: "here", tag: nil, message: "message",
+        createdAt: now.addingTimeInterval(-13 * 60 * 60), in: db)
+      try db.execute(
+        sql: "UPDATE proactive_candidates SET expiresAt = ? WHERE id = 'stale'",
+        arguments: [now.addingTimeInterval(-60)])
+      XCTAssertEqual(
+        try ContextProactiveCandidateLookup.lookupArmed(
+          bucketID: "here", tags: [], now: now, in: db
+        ).map(\.id),
+        [],
+        "lookup must not return an overdue row as armed")
+      try ContextProactiveCandidateLookup.expireStale(now: now, in: db)
+      XCTAssertEqual(
+        try String.fetchOne(db, sql: "SELECT state FROM proactive_candidates WHERE id = 'stale'"),
+        "expired")
+      XCTAssertEqual(
+        try ContextProactiveCandidateLookup.lookupArmed(
+          bucketID: "here", tags: [], now: now, in: db
+        ).map(\.id),
+        [])
     }
   }
 

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -248,6 +248,30 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       "the invalid first assignment for b1 must not claim the bucket and drop the valid one")
   }
 
+  func testAcceptedAssignmentsLetALaterValidProposalWinAfterAnUnattestableFirstOneForTheSameBucket() {
+    let response = ContextWorkstreamTagging.Response(
+      workstreams: [.init(label: "Hermes", evidence: "two groups")],
+      assignments: [
+        // b1's first proposal sanitizes but is absent from b1's own facts;
+        // it must not claim the bucket and drop b1's later attestable one.
+        .init(group: "G1", label: "Hermes"),
+        .init(group: "G1", label: "Car"),
+        .init(group: "G2", label: "Hermes"),
+      ])
+    let accepted = ContextWorkstreamTagging.acceptedAssignments(
+      response: response,
+      batchIDs: ["b1", "b2"],
+      existingTags: ["car"],
+      observationsByBucket: [
+        "b1": "The CAR contract review is due.",
+        "b2": "Hermes PR blocked.",
+      ])
+    XCTAssertEqual(
+      Set(accepted.map { "\($0.bucketID):\($0.tag)" }),
+      ["b1:car", "b2:hermes"],
+      "an unattestable first proposal must not claim the bucket and drop the later valid one")
+  }
+
   func testInsertArmedCandidatesLetsALaterValidCandidateWinAfterAnEarlierInvalidOneForTheSameBucket() throws {
     let queue = try migratedQueue()
     try queue.write { db in

--- a/desktop/macos/changelog/unreleased/20260816-workstream-label-attestation.json
+++ b/desktop/macos/changelog/unreleased/20260816-workstream-label-attestation.json
@@ -1,0 +1,3 @@
+{
+  "change": "A workstream label now has to appear in the facts of the bucket it is applied to, so one bucket's label no longer gets pinned to another"
+}

--- a/desktop/macos/changelog/unreleased/20260816-workstream-label-attestation.json
+++ b/desktop/macos/changelog/unreleased/20260816-workstream-label-attestation.json
@@ -1,3 +1,3 @@
 {
-  "change": "A workstream label now has to appear in the facts of the bucket it is applied to, so one bucket's label no longer gets pinned to another"
+  "change": "A workstream label now stays attached to the work it was earned from, so a label no longer shows up on another workstream's tasks"
 }


### PR DESCRIPTION
## Summary

Two scope defects in the workstream reconciler, both found by reading live dogfood rows rather
than by a failing test.

**1. A label was attested against the wrong text.** `acceptedAssignments` validated a proposed
label by searching the concatenated observations of *every group in the batch*. Any term that
appeared anywhere in the batch therefore satisfied the check for every bucket in it. Measured on
live data: bucket `1bfc86de-c6e5-4aaf-91ad-3b40fce94e2d` carries 193 facts, none of which contain
the string `stably`, and it was tagged `stably` — a label earned by a different bucket in the same
batch.

The check now runs against the tagged bucket's own facts, threaded through as
`observationsByBucket`. A bucket that cannot support a label keeps none, so `null` remains a
correct and expected outcome rather than the bucket borrowing a neighbour's label.

**2. An expired candidate could be reported as armed.** `state` stays `'armed'` in the column
until a sweep runs, so a row whose `expiresAt` had passed was still handed to the gate as live.
`lookupArmed` now runs `expireStale` in the same write and filters on `effectiveState(at:)`.

## Which layer

The attestation fix is in the acceptance step, not the prompt: the model may propose whatever it
likes, and the client decides what is supportable. Doing it here keeps `null` cheap and means a
weaker model cannot widen label scope.

The expiry fix deliberately changes `lookupArmed` from a read to a write so the sweep and the
lookup cannot interleave. The alternative — filtering in the caller — leaves the stale row in the
table to be re-read by the next caller.

## What is deliberately NOT in this PR

The branch originally also defined `notify_worthiness` in the extraction prompt. That change is
**dropped**, because measurement did not support it. Scoring 54 real statements shown with their
on-screen evidence, 7 runs per arm through the `proactive_extraction` lane:

| arm | AUC | overall mean |
|---|---|---|
| bare field (ships today) | 0.546 (sd 0.059) | 0.257 |
| with the proposed definition | 0.580 (sd 0.074) | 0.383 |

The ranking gain is inside run-to-run noise, while the mean rises 49%. Four gates key on absolute
thresholds of this field (0.3 and 0.6), so shipping it would arm materially more candidates
without ranking them any better. It needs a different approach, not a prose definition.

## Product invariants affected

None. Labelling and candidate liveness only; no delivery, transcript, or session behavior changes.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — exit 0.
- `xcrun swift test --package-path Desktop --filter 'Context'` — 376 tests, 0 failures, exit 0.
- New reconciler tests cover a label supported by one bucket and not another in the same batch,
  and a candidate whose `expiresAt` has passed.

## Failure class (fixes)

Failure-Class: FC-attestation-scoped-to-batch-not-item

Defined in the registry-only PR #11665, which must merge first.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

