### PR TITLE
chore(failure-classes): add FC-cache-prefix-evicted-from-head

### DIFF
--- a/.github/failure-classes/FC-cache-prefix-evicted-from-head.json
+++ b/.github/failure-classes/FC-cache-prefix-evicted-from-head.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-cache-prefix-evicted-from-head",
+  "violated_contract": "A buffer whose head is a provider cache prefix must not be evicted from that head on every write. Prompt caching matches on longest common prefix, so removing the oldest entries — which live at the head — invalidates the entire cached segment, while appending to the tail preserves it. A structure that appends at one end and evicts at the other cannot hold a cache prefix if it is trimmed to its exact budget on every publish.",
+  "canonical_prevention": "Evict to a low-water mark below the budget rather than to the budget itself, so one prefix break buys many stable writes, and keep the eviction in a pure function with a test that appends repeatedly past saturation and asserts the head is unchanged across those writes. Verify with a negative control: restoring trim-to-budget must fail that test.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift"
+  ],
+  "evidence_prs": [
+    11668
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift"
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
## Summary

Registry-only PR adding one failure class: `FC-cache-prefix-evicted-from-head`.

Prompt caching matches on longest common prefix. A buffer that **appends at the tail and evicts at
the head** therefore destroys its own cache prefix every time it evicts — and if it is trimmed to
its exact byte budget on every write, it evicts on every write once saturated. Appending is safe;
the eviction end is what matters, and it is easy to miss because the structure looks append-only.

## Evidence

Measured in the desktop context-bucket store across 138 live version transitions: the frozen ranked
segment's prefix survived into the next version only 59% of the time, and for the two buckets
sitting at the 16KB budget the median surviving share was 0.00 — consecutive versions shared 8
bytes, the length of `"- entry:"`. Observable consequence: 0 cached tokens across all 91 recorded
director calls, on the largest and longest-lived buckets, i.e. exactly where caching was worth the
most.

## Why a new class

`FC-shared-cache-reader-format` concerns the format two readers agree on, not prefix stability.
`FC-mutable-release-pointer-cache-staleness` is a staleness contract — reading something older than
expected — where here the entry is correct and simply never matches. Nothing in the registry covers
"the write pattern invalidates the cache key's prefix."

## Guard artifact

Named, not deferred: a pure eviction function with a test that appends repeatedly past saturation
and asserts the head is unchanged across those writes, plus a negative control in which restoring
trim-to-budget fails that test. Both are written and passing on the instance-fix branch
`fix/frozen-segment-prefix-hysteresis`, which is blocked on this PR because `failure-class-protocol`
validates a declaration against the merge base.

## Product invariants affected

None. Registry metadata only — no product code, no workflow, no behavior.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

