### PR TITLE
fix(desktop): stop evicting the frozen segment's cache prefix on every publish

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -143,6 +143,24 @@ enum ContextBucketPromptAssembler {
   /// billed at cached rates.
   static let frozenRankedByteBudget = 16_000
 
+  /// Eviction drops the *oldest* lines, which live at the head — exactly the bytes
+  /// the cache prefix is made of. Trimming to the budget on every publish therefore
+  /// moved the head every time a saturated bucket published, and `publishVersion`
+  /// runs on every completed visit.
+  ///
+  /// Measured on live dogfood data before this change: across 138 version
+  /// transitions the frozen prefix survived into the next version only 59% of the
+  /// time, and for the two buckets actually at the budget the median surviving
+  /// share was 0.00 — consecutive versions shared 8 bytes, the length of
+  /// `"- entry:"`. Those are the largest buckets, so caching failed precisely
+  /// where it was worth the most: 0 cached tokens across 91 recorded director calls.
+  ///
+  /// Evicting down to a low-water mark instead spends one prefix break to buy many
+  /// stable publishes. The gap is refilled at roughly 500 bytes per compaction, so
+  /// a 4_000-byte gap holds the prefix steady for about eight publishes rather than
+  /// breaking it on every one.
+  static let frozenRankedLowWaterMark = 12_000
+
   /// Deliberately constant. Everything above the frozen segment is part of the
   /// longest-common-prefix the gateway matches on, so a per-visit counter here
   /// made a cross-visit cache hit structurally impossible — it changed bytes
@@ -422,6 +440,24 @@ enum ContextBucketCompactionPolicy {
     // short, so context cannot disappear between the tail and frozen segment.
     return uncompressedCount > retainedTailCount
   }
+
+  /// Drop the oldest ranked lines when the frozen segment is over budget.
+  ///
+  /// Eviction takes from the head, where the oldest lines are and where the cache
+  /// prefix also is, so this is the one operation that can invalidate the prefix.
+  /// It therefore evicts only when the budget is genuinely exceeded, and then all
+  /// the way to the low-water mark, so the head stays put across the publishes that
+  /// follow. Trimming to exactly the budget instead moved the head on every publish
+  /// of a saturated bucket.
+  static func evictToLowWaterMark(_ lines: [String]) -> [String] {
+    func bytes(_ lines: [String]) -> Int { lines.reduce(0) { $0 + $1.utf8.count } }
+    guard bytes(lines) > ContextBucketPromptAssembler.frozenRankedByteBudget else { return lines }
+    var kept = lines
+    while bytes(kept) > ContextBucketPromptAssembler.frozenRankedLowWaterMark, kept.count > 1 {
+      kept.removeFirst()
+    }
+    return kept
+  }
 }
 
 /// What a departure extraction just persisted, beyond the published version:
@@ -646,11 +682,7 @@ extension ContextBucketStore {
         try db.execute(
           sql: "UPDATE bucket_entries SET isCompacted = 1 WHERE id = ?", arguments: [row["id"] as String])
       }
-      while rankedLines.reduce(0, { $0 + $1.utf8.count }) > ContextBucketPromptAssembler.frozenRankedByteBudget,
-        rankedLines.count > 1
-      {
-        rankedLines.removeFirst()
-      }
+      rankedLines = ContextBucketCompactionPolicy.evictToLowWaterMark(rankedLines)
       frozen = Data(rankedLines.joined().utf8)
     }
     // Constant on purpose: this string is published above the frozen segment on

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -563,6 +563,41 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
       "the rolling tail must keep roughly the room it had before the frozen budget grew")
   }
 
+  /// The frozen segment's head is the cache prefix. Eviction takes from the head,
+  /// so trimming to exactly the budget moved the prefix on every publish of a
+  /// saturated bucket — measured at 0 cached tokens across 91 director calls.
+  func testSaturatedFrozenSegmentKeepsItsHeadAcrossManyPublishes() {
+    let line = { (n: Int) in "- entry:\(String(format: "%05d", n)) \(String(repeating: "n", count: 480))\n" }
+    // Start just over budget so the first publish evicts, then keep appending.
+    var lines = (0..<40).map(line)
+    XCTAssertGreaterThan(
+      lines.reduce(0) { $0 + $1.utf8.count }, ContextBucketPromptAssembler.frozenRankedByteBudget)
+
+    lines = ContextBucketCompactionPolicy.evictToLowWaterMark(lines)
+    let headAfterEviction = try? XCTUnwrap(lines.first)
+    XCTAssertLessThanOrEqual(
+      lines.reduce(0) { $0 + $1.utf8.count },
+      ContextBucketPromptAssembler.frozenRankedLowWaterMark)
+
+    // Every later publish appends one compacted entry, as `publishVersion` does.
+    var publishesWithAnUnchangedHead = 0
+    for n in 40..<48 {
+      lines.append(line(n))
+      lines = ContextBucketCompactionPolicy.evictToLowWaterMark(lines)
+      if lines.first == headAfterEviction { publishesWithAnUnchangedHead += 1 }
+    }
+    XCTAssertEqual(
+      publishesWithAnUnchangedHead, 8,
+      "the cache prefix must survive the publishes between evictions, not break on each one")
+  }
+
+  func testEvictionOnlyRunsWhenTheBudgetIsActuallyExceeded() {
+    let lines = ["- entry:one a\n", "- entry:two b\n"]
+    XCTAssertEqual(
+      ContextBucketCompactionPolicy.evictToLowWaterMark(lines), lines,
+      "a segment under budget must be returned untouched, head included")
+  }
+
   func testAssembleIgnoresAVolatileStoredHeaderSoTheCachePrefixStaysStable() {
     let snapshot = ContextBucketSnapshot(
       bucketID: "bucket", versionID: 41, version: 41,

--- a/desktop/macos/changelog/unreleased/20260816-frozen-prefix-hysteresis.json
+++ b/desktop/macos/changelog/unreleased/20260816-frozen-prefix-hysteresis.json
@@ -1,0 +1,3 @@
+{
+  "change": "Long-running work contexts now reuse their cached prompt history instead of rebuilding it on every visit"
+}


### PR DESCRIPTION
## Summary

The frozen ranked segment is the director prompt's cache prefix. Eviction removes lines from the
**head** — where the oldest lines are, and where the prefix is — while compaction appends to the
tail. Trimming to exactly `frozenRankedByteBudget` on every publish therefore moved the head every
time a saturated bucket published, and `publishVersion` runs on every completed visit.

Measured on live dogfood data across 138 version transitions: the frozen prefix survived into the
next version only **59%** of the time overall, and for the two buckets actually sitting at the
budget the median surviving share was **0.00** — consecutive versions of
`1bfc86de-c6e5-4aaf-91ad-3b40fce94e2d` (~15.8KB against a 16KB budget) shared **8 bytes**, which is
the length of `"- entry:"`. Those are the largest, longest-lived buckets, so caching failed
precisely where it was worth the most.

The observable consequence: **0 cached tokens across all 91 recorded director calls.**

```
bucket      transitions   prefix preserved   median share
1bfc86de             61                 26           0.00
46d04863             30                 11           0.00
b5ca9de8             16                 14           1.00
six others         3–7 each            all           1.00
```

## The change

Evict only when the budget is genuinely exceeded, and then down to a low-water mark of 12,000
bytes rather than to the budget. One prefix break then buys many stable publishes: the gap refills
at roughly 500 bytes per compaction, so the head holds for about eight publishes instead of moving
on every one.

The eviction is lifted out of `publishVersion` into
`ContextBucketCompactionPolicy.evictToLowWaterMark` so the behaviour is testable without a
database. The policy is unchanged — still oldest-first — only its cadence.

## Which layer

In the compaction policy, not the prompt builder or the gateway. The prefix is already assembled
least-volatile-first and the cache key is already constant; both were correct. The remaining
volatility was being introduced by the store, one line at a time, and no amount of prompt-side or
gateway-side work could have compensated.

This is a cost change with a context side effect worth naming: immediately after an eviction a
saturated bucket carries up to 4,000 fewer bytes of frozen history than it does today. That is
history already past the compaction horizon, and the facts and rolling tail are untouched.

## Product invariants affected

None. No delivery, transcript, session identity, or ordering behavior changes.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — exit 0.
- `xcrun swift test --package-path Desktop --filter 'Context'` — 376 tests, 0 failures, exit 0.
- **Negative control**: setting the low-water mark back to the budget (the old behaviour) fails the
  new test with `("0") is not equal to ("8")` — 0 of 8 publishes preserve the head, which is the
  defect exactly.
- `testEvictionOnlyRunsWhenTheBudgetIsActuallyExceeded` pins that an under-budget segment is
  returned untouched, head included.

## Expected effect, replayed on real history

Replaying every real compaction for the four buckets with ≥15 entries — the actual entry stream in
its actual order, through both eviction policies — counting publishes whose head is byte-identical
to the previous publish:

```
bucket      publishes   stable now   stable after
1bfc86de           61           27             55
46d04863           30           21             28
5c756aa0            9            9              9
b5ca9de8           16           14             15
TOTAL             116           71            107        61%  ->  92%
```

The replay's 61% for current behaviour lands within two points of the 59% measured independently
from stored `bucket_versions` blobs, which is the check that the replay is faithful. The gain is
concentrated in `1bfc86de`, the bucket at the budget — exactly the one that is expensive.

## Not measured here

The end-to-end hit rate on a live bundle: that needs a rebuild plus a saturated bucket publishing
several times, which is a dogfooding run rather than a test. The unit test pins the property, and
the replay above estimates the effect; neither is a substitute for watching `cached_tokens` go
non-zero in a running build.

## Failure class (fixes)

Failure-Class: FC-cache-prefix-evicted-from-head
