### PR TITLE
feat(llm): default cache on and isolate Flex controls

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -150,7 +150,7 @@ env:
   - name: OMI_LLM_GATEWAY_FEATURE_MODE
     value: "gateway"
   - name: OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED
-    value: "false"
+    value: "true"
   - name: OMI_LLM_CHAT_AGENT_ROUTE
     value: "gateway"
   - name: PUBLIC_SHARED_CONVERSATION_CHAT_MODE

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -130,7 +130,7 @@ env:
   - name: OMI_LLM_GATEWAY_FEATURE_MODE
     value: "gateway"
   - name: OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED
-    value: "false"
+    value: "true"
   - name: OMI_LLM_CHAT_AGENT_ROUTE
     value: "gateway"
   - name: PUBLIC_SHARED_CONVERSATION_CHAT_MODE

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -45,7 +45,7 @@ environments:
             value: gateway
             category: rollout
           OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED:
-            value: 'false'
+            value: 'true'
             category: rollout
           OMI_LLM_CHAT_AGENT_ROUTE:
             value: gateway
@@ -1022,7 +1022,7 @@ environments:
             value: gateway
             category: rollout
           OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED:
-            value: 'false'
+            value: 'true'
             category: rollout
           OMI_LLM_CHAT_AGENT_ROUTE:
             value: gateway

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -52,7 +52,7 @@ environment_shared:
           value: gateway
           category: rollout
         OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED:
-          value: 'false'
+          value: 'true'
           category: rollout
         OMI_LLM_CHAT_AGENT_ROUTE:
           value: gateway

--- a/backend/llm_gateway/gateway/accounting.py
+++ b/backend/llm_gateway/gateway/accounting.py
@@ -656,15 +656,24 @@ def _estimate_cost(
     )
     if cache_write_rate is not None:
         numerator += usage.cache_write_tokens * cache_write_rate
-    cache_savings_numerator = usage.cached_input_tokens * max(
-        rate_card.input_micro_usd_per_million - rate_card.cached_input_micro_usd_per_million,
-        0,
+    # Compare the cache-aware input bill with the counterfactual bill for all
+    # input tokens at this tier's ordinary input rate.  Cache writes are part
+    # of that prompt-token counterfactual too, so their premium (or discount)
+    # is included in the net savings.  This intentionally may be negative for
+    # a cache miss whose write has not yet been amortized by a later read.
+    cache_savings_numerator = usage.cached_input_tokens * (
+        rate_card.input_micro_usd_per_million - rate_card.cached_input_micro_usd_per_million
     )
+    if usage.cache_write_tokens:
+        # A missing write rate was rejected above whenever write tokens are
+        # present, so this is safe after the guard at the top of this block.
+        assert cache_write_rate is not None
+        cache_savings_numerator += usage.cache_write_tokens * (rate_card.input_micro_usd_per_million - cache_write_rate)
     if provider.strip().lower() == 'openai' and traffic_type == 'flex':
         # OpenAI documents Flex tokens at Batch API rates (50% below the
         # synchronous Standard rates represented by this rate card).
         numerator //= 2
-        cache_savings_numerator //= 2
+        cache_savings_numerator = _half_toward_zero(cache_savings_numerator)
         cost_basis = 'flex_batch_token_rates_excludes_cache_storage'
     else:
         cost_basis = 'marginal_token_rates_excludes_cache_storage'
@@ -674,7 +683,14 @@ def _estimate_cost(
 
 
 def _rounded_micro_usd(numerator: int) -> int:
-    return (numerator + TOKENS_PER_MILLION // 2) // TOKENS_PER_MILLION
+    if numerator >= 0:
+        return (numerator + TOKENS_PER_MILLION // 2) // TOKENS_PER_MILLION
+    return -((-numerator + TOKENS_PER_MILLION // 2) // TOKENS_PER_MILLION)
+
+
+def _half_toward_zero(value: int) -> int:
+    """Scale a signed numerator by Flex's 50% factor without floor bias."""
+    return value // 2 if value >= 0 else -((-value) // 2)
 
 
 @lru_cache(maxsize=1)

--- a/backend/runtime_images.json
+++ b/backend/runtime_images.json
@@ -152,6 +152,10 @@
             "workdir": "/app",
             "entrypoints": ["job"],
             "image_import_smoke": true,
+            "smoke_environment": {
+                "ENCRYPTION_SECRET": "0123456789abcdef0123456789abcdef",
+                "OPENAI_API_KEY": "fake-notifications-image-smoke-only"
+            },
             "dependency_probe_smoke": true,
             "pull_request_smoke": true,
             "dependency_probe_exclusions": {

--- a/backend/tests/unit/test_conversation_structure_timezone.py
+++ b/backend/tests/unit/test_conversation_structure_timezone.py
@@ -340,9 +340,12 @@ def test_gpt56_cache_keys_are_stable_versioned_and_never_include_request_content
     assert not conv_proc._has_gpt56_cacheable_static_prefix('short prefix')
 
 
-def test_gpt56_explicit_cache_requires_gateway_and_rollout_flag(monkeypatch):
+def test_gpt56_explicit_cache_defaults_on_in_gateway_and_honors_kill_switch(monkeypatch):
     monkeypatch.setattr(conv_proc, 'should_route_features_through_gateway', lambda: True)
     monkeypatch.delenv(conv_proc.GPT56_EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+    assert conv_proc._gpt56_explicit_cache_enabled()
+
+    monkeypatch.setenv(conv_proc.GPT56_EXPLICIT_CACHE_ENABLED_ENV, 'false')
     assert not conv_proc._gpt56_explicit_cache_enabled()
 
     monkeypatch.setenv(conv_proc.GPT56_EXPLICIT_CACHE_ENABLED_ENV, 'true')
@@ -356,13 +359,13 @@ def test_unique_prompt_routes_drop_legacy_cache_key_whenever_gateway_mode_is_on(
     """Regression (cubic review): the None/legacy cache_key split keys on gateway mode.
 
     get_reprocess_transcript_structure and get_app_result have no cacheable
-    static prefix. With the gateway on but the rollout flag off (the default
-    fail-closed state) they must still pass cache_key=None: a legacy
+    static prefix. With the gateway on they must still pass cache_key=None: a legacy
     prompt_cache_key would opt these unique-prompt requests back into
-    implicit, billable cache writes.
+    implicit, billable cache writes. The explicit cache kill switch is set
+    below to verify the old fully-disabled behavior remains available.
     """
     monkeypatch.setattr(conv_proc, 'should_route_features_through_gateway', lambda: True)
-    monkeypatch.delenv(conv_proc.GPT56_EXPLICIT_CACHE_ENABLED_ENV, raising=False)
+    monkeypatch.setenv(conv_proc.GPT56_EXPLICIT_CACHE_ENABLED_ENV, 'false')
 
     captured: dict = {}
 

--- a/backend/tests/unit/test_llm_gateway_accounting.py
+++ b/backend/tests/unit/test_llm_gateway_accounting.py
@@ -170,6 +170,91 @@ def test_openai_usage_parses_cache_writes_and_prices_luna_write_tokens() -> None
     assert event.rate_card_id == 'openai.gpt-5.6-luna.2026-07-30'
 
 
+def test_cache_write_only_miss_reports_negative_net_cache_savings() -> None:
+    trace = AttemptTrace()
+    attempt = trace.record(
+        provider='openai',
+        configured_model='gpt-5.6-luna',
+        route_artifact_id='route.test.001',
+        fallback_reason=None,
+        retry_ordinal=0,
+        outcome='success',
+        error_class='none',
+        metadata=ProviderResponseMetadata(
+            usage=ProviderUsage(
+                prompt_tokens=1_000_000,
+                cache_write_tokens=1_000_000,
+                cache_write_ttl='30m',
+            )
+        ),
+    )
+
+    event = build_accounting_event(_context(), attempt)
+
+    # A write costs $0.25/M while the ordinary input counterfactual costs
+    # $0.20/M, so this first miss is a $0.05/M net loss until it is reused.
+    assert event.estimated_cost_micro_usd == 250_000
+    assert event.estimated_cache_savings_micro_usd == -50_000
+
+
+def test_cache_write_and_read_report_net_cache_savings() -> None:
+    trace = AttemptTrace()
+    attempt = trace.record(
+        provider='openai',
+        configured_model='gpt-5.6-luna',
+        route_artifact_id='route.test.001',
+        fallback_reason=None,
+        retry_ordinal=0,
+        outcome='success',
+        error_class='none',
+        metadata=ProviderResponseMetadata(
+            usage=ProviderUsage(
+                prompt_tokens=2_000_000,
+                cached_input_tokens=1_000_000,
+                uncached_input_tokens=0,
+                cache_write_tokens=1_000_000,
+                cache_write_ttl='30m',
+                output_tokens=1_000_000,
+            )
+        ),
+    )
+
+    event = build_accounting_event(_context(), attempt)
+
+    # Counterfactual input bill: 2M * $0.20 = $0.40. Actual input bill is
+    # 1M * $0.02 + 1M * $0.25 = $0.27, for $0.13 net savings.
+    assert event.estimated_cost_micro_usd == 1_470_000
+    assert event.estimated_cache_savings_micro_usd == 130_000
+
+
+def test_flex_halves_complete_net_cache_savings_and_total_cost() -> None:
+    trace = AttemptTrace()
+    attempt = trace.record(
+        provider='openai',
+        configured_model='gpt-5.6-luna',
+        route_artifact_id='route.test.001',
+        fallback_reason=None,
+        retry_ordinal=0,
+        outcome='success',
+        error_class='none',
+        metadata=ProviderResponseMetadata(
+            usage=ProviderUsage(
+                prompt_tokens=2_000_000,
+                cached_input_tokens=1_000_000,
+                cache_write_tokens=1_000_000,
+                cache_write_ttl='30m',
+                output_tokens=1_000_000,
+            ),
+            traffic_type='flex',
+        ),
+    )
+
+    event = build_accounting_event(_context(), attempt)
+
+    assert event.estimated_cost_micro_usd == 735_000
+    assert event.estimated_cache_savings_micro_usd == 65_000
+
+
 def test_empty_usage_object_is_unreported_not_a_zero_cost_completion() -> None:
     metadata = openai_usage_from_response({'id': 'chatcmpl-empty', 'model': 'gpt-5.4-nano', 'usage': {}})
     trace = AttemptTrace()

--- a/backend/tests/unit/test_memory_promotion_flex.py
+++ b/backend/tests/unit/test_memory_promotion_flex.py
@@ -18,9 +18,10 @@ class _Db:
     def __init__(self, payload):
         self.payload = payload
         self.reads = 0
+        self.paths = []
 
     def document(self, path):
-        assert path == promotion_flex.BACKGROUND_FLEX_CONTROL_PATH
+        self.paths.append(path)
         outer = self
 
         class _Ref:
@@ -60,6 +61,38 @@ def test_static_capability_defaults_off_without_firestore_read(monkeypatch):
     assert db.reads == 0
 
 
+def test_background_flex_control_path_isolated_by_environment(monkeypatch):
+    monkeypatch.setenv(promotion_flex.BACKGROUND_FLEX_CAPABLE_ENV, "true")
+
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
+    dev_db = _Db(_flex_payload())
+    assert promotion_flex.background_flex_control_path() == "llm_runtime_controls/background_flex_dev"
+    assert promotion_flex.read_promotion_flex_control(db_client=dev_db).enabled is True
+
+    monkeypatch.setenv("OMI_ENV_STAGE", "prod")
+    prod_db = _Db({"enabled": False, "generation": 7})
+    assert promotion_flex.background_flex_control_path() == "llm_runtime_controls/background_flex_prod"
+    assert promotion_flex.read_promotion_flex_control(db_client=prod_db).enabled is False
+
+    assert dev_db.paths == ["llm_runtime_controls/background_flex_dev"]
+    assert prod_db.paths == ["llm_runtime_controls/background_flex_prod"]
+    assert dev_db.paths != prod_db.paths
+
+
+@pytest.mark.parametrize("stage", [None, "", "local", "offline", "staging", "production"])
+def test_missing_or_unsupported_environment_fails_closed_without_firestore_read(monkeypatch, stage):
+    monkeypatch.setenv(promotion_flex.BACKGROUND_FLEX_CAPABLE_ENV, "true")
+    if stage is None:
+        monkeypatch.delenv("OMI_ENV_STAGE", raising=False)
+    else:
+        monkeypatch.setenv("OMI_ENV_STAGE", stage)
+    db = _Db(_flex_payload())
+
+    assert promotion_flex.background_flex_control_path() is None
+    assert promotion_flex.read_promotion_flex_control(db_client=db) == promotion_flex.PromotionFlexControl()
+    assert db.reads == 0
+
+
 def test_gateway_flex_client_has_no_sdk_retry(monkeypatch):
     calls = []
     monkeypatch.setattr(
@@ -87,6 +120,7 @@ def test_gateway_flex_client_has_no_sdk_retry(monkeypatch):
 )
 def test_missing_or_invalid_live_control_fails_to_standard(monkeypatch, payload):
     monkeypatch.setenv(promotion_flex.BACKGROUND_FLEX_CAPABLE_ENV, "true")
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
 
     assert promotion_flex.read_promotion_flex_control(db_client=_Db(payload)) == promotion_flex.PromotionFlexControl()
 
@@ -103,6 +137,7 @@ def test_one_enabled_control_routes_every_scheduled_workload_to_flex(
     monkeypatch, standard_feature, flex_feature, workload
 ):
     monkeypatch.setenv(promotion_flex.BACKGROUND_FLEX_CAPABLE_ENV, "true")
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
     db = _Db(_flex_payload())
     calls = []
     router = promotion_flex.PromotionFlexRunRouter(
@@ -126,6 +161,7 @@ def test_one_enabled_control_routes_every_scheduled_workload_to_flex(
 
 def test_disabled_control_selects_no_flex_model(monkeypatch):
     monkeypatch.setenv(promotion_flex.BACKGROUND_FLEX_CAPABLE_ENV, "true")
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
     router = promotion_flex.PromotionFlexRunRouter(db_client=_Db({"enabled": False, "generation": 1}))
 
     assert (
@@ -142,6 +178,7 @@ def test_disabled_control_selects_no_flex_model(monkeypatch):
 
 def test_router_discards_result_when_live_generation_changes(monkeypatch):
     monkeypatch.setenv(promotion_flex.BACKGROUND_FLEX_CAPABLE_ENV, "true")
+    monkeypatch.setenv("OMI_ENV_STAGE", "dev")
     db = _Db(_flex_payload())
 
     class _ChangingModel(_Model):

--- a/backend/tests/unit/test_prompt_caching.py
+++ b/backend/tests/unit/test_prompt_caching.py
@@ -339,12 +339,12 @@ def test_explicit_cache_system_message_preserves_parser_schema_braces():
 
 
 def test_gateway_formatted_instructions_without_explicit_cache_stay_a_concrete_message():
-    """Flag-off gateway mode must not degrade pre-formatted instructions to a tuple template.
+    """The explicit-cache kill switch must not degrade pre-formatted instructions to a tuple template.
 
     Gateway mode pre-formats the parser schema (with literal JSON braces) into
     instructions_text. If that text were passed as a ('system', ...) template
     tuple, ChatPromptTemplate would parse the braces as variables and fail
-    before the LLM call — the default fail-closed state would be broken.
+    before the LLM call — the cache-off rollback path would be broken.
     """
     from langchain_core.prompts import ChatPromptTemplate
 

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -158,7 +158,7 @@ def _env_flag_enabled(name: str, *, default: bool = False) -> bool:
 
 
 def _gpt56_explicit_cache_enabled() -> bool:
-    return should_route_features_through_gateway() and _env_flag_enabled(GPT56_EXPLICIT_CACHE_ENABLED_ENV)
+    return should_route_features_through_gateway() and _env_flag_enabled(GPT56_EXPLICIT_CACHE_ENABLED_ENV, default=True)
 
 
 def _env_sample_rate(name: str, *, default: float = 0.0) -> float:

--- a/backend/utils/memory/ARCHITECTURE.md
+++ b/backend/utils/memory/ARCHITECTURE.md
@@ -109,8 +109,11 @@ extractor share one optional OpenAI Flex switch and use dedicated gateway lanes.
 Manual and post-OAuth X syncs remain Standard. Ordinary `memory_conflict`,
 `memory_l2`, and `memories` traffic keeps its Standard timeout and cannot
 request Flex. `OMI_BACKGROUND_FLEX_CAPABLE` is present only on the two owning
-jobs. The live Firestore control at `llm_runtime_controls/background_flex`
-must contain exactly:
+jobs. The live Firestore control is stage-scoped because dev and prod can share
+the customer Firestore project: dev uses
+`llm_runtime_controls/background_flex_dev`, and prod uses
+`llm_runtime_controls/background_flex_prod`. Each document must contain
+exactly:
 
 ```json
 {"enabled":false,"generation":1}

--- a/backend/utils/memory/promotion_flex.py
+++ b/backend/utils/memory/promotion_flex.py
@@ -2,7 +2,12 @@
 
 Once the owning jobs are deployed capable, operators can move every eligible
 scheduled call between Flex and the legacy Standard path without a redeploy by
-updating the single ``llm_runtime_controls/background_flex`` Firestore document.
+updating the single environment-scoped Firestore document for that stage.
+
+The dev and prod jobs can share the customer Firestore project, so the control
+document is deliberately stage-scoped. A missing, unsupported, or malformed
+``OMI_ENV_STAGE`` fails closed to Standard rather than risking a cross-stage
+toggle.
 """
 
 from __future__ import annotations
@@ -18,20 +23,16 @@ from utils.llm.clients import feature_auto_lane_id, get_or_create_omi_gateway_ll
 logger = logging.getLogger(__name__)
 
 BACKGROUND_FLEX_CAPABLE_ENV = "OMI_BACKGROUND_FLEX_CAPABLE"
-BACKGROUND_FLEX_CONTROL_PATH = "llm_runtime_controls/background_flex"
+BACKGROUND_FLEX_CONTROL_COLLECTION = "llm_runtime_controls"
+BACKGROUND_FLEX_CONTROL_DOCUMENT_PREFIX = "background_flex"
 BACKGROUND_FLEX_TIMEOUT_SECONDS = 900.0
 BACKGROUND_FLEX_LEASE_SECONDS = 1_200
 BACKGROUND_FLEX_JOB_BUDGET_SECONDS = 3_600.0
 BACKGROUND_FLEX_JOB_SAFETY_SECONDS = 300.0
 
-# Compatibility names retained while promotion call sites migrate with the rest
-# of this PR. They all point at the one shared background control.
-MEMORY_PROMOTION_FLEX_CAPABLE_ENV = BACKGROUND_FLEX_CAPABLE_ENV
-MEMORY_PROMOTION_FLEX_CONTROL_PATH = BACKGROUND_FLEX_CONTROL_PATH
-MEMORY_PROMOTION_FLEX_TIMEOUT_SECONDS = BACKGROUND_FLEX_TIMEOUT_SECONDS
+# The maintenance cron still imports this lease constant while its call sites
+# migrate to the shared Flex router.
 MEMORY_PROMOTION_FLEX_LEASE_SECONDS = BACKGROUND_FLEX_LEASE_SECONDS
-MEMORY_MAINTENANCE_JOB_BUDGET_SECONDS = BACKGROUND_FLEX_JOB_BUDGET_SECONDS
-MEMORY_PROMOTION_FLEX_JOB_SAFETY_SECONDS = BACKGROUND_FLEX_JOB_SAFETY_SECONDS
 
 _TRANSIENT_FLEX_STATUS_CODES = frozenset({408, 409, 429, 500, 502, 503, 504})
 _TRANSIENT_FLEX_EXCEPTION_NAMES = frozenset(
@@ -65,16 +66,31 @@ def promotion_flex_capable() -> bool:
     return os.getenv(BACKGROUND_FLEX_CAPABLE_ENV, "false").strip().lower() in {"1", "true", "yes"}
 
 
+def background_flex_control_path() -> Optional[str]:
+    """Return the strict stage-scoped control document path.
+
+    Dev and prod intentionally use separate Firestore documents because their
+    jobs may read the same customer-data project. Other stages are not allowed
+    to read or write a live Flex switch; callers must use the Standard path.
+    """
+
+    stage = os.getenv("OMI_ENV_STAGE", "").strip().lower()
+    if stage not in {"dev", "prod"}:
+        return None
+    return f"{BACKGROUND_FLEX_CONTROL_COLLECTION}/{BACKGROUND_FLEX_CONTROL_DOCUMENT_PREFIX}_{stage}"
+
+
 def _standard_control() -> PromotionFlexControl:
     return PromotionFlexControl()
 
 
 def read_promotion_flex_control(*, db_client: Any) -> PromotionFlexControl:
     """Read the strict shared control, failing safely to Standard."""
-    if not promotion_flex_capable():
+    control_path = background_flex_control_path()
+    if not promotion_flex_capable() or control_path is None:
         return _standard_control()
     try:
-        snapshot = db_client.document(BACKGROUND_FLEX_CONTROL_PATH).get()
+        snapshot = db_client.document(control_path).get()
         if not getattr(snapshot, "exists", False):
             return _standard_control()
         payload = snapshot.to_dict()
@@ -233,19 +249,18 @@ class PromotionFlexRunRouter:
 
 __all__ = [
     "BACKGROUND_FLEX_CAPABLE_ENV",
-    "BACKGROUND_FLEX_CONTROL_PATH",
+    "BACKGROUND_FLEX_CONTROL_COLLECTION",
+    "BACKGROUND_FLEX_CONTROL_DOCUMENT_PREFIX",
     "BACKGROUND_FLEX_JOB_BUDGET_SECONDS",
     "BACKGROUND_FLEX_JOB_SAFETY_SECONDS",
     "BACKGROUND_FLEX_LEASE_SECONDS",
     "BACKGROUND_FLEX_TIMEOUT_SECONDS",
-    "MEMORY_PROMOTION_FLEX_CAPABLE_ENV",
-    "MEMORY_PROMOTION_FLEX_CONTROL_PATH",
     "MEMORY_PROMOTION_FLEX_LEASE_SECONDS",
-    "MEMORY_PROMOTION_FLEX_TIMEOUT_SECONDS",
     "PromotionFlexControl",
     "PromotionFlexControlChanged",
     "PromotionFlexDeferred",
     "PromotionFlexRunRouter",
+    "background_flex_control_path",
     "promotion_flex_capable",
     "read_promotion_flex_control",
 ]


### PR DESCRIPTION
## What changed and why

Make explicit GPT-5.6 prompt caching the gateway-mode default while preserving `OMI_LLM_GPT56_EXPLICIT_CACHE_ENABLED=false` as the immediate rollback. Isolate the shared scheduled-background Flex switch per environment, report cache savings net of write premiums, and give the notifications image smoke the safe dummy import environment it requires.

This follows live dev proof on the merged precursor: two identical conversation-structure calls produced a 1,832-token cache write followed by a 1,832-token cache read. The pair saved approximately 238 micro-USD net after the write premium, about 31% versus ordinary input pricing for both prefixes.

## Product invariants affected

INV-MEM-1 — unchanged: the patch changes only scheduling/routing and cost accounting, not the three memory tiers or their access policy.

## How it was verified

- 319 focused unit/contract tests passed across prompt caching, Flex routing, gateway accounting, runtime environment composition, runtime images, and gateway coverage.
- `backend/scripts/check_runtime_env_compose.sh` reported the rendered manifest up to date.
- `validate-backend-runtime-env.py --env {dev,prod} --check-workflows` passed.
- Runtime-image source closure passed for all 13 registered images.
- Local notifications container smoke reached Docker invocation; the final build could not run because this host has no Docker daemon. PR CI exercises the same image smoke with Docker.
- `git diff --check` passed.

## Tests

- `test_gpt56_explicit_cache_defaults_on_in_gateway_and_honors_kill_switch`
- `test_background_flex_control_path_isolated_by_environment`
- `test_missing_or_unsupported_environment_fails_closed_without_firestore_read`
- `test_cache_write_only_miss_reports_negative_net_cache_savings`
- `test_cache_write_and_read_report_net_cache_savings`
- `test_flex_halves_complete_net_cache_savings_and_total_cost`

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

