### PR TITLE
ci: bump Codemagic Flutter to 3.44.5 to match GitHub Actions

### DIFF
--- a/app/setup.sh
+++ b/app/setup.sh
@@ -5,7 +5,7 @@
 # Prerequisites (stable versions, use these or higher):
 #
 # Common for all developers:
-# - Flutter SDK (v3.41.9)
+# - Flutter SDK (v3.44.5)
 # - Opus Codec: https://opus-codec.org
 #
 # For iOS Developers:
@@ -29,7 +29,7 @@ echo "👋 Yo folks! Welcome to the OMI Mobile Project - We're hiring! Join us o
 echo "Prerequisites (stable versions, use these or higher):"
 echo ""
 echo "Common for all developers:"
-echo "- Flutter SDK (v3.41.9)"
+echo "- Flutter SDK (v3.44.5)"
 echo "- Opus Codec: https://opus-codec.org"
 echo ""
 echo "For iOS Developers:"

--- a/app/setup/scripts/setup.ps1
+++ b/app/setup/scripts/setup.ps1
@@ -3,7 +3,7 @@
 # Prerequisites (stable versions, use these or higher):
 #
 # Common for all developers:
-# - Flutter SDK (v3.41.9)
+# - Flutter SDK (v3.44.5)
 # - Opus Codec: https://opus-codec.org
 #
 # For iOS Developers:
@@ -25,7 +25,7 @@ Write-Host "👋 Yo folks! Welcome to the OMI Mobile Project - We're hiring! Joi
 Write-Host "Prerequisites (stable versions, use these or higher):"
 Write-Host ""
 Write-Host "Common for all developers:"
-Write-Host "- Flutter SDK (v3.41.9)"
+Write-Host "- Flutter SDK (v3.44.5)"
 Write-Host "- Opus Codec: https://opus-codec.org"
 Write-Host ""
 Write-Host "For iOS Developers:"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -23,7 +23,7 @@ workflows:
         - shorebird
       vars:
         APP_ID: 6502156163
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
@@ -237,7 +237,7 @@ workflows:
         PACKAGE_NAME: "com.friend.ios"
         APP_ID: 6502156163
         JAVA_TOOL_OPTIONS: "-Xmx8g"
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 16.4
       cocoapods: 1.16.2
       java: 21
@@ -454,7 +454,7 @@ workflows:
         - shorebird
       vars:
         APP_ID: 6502156163
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
@@ -639,7 +639,7 @@ workflows:
       vars:
         APP_ID: 6502156163
         BUNDLE_ID: "com.friend-app-with-wearable.ios12"
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
@@ -829,7 +829,7 @@ workflows:
       vars:
         PACKAGE_NAME: "com.friend.ios"
         JAVA_TOOL_OPTIONS: "-Xmx8g"
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 16.4
       cocoapods: 1.16.2
       java: 21
@@ -1001,7 +1001,7 @@ workflows:
         - shorebird
       vars:
         APP_ID: 6502156163
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
@@ -1135,7 +1135,7 @@ workflows:
         PLATFORM: "macos"
         BUNDLE_ID: "com.friend-app-with-wearable.ios12"
         DMGBUILD_VERSION: "1.6.7"
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 26.0.1
       cocoapods: 1.16.2
     cache:
@@ -1667,7 +1667,7 @@ workflows:
         - shorebird
       vars:
         PACKAGE_NAME: "com.friend.ios"
-      flutter: 3.41.9
+      flutter: 3.44.5
       xcode: 16.4
       cocoapods: 1.16.2
       java: 21

--- a/docs/doc/developer/AppSetup.mdx
+++ b/docs/doc/developer/AppSetup.mdx
@@ -171,7 +171,7 @@ Manual setup gives you full control, allowing you to use your own backend.
     <AccordionGroup>
       <Accordion title="Example output" icon="terminal">
         ```
-        [✓] Flutter (Channel stable, 3.41.9, on macOS 15.4.1)
+        [✓] Flutter (Channel stable, 3.44.5, on macOS 15.4.1)
         [✓] Android toolchain - develop for Android devices (Android SDK version 36.0.0)
         [✓] Xcode - develop for iOS and macOS (Xcode 16.4)
         [✓] Chrome - develop for the web
@@ -183,7 +183,7 @@ Manual setup gives you full control, allowing you to use your own backend.
       </Accordion>
       <Accordion title="Recommended versions" icon="info-circle">
         This project is tested with specific tool versions. See [`app/setup.sh`](https://github.com/BasedHardware/omi/blob/main/app/setup.sh) for recommended versions:
-        - Flutter 3.41.9
+        - Flutter 3.44.5
         - Xcode 16.4
         - Android SDK Platform 35
         - NDK 28.2.13676358

--- a/docs/rayban-meta-dat-setup.md
+++ b/docs/rayban-meta-dat-setup.md
@@ -14,7 +14,7 @@ capture + HFP audio. Full mode is required for founder acceptance.
    only for a future beta-channel distribution build.
 3. DAT apps cannot ship through the App Store yet. Use a local development
    build for this checklist.
-4. Xcode 26 with the iOS 26 SDK, CocoaPods 1.16.2, Flutter 3.41.9, and an iOS
+4. Xcode 26 with the iOS 26 SDK, CocoaPods 1.16.2, Flutter 3.44.5, and an iOS
    15.2+ device. The current `.allowBluetoothHFP` source requires the iOS 26
    SDK even though the app back-deploys to iOS 15.2.
 
@@ -94,7 +94,7 @@ cd ../app
 # USE_WEB_AUTH=true
 # USE_AUTH_CUSTOM_TOKEN=true
 
-FLUTTER_BIN=/path/to/flutter-3.41.9/bin/flutter \
+FLUTTER_BIN=/path/to/flutter-3.44.5/bin/flutter \
   scripts/rayban_dat.sh run -d <physical-iphone-id>
 ```
 

--- a/docs/rayban-meta-founder-acceptance.md
+++ b/docs/rayban-meta-founder-acceptance.md
@@ -43,7 +43,7 @@ signing errors. Instead:
       `USE_AUTH_CUSTOM_TOKEN`/`USE_WEB_AUTH` flow match (custom-token auth; a
       natively-minted Firebase token is rejected by `api.omiapi.com` with 401).
 - [ ] Build and install via
-      `FLUTTER_BIN=/path/to/flutter-3.41.9/bin/flutter app/scripts/rayban_dat.sh run -d <device-id>`.
+      `FLUTTER_BIN=/path/to/flutter-3.44.5/bin/flutter app/scripts/rayban_dat.sh run -d <device-id>`.
       Never hand-install a stale `build/ios/iphoneos/Runner.app`.
 - [ ] Before pairing, inspect the launch log: no duplicate SwiftProtobuf class
       warning, `SIGSEGV`, `EXC_BAD_ACCESS`, or `swift_getObjectType` crash.


### PR DESCRIPTION
## What

Every Codemagic mobile build has been failing at `Get Flutter packages` since 15 Aug:

```
The current Dart SDK version is 3.11.5.

Because flutter_contacts 2.3.1 requires SDK version ^3.12.0 and no versions of
flutter_contacts match >2.3.1 <3.0.0, flutter_contacts ^2.3.1 is forbidden.
So, because omi depends on flutter_contacts ^2.3.1, version solving failed.
```

Bumps the eight Codemagic Flutter pins from `3.41.9` to `3.44.5`, matching what GitHub Actions already runs.

## Why it broke

Two commits, three days apart, neither wrong on its own:

- **`35c146d3fa`** (12 Aug, *stabilize mobile and Swift release CI*) moved **GitHub Actions** to Flutter 3.44.5 and left **Codemagic** on 3.41.9. From then on the two lanes ran different Flutter versions.
- **`34e2ba8e72`** (15 Aug, #11595, *migrate flutter_contacts to 2.x*) bumped `flutter_contacts: ^1.1.9+2` → `^2.3.1`, which requires Dart `^3.12.0`. It touched `pubspec.yaml`, `pubspec.lock` and three call sites — correctly — and nothing else.

| Lane | Flutter | Dart | Result |
|---|---|---|---|
| GitHub Actions | 3.44.5 | 3.12.2 | passes |
| Codemagic | 3.41.9 | 3.11.5 | `version solving failed` |

**CI could not have caught this.** #11595 was green on GitHub Actions because that lane was already on a Flutter new enough to satisfy the new constraint. The failure only appears on the lane whose version nothing checks.

## Scope

All eight workflows with a Flutter pin were affected — every internal and store build path:

`ios-internal-auto`, `android-internal-auto`, `ios-prod-testflight`, `macos-prod-appstore`, `android-prod-internal`, `ios-prod-patch`, `macos-prod-legacy-no-publish`, `android-prod-patch`

Also updated the developer-facing copies of the same pin, which would otherwise hand a new contributor a toolchain that cannot resolve this repo: `app/setup.sh`, `app/setup/scripts/setup.ps1`, `docs/doc/developer/AppSetup.mdx`, `docs/rayban-meta-dat-setup.md`, `docs/rayban-meta-founder-acceptance.md`.

Left alone: `app/ios/test/rayban_dat_plugin_boundary_test.rb:233`, where `'version' => '3.41.9'` is arbitrary fixture content inside a fake `.flutter-plugins-dependencies` blob for a plugin-registration test, not a toolchain pin.

`xcode`, `cocoapods` and `java` pins are unchanged.

## Why 3.44.5 and not 3.47.0

`pub` suggests 3.47.0, but 3.44.5 is the version GitHub Actions already runs green on this exact `pubspec.lock`. Matching the lane that works is the smaller change; moving both lanes to a newer Flutter is a separate decision with its own verification.

## Verification

Reproduced and fixed locally on the real toolchains, against this repo's unmodified `pubspec.yaml`/`pubspec.lock`:

- Flutter **3.41.x** (Dart 3.11.0): `flutter pub get` fails with the identical `version solving failed` error.
- Flutter **3.44.5** (Dart 3.12.2, confirmed via `dart --version`): `flutter pub get` → `Got dependencies!`, and `git status` is clean afterwards, so the lockfile does not drift.
- `app/test.sh` on 3.44.5 at this branch's base — **1338 passed**, whole suite green on the toolchain this PR moves Codemagic to.
- `codemagic.yaml` parses as YAML and all 8 pins read `3.44.5`; asserted programmatically rather than by eye.
- `make preflight` — 11/11.

Not verified: the Codemagic build itself. I cannot trigger one, so the first real proof is the next build after merge. The failing step is `pub get`, which is exactly what was reproduced above.

## Follow-up (deliberately not in this PR)

Nothing checks that `codemagic.yaml` and the GitHub workflow pins agree, which is the actual reason a routine dependency bump took out every release lane while CI stayed green. A manifest check comparing the two would have failed #11595 in CI instead of at build time. Left out to keep this PR to the unblock; happy to add it separately.
