### PR TITLE
Refresh the Codemagic fixture digests broken by the Flutter 3.44.5 bump (unblocks Hygiene on every PR)

### DIFF
--- a/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
+++ b/.github/scripts/fixtures/codemagic_workflow_contract/v1.json
@@ -1,6 +1,6 @@
 {
-  "codemagic_raw_sha256": "941fd7588a169eeb5307b8f90f76bfe874960365b8ca0e879dd9234373c5081a",
-  "codemagic_semantic_sha256": "a2d952c0d27db55dcd558e49805f096d5a884a55d8db2fa124a61fa5315a5876",
+  "codemagic_raw_sha256": "826c7aba7465777a0965c2ab50b1fc12070f2aefbbb7b1d80e326355b21a206d",
+  "codemagic_semantic_sha256": "a72c79d0e2bec1339d777e3be3c928b1d0f5eeb39071467979b83537ae0ccf25",
   "omi-desktop-swift-preview": {
     "semantic_sha256": "119fd99599dc625f923305cedc27e300b83bb6df30a66e4beb3a2da3ada39f17"
   },


### PR DESCRIPTION
## Summary

Main's Hygiene lane is red for every PR right now: #11672 (92a2ff1172) bumped the eight Codemagic Flutter pins to 3.44.5 without refreshing the reviewed digest fixture, and the release-process guard is built to fail exactly then. This PR is the two-line fixture refresh that re-approves the current document.

This is the same unblock class as #11629 (a desktop route landed without its spec entry and broke an inventory guard for every open PR).

## What changed and how it was computed

Only `.github/scripts/fixtures/codemagic_workflow_contract/v1.json`, two values. Both digests were recomputed with the check script's own functions, not by hand: `_read_security_bound_file` + `_sha256_bytes` for the raw digest, and `_sha256_text(_canonical_json(document))` over the safe-loaded document for the semantic digest, against `codemagic.yaml` exactly as merged at 94487a41fb.

- codemagic_raw_sha256: 941fd758... to 826c7aba...
- codemagic_semantic_sha256: a2d952c0... to a72c79d0...

## Review surface

The fixture is a reviewed security boundary, so what matters is what these digests newly approve: precisely the 16-line version-pin diff of 92a2ff1172 (eight `flutter:` pins to 3.44.5), which was itself reviewed and merged. No workflow topology, credential, publishing step, or script content changed, and the guard's narrower per-workflow contract checks pass unchanged before and after.

## Verification

- `check-release-process-guards.py` reported the two digest errors before this change and reports zero errors after.
- Its test file goes from 11 local failures to 9: the two digest-dependent tests (`test_fixture_independently_hashes_only_current_codemagic_source` and one sibling) now pass; the remaining nine are POSIX symlink and O_NOFOLLOW tests that fail identically on clean main under Windows and run properly on the Linux CI runner.
- Guard doctrine note from the script itself: "Future Codemagic edits must intentionally update the reviewed fixture digests" - this PR is that intentional update, one commit late.

Product invariants affected: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

