### PR TITLE
fix(app): disable Swift Package Manager to unbreak iOS archives

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -180,6 +180,14 @@ flutter_launcher_icons:
   image_path: "assets/images/app_launcher_icon.png"
 
 flutter:
+  # Flutter 3.44 turned Swift Package Manager on by default for iOS/macOS.
+  # firebase_crashlytics 4.3.2 is built against firebase_core 3.11.0 while
+  # firebase_messaging 15.2.5 is built against 3.13.0, so SPM cannot resolve a
+  # single `flutterfire` package version and every iOS archive fails. CocoaPods
+  # tolerates the skew. Re-enable once the Firebase plugin versions are aligned;
+  # Flutter will eventually stop honouring this. https://github.com/BasedHardware/omi/issues/11676
+  config:
+    enable-swift-package-manager: false
   generate: true
   uses-material-design: true
   assets:


### PR DESCRIPTION
## What

Every iOS archive has failed since #11672 merged:

```
xcodebuild: error: Could not resolve package dependencies:
  Failed to resolve dependencies Dependencies could not be resolved because
  'firebase_crashlytics-4.3.2' depends on 'flutterfire' 3.11.0-firebase-core-swift and
  'firebase_messaging-15.2.5' depends on 'flutterfire' 3.13.0-firebase-core-swift.
```

Disables Swift Package Manager at the project level, restoring the CocoaPods plugin resolution that has been shipping all along. Four lines in `app/pubspec.yaml`.

## Why it broke

#11672 moved Codemagic from Flutter 3.41.9 to 3.44.5 to fix `pub get`. That was the right fix for the Dart constraint, but 3.44 also flips a default I did not check. From `flutter_tools/lib/src/features.dart`:

```dart
// 3.41.9
const swiftPackageManager = Feature(
  stable: FeatureChannelSetting(available: true),                          // → off
);

// 3.44.5
const swiftPackageManager = Feature(
  stable: FeatureChannelSetting(available: true, enabledByDefault: true),  // → ON
);
```

3.41.9 resolved iOS plugins through CocoaPods. 3.44.5 resolves them as Swift packages, which exposes a version skew that was **already in the repo and invisible under CocoaPods**:

| Pinned in `app/pubspec.yaml` | Declares |
|---|---|
| `firebase_core: 3.13.0` | — |
| `firebase_messaging: 15.2.5` | `firebase_core: ^3.13.0` |
| `firebase_crashlytics: 4.3.2` | `firebase_core: ^3.11.0` |

`firebase_crashlytics` is two minor versions behind the pinned core. CocoaPods tolerates that; SPM will not hold two versions of the same `flutterfire` package, so resolution fails outright.

## Why this fix and not the version bump

The durable fix is aligning the Firebase plugins — tracked in #11676, with `firebase_crashlytics 4.3.5` as the release built against `firebase_core 3.13.0`. That is a runtime dependency change to a shipping app whose only real acceptance test is an iOS archive, so it should land deliberately rather than as a hotfix.

This change instead restores the exact plugin resolution that was in production before #11672, which is the smallest thing that unblocks the release lanes.

Placed in `pubspec.yaml` rather than as a Codemagic env var or `flutter config` call: the project manifest is first in Flutter's resolution order (project → global config → environment), so it fixes local builds and every CI lane from one checked-in place, instead of leaving contributors on 3.44.x to rediscover this.

Flutter warns that disabling "will not be allowed in a future version", so #11676 is not optional — the comment in `pubspec.yaml` links it.

`meta-wearables-dat-ios` is unaffected: it is a direct `XCRemoteSwiftPackageReference` in `Runner.xcodeproj`, resolved by Xcode independently of Flutter's plugin SPM integration. The failing log shows it fetching successfully before Flutter's step failed.

## Verification

I have no macOS, so I cannot run the archive that failed. What I could prove locally, I did:

- **The key is live and correctly spelled.** Negative control: setting `enable-swift-package-manager: "not-a-bool"` in this pubspec makes `flutter pub get` exit with

  ```
  The "enable-swift-package-manager" property in "flutter: config:" in pubspec.yaml
  must be a boolean, but got not-a-bool (String)
  ```

  That message is emitted from `_isEnabledAtProjectLevel` reading `flutterDescriptor['config']['enable-swift-package-manager']`, so Flutter is demonstrably reading this key from this file. A typo would have silently no effect; this rules that out.
- `flutter pub get` with the real value — `Got dependencies!`, lockfile unchanged.
- `app/test.sh` on Flutter 3.44.5 with the flag set — **1338 passed**, exit 0.
- `make preflight` — 11/11.

**Not verified: the iOS archive.** `.flutter-plugins-dependencies` reports `swift_package_manager_enabled: {ios: false, macos: false}` on Linux whether or not the flag is set, because `usesSwiftPackageManager` is `featureFlags.isSwiftPackageManagerEnabled && compatibleWithSwiftPackageManager` and the second term needs Xcode. So that file is not evidence either way here, and I am not citing it as such. The first real proof is the next Codemagic iOS build.

## Follow-up

- #11676 — align the Firebase plugin versions and remove this flag.
- Still unaddressed from #11672: nothing compares the Codemagic and GitHub Actions Flutter pins. Worth noting that a drift check would not have caught *this* one either — both lanes now agree on 3.44.5 and the SPM default bites both. The gap this exposes is different: a Flutter major/minor bump changes build-system defaults, and neither lane builds iOS in PR CI, so only a post-merge Codemagic run can catch it.
