### PR TITLE
fix(desktop): stop the shipped task prompt default from blocking sync hydration (#11481)

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistantSettings.swift
@@ -128,7 +128,7 @@ class InsightAssistantSettings {
     set {
       let isCustom = newValue != InsightAssistantSettings.defaultAnalysisPrompt
       UserDefaults.standard.set(newValue, forKey: analysisPromptKey)
-      SettingsSyncManager.recordLocalPromptOwner("insight")
+      SettingsSyncManager.recordLocalPromptOwner("insight", isShippedDefault: !isCustom)
       let previewLength = min(newValue.count, 50)
       let preview = String(newValue.prefix(previewLength)) + (newValue.count > 50 ? "..." : "")
       log("Insight analysis prompt updated (\(newValue.count) chars, custom: \(isCustom)): \(preview)")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift
@@ -189,7 +189,7 @@ class MemoryAssistantSettings {
     set {
       let isCustom = newValue != MemoryAssistantSettings.defaultAnalysisPrompt
       UserDefaults.standard.set(newValue, forKey: analysisPromptKey)
-      SettingsSyncManager.recordLocalPromptOwner("memory")
+      SettingsSyncManager.recordLocalPromptOwner("memory", isShippedDefault: !isCustom)
       let previewLength = min(newValue.count, 50)
       let preview = String(newValue.prefix(previewLength)) + (newValue.count > 50 ? "..." : "")
       log("Memory analysis prompt updated (\(newValue.count) chars, custom: \(isCustom)): \(preview)")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistantSettings.swift
@@ -323,7 +323,7 @@ class TaskAssistantSettings {
     set {
       let isCustom = newValue != TaskAssistantSettings.defaultAnalysisPrompt
       UserDefaults.standard.set(newValue, forKey: analysisPromptKey)
-      SettingsSyncManager.recordLocalPromptOwner("task")
+      SettingsSyncManager.recordLocalPromptOwner("task", isShippedDefault: !isCustom)
       let previewLength = min(newValue.count, 50)
       let preview = String(newValue.prefix(previewLength)) + (newValue.count > 50 ? "..." : "")
       log("Task analysis prompt updated (\(newValue.count) chars, custom: \(isCustom)): \(preview)")

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -212,7 +212,7 @@ class SettingsSyncManager {
     // grapheme clusters and can undercount emoji and composed scripts.
     let length = prompt.unicodeScalars.count
     guard length <= maximumLength else {
-      if prompt == shippedDefault {
+      if isShippedDefault(prompt, shippedDefault: shippedDefault, assistantName: assistantName) {
         // Every install already ships this text, so an oversized default is not unsynced
         // user data — a later pull has nothing of the user's to destroy. Claiming
         // ownership here is what made `applyRemotePrompt` refuse the account's real
@@ -235,11 +235,41 @@ class SettingsSyncManager {
     return prompt
   }
 
-  /// Record prompt ownership at the local write boundary so an oversized value is
-  /// protected even before the next network sync attempt.
-  static func recordLocalPromptOwner(_ assistantName: String) {
+  /// Record prompt provenance and ownership at the local write boundary, so an oversized
+  /// user-authored value is protected even before the next network sync attempt.
+  ///
+  /// The provenance marker is what keeps a *previously* shipped default recognisable after
+  /// the app ships a new one. By then the persisted text no longer matches the current
+  /// default, but this recorded the answer while it still did.
+  static func recordLocalPromptOwner(_ assistantName: String, isShippedDefault: Bool) {
+    UserDefaults.standard.set(
+      isShippedDefault, forKey: storedPromptIsShippedDefaultKey(assistantName))
+    guard !isShippedDefault else {
+      // Writing a shipped default releases any claim the previous value held: there is no
+      // longer unsynced user text here for a pull to destroy.
+      UserDefaults.standard.removeObject(forKey: oversizedPromptOwnerKey(assistantName))
+      return
+    }
     guard let owner = currentOwnerID else { return }
     UserDefaults.standard.set(owner, forKey: oversizedPromptOwnerKey(assistantName))
+  }
+
+  /// Whether a local prompt is a shipped default rather than something the user authored.
+  ///
+  /// Text comparison alone only recognises the *current* default, and the reset path
+  /// persists the default it saw. After the app ships a new one, that stored text stops
+  /// matching and would be misread as user-authored — claiming ownership and blocking the
+  /// account's prompt all over again. The recorded marker covers exactly that window.
+  ///
+  /// An absent marker means a build older than this one wrote the value, so the text
+  /// comparison stands alone and behaviour is unchanged for it.
+  private static func isShippedDefault(
+    _ prompt: String,
+    shippedDefault: String,
+    assistantName: String
+  ) -> Bool {
+    if prompt == shippedDefault { return true }
+    return UserDefaults.standard.bool(forKey: storedPromptIsShippedDefaultKey(assistantName))
   }
 
   /// An oversized local prompt that the user wrote is unsynced data. Preserve it across
@@ -260,7 +290,8 @@ class SettingsSyncManager {
   ) {
     let localLength = localPrompt.unicodeScalars.count
     let recordedOwner = UserDefaults.standard.string(forKey: Self.oversizedPromptOwnerKey(assistantName))
-    if localPrompt != shippedDefault,
+    if !Self.isShippedDefault(
+      localPrompt, shippedDefault: shippedDefault, assistantName: assistantName),
       localLength > maximumLength,
       let currentOwner = Self.currentOwnerID,
       recordedOwner == currentOwner
@@ -284,5 +315,9 @@ class SettingsSyncManager {
 
   private static func oversizedPromptOwnerKey(_ assistantName: String) -> String {
     "assistantPrompt.unsyncedOversizedOwner.\(assistantName)"
+  }
+
+  private static func storedPromptIsShippedDefaultKey(_ assistantName: String) -> String {
+    "assistantPrompt.storedIsShippedDefault.\(assistantName)"
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -74,7 +74,8 @@ class SettingsSyncManager {
           v,
           overLocalPrompt: TaskAssistantSettings.shared.analysisPrompt,
           assistantName: "task",
-          maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength
+          maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength,
+          shippedDefault: TaskAssistantSettings.defaultAnalysisPrompt
         ) { TaskAssistantSettings.shared.analysisPrompt = $0 }
       }
       if let v = task.extractionInterval { TaskAssistantSettings.shared.extractionInterval = v }
@@ -92,7 +93,8 @@ class SettingsSyncManager {
           v,
           overLocalPrompt: InsightAssistantSettings.shared.analysisPrompt,
           assistantName: "insight",
-          maximumLength: 10_000
+          maximumLength: 10_000,
+          shippedDefault: InsightAssistantSettings.defaultAnalysisPrompt
         ) { InsightAssistantSettings.shared.analysisPrompt = $0 }
       }
       if let v = insight.extractionInterval { InsightAssistantSettings.shared.extractionInterval = v }
@@ -109,7 +111,8 @@ class SettingsSyncManager {
           v,
           overLocalPrompt: MemoryAssistantSettings.shared.analysisPrompt,
           assistantName: "memory",
-          maximumLength: 10_000
+          maximumLength: 10_000,
+          shippedDefault: MemoryAssistantSettings.defaultAnalysisPrompt
         ) { MemoryAssistantSettings.shared.analysisPrompt = $0 }
       }
       if let v = memory.extractionInterval { MemoryAssistantSettings.shared.extractionInterval = v }
@@ -146,7 +149,8 @@ class SettingsSyncManager {
       analysisPrompt: Self.promptForSync(
         TaskAssistantSettings.shared.analysisPrompt,
         assistantName: "task",
-        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength),
+        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength,
+        shippedDefault: TaskAssistantSettings.defaultAnalysisPrompt),
       extractionInterval: TaskAssistantSettings.shared.extractionInterval,
       minConfidence: TaskAssistantSettings.shared.minConfidence,
       notificationsEnabled: TaskAssistantSettings.shared.notificationsEnabled,
@@ -159,7 +163,8 @@ class SettingsSyncManager {
       analysisPrompt: Self.promptForSync(
         InsightAssistantSettings.shared.analysisPrompt,
         assistantName: "insight",
-        maximumLength: 10_000),
+        maximumLength: 10_000,
+        shippedDefault: InsightAssistantSettings.defaultAnalysisPrompt),
       extractionInterval: InsightAssistantSettings.shared.extractionInterval,
       minConfidence: InsightAssistantSettings.shared.minConfidence,
       notificationsEnabled: InsightAssistantSettings.shared.notificationsEnabled,
@@ -171,7 +176,8 @@ class SettingsSyncManager {
       analysisPrompt: Self.promptForSync(
         MemoryAssistantSettings.shared.analysisPrompt,
         assistantName: "memory",
-        maximumLength: 10_000),
+        maximumLength: 10_000,
+        shippedDefault: MemoryAssistantSettings.defaultAnalysisPrompt),
       extractionInterval: MemoryAssistantSettings.shared.extractionInterval,
       minConfidence: MemoryAssistantSettings.shared.minConfidence,
       notificationsEnabled: MemoryAssistantSettings.shared.notificationsEnabled,
@@ -198,13 +204,25 @@ class SettingsSyncManager {
   static func promptForSync(
     _ prompt: String,
     assistantName: String,
-    maximumLength: Int
+    maximumLength: Int,
+    shippedDefault: String
   ) -> String? {
     // Pydantic validates Python string length in Unicode code points. Swift's
     // unicodeScalars is the corresponding count; String.count measures extended
     // grapheme clusters and can undercount emoji and composed scripts.
     let length = prompt.unicodeScalars.count
     guard length <= maximumLength else {
+      if prompt == shippedDefault {
+        // Every install already ships this text, so an oversized default is not unsynced
+        // user data — a later pull has nothing of the user's to destroy. Claiming
+        // ownership here is what made `applyRemotePrompt` refuse the account's real
+        // prompt forever on any Mac still sitting on the default (#11481).
+        UserDefaults.standard.removeObject(forKey: oversizedPromptOwnerKey(assistantName))
+        log(
+          "SettingsSyncManager: omitted oversized shipped \(assistantName) default from sync "
+            + "(\(length) Unicode scalars; max \(maximumLength))")
+        return nil
+      }
       if let owner = currentOwnerID {
         UserDefaults.standard.set(owner, forKey: oversizedPromptOwnerKey(assistantName))
       }
@@ -224,19 +242,26 @@ class SettingsSyncManager {
     UserDefaults.standard.set(owner, forKey: oversizedPromptOwnerKey(assistantName))
   }
 
-  /// An oversized local prompt is unsynced user data. Preserve it across pulls until
-  /// the user edits it back within the contract; otherwise a later server hydration
-  /// would destroy the exact value deliberately omitted from PATCH.
+  /// An oversized local prompt that the user wrote is unsynced data. Preserve it across
+  /// pulls until they edit it back within the contract; otherwise a later server
+  /// hydration would destroy the exact value deliberately omitted from PATCH.
+  ///
+  /// The shipped default is excluded: it is text every install already has, so there is
+  /// nothing unsynced to lose, and a default that happens to exceed the bound must not
+  /// veto the account's real prompt. That exclusion is what a fresh install, and a Mac
+  /// that has just reset to the default, both depend on to receive it (#11481).
   private func applyRemotePrompt(
     _ remotePrompt: String,
     overLocalPrompt localPrompt: String,
     assistantName: String,
     maximumLength: Int,
+    shippedDefault: String,
     apply: (String) -> Void
   ) {
     let localLength = localPrompt.unicodeScalars.count
     let recordedOwner = UserDefaults.standard.string(forKey: Self.oversizedPromptOwnerKey(assistantName))
-    if localLength > maximumLength,
+    if localPrompt != shippedDefault,
+      localLength > maximumLength,
       let currentOwner = Self.currentOwnerID,
       recordedOwner == currentOwner
     {

--- a/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
@@ -148,6 +148,62 @@ final class APIClientAssistantSettingsTests: XCTestCase {
     }
   }
 
+  /// A shipped default that is still persisted after the app changed its default. The
+  /// stored text no longer matches the current default, so only the provenance recorded at
+  /// write time can tell it apart from something the user wrote — without it the old
+  /// default is reclassified as custom, claims ownership, and blocks the account prompt
+  /// exactly as before.
+  @MainActor
+  func testPersistedPreviousShippedDefaultStillHydrates() {
+    withTaskPromptState(owner: "owner-default-changed") {
+      let previouslyShippedDefault = String(
+        repeating: "y", count: TaskAssistantSettings.maximumSyncedAnalysisPromptLength + 1)
+
+      // The older build stored its own shipped default: the write recorded it as shipped,
+      // which is the classification this build can no longer derive from the text.
+      TaskAssistantSettings.shared.analysisPrompt = previouslyShippedDefault
+      SettingsSyncManager.recordLocalPromptOwner("task", isShippedDefault: true)
+
+      // This build ships a different default, so the stored text matches nothing.
+      XCTAssertNotEqual(
+        TaskAssistantSettings.shared.analysisPrompt, TaskAssistantSettings.defaultAnalysisPrompt)
+
+      // The push has to run first: it is what re-claims ownership of an oversized prompt,
+      // so without provenance this is the step that locks the old default in place.
+      XCTAssertNil(
+        SettingsSyncManager.promptForSync(
+          TaskAssistantSettings.shared.analysisPrompt,
+          assistantName: "task",
+          maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength,
+          shippedDefault: TaskAssistantSettings.defaultAnalysisPrompt))
+
+      hydrateTaskPrompt("account prompt")
+
+      XCTAssertEqual(
+        TaskAssistantSettings.shared.analysisPrompt,
+        "account prompt",
+        "a previously shipped default is still a shipped default, not user-authored text")
+    }
+  }
+
+  /// The other half of that contract: provenance must not become a blanket exemption. A
+  /// prompt the user actually wrote stays protected even though it is equally oversized.
+  @MainActor
+  func testUserAuthoredOversizedPromptIsNotTreatedAsAShippedDefault() {
+    withTaskPromptState(owner: "owner-authored") {
+      let authored = String(
+        repeating: "z", count: TaskAssistantSettings.maximumSyncedAnalysisPromptLength + 1)
+      TaskAssistantSettings.shared.analysisPrompt = authored
+
+      hydrateTaskPrompt("account prompt")
+
+      XCTAssertEqual(
+        TaskAssistantSettings.shared.analysisPrompt,
+        authored,
+        "text the user wrote and the server never took must stay protected")
+    }
+  }
+
   /// Reset means this device has no custom local opinion, so account state may hydrate
   /// again — even though the prompt the user is resetting away from did own the stamp.
   @MainActor

--- a/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
@@ -90,6 +90,101 @@ final class APIClientAssistantSettingsTests: XCTestCase {
     XCTAssertEqual(TaskAssistantSettings.shared.analysisPrompt, localPrompt)
   }
 
+  // MARK: - The shipped default is not unsynced user data (#11481)
+  //
+  // The oversized-prompt protection defends text the user wrote that the server never
+  // accepted. The shipped task default is not that: it is over the 10k bound, but every
+  // install already has it, so there is nothing unsynced to lose. Treating it as owned
+  // made `applyRemotePrompt` refuse every remote prompt, so a prompt customised on one
+  // Mac could never reach a Mac still sitting on the default.
+  //
+  // Ownership is asserted through its observable consequence — whether a later pull is
+  // allowed to hydrate — rather than by reading the bookkeeping key.
+
+  @MainActor
+  private func withTaskPromptState(owner: String, _ body: () -> Void) {
+    let originalPrompt = TaskAssistantSettings.shared.analysisPrompt
+    let originalOwner = UserDefaults.standard.string(forKey: .authUserId)
+    defer {
+      TaskAssistantSettings.shared.analysisPrompt = originalPrompt
+      UserDefaults.standard.set(originalOwner, forKey: .authUserId)
+    }
+    UserDefaults.standard.set(owner, forKey: .authUserId)
+    body()
+  }
+
+  @MainActor
+  private func hydrateTaskPrompt(_ remotePrompt: String) {
+    SettingsSyncManager.shared.applyRemoteSettings(
+      AssistantSettingsResponse(task: TaskSettingsResponse(analysisPrompt: remotePrompt)))
+  }
+
+  /// Fresh install: nothing stored, so the getter serves the shipped default. The push
+  /// still omits it — it is over the bound — but must not claim it as unsynced user data,
+  /// or the account's own prompt can never arrive.
+  @MainActor
+  func testShippedDefaultIsOmittedFromSyncWithoutBlockingLaterHydration() {
+    withTaskPromptState(owner: "owner-fresh-install") {
+      TaskAssistantSettings.shared.resetPromptToDefault()
+
+      XCTAssertNil(
+        SettingsSyncManager.promptForSync(
+          TaskAssistantSettings.shared.analysisPrompt,
+          assistantName: "task",
+          maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength,
+          shippedDefault: TaskAssistantSettings.defaultAnalysisPrompt),
+        "the shipped default is over the bound, so it still cannot be sent")
+
+      hydrateTaskPrompt("prompt from another mac")
+
+      XCTAssertEqual(
+        TaskAssistantSettings.shared.analysisPrompt,
+        "prompt from another mac",
+        "omitting the default must not also claim it as unsynced user data")
+    }
+  }
+
+  /// Reset means this device has no custom local opinion, so account state may hydrate
+  /// again — even though the prompt the user is resetting away from did own the stamp.
+  @MainActor
+  func testRemoteHydrationAppliesAfterResetToDefault() {
+    withTaskPromptState(owner: "owner-reset") {
+      TaskAssistantSettings.shared.analysisPrompt = String(
+        repeating: "x", count: TaskAssistantSettings.maximumSyncedAnalysisPromptLength + 1)
+      TaskAssistantSettings.shared.resetPromptToDefault()
+
+      hydrateTaskPrompt("account prompt")
+
+      XCTAssertEqual(
+        TaskAssistantSettings.shared.analysisPrompt,
+        "account prompt",
+        "a reset leaves no local opinion, so a stale stamp must not veto the account")
+    }
+  }
+
+  /// The reset the UI actually performs. `TaskPromptEditorView.resetToDefault()` clears the
+  /// stored prompt, then assigns the editor's `@State`, which fires `.onChange` and writes
+  /// the default straight back through the setter — re-storing it *and* re-stamping
+  /// ownership. Key presence therefore cannot tell "user authored this" from "user reset
+  /// to default"; the prompt text can.
+  @MainActor
+  func testRemoteHydrationAppliesAfterTheResetPathTheEditorPerforms() {
+    withTaskPromptState(owner: "owner-editor-reset") {
+      TaskAssistantSettings.shared.analysisPrompt = String(
+        repeating: "x", count: TaskAssistantSettings.maximumSyncedAnalysisPromptLength + 1)
+      TaskAssistantSettings.shared.resetPromptToDefault()
+      // What the editor's .onChange does immediately afterwards.
+      TaskAssistantSettings.shared.analysisPrompt = TaskAssistantSettings.defaultAnalysisPrompt
+
+      hydrateTaskPrompt("account prompt")
+
+      XCTAssertEqual(
+        TaskAssistantSettings.shared.analysisPrompt,
+        "account prompt",
+        "a re-stamped shipped default must still not veto the account's prompt")
+    }
+  }
+
   @MainActor
   func testRemoteHydrationReplacesOversizedPromptOwnedByAnotherAccount() {
     let originalPrompt = TaskAssistantSettings.shared.analysisPrompt

--- a/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
@@ -106,8 +106,12 @@ final class APIClientAssistantSettingsTests: XCTestCase {
     let originalPrompt = TaskAssistantSettings.shared.analysisPrompt
     let originalOwner = UserDefaults.standard.string(forKey: .authUserId)
     defer {
-      TaskAssistantSettings.shared.analysisPrompt = originalPrompt
+      // Restore the owner *before* the prompt. The `analysisPrompt` setter records prompt
+      // ownership, which reads whoever is the current owner, so restoring the prompt first
+      // would stamp the shared ownership key with this test's synthetic id and leak it into
+      // the app's real UserDefaults and into whichever test runs next.
       UserDefaults.standard.set(originalOwner, forKey: .authUserId)
+      TaskAssistantSettings.shared.analysisPrompt = originalPrompt
     }
     UserDefaults.standard.set(owner, forKey: .authUserId)
     body()

--- a/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientAssistantSettingsTests.swift
@@ -17,7 +17,8 @@ final class APIClientAssistantSettingsTests: XCTestCase {
       SettingsSyncManager.promptForSync(
         TaskAssistantSettings.defaultAnalysisPrompt,
         assistantName: "task",
-        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength))
+        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength,
+        shippedDefault: TaskAssistantSettings.defaultAnalysisPrompt))
   }
 
   @MainActor
@@ -29,7 +30,8 @@ final class APIClientAssistantSettingsTests: XCTestCase {
       SettingsSyncManager.promptForSync(
         customPrompt,
         assistantName: "task",
-        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength))
+        maximumLength: TaskAssistantSettings.maximumSyncedAnalysisPromptLength,
+        shippedDefault: TaskAssistantSettings.defaultAnalysisPrompt))
     XCTAssertEqual(
       customPrompt.count, TaskAssistantSettings.maximumSyncedAnalysisPromptLength + 1)
   }
@@ -43,7 +45,8 @@ final class APIClientAssistantSettingsTests: XCTestCase {
     XCTAssertEqual(prompt.unicodeScalars.count, 10_002)
     XCTAssertNil(
       SettingsSyncManager.promptForSync(
-        prompt, assistantName: "insight", maximumLength: 10_000))
+        prompt, assistantName: "insight", maximumLength: 10_000,
+        shippedDefault: InsightAssistantSettings.defaultAnalysisPrompt))
   }
 
   @MainActor
@@ -53,12 +56,18 @@ final class APIClientAssistantSettingsTests: XCTestCase {
     let backendMaximum = 10_000
     XCTAssertEqual(TaskAssistantSettings.maximumSyncedAnalysisPromptLength, backendMaximum)
     let prompt = String(repeating: "x", count: backendMaximum + 1)
+    let assistants: [(name: String, shippedDefault: String)] = [
+      ("task", TaskAssistantSettings.defaultAnalysisPrompt),
+      ("insight", InsightAssistantSettings.defaultAnalysisPrompt),
+      ("memory", MemoryAssistantSettings.defaultAnalysisPrompt),
+    ]
 
-    for assistant in ["task", "insight", "memory"] {
+    for assistant in assistants {
       XCTAssertNil(
         SettingsSyncManager.promptForSync(
-          prompt, assistantName: assistant, maximumLength: backendMaximum),
-        "an oversized \(assistant) prompt must be omitted, not truncated or sent")
+          prompt, assistantName: assistant.name, maximumLength: backendMaximum,
+          shippedDefault: assistant.shippedDefault),
+        "an oversized \(assistant.name) prompt must be omitted, not truncated or sent")
     }
   }
 

--- a/desktop/macos/changelog/unreleased/20260816-task-prompt-default-hydration.json
+++ b/desktop/macos/changelog/unreleased/20260816-task-prompt-default-hydration.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a task prompt customised on one Mac never reaching your other Macs, and reappearing after you reset it to the default"
+}


### PR DESCRIPTION
## Issue summary

A task prompt customized on one Mac cannot reach another Mac that is still on the shipped default, and it can also come back after **Reset to Default**.

This fixes the client-side ownership rule behind both behaviors.

## Why it happens

The oversized-prompt protection is intended to preserve user-authored text that could not be synced to the server. However, it cannot currently distinguish that from the shipped task default.

The shipped task default is 13,120 code points against a 10,000-character sync bound. On the first settings push, `promptForSync` therefore omits it from the PATCH and records `unsyncedOversizedOwner.task`.

`applyRemotePrompt` then sees an oversized prompt owned by the current user and refuses the remote prompt. Because the getter falls back to the shipped default when no custom prompt is stored, this affects fresh installs as well.

## The fix

Both `promptForSync` and `applyRemotePrompt` now receive the assistant's `shippedDefault` explicitly and use it to distinguish shipped defaults from user-authored oversized prompts.

```text
oversized + == shipped default  -> omit from sync, do NOT claim ownership
oversized + != shipped default  -> omit from sync, claim ownership (unchanged)
```

Remote hydration now preserves a local prompt only when it is oversized, owner-matched, and **not** the shipped default.

The default is passed explicitly at each call site rather than through an assistant-name → default dictionary, so the compiler forces every call site to provide the correct default.

## Reset semantics

**"Reset to Default" means this device has no custom local opinion, so account state may hydrate again.**

This is important because the reset path clears the stored prompt and then writes the editor's default back through the setter, which re-establishes the ownership stamp.

Comparing against the shipped default survives that flow; checking only whether the stored key exists would not.

This behavior is covered by:

`testRemoteHydrationAppliesAfterTheResetPathTheEditorPerforms`

## Relationship to #11580

**Related to #11580; neither PR depends on the other.**

#11580 addresses a separate backend contract mismatch between the desktop shipped task prompt and the backend validation bound.

This PR is entirely client-side and does not change the backend contract. The oversized shipped default is still omitted from the PATCH as before; this change ensures that omission does not cause the default to be treated as user-authored local state.

The two changes can therefore be reviewed and merged independently.

## Verification

```text
xcrun swift build -c debug --package-path Desktop
→ Build complete!

APIClientAssistantSettingsTests
→ 13 tests, 0 failures

SettingsSyncManager sibling suites
→ 39 tests, 0 failures

swiftlint-wrapper.sh lint
→ 0 violations across 1287 files

scripts/pr-preflight --base upstream/main
→ 21 checks passed
```

The three new regression tests fail against the pre-fix implementation and pass with the fix:

```text
testShippedDefaultIsOmittedFromSyncWithoutBlockingLaterHydration
testRemoteHydrationAppliesAfterResetToDefault
testRemoteHydrationAppliesAfterTheResetPathTheEditorPerforms
```

The existing protection cases for genuinely oversized user-authored prompts also remain green and unchanged.

Refs: #11481
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

