### PR TITLE
feat(app): add local-only Custom STT transport policy

### DIFF
--- a/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
@@ -52,10 +52,14 @@ class MainActivity: FlutterActivity() {
         PhoneMicHostApi.setUp(flutterEngine.dartExecutor.binaryMessenger, PhoneMicHostApiImpl(PhoneMicController.instance))
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, NATIVE_BLE_TRANSCRIPT_CHANNEL).setMethodCallHandler {
             call, result ->
-            if (call.method == "drain") {
-                result.success(OmiBackgroundAudioStreamer.drainCachedTranscriptMessages())
-            } else {
-                result.notImplemented()
+            when (call.method) {
+                "drain" -> result.success(OmiBackgroundAudioStreamer.drainCachedTranscriptMessages())
+                "reconcile" -> {
+                    val enabled = call.argument<Boolean>("enabled") ?: false
+                    OmiBleForegroundService.reconcileBackgroundAudioStreaming(enabled)
+                    result.success(true)
+                }
+                else -> result.notImplemented()
             }
         }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/CustomSttRawAudioPolicy.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/CustomSttRawAudioPolicy.kt
@@ -3,13 +3,33 @@ package com.friend.ios.batch
 import org.json.JSONObject
 
 internal object CustomSttRawAudioPolicy {
+    private val knownProviders = setOf(
+        "omi", "omiParakeet", "openai", "openaiDiarize", "deepgram", "deepgramLive",
+        "falai", "gemini", "geminiLive", "localWhisper", "custom", "customLive", "onDeviceWhisper",
+    )
+
     fun allowsForwarding(rawConfig: String): Boolean {
         if (rawConfig.isEmpty()) return true
 
         return try {
             val config = JSONObject(rawConfig)
-            config.optString("provider", "omi") == "omi" ||
+            val provider = config.opt("provider")
+            if (provider !is String || provider !in knownProviders) {
+                false
+            } else if (config.has("privacy_policy")) {
+                // An explicit typed policy is authoritative. Unknown or
+                // malformed values fail privacy-closed; only a missing field
+                // falls back to the legacy provider/boolean migration.
+                when (config.opt("privacy_policy")) {
+                    "full" -> true
+                    "transcriptOnly", "localOnly" -> false
+                    else -> false
+                }
+            } else if (provider == "omi") {
+                true
+            } else {
                 config.optBoolean("send_raw_audio_to_omi", true)
+            }
         } catch (_: Exception) {
             false
         }

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
@@ -57,7 +57,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         .connectTimeout(15, TimeUnit.SECONDS)
         .build()
     private val lock = Any()
-    private val pendingFrames = ArrayDeque<ByteArray>()
+    private val pendingFrames = OmiBackgroundAudioStreamingLifecycle(MAX_PENDING_FRAMES)
     private var socket: WebSocket? = null
     private var connecting = false
     private var connected = false
@@ -90,19 +90,30 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             connected = false
             activeUrl = null
             activeConfig = null
-            pendingFrames.clear()
+            pendingFrames.invalidateSession()
         }
+        clearCachedTranscriptMessages()
         socketToClose?.close(1000, reason)
     }
 
     fun handleCharacteristic(address: String, serviceUuid: String, characteristicUuid: String, value: ByteArray) {
+        // Capture before parsing or transforming. stop()/reconfigure invalidates
+        // this generation, so a callback already in flight cannot attach its
+        // old BLE payload to a later re-enabled stream with the same config.
+        val callbackGeneration = synchronized(lock) { pendingFrames.currentGeneration() }
         val config = loadConfig()
         if (config == null) {
-            if (socket != null) stop("disabled")
+            val hasActiveStream = synchronized(lock) {
+                socket != null || connecting || connected || activeConfig != null
+            }
+            if (hasActiveStream) stop("disabled")
             return
         }
         if (OmiBleManager.isFlutterAlive && boolPref("nativeBleForegroundReady", false)) {
-            if (socket != null) stop("foreground_ready")
+            val hasActiveStream = synchronized(lock) {
+                socket != null || connecting || connected || activeConfig != null
+            }
+            if (hasActiveStream) stop("foreground_ready")
             return
         }
         if (!config.deviceId.equals(address, ignoreCase = true)) return
@@ -111,10 +122,10 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         val frames = transformFrames(config, value)
         if (frames.isEmpty()) return
 
-        ensureSocket(config)
+        val session = ensureSocket(config, callbackGeneration) ?: return
 
         for (frame in frames) {
-            sendOrQueue(frame)
+            sendOrQueue(config, session, frame)
         }
     }
 
@@ -147,16 +158,26 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             }
         }
 
-    private fun ensureSocket(config: Config) {
-        val now = System.currentTimeMillis()
-        if (now - lastFailureAtMs < RECONNECT_BACKOFF_MS) return
-
-        val url = buildUrl(config) ?: return
-        val request = buildRequest(url) ?: return
-
+    private fun ensureSocket(
+        config: Config,
+        callbackGeneration: Long
+    ): OmiBackgroundAudioStreamingLifecycle.Session? {
         synchronized(lock) {
+            // The callback may have loaded this config before a concurrent
+            // policy transition. Re-read it under the stream monitor before
+            // opening anything, including after the reconnect backoff check.
+            if (!pendingFrames.isGenerationCurrent(callbackGeneration)) return null
+            val currentConfig = loadConfig()
+            if (currentConfig == null || currentConfig != config) return null
+
+            val now = System.currentTimeMillis()
+            if (now - lastFailureAtMs < RECONNECT_BACKOFF_MS) return null
+
+            val url = buildUrl(currentConfig) ?: return null
+            val request = buildRequest(url) ?: return null
+
             if ((connecting || connected) && activeUrl == url && activeConfig == config && socket != null) {
-                return
+                return pendingFrames.currentSession()
             }
 
             socket?.close(1000, "reconfigure")
@@ -164,24 +185,46 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             connecting = true
             connected = false
             activeUrl = url
-            activeConfig = config
+            val configChanged = activeConfig != currentConfig
+            activeConfig = currentConfig
             sentFrames = 0
+            if (configChanged) {
+                pendingFrames.invalidateSession()
+            }
+            val session = pendingFrames.beginSession()
 
-            Log.i(TAG, "Opening background transcription websocket (codec=${config.codec}, source=${config.source})")
-            socket = client.newWebSocket(request, listener())
+            Log.i(TAG, "Opening background transcription websocket (codec=${currentConfig.codec}, source=${currentConfig.source})")
+            socket = client.newWebSocket(request, listener(session))
+            return session
         }
     }
 
-    private fun listener(): WebSocketListener = object : WebSocketListener() {
+    private fun listener(session: OmiBackgroundAudioStreamingLifecycle.Session): WebSocketListener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
-            val queued = mutableListOf<ByteArray>()
+            var queued = emptyList<ByteArray>()
+            var closeReason: String? = null
             synchronized(lock) {
-                if (webSocket != socket) return
-                connecting = false
-                connected = true
-                while (pendingFrames.isNotEmpty()) {
-                    queued.add(pendingFrames.removeFirst())
+                if (webSocket != socket || !pendingFrames.isCurrent(session)) return
+                val currentConfig = loadConfig()
+                val policyAllowsStreaming = currentConfig != null && currentConfig == activeConfig
+                if (!policyAllowsStreaming) {
+                    pendingFrames.drainOnOpen(session, policyAllowsStreaming = false)
+                    socket = null
+                    connecting = false
+                    connected = false
+                    activeUrl = null
+                    activeConfig = null
+                    closeReason = "policy_disabled"
+                } else {
+                    connecting = false
+                    connected = true
+                    queued = pendingFrames.drainOnOpen(session, policyAllowsStreaming = true)
                 }
+            }
+            closeReason?.let { reason ->
+                Log.i(TAG, "Discarding queued background audio after policy changed")
+                webSocket.close(1000, reason)
+                return
             }
             Log.i(TAG, "Background transcription socket connected")
             for (frame in queued) {
@@ -190,7 +233,15 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         }
 
         override fun onMessage(webSocket: WebSocket, text: String) {
-            cacheTranscriptMessage(text)
+            synchronized(lock) {
+                val currentConfig = loadConfig()
+                if (webSocket != socket || !connected || !pendingFrames.isCurrent(session) ||
+                    currentConfig == null || currentConfig != activeConfig
+                ) {
+                    return
+                }
+                cacheTranscriptMessage(text)
+            }
             Log.d(TAG, "Background transcription message received (${text.length} chars)")
         }
 
@@ -200,55 +251,80 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
             synchronized(lock) {
-                if (webSocket != socket) return
+                if (webSocket != socket || !pendingFrames.isCurrent(session)) return
                 socket = null
                 connecting = false
                 connected = false
+                activeUrl = null
+                activeConfig = null
+                pendingFrames.invalidateSession()
+                sentFrames = 0
             }
             Log.i(TAG, "Background transcription socket closed (code=$code)")
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
             synchronized(lock) {
-                if (webSocket != socket) return
+                if (webSocket != socket || !pendingFrames.isCurrent(session)) return
                 socket = null
                 connecting = false
                 connected = false
+                activeUrl = null
+                activeConfig = null
+                pendingFrames.invalidateSession()
+                sentFrames = 0
                 lastFailureAtMs = System.currentTimeMillis()
             }
             Log.w(TAG, "Background transcription socket failed: ${t.message}")
         }
     }
 
-    private fun sendOrQueue(frame: ByteArray) {
+    private fun sendOrQueue(
+        config: Config,
+        session: OmiBackgroundAudioStreamingLifecycle.Session,
+        frame: ByteArray
+    ) {
         var target: WebSocket? = null
         synchronized(lock) {
-            target = if (connected) socket else null
+            // A callback can reach this method after stop() or after the
+            // persisted policy/config changed. Never queue that stale audio.
+            val currentConfig = loadConfig()
+            if (currentConfig == null || currentConfig != config || !pendingFrames.isCurrent(session)) return
+
+            target = if (connected && activeConfig == currentConfig) socket else null
             if (target == null) {
-                queueFrameLocked(frame)
+                queueFrameLocked(session, frame)
                 return
             }
         }
         val webSocket = target ?: return
         if (!sendFrame(webSocket, frame)) {
             synchronized(lock) {
-                queueFrameLocked(frame)
+                val currentConfig = loadConfig()
+                if (currentConfig == config && currentConfig == activeConfig && pendingFrames.isCurrent(session)) {
+                    queueFrameLocked(session, frame)
+                }
             }
         }
     }
 
-    private fun sendFrame(webSocket: WebSocket, frame: ByteArray): Boolean {
+    private fun sendFrame(webSocket: WebSocket, frame: ByteArray): Boolean = synchronized(lock) {
+        // Serialize sends with stop(). Once a disabling reconcile has acquired
+        // this lock and returned, no stale frame can be written to the old
+        // socket. Revalidate persisted policy at the final send boundary too.
+        val currentConfig = loadConfig()
+        if (webSocket != socket || !connected || currentConfig == null || currentConfig != activeConfig) {
+            return@synchronized false
+        }
+
         val sent = webSocket.send(frame.toByteString())
         if (sent) {
-            val totalSent = synchronized(lock) {
-                sentFrames += 1
-                sentFrames
-            }
-            if (totalSent % 100 == 0) {
-                Log.i(TAG, "Sent $totalSent background BLE audio frames")
+            sentFrames += 1
+            if (sentFrames % 100 == 0) {
+                Log.i(TAG, "Sent $sentFrames background BLE audio frames")
             }
         }
-        return sent
+        sent
     }
 
     private fun cacheTranscriptMessage(text: String) {
@@ -263,11 +339,14 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
         }
     }
 
-    private fun queueFrameLocked(frame: ByteArray) {
-        if (pendingFrames.size >= MAX_PENDING_FRAMES) {
-            pendingFrames.removeFirst()
+    private fun clearCachedTranscriptMessages() {
+        synchronized(transcriptCacheLock) {
+            cachedTranscriptMessages.clear()
         }
-        pendingFrames.addLast(frame.copyOf())
+    }
+
+    private fun queueFrameLocked(session: OmiBackgroundAudioStreamingLifecycle.Session, frame: ByteArray) {
+        pendingFrames.queueFrameIfCurrent(session, frame)
     }
 
     private fun loadConfig(): Config? {

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
@@ -185,12 +185,9 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
             connecting = true
             connected = false
             activeUrl = url
-            val configChanged = activeConfig != currentConfig
             activeConfig = currentConfig
             sentFrames = 0
-            if (configChanged) {
-                pendingFrames.invalidateSession()
-            }
+            pendingFrames.invalidateSession()
             val session = pendingFrames.beginSession()
 
             Log.i(TAG, "Opening background transcription websocket (codec=${currentConfig.codec}, source=${currentConfig.source})")

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycle.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycle.kt
@@ -1,0 +1,73 @@
+package com.friend.ios.batch
+
+import java.util.ArrayDeque
+
+/**
+ * Pure session/queue guard used by [OmiBackgroundAudioStreamer]. Callback
+ * session tokens make stale WebSocket callbacks testable without an Android
+ * device or a live WebSocket; the streamer still revalidates persisted policy
+ * while holding its monitor before touching this guard.
+ */
+internal class OmiBackgroundAudioStreamingLifecycle(private val maxPendingFrames: Int) {
+    class Session internal constructor(val generation: Long)
+
+    private val pendingFrames = ArrayDeque<ByteArray>()
+    private var nextSessionId = 0L
+    private var invalidationGeneration = 0L
+    private var activeSession: Session? = null
+
+    val pendingFrameCount: Int
+        get() = pendingFrames.size
+
+    fun beginSession(): Session {
+        val session = Session(++nextSessionId)
+        activeSession = session
+        return session
+    }
+
+    fun isCurrent(session: Session): Boolean = activeSession == session
+
+    fun currentSession(): Session? = activeSession
+
+    fun currentGeneration(): Long = invalidationGeneration
+
+    fun isGenerationCurrent(generation: Long): Boolean = invalidationGeneration == generation
+
+    fun queueFrame(frame: ByteArray) {
+        if (pendingFrames.size >= maxPendingFrames) pendingFrames.removeFirst()
+        pendingFrames.addLast(frame.copyOf())
+    }
+
+    /** Queue only for the caller's live session; stale callbacks cannot add audio to a later session. */
+    fun queueFrameIfCurrent(session: Session, frame: ByteArray): Boolean {
+        if (!isCurrent(session)) return false
+        queueFrame(frame)
+        return true
+    }
+
+    /**
+     * Drains only for the live session and after the caller has revalidated the
+     * current policy. A denied or stale open clears the queue and invalidates
+     * the session, so it cannot leak audio captured before the transition.
+     */
+    fun drainOnOpen(session: Session, policyAllowsStreaming: Boolean): List<ByteArray> {
+        if (!policyAllowsStreaming || !isCurrent(session)) {
+            invalidateSession()
+            return emptyList()
+        }
+
+        val queued = pendingFrames.toList()
+        pendingFrames.clear()
+        return queued
+    }
+
+    fun clear() {
+        pendingFrames.clear()
+    }
+
+    fun invalidateSession() {
+        invalidationGeneration += 1
+        activeSession = null
+        pendingFrames.clear()
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycle.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycle.kt
@@ -9,10 +9,9 @@ import java.util.ArrayDeque
  * while holding its monitor before touching this guard.
  */
 internal class OmiBackgroundAudioStreamingLifecycle(private val maxPendingFrames: Int) {
-    class Session internal constructor(val generation: Long)
+    class Session internal constructor()
 
     private val pendingFrames = ArrayDeque<ByteArray>()
-    private var nextSessionId = 0L
     private var invalidationGeneration = 0L
     private var activeSession: Session? = null
 
@@ -20,7 +19,7 @@ internal class OmiBackgroundAudioStreamingLifecycle(private val maxPendingFrames
         get() = pendingFrames.size
 
     fun beginSession(): Session {
-        val session = Session(++nextSessionId)
+        val session = Session()
         activeSession = session
         return session
     }
@@ -51,7 +50,10 @@ internal class OmiBackgroundAudioStreamingLifecycle(private val maxPendingFrames
      * the session, so it cannot leak audio captured before the transition.
      */
     fun drainOnOpen(session: Session, policyAllowsStreaming: Boolean): List<ByteArray> {
-        if (!policyAllowsStreaming || !isCurrent(session)) {
+        if (!isCurrent(session)) {
+            return emptyList()
+        }
+        if (!policyAllowsStreaming) {
             invalidateSession()
             return emptyList()
         }
@@ -59,10 +61,6 @@ internal class OmiBackgroundAudioStreamingLifecycle(private val maxPendingFrames
         val queued = pendingFrames.toList()
         pendingFrames.clear()
         return queued
-    }
-
-    fun clear() {
-        pendingFrames.clear()
     }
 
     fun invalidateSession() {

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/LazyResourceHandle.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/LazyResourceHandle.kt
@@ -1,0 +1,27 @@
+package com.friend.ios.ble
+
+/**
+ * Lazily owns a resource while allowing policy transitions to stop only an
+ * already-created resource. A disabled policy must not construct a dormant
+ * resource merely to stop it.
+ */
+internal class LazyResourceHandle<T>(private val factory: () -> T) {
+    private val lock = Any()
+    private var value: T? = null
+
+    fun getOrCreate(): T = synchronized(lock) {
+        value ?: factory().also { value = it }
+    }
+
+    fun stopIfInitialized(stop: (T) -> Unit): Boolean {
+        val current = synchronized(lock) { value } ?: return false
+        stop(current)
+        return true
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            value = null
+        }
+    }
+}

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -140,6 +140,15 @@ class OmiBleForegroundService : Service() {
                 Log.e(TAG, "Failed to stop service", e)
             }
         }
+
+        /**
+         * Reconcile Flutter's native Omi-audio policy without creating a
+         * streamer just to stop it. The existing streamer owns its pending
+         * frame queue and closes it synchronously when disabled.
+         */
+        fun reconcileBackgroundAudioStreaming(enabled: Boolean, reason: String = "flutter_policy_disabled") {
+            if (!enabled) instance?.stopBackgroundAudioStreamingIfInitialized(reason)
+        }
     }
 
     // ── Per-device state ──
@@ -169,10 +178,16 @@ class OmiBleForegroundService : Service() {
     private var isBluetoothEnabled = true
     private val syncLock = Any()
     private val bleManager get() = OmiBleManager.instance
-    private val backgroundAudioStreamer by lazy { OmiBackgroundAudioStreamer(applicationContext) }
+    private val backgroundAudioStreamer = LazyResourceHandle {
+        OmiBackgroundAudioStreamer(applicationContext)
+    }
     private val batchAudioWriter by lazy { OmiBatchAudioWriter(applicationContext) }
     private val limitlessBatchWriter by lazy { LimitlessBatchAudioWriter(applicationContext) }
     private val limitlessDrainEngine by lazy { LimitlessFlashDrainEngine(applicationContext, limitlessBatchWriter) }
+
+    private fun stopBackgroundAudioStreamingIfInitialized(reason: String) {
+        backgroundAudioStreamer.stopIfInitialized { it.stop(reason) }
+    }
 
     // ── Connection listener — receives GATT events from OmiBleManager ──
 
@@ -286,7 +301,7 @@ class OmiBleForegroundService : Service() {
         // so native keeps receiving audio after the Flutter engine is gone. Never deferred
         // to Dart: enabling notifications is idempotent, and waiting on an engine that is
         // gone left the characteristic subscribed by nobody (issue #10847).
-        val target = backgroundAudioStreamer.configuredAudioTargetFor(address)
+        val target = backgroundAudioStreamer.getOrCreate().configuredAudioTargetFor(address)
             ?: batchAudioWriter.configuredAudioTargetFor(address)
             ?: return
         val hasTarget = services.any { service ->
@@ -700,7 +715,7 @@ class OmiBleForegroundService : Service() {
                 // Batch mode and background streaming are mutually exclusive (gated by
                 // their respective prefs); calling all sinks is safe — each self-gates.
                 batchAudioWriter.handleCharacteristic(address, serviceUuid, characteristicUuid, value)
-                backgroundAudioStreamer.handleCharacteristic(address, serviceUuid, characteristicUuid, value)
+                backgroundAudioStreamer.getOrCreate().handleCharacteristic(address, serviceUuid, characteristicUuid, value)
                 limitlessDrainEngine.handleCharacteristic(address, serviceUuid, characteristicUuid, value)
             }
         }
@@ -760,7 +775,8 @@ class OmiBleForegroundService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "Service destroying")
         isDestroying = true
-        backgroundAudioStreamer.stop("service_destroyed")
+        backgroundAudioStreamer.stopIfInitialized { it.stop("service_destroyed") }
+        backgroundAudioStreamer.clear()
         batchAudioWriter.stop("service_destroyed")
         limitlessDrainEngine.stop("service_destroyed")
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -286,6 +286,7 @@ class OmiBleForegroundService : Service() {
     }
 
     private fun fireDeviceReady(address: String, services: List<BleService>) {
+        if (isDestroying) return
         val addr = address.uppercase()
         ensureBackgroundAudioSubscription(addr, services)
         limitlessDrainEngine.onDeviceReady(addr)

--- a/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/ble/OmiBleForegroundService.kt
@@ -712,6 +712,7 @@ class OmiBleForegroundService : Service() {
                 characteristicUuid: String,
                 value: ByteArray
             ) {
+                if (isDestroying) return
                 // Batch mode and background streaming are mutually exclusive (gated by
                 // their respective prefs); calling all sinks is safe — each self-gates.
                 batchAudioWriter.handleCharacteristic(address, serviceUuid, characteristicUuid, value)

--- a/app/android/app/src/test/kotlin/com/friend/ios/batch/CustomSttRawAudioPolicyTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/batch/CustomSttRawAudioPolicyTest.kt
@@ -30,7 +30,65 @@ class CustomSttRawAudioPolicyTest {
     }
 
     @Test
+    fun typedPrivacyPoliciesControlRawAudioForwarding() {
+        assertTrue(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"full"}"""
+            )
+        )
+        assertFalse(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"transcriptOnly"}"""
+            )
+        )
+        assertFalse(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"localOnly"}"""
+            )
+        )
+    }
+
+    @Test
+    fun typedPrivacyPolicyTakesPrecedenceOverLegacyBoolean() {
+        assertTrue(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"full","send_raw_audio_to_omi":false}"""
+            )
+        )
+        assertFalse(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"transcriptOnly","send_raw_audio_to_omi":true}"""
+            )
+        )
+        assertFalse(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"localOnly","send_raw_audio_to_omi":true}"""
+            )
+        )
+    }
+
+    @Test
+    fun unknownTypedPrivacyPolicyFailsClosedRegardlessOfLegacyBoolean() {
+        assertFalse(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":"unknown","send_raw_audio_to_omi":true}"""
+            )
+        )
+        assertFalse(
+            CustomSttRawAudioPolicy.allowsForwarding(
+                """{"provider":"onDeviceWhisper","privacy_policy":42,"send_raw_audio_to_omi":true}"""
+            )
+        )
+    }
+
+    @Test
     fun malformedCustomSttConfigFailsClosed() {
         assertFalse(CustomSttRawAudioPolicy.allowsForwarding("{not-json"))
+    }
+
+    @Test
+    fun missingOrUnknownProviderFailsClosed() {
+        assertFalse(CustomSttRawAudioPolicy.allowsForwarding("{}"))
+        assertFalse(CustomSttRawAudioPolicy.allowsForwarding("""{"provider":"bogus"}"""))
     }
 }

--- a/app/android/app/src/test/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycleTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycleTest.kt
@@ -81,6 +81,17 @@ class OmiBackgroundAudioStreamingLifecycleTest {
     }
 
     @Test
+    fun staleOpenCannotInvalidateNewerSession() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val staleSession = lifecycle.beginSession()
+        lifecycle.invalidateSession()
+        val currentSession = lifecycle.beginSession()
+
+        assertTrue(lifecycle.drainOnOpen(staleSession, policyAllowsStreaming = false).isEmpty())
+        assertTrue(lifecycle.queueFrameIfCurrent(currentSession, byteArrayOf(2)))
+    }
+
+    @Test
     fun failedSessionQueueIsClearedBeforeAReenableSessionStarts() {
         val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
         val failedSession = lifecycle.beginSession()

--- a/app/android/app/src/test/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycleTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamingLifecycleTest.kt
@@ -1,0 +1,110 @@
+package com.friend.ios.batch
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OmiBackgroundAudioStreamingLifecycleTest {
+    @Test
+    fun policyDisabledAtOpenClearsQueuedFramesAndSendsNothing() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val session = lifecycle.beginSession()
+        lifecycle.queueFrame(byteArrayOf(1, 2))
+        lifecycle.queueFrame(byteArrayOf(3, 4))
+
+        val drained = lifecycle.drainOnOpen(session, policyAllowsStreaming = false)
+
+        assertTrue(drained.isEmpty())
+        assertEquals(0, lifecycle.pendingFrameCount)
+        assertTrue(!lifecycle.isCurrent(session))
+    }
+
+    @Test
+    fun allowedOpenDrainsQueuedFramesInOrder() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val session = lifecycle.beginSession()
+        lifecycle.queueFrame(byteArrayOf(1, 2))
+        lifecycle.queueFrame(byteArrayOf(3, 4))
+
+        val drained = lifecycle.drainOnOpen(session, policyAllowsStreaming = true)
+
+        assertEquals(2, drained.size)
+        assertArrayEquals(byteArrayOf(1, 2), drained[0])
+        assertArrayEquals(byteArrayOf(3, 4), drained[1])
+        assertEquals(0, lifecycle.pendingFrameCount)
+    }
+
+    @Test
+    fun pendingQueueKeepsOnlyTheNewestFramesAndCopiesInput() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 2)
+        val session = lifecycle.beginSession()
+        val first = byteArrayOf(1)
+        lifecycle.queueFrame(first)
+        first[0] = 9
+        lifecycle.queueFrame(byteArrayOf(2))
+        lifecycle.queueFrame(byteArrayOf(3))
+
+        val drained = lifecycle.drainOnOpen(session, policyAllowsStreaming = true)
+
+        assertEquals(2, drained.size)
+        assertArrayEquals(byteArrayOf(2), drained[0])
+        assertArrayEquals(byteArrayOf(3), drained[1])
+    }
+
+    @Test
+    fun staleCallbackCannotQueueAfterPolicyDisable() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val staleSession = lifecycle.beginSession()
+        lifecycle.invalidateSession()
+
+        assertTrue(!lifecycle.isCurrent(staleSession))
+        assertTrue(!lifecycle.queueFrameIfCurrent(staleSession, byteArrayOf(9)))
+        assertEquals(0, lifecycle.pendingFrameCount)
+    }
+
+    @Test
+    fun staleCallbackCannotQueueIntoAReenabledSession() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val staleSession = lifecycle.beginSession()
+        val staleGeneration = lifecycle.currentGeneration()
+        lifecycle.invalidateSession()
+        val reenabledSession = lifecycle.beginSession()
+
+        assertTrue(!lifecycle.isGenerationCurrent(staleGeneration))
+        assertTrue(!lifecycle.queueFrameIfCurrent(staleSession, byteArrayOf(1)))
+        assertTrue(lifecycle.queueFrameIfCurrent(reenabledSession, byteArrayOf(2)))
+        val drained = lifecycle.drainOnOpen(reenabledSession, policyAllowsStreaming = true)
+
+        assertEquals(1, drained.size)
+        assertArrayEquals(byteArrayOf(2), drained.single())
+    }
+
+    @Test
+    fun failedSessionQueueIsClearedBeforeAReenableSessionStarts() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val failedSession = lifecycle.beginSession()
+        lifecycle.queueFrameIfCurrent(failedSession, byteArrayOf(1))
+        lifecycle.invalidateSession()
+
+        val reenabledSession = lifecycle.beginSession()
+        lifecycle.queueFrameIfCurrent(reenabledSession, byteArrayOf(2))
+        val drained = lifecycle.drainOnOpen(reenabledSession, policyAllowsStreaming = true)
+
+        assertTrue(!lifecycle.isCurrent(failedSession))
+        assertEquals(1, drained.size)
+        assertArrayEquals(byteArrayOf(2), drained.single())
+    }
+
+    @Test
+    fun closedSessionQueueIsInvalidatedBeforeSameConfigReconnects() {
+        val lifecycle = OmiBackgroundAudioStreamingLifecycle(maxPendingFrames = 3)
+        val closedSession = lifecycle.beginSession()
+        lifecycle.queueFrameIfCurrent(closedSession, byteArrayOf(1))
+        lifecycle.invalidateSession()
+
+        val reconnectSession = lifecycle.beginSession()
+        assertTrue(!lifecycle.queueFrameIfCurrent(closedSession, byteArrayOf(9)))
+        assertTrue(lifecycle.drainOnOpen(reconnectSession, policyAllowsStreaming = true).isEmpty())
+    }
+}

--- a/app/android/app/src/test/kotlin/com/friend/ios/ble/LazyResourceHandleTest.kt
+++ b/app/android/app/src/test/kotlin/com/friend/ios/ble/LazyResourceHandleTest.kt
@@ -1,0 +1,30 @@
+package com.friend.ios.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LazyResourceHandleTest {
+    @Test
+    fun stoppingAnUninitializedResourceDoesNotCreateIt() {
+        var creations = 0
+        val handle = LazyResourceHandle {
+            creations += 1
+            Any()
+        }
+
+        assertFalse(handle.stopIfInitialized { error("a dormant resource must not be stopped") })
+        assertEquals(0, creations)
+    }
+
+    @Test
+    fun stoppingAnExistingResourceInvokesTheStopper() {
+        var stopped = 0
+        val handle = LazyResourceHandle { Any() }
+        handle.getOrCreate()
+
+        assertTrue(handle.stopIfInitialized { stopped += 1 })
+        assertEquals(1, stopped)
+    }
+}

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -182,7 +182,7 @@ class SharedPreferencesUtil {
     } catch (e, stack) {
       Logger.debug('Error parsing customSttConfig: $e');
       Logger.debug('Stack: $stack');
-      return CustomSttConfig.defaultConfig;
+      return CustomSttConfig.privacySafeFallbackConfig;
     }
   }
 

--- a/app/lib/models/custom_stt_config.dart
+++ b/app/lib/models/custom_stt_config.dart
@@ -219,7 +219,7 @@ class CustomSttConfig {
   /// Used only when a persisted Custom STT blob cannot be decoded. A corrupt
   /// preference must not silently restore Omi audio egress.
   static const privacySafeFallbackConfig = CustomSttConfig(
-    provider: SttProvider.customLive,
+    provider: SttProvider.omi,
     privacyPolicy: SttPrivacyPolicy.localOnly,
   );
 

--- a/app/lib/models/custom_stt_config.dart
+++ b/app/lib/models/custom_stt_config.dart
@@ -4,6 +4,33 @@ import 'package:omi/models/stt_provider.dart';
 import 'package:omi/models/stt_response_schema.dart';
 import 'package:omi/utils/logger.dart';
 
+/// Controls which Custom STT data is forwarded to Omi.
+///
+/// [full] preserves the original composite behavior. [transcriptOnly] keeps
+/// Omi text processing while withholding raw audio. [localOnly] keeps the
+/// primary Custom STT path local to the app and does not create an Omi
+/// secondary transcription socket.
+enum SttPrivacyPolicy { full, transcriptOnly, localOnly }
+
+SttPrivacyPolicy? _parsePrivacyPolicy(dynamic value) {
+  if (value is! String) return null;
+  for (final policy in SttPrivacyPolicy.values) {
+    if (policy.name == value) return policy;
+  }
+  return null;
+}
+
+/// Migrate persisted configs without changing the established #10447 default.
+/// An explicit but invalid new policy fails privacy-closed to
+/// [SttPrivacyPolicy.localOnly] and does not consult the legacy boolean.
+SttPrivacyPolicy _migratePrivacyPolicy(Map<String, dynamic> json) {
+  if (json.containsKey('privacy_policy')) {
+    return _parsePrivacyPolicy(json['privacy_policy']) ?? SttPrivacyPolicy.localOnly;
+  }
+  if (json['send_raw_audio_to_omi'] == false) return SttPrivacyPolicy.transcriptOnly;
+  return SttPrivacyPolicy.full;
+}
+
 class CustomSttConfig {
   final SttProvider provider;
   final String? apiKey;
@@ -17,7 +44,7 @@ class CustomSttConfig {
   final Map<String, String>? params;
   final String? audioFieldName;
   final Map<String, dynamic>? schemaJson;
-  final bool sendRawAudioToOmi;
+  final SttPrivacyPolicy privacyPolicy;
 
   const CustomSttConfig({
     required this.provider,
@@ -32,7 +59,7 @@ class CustomSttConfig {
     this.params,
     this.audioFieldName,
     this.schemaJson,
-    this.sendRawAudioToOmi = true,
+    this.privacyPolicy = SttPrivacyPolicy.full,
   });
 
   /// Determine if live/streaming based on request_type
@@ -41,6 +68,12 @@ class CustomSttConfig {
   bool get isPolling => SttRequestType.isPolling(effectiveRequestType);
 
   bool get isEnabled => provider != SttProvider.omi;
+
+  /// Whether raw audio frames are forwarded to the Omi secondary socket.
+  bool get forwardsRawAudioToOmi => privacyPolicy == SttPrivacyPolicy.full;
+
+  /// Whether the Omi secondary transcription socket must not be constructed.
+  bool get isLocalOnlyPolicy => privacyPolicy == SttPrivacyPolicy.localOnly;
 
   SttProviderConfig get providerConfig => SttProviderConfig.get(provider);
 
@@ -116,7 +149,7 @@ class CustomSttConfig {
       'request_type': requestType,
       'headers': headers,
       'params': params,
-      'send_raw_audio_to_omi': sendRawAudioToOmi,
+      'privacy_policy': privacyPolicy.name,
     };
 
     final jsonStr = jsonEncode(configData);
@@ -139,7 +172,10 @@ class CustomSttConfig {
         'params': params,
         'audio_field_name': audioFieldName,
         'schema': schemaJson,
-        'send_raw_audio_to_omi': sendRawAudioToOmi,
+        'privacy_policy': privacyPolicy.name,
+        // Keep the legacy field for older clients. The typed policy is
+        // authoritative when both fields are present.
+        'send_raw_audio_to_omi': forwardsRawAudioToOmi,
       };
 
   factory CustomSttConfig.fromJson(Map<String, dynamic> json) {
@@ -152,8 +188,17 @@ class CustomSttConfig {
       return null;
     }
 
+    final rawProvider = json['provider'];
+    if (rawProvider is! String) {
+      throw const FormatException('Custom STT provider is missing or malformed');
+    }
+    final provider = SttProvider.tryFromString(rawProvider);
+    if (provider == null) {
+      throw FormatException('Unknown Custom STT provider: $rawProvider');
+    }
+
     return CustomSttConfig(
-      provider: SttProvider.fromString(json['provider'] ?? 'omi'),
+      provider: provider,
       apiKey: json['api_key'],
       language: json['language'],
       model: json['model'],
@@ -165,11 +210,18 @@ class CustomSttConfig {
       params: safeStringMap(json['params']),
       audioFieldName: json['audio_field_name'],
       schemaJson: json['schema'] != null ? Map<String, dynamic>.from(json['schema']) : null,
-      sendRawAudioToOmi: json['send_raw_audio_to_omi'] != false,
+      privacyPolicy: _migratePrivacyPolicy(json),
     );
   }
 
   static const defaultConfig = CustomSttConfig(provider: SttProvider.omi);
+
+  /// Used only when a persisted Custom STT blob cannot be decoded. A corrupt
+  /// preference must not silently restore Omi audio egress.
+  static const privacySafeFallbackConfig = CustomSttConfig(
+    provider: SttProvider.customLive,
+    privacyPolicy: SttPrivacyPolicy.localOnly,
+  );
 
   /// Copy with new values
   CustomSttConfig copyWith({
@@ -185,7 +237,7 @@ class CustomSttConfig {
     Map<String, String>? params,
     String? audioFieldName,
     Map<String, dynamic>? schemaJson,
-    bool? sendRawAudioToOmi,
+    SttPrivacyPolicy? privacyPolicy,
   }) {
     return CustomSttConfig(
       provider: provider ?? this.provider,
@@ -200,7 +252,7 @@ class CustomSttConfig {
       params: params ?? this.params,
       audioFieldName: audioFieldName ?? this.audioFieldName,
       schemaJson: schemaJson ?? this.schemaJson,
-      sendRawAudioToOmi: sendRawAudioToOmi ?? this.sendRawAudioToOmi,
+      privacyPolicy: privacyPolicy ?? this.privacyPolicy,
     );
   }
 

--- a/app/lib/models/stt_provider.dart
+++ b/app/lib/models/stt_provider.dart
@@ -20,6 +20,13 @@ enum SttProvider {
   static SttProvider fromString(String value) {
     return SttProvider.values.firstWhere((e) => e.name == value, orElse: () => SttProvider.omi);
   }
+
+  static SttProvider? tryFromString(String value) {
+    for (final provider in SttProvider.values) {
+      if (provider.name == value) return provider;
+    }
+    return null;
+  }
 }
 
 /// Request types determine how audio is sent and whether it's streaming

--- a/app/lib/pages/settings/transcription_settings_page.dart
+++ b/app/lib/pages/settings/transcription_settings_page.dart
@@ -46,7 +46,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
   bool _showAdvanced = false;
   bool _showLogs = true;
   bool _isSaving = false;
-  bool _sendRawAudioToOmi = true;
+  SttPrivacyPolicy _privacyPolicy = SttPrivacyPolicy.full;
   String? _validationError;
 
   // On-device model download state
@@ -194,7 +194,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
     _hostController.text = config?.host ?? '127.0.0.1';
     _portController.text = (config?.port ?? 8080).toString();
     _urlController.text = config?.url ?? '';
-    _sendRawAudioToOmi = config?.sendRawAudioToOmi ?? true;
+    _privacyPolicy = config?.privacyPolicy ?? SttPrivacyPolicy.full;
 
     // Auto-detect model for on-device whisper if not set
     if (_selectedProvider == SttProvider.onDeviceWhisper && _urlController.text.isEmpty) {
@@ -377,7 +377,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
     String? url,
     String? host,
     int? port,
-    bool? sendRawAudioToOmi,
+    SttPrivacyPolicy? privacyPolicy,
   }) {
     final current = _configsPerProvider[_selectedProvider];
     final providerDefaults = SttProviderConfig.get(_selectedProvider);
@@ -395,7 +395,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
       params: current?.params,
       audioFieldName: current?.audioFieldName,
       schemaJson: current?.schemaJson,
-      sendRawAudioToOmi: sendRawAudioToOmi ?? current?.sendRawAudioToOmi ?? _sendRawAudioToOmi,
+      privacyPolicy: privacyPolicy ?? current?.privacyPolicy ?? _privacyPolicy,
     );
   }
 
@@ -463,7 +463,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
       params: params,
       audioFieldName: audioFieldName,
       schemaJson: schemaJson,
-      sendRawAudioToOmi: _sendRawAudioToOmi,
+      privacyPolicy: _privacyPolicy,
     );
   }
 
@@ -616,7 +616,8 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
       if (config.params != null) 'params': config.params,
       if (config.audioFieldName != null) 'audio_field_name': config.audioFieldName,
       if (config.schemaJson != null) 'schema': config.schemaJson,
-      'send_raw_audio_to_omi': config.sendRawAudioToOmi,
+      'privacy_policy': config.privacyPolicy.name,
+      'send_raw_audio_to_omi': config.forwardsRawAudioToOmi,
     };
 
     final jsonString = const JsonEncoder.withIndent('  ').convert(exportableConfig);
@@ -745,7 +746,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
         _urlController.text = config.url ?? '';
         _hostController.text = config.host ?? '127.0.0.1';
         _portController.text = (config.port ?? 8080).toString();
-        _sendRawAudioToOmi = config.sendRawAudioToOmi;
+        _privacyPolicy = config.privacyPolicy;
 
         // Update JSON configs
         if (config.requestType != null || config.headers != null || config.params != null) {
@@ -1183,7 +1184,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
     if (_isCodecCompatible || !_useCustomStt) return const SizedBox.shrink();
 
     final codecReason = _connectedDeviceCodec?.customSttUnsupportedReason ?? 'unsupported format';
-    final warningText = _sendRawAudioToOmi
+    final warningText = _privacyPolicy == SttPrivacyPolicy.full
         ? context.l10n.deviceUsesCodec(_connectedDeviceName ?? context.l10n.device, codecReason)
         : context.l10n.transcriptionUnavailable;
     return Padding(
@@ -1325,6 +1326,21 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
   }
 
   Widget _buildRawAudioForwardingSetting() {
+    if (_privacyPolicy == SttPrivacyPolicy.localOnly) {
+      return Material(
+        color: const Color(0xFF1A1A1A),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: BorderSide(color: Colors.grey.shade800),
+        ),
+        child: ListTile(
+          leading: const Icon(Icons.lock_outline, color: Colors.white70),
+          title: Text(context.l10n.privacyInformation, style: const TextStyle(color: Colors.white, fontSize: 14)),
+          subtitle: Text(_privacyPolicy.name, style: TextStyle(color: Colors.grey.shade500, fontSize: 12)),
+        ),
+      );
+    }
+
     return Material(
       color: const Color(0xFF1A1A1A),
       shape: RoundedRectangleBorder(
@@ -1333,11 +1349,11 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
       ),
       clipBehavior: Clip.antiAlias,
       child: SwitchListTile(
-        value: _sendRawAudioToOmi,
+        value: _privacyPolicy == SttPrivacyPolicy.full,
         onChanged: (value) {
           setState(() {
-            _sendRawAudioToOmi = value;
-            _updateCurrentProviderConfig(sendRawAudioToOmi: value);
+            _privacyPolicy = value ? SttPrivacyPolicy.full : SttPrivacyPolicy.transcriptOnly;
+            _updateCurrentProviderConfig(privacyPolicy: _privacyPolicy);
           });
         },
         secondary: const Icon(Icons.cloud_upload_outlined, color: Colors.white70),
@@ -2051,7 +2067,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
               params: null,
               audioFieldName: null,
               schemaJson: current.schemaJson,
-              sendRawAudioToOmi: current.sendRawAudioToOmi,
+              privacyPolicy: current.privacyPolicy,
             );
           }
           _regenerateRequestJson(_selectedProvider);
@@ -2214,7 +2230,7 @@ class _TranscriptionSettingsPageState extends State<TranscriptionSettingsPage> {
                 params: current.params,
                 audioFieldName: current.audioFieldName,
                 schemaJson: schemaJson,
-                sendRawAudioToOmi: current.sendRawAudioToOmi,
+                privacyPolicy: current.privacyPolicy,
               );
             } catch (_) {}
           }

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -1030,7 +1030,6 @@ class CaptureController extends ChangeNotifier
 
         final socketPayload = _activeSource?.getSocketPayload(snapshot) ?? snapshot;
         if (_sendAudioIfPolicyCurrent(socketPayload)) {
-
           // Track bytes sent to websocket
           _metrics.addSocketBytes(socketPayload.length);
 
@@ -1208,10 +1207,7 @@ class CaptureController extends ChangeNotifier
     await SharedPreferencesUtil().saveString('batchAudioDir', docsDir.path);
 
     await SharedPreferencesUtil().saveBool('nativeBleForegroundReady', false);
-    await SharedPreferencesUtil().saveBool(
-      'nativeBleStreamingEnabled',
-      _shouldEnableNativeBackgroundStreaming,
-    );
+    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', _shouldEnableNativeBackgroundStreaming);
     Logger.debug(
       '[batch] config saved: batchMode=$batchMode dir=${docsDir.path} '
       'deviceId=${device.id} svc=${audioTarget.key} char=${audioTarget.value} type=${device.type.name}',
@@ -1269,10 +1265,7 @@ class CaptureController extends ChangeNotifier
 
   Future<void> _reconcileNativeBackgroundStreamingPolicy() async {
     final shouldEnable = _shouldEnableNativeBackgroundStreaming;
-    await SharedPreferencesUtil().saveBool(
-      'nativeBleStreamingEnabled',
-      shouldEnable,
-    );
+    await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', shouldEnable);
 
     if (shouldEnable || !Platform.isAndroid) return;
 

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -219,8 +219,7 @@ class CaptureController extends ChangeNotifier
             final frames = _activeSource?.processBytes(bytes) ?? [];
             for (final frame in frames) {
               _wal.getSyncs().phone.onFrameCaptured(frame);
-              if (_socket?.state == SocketServiceState.connected) {
-                _socket?.send(frame.payload);
+              if (_sendAudioIfPolicyCurrent(frame.payload)) {
                 _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
               }
             }
@@ -598,11 +597,25 @@ class CaptureController extends ChangeNotifier
   /// This resets the socket connection to use the new configuration
   Future<void> onTranscriptionSettingsChanged() async {
     Logger.debug("Transcription settings changed, refreshing socket connection...");
+    // Detach the old socket synchronously, before any awaited native or speech-
+    // profile reconciliation. Phone-mic and BLE callbacks must not get another
+    // chance to send through the previous policy while this method yields.
+    final previousSocket = _socket;
+    _socket = null;
+    _transcriptServiceReady = false;
+    await previousSocket?.stop(reason: 'transcription settings changed');
+
+    final customSttConfig = SharedPreferencesUtil().customSttConfig;
+    if (customSttConfig.isEnabled && customSttConfig.isLocalOnlyPolicy) {
+      // This awaited operation shares SocketServicePool's creation mutex, so
+      // an already-connected speech-profile socket cannot survive the policy
+      // transition or race with a new one.
+      await ServiceManager.instance().socket.stopSpeechProfile();
+    }
     await _reconcileNativeBackgroundStreamingPolicy();
 
     // Handle device recording
     if (_recordingDevice != null) {
-      await _socket?.stop(reason: 'transcription settings changed');
       BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
       await _initiateWebsocket(audioCodec: codec, force: true, source: _getConversationSourceFromDevice());
       return;
@@ -610,7 +623,6 @@ class CaptureController extends ChangeNotifier
 
     // Handle phone mic recording
     if (recordingState == RecordingState.record) {
-      await _socket?.stop(reason: 'transcription settings changed');
       await _initiateWebsocket(
         audioCodec: BleAudioCodec.pcm16,
         sampleRate: 16000,
@@ -962,6 +974,20 @@ class CaptureController extends ChangeNotifier
     );
   }
 
+  /// Final Dart audio-egress boundary shared by BLE and phone-mic paths.
+  /// Returns true only when the payload was sent through a socket created for
+  /// the currently persisted STT policy.
+  bool _sendAudioIfPolicyCurrent(List<int> payload) {
+    final activeSocket = _socket;
+    final persistedConfig = SharedPreferencesUtil().customSttConfig;
+    final persistedSttConfigId = persistedConfig.isEnabled ? persistedConfig.sttConfigId : 'omi:default';
+    if (activeSocket?.state != SocketServiceState.connected || activeSocket?.sttConfigId != persistedSttConfigId) {
+      return false;
+    }
+    activeSocket?.send(payload);
+    return true;
+  }
+
   Future<bool> streamAudioToWs(String deviceId, BleAudioCodec codec) async {
     Logger.debug('streamAudioToWs in capture_provider');
     _bleBytesStream?.cancel();
@@ -1002,10 +1028,8 @@ class CaptureController extends ChangeNotifier
           }
         }
 
-        // Send WS
-        if (_socket?.state == SocketServiceState.connected) {
-          final socketPayload = _activeSource?.getSocketPayload(snapshot) ?? snapshot;
-          _socket?.send(socketPayload);
+        final socketPayload = _activeSource?.getSocketPayload(snapshot) ?? snapshot;
+        if (_sendAudioIfPolicyCurrent(socketPayload)) {
 
           // Track bytes sent to websocket
           _metrics.addSocketBytes(socketPayload.length);
@@ -1234,7 +1258,7 @@ class CaptureController extends ChangeNotifier
 
   bool get _nativeOmiRawAudioAllowed {
     final config = SharedPreferencesUtil().customSttConfig;
-    return !config.isEnabled || config.sendRawAudioToOmi;
+    return !config.isEnabled || config.forwardsRawAudioToOmi;
   }
 
   bool get _shouldEnableNativeBackgroundStreaming =>
@@ -1244,10 +1268,24 @@ class CaptureController extends ChangeNotifier
       _nativeOmiRawAudioAllowed;
 
   Future<void> _reconcileNativeBackgroundStreamingPolicy() async {
+    final shouldEnable = _shouldEnableNativeBackgroundStreaming;
     await SharedPreferencesUtil().saveBool(
       'nativeBleStreamingEnabled',
-      _shouldEnableNativeBackgroundStreaming,
+      shouldEnable,
     );
+
+    if (shouldEnable || !Platform.isAndroid) return;
+
+    // The native foreground service can outlive this Flutter engine. Await the
+    // bridge so an existing native Omi streamer is closed before this policy
+    // transition returns; the native side is a no-op when no streamer exists.
+    try {
+      await _nativeBleTranscriptChannel.invokeMethod<void>('reconcile', {'enabled': false});
+    } on MissingPluginException {
+      return;
+    } catch (e) {
+      Logger.debug('Failed to reconcile native BLE transcript streaming: $e');
+    }
   }
 
   /// Enable or disable Background Mode through CaptureProvider so the provider
@@ -1488,8 +1526,7 @@ class CaptureController extends ChangeNotifier
               for (final frame in frames) {
                 _wal.getSyncs().phone.onFrameCaptured(frame);
 
-                if (_socket?.state == SocketServiceState.connected) {
-                  _socket?.send(frame.payload);
+                if (_sendAudioIfPolicyCurrent(frame.payload)) {
                   _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
                 }
               }
@@ -1538,8 +1575,7 @@ class CaptureController extends ChangeNotifier
       final flushed = _activeSource?.flush() ?? [];
       for (final frame in flushed) {
         _wal.getSyncs().phone.onFrameCaptured(frame);
-        if (_socket?.state == SocketServiceState.connected) {
-          _socket?.send(frame.payload);
+        if (_sendAudioIfPolicyCurrent(frame.payload)) {
           _wal.getSyncs().phone.markFrameSynced(frame.syncKey);
         }
       }

--- a/app/lib/services/capture/capture_controller.dart
+++ b/app/lib/services/capture/capture_controller.dart
@@ -606,7 +606,7 @@ class CaptureController extends ChangeNotifier
     await previousSocket?.stop(reason: 'transcription settings changed');
 
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
-    if (customSttConfig.isEnabled && customSttConfig.isLocalOnlyPolicy) {
+    if (customSttConfig.isLocalOnlyPolicy) {
       // This awaited operation shares SocketServicePool's creation mutex, so
       // an already-connected speech-profile socket cannot survive the policy
       // transition or race with a new one.
@@ -981,7 +981,11 @@ class CaptureController extends ChangeNotifier
     final activeSocket = _socket;
     final persistedConfig = SharedPreferencesUtil().customSttConfig;
     final persistedSttConfigId = persistedConfig.isEnabled ? persistedConfig.sttConfigId : 'omi:default';
-    if (activeSocket?.state != SocketServiceState.connected || activeSocket?.sttConfigId != persistedSttConfigId) {
+    final allowsDefaultOmiFallback = activeSocket?.sttConfigId == 'omi:default' &&
+        persistedConfig.isEnabled &&
+        persistedConfig.forwardsRawAudioToOmi;
+    if (activeSocket?.state != SocketServiceState.connected ||
+        (activeSocket?.sttConfigId != persistedSttConfigId && !allowsDefaultOmiFallback)) {
       return false;
     }
     activeSocket?.send(payload);
@@ -1254,7 +1258,7 @@ class CaptureController extends ChangeNotifier
 
   bool get _nativeOmiRawAudioAllowed {
     final config = SharedPreferencesUtil().customSttConfig;
-    return !config.isEnabled || config.forwardsRawAudioToOmi;
+    return !config.isLocalOnlyPolicy && (!config.isEnabled || config.forwardsRawAudioToOmi);
   }
 
   bool get _shouldEnableNativeBackgroundStreaming =>

--- a/app/lib/services/sockets.dart
+++ b/app/lib/services/sockets.dart
@@ -187,7 +187,7 @@ class SocketServicePool extends ISocketService {
     // Speech-profile onboarding is a separate Omi transcription egress path.
     // Keep localOnly independent of that backend as well.
     final customSttConfig = SharedPreferencesUtil().customSttConfig;
-    if (customSttConfig.isEnabled && customSttConfig.isLocalOnlyPolicy) {
+    if (customSttConfig.isLocalOnlyPolicy) {
       Logger.debug("socket speech profile > blocked: localOnly policy active");
       DebugLogManager.logWarning('speech_profile_socket_blocked_local_only', {'reason': 'local_only_policy'});
       return null;
@@ -199,7 +199,7 @@ class SocketServicePool extends ISocketService {
       // while still holding the same mutex used for socket creation so a
       // localOnly transition cannot race into a new speech-profile socket.
       final currentConfig = SharedPreferencesUtil().customSttConfig;
-      if (currentConfig.isEnabled && currentConfig.isLocalOnlyPolicy) {
+      if (currentConfig.isLocalOnlyPolicy) {
         Logger.debug("socket speech profile > blocked after mutex: localOnly policy active");
         DebugLogManager.logWarning('speech_profile_socket_blocked_local_only', {'reason': 'local_only_policy'});
         return null;

--- a/app/lib/services/sockets.dart
+++ b/app/lib/services/sockets.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/services/sockets/transcription_service.dart';
+import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/mutex.dart';
 
@@ -12,6 +14,8 @@ abstract class ISocketService {
   void start();
 
   void stop();
+
+  Future<void> stopSpeechProfile();
 
   Future<TranscriptSegmentSocketService?> conversation({
     required BleAudioCodec codec,
@@ -33,9 +37,21 @@ abstract class ISocketService {
 
 abstract interface class ISocketServiceSubsciption {}
 
+typedef SpeechProfileSocketFactory = TranscriptSegmentSocketService Function(
+  int sampleRate,
+  BleAudioCodec codec,
+  String language, {
+  String? source,
+});
+
 class SocketServicePool extends ISocketService {
+  SocketServicePool({SpeechProfileSocketFactory? speechProfileFactory, Mutex? mutex})
+      : _speechProfileFactory = speechProfileFactory ?? _createSpeechProfileSocket,
+        _mutex = mutex ?? Mutex();
+
   TranscriptSegmentSocketService? _socket;
   TranscriptSegmentSocketService? _speechProfileSocket;
+  final SpeechProfileSocketFactory _speechProfileFactory;
 
   @override
   void start() {}
@@ -46,8 +62,22 @@ class SocketServicePool extends ISocketService {
     await _speechProfileSocket?.stop();
   }
 
-  // Warn: Should use a better solution to prevent race conditions
-  final Mutex _mutex = Mutex();
+  final Mutex _mutex;
+
+  static TranscriptSegmentSocketService _createSpeechProfileSocket(
+    int sampleRate,
+    BleAudioCodec codec,
+    String language, {
+    String? source,
+  }) {
+    return SpeechProfileTranscriptSegmentSocketService.create(
+      sampleRate,
+      codec,
+      language,
+      source: source,
+      onboardingMode: true,
+    );
+  }
 
   Future<TranscriptSegmentSocketService?> socket({
     required BleAudioCodec codec,
@@ -60,6 +90,12 @@ class SocketServicePool extends ISocketService {
     await _mutex.acquire();
     try {
       final sttConfigId = customSttConfig?.sttConfigId ?? 'omi:default';
+      final persistedConfig = SharedPreferencesUtil().customSttConfig;
+      final persistedSttConfigId = persistedConfig.isEnabled ? persistedConfig.sttConfigId : 'omi:default';
+      if (sttConfigId != persistedSttConfigId) {
+        Logger.debug('Dropping stale transcription socket request after STT policy changed');
+        return null;
+      }
 
       // Check if we can reuse existing socket (same codec, sample rate, config, and connected)
       if (!force &&
@@ -101,6 +137,15 @@ class SocketServicePool extends ISocketService {
         return null;
       }
 
+      final latestConfig = SharedPreferencesUtil().customSttConfig;
+      final latestSttConfigId = latestConfig.isEnabled ? latestConfig.sttConfigId : 'omi:default';
+      if (sttConfigId != latestSttConfigId) {
+        final staleSocket = _socket;
+        _socket = null;
+        await staleSocket?.stop(reason: 'STT policy changed while socket was connecting');
+        return null;
+      }
+
       return _socket;
     } finally {
       _mutex.release();
@@ -139,17 +184,35 @@ class SocketServicePool extends ISocketService {
   }) async {
     Logger.debug("socket speech profile > $codec $sampleRate $force source: $source");
 
+    // Speech-profile onboarding is a separate Omi transcription egress path.
+    // Keep localOnly independent of that backend as well.
+    final customSttConfig = SharedPreferencesUtil().customSttConfig;
+    if (customSttConfig.isEnabled && customSttConfig.isLocalOnlyPolicy) {
+      Logger.debug("socket speech profile > blocked: localOnly policy active");
+      DebugLogManager.logWarning('speech_profile_socket_blocked_local_only', {'reason': 'local_only_policy'});
+      return null;
+    }
+
     await _mutex.acquire();
     try {
+      // The caller may have waited while settings changed. Re-read policy
+      // while still holding the same mutex used for socket creation so a
+      // localOnly transition cannot race into a new speech-profile socket.
+      final currentConfig = SharedPreferencesUtil().customSttConfig;
+      if (currentConfig.isEnabled && currentConfig.isLocalOnlyPolicy) {
+        Logger.debug("socket speech profile > blocked after mutex: localOnly policy active");
+        DebugLogManager.logWarning('speech_profile_socket_blocked_local_only', {'reason': 'local_only_policy'});
+        return null;
+      }
+
       // Use separate socket for speech profile to avoid conflicts with conversation socket
       await _speechProfileSocket?.stop();
 
-      _speechProfileSocket = SpeechProfileTranscriptSegmentSocketService.create(
+      _speechProfileSocket = _speechProfileFactory(
         sampleRate,
         codec,
         language,
         source: source,
-        onboardingMode: true,
       );
 
       await _speechProfileSocket?.start();
@@ -158,6 +221,18 @@ class SocketServicePool extends ISocketService {
       }
 
       return _speechProfileSocket;
+    } finally {
+      _mutex.release();
+    }
+  }
+
+  @override
+  Future<void> stopSpeechProfile() async {
+    await _mutex.acquire();
+    try {
+      final socket = _speechProfileSocket;
+      _speechProfileSocket = null;
+      await socket?.stop(reason: 'localOnly policy transition');
     } finally {
       _mutex.release();
     }

--- a/app/lib/services/sockets.dart
+++ b/app/lib/services/sockets.dart
@@ -208,6 +208,13 @@ class SocketServicePool extends ISocketService {
       // Use separate socket for speech profile to avoid conflicts with conversation socket
       await _speechProfileSocket?.stop();
 
+      final stoppedConfig = SharedPreferencesUtil().customSttConfig;
+      if (stoppedConfig.isLocalOnlyPolicy) {
+        Logger.debug("socket speech profile > blocked after stop: localOnly policy active");
+        DebugLogManager.logWarning('speech_profile_socket_blocked_local_only', {'reason': 'local_only_policy'});
+        return null;
+      }
+
       _speechProfileSocket = _speechProfileFactory(
         sampleRate,
         codec,

--- a/app/lib/services/sockets/local_only_transcription_socket.dart
+++ b/app/lib/services/sockets/local_only_transcription_socket.dart
@@ -1,0 +1,68 @@
+import 'package:omi/services/sockets/pure_socket.dart';
+
+/// Pass-through transport for the `localOnly` policy.
+///
+/// This type intentionally owns only the Custom STT primary socket. The Omi
+/// secondary is not allocated, so it cannot be connected or become a hidden
+/// dependency of the local transcript path.
+class LocalOnlyTranscriptionSocket implements IPureSocket {
+  final IPureSocket primarySocket;
+
+  IPureSocketListener? _listener;
+  late final _LocalOnlyPrimaryListener _primaryListener;
+
+  LocalOnlyTranscriptionSocket({required this.primarySocket}) {
+    _primaryListener = _LocalOnlyPrimaryListener(this);
+    primarySocket.setListener(_primaryListener);
+  }
+
+  @override
+  PureSocketStatus get status => primarySocket.status;
+
+  @override
+  void setListener(IPureSocketListener listener) {
+    _listener = listener;
+  }
+
+  @override
+  Future<bool> connect() => primarySocket.connect();
+
+  @override
+  Future disconnect() => primarySocket.disconnect();
+
+  @override
+  Future stop() => primarySocket.stop();
+
+  @override
+  void send(dynamic message) => primarySocket.send(message);
+
+  @override
+  void onConnected() => _listener?.onConnected();
+
+  @override
+  void onMessage(dynamic message) => _listener?.onMessage(message);
+
+  @override
+  void onClosed([int? closeCode]) => _listener?.onClosed(closeCode);
+
+  @override
+  void onError(Object err, StackTrace trace) => _listener?.onError(err, trace);
+}
+
+class _LocalOnlyPrimaryListener implements IPureSocketListener {
+  final LocalOnlyTranscriptionSocket _owner;
+
+  _LocalOnlyPrimaryListener(this._owner);
+
+  @override
+  void onConnected() => _owner.onConnected();
+
+  @override
+  void onMessage(dynamic message) => _owner.onMessage(message);
+
+  @override
+  void onClosed([int? closeCode]) => _owner.onClosed(closeCode);
+
+  @override
+  void onError(Object err, StackTrace trace) => _owner.onError(err, trace);
+}

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -9,6 +9,7 @@ import 'package:omi/backend/schema/transcript_segment.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/models/custom_stt_config.dart';
 import 'package:omi/models/stt_provider.dart';
+import 'package:omi/services/sockets/local_only_transcription_socket.dart';
 import 'package:omi/services/sockets/on_device_apple_provider.dart';
 import 'package:omi/services/sockets/on_device_whisper_provider.dart';
 import 'package:omi/services/sockets/pure_socket.dart';
@@ -288,6 +289,19 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
   }
 }
 
+typedef CustomSttPrimarySocketFactory = IPureSocket Function(
+  int sampleRate,
+  BleAudioCodec codec,
+  CustomSttConfig config,
+);
+
+typedef CustomSttSecondaryServiceFactory = TranscriptSegmentSocketService Function(
+  int sampleRate,
+  BleAudioCodec codec,
+  String language, {
+  String? source,
+});
+
 class TranscriptSocketServiceFactory {
   TranscriptSocketServiceFactory._();
 
@@ -305,7 +319,7 @@ class TranscriptSocketServiceFactory {
   }
 
   static bool shouldBlockUnsupportedCodecFallback(BleAudioCodec codec, CustomSttConfig config) {
-    return config.isEnabled && !isCodecSupportedForCustomStt(codec) && !config.sendRawAudioToOmi;
+    return config.isEnabled && !isCodecSupportedForCustomStt(codec) && !config.forwardsRawAudioToOmi;
   }
 
   /// Create default Omi transcription service
@@ -345,6 +359,8 @@ class TranscriptSocketServiceFactory {
     String language,
     CustomSttConfig config, {
     String? source,
+    CustomSttPrimarySocketFactory? primarySocketFactory,
+    CustomSttSecondaryServiceFactory? secondaryServiceFactory,
   }) {
     if (!config.isEnabled) {
       return createDefault(sampleRate, codec, language, source: source);
@@ -358,9 +374,19 @@ class TranscriptSocketServiceFactory {
     );
 
     // Create primary socket based on isLive/isPolling
-    final primarySocket = config.isLive
-        ? _createStreamingSocket(sampleRate, codec, config)
-        : _createPollingSocket(sampleRate, codec, config);
+    final primarySocket = (primarySocketFactory ?? _createPrimarySocket)(sampleRate, codec, config);
+
+    if (config.isLocalOnlyPolicy) {
+      return TranscriptSegmentSocketService.withSocket(
+        sampleRate,
+        codec,
+        effectiveLang,
+        LocalOnlyTranscriptionSocket(primarySocket: primarySocket),
+        source: source,
+        customSttMode: true,
+        sttConfigId: sttConfigId,
+      );
+    }
 
     // Wrap with composite service (primary STT + Omi backend)
     return _createCompositeService(
@@ -371,8 +397,15 @@ class TranscriptSocketServiceFactory {
       source: source,
       sttConfigId: sttConfigId,
       sttProvider: config.provider.name,
-      forwardRawAudioToSecondary: config.sendRawAudioToOmi,
+      forwardRawAudioToSecondary: config.forwardsRawAudioToOmi,
+      secondaryServiceFactory: secondaryServiceFactory ?? _createSecondaryService,
     );
+  }
+
+  static IPureSocket _createPrimarySocket(int sampleRate, BleAudioCodec codec, CustomSttConfig config) {
+    return config.isLive
+        ? _createStreamingSocket(sampleRate, codec, config)
+        : _createPollingSocket(sampleRate, codec, config);
   }
 
   /// Create streaming WebSocket for live STT
@@ -499,13 +532,9 @@ class TranscriptSocketServiceFactory {
     String? sttConfigId,
     String? sttProvider,
     required bool forwardRawAudioToSecondary,
+    required CustomSttSecondaryServiceFactory secondaryServiceFactory,
   }) {
-    final secondaryService = CustomSttTranscriptSegmentSocketService.create(
-      sampleRate,
-      codec,
-      language,
-      source: source,
-    );
+    final secondaryService = secondaryServiceFactory(sampleRate, codec, language, source: source);
     final compositeSocket = CompositeTranscriptionSocket(
       primarySocket: primarySocket,
       secondarySocket: secondaryService.socket,
@@ -521,5 +550,14 @@ class TranscriptSocketServiceFactory {
       customSttMode: true,
       sttConfigId: sttConfigId,
     );
+  }
+
+  static TranscriptSegmentSocketService _createSecondaryService(
+    int sampleRate,
+    BleAudioCodec codec,
+    String language, {
+    String? source,
+  }) {
+    return CustomSttTranscriptSegmentSocketService.create(sampleRate, codec, language, source: source);
   }
 }

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -980,7 +980,7 @@ void main() {
       await SharedPreferencesUtil().saveCustomSttConfig(
         const CustomSttConfig(
           provider: SttProvider.onDeviceWhisper,
-          sendRawAudioToOmi: false,
+          privacyPolicy: SttPrivacyPolicy.transcriptOnly,
         ),
       );
       final provider = CaptureProvider();
@@ -1087,7 +1087,7 @@ void main() {
       await SharedPreferencesUtil().saveCustomSttConfig(
         const CustomSttConfig(
           provider: SttProvider.onDeviceWhisper,
-          sendRawAudioToOmi: false,
+          privacyPolicy: SttPrivacyPolicy.transcriptOnly,
         ),
       );
       await SharedPreferencesUtil().saveBool('nativeBleStreamingEnabled', true);

--- a/app/test/unit/composite_transcription_socket_test.dart
+++ b/app/test/unit/composite_transcription_socket_test.dart
@@ -101,7 +101,7 @@ void main() {
       const config = CustomSttConfig(
         provider: SttProvider.customLive,
         url: 'wss://stt.example.test/live',
-        sendRawAudioToOmi: false,
+        privacyPolicy: SttPrivacyPolicy.transcriptOnly,
       );
 
       final service = TranscriptSocketServiceFactory.createFromCustomConfig(
@@ -119,7 +119,7 @@ void main() {
       const config = CustomSttConfig(
         provider: SttProvider.customLive,
         url: 'wss://stt.example.test/live',
-        sendRawAudioToOmi: false,
+        privacyPolicy: SttPrivacyPolicy.transcriptOnly,
       );
 
       expect(
@@ -132,7 +132,7 @@ void main() {
       const config = CustomSttConfig(
         provider: SttProvider.customLive,
         url: 'wss://stt.example.test/live',
-        sendRawAudioToOmi: true,
+        privacyPolicy: SttPrivacyPolicy.full,
       );
 
       expect(
@@ -145,7 +145,7 @@ void main() {
       const config = CustomSttConfig(
         provider: SttProvider.customLive,
         url: 'wss://stt.example.test/live',
-        sendRawAudioToOmi: false,
+        privacyPolicy: SttPrivacyPolicy.transcriptOnly,
       );
 
       expect(

--- a/app/test/unit/custom_stt_config_test.dart
+++ b/app/test/unit/custom_stt_config_test.dart
@@ -1,34 +1,93 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/models/custom_stt_config.dart';
+import 'package:omi/models/stt_provider.dart';
 
 void main() {
-  group('CustomSttConfig raw audio forwarding', () {
-    test('legacy configs keep forwarding raw audio to Omi', () {
+  group('CustomSttConfig privacy policy migration', () {
+    test('missing or unknown providers are rejected instead of becoming Omi', () {
+      expect(() => CustomSttConfig.fromJson({}), throwsFormatException);
+      expect(() => CustomSttConfig.fromJson({'provider': 'bogus'}), throwsFormatException);
+    });
+
+    test('legacy config without a field keeps full forwarding', () {
       final config = CustomSttConfig.fromJson({'provider': 'customLive'});
 
-      expect(config.toJson()['send_raw_audio_to_omi'], isTrue);
+      expect(config.privacyPolicy, SttPrivacyPolicy.full);
+      expect(config.forwardsRawAudioToOmi, isTrue);
     });
 
-    test('disabled forwarding survives a JSON round trip', () {
+    test('legacy send_raw_audio_to_omi false migrates to transcriptOnly', () {
+      final config = CustomSttConfig.fromJson({'provider': 'customLive', 'send_raw_audio_to_omi': false});
+
+      expect(config.privacyPolicy, SttPrivacyPolicy.transcriptOnly);
+      expect(config.forwardsRawAudioToOmi, isFalse);
+    });
+
+    test('legacy send_raw_audio_to_omi true migrates to full', () {
+      final config = CustomSttConfig.fromJson({'provider': 'customLive', 'send_raw_audio_to_omi': true});
+
+      expect(config.privacyPolicy, SttPrivacyPolicy.full);
+    });
+
+    test('explicit privacy_policy takes precedence over the legacy boolean', () {
+      for (final policy in SttPrivacyPolicy.values) {
+        final config = CustomSttConfig.fromJson({
+          'provider': 'customLive',
+          'privacy_policy': policy.name,
+          'send_raw_audio_to_omi': policy == SttPrivacyPolicy.full ? false : true,
+        });
+
+        expect(config.privacyPolicy, policy);
+      }
+    });
+
+    test('unknown privacy_policy fails privacy-closed to localOnly', () {
       final config = CustomSttConfig.fromJson({
         'provider': 'customLive',
-        'send_raw_audio_to_omi': false,
-      });
-
-      expect(config.toJson()['send_raw_audio_to_omi'], isFalse);
-    });
-
-    test('forwarding policy participates in the config identity', () {
-      final forwarding = CustomSttConfig.fromJson({
-        'provider': 'customLive',
+        'privacy_policy': 'not_a_real_policy',
         'send_raw_audio_to_omi': true,
       });
-      final transcriptOnly = CustomSttConfig.fromJson({
+
+      expect(config.privacyPolicy, SttPrivacyPolicy.localOnly);
+      expect(config.forwardsRawAudioToOmi, isFalse);
+    });
+
+    test('invalid privacy_policy types fail privacy-closed', () {
+      final config = CustomSttConfig.fromJson({
         'provider': 'customLive',
-        'send_raw_audio_to_omi': false,
+        'privacy_policy': 42,
+        'send_raw_audio_to_omi': true,
       });
 
-      expect(forwarding.sttConfigId, isNot(transcriptOnly.sttConfigId));
+      expect(config.privacyPolicy, SttPrivacyPolicy.localOnly);
+    });
+
+    test('toJson dual-writes typed and legacy forwarding fields', () {
+      for (final policy in SttPrivacyPolicy.values) {
+        final config = CustomSttConfig(provider: SttProvider.customLive, privacyPolicy: policy);
+        final json = config.toJson();
+
+        expect(json['privacy_policy'], policy.name);
+        expect(json['send_raw_audio_to_omi'], policy == SttPrivacyPolicy.full);
+        expect(CustomSttConfig.fromJson(json).privacyPolicy, policy);
+      }
+    });
+
+    test('privacy policy participates in the socket identity', () {
+      final full = CustomSttConfig.fromJson({'provider': 'customLive', 'privacy_policy': 'full'});
+      final transcriptOnly = CustomSttConfig.fromJson({'provider': 'customLive', 'privacy_policy': 'transcriptOnly'});
+      final localOnly = CustomSttConfig.fromJson({'provider': 'customLive', 'privacy_policy': 'localOnly'});
+
+      expect(full.sttConfigId, isNot(transcriptOnly.sttConfigId));
+      expect(transcriptOnly.sttConfigId, isNot(localOnly.sttConfigId));
+      expect(full.sttConfigId, isNot(localOnly.sttConfigId));
+    });
+
+    test('copyWith preserves or changes the typed policy', () {
+      const config = CustomSttConfig(provider: SttProvider.customLive, privacyPolicy: SttPrivacyPolicy.transcriptOnly);
+
+      expect(config.copyWith().privacyPolicy, SttPrivacyPolicy.transcriptOnly);
+      expect(config.copyWith(privacyPolicy: SttPrivacyPolicy.localOnly).privacyPolicy, SttPrivacyPolicy.localOnly);
     });
   });
 }

--- a/app/test/unit/local_only_transcription_socket_test.dart
+++ b/app/test/unit/local_only_transcription_socket_test.dart
@@ -1,0 +1,415 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/backend/schema/message_event.dart';
+import 'package:omi/backend/schema/transcript_segment.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/models/custom_stt_config.dart';
+import 'package:omi/models/stt_provider.dart';
+import 'package:omi/services/sockets.dart';
+import 'package:omi/services/sockets/local_only_transcription_socket.dart';
+import 'package:omi/services/sockets/pure_socket.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+import 'package:omi/utils/mutex.dart';
+
+void main() {
+  setUpAll(() {
+    Env.init(_TestEnvFields());
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  group('LocalOnlyTranscriptionSocket', () {
+    test('delegates transport operations to the primary only', () async {
+      final primary = _FakeSocket();
+      final socket = LocalOnlyTranscriptionSocket(primarySocket: primary);
+
+      expect(socket, isNot(isA<CompositeTranscriptionSocket>()));
+      expect(socket.status, PureSocketStatus.notConnected);
+      expect(await socket.connect(), isTrue);
+      expect(primary.connectCalls, 1);
+
+      socket.send('ping');
+      expect(primary.sent, ['ping']);
+
+      await socket.disconnect();
+      await socket.stop();
+      expect(primary.disconnectCalls, 2);
+      expect(primary.stopCalls, 1);
+    });
+
+    test('makes primary transcript segments observable by the existing service listener', () async {
+      final primary = _FakeSocket();
+      final localOnlySocket = LocalOnlyTranscriptionSocket(primarySocket: primary);
+      final service = TranscriptSegmentSocketService.withSocket(
+        16000,
+        BleAudioCodec.pcm16,
+        'en',
+        localOnlySocket,
+        customSttMode: true,
+      );
+
+      final receivedSegments = <TranscriptSegment>[];
+      service.subscribe('local-only-test', _RecordingListener(onSegments: receivedSegments.addAll));
+
+      await localOnlySocket.connect();
+      primary.emitMessage(
+        jsonEncode([
+          {
+            'id': 's1',
+            'text': 'hello from the primary',
+            'speaker': 'SPEAKER_00',
+            'is_user': false,
+            'start': 0.0,
+            'end': 1.0,
+          },
+        ]),
+      );
+
+      expect(receivedSegments, hasLength(1));
+      expect(receivedSegments.single.text, 'hello from the primary');
+    });
+
+    test('forwards primary lifecycle events without a secondary listener', () {
+      final primary = _FakeSocket();
+      final socket = LocalOnlyTranscriptionSocket(primarySocket: primary);
+      final listener = _RecordingPureSocketListener();
+      socket.setListener(listener);
+
+      primary.emitConnected();
+      primary.emitClosed(1000);
+      final error = Exception('primary failed');
+      primary.emitError(error);
+
+      expect(listener.connectedCount, 1);
+      expect(listener.closedCodes, [1000]);
+      expect(listener.errors, [error]);
+    });
+  });
+
+  group('TranscriptSocketServiceFactory privacy policy branches', () {
+    test('localOnly starts the primary, exposes its transcript, and skips the Omi factory', () async {
+      const config = CustomSttConfig(
+        provider: SttProvider.customLive,
+        url: 'wss://stt.example.test/live',
+        privacyPolicy: SttPrivacyPolicy.localOnly,
+      );
+      final primary = _FakeSocket();
+      var secondaryFactoryCalls = 0;
+
+      final service = TranscriptSocketServiceFactory.createFromCustomConfig(
+        16000,
+        BleAudioCodec.pcm16,
+        'en',
+        config,
+        primarySocketFactory: (_, __, ___) => primary,
+        secondaryServiceFactory: (_, __, ___, {String? source}) {
+          secondaryFactoryCalls++;
+          throw StateError('localOnly must not construct the Omi secondary service: $source');
+        },
+      );
+      final receivedSegments = <TranscriptSegment>[];
+      service.subscribe('local-only-factory-test', _RecordingListener(onSegments: receivedSegments.addAll));
+
+      expect(service.socket, isA<LocalOnlyTranscriptionSocket>());
+      expect(service.socket, isNot(isA<CompositeTranscriptionSocket>()));
+      await service.start();
+      primary.emitMessage(
+        jsonEncode([
+          {
+            'id': 'factory-s1',
+            'text': 'primary transcript remains visible',
+            'speaker': 'SPEAKER_00',
+            'is_user': false,
+            'start': 0.0,
+            'end': 1.0,
+          },
+        ]),
+      );
+
+      expect(primary.connectCalls, 1);
+      expect(secondaryFactoryCalls, 0);
+      expect(receivedSegments.single.text, 'primary transcript remains visible');
+    });
+
+    test('full and transcriptOnly retain the existing composite behavior', () {
+      const fullConfig = CustomSttConfig(
+        provider: SttProvider.customLive,
+        url: 'wss://stt.example.test/live',
+        privacyPolicy: SttPrivacyPolicy.full,
+      );
+      const transcriptOnlyConfig = CustomSttConfig(
+        provider: SttProvider.customLive,
+        url: 'wss://stt.example.test/live',
+        privacyPolicy: SttPrivacyPolicy.transcriptOnly,
+      );
+
+      final fullService = TranscriptSocketServiceFactory.createFromCustomConfig(
+        16000,
+        BleAudioCodec.pcm16,
+        'en',
+        fullConfig,
+      );
+      final transcriptOnlyService = TranscriptSocketServiceFactory.createFromCustomConfig(
+        16000,
+        BleAudioCodec.pcm16,
+        'en',
+        transcriptOnlyConfig,
+      );
+
+      expect(fullService.socket, isA<CompositeTranscriptionSocket>());
+      expect((fullService.socket as CompositeTranscriptionSocket).forwardRawAudioToSecondary, isTrue);
+      expect(transcriptOnlyService.socket, isA<CompositeTranscriptionSocket>());
+      expect((transcriptOnlyService.socket as CompositeTranscriptionSocket).forwardRawAudioToSecondary, isFalse);
+    });
+  });
+
+  test('localOnly blocks the separate Omi speech-profile socket path', () async {
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        url: 'wss://stt.example.test/live',
+        privacyPolicy: SttPrivacyPolicy.localOnly,
+      ),
+    );
+
+    final socket = SocketServicePool();
+    final speechProfile = await socket.speechProfile(codec: BleAudioCodec.pcm16, sampleRate: 16000, language: 'en');
+
+    expect(speechProfile, isNull);
+  });
+
+  test('malformed persisted Custom STT config fails privacy-closed', () async {
+    await SharedPreferencesUtil().saveString('customSttConfig', '{not-json');
+
+    final config = SharedPreferencesUtil().customSttConfig;
+
+    expect(config.provider, SttProvider.customLive);
+    expect(config.privacyPolicy, SttPrivacyPolicy.localOnly);
+    expect(config.forwardsRawAudioToOmi, isFalse);
+  });
+
+  test('semantically invalid persisted Custom STT config fails privacy-closed', () async {
+    for (final rawConfig in ['{}', '{"provider":"bogus"}']) {
+      await SharedPreferencesUtil().saveString('customSttConfig', rawConfig);
+
+      final config = SharedPreferencesUtil().customSttConfig;
+
+      expect(config.provider, SttProvider.customLive);
+      expect(config.privacyPolicy, SttPrivacyPolicy.localOnly);
+      expect(config.forwardsRawAudioToOmi, isFalse);
+    }
+  });
+
+  test('conversation pool drops a request whose policy is already stale', () async {
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        privacyPolicy: SttPrivacyPolicy.localOnly,
+      ),
+    );
+    final pool = SocketServicePool();
+
+    final socket = await pool.socket(
+      codec: BleAudioCodec.pcm16,
+      sampleRate: 16000,
+      language: 'en',
+      customSttConfig: const CustomSttConfig(
+        provider: SttProvider.customLive,
+        privacyPolicy: SttPrivacyPolicy.full,
+      ),
+    );
+
+    expect(socket, isNull);
+  });
+
+  test('localOnly revalidation after waiting on the mutex prevents speech socket creation', () async {
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        privacyPolicy: SttPrivacyPolicy.full,
+      ),
+    );
+
+    final mutex = Mutex();
+    await mutex.acquire();
+    var factoryCalls = 0;
+    final pool = SocketServicePool(
+      mutex: mutex,
+      speechProfileFactory: (_, __, ___, {String? source}) {
+        factoryCalls++;
+        return TranscriptSegmentSocketService.withSocket(16000, BleAudioCodec.pcm16, 'en', _FakeSocket());
+      },
+    );
+
+    final pending = pool.speechProfile(codec: BleAudioCodec.pcm16, sampleRate: 16000, language: 'en');
+    await Future<void>.delayed(Duration.zero);
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        privacyPolicy: SttPrivacyPolicy.localOnly,
+      ),
+    );
+    mutex.release();
+
+    expect(await pending, isNull);
+    expect(factoryCalls, 0);
+  });
+
+  test('awaited speech-profile stop closes an active socket on localOnly transition', () async {
+    final speechSocket = _FakeSocket();
+    final pool = SocketServicePool(
+      speechProfileFactory: (_, __, ___, {String? source}) {
+        return TranscriptSegmentSocketService.withSocket(16000, BleAudioCodec.pcm16, 'en', speechSocket);
+      },
+    );
+
+    final created = await pool.speechProfile(codec: BleAudioCodec.pcm16, sampleRate: 16000, language: 'en');
+    expect(created, isNotNull);
+    expect(speechSocket.connectCalls, 1);
+
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        privacyPolicy: SttPrivacyPolicy.localOnly,
+      ),
+    );
+    await pool.stopSpeechProfile();
+
+    expect(speechSocket.stopCalls, 1);
+    expect(speechSocket.status, PureSocketStatus.disconnected);
+  });
+}
+
+class _TestEnvFields implements EnvFields {
+  @override
+  String? get apiBaseUrl => 'https://api.example.test/';
+
+  @override
+  String? get googleClientId => null;
+
+  @override
+  String? get googleClientSecret => null;
+
+  @override
+  String? get googleMapsApiKey => null;
+
+  @override
+  String? get intercomAndroidApiKey => null;
+
+  @override
+  String? get intercomAppId => null;
+
+  @override
+  String? get intercomIOSApiKey => null;
+
+  @override
+  String? get posthogApiKey => null;
+
+  @override
+  bool? get useAuthCustomToken => false;
+
+  @override
+  bool? get useWebAuth => false;
+}
+
+class _FakeSocket implements IPureSocket {
+  final List<dynamic> sent = [];
+  IPureSocketListener? _listener;
+  PureSocketStatus _status = PureSocketStatus.notConnected;
+  int connectCalls = 0;
+  int disconnectCalls = 0;
+  int stopCalls = 0;
+
+  @override
+  PureSocketStatus get status => _status;
+
+  @override
+  Future<bool> connect() async {
+    connectCalls++;
+    _status = PureSocketStatus.connected;
+    _listener?.onConnected();
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    _status = PureSocketStatus.disconnected;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    await disconnect();
+  }
+
+  @override
+  void onClosed([int? closeCode]) => _listener?.onClosed(closeCode);
+
+  @override
+  void onConnected() => _listener?.onConnected();
+
+  @override
+  void onError(Object err, StackTrace trace) => _listener?.onError(err, trace);
+
+  @override
+  void onMessage(dynamic message) => _listener?.onMessage(message);
+
+  @override
+  void send(dynamic message) => sent.add(message);
+
+  @override
+  void setListener(IPureSocketListener listener) => _listener = listener;
+
+  void emitMessage(dynamic message) => _listener?.onMessage(message);
+  void emitConnected() => _listener?.onConnected();
+  void emitClosed([int? closeCode]) => _listener?.onClosed(closeCode);
+  void emitError(Object err) => _listener?.onError(err, StackTrace.current);
+}
+
+class _RecordingPureSocketListener implements IPureSocketListener {
+  int connectedCount = 0;
+  final List<int?> closedCodes = [];
+  final List<Object> errors = [];
+
+  @override
+  void onConnected() => connectedCount++;
+
+  @override
+  void onMessage(dynamic message) {}
+
+  @override
+  void onClosed([int? closeCode]) => closedCodes.add(closeCode);
+
+  @override
+  void onError(Object err, StackTrace trace) => errors.add(err);
+}
+
+class _RecordingListener implements ITransctiptSegmentSocketServiceListener {
+  _RecordingListener({required this.onSegments});
+
+  final void Function(List<TranscriptSegment> segments) onSegments;
+
+  @override
+  void onSegmentReceived(List<TranscriptSegment> segments) => onSegments(segments);
+
+  @override
+  void onMessageEventReceived(MessageEvent event) {}
+
+  @override
+  void onConnected() {}
+
+  @override
+  void onClosed([int? closeCode]) {}
+
+  @override
+  void onError(Object err) {}
+}

--- a/app/test/unit/local_only_transcription_socket_test.dart
+++ b/app/test/unit/local_only_transcription_socket_test.dart
@@ -191,7 +191,7 @@ void main() {
 
     final config = SharedPreferencesUtil().customSttConfig;
 
-    expect(config.provider, SttProvider.customLive);
+    expect(config.provider, SttProvider.omi);
     expect(config.privacyPolicy, SttPrivacyPolicy.localOnly);
     expect(config.forwardsRawAudioToOmi, isFalse);
   });
@@ -202,7 +202,7 @@ void main() {
 
       final config = SharedPreferencesUtil().customSttConfig;
 
-      expect(config.provider, SttProvider.customLive);
+      expect(config.provider, SttProvider.omi);
       expect(config.privacyPolicy, SttPrivacyPolicy.localOnly);
       expect(config.forwardsRawAudioToOmi, isFalse);
     }

--- a/app/test/unit/local_only_transcription_socket_test.dart
+++ b/app/test/unit/local_only_transcription_socket_test.dart
@@ -286,6 +286,34 @@ void main() {
     expect(speechSocket.stopCalls, 1);
     expect(speechSocket.status, PureSocketStatus.disconnected);
   });
+
+  test('speech-profile revalidates policy after stopping the previous socket', () async {
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        privacyPolicy: SttPrivacyPolicy.full,
+      ),
+    );
+    final speechSocket = _FakeSocket();
+    var factoryCalls = 0;
+    final pool = SocketServicePool(
+      speechProfileFactory: (_, __, ___, {String? source}) {
+        factoryCalls++;
+        return TranscriptSegmentSocketService.withSocket(16000, BleAudioCodec.pcm16, 'en', speechSocket);
+      },
+    );
+
+    expect(await pool.speechProfile(codec: BleAudioCodec.pcm16, sampleRate: 16000, language: 'en'), isNotNull);
+    speechSocket.onStop = () => SharedPreferencesUtil().saveCustomSttConfig(
+          const CustomSttConfig(
+            provider: SttProvider.customLive,
+            privacyPolicy: SttPrivacyPolicy.localOnly,
+          ),
+        );
+
+    expect(await pool.speechProfile(codec: BleAudioCodec.pcm16, sampleRate: 16000, language: 'en'), isNull);
+    expect(factoryCalls, 1);
+  });
 }
 
 class _TestEnvFields implements EnvFields {
@@ -327,6 +355,7 @@ class _FakeSocket implements IPureSocket {
   int connectCalls = 0;
   int disconnectCalls = 0;
   int stopCalls = 0;
+  Future<void> Function()? onStop;
 
   @override
   PureSocketStatus get status => _status;
@@ -349,6 +378,7 @@ class _FakeSocket implements IPureSocket {
   Future<void> stop() async {
     stopCalls++;
     await disconnect();
+    await onStop?.call();
   }
 
   @override

--- a/app/test/widgets/transcription_settings_forwarding_test.dart
+++ b/app/test/widgets/transcription_settings_forwarding_test.dart
@@ -20,11 +20,11 @@ void main() {
 
     const onDeviceConfig = CustomSttConfig(
       provider: SttProvider.onDeviceWhisper,
-      sendRawAudioToOmi: false,
+      privacyPolicy: SttPrivacyPolicy.transcriptOnly,
     );
     const cloudConfig = CustomSttConfig(
       provider: SttProvider.openai,
-      sendRawAudioToOmi: true,
+      privacyPolicy: SttPrivacyPolicy.full,
     );
     await SharedPreferencesUtil().saveCustomSttConfig(onDeviceConfig);
     await SharedPreferencesUtil().saveConfigForProvider(SttProvider.onDeviceWhisper, onDeviceConfig);
@@ -78,8 +78,47 @@ void main() {
 
     expect(forwardingTile().value, isFalse);
     expect(
-      SharedPreferencesUtil().getConfigForProvider(SttProvider.onDeviceWhisper)?.sendRawAudioToOmi,
+      SharedPreferencesUtil().getConfigForProvider(SttProvider.onDeviceWhisper)?.forwardsRawAudioToOmi,
       isFalse,
     );
+  });
+
+  testWidgets('imported localOnly shows a read-only policy state without transcriptOnly copy', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    await SharedPreferencesUtil().saveCustomSttConfig(
+      const CustomSttConfig(
+        provider: SttProvider.customLive,
+        url: 'wss://stt.example.test/live',
+        privacyPolicy: SttPrivacyPolicy.localOnly,
+      ),
+    );
+
+    final captureProvider = CaptureProvider();
+    addTearDown(captureProvider.dispose);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<CaptureProvider>.value(
+        value: captureProvider,
+        child: const MaterialApp(
+          localizationsDelegates: [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: TranscriptionSettingsPage(),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('localOnly'), findsOneWidget);
+    expect(
+        find.text(
+            'Turn off to prevent raw audio from being sent to Omi. Transcripts and data needed by cloud features may still be sent to Omi.'),
+        findsNothing);
+    expect(find.byType(SwitchListTile), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

Adds the transport/privacy foundation for Custom STT `localOnly` mode, building on #10447 and moving #10431 forward.

- Replaces the legacy raw-audio boolean internally with a typed `full` / `transcriptOnly` / `localOnly` policy while dual-writing the legacy field for older clients.
- `localOnly` creates only the primary Custom STT socket. It never allocates or connects the secondary Omi transcription socket, while primary transcript segments remain observable by the existing capture pipeline.
- Applies the same policy to Android background BLE streaming and the separate speech-profile socket path.
- Makes policy transitions race-safe: stale socket requests are rejected, audio egress revalidates the current socket identity, and native pending-frame queues are generation-scoped and invalidated on stop, close, failure, or policy change.
- Malformed, unknown, or semantically invalid persisted Custom STT configuration fails privacy-closed instead of silently restoring Omi audio egress.

## Policy behavior

| Policy | Audio to Custom STT | Audio to Omi | Custom transcripts to Omi |
| --- | --- | --- | --- |
| `full` | yes | yes | yes |
| `transcriptOnly` | yes | no | yes |
| `localOnly` | yes | no | no |

The typed field is authoritative when both typed and legacy fields exist. Legacy `send_raw_audio_to_omi: false` migrates to `transcriptOnly`; configurations without either field preserve the previous `full` behavior.

## Scope

This is the transport-only first slice of #10431:

- No durable local conversation persistence.
- No local folders/search/export behavior.
- No localization expansion.
- Imported `localOnly` configurations are displayed as a read-only policy state; this PR does not expose a new selectable end-user mode yet.

## Privacy/race hardening

The implementation covers the concrete transition races found during adversarial review:

- foreground BLE and phone-mic callbacks cannot send through a socket created for an older policy;
- a socket connecting concurrently with a settings change is stopped and discarded;
- Android callbacks cannot queue or drain frames from an invalidated generation;
- native reconciliation failures still leave the persisted policy as an egress check;
- reconnecting with the same native config cannot inherit frames from a closed or failed session.

## Verification

After rebasing onto current `upstream/main`:

```text
mise x flutter@3.44.5 -- bash test.sh
→ 1,355 passed / 2 skipped

mise x flutter@3.44.5 -- scripts/analyze_ratchet.sh
→ passed (one baseline improvement)

Hermetic Kotlin/JVM smoke suite, Java 17 + Gradle 8.14.2
→ 17 passed / 0 failed

scripts/pr-preflight --base upstream/main --head HEAD
→ 12 checks passed

git diff --check upstream/main...HEAD
→ clean
```

The host does not have an Android SDK, so a full APK build and physical BLE transition test were not available. The extracted Android policy, lifecycle, and lazy-resource boundaries are compiled and tested in the hermetic Kotlin suite.

Product invariants affected: none.

Refs: #10431, #10447


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Failure-Class: none
