### PR TITLE
fix(app): honor OMI_SHARE_BASE_URL for Flutter share links (#4339)

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -17,6 +17,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/backend/http/api/apps.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/utils/share_links.dart';
 import 'package:omi/pages/apps/app_detail/reviews_list_page.dart';
 import 'package:omi/pages/apps/app_detail/widgets/review_avatar.dart';
 import 'package:omi/pages/apps/app_home_web_page.dart';
@@ -687,7 +688,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                   box != null ? box.localToGlobal(Offset.zero) & box.size : null;
 
                               await Share.share(
-                                'https://h.omi.me/apps/${app.id}',
+                                appShareUrl(app.id),
                                 subject: app.name,
                                 sharePositionOrigin: sharePositionOrigin,
                               );

--- a/app/lib/pages/conversation_detail/share.dart
+++ b/app/lib/pages/conversation_detail/share.dart
@@ -3,9 +3,10 @@ import 'dart:ui';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/utils/share_links.dart';
 
 void shareConversationLink(ServerConversation conversation, {Rect? sharePositionOrigin}) {
-  final content = 'https://h.omi.me/conversations/${conversation.id}';
+  final content = conversationShareUrl(conversation.id);
   final subject = conversation.structured.title;
   Share.share(content, subject: subject.isEmpty ? null : subject, sharePositionOrigin: sharePositionOrigin);
 }

--- a/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/share_to_contacts_sheet.dart
@@ -13,6 +13,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/share_links.dart';
 
 /// Contact with phone number for sharing
 class ShareableContact {
@@ -186,7 +187,7 @@ class _ShareToContactsBottomSheetState extends State<ShareToContactsBottomSheet>
       }
 
       // Build the share link and message
-      final shareLink = 'https://h.omi.me/conversations/${widget.conversation.id}';
+      final shareLink = conversationShareUrl(widget.conversation.id);
       final message = l10n.heresWhatWeDiscussed(shareLink);
 
       // Build recipients string (comma-separated phone numbers)

--- a/app/lib/pages/settings/daily_summary_detail_page.dart
+++ b/app/lib/pages/settings/daily_summary_detail_page.dart
@@ -17,6 +17,7 @@ import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/daily_summary_journey.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_service.dart';
+import 'package:omi/utils/share_links.dart';
 
 class DailySummaryDetailPage extends StatefulWidget {
   final String summaryId;
@@ -109,7 +110,7 @@ class _DailySummaryDetailPageState extends State<DailySummaryDetailPage> with Si
         return;
       }
       PlatformManager.instance.analytics.dailySummaryShared(summaryId: widget.summaryId, date: summary.date);
-      final url = 'https://h.omi.me/recaps/${widget.summaryId}';
+      final url = recapShareUrl(widget.summaryId);
       await SharePlus.instance.share(ShareParams(uri: Uri.parse(url), subject: summary.headline));
     } finally {
       if (mounted) setState(() => _isSharing = false);

--- a/app/lib/utils/share_links.dart
+++ b/app/lib/utils/share_links.dart
@@ -1,0 +1,44 @@
+/// Public share-link base URL for self-hosting (#4339).
+///
+/// Matches backend `OMI_SHARE_BASE_URL` / desktop share helpers.
+/// Override at build time with `--dart-define=OMI_SHARE_BASE_URL=https://share.example.com`.
+
+const defaultShareBaseUrl = 'https://h.omi.me';
+
+const _shareBaseFromDefine = String.fromEnvironment('OMI_SHARE_BASE_URL');
+
+final _hostOk = RegExp(r'^[A-Za-z0-9.-]+$');
+
+/// Return the configured share origin (no trailing slash).
+///
+/// [raw] is for tests; production callers omit it so the dart-define / default apply.
+String shareBaseUrl([String? raw]) {
+  var value = (raw ?? _shareBaseFromDefine).trim();
+  if (value.isEmpty) {
+    value = defaultShareBaseUrl;
+  }
+  if (!value.contains('://')) {
+    value = 'https://$value';
+  }
+  final uri = Uri.tryParse(value);
+  if (uri == null ||
+      uri.host.isEmpty ||
+      (uri.scheme != 'http' && uri.scheme != 'https') ||
+      !_hostOk.hasMatch(uri.host)) {
+    return defaultShareBaseUrl;
+  }
+  return value.replaceFirst(RegExp(r'/+$'), '');
+}
+
+/// Join [shareBaseUrl] with a path (leading slash optional).
+String buildShareUrl(String path, {String? raw}) {
+  final normalized = path.startsWith('/') ? path : '/$path';
+  return '${shareBaseUrl(raw)}$normalized';
+}
+
+String conversationShareUrl(String conversationId, {String? raw}) =>
+    buildShareUrl('/conversations/$conversationId', raw: raw);
+
+String appShareUrl(String appId, {String? raw}) => buildShareUrl('/apps/$appId', raw: raw);
+
+String recapShareUrl(String summaryId, {String? raw}) => buildShareUrl('/recaps/$summaryId', raw: raw);

--- a/app/lib/utils/share_links.dart
+++ b/app/lib/utils/share_links.dart
@@ -1,7 +1,7 @@
-/// Public share-link base URL for self-hosting (#4339).
-///
-/// Matches backend `OMI_SHARE_BASE_URL` / desktop share helpers.
-/// Override at build time with `--dart-define=OMI_SHARE_BASE_URL=https://share.example.com`.
+// Public share-link base URL for self-hosting (#4339).
+//
+// Matches backend `OMI_SHARE_BASE_URL` / desktop share helpers.
+// Override at build time with `--dart-define=OMI_SHARE_BASE_URL=https://share.example.com`.
 
 const defaultShareBaseUrl = 'https://h.omi.me';
 
@@ -23,11 +23,19 @@ String shareBaseUrl([String? raw]) {
   final uri = Uri.tryParse(value);
   if (uri == null ||
       uri.host.isEmpty ||
+      uri.userInfo.isNotEmpty ||
+      uri.hasQuery ||
+      uri.hasFragment ||
       (uri.scheme != 'http' && uri.scheme != 'https') ||
       !_hostOk.hasMatch(uri.host)) {
     return defaultShareBaseUrl;
   }
-  return value.replaceFirst(RegExp(r'/+$'), '');
+  final origin = uri.hasPort ? '${uri.scheme}://${uri.host}:${uri.port}' : '${uri.scheme}://${uri.host}';
+  final path = uri.path.replaceFirst(RegExp(r'/+$'), '');
+  if (path.isEmpty || path == '/') {
+    return origin;
+  }
+  return '$origin$path';
 }
 
 /// Join [shareBaseUrl] with a path (leading slash optional).

--- a/app/test/unit/share_links_test.dart
+++ b/app/test/unit/share_links_test.dart
@@ -16,6 +16,17 @@ void main() {
     test('falls back for malformed overrides', () {
       expect(shareBaseUrl('ftp://share.example.com'), defaultShareBaseUrl);
       expect(shareBaseUrl('not a url'), defaultShareBaseUrl);
+      expect(shareBaseUrl('https://share.example.com?x=1'), defaultShareBaseUrl);
+      expect(shareBaseUrl('https://share.example.com#frag'), defaultShareBaseUrl);
+      expect(shareBaseUrl('https://user:pass@share.example.com'), defaultShareBaseUrl);
+    });
+
+    test('preserves path prefix without query or fragment', () {
+      expect(shareBaseUrl('https://share.example.com/omi/'), 'https://share.example.com/omi');
+      expect(
+        conversationShareUrl('c1', raw: 'https://share.example.com/omi/'),
+        'https://share.example.com/omi/conversations/c1',
+      );
     });
   });
 

--- a/app/test/unit/share_links_test.dart
+++ b/app/test/unit/share_links_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/utils/share_links.dart';
+
+void main() {
+  group('shareBaseUrl', () {
+    test('defaults to production h.omi.me', () {
+      expect(shareBaseUrl(''), defaultShareBaseUrl);
+      expect(shareBaseUrl(null), defaultShareBaseUrl);
+    });
+
+    test('honors overrides and strips trailing slash', () {
+      expect(shareBaseUrl('https://share.example.com/'), 'https://share.example.com');
+      expect(shareBaseUrl('share.example.com'), 'https://share.example.com');
+    });
+
+    test('falls back for malformed overrides', () {
+      expect(shareBaseUrl('ftp://share.example.com'), defaultShareBaseUrl);
+      expect(shareBaseUrl('not a url'), defaultShareBaseUrl);
+    });
+  });
+
+  group('typed share URLs', () {
+    test('conversation / app / recap paths', () {
+      expect(
+        conversationShareUrl('c1', raw: 'https://share.example.com'),
+        'https://share.example.com/conversations/c1',
+      );
+      expect(appShareUrl('a1', raw: 'https://share.example.com'), 'https://share.example.com/apps/a1');
+      expect(recapShareUrl('r1', raw: 'https://share.example.com'), 'https://share.example.com/recaps/r1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Finish the Flutter leftover for #4339 after backend (#11189) and desktop (#11190): conversation / app / recap share URLs go through `share_links.dart` instead of hardcoded `https://h.omi.me`.
- Override with `--dart-define=OMI_SHARE_BASE_URL=…` (same env name as backend). Malformed values fail closed to production.
- Universal Link / app-link host entries in iOS/Android manifests stay on `h.omi.me` (receiving production links); this PR only changes link *generation*.

## Test plan
- [x] `flutter test test/unit/share_links_test.dart` (4 passed)
- [ ] Physical share sheet smoke — not run (no kit)

## Honest gaps
- Physical / on-device smoke not run (no kit).
- Web frontend share generation not audited in this PR (scope = Flutter leftover called out after #11189/#11190).

Failure-Class: none