### PR TITLE
fix(backend): drop only the ungrounded memory candidate, not the whole run (#11685)

### DIFF
--- a/backend/tests/unit/test_memory_replace_policy.py
+++ b/backend/tests/unit/test_memory_replace_policy.py
@@ -225,6 +225,70 @@ def test_canonical_capture_preserves_prior_state_when_candidate_has_any_unground
     mock_service.replace_conversation_memories.assert_not_called()
 
 
+def test_canonical_capture_drops_only_the_ungrounded_candidate(monkeypatch):
+    """One ungrounded candidate must not discard its grounded siblings."""
+    pc = _load_process_conversation()
+    from models.conversation import Conversation
+    from models.conversation_enums import CategoryEnum, ConversationSource
+    from models.structured import Structured
+    from models.transcript_segment import TranscriptSegment
+
+    mock_service = MagicMock()
+    monkeypatch.setattr(pc, "MemoryService", lambda db_client: mock_service)
+    monkeypatch.setattr(
+        pc,
+        "extract_canonical_l1_memory_candidates",
+        MagicMock(
+            return_value=[
+                SimpleNamespace(
+                    content="The user works at Acme.",
+                    evidence_quotes=["I work at Acme"],
+                    speaker_label="SPEAKER_00",
+                    speaker_scope="session-local",
+                    about="the user",
+                    risk_flags=[],
+                    archive_class="general",
+                ),
+                SimpleNamespace(
+                    content="The user was diagnosed with condition X.",
+                    evidence_quotes=["I was diagnosed with condition X"],
+                    speaker_label="SPEAKER_00",
+                    speaker_scope="session-local",
+                    about="the user",
+                    risk_flags=[],
+                    archive_class="general",
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
+
+    conversation = Conversation(
+        id="conv-partially-grounded",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title="Test", overview="Overview", category=CategoryEnum.personal),
+        transcript_segments=[
+            TranscriptSegment(
+                text="I work at Acme and we talked about the grocery list.",
+                speaker="SPEAKER_00",
+                is_user=True,
+                start=0.0,
+                end=4.0,
+            )
+        ],
+    )
+
+    result = pc._extract_memories_canonical("uid-partial-grounding", conversation, db_client=MagicMock())
+
+    assert result.count == 1
+    replacement_payloads = mock_service.replace_conversation_memories.call_args.args[2]
+    assert len(replacement_payloads) == 1
+    assert replacement_payloads[0]["content"] == "The user works at Acme."
+
+
 @pytest.mark.parametrize(
     "matched_segments",
     [

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -909,13 +909,19 @@ def _extract_memories_canonical(
             language=language,
             strict=True,
         )
+        ungrounded_candidates = 0
         for candidate in extracted_candidates:
             evidence_quotes = _grounded_l1_evidence_quotes(
                 candidate.evidence_quotes,
                 conversation.transcript_segments,
             )
             if not evidence_quotes:
-                raise ValueError("canonical memory extraction returned evidence without a unique source binding")
+                # A quote that binds to no single segment is a verdict on this
+                # candidate, not on the run. Dropping it keeps the capture fence
+                # intact — nothing unbound is written — without discarding the
+                # grounded siblings and the rest of conversation finalization.
+                ungrounded_candidates += 1
+                continue
             subject_entity_id, subject_attribution, subject_kind = _l1_candidate_subject(
                 source_id=conversation.id,
                 about=candidate.about,
@@ -942,6 +948,25 @@ def _extract_memories_canonical(
                     _l1_candidate_sensitivity_labels(candidate),
                     True,
                 )
+            )
+        if extracted_candidates and not capture_candidates:
+            # Every candidate failed grounding: the run itself is untrustworthy,
+            # so it must not submit the empty replacement that would retract the
+            # source's existing memories.
+            raise ValueError("canonical memory extraction returned evidence without a unique source binding")
+        if ungrounded_candidates:
+            logger.warning(
+                "canonical memory extraction dropped %s of %s ungrounded candidates conversation=%s",
+                ungrounded_candidates,
+                len(extracted_candidates),
+                conversation.id,
+            )
+            record_fallback(
+                component='other',
+                from_mode='canonical_memory_extraction',
+                to_mode='grounded_candidates_only',
+                reason='other',
+                outcome='degraded',
             )
 
     is_locked = conversation.is_locked


### PR DESCRIPTION
Fixes #11685.

## Bug

`_extract_memories_canonical` raised `ValueError("canonical memory extraction returned evidence without a unique source binding")` as soon as **one** L1 candidate's evidence quotes failed to bind to exactly one transcript segment. That is a per-candidate trust verdict, but raising it aborted the whole run — and because `_extract_memories` is called synchronously near the end of `process_conversation` (`:1532`), the rest of finalization went with it: the run's correctly-grounded candidates, `_save_action_items`, `_update_goal_progress`, the desktop meeting Chat receipt, and the lazy-enrich handler's terminal transition (it re-marks the conversation `deferred: True`, so the user sees no summary until they reopen it). On `backend-sync` there is no retry at all — the merged conversation just keeps its stale enrichment.

## Root cause

`_grounded_l1_evidence_quotes` returns `[]` when any one quote of a candidate does not match **exactly one** segment: 0 matches (the model paraphrased, or quoted across a segment boundary) or 2+ matches (a short phrase repeated in two segments). The caller escalated that per-candidate `[]` to a run-scope raise.

## Fix

Skip the ungrounded candidate and continue. The fence is unchanged — nothing unbound is ever written — and the run's grounded siblings survive. **Every** candidate failing to ground still raises: `replace_conversation_memories` is called unconditionally at `:1012`, so continuing there would submit an empty replacement and retract the source's existing memories on the strength of a run we just decided not to trust. Dropped candidates emit a bounded `logger.warning` plus the shared `record_fallback` (`outcome=degraded`), per `docs/agents/fallback-telemetry.md`.

## Production evidence (`based-hardware`, 2026-08-16 03:00Z → 15:30Z)

- `lazy enrich` outcomes: **42 complete / 39 failed**, and **27 of the 39 failures** are this error — ~1 in 3 of all lazy enrichments.
- Same error fires continuously on `backend-sync` (`_reprocess_merged_conversations`).
- Extraction is not systematically broken in that window: **332** conversations saved ≥1 canonical memory (**209** of them ≥2) and 468 extracted none. Candidates fail grounding individually, which is exactly what this PR stops from being fatal.

## Verification

- New regression test `test_canonical_capture_drops_only_the_ungrounded_candidate` (two candidates, one ungrounded): **fails on pre-fix `process_conversation.py` with the verbatim production `ValueError`**, passes with the fix.
- The existing fail-closed guard `test_canonical_capture_preserves_prior_state_when_candidate_has_any_ungrounded_quote` is untouched and still passes — its single ungrounded candidate is now the "every candidate ungrounded" case, so no source replacement is submitted.
- `BACKEND_UNIT_TEST_FILE_LIST=… bash backend/test.sh` on `tests/unit/test_memory_replace_policy.py`: **15 passed**.
- `make preflight` green.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 1781 -> 1806 | +25 lines: a `continue` branch with its rationale, the all-candidates-ungrounded fail-closed guard, and the required `record_fallback` site. Splitting this 1.8k-line module is unrelated to a live production fix.

🤖 automated by hourly watchdog — tested and merged

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

