### PR TITLE
fix(desktop): align Rewind owner snapshot isCurrent with capture (#11572)

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindCaptureExclusion.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindCaptureExclusion.swift
@@ -5,17 +5,27 @@ struct RewindCaptureOwnerSnapshot: Equatable, Sendable {
   let generation: UInt64
   let authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot?
 
+  /// Prefer authenticated owner, then Rewind DB owner, then anonymous.
+  /// `capture()` and `isCurrent()` must use the same order (#11572).
+  static func resolvedOwnerID(
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? =
+      RuntimeOwnerIdentity
+      .captureAuthorizationSnapshot()
+  ) -> String {
+    authorizationSnapshot?.ownerID ?? RewindDatabase.currentUserId ?? "anonymous"
+  }
+
   static func capture() -> RewindCaptureOwnerSnapshot? {
     let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot()
     guard let generation = RewindCaptureOwnerGeneration.snapshot() else { return nil }
     return RewindCaptureOwnerSnapshot(
-      ownerID: authorizationSnapshot?.ownerID ?? RewindDatabase.currentUserId ?? "anonymous",
+      ownerID: resolvedOwnerID(authorizationSnapshot: authorizationSnapshot),
       generation: generation,
       authorizationSnapshot: authorizationSnapshot)
   }
 
   func isCurrent() -> Bool {
-    let currentOwnerID = RewindDatabase.currentUserId ?? "anonymous"
+    let currentOwnerID = Self.resolvedOwnerID()
     guard currentOwnerID == ownerID,
       RewindCaptureOwnerGeneration.isCurrent(generation)
     else { return false }

--- a/desktop/macos/Desktop/Tests/RewindCaptureExclusionGenerationTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindCaptureExclusionGenerationTests.swift
@@ -187,4 +187,34 @@ final class RewindCaptureExclusionGenerationTests: XCTestCase {
     XCTAssertTrue(resumed.isCurrent())
     await OCREmbeddingService.shared.reset()
   }
+
+  /// #11572: launch / CI window where `auth_userId` is set but RewindDatabase
+  /// has not resolved `currentUserId` yet. Capture preferred auth; isCurrent
+  /// used to compare only the DB id and permanently fail-closed.
+  func testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase() {
+    let defaults = UserDefaults.standard
+    let previousAuth = defaults.object(forKey: .authUserId)
+    let previousDB = RewindDatabase.currentUserId
+    defer {
+      if let previousAuth {
+        defaults.set(previousAuth, forKey: .authUserId)
+      } else {
+        defaults.removeObject(forKey: .authUserId)
+      }
+      RewindDatabase.currentUserId = previousDB
+    }
+
+    let authOwner = "auth-leading-\(UUID().uuidString)"
+    defaults.set(authOwner, forKey: .authUserId)
+    RewindDatabase.currentUserId = nil
+
+    guard let snapshot = RewindCaptureOwnerSnapshot.capture() else {
+      XCTFail("expected capture with auth_userId set")
+      return
+    }
+    XCTAssertEqual(snapshot.ownerID, authOwner)
+    XCTAssertTrue(
+      snapshot.isCurrent(),
+      "auth-backed snapshot must stay current while RewindDatabase.currentUserId is still nil")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260816-rewind-owner-snapshot-iscurrent.json
+++ b/desktop/macos/changelog/unreleased/20260816-rewind-owner-snapshot-iscurrent.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Rewind capture ownership checks dropping frames right after sign-in"
+}


### PR DESCRIPTION
## Summary
- Fixes #11572: `RewindCaptureOwnerSnapshot.capture()` preferred `auth_userId` while `isCurrent()` compared only `RewindDatabase.currentUserId`, so auth-set / DB-unresolved windows permanently fail-closed (launch + CI UserDefaults leakage).
- Shared `resolvedOwnerID()` for both paths; authorization currency check unchanged.
- Regression: auth-backed snapshot stays current when `RewindDatabase.currentUserId` is still nil.

## Test plan
- [x] `xcrun swift test --package-path Desktop --filter RewindCaptureExclusionGenerationTests` → 9 passed (incl. new auth-leading case)
- [ ] Named-bundle Rewind launch smoke — not run (no kit / not required for this fence)

## Honest gaps
- Physical / named-bundle Rewind UI smoke not run.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

