### PR TITLE
fix(web): honor WEB_URL for share links and deep-link hosts (#4339)

### DIFF
--- a/web/frontend/src/__tests__/share-base-url.test.mjs
+++ b/web/frontend/src/__tests__/share-base-url.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { DEFAULT_SHARE_BASE_URL, shareBaseUrl, shareHost } from '../lib/share-base-url.mjs';
+import { getOmiPlatformDeepLink } from '../lib/conversation-share-platform-link.mjs';
+
+describe('shareBaseUrl (#4339)', () => {
+  it('defaults to production h.omi.me', () => {
+    assert.equal(shareBaseUrl(''), DEFAULT_SHARE_BASE_URL);
+    assert.equal(shareBaseUrl(undefined), DEFAULT_SHARE_BASE_URL);
+  });
+
+  it('honors overrides and strips trailing slash', () => {
+    assert.equal(shareBaseUrl('https://share.example.com/'), 'https://share.example.com');
+    assert.equal(shareBaseUrl('share.example.com'), 'https://share.example.com');
+    assert.equal(shareBaseUrl('https://share.example.com/omi/'), 'https://share.example.com/omi');
+  });
+
+  it('rejects query, fragment, and userinfo', () => {
+    assert.equal(shareBaseUrl('https://share.example.com?x=1'), DEFAULT_SHARE_BASE_URL);
+    assert.equal(shareBaseUrl('https://share.example.com#frag'), DEFAULT_SHARE_BASE_URL);
+    assert.equal(shareBaseUrl('https://user:pass@share.example.com'), DEFAULT_SHARE_BASE_URL);
+  });
+
+  it('exposes hostname for deep links', () => {
+    assert.equal(shareHost('https://share.example.com/omi/'), 'share.example.com');
+  });
+});
+
+describe('getOmiPlatformDeepLink share host override', () => {
+  it('uses a custom host when provided', () => {
+    const href = getOmiPlatformDeepLink(
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      'chat/tok',
+      { shareHost: 'share.example.com' },
+    );
+    assert.equal(href, 'omi://share.example.com/chat/tok');
+  });
+});

--- a/web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs
+++ b/web/frontend/src/__tests__/wrapped-unlimited-deeplink-parity.test.mjs
@@ -73,6 +73,18 @@ describe('wrapped / unlimited acquisition parity contract', () => {
     assert.doesNotMatch(unlimitedSource, /omi:\/\/h\.omi\.me\/unlimited/);
   });
 
+  it('routes chat and tasks Open-in-Omi through the shared deep-link helper', () => {
+    const chatSource = readFileSync(new URL('../app/chat/[token]/page.tsx', import.meta.url), 'utf8');
+    const tasksSource = readFileSync(
+      new URL('../app/tasks/[token]/page.tsx', import.meta.url),
+      'utf8',
+    );
+    assert.match(chatSource, /getOmiPlatformDeepLink/);
+    assert.match(tasksSource, /getOmiPlatformDeepLink/);
+    assert.doesNotMatch(chatSource, /intent:\/\/h\.omi\.me\/chat/);
+    assert.doesNotMatch(tasksSource, /omi:\/\/h\.omi\.me\/tasks/);
+  });
+
   it('registers Android App Link for /wrapped', () => {
     assert.match(manifestSource, /android:path="\/wrapped"/);
     assert.match(manifestSource, /android:path="\/unlimited"/);

--- a/web/frontend/src/app/chat/[token]/page.tsx
+++ b/web/frontend/src/app/chat/[token]/page.tsx
@@ -1,5 +1,6 @@
 import getSharedChat from '@/src/actions/chat/get-shared-chat';
 import envConfig from '@/src/constants/envConfig';
+import { getOmiPlatformDeepLink } from '@/src/lib/conversation-share-platform-link.mjs';
 import { Metadata, ResolvingMetadata } from 'next';
 import { headers } from 'next/headers';
 import Image from 'next/image';
@@ -62,16 +63,7 @@ export async function generateMetadata(
 }
 
 function getPlatformLink(userAgent: string, token: string) {
-  const isAndroid = /android/i.test(userAgent);
-  const isIOS = /iphone|ipad|ipod/i.test(userAgent);
-
-  return isAndroid
-    ? `intent://h.omi.me/chat/${token}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
-        'https://play.google.com/store/apps/details?id=com.friend.ios',
-      )};end`
-    : isIOS
-    ? `omi://h.omi.me/chat/${token}`
-    : 'https://omi.me';
+  return getOmiPlatformDeepLink(userAgent, `chat/${token}`);
 }
 
 function formatTimestamp(timestamp: string | null) {

--- a/web/frontend/src/app/memories/[id]/page.tsx
+++ b/web/frontend/src/app/memories/[id]/page.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata(
 
   const ogUrl = prevData.metadataBase
     ? new URL(`/conversations/${params.id}`, prevData.metadataBase).toString()
-    : `https://h.omi.me/conversations/${params.id}`;
+    : `${envConfig.WEB_URL}/conversations/${params.id}`;
 
   return {
     title,

--- a/web/frontend/src/app/robots.ts
+++ b/web/frontend/src/app/robots.ts
@@ -1,11 +1,13 @@
 import { MetadataRoute } from 'next';
 
+import envConfig from '@/src/constants/envConfig';
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: '*',
       allow: ['/'],
     },
-    sitemap: 'https://h.omi.me/sitemap.xml',
+    sitemap: `${envConfig.WEB_URL}/sitemap.xml`,
   };
 }

--- a/web/frontend/src/app/tasks/[token]/page.tsx
+++ b/web/frontend/src/app/tasks/[token]/page.tsx
@@ -1,5 +1,6 @@
 import getSharedTasks from '@/src/actions/tasks/get-shared-tasks';
 import envConfig from '@/src/constants/envConfig';
+import { getOmiPlatformDeepLink } from '@/src/lib/conversation-share-platform-link.mjs';
 import { Metadata, ResolvingMetadata } from 'next';
 import { headers } from 'next/headers';
 import Image from 'next/image';
@@ -61,19 +62,8 @@ export async function generateMetadata(
 }
 
 function getPlatformLink(userAgent: string, token: string) {
-  const isAndroid = /android/i.test(userAgent);
-  const isIOS = /iphone|ipad|ipod/i.test(userAgent);
-
-  // iOS: Use custom URL scheme because Universal Links don't trigger for same-domain navigation
-  // (user is already on h.omi.me, so tapping https://h.omi.me/... just reloads the page)
-  // Android: Use intent:// with fallback to Google Play if app not installed
-  return isAndroid
-    ? `intent://h.omi.me/tasks/${token}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
-        'https://play.google.com/store/apps/details?id=com.friend.ios',
-      )};end`
-    : isIOS
-    ? `omi://h.omi.me/tasks/${token}`
-    : 'https://omi.me';
+  // iOS: custom scheme — Universal Links don't fire for same-domain navigation.
+  return getOmiPlatformDeepLink(userAgent, `tasks/${token}`);
 }
 
 function formatDueDate(dateStr: string): string {

--- a/web/frontend/src/components/plugins/identify-plugin.tsx
+++ b/web/frontend/src/components/plugins/identify-plugin.tsx
@@ -8,6 +8,7 @@ import { NavArrowRight } from 'iconoir-react';
 import ErrorIdentifyPlugin from './error-identify-plugin';
 import IdentifyPluginLoader from './identify-plugin-loader';
 import { getPluginFromCache, setPluginInCache, hasPluginInCache } from './plugin-cache';
+import envConfig from '@/src/constants/envConfig';
 
 interface IdentifyPluginProps {
   pluginId: string;
@@ -48,7 +49,7 @@ function IdentifyPlugin({ pluginId }: IdentifyPluginProps) {
   }
 
   const isPublic = !pluginCommunity.private;
-  const pluginUrl = `https://h.omi.me/apps/${pluginId}`;
+  const pluginUrl = `${envConfig.WEB_URL}/apps/${pluginId}`;
 
   const content = (
     <>

--- a/web/frontend/src/constants/envConfig.ts
+++ b/web/frontend/src/constants/envConfig.ts
@@ -1,8 +1,10 @@
+import { shareBaseUrl } from '@/src/lib/share-base-url.mjs';
+
 const envConfig = {
   API_URL: process.env.API_URL,
   NODE_ENV: process.env.NEXT_PUBLIC_NODE_ENV,
   IS_DEVELOPMENT: process.env.NEXT_PUBLIC_NODE_ENV === 'development',
-  WEB_URL: process.env.WEB_URL ?? 'https://h.omi.me',
+  WEB_URL: shareBaseUrl(process.env.WEB_URL),
   GLEAP_API_KEY: process.env.NEXT_PUBLIC_GLEAP_API_KEY,
   ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID ?? '',
   ALGOLIA_SEARCH_API_KEY: process.env.NEXT_PUBLIC_ALGOLIA_API_KEY ?? '',

--- a/web/frontend/src/lib/conversation-share-platform-link.mjs
+++ b/web/frontend/src/lib/conversation-share-platform-link.mjs
@@ -3,15 +3,18 @@
  * Kept as plain JS so node:test can import and assert branches without a TS loader.
  */
 
+import { shareHost } from './share-base-url.mjs';
+
 const PLAY_STORE =
   'https://play.google.com/store/apps/details?id=com.friend.ios';
 
 /**
  * @param {string} userAgent
- * @param {string} path path under h.omi.me without a leading slash (e.g. "unlimited", "conversations/abc")
+ * @param {string} path path under the share host without a leading slash (e.g. "unlimited", "conversations/abc")
+ * @param {{ shareHost?: string }} [options]
  * @returns {string}
  */
-export function getOmiPlatformDeepLink(userAgent, path) {
+export function getOmiPlatformDeepLink(userAgent, path, options = {}) {
   const normalized = String(path || '')
     .replace(/^\/+/, '')
     .replace(/\/+$/, '');
@@ -19,25 +22,27 @@ export function getOmiPlatformDeepLink(userAgent, path) {
     return 'https://omi.me';
   }
 
+  const host = options.shareHost || shareHost();
   const isAndroid = /android/i.test(userAgent);
   const isIOS = /iphone|ipad|ipod/i.test(userAgent);
 
-  // iOS: custom scheme — Universal Links do not fire for same-domain taps on h.omi.me.
+  // iOS: custom scheme — Universal Links do not fire for same-domain taps.
   // Android: intent:// with Play Store fallback when the app is missing.
   return isAndroid
-    ? `intent://h.omi.me/${normalized}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
+    ? `intent://${host}/${normalized}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
         PLAY_STORE,
       )};end`
     : isIOS
-      ? `omi://h.omi.me/${normalized}`
+      ? `omi://${host}/${normalized}`
       : 'https://omi.me';
 }
 
 /**
  * @param {string} userAgent
  * @param {string} conversationId
+ * @param {{ shareHost?: string }} [options]
  * @returns {string}
  */
-export function getConversationSharePlatformLink(userAgent, conversationId) {
-  return getOmiPlatformDeepLink(userAgent, `conversations/${conversationId}`);
+export function getConversationSharePlatformLink(userAgent, conversationId, options = {}) {
+  return getOmiPlatformDeepLink(userAgent, `conversations/${conversationId}`, options);
 }

--- a/web/frontend/src/lib/share-base-url.mjs
+++ b/web/frontend/src/lib/share-base-url.mjs
@@ -1,0 +1,55 @@
+/**
+ * Public share / web origin for self-hosting (#4339).
+ * Matches backend OMI_SHARE_BASE_URL and Flutter/desktop share helpers.
+ * Kept as plain JS so node:test can assert without a TS loader.
+ */
+
+export const DEFAULT_SHARE_BASE_URL = 'https://h.omi.me';
+
+/**
+ * @param {string | undefined | null} raw
+ * @returns {string} origin (+ optional path prefix), no trailing slash
+ */
+export function shareBaseUrl(raw = process.env.WEB_URL) {
+  let value = String(raw ?? '').trim();
+  if (!value) value = DEFAULT_SHARE_BASE_URL;
+  if (!value.includes('://')) value = `https://${value}`;
+
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return DEFAULT_SHARE_BASE_URL;
+  }
+
+  if (
+    !['http:', 'https:'].includes(url.protocol) ||
+    !url.hostname ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    return DEFAULT_SHARE_BASE_URL;
+  }
+
+  const origin = url.port
+    ? `${url.protocol}//${url.hostname}:${url.port}`
+    : `${url.protocol}//${url.hostname}`;
+  const path = url.pathname.replace(/\/+$/, '');
+  if (!path || path === '/') return origin;
+  return `${origin}${path}`;
+}
+
+/**
+ * Hostname used in intent:// / omi:// deep links.
+ * @param {string | undefined | null} raw
+ * @returns {string}
+ */
+export function shareHost(raw = process.env.WEB_URL) {
+  try {
+    return new URL(shareBaseUrl(raw)).hostname;
+  } catch {
+    return 'h.omi.me';
+  }
+}


### PR DESCRIPTION
## Summary
- Continues #4339 after backend/desktop/Flutter: public web share/canonical URLs and `intent://` / `omi://` hosts go through normalized `WEB_URL` (`share-base-url.mjs`) instead of hardcoded `h.omi.me`.
- Chat/tasks Open-in-Omi paths reuse `getOmiPlatformDeepLink` (same helper as wrapped/unlimited).
- Fail-closed on query/fragment/userinfo in the base URL (same contract as Flutter #11686).

## Test plan
- [x] `cd web/frontend && npm test` → 67 passed
- [ ] Deployed self-host WEB_URL smoke — not run

## Honest gaps
- Marketplace `utm_source=h.omi.me` strings left as analytics constants (not share generation).
- Native Universal Link host allowlists stay production `h.omi.me` (receiving links), same as Flutter #11686.

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

