### PR TITLE
fix(app): remove deepPurple from language selection dialog (#11655)

### DIFF
--- a/app/lib/pages/settings/language_selection_dialog.dart
+++ b/app/lib/pages/settings/language_selection_dialog.dart
@@ -128,7 +128,7 @@ class LanguageSelectionDialog {
                         ),
                         focusedBorder: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(8),
-                          borderSide: const BorderSide(color: Colors.deepPurple),
+                          borderSide: const BorderSide(color: Colors.white),
                         ),
                       ),
                     ),
@@ -147,10 +147,9 @@ class LanguageSelectionDialog {
 
                                 return ListTile(
                                   title: Text(language.key, style: const TextStyle(color: Colors.white)),
-                                  trailing:
-                                      isSelected ? const Icon(Icons.check_circle, color: Colors.deepPurple) : null,
+                                  trailing: isSelected ? const Icon(Icons.check_circle, color: Colors.white) : null,
                                   selected: isSelected,
-                                  selectedTileColor: Colors.deepPurple.withValues(alpha: 0.2),
+                                  selectedTileColor: Colors.white.withValues(alpha: 0.12),
                                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
                                   onTap: () {
                                     setState(() {
@@ -220,9 +219,10 @@ class LanguageSelectionDialog {
                           }
                         },
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.deepPurple,
-                    disabledBackgroundColor: Colors.deepPurple.withValues(alpha: 0.3),
-                    foregroundColor: Colors.white,
+                    backgroundColor: Colors.white,
+                    disabledBackgroundColor: Colors.white.withValues(alpha: 0.3),
+                    foregroundColor: Colors.black,
+                    disabledForegroundColor: Colors.black.withValues(alpha: 0.4),
                   ),
                   child: Text(context.l10n.confirm),
                 ),


### PR DESCRIPTION
## Summary
- Fixes #11655 / **INV-UI-1**: `language_selection_dialog.dart` used `Colors.deepPurple` in five places (focus border, check icon, selected tile, Confirm + disabled Confirm).
- Replaced with white/neutral accents; Confirm is white with black label for contrast on the dark dialog.

## Test plan
- [x] `rg deepPurple language_selection_dialog.dart` → empty
- [x] `.github/scripts/check_brand_ui.py` vs `origin/main` → pass (purple count decreases)
- [ ] Physical language-dialog smoke — not run (no kit)

## Honest gaps
- Physical / on-device smoke not run (no kit).

Product invariants affected
INV-UI-1

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

