### PR TITLE
fix(web): replace leftover friend-dev-kit-2 product URLs (#5855)

### DIFF
--- a/docs/doc/get_started/introduction.mdx
+++ b/docs/doc/get_started/introduction.mdx
@@ -44,7 +44,7 @@ New to Omi? Follow these steps to get up and running.
 
 <Steps>
   <Step title="Get an Omi Device" icon="cart-shopping">
-    [Buy a pre-built device](https://www.omi.me/products/omi-dev-kit-2) or [build your own](/doc/assembly/Build_the_device)
+    [Buy a pre-built device](https://www.omi.me/) or [build your own](/doc/assembly/Build_the_device)
   </Step>
   <Step title="Install the App" icon="mobile">
     Download from the [App Store](https://apps.apple.com/us/app/friend-ai-wearable/id6502156163) or [Google Play](https://play.google.com/store/apps/details?id=com.friend.ios)

--- a/docs/doc/get_started/introduction.mdx
+++ b/docs/doc/get_started/introduction.mdx
@@ -44,7 +44,7 @@ New to Omi? Follow these steps to get up and running.
 
 <Steps>
   <Step title="Get an Omi Device" icon="cart-shopping">
-    [Buy a pre-built device](https://omi.me/products/friend-dev-kit-2) or [build your own](/doc/assembly/Build_the_device)
+    [Buy a pre-built device](https://www.omi.me/products/omi-dev-kit-2) or [build your own](/doc/assembly/Build_the_device)
   </Step>
   <Step title="Install the App" icon="mobile">
     Download from the [App Store](https://apps.apple.com/us/app/friend-ai-wearable/id6502156163) or [Google Play](https://play.google.com/store/apps/details?id=com.friend.ios)

--- a/web/app/src/components/layout/Footer.tsx
+++ b/web/app/src/components/layout/Footer.tsx
@@ -73,11 +73,11 @@ export function Footer() {
             <li>
               <a
                 className="text-zinc-400 hover:text-white hover:underline md:text-base"
-                href="https://www.omi.me/products/omi-dev-kit-2"
+                href="https://www.omi.me/"
                 target="_blank"
                 rel="noreferrer"
               >
-                Omi DEV KIT 2
+                Buy Omi
               </a>
             </li>
           </ul>

--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -73,7 +73,7 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
   const appStoreUrl = 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163';
   const playStoreUrl = 'https://play.google.com/store/apps/details?id=com.friend.ios';
   const productUrl =
-    'https://www.omi.me/products/friend-dev-kit-2?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_floating_banner';
+    'https://www.omi.me/products/omi-dev-kit-2?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_floating_banner';
 
   return {
     __html: JSON.stringify([

--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Image from 'next/image';
 import { ProductBanner } from '@/src/app/components/product-banner';
+import { PRODUCT_INFO } from '@/src/app/components/product-banner/types';
 import { getAppById, getAppsByCategory } from '@/src/lib/api/apps';
 import envConfig from '@/src/constants/envConfig';
 
@@ -72,8 +73,6 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
   const canonicalUrl = `${envConfig.WEB_URL}/apps/${plugin.id}`;
   const appStoreUrl = 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163';
   const playStoreUrl = 'https://play.google.com/store/apps/details?id=com.friend.ios';
-  const productUrl =
-    'https://www.omi.me/?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_floating_banner';
 
   return {
     __html: JSON.stringify([
@@ -109,7 +108,7 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
         '@context': 'https://schema.org',
         '@type': 'Product',
         name: 'Omi',
-        description: 'AI-powered wearable necklace. Real-time AI voice assistant.',
+        description: 'AI-powered wearable. Real-time AI voice assistant.',
         brand: {
           '@type': 'Brand',
           name: 'OMI',
@@ -119,7 +118,7 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
           price: '89',
           priceCurrency: 'USD',
           availability: 'https://schema.org/InStock',
-          url: productUrl,
+          url: PRODUCT_INFO.url,
           priceValidUntil: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
             .toISOString()
             .split('T')[0], // Valid for 1 year

--- a/web/frontend/src/app/apps/[id]/page.tsx
+++ b/web/frontend/src/app/apps/[id]/page.tsx
@@ -73,7 +73,7 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
   const appStoreUrl = 'https://apps.apple.com/us/app/friend-ai-wearable/id6502156163';
   const playStoreUrl = 'https://play.google.com/store/apps/details?id=com.friend.ios';
   const productUrl =
-    'https://www.omi.me/products/omi-dev-kit-2?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_floating_banner';
+    'https://www.omi.me/?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_floating_banner';
 
   return {
     __html: JSON.stringify([
@@ -108,7 +108,7 @@ export function generateStructuredData(plugin: Plugin, categoryName: string) {
       {
         '@context': 'https://schema.org',
         '@type': 'Product',
-        name: 'OMI Necklace',
+        name: 'Omi',
         description: 'AI-powered wearable necklace. Real-time AI voice assistant.',
         brand: {
           '@type': 'Brand',

--- a/web/frontend/src/app/apps/category/[category]/page.tsx
+++ b/web/frontend/src/app/apps/category/[category]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(props: CategoryPageProps): Promise<Metada
   const metadata = getCategoryMetadata(category);
 
   const title = `${metadata.title} - OMI Apps Marketplace`;
-  const description = `${metadata.description} Browse ${categoryPlugins.length}+ ${category} apps for your OMI Necklace.`;
+  const description = `${metadata.description} Browse ${categoryPlugins.length}+ ${category} apps for your Omi.`;
 
   const baseMetadata = getBaseMetadata(title, description);
   const canonicalUrl = `https://omi.me/apps/category/${category}`;

--- a/web/frontend/src/app/apps/page.tsx
+++ b/web/frontend/src/app/apps/page.tsx
@@ -31,8 +31,8 @@ async function getPluginsData() {
 
 export async function generateMetadata(): Promise<Metadata> {
   const appsCount = await getAppsCount();
-  const title = 'OMI Apps Marketplace - AI-Powered Apps for Your OMI Necklace';
-  const description = `Discover and install ${appsCount}+ AI-powered apps for your OMI Necklace. Browse apps across productivity, entertainment, health, and more. Transform your OMI experience with voice-controlled applications.`;
+  const title = 'OMI Apps Marketplace - AI-Powered Apps for Your Omi';
+  const description = `Discover and install ${appsCount}+ AI-powered apps for your Omi. Browse apps across productivity, entertainment, health, and more. Transform your OMI experience with voice-controlled applications.`;
 
   return {
     title,

--- a/web/frontend/src/app/apps/utils/metadata.ts
+++ b/web/frontend/src/app/apps/utils/metadata.ts
@@ -99,11 +99,11 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
 };
 
 const productInfo = {
-  name: 'OMI Necklace',
-  description: 'AI-powered wearable necklace. Real-time AI voice assistant.',
+  name: 'Omi',
+  description: 'AI-powered wearable. Real-time AI voice assistant.',
   price: '89',
   currency: 'USD',
-  url: 'https://www.omi.me/products/omi-dev-kit-2',
+  url: 'https://www.omi.me/',
 };
 
 const appStoreInfo = {

--- a/web/frontend/src/app/apps/utils/metadata.ts
+++ b/web/frontend/src/app/apps/utils/metadata.ts
@@ -103,7 +103,7 @@ const productInfo = {
   description: 'AI-powered wearable necklace. Real-time AI voice assistant.',
   price: '89',
   currency: 'USD',
-  url: 'https://www.omi.me/products/friend-dev-kit-2',
+  url: 'https://www.omi.me/products/omi-dev-kit-2',
 };
 
 const appStoreInfo = {

--- a/web/frontend/src/app/apps/utils/metadata.ts
+++ b/web/frontend/src/app/apps/utils/metadata.ts
@@ -10,7 +10,7 @@ export interface CategoryMetadata {
 
 export const categoryMetadata: Record<string, CategoryMetadata> = {
   productivity: {
-    title: 'Productivity Apps for OMI Necklace',
+    title: 'Productivity Apps for Omi',
     description:
       'Enhance your daily workflow with OMI productivity apps. From voice-controlled task management to AI-powered note-taking, transform how you work with hands-free efficiency.',
     keywords: [
@@ -22,9 +22,9 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     ],
   },
   entertainment: {
-    title: 'Entertainment Apps for OMI Necklace',
+    title: 'Entertainment Apps for Omi',
     description:
-      'Discover entertainment apps for your OMI Necklace. Enjoy music, games, and interactive experiences designed for voice control and ambient computing.',
+      'Discover entertainment apps for your Omi. Enjoy music, games, and interactive experiences designed for voice control and ambient computing.',
     keywords: [
       'entertainment apps',
       'music',
@@ -34,7 +34,7 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     ],
   },
   health: {
-    title: 'Health & Wellness Apps for OMI Necklace',
+    title: 'Health & Wellness Apps for Omi',
     description:
       'Take control of your wellness journey with OMI health apps. Track fitness, monitor health metrics, and get AI-powered wellness insights through your wearable companion.',
     keywords: [
@@ -49,7 +49,7 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     ],
   },
   social: {
-    title: 'Social Apps for OMI Necklace',
+    title: 'Social Apps for Omi',
     description:
       'Stay connected with OMI social apps. Experience new ways to communicate, share, and interact with friends and family through your AI-powered necklace.',
     keywords: [
@@ -61,7 +61,7 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     ],
   },
   integration: {
-    title: 'Integration Apps for OMI Necklace',
+    title: 'Integration Apps for Omi',
     description:
       'Connect your digital world with OMI integration apps. Seamlessly control smart home devices, sync with your favorite services, and automate your life.',
     keywords: [
@@ -73,9 +73,9 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     ],
   },
   utility: {
-    title: 'Utility Apps for OMI Necklace',
+    title: 'Utility Apps for Omi',
     description:
-      'Essential utility apps for your OMI Necklace. Access practical tools and helpful functions through voice commands and AI assistance.',
+      'Essential utility apps for your Omi. Access practical tools and helpful functions through voice commands and AI assistance.',
     keywords: [
       'utility apps',
       'tools',
@@ -85,7 +85,7 @@ export const categoryMetadata: Record<string, CategoryMetadata> = {
     ],
   },
   lifestyle: {
-    title: 'Lifestyle Apps for OMI Necklace',
+    title: 'Lifestyle Apps for Omi',
     description:
       'Enhance your daily life with OMI lifestyle apps. From personal organization to habit tracking, make everyday tasks more intuitive with AI assistance.',
     keywords: [
@@ -169,7 +169,7 @@ export function generateCollectionPageSchema() {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: 'OMI Apps Marketplace',
-    description: 'Discover and install AI-powered apps for your OMI Necklace.',
+    description: 'Discover and install AI-powered apps for your Omi.',
     url: `${envConfig.WEB_URL}/apps`,
     isPartOf: {
       '@type': 'WebSite',
@@ -235,7 +235,7 @@ export function getCategoryMetadata(category: string): CategoryMetadata {
   const uiMetadata = getUICategoryMetadata(category);
 
   return {
-    title: `${uiMetadata.displayName} Apps for OMI Necklace`,
+    title: `${uiMetadata.displayName} Apps for Omi`,
     description: `${uiMetadata.description}. Browse and discover apps designed for voice control and ambient computing.`,
     keywords: [
       `${category.toLowerCase()} apps`,

--- a/web/frontend/src/app/components/product-banner/types.ts
+++ b/web/frontend/src/app/components/product-banner/types.ts
@@ -21,7 +21,7 @@ export interface CategoryBannerProps extends ProductBannerBase {
 export const PRODUCT_INFO = {
   name: 'Omi',
   price: '$89',
-  // Canonical storefront (legacy omi-dev-kit-2 / friend-dev-kit-2 slugs redirect here).
+  // Canonical storefront (legacy omi-dev-kit-2 / friend-dev-kit-2 slugs redirect into the storefront).
   url: 'https://www.omi.me/?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_app_detail_page',
   shipping: 'Ships Worldwide',
   images: {

--- a/web/frontend/src/app/components/product-banner/types.ts
+++ b/web/frontend/src/app/components/product-banner/types.ts
@@ -19,9 +19,10 @@ export interface CategoryBannerProps extends ProductBannerBase {
 }
 
 export const PRODUCT_INFO = {
-  name: 'OMI Necklace',
+  name: 'Omi',
   price: '$89',
-  url: 'https://www.omi.me/products/omi-dev-kit-2?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_app_detail_page',
+  // Canonical storefront (legacy omi-dev-kit-2 / friend-dev-kit-2 slugs redirect here).
+  url: 'https://www.omi.me/?ref=omi_marketplace&utm_source=h.omi.me&utm_campaign=omi_marketplace_app_detail_page',
   shipping: 'Ships Worldwide',
   images: {
     primary: '/omi_1.webp',

--- a/web/frontend/src/components/shared/footer.tsx
+++ b/web/frontend/src/components/shared/footer.tsx
@@ -89,11 +89,11 @@ export default function Footer() {
             <li>
               <a
                 className="text-zinc-400 hover:text-white hover:underline md:text-base"
-                href={'https://www.omi.me/products/omi-dev-kit-2'}
+                href={'https://www.omi.me/'}
                 target="_blank"
                 rel="noreferrer"
               >
-                Omi DEV KIT 2
+                Buy Omi
               </a>
             </li>
           </ul>

--- a/web/personas-open-source/src/app/chat/page.tsx
+++ b/web/personas-open-source/src/app/chat/page.tsx
@@ -642,7 +642,7 @@ function ChatContent() {
       }`}
     >
       <Link
-        href="https://www.omi.me/products/omi-dev-kit-2?ref=personas&utm_source=personas.omi.me&utm_campaign=personas_chat"
+        href="https://www.omi.me/?ref=personas&utm_source=personas.omi.me&utm_campaign=personas_chat"
         target="_blank"
         rel="noopener noreferrer"
         className="relative block h-[200px] w-[220px] overflow-hidden rounded-2xl bg-black shadow-2xl"


### PR DESCRIPTION
## Summary
- Fixes remaining #5855 marketplace CTAs: live storefront sells **Omi** (checkout), not Friend/Duo/Dev Kit product slugs.
- Order Now / product JSON-LD / footers / personas buy popup / docs get-started → \`https://www.omi.me/\` (same destination as #11184), with marketplace UTM params kept where they existed.
- Banner + structured-data product name → \`Omi\`; footer label \`Omi DEV KIT 2\` → \`Buy Omi\`.
- Leaves hardware DevKit docs (\`DevKit1.mdx\` / \`DevKit2.mdx\`) alone — those pages are about the Dev Kit SKU.

## Test plan
- [x] Consumer Order Now / footer buy links no longer reference \`*-dev-kit-2\`
- [x] \`PRODUCT_INFO.url\` and app-detail JSON-LD land on \`www.omi.me\`
- [x] Click Order Now on h.omi.me app detail → www.omi.me → checkout — run

Failure-Class: none