### PR TITLE
fix(app): remove deepPurple from onboarding primary language picker (INV-UI-1)

### DIFF
--- a/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
+++ b/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
@@ -134,7 +134,7 @@ class _LanguageSelectorWidgetState extends State<LanguageSelectorWidget> {
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(8),
-                borderSide: const BorderSide(color: Colors.deepPurple),
+                borderSide: const BorderSide(color: Colors.white),
               ),
             ),
           ),
@@ -154,9 +154,9 @@ class _LanguageSelectorWidgetState extends State<LanguageSelectorWidget> {
 
                       return ListTile(
                         title: Text(language.key, style: const TextStyle(color: Colors.white)),
-                        trailing: isSelected ? const Icon(Icons.check_circle, color: Colors.deepPurple) : null,
+                        trailing: isSelected ? const Icon(Icons.check_circle, color: Colors.white) : null,
                         selected: isSelected,
-                        selectedTileColor: Colors.deepPurple.withValues(alpha: 0.2),
+                        selectedTileColor: Colors.white.withValues(alpha: 0.12),
                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
                         onTap: () {
                           setState(() {
@@ -197,8 +197,9 @@ class _PrimaryLanguageWidgetState extends State<PrimaryLanguageWidget> {
           selectedLanguage = savedLanguage;
           // Find the language name for the saved language code
           try {
-            selectedLanguageName =
-                homeProvider.availableLanguages.entries.firstWhere((entry) => entry.value == savedLanguage).key;
+            selectedLanguageName = homeProvider.availableLanguages.entries
+                .firstWhere((entry) => entry.value == savedLanguage)
+                .key;
           } catch (e) {
             // If language not found in the map, just use the code
             selectedLanguageName = savedLanguage;


### PR DESCRIPTION
## Summary
- INV-UI-1 follow-up to #11693 / #11655: onboarding \`primary_language_widget.dart\` still used \`Colors.deepPurple\` for focus border, check icon, and selected tile.
- Same white/neutral treatment as the settings language dialog (does not race #11524 apps-page sweep).

## Test plan
- [x] \`rg deepPurple primary_language_widget.dart\` → empty
- [x] \`.github/scripts/check_brand_ui.py\` vs \`origin/main\` → pass
- [ ] Physical onboarding language smoke — not run (no kit)

## Honest gaps
- Physical / on-device smoke not run (no kit).

Product invariants affected
INV-UI-1

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

