### PR TITLE
fix(app): remove deepPurple from shared confirmation dialogs (INV-UI-1)

### DIFF
--- a/app/lib/utils/sync_confirmation.dart
+++ b/app/lib/utils/sync_confirmation.dart
@@ -24,7 +24,7 @@ Future<bool> confirmSyncForCustomStt(BuildContext context) async {
     message: l.syncCustomSttWarningMessage,
     confirmLabel: l.sync,
     cancelLabel: l.cancel,
-    confirmColor: Colors.deepPurpleAccent,
+    confirmColor: Colors.white,
   );
   return confirmed ?? false;
 }

--- a/app/lib/widgets/confirmation_dialog.dart
+++ b/app/lib/widgets/confirmation_dialog.dart
@@ -88,7 +88,7 @@ class _ConfirmationDialogState extends State<ConfirmationDialog> {
                       checkboxTheme: CheckboxThemeData(
                         fillColor: WidgetStateProperty.resolveWith<Color>((Set<WidgetState> states) {
                           if (states.contains(WidgetState.selected)) {
-                            return Colors.deepPurple;
+                            return Colors.white;
                           }
                           return Colors.grey.shade700;
                         }),
@@ -117,8 +117,8 @@ class _ConfirmationDialogState extends State<ConfirmationDialog> {
           TextButton(
             onPressed: widget.onConfirm,
             style: TextButton.styleFrom(
-              foregroundColor: Colors.white,
-              backgroundColor: Colors.deepPurple,
+              foregroundColor: Colors.black,
+              backgroundColor: Colors.white,
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
             ),
@@ -148,11 +148,7 @@ class _ConfirmationDialogState extends State<ConfirmationDialog> {
                 mainAxisAlignment: MainAxisAlignment.start,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  CupertinoCheckbox(
-                    value: _checkboxValue,
-                    onChanged: _updateCheckboxValue,
-                    activeColor: Colors.deepPurple,
-                  ),
+                  CupertinoCheckbox(value: _checkboxValue, onChanged: _updateCheckboxValue, activeColor: Colors.white),
                   const SizedBox(width: 8),
                   Text(widget.checkboxText!, style: TextStyle(fontSize: 14, color: Colors.grey.shade300)),
                 ],
@@ -175,7 +171,7 @@ class _ConfirmationDialogState extends State<ConfirmationDialog> {
             isDefaultAction: true,
             child: Text(
               widget.confirmText ?? context.l10n.confirm,
-              style: const TextStyle(fontSize: 16, color: Colors.deepPurple, fontWeight: FontWeight.w600),
+              style: const TextStyle(fontSize: 16, color: Colors.white, fontWeight: FontWeight.w600),
             ),
           ),
         ],

--- a/app/lib/widgets/confirmation_dialog.dart
+++ b/app/lib/widgets/confirmation_dialog.dart
@@ -92,6 +92,7 @@ class _ConfirmationDialogState extends State<ConfirmationDialog> {
                           }
                           return Colors.grey.shade700;
                         }),
+                        checkColor: WidgetStateProperty.all(Colors.black),
                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
                       ),
                     ),
@@ -148,7 +149,12 @@ class _ConfirmationDialogState extends State<ConfirmationDialog> {
                 mainAxisAlignment: MainAxisAlignment.start,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  CupertinoCheckbox(value: _checkboxValue, onChanged: _updateCheckboxValue, activeColor: Colors.white),
+                  CupertinoCheckbox(
+                    value: _checkboxValue,
+                    onChanged: _updateCheckboxValue,
+                    activeColor: Colors.white,
+                    checkColor: CupertinoColors.black,
+                  ),
                   const SizedBox(width: 8),
                   Text(widget.checkboxText!, style: TextStyle(fontSize: 14, color: Colors.grey.shade300)),
                 ],


### PR DESCRIPTION
## Summary
- INV-UI-1: shared \`ConfirmationDialog\` used \`Colors.deepPurple\` in four places (Android confirm button + checkbox; iOS confirm label + checkbox).
- Custom-STT offline sync gate passed \`Colors.deepPurpleAccent\` into \`OmiConfirmDialog\` — switched to white.
- Does not race #11524 (apps pages only).

## Test plan
- [x] \`rg deepPurple\` on both files → empty
- [x] brand ratchet vs \`origin/main\` → pass
- [ ] Physical confirm/sync dialog smoke — not run (no kit)

## Honest gaps
- Physical / on-device smoke not run (no kit).

Product invariants affected
INV-UI-1

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

