### PR TITLE
fix(backend): key the all-ungrounded memory guard on candidates seen, not container truthiness (#11685)

### DIFF
--- a/backend/tests/unit/test_memory_replace_policy.py
+++ b/backend/tests/unit/test_memory_replace_policy.py
@@ -289,6 +289,51 @@ def test_canonical_capture_drops_only_the_ungrounded_candidate(monkeypatch):
     assert replacement_payloads[0]["content"] == "The user works at Acme."
 
 
+def test_canonical_capture_accepts_an_extractor_that_yields_no_candidates(monkeypatch):
+    """An extractor that returns zero candidates is a quiet conversation, not a failed run.
+
+    The all-ungrounded guard must key off candidates the loop actually saw. Keying
+    off the returned container's truthiness misreads any truthy-but-empty iterable
+    (a generator's stand-in, a test double) as "every candidate failed grounding"
+    and aborts conversation finalization for a conversation with nothing to learn.
+    """
+    pc = _load_process_conversation()
+    from models.conversation import Conversation
+    from models.conversation_enums import CategoryEnum, ConversationSource
+    from models.structured import Structured
+    from models.transcript_segment import TranscriptSegment
+
+    mock_service = MagicMock()
+    monkeypatch.setattr(pc, "MemoryService", lambda db_client: mock_service)
+    # Truthy, but yields nothing — exactly what a bare MagicMock extractor does.
+    monkeypatch.setattr(pc, "extract_canonical_l1_memory_candidates", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
+
+    conversation = Conversation(
+        id="conv-no-candidates",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title="Test", overview="Overview", category=CategoryEnum.personal),
+        transcript_segments=[
+            TranscriptSegment(
+                text="We talked about the weather.",
+                speaker="SPEAKER_00",
+                is_user=True,
+                start=0.0,
+                end=4.0,
+            )
+        ],
+    )
+
+    result = pc._extract_memories_canonical("uid-no-candidates", conversation, db_client=MagicMock())
+
+    assert result.count == 0
+    replacement_payloads = mock_service.replace_conversation_memories.call_args.args[2]
+    assert replacement_payloads == []
+
+
 @pytest.mark.parametrize(
     "matched_segments",
     [

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -910,7 +910,9 @@ def _extract_memories_canonical(
             strict=True,
         )
         ungrounded_candidates = 0
+        seen_candidates = 0
         for candidate in extracted_candidates:
+            seen_candidates += 1
             evidence_quotes = _grounded_l1_evidence_quotes(
                 candidate.evidence_quotes,
                 conversation.transcript_segments,
@@ -949,16 +951,18 @@ def _extract_memories_canonical(
                     True,
                 )
             )
-        if extracted_candidates and not capture_candidates:
+        if seen_candidates and not capture_candidates:
             # Every candidate failed grounding: the run itself is untrustworthy,
             # so it must not submit the empty replacement that would retract the
-            # source's existing memories.
+            # source's existing memories. Count what the loop actually yielded —
+            # the extractor's return value is only known to be iterable, so its
+            # truthiness is not a statement about how many candidates it holds.
             raise ValueError("canonical memory extraction returned evidence without a unique source binding")
         if ungrounded_candidates:
             logger.warning(
                 "canonical memory extraction dropped %s of %s ungrounded candidates conversation=%s",
                 ungrounded_candidates,
-                len(extracted_candidates),
+                seen_candidates,
                 conversation.id,
             )
             record_fallback(


### PR DESCRIPTION
## Bug

`Backend Unit Tests` has been red on `main` since 5af7e53fd7 (PR #11688, the fix for #11685).
`tests/unit/test_process_conversation_usage_context.py::test_app_summary_results_reach_the_database`
fails with `ValueError: canonical memory extraction returned evidence without a unique source binding`.

Three consecutive main pushes are red (5af7e53fd7, 43b30d6783, 13de4503d4); every other lane on
13de4503d4 is green, so this single file is the whole red.

## Root cause

PR #11688 stopped one ungrounded L1 candidate from aborting the entire canonical extraction run,
and kept a guard for the genuinely untrustworthy case — *every* candidate failed grounding — because
`replace_conversation_memories` is called unconditionally and an empty replacement would retract the
source's existing memories.

That guard was gated on `extracted_candidates and not capture_candidates`: the **truthiness** of
whatever `extract_canonical_l1_memory_candidates` returned. Truthiness is not a count. Any truthy
object that yields nothing when iterated reads as "candidates existed and all of them failed
grounding", so the guard fires on a conversation that simply produced no candidates and aborts its
finalization. `test_app_summary_results_reach_the_database` stubs the extractor with a bare
`MagicMock` — truthy, iterates empty — and trips exactly that.

## Fix

Count the candidates the loop actually yielded and gate the raise on that count. Behaviour for a real
list is unchanged (a non-empty list yields non-zero); the guard now states what it means, and the
dropped-candidate warning reports the counted total instead of `len()` on the same container.

## Tested

```
cd backend
: > /tmp/f.txt
echo tests/unit/test_process_conversation_usage_context.py >> /tmp/f.txt
echo tests/unit/test_memory_replace_policy.py >> /tmp/f.txt
BACKEND_UNIT_TEST_FILE_LIST=/tmp/f.txt bash test.sh
```

- before: `test_process_conversation_usage_context.py` → **1 failed, 29 passed** (reproduces CI exactly)
- after: **30 passed**; `test_memory_replace_policy.py` **16 passed**
- verified at `5af7e53fd7^` that the same file was **30 passed**, confirming #11688 is the breaking commit
- new regression test `test_canonical_capture_accepts_an_extractor_that_yields_no_candidates` calls
  `_extract_memories_canonical` through the real seam; reverting only the `process_conversation.py`
  hunk makes it fail, so it does catch this
- `make preflight` green

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 1806 -> 1810 | one loop counter plus the comment explaining why the guard counts observed candidates instead of reading the container's truthiness

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

