### PR TITLE
fix(app): reconnect onboarding's socket and complete it despite a failed speech-profile upload

### DIFF
--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -51,6 +51,8 @@ class SpeechProfileProvider extends ChangeNotifier
   bool uploadingProfile = false;
   bool profileCompleted = false;
   Timer? forceCompletionTimer;
+  Timer? _reconnectTimer;
+  bool _reconnecting = false;
 
   bool isInitialising = false;
   bool isInitialised = false;
@@ -176,17 +178,35 @@ class SpeechProfileProvider extends ChangeNotifier
         SharedPreferencesUtil().hasSetPrimaryLanguage ? SharedPreferencesUtil().userPrimaryLanguage : "multi";
     int rate = sampleRate ?? (codec.isOpusSupported() ? 16000 : 8000);
 
-    _socket = await ServiceManager.instance().socket.speechProfile(
-          codec: codec,
-          sampleRate: rate,
-          language: language,
-          force: force,
-        );
+    _socket = await openSpeechProfileSocket(
+      codec: codec,
+      sampleRate: rate,
+      language: language,
+      force: force,
+    );
     if (_socket == null) {
       throw Exception("Can not create new speech profile socket");
     }
     _socket?.subscribe(this, this);
     await _socket?.requestFirstOnboardingQuestion();
+  }
+
+  /// Opens the speech-profile socket. Overridden in tests to control the
+  /// timing of an attempt; production always goes through the socket service
+  /// pool. Mirrors CaptureProvider.openConversationSocket.
+  @visibleForTesting
+  Future<TranscriptSegmentSocketService?> openSpeechProfileSocket({
+    required BleAudioCodec codec,
+    required int sampleRate,
+    required String language,
+    required bool force,
+  }) {
+    return ServiceManager.instance().socket.speechProfile(
+          codec: codec,
+          sampleRate: sampleRate,
+          language: language,
+          force: force,
+        );
   }
 
   /// Start phone microphone streaming (alternative to BLE device streaming).
@@ -296,6 +316,8 @@ class SpeechProfileProvider extends ChangeNotifier
         _processConversationCallback!();
       }
 
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
       uploadingProfile = false;
       profileCompleted = true;
       text = '';
@@ -408,6 +430,8 @@ class SpeechProfileProvider extends ChangeNotifier
     connectionStateListener?.cancel();
     _bleBytesStream?.cancel();
     forceCompletionTimer?.cancel();
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
 
     _stopPhoneMicStreaming();
 
@@ -432,6 +456,7 @@ class SpeechProfileProvider extends ChangeNotifier
     connectionStateListener?.cancel();
     _bleBytesStream?.cancel();
     forceCompletionTimer?.cancel();
+    _reconnectTimer?.cancel();
     _finalizedCallback = null;
     _socket?.unsubscribe(this);
     ServiceManager.instance().device.unsubscribe(this);
@@ -473,6 +498,7 @@ class SpeechProfileProvider extends ChangeNotifier
     // Only notify error if we're still recording and not completed
     if (startedRecording && !profileCompleted && !uploadingProfile) {
       notifyError('SOCKET_DISCONNECTED');
+      _scheduleReconnect();
     }
   }
 
@@ -481,7 +507,58 @@ class SpeechProfileProvider extends ChangeNotifier
     Logger.debug('Speech profile socket error: $err');
     if (startedRecording && !profileCompleted && !uploadingProfile) {
       notifyError('SOCKET_ERROR');
+      _scheduleReconnect();
     }
+  }
+
+  /// Retry connecting on an interval until it succeeds or the flow ends.
+  ///
+  /// Unlike the main capture socket (CaptureProvider._startKeepAliveServices),
+  /// this socket previously had no reconnect at all: once dropped,
+  /// skipCurrentQuestion() and outgoing mic audio are both no-ops gated on
+  /// `_socket?.state == connected` (see below), so onboarding hung forever
+  /// until the app was force-relaunched.
+  ///
+  /// The backend keeps no onboarding state across connections
+  /// (OnboardingHandler is constructed fresh per websocket in
+  /// routers/listen/runtime.py), so a reconnect always restarts the question
+  /// sequence from the top. Reset locally to match rather than showing a
+  /// stale question index against a server that has actually restarted.
+  void _scheduleReconnect() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer.periodic(const Duration(seconds: 5), (timer) async {
+      if (profileCompleted || uploadingProfile || _socket?.state == SocketServiceState.connected) {
+        timer.cancel();
+        return;
+      }
+
+      // _initiateWebsocket is async, so without this guard a slow attempt
+      // still in flight would overlap with the next 5s tick and open a
+      // second socket concurrently — the same failure mode CaptureProvider's
+      // keep-alive hit in #11305.
+      if (_reconnecting) return;
+      _reconnecting = true;
+
+      Logger.debug('Speech profile socket reconnect attempt');
+      try {
+        if (usePhoneMic) {
+          await _initiateWebsocket(codec: BleAudioCodec.pcm16, sampleRate: 16000, force: true);
+        } else if (device != null) {
+          final codec = await _getAudioCodec(device!.id);
+          await _initiateWebsocket(codec: codec, force: true);
+        } else {
+          return;
+        }
+
+        currentQuestionIndex = 0;
+        currentQuestion = '';
+        notifyListeners();
+      } catch (e) {
+        Logger.debug('Speech profile socket reconnect failed: $e');
+      } finally {
+        _reconnecting = false;
+      }
+    });
   }
 
   @override
@@ -534,5 +611,8 @@ class SpeechProfileProvider extends ChangeNotifier
   }
 
   @override
-  void onConnected() {}
+  void onConnected() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+  }
 }

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -60,8 +61,8 @@ class SpeechProfileProvider extends ChangeNotifier
   String text = '';
   SpeechProfileProgressState progressState = SpeechProfileProgressState.keepSpeaking;
 
-  late Function? _finalizedCallback;
-  late Function? _processConversationCallback;
+  Function? _finalizedCallback;
+  Function? _processConversationCallback;
 
   /// only used during onboarding /////
   SpeechProfileLoadingState loadingState = SpeechProfileLoadingState.uploading;
@@ -209,6 +210,11 @@ class SpeechProfileProvider extends ChangeNotifier
         );
   }
 
+  /// Uploads the recorded speech-profile audio. Overridden in tests to avoid
+  /// a real network call.
+  @visibleForTesting
+  Future<bool> uploadSpeechProfile(File file) => uploadProfile(file);
+
   /// Start phone microphone streaming (alternative to BLE device streaming).
   /// Returns false when the mic could not be acquired — contention with a live
   /// conversation throws a [StateError] — so [initialise] fails visibly instead
@@ -277,7 +283,7 @@ class SpeechProfileProvider extends ChangeNotifier
       bool uploadSuccess = false;
       bool uploadFailedDueToShortAudio = false;
       try {
-        uploadSuccess = await uploadProfile(data.item1).timeout(
+        uploadSuccess = await uploadSpeechProfile(data.item1).timeout(
           const Duration(seconds: 30),
           onTimeout: () {
             Logger.debug('Profile upload timed out after 30 seconds');
@@ -293,15 +299,7 @@ class SpeechProfileProvider extends ChangeNotifier
       }
 
       if (!uploadSuccess) {
-        // Upload failed - notify user but still process conversation
-        uploadingProfile = false;
-        notifyError(uploadFailedDueToShortAudio ? 'TOO_SHORT' : 'UPLOAD_FAILED');
-
-        // Still trigger conversation processing
-        if (_processConversationCallback != null) {
-          Logger.debug('Triggering conversation processing despite upload failure...');
-          _processConversationCallback!();
-        }
+        completeAfterUploadFailure(tooShort: uploadFailedDueToShortAudio);
         return;
       }
 
@@ -328,6 +326,32 @@ class SpeechProfileProvider extends ChangeNotifier
         _finalizedCallback!();
       }
     }
+  }
+
+  /// Upload failed - notify user but still complete onboarding. A failed
+  /// voice-print upload (e.g. no speech-profiles bucket configured, as in the
+  /// local dev harness) is a degraded feature, not a reason to trap the user
+  /// on the last onboarding question forever: the "All Done" continue button
+  /// in speech_profile_widget.dart is gated on profileCompleted, which this
+  /// branch previously never set. Separated from finalize() so it's directly
+  /// testable without a real (opus-decoder-backed) WavBytesUtil.
+  @visibleForTesting
+  void completeAfterUploadFailure({required bool tooShort}) {
+    uploadingProfile = false;
+    notifyError(tooShort ? 'TOO_SHORT' : 'UPLOAD_FAILED');
+
+    // Still trigger conversation processing
+    if (_processConversationCallback != null) {
+      Logger.debug('Triggering conversation processing despite upload failure...');
+      _processConversationCallback!();
+    }
+
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    profileCompleted = true;
+    text = '';
+    updateLoadingState(SpeechProfileLoadingState.allSet);
+    notifyListeners();
   }
 
   // TODO: use connection directly

--- a/app/test/providers/speech_profile_provider_test.dart
+++ b/app/test/providers/speech_profile_provider_test.dart
@@ -1,0 +1,176 @@
+import 'dart:io';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/bt_device/bt_device.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/providers/speech_profile_provider.dart';
+import 'package:omi/services/services.dart';
+import 'package:omi/services/sockets/pure_socket.dart';
+import 'package:omi/services/sockets/transcription_service.dart';
+
+/// Minimal EnvFields stub so Env-backed code paths don't hit a
+/// LateInitializationError (mirrors capture_provider_test.dart's fixture).
+class _TestEnvFields implements EnvFields {
+  @override
+  String? get posthogApiKey => null;
+  @override
+  String? get apiBaseUrl => 'http://127.0.0.1:8000/';
+  @override
+  String? get googleMapsApiKey => null;
+  @override
+  String? get intercomAppId => null;
+  @override
+  String? get intercomIOSApiKey => null;
+  @override
+  String? get intercomAndroidApiKey => null;
+  @override
+  String? get googleClientId => null;
+  @override
+  String? get googleClientSecret => null;
+  @override
+  bool? get useWebAuth => false;
+  @override
+  bool? get useAuthCustomToken => false;
+}
+
+/// Always-connected fake so a successful reconnect looks identical to a real
+/// one to TranscriptSegmentSocketService.state.
+class _FakeConnectedSocket implements IPureSocket {
+  @override
+  PureSocketStatus status = PureSocketStatus.connected;
+
+  @override
+  Future<bool> connect() async => true;
+
+  @override
+  Future disconnect() async {}
+
+  @override
+  Future stop() async {}
+
+  @override
+  void send(dynamic message) {}
+
+  @override
+  void setListener(IPureSocketListener listener) {}
+
+  @override
+  void onMessage(dynamic message) {}
+
+  @override
+  void onConnected() {}
+
+  @override
+  void onClosed() {}
+
+  @override
+  void onError(Object err, StackTrace trace) {}
+}
+
+/// Counts reconnect attempts instead of hitting the real socket service pool,
+/// mirroring capture_provider_test.dart's _GatedSocketCaptureProvider pattern
+/// for CaptureProvider.openConversationSocket.
+class _CountingSpeechProfileProvider extends SpeechProfileProvider {
+  int openCalls = 0;
+
+  @override
+  Future<TranscriptSegmentSocketService?> openSpeechProfileSocket({
+    required BleAudioCodec codec,
+    required int sampleRate,
+    required String language,
+    required bool force,
+  }) async {
+    openCalls++;
+    return TranscriptSegmentSocketService.withSocket(
+      sampleRate,
+      codec,
+      language,
+      _FakeConnectedSocket(),
+      onboardingMode: true,
+    );
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async {
+        if (call.method == 'getApplicationDocumentsDirectory') return Directory.systemTemp.path;
+        return null;
+      },
+    );
+    try {
+      Env.init(_TestEnvFields());
+    } catch (_) {
+      // Env._instance is late final — ignore if already initialized in this isolate.
+    }
+    try {
+      await ServiceManager.init();
+    } catch (_) {
+      // Ignore if already initialized by another test.
+    }
+  });
+
+  // Regression coverage: previously the onboarding websocket had no reconnect
+  // at all. Once it dropped mid-flow, both live mic audio and
+  // skipCurrentQuestion() (services/sockets/transcription_service.dart-backed,
+  // gated on `_socket?.state == connected`) silently did nothing forever,
+  // requiring a full app relaunch to unstick onboarding.
+  group('onboarding socket reconnect', () {
+    test('reconnects on an interval after the socket drops mid-onboarding, then stops', () {
+      fakeAsync((async) {
+        final provider = _CountingSpeechProfileProvider();
+        provider.usePhoneMic = true;
+        provider.updateStartedRecording(true);
+        provider.currentQuestionIndex = 3;
+        provider.currentQuestion = 'What do you have planned for today?';
+
+        provider.onClosed(1006);
+        async.flushMicrotasks();
+        expect(provider.openCalls, 0, reason: 'a reconnect is scheduled on an interval, not attempted immediately');
+
+        async.elapse(const Duration(seconds: 5));
+        expect(provider.openCalls, 1, reason: 'the first tick must attempt a reconnect');
+
+        // The backend keeps no onboarding state across connections
+        // (OnboardingHandler is constructed fresh per websocket), so a
+        // reconnect always restarts the question sequence from the top.
+        expect(provider.currentQuestionIndex, 0);
+        expect(provider.currentQuestion, '');
+
+        // The fake socket reports connected immediately, so the periodic
+        // timer must stop rather than opening a second socket on the next
+        // tick.
+        async.elapse(const Duration(seconds: 15));
+        expect(provider.openCalls, 1, reason: 'timer must stop once reconnected, not keep firing');
+
+        provider.dispose();
+      });
+    });
+
+    test('does not schedule a reconnect once the profile is already completed', () {
+      fakeAsync((async) {
+        final provider = _CountingSpeechProfileProvider();
+        provider.usePhoneMic = true;
+        provider.updateStartedRecording(true);
+        provider.profileCompleted = true;
+
+        provider.onClosed(1000);
+        async.elapse(const Duration(seconds: 30));
+
+        expect(provider.openCalls, 0, reason: 'onboarding already finished; nothing to reconnect');
+
+        provider.dispose();
+      });
+    });
+  });
+}

--- a/app/test/providers/speech_profile_provider_test.dart
+++ b/app/test/providers/speech_profile_provider_test.dart
@@ -173,4 +173,35 @@ void main() {
       });
     });
   });
+
+  // Regression coverage: finalize()'s upload-failure branch commented "still
+  // process conversation" but never set profileCompleted, so the "All Done"
+  // continue button (gated on provider.profileCompleted in
+  // speech_profile_widget.dart) never appeared — trapping the user on the
+  // last onboarding question forever whenever the speech-profile upload
+  // fails (e.g. BUCKET_SPEECH_PROFILES unconfigured locally).
+  group('onboarding completes even when the speech-profile upload fails', () {
+    test('marks the profile completed after an upload failure', () {
+      final provider = SpeechProfileProvider();
+
+      provider.completeAfterUploadFailure(tooShort: false);
+
+      expect(provider.profileCompleted, isTrue, reason: 'the user must be able to leave onboarding');
+      expect(provider.uploadingProfile, isFalse);
+      expect(provider.error, 'UPLOAD_FAILED');
+
+      provider.dispose();
+    });
+
+    test('marks the profile completed after a too-short-audio failure', () {
+      final provider = SpeechProfileProvider();
+
+      provider.completeAfterUploadFailure(tooShort: true);
+
+      expect(provider.profileCompleted, isTrue, reason: 'the user must be able to leave onboarding');
+      expect(provider.error, 'TOO_SHORT');
+
+      provider.dispose();
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Two independent bugs were trapping users on the last onboarding question, verified live against the local dev harness (Omi CV1 + Limitless Pendant + phone mic):

1. **The onboarding websocket had no reconnect.** `/v4/listen` sessions in `onboarding=enabled` mode drop periodically (confirmed independent of any connected pendant). Once dropped, `SpeechProfileProvider.skipCurrentQuestion()` and outgoing mic audio are both gated on `_socket?.state == connected` and silently became permanent no-ops — matching the reported symptom exactly: spoke an answer, saw the transcription, screen never advanced, and "Skip this question" did nothing. `pure_socket.dart` / `transcription_service.dart` had zero reconnect logic for this socket, unlike `CaptureProvider._startKeepAliveServices`, which already has this pattern for the main recording socket.

2. **`finalize()`'s upload-failure branch never completed onboarding.** The comment said *"Upload failed - notify user but still process conversation"*, and conversation processing did proceed — but `profileCompleted` was never set. The "All Done" continue button in both `speech_profile_widget.dart` and `speech_profile/page.dart` is gated on exactly that field. Since the speech-profile upload fails on every local-harness run (`BUCKET_SPEECH_PROFILES` unconfigured there — filed separately as a harness gap, not part of this fix), every onboarding run that reached the last question was silently trapped, independent of bug 1.

## Fixes

- `SpeechProfileProvider` now retries the onboarding socket on a 5s interval after a drop, guarded against overlapping in-flight attempts (same class of race as #11305). Because `OnboardingHandler` (backend) keeps no state across connections, a successful reconnect resets the local question index to match the server restarting from the top.
- Extracted the upload-failure handling into `completeAfterUploadFailure()`, which now sets `profileCompleted = true` on both the `TOO_SHORT` and generic `UPLOAD_FAILED` paths (matching the success path, minus `hasSpeakerProfile = true` since no profile was actually saved).
- Small adjacent cleanup: dropped a stray `late` on two nullable callback fields (`_finalizedCallback`, `_processConversationCallback`) that don't need it (already null-checked everywhere they're read) — it was blocking the provider from being constructed in a test without the full `initialise()` flow.

## Test plan

- [x] `flutter test test/providers/speech_profile_provider_test.dart` — 4 new tests: reconnect-after-drop, no-reconnect-once-completed, complete-on-upload-failure, complete-on-too-short-audio. All pass.
- [x] `flutter analyze` clean on both changed files.
- [x] **Verified live on device** against the local dev harness: fresh onboarding run through all 6 questions, reached the app's own Profile settings screen. Confirmed via `backend.log` correlated to the exact run: a single onboarding websocket session start-to-finish, `/v3/upload-audio` still 500s (expected — harness gap, unrelated to this fix), but `process_conversation completed` / `POST /v1/conversations 200 OK` followed by normal app traffic, proving the app moved past onboarding despite the upload failure.
- [x] Reconnect path exercised live in an earlier run (socket dropped and successfully recovered mid-onboarding, confirmed via a fresh `/v4/listen` connection in `backend.log` immediately after a `reason=disconnect`).

## Product invariants

None — no locked invariant path globs touched (`scripts/pr-preflight --suggest` confirms).

## Failure class

Failure-Class: none

Both are first-observed, independent instance fixes in this subsystem — no existing failure-class in `.github/failure-classes/` matches either shape, and neither has a second prior occurrence in this codebase to warrant registering a new one now.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

