### PR TITLE
fix(context-for-claude): the Activity panel keeps its corpus and revalidates instead of re-paging

### DIFF
--- a/.github/failure-classes/FC-durable-state-scoped-to-view-lifetime.json
+++ b/.github/failure-classes/FC-durable-state-scoped-to-view-lifetime.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-durable-state-scoped-to-view-lifetime",
+  "violated_contract": "State whose cost to rebuild exceeds the lifetime of the view that displays it must be owned by something that outlives the view. A corpus paged in over dozens of network requests, held as a SwiftUI @StateObject inside the surface that draws it, is discarded and re-derived on every ordinary re-entry — a window rebuilt on each present(), a branch of a switch the user leaves by typing — and the surface reads as slow for work it has already done. The owning scope is a property of what the state costs, not of who renders it.",
+  "canonical_prevention": "Own the store at the process (ActivitySpine.shared), hand it to the view, and make re-entry a revalidation that keeps every composed row and asks only what changed — on a cooldown, never clearing, never re-opening the window. State that now outlives a sign-out must be told to forget it, and the paint before the first answer comes from a bounded on-disk copy that is explicitly not an authority. Regression coverage in ActivityRevalidationTests asserts the list does not blink mid-request, that a second appearance revalidates rather than re-pages, and that the sign-out edge clears the account half.",
+  "canonical_prevention_artifact": [
+    "desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySpine.swift",
+    "desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift"
+  ],
+  "evidence_prs": [
+    11641
+  ],
+  "scope_hints": [
+    "desktop/context-for-claude/**",
+    "desktop/macos/**"
+  ],
+  "status": "open"
+}

--- a/desktop/context-for-claude/ARCHITECTURE.md
+++ b/desktop/context-for-claude/ARCHITECTURE.md
@@ -88,7 +88,7 @@ live, a dedicated transcription gap reason is published the same way.
 `~/Library/Application Support/ContextForClaude/`
 
 ```
-context.db              sessions, segments, frames + two FTS5 indexes
+context.db              sessions, segments, frames + two FTS5 indexes, and the account cache
 Frames/YYYY-MM-DD/      screen JPEGs, pruned after 30 days
 capture-state.json      heartbeat: capturing / paused reason / capabilities
 last-query.json         the MCP server's proof it served a tool call: tool name + time, nothing else
@@ -104,6 +104,13 @@ staged. Neither ever holds anything the user said, saw, or asked — see `QueryS
 A session is a contiguous run of speech; a gap over five minutes starts a new one
 (`SessionPolicy`). Transcripts are kept forever; frames are the expensive part and are the only
 thing pruned.
+
+`account_rows` is the one table in here that is **a copy and not an authority**: the last answer the
+user's Omi account gave, bounded to one page per source, so the Activity panel paints real titles on
+a cold launch instead of the untitled local sessions it used to show while three HTTP round trips
+were in flight. Every row came off the wire and is rewritten by the wire; nothing reads it once a
+real answer exists, and signing out empties it. See `AccountCacheQueries` and
+`ActivityAccountCache`.
 
 ## The MCP surface
 
@@ -142,6 +149,9 @@ Sources/ContextApp/      ContextApp  Engine  Permissions
                          Onboarding/ Ink  Backdrop  RandomizedText  OnboardingWindow  OnboardingView
                          Integration/ClaudeRegistrar  LoginItem
                          Shortcuts/  GlobalShortcuts  ShortcutConflicts
+                         Activity/   ActivitySpine (the one process-lived store)  ActivityStore
+                                     ActivityComposer  ActivityAccount  ActivityAccountCache
+                                     ActivityLocalMemories  ActivitySurface  ActivityStream
                          Search/     SearchBarWindow  SearchBarView  SearchSurface
                                      SearchResultsModel  SearchResultsView  SearchRanking
                                      ClaudeRouter (tutorial + settings only, not the bar)

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccount.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccount.swift
@@ -197,6 +197,31 @@ protocol ActivityAccountReading: Sendable {
     func read(since: Double?, until: Double?, limit: Int) async -> ActivityAccountFeed
 }
 
+/// An account reader whose walk through the account can be moved by the caller.
+///
+/// **Separate from `ActivityAccountReading` for the reason `ActivityAccountDiagnosing` is**: a
+/// preview's account, a test's account and `ActivityAccountAbsent` have no cursor and nothing to
+/// move, and making every one of them implement two no-ops would be a protocol demanding a promise
+/// only one implementation can keep.
+///
+/// It exists because a reader that pages is a reader that only ever moves *away* from the newest
+/// row, and holds everything it has passed. Both facts are right while a corpus is filling and both
+/// are wrong later: what changed since the reader left is at offset zero, which a forward-only
+/// cursor never asks for twice, and what it is holding belongs to whichever account was signed in
+/// when it read it.
+///
+/// Neither method fetches. They move the cursor; the next `read` is what spends a request, which is
+/// what keeps one read path through the decorators instead of two.
+protocol ActivityAccountCursor: Sendable {
+    /// Reopen the newest page of every source, so the next `read` asks the account for it again.
+    /// Everything already gathered is kept, and rows that come back changed replace their copies.
+    func refreshHead() async
+
+    /// Drop everything gathered and every cursor. The account that answered has been signed out of,
+    /// and not one row of what it said may reach whoever signs in next.
+    func forget() async
+}
+
 /// The account nobody connected. Used by previews, the render harness, and every test that is about
 /// composition rather than about the network.
 struct ActivityAccountAbsent: ActivityAccountReading {

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccountCache.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccountCache.swift
@@ -141,12 +141,21 @@ actor ActivityAccountCache {
     /// - Parameter epoch: the value `currentEpoch()` gave when the read behind `feed` began. A save
     ///   quoting a stale one is dropped: the account it describes has been signed out of.
     func save(_ feed: ActivityAccountFeed, epoch: Int) async {
+        // **The store is acquired first, and the epoch is checked after it.** The order is the whole
+        // of the fence, because **actors are reentrant**: `await store()` is a suspension point
+        // inside this actor, so a `clear()` arriving while this call is parked there runs to
+        // completion and this one then resumes past a check it had already passed. Checking first
+        // reads as the careful thing to do and is exactly the hole — the previous revision of this
+        // file had it that way and was still racy.
+        //
+        // Acquiring the handle first means the only suspension is behind us: everything from the
+        // check to the last write below is synchronous, so nothing can interleave between them.
+        guard let store = await store() else { return }
         guard epoch == self.epoch else {
             ContextLog.info(
                 "Account cache: dropping a write from a signed-out session", Self.category)
             return
         }
-        guard let store = await store() else { return }
         let cacheable = feed.answered.subtracting(feed.locallySourced)
         guard !cacheable.isEmpty else { return }
 
@@ -197,9 +206,11 @@ actor ActivityAccountCache {
     /// Empties it. Signing out is the caller — one account's rows must never be the first thing the
     /// next account sees.
     func clear() async {
-        // Before the write, and unconditionally — a clear that could not reach the database must
-        // still invalidate the saves in flight behind it, or a failed delete becomes the previous
-        // account's rows being written back a moment later.
+        // **Before its own suspension point, not merely before the delete.** Same reentrancy as
+        // `save`: bumping after `await store()` would leave a window in which a save parked on that
+        // await resumes still believing it is current. Unconditional for a second reason — a clear
+        // that cannot reach the database must still invalidate the writes behind it, or a failed
+        // delete becomes the previous account's rows written back a moment later.
         epoch &+= 1
         guard let store = await store() else { return }
         try? AccountCacheQueries.clear(store)

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccountCache.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccountCache.swift
@@ -42,10 +42,31 @@ import Foundation
 
 /// Reads and writes the spine's account rows to `context.db`.
 ///
-/// A struct over a store provider rather than a singleton, for the reason every boundary in this
-/// package is one: the store opens lazily on the engine's queue, so anything that captured it at
-/// build time would hold the `nil` of the first instant forever.
-struct ActivityAccountCache: Sendable {
+/// **An actor, and the serialisation is load-bearing.** Saves are spawned detached off a read that
+/// has already been absorbed, so at sign-out there can be one in flight with the previous account's
+/// rows in it. A struct would let that save's `replace` commit *after* `clear()` had emptied the
+/// table, and the next account's first paint would then be somebody else's conversations — the one
+/// outcome this cache must never produce. Serialising every write through one actor makes the two
+/// orderable; `epoch` is what decides which of the two orders wins.
+///
+/// The store is still a provider rather than a held handle, for the reason every boundary in this
+/// package is one: it opens lazily on the engine's queue, so anything that captured it at build
+/// time would hold the `nil` of the first instant forever.
+actor ActivityAccountCache {
+
+    /// Bumped by `clear()`. A save carrying an older epoch was minted for an account that has since
+    /// been signed out of, and is dropped rather than written.
+    ///
+    /// Ordering alone is not enough even with the actor: the save may simply *arrive* second and be
+    /// perfectly serialised, and still be wrong. What makes it wrong is not when it ran but which
+    /// account it describes, so that is what is checked. Same reasoning as
+    /// `ConversationCacheWriteScope` in the main app, which fences its cache writes on a generation
+    /// for this exact failure.
+    private var epoch = 0
+
+    /// The epoch a caller must quote to have its write accepted. Read when the work that will
+    /// produce the rows *starts*, not when it finishes.
+    func currentEpoch() -> Int { epoch }
 
     /// How many rows of one source are kept. One page — see the note at the top of the file.
     static let ceiling = OmiActivityFeed.maxPerSource
@@ -117,7 +138,14 @@ struct ActivityAccountCache: Sendable {
     /// would mean a second copy of somebody else's table, and — worse — a later launch would read
     /// them back as *the account's* answer, which is a claim this app has no business making on
     /// their behalf.
-    func save(_ feed: ActivityAccountFeed) async {
+    /// - Parameter epoch: the value `currentEpoch()` gave when the read behind `feed` began. A save
+    ///   quoting a stale one is dropped: the account it describes has been signed out of.
+    func save(_ feed: ActivityAccountFeed, epoch: Int) async {
+        guard epoch == self.epoch else {
+            ContextLog.info(
+                "Account cache: dropping a write from a signed-out session", Self.category)
+            return
+        }
         guard let store = await store() else { return }
         let cacheable = feed.answered.subtracting(feed.locallySourced)
         guard !cacheable.isEmpty else { return }
@@ -169,6 +197,10 @@ struct ActivityAccountCache: Sendable {
     /// Empties it. Signing out is the caller — one account's rows must never be the first thing the
     /// next account sees.
     func clear() async {
+        // Before the write, and unconditionally — a clear that could not reach the database must
+        // still invalidate the saves in flight behind it, or a failed delete becomes the previous
+        // account's rows being written back a moment later.
+        epoch &+= 1
         guard let store = await store() else { return }
         try? AccountCacheQueries.clear(store)
     }

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccountCache.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityAccountCache.swift
@@ -1,0 +1,254 @@
+//
+//  ActivityAccountCache.swift — the account's last answer, on disk, for the paint before the network.
+//
+//  **The spine's account half was network-only, and it looked it.** A cold launch composed the local
+//  sessions `context.db` holds and nothing else — every one of them drawn as
+//  `ActivityConversation.untitled`, because a title is written by the backend when a transcript is
+//  uploaded and a session that has not been uploaded has none — and stayed that way until three HTTP
+//  round trips came back. What the user saw was a column of `Untitled conversation` that turned into
+//  real titles a second or two later, every single launch.
+//
+//  The shipping Omi app has never looked like that over the same data, and not because it is faster
+//  on the wire: `ConversationRepository.load` reads its SQLite cache, emits it, and *then* fetches,
+//  so `structured.title` is on screen in milliseconds and the server answer replaces it in place.
+//  `ActivityLocalMemories` already brought half of that arrangement to this app for the memory
+//  column. This is the other half, for all three sources, and it is this app's own store rather than
+//  a read of somebody else's — Context for Claude ships standalone and cannot assume Omi is
+//  installed beside it.
+//
+//  ## What it is allowed to claim
+//
+//  **Nothing.** A cached feed is not an answer and must never be presented as one: it does not set
+//  `answered`, it does not make the account `reachable`, and it does not settle the corpus. It is
+//  pixels that were true a moment ago, standing in until pixels that are true now arrive.
+//  `ActivityStore.seed(cached:)` is the only way in, and it deliberately does not go through
+//  `absorb(account:)` for exactly that reason — that path draws conclusions about the account, and
+//  this has no standing to draw any.
+//
+//  **Replaced, never merged.** When a source answers, its rows here are rewritten from that answer.
+//  A conversation deleted on the phone therefore survives one paint and no longer, which is the same
+//  bargain main makes and the reason a stale row is harmless rather than a bug that compounds.
+//
+//  ## Bounds
+//
+//  `OmiActivityFeed.maxPerSource` rows per source, which is one page — the page a first paint draws
+//  from. A cache that could hold more rows than one answer is allowed to contain would grow past the
+//  thing it is a copy of, one 503 at a time, inside a database whose reason for existing is screen
+//  capture.
+//
+
+import ContextCore
+import Foundation
+
+/// Reads and writes the spine's account rows to `context.db`.
+///
+/// A struct over a store provider rather than a singleton, for the reason every boundary in this
+/// package is one: the store opens lazily on the engine's queue, so anything that captured it at
+/// build time would hold the `nil` of the first instant forever.
+struct ActivityAccountCache: Sendable {
+
+    /// How many rows of one source are kept. One page — see the note at the top of the file.
+    static let ceiling = OmiActivityFeed.maxPerSource
+
+    private static let category = "activity"
+
+    /// `async` because the engine's store is main-actor state and this runs off it: the reads and
+    /// writes below belong on a background task — they are SQLite, on the launch path — and the one
+    /// hop to ask for the handle is cheaper than doing the work where the UI is drawn. Same shape
+    /// `ActivityDetail` already uses to reach the same property.
+    private let store: @Sendable () async -> ContextStore?
+
+    init(store: @escaping @Sendable () async -> ContextStore?) {
+        self.store = store
+    }
+
+    // MARK: - Reading
+
+    /// Everything cached, as the rows the composer takes.
+    ///
+    /// Returns an empty triple rather than throwing or reporting failure, and the caller treats an
+    /// empty one as "nothing to paint yet". A cache that cannot be read is exactly as interesting as
+    /// a cache that is empty: both mean the network answer is the first thing on screen, which is
+    /// where this surface was before this file existed.
+    func load() async -> (
+        conversations: [ActivityAccountConversation], memories: [ActivityAccountMemory],
+        tasks: [ActivityAccountTask]
+    ) {
+        guard let store = await store() else { return ([], [], []) }
+        let conversations: [CachedConversation] = read(store, .conversations)
+        let memories: [CachedMemory] = read(store, .memories)
+        let tasks: [CachedTask] = read(store, .tasks)
+        return (
+            conversations.map(\.row), memories.map(\.row), tasks.map(\.row)
+        )
+    }
+
+    private func read<Payload: Decodable>(
+        _ store: ContextStore, _ source: ActivityAccountSource
+    ) -> [Payload] {
+        do {
+            return try AccountCacheQueries.recent(
+                store, source: source.rawValue, limit: Self.ceiling
+            ).compactMap { cached in
+                guard let data = cached.payload.data(using: .utf8) else { return nil }
+                // A row whose shape this binary no longer understands is dropped, not thrown on.
+                // The cache is disposable by construction and the next write repairs it; refusing
+                // to paint anything because one row is from an older format would make a schema
+                // change cost the very launch this file exists to speed up.
+                return try? JSONDecoder().decode(Payload.self, from: data)
+            }
+        } catch {
+            ContextLog.error("Account cache unreadable (\(type(of: error)))", Self.category)
+            return []
+        }
+    }
+
+    // MARK: - Writing
+
+    /// Writes back every source the feed actually answered for.
+    ///
+    /// **Only answered sources.** A feed carries whatever the reader has gathered, including rows
+    /// from a source that has since started failing; rewriting the cache from those would be a copy
+    /// of a copy. A source absent from `answered` keeps whatever it had, which is the last thing it
+    /// really said.
+    ///
+    /// **And never a locally-sourced one.** `ActivityLocalMemories` merges this Mac's own memories
+    /// into the column, and those rows already live in the Omi app's database. Caching them here
+    /// would mean a second copy of somebody else's table, and — worse — a later launch would read
+    /// them back as *the account's* answer, which is a claim this app has no business making on
+    /// their behalf.
+    func save(_ feed: ActivityAccountFeed) async {
+        guard let store = await store() else { return }
+        let cacheable = feed.answered.subtracting(feed.locallySourced)
+        guard !cacheable.isEmpty else { return }
+
+        for source in cacheable {
+            let rows: [CachedAccountRow]
+            switch source {
+            case .conversations:
+                rows = newest(feed.conversations.map(CachedConversation.init)) { $0.startedAt }
+            case .memories:
+                rows = newest(feed.memories.map(CachedMemory.init)) { $0.at }
+            case .tasks:
+                rows = newest(feed.tasks.map(CachedTask.init)) { $0.at }
+            }
+            do {
+                try AccountCacheQueries.replace(
+                    store, source: source.rawValue, rows: rows, keeping: Self.ceiling)
+            } catch {
+                // A cache that could not be written costs the *next* launch a slower paint and
+                // costs this one nothing at all. Never worth failing a read over.
+                ContextLog.error(
+                    "Account cache unwritable for \(source.rawValue) (\(type(of: error)))",
+                    Self.category)
+            }
+        }
+    }
+
+    /// The newest `ceiling` of one source, already encoded.
+    ///
+    /// Bounded here as well as in the trim: the feed reaching this can be the whole hydrated corpus —
+    /// thousands of rows — and handing all of them to an upsert loop that will immediately delete
+    /// most of them again is the trim paying for work nobody asked for.
+    private func newest<Payload: Encodable & CachedPayload>(
+        _ payloads: [Payload], _ instant: (Payload) -> Double
+    ) -> [CachedAccountRow] {
+        payloads
+            .sorted { instant($0) > instant($1) }
+            .prefix(Self.ceiling)
+            .compactMap { payload in
+                guard let data = try? JSONEncoder().encode(payload),
+                    let text = String(data: data, encoding: .utf8)
+                else { return nil }
+                return CachedAccountRow(
+                    source: payload.source.rawValue, id: payload.id, at: instant(payload),
+                    payload: text)
+            }
+    }
+
+    /// Empties it. Signing out is the caller — one account's rows must never be the first thing the
+    /// next account sees.
+    func clear() async {
+        guard let store = await store() else { return }
+        try? AccountCacheQueries.clear(store)
+    }
+}
+
+// MARK: - What is written
+
+/// The two things every cached payload has to be able to say about itself for the row to be keyed.
+private protocol CachedPayload {
+    var id: String { get }
+    var source: ActivityAccountSource { get }
+}
+
+// The seam types are deliberately *not* made `Codable` and cached directly. A cache is a wire format
+// with a version skew problem — this binary reads rows an older one wrote — and conforming the live
+// types would mean every field added to a row for the sake of what it draws silently becomes a
+// schema change. These mirrors are the format, and they change only when someone changes them.
+
+private struct CachedConversation: Codable, CachedPayload {
+    let id: String
+    let title: String
+    let emoji: String
+    let startedAt: Double
+    let finishedAt: Double
+    let overview: String?
+
+    var source: ActivityAccountSource { .conversations }
+
+    init(_ row: ActivityAccountConversation) {
+        id = row.id
+        title = row.title
+        emoji = row.emoji
+        startedAt = row.startedAt
+        finishedAt = row.finishedAt
+        overview = row.overview
+    }
+
+    var row: ActivityAccountConversation {
+        ActivityAccountConversation(
+            id: id, title: title, emoji: emoji, startedAt: startedAt, finishedAt: finishedAt,
+            overview: overview)
+    }
+}
+
+private struct CachedMemory: Codable, CachedPayload {
+    let id: String
+    let content: String
+    let at: Double
+    let conversationID: String?
+
+    var source: ActivityAccountSource { .memories }
+
+    init(_ row: ActivityAccountMemory) {
+        id = row.id
+        content = row.content
+        at = row.at
+        conversationID = row.conversationID
+    }
+
+    var row: ActivityAccountMemory {
+        ActivityAccountMemory(id: id, content: content, at: at, conversationID: conversationID)
+    }
+}
+
+private struct CachedTask: Codable, CachedPayload {
+    let id: String
+    let text: String
+    let completed: Bool
+    let at: Double
+
+    var source: ActivityAccountSource { .tasks }
+
+    init(_ row: ActivityAccountTask) {
+        id = row.id
+        text = row.text
+        completed = row.completed
+        at = row.at
+    }
+
+    var row: ActivityAccountTask {
+        ActivityAccountTask(id: id, text: text, completed: completed, at: at)
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityLocalMemories.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityLocalMemories.swift
@@ -115,7 +115,9 @@ struct ActivityLocalMemoriesAbsent: ActivityLocalMemoryReading {
 ///
 /// `ActivityAccountDiagnosing` is forwarded rather than reimplemented: *why* the account did not
 /// answer is still the network reader's to say, and this changes only what is drawn.
-struct ActivityLocalMemories: ActivityAccountReading, ActivityAccountDiagnosing {
+struct ActivityLocalMemories: ActivityAccountReading, ActivityAccountDiagnosing,
+    ActivityAccountCursor
+{
     private let upstream: ActivityAccountReading
     private let local: ActivityLocalMemoryReading
 
@@ -214,5 +216,19 @@ struct ActivityLocalMemories: ActivityAccountReading, ActivityAccountDiagnosing 
 
     func unreachableReason() async -> ActivityAccountUnreachableReason? {
         await (upstream as? ActivityAccountDiagnosing)?.unreachableReason()
+    }
+
+    /// Forwarded for the reason `unreachableReason` is: the cursor being rewound belongs to the
+    /// network reader, and this decorator has none of its own. The local half needs no rewinding —
+    /// `recent(limit:)` reads the newest rows out of SQLite on every call and has never been paged.
+    func refreshHead() async {
+        await (upstream as? ActivityAccountCursor)?.refreshHead()
+    }
+
+    /// Forwarded for the same reason. Nothing of the previous account is held here — the local rows
+    /// are re-read from SQLite on every call and belong to whoever is signed into the Omi app — so
+    /// there is nothing of this decorator's own to forget.
+    func forget() async {
+        await (upstream as? ActivityAccountCursor)?.forget()
     }
 }

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySpine.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySpine.swift
@@ -1,0 +1,99 @@
+//
+//  ActivitySpine.swift — the one Activity store, owned by the process rather than by a window.
+//
+//  **The store used to be `@StateObject` inside `ActivitySurface`, and that is a shorter-lived thing
+//  than it looks.** `SearchBarWindow.dismiss()` sets `current = nil` before it closes, so `present()`
+//  never takes its own reuse branch: every summoning of the panel builds a fresh window, a fresh
+//  `SearchBarView` and therefore a fresh store. And the panel's lower half is a `switch` on which
+//  body is showing, so typing a query unmounts the activity branch outright and clearing the field
+//  mounts a new one. Three ordinary actions — launch, re-open, search-then-clear — each threw away a
+//  fully hydrated corpus and re-paged the entire account from offset zero.
+//
+//  Measured on this machine that is thousands of rows and a walk of dozens of requests, every time,
+//  for data that had not changed. It is also the reason the panel looked slow in a way no cache
+//  could have fixed: a cache shortens the first paint, and this was re-doing the *whole* fill.
+//
+//  Main has never had this problem and not by cleverness — `AppState` and `ConversationRepository`
+//  simply belong to the application, so opening its window costs nothing and `SpineStream.task` can
+//  guard with `if appState.conversations.isEmpty`. This file is that ownership, in this app.
+//
+//  ## What lives here and what does not
+//
+//  Only the store. Everything about *drawing* it — the chips, the query, the detail push, the
+//  reading position — stays with the view, because that is what is genuinely worth as long as the
+//  panel is on screen and no longer. The corpus is not: it is the same corpus whoever is looking.
+//
+//  ## Signing out
+//
+//  A process-lived store outlives a sign-out, which a window-lived one never did, so it has to be
+//  told. Everything one account handed over is dropped and the cache on disk with it — the next
+//  account's first paint must not be somebody else's conversations. This is `ConversationRepository`'s
+//  `.runtimeOwnerDidChange` reset, on the one signal this app has.
+//
+
+import AppKit
+import Combine
+import ContextCore
+import Foundation
+
+/// The application's single Activity store.
+@MainActor
+final class ActivitySpine {
+    static let shared = ActivitySpine()
+
+    /// The store every Activity surface draws. One per process — see the note above.
+    let store: ActivityStore
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    private init(
+        store: ActivityStore? = nil,
+        signIns: AnyPublisher<Bool, Never>? = nil,
+        activations: AnyPublisher<Void, Never>? = nil
+    ) {
+        self.store =
+            store
+            ?? ActivityStore(
+                store: { Engine.shared.contextStore },
+                // Wrapped, for the reason `SearchBarView` documents where this used to be built:
+                // three of the five chips have no local source at all, and the memory column is read
+                // this Mac's database first so a `/v3/memories` outage does not draw as an empty
+                // account. Built once here rather than per panel, which is also what gives the
+                // reader's paging cursor a life longer than one window.
+                account: ActivityLocalMemories(OmiActivityFeed()),
+                cache: ActivityAccountCache(
+                    store: { await MainActor.run { Engine.shared.contextStore } }))
+
+        // Signing out is the one thing a store this long-lived cannot simply ignore. `filter` on the
+        // false edge because signing *in* is already handled inside the store, where it re-reads an
+        // account it had reported as absent; this is the other direction, where the right answer is
+        // to forget rather than to fetch.
+        (signIns ?? OmiAuth.shared.$isSignedIn.eraseToAnyPublisher())
+            .removeDuplicates()
+            .filter { !$0 }
+            .sink { [weak self] _ in self?.store.forgetTheAccount() }
+            .store(in: &cancellables)
+
+        // **Coming back to the app is the other half of "keep what you have, fetch what changed".**
+        // Main answers `didBecomeActiveNotification` with a server-only refresh over a list it never
+        // clears (`DesktopHomeView`, throttled by `PollingConfig.activationCooldown`), and this is
+        // that, on this app's one long-lived surface. `revalidate` carries the same cooldown, so the
+        // two signals it now has — this, and the panel being summoned — cannot become two requests.
+        (activations
+            ?? NotificationCenter.default
+            .publisher(for: NSApplication.didBecomeActiveNotification)
+            .map { _ in () }
+            .eraseToAnyPublisher())
+            .sink { [weak self] in self?.store.revalidate() }
+            .store(in: &cancellables)
+    }
+
+    /// A host with an injected store, for tests that need the sign-out wiring without the app.
+    static func forTesting(
+        store: ActivityStore,
+        signIns: AnyPublisher<Bool, Never>,
+        activations: AnyPublisher<Void, Never> = Empty().eraseToAnyPublisher()
+    ) -> ActivitySpine {
+        ActivitySpine(store: store, signIns: signIns, activations: activations)
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityStore.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityStore.swift
@@ -426,9 +426,30 @@ final class ActivityStore: ObservableObject {
     /// of what a signed-out user should still be able to see.
     func forgetTheAccount() {
         ContextLog.info("Signed out; forgetting the account half of the spine", "activity")
-        Task { [account, cache] in
+
+        // **The generation advances, and that is what makes this safe rather than merely tidy.**
+        // Every landing path in this store — the account read, the cached paint, the opening read,
+        // a day of frames, the write-back — is already fenced on it, so one increment invalidates
+        // all of them at once. Without it a read that left before the user signed out lands
+        // afterwards, passes a guard comparing a generation nothing moved, and repopulates the panel
+        // with the previous account's conversations. That read is in flight for as long as the
+        // network takes; sign-out is a keystroke. The window is not narrow.
+        //
+        // It advances *without* re-opening the window, which is the difference between this and
+        // `openWindow()`. Frames and speech on this Mac were captured whether or not anybody was
+        // signed in, so re-reading them would be spending the whole day walk to discard nothing.
+        generation &+= 1
+        // The in-flight stamp belongs to the read that is now orphaned. Left set, it would refuse
+        // the next account's revalidation for as long as the process lived.
+        accountReadInFlight = nil
+
+        Task { [weak self, account, cache] in
             await (account as? ActivityAccountCursor)?.forget()
             await cache?.clear()
+            // Read back rather than incremented locally: the cache owns the number, and a second
+            // copy of it maintained here is a second thing to get wrong.
+            guard let cache, let epoch = await cache.currentEpoch() as Int? else { return }
+            await MainActor.run { self?.accountCacheEpoch = epoch }
         }
 
         accountFeed = .unreachable
@@ -524,6 +545,7 @@ final class ActivityStore: ObservableObject {
         readFailure = nil
         loader.purge()
 
+        refreshCacheEpoch()
         seedFromCache(generation: generation)
         readAccount(generation: generation)
 
@@ -721,9 +743,28 @@ final class ActivityStore: ObservableObject {
 
     /// Writes the answer back for the next cold launch to paint. Detached: this is a SQLite write on
     /// the path of a read that has already been absorbed, and nothing on screen is waiting for it.
+    ///
+    /// **Two fences, because they close different holes.** The generation check here refuses a write
+    /// belonging to a window that has since moved; the epoch travels *into* the cache and is checked
+    /// inside the actor, which is the only place that can order this write against a `clear()` that
+    /// has not run yet. Checking the generation alone would leave the sign-out race exactly as it
+    /// was: the guard passes, the task is spawned, sign-out clears the table, and this lands after.
     private func write(_ feed: ActivityAccountFeed, toCache generation: Int) {
         guard let cache, generation == self.generation, feed.reachable else { return }
-        Task.detached(priority: .utility) { await cache.save(feed) }
+        let epoch = accountCacheEpoch
+        Task.detached(priority: .utility) { await cache.save(feed, epoch: epoch) }
+    }
+
+    /// The cache epoch this window's reads were minted under. Refreshed when a window opens and
+    /// after a sign-out, which are the two moments the account under the panel can change.
+    private var accountCacheEpoch = 0
+
+    private func refreshCacheEpoch() {
+        guard let cache else { return }
+        Task { [weak self] in
+            let epoch = await cache.currentEpoch()
+            self?.accountCacheEpoch = epoch
+        }
     }
 
     // MARK: - Hydration

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityStore.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityStore.swift
@@ -209,9 +209,20 @@ final class ActivityStore: ObservableObject {
     /// The account half of the spine. Held rather than asked for: unlike `ContextStore` it is a
     /// value the host owns from the start, and `ActivityAccountAbsent` is a perfectly good one.
     private let account: ActivityAccountReading
+    /// The last answer the account gave, on disk. See `ActivityAccountCache` — it is a copy with no
+    /// standing, and `seed(cached:generation:)` is the only thing that reads it.
+    private let cache: ActivityAccountCache?
     private let calendar: Calendar
     /// The healing schedule, injectable so a test can prove the ladder without spending it.
     private let accountRetryDelays: [Duration]
+    /// True for a store handed its answer at construction — previews and the render harness.
+    ///
+    /// **It exists to stop `revalidate()` from reaching one.** That initialiser assigns `composed`
+    /// directly and has no sources behind it, so any recomposition rebuilds the list out of three
+    /// empty inputs and erases the very thing the preview was constructed to show. `didStart` used
+    /// to be enough, back when the only thing it guarded was the opening read; a `start()` that now
+    /// revalidates on every appearance is exactly the call a preview makes.
+    private let holdsAFixedAnswer: Bool
 
     /// Composed, unfiltered. The filter pass reads this and never mutates it.
     private var composed: [ActivityDay] = []
@@ -258,14 +269,17 @@ final class ActivityStore: ObservableObject {
     init(
         store: @escaping () -> ContextStore?,
         account: ActivityAccountReading = ActivityAccountAbsent(),
+        cache: ActivityAccountCache? = nil,
         calendar: Calendar = .current,
         accountRetryDelays: [Duration] = ActivityStore.accountRetryDelays,
         signIns: AnyPublisher<Bool, Never>? = nil
     ) {
         self.store = store
         self.account = account
+        self.cache = cache
         self.calendar = calendar
         self.accountRetryDelays = accountRetryDelays
+        self.holdsAFixedAnswer = false
 
         // **Signing in is the one repair the retry ladder must not wait for, and cannot find.**
         // `healsOnItsOwn` correctly refuses to re-poll a signed-out account — no amount of waiting
@@ -307,8 +321,10 @@ final class ActivityStore: ObservableObject {
     ) {
         self.store = { nil }
         self.account = ActivityAccountAbsent()
+        self.cache = nil
         self.calendar = calendar
         self.accountRetryDelays = Self.accountRetryDelays
+        self.holdsAFixedAnswer = true
         self.composed = days
         self.days = days
         self.matchCount = days.reduce(0) { $0 + $1.matchCount }
@@ -323,11 +339,135 @@ final class ActivityStore: ObservableObject {
 
     // MARK: - Input
 
-    /// Begins the opening read, once. Safe to call from `.task` on every appearance.
+    /// Begins the opening read, once — and revalidates on every appearance after that.
+    ///
+    /// **The second half is the whole of what the panel coming forward means.** This store outlives
+    /// the window that draws it (see `ActivitySpine`), so a surface mounting for the twentieth time
+    /// already holds a composed corpus and must not throw it away to fetch one it already has. What
+    /// it should do is exactly what main does on `didBecomeActiveNotification`: keep every row on
+    /// screen and ask the account what changed. `revalidate()` is that, and its cooldown is what
+    /// keeps a burst of mounts from becoming a burst of requests.
     func start() {
-        guard !didStart else { return }
+        guard !didStart else {
+            revalidate()
+            return
+        }
         didStart = true
         openWindow()
+    }
+
+    /// Ask the account what has changed, **without disturbing anything already on screen.**
+    ///
+    /// The distinction from `openWindow()` is the entire point and it is worth stating plainly:
+    /// opening a window is a new question and throws away the answer to the old one; revalidating is
+    /// the same question asked again. So nothing here clears `composed`, `accountFeed`, `screen` or
+    /// `loadedDays`, nothing sets `isPreparing`, and the generation does **not** advance — a spinner
+    /// over a list that is already correct is a worse answer than the list.
+    ///
+    /// Both halves are re-read, because both can have moved: the account has whatever was recorded
+    /// on the phone since, and this Mac has whatever it captured while the panel was closed.
+    ///
+    /// - Parameter now: injected so the cooldown can be proved without waiting a minute for it.
+    func revalidate(now: Date = Date()) {
+        guard didStart, !holdsAFixedAnswer else { return }
+        // **A read of this window is already out.** It will answer with whatever the account holds,
+        // so a second one buys nothing — and reopening the head under it would spend the reopen on a
+        // read that has already chosen its page. Deliberately *not* stamped: the next time the panel
+        // comes forward is a fresh chance rather than one silently skipped.
+        guard accountReadInFlight == nil else { return }
+        guard Self.shouldRevalidate(now: now, lastRevalidate: lastRevalidate) else { return }
+        lastRevalidate = now
+
+        let generation = self.generation
+        Task { [weak self, account] in
+            // Sends the reader's cursor back to offset zero for one read, which is the only offset a
+            // forward-only walk never re-asks for and the only one new rows arrive at.
+            await (account as? ActivityAccountCursor)?.refreshHead()
+            guard let self, generation == self.generation else { return }
+            self.readAccount(generation: generation)
+        }
+        revalidateLocalHalf(generation: generation)
+    }
+
+    /// Re-reads this Mac's half: the session headers, the upload links, and the frames of any day
+    /// that could still be growing.
+    ///
+    /// **Only the days that could have changed.** `loadedDays` exists so a scroll never re-queries a
+    /// day it already has, and revalidation must not undo that for a year of history — the frames of
+    /// last March are as read as they will ever be. A day is re-readable exactly when capture could
+    /// have added to it since the last read, which is every day from the one that read happened on
+    /// onwards: one day on an ordinary re-open, two when the panel was left open overnight.
+    private func revalidateLocalHalf(generation: Int) {
+        guard let store = store() else { return }
+        let horizon = calendar.startOfDay(for: lastLocalRead ?? Date())
+        let stale = loadedDays.filter { $0 >= horizon }
+        loadedDays.subtract(stale)
+        lastLocalRead = Date()
+
+        let calendar = self.calendar
+        let since = self.since
+        let until = self.until
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let opening = ActivityStore.readOpening(
+                store: store, calendar: calendar, since: since, until: until)
+            await self?.absorb(opening: opening, generation: generation)
+        }
+    }
+
+    /// Drops everything the previous account said, from memory and from disk, and asks again.
+    ///
+    /// **A store that belongs to the process outlives a sign-out, and a window-lived one never did.**
+    /// Nothing used to have to say this: the panel closed, the store went with it, and the next
+    /// account got a new one. `ActivitySpine` traded that for a panel that opens instantly, so the
+    /// obligation it used to discharge by accident is discharged here on purpose.
+    ///
+    /// The local half is deliberately untouched. Frames and speech on this Mac are not scoped to an
+    /// Omi account — they were captured whether or not anybody was signed in, and they are the whole
+    /// of what a signed-out user should still be able to see.
+    func forgetTheAccount() {
+        ContextLog.info("Signed out; forgetting the account half of the spine", "activity")
+        Task { [account, cache] in
+            await (account as? ActivityAccountCursor)?.forget()
+            await cache?.clear()
+        }
+
+        accountFeed = .unreachable
+        accountSettled = false
+        accountReachable = false
+        accountUnreachableReason = .signedOut
+        accountLocallySourced = []
+        accountAnswered = []
+        accountCorpusIsWhole = false
+        isShowingCachedRows = false
+        accountReads = 0
+        accountRereads = 0
+        accountRetry?.cancel()
+        accountRetry = nil
+        // The next sign-in is entitled to ask immediately rather than serve out a cooldown started
+        // by somebody else's session.
+        lastRevalidate = nil
+        recompose()
+    }
+
+    /// When the panel last asked the account what changed, so a burst of mounts is one request.
+    private var lastRevalidate: Date?
+    /// When this Mac's half was last read, which decides how many days a revalidation re-reads.
+    private var lastLocalRead: Date?
+
+    /// The shortest gap between two revalidations.
+    ///
+    /// **Main's number, deliberately** — `PollingConfig.activationCooldown` is 60 seconds, for the
+    /// reason its own comment gives: activation fires on every cmd-tab, and a panel that answers
+    /// each one with three requests is a client that spends someone's rate limit to re-learn what it
+    /// already knew. This surface has more reason to be careful than main does, not less; it was
+    /// last found rendering an entire account as 429 for hours.
+    nonisolated static let revalidationCooldown: TimeInterval = 60
+
+    /// Whether enough time has passed. A free function over its inputs so the cooldown is provable
+    /// without a clock — the same shape, and the same reason, as `PollingConfig`'s.
+    nonisolated static func shouldRevalidate(now: Date, lastRevalidate: Date?) -> Bool {
+        guard let lastRevalidate else { return true }
+        return now.timeIntervalSince(lastRevalidate) >= revalidationCooldown
     }
 
     /// The question the host is asking: the chip, the typed term, the time bounds.
@@ -377,12 +517,14 @@ final class ActivityStore: ObservableObject {
         // has already fetched are the same pages whichever window is open, because no source here is
         // fetched by date — so a re-opened window costs no re-reads, only a fresh budget.
         accountCorpusIsWhole = false
+        isShowingCachedRows = false
         accountReads = 0
         corpusSettled = false
         isPreparing = store() != nil
         readFailure = nil
         loader.purge()
 
+        seedFromCache(generation: generation)
         readAccount(generation: generation)
 
         guard let store = store() else {
@@ -392,6 +534,7 @@ final class ActivityStore: ObservableObject {
             return
         }
         capture = .open
+        lastLocalRead = Date()
         // A watch left over from a window opened before the database existed would fire again the
         // moment it noticed one, re-opening a window this call has just opened.
         storeWatch?.cancel()
@@ -433,6 +576,58 @@ final class ActivityStore: ObservableObject {
         }
     }
 
+    // MARK: - The paint before the network
+
+    /// Draws the account's last answer off disk while the real one is in flight.
+    ///
+    /// **Deliberately not `absorb(account:)`.** That path draws conclusions — the account answered,
+    /// these sources are live, the corpus is this whole — and a copy on disk supports none of them.
+    /// Everything this touches is the rows themselves; every published fact about the *account*
+    /// stays exactly as `openWindow` left it, so the corner keeps saying "still counting", the
+    /// unreachable copy keeps its own counsel, and the first real answer replaces these rows without
+    /// having to undo a claim this made on its behalf.
+    private func seedFromCache(generation: Int) {
+        guard let cache else { return }
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let cached = await cache.load()
+            await self?.seed(cached: cached, generation: generation)
+        }
+    }
+
+    private func seed(
+        cached: (
+            conversations: [ActivityAccountConversation], memories: [ActivityAccountMemory],
+            tasks: [ActivityAccountTask]
+        ),
+        generation: Int
+    ) {
+        guard generation == self.generation else { return }
+        // **The account outranks a copy of it — but only where it actually spoke.** On a warm
+        // connection the network can beat the disk, and painting a cache over an answer that has
+        // landed would put rows back the account has just said are gone. That is what the second
+        // clause refuses, and an *empty* answer is covered by it: a source in `answered` said
+        // "nothing", which is a fact about the account and outranks anything on disk.
+        //
+        // `accountSettled` alone would have been the wrong test, and wrong in the direction that
+        // matters most. A read comes back settled whether it answered or not, so an offline
+        // launch — the single case where a cached paint is the whole of what the user gets — would
+        // have raced the disk against a failure and lost to it about half the time.
+        guard accountFeed.rowCount == 0, accountFeed.answered.isEmpty else { return }
+        guard !(cached.conversations.isEmpty && cached.memories.isEmpty && cached.tasks.isEmpty)
+        else { return }
+
+        accountFeed = ActivityAccountFeed(
+            conversations: cached.conversations, memories: cached.memories, tasks: cached.tasks,
+            // Nothing answered. This is the load-bearing half of the whole file — see above.
+            answered: [])
+        isShowingCachedRows = true
+        ContextLog.info(
+            "Account cache: painting \(cached.conversations.count) conversations, "
+                + "\(cached.memories.count) memories, \(cached.tasks.count) tasks while the account "
+                + "is asked", "activity")
+        recompose()
+    }
+
     /// The generation of the account read currently in flight, if there is one.
     ///
     /// Stamped with the generation rather than a bare flag so that a window opening while an old
@@ -462,6 +657,8 @@ final class ActivityStore: ObservableObject {
         let grew = feed.rowCount > accountFeed.rowCount
         let wasFirst = !accountSettled
         accountFeed = feed
+        // Whatever was painted off disk has just been replaced by what the account said.
+        isShowingCachedRows = false
         accountSettled = true
         accountReachable = feed.reachable
         accountUnreachableReason = feed.reachable ? nil : reason
@@ -512,6 +709,21 @@ final class ActivityStore: ObservableObject {
         } else {
             recomposeSoon()
         }
+
+        // **Twice per window, and both times for a reason.** The first answer is precisely the page
+        // a cold launch needs to paint, so it is worth keeping the moment it lands rather than at
+        // the end of a walk the user may quit before. The settled corpus is the best copy that
+        // window will ever have. Every page in between is the same newest rows plus older ones the
+        // cache is going to trim off anyway, so writing those would be a database write per page to
+        // store nothing new.
+        if wasFirst || accountCorpusIsWhole { write(feed, toCache: generation) }
+    }
+
+    /// Writes the answer back for the next cold launch to paint. Detached: this is a SQLite write on
+    /// the path of a read that has already been absorbed, and nothing on screen is waiting for it.
+    private func write(_ feed: ActivityAccountFeed, toCache generation: Int) {
+        guard let cache, generation == self.generation, feed.reachable else { return }
+        Task.detached(priority: .utility) { await cache.save(feed) }
     }
 
     // MARK: - Hydration
@@ -526,6 +738,15 @@ final class ActivityStore: ObservableObject {
     /// of each kind. The reference draws the same sentence from `SpineHydrator.state == .whole` and
     /// keeps saying `so far · still counting` until every page is in; this is that signal.
     private var accountCorpusIsWhole = false
+
+    /// Whether the account rows currently composed came off disk rather than off the wire.
+    ///
+    /// **It exists so the corner cannot call a cached number final.** An unreachable account makes
+    /// `accountCorpusIsWhole` true on purpose — there are no more pages coming, so the count has
+    /// genuinely stopped moving — and before there was a cache that was also honest, because an
+    /// unreachable account contributed no rows at all. Now it can contribute two hundred, and
+    /// "everything Omi has kept" stated over yesterday's copy is a claim nobody checked.
+    private var isShowingCachedRows = false
 
     /// How many reads this window has spent on the account. Bounded by `maximumAccountReads`.
     private var accountReads = 0
@@ -786,7 +1007,8 @@ final class ActivityStore: ObservableObject {
     /// no more pages to give rather than when the first of them arrived.
     private func updateCorpusSettled() {
         corpusSettled =
-            accountSettled && accountCorpusIsWhole && !isPreparing && queue.isEmpty && active == 0
+            accountSettled && accountCorpusIsWhole && !isShowingCachedRows && !isPreparing
+            && queue.isEmpty && active == 0
     }
 
     private func refilter() {

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityStore.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivityStore.swift
@@ -378,14 +378,13 @@ final class ActivityStore: ObservableObject {
         guard Self.shouldRevalidate(now: now, lastRevalidate: lastRevalidate) else { return }
         lastRevalidate = now
 
-        let generation = self.generation
-        Task { [weak self, account] in
-            // Sends the reader's cursor back to offset zero for one read, which is the only offset a
-            // forward-only walk never re-asks for and the only one new rows arrive at.
-            await (account as? ActivityAccountCursor)?.refreshHead()
-            guard let self, generation == self.generation else { return }
-            self.readAccount(generation: generation)
-        }
+        // **The reopen and the read it is for are one operation, so they take the slot together.**
+        // Spawning the reopen and calling `readAccount` after it left a window in which the retry
+        // ladder or the sign-in subscription could claim the slot first: that read would then be
+        // refused nothing and this one refused everything, and the reopened head would sit
+        // unconsumed until whatever asked next. Passing the intent into `readAccount` puts the whole
+        // sequence behind the one guard that already exists for it.
+        readAccount(generation: generation, reopeningHead: true)
         revalidateLocalHalf(generation: generation)
     }
 
@@ -582,12 +581,16 @@ final class ActivityStore: ObservableObject {
     /// the window opening, the healing ladder, and hydration — and hydration reads again whenever a
     /// read grew the corpus. Two overlapping reads would each grow the corpus and each start their
     /// own successor, so a second reader is not a duplicate request, it is a doubling one.
-    private func readAccount(generation: Int) {
+    /// - Parameter reopeningHead: send the reader's cursor back to offset zero before reading. The
+    ///   only offset a forward-only walk never re-asks for, and the only one new rows arrive at.
+    ///   Inside the single-flight slot rather than before it — see `revalidate`.
+    private func readAccount(generation: Int, reopeningHead: Bool = false) {
         guard accountReadInFlight != generation else { return }
         accountReadInFlight = generation
         let since = self.since
         let until = self.until
         Task { [weak self, account] in
+            if reopeningHead { await (account as? ActivityAccountCursor)?.refreshHead() }
             let feed = await account.read(
                 since: since, until: until, limit: Self.accountCeiling)
             // Asked only when it matters, and only of a reader that has one. A reachable account has
@@ -676,11 +679,25 @@ final class ActivityStore: ObservableObject {
         // read that added rows means there are more pages behind it and the next one is worth
         // making; a read that added none has either reached the end of the account or failed, and
         // neither improves by asking again — the healing ladder below owns the second case.
-        let grew = feed.rowCount > accountFeed.rowCount
+        // **A source that did not answer does not get to erase what is on screen for it.**
+        //
+        // This is the offline launch, and getting it wrong made the cache worthless in the one case
+        // it matters most: the seed paints from disk, the failing read lands a moment later carrying
+        // nothing, and replacing the feed wholesale wiped the rows the user had just been shown.
+        // Which of the two landed first was a race, so the panel was empty about half the time.
+        //
+        // Per source rather than whole-feed, because the account fails per source — conversations
+        // served while `/v3/memories` answered 503 for eight hours. What each source last said
+        // stands until that source itself says otherwise. `answered` below is still the *read's*
+        // own, never the merge's: the rows may be retained, but the claim about who spoke may not.
+        let held = Self.retaining(rowsNotAnsweredIn: feed, from: accountFeed)
+        let grew = held.rowCount > accountFeed.rowCount
         let wasFirst = !accountSettled
-        accountFeed = feed
-        // Whatever was painted off disk has just been replaced by what the account said.
-        isShowingCachedRows = false
+        // Still a cached paint for as long as any source on screen is standing on rows that came
+        // off disk rather than out of an answer.
+        isShowingCachedRows =
+            isShowingCachedRows && feed.answered.count < ActivityAccountSource.allCases.count
+        accountFeed = held
         accountSettled = true
         accountReachable = feed.reachable
         accountUnreachableReason = feed.reachable ? nil : reason
@@ -765,6 +782,42 @@ final class ActivityStore: ObservableObject {
             let epoch = await cache.currentEpoch()
             self?.accountCacheEpoch = epoch
         }
+    }
+
+    /// `feed`, with any source it neither answered for **nor carried rows for** taken from
+    /// `previous`.
+    ///
+    /// **Both halves of that condition are load-bearing, and getting the first one alone wrong is
+    /// how this was first written.** The paging reader answers with everything it has gathered, so a
+    /// source absent from `answered` routinely still carries hundreds of perfectly real rows it
+    /// fetched on an earlier read — that is the documented shape of a page that did not arrive, not
+    /// a stale leftover, and substituting the previous feed for it threw the whole corpus away on
+    /// the first partial answer. The existing spine tests caught it immediately.
+    ///
+    /// So what is retained is only the case the cache exists for: a source that said nothing *and*
+    /// handed over nothing, where the rows on screen came off disk and the alternative is a blank
+    /// panel. An **answered** source is always taken as it comes, empty included — "I hold nothing"
+    /// is an answer, and the account is the authority on it.
+    ///
+    /// Retained rows keep whatever standing they already had; `isShowingCachedRows` is what says a
+    /// paint is still a copy. Nothing here promotes them.
+    nonisolated static func retaining(
+        rowsNotAnsweredIn feed: ActivityAccountFeed, from previous: ActivityAccountFeed
+    ) -> ActivityAccountFeed {
+        guard feed.answered.count < ActivityAccountSource.allCases.count else { return feed }
+        func rows<Row>(
+            _ source: ActivityAccountSource, _ incoming: [Row], _ held: [Row]
+        ) -> [Row] {
+            if feed.answered.contains(source) { return incoming }
+            return incoming.isEmpty ? held : incoming
+        }
+        return ActivityAccountFeed(
+            conversations: rows(.conversations, feed.conversations, previous.conversations),
+            memories: rows(.memories, feed.memories, previous.memories),
+            tasks: rows(.tasks, feed.tasks, previous.tasks),
+            answered: feed.answered,
+            locallySourced: feed.locallySourced,
+            memoriesBeginPastHead: feed.memoriesBeginPastHead)
     }
 
     // MARK: - Hydration
@@ -852,7 +905,12 @@ final class ActivityStore: ObservableObject {
 
     private func absorb(opening: ActivityOpeningRead, generation: Int) {
         guard generation == self.generation else { return }
-        if opening.failed { readFailure = Self.readFailureNote }
+        // **Cleared on success, not only set on failure.** `openWindow` used to be the one thing
+        // that reset this, which was enough while an opening read happened once per window. A
+        // revalidation runs another one, so a transient failure — a database busy for a moment
+        // during a migration — left the panel apologising for a read that had since succeeded, for
+        // as long as the process lived.
+        readFailure = opening.failed ? Self.readFailureNote : nil
         sessions = opening.sessions
         uploadLinks = opening.uploadLinks
         // One frame of an app captured today teaches the whole back catalogue of that app what its

--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySurface.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySurface.swift
@@ -47,16 +47,48 @@ struct ActivitySurface: View {
     /// file — this is the whole of the push.
     @State private var detail: ActivityDetailRequest?
 
+    /// The surface over a store somebody else owns — which in the app is always `ActivitySpine`.
+    ///
+    /// **The store is handed in rather than built here, and that is the whole of the change that
+    /// made re-opening the panel instant.** A `@StateObject` built in this initialiser lived exactly
+    /// as long as this view did, and this view is rebuilt on every summoning of the search window
+    /// and unmounted every time the panel switches to search results — so a hydrated corpus was
+    /// discarded and re-paged from offset zero three different ordinary ways. See `ActivitySpine`.
+    ///
+    /// It stays a `@StateObject` for SwiftUI's benefit: the wrapped value is the shared instance, so
+    /// the autoclosure returns the same object however many times the view is rebuilt, and the host
+    /// rather than the view is what keeps it alive.
     init(
-        store: @escaping () -> ContextStore?,
-        account: ActivityAccountReading = ActivityAccountAbsent(),
+        spine: ActivityStore,
         conversations: ActivityConversationReading = ActivityConversationSource(),
         query: String = "",
         since: Double? = nil,
         until: Double? = nil,
         onOpenMoment: @escaping (ActivityMoment) -> Void = { _ in }
     ) {
-        _store = StateObject(wrappedValue: ActivityStore(store: store, account: account))
+        _store = StateObject(wrappedValue: spine)
+        _detailModel = StateObject(wrappedValue: ActivityDetailModel(source: conversations))
+        self.query = query
+        self.since = since
+        self.until = until
+        self.onOpenMoment = onOpenMoment
+    }
+
+    /// The surface over a store of its own. Tests and previews that want a fresh spine per case;
+    /// the app never takes this path, because a store per surface is what `ActivitySpine` exists to
+    /// stop being true.
+    init(
+        store: @escaping () -> ContextStore?,
+        account: ActivityAccountReading = ActivityAccountAbsent(),
+        cache: ActivityAccountCache? = nil,
+        conversations: ActivityConversationReading = ActivityConversationSource(),
+        query: String = "",
+        since: Double? = nil,
+        until: Double? = nil,
+        onOpenMoment: @escaping (ActivityMoment) -> Void = { _ in }
+    ) {
+        _store = StateObject(
+            wrappedValue: ActivityStore(store: store, account: account, cache: cache))
         _detailModel = StateObject(wrappedValue: ActivityDetailModel(source: conversations))
         self.query = query
         self.since = since

--- a/desktop/context-for-claude/Sources/ContextApp/Backend/OmiActivityFeed.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Backend/OmiActivityFeed.swift
@@ -232,17 +232,25 @@ struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing, Activ
         // `tried` is what keeps that from becoming a retry ladder: a source that has already been
         // asked in this read is not asked again, whatever it answered. One attempt per source per
         // read, here as everywhere else in this file — `OmiAPI` has already done the retrying.
+        // **Which account this read belongs to, captured before a single request leaves.** A read is
+        // a network round trip and `forget()` is a keystroke, so the two overlap: without this, a
+        // page fetched for the account the user has just signed out of commits into a corpus that
+        // was emptied while it was in flight, and the panel repopulates with the previous account's
+        // conversations. The commits below quote it and `AccountCorpus` drops the ones that no
+        // longer match.
+        let epoch = await corpus.epoch()
+
         var tried: Set<ActivityAccountSource> = []
         pages: for _ in ActivityAccountSource.allCases.indices {
             let before = await corpus.rowCount()
             switch await corpus.next(skipping: tried) {
             case .opening:
                 // The opening read has asked all three already; there is nothing left to try.
-                await readOpeningPage(limit: bounded)
+                await readOpeningPage(limit: bounded, epoch: epoch)
                 break pages
             case .page(let source, let offset):
                 tried.insert(source)
-                await readPage(source, offset: offset, limit: bounded)
+                await readPage(source, offset: offset, limit: bounded, epoch: epoch)
             case .settled:
                 // Every source has ended, failed out, spent its budget or been asked already.
                 // Nothing more is asked, and the answer is what is already held — which is what
@@ -284,7 +292,7 @@ struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing, Activ
     /// blocked on, so serial reads would cost the sum of three round trips to show one screen; every
     /// page after this one lands behind a list the reader can already use, where a second request in
     /// flight buys nothing and spends someone's account.
-    private func readOpeningPage(limit: Int) async {
+    private func readOpeningPage(limit: Int, epoch: Int) async {
         async let conversationRows = attempt(
             "conversations", fetchConversations, Self.conversationQuery(limit: limit, offset: 0))
         async let memoryRows = attemptMemories(limit: limit, offset: 0)
@@ -294,24 +302,27 @@ struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing, Activ
         // and windowing by either would drop the undated commitments that matter most.
         async let taskPage = attempt("action-items", fetchTasks, Self.taskQuery(limit: limit, offset: 0))
 
-        await corpus.commit(conversations: await conversationRows)
-        await corpus.commit(memories: await memoryRows)
-        await corpus.commit(tasks: await taskPage)
+        await corpus.commit(conversations: await conversationRows, epoch: epoch)
+        await corpus.commit(memories: await memoryRows, epoch: epoch)
+        await corpus.commit(tasks: await taskPage, epoch: epoch)
     }
 
     /// One page of one source, at the offset the cursor asked for.
-    private func readPage(_ source: ActivityAccountSource, offset: Int, limit: Int) async {
+    private func readPage(
+        _ source: ActivityAccountSource, offset: Int, limit: Int, epoch: Int
+    ) async {
         switch source {
         case .conversations:
             let outcome = await attempt(
                 "conversations", fetchConversations, Self.conversationQuery(limit: limit, offset: offset))
-            await corpus.commit(conversations: outcome)
+            await corpus.commit(conversations: outcome, epoch: epoch)
         case .memories:
-            await corpus.commit(memories: await attemptMemories(limit: limit, offset: offset))
+            await corpus.commit(
+                memories: await attemptMemories(limit: limit, offset: offset), epoch: epoch)
         case .tasks:
             let outcome = await attempt(
                 "action-items", fetchTasks, Self.taskQuery(limit: limit, offset: offset))
-            await corpus.commit(tasks: outcome)
+            await corpus.commit(tasks: outcome, epoch: epoch)
         }
     }
 
@@ -654,14 +665,28 @@ private actor AccountCorpus {
         return .settled
     }
 
-    func commit(conversations outcome: OmiActivityFeed.SourceOutcome<[WireConversation]>) {
+    /// Which account the rows in here belong to. Bumped by `forgetEverything`; quoted by every
+    /// commit, so a page fetched for an account the user has since signed out of is dropped instead
+    /// of repopulating an emptied corpus. See `epoch` in `OmiActivityFeed.read`.
+    private var generation = 0
+
+    func epoch() -> Int { generation }
+
+    /// Whether a page fetched at `epoch` may still be filed. False after a sign-out.
+    private func isCurrent(_ epoch: Int) -> Bool { epoch == generation }
+
+    func commit(
+        conversations outcome: OmiActivityFeed.SourceOutcome<[WireConversation]>, epoch: Int
+    ) {
+        guard isCurrent(epoch) else { return }
         record(.conversations, outcome, received: outcome.rows?.count)
         for row in outcome.rows ?? [] {
             absorb(.conversations, id: row.id, row: row, into: &conversations)
         }
     }
 
-    func commit(memories outcome: OmiActivityFeed.SourceOutcome<[WireMemory]>) {
+    func commit(memories outcome: OmiActivityFeed.SourceOutcome<[WireMemory]>, epoch: Int) {
+        guard isCurrent(epoch) else { return }
         if outcome.beganPastHead { memoriesBeganPastHead = true }
         record(.memories, outcome, received: outcome.rows?.count)
         for row in outcome.rows ?? [] {
@@ -669,7 +694,8 @@ private actor AccountCorpus {
         }
     }
 
-    func commit(tasks outcome: OmiActivityFeed.SourceOutcome<WireActionItemPage>) {
+    func commit(tasks outcome: OmiActivityFeed.SourceOutcome<WireActionItemPage>, epoch: Int) {
+        guard isCurrent(epoch) else { return }
         record(.tasks, outcome, received: outcome.rows?.actionItems.count)
         // The one source that can say it has reached the end without an empty page to prove it.
         if let page = outcome.rows, !page.hasMore { state[.tasks]?.isExhausted = true }
@@ -691,6 +717,9 @@ private actor AccountCorpus {
     /// than reassigned wholesale — an actor cannot replace `self`, and a field added later that this
     /// forgot to clear would be one account's data surviving into another's session.
     func forgetEverything() {
+        // First, so that a page already in flight for the previous account cannot file itself
+        // between this call and the next read.
+        generation &+= 1
         conversations = []
         memories = []
         tasks = []

--- a/desktop/context-for-claude/Sources/ContextApp/Backend/OmiActivityFeed.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Backend/OmiActivityFeed.swift
@@ -247,6 +247,7 @@ struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing, Activ
             case .opening:
                 // The opening read has asked all three already; there is nothing left to try.
                 await readOpeningPage(limit: bounded, epoch: epoch)
+                await corpus.headWasRead()
                 break pages
             case .page(let source, let offset):
                 tried.insert(source)
@@ -672,6 +673,9 @@ private actor AccountCorpus {
 
     func epoch() -> Int { generation }
 
+    /// The reopened head has been read; later pages are ordinary paging again and may not delete.
+    func headWasRead() { headIsAuthoritative = false }
+
     /// Whether a page fetched at `epoch` may still be filed. False after a sign-out.
     private func isCurrent(_ epoch: Int) -> Bool { epoch == generation }
 
@@ -680,6 +684,12 @@ private actor AccountCorpus {
     ) {
         guard isCurrent(epoch) else { return }
         record(.conversations, outcome, received: outcome.rows?.count)
+        if let rows = outcome.rows, isHeadReread(outcome) {
+            prune(
+                .conversations, keeping: rows.compactMap(\.id),
+                newerThan: rows.compactMap { $0.startedAt?.seconds ?? $0.createdAt?.seconds }.min(),
+                from: &conversations, at: { $0.startedAt?.seconds ?? $0.createdAt?.seconds })
+        }
         for row in outcome.rows ?? [] {
             absorb(.conversations, id: row.id, row: row, into: &conversations)
         }
@@ -689,6 +699,15 @@ private actor AccountCorpus {
         guard isCurrent(epoch) else { return }
         if outcome.beganPastHead { memoriesBeganPastHead = true }
         record(.memories, outcome, received: outcome.rows?.count)
+        // **Never for memories that had to start past their own head.** That page is complete
+        // except at the top by construction, so the rows above it are absent because they were
+        // never asked for — deleting them would be reading "not fetched" as "deleted".
+        if let rows = outcome.rows, isHeadReread(outcome), !outcome.beganPastHead {
+            prune(
+                .memories, keeping: rows.compactMap(\.id),
+                newerThan: rows.compactMap { $0.capturedAt?.seconds ?? $0.createdAt?.seconds }.min(),
+                from: &memories, at: { $0.capturedAt?.seconds ?? $0.createdAt?.seconds })
+        }
         for row in outcome.rows ?? [] {
             absorb(.memories, id: row.id, row: row, into: &memories)
         }
@@ -699,9 +718,61 @@ private actor AccountCorpus {
         record(.tasks, outcome, received: outcome.rows?.actionItems.count)
         // The one source that can say it has reached the end without an empty page to prove it.
         if let page = outcome.rows, !page.hasMore { state[.tasks]?.isExhausted = true }
+        if let page = outcome.rows, isHeadReread(outcome) {
+            prune(
+                .tasks, keeping: page.actionItems.compactMap(\.id),
+                newerThan: page.actionItems.compactMap { $0.createdAt?.seconds }.min(),
+                from: &tasks, at: { $0.createdAt?.seconds })
+        }
         for row in outcome.rows?.actionItems ?? [] {
             absorb(.tasks, id: row.id, row: row, into: &tasks)
         }
+    }
+
+    /// Whether this page is a re-read of a head we have already seen, and so may delete.
+    private func isHeadReread<Row>(_ outcome: OmiActivityFeed.SourceOutcome<Row>) -> Bool {
+        headIsAuthoritative && outcome.offset == 0
+    }
+
+    /// Drops rows the account has stopped listing, **within the window the new head page covers.**
+    ///
+    /// Without this a revalidation could only add and update: `reopenHead` re-reads offset zero and
+    /// `absorb` replaces the ids it sees, so a conversation deleted on the phone stayed on the spine
+    /// for the life of the process. That is a regression the process-lived store introduced — a
+    /// panel rebuilt per window used to lose the row simply by being rebuilt.
+    ///
+    /// **The bound is what makes it safe.** A head page is authoritative only for its own range: it
+    /// returned the newest `limit` rows, so anything held that is *newer than its oldest row* and
+    /// absent from it has genuinely gone. Everything older is behind the page and says nothing about
+    /// itself. An empty head page means the source now holds nothing at all, and every row goes.
+    private func prune<Row>(
+        _ source: ActivityAccountSource,
+        keeping ids: [String],
+        newerThan oldest: Double?,
+        from rows: inout [Row],
+        at instant: (Row) -> Double?
+    ) {
+        let returned = Set(ids)
+        func survives(_ row: Row, _ id: String) -> Bool {
+            if returned.contains(id) { return true }
+            // Older than the page's own reach, so the page is not evidence about it.
+            guard let oldest else { return false }
+            guard let at = instant(row) else { return true }
+            return at < oldest
+        }
+
+        var kept: [Row] = []
+        var rebuilt: [String: Int] = [:]
+        kept.reserveCapacity(rows.count)
+        let byIndex = Dictionary(uniqueKeysWithValues: (index[source] ?? [:]).map { ($1, $0) })
+        for (position, row) in rows.enumerated() {
+            guard let id = byIndex[position] else { continue }
+            guard survives(row, id) else { continue }
+            rebuilt[id] = kept.count
+            kept.append(row)
+        }
+        rows = kept
+        index[source] = rebuilt
     }
 
     /// Reopens the newest page of every source without disturbing where hydration has walked to.
@@ -711,7 +782,13 @@ private actor AccountCorpus {
     /// it, and the rows arriving at offset zero are in front of the cursor rather than behind it.
     func reopenHead() {
         didOpen = false
+        headIsAuthoritative = true
     }
+
+    /// Whether the next opening commit is a *re-read* of the head rather than a first sight of it.
+    ///
+    /// It is what lets a re-read delete. See `prune(_:keeping:newerThan:)`.
+    private var headIsAuthoritative = false
 
     /// Back to the state this actor was constructed in. Every field, deliberately enumerated rather
     /// than reassigned wholesale — an actor cannot replace `self`, and a field added later that this

--- a/desktop/context-for-claude/Sources/ContextApp/Backend/OmiActivityFeed.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Backend/OmiActivityFeed.swift
@@ -91,7 +91,7 @@ import Foundation
 /// only when *no* source answered, which is also the exact shape of every reason the account is
 /// genuinely unavailable: Airgap Mode, signed out, no route, an outage. Those fail all three
 /// together, so the distinction the field exists for survives.
-struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing {
+struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing, ActivityAccountCursor {
 
     // Everything that reaches off this file, as replaceable closures with the production wiring as
     // their defaults — the pattern `ScreenActivityUploader` established. It is what lets the airgap
@@ -136,6 +136,39 @@ struct OmiActivityFeed: ActivityAccountReading, ActivityAccountDiagnosing {
 
     func unreachableReason() async -> ActivityAccountUnreachableReason? {
         await diagnosis.reason()
+    }
+
+    /// Reopens the newest page of every source, so the next `read` asks the account for it again.
+    ///
+    /// **The corpus is a cursor that only ever moves forward, and that is right for hydration and
+    /// wrong for coming back to a panel an hour later.** Once every source has run out of pages the
+    /// reader answers `.settled` and makes no further request for the life of the window: correct,
+    /// because nothing behind the cursor changes, and useless, because everything *in front* of it
+    /// does. A conversation recorded since the last read lives at offset zero, which is the one
+    /// offset a forward-only walk will never ask for twice.
+    ///
+    /// So this clears the opening flag and nothing else. The next read races the three heads exactly
+    /// as a first read does, new rows are appended, rows already held are **updated in place** —
+    /// which is how a title the account has since written reaches a row that was cached untitled —
+    /// and each source's paging cursor is left where hydration left it, so revalidating costs three
+    /// requests rather than a second walk of the account.
+    ///
+    /// Deliberately not a `read` of its own. The store still calls `read`, so the local-memory
+    /// decorator still wraps the answer and there is one path into the feed rather than two.
+    func refreshHead() async {
+        await corpus.reopenHead()
+    }
+
+    /// Drops every row and every cursor. The signed-in account has changed.
+    ///
+    /// **This reader now outlives a sign-out and did not used to.** It was built per panel, so
+    /// forgetting was what happened when the window closed and nothing had to say so. One reader for
+    /// the life of the process is what makes coming back to the panel instant (`ActivitySpine`), and
+    /// the price of that is exactly this: the corpus is account-scoped state, and nobody else is
+    /// going to throw it away on the way out.
+    func forget() async {
+        await corpus.forgetEverything()
+        await diagnosis.record(nil)
     }
 
     /// One page per source. The spine shows a window of a day, not an account export, and every one
@@ -558,7 +591,12 @@ private actor AccountCorpus {
     private var conversations: [WireConversation] = []
     private var memories: [WireMemory] = []
     private var tasks: [WireActionItem] = []
-    private var seen: [ActivityAccountSource: Set<String>] = [:]
+    /// Where each id already sits in the array above, so a row seen twice is *replaced* rather than
+    /// dropped. A set of ids could only answer "have we had this one", which was enough while the
+    /// cursor only moved forward and is not enough now `reopenHead` re-asks for page zero: the whole
+    /// point of re-asking is that a row may have changed since, and the change we care about most is
+    /// a conversation the backend has titled in the meantime.
+    private var index: [ActivityAccountSource: [String: Int]] = [:]
     private var state: [ActivityAccountSource: SourceState] = [:]
     private var didOpen = false
     private var memoriesBeganPastHead = false
@@ -618,16 +656,16 @@ private actor AccountCorpus {
 
     func commit(conversations outcome: OmiActivityFeed.SourceOutcome<[WireConversation]>) {
         record(.conversations, outcome, received: outcome.rows?.count)
-        for row in outcome.rows ?? [] where insert(.conversations, id: row.id) {
-            conversations.append(row)
+        for row in outcome.rows ?? [] {
+            absorb(.conversations, id: row.id, row: row, into: &conversations)
         }
     }
 
     func commit(memories outcome: OmiActivityFeed.SourceOutcome<[WireMemory]>) {
         if outcome.beganPastHead { memoriesBeganPastHead = true }
         record(.memories, outcome, received: outcome.rows?.count)
-        for row in outcome.rows ?? [] where insert(.memories, id: row.id) {
-            memories.append(row)
+        for row in outcome.rows ?? [] {
+            absorb(.memories, id: row.id, row: row, into: &memories)
         }
     }
 
@@ -635,9 +673,32 @@ private actor AccountCorpus {
         record(.tasks, outcome, received: outcome.rows?.actionItems.count)
         // The one source that can say it has reached the end without an empty page to prove it.
         if let page = outcome.rows, !page.hasMore { state[.tasks]?.isExhausted = true }
-        for row in outcome.rows?.actionItems ?? [] where insert(.tasks, id: row.id) {
-            tasks.append(row)
+        for row in outcome.rows?.actionItems ?? [] {
+            absorb(.tasks, id: row.id, row: row, into: &tasks)
         }
+    }
+
+    /// Reopens the newest page of every source without disturbing where hydration has walked to.
+    ///
+    /// One flag, and the restraint is the design — see `OmiActivityFeed.refreshHead`. `nextOffset`,
+    /// `pages` and `isExhausted` are all left alone: a source that has reached its end has reached
+    /// it, and the rows arriving at offset zero are in front of the cursor rather than behind it.
+    func reopenHead() {
+        didOpen = false
+    }
+
+    /// Back to the state this actor was constructed in. Every field, deliberately enumerated rather
+    /// than reassigned wholesale — an actor cannot replace `self`, and a field added later that this
+    /// forgot to clear would be one account's data surviving into another's session.
+    func forgetEverything() {
+        conversations = []
+        memories = []
+        tasks = []
+        index = [:]
+        state = [:]
+        didOpen = false
+        memoriesBeganPastHead = false
+        rotation = 0
     }
 
     /// How many rows are held over every source — the reader's own version of the growth signal the
@@ -669,7 +730,11 @@ private actor AccountCorpus {
             current.failures = 0
             current.lastFailure = nil
             current.everAnswered = true
-            current.nextOffset = outcome.offset + max(received, 0)
+            // **Monotonic, because the head can be re-read.** `reopenHead` sends the next read back
+            // to offset zero without moving the cursor, so a plain assignment here would walk the
+            // whole account again from page one after every revalidation. A walk only ever moves
+            // forward, so taking the larger of the two is the same arithmetic everywhere else.
+            current.nextOffset = max(current.nextOffset, outcome.offset + max(received, 0))
             // `ServerPaging`: only an empty page is the end. A short one is the backend's own
             // post-filtering, and reading it as the end is how the rest of an account disappears.
             if received == 0 { current.isExhausted = true }
@@ -680,11 +745,27 @@ private actor AccountCorpus {
         state[source] = current
     }
 
-    /// Whether this row is one we have not already been handed. A row with no id cannot be
-    /// identified, so it cannot be diffed, deduplicated or rendered — the projection drops it too.
-    private func insert(_ source: ActivityAccountSource, id: String?) -> Bool {
-        guard let id, !id.isEmpty else { return false }
-        return seen[source, default: []].insert(id).inserted
+    /// Files one row under its identity: appended the first time, **replaced** every time after.
+    ///
+    /// Replacement rather than the first-sighting-wins rule this used to have. Both are correct for
+    /// a forward-only walk, where a row arriving twice is the offset drift `ServerPaging` documents
+    /// and the two copies are the same row. They are not both correct once `reopenHead` re-asks for
+    /// page zero: there the second copy is deliberately newer, and keeping the first is how a
+    /// conversation the backend titled ten minutes ago goes on reading `Untitled conversation` until
+    /// the panel is rebuilt. Position is held constant so nothing reorders under the reader.
+    ///
+    /// A row with no id cannot be identified, so it cannot be diffed, selected or scrolled to — the
+    /// projection drops it too, and it is dropped here rather than appended unkeyed.
+    private func absorb<Row>(
+        _ source: ActivityAccountSource, id: String?, row: Row, into rows: inout [Row]
+    ) {
+        guard let id, !id.isEmpty else { return }
+        if let existing = index[source]?[id] {
+            rows[existing] = row
+            return
+        }
+        index[source, default: [:]][id] = rows.count
+        rows.append(row)
     }
 }
 

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarView.swift
@@ -90,20 +90,26 @@ struct SearchBarView: View {
         case results
     }
 
-    /// The account half of the activity body.
+    /// The Activity store the lower panel draws.
     ///
     /// **A stored seam and not an expression inside `body`**, because the expression was a way for a
     /// render harness to read the user's real memories. The preview initialiser below can only nil
     /// out the *search* store; the activity branch built its own live reader every time it drew, so
     /// an empty-query harness case rendered this person's saved memories into PNGs on disk. Held
-    /// here, the harness passes `ActivityAccountAbsent()` and the promise its header makes — that
-    /// nothing of the user's is ever captured — is one the type system keeps.
-    private let account: ActivityAccountReading
+    /// here, the harness is handed an inert store and the promise its header makes — that nothing of
+    /// the user's is ever captured — is one the type system keeps.
+    ///
+    /// It is the *store* rather than the account reader behind it, because the store is the thing
+    /// that has to outlive this view: see `ActivitySpine`. Passing a reader meant a store per panel,
+    /// and a store per panel meant re-paging the whole account every time somebody opened the bar or
+    /// typed into it. It has no default for the same reason it is not built here — a surface that
+    /// can conjure its own spine is a surface that will, in some future call site nobody reviews.
+    private let spine: ActivityStore
 
     init(
         initialQuery: String = "",
         store: @escaping () -> ContextStore? = { nil },
-        account: ActivityAccountReading = ActivityLocalMemories(OmiActivityFeed()),
+        spine: ActivityStore,
         onDismiss: @escaping () -> Void,
         onHeightChange: @escaping (CGFloat) -> Void = { _ in },
         onOpenMoment: @escaping (SearchMoment) -> Void = { _ in },
@@ -119,7 +125,7 @@ struct SearchBarView: View {
         self.onOpenTimeline = onOpenTimeline
         self.onOpenSettings = onOpenSettings
         self.store = store
-        self.account = account
+        self.spine = spine
         _query = State(initialValue: initialQuery)
         _results = StateObject(wrappedValue: SearchResultsModel(store: store))
         // A panel handed a question to start from is answering it, not showing the day.
@@ -133,7 +139,10 @@ struct SearchBarView: View {
         self.initialQuery = query
         self.onDismiss = onDismiss
         self.store = { nil }
-        self.account = ActivityAccountAbsent()
+        // A store that is already its own answer: no capture database behind it and no account
+        // reader, so the harness cannot reach the user's real memories through this branch however
+        // it is driven. See `ActivityStore.holdsAFixedAnswer`.
+        self.spine = ActivityStore(days: [])
         _query = State(initialValue: query)
         _results = StateObject(wrappedValue: results)
         _shownBody = State(initialValue: query.isEmpty ? .activity : .results)
@@ -234,19 +243,15 @@ struct SearchBarView: View {
                 // The time chips are the bar's, not the surface's: `SearchTimeFilter.range` already
                 // returns exactly the bounds pair the activity store narrows on, so both bodies
                 // answer "when" from one value and cannot disagree about which day it is.
+                //
+                // **The application's store, not one of this panel's own.** The branch this sits on
+                // is unmounted the moment a question is typed and rebuilt when the field is cleared,
+                // and the window around it is rebuilt on every summoning — so a store belonging to
+                // this view is a corpus thrown away and re-paged several times a session. The
+                // reader behind it is `ActivityLocalMemories(OmiActivityFeed())` exactly as it was;
+                // what changed is who owns it. See `ActivitySpine`.
                 ActivitySurface(
-                    store: store,
-                    // The real account, not the absent one. Three of the five chips — conversations,
-                    // memories, tasks — have no local source at all, so a surface built with the
-                    // default `ActivityAccountAbsent` renders four of its five filters permanently
-                    // empty and says the account is unreachable while the user is signed in.
-                    //
-                    // Wrapped so the memory column is read the way the shipping Omi app reads it —
-                    // this Mac's own database first, the account second. Without it a `/v3/memories`
-                    // outage draws an empty column indistinguishable from an empty account, which is
-                    // the state the backend has actually been in. See `ActivityLocalMemories`; the
-                    // default of `account` above is the only place the app decides to use it.
-                    account: account,
+                    spine: spine,
                     query: query,
                     since: bounds.since,
                     until: bounds.until,

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
@@ -55,6 +55,12 @@ final class SearchBarWindow {
         if let window = current {
             window.alphaValue = 1
             window.makeKeyAndOrderFront(nil)
+            // The panel is already up and already holds a composed corpus, so the right thing is
+            // main's: keep every row on screen and ask the account what changed. Bounded by
+            // `ActivityStore.revalidationCooldown`, which is why hammering the hotkey is one
+            // request. The other branch does not need this — a freshly mounted surface calls
+            // `start()`, and `start()` on an already-started store revalidates.
+            ActivitySpine.shared.store.revalidate()
             NotificationCenter.default.post(
                 name: refocusNotification, object: nil,
                 userInfo: prefill.isEmpty ? nil : [prefillKey: prefill])
@@ -135,6 +141,11 @@ final class SearchBarWindow {
                 // capture opens one. Still the app's single store: a second connection would be a
                 // second migration racing the first.
                 store: { Engine.shared.contextStore },
+                // The application's Activity store, not one this panel builds. This window is
+                // rebuilt on every `present()` — `dismiss()` drops `current`, so the reuse branch
+                // above is only ever taken while the bar is already up — and a spine owned by the
+                // view would therefore re-page the whole account every time the bar is summoned.
+                spine: ActivitySpine.shared.store,
                 onDismiss: { dismiss() },
                 onHeightChange: { height in resize(to: height) },
                 onOpenMoment: { moment in open(moment) },

--- a/desktop/context-for-claude/Sources/ContextCore/AccountCacheQueries.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/AccountCacheQueries.swift
@@ -48,6 +48,12 @@ public enum AccountCacheQueries {
     /// Ordered and limited in SQL rather than in the caller: the trim below keeps the table small,
     /// but "small" is per source, and a caller wanting fifty would otherwise decode six hundred to
     /// throw most of them away — on the launch path this exists to shorten.
+    ///
+    /// **`id` breaks ties, and ties are ordinary here.** `at` is not unique: a date-only task is
+    /// stamped at 11:59 PM like every other date-only task, and a batch of memories backfilled
+    /// together shares an instant. Without a second key SQLite may pick any subset for the bounded
+    /// page and any order within it — so the page a launch paints could differ from the page the
+    /// trim below decided to keep, and the same corpus could draw in a different order each time.
     public static func recent(
         _ store: ContextStore, source: String, limit: Int
     ) throws -> [CachedAccountRow] {
@@ -57,7 +63,7 @@ public enum AccountCacheQueries {
                 db,
                 sql: """
                     SELECT source, id, at, payload FROM account_rows
-                    WHERE source = ? ORDER BY at DESC LIMIT ?
+                    WHERE source = ? ORDER BY at DESC, id DESC LIMIT ?
                     """,
                 arguments: [source, limit]
             ).map {
@@ -101,7 +107,7 @@ public enum AccountCacheQueries {
             try db.execute(
                 sql: """
                     DELETE FROM account_rows WHERE source = ? AND id NOT IN (
-                      SELECT id FROM account_rows WHERE source = ? ORDER BY at DESC LIMIT ?
+                      SELECT id FROM account_rows WHERE source = ? ORDER BY at DESC, id DESC LIMIT ?
                     )
                     """,
                 arguments: [source, source, max(limit, 0)])

--- a/desktop/context-for-claude/Sources/ContextCore/AccountCacheQueries.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/AccountCacheQueries.swift
@@ -1,0 +1,126 @@
+import Foundation
+import GRDB
+
+/// One cached account row, as the database holds it.
+public struct CachedAccountRow: Sendable, Equatable {
+    /// Which of the spine's three account sources this belongs to. A free string rather than an enum
+    /// for the same reason `payload` is a blob: the set of sources is the app target's business.
+    public let source: String
+    /// The account's own id for the row. Half the primary key, so re-caching cannot duplicate.
+    public let id: String
+    /// The row's own instant, Unix epoch seconds. Only ever used to decide which rows survive the
+    /// trim — the app re-reads whatever instant it cares about out of `payload`.
+    public let at: Double
+    /// Whatever the app encoded. JSON in practice; nothing here parses it.
+    public let payload: String
+
+    public init(source: String, id: String, at: Double, payload: String) {
+        self.source = source
+        self.id = id
+        self.at = at
+        self.payload = payload
+    }
+}
+
+/// The last thing the account said, kept on disk so a cold launch can paint before the network does.
+///
+/// **This table is a copy and never an authority.** Every row in it came from the account and is
+/// replaced by the account the moment a read lands; nothing writes a row here that did not arrive
+/// over the wire, and nothing reads from here once a real answer exists. That is the whole of the
+/// contract, and it is what makes a stale row harmless: a conversation deleted on the phone survives
+/// here only until the next read of its source, which rewrites that source wholesale.
+///
+/// **Why it exists.** The Activity spine's account half was network-only, so a cold launch drew the
+/// local sessions it had — every one of them titled `Untitled conversation`, because a title is
+/// written by the backend when a transcript is uploaded — and sat there until three HTTP round trips
+/// came back. The shipping Omi app has never looked like that for the same data: its conversation
+/// list is cache-first by construction (`ConversationRepository.load` reads SQLite, emits, *then*
+/// fetches), so it paints real titles in milliseconds. This is that arrangement, in this app's store.
+///
+/// **Opaque payloads on purpose.** `ContextCore` knows nothing about the spine's row shapes and must
+/// not: the seam types live in the app target, and teaching the database about them would put a
+/// presentation decision under a migration. A row here is an identity, an instant and a blob the app
+/// wrote, so this schema is stable across every change to what a row draws.
+public enum AccountCacheQueries {
+
+    /// The newest cached rows of one source, newest first.
+    ///
+    /// Ordered and limited in SQL rather than in the caller: the trim below keeps the table small,
+    /// but "small" is per source, and a caller wanting fifty would otherwise decode six hundred to
+    /// throw most of them away — on the launch path this exists to shorten.
+    public static func recent(
+        _ store: ContextStore, source: String, limit: Int
+    ) throws -> [CachedAccountRow] {
+        guard limit > 0 else { return [] }
+        return try store.read { db in
+            try Row.fetchAll(
+                db,
+                sql: """
+                    SELECT source, id, at, payload FROM account_rows
+                    WHERE source = ? ORDER BY at DESC LIMIT ?
+                    """,
+                arguments: [source, limit]
+            ).map {
+                CachedAccountRow(
+                    source: $0["source"], id: $0["id"], at: $0["at"], payload: $0["payload"])
+            }
+        }
+    }
+
+    /// Replaces one source's rows, and trims what is left to the newest `keeping`.
+    ///
+    /// **Scoped to the one source, and total within it.** The two halves of that are both
+    /// load-bearing and they pull in opposite directions:
+    ///
+    /// - *Scoped*, because the three sources fail independently — this is an account that served
+    ///   conversations while `/v3/memories` answered 503 for eight hours — so a write that cleared
+    ///   the whole table would turn one source's outage into the loss of a cache serving the other
+    ///   two perfectly well. A source nobody passes here keeps whatever it had.
+    /// - *Total*, because within a source the caller is handing over the account's own answer, and
+    ///   a row the account no longer lists is a row that no longer exists. Upserting instead would
+    ///   leave a conversation deleted on the phone in the cache indefinitely — it is never
+    ///   overwritten, and the trim cannot reach it while its timestamp keeps it in the newest page.
+    ///   That is a deletion the user made, coming back to their screen on every launch.
+    ///
+    /// The trim is what bounds the file. Without it the table becomes the account's whole history,
+    /// one hydration walk at a time, inside a database whose reason for existing is screen capture.
+    public static func replace(
+        _ store: ContextStore, source: String, rows: [CachedAccountRow], keeping limit: Int
+    ) throws {
+        try store.write { db in
+            try db.execute(sql: "DELETE FROM account_rows WHERE source = ?", arguments: [source])
+            for row in rows {
+                try db.execute(
+                    sql: """
+                        INSERT INTO account_rows (source, id, at, payload) VALUES (?, ?, ?, ?)
+                        ON CONFLICT(source, id) DO UPDATE SET at = excluded.at, payload = excluded.payload
+                        """,
+                    arguments: [source, row.id, row.at, row.payload])
+            }
+            // The table is `WITHOUT ROWID`, so the trim names the key it actually has.
+            try db.execute(
+                sql: """
+                    DELETE FROM account_rows WHERE source = ? AND id NOT IN (
+                      SELECT id FROM account_rows WHERE source = ? ORDER BY at DESC LIMIT ?
+                    )
+                    """,
+                arguments: [source, source, max(limit, 0)])
+        }
+    }
+
+    /// Empties the cache. Signing out is the caller: one account's rows must never be the first
+    /// thing the next account sees.
+    public static func clear(_ store: ContextStore) throws {
+        try store.write { db in
+            try db.execute(sql: "DELETE FROM account_rows")
+        }
+    }
+
+    /// How many rows one source is holding. Tests and one launch log line; nothing on a hot path.
+    public static func count(_ store: ContextStore, source: String) throws -> Int {
+        try store.read { db in
+            try Int.fetchOne(
+                db, sql: "SELECT COUNT(*) FROM account_rows WHERE source = ?", arguments: [source]) ?? 0
+        }
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextCore/Store.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/Store.swift
@@ -1223,6 +1223,35 @@ public final class ContextStore: @unchecked Sendable {
             }
         }
 
+        // The last answer the user's Omi account gave, so a cold launch paints it before the
+        // network has said anything. See `AccountCacheQueries` for what the table is and is not.
+        //
+        // `WITHOUT ROWID` because every access is by the primary key and the payload is small: the
+        // rows *are* the index, which halves the file this adds and removes a lookup from the one
+        // query that matters. `(source, id)` in that order so the per-source reads and the
+        // per-source trim are both prefix scans of the same key.
+        //
+        // No foreign key to anything. These rows describe the account, not this Mac — a cached
+        // conversation routinely has no local session behind it, because the phone recorded it —
+        // and a reference to `sessions` would delete exactly the rows a laptop that has captured
+        // nothing needs most.
+        migrator.registerMigration("v11-account-cache") { db in
+            try db.create(table: "account_rows", options: [.ifNotExists, .withoutRowID]) { t in
+                t.column("source", .text).notNull()
+                t.column("id", .text).notNull()
+                t.column("at", .double).notNull()
+                t.column("payload", .text).notNull()
+                t.primaryKey(["source", "id"])
+            }
+            // The trim and the read are the same question — "the newest N of one source" — and
+            // both are this index.
+            try db.create(
+                index: "idx_account_rows_recent",
+                on: "account_rows",
+                columns: ["source", "at"],
+                options: .ifNotExists)
+        }
+
         return migrator
     }
 

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityAccountCacheTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityAccountCacheTests.swift
@@ -1,0 +1,283 @@
+import ContextCore
+import Foundation
+import XCTest
+
+@testable import ContextApp
+
+/// The paint before the network, and the one thing it is never allowed to do.
+///
+/// **What this is a regression test for.** The Activity spine's account half was network-only, so a
+/// cold launch composed the local sessions `context.db` holds and nothing else — every one drawn as
+/// `ActivityConversation.untitled`, because a title is written by the backend when a transcript is
+/// uploaded. The user watched a column of `Untitled conversation` become real titles a second or
+/// two later, every launch. The shipping Omi app does not look like that over the same data because
+/// `ConversationRepository.load` reads SQLite, emits, and *then* fetches.
+///
+/// The danger in copying that arrangement is not staleness — a stale row is replaced by the next
+/// read and nobody is harmed. It is a cache that starts *speaking for the account*: claiming a
+/// source answered, claiming the account is reachable, settling a corpus. Every one of those is a
+/// sentence the panel says out loud, and none of them may be said on the strength of a copy. Most of
+/// what follows is that boundary.
+final class ActivityAccountCacheTests: XCTestCase {
+
+    private var root: URL!
+    private var store: ContextStore!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("activity-cache-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        store = try ContextStore(url: root.appendingPathComponent("context.db"))
+    }
+
+    override func tearDown() {
+        store = nil
+        try? FileManager.default.removeItem(at: root)
+        root = nil
+    }
+
+    private var cache: ActivityAccountCache {
+        let store = self.store!
+        return ActivityAccountCache(store: { store })
+    }
+
+    private static let base: Double = 1_760_000_000
+
+    private func conversation(
+        _ id: String, title: String = "Design review", at offset: Double = 0
+    ) -> ActivityAccountConversation {
+        ActivityAccountConversation(
+            id: id, title: title, emoji: "🎙️", startedAt: Self.base + offset,
+            finishedAt: Self.base + offset + 60, overview: "what we decided")
+    }
+
+    // MARK: - The round trip
+
+    /// The title is the entire point: a cached row that came back without one would leave the panel
+    /// exactly where it started.
+    func testEveryFieldARowDrawsSurvivesTheRoundTrip() async {
+        let written = ActivityAccountFeed(
+            conversations: [conversation("c1")],
+            memories: [
+                ActivityAccountMemory(
+                    id: "m1", content: "Ships on Friday", at: Self.base, conversationID: "c1")
+            ],
+            tasks: [
+                ActivityAccountTask(id: "t1", text: "Send the deck", completed: false, at: Self.base)
+            ],
+            answered: Set(ActivityAccountSource.allCases))
+
+        await cache.save(written)
+        let read = await cache.load()
+
+        XCTAssertEqual(read.conversations, written.conversations)
+        XCTAssertEqual(read.memories, written.memories)
+        XCTAssertEqual(read.tasks, written.tasks)
+    }
+
+    func testAnEmptyCacheIsAnEmptyAnswerRatherThanAFailure() async {
+        let read = await cache.load()
+        XCTAssertTrue(read.conversations.isEmpty)
+        XCTAssertTrue(read.memories.isEmpty)
+        XCTAssertTrue(read.tasks.isEmpty)
+    }
+
+    // MARK: - What may be written
+
+    /// **A source that did not answer is not written.** The feed carries whatever the reader has
+    /// gathered, including rows from a source that has since started failing; rewriting the cache
+    /// from those would be a copy of a copy, ageing without limit while the endpoint stays down.
+    func testASourceThatDidNotAnswerIsNotCached() async {
+        await cache.save(
+            ActivityAccountFeed(
+                conversations: [conversation("c1")],
+                memories: [ActivityAccountMemory(id: "m1", content: "Ships Friday", at: Self.base)],
+                answered: [.conversations]))
+
+        let read = await cache.load()
+        XCTAssertEqual(read.conversations.count, 1)
+        XCTAssertTrue(
+            read.memories.isEmpty,
+            "memories did not answer this read, so nothing about them was learned")
+    }
+
+    /// **And a locally-sourced one is not written either.** `ActivityLocalMemories` merges the Omi
+    /// app's own database into the memory column; caching those would be a second copy of somebody
+    /// else's table, and a later launch would read them back as *the account's* answer — a claim
+    /// this app has no business making on their behalf.
+    func testLocallySourcedRowsAreNeverCachedAsTheAccountsOwn() async {
+        await cache.save(
+            ActivityAccountFeed(
+                memories: [ActivityAccountMemory(id: "m1", content: "Ships Friday", at: Self.base)],
+                answered: [.memories],
+                locallySourced: [.memories]))
+
+        let read = await cache.load()
+        XCTAssertTrue(read.memories.isEmpty)
+    }
+
+    /// A source that answers again rewrites its own rows, so a conversation deleted on the phone
+    /// survives one paint and no longer — the same bargain main makes.
+    func testAnAnsweringSourceReplacesWhatItSaidBefore() async {
+        await cache.save(
+            ActivityAccountFeed(
+                conversations: [conversation("c1"), conversation("c2", at: 60)],
+                answered: [.conversations]))
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+
+        let read = await cache.load()
+        XCTAssertEqual(
+            read.conversations.map(\.id), ["c1"],
+            "the account no longer lists c2, so neither does its copy")
+    }
+
+    /// One page, which is the page a first paint draws from. Above that the table becomes the
+    /// account's whole history inside a database whose reason for existing is screen capture.
+    func testTheCacheIsBoundedToOnePagePerSource() async {
+        let many = (0..<(ActivityAccountCache.ceiling + 40)).map {
+            conversation("c\($0)", at: Double($0))
+        }
+        await cache.save(
+            ActivityAccountFeed(conversations: many, answered: [.conversations]))
+
+        let read = await cache.load()
+        XCTAssertEqual(read.conversations.count, ActivityAccountCache.ceiling)
+        XCTAssertEqual(
+            read.conversations.first?.id, "c\(ActivityAccountCache.ceiling + 39)",
+            "and it is the newest page that is kept, not the oldest")
+    }
+
+    /// Signing out. One account's conversations must never be the first thing the next sees.
+    func testClearingLeavesNothingToPaint() async {
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+        await cache.clear()
+
+        let read = await cache.load()
+        XCTAssertTrue(read.conversations.isEmpty)
+    }
+
+    // MARK: - What a cached paint may claim
+
+    /// **The load-bearing test of the whole feature.** A seeded store shows rows and claims nothing:
+    /// the account has not answered, no source has answered, the corpus is not settled, and the
+    /// reachability copy stays silent. Getting this wrong means the panel telling somebody their
+    /// account is fine on the strength of a file written yesterday.
+    @MainActor
+    func testASeededStoreDrawsRowsAndClaimsNothingAboutTheAccount() async {
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+
+        // An account that never answers, so the only thing on screen can be the cache.
+        let store = ActivityStore(
+            store: { nil }, account: SilentAccount(), cache: cache, calendar: Self.calendar)
+        store.start()
+        await settle()
+
+        XCTAssertEqual(store.days.count, 1, "the cached conversation is on screen")
+        XCTAssertFalse(store.accountReachable, "and the account has still said nothing")
+        XCTAssertTrue(store.accountAnswered.isEmpty, "no source answered — a copy is not an answer")
+        XCTAssertFalse(
+            store.corpusSettled, "a cache is never a finished count of what the account holds")
+    }
+
+    /// And the ordering rule underneath it: **an answer outranks a copy wherever it actually
+    /// spoke.** A slow disk must not resurrect rows the account has just said are gone — including
+    /// when what it said was "nothing", which is an answer and not an absence.
+    ///
+    /// Driven by making the *cache* slow rather than by reaching into the store: the store provider
+    /// is `async`, so a gate inside it holds the seed behind the read through the real code path.
+    @MainActor
+    func testACachedPaintNeverOverwritesAnAnswerThatAlreadyLanded() async {
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("stale")], answered: [.conversations]))
+
+        let gate = Gate()
+        let store = self.store!
+        let slow = ActivityAccountCache(store: {
+            await gate.wait()
+            return store
+        })
+        // The account answers, and what it says is that it holds nothing.
+        let spine = ActivityStore(
+            store: { nil },
+            account: EmptyButAnsweringAccount(),
+            cache: slow,
+            calendar: Self.calendar)
+
+        spine.start()
+        await settle()
+        XCTAssertTrue(spine.days.isEmpty, "the account answered, and it answered with nothing")
+
+        await gate.open()
+        await settle()
+
+        XCTAssertTrue(
+            spine.days.isEmpty,
+            "a cache read that lands after the account must not put the row back")
+    }
+
+    /// The other side of the same rule, and the reason it is not simply "did a read come back".
+    /// **An offline launch is where a cached paint is the whole of what the user gets**, and a read
+    /// that failed comes back just as settled as one that succeeded.
+    @MainActor
+    func testAnUnreachableAccountStillGetsTheCachedPaint() async {
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+
+        let store = ActivityStore(
+            store: { nil }, account: SilentAccount(), cache: cache, calendar: Self.calendar)
+        store.start()
+        await settle()
+        // The failing read has certainly landed by now; the cache still has to paint behind it.
+        XCTAssertFalse(store.accountReachable, "precondition: nobody answered")
+        XCTAssertEqual(
+            store.days.count, 1,
+            "an offline launch shows what the account last said, which is the whole point")
+    }
+
+    private static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+        try? await Task.sleep(nanoseconds: 60_000_000)
+        for _ in 0..<8 { await Task.yield() }
+    }
+}
+
+/// An account that answers nothing, ever. The only way to be sure what is on screen came off disk.
+private struct SilentAccount: ActivityAccountReading {
+    func read(since: Double?, until: Double?, limit: Int) async -> ActivityAccountFeed {
+        .unreachable
+    }
+}
+
+/// An account that answers — and what it says is that it is empty. Distinct from `SilentAccount` in
+/// exactly the way the seed guard is about: this one spoke.
+private struct EmptyButAnsweringAccount: ActivityAccountReading {
+    func read(since: Double?, until: Double?, limit: Int) async -> ActivityAccountFeed {
+        ActivityAccountFeed(answered: Set(ActivityAccountSource.allCases))
+    }
+}
+
+/// A latch, so a test can hold the disk behind the network and assert on the order.
+private actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters = []
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityAccountCacheTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityAccountCacheTests.swift
@@ -28,18 +28,24 @@ final class ActivityAccountCacheTests: XCTestCase {
             .appendingPathComponent("activity-cache-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         store = try ContextStore(url: root.appendingPathComponent("context.db"))
+        let store = self.store!
+        cache = ActivityAccountCache(store: { store })
     }
 
     override func tearDown() {
+        cache = nil
         store = nil
         try? FileManager.default.removeItem(at: root)
         root = nil
     }
 
-    private var cache: ActivityAccountCache {
-        let store = self.store!
-        return ActivityAccountCache(store: { store })
-    }
+    /// One actor per test, held rather than rebuilt on each access: the epoch that fences writes
+    /// against a sign-out lives *in* the actor, so a computed property handing out a fresh instance
+    /// every time would make every test quietly epoch-0 and the fence untestable.
+    private var cache: ActivityAccountCache!
+
+    /// The epoch a write must quote to be accepted. Zero until something clears.
+    private func epoch() async -> Int { await cache.currentEpoch() }
 
     private static let base: Double = 1_760_000_000
 
@@ -67,7 +73,7 @@ final class ActivityAccountCacheTests: XCTestCase {
             ],
             answered: Set(ActivityAccountSource.allCases))
 
-        await cache.save(written)
+        await cache.save(written, epoch: await epoch())
         let read = await cache.load()
 
         XCTAssertEqual(read.conversations, written.conversations)
@@ -92,7 +98,7 @@ final class ActivityAccountCacheTests: XCTestCase {
             ActivityAccountFeed(
                 conversations: [conversation("c1")],
                 memories: [ActivityAccountMemory(id: "m1", content: "Ships Friday", at: Self.base)],
-                answered: [.conversations]))
+                answered: [.conversations]), epoch: await epoch())
 
         let read = await cache.load()
         XCTAssertEqual(read.conversations.count, 1)
@@ -110,7 +116,7 @@ final class ActivityAccountCacheTests: XCTestCase {
             ActivityAccountFeed(
                 memories: [ActivityAccountMemory(id: "m1", content: "Ships Friday", at: Self.base)],
                 answered: [.memories],
-                locallySourced: [.memories]))
+                locallySourced: [.memories]), epoch: await epoch())
 
         let read = await cache.load()
         XCTAssertTrue(read.memories.isEmpty)
@@ -122,9 +128,10 @@ final class ActivityAccountCacheTests: XCTestCase {
         await cache.save(
             ActivityAccountFeed(
                 conversations: [conversation("c1"), conversation("c2", at: 60)],
-                answered: [.conversations]))
+                answered: [.conversations]), epoch: await epoch())
         await cache.save(
-            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]),
+            epoch: await epoch())
 
         let read = await cache.load()
         XCTAssertEqual(
@@ -139,7 +146,7 @@ final class ActivityAccountCacheTests: XCTestCase {
             conversation("c\($0)", at: Double($0))
         }
         await cache.save(
-            ActivityAccountFeed(conversations: many, answered: [.conversations]))
+            ActivityAccountFeed(conversations: many, answered: [.conversations]), epoch: await epoch())
 
         let read = await cache.load()
         XCTAssertEqual(read.conversations.count, ActivityAccountCache.ceiling)
@@ -151,11 +158,50 @@ final class ActivityAccountCacheTests: XCTestCase {
     /// Signing out. One account's conversations must never be the first thing the next sees.
     func testClearingLeavesNothingToPaint() async {
         await cache.save(
-            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]),
+            epoch: await epoch())
         await cache.clear()
 
         let read = await cache.load()
         XCTAssertTrue(read.conversations.isEmpty)
+    }
+
+    /// **The second race cubic caught.** A save is spawned detached off a read that has already
+    /// been absorbed, so at sign-out there can be one in flight carrying the previous account's
+    /// rows. Serialising through the actor makes the two orderable but does not decide the order —
+    /// the save can simply arrive second and be perfectly serialised, and still be wrong. The epoch
+    /// is what makes "which account is this" the question rather than "which ran last".
+    func testASaveMintedBeforeSignOutCannotRepopulateTheClearedCache() async {
+        let minted = await epoch()
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]),
+            epoch: minted)
+        let seeded = await cache.load()
+        XCTAssertFalse(seeded.conversations.isEmpty, "precondition")
+
+        // Sign-out.
+        await cache.clear()
+        // …and the write that was already on its way, quoting the epoch it was minted under.
+        await cache.save(
+            ActivityAccountFeed(conversations: [conversation("c2")], answered: [.conversations]),
+            epoch: minted)
+
+        let afterSignOut = await cache.load()
+        XCTAssertTrue(
+            afterSignOut.conversations.isEmpty,
+            "the next account's first paint must not be the previous account's conversations")
+    }
+
+    /// The epoch invalidates writes even when the delete itself could not run — a clear that failed
+    /// to reach the database must still stop the saves behind it, or a failed delete becomes the
+    /// previous account's rows written back a moment later.
+    func testAClearThatCannotReachTheDatabaseStillInvalidatesWritesBehindIt() async {
+        let absent = ActivityAccountCache(store: { nil })
+        let minted = await absent.currentEpoch()
+        await absent.clear()
+        let after = await absent.currentEpoch()
+        XCTAssertNotEqual(
+            after, minted, "the fence advances on intent, not on the delete succeeding")
     }
 
     // MARK: - What a cached paint may claim
@@ -167,15 +213,15 @@ final class ActivityAccountCacheTests: XCTestCase {
     @MainActor
     func testASeededStoreDrawsRowsAndClaimsNothingAboutTheAccount() async {
         await cache.save(
-            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]),
+            epoch: await epoch())
 
         // An account that never answers, so the only thing on screen can be the cache.
         let store = ActivityStore(
             store: { nil }, account: SilentAccount(), cache: cache, calendar: Self.calendar)
         store.start()
-        await settle()
+        await waitUntil("the cached conversation to paint") { store.days.count == 1 }
 
-        XCTAssertEqual(store.days.count, 1, "the cached conversation is on screen")
         XCTAssertFalse(store.accountReachable, "and the account has still said nothing")
         XCTAssertTrue(store.accountAnswered.isEmpty, "no source answered — a copy is not an answer")
         XCTAssertFalse(
@@ -191,7 +237,8 @@ final class ActivityAccountCacheTests: XCTestCase {
     @MainActor
     func testACachedPaintNeverOverwritesAnAnswerThatAlreadyLanded() async {
         await cache.save(
-            ActivityAccountFeed(conversations: [conversation("stale")], answered: [.conversations]))
+            ActivityAccountFeed(conversations: [conversation("stale")], answered: [.conversations]),
+            epoch: await epoch())
 
         let gate = Gate()
         let store = self.store!
@@ -207,7 +254,7 @@ final class ActivityAccountCacheTests: XCTestCase {
             calendar: Self.calendar)
 
         spine.start()
-        await settle()
+        await waitUntil("the account's own answer") { !spine.accountAnswered.isEmpty }
         XCTAssertTrue(spine.days.isEmpty, "the account answered, and it answered with nothing")
 
         await gate.open()
@@ -224,17 +271,16 @@ final class ActivityAccountCacheTests: XCTestCase {
     @MainActor
     func testAnUnreachableAccountStillGetsTheCachedPaint() async {
         await cache.save(
-            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]))
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]),
+            epoch: await epoch())
 
         let store = ActivityStore(
             store: { nil }, account: SilentAccount(), cache: cache, calendar: Self.calendar)
         store.start()
-        await settle()
-        // The failing read has certainly landed by now; the cache still has to paint behind it.
-        XCTAssertFalse(store.accountReachable, "precondition: nobody answered")
-        XCTAssertEqual(
-            store.days.count, 1,
-            "an offline launch shows what the account last said, which is the whole point")
+        await waitUntil("the cached paint behind a failing read") { store.days.count == 1 }
+        XCTAssertFalse(
+            store.accountReachable,
+            "and nobody answered — an offline launch showing the last answer is the whole point")
     }
 
     private static let calendar: Calendar = {
@@ -243,6 +289,29 @@ final class ActivityAccountCacheTests: XCTestCase {
         return calendar
     }()
 
+    /// Waits until `condition` holds, or fails.
+    ///
+    /// **Not a fixed sleep.** A sleep long enough to be safe on a loaded CI box costs every green
+    /// run; one short enough to be cheap is a flake, and a suite people distrust is worse than a
+    /// smaller one. This returns the instant the work lands and only spends the deadline when
+    /// something is genuinely broken.
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 5,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await MainActor.run(body: condition) { return }
+            await Task.yield()
+        }
+        XCTFail("timed out waiting for \(description)", file: file, line: line)
+    }
+
+    /// For the one assertion that is about something *not* happening and so has no state to wait
+    /// on. It waits on a positive signal first, so this only covers the last hop back.
     private func settle() async {
         for _ in 0..<8 { await Task.yield() }
         try? await Task.sleep(nanoseconds: 60_000_000)

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityAccountCacheTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityAccountCacheTests.swift
@@ -192,6 +192,38 @@ final class ActivityAccountCacheTests: XCTestCase {
             "the next account's first paint must not be the previous account's conversations")
     }
 
+    /// **The reentrancy hole, which the first version of the fence did not close.**
+    ///
+    /// `await store()` is a suspension point *inside* the actor, and actors are reentrant — so a
+    /// `clear()` arriving while a save is parked there runs to completion, and the save then resumes
+    /// past an epoch check it had already passed. Checking the epoch before acquiring the store
+    /// reads as the careful order and is exactly the bug.
+    func testASaveSuspendedWhenSignOutLandsIsStillDropped() async {
+        let gate = FirstCallerGate()
+        let store = self.store!
+        let reentrant = ActivityAccountCache(store: {
+            await gate.holdTheFirstCaller()
+            return store
+        })
+        let minted = await reentrant.currentEpoch()
+
+        // A save that will park inside the provider.
+        async let saving: Void = reentrant.save(
+            ActivityAccountFeed(conversations: [conversation("c1")], answered: [.conversations]),
+            epoch: minted)
+        await gate.waitUntilHeld()
+
+        // Sign-out, reentering the actor while that save is suspended.
+        await reentrant.clear()
+        await gate.release()
+        await saving
+
+        let read = await reentrant.load()
+        XCTAssertTrue(
+            read.conversations.isEmpty,
+            "a save parked across a sign-out may not resume into the next account's cache")
+    }
+
     /// The epoch invalidates writes even when the delete itself could not run — a clear that failed
     /// to reach the database must still stop the saves behind it, or a failed delete becomes the
     /// previous account's rows written back a moment later.
@@ -331,6 +363,32 @@ private struct SilentAccount: ActivityAccountReading {
 private struct EmptyButAnsweringAccount: ActivityAccountReading {
     func read(since: Double?, until: Double?, limit: Int) async -> ActivityAccountFeed {
         ActivityAccountFeed(answered: Set(ActivityAccountSource.allCases))
+    }
+}
+
+/// Holds the *first* caller only, so a test can park one actor method inside its suspension point
+/// and let a second one reenter past it. A plain gate would deadlock: the reentering call goes
+/// through the same provider.
+private actor FirstCallerGate {
+    private var held = false
+    private var released = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func holdTheFirstCaller() async {
+        guard !held else { return }
+        held = true
+        guard !released else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitUntilHeld() async {
+        while !held { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+        for waiter in waiters { waiter.resume() }
+        waiters = []
     }
 }
 

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
@@ -173,6 +173,56 @@ final class ActivityRevalidationTests: XCTestCase {
             store.days.isEmpty, "the previous account's conversations are off the screen")
     }
 
+    /// **The race cubic caught, and the reason `forgetTheAccount` advances the generation.**
+    ///
+    /// An account read is a network round trip; signing out is a keystroke. The two overlap
+    /// routinely, and before the fence the read that left *before* the sign-out landed after it,
+    /// passed a guard comparing a generation nothing had moved, and repainted the panel with the
+    /// previous account's conversations — after the store had just finished forgetting them.
+    @MainActor
+    func testAReadInFlightWhenTheUserSignsOutCannotRepaintTheirAccount() async {
+        let gate = Gate()
+        let account = HeldAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]), gate: gate)
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+
+        // A read is now in flight, blocked inside the account.
+        store.start()
+        await waitUntil("the read to reach the account") { account.started > 0 }
+        XCTAssertTrue(store.days.isEmpty, "precondition: nothing has landed yet")
+
+        store.forgetTheAccount()
+        await gate.open()
+        await settle()
+
+        XCTAssertTrue(
+            store.days.isEmpty,
+            "a read minted before the sign-out may not repaint the previous account")
+        XCTAssertFalse(store.accountReachable)
+        XCTAssertEqual(store.accountUnreachableReason, .signedOut)
+    }
+
+    /// And the panel must still work for whoever signs in next — the fence may invalidate the old
+    /// read without also wedging the store against the new one.
+    @MainActor
+    func testTheNextAccountCanStillBeReadAfterASignOutInvalidatedAReadInFlight() async {
+        let gate = Gate()
+        let account = HeldAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]), gate: gate)
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+
+        store.start()
+        await waitUntil("the read to reach the account") { account.started > 0 }
+        store.forgetTheAccount()
+        await gate.open()
+        await settle()
+
+        // Signed in again: `revalidate` is the path the store's own sign-in subscription takes.
+        store.revalidate(now: Date(timeIntervalSince1970: Self.base))
+        await waitUntil("the new account's rows") { !store.days.isEmpty }
+        XCTAssertTrue(store.accountReachable)
+    }
+
     /// And the wiring that calls it, so the sign-out edge cannot be quietly disconnected.
     @MainActor
     func testTheSpineForgetsTheAccountWhenTheSignInPublisherGoesFalse() async {
@@ -222,8 +272,31 @@ final class ActivityRevalidationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    /// Lets the store's detached reads and its main-actor absorption run. Several hops, because a
-    /// read crosses the actor twice and the seed crosses it a third time.
+    /// Waits until `condition` holds, or fails the test.
+    ///
+    /// **Not a fixed sleep.** A sleep long enough to be safe on a loaded CI box is a sleep that
+    /// costs every green run, and one short enough to be cheap is a flake — the suite people stop
+    /// trusting. This returns the instant the work lands and only spends the deadline when
+    /// something is actually broken, which is the shape a hermetic test wants.
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 5,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await MainActor.run(body: condition) { return }
+            await Task.yield()
+        }
+        XCTFail("timed out waiting for \(description)", file: file, line: line)
+    }
+
+    /// Lets the store's detached reads and its main-actor absorption run, for the assertions that
+    /// are about something *not* happening and so have no state to wait on. Bounded and short: the
+    /// positive half of every one of those tests is waited for properly first, so by the time this
+    /// runs the machinery is already known to be idle.
     private func settle() async {
         for _ in 0..<8 { await Task.yield() }
         try? await Task.sleep(nanoseconds: 40_000_000)
@@ -270,4 +343,48 @@ private final class CountingAccount: ActivityAccountReading, ActivityAccountCurs
 
     func refreshHead() async { lock.withLock { _refreshes += 1 } }
     func forget() async { lock.withLock { _forgets += 1 } }
+}
+
+/// An account whose read blocks until the test lets it finish, so a sign-out can be driven into the
+/// exact window where a response is already on its way back.
+private final class HeldAccount: ActivityAccountReading, ActivityAccountCursor, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _started = 0
+    private let feed: ActivityAccountFeed
+    private let gate: Gate
+
+    init(feed: ActivityAccountFeed, gate: Gate) {
+        self.feed = feed
+        self.gate = gate
+    }
+
+    /// How many reads have reached the account. The signal a test waits on to know the request is
+    /// genuinely in flight rather than merely scheduled.
+    var started: Int { lock.withLock { _started } }
+
+    func read(since: Double?, until: Double?, limit: Int) async -> ActivityAccountFeed {
+        lock.withLock { _started += 1 }
+        await gate.wait()
+        return feed
+    }
+
+    func refreshHead() async {}
+    func forget() async {}
+}
+
+/// A latch, so a test can hold a response mid-flight and assert on the ordering around it.
+private actor Gate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters = []
+    }
 }

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
@@ -66,11 +66,13 @@ final class ActivityRevalidationTests: XCTestCase {
         let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
 
         store.start()
-        await settle()
+        await waitUntil("the opening read and its hydration") { store.corpusSettled }
         XCTAssertEqual(store.days.count, 1, "precondition: the first read painted something")
         let painted = store.days
-        // The opening read is followed by hydration's own reads until the corpus stops growing, so
-        // the baseline is measured rather than assumed — this suite is about what revalidation adds.
+        // **Waited to quiescence, not merely to first paint.** The opening read is followed by
+        // hydration's own reads until the corpus stops growing, and a baseline captured mid-walk
+        // would have the revalidation refused by the single-flight guard — a green-looking test
+        // that measured the wrong thing.
         let opened = account.reads
 
         store.revalidate(now: Date(timeIntervalSince1970: Self.base))
@@ -81,10 +83,8 @@ final class ActivityRevalidationTests: XCTestCase {
         XCTAssertEqual(store.days, painted, "the list may not blink while the account is asked")
         XCTAssertFalse(store.isPreparing, "and a list that is already correct is not 'preparing'")
 
-        await settle()
-        XCTAssertEqual(store.days, painted)
-        XCTAssertGreaterThan(
-            account.reads, opened, "and the account really was asked")
+        await waitUntil("the revalidating read") { account.reads > opened }
+        XCTAssertEqual(store.days, painted, "and it still has not blinked now the read has landed")
         XCTAssertEqual(account.refreshes, 1, "through the head, which is where new rows arrive")
     }
 
@@ -96,21 +96,19 @@ final class ActivityRevalidationTests: XCTestCase {
             feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
         let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
         store.start()
-        await settle()
+        await waitUntil("the opening read and its hydration") { store.corpusSettled }
         let opened = account.reads
 
         let now = Date(timeIntervalSince1970: Self.base)
         store.revalidate(now: now)
-        await settle()
-        XCTAssertEqual(account.reads, opened + 1)
+        await waitUntil("the first revalidation") { account.reads == opened + 1 }
 
         store.revalidate(now: now.addingTimeInterval(30))
         await settle()
         XCTAssertEqual(account.reads, opened + 1, "inside the cooldown, nothing is asked")
 
         store.revalidate(now: now.addingTimeInterval(61))
-        await settle()
-        XCTAssertEqual(account.reads, opened + 2, "and outside it, the panel asks again")
+        await waitUntil("the revalidation past the cooldown") { account.reads == opened + 2 }
     }
 
     /// `start()` is called from `.task` on every appearance, and the surface now appears many times
@@ -122,14 +120,12 @@ final class ActivityRevalidationTests: XCTestCase {
         let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
 
         store.start()
-        await settle()
+        await waitUntil("the opening read and its hydration") { store.corpusSettled }
         let painted = store.days
         let opened = account.reads
 
         store.start()
-        await settle()
-
-        XCTAssertEqual(account.reads, opened + 1, "a second appearance asks what changed")
+        await waitUntil("the second appearance to ask") { account.reads == opened + 1 }
         XCTAssertEqual(store.days, painted, "and does not rebuild the list to do it")
     }
 
@@ -222,11 +218,10 @@ final class ActivityRevalidationTests: XCTestCase {
             feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
         let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
         store.start()
-        await settle()
-        XCTAssertTrue(store.accountReachable, "precondition")
+        await waitUntil("the opening read and its hydration") { store.corpusSettled }
 
         store.forgetTheAccount()
-        await settle()
+        await waitUntil("the account half to be dropped") { store.days.isEmpty }
 
         XCTAssertFalse(store.accountReachable)
         XCTAssertEqual(store.accountUnreachableReason, .signedOut)
@@ -297,14 +292,12 @@ final class ActivityRevalidationTests: XCTestCase {
         withExtendedLifetime(spine) {}
 
         store.start()
-        await settle()
-        XCTAssertTrue(store.accountReachable, "precondition")
+        await waitUntil("the opening read and its hydration") { store.corpusSettled }
 
         signIns.send(false)
-        await settle()
+        await waitUntil("the spine to forget the account") { store.days.isEmpty }
 
         XCTAssertEqual(store.accountUnreachableReason, .signedOut)
-        XCTAssertTrue(store.days.isEmpty)
     }
 
     /// Activation is the other signal, and it is the one main uses. Driven through an injected
@@ -323,13 +316,11 @@ final class ActivityRevalidationTests: XCTestCase {
         withExtendedLifetime(spine) {}
 
         store.start()
-        await settle()
+        await waitUntil("the opening read and its hydration") { store.corpusSettled }
         let opened = account.reads
 
         activations.send(())
-        await settle()
-
-        XCTAssertEqual(account.reads, opened + 1)
+        await waitUntil("activation to revalidate") { account.reads == opened + 1 }
     }
 
     // MARK: - Helpers

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
@@ -1,0 +1,273 @@
+import Combine
+import ContextCore
+import Foundation
+import XCTest
+
+@testable import ContextApp
+
+/// Coming back to the Activity panel, and what may not happen when you do.
+///
+/// **The defect these are written against.** The Activity store was a `@StateObject` inside
+/// `ActivitySurface`, and three ordinary actions destroyed it: `SearchBarWindow.dismiss()` drops
+/// `current` so every summoning builds a new window and a new view, and the panel's lower half is a
+/// `switch` on which body is showing, so typing a query unmounts the activity branch and clearing
+/// the field mounts a fresh one. Each of those threw away a fully hydrated corpus and re-paged the
+/// account from offset zero. On the measured account that is thousands of rows and dozens of
+/// requests, repeated, for data that had not changed — and on the way there the panel drew local
+/// sessions as `Untitled conversation`, because a title is written by the backend and a session
+/// that has not been uploaded has none.
+///
+/// So the store now belongs to the process (`ActivitySpine`) and coming back is a *revalidation*:
+/// keep every row that is on screen, ask the account what changed, throttled. These prove the
+/// "keep" half as hard as the "ask" half, because the failure mode of getting it wrong is a spinner
+/// over a list that was already correct.
+final class ActivityRevalidationTests: XCTestCase {
+
+    private static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    /// 2025-10-09T08:53:20Z, the same fixed epoch the other Activity suites use.
+    private static let base: Double = 1_760_000_000
+
+    // MARK: - The cooldown
+
+    /// Main's number and main's shape: `PollingConfig.shouldAllowActivationRefresh` is a free
+    /// function over its inputs precisely so the boundary can be asserted rather than waited for,
+    /// and a regression from `>=` to `>` is caught rather than shipped.
+    func testTheCooldownIsAMinuteAndTheBoundaryIsInclusive() {
+        let now = Date(timeIntervalSince1970: Self.base)
+
+        XCTAssertTrue(
+            ActivityStore.shouldRevalidate(now: now, lastRevalidate: nil),
+            "a panel that has never revalidated may do so immediately")
+        XCTAssertFalse(
+            ActivityStore.shouldRevalidate(now: now, lastRevalidate: now),
+            "twice in the same instant is one request")
+        XCTAssertFalse(
+            ActivityStore.shouldRevalidate(
+                now: now, lastRevalidate: now.addingTimeInterval(-59)))
+        XCTAssertTrue(
+            ActivityStore.shouldRevalidate(
+                now: now, lastRevalidate: now.addingTimeInterval(-60)),
+            "the boundary is inclusive, as PollingConfig's is")
+    }
+
+    // MARK: - Keeping what is on screen
+
+    /// **The requirement, stated as a test.** A revalidation must not empty the list it is
+    /// refreshing: the rows stay, the count stays, and nothing goes back to `isPreparing`.
+    @MainActor
+    func testRevalidatingKeepsEveryRowOnScreen() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+
+        store.start()
+        await settle()
+        XCTAssertEqual(store.days.count, 1, "precondition: the first read painted something")
+        let painted = store.days
+        // The opening read is followed by hydration's own reads until the corpus stops growing, so
+        // the baseline is measured rather than assumed — this suite is about what revalidation adds.
+        let opened = account.reads
+
+        store.revalidate(now: Date(timeIntervalSince1970: Self.base))
+
+        // Checked synchronously, before the read can possibly have come back: the moment that
+        // matters is the one *during* the request, which is when a store that cleared itself would
+        // be showing an empty panel.
+        XCTAssertEqual(store.days, painted, "the list may not blink while the account is asked")
+        XCTAssertFalse(store.isPreparing, "and a list that is already correct is not 'preparing'")
+
+        await settle()
+        XCTAssertEqual(store.days, painted)
+        XCTAssertGreaterThan(
+            account.reads, opened, "and the account really was asked")
+        XCTAssertEqual(account.refreshes, 1, "through the head, which is where new rows arrive")
+    }
+
+    /// The throttle, through the store rather than through the free function: two summonings in a
+    /// row are one request, and a minute later is another.
+    @MainActor
+    func testASecondRevalidationInsideTheCooldownAsksNothing() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+        store.start()
+        await settle()
+        let opened = account.reads
+
+        let now = Date(timeIntervalSince1970: Self.base)
+        store.revalidate(now: now)
+        await settle()
+        XCTAssertEqual(account.reads, opened + 1)
+
+        store.revalidate(now: now.addingTimeInterval(30))
+        await settle()
+        XCTAssertEqual(account.reads, opened + 1, "inside the cooldown, nothing is asked")
+
+        store.revalidate(now: now.addingTimeInterval(61))
+        await settle()
+        XCTAssertEqual(account.reads, opened + 2, "and outside it, the panel asks again")
+    }
+
+    /// `start()` is called from `.task` on every appearance, and the surface now appears many times
+    /// over one store's life. The first call opens the window; every later one revalidates.
+    @MainActor
+    func testStartingAnAlreadyStartedStoreRevalidatesRatherThanReopening() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+
+        store.start()
+        await settle()
+        let painted = store.days
+        let opened = account.reads
+
+        store.start()
+        await settle()
+
+        XCTAssertEqual(account.reads, opened + 1, "a second appearance asks what changed")
+        XCTAssertEqual(store.days, painted, "and does not rebuild the list to do it")
+    }
+
+    /// A store handed its answer at construction has no sources behind it, so recomposing rebuilds
+    /// the list out of three empty inputs and erases the very thing it was built to show. The render
+    /// harness calls `start()`; this is what stops that from blanking every preview.
+    @MainActor
+    func testAPreviewStoreIsNeverRevalidated() async {
+        let store = ActivityStore(days: [day(with: [])], calendar: Self.calendar)
+        let painted = store.days
+        XCTAssertFalse(painted.isEmpty, "precondition")
+
+        store.start()
+        store.revalidate(now: Date(timeIntervalSince1970: Self.base))
+        await settle()
+
+        XCTAssertEqual(store.days, painted)
+    }
+
+    // MARK: - Signing out
+
+    /// A window-lived store forgot the account by dying. A process-lived one has to be told, and
+    /// what it must forget is the account half only — frames and speech on this Mac were captured
+    /// whether or not anybody was signed in.
+    @MainActor
+    func testSigningOutDropsTheAccountAndSaysWhy() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+        store.start()
+        await settle()
+        XCTAssertTrue(store.accountReachable, "precondition")
+
+        store.forgetTheAccount()
+        await settle()
+
+        XCTAssertFalse(store.accountReachable)
+        XCTAssertEqual(store.accountUnreachableReason, .signedOut)
+        XCTAssertTrue(store.accountAnswered.isEmpty)
+        XCTAssertTrue(
+            store.days.isEmpty, "the previous account's conversations are off the screen")
+    }
+
+    /// And the wiring that calls it, so the sign-out edge cannot be quietly disconnected.
+    @MainActor
+    func testTheSpineForgetsTheAccountWhenTheSignInPublisherGoesFalse() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+        let signIns = CurrentValueSubject<Bool, Never>(true)
+        let spine = ActivitySpine.forTesting(
+            store: store, signIns: signIns.eraseToAnyPublisher())
+        withExtendedLifetime(spine) {}
+
+        store.start()
+        await settle()
+        XCTAssertTrue(store.accountReachable, "precondition")
+
+        signIns.send(false)
+        await settle()
+
+        XCTAssertEqual(store.accountUnreachableReason, .signedOut)
+        XCTAssertTrue(store.days.isEmpty)
+    }
+
+    /// Activation is the other signal, and it is the one main uses. Driven through an injected
+    /// publisher rather than by posting `NSApplication.didBecomeActiveNotification`, which a test
+    /// process fires for reasons of its own.
+    @MainActor
+    func testTheSpineRevalidatesWhenTheAppBecomesActive() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+        let activations = PassthroughSubject<Void, Never>()
+        let spine = ActivitySpine.forTesting(
+            store: store,
+            signIns: Empty<Bool, Never>().eraseToAnyPublisher(),
+            activations: activations.eraseToAnyPublisher())
+        withExtendedLifetime(spine) {}
+
+        store.start()
+        await settle()
+        let opened = account.reads
+
+        activations.send(())
+        await settle()
+
+        XCTAssertEqual(account.reads, opened + 1)
+    }
+
+    // MARK: - Helpers
+
+    /// Lets the store's detached reads and its main-actor absorption run. Several hops, because a
+    /// read crosses the actor twice and the seed crosses it a third time.
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+        try? await Task.sleep(nanoseconds: 40_000_000)
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    private func conversation(_ id: String, at offset: Double) -> ActivityAccountConversation {
+        ActivityAccountConversation(
+            id: id, title: "Titled \(id)", emoji: "💬", startedAt: Self.base + offset,
+            finishedAt: Self.base + offset + 60, overview: nil)
+    }
+
+    private func day(with rows: [ActivityRow]) -> ActivityDay {
+        ActivityDay(
+            id: Self.calendar.startOfDay(for: Date(timeIntervalSince1970: Self.base)),
+            title: "TODAY", momentCount: 0, conversationCount: 0, memoryCount: 0, taskCount: 0,
+            rows: rows)
+    }
+}
+
+/// An account that answers the same feed every time and counts how often it was asked.
+///
+/// `@unchecked Sendable` over a lock rather than an actor: the seam is `Sendable` and synchronous
+/// from the store's point of view, and a counter behind a lock keeps the assertions readable.
+private final class CountingAccount: ActivityAccountReading, ActivityAccountCursor, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _reads = 0
+    private var _refreshes = 0
+    private var _forgets = 0
+    private let feed: ActivityAccountFeed
+
+    init(feed: ActivityAccountFeed) {
+        self.feed = feed
+    }
+
+    var reads: Int { lock.withLock { _reads } }
+    var refreshes: Int { lock.withLock { _refreshes } }
+    var forgets: Int { lock.withLock { _forgets } }
+
+    func read(since: Double?, until: Double?, limit: Int) async -> ActivityAccountFeed {
+        lock.withLock { _reads += 1 }
+        return feed
+    }
+
+    func refreshHead() async { lock.withLock { _refreshes += 1 } }
+    func forget() async { lock.withLock { _forgets += 1 } }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ActivityRevalidationTests.swift
@@ -149,6 +149,68 @@ final class ActivityRevalidationTests: XCTestCase {
         XCTAssertEqual(store.days, painted)
     }
 
+    // MARK: - What a failing read may not erase
+
+    /// **The offline launch, which is the case the cache exists for.**
+    ///
+    /// The seed paints from disk and the failing read lands a moment later carrying nothing. Taking
+    /// the read wholesale wiped the rows the user had just been shown, and which of the two landed
+    /// first was a race — so the panel was empty about half the time, on the one launch where the
+    /// cache is the whole of the answer.
+    func testASourceThatSaidNothingAndCarriedNothingKeepsWhatIsOnScreen() {
+        let painted = ActivityAccountFeed(
+            conversations: [conversation("cached", at: 0)], answered: [])
+
+        let held = ActivityStore.retaining(rowsNotAnsweredIn: .unreachable, from: painted)
+
+        XCTAssertEqual(held.conversations.map(\.id), ["cached"])
+        XCTAssertTrue(held.answered.isEmpty, "and it still reports that nobody answered")
+    }
+
+    /// **The half that a first attempt at this got wrong.** The paging reader answers with
+    /// everything it has gathered, so a source absent from `answered` routinely carries hundreds of
+    /// real rows fetched on an earlier read. Those are the corpus, not a stale leftover.
+    func testASourceThatSaidNothingButCarriedRowsKeepsTheRowsItCarried() {
+        let previous = ActivityAccountFeed(
+            conversations: [conversation("old", at: 0)], answered: [])
+        let carrying = ActivityAccountFeed(
+            conversations: [conversation("a", at: 0), conversation("b", at: 60)],
+            answered: [.memories, .tasks])
+
+        let held = ActivityStore.retaining(rowsNotAnsweredIn: carrying, from: previous)
+
+        XCTAssertEqual(held.conversations.map(\.id), ["a", "b"])
+    }
+
+    /// And an **answered** source is taken as it comes, empty included: "I hold nothing" is an
+    /// answer, and the account is the authority on it. Retaining here would resurrect deletions.
+    func testAnAnsweredSourceIsTakenEvenWhenItIsEmpty() {
+        let previous = ActivityAccountFeed(
+            conversations: [conversation("deleted", at: 0)], answered: [])
+        let emptied = ActivityAccountFeed(
+            conversations: [], answered: Set(ActivityAccountSource.allCases))
+
+        let held = ActivityStore.retaining(rowsNotAnsweredIn: emptied, from: previous)
+
+        XCTAssertTrue(held.conversations.isEmpty)
+    }
+
+    /// A transient failure in the opening read must not outlive the read that succeeded after it.
+    /// `openWindow` used to be the only thing that reset this, which was enough while an opening
+    /// read happened once per window — a revalidation runs another one.
+    @MainActor
+    func testASuccessfulRevalidationClearsAStaleCaptureFailure() async {
+        let account = CountingAccount(
+            feed: ActivityAccountFeed(conversations: [conversation("a", at: 0)]))
+        let store = ActivityStore(store: { nil }, account: account, calendar: Self.calendar)
+        store.start()
+        await settle()
+
+        XCTAssertNil(
+            store.readFailure,
+            "a store with no capture database reports its availability, not a read failure")
+    }
+
     // MARK: - Signing out
 
     /// A window-lived store forgot the account by dying. A process-lived one has to be told, and

--- a/desktop/context-for-claude/Tests/ContextAppTests/OmiActivityFeedTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/OmiActivityFeedTests.swift
@@ -1182,6 +1182,55 @@ extension OmiActivityFeedTests {
             "and what it holds is what this read returned, not what the last account said")
     }
 
+    /// **The third of the sign-out races.** `read` fetches and *then* commits, so a `forget()` that
+    /// lands between the two used to have its emptied corpus repopulated by the page already on its
+    /// way back — the previous account's conversations, filed after the store had finished
+    /// forgetting them. The epoch is captured before a request leaves and quoted by every commit.
+    ///
+    /// **The two accounts return different ids on purpose.** The corpus files rows by identity and
+    /// replaces one it already holds, so a test where both reads return the same id cannot tell a
+    /// surviving row from a re-fetched one — it passes with the fence torn out, which is worth
+    /// nothing. Distinct ids make the difference a row count: one row if the sign-out was honoured,
+    /// two if the previous account's page survived it.
+    func testAPageFetchedBeforeSignOutIsNeverFiled() async {
+        let gate = ReadGate()
+        let calls = Counter()
+        let feed = OmiActivityFeed(
+            isAirgapped: { false },
+            isSignedIn: { true },
+            fetchConversations: { _ in
+                let first = await calls.next() == 0
+                // Only the first read — the one raced with the sign-out — is held.
+                if first { await gate.arriveAndWait() }
+                let id = first ? "previous-account" : "next-account"
+                return [
+                    WireConversation(
+                        id: id, createdAt: nil, startedAt: WireInstant(seconds: 1_786_000_000),
+                        finishedAt: nil,
+                        structured: WireConversation.WireStructured(
+                            title: id, overview: nil, emoji: "🎙️"))
+                ]
+            },
+            fetchMemories: { _ in [] },
+            fetchTasks: { _ in WireActionItemPage(actionItems: []) },
+            now: { Self.placement })
+
+        async let reading = feed.read(since: nil, until: nil, limit: 10)
+        await gate.waitUntilArrived()
+
+        // Sign-out, while the previous account's response is in flight.
+        await feed.forget()
+        await gate.open()
+        _ = await reading
+
+        // The read's own return value may carry what it fetched — it is a value, not state. What
+        // must not have happened is the *filing*, so the next account's read sees its own row alone.
+        let next = await feed.read(since: nil, until: nil, limit: 10)
+        XCTAssertEqual(
+            next.conversations.map(\.id), ["next-account"],
+            "the previous account's page was in flight across the sign-out and must not be held")
+    }
+
     private static func readUntilSettled(
         _ feed: OmiActivityFeed, limit: Int, reads: Int = 40
     ) async -> ActivityAccountFeed {
@@ -1292,5 +1341,39 @@ private actor RetitlingBackend {
                 structured: WireConversation.WireStructured(
                     title: currentTitle, overview: nil, emoji: "🎙️"))
         ]
+    }
+}
+
+/// A latch that also reports when the request reached it, so a test can drive a sign-out into the
+/// window between a fetch leaving and its response being filed.
+private actor ReadGate {
+    private var arrived = false
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+        arrived = true
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitUntilArrived() async {
+        while !arrived { await Task.yield() }
+    }
+
+    func open() {
+        isOpen = true
+        for waiter in waiters { waiter.resume() }
+        waiters = []
+    }
+}
+
+/// A call counter, so a fetcher can answer differently for the read before a sign-out and the read
+/// after it.
+private actor Counter {
+    private var count = 0
+    func next() -> Int {
+        defer { count += 1 }
+        return count
     }
 }

--- a/desktop/context-for-claude/Tests/ContextAppTests/OmiActivityFeedTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/OmiActivityFeedTests.swift
@@ -1113,6 +1113,75 @@ extension OmiActivityFeedTests {
 
     /// Reads until the reader stops asking for anything, the way `ActivityStore` does: again while
     /// the answer keeps growing, and once more to find out that it has stopped.
+    // MARK: - Coming back to a settled corpus
+
+    /// **The cursor only ever moves away from the newest row, and that is the one place new rows
+    /// arrive.** Once every source is exhausted the reader answers `.settled` and makes no further
+    /// request — correct while nothing behind the cursor changes, useless the moment somebody comes
+    /// back to the panel an hour later. `refreshHead` is the reopening, and this is what it must
+    /// cost: three requests at offset zero, not a second walk of the account.
+    func testRefreshingTheHeadRereadsOffsetZeroWithoutWalkingTheAccountAgain() async {
+        let backend = PagingBackend(conversations: 5, memories: 0, tasks: 0)
+        let feed = Self.feed(over: backend)
+
+        _ = await Self.readUntilSettled(feed, limit: 2)
+        let walked = await backend.asks("conversations")
+        XCTAssertEqual(walked, [0, 2, 4, 5], "precondition: the whole account is in")
+
+        await feed.refreshHead()
+        _ = await Self.readUntilSettled(feed, limit: 2)
+
+        let reasked = await backend.asks("conversations")
+        XCTAssertEqual(
+            reasked, walked + [0], "one request at the head, and the walk is not repeated")
+    }
+
+    /// **The regression this pair of changes exists for, at the reader.** A conversation is
+    /// uploaded before the backend has titled it, so the row the account first hands over is
+    /// untitled; the title lands minutes later. A corpus whose de-duplication was
+    /// first-sighting-wins would keep the untitled copy for the life of the process, which is the
+    /// panel saying `Untitled conversation` over a conversation that has had a name for an hour.
+    func testARowTheAccountHasSinceTitledReplacesTheUntitledCopy() async {
+        let backend = RetitlingBackend()
+        let feed = OmiActivityFeed(
+            isAirgapped: { false },
+            isSignedIn: { true },
+            fetchConversations: { try await backend.conversations($0) },
+            fetchMemories: { _ in [] },
+            fetchTasks: { _ in WireActionItemPage(actionItems: []) },
+            now: { Self.placement })
+
+        let first = await feed.read(since: nil, until: nil, limit: 10)
+        XCTAssertEqual(first.conversations.map(\.title), [""], "the backend has not named it yet")
+
+        await backend.title("Design review")
+        await feed.refreshHead()
+        let second = await feed.read(since: nil, until: nil, limit: 10)
+
+        XCTAssertEqual(second.conversations.count, 1, "one conversation, not two copies of one")
+        XCTAssertEqual(second.conversations.map(\.title), ["Design review"])
+    }
+
+    /// Signing out. The reader now outlives a sign-out — it belongs to the process rather than to a
+    /// panel — so everything the previous account handed over has to go, cursors included.
+    func testForgettingDropsEveryRowAndReopensFromTheTop() async {
+        let backend = PagingBackend(conversations: 3, memories: 0, tasks: 0)
+        let feed = Self.feed(over: backend)
+
+        let settled = await Self.readUntilSettled(feed, limit: 10)
+        XCTAssertEqual(settled.conversations.count, 3, "precondition")
+
+        await feed.forget()
+        let after = await feed.read(since: nil, until: nil, limit: 10)
+
+        let asks = await backend.asks("conversations")
+        XCTAssertEqual(
+            asks.last, 0, "the next read starts at the top, as a first read does")
+        XCTAssertEqual(
+            after.conversations.count, 3,
+            "and what it holds is what this read returned, not what the last account said")
+    }
+
     private static func readUntilSettled(
         _ feed: OmiActivityFeed, limit: Int, reads: Int = 40
     ) async -> ActivityAccountFeed {
@@ -1204,5 +1273,24 @@ private actor PagingBackend {
         let total = counts[source] ?? 0
         guard offset < total else { return offset..<offset }
         return offset..<min(offset + limit, total)
+    }
+}
+
+/// One conversation whose title the backend fills in later — the ordinary lifecycle of an uploaded
+/// transcript, and the reason a corpus has to be able to replace a row it already holds.
+private actor RetitlingBackend {
+    private var currentTitle = ""
+
+    func title(_ title: String) { currentTitle = title }
+
+    func conversations(_ query: [String: String]) -> [WireConversation] {
+        guard (Int(query["offset"] ?? "0") ?? 0) == 0 else { return [] }
+        return [
+            WireConversation(
+                id: "c0", createdAt: nil, startedAt: WireInstant(seconds: 1_786_000_000),
+                finishedAt: nil,
+                structured: WireConversation.WireStructured(
+                    title: currentTitle, overview: nil, emoji: "🎙️"))
+        ]
     }
 }

--- a/desktop/context-for-claude/Tests/ContextAppTests/OmiActivityFeedTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/OmiActivityFeedTests.swift
@@ -1231,6 +1231,58 @@ extension OmiActivityFeedTests {
             "the previous account's page was in flight across the sign-out and must not be held")
     }
 
+    /// **A revalidation has to be able to delete, and until the head became authoritative it could
+    /// only add.** `reopenHead` re-reads offset zero and `absorb` replaces the ids it sees, so a
+    /// conversation deleted on the phone stayed on the spine for the life of the process. That is a
+    /// regression the process-lived store introduced: a panel rebuilt per window used to lose the
+    /// row simply by being rebuilt.
+    func testAHeadRereadDropsARowTheAccountHasStoppedListing() async {
+        let backend = MutableHeadBackend(ids: ["c2", "c1", "c0"])
+        let feed = Self.feed(overMutableHead: backend)
+
+        let first = await feed.read(since: nil, until: nil, limit: 10)
+        XCTAssertEqual(first.conversations.map(\.id), ["c2", "c1", "c0"], "precondition")
+
+        // c1 is deleted on the phone.
+        await backend.set(ids: ["c2", "c0"])
+        await feed.refreshHead()
+        let second = await feed.read(since: nil, until: nil, limit: 10)
+
+        XCTAssertEqual(
+            second.conversations.map(\.id), ["c2", "c0"],
+            "a row absent from a re-read of the head, within the head's own range, has gone")
+    }
+
+    /// **And it may only delete within the range the head page actually covers.** A head page
+    /// returned the newest `limit` rows and is evidence about nothing older; treating its absence as
+    /// a deletion would empty the account behind it on every revalidation.
+    func testAHeadRereadNeverDeletesRowsOlderThanItsOwnPage() async {
+        let backend = MutableHeadBackend(ids: ["c4", "c3", "c2", "c1", "c0"])
+        let feed = Self.feed(overMutableHead: backend)
+
+        // Page the whole account in two at a time.
+        let all = await Self.readUntilSettled(feed, limit: 2)
+        XCTAssertEqual(all.conversations.count, 5, "precondition")
+
+        // The head is re-read at a page size of two, so it can only speak for c4 and c3.
+        await feed.refreshHead()
+        let after = await Self.readUntilSettled(feed, limit: 2)
+
+        XCTAssertEqual(
+            Set(after.conversations.map(\.id)), ["c0", "c1", "c2", "c3", "c4"],
+            "everything behind the head page is untouched by a re-read of it")
+    }
+
+    private static func feed(overMutableHead backend: MutableHeadBackend) -> OmiActivityFeed {
+        OmiActivityFeed(
+            isAirgapped: { false },
+            isSignedIn: { true },
+            fetchConversations: { try await backend.conversations($0) },
+            fetchMemories: { _ in [] },
+            fetchTasks: { _ in WireActionItemPage(actionItems: []) },
+            now: { placement })
+    }
+
     private static func readUntilSettled(
         _ feed: OmiActivityFeed, limit: Int, reads: Int = 40
     ) async -> ActivityAccountFeed {
@@ -1375,5 +1427,32 @@ private actor Counter {
     func next() -> Int {
         defer { count += 1 }
         return count
+    }
+}
+
+/// A conversations endpoint whose row set the test can change between reads, newest id first.
+///
+/// Instants descend with position so a page's "oldest row" is well defined — which is what bounds
+/// what a head re-read is allowed to delete.
+private actor MutableHeadBackend {
+    private var ids: [String]
+
+    init(ids: [String]) { self.ids = ids }
+
+    func set(ids: [String]) { self.ids = ids }
+
+    func conversations(_ query: [String: String]) -> [WireConversation] {
+        let offset = Int(query["offset"] ?? "0") ?? 0
+        let limit = Int(query["limit"] ?? "1") ?? 1
+        guard offset < ids.count else { return [] }
+        let page = ids[offset..<min(offset + limit, ids.count)]
+        return page.enumerated().map { position, id in
+            WireConversation(
+                id: id, createdAt: nil,
+                startedAt: WireInstant(seconds: 1_786_000_000 - Double(offset + position)),
+                finishedAt: nil,
+                structured: WireConversation.WireStructured(
+                    title: id, overview: nil, emoji: "🎙️"))
+        }
     }
 }

--- a/desktop/context-for-claude/Tests/ContextCoreTests/AccountCacheQueriesTests.swift
+++ b/desktop/context-for-claude/Tests/ContextCoreTests/AccountCacheQueriesTests.swift
@@ -1,0 +1,149 @@
+import ContextCore
+import XCTest
+
+/// What the account cache table has to do, and — more importantly — what it must not do to the
+/// sources nobody wrote.
+///
+/// The whole reason this table exists is a launch that had nothing to paint until the network
+/// answered. The whole reason it is *per source* is that the account's three endpoints fail
+/// independently, and a cache that a single 503 could wipe would be worse than no cache at all: it
+/// would be a surface that looks fine until the day the backend has a bad hour, and then looks
+/// exactly as broken as before while claiming to be fixed.
+final class AccountCacheQueriesTests: XCTestCase {
+    private var fixture: Fixture!
+
+    override func setUpWithError() throws {
+        fixture = try Fixture(seeded: false)
+    }
+
+    override func tearDown() {
+        fixture.tearDown()
+        fixture = nil
+    }
+
+    private func row(_ id: String, at: Double, _ payload: String = "{}") -> CachedAccountRow {
+        CachedAccountRow(source: "conversations", id: id, at: at, payload: payload)
+    }
+
+    func testARowSurvivesTheRoundTrip() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations",
+            rows: [row("a", at: 10, #"{"title":"Standup"}"#)], keeping: 50)
+
+        let read = try AccountCacheQueries.recent(fixture.store, source: "conversations", limit: 50)
+
+        XCTAssertEqual(read.count, 1)
+        XCTAssertEqual(read.first?.id, "a")
+        XCTAssertEqual(read.first?.at, 10)
+        XCTAssertEqual(read.first?.payload, #"{"title":"Standup"}"#)
+    }
+
+    /// Newest first, because the caller is drawing a spine that starts at today and a `LIMIT` over
+    /// the wrong order would keep the oldest rows in the account.
+    func testRowsComeBackNewestFirst() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations",
+            rows: [row("old", at: 1), row("new", at: 3), row("middle", at: 2)], keeping: 50)
+
+        XCTAssertEqual(
+            try AccountCacheQueries.recent(fixture.store, source: "conversations", limit: 50)
+                .map(\.id),
+            ["new", "middle", "old"])
+    }
+
+    /// The same id written twice is one row carrying the second write. This is what makes a
+    /// conversation the backend has since titled reach the cache without duplicating it.
+    func testWritingTheSameIdAgainUpdatesItRatherThanDuplicatingIt() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: [row("a", at: 10, #"{"title":""}"#)],
+            keeping: 50)
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations",
+            rows: [row("a", at: 11, #"{"title":"Named at last"}"#)], keeping: 50)
+
+        let read = try AccountCacheQueries.recent(fixture.store, source: "conversations", limit: 50)
+        XCTAssertEqual(read.count, 1)
+        XCTAssertEqual(read.first?.payload, #"{"title":"Named at last"}"#)
+        XCTAssertEqual(read.first?.at, 11)
+    }
+
+    /// **The bound is the reason this table can live in a capture database.** Without it, one
+    /// hydration walk a day writes the account's whole history into the file that holds the user's
+    /// screenshots.
+    func testTheTrimKeepsOnlyTheNewest() throws {
+        let rows = (1...10).map { row("id-\($0)", at: Double($0)) }
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: rows, keeping: 3)
+
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "conversations"), 3)
+        XCTAssertEqual(
+            try AccountCacheQueries.recent(fixture.store, source: "conversations", limit: 50)
+                .map(\.id),
+            ["id-10", "id-9", "id-8"])
+    }
+
+    /// **The test this table exists for.** Writing one source must be invisible to the other two:
+    /// the observed backend state is conversations serving normally while `/v3/memories` answers
+    /// 503, and a write that cleared the table would spend a healthy source's cache on a sick one's
+    /// outage.
+    func testWritingOneSourceLeavesTheOthersAlone() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "memories",
+            rows: [CachedAccountRow(source: "memories", id: "m1", at: 5, payload: "{}")],
+            keeping: 50)
+        try AccountCacheQueries.replace(
+            fixture.store, source: "tasks",
+            rows: [CachedAccountRow(source: "tasks", id: "t1", at: 5, payload: "{}")], keeping: 50)
+
+        // Conversations answer; the other two do not, so nobody writes them.
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: [row("c1", at: 6)], keeping: 50)
+
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "memories"), 1)
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "tasks"), 1)
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "conversations"), 1)
+    }
+
+    /// And the trim of one source may not reach into another's rows either, which is the way the
+    /// isolation above is most easily broken by a `DELETE` that forgets its `WHERE`.
+    func testTheTrimIsScopedToItsOwnSource() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "memories",
+            rows: (1...5).map { CachedAccountRow(source: "memories", id: "m\($0)", at: Double($0), payload: "{}") },
+            keeping: 50)
+
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations",
+            rows: (1...5).map { row("c\($0)", at: Double($0)) }, keeping: 1)
+
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "conversations"), 1)
+        XCTAssertEqual(
+            try AccountCacheQueries.count(fixture.store, source: "memories"), 5,
+            "trimming one source must not touch another")
+    }
+
+    /// Signing out. One account's rows must never be the first thing the next account sees.
+    func testClearEmptiesEverySource() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: [row("c1", at: 1)], keeping: 50)
+        try AccountCacheQueries.replace(
+            fixture.store, source: "memories",
+            rows: [CachedAccountRow(source: "memories", id: "m1", at: 1, payload: "{}")],
+            keeping: 50)
+
+        try AccountCacheQueries.clear(fixture.store)
+
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "conversations"), 0)
+        XCTAssertEqual(try AccountCacheQueries.count(fixture.store, source: "memories"), 0)
+    }
+
+    /// A limit of zero is a caller asking for nothing, not a caller asking for everything — the
+    /// shape `LIMIT 0` and `LIMIT -1` disagree about in SQLite.
+    func testAskingForNothingReturnsNothing() throws {
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: [row("c1", at: 1)], keeping: 50)
+
+        XCTAssertTrue(
+            try AccountCacheQueries.recent(fixture.store, source: "conversations", limit: 0).isEmpty)
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextCoreTests/AccountCacheQueriesTests.swift
+++ b/desktop/context-for-claude/Tests/ContextCoreTests/AccountCacheQueriesTests.swift
@@ -122,6 +122,30 @@ final class AccountCacheQueriesTests: XCTestCase {
             "trimming one source must not touch another")
     }
 
+    /// **Ties on `at` are ordinary, so the order may not depend on them alone.** A date-only task is
+    /// stamped at 11:59 PM like every other one; a backfilled batch of memories shares an instant.
+    /// Without `id` as a second key SQLite may return any subset in any order, so the page a launch
+    /// paints can disagree with the page the trim decided to keep.
+    func testRowsSharingAnInstantAreOrderedAndTrimmedStably() throws {
+        let tied = ["b", "d", "a", "c"].map { row($0, at: 100) }
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: tied, keeping: 50)
+
+        let first = try AccountCacheQueries.recent(
+            fixture.store, source: "conversations", limit: 50
+        ).map(\.id)
+        XCTAssertEqual(first, ["d", "c", "b", "a"], "id decides, descending, when the instant cannot")
+
+        // And the trim keeps the same rows the read would have shown, which is the half that
+        // silently loses data when the two orders disagree.
+        try AccountCacheQueries.replace(
+            fixture.store, source: "conversations", rows: tied, keeping: 2)
+        XCTAssertEqual(
+            try AccountCacheQueries.recent(fixture.store, source: "conversations", limit: 50)
+                .map(\.id),
+            ["d", "c"])
+    }
+
     /// Signing out. One account's rows must never be the first thing the next account sees.
     func testClearEmptiesEverySource() throws {
         try AccountCacheQueries.replace(

--- a/desktop/context-for-claude/Tests/ContextCoreTests/StoreTests.swift
+++ b/desktop/context-for-claude/Tests/ContextCoreTests/StoreTests.swift
@@ -164,9 +164,9 @@ final class StoreTests: XCTestCase {
         // migration re-runs on every launch and fails on the second one.
         XCTAssertEqual(
             applied,
-            ["v1", "v10-ax-node-last-seen", "v3-segment-confidence", "v4-segment-speaker",
-             "v5-cloud-segment-identity", "v6-accessibility-tree", "v7-frame-bundle-id",
-             "v8-frame-showable-index", "v9-frame-bundle-by-app-index"])
+            ["v1", "v10-ax-node-last-seen", "v11-account-cache", "v3-segment-confidence",
+             "v4-segment-speaker", "v5-cloud-segment-identity", "v6-accessibility-tree",
+             "v7-frame-bundle-id", "v8-frame-showable-index", "v9-frame-bundle-by-app-index"])
 
         // The ledger is shared with `UploadQueue`, which registers `v2-uploads` outside this
         // migrator and skips itself when its identifier is already recorded. Proving the two live
@@ -179,7 +179,7 @@ final class StoreTests: XCTestCase {
             coexisting,
             ["v1", "v3-segment-confidence", "v4-segment-speaker", "v5-cloud-segment-identity",
              "v6-accessibility-tree", "v7-frame-bundle-id", "v8-frame-showable-index",
-             "v9-frame-bundle-by-app-index", "v10-ax-node-last-seen",
+             "v9-frame-bundle-by-app-index", "v10-ax-node-last-seen", "v11-account-cache",
              UploadQueue.migrationIdentifier])
         XCTAssertTrue(try tableExists("uploads", in: upgraded), "the uploads migration was skipped")
 
@@ -270,9 +270,9 @@ final class StoreTests: XCTestCase {
         // never appear.
         XCTAssertEqual(
             applied,
-            ["v1", "v10-ax-node-last-seen", "v3-segment-confidence", "v4-segment-speaker",
-             "v5-cloud-segment-identity", "v6-accessibility-tree", "v7-frame-bundle-id",
-             "v8-frame-showable-index", "v9-frame-bundle-by-app-index"])
+            ["v1", "v10-ax-node-last-seen", "v11-account-cache", "v3-segment-confidence",
+             "v4-segment-speaker", "v5-cloud-segment-identity", "v6-accessibility-tree",
+             "v7-frame-bundle-id", "v8-frame-showable-index", "v9-frame-bundle-by-app-index"])
 
         // The ledger is shared with `UploadQueue`, which registers `v2-uploads` outside this
         // migrator. Proving they still coexist is the only way to know `v4-` did not claim a slot
@@ -285,7 +285,7 @@ final class StoreTests: XCTestCase {
             coexisting,
             ["v1", "v3-segment-confidence", "v4-segment-speaker", "v5-cloud-segment-identity",
              "v6-accessibility-tree", "v7-frame-bundle-id", "v8-frame-showable-index",
-             "v9-frame-bundle-by-app-index", "v10-ax-node-last-seen",
+             "v9-frame-bundle-by-app-index", "v10-ax-node-last-seen", "v11-account-cache",
              UploadQueue.migrationIdentifier])
         XCTAssertTrue(try tableExists("uploads", in: upgraded), "the uploads migration was skipped")
 


### PR DESCRIPTION
## What was wrong

Opening the Context for Claude panel re-paged the user's whole Omi account — every time — and drew `Untitled conversation` over their day while it did.

Three causes, and the largest was not the network:

1. **The Activity store was window-lived.** `SearchBarWindow.dismiss()` nils `current` before closing, so `present()` never takes its own reuse branch: every summoning builds a new window, a new `SearchBarView` and a new `ActivityStore`. The lower panel is also a `switch` on which body is showing, so typing a query unmounts the activity branch outright and clearing the field mounts a fresh one. Launch, re-open, and search-then-clear each discarded a fully hydrated corpus and walked the account again from offset zero — thousands of rows and dozens of requests, for data that had not changed.
2. **Nothing was on disk.** The account half was network-only, so the first paint was whatever `context.db` held: local speech sessions, untitled by construction, because a title is written by the backend when a transcript is uploaded.
3. **The reader could only move forward.** Once every source was exhausted the corpus answered `.settled` and never asked again — and offset zero, the one offset a forward-only walk never re-asks for, is exactly where rows recorded since arrive.

The shipping Omi app has never looked like this over the same data, and not because it is faster on the wire: `ConversationRepository.load` reads SQLite, emits, and *then* fetches, and `AppState` belongs to the application rather than to a window.

## What changed

- **`ActivitySpine`** owns one `ActivityStore` for the process. The view is handed it instead of building one.
- **`ActivityAccountCache` + `account_rows`** (migration `v11-account-cache`) keep the newest page of each source so a cold launch paints real titles in milliseconds.
- **`revalidate()`** is what coming back means: keep every row on screen, ask the account what changed, on main's own 60-second cooldown (`PollingConfig.activationCooldown`). Signalled from `present()`, from a re-appearing surface, and from `NSApplication.didBecomeActiveNotification`.
- **`ActivityAccountCursor`** — `refreshHead()` reopens the heads without disturbing where hydration walked to, so a revalidation costs three requests rather than a second walk; `forget()` drops everything at sign-out.
- The corpus **replaces** a row it already holds instead of dropping it, which is how a title the backend wrote ten minutes ago reaches a row first seen untitled.

## Correctness properties, each with a test

- **A cached paint never speaks for the account.** No `answered`, nothing `reachable`, corpus not settled (`isShowingCachedRows`).
- **An answer outranks a copy only where the account actually spoke.** Guarding on "a read came back" loses the offline launch about half the time — the one case where the cache is the whole answer.
- **A source that said nothing *and* carried nothing keeps what is on screen.** Retaining on `answered` alone is wrong: the paging reader answers with everything it has gathered, so a source absent from `answered` routinely carries real rows fetched earlier.
- **An answered source is taken as it comes, empty included** — "I hold nothing" is an answer, and retaining there would resurrect deletions.
- **A head re-read may delete, but only within its own range.** A row newer than the page's oldest returned row and absent from it has gone; everything behind the page is untouched. Memories that had to start past their own head never prune.
- **Sign-out invalidates work already in flight**, at all three layers: the store's `generation`, the cache's write epoch, the corpus's epoch. An account read is a network round trip and signing out is a keystroke.

## Review history worth reading

Five findings in the first review round and four in the second were real; all are fixed. Two of my own fixes were wrong and the tests caught them:

- My first corpus regression test **passed against its bug** — the corpus replaces a row it already holds and both reads returned the same id, so it could not tell a survivor from a re-fetch. Distinct ids make the difference a row count.
- I reported the cache save/clear race fixed one round before it was. The epoch check sat before `await store()`, and **actors are reentrant**: that await is a suspension point inside the actor, so a `clear()` arriving while a save is parked there runs to completion and the save resumes past a check it had already passed. The handle is now acquired first and the epoch checked after, so check-to-write is synchronous.

Every fence was verified by removing it and confirming its test fails — including **both** directions of the prune bound, since a test that only proves deletion happens would pass while it deleted the whole account.

**Not changed, deliberately:** `locallySourced` excluding the whole memories source from caching. After `ActivityLocalMemories` merges there is no per-row provenance, so caching "only the account's rows" needs the decorator to keep them separate — and the users it would help already read memories from `omi.db` locally on every launch. Caching them would mean a second copy of another app's table that a later launch reads back as *the account's* answer.

## Verification

```
swift test   # 1581 tests, 7 skipped, 0 failures — three consecutive clean runs
```

New coverage: `ActivityRevalidationTests` (14), `ActivityAccountCacheTests` (13), `AccountCacheQueriesTests` (9), `OmiActivityFeedTests` (+5).

**Test rewrite disclosure.** `StoreTests`' two migration-ledger enumerations gained `v11-account-cache`. They assert the exact set of identifiers `ContextStore.makeMigrator()` registers; the new value is read off the migration in this PR rather than chosen, and a missing entry means the migration re-runs on every launch and throws on the second — which is what those assertions exist to catch.

**Live UI verification is not available for this app from a local build, and I am saying so rather than implying a run happened.** A dev-signed build under the shipped bundle id rewrites both of the user's Claude MCP configs at startup and writes TCC records shared with the installed app. Coverage here is behavioural; the notarized build is what exercises it end to end.

## Product invariants affected

None — `scripts/pr-preflight --suggest` reports no invariant globs matched by this diff.

## Failure class (fixes)

Failure-Class: new

`FC-durable-state-scoped-to-view-lifetime`. State whose cost to rebuild exceeds the lifetime of the view that displays it must be owned by something that outlives the view. The guard surface is `ActivitySpine` plus `ActivityRevalidationTests`, which asserts the three properties a re-entry must have: the list does not blink, a second appearance revalidates rather than re-pages, and the account half is dropped on sign-out.

`evidence_prs` cites #11641, the PR that shipped the app carrying the defective contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
