### PR TITLE
fix(dev-harness): tell dev-init.sh's next-steps hint about make dev-up

### DIFF
--- a/scripts/dev-harness/dev-init.sh
+++ b/scripts/dev-harness/dev-init.sh
@@ -39,4 +39,5 @@ bash scripts/install-git-hooks.sh
 
 echo ""
 echo "Next: add your four API keys to backend/.env.local-dev, then run:"
-echo "  make dev-desktop"
+echo "  make dev-up        # start the harness for mobile/iOS testing"
+echo "  make dev-desktop   # start the harness and the desktop app"

--- a/scripts/dev-harness/tests/test_dev_init.py
+++ b/scripts/dev-harness/tests/test_dev_init.py
@@ -139,3 +139,17 @@ def test_dev_init_installs_hooks_in_a_main_checkout(tmp_path: Path) -> None:
     hook = _hooks_dir(repo) / "pre-commit"
     assert hook.is_file() and os.access(hook, os.X_OK), result.stdout
     assert (repo / "backend/.env.local-dev").is_file(), result.stdout
+
+
+def test_dev_init_next_steps_cover_mobile_and_desktop(tmp_path: Path) -> None:
+    """The closing hint used to name only `make dev-desktop`, so anyone setting
+    up the harness for mobile/iOS testing against it (which needs `make
+    dev-up`, not the desktop app) was pointed at the wrong command.
+    """
+    repo = _fixture_repo(tmp_path)
+
+    result = _run_dev_init(repo)
+
+    assert result.returncode == 0, result.stdout
+    assert "make dev-up" in result.stdout, result.stdout
+    assert "make dev-desktop" in result.stdout, result.stdout


### PR DESCRIPTION
## Summary

`make dev-init`'s closing "Next" hint told every user to run `make dev-desktop`, even when they were setting up the harness purely for mobile/iOS testing (which needs `make dev-up`, not the desktop app). Surfaced while picking a paused community-build iOS PR (#7641) back up for on-device testing.

Fixes #11707.

## Fix

`scripts/dev-harness/dev-init.sh`'s closing message now names both commands with a one-line note on which is for which, since the script itself has no way to know which flow the developer wants — the setup steps above it (backend venv, secrets file, git hooks) are identical either way.

## Test plan

- [x] New regression test `test_dev_init_next_steps_cover_mobile_and_desktop` (`scripts/dev-harness/tests/test_dev_init.py`) — runs the real script hermetically (existing fixture pattern) and asserts both `make dev-up` and `make dev-desktop` appear in the closing guidance.
- [x] `python3 -m pytest scripts/dev-harness/tests/test_dev_init.py -v` — 3 passed (2 existing + 1 new).
- [x] Full dev-harness suite (`bash scripts/dev-harness/run-tests.sh`) — 72 passed, 7 skipped, no regressions.

## Product invariants

None.

## Failure class

Failure-Class: none

First-observed instance fix — no existing failure-class matches a hardcoded next-step hint, and this is a one-off documentation-in-code gap, not a recurring pattern.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

