### PR TITLE
Stop three mechanics from destroying the notifications the system exists to send

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -85,17 +85,33 @@ enum BucketFactValidator {
     }
   }
 
+  /// Validity is evidence-resolution only. A missing identifier no longer
+  /// demotes a fact to `needs_review`.
+  ///
+  /// The identifier requirement was measured to have no discriminative value:
+  /// on 2,461 live facts it demoted 41.9% of content statements and 41.5% of
+  /// scenery statements — identical rates — while `needs_review` makes a fact
+  /// invisible to the director, the reconciler, pooling, and candidate
+  /// grounding, and the write path forces its worthiness to 0. 1,083 of the
+  /// 1,085 demotions failed on identifiers alone (evidence resolved fine), and
+  /// the destroyed half included exactly the class the system exists for
+  /// ("Aarav asked me to reach out to you to change my status from a
+  /// contributor to a maintainer" died here). The magnitude is usage-dependent
+  /// (18.4% on an independent beta install), but the mechanism is the same.
+  ///
+  /// Identifier omission is a known behavior of the extraction model, not a
+  /// quality signal: it leaves structured fields empty even while writing the
+  /// same information into the statement (measured 0/39 on real work screens).
+  /// Identifiers that ARE supplied still pass through `acceptedIdentifiers`,
+  /// which requires them to appear in the quoted evidence.
   static func validity(
-    identifiers: [String], evidenceText: String, evidenceRefs: [String], duplicate: Bool
+    evidenceText: String, evidenceRefs: [String], duplicate: Bool
   ) -> BucketFactValidity {
     if duplicate { return .superseded }
-    let hasIdentifier = identifiers.contains {
-      !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
     let evidenceResolves =
       !evidenceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       && !evidenceRefs.isEmpty
-    return hasIdentifier && evidenceResolves ? .validated : .needsReview
+    return evidenceResolves ? .validated : .needsReview
   }
 
   /// Model bookkeeping (`fact-001`, `f-002`, `visit:3`) and handles that never
@@ -388,6 +404,9 @@ enum ContextProactivityPromptBuilder {
       - A material change, status update, recommendation, or useful follow-up without an
         explicit commitment, promise, or request is insight or suggest. Never infer an
         owner or a due date. Never create a task candidate from actionability alone.
+      - A commitment is required only for task_candidate. Insight, suggest, and resurface
+        never require one: new, useful, grounded information the user has not seen is
+        enough. Do not stay silent just because nobody made a commitment.
       Use only supplied bucket-entry refs.
       Timestamps supplied below are already in the user's local time zone. When a message
       mentions a date or time, use that local form as written; never convert to or mention UTC.\(lookup)
@@ -621,7 +640,6 @@ extension ContextBucketStore {
               sql: "SELECT EXISTS(SELECT 1 FROM bucket_facts WHERE bucketID = ? AND statement = ?)",
               arguments: [bucketID, statement]) ?? false
           let validity = BucketFactValidator.validity(
-            identifiers: identifiers,
             evidenceText: evidenceText,
             evidenceRefs: evidenceRefs,
             duplicate: duplicate)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -646,6 +646,27 @@ actor ContextBucketStore {
       }) ?? []
   }
 
+  /// Candidate-sourced deliveries that actually reached the user in the last
+  /// 24-hour window, for the candidate show ceiling. Fails closed to the
+  /// ceiling (treats an unreadable database as "ceiling reached") so a storage
+  /// error can never turn into extra interruptions.
+  func candidateDeliveriesInWindow(now: Date = Date()) async -> Int {
+    let (pool, _) = await RewindDatabase.shared.getDatabaseQueueWithGeneration()
+    guard let pool else { return Int.max }
+    let windowStart = ContextDeliveryBudget.dailyWindowStart(now: now)
+    return
+      (try? await pool.read { db in
+        try Int.fetchOne(
+          db,
+          sql: """
+            SELECT COUNT(*) FROM proactive_deliveries
+            WHERE deliveredAt >= ? AND lifecycleState = 'delivered'
+              AND provenanceJson LIKE '%"source":"candidate"%'
+            """,
+          arguments: [windowStart]) ?? 0
+      }) ?? Int.max
+  }
+
   func recentContextPool(
     excludingBucketID: String, now: Date = Date()
   ) async -> [ContextWorkstreamPoolItem] {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextDeliveryAuthority.swift
@@ -143,6 +143,19 @@ enum ContextDeliveryBudget {
     return base * max(1, planMultiplier)
   }
 
+  /// Ceiling on candidate-sourced deliveries per 24-hour window, inside the
+  /// overall daily budget.
+  ///
+  /// The rewritten candidate gate swung from a 4% to a 71% pass rate (n=7 —
+  /// far too small to size the true rate, which is exactly why a ceiling is
+  /// warranted while dogfood measures it): a gate that now returns parseable
+  /// JSON will act on its own `show=true` default. Cooldown and the daily
+  /// budget bound the total interruption rate, but not the *mix* — without a
+  /// ceiling, armed candidates could crowd the entire budget. The check runs
+  /// before the gate's model call, so a capped candidate costs no tokens and
+  /// stays armed for a quieter window rather than being retired.
+  static let candidateDailyShowCeiling = 8
+
   static func cooldownSeconds(frequencyLevel: Int) -> TimeInterval {
     switch frequencyLevel {
     case 1: return 60 * 60

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextFactWritePolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextFactWritePolicy.swift
@@ -146,10 +146,62 @@ enum ContextFactWritePolicy {
       "\\b([A-Z][a-z]{2,}(?:\\s+[A-Z][a-z]{2,})?)\\s+(?:also\\s+|then\\s+|again\\s+|later\\s+)?"
       + speechVerbs + "\\b")
 
+  // MARK: - Prompt-echo detection
+  //
+  // The anchored machinery patterns above catch near-verbatim echoes; live data
+  // shows the model also *paraphrases* its instructions into facts — "The
+  // designated destination value is set to unknown/.", "If domain confidence is
+  // low, the response should be unknown/.", "The user requires that each factual
+  // record be a plain declarative sentence." — 77 such statements in the 2,531-
+  // fact corpus this was fitted on, every one a genuine echo on reading. The
+  // detector is deliberately conjunctive so no single pattern can delete a real
+  // fact: an *instruction-reporting frame* (a subject like user/task/instructions
+  // followed by a requesting verb) must co-occur with *prompt-specific
+  // vocabulary* (terms that exist only in these prompts). Negatives verified to
+  // pass: "Push to unknown/production failed." (vocabulary, no frame), "The
+  // response should be sent to the customer before EOD." (frame, no vocabulary),
+  // "The destination branch cannot fast-forward." (neither).
+
+  /// Terms that occur in the extraction/destination prompts and essentially
+  /// nowhere in real work prose.
+  /// `unknown/` sits outside the word-boundary group: the slash is already a
+  /// delimiter, and a trailing `\b` cannot match between `/` and end-of-sentence
+  /// punctuation, which made "… should be unknown/." invisibly unmatched.
+  private static let echoVocabularyPattern =
+    #"(?i)(?:\bunknown/|\b(?:page-group|evidence_refs|evidence_text|notify_worthiness"#
+    + #"|token summary|factual records?|declarative sentences?|on-screen wording"#
+    + #"|site suffix|screen-derived|quoted data|domain/section|facts list"#
+    + #"|evidence reference|handles copied|copied from (?:the )?(?:quoted )?on-screen)\b)"#
+
+  /// "<instruction-ish subject> … <requesting verb>" within one clause.
+  private static let echoFramePattern =
+    #"(?i)\b(?:user|task|instructions?|rules?|content|output|format|prompt"#
+    + #"|requirements?|response|statements?|records?|evidence(?: blocks?| text)?|summary)\b"#
+    + #"[^.]{0,50}\b(?:requests?|requires?|required|instructed|instructs?|specif\w+"#
+    + #"|demands?|asks?|must|should|needs? to|are to be|is to be)\b"#
+
+  /// The destination-abstention echo family ("Destination is set to unknown/",
+  /// "Direct instruction to set destination path to unknown/"). Requires the
+  /// word "destination" (or an explicit "set to") near `unknown/`, so "Push to
+  /// unknown/production failed." — a real fact containing the bare token — is
+  /// untouched.
+  private static let destinationEchoPatterns: [String] = [
+    #"(?i)\bdestination\b[^.]{0,50}\bunknown/"#,
+    #"(?i)\b(?:is|are|be|been)\s+set\s+to\b[^.]{0,25}\bunknown/"#,
+  ]
+
+  static func isPromptEcho(_ statement: String) -> Bool {
+    if matchesAny(destinationEchoPatterns, in: statement) { return true }
+    return statement.range(of: echoVocabularyPattern, options: .regularExpression) != nil
+      && statement.range(of: echoFramePattern, options: .regularExpression) != nil
+  }
+
   static func verdict(_ statement: String) -> ContextFactWriteVerdict {
     let trimmed = statement.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return .dropMachinery }
-    if matchesAny(machineryPatterns, in: trimmed) { return .dropMachinery }
+    if matchesAny(machineryPatterns, in: trimmed) || isPromptEcho(trimmed) {
+      return .dropMachinery
+    }
     if isHumanEvent(trimmed) { return .floorHumanEvent }
     if matchesAny(sceneryPatterns, in: trimmed) { return .capScenery }
     return .pass
@@ -183,8 +235,9 @@ enum ContextFactWritePolicy {
   /// Asserted by the tests so a typo cannot quietly disable enforcement.
   static var allPatternsCompile: Bool {
     humanEventRegex != nil
-      && (machineryPatterns + sceneryPatterns).allSatisfy {
-        (try? NSRegularExpression(pattern: $0)) != nil
-      }
+      && (machineryPatterns + sceneryPatterns + destinationEchoPatterns
+        + [echoVocabularyPattern, echoFramePattern]).allSatisfy {
+          (try? NSRegularExpression(pattern: $0)) != nil
+        }
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -44,8 +44,32 @@ enum ContextDirectorEligibility {
 }
 
 enum ContextDirectorGrounding {
-  static func permitsNonSilence(entryRefs: [String], factIDs: [String]) -> Bool {
-    !entryRefs.isEmpty && !factIDs.isEmpty
+  /// Grounding requirement, per decision type.
+  ///
+  /// The old rule demanded a bucket-entry ref AND a validated-fact ref for every
+  /// non-silence decision. But a resurface grounds on an *open task* — supplied
+  /// in the prompt, not citable as a bucket entry — connected to the current
+  /// context, so its natural citation is the validated fact(s) evidencing the
+  /// connection, with no entry ref at all. Measured on two independent
+  /// installations: every suppressed row with non-empty fact_ids is a decision
+  /// the model made to speak that this guard overrode (the silence path forcibly
+  /// empties fact_ids), and there were 9 of them in our dogfood window and 7 of
+  /// 76 on an independent beta install — including "This is an overdue open task
+  /// with a timely connection to the active overnight fleetctl workflow", the
+  /// exact class resurface exists for. Cross-workstream pooling being enabled
+  /// did not prevent the vetoes, so the guard itself was the cause.
+  ///
+  /// Deliberately NOT relaxed to a blanket OR: insight, suggest, and
+  /// task_candidate make new claims about bucket content and keep the full
+  /// anti-hallucination invariant (at least one entry ref and one fact ref).
+  /// Resurface requires at least one citation of either kind — never zero.
+  static func permitsNonSilence(
+    decision: String, entryRefs: [String], factIDs: [String]
+  ) -> Bool {
+    if decision == "resurface" {
+      return !entryRefs.isEmpty || !factIDs.isEmpty
+    }
+    return !entryRefs.isEmpty && !factIDs.isEmpty
   }
 }
 
@@ -501,13 +525,22 @@ actor ContextProactivityEngine {
           message: nil, state: "suppressed")
         return
       }
-      // Deliberately evaluated on bucket refs alone: a delivery must still stand
-      // on at least one bucket entry and one validated bucket fact, exactly as
-      // before the retrieval hop existed. Retrieved refs are additive citations
-      // and can never substitute for bucket grounding.
-      guard ContextDirectorGrounding.permitsNonSilence(entryRefs: entryRefs, factIDs: factIDs) else {
+      // Deliberately evaluated on bucket refs alone: retrieved refs are additive
+      // citations and can never substitute for bucket grounding. When the guard
+      // vetoes, the row records what the model actually decided and why it was
+      // suppressed — a forced silence was previously indistinguishable from a
+      // model-chosen one, which made the veto rate invisible until it was
+      // recovered from the fact_ids side effect.
+      guard
+        ContextDirectorGrounding.permitsNonSilence(
+          decision: decision.decision, entryRefs: entryRefs, factIDs: factIDs)
+      else {
+        provenance["suppression_reason"] = "grounding_veto"
+        provenance["model_decision"] = decision.decision
+        let vetoData = try JSONSerialization.data(withJSONObject: provenance, options: [.sortedKeys])
         try await store.completeDelivery(
-          id: deliveryID, decisionType: "silence", provenanceJSON: provenanceJSON,
+          id: deliveryID, decisionType: "silence",
+          provenanceJSON: String(data: vetoData, encoding: .utf8) ?? provenanceJSON,
           message: nil, state: "suppressed")
         return
       }
@@ -663,6 +696,20 @@ actor ContextProactivityEngine {
         deliveryID: deliveryID,
         decisionType: "silence",
         provenanceJSON: "{\"failure\":\"pre_model_gate\"}",
+        state: "suppressed")
+      return
+    }
+    // Candidate-mix ceiling, checked before the gate's model call so a capped
+    // candidate costs no tokens. The candidate is deliberately NOT declined:
+    // it stays armed for a window with headroom, unlike a gate refusal, which
+    // retires it. The visit's delivery row still terminates as suppressed.
+    let candidateShows = await store.candidateDeliveriesInWindow(now: currentFrame.captureTime)
+    guard candidateShows < ContextDeliveryBudget.candidateDailyShowCeiling else {
+      log("Context candidate suppressed before model: candidate_show_ceiling")
+      await terminalize(
+        deliveryID: deliveryID,
+        decisionType: "silence",
+        provenanceJSON: "{\"failure\":\"candidate_show_ceiling\"}",
         state: "suppressed")
       return
     }

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -34,6 +34,9 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     "- A material change, status update, recommendation, or useful follow-up without an",
     "  explicit commitment, promise, or request is insight or suggest. Never infer an",
     "  owner or a due date. Never create a task candidate from actionability alone.",
+    "- A commitment is required only for task_candidate. Insight, suggest, and resurface",
+    "  never require one: new, useful, grounded information the user has not seen is",
+    "  enough. Do not stay silent just because nobody made a commitment.",
     "Use only supplied bucket-entry refs.",
     "Timestamps supplied below are already in the user's local time zone. When a message",
     "mentions a date or time, use that local form as written; never convert to or mention UTC.",
@@ -423,20 +426,30 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     XCTAssertEqual(prompt.subdata(in: try XCTUnwrap(prompt.range(of: frozen))), frozen)
   }
 
-  func testOnlyResolvableIdentifiedFactsValidate() {
+  func testValidityIsEvidenceResolutionOnly() {
+    // A missing identifier no longer demotes: on live data the identifier
+    // requirement demoted content and scenery at identical rates (41.9% vs
+    // 41.5%) while making the fact invisible to every downstream consumer.
     XCTAssertEqual(
       BucketFactValidator.validity(
-        identifiers: ["PR-123"], evidenceText: "PR-123 is blocked", evidenceRefs: ["visit:1"],
-        duplicate: false),
+        evidenceText: "PR-123 is blocked", evidenceRefs: ["visit:1"], duplicate: false),
       .validated)
     XCTAssertEqual(
       BucketFactValidator.validity(
-        identifiers: [], evidenceText: "do this immediately", evidenceRefs: ["visit:1"],
-        duplicate: false),
-      .needsReview)
+        evidenceText: "Aarav: can you change my status from contributor to maintainer?",
+        evidenceRefs: ["visit:1"], duplicate: false),
+      .validated,
+      "an identifier-less fact with resolvable evidence must validate")
+    XCTAssertEqual(
+      BucketFactValidator.validity(evidenceText: "  ", evidenceRefs: ["visit:1"], duplicate: false),
+      .needsReview, "empty evidence text still demotes")
     XCTAssertEqual(
       BucketFactValidator.validity(
-        identifiers: ["PR-123"], evidenceText: "same", evidenceRefs: ["visit:1"], duplicate: true),
+        evidenceText: "quoted wording", evidenceRefs: [], duplicate: false),
+      .needsReview, "unresolvable evidence refs still demote")
+    XCTAssertEqual(
+      BucketFactValidator.validity(
+        evidenceText: "same", evidenceRefs: ["visit:1"], duplicate: true),
       .superseded)
   }
 
@@ -525,7 +538,6 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
         existingFacts: existing))
     XCTAssertEqual(
       BucketFactValidator.validity(
-        identifiers: ["handoff-013"],
         evidenceText: "The handoff is complete.",
         evidenceRefs: ["visit:2"],
         duplicate: false),

--- a/desktop/macos/Desktop/Tests/ContextFactWritePolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextFactWritePolicyTests.swift
@@ -136,4 +136,47 @@ final class ContextFactWritePolicyTests: XCTestCase {
   func testEveryPatternCompiles() {
     XCTAssertTrue(ContextFactWritePolicy.allPatternsCompile)
   }
+
+  /// Paraphrased instruction echoes from live data (77 of 2,531 corpus facts,
+  /// every one verified an echo by reading). The anchored machinery patterns
+  /// miss these because the model rewords; the conjunctive frame+vocabulary
+  /// detector catches them.
+  func testParaphrasedInstructionEchoesAreDropped() {
+    for statement in [
+      "The designated destination value is set to unknown/.",
+      "There is a note indicating a destination should be set to unknown/.",
+      "Destination is set to unknown/ per instruction.",
+      "If domain confidence is low, the response should be unknown/.",
+      "The user requires that each factual record be a plain declarative sentence.",
+      "The task requires filling identifiers with names or handles copied from on-screen text.",
+      "Instructions require plain declarative sentences without labels or numbering.",
+      "The user asks to identify the website page-group this tab belongs to, as destination.",
+      "Format requirement: statements must be plain declarative sentences suitable for colleagues.",
+    ] {
+      XCTAssertEqual(ContextFactWritePolicy.verdict(statement), .dropMachinery, statement)
+    }
+  }
+
+  /// The negatives the echo detector was tested against before adoption: real
+  /// facts that share single ingredients with echoes (the bare `unknown/`
+  /// token, an instruction-shaped frame with no prompt vocabulary) must never
+  /// be dropped. This is the class the earlier unanchored patterns deleted.
+  func testRealFactsSharingEchoIngredientsAreNotDropped() {
+    XCTAssertNotEqual(
+      ContextFactWritePolicy.verdict("Push to unknown/production failed."), .dropMachinery)
+    XCTAssertNotEqual(
+      ContextFactWritePolicy.verdict("The destination branch cannot fast-forward."),
+      .dropMachinery)
+    XCTAssertNotEqual(
+      ContextFactWritePolicy.verdict("The response should be sent to the customer before EOD."),
+      .dropMachinery)
+    XCTAssertNotEqual(
+      ContextFactWritePolicy.verdict(
+        "The user must re-authenticate before the deploy can continue."),
+      .dropMachinery)
+    XCTAssertNotEqual(
+      ContextFactWritePolicy.verdict(
+        "A policy note states that undivisible PRs involve an outside collaborator with repo Admin rights."),
+      .dropMachinery)
+  }
 }

--- a/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextProactivityEngineTests.swift
@@ -150,14 +150,33 @@ final class ContextProactivityEngineTests: XCTestCase {
     }
   }
 
-  func testNonSilenceGroundingRequiresBothValidatedEntryAndFactCitations() {
+  func testNonSilenceGroundingIsPerDecisionType() {
+    // insight/suggest/task_candidate make new claims about bucket content and
+    // keep the full anti-hallucination invariant: one entry ref AND one fact ref.
+    for decision in ["insight", "suggest", "task_candidate"] {
+      XCTAssertTrue(
+        ContextDirectorGrounding.permitsNonSilence(
+          decision: decision, entryRefs: ["entry:one"], factIDs: ["fact:one"]))
+      XCTAssertFalse(
+        ContextDirectorGrounding.permitsNonSilence(
+          decision: decision, entryRefs: ["entry:one"], factIDs: []))
+      XCTAssertFalse(
+        ContextDirectorGrounding.permitsNonSilence(
+          decision: decision, entryRefs: [], factIDs: ["fact:one"]))
+    }
+    // A resurface grounds on an open task connected to current context; its
+    // citable half is the validated fact evidencing the connection. Nine of
+    // these were vetoed in one dogfood window by the old unconditional AND.
     XCTAssertTrue(
       ContextDirectorGrounding.permitsNonSilence(
-        entryRefs: ["entry:one"], factIDs: ["fact:one"]))
+        decision: "resurface", entryRefs: [], factIDs: ["fact:one"]))
+    XCTAssertTrue(
+      ContextDirectorGrounding.permitsNonSilence(
+        decision: "resurface", entryRefs: ["entry:one"], factIDs: []))
     XCTAssertFalse(
-      ContextDirectorGrounding.permitsNonSilence(entryRefs: ["entry:one"], factIDs: []))
-    XCTAssertFalse(
-      ContextDirectorGrounding.permitsNonSilence(entryRefs: [], factIDs: ["fact:one"]))
+      ContextDirectorGrounding.permitsNonSilence(
+        decision: "resurface", entryRefs: [], factIDs: []),
+      "a resurface with no citation of either kind stays vetoed")
   }
 
   @MainActor
@@ -888,8 +907,10 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
             evidenceRefs: ["visit:1"],
             confidence: 1,
             notifyWorthiness: 0.6),
-          // Higher worthiness, but no identifier: needs_review, so it must not
-          // count toward the departure-evaluation admission signal.
+          // No identifier, but resolvable evidence: validates under
+          // evidence-only validity, so its 0.9 IS the admission signal. (The
+          // old identifier gate demoted this shape to needs_review and zeroed
+          // it — measured at zero discriminative value on live data.)
           BucketExtraction.Fact(
             statement: "unidentified claim",
             identifiers: [],
@@ -897,6 +918,14 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
             evidenceRefs: ["visit:1"],
             confidence: 1,
             notifyWorthiness: 0.9),
+          // Unresolvable evidence still demotes and must not count.
+          BucketExtraction.Fact(
+            statement: "evidence-free claim",
+            identifiers: ["handle"],
+            evidenceText: " ",
+            evidenceRefs: ["visit:1"],
+            confidence: 1,
+            notifyWorthiness: 1.0),
         ]),
       for: fence,
       appName: "Test App",
@@ -905,7 +934,7 @@ final class ContextDepartureEvaluationStoreTests: XCTestCase {
       now: now)
 
     let writeResult = try XCTUnwrap(result)
-    XCTAssertEqual(writeResult.maximumValidatedWorthiness, 0.6, accuracy: 0.000_001)
+    XCTAssertEqual(writeResult.maximumValidatedWorthiness, 0.9, accuracy: 0.000_001)
     XCTAssertTrue(
       ContextDepartureEvaluationPolicy.triggers(
         maximumValidatedWorthiness: writeResult.maximumValidatedWorthiness, flagEnabled: true))

--- a/desktop/macos/changelog/unreleased/20260816-proactive-task-connections.json
+++ b/desktop/macos/changelog/unreleased/20260816-proactive-task-connections.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive notifications now surface timely connections to your open and overdue tasks instead of staying silent, and no longer discard facts that lack a ticket number or a name."
+}


### PR DESCRIPTION
## Summary

Three mechanics defects were each destroying the notifications this system exists to send, at a
different stage of the pipeline. All three were found by measurement on live data, and two of them
reproduce on a **second, independent installation** belonging to a different user.

1. **The identifier gate zeroed 42.8% of all facts with no discriminative value.**
2. **A grounding `AND` gate silently vetoed the model's best decisions** — the ones connecting the
   current screen to an open or overdue task.
3. **The director's bar was "explicit user commitment"**, which screen context almost never contains.

Plus a conjunctive prompt-echo detector, a candidate-mix ceiling, and veto observability.

## ⚠️ This changes production behaviour

Unlike #11705, which was entirely behind dogfood flags, three changes here are **unflagged and
affect every build including beta**:

| change | scope |
|---|---|
| `BucketFactValidator.validity` — identifier requirement removed | **production** |
| `ContextDirectorGrounding.permitsNonSilence` — resurface grounds on either citation | **production** |
| director contract — commitment required only for `task_candidate` | **production** |
| candidate daily show ceiling of 8 | dogfood only (candidate path is non-production) |
| prompt-echo detector | dogfood only (behind `isFactWritePolicyEnabled`) |

This is deliberate — beta is where the notification quality problem actually shows — but it should
be a conscious merge decision, not a surprise.

## 1. Validity is evidence-resolution only

`validity` required `hasIdentifier && evidenceResolves`. On 2,531 live facts it demoted:

| | n | demoted to `needs_review` |
|---|---|---|
| content statements | 1,762 | **41.9%** |
| scenery statements | 699 | **41.5%** |

Identical rates — the requirement carries no signal about quality. **1,083 of the 1,085 demotions
failed on identifiers alone**; evidence resolved in all but one. And `needs_review` is not a soft
signal: it makes a fact invisible to the director, the reconciler, pooling and candidate grounding,
and the write path forces its worthiness to 0. Facts destroyed this way include exactly the class
the feature exists for — *"Aarav asked me to reach out to you to change my status from a contributor
to a maintainer"*, *"A component or service Hermes M4 SF sales was retired; LaunchAgent disabled"*.

Identifier omission is measured model behaviour, not a quality signal: the extraction model leaves
structured fields empty while writing the same information into the statement (0/39 on real work
frames). Identifiers that *are* supplied still pass `acceptedIdentifiers`, which requires them to
appear verbatim in the quoted evidence, so the anti-fabrication check on identifiers is unchanged.

Magnitude is usage-dependent — 18.4% on the independent beta install versus 42% here — but the
mechanism is identical on both.

## 2. Grounding is per decision type

```swift
// before: every non-silence decision
!entryRefs.isEmpty && !factIDs.isEmpty
```

A resurface grounds on an **open task** — supplied in the prompt, not citable as a bucket entry — so
its natural citation is the validated fact evidencing the connection, with no entry ref at all. The
guard demanded one anyway.

Because the silence path forcibly empties `factIDs`, **any suppressed row with non-empty `fact_ids`
is provably a decision the model made to speak that this guard overrode**. There were **9** in one
dogfood window and **7 of 76** on the independent install, including:

```
facts=2 entries=0 :: This is an overdue open task with a timely connection to the active
                     overnight fleetctl workflow.
facts=1 entries=0 :: The file's presence connects directly to an existing open task to send
                     a contract; this is a concrete next step not otherwise visible.
```

Cross-workstream pooling was **enabled** in our window and did not prevent the vetoes, which rules
out the "pooling would have grounded these" hypothesis and isolates the guard as the cause.

Resurface now needs one citation of **either** kind — never zero. Insight, suggest and
task_candidate make new claims about bucket content and keep the full entry-AND-fact invariant.
This is deliberately not a blanket relaxation to `OR`.

Vetoes now record `suppression_reason: "grounding_veto"` and `model_decision`. Previously a forced
silence was indistinguishable in the schema from a model-chosen one, which is why this went
unnoticed — the finding was only recoverable from the `fact_ids` side effect.

## 3. The commitment bar is scoped to task_candidate

Clustering director suppression reasoning:

| | independent beta install | our dogfood |
|---|---|---|
| cites absent commitment / user-owned request | 60 of 76 (79%) | **155 of 170 (91%)** |

An ambient-context feature that speaks only on an explicit verbal commitment will, by construction,
almost never speak. One added contract bullet scopes the requirement to `task_candidate`; insight,
suggest and resurface require new, useful, grounded information the user has not seen.

## 4. Prompt-echo detector, candidate ceiling, observability

The anchored machinery patterns from #11705 catch near-verbatim echoes; the model also *paraphrases*
its own instructions into facts (*"The designated destination value is set to unknown/."*,
*"Instructions require plain declarative sentences without labels or numbering."*). 77 such
statements in the 2,531-fact corpus, every one verified an echo by reading.

The detector is **conjunctive** so no single pattern can delete a real fact: an instruction-reporting
frame must co-occur with prompt-specific vocabulary. Verified negatives, all pinned in tests:
`Push to unknown/production failed.` (vocabulary, no frame), `The response should be sent to the
customer before EOD.` (frame, no vocabulary), `The destination branch cannot fast-forward.` (neither).

This has to land **with** the validity change: several destination echoes currently die only because
they lack identifiers.

The candidate gate's rewrite swung its pass rate from 4% to 71% (n=7). Cooldown and the daily budget
bound total interruptions but not the *mix*, so candidate-sourced deliveries get a ceiling of 8 per
24h, checked **before** the gate's model call so a capped candidate costs no tokens, and left armed
rather than retired.

## Dogfood results on this branch

Live on the `omi-qa-buckets-dest` bundle, comparing the window before this branch to the window on it:

| | merged main (n=185 facts) | this branch (n=89 facts) |
|---|---|---|
| validated | 47% | **99%** (0 `needs_review`) |
| arming-eligible (≥0.6) | 21.1% | **25.8%** |
| suppressions citing absent commitment | 88% (8/9) | 50% (3/6) |
| `grounding_veto` rows | n/a | **0** |
| prompt echoes stored | 1 | **0** |

Making 42.8% of the corpus visible raised arming by under 5 points, not 2× — the downstream gates
absorb it. One resurface delivered, of exactly the intended class:

> The agentctl workspace is open on a planning prompt, with context showing `issue-19-unreconciled`.
> This connects directly to your overdue task to investigate agentctl status and make a plan for
> Nik Shevchenko today.

Delivery rate was 1 of 23 attempts, so no over-firing in this window.

## What is not measured, stated rather than hidden

- **The true post-change arming rate has no offline estimate.** The old code forced `worthiness = 0`
  on every `needs_review` fact, so the extraction model's original scores for those 1,083 facts are
  destroyed and cannot be replayed. Dogfood is the only instrument, and the window above is 89 facts.
- **Commitment scoping rests on n=6** suppressions post-change. Direction only.
- **The candidate ceiling has not been exercised** — 7 candidates armed, no candidate-sourced
  delivery in the window. The constant 8 is low-confidence sizing and deliberately cheap to retune.
- **Resurface accuracy is unverified.** We know these messages were being vetoed and that they read
  well in the model's own reasoning; nobody has confirmed a delivered resurface is factually right.
- **The echo detector was fitted on the current corpus** with the next dogfood window as its
  held-out test. That window returned 0 stored echoes against 1 in the control, which is the right
  direction on a small sample, not proof.
- **Near-duplicate facts are now more costly**, because they are no longer being zeroed by the
  identifier gate: 4 of the 23 arming-eligible facts in the newest window are one usage statistic
  restated. Not addressed here; it is the clearest next target.

## Cache: investigated, no change, client exonerated

Recorded because it closes a thread, not because this PR changes anything. Frozen-prefix stability
after #11669 measured at 96% on live data (182/190 transitions). Direct probes of the exact
production prompt shape read cached tokens fine — until the same single-prefix control that read
1,792 tokens read **0 an hour later with byte-identical code**, and an 8-prefix probe read 0 under
both shared and per-prefix cache keys in the same window. Provider prefix caching is best-effort and
time-varying for this org and model. No client-side change is warranted on this evidence.

## Verification

- `xcrun swift build -c debug --package-path Desktop` — exit 0.
- `xcrun swift test --package-path Desktop --filter 'Context'` — **392 tests, 0 failures**.
- Prompt goldens updated to new exact text; still strict equality, not loosened.
- Running on the dogfood bundle with Screen Recording intact and `capture_health: active`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

