### PR TITLE
fix(macos): keep Brain Map replay, focus, and Escape on the map

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -3509,6 +3509,7 @@ private struct CanonicalMemoryAtlasSurface: View {
 
   private var asOfLabel: String {
     guard let asOf = asOfDate else { return "Now — the whole map" }
+    guard MemoryAtlasPlayback.isCredible(asOf) else { return "Import replay" }
     let formatter = DateFormatter()
     formatter.dateStyle = .medium
     formatter.timeStyle = .none
@@ -3519,7 +3520,7 @@ private struct CanonicalMemoryAtlasSurface: View {
   }
 
   private func shortDate(_ date: Date?) -> String {
-    guard let date else { return "" }
+    guard let date, MemoryAtlasPlayback.isCredible(date) else { return "" }
     let formatter = DateFormatter()
     formatter.dateFormat = "MMM d, yyyy"
     return formatter.string(from: date)
@@ -3723,11 +3724,8 @@ private struct CanonicalMemoryAtlasSurface: View {
   }
 
   private func point(for normalized: CGPoint, in size: CGSize) -> CGPoint {
-    let span = MemoryAtlasLayoutEngine.projectionSpan(of: size)
-    return CGPoint(
-      x: (normalized.x - 0.5) * span * zoom + size.width / 2 + pan.width,
-      y: (normalized.y - 0.5) * span * zoom + size.height / 2 + pan.height
-    )
+    MemoryAtlasRenderPlanner.renderedPoint(
+      for: normalized, viewportSize: size, zoom: zoom, pan: pan)
   }
 
   private func canvasPaintBounds(for size: CGSize) -> CGRect {

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift
@@ -96,146 +96,6 @@ enum MemoryAtlasCluster: String, CaseIterable, Identifiable {
   }
 }
 
-/// The time axis behind the atlas. Built from entity `createdAt` timestamps so
-/// the user can scrub — or watch — their memory come into being. Playback is
-/// density-aware: a tight imported/backfilled cluster is expanded into a short,
-/// deterministic sequence instead of appearing as one unreadable burst. Dates
-/// shown to the user always remain the original dates from memory data.
-struct MemoryAtlasTimeline: Equatable {
-  struct Entry: Equatable {
-    let nodeID: String
-    let createdAt: Date
-    let playbackFraction: Double
-  }
-
-  let start: Date
-  let end: Date
-  /// Entity-birth counts across the density-expanded playback axis, for the
-  /// histogram. This describes animation pacing, not rewritten history.
-  let buckets: [Int]
-  let entries: [Entry]
-  let playbackFractionByNodeID: [String: Double]
-
-  var hasChronologicalRange: Bool { end > start }
-  var span: TimeInterval { max(end.timeIntervalSince(start), 1) }
-
-  func date(atFraction fraction: Double) -> Date {
-    let clamped = min(max(fraction, 0), 1)
-    guard let first = entries.first else {
-      return start.addingTimeInterval(span * clamped)
-    }
-    guard clamped > first.playbackFraction else { return first.createdAt }
-    // This deliberately steps to the last real creation date rather than
-    // interpolating an invented timestamp between two memories.
-    return entries[max(firstPlaybackIndex(after: clamped) - 1, 0)].createdAt
-  }
-
-  func fraction(for date: Date) -> Double {
-    guard let first = entries.first, let last = entries.last else { return 1 }
-    guard date > first.createdAt else { return first.playbackFraction }
-    guard date < last.createdAt else { return last.playbackFraction }
-    return entries[max(firstDateIndex(after: date) - 1, 0)].playbackFraction
-  }
-
-  func isVisible(nodeID: String, at fraction: Double) -> Bool {
-    (playbackFractionByNodeID[nodeID] ?? 1) <= min(max(fraction, 0), 1)
-  }
-
-  func visibleNodeCount(at fraction: Double) -> Int {
-    let clamped = min(max(fraction, 0), 1)
-    return firstPlaybackIndex(after: clamped)
-  }
-
-  func spawnProgress(nodeID: String, at fraction: Double) -> Double {
-    guard let bornAt = playbackFractionByNodeID[nodeID] else { return 0 }
-    let age = fraction - bornAt
-    let window = max(0.012, min(0.05, 5 / Double(max(entries.count, 1))))
-    guard age >= 0, age < window else { return 0 }
-    return 1 - age / window
-  }
-
-  /// Retained for the legacy Date-based preview path. Live replay uses
-  /// `spawnProgress(nodeID:at:)` so dense imports bloom one-at-a-time.
-  var spawnWindow: TimeInterval { span / 26 }
-
-  private func firstPlaybackIndex(after fraction: Double) -> Int {
-    var lower = 0
-    var upper = entries.count
-    while lower < upper {
-      let middle = lower + (upper - lower) / 2
-      if entries[middle].playbackFraction > fraction {
-        upper = middle
-      } else {
-        lower = middle + 1
-      }
-    }
-    return lower
-  }
-
-  private func firstDateIndex(after date: Date) -> Int {
-    var lower = 0
-    var upper = entries.count
-    while lower < upper {
-      let middle = lower + (upper - lower) / 2
-      if entries[middle].createdAt > date {
-        upper = middle
-      } else {
-        lower = middle + 1
-      }
-    }
-    return lower
-  }
-
-  static func make(from nodes: [KnowledgeGraphNode], bucketCount: Int = 40) -> MemoryAtlasTimeline? {
-    let orderedNodes = nodes.sorted {
-      if $0.createdAt == $1.createdAt { return $0.id < $1.id }
-      return $0.createdAt < $1.createdAt
-    }
-    guard orderedNodes.count > 1, let start = orderedNodes.first?.createdAt, let end = orderedNodes.last?.createdAt
-    else {
-      return nil
-    }
-
-    let hasChronologicalRange = end > start
-    let chronologicalSpan = max(end.timeIntervalSince(start), 1)
-    // Chronology remains the majority signal for naturally distributed
-    // memories, while rank gives dense imports enough playback room to be
-    // comprehensible. Both inputs are monotonic, so this cannot reorder data
-    // or fabricate a date.
-    let chronologicalWeight = hasChronologicalRange ? 0.32 : 0
-    let densityWeight = 1 - chronologicalWeight
-    let denominator = Double(max(orderedNodes.count - 1, 1))
-    let entries = orderedNodes.enumerated().map { index, node in
-      let chronologicalFraction =
-        hasChronologicalRange
-        ? node.createdAt.timeIntervalSince(start) / chronologicalSpan
-        : 0
-      let densityFraction = Double(index) / denominator
-      return Entry(
-        nodeID: node.id,
-        createdAt: node.createdAt,
-        playbackFraction: chronologicalWeight * chronologicalFraction + densityWeight * densityFraction
-      )
-    }
-
-    var buckets = Array(repeating: 0, count: max(bucketCount, 1))
-    for entry in entries {
-      let index = min(
-        buckets.count - 1,
-        max(0, Int(entry.playbackFraction * Double(buckets.count)))
-      )
-      buckets[index] += 1
-    }
-    return MemoryAtlasTimeline(
-      start: start,
-      end: end,
-      buckets: buckets,
-      entries: entries,
-      playbackFractionByNodeID: Dictionary(lastWriteWins: entries.map { ($0.nodeID, $0.playbackFraction) })
-    )
-  }
-}
-
 struct MemoryAtlasEdgePlacement: Identifiable {
   let edge: KnowledgeGraphEdge
   let source: CGPoint
@@ -471,64 +331,6 @@ enum MemoryAtlasDetailLevel: Equatable {
   case detail
   case focus
   case inspect
-}
-
-enum MemoryAtlasZoomPolicy {
-  /// At or below this entity count the whole atlas fits on one screen, so the
-  /// density budgets tuned for thousands of entities stop being a kindness and
-  /// start being the reason the page looks empty.
-  static let smallAtlasCeiling = 60
-  static let minimumZoom: CGFloat = 0.75
-  /// Where reading the map as a whole ends and reading one part of it begins.
-  /// Named because four places were deciding it independently with the same
-  /// literal, and one of them now also decides whether the user is still
-  /// inside a neighbourhood.
-  static let neighborhoodZoom: CGFloat = 1.35
-  static let compactMaximumZoom: CGFloat = 1.35
-  static let focusModeZoom: CGFloat = 3.2
-  static let inspectModeZoom: CGFloat = 7.5
-  static let focusTargetZoom: CGFloat = 4
-
-  /// The final inspection level needs enough screen-space for every entity to
-  /// have a readable label. A square-root curve tracks the area required by a
-  /// larger graph: four times as many entities need roughly twice the zoom.
-  /// This intentionally has no arbitrary product ceiling, so a growing memory
-  /// graph always has a reachable all-labelled state.
-  static func fullyLabelledZoom(nodeCount: Int) -> CGFloat {
-    // Labels need substantially more room than dots. The 3.6x factor comes
-    // from the label footprint rather than node radius, then rounds to a
-    // usable 500% increment for the zoom control. This yields 16,000% for
-    // the sampled ~1,946-entity graph, leaving dense constellations legible.
-    let densityScaledZoom = ceil(sqrt(CGFloat(max(nodeCount, 1))) * 3.6 / 5) * 5
-    return max(16, densityScaledZoom)
-  }
-
-  /// Begins Canvas-based labels before the final all-labelled state. This uses
-  /// the same density curve as the maximum zoom, so a larger memory graph
-  /// earns more room before every visible dot is named. At this level Canvas
-  /// draws labels only for nodes inside the current viewport; it never creates
-  /// a SwiftUI label view per entity.
-  static func automaticCanvasLabelZoom(nodeCount: Int) -> CGFloat {
-    let threshold = fullyLabelledZoom(nodeCount: nodeCount) * 0.25
-    return max(inspectModeZoom, ceil(threshold * 2) / 2)
-  }
-
-  static func maximumZoom(nodeCount: Int, compact: Bool) -> CGFloat {
-    compact ? compactMaximumZoom : fullyLabelledZoom(nodeCount: nodeCount)
-  }
-
-  static func focusedZoom(currentZoom: CGFloat, nodeCount: Int, compact: Bool) -> CGFloat {
-    min(max(currentZoom, focusTargetZoom), maximumZoom(nodeCount: nodeCount, compact: compact))
-  }
-
-  static func panPreservingCenterZoom(
-    _ pan: CGSize,
-    from currentZoom: CGFloat,
-    to nextZoom: CGFloat
-  ) -> CGSize {
-    let ratio = nextZoom / max(currentZoom, minimumZoom)
-    return CGSize(width: pan.width * ratio, height: pan.height * ratio)
-  }
 }
 
 struct MemoryAtlasRenderPlan {
@@ -1954,6 +1756,47 @@ enum MemoryAtlasHitTesting {
 
 // MARK: - Canonical Atlas Containers
 
+/// Holds the canvas until a complete graph is ready, so the first visit cannot
+/// paint a synthetic owner as the whole map.
+private struct CanonicalMemoryAtlasLoadGate<Content: View>: View {
+  @ObservedObject var viewModel: MemoryGraphViewModel
+  @ViewBuilder var content: () -> Content
+
+  var body: some View {
+    switch MemoryAtlasSurfacePresentation.phase(
+      isLoading: viewModel.isLoading,
+      isEmpty: viewModel.isEmpty,
+      hasProjection: viewModel.canonicalAtlasProjection != nil,
+      hasAttemptedLoad: viewModel.hasAttemptedCanonicalAtlasLoad
+    ) {
+    case .loading:
+      ZStack {
+        Color.clear
+        ProgressView()
+          .controlSize(.regular)
+          .tint(Ink.secondary)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .accessibilityIdentifier("canonical_memory_atlas_loading")
+    case .empty:
+      VStack(spacing: OmiSpacing.sm) {
+        Image(systemName: "brain")
+          .scaledFont(size: OmiType.heading)
+          .foregroundColor(Ink.secondary)
+        Text("Brain map will appear once enough linked memories are available.")
+          .scaledFont(size: 12.5)
+          .foregroundColor(Ink.secondary)
+          .multilineTextAlignment(.center)
+      }
+      .padding(OmiSpacing.lg)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .accessibilityIdentifier("canonical_memory_atlas_empty")
+    case .ready:
+      content()
+    }
+  }
+}
+
 struct CanonicalMemoryAtlasPage: View {
   @ObservedObject var viewModel: MemoryGraphViewModel
   let onBack: () -> Void
@@ -2012,16 +1855,18 @@ struct CanonicalMemoryAtlasPage: View {
 
       Divider().overlay(Ink.separator.opacity(0.25))
 
-      CanonicalMemoryAtlasSurface(
-        graph: viewModel.canonicalAtlasProjection?.graph ?? viewModel.graphResponse,
-        projection: viewModel.canonicalAtlasProjection,
-        compact: false,
-        evidenceProvider: evidenceProvider,
-        onOpenMemory: onOpenMemory,
-        onRebuild: { Task { await viewModel.rebuildCanonicalAtlas() } },
-        isRebuilding: viewModel.isRebuilding,
-        onLeave: onBack
-      )
+      CanonicalMemoryAtlasLoadGate(viewModel: viewModel) {
+        CanonicalMemoryAtlasSurface(
+          graph: viewModel.canonicalAtlasProjection?.graph ?? viewModel.graphResponse,
+          projection: viewModel.canonicalAtlasProjection,
+          compact: false,
+          evidenceProvider: evidenceProvider,
+          onOpenMemory: onOpenMemory,
+          onRebuild: { Task { await viewModel.rebuildCanonicalAtlas() } },
+          isRebuilding: viewModel.isRebuilding,
+          onLeave: onBack
+        )
+      }
     }
     .background(Color.clear)
     .accessibilityIdentifier("canonical_memory_atlas_page")
@@ -2050,16 +1895,18 @@ struct CanonicalMemoryAtlasTabView: View {
   var onLeave: (() -> Void)?
 
   var body: some View {
-    CanonicalMemoryAtlasSurface(
-      graph: viewModel.canonicalAtlasProjection?.graph ?? viewModel.graphResponse,
-      projection: viewModel.canonicalAtlasProjection,
-      compact: false,
-      evidenceProvider: evidenceProvider,
-      onOpenMemory: onOpenMemory,
-      onRebuild: { Task { await viewModel.rebuildCanonicalAtlas() } },
-      isRebuilding: viewModel.isRebuilding,
-      onLeave: onLeave
-    )
+    CanonicalMemoryAtlasLoadGate(viewModel: viewModel) {
+      CanonicalMemoryAtlasSurface(
+        graph: viewModel.canonicalAtlasProjection?.graph ?? viewModel.graphResponse,
+        projection: viewModel.canonicalAtlasProjection,
+        compact: false,
+        evidenceProvider: evidenceProvider,
+        onOpenMemory: onOpenMemory,
+        onRebuild: { Task { await viewModel.rebuildCanonicalAtlas() } },
+        isRebuilding: viewModel.isRebuilding,
+        onLeave: onLeave
+      )
+    }
     .background(Color.clear)
     .accessibilityIdentifier("canonical_memory_atlas_tab")
     .task { await viewModel.prepareCanonicalAtlas() }
@@ -2326,6 +2173,10 @@ private struct CanonicalMemoryAtlasSurface: View {
     }
     .animation(OmiMotion.gated(.easeOut(duration: 0.18)), value: selectedNodeID)
     .task(id: evidenceSelectionKey) { await loadEvidence() }
+    .onEscapeKey(priority: .content) {
+      guard !compact else { return false }
+      return dismissTopmostState()
+    }
   }
 
   @ViewBuilder
@@ -2435,7 +2286,6 @@ private struct CanonicalMemoryAtlasSurface: View {
               onScroll: { delta, location in
                 scrollZoom(by: delta, anchoredAt: location, in: proxy.size)
               },
-              onEscape: dismissTopmostState,
               onFocusSearch: { searchIsFocused = true }
             )
             .accessibilityHidden(true)
@@ -2541,8 +2391,7 @@ private struct CanonicalMemoryAtlasSurface: View {
         snapshot.nodeByID[edge.edge.sourceId] != nil
       {
         selectionTrail.removeAll()
-        selectedNodeID = edge.edge.sourceId
-        selectedEdgeID = edgeID
+        adoptSelection(edge.edge.sourceId, edgeID: edgeID)
         return
       }
       // By name as well as by id, because an entity's id is a server key
@@ -2558,8 +2407,7 @@ private struct CanonicalMemoryAtlasSurface: View {
         snapshot.nodeByID[$0] != nil ? $0 : nil
       }) ?? named?.id {
         selectionTrail.removeAll()
-        selectedEdgeID = nil
-        selectedNodeID = nodeID
+        adoptSelection(nodeID)
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationMemoryAtlasTimeRequested)) {
@@ -3256,9 +3104,12 @@ private struct CanonicalMemoryAtlasSurface: View {
     let hitDiameter = max(diameter, 24)
 
     return Button {
-      selectionTrail.removeAll()
-      selectedEdgeID = nil
-      selectedNodeID = selected ? nil : placement.id
+      if selected {
+        clearSelection(resetCamera: true)
+      } else {
+        selectionTrail.removeAll()
+        adoptSelection(placement.id)
+      }
     } label: {
       ZStack {
         if selected {
@@ -3337,7 +3188,7 @@ private struct CanonicalMemoryAtlasSurface: View {
       onOpenMemory: openCitedMemory,
       onBack: backAction,
       onFocus: { focus(on: placement) },
-      onClose: clearSelection
+      onClose: { clearSelection(resetCamera: true) }
     )
   }
 
@@ -3376,7 +3227,7 @@ private struct CanonicalMemoryAtlasSurface: View {
       onOpenMemory: openCitedMemory,
       onBack: backAction,
       onFocus: { focus(on: anchor) },
-      onClose: clearSelection
+      onClose: { clearSelection(resetCamera: true) }
     )
   }
 
@@ -3392,20 +3243,27 @@ private struct CanonicalMemoryAtlasSurface: View {
     if let current = selectedNodeID, current != row.otherNodeID {
       selectionTrail.append(current)
     }
-    selectedEdgeID = nil
-    selectedNodeID = row.otherNodeID
+    adoptSelection(row.otherNodeID)
   }
 
   private func goBack() {
     guard let previous = selectionTrail.popLast() else { return }
-    selectedEdgeID = nil
-    selectedNodeID = previous
+    adoptSelection(previous)
   }
 
-  private func clearSelection() {
+  private func adoptSelection(_ nodeID: String, edgeID: String? = nil) {
+    selectedEdgeID = edgeID
+    selectedNodeID = nodeID
+    if let placement = snapshot.nodeByID[nodeID] {
+      focus(on: placement)
+    }
+  }
+
+  private func clearSelection(resetCamera: Bool = false) {
     selectionTrail.removeAll()
     selectedEdgeID = nil
     selectedNodeID = nil
+    if resetCamera { resetViewport(preservingNeighbourhood: true) }
   }
 
   private func selectionStrip(for placement: MemoryAtlasNodePlacement) -> some View {
@@ -3462,7 +3320,7 @@ private struct CanonicalMemoryAtlasSurface: View {
       .foregroundColor(Ink.secondary)
 
       Button {
-        clearSelection()
+        clearSelection(resetCamera: true)
       } label: {
         Image(systemName: "xmark")
           .scaledFont(size: 10, weight: .semibold)
@@ -3695,7 +3553,7 @@ private struct CanonicalMemoryAtlasSurface: View {
     isCameraMoving = true
     playbackTask = Task { @MainActor in
       var last = Date()
-      let totalSeconds = 6.5
+      let totalSeconds = MemoryAtlasPlayback.duration(entityCount: snapshot.nodes.count)
       while !Task.isCancelled {
         try? await Task.sleep(nanoseconds: 33_000_000)
         if Task.isCancelled { return }
@@ -3932,12 +3790,13 @@ private struct CanonicalMemoryAtlasSurface: View {
 
   private func selectFirstSearchResult() {
     guard let matchingNodeIDs, !matchingNodeIDs.isEmpty else { return }
-    selectionTrail.removeAll()
-    selectedEdgeID = nil
-    selectedNodeID =
-      snapshot.nodes.first {
+    guard
+      let nodeID = snapshot.nodes.first(where: {
         matchingNodeIDs.contains($0.id) && nodeIsVisibleAtCurrentTime($0)
-      }?.id
+      })?.id
+    else { return }
+    selectionTrail.removeAll()
+    adoptSelection(nodeID)
   }
 
   /// Routes a click on the canvas to whatever it landed on.
@@ -3950,8 +3809,7 @@ private struct CanonicalMemoryAtlasSurface: View {
       // Reaching for something on the canvas starts a fresh trail; only
       // following a listed connection extends one.
       selectionTrail.removeAll()
-      selectedEdgeID = nil
-      selectedNodeID = node.id
+      adoptSelection(node.id)
       return
     }
 
@@ -3974,8 +3832,7 @@ private struct CanonicalMemoryAtlasSurface: View {
       snapshot.nodeByID[hit.edge.sourceId] != nil
     else { return }
     selectionTrail.removeAll()
-    selectedNodeID = hit.edge.sourceId
-    selectedEdgeID = hit.id
+    adoptSelection(hit.edge.sourceId, edgeID: hit.id)
   }
 
   private func nearestNode(to location: CGPoint, in size: CGSize, visibleNodes: [MemoryAtlasNodePlacement] = [])
@@ -4027,24 +3884,34 @@ private struct CanonicalMemoryAtlasSurface: View {
 
   private func focus(on placement: MemoryAtlasNodePlacement) {
     guard viewportSize.width > 0, viewportSize.height > 0 else { return }
-    let focusedZoom = MemoryAtlasZoomPolicy.focusedZoom(
+    var positions = [placement.normalizedPosition]
+    if let neighborIDs = snapshot.neighborIDsByNodeID[placement.id] {
+      for neighborID in neighborIDs {
+        if let neighbor = snapshot.nodeByID[neighborID] {
+          positions.append(neighbor.normalizedPosition)
+        }
+      }
+    }
+    let camera = MemoryAtlasZoomPolicy.focusedNeighborhood(
+      positions: positions,
+      viewport: viewportSize,
       currentZoom: zoom,
-      nodeCount: snapshot.nodes.count,
-      compact: compact
-    )
-    let focusedPan = CGSize(
-      width: (0.5 - placement.normalizedPosition.x) * viewportSize.width * focusedZoom,
-      height: (0.5 - placement.normalizedPosition.y) * viewportSize.height * focusedZoom
+      zoomRange: MemoryAtlasZoomPolicy.minimumZoom...maximumZoom
     )
     withAnimation(.easeOut(duration: 0.22)) {
-      zoom = focusedZoom
-      settledZoom = focusedZoom
-      pan = focusedPan
-      settledPan = focusedPan
+      zoom = camera.zoom
+      settledZoom = camera.zoom
+      pan = camera.pan
+      settledPan = camera.pan
     }
   }
 
-  private func resetViewport() {
+  private func resetViewport(preservingNeighbourhood: Bool = false) {
+    if preservingNeighbourhood, enteredRegionID != nil {
+      departureZoom = MemoryAtlasNeighbourhoodLabels.overviewDepartureZoom(
+        neighbourhoodZoom: MemoryAtlasZoomPolicy.neighborhoodZoom,
+        minimumZoom: MemoryAtlasZoomPolicy.minimumZoom)
+    }
     withAnimation(.easeOut(duration: 0.2)) {
       zoom = 1
       settledZoom = 1
@@ -4071,7 +3938,7 @@ private struct CanonicalMemoryAtlasSurface: View {
     case .selectionStep:
       goBack()
     case .selection:
-      clearSelection()
+      clearSelection(resetCamera: true)
     case .neighbourhood:
       leaveNeighbourhood()
     case .passThrough:
@@ -4092,12 +3959,10 @@ private struct CanonicalMemoryAtlasSurface: View {
 /// owned by SwiftUI.
 private struct MemoryAtlasInputMonitor: NSViewRepresentable {
   let onScroll: (CGFloat, CGPoint) -> Void
-  /// Reports whether the map used the key. False hands it back to the page.
-  let onEscape: () -> Bool
   let onFocusSearch: () -> Void
 
   func makeCoordinator() -> Coordinator {
-    Coordinator(onScroll: onScroll, onEscape: onEscape, onFocusSearch: onFocusSearch)
+    Coordinator(onScroll: onScroll, onFocusSearch: onFocusSearch)
   }
 
   func makeNSView(context: Context) -> PassiveEventView {
@@ -4113,7 +3978,6 @@ private struct MemoryAtlasInputMonitor: NSViewRepresentable {
 
   func updateNSView(_ nsView: PassiveEventView, context: Context) {
     context.coordinator.onScroll = onScroll
-    context.coordinator.onEscape = onEscape
     context.coordinator.onFocusSearch = onFocusSearch
   }
 
@@ -4149,7 +4013,6 @@ private struct MemoryAtlasInputMonitor: NSViewRepresentable {
 
   final class Coordinator {
     var onScroll: (CGFloat, CGPoint) -> Void
-    var onEscape: () -> Bool
     var onFocusSearch: () -> Void
     fileprivate var windowNumber: Int?
     fileprivate var frameInWindow: CGRect = .zero
@@ -4157,11 +4020,9 @@ private struct MemoryAtlasInputMonitor: NSViewRepresentable {
 
     init(
       onScroll: @escaping (CGFloat, CGPoint) -> Void,
-      onEscape: @escaping () -> Bool,
       onFocusSearch: @escaping () -> Void
     ) {
       self.onScroll = onScroll
-      self.onEscape = onEscape
       self.onFocusSearch = onFocusSearch
     }
 
@@ -4170,10 +4031,6 @@ private struct MemoryAtlasInputMonitor: NSViewRepresentable {
         [weak self] event in
         guard let self, event.windowNumber == self.windowNumber else {
           return event
-        }
-
-        if event.type == .keyDown, event.keyCode == 53 {
-          return self.onEscape() ? nil : event
         }
 
         if event.type == .keyDown,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPlayback.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPlayback.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+/// How the Brain Map grows over time.
+///
+/// Calendar time is a poor playback axis: years of silence between clusters
+/// make replay pause on an almost-empty map. Missing `created_at` values also
+/// decode as the Unix epoch, which used to pin the left of the scrubber at
+/// 1969. Playback therefore compresses long quiet stretches, ignores epoch
+/// placeholders, and still spends extra time inside dense imports so they do
+/// not appear as one burst.
+enum MemoryAtlasPlayback {
+  /// Accounts with more than this many entities get a four-second replay.
+  /// Smaller maps finish sooner so a handful of memories is not stretched.
+  static let fewEntityCeiling = 12
+  static let manyReplaySeconds: TimeInterval = 4
+  static let fewReplaySeconds: TimeInterval = 2
+  /// A calendar gap longer than this is treated as one short beat instead of
+  /// occupying a proportional slice of the four-second replay.
+  static let maxUncompressedGap: TimeInterval = 12 * 60 * 60
+  /// Unix-epoch sentinels from missing timestamps. Anything earlier is not a
+  /// real memory date and must not own the chronological axis.
+  static let earliestCredibleDate = Date(timeIntervalSince1970: 1_000_000_000)
+  /// Chronology after gap-compression. Density still gets the majority so a
+  /// same-day import can bloom one entity at a time.
+  static let chronologicalWeight = 0.18
+
+  static func duration(entityCount: Int) -> TimeInterval {
+    entityCount > fewEntityCeiling ? manyReplaySeconds : fewReplaySeconds
+  }
+
+  static func isCredible(_ date: Date) -> Bool {
+    date >= earliestCredibleDate
+  }
+
+  /// Dates that may stretch the axis. Epoch placeholders collapse onto the
+  /// first real timestamp so they still appear, just not in 1969.
+  static func effectiveDates(from dates: [Date]) -> [Date] {
+    let credible = dates.filter(isCredible)
+    let floor = credible.min() ?? Date()
+    return dates.map { isCredible($0) ? $0 : floor }
+  }
+
+  /// Running compressed time for a sorted date list. Each inter-event gap is
+  /// capped so a silent year cannot steal a third of the replay.
+  static func compressedOffsets(for dates: [Date]) -> [TimeInterval] {
+    guard let first = dates.first else { return [] }
+    var offsets: [TimeInterval] = [0]
+    offsets.reserveCapacity(dates.count)
+    var elapsed: TimeInterval = 0
+    var previous = first
+    for date in dates.dropFirst() {
+      elapsed += min(max(date.timeIntervalSince(previous), 0), maxUncompressedGap)
+      offsets.append(elapsed)
+      previous = date
+    }
+    return offsets
+  }
+}
+
+/// The time axis behind the atlas. Built from entity `createdAt` timestamps so
+/// the user can scrub — or watch — their memory come into being. Playback is
+/// density-aware: a tight imported/backfilled cluster is expanded into a short,
+/// deterministic sequence instead of appearing as one unreadable burst. Dates
+/// shown to the user always remain the original dates from memory data.
+struct MemoryAtlasTimeline: Equatable {
+  struct Entry: Equatable {
+    let nodeID: String
+    let createdAt: Date
+    let playbackFraction: Double
+  }
+
+  let start: Date
+  let end: Date
+  /// Entity-birth counts across the density-expanded playback axis, for the
+  /// histogram. This describes animation pacing, not rewritten history.
+  let buckets: [Int]
+  let entries: [Entry]
+  let playbackFractionByNodeID: [String: Double]
+
+  var hasChronologicalRange: Bool { end > start }
+  var span: TimeInterval { max(end.timeIntervalSince(start), 1) }
+
+  func date(atFraction fraction: Double) -> Date {
+    let clamped = min(max(fraction, 0), 1)
+    guard let first = entries.first else {
+      return start.addingTimeInterval(span * clamped)
+    }
+    guard clamped > first.playbackFraction else { return first.createdAt }
+    // This deliberately steps to the last real creation date rather than
+    // interpolating an invented timestamp between two memories.
+    return entries[max(firstPlaybackIndex(after: clamped) - 1, 0)].createdAt
+  }
+
+  func fraction(for date: Date) -> Double {
+    guard let first = entries.first, let last = entries.last else { return 1 }
+    guard date > first.createdAt else { return first.playbackFraction }
+    guard date < last.createdAt else { return last.playbackFraction }
+    return entries[max(firstDateIndex(after: date) - 1, 0)].playbackFraction
+  }
+
+  func isVisible(nodeID: String, at fraction: Double) -> Bool {
+    (playbackFractionByNodeID[nodeID] ?? 1) <= min(max(fraction, 0), 1)
+  }
+
+  func visibleNodeCount(at fraction: Double) -> Int {
+    let clamped = min(max(fraction, 0), 1)
+    return firstPlaybackIndex(after: clamped)
+  }
+
+  func spawnProgress(nodeID: String, at fraction: Double) -> Double {
+    guard let bornAt = playbackFractionByNodeID[nodeID] else { return 0 }
+    let age = fraction - bornAt
+    let window = max(0.012, min(0.05, 5 / Double(max(entries.count, 1))))
+    guard age >= 0, age < window else { return 0 }
+    return 1 - age / window
+  }
+
+  /// Retained for the legacy Date-based preview path. Live replay uses
+  /// `spawnProgress(nodeID:at:)` so dense imports bloom one-at-a-time.
+  var spawnWindow: TimeInterval { span / 26 }
+
+  private func firstPlaybackIndex(after fraction: Double) -> Int {
+    var lower = 0
+    var upper = entries.count
+    while lower < upper {
+      let middle = lower + (upper - lower) / 2
+      if entries[middle].playbackFraction > fraction {
+        upper = middle
+      } else {
+        lower = middle + 1
+      }
+    }
+    return lower
+  }
+
+  private func firstDateIndex(after date: Date) -> Int {
+    var lower = 0
+    var upper = entries.count
+    while lower < upper {
+      let middle = lower + (upper - lower) / 2
+      if entries[middle].createdAt > date {
+        upper = middle
+      } else {
+        lower = middle + 1
+      }
+    }
+    return lower
+  }
+
+  static func make(from nodes: [KnowledgeGraphNode], bucketCount: Int = 40) -> MemoryAtlasTimeline? {
+    let orderedNodes = nodes.sorted {
+      if $0.createdAt == $1.createdAt { return $0.id < $1.id }
+      return $0.createdAt < $1.createdAt
+    }
+    guard orderedNodes.count > 1, let start = orderedNodes.first?.createdAt, let end = orderedNodes.last?.createdAt
+    else {
+      return nil
+    }
+
+    let effectiveDates = MemoryAtlasPlayback.effectiveDates(from: orderedNodes.map(\.createdAt))
+    let axisStart = effectiveDates.min() ?? start
+    let axisEnd = effectiveDates.max() ?? end
+    let hasChronologicalRange = axisEnd > axisStart
+    let compressedOffsets = MemoryAtlasPlayback.compressedOffsets(for: effectiveDates)
+    let compressedSpan = max(compressedOffsets.last ?? 0, 1)
+    // Chronology remains a minority signal for naturally distributed
+    // memories, while rank gives dense imports enough playback room to be
+    // comprehensible. Both inputs are monotonic, so this cannot reorder data
+    // or fabricate a date.
+    let chronologicalWeight = hasChronologicalRange ? MemoryAtlasPlayback.chronologicalWeight : 0
+    let densityWeight = 1 - chronologicalWeight
+    let denominator = Double(max(orderedNodes.count - 1, 1))
+    let entries = orderedNodes.enumerated().map { index, node in
+      let chronologicalFraction =
+        hasChronologicalRange
+        ? compressedOffsets[index] / compressedSpan
+        : 0
+      let densityFraction = Double(index) / denominator
+      return Entry(
+        nodeID: node.id,
+        createdAt: effectiveDates[index],
+        playbackFraction: chronologicalWeight * chronologicalFraction + densityWeight * densityFraction
+      )
+    }
+
+    var buckets = Array(repeating: 0, count: max(bucketCount, 1))
+    for entry in entries {
+      let index = min(
+        buckets.count - 1,
+        max(0, Int(entry.playbackFraction * Double(buckets.count)))
+      )
+      buckets[index] += 1
+    }
+    return MemoryAtlasTimeline(
+      start: axisStart,
+      end: axisEnd,
+      buckets: buckets,
+      entries: entries,
+      playbackFractionByNodeID: Dictionary(lastWriteWins: entries.map { ($0.nodeID, $0.playbackFraction) })
+    )
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPlayback.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPlayback.swift
@@ -33,10 +33,11 @@ enum MemoryAtlasPlayback {
   }
 
   /// Dates that may stretch the axis. Epoch placeholders collapse onto the
-  /// first real timestamp so they still appear, just not in 1969.
+  /// first real timestamp so they still appear, just not in 1969. A graph with
+  /// no credible dates keeps the placeholders instead of inventing today.
   static func effectiveDates(from dates: [Date]) -> [Date] {
-    let credible = dates.filter(isCredible)
-    let floor = credible.min() ?? Date()
+    guard let first = dates.first else { return [] }
+    let floor = dates.lazy.filter(isCredible).min() ?? first
     return dates.map { isCredible($0) ? $0 : floor }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSurfacePresentation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSurfacePresentation.swift
@@ -20,8 +20,10 @@ enum MemoryAtlasSurfacePresentation {
     hasProjection: Bool,
     hasAttemptedLoad: Bool
   ) -> Phase {
-    if hasProjection { return .ready }
+    // An empty server graph still used to mint a synthetic owner projection.
+    // Presence of that object is not readiness — it is the lonely-node flash.
+    if hasProjection && !isEmpty { return .ready }
     if isLoading || !hasAttemptedLoad { return .loading }
-    return isEmpty ? .empty : .ready
+    return .empty
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSurfacePresentation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSurfacePresentation.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// What the Brain Map tab shows before a canonical graph is ready.
+///
+/// The surface used to mount on an empty response and invent a synthetic
+/// owner node, so the first visit painted one lonely person for several
+/// seconds while pages were still arriving. Loading and emptiness are
+/// distinct: a spinner while the fetch is in flight, the empty copy only
+/// after that fetch has resolved to nothing.
+enum MemoryAtlasSurfacePresentation {
+  enum Phase: Equatable {
+    case loading
+    case empty
+    case ready
+  }
+
+  static func phase(
+    isLoading: Bool,
+    isEmpty: Bool,
+    hasProjection: Bool,
+    hasAttemptedLoad: Bool
+  ) -> Phase {
+    if hasProjection { return .ready }
+    if isLoading || !hasAttemptedLoad { return .loading }
+    return isEmpty ? .empty : .ready
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasTerritoryLabels.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasTerritoryLabels.swift
@@ -291,6 +291,17 @@ enum MemoryAtlasNeighbourhoodLabels {
     return departure > minimumZoom ? departure : nil
   }
 
+  /// Zoom-out floor after Escape (or inspector close) has sent the camera
+  /// home while the neighbourhood is still the next layer on the stack.
+  ///
+  /// The original threshold sits above zoom 1, so a selection-clear that
+  /// resets the viewport would otherwise also end the island. Rebinding from
+  /// the overview camera keeps that layer for the next Escape; a later
+  /// pinch below this floor can still leave.
+  static func overviewDepartureZoom(neighbourhoodZoom: CGFloat, minimumZoom: CGFloat) -> CGFloat? {
+    departureZoom(enteredAt: 1, neighbourhoodZoom: neighbourhoodZoom, minimumZoom: minimumZoom)
+  }
+
   /// Places on the island where its whole name would sit on land, nearest the
   /// middle first.
   ///

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasZoomPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasZoomPolicy.swift
@@ -1,0 +1,98 @@
+import CoreGraphics
+
+enum MemoryAtlasZoomPolicy {
+  /// At or below this entity count the whole atlas fits on one screen, so the
+  /// density budgets tuned for thousands of entities stop being a kindness and
+  /// start being the reason the page looks empty.
+  static let smallAtlasCeiling = 60
+  static let minimumZoom: CGFloat = 0.75
+  /// Where reading the map as a whole ends and reading one part of it begins.
+  /// Named because four places were deciding it independently with the same
+  /// literal, and one of them now also decides whether the user is still
+  /// inside a neighbourhood.
+  static let neighborhoodZoom: CGFloat = 1.35
+  static let compactMaximumZoom: CGFloat = 1.35
+  static let focusModeZoom: CGFloat = 3.2
+  static let inspectModeZoom: CGFloat = 7.5
+  static let focusTargetZoom: CGFloat = 4
+
+  /// The final inspection level needs enough screen-space for every entity to
+  /// have a readable label. A square-root curve tracks the area required by a
+  /// larger graph: four times as many entities need roughly twice the zoom.
+  /// This intentionally has no arbitrary product ceiling, so a growing memory
+  /// graph always has a reachable all-labelled state.
+  static func fullyLabelledZoom(nodeCount: Int) -> CGFloat {
+    // Labels need substantially more room than dots. The 3.6x factor comes
+    // from the label footprint rather than node radius, then rounds to a
+    // usable 500% increment for the zoom control. This yields 16,000% for
+    // the sampled ~1,946-entity graph, leaving dense constellations legible.
+    let densityScaledZoom = ceil(sqrt(CGFloat(max(nodeCount, 1))) * 3.6 / 5) * 5
+    return max(16, densityScaledZoom)
+  }
+
+  /// Begins Canvas-based labels before the final all-labelled state. This uses
+  /// the same density curve as the maximum zoom, so a larger memory graph
+  /// earns more room before every visible dot is named. At this level Canvas
+  /// draws labels only for nodes inside the current viewport; it never creates
+  /// a SwiftUI label view per entity.
+  static func automaticCanvasLabelZoom(nodeCount: Int) -> CGFloat {
+    let threshold = fullyLabelledZoom(nodeCount: nodeCount) * 0.25
+    return max(inspectModeZoom, ceil(threshold * 2) / 2)
+  }
+
+  static func maximumZoom(nodeCount: Int, compact: Bool) -> CGFloat {
+    compact ? compactMaximumZoom : fullyLabelledZoom(nodeCount: nodeCount)
+  }
+
+  static func focusedZoom(currentZoom: CGFloat, nodeCount: Int, compact: Bool) -> CGFloat {
+    min(max(currentZoom, focusTargetZoom), maximumZoom(nodeCount: nodeCount, compact: compact))
+  }
+
+  static func panPreservingCenterZoom(
+    _ pan: CGSize,
+    from currentZoom: CGFloat,
+    to nextZoom: CGFloat
+  ) -> CGSize {
+    let ratio = nextZoom / max(currentZoom, minimumZoom)
+    return CGSize(width: pan.width * ratio, height: pan.height * ratio)
+  }
+
+  /// Camera that frames a selected entity and the neighbours currently
+  /// highlighted with it. A lone node keeps the crosshair's tight focus zoom;
+  /// a connected set uses the same coverage rule as entering a neighbourhood
+  /// so every highlighted mark stays on screen.
+  static func focusedNeighborhood(
+    positions: [CGPoint],
+    viewport: CGSize,
+    currentZoom: CGFloat,
+    zoomRange: ClosedRange<CGFloat>
+  ) -> (zoom: CGFloat, pan: CGSize) {
+    guard let first = positions.first else {
+      return (min(max(currentZoom, zoomRange.lowerBound), zoomRange.upperBound), .zero)
+    }
+    if positions.count == 1 {
+      let zoom = min(max(currentZoom, focusTargetZoom), zoomRange.upperBound)
+      let span = MemoryAtlasLayoutEngine.projectionSpan(of: viewport)
+      return (
+        zoom,
+        CGSize(
+          width: (0.5 - first.x) * span * zoom,
+          height: (0.5 - first.y) * span * zoom)
+      )
+    }
+
+    var minimum = first
+    var maximum = first
+    for point in positions.dropFirst() {
+      minimum = CGPoint(x: min(minimum.x, point.x), y: min(minimum.y, point.y))
+      maximum = CGPoint(x: max(maximum.x, point.x), y: max(maximum.y, point.y))
+    }
+    let center = CGPoint(x: (minimum.x + maximum.x) / 2, y: (minimum.y + maximum.y) / 2)
+    let radius = max(hypot(maximum.x - minimum.x, maximum.y - minimum.y) / 2, 0.04)
+    return MemoryAtlasNeighbourhoodLabels.entering(
+      center: center,
+      radius: radius,
+      viewport: viewport,
+      zoomRange: zoomRange)
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasZoomPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasZoomPolicy.swift
@@ -44,10 +44,6 @@ enum MemoryAtlasZoomPolicy {
     compact ? compactMaximumZoom : fullyLabelledZoom(nodeCount: nodeCount)
   }
 
-  static func focusedZoom(currentZoom: CGFloat, nodeCount: Int, compact: Bool) -> CGFloat {
-    min(max(currentZoom, focusTargetZoom), maximumZoom(nodeCount: nodeCount, compact: compact))
-  }
-
   static func panPreservingCenterZoom(
     _ pan: CGSize,
     from currentZoom: CGFloat,

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -166,6 +166,9 @@ class MemoryGraphViewModel: ObservableObject {
   /// canonical graph revision. The SwiftUI Brain Map can re-render freely
   /// without rebuilding the relationship layout or losing its gesture cache.
   @Published private(set) var canonicalAtlasProjection: MemoryAtlasProjection?
+  /// False until `prepareCanonicalAtlas` finishes once, so the tab can show a
+  /// loader instead of a synthetic owner node on the first visit.
+  @Published private(set) var hasAttemptedCanonicalAtlasLoad = false
 
   let scene = SCNScene()
   let cameraNode = SCNNode()
@@ -294,9 +297,18 @@ class MemoryGraphViewModel: ObservableObject {
       graphResponse = KnowledgeGraphResponse(nodes: [], edges: [])
       canonicalAtlasProjection = nil
       isEmpty = true
+      isLoading = true
+    }
+    defer {
+      if generation == sessionGeneration {
+        hasAttemptedCanonicalAtlasLoad = true
+      }
     }
     guard let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
       log("Memory atlas: canonical load skipped while owner authorization is unavailable")
+      if generation == sessionGeneration, !hasLoadedCanonicalAtlas {
+        isLoading = false
+      }
       return
     }
     isPreparing = true
@@ -717,6 +729,7 @@ class MemoryGraphViewModel: ObservableObject {
     isPreparing = false
     hasRunEmptyBootstrap = false
     hasLoadedCanonicalAtlas = false
+    hasAttemptedCanonicalAtlasLoad = false
     loadedGraphSignature = nil
     cameraNode.position = SCNVector3(0, 0, 2000)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -166,8 +166,9 @@ class MemoryGraphViewModel: ObservableObject {
   /// canonical graph revision. The SwiftUI Brain Map can re-render freely
   /// without rebuilding the relationship layout or losing its gesture cache.
   @Published private(set) var canonicalAtlasProjection: MemoryAtlasProjection?
-  /// False until `prepareCanonicalAtlas` finishes once, so the tab can show a
-  /// loader instead of a synthetic owner node on the first visit.
+  /// False until a canonical fetch has returned, so the tab can show a loader
+  /// instead of a synthetic owner or a fake empty map. Failures stay in
+  /// loading and retry instead of counting as "attempted."
   @Published private(set) var hasAttemptedCanonicalAtlasLoad = false
 
   let scene = SCNScene()
@@ -299,16 +300,8 @@ class MemoryGraphViewModel: ObservableObject {
       isEmpty = true
       isLoading = true
     }
-    defer {
-      if generation == sessionGeneration {
-        hasAttemptedCanonicalAtlasLoad = true
-      }
-    }
     guard let authorizationSnapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else {
       log("Memory atlas: canonical load skipped while owner authorization is unavailable")
-      if generation == sessionGeneration, !hasLoadedCanonicalAtlas {
-        isLoading = false
-      }
       return
     }
     isPreparing = true
@@ -333,28 +326,48 @@ class MemoryGraphViewModel: ObservableObject {
       }
     }
 
-    do {
-      let response = try await canonicalGraphFetcher(authorizationSnapshot)
-      guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
+    var lastError: Error?
+    for attempt in 1...3 {
+      guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot),
+        !Task.isCancelled
+      else { return }
+      do {
+        let response = try await canonicalGraphFetcher(authorizationSnapshot)
+        guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
+          return
+        }
+        let hasContent = Self.hasAtlasContent(response)
+        var projection: MemoryAtlasProjection?
+        if hasContent {
+          let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+          let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+          let ownerName = givenName.isEmpty ? displayName : givenName
+          projection = await Task.detached(priority: .userInitiated) {
+            MemoryAtlasProjection(graph: response.atlasResponse, userName: ownerName.isEmpty ? nil : ownerName)
+          }.value
+          guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
+            return
+          }
+        }
+        canonicalAtlasProjection = projection
+        graphResponse = response
+        isEmpty = !hasContent
+        hasLoadedCanonicalAtlas = true
+        hasAttemptedCanonicalAtlasLoad = true
+        lastLoadedAt = Date()
+        log("Memory atlas: \(response.atlasNodes.count) nodes, \(response.edges.count) edges")
         return
-      }
-      let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
-      let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-      let ownerName = givenName.isEmpty ? displayName : givenName
-      let projection = await Task.detached(priority: .userInitiated) {
-        MemoryAtlasProjection(graph: response.atlasResponse, userName: ownerName.isEmpty ? nil : ownerName)
-      }.value
-      guard isCanonicalLoadCurrent(generation: generation, authorizationSnapshot: authorizationSnapshot) else {
+      } catch is CancellationError {
         return
+      } catch {
+        lastError = error
+        if attempt < 3 {
+          try? await Task.sleep(nanoseconds: 800_000_000)
+        }
       }
-      canonicalAtlasProjection = projection
-      graphResponse = response
-      isEmpty = !Self.hasAtlasContent(response)
-      hasLoadedCanonicalAtlas = true
-      lastLoadedAt = Date()
-      log("Memory atlas: \(response.atlasNodes.count) nodes, \(response.edges.count) edges")
-    } catch {
-      log("Failed to load memory atlas: \(error.localizedDescription)")
+    }
+    if let lastError {
+      log("Failed to load memory atlas: \(lastError.localizedDescription)")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/EscapeKeyDispatchTests.swift
+++ b/desktop/macos/Desktop/Tests/EscapeKeyDispatchTests.swift
@@ -99,4 +99,37 @@ final class EscapeKeyDispatchTests: XCTestCase {
     XCTAssertNil(editingNoteId)
     XCTAssertFalse(rewindHandled)
   }
+
+  @MainActor
+  func testAtlasSelectionTakesEscapeBeforeLeavingThePage() {
+    let window = NSWindow(contentRect: .zero, styleMask: [], backing: .buffered, defer: true)
+    var selected = true
+    var leftMap = false
+    let navigation = WindowEscapeKeyMonitor.shared.register(window: window, priority: .navigation) {
+      leftMap = true
+      return true
+    }
+    let content = WindowEscapeKeyMonitor.shared.register(window: window, priority: .content) {
+      switch MemoryAtlasDismissal.next(
+        isSearching: false, hasSelection: selected, hasTrail: false, isInsideNeighbourhood: false)
+      {
+      case .selection:
+        selected = false
+        return true
+      case .passThrough:
+        leftMap = true
+        return true
+      default:
+        return true
+      }
+    }
+    defer {
+      WindowEscapeKeyMonitor.shared.unregister(content)
+      WindowEscapeKeyMonitor.shared.unregister(navigation)
+    }
+
+    XCTAssertTrue(WindowEscapeKeyMonitor.shared.dispatchEscape(in: window))
+    XCTAssertFalse(selected)
+    XCTAssertFalse(leftMap)
+  }
 }

--- a/desktop/macos/Desktop/Tests/MemoryAtlasConnectionSelectionTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasConnectionSelectionTests.swift
@@ -207,13 +207,20 @@ final class MemoryAtlasConnectionSelectionTests: XCTestCase {
     XCTAssertTrue(
       String(source[picker.lowerBound...].prefix(1600)).contains("selectionTrail.removeAll()"),
       "Reaching for something on the canvas must start a fresh trail")
+    XCTAssertTrue(
+      String(source[picker.lowerBound...].prefix(1600)).contains("adoptSelection("),
+      "Selecting an entity must reuse the Focus camera so the neighbourhood is framed")
 
-    guard let clear = source.range(of: "private func clearSelection() {") else {
+    guard let clear = source.range(of: "private func clearSelection(") else {
       return XCTFail("Clearing the selection must be one entry point")
     }
     XCTAssertTrue(
-      String(source[clear.lowerBound...].prefix(300)).contains("selectionTrail.removeAll()"),
+      String(source[clear.lowerBound...].prefix(400)).contains("selectionTrail.removeAll()"),
       "Closing the inspector must not leave a trail behind for the next selection")
+    XCTAssertTrue(
+      String(source[clear.lowerBound...].prefix(400)).contains(
+        "resetViewport(preservingNeighbourhood: true)"),
+      "Homed camera after clearing a selection must keep the neighbourhood layer for the next Escape")
   }
 
   private func atlasSource() throws -> String {

--- a/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasLayoutTests.swift
@@ -937,6 +937,30 @@ final class MemoryAtlasLayoutTests: XCTestCase {
     XCTAssertLessThan(CGFloat(1), floor, "Zooming back out to the whole map is")
   }
 
+  /// Escape that clears a selection and homes the camera must not also spend
+  /// the neighbourhood layer. The original departure floor treats zoom 1 as
+  /// leaving; the overview rebind sits at or below that camera so the island
+  /// stays until the next press, while a later pinch-out can still exit.
+  func testOverviewResetDoesNotSpendTheNeighbourhoodLayer() throws {
+    let minimum = MemoryAtlasZoomPolicy.minimumZoom
+    let neighbourhood = MemoryAtlasZoomPolicy.neighborhoodZoom
+    let entered = MemoryAtlasNeighbourhoodLabels.entering(
+      center: CGPoint(x: 0.3, y: 0.6), radius: 0.05,
+      viewport: CGSize(width: 900, height: 700),
+      zoomRange: minimum...12)
+    let original = try XCTUnwrap(
+      MemoryAtlasNeighbourhoodLabels.departureZoom(
+        enteredAt: entered.zoom, neighbourhoodZoom: neighbourhood, minimumZoom: minimum))
+    XCTAssertLessThan(CGFloat(1), original, "Fixture: the original floor treats overview as leaving")
+
+    let rebound = try XCTUnwrap(
+      MemoryAtlasNeighbourhoodLabels.overviewDepartureZoom(
+        neighbourhoodZoom: neighbourhood, minimumZoom: minimum))
+    XCTAssertGreaterThanOrEqual(
+      CGFloat(1), rebound, "Homed camera after clearing a selection must not count as leaving")
+    XCTAssertGreaterThan(rebound, minimum, "A later pinch-out can still leave")
+  }
+
   /// A place entered without moving the camera has no zoom-out exit, and the
   /// map must say so rather than set one nobody can reach.
   ///

--- a/desktop/macos/Desktop/Tests/MemoryAtlasPlaybackTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasPlaybackTests.swift
@@ -32,6 +32,15 @@ final class MemoryAtlasPlaybackTests: XCTestCase {
     XCTAssertEqual(timeline.date(atFraction: 0), real)
   }
 
+  func testAllUnknownTimestampsDoNotBecomeToday() {
+    let epoch = Date(timeIntervalSince1970: 0)
+    let laterEpoch = epoch.addingTimeInterval(1)
+    let dates = MemoryAtlasPlayback.effectiveDates(from: [epoch, laterEpoch])
+    XCTAssertEqual(dates, [epoch, epoch])
+    XCTAssertFalse(dates.contains { MemoryAtlasPlayback.isCredible($0) })
+    XCTAssertLessThan(dates[0].timeIntervalSince1970, 1_000)
+  }
+
   func testAYearOfSilenceOccupiesLittleReplayTime() throws {
     let base = Date(timeIntervalSince1970: 1_700_000_000)
     let graph = KnowledgeGraphResponse(
@@ -126,12 +135,11 @@ final class MemoryAtlasCameraTests: XCTestCase {
     )
 
     XCTAssertGreaterThan(camera.zoom, 1)
-    let span = MemoryAtlasLayoutEngine.projectionSpan(of: viewport)
     for position in positions {
-      let x = (position.x - 0.5) * span * camera.zoom + viewport.width / 2 + camera.pan.width
-      let y = (position.y - 0.5) * span * camera.zoom + viewport.height / 2 + camera.pan.height
+      let point = MemoryAtlasRenderPlanner.renderedPoint(
+        for: position, viewportSize: viewport, zoom: camera.zoom, pan: camera.pan)
       XCTAssertTrue(
-        (0...viewport.width).contains(x) && (0...viewport.height).contains(y),
+        (0...viewport.width).contains(point.x) && (0...viewport.height).contains(point.y),
         "A highlighted neighbour must remain on screen after focus")
     }
   }
@@ -161,5 +169,12 @@ final class MemoryAtlasSurfacePresentationTests: XCTestCase {
       MemoryAtlasSurfacePresentation.phase(
         isLoading: true, isEmpty: false, hasProjection: true, hasAttemptedLoad: true),
       .ready)
+  }
+
+  func testASyntheticOwnerProjectionIsNotReady() {
+    XCTAssertEqual(
+      MemoryAtlasSurfacePresentation.phase(
+        isLoading: false, isEmpty: true, hasProjection: true, hasAttemptedLoad: true),
+      .empty)
   }
 }

--- a/desktop/macos/Desktop/Tests/MemoryAtlasPlaybackTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryAtlasPlaybackTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class MemoryAtlasPlaybackTests: XCTestCase {
+  func testReplayDurationIsFourSecondsOnceThereAreMoreThanAFewEntities() {
+    XCTAssertEqual(MemoryAtlasPlayback.duration(entityCount: 4), 2)
+    XCTAssertEqual(MemoryAtlasPlayback.duration(entityCount: 12), 2)
+    XCTAssertEqual(MemoryAtlasPlayback.duration(entityCount: 13), 4)
+    XCTAssertEqual(MemoryAtlasPlayback.duration(entityCount: 1_200), 4)
+  }
+
+  func testEpochPlaceholdersDoNotOwnTheTimelineStart() throws {
+    let real = Date(timeIntervalSince1970: 1_700_000_000)
+    let graph = KnowledgeGraphResponse(
+      nodes: [
+        KnowledgeGraphNode(
+          id: "missing-stamp", label: "Imported", nodeType: .concept,
+          createdAt: Date(timeIntervalSince1970: 0)),
+        KnowledgeGraphNode(id: "david", label: "David", nodeType: .person, createdAt: real),
+        KnowledgeGraphNode(
+          id: "later", label: "Later", nodeType: .thing, createdAt: real.addingTimeInterval(86_400)),
+      ],
+      edges: []
+    )
+
+    let timeline = try XCTUnwrap(
+      MemoryAtlasLayoutEngine.makeSnapshot(graph: graph, userName: "David").timeline)
+
+    XCTAssertEqual(timeline.start, real)
+    XCTAssertGreaterThan(timeline.start, MemoryAtlasPlayback.earliestCredibleDate)
+    XCTAssertEqual(timeline.date(atFraction: 0), real)
+  }
+
+  func testAYearOfSilenceOccupiesLittleReplayTime() throws {
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    let graph = KnowledgeGraphResponse(
+      nodes: [
+        KnowledgeGraphNode(id: "early", label: "Early", nodeType: .person, createdAt: base),
+        KnowledgeGraphNode(
+          id: "late-a", label: "Late A", nodeType: .concept,
+          createdAt: base.addingTimeInterval(365 * 86_400)),
+        KnowledgeGraphNode(
+          id: "late-b", label: "Late B", nodeType: .concept,
+          createdAt: base.addingTimeInterval(365 * 86_400 + 3_600)),
+      ],
+      edges: []
+    )
+
+    let timeline = try XCTUnwrap(
+      MemoryAtlasLayoutEngine.makeSnapshot(graph: graph, userName: nil).timeline)
+    let early = try XCTUnwrap(timeline.entries.first { $0.nodeID == "early" })
+    let lateA = try XCTUnwrap(timeline.entries.first { $0.nodeID == "late-a" })
+
+    XCTAssertLessThan(
+      lateA.playbackFraction - early.playbackFraction,
+      0.65,
+      "A silent year must not consume most of the replay")
+    XCTAssertGreaterThan(
+      lateA.playbackFraction - early.playbackFraction,
+      0.05,
+      "The later cluster should still arrive after the earlier one")
+  }
+
+  func testStaticCheckerAtlasEscapeJoinsTheWindowMonitorAtContentPriority() throws {
+    let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let sourceURL =
+      testsDirectory
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/Pages/MemoryGraph/CanonicalMemoryAtlasView.swift")
+    // omi-test-quality: source-inspection -- static contract: atlas Escape must register on WindowEscapeKeyMonitor at content priority so Chat-first navigation cannot leave Brain Map before a selection is cleared; the competing local monitor is the defect this wiring prevents.
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    XCTAssertTrue(
+      source.contains(".onEscapeKey(priority: .content)"),
+      "Brain Map Escape must run at content priority, ahead of leaving the page")
+    XCTAssertFalse(
+      source.contains("event.keyCode == 53"),
+      "A racing AppKit Escape monitor is what used to exit Brain Map while a node was selected")
+    XCTAssertTrue(
+      source.contains("MemoryAtlasPlayback.duration(entityCount:"),
+      "Replay duration must come from the shared four-second policy")
+  }
+
+  func testCompressedOffsetsCapCalendarGaps() {
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    let dates = [
+      base,
+      base.addingTimeInterval(60),
+      base.addingTimeInterval(365 * 86_400),
+    ]
+    let offsets = MemoryAtlasPlayback.compressedOffsets(for: dates)
+
+    XCTAssertEqual(offsets.count, 3)
+    XCTAssertEqual(offsets[0], 0)
+    XCTAssertEqual(offsets[1], 60)
+    XCTAssertEqual(offsets[2], 60 + MemoryAtlasPlayback.maxUncompressedGap)
+  }
+}
+
+final class MemoryAtlasCameraTests: XCTestCase {
+  func testALoneNodeKeepsTheCrosshairFocusZoom() {
+    let camera = MemoryAtlasZoomPolicy.focusedNeighborhood(
+      positions: [CGPoint(x: 0.7, y: 0.3)],
+      viewport: CGSize(width: 900, height: 700),
+      currentZoom: 1,
+      zoomRange: MemoryAtlasZoomPolicy.minimumZoom...16
+    )
+
+    XCTAssertEqual(camera.zoom, MemoryAtlasZoomPolicy.focusTargetZoom)
+    XCTAssertNotEqual(camera.pan, .zero)
+  }
+
+  func testConnectedNodesStayInsideTheFramedViewport() {
+    let positions = [
+      CGPoint(x: 0.45, y: 0.48),
+      CGPoint(x: 0.55, y: 0.52),
+      CGPoint(x: 0.50, y: 0.44),
+    ]
+    let viewport = CGSize(width: 900, height: 700)
+    let camera = MemoryAtlasZoomPolicy.focusedNeighborhood(
+      positions: positions,
+      viewport: viewport,
+      currentZoom: 1,
+      zoomRange: MemoryAtlasZoomPolicy.minimumZoom...16
+    )
+
+    XCTAssertGreaterThan(camera.zoom, 1)
+    let span = MemoryAtlasLayoutEngine.projectionSpan(of: viewport)
+    for position in positions {
+      let x = (position.x - 0.5) * span * camera.zoom + viewport.width / 2 + camera.pan.width
+      let y = (position.y - 0.5) * span * camera.zoom + viewport.height / 2 + camera.pan.height
+      XCTAssertTrue(
+        (0...viewport.width).contains(x) && (0...viewport.height).contains(y),
+        "A highlighted neighbour must remain on screen after focus")
+    }
+  }
+}
+
+final class MemoryAtlasSurfacePresentationTests: XCTestCase {
+  func testFirstVisitShowsALoaderInsteadOfAnEmptyMap() {
+    XCTAssertEqual(
+      MemoryAtlasSurfacePresentation.phase(
+        isLoading: false, isEmpty: true, hasProjection: false, hasAttemptedLoad: false),
+      .loading)
+    XCTAssertEqual(
+      MemoryAtlasSurfacePresentation.phase(
+        isLoading: true, isEmpty: true, hasProjection: false, hasAttemptedLoad: false),
+      .loading)
+  }
+
+  func testAResolvedEmptyGraphIsEmptyNotLoading() {
+    XCTAssertEqual(
+      MemoryAtlasSurfacePresentation.phase(
+        isLoading: false, isEmpty: true, hasProjection: false, hasAttemptedLoad: true),
+      .empty)
+  }
+
+  func testALoadedProjectionIsReadyEvenIfARefreshIsInFlight() {
+    XCTAssertEqual(
+      MemoryAtlasSurfacePresentation.phase(
+        isLoading: true, isEmpty: false, hasProjection: true, hasAttemptedLoad: true),
+      .ready)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260816-brain-map-replay-zoom.json
+++ b/desktop/macos/changelog/unreleased/20260816-brain-map-replay-zoom.json
@@ -1,0 +1,3 @@
+{
+  "change": "Made Brain Map replay skip quiet stretches, finish in about four seconds, zoom to a selected entity and its connections, and keep Escape from leaving the map while something is selected"
+}

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -32,6 +32,9 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasGeometry.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasOwnerIdentity.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSnapshotCache.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasPlayback.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasZoomPolicy.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryAtlasSurfacePresentation.swift
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryExportDestinationSheet.swift
@@ -172,7 +175,7 @@ steps:
 
   - id: S13
     name: Escape backs out one layer per press
-    do: "Press Escape three times with the main window key (not the floating bar). First clears the selection and leaves the island drawn; second leaves the neighbourhood and brings every other coastline back without moving the camera; third closes the Brain Map page back to Memories."
+    do: "Press Escape three times with the main window key (not the floating bar). First clears the selection, resets the camera to the whole map, and leaves the island drawn; second leaves the neighbourhood and brings every other coastline back without moving the camera; third closes the Brain Map page back to Memories."
     expect:
       text_visible:
         - Memories


### PR DESCRIPTION
## Summary
- Brain Map replay compresses silent calendar gaps and finishes in about four seconds once there are more than a handful of entities (two seconds for smaller maps). Epoch placeholder dates no longer pin the scrubber at 1969.
- Clicking a node, or hopping a connection, frames that entity and its neighbours with the same camera as Focus. Escape peels selection first, homes the camera without spending the neighbourhood layer, and only then leaves Brain Map.
- First load shows a spinner instead of a lonely owner node while the graph is still fetching.

## Product invariants affected
- `INV-MEM-1`: this PR touches `desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryGraph/**`. It does not add memory tiers or change default access policy.

## Failure-Class
Failure-Class: none

## Test plan
- [ ] Open Brain Map: spinner until the graph is ready, not a single lonely user node
- [ ] Play replay on a large map: ~4 seconds; quiet stretches do not stall; left date is not Dec 31, 1969
- [ ] Click a node: camera frames it and its connections; hopping Connections re-frames; Focus/crosshair still works
- [ ] Esc with a selection: deselects and shows the whole map without leaving Brain Map
- [ ] Inside a neighbourhood with a selection: first Esc clears selection and homes the camera while the island stays drawn; second Esc leaves the neighbourhood; third Esc returns to Memories

## Verification
- `xcrun swift test -c debug --package-path Desktop --filter MemoryAtlasLayoutTests/testOverviewResetDoesNotSpendTheNeighbourhoodLayer --filter MemoryAtlasConnectionSelectionTests --filter MemoryAtlasPlaybackTests --filter EscapeKeyDispatchTests` — 22 tests passed
- Named QA bundle `/Applications/omi-brain-map-replay.app` was exercised against the live Brain Map before review; the neighbourhood Escape rebind landed from that review

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

