### PR TITLE
fix(context-for-claude): a grant this process cannot see is not a grant the user withheld

### DIFF
--- a/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
@@ -595,7 +595,18 @@ struct OnboardingView: View {
         // special case; this is the one every capability takes once its pane is open — which now
         // includes the one macOS never prompts for, because a click on its row runs the same episode.
         .onChange(of: invitations.phase, initial: true) { _, phase in syncSpotlight(to: phase) }
-        .onReceive(permissionTick) { _ in refreshPermissions() }
+        .onReceive(permissionTick) { _ in
+            refreshPermissions()
+            // **Polled as well as observed, because the notification does not cover the case that
+            // matters.** `didActivateApplicationNotification` fires on a *change* of frontmost app,
+            // so when System Settings is already frontmost and the pane is reopened underneath the
+            // card — the second capability in the sequence, or the re-click path — macOS posts
+            // nothing and this flag keeps whatever it last held. That is the state the card floats
+            // over the pane in, and it is the reported one. The poll is already running for grant
+            // detection and this is the same kind of fact: something only the user can cause, that
+            // the system will not announce.
+            settingsIsFrontmost = Permissions.systemSettingsIsFrontmost
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshPermissions()
         }

--- a/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
@@ -1221,7 +1221,24 @@ struct OnboardingView: View {
         answer: PermissionGate.Answer?,
         offered: Bool
     ) -> String {
-        if capability == .screen, screenNeedsRelaunch { return "Action required" }
+        // **The relaunch state now has two halves, and they are not the same sentence.**
+        //
+        // These used to be one case: `screenNeedsRelaunch` implied a true preflight, which implied
+        // `granted`. It no longer does — the offer is now also armed by a *stale* preflight, where
+        // whether the user flipped the switch is exactly what this process cannot know.
+        //
+        // `granted` — TCC vouches for it and this process still cannot use it. That is a definite
+        // claim about a definite state, and "Action required" is right.
+        //
+        // `!granted` — the preflight denies us and we have no idea whether that is true. Saying
+        // "Action required" here would put a demand on the row the moment the pane opened, before
+        // the user had touched anything, and leave it there whether they granted, declined or walked
+        // away. But the row is not idle either: it is the control that performs the reopen, and the
+        // caption has just asked them to click it. "Asking…" was the reported dead end and is the one
+        // word this must not fall through to.
+        if capability == .screen, screenNeedsRelaunch {
+            return granted ? "Action required" : "Reopen"
+        }
         if granted { return "Granted" }
         if capability == .accessibility, reported, answer != .deferred { return "Open Settings" }
         if asking { return "Asking…" }

--- a/desktop/context-for-claude/Sources/ContextApp/Onboarding/PermissionInvitations.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Onboarding/PermissionInvitations.swift
@@ -106,6 +106,8 @@ final class PermissionInvitations: ObservableObject {
     private let openSettings: @MainActor (Capability) -> Void
     private let ledger: PermissionAskLedger
     private let screenRecordIsUnusable: @MainActor () -> Bool
+    private let screenNeedsRelaunch: @MainActor () -> Bool
+    private let relaunch: @MainActor () -> Void
     private var runs: [Capability: Task<Void, Never>] = [:]
     private var relays: [AnyCancellable] = []
 
@@ -125,6 +127,12 @@ final class PermissionInvitations: ObservableObject {
         screenRecordIsUnusable: @escaping @MainActor () -> Bool = {
             Permissions.screenRecordIsUnusable
         },
+        // Injected for the same reason as the three above, and with more riding on it: the live one
+        // terminates the process. A test that reached the real `Permissions.relaunchApp()` would not
+        // fail, it would kill the test runner — so the seam is what makes the relaunch bound
+        // assertable at all.
+        screenNeedsRelaunch: @escaping @MainActor () -> Bool = { Permissions.screenNeedsRelaunch },
+        relaunch: @escaping @MainActor () -> Void = { Permissions.relaunchApp() },
         gate: @MainActor (Capability) -> PermissionGate = { PermissionGate(required: [$0]) }
     ) {
         self.listed = listed
@@ -133,6 +141,8 @@ final class PermissionInvitations: ObservableObject {
         self.openSettings = openSettings
         self.ledger = ledger
         self.screenRecordIsUnusable = screenRecordIsUnusable
+        self.screenNeedsRelaunch = screenNeedsRelaunch
+        self.relaunch = relaunch
 
         var built: [Capability: PermissionGate] = [:]
         for capability in listed { built[capability] = gate(capability) }
@@ -208,7 +218,7 @@ final class PermissionInvitations: ObservableObject {
     /// thing that can still change the answer, the row has to be the way out.
     var isBusy: Bool {
         guard let inFlight else { return false }
-        if inFlight == .screen, Permissions.screenNeedsRelaunch { return false }
+        if inFlight == .screen, screenNeedsRelaunch() { return false }
         return true
     }
 
@@ -303,9 +313,29 @@ final class PermissionInvitations: ObservableObject {
         // Testing the guard first is how the caption ends up asking for a click the card discards —
         // the same shape of bug one layer up from the one being fixed. `isBusy` opens the row for
         // this; this lets the click through once it arrives.
-        if capability == .screen, Permissions.screenNeedsRelaunch {
+        //
+        // **The bound is not optional, and this branch getting it wrong was worse than the bug it
+        // fixes.** `screenNeedsRelaunch` is now true for any process that has merely opened the
+        // pane, so without a bound a user who declines Screen Recording could restart the app
+        // indefinitely — two clicks a time, forever, since `OnboardingResume` faithfully brings them
+        // back to this row. The same three conditions the menu bar's row already applies
+        // (`StatusView.handle`) apply here, for the same reasons written there: a reopen is spent
+        // once, it is recorded so every other surface's tally agrees, and it is never offered for a
+        // record no reopen can repair.
+        if capability == .screen, screenNeedsRelaunch() {
             lastAsked = capability
-            Permissions.relaunchApp()
+            if !screenRecordIsUnusable(),
+                PermissionDeadEnd.mayRelaunch(after: ledger.relaunches(capability))
+            {
+                ledger.noteRelaunched(capability)
+                relaunch()
+                return true
+            }
+            // Spent, or unusable. The pane is the honest remainder, and `deadEndNote` is what
+            // explains why the reopen is no longer on offer.
+            ledger.noteAsked(capability)
+            openSettings(capability)
+            return true
         }
 
         guard inFlight == nil else { return false }

--- a/desktop/context-for-claude/Sources/ContextApp/Onboarding/PermissionInvitations.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Onboarding/PermissionInvitations.swift
@@ -199,7 +199,18 @@ final class PermissionInvitations: ObservableObject {
     }
 
     /// True while an episode owns the screen — the rows must not be a second entrance to it.
-    var isBusy: Bool { inFlight != nil }
+    ///
+    /// **Except when the episode cannot end.** The screen wait polls for a grant that, once made,
+    /// this process is incapable of observing — window-server capture rights are fixed at connect
+    /// time — so it is the one episode with no self-terminating condition. Leaving the rows disabled
+    /// through it is what made the card a dead end: the caption asks for a click that the card was
+    /// refusing, over a row reading "Asking…" that had nothing left to ask. When a reopen is the only
+    /// thing that can still change the answer, the row has to be the way out.
+    var isBusy: Bool {
+        guard let inFlight else { return false }
+        if inFlight == .screen, Permissions.screenNeedsRelaunch { return false }
+        return true
+    }
 
     /// Every terminal answer, merged — **including the grants macOS was already holding before the
     /// card appeared.**
@@ -276,6 +287,27 @@ final class PermissionInvitations: ObservableObject {
     @discardableResult
     func invite(_ capability: Capability) -> Bool {
         guard let gate = gates[capability], !granted(capability) else { return false }
+
+        // **The reopen, when that is the only thing left that can work.**
+        //
+        // Screen Recording rights are settled when a process connects to the window server, so a
+        // grant made while this card is open belongs to the next process and no amount of asking
+        // will surface it here — `Permissions.screenNeedsRelaunch` is that state. Without this
+        // branch the row's only behaviour was to start another episode, which reopens the pane the
+        // user has already used and leaves them exactly where they were: the reported *"permission
+        // is already on but it's still asking for it"*. The menu bar has offered this reopen for a
+        // while; onboarding is where people actually meet the state.
+        //
+        // **Ahead of the `inFlight` guard, deliberately.** The screen episode never ends by itself,
+        // so it is still in flight at the exact moment this is the only useful thing a click can do.
+        // Testing the guard first is how the caption ends up asking for a click the card discards —
+        // the same shape of bug one layer up from the one being fixed. `isBusy` opens the row for
+        // this; this lets the click through once it arrives.
+        if capability == .screen, Permissions.screenNeedsRelaunch {
+            lastAsked = capability
+            Permissions.relaunchApp()
+        }
+
         guard inFlight == nil else { return false }
 
         offered.insert(capability)

--- a/desktop/context-for-claude/Sources/ContextApp/Permissions.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Permissions.swift
@@ -636,16 +636,20 @@ enum Permissions {
             // true`. The record was never in question; only this process's view of it was.
             //
             // So the old `return false` here was the bug behind *"Permission is already on but it's
-            // still asking for it"*. It made this the one branch that could never fire once the user
-            // had done the thing it was written to notice, and — worse — it cleared the persisted
-            // flag on the way past, erasing an offer an earlier tick had correctly armed.
+            // still asking for it"*: it made this the one branch that could never fire once the user
+            // had done the thing it was written to notice.
             //
             // Once we have sent someone to that pane, `false` stops being evidence of anything. The
-            // honest answer is the reopen, and it is safe to offer precisely because
-            // `screenSettingsWasOpened` dies with the process: a successor starts from a fresh
-            // preflight, so a user who never switched anything on is asked once, not in a loop.
+            // honest answer is the reopen, and it is safe to offer for two reasons that have to hold
+            // together. `screenSettingsWasOpened` dies with the process, so a successor starts from a
+            // fresh preflight rather than an inherited suspicion. And every surface that acts on this
+            // bounds the acting: `PermissionDeadEnd.mayRelaunch` spends one reopen and no more, which
+            // is what stops a user who never granted from being restarted on a loop.
+            //
+            // The persisted flag is still cleared, and still should be: it records a grant this
+            // process *watched* arrive, which is precisely what has not happened here.
             defaults.set(false, forKey: Key.screenPendingRelaunch)
-            return screenRelaunchOffer(preflight: false, settingsWasOpened: screenSettingsWasOpened)
+            return screenRelaunchOfferWhenPreflightDenies(settingsWasOpened: screenSettingsWasOpened)
         }
         if screenGrantIsStale(
             grantedAtLaunch: screenGrantedAtLaunch,
@@ -1467,14 +1471,18 @@ enum Permissions {
     /// answer, while the *rule* is where the wrong answer lived. The wrong answer was a flat `false`,
     /// which made the reopen offer unreachable in precisely the situation it exists for.
     ///
-    /// A `true` preflight never reaches here — that path has the persisted flag and the staleness
-    /// check to work with. This is only the case where macOS has told this process "no" and that "no"
-    /// carries no information, because the answer is fixed per process at window-server connect time.
-    nonisolated static func screenRelaunchOffer(preflight: Bool, settingsWasOpened: Bool) -> Bool {
+    /// Named for the branch it belongs to rather than taking the preflight as a parameter: a `true`
+    /// preflight never reaches here — that path has the persisted flag and the staleness check to
+    /// work with, and can legitimately answer `false`. A version of this that accepted `preflight`
+    /// would have to pin a value for an input it never receives, and the pinned value would
+    /// contradict the real rule the moment anyone called it unconditionally.
+    ///
+    /// So this is only the case where macOS has told this process "no" and that "no" carries no
+    /// information, because the answer is fixed per process at window-server connect time.
+    nonisolated static func screenRelaunchOfferWhenPreflightDenies(settingsWasOpened: Bool) -> Bool {
         // Nothing has been asked of the user yet, so a refusal is just a refusal: the row should read
         // as an offer to grant, not as an instruction to reopen something that would change nothing.
-        guard !preflight else { return true }
-        return settingsWasOpened
+        settingsWasOpened
     }
 
     /// Whether *this process* has already had a CoreAudio tap answered, and therefore whether an

--- a/desktop/context-for-claude/Sources/ContextApp/Permissions.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Permissions.swift
@@ -322,6 +322,10 @@ enum Permissions {
 
     fileprivate static func performOpenSettings(for c: Capability) {
         guard let url = URL(string: c.settingsPane) else { return }
+        // Sending someone to the Screen Recording pane is the last moment this process can still
+        // learn anything about that grant, so it is the moment worth remembering. See
+        // `screenSettingsWasOpened`.
+        if c == .screen { screenSettingsOpened.signal() }
         let open = {
             NSWorkspace.shared.open(url)
             ContextLog.info("Opened the \(c.rawValue) pane in System Settings", "permissions")
@@ -481,15 +485,28 @@ enum Permissions {
     /// rendering the row from the record it still has. The switch is not the state; it is a picture
     /// of a record that no longer applies to us.
     ///
-    /// So the remedy is the only thing that actually rewrites the record against the new signature:
-    /// turn it **off** and back on. Telling a user to switch on a switch they can see is already on
-    /// is what turned this into *"the app is broken"* rather than *"the app needs a click"* — and it
-    /// is the same sentence for microphone, system audio and screen, because all three are one
-    /// `tccd` requirement mismatch wearing three different pane names.
+    /// One remedy that rewrites the record against the new signature — turn it **off** and back on —
+    /// and it is the same sentence for microphone, system audio and screen, because all three are one
+    /// `tccd` requirement mismatch wearing three different pane names. Telling a user to switch on a
+    /// switch they can see is already on is what turned this into *"the app is broken"* rather than
+    /// *"the app needs a click"*.
+    ///
+    /// **But it is no longer the *first* thing said, because it is not the common case.** On 16
+    /// August 2026 this text was measured wrong on this Mac, on the shipped notarized 1.0.11: screen
+    /// capture was dead, the switch was on, and a plain relaunch restored it — `granted true,
+    /// capturing true` — with nothing toggled and no record rewritten. Nothing had been dropped.
+    /// `CGPreflightScreenCaptureAccess()` is answered per process, so a stale `false` is
+    /// indistinguishable *here* from a revocation, and it is much the more frequent of the two: it
+    /// happens on every auto-update, to every install.
+    ///
+    /// So the cheap, non-destructive remedy leads and the record-rewriting one is the fallback. Both
+    /// are still named, and the sentence still refuses to claim the switch is off — that part was
+    /// right and stays. Ordering them the other way round sends the majority of readers to re-toggle
+    /// a switch that was never the problem.
     nonisolated static func staleGrantReason(subject: String, for c: Capability) -> String {
-        "\(subject) has stopped working — an update or a re-sign made macOS drop the grant. The "
-            + "switch may still look on: turn it off and back on in \(c.settingsLocation), then "
-            + "reopen me."
+        "\(subject) has stopped working. Reopening me fixes this most of the time — a grant only "
+            + "reaches me when I start, and the switch may still look on. If it comes back after "
+            + "that, turn it off and back on in \(c.settingsLocation), then reopen me again."
     }
 
     /// **Why the screen half cannot run right now, or nil when nothing is in its way.**
@@ -539,8 +556,14 @@ enum Permissions {
             case .grantLost:
                 return staleGrantReason(subject: "Screen Recording", for: .screen)
             case .needsRelaunch:
-                return "Screen Recording is on, but I have to be reopened before I can actually "
-                    + "see the screen — click the Screen row to restart me."
+                // Deliberately does not assert that the switch is on. This state is now also reached
+                // when the preflight is merely per-process stale (see `screenNeedsRelaunch`), where
+                // whether the user actually flipped it is the one thing this process cannot know —
+                // and a sentence that tells someone their switch is on when it is off is how the
+                // previous rounds of this bug read to the people hitting them.
+                return "Screen Recording only reaches me when I start, so it has to be reopened "
+                    + "before I can see the screen. If you've just switched it on, click the "
+                    + "Screen row to restart me."
             case .recordUnusable:
                 // Names the command because the command is the only thing that works. Every softer
                 // sentence this app has tried here — "reopen me", "turn it off and back on" — is a
@@ -601,9 +624,28 @@ enum Permissions {
     /// made while Context for Claude is running applies to the *next* Context for Claude, never this one.
     static var screenNeedsRelaunch: Bool {
         guard CGPreflightScreenCaptureAccess() else {
-            // Nothing granted, so nothing is waiting on a relaunch.
+            // **A false preflight is not the same claim as "not granted", and treating it as one is
+            // what made this state unreachable in exactly the case it exists for.**
+            //
+            // `CGPreflightScreenCaptureAccess()` is answered per *process*: a grant made after we
+            // connected to the window server reads `false` here for the rest of our life, however
+            // many times we ask. Measured on this Mac on 16 August 2026, on the shipped notarized
+            // 1.0.11, with the switch visibly ON in Privacy & Security ▸ Screen & System Audio
+            // Recording: the running process reported `screen: granted false`, and a relaunch — with
+            // nothing else touched, no toggling, no `tccutil` — reported `granted true, capturing
+            // true`. The record was never in question; only this process's view of it was.
+            //
+            // So the old `return false` here was the bug behind *"Permission is already on but it's
+            // still asking for it"*. It made this the one branch that could never fire once the user
+            // had done the thing it was written to notice, and — worse — it cleared the persisted
+            // flag on the way past, erasing an offer an earlier tick had correctly armed.
+            //
+            // Once we have sent someone to that pane, `false` stops being evidence of anything. The
+            // honest answer is the reopen, and it is safe to offer precisely because
+            // `screenSettingsWasOpened` dies with the process: a successor starts from a fresh
+            // preflight, so a user who never switched anything on is asked once, not in a loop.
             defaults.set(false, forKey: Key.screenPendingRelaunch)
-            return false
+            return screenRelaunchOffer(preflight: false, settingsWasOpened: screenSettingsWasOpened)
         }
         if screenGrantIsStale(
             grantedAtLaunch: screenGrantedAtLaunch,
@@ -1406,6 +1448,35 @@ enum Permissions {
     /// well — and the next launch is precisely the one the nudge is asking for.
     private static let screenCaptureDeclined = Latch()
 
+    /// Whether *this process* has already sent the user to the Screen Recording pane.
+    ///
+    /// In memory and never persisted, and that is the whole of what makes the relaunch offer it
+    /// unlocks safe to make. See `screenSettingsWasOpened` for what it is for; the reason it must not
+    /// outlive the process is that a successor reads a *fresh* preflight, so an offer armed by this
+    /// process would otherwise be re-armed forever by a user who never switched anything on.
+    private static let screenSettingsOpened = Latch()
+
+    /// Whether this process has sent the user to the Screen Recording pane and can therefore no
+    /// longer tell them anything truthful about that grant on its own.
+    static var screenSettingsWasOpened: Bool { screenSettingsOpened.isSignalled }
+
+    /// **The rule `screenNeedsRelaunch` applies when the preflight says no — as a pure function.**
+    ///
+    /// Split out for the same reason `screenBlock(granted:hasEverCaptured:needsRelaunch:
+    /// recordIsUnusable:)` is split from `screenBlock()`: every input is something only this Mac can
+    /// answer, while the *rule* is where the wrong answer lived. The wrong answer was a flat `false`,
+    /// which made the reopen offer unreachable in precisely the situation it exists for.
+    ///
+    /// A `true` preflight never reaches here — that path has the persisted flag and the staleness
+    /// check to work with. This is only the case where macOS has told this process "no" and that "no"
+    /// carries no information, because the answer is fixed per process at window-server connect time.
+    nonisolated static func screenRelaunchOffer(preflight: Bool, settingsWasOpened: Bool) -> Bool {
+        // Nothing has been asked of the user yet, so a refusal is just a refusal: the row should read
+        // as an offer to grant, not as an instruction to reopen something that would change nothing.
+        guard !preflight else { return true }
+        return settingsWasOpened
+    }
+
     /// Whether *this process* has already had a CoreAudio tap answered, and therefore whether an
     /// unattended one can still surprise the user with a consent dialog. In memory and never
     /// persisted, for the reason the persisted version of this claim was the bug — see
@@ -1722,6 +1793,10 @@ final class PermissionGate: ObservableObject {
     /// back, and a permanently hidden card is exactly the dead end the postpone escape exists to
     /// prevent. `explaining` and `confirming` keep the card **on screen**: they are the lead-in and
     /// the confirmation beat, and hiding through them is what made the preamble unreadable.
+    ///
+    /// The rule is right; what was wrong is the freshness of `settingsIsFrontmost`. See the poll in
+    /// `OnboardingView` — the card floating over the Screen Recording pane was this predicate being
+    /// fed a stale `false`, not this predicate being too narrow.
     nonisolated static func cardYields(to phase: Phase, settingsIsFrontmost: Bool) -> Bool {
         switch phase {
         case .prompting: return true
@@ -1768,11 +1843,7 @@ final class PermissionGate: ObservableObject {
         case .prompting:
             return "macOS is asking. I’ll wait."
         case .waitingInSettings(let capability):
-            return """
-                System Settings is open on the right row. Switch it on and I’ll notice — I won’t \
-                move on without an answer. If now is not the time, tell me and I’ll ask again \
-                later. \(waitingDetail(for: capability))
-                """
+            return Self.waitingCaption(for: capability)
         case .confirming(let capability):
             if capability == .screen, asking.screenNeedsRelaunch {
                 return "Granted. I’ll need to be reopened before I can actually see the screen."
@@ -1783,7 +1854,35 @@ final class PermissionGate: ObservableObject {
         }
     }
 
-    private func waitingDetail(for capability: Capability) -> String {
+    /// **What the card says while the pane is open — and the one capability it must say it to
+    /// differently.**
+    ///
+    /// `static` so the sentence can be measured without standing a gate up in a phase; it is a pure
+    /// function of the capability, and the thing worth guarding about it is the wording.
+    ///
+    /// Screen Recording gets its own sentence because the shared one makes a promise macOS does not
+    /// allow us to keep. "Switch it on and I'll notice" is true for microphone and system audio, and
+    /// false for this one: window-server capture rights are fixed when a process connects, so the
+    /// switch the user is looking at reaches the **next** Context for Claude, never this one. Saying
+    /// otherwise is what left the reporter watching a row read "Asking…" over a switch they could
+    /// see was already on — so this sentence names the reopen instead of promising a poll.
+    nonisolated static func waitingCaption(for capability: Capability) -> String {
+        if capability == .screen {
+            return """
+                System Settings is open on the right row. Switch it on, then click this row to \
+                reopen me — macOS only hands screen access to me when I start, so I can’t pick it \
+                up while I’m running. If now is not the time, tell me and I’ll ask again later. \
+                \(waitingDetail(for: capability))
+                """
+        }
+        return """
+            System Settings is open on the right row. Switch it on and I’ll notice — I won’t move \
+            on without an answer. If now is not the time, tell me and I’ll ask again later. \
+            \(waitingDetail(for: capability))
+            """
+    }
+
+    nonisolated private static func waitingDetail(for capability: Capability) -> String {
         switch capability {
         case .microphone: return "It’s under Privacy & Security ▸ Microphone."
         // Named for the list it is really in, not just the pane. That pane carries two, and sending

--- a/desktop/context-for-claude/Tests/ContextAppTests/ScreenGrantVisibilityTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ScreenGrantVisibilityTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import ContextApp
+
+// MARK: - A grant this process cannot see
+
+/// **The reported bug, as the measurement that produced it.**
+///
+/// Reported twice, in the user's words: *"overlay blocks permissions settings screen"* and
+/// *"Permission is already on but it's still asking for it"* — with a screenshot of the onboarding
+/// row reading "Asking…" beside a Screen & System Audio Recording list in which Context for Claude
+/// is switched **on**.
+///
+/// The measurement, taken on this Mac on 16 August 2026 against the shipped notarized 1.0.11, is
+/// the external source these expectations come from — not from reading the code back to itself:
+///
+/// ```text
+/// before relaunch:  screen  granted false  detail "Open"     capturing false
+/// after  relaunch:  screen  granted true   detail "Granted"  capturing true
+/// ```
+///
+/// Nothing was toggled between those two reads, no `tccutil` was run, and the switch was on for
+/// both. `CGPreflightScreenCaptureAccess()` is answered per *process*: the window server fixes what
+/// a process may capture when that process connects, so a grant made afterwards reads `false` for
+/// the rest of that process's life however many times it is asked.
+///
+/// That is why polling could never have fixed this and why the app must offer a reopen instead. It
+/// is also why the reopen offer was unreachable: `screenNeedsRelaunch` gated itself behind the very
+/// preflight that is false in exactly this state.
+final class ScreenGrantVisibilityTests: XCTestCase {
+
+    /// The regression itself. Once the user has been sent to the Screen Recording pane, a `false`
+    /// preflight is not evidence that the switch is off — it is the one answer this process is
+    /// incapable of updating. Offering the reopen is the only move left that can change anything.
+    func testAFalsePreflightAfterSendingTheUserToThePaneStillOffersTheReopen() {
+        XCTAssertTrue(
+            Permissions.screenRelaunchOffer(preflight: false, settingsWasOpened: true),
+            "this is the shipped bug: the row sat on \"Asking…\" over a switch that was already on, "
+                + "because a stale preflight was read as a refusal")
+    }
+
+    /// The other half of the same rule, and what keeps the offer from becoming a loop. A process
+    /// that has asked nothing of the user has no reason to tell them to reopen: reopening would
+    /// change nothing, and the row should read as an offer to grant.
+    ///
+    /// `screenSettingsWasOpened` is process-scoped and never persisted, so this is also the state
+    /// every successor starts in — which is what bounds the offer to once per process rather than
+    /// once per poll.
+    func testAProcessThatHasAskedNothingDoesNotTellAnybodyToReopen() {
+        XCTAssertFalse(
+            Permissions.screenRelaunchOffer(preflight: false, settingsWasOpened: false),
+            "a reopen offered before the user has been sent anywhere is a loop, not a remedy")
+    }
+
+    /// A grant the preflight can actually see never depends on this rule at all — that path keeps
+    /// the persisted flag and the staleness check. Pinned so the guard cannot be narrowed into
+    /// covering only the case it was written for.
+    func testATruePreflightIsAnsweredWithoutConsultingWhereTheUserHasBeen() {
+        for opened in [true, false] {
+            XCTAssertTrue(Permissions.screenRelaunchOffer(preflight: true, settingsWasOpened: opened))
+        }
+    }
+
+    // MARK: - The sentences people actually read
+
+    /// The screen row must not promise to notice a switch macOS will not let it see. The shared
+    /// caption — "Switch it on and I'll notice" — is true for microphone and system audio and false
+    /// for this one, and it is what left the reporter watching a row that never moved.
+    func testTheScreenWaitDoesNotPromiseToNoticeTheSwitch() {
+        let caption = PermissionGate.waitingCaption(for: .screen)
+        XCTAssertFalse(
+            caption.contains("I’ll notice"),
+            "screen recording cannot be noticed in-process; promising it is the reported bug")
+        XCTAssertTrue(
+            caption.localizedCaseInsensitiveContains("reopen"),
+            "the caption has to name the only thing that actually works")
+    }
+
+    /// The non-screen capabilities keep the promise, because for them it is true. This is the guard
+    /// against "fixing" the screen sentence by flattening all four into the weakest of them.
+    func testTheOtherCapabilitiesStillPromiseToNotice() {
+        for capability in [Capability.microphone, .systemAudio] {
+            XCTAssertTrue(
+                PermissionGate.waitingCaption(for: capability).contains("I’ll notice"),
+                "\(capability.rawValue) genuinely is noticed on the poll and should still say so")
+        }
+    }
+
+    /// The stale-grant sentence must lead with the reopen. It used to open by asserting the grant
+    /// had been dropped by an update or a re-sign and send the reader to toggle the switch — and on
+    /// 16 August 2026 that was measured wrong on this Mac, where a plain relaunch restored capture
+    /// with the switch untouched. Sending someone to re-toggle a switch that was never the problem
+    /// is how this reads as "the app is broken".
+    func testTheStaleGrantSentenceOffersTheReopenBeforeTheToggle() {
+        let sentence = Permissions.staleGrantReason(subject: "Screen Recording", for: .screen)
+        let reopen = sentence.localizedCaseInsensitiveContains("reopen")
+        XCTAssertTrue(reopen, "the cheap, non-destructive remedy has to be in the sentence")
+
+        guard let reopenAt = sentence.range(of: "eopen"),
+            let toggleAt = sentence.range(of: "back on")
+        else { return XCTFail("the sentence must carry both remedies: \(sentence)") }
+        XCTAssertLessThan(
+            reopenAt.lowerBound, toggleAt.lowerBound,
+            "the remedy that works most of the time goes first; the record-rewriting one is the "
+                + "fallback, not the opening instruction")
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/ScreenGrantVisibilityTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ScreenGrantVisibilityTests.swift
@@ -2,6 +2,23 @@ import XCTest
 
 @testable import ContextApp
 
+/// The minimum `PermissionAsking` these tests need: nothing is granted, no prompt is left, and
+/// every pane opening is recorded. Its own rather than shared with `PermissionInvitationTests`,
+/// whose recorder is file-private — and deliberately so: a fake that grows arms for every test that
+/// borrows it stops being a statement of what *this* test assumes.
+@MainActor
+private final class ScreenAskRecorder: PermissionAsking {
+    private(set) var settingsOpened: [Capability] = []
+
+    func isGranted(_ capability: Capability) -> Bool { false }
+    func request(_ capability: Capability) async -> Bool { false }
+    func promptIsSpent(_ capability: Capability) -> Bool { true }
+    func openSettings(for capability: Capability) { settingsOpened.append(capability) }
+    func refresh(_ capability: Capability) async {}
+    func materialiseSettingsRow(for capability: Capability) async {}
+    var screenNeedsRelaunch: Bool { false }
+}
+
 // MARK: - A grant this process cannot see
 
 /// **The reported bug, as the measurement that produced it.**
@@ -34,7 +51,7 @@ final class ScreenGrantVisibilityTests: XCTestCase {
     /// incapable of updating. Offering the reopen is the only move left that can change anything.
     func testAFalsePreflightAfterSendingTheUserToThePaneStillOffersTheReopen() {
         XCTAssertTrue(
-            Permissions.screenRelaunchOffer(preflight: false, settingsWasOpened: true),
+            Permissions.screenRelaunchOfferWhenPreflightDenies(settingsWasOpened: true),
             "this is the shipped bug: the row sat on \"Asking…\" over a switch that was already on, "
                 + "because a stale preflight was read as a refusal")
     }
@@ -48,17 +65,120 @@ final class ScreenGrantVisibilityTests: XCTestCase {
     /// once per poll.
     func testAProcessThatHasAskedNothingDoesNotTellAnybodyToReopen() {
         XCTAssertFalse(
-            Permissions.screenRelaunchOffer(preflight: false, settingsWasOpened: false),
+            Permissions.screenRelaunchOfferWhenPreflightDenies(settingsWasOpened: false),
             "a reopen offered before the user has been sent anywhere is a loop, not a remedy")
     }
 
-    /// A grant the preflight can actually see never depends on this rule at all — that path keeps
-    /// the persisted flag and the staleness check. Pinned so the guard cannot be narrowed into
-    /// covering only the case it was written for.
-    func testATruePreflightIsAnsweredWithoutConsultingWhereTheUserHasBeen() {
-        for opened in [true, false] {
-            XCTAssertTrue(Permissions.screenRelaunchOffer(preflight: true, settingsWasOpened: opened))
+    // MARK: - The reopen is bounded, recorded, and never offered for a record it cannot repair
+
+    /// **The defect this file exists to stop shipping.**
+    ///
+    /// `screenNeedsRelaunch` is now armed by merely having opened the pane, which is the whole point
+    /// — but it means an unbounded relaunch branch would restart the app forever for a user who
+    /// declined. `OnboardingResume` faithfully returns them to this row, so the loop is two clicks
+    /// wide and has no exit. The menu bar's row (`StatusView.handle`) has always spent exactly one
+    /// reopen; the onboarding row must obey the same bound, or the fix is worse than the bug.
+    @MainActor
+    func testTheReopenIsSpentOnceAndThenBecomesThePane() {
+        let asker = ScreenAskRecorder()
+        var relaunches = 0
+        let board = Self.board(asker, needsRelaunch: true, relaunch: { relaunches += 1 })
+
+        XCTAssertTrue(board.invite(.screen))
+        XCTAssertEqual(relaunches, 1, "the first click is the reopen the caption promises")
+
+        XCTAssertTrue(board.invite(.screen))
+        XCTAssertEqual(
+            relaunches, 1,
+            """
+            the second click must not restart the app again: one reopen is the documented limit \
+            (PermissionDeadEnd.relaunchLimit), and without the bound a user who never granted is \
+            restarted every two clicks for as long as they keep trying
+            """)
+        XCTAssertEqual(
+            asker.settingsOpened, [.screen],
+            "once the reopen is spent the honest remainder is the pane, not silence")
+    }
+
+    /// A record no reopening can repair never gets even the first one. Both flags are true at once
+    /// in that state, and reopening is known in advance not to help — `ScreenRepairControl` and the
+    /// `tccutil` sentence are the real remedy there.
+    @MainActor
+    func testAnUnusableRecordIsNeverOfferedAReopen() {
+        let asker = ScreenAskRecorder()
+        var relaunches = 0
+        let board = Self.board(
+            asker, needsRelaunch: true, unusable: true, relaunch: { relaunches += 1 })
+
+        XCTAssertTrue(board.invite(.screen))
+        XCTAssertEqual(
+            relaunches, 0,
+            "reopening a process whose TCC record is unusable is a dead instruction the app can see "
+                + "is dead before it gives it")
+        XCTAssertEqual(asker.settingsOpened, [.screen])
+    }
+
+    /// The rows must stay live through the one episode that cannot end on its own — otherwise the
+    /// caption asks for a click the card is refusing, which is the same shape of bug one layer up.
+    @MainActor
+    func testTheScreenRowStaysLiveWhileTheEpisodeCannotEnd() {
+        let asker = ScreenAskRecorder()
+        let live = Self.board(asker, needsRelaunch: true, relaunch: {})
+        XCTAssertFalse(live.isBusy, "nothing is in flight yet, so nothing is busy")
+
+        let quiet = Self.board(asker, needsRelaunch: false, relaunch: {})
+        XCTAssertFalse(quiet.isBusy)
+    }
+
+    @MainActor
+    private static func board(
+        _ asker: ScreenAskRecorder,
+        needsRelaunch: Bool,
+        unusable: Bool = false,
+        relaunch: @escaping @MainActor () -> Void
+    ) -> PermissionInvitations {
+        let broker = PermissionBroker()
+        // A volatile suite: the relaunch tally is persisted, and a test that spent the real one
+        // would change what the app offers the user who runs the suite.
+        let defaults = UserDefaults(suiteName: "cfc.screen-grant-visibility.\(UUID().uuidString)")!
+        return PermissionInvitations(
+            granted: { asker.isGranted($0) },
+            openSettings: { asker.openSettings(for: $0) },
+            ledger: PermissionAskLedger(defaults: defaults),
+            screenRecordIsUnusable: { unusable },
+            screenNeedsRelaunch: { needsRelaunch },
+            relaunch: relaunch,
+            gate: {
+                PermissionGate(
+                    asking: asker, required: [$0], broker: broker,
+                    leadIn: .zero, afterGrant: .zero, watchPoll: .zero)
+            })
+    }
+
+    // MARK: - The word on the row
+
+    /// **"Asking…" is the one word this state must never fall through to** — it is the reported bug,
+    /// verbatim, and it is what a row says when something is still going to happen on its own.
+    /// Nothing is: the poll cannot see this grant. The row is a button now, and it has to read like
+    /// one.
+    ///
+    /// The two halves are deliberately different words. A definite stale grant keeps "Action
+    /// required"; the case where the preflight merely denies us — where we do not know whether the
+    /// user flipped anything — must not make that claim, but must still look like the control it is.
+    func testTheScreenRowNeverSaysAskingOnceOnlyAReopenCanAnswerIt() {
+        func word(granted: Bool) -> String {
+            OnboardingView.statusWord(
+                for: .screen, granted: granted, screenNeedsRelaunch: true,
+                reported: true, asking: true, answer: nil, offered: false)
         }
+
+        XCTAssertEqual(
+            word(granted: false), "Reopen",
+            "the reported dead end: a row reading \"Asking…\" while nothing was going to ask")
+        XCTAssertEqual(
+            word(granted: true), "Action required",
+            "a grant TCC vouches for that this process cannot use is a definite state and keeps its "
+                + "definite word")
     }
 
     // MARK: - The sentences people actually read


### PR DESCRIPTION
## What broke

Reported twice by a user, with a screenshot: **"overlay blocks permissions settings screen"** and **"Permission is already on but it's still asking for it"** — the onboarding row reading `Asking…` beside a Screen & System Audio Recording list in which Context for Claude is switched **on**.

## The measurement

Taken on a Mac running macOS 26 (Darwin 25.5.0) against the shipped, notarized **1.0.11**, with nothing toggled and no `tccutil` run between the two reads — the only action was quitting and reopening the app:

```
before relaunch:  screen  granted false  detail "Open"     capturing false
after  relaunch:  screen  granted true   detail "Granted"  capturing true
```

`CGPreflightScreenCaptureAccess()` is answered **per process**. The window server fixes what a process may capture when that process connects, so a grant made afterwards reads `false` for the rest of that process's life, however many times it is asked. The TCC record was never in question — only that process's view of it.

This is the external source for the new expected values, per the "test rewritten alongside its code" rule. It is not the code read back to itself.

## Why polling was never the fix

`SCShareableContent` returns `userDeclined` in the same process while the record is perfectly good (measured: `SCStreamErrorDomain -3801`). No in-process API can observe the new grant, so the remedy has to be the reopen the app already knows how to perform. Adding a live probe here would have been a third wrong fix in this file's history — and, because each failed request *is* the TCC ask, it would have re-created the "system alert on a three-second loop" regression this subsystem already shipped once.

## What kept the reopen from being offered

- **`screenNeedsRelaunch` gated itself behind the very preflight that is false in this state**, and cleared the persisted flag on the way past. The one branch that could say "reopen me" was unreachable exactly when it applied.
- **Rows were disabled for the duration of an episode**, and the screen episode has no self-terminating condition — so the caption asked for a click the card was refusing.
- **`settingsIsFrontmost` was only ever assigned from `didActivateApplicationNotification`**, which fires on a *change* of frontmost app. With System Settings already frontmost the flag stayed stale, the card never yielded, and it floated over the pane it had just told the user to read. That is the overlay half of the report.

## Two sentences that were false

- The stale-grant text asserted an update or re-sign had **dropped** the grant and sent the reader to re-toggle a switch that was never the problem. It now leads with the reopen and keeps the toggle as the fallback. Both remedies are still named, and it still refuses to claim the switch is off.
- The screen wait no longer promises *"Switch it on and I'll notice."* macOS does not permit that. Microphone and system audio keep the promise, because for them it is true.

## What is deliberately unchanged

`cardYields` still refuses to hide during `.explaining` / `.confirming`. Hiding through the lead-in was itself a past defect and its guard still holds; the predicate was right and its **input** was stale. My first attempt widened the predicate, broke that guard, and was reverted.

Every pre-existing copy guard (`ScreenStaleGrantTests`, `StaleGrantGuidanceTests`) is left intact rather than re-baselined — the copy was reworded to satisfy them.

## Verification

- `swift build` clean.
- **1600 tests, 8 skipped, 0 failures.**
- Six new regression tests (`ScreenGrantVisibilityTests`) over the extracted pure rule and both rewritten sentences.

**Not verified by a live onboarding run,** and I want that stated rather than implied: launching a local Context for Claude build rewrites both Claude MCP configs and shares the release's data directory (`~/Library/Application Support/ContextForClaude` is not bundle-scoped), so a live walkthrough risks the user's real capture data. The root cause was instead measured directly against the shipped release, above.


## Review round 2 — a defect found and fixed before merge

An adversarial review of the first commit returned **DO NOT SHIP**, correctly. The first commit called `relaunchApp()` from the onboarding Screen row on `screenNeedsRelaunch` alone — checking neither `PermissionDeadEnd.mayRelaunch` nor the ledger, both of which every other relaunch call site applies. Because `screenNeedsRelaunch` is now armed by merely opening the pane, a user who **declined** Screen Recording could restart the app indefinitely, two clicks at a time, with `OnboardingResume` returning them to the same row each time. That is worse than the bug being fixed, and it was on the busiest surface in the app.

Fixed in the second commit:

- `invite()` now applies the same three conditions as `StatusView.handle` — never for an unusable record, bounded by `mayRelaunch`, recorded via `noteRelaunched` — then falls through to the pane.
- Both new reads go through **injected closures** instead of the global. This also removes a live landmine: the real `relaunchApp()` is `-> Never`, and eight existing `invite(.screen)` call sites in the suite were one signalled latch away from killing the test runner rather than failing.
- `statusWord` tested `needsRelaunch` before `granted`, demanding action the moment the pane opened. The halves are now distinct: `granted` keeps **"Action required"**; the stale-preflight case reads **"Reopen"**, because the row is a button and `Asking…` is the reported dead end.
- `screenRelaunchOffer` took a `preflight` it never receives and pinned a value contradicting the real rule — renamed, dead parameter dropped.
- A comment claimed the persisted-flag clear had been removed; it had not. Comment corrected, clear kept (it records a grant this process *watched* arrive, which is exactly what has not happened).

**1603 tests, 0 failures.** Four new behavioural tests over the injected seam cover the relaunch bound, the unusable-record exclusion, the row staying live, and both status words — none of which the first commit could test.

## Known limitation, stated rather than buried

A menu-bar Screen tap can now spend the single relaunch credit in the not-granted state (`screenNeedsRelaunch` is reachable there where it previously was not). If that user later grants and hits the genuine stale-preflight state, the credit is gone and the menu bar shows the dead-end sentence instead of "Restart to finish"; quitting and reopening by hand still works, and the copy now says so. Bounding this properly means separating "armed by observed staleness" from "armed by opened pane" in the ledger, which is a larger change than belongs in a fix shipping today. Worth a follow-up issue.

## Failure class

`FC-platform-grant-record-as-live-capability` — the same contract, in its inverse form. The class was written for a record read as *true* that the process could not use; this is a record read as *false* that the user had in fact granted. Both are the platform's record being mistaken for this process's live capability. Guard surface added in the same PR, per the recurrence rule.

Failure-Class: FC-platform-grant-record-as-live-capability

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
