### PR TITLE
fix(billing): stop selling Neo and desktop plans on the wrong mobile sheet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ These rules apply to every AI agent working in this repository. This file is **h
 | Product behavior | `PRODUCT.md` + `docs/product/invariants/` — locked invariants and guard tests |
 | A rule shared across app/macOS/Windows (buckets, day grouping, wire decode) | `contracts/parity/README.md` — shared fixtures, per-platform conformance suites, divergence register |
 | Fallback/fail-open branches | `docs/agents/fallback-telemetry.md` — when to call `record_fallback` |
+| Mobile/desktop plan catalog | `docs/agents/plan-catalog.md` — who sees Plus/Neo/Operator/Architect |
 | App flows / E2E | `app/e2e/SKILL.md`, `desktop/macos/e2e/SKILL.md` |
 | Cursor Cloud VM (Linux x86) | `.cursor/cloud-agent-environment.md` — hermetic E2E harness, known failures |
 

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-      );
+            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+          );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-    );
+          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+        );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -939,8 +939,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded =
-                                  sub?.currentPeriodEnd != null &&
+                              final periodEnded = sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1015,8 +1014,7 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption =
-                                _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -1169,18 +1169,24 @@ class _PlansSheetState extends State<PlansSheet> {
                         _buildPromoCodeField(),
                         const SizedBox(height: 16),
 
-                        // Continue/Keep Unlimited button - only show for non-annual unlimited users
+                        // Continue/Upgrade — hidden for same-tier annual (nothing to
+                        // change) and for desktop-plan → mobile-tier switches.
                         Builder(
                           builder: (context) {
                             final currentPlan = _getCurrentPlanDetails();
                             final isOnAnnualPlan = currentPlan?['interval'] == 'year';
                             final hasScheduledUpgrade = _hasScheduledUpgrade();
                             final usageProvider = context.read<UsageProvider>();
-                            final shouldShowContinueButton = !isOnAnnualPlan &&
-                                !hasScheduledUpgrade &&
-                                !isCancelled &&
-                                !usageProvider.isLoadingPlans &&
-                                usageProvider.availablePlans != null;
+                            final currentSub = usageProvider.subscription?.subscription;
+                            final shouldShowContinueButton = shouldShowPlanContinueButton(
+                              isOnAnnualPlan: isOnAnnualPlan,
+                              hasScheduledUpgrade: hasScheduledUpgrade,
+                              isCancelled: isCancelled,
+                              plansLoaded: !usageProvider.isLoadingPlans && usageProvider.availablePlans != null,
+                              selectedTierId: selectedTierId,
+                              currentTierId: currentSub?.plan.wireName,
+                              currentGrantsDesktop: currentSub?.plan.grantsDesktop ?? false,
+                            );
 
                             if (!shouldShowContinueButton) {
                               return const SizedBox.shrink();

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -358,13 +358,13 @@ class _PlansSheetState extends State<PlansSheet> {
     Map<String, dynamic>? selectedPlanData;
     if (tierId != null) {
       selectedPlanData = plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-            (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
-          );
+        (plan) => plan['plan_id'] == tierId && plan['interval'] == (isYearly ? 'year' : 'month'),
+      );
     }
     // Fallback to old behavior (first plan matching interval) for backwards compat
     selectedPlanData ??= plans.cast<Map<String, dynamic>>().firstWhereOrNull(
-          (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
-        );
+      (plan) => plan['interval'] == (isYearly ? 'year' : 'month'),
+    );
 
     if (selectedPlanData == null) {
       AppSnackbar.showSnackbarError(context.l10n.selectedPlanNotAvailable);
@@ -939,7 +939,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             builder: (context) {
                               // Check if subscription period has ended
                               final sub = provider.subscription?.subscription;
-                              final periodEnded = sub?.currentPeriodEnd != null &&
+                              final periodEnded =
+                                  sub?.currentPeriodEnd != null &&
                                   DateTime.fromMillisecondsSinceEpoch(
                                     sub!.currentPeriodEnd! * 1000,
                                   ).isBefore(DateTime.now());
@@ -1014,7 +1015,8 @@ class _PlansSheetState extends State<PlansSheet> {
                         // Training Data Opt-in Option - only show after plans are loaded
                         Consumer2<UsageProvider, UserProvider>(
                           builder: (context, usageProvider, userProvider, child) {
-                            final shouldShowTrainingOption = _showTrainingDataOptIn &&
+                            final shouldShowTrainingOption =
+                                _showTrainingDataOptIn &&
                                 !usageProvider.isLoadingPlans &&
                                 usageProvider.availablePlans != null;
 

--- a/app/lib/utils/plan_pricing.dart
+++ b/app/lib/utils/plan_pricing.dart
@@ -51,3 +51,28 @@ int? _annualMonthsFree(List<Map<String, dynamic>> plans) {
   if (monthlyAmount == null || yearlyAmount == null || monthlyAmount <= 0) return null;
   return (monthlyAmount, yearlyAmount);
 }
+
+/// Whether the mobile plans sheet should show Continue / Upgrade.
+///
+/// Locked (docs/agents/plan-catalog.md) — do not restore `!isOnAnnualPlan`:
+/// that hid Continue for every annual subscriber and blocked Plus → Unlimited.
+/// Hide only when the user is already on the selected tier's annual price.
+/// Desktop-entitled plans are manage-only on this sheet: same-tier
+/// monthly→annual is still a management action; switching onto Plus /
+/// Unlimited / Neo is not.
+bool shouldShowPlanContinueButton({
+  required bool isOnAnnualPlan,
+  required bool hasScheduledUpgrade,
+  required bool isCancelled,
+  required bool plansLoaded,
+  String? selectedTierId,
+  String? currentTierId,
+  bool currentGrantsDesktop = false,
+}) {
+  if (!plansLoaded || isCancelled || hasScheduledUpgrade) return false;
+  if (currentGrantsDesktop && selectedTierId != null && currentTierId != null && selectedTierId != currentTierId) {
+    return false;
+  }
+  if (isOnAnnualPlan && (selectedTierId == null || selectedTierId == currentTierId)) return false;
+  return true;
+}

--- a/app/test/utils/plan_pricing_test.dart
+++ b/app/test/utils/plan_pricing_test.dart
@@ -82,4 +82,132 @@ void main() {
       expect(bestAnnualDiscountPercent(const []), isNull);
     });
   });
+
+  group('shouldShowPlanContinueButton', () {
+    test('hides when plans are loading, cancelled, or a change is already scheduled', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: false,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: false,
+          hasScheduledUpgrade: false,
+          isCancelled: true,
+          plansLoaded: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: false,
+          hasScheduledUpgrade: true,
+          isCancelled: false,
+          plansLoaded: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('shows for monthly users, including same-tier monthly→annual', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: false,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+          selectedTierId: 'plus',
+          currentTierId: 'plus',
+        ),
+        isTrue,
+      );
+    });
+
+    test('hides for annual users already on the selected tier', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: true,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+          selectedTierId: 'plus',
+          currentTierId: 'plus',
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: true,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('shows for annual Plus selecting Unlimited — do not restore !isOnAnnualPlan', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: true,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+          selectedTierId: 'unlimited_v2',
+          currentTierId: 'plus',
+        ),
+        isTrue,
+      );
+    });
+
+    test('hides desktop-plan Continue onto a mobile tier (manage-only)', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: false,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+          selectedTierId: 'plus',
+          currentTierId: 'architect',
+          currentGrantsDesktop: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('still shows monthly→annual Continue on a desktop plan', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: false,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+          selectedTierId: 'architect',
+          currentTierId: 'architect',
+          currentGrantsDesktop: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('hides same-tier annual Continue on a desktop plan', () {
+      expect(
+        shouldShowPlanContinueButton(
+          isOnAnnualPlan: true,
+          hasScheduledUpgrade: false,
+          isCancelled: false,
+          plansLoaded: true,
+          selectedTierId: 'architect',
+          currentTierId: 'architect',
+          currentGrantsDesktop: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -28,6 +28,7 @@ from utils.subscription import (
     get_plan_limits,
     is_paid_plan,
     filter_plans_for_user,
+    desktop_to_consumer_plan_change_error,
     should_show_new_plans,
     adapt_plans_for_legacy_client,
     clear_trial_paywall_cache,
@@ -450,11 +451,8 @@ def get_available_plans_endpoint(
                 scheduled_price_id = price_map.get(scheduled_price_id, scheduled_price_id)
 
         current_plan = current_subscription.plan if current_subscription else PlanType.basic
-        ever_purchased = subscription_utils.has_ever_purchased(uid, current_subscription)
         pricing_options: List[PricingOption] = []
-        for definition in filter_plans_for_user(
-            all_definitions, current_plan, platform=x_app_platform, ever_purchased=ever_purchased
-        ):
+        for definition in filter_plans_for_user(all_definitions, current_plan, platform=x_app_platform):
             monthly_price_id = definition["monthly_price_id"]
             annual_price_id = definition["annual_price_id"]
             if monthly_price_id:
@@ -693,12 +691,9 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
         target_interval = target_price.recurring.interval  # "month" or "year"
         current_plan = get_plan_type_from_price_id(current_price_id)
 
-        # Block downgrades from Architect to Unlimited
-        if current_plan == PlanType.architect and target_plan == PlanType.unlimited:
-            raise HTTPException(
-                status_code=400,
-                detail="Downgrading from Architect to Unlimited is not available. Please contact support if you need to change your plan.",
-            )
+        desktop_change_error = desktop_to_consumer_plan_change_error(current_plan, target_plan)
+        if desktop_change_error:
+            raise HTTPException(status_code=400, detail=desktop_change_error)
 
         # Validate and resolve promotion code if provided
         resolved_promo_id = None

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -95,7 +95,6 @@ from utils.subscription import (
     neo_grandfather_until,
     reconcile_basic_plan_with_stripe,
     filter_plans_for_user,
-    has_ever_purchased,
     should_show_new_plans,
     adapt_plans_for_legacy_client,
     wire_plan_for_client,
@@ -1260,10 +1259,7 @@ def get_user_subscription_endpoint(
     if not new_plans_enabled:
         all_definitions = adapt_plans_for_legacy_client(all_definitions)
     available_plans: List[SubscriptionPlan] = []
-    ever_purchased = has_ever_purchased(uid, raw_subscription)
-    definitions_for_user = filter_plans_for_user(
-        all_definitions, subscription.plan, platform=x_app_platform, ever_purchased=ever_purchased
-    )
+    definitions_for_user = filter_plans_for_user(all_definitions, subscription.plan, platform=x_app_platform)
     for definition in definitions_for_user:
         plan_prices: List[PricingOption] = []
         monthly_price_id = definition["monthly_price_id"]

--- a/backend/tests/unit/test_payment_promotion_codes.py
+++ b/backend/tests/unit/test_payment_promotion_codes.py
@@ -279,6 +279,7 @@ def _setup_payment_module(include_client: bool = True) -> Any:
     sub_mod.clear_trial_paywall_cache = MagicMock()
     sub_mod.find_active_paid_subscription_for_user = MagicMock()
     sub_mod.price_ids_match_plan_and_interval = MagicMock(return_value=True)
+    sub_mod.desktop_to_consumer_plan_change_error = MagicMock(return_value=None)
 
     fallback_mod = types.ModuleType("utils.observability.fallback")
     fallback_mod.record_fallback = MagicMock()

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -148,9 +148,7 @@ def test_filter_plans_mobile_new_user_sees_only_plus_and_unlimited_v2(load_subsc
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
         for platform in ('ios', 'android'):
-            filtered = sub_mod.filter_plans_for_user(
-                definitions, PlanType.basic, platform=platform, ever_purchased=False
-            )
+            filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform=platform)
             plan_ids = [d['plan_id'] for d in filtered]
             assert plan_ids == ['plus', 'unlimited_v2'], (platform, plan_ids)
 
@@ -164,24 +162,60 @@ def test_filter_plans_desktop_hides_mobile_tiers(load_subscription):
         assert plan_ids == ['operator', 'architect'], plan_ids
 
 
-def test_filter_plans_shows_neo_on_mobile_for_past_purchaser(load_subscription):
-    """Mobile users who have bought a plan before still see Neo (resubscribe)."""
+def test_filter_plans_hides_neo_on_mobile_for_non_neo_subscribers(load_subscription):
+    """Neo is current-Neo only. Architect/Plus/Unlimited/basic must not see it.
+
+    Regression: `ever_purchased` was any paid plan, so Architect subscribers
+    saw Neo on the phone sheet next to cheaper Plus. Do not restore that leak.
+    """
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='ios', ever_purchased=True)
+        for plan in (PlanType.basic, PlanType.plus, PlanType.unlimited_v2):
+            filtered = sub_mod.filter_plans_for_user(definitions, plan, platform='ios')
+            plan_ids = [d['plan_id'] for d in filtered]
+            assert 'unlimited' not in plan_ids, (plan, plan_ids)
+            assert plan_ids == ['plus', 'unlimited_v2'], (plan, plan_ids)
 
-    assert 'unlimited' in [d['plan_id'] for d in filtered]
+
+def test_filter_plans_mobile_desktop_plans_are_manage_only(load_subscription):
+    """Operator/Architect on iOS/Android see only their current plan.
+
+    Cheaper mobile SKUs must not appear: Continue onto them is an immediate
+    prorated swap that strips desktop. Desktop/web keep the full desktop catalog.
+    """
+    with load_subscription() as sub_mod:
+        definitions = sub_mod.get_paid_plan_definitions()
+        for platform in ('ios', 'android'):
+            architect = [
+                d['plan_id'] for d in sub_mod.filter_plans_for_user(definitions, PlanType.architect, platform=platform)
+            ]
+            operator = [
+                d['plan_id'] for d in sub_mod.filter_plans_for_user(definitions, PlanType.operator, platform=platform)
+            ]
+            assert architect == ['architect'], (platform, architect)
+            assert operator == ['operator'], (platform, operator)
+
+        desktop = [
+            d['plan_id'] for d in sub_mod.filter_plans_for_user(definitions, PlanType.architect, platform='macos')
+        ]
+        assert desktop == ['operator', 'architect'], desktop
 
 
 def test_filter_plans_shows_neo_on_mobile_for_current_neo_subscriber(load_subscription):
-    """Current Neo subscribers always see Neo even without ever_purchased flag."""
+    """Current Neo subscribers (including cancel-at-period-end) still see Neo to manage it.
+
+    Plus + Unlimited stay visible so they can migrate off the deprecated SKU.
+    """
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(
-            definitions, PlanType.unlimited, platform='android', ever_purchased=False
-        )
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.unlimited, platform='android')
 
-    assert 'unlimited' in [d['plan_id'] for d in filtered]
+    plan_ids = [d['plan_id'] for d in filtered]
+    assert 'unlimited' in plan_ids
+    assert 'plus' in plan_ids
+    assert 'unlimited_v2' in plan_ids
+    assert 'architect' not in plan_ids
+    assert 'operator' not in plan_ids
 
 
 def test_filter_plans_hides_neo_on_web_for_new_user(load_subscription):
@@ -194,7 +228,7 @@ def test_filter_plans_hides_neo_on_web_for_new_user(load_subscription):
     """
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='web', ever_purchased=False)
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='web')
     plan_ids = [d['plan_id'] for d in filtered]
     assert 'unlimited' not in plan_ids  # Neo hidden
     assert 'plus' in plan_ids
@@ -207,7 +241,7 @@ def test_filter_plans_shows_neo_on_web_for_current_neo_subscriber(load_subscript
     """Existing Neo subscribers still see Neo on web so they can manage/cancel."""
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.unlimited, platform='web', ever_purchased=True)
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.unlimited, platform='web')
     assert 'unlimited' in [d['plan_id'] for d in filtered]
 
 
@@ -215,7 +249,7 @@ def test_filter_plans_keeps_neo_for_unknown_platform(load_subscription):
     """A header-less / unknown platform is still unfiltered — Neo stays visible."""
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform=None, ever_purchased=False)
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform=None)
 
     assert 'unlimited' in [d['plan_id'] for d in filtered]
 
@@ -228,7 +262,7 @@ def test_filter_plans_hides_neo_on_windows_for_new_user(load_subscription):
     """
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='windows', ever_purchased=False)
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='windows')
     plan_ids = [d['plan_id'] for d in filtered]
     assert 'unlimited' not in plan_ids
     assert 'operator' in plan_ids
@@ -247,9 +281,7 @@ def test_neo_hidden_from_purchase_on_every_client_platform(load_subscription):
     with load_subscription() as sub_mod:
         definitions = sub_mod.get_paid_plan_definitions()
         for platform in ('ios', 'android', 'macos', 'windows', 'web'):
-            filtered = sub_mod.filter_plans_for_user(
-                definitions, PlanType.basic, platform=platform, ever_purchased=False
-            )
+            filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform=platform)
             plan_ids = [d['plan_id'] for d in filtered]
             assert 'unlimited' not in plan_ids, (platform, plan_ids)
             assert plan_ids, platform  # never an empty catalog
@@ -267,7 +299,7 @@ def test_windows_full_catalog_matches_macos_canonical(load_subscription):
         # Windows is a modern desktop client → new catalog, no legacy adaptation.
         assert sub_mod.should_show_new_plans('windows', '0.1.0') is True
         definitions = sub_mod.get_paid_plan_definitions()
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='windows', ever_purchased=False)
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='windows')
     by_id = {d['plan_id']: d for d in filtered}
     assert 'operator' in by_id
     assert 'architect' in by_id
@@ -291,23 +323,17 @@ def test_windows_is_a_desktop_platform(load_subscription):
         assert 'android' not in sub_mod.DESKTOP_PLATFORMS
 
 
-def test_has_ever_purchased_signals(monkeypatch, load_subscription):
-    """Paid plan, stored stripe sub id, or a stripe customer id each count as purchased."""
+def test_desktop_to_consumer_plan_change_is_blocked(load_subscription):
+    """Architect/Operator cannot swap onto Plus/Unlimited/Neo. Operator ↔ Architect stays open."""
     with load_subscription() as sub_mod:
-        monkeypatch.setattr(sub_mod.users_db, 'get_stripe_customer_id', lambda uid: None, raising=False)
-
-        paid = Subscription(plan=PlanType.operator, limits=PlanLimits())
-        assert sub_mod.has_ever_purchased('u', paid)
-
-        lapsed = Subscription(plan=PlanType.basic, stripe_subscription_id='sub_123', limits=PlanLimits())
-        assert sub_mod.has_ever_purchased('u', lapsed)
-
-        new_user = Subscription(plan=PlanType.basic, limits=PlanLimits())
-        assert not sub_mod.has_ever_purchased('u', new_user)
-
-        # No cheap signal on the subscription, but a stored Stripe customer id exists.
-        monkeypatch.setattr(sub_mod.users_db, 'get_stripe_customer_id', lambda uid: 'cus_123', raising=False)
-        assert sub_mod.has_ever_purchased('u', new_user)
+        err = sub_mod.desktop_to_consumer_plan_change_error
+        for current in (PlanType.architect, PlanType.operator):
+            for target in (PlanType.plus, PlanType.unlimited_v2, PlanType.unlimited, PlanType.basic):
+                assert err(current, target), (current, target)
+        assert err(PlanType.architect, PlanType.operator) is None
+        assert err(PlanType.operator, PlanType.architect) is None
+        assert err(PlanType.plus, PlanType.unlimited_v2) is None
+        assert err(PlanType.unlimited, PlanType.plus) is None
 
 
 def test_legacy_client_adaptation(load_subscription):
@@ -377,7 +403,7 @@ def test_web_full_catalog_shows_new_plans_and_hides_neo(load_subscription):
         assert new_plans_enabled is True
         definitions = sub_mod.get_paid_plan_definitions()
         # No legacy adaptation for web (new_plans_enabled) → raw canonical catalog.
-        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='web', ever_purchased=False)
+        filtered = sub_mod.filter_plans_for_user(definitions, PlanType.basic, platform='web')
     by_id = {d['plan_id']: d for d in filtered}
     assert set(by_id) == {'plus', 'unlimited_v2', 'operator', 'architect'}, by_id
     assert 'unlimited' not in by_id  # Neo hidden

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -485,7 +485,8 @@ def _platform_hidden_plans(platform: Optional[str]) -> Set[PlanType]:
     Mobile sells Plus + Unlimited; desktop sells Operator + Architect; web sells
     all four. Neo is deprecated everywhere and hidden on every platform. A
     subscriber on a hidden plan still sees it via `filter_plans_for_user`'s
-    current-plan / ever-purchased escapes.
+    current-plan escape (Neo) or the mobile manage-only fast path (Operator /
+    Architect). See docs/agents/plan-catalog.md.
     """
     p = (platform or '').lower()
     if p in _MOBILE_PLATFORM_TOKENS:
@@ -497,51 +498,55 @@ def _platform_hidden_plans(platform: Optional[str]) -> Set[PlanType]:
     return set()
 
 
-def has_ever_purchased(uid: str, subscription: Optional[Subscription] = None) -> bool:
-    """True if the user has ever gone through subscription checkout.
+def desktop_to_consumer_plan_change_error(current_plan: PlanType, target_plan: PlanType) -> Optional[str]:
+    """Error text if a desktop-entitled plan would be swapped onto a consumer tier.
 
-    Used to keep the deprecated Neo plan visible on mobile to lapsed/returning
-    subscribers (so they can resubscribe) while hiding it from brand-new users
-    who never bought a plan. A Stripe customer id is created at first checkout
-    and persists across cancellations and plan changes; a current paid plan or
-    a stored stripe_subscription_id are cheaper positive signals checked first.
+    Operator and Architect are manage-only from mobile: cancel or wait out the
+    period. Immediate proration onto Plus / Unlimited / Neo strips desktop.
+    Same-family desktop changes (Operator ↔ Architect) stay allowed for the
+    desktop and web storefronts. Do not add a "user confirmed in the app"
+    exception — confirmation is not this boundary. See docs/agents/plan-catalog.md.
     """
-    if subscription is not None:
-        if is_paid_plan(subscription.plan):
-            return True
-        if subscription.stripe_subscription_id:
-            return True
-    return bool(users_db.get_stripe_customer_id(uid))
+    if current_plan in DESKTOP_ENTITLED_PLAN_TYPES and target_plan not in DESKTOP_ENTITLED_PLAN_TYPES:
+        return (
+            "This plan is managed from desktop. Switching to a mobile plan is not "
+            "available here. Cancel at period end or contact support."
+        )
+    return None
 
 
 def filter_plans_for_user(
     definitions: List[Dict[str, Any]],
     current_plan: PlanType,
     platform: Optional[str] = None,
-    ever_purchased: bool = False,
 ) -> List[Dict[str, Any]]:
     """Drop legacy / platform-hidden plans from the purchase catalog.
 
-    Subscribers already on a "wrong-platform" plan (e.g. a Neo subscriber
-    opening the desktop app) still see their current plan so the management UI
-    works. On mobile, Neo also stays visible to anyone who has ever purchased a
-    plan (`ever_purchased`) so lapsed subscribers can resubscribe — new /
-    never-paid users don't see it. Only the *purchase* catalog is filtered.
+    Locked audience rules (docs/agents/plan-catalog.md) — do not re-widen:
+
+    1. Neo (`unlimited`) is shown only when `current_plan` is already Neo
+       (active or cancel-at-period-end). Never gate it on "has ever paid".
+    2. On mobile, Operator / Architect are manage-only: return *only* the
+       current desktop plan so cheaper mobile tiers cannot be purchased
+       from the phone. Desktop and web keep selling both.
+    3. Fully churned ex-Neo users are `basic` and receive Plus + Unlimited,
+       the replacement catalog, not the deprecated Neo SKU.
+
+    The current-plan escape still applies on desktop/web so a Neo subscriber
+    opening those surfaces can manage/cancel.
     """
-    hidden = _platform_hidden_plans(platform)
     is_mobile = (platform or '').lower() in _MOBILE_PLATFORM_TOKENS
+    if is_mobile and current_plan in DESKTOP_ENTITLED_PLAN_TYPES:
+        return [d for d in definitions if d.get('plan_type') == current_plan]
+
+    hidden = _platform_hidden_plans(platform)
     out: List[Dict[str, Any]] = []
     for d in definitions:
         plan_type = d.get('plan_type')
         if d.get('legacy') and plan_type != current_plan:
             continue
         if plan_type in hidden and plan_type != current_plan:
-            # Mobile-only escape: keep the deprecated Neo plan visible to users
-            # who have bought a plan before (so they can resubscribe/manage).
-            if is_mobile and plan_type == PlanType.unlimited and ever_purchased:
-                pass
-            else:
-                continue
+            continue
         out.append(d)
     return out
 

--- a/docs/agents/plan-catalog.md
+++ b/docs/agents/plan-catalog.md
@@ -1,0 +1,49 @@
+# Plan catalog audience
+
+Locked purchase-catalog rules. Tests in
+`backend/tests/unit/test_subscription_restructure.py` and
+`app/test/utils/plan_pricing_test.dart` enforce them. Do not re-widen a
+filter because a paid user "might want to resubscribe" or because the
+phone sheet looks empty.
+
+## Storefronts
+
+| Surface | Sells | Does not sell |
+|---|---|---|
+| Mobile (`ios` / `android`) | Plus + Unlimited (`unlimited_v2`) | Operator, Architect, Neo |
+| Desktop (`macos` / `windows`) | Operator + Architect | Plus, Unlimited, Neo |
+| Web | Plus + Unlimited + Operator + Architect | Neo |
+
+Neo (`PlanType.unlimited`) is the deprecated pre-Plus Unlimited. It is
+never a new-user SKU on any real client platform.
+
+## Three audience rules
+
+1. **Neo is current-Neo only.** Show Neo iff `current_plan == unlimited`
+   (active or cancel-at-period-end). Do **not** key it off "has ever
+   paid" / Stripe customer id. That leak put Neo on Architect and Plus
+   sheets, where Plus looked strictly cheaper because Neo's simplified
+   mobile card omits unlimited transcription.
+   Fully churned ex-Neo users are `basic` and get Plus + Unlimited, the
+   replacement catalog. Do not bring Neo back for them.
+
+2. **Desktop plans are manage-only on mobile.** An Operator or Architect
+   subscriber opening iOS/Android sees **only** their current plan
+   (Active, cancel, portal). They cannot Continue onto Plus / Unlimited /
+   Neo. Immediate Stripe proration would strip desktop entitlement.
+   Operator ↔ Architect stays allowed on desktop and web.
+   The upgrade API (`desktop_to_consumer_plan_change_error`) is the
+   same boundary: confirmation in the app is not an exception.
+
+3. **Annual Continue is for a real change.** Hide Continue when the user
+   is already on the selected tier's annual price. Show it when they
+   pick a *different* tier (e.g. annual Plus → Unlimited) or a
+   monthly→annual switch on the same tier. Do not restore the old
+   `!isOnAnnualPlan` hide — that blocked Plus→Unlimited for annual
+   subscribers.
+
+## Where the code lives
+
+- Catalog filter: `backend/utils/subscription.py` → `filter_plans_for_user`
+- Upgrade guard: `backend/utils/subscription.py` → `desktop_to_consumer_plan_change_error`
+- Continue button: `app/lib/utils/plan_pricing.dart` → `shouldShowPlanContinueButton`


### PR DESCRIPTION
## Summary

- **Neo is current-Neo only.** The mobile sheet no longer shows Neo to anyone who has ever paid. `ever_purchased` was any paid plan / Stripe customer id, so Architect (and Plus) subscribers saw a deprecated SKU that looked strictly worse than Plus. Neo stays visible only while `current_plan == unlimited` (active or cancel-at-period-end). Fully churned ex-Neo users are `basic` and get Plus + Unlimited, the replacement catalog.
- **Desktop plans are manage-only on mobile.** An Operator or Architect subscriber opening iOS/Android sees only their current plan (Active, cancel, portal). Continue onto Plus / Unlimited / Neo is hidden, and the upgrade API rejects those swaps. Immediate Stripe proration would strip desktop. Operator ↔ Architect stays allowed on desktop and web.
- **Annual Continue is for a real change.** The old `!isOnAnnualPlan` hide blocked Plus → Unlimited for annual subscribers. Continue now shows when the selected tier differs, and still hides when the user is already on that tier's annual price. Same-tier monthly→annual still works, including on a desktop plan.

Do not re-widen these filters. The locked rationale is `docs/agents/plan-catalog.md` (indexed from root `AGENTS.md`). Tests in `backend/tests/unit/test_subscription_restructure.py` and `app/test/utils/plan_pricing_test.dart` fail if Neo is keyed off "ever paid" again or if `!isOnAnnualPlan` is restored.

## Failure-Class

Failure-Class: none

The audience leak is a one-off catalog predicate, not a registered recurring class. The reusable guard is `filter_plans_for_user` plus `desktop_to_consumer_plan_change_error`, locked by tests that fail if Neo is keyed off "ever paid" again.

## Test plan

- [x] `backend/.venv/bin/python -m pytest tests/unit/test_subscription_restructure.py tests/unit/test_payment_price_id_validation.py -v` — 46 passed
- [x] `cd app && flutter test test/utils/plan_pricing_test.dart` — 18 passed
- [ ] Not exercised on a physical phone: Architect annual sheet should show only Architect (no Plus/Neo/Unlimited, no Continue); annual Plus selecting Unlimited should show Continue


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

