### PR TITLE
fix(desktop): repair the shell monitor retain cycle and unbreak swift test

### DIFF
--- a/desktop/macos/Desktop/Package.swift
+++ b/desktop/macos/Desktop/Package.swift
@@ -1,6 +1,15 @@
 // swift-tools-version: 6.0
 import PackageDescription
 
+// Frameworks such as Sparkle are built into Products/<config>/, but a test bundle's
+// generated rpaths only cover PackageFrameworks/. Without this the bundle builds and
+// then fails to dlopen, which reads as an unrelated test failure.
+// ponytail: one rpath on every test target, rather than working out which ones link
+// Sparkle transitively.
+let testBundleFrameworkSearchPath = LinkerSetting.unsafeFlags([
+  "-Xlinker", "-rpath", "-Xlinker", "@loader_path/../../..",
+])
+
 let package = Package(
   name: "Omi Computer",
   platforms: [
@@ -129,7 +138,8 @@ let package = Package(
       ],
       swiftSettings: [
         .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
-      ]
+      ],
+      linkerSettings: [testBundleFrameworkSearchPath]
     ),
     .testTarget(
       name: "OmiSupportTests",
@@ -137,7 +147,8 @@ let package = Package(
       path: "Tests/OmiSupportTests",
       swiftSettings: [
         .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
-      ]
+      ],
+      linkerSettings: [testBundleFrameworkSearchPath]
     ),
     .testTarget(
       name: "OmiWALTests",
@@ -145,7 +156,8 @@ let package = Package(
       path: "Tests/OmiWALTests",
       swiftSettings: [
         .unsafeFlags(["-strict-concurrency=complete", "-warnings-as-errors"])
-      ]
+      ],
+      linkerSettings: [testBundleFrameworkSearchPath]
     ),
     .testTarget(
       name: "VoiceTurnDomainTests",
@@ -153,7 +165,8 @@ let package = Package(
         .target(name: "Omi Computer"),
         "VoiceTurnDomain",
       ],
-      path: "Tests/VoiceTurnDomainTests"
+      path: "Tests/VoiceTurnDomainTests",
+      linkerSettings: [testBundleFrameworkSearchPath]
     ),
     .testTarget(
       name: "SemanticFeatureSentinels",
@@ -161,7 +174,8 @@ let package = Package(
       path: "Tests/SemanticFeatureSentinels",
       swiftSettings: [
         .unsafeFlags(["-strict-concurrency=complete"])
-      ]
+      ],
+      linkerSettings: [testBundleFrameworkSearchPath]
     ),
   ],
   swiftLanguageModes: [.v6]

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -54,8 +54,8 @@ final class ShellMouseInterceptionSync {
 
   init(window: NSWindow) {
     self.window = window
-    let scheduleReconciliation: @Sendable () -> Void = {
-      DispatchQueue.main.async { [weak self] in self?.sync() }
+    let scheduleReconciliation: @Sendable () -> Void = { [weak self] in
+      DispatchQueue.main.async { self?.sync() }
     }
     if let global = NSEvent.addGlobalMonitorForEvents(
       matching: [.mouseMoved, .leftMouseDragged],

--- a/desktop/macos/changelog/unreleased/20260817-shell-monitor-leak.json
+++ b/desktop/macos/changelog/unreleased/20260817-shell-monitor-leak.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed a memory leak where each window kept its mouse-tracking helper alive for as long as the app was running."
+}


### PR DESCRIPTION
## Why

Both of these made local desktop development impossible on Xcode 27, and one of them is a real memory leak that has been shipping.

## 1. Shell mouse-monitor retain cycle

```swift
let scheduleReconciliation: @Sendable () -> Void = {
  DispatchQueue.main.async { [weak self] in self?.sync() }   // weak on the wrong closure
}
```

`ShellMouseInterceptionSync` stores its event monitors in `self.monitors`, and those handlers call `scheduleReconciliation` — which captured `self` **strongly**. The `[weak self]` applied to the inner dispatch block, not to the stored capture, so the cycle was never broken:

`self → monitors → handler → closure → self`

Every shell window leaked its interception sync for the process lifetime. Moving the capture list to the outer closure makes the weak capture the one that actually governs the stored reference.

Swift 6.4 reports this as `ImplicitStrongCapture`. Because the package builds with `-warnings-as-errors`, that one line fails the entire debug build of `main` on Xcode 27. Earlier toolchains accepted it silently — which is exactly how a real leak sat behind a diagnostic nobody could see.

## 2. Test bundles missing an rpath

`swift test` could not load **any** xctest bundle:

```
Library not loaded: @rpath/Sparkle.framework/Versions/B/Sparkle
```

Generated rpaths cover `Products/<config>/PackageFrameworks/`, but Sparkle and friends are built into `Products/<config>/` itself — one level up. One unloadable bundle aborts the whole run, so a single target's missing rpath hid every test in the package, and it surfaces as a test failure rather than a link error.

Every test target now carries `@loader_path/../../..`. Applied uniformly rather than working out which targets link Sparkle transitively — a search path costs nothing on the ones that don't need it.

## Verification

```
xcrun swift build -c debug --package-path Desktop     Build complete
  (-warnings-as-errors intact; fails on main without fix 1)

xcrun swift test --package-path Desktop               5272 tests, 1 skipped, 0 failures
  (on main this cannot load a single bundle)

swift-format lint                                     clean
```

The full desktop suite runs locally, which it did not before this PR.

## Note

No test is added for the retain cycle. A leak check would need a teardown harness this package doesn't have, and the compiler now rejects the pattern outright under `-warnings-as-errors` — which is a stronger guard than a test, as long as the flag stays. Found while working on #11657, where both problems forced me to verify desktop changes through workarounds.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted linker and capture-list fixes for tests and shell click-through; no auth, data, or broad behavioral refactors.
> 
> **Overview**
> Fixes two desktop/macOS issues that blocked **Xcode 27** local builds and **`swift test`**.
> 
> **`ShellMouseInterceptionSync`** now applies **`[weak self]`** on the stored `scheduleReconciliation` closure instead of only on the inner `DispatchQueue.main.async` block, breaking **`self → monitors → handler → closure → self`** so each shell window’s mouse helper can be released instead of leaking for the process lifetime (also clears Swift 6.4 **`ImplicitStrongCapture`** under **`-warnings-as-errors`**).
> 
> **`Package.swift`** adds a shared linker **rpath** (`@loader_path/../../..`) on every test target so xctest bundles can **dlopen** frameworks like **Sparkle** from `Products/<config>/`, not only `PackageFrameworks/`.
> 
> Changelog notes the shell mouse-tracking leak fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb028f9549fc822814f9900558b86f22cd70dafd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->