### PR TITLE
fix(macos): stop the update chip from reserving a blank ProgressView gap

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopUpdateStatusPresentation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopUpdateStatusPresentation.swift
@@ -125,6 +125,52 @@ enum DesktopUpdateStatusPresentation {
   }
 }
 
+/// Compact spinner for update chrome. macOS `ProgressView()` defaults to a
+/// linear bar (~100pt+), which left a blank gap beside "Downloading…" in the
+/// top-bar chip; pin circular style and a caption-sized frame.
+struct DesktopUpdateStatusProgressIndicator: View {
+  var diameter: CGFloat = 16
+
+  var body: some View {
+    ProgressView()
+      .progressViewStyle(.circular)
+      .controlSize(.small)
+      .tint(Ink.surface)
+      .frame(width: diameter, height: diameter)
+  }
+}
+
+/// Production label for `DesktopUpdateStatusChip`, extracted so layout tests
+/// can measure the hugging width without Sparkle session state.
+struct DesktopUpdateStatusChipLabel: View {
+  let kind: DesktopUpdateStatusPresentation.Kind
+  var glowAnimating: Bool = false
+
+  var body: some View {
+    HStack(spacing: OmiSpacing.xs) {
+      if kind.showsProgress {
+        DesktopUpdateStatusProgressIndicator()
+      } else {
+        Image(systemName: "arrow.down.circle.fill")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundColor(Ink.surface)
+      }
+
+      Text(kind.compactTitle)
+        .scaledFont(size: OmiType.caption, weight: .semibold)
+        .foregroundColor(Ink.surface)
+        .lineLimit(1)
+    }
+    .padding(.horizontal, OmiSpacing.sm)
+    .frame(height: 30)
+    .background(
+      RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+        .fill(Ink.primary)
+    )
+    .shadow(color: Ink.primary.opacity(glowAnimating ? 0.55 : 0.25), radius: 6)
+  }
+}
+
 /// Compact chip shown in `DesktopTopBar` so chat-first shell users see Sparkle
 /// progress (the legacy sidebar widget is unreachable when `usesChatFirstShell`).
 struct DesktopUpdateStatusChip: View {
@@ -149,29 +195,7 @@ struct DesktopUpdateStatusChip: View {
           updaterViewModel.checkForUpdates()
         }
       }) {
-        HStack(spacing: OmiSpacing.xs) {
-          if kind.showsProgress {
-            ProgressView()
-              .controlSize(.small)
-              .tint(Ink.surface)
-          } else {
-            Image(systemName: "arrow.down.circle.fill")
-              .scaledFont(size: OmiType.caption, weight: .semibold)
-              .foregroundColor(Ink.surface)
-          }
-
-          Text(kind.compactTitle)
-            .scaledFont(size: OmiType.caption, weight: .semibold)
-            .foregroundColor(Ink.surface)
-            .lineLimit(1)
-        }
-        .padding(.horizontal, OmiSpacing.sm)
-        .frame(height: 30)
-        .background(
-          RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
-            .fill(Ink.primary)
-        )
-        .shadow(color: Ink.primary.opacity(glowAnimating ? 0.55 : 0.25), radius: 6)
+        DesktopUpdateStatusChipLabel(kind: kind, glowAnimating: glowAnimating)
       }
       .buttonStyle(.plain)
       .help(kind.accessibilityLabel)
@@ -214,10 +238,7 @@ struct DesktopUpdateStatusBanner: View {
       }) {
         HStack(spacing: OmiSpacing.md) {
           if kind.showsProgress {
-            ProgressView()
-              .controlSize(.small)
-              .tint(Ink.surface)
-              .frame(width: iconWidth)
+            DesktopUpdateStatusProgressIndicator(diameter: iconWidth)
           } else {
             Image(systemName: "arrow.down.circle.fill")
               .scaledFont(size: OmiType.subheading)

--- a/desktop/macos/Desktop/Tests/DesktopUpdateStatusChipLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopUpdateStatusChipLayoutTests.swift
@@ -1,0 +1,44 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class DesktopUpdateStatusChipLayoutTests: XCTestCase {
+  func testProgressIndicatorDoesNotReserveLinearBarWidth() {
+    let constrained = NSHostingView(
+      rootView: DesktopUpdateStatusProgressIndicator().fixedSize()
+    ).fittingSize
+
+    XCTAssertEqual(constrained.width, 16, accuracy: 0.5)
+    XCTAssertEqual(constrained.height, 16, accuracy: 0.5)
+
+    let defaultMacProgress = NSHostingView(
+      rootView: ProgressView().controlSize(.small).fixedSize()
+    ).fittingSize.width
+    // On macOS the unstyled control is a linear bar. If a future SDK already
+    // hugs, this still passes; the chip-width test below is the user-visible
+    // contract.
+    if defaultMacProgress > 40 {
+      XCTAssertLessThan(constrained.width, defaultMacProgress)
+    }
+  }
+
+  func testDownloadingChipHugsCaptionInsteadOfLeavingABlankGap() {
+    let downloading = chipWidth(for: .downloading(version: "0.12.183"))
+    let available = chipWidth(for: .updateAvailable(version: "0.12.183"))
+
+    // "Downloading v0.12.183…" is longer than "Update v0.12.183", but a default
+    // macOS ProgressView would add ~100pt of empty bar. Keep the extra under
+    // one caption-sized spinner plus a little tracking.
+    XCTAssertLessThan(downloading - available, 80)
+    XCTAssertLessThan(downloading, 230)
+  }
+
+  private func chipWidth(for kind: DesktopUpdateStatusPresentation.Kind) -> CGFloat {
+    NSHostingView(
+      rootView: DesktopUpdateStatusChipLabel(kind: kind).fixedSize()
+    ).fittingSize.width
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260816-update-chip-progress-gap.json
+++ b/desktop/macos/changelog/unreleased/20260816-update-chip-progress-gap.json
@@ -1,0 +1,3 @@
+{
+  "change": "While downloading an update, the loading spinner now sits right next to the version instead of leaving a blank gap"
+}


### PR DESCRIPTION
## Summary
- The top-bar "Downloading v…" chip was not missing a glyph. macOS `ProgressView()` defaults to a linear bar (~100pt+), so the spinner sat in a blank gap beside the version.
- Pin a circular control to a caption-sized frame so the spinner sits next to the text. The same indicator is used by the legacy sidebar banner.

## Product invariants affected
none

## Failure-Class
Failure-Class: none

This is a one-off SwiftUI control-sizing bug, not a registered recurring class. The layout test fails if the chip reserves linear-bar width again.

## Test plan
- [x] `./scripts/dev-feedback.py --once swift 'DesktopUpdateStatusChipLayoutTests|DesktopUpdateStatusPresentationTests'` — 10 tests passed
- [x] Isolated render of the production `DesktopUpdateStatusChipLabel` for `Downloading v0.12.183…` — spinner sits next to the caption; no blank bar
- [ ] Trigger a real Sparkle download in a named bundle and confirm the live top-bar chip hugs the text

## Verification
- Focused Swift tests: 10 passed (2 new layout tests + 8 existing presentation tests)
- Rendered the production chip label and confirmed the spinner is adjacent to the version string
- Did not launch a named bundle through a live Sparkle download; the chip is only visible during an update session

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

