### PR TITLE
fix(backend): fail a rejected Deepgram live connect over to Modulate (#11695)

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -49,6 +49,7 @@ from utils.stt.streaming import (
     STTService,
     connect_stt_socket_with_fallback,
     make_stream_callback,
+    modulate_is_configured_fallback,
     process_audio_dg,
     process_audio_modulate,
     process_audio_parakeet,
@@ -183,15 +184,33 @@ class ListenReceiver:
         if self.host.stt_service == STTService.modulate:
             return await process_audio_modulate(modulate_callback or callback, sample_rate, self.host.stt_language)
         if self.host.stt_service == STTService.deepgram:
-            return await process_audio_dg(
-                callback,
-                self.host.stt_language,
-                sample_rate,
-                1,
-                model=self.host.stt_model,
-                keywords=keywords,
-                is_active=lambda: self.host.state.active,
+
+            def connect_deepgram() -> Any:
+                return process_audio_dg(
+                    callback,
+                    self.host.stt_language,
+                    sample_rate,
+                    1,
+                    model=self.host.stt_model,
+                    keywords=keywords,
+                    is_active=lambda: self.host.state.active,
+                )
+
+            if not modulate_is_configured_fallback(self.host.stt_language):
+                return await connect_deepgram()
+            socket, actual_service = await connect_stt_socket_with_fallback(
+                primary_service=STTService.deepgram,
+                connect_primary=connect_deepgram,
+                connect_modulate=lambda: process_audio_modulate(
+                    modulate_callback or callback,
+                    sample_rate,
+                    self.host.stt_language,
+                ),
             )
+            self.host.stt_service = actual_service
+            if actual_service == STTService.modulate:
+                self.host.stt_model = 'velma-2'
+            return socket
         raise RuntimeError(f'Unsupported serving STT provider {self.host.stt_service!r}')
 
     async def _drain_stt_sockets(self) -> None:

--- a/backend/tests/unit/test_deepgram_connection_fallback.py
+++ b/backend/tests/unit/test_deepgram_connection_fallback.py
@@ -1,0 +1,192 @@
+"""Regression (#11695): a Deepgram account that rejects every live connect must
+not take the deployment's transcription down.
+
+``STT_SERVICE_MODELS`` states an ordered preference (prod's Deepgram canary runs
+``dg-nova-3,modulate-velma-2,parakeet``), but a Deepgram socket that failed to
+open returned ``None`` straight to ``initialize_stt``, which terminalized the
+session instead of advancing to the next configured provider. Deepgram answering
+every WebSocket upgrade with HTTP 402 therefore killed 100% of the sessions that
+deployment served.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from routers.listen import receiver as receiver_mod
+from routers.listen.receiver import ListenReceiver
+from utils.stt import streaming
+from utils.stt.streaming import STTService
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+def _deepgram_receiver():
+    """Duck-typed receiver exposing only what `_create_stt_socket` touches."""
+    host = SimpleNamespace(
+        state=SimpleNamespace(active=True),
+        stt_service=STTService.deepgram,
+        stt_language='en',
+        stt_model='nova-3',
+        vocabulary=[],
+    )
+    return SimpleNamespace(host=host)
+
+
+@pytest.mark.anyio
+async def test_rejected_deepgram_connect_serves_the_session_from_modulate():
+    receiver = _deepgram_receiver()
+    modulate_socket = object()
+
+    with (
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=None)) as dg,
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=modulate_socket)),
+        patch.object(receiver_mod, 'modulate_is_configured_fallback', return_value=True),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    dg.assert_awaited_once()
+    assert socket is modulate_socket
+    assert receiver.host.stt_service == STTService.modulate
+    assert receiver.host.stt_model == 'velma-2'
+
+
+@pytest.mark.anyio
+async def test_modulate_fallback_receives_its_own_stream_callback():
+    """Modulate segments need the Modulate-shaped callback, as on the Parakeet path."""
+    receiver = _deepgram_receiver()
+    modulate_callback = MagicMock(name='modulate_callback')
+
+    with (
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=None)),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=object())) as modulate,
+        patch.object(receiver_mod, 'modulate_is_configured_fallback', return_value=True),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000, modulate_callback=modulate_callback)
+
+    assert modulate.await_args.args[0] is modulate_callback
+
+
+@pytest.mark.anyio
+async def test_healthy_deepgram_connect_keeps_serving_deepgram():
+    receiver = _deepgram_receiver()
+    dg_socket = object()
+
+    with (
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=dg_socket)),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock()) as modulate,
+        patch.object(receiver_mod, 'modulate_is_configured_fallback', return_value=True),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    assert socket is dg_socket
+    assert receiver.host.stt_service == STTService.deepgram
+    modulate.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_no_fallback_when_the_deployment_does_not_configure_modulate():
+    """Without Modulate in the serving policy the session still fails closed."""
+    receiver = _deepgram_receiver()
+
+    with (
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=None)),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock()) as modulate,
+        patch.object(receiver_mod, 'modulate_is_configured_fallback', return_value=False),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    assert socket is None
+    assert receiver.host.stt_service == STTService.deepgram
+    modulate.assert_not_awaited()
+
+
+def test_modulate_is_a_configured_fallback_only_when_the_policy_lists_it():
+    with patch.object(streaming, 'stt_service_models', ['dg-nova-3', ' modulate-velma-2', 'parakeet']):
+        assert streaming.modulate_is_configured_fallback('en') is True
+        # Velma-2 has no capability for an unknown code, so the session must not move.
+        assert streaming.modulate_is_configured_fallback('zz') is False
+    with patch.object(streaming, 'stt_service_models', ['dg-nova-3']):
+        assert streaming.modulate_is_configured_fallback('en') is False
+
+
+@pytest.mark.anyio
+async def test_repeated_rejections_open_the_deepgram_circuit():
+    """A dead Deepgram account stops costing every new session a connect attempt."""
+    circuit = MagicMock()
+    circuit.allow_request.return_value = True
+    fallback_socket = object()
+
+    with patch.object(streaming, '_deepgram_circuit', circuit), patch.object(streaming, 'record_fallback') as record:
+        socket, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.deepgram,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=fallback_socket),
+        )
+
+    assert socket is fallback_socket
+    assert service == STTService.modulate
+    circuit.record_failure.assert_called_once_with()
+    record.assert_called_once_with(
+        component='stt_selection',
+        from_mode='deepgram',
+        to_mode='modulate',
+        reason='config_incomplete',
+        outcome='recovered',
+    )
+
+
+@pytest.mark.anyio
+async def test_open_deepgram_circuit_skips_the_connect_attempt():
+    circuit = MagicMock()
+    circuit.allow_request.return_value = False
+    connect_primary = AsyncMock()
+
+    with patch.object(streaming, '_deepgram_circuit', circuit), patch.object(streaming, 'record_fallback') as record:
+        socket, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.deepgram,
+            connect_primary=connect_primary,
+            connect_modulate=AsyncMock(return_value=object()),
+        )
+
+    assert service == STTService.modulate
+    assert socket is not None
+    connect_primary.assert_not_awaited()
+    assert record.call_args.kwargs['reason'] == 'circuit_open'
+
+
+@pytest.mark.anyio
+async def test_the_deepgram_and_parakeet_circuits_stay_independent():
+    """A dead Deepgram account must not open Parakeet's circuit, or vice versa."""
+    parakeet_circuit = MagicMock()
+    parakeet_circuit.allow_request.return_value = True
+
+    with (
+        patch.object(streaming, '_parakeet_circuit', parakeet_circuit),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.deepgram,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=object()),
+        )
+
+    parakeet_circuit.record_failure.assert_not_called()
+    parakeet_circuit.allow_request.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_modulate_primary_is_still_rejected():
+    with pytest.raises(ValueError, match='modulate'):
+        await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.modulate,
+            connect_primary=AsyncMock(),
+            connect_modulate=AsyncMock(),
+        )

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -72,6 +72,19 @@ _parakeet_circuit = ProviderCircuitBreaker(
     cooldown_seconds=float(os.getenv('PARAKEET_CIRCUIT_COOLDOWN_SECONDS', '30')),
 )
 
+_deepgram_circuit = ProviderCircuitBreaker(
+    failure_threshold=int(os.getenv('DEEPGRAM_CIRCUIT_FAILURE_THRESHOLD', '3')),
+    cooldown_seconds=float(os.getenv('DEEPGRAM_CIRCUIT_COOLDOWN_SECONDS', '30')),
+)
+
+
+def _circuit_for_primary(primary_service: STTService) -> ProviderCircuitBreaker:
+    if primary_service == STTService.parakeet:
+        return _parakeet_circuit
+    if primary_service == STTService.deepgram:
+        return _deepgram_circuit
+    raise ValueError(f'connection fallback is not defined for a {primary_service.value} primary')
+
 
 async def connect_stt_socket_with_fallback(
     *,
@@ -79,35 +92,41 @@ async def connect_stt_socket_with_fallback(
     connect_primary: Callable[[], Awaitable[Optional[STTSocket]]],
     connect_modulate: Callable[[], Awaitable[Optional[STTSocket]]],
 ) -> Tuple[STTSocket, STTService]:
-    """Connect Parakeet before audio starts, falling back once to Modulate.
+    """Connect the selected primary before audio starts, falling back once to Modulate.
+
+    ``STT_SERVICE_MODELS`` states an ordered preference, so a primary that
+    cannot open a socket must advance to the next configured provider instead
+    of failing the session — a Deepgram account rejecting every connect with
+    HTTP 402 otherwise takes the whole deployment's live transcription down
+    (#11695).
 
     The circuit is deliberately process-local and never owns capacity. The
     Parakeet service rejects excess streams at its GPU boundary; this helper
-    only avoids repeated connection latency while that provider is unhealthy.
+    only avoids repeated connection latency while a provider is unhealthy.
     """
-    if primary_service != STTService.parakeet:
-        raise ValueError('connection fallback is defined only for a Parakeet primary')
+    circuit = _circuit_for_primary(primary_service)
 
     reason = 'circuit_open'
-    if _parakeet_circuit.allow_request():
+    if circuit.allow_request():
         try:
             socket = await connect_primary()
-            if socket is None:
-                raise ParakeetConnectionError('config_incomplete', 'Parakeet returned no socket')
-            _parakeet_circuit.record_success()
-            return socket, STTService.parakeet
+            if socket is not None:
+                circuit.record_success()
+                return socket, primary_service
+            reason = 'config_incomplete'
+            circuit.record_failure()
         except ParakeetConnectionError as error:
             reason = error.reason
             if reason in EXPECTED_REJECTIONS:
-                _parakeet_circuit.record_rejection(reason)
+                circuit.record_rejection(reason)
             else:
-                _parakeet_circuit.record_failure()
+                circuit.record_failure()
         except (asyncio.TimeoutError, TimeoutError):
             reason = 'timeout'
-            _parakeet_circuit.record_failure()
+            circuit.record_failure()
         except Exception:
             reason = 'provider_5xx'
-            _parakeet_circuit.record_failure()
+            circuit.record_failure()
 
     try:
         fallback_socket = await connect_modulate()
@@ -116,7 +135,7 @@ async def connect_stt_socket_with_fallback(
     except Exception:
         record_fallback(
             component='stt_selection',
-            from_mode=STTService.parakeet.value,
+            from_mode=primary_service.value,
             to_mode=STTService.modulate.value,
             reason=reason,
             outcome='exhausted',
@@ -125,7 +144,7 @@ async def connect_stt_socket_with_fallback(
 
     record_fallback(
         component='stt_selection',
-        from_mode=STTService.parakeet.value,
+        from_mode=primary_service.value,
         to_mode=STTService.modulate.value,
         reason=reason,
         outcome='recovered',
@@ -261,6 +280,20 @@ deepgram_nova3_languages = {
 # Compatibility export for callers. Its value is owned by stt_provider_policy.
 DEFAULT_STT_SERVICE_MODELS = default_models_for_surface(STTServingSurface.STREAMING)
 stt_service_models = os.getenv('STT_SERVICE_MODELS', ','.join(DEFAULT_STT_SERVICE_MODELS)).split(',')
+
+
+def modulate_is_configured_fallback(language: Optional[str]) -> bool:
+    """Return whether Modulate may take over a session whose primary failed.
+
+    ``STT_SERVICE_MODELS`` is an ordered preference list, so Modulate serves a
+    failed primary only where the deployment actually lists it and Velma-2
+    accepts the session language.
+    """
+    return (
+        'modulate-velma-2' in (model.strip() for model in stt_service_models)
+        and provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.STREAMING)
+        and modulate_supports_language(language)
+    )
 
 
 def _stt_selection_from_mode(_language: str, base_lang: str) -> str:


### PR DESCRIPTION
## Bug

`prod-omi-backend-listen-dg-canary` runs `STT_SERVICE_MODELS=dg-nova-3,modulate-velma-2,parakeet` and, because the `prod-omi-backend-listen` Service selects only on `app.kubernetes.io/name=backend-listen` (no `variant` selector), it fronts a share of all prod live-listen traffic. Since **2026-08-16T22:12:14Z** the managed Deepgram account has rejected *every* live WebSocket upgrade with **HTTP 402** — still true at 03:54Z, ~30h later:

```
prod-omi-backend-listen-dg-canary-77f44c5d75-*
  WebSocketException in ListenWebSocketClient.start: server rejected WebSocket connection: HTTP 402
"Deepgram connection started: True"  → newest hit 2026-08-16T22:12:14Z, nothing after it
```

Every one of those sessions **died** rather than moving to the healthy `modulate-velma-2` listed right behind Deepgram in the same config. Tracked in #11695.

## Root cause

`STT_SERVICE_MODELS` is an ordered preference list, but only *selection* honors the order. Once `get_stt_service_for_language` picked Deepgram, `ListenReceiver._create_stt_socket` called `process_audio_dg` directly; on a failed connect that returns `None`, which `initialize_stt` turns into `terminate_live_stt_session(reason='initialization_failed')`. There is no path from a failed primary back to the next configured provider.

`connect_stt_socket_with_fallback` already implements exactly that handoff — but it hard-rejected any non-Parakeet primary (`raise ValueError('connection fallback is defined only for a Parakeet primary')`).

## Fix

- `connect_stt_socket_with_fallback` now accepts any primary that owns a circuit (Parakeet, Deepgram) via `_circuit_for_primary`, and reports `from_mode` as the actual primary. The two circuits are separate instances, so a dead Deepgram account cannot open Parakeet's circuit or vice versa. The Parakeet path's observable behavior is unchanged (the `None`-socket case already recorded a `config_incomplete` failure; it no longer round-trips through a raise it catches itself).
- The Deepgram branch of `_create_stt_socket` uses the helper, mirroring the Parakeet branch (including handing Modulate its own stream callback and re-stamping `stt_service`/`stt_model` so `_serving_provider`, VAD passthrough and death-monitor telemetry name the provider actually serving).
- Gated on `modulate_is_configured_fallback`: the deployment must actually list `modulate-velma-2`, the provider must be enabled for the streaming surface, and Velma-2 must accept the session language. Where Modulate is **not** a configured fallback the session still fails closed exactly as today — no new provider is introduced anywhere the serving policy did not already name one.
- Repeated rejections open a process-local Deepgram circuit (`DEEPGRAM_CIRCUIT_FAILURE_THRESHOLD`/`_COOLDOWN_SECONDS`, defaults 3/30s), so a dead account stops costing every new session three connect attempts + backoff.

This does not fix the Deepgram balance — that is an account/billing action and is called out in #11695. It stops a single provider's outage from taking live transcription down when the config already names a healthy successor.

## Tested

- New `backend/tests/unit/test_deepgram_connection_fallback.py` (9 tests) drives the production seam `ListenReceiver._create_stt_socket` with `process_audio_dg` returning `None` (the 402 case) and asserts the session is served by Modulate with `stt_service`/`stt_model` re-stamped; plus healthy-Deepgram, no-Modulate-configured (still fails closed), callback routing, circuit independence and open-circuit skip. All 9 pass.
- `backend/test.sh` over the 61-file stt/listen/transcribe slice: the failing-file set is **identical** to the same slice run on clean `origin/main` (7 files, all locally environment-dependent), i.e. this change adds no failures.
- `make preflight` green.

Not verified against live prod traffic — a real 402-rejecting Deepgram session cannot be reproduced locally. Backend prod deploy stays a separate, manual `gcp_backend.yml` run.

Line-Count-Exception: backend/utils/stt/streaming.py | 1523 -> 1556 | generalizing the existing connect-fallback helper to a second primary plus the serving-policy predicate; the file is the STT streaming boundary and splitting it is out of scope for a live-outage fix

Failure-Class: FC-recoverable-provider-failure-terminal

Fixes #11695

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

