### PR TITLE
fix: restore conversation deletion

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -140,7 +140,7 @@ Future<bool> deleteConversationServer(String conversationId) async {
   );
   if (response == null) return false;
   Logger.debug('deleteConversation: ${response.statusCode}');
-  return response.statusCode == 204;
+  return response.statusCode >= 200 && response.statusCode < 300;
 }
 
 Future<bool> unlinkCalendarEvent(String conversationId) async {

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -442,11 +442,27 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
         builder: (c) => getDialog(
           context,
           () => Navigator.pop(context),
-          () {
+          () async {
             final convoProvider = context.read<ConversationProvider>();
-            convoProvider.deleteConversation(provider.conversation);
             Navigator.pop(context); // Close dialog
-            Navigator.pop(context, {'deleted': true}); // Close detail page
+            final deleted = await convoProvider.deleteConversation(provider.conversation);
+            if (!context.mounted) return;
+            if (deleted) {
+              Navigator.pop(context, {'deleted': true}); // Close detail page
+              return;
+            }
+            showDialog(
+              context: context,
+              builder: (c) => getDialog(
+                context,
+                () => Navigator.pop(context),
+                () => Navigator.pop(context),
+                context.l10n.unableToDeleteConversation,
+                context.l10n.somethingWentWrongTryAgain,
+                singleButton: true,
+                okButtonText: context.l10n.ok,
+              ),
+            );
           },
           context.l10n.deleteConversationTitle,
           context.l10n.deleteConversationMessage,

--- a/app/lib/pages/conversations/widgets/conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/conversation_list_item.dart
@@ -336,8 +336,15 @@ class _ConversationListItemState extends State<ConversationListItem> {
                           },
                           onDismissed: (direction) async {
                             var conversation = widget.conversation;
+                            final messenger = ScaffoldMessenger.of(context);
+                            final l10n = context.l10n;
                             PlatformManager.instance.analytics.conversationSwipedToDelete(conversation);
-                            provider.deleteConversationLocally(conversation, widget.date);
+                            final deleted = await provider.deleteConversationLocally(conversation, widget.date);
+                            if (!deleted) {
+                              messenger.showSnackBar(
+                                SnackBar(content: Text(l10n.unableToDeleteConversation)),
+                              );
+                            }
                           },
                           child: Padding(
                             padding: PlatformService.isMobile

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -1225,11 +1225,11 @@ class ConversationProvider extends ChangeNotifier {
     return items.where((c) => !memoriesToDelete.containsKey(c.id)).toList();
   }
 
-  void deleteConversationLocally(ServerConversation conversation, DateTime date) {
+  Future<bool> deleteConversationLocally(ServerConversation conversation, DateTime date) async {
     if (lastDeletedConversationId != null &&
         memoriesToDelete.containsKey(lastDeletedConversationId) &&
         DateTime.now().difference(deleteTimestamps[lastDeletedConversationId]!) < const Duration(seconds: 3)) {
-      deleteConversationOnServer(lastDeletedConversationId!);
+      unawaited(deleteConversationOnServer(lastDeletedConversationId!));
     }
 
     memoriesToDelete[conversation.id] = conversation;
@@ -1244,23 +1244,23 @@ class ConversationProvider extends ChangeNotifier {
       }
     }
     notifyListeners();
-    Future.delayed(const Duration(seconds: 3), () {
-      if (memoriesToDelete.containsKey(conversation.id) && lastDeletedConversationId == conversation.id) {
-        deleteConversationOnServer(conversation.id);
-      }
-    });
+    await Future<void>.delayed(const Duration(seconds: 3));
+    if (memoriesToDelete.containsKey(conversation.id) && lastDeletedConversationId == conversation.id) {
+      return deleteConversationOnServer(conversation.id);
+    }
+    return true;
   }
 
-  void deleteConversationOnServer(String conversationId) {
+  Future<bool> deleteConversationOnServer(String conversationId) async {
     final generation = _sessionGeneration;
     final wasLoadedFromServer = _conversationServerLoadedIds.contains(conversationId);
-    final deleteFuture =
-        conversationDeleteFetcherOverride?.call(conversationId) ?? deleteConversationServer(conversationId);
-    unawaited(deleteFuture.then((succeeded) {
+    try {
+      final succeeded =
+          await (conversationDeleteFetcherOverride?.call(conversationId) ?? deleteConversationServer(conversationId));
       // A DELETE can outlive sign-out/account switching. Its result belongs
       // to the session that started it; never let an old account mutate the
       // new provider's tombstones, cursor, revision, or loading state.
-      if (generation != _sessionGeneration) return;
+      if (generation != _sessionGeneration) return false;
       // Only rebase the server cursor after the backend confirms deletion. A
       // failed DELETE leaves the row in the server sequence and must not make
       // the next page skip an item.
@@ -1283,16 +1283,39 @@ class ConversationProvider extends ChangeNotifier {
           group.removeWhere((conversation) => conversation.id == conversationId);
         }
         groupedConversations.removeWhere((_, group) => group.isEmpty);
+      } else {
+        _restoreFailedDelete(conversationId);
       }
       _clearDeleteTombstone(conversationId);
       notifyListeners();
-    }, onError: (Object _, StackTrace __) {
+      return succeeded;
+    } catch (_) {
       // Match the prior behavior on a failed request: release the local
       // tombstone, but do not rebase the server cursor.
-      if (generation != _sessionGeneration) return;
+      if (generation != _sessionGeneration) return false;
+      _restoreFailedDelete(conversationId);
       _clearDeleteTombstone(conversationId);
       notifyListeners();
-    }));
+      return false;
+    }
+  }
+
+  void _restoreFailedDelete(String conversationId) {
+    final conversation = memoriesToDelete[conversationId];
+    if (conversation == null) return;
+    if (!conversations.any((item) => item.id == conversationId)) {
+      conversations.add(conversation);
+      conversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
+    }
+    if (hasActiveSearch && !searchedConversations.any((item) => item.id == conversationId)) {
+      searchedConversations.add(conversation);
+      searchedConversations.sort((a, b) => (b.startedAt ?? b.createdAt).compareTo(a.startedAt ?? a.createdAt));
+    }
+    if (hasActiveSearch) {
+      _groupSearchConvosByDateWithoutNotify();
+    } else {
+      _groupConversationsByDateWithoutNotify();
+    }
   }
 
   void _clearDeleteTombstone(String conversationId) {
@@ -1319,14 +1342,15 @@ class ConversationProvider extends ChangeNotifier {
 
   /////////////////////////////////////////////////////////////////
 
-  void deleteConversation(ServerConversation conversation) {
+  Future<bool> deleteConversation(ServerConversation conversation) async {
     conversations.removeWhere((element) => element.id == conversation.id);
     searchedConversations.removeWhere((element) => element.id == conversation.id);
     // Keep a tombstone through the in-flight DELETE so a concurrent list
     // response cannot reinsert the just-removed row before confirmation.
     memoriesToDelete[conversation.id] = conversation;
-    deleteConversationOnServer(conversation.id);
+    final succeeded = await deleteConversationOnServer(conversation.id);
     groupConversationsByDate();
+    return succeeded;
   }
 
   @override

--- a/app/test/providers/conversation_provider_processing_reconcile_test.dart
+++ b/app/test/providers/conversation_provider_processing_reconcile_test.dart
@@ -679,6 +679,19 @@ void main() {
     expect(provider.conversationServerOffset, 50);
   });
 
+  test('failed delete restores the conversation to the visible list', () async {
+    final conversation = _conversation('page-10', status: ConversationStatus.completed);
+    final provider = ConversationProvider(isSignedIn: () => true);
+    provider.conversationDeleteFetcherOverride = (_) async => false;
+    addTearDown(provider.dispose);
+
+    provider.conversations = [conversation];
+    await provider.deleteConversation(conversation);
+
+    expect(provider.conversations, [conversation]);
+    expect(provider.memoriesToDelete, isEmpty);
+  });
+
   test('delete completion from a prior session cannot mutate the new session', () async {
     final delete = Completer<bool>();
     final provider = ConversationProvider(isSignedIn: () => true);

--- a/backend/database/memory_apply_store.py
+++ b/backend/database/memory_apply_store.py
@@ -350,6 +350,34 @@ def replace_conversation_source_firestore(
     )
 
 
+def retract_conversation_source_firestore(
+    *,
+    uid: str,
+    conversation_id: str,
+    replacement_id: str,
+    replacement_digest: str,
+    replacement_operation: MemoryOperation,
+    observed_control: MemoryControlState,
+    expected_source_items: List[MemoryItem],
+    expected_reactivation_items: List[MemoryItem],
+    db_client: Any = db,
+) -> ConversationSourceReplacementResult:
+    transaction = db_client.transaction()
+    return _replace_conversation_source_firestore_transaction(
+        transaction,
+        db_client,
+        uid,
+        conversation_id,
+        replacement_id,
+        replacement_digest,
+        replacement_operation,
+        observed_control,
+        expected_source_items,
+        expected_reactivation_items,
+        [],
+    )
+
+
 def tombstone_memory_items_firestore(
     *,
     uid: str,
@@ -1928,5 +1956,6 @@ __all__ = [
     "apply_long_term_patch_firestore",
     "atomic_bump_source_generation",
     "replace_conversation_source_firestore",
+    "retract_conversation_source_firestore",
     "tombstone_memory_items_firestore",
 ]

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -647,7 +647,7 @@ def test_memory_service_retract_records_empty_source_replacement():
     assert any(path.startswith(f"users/{LEGACY_UID}/memory_outbox/") for path in db.docs)
 
 
-def test_conversation_delete_cascade_tombstones_canonical_and_emits_durable_deletes(monkeypatch, canonical_db):
+def test_conversation_delete_cascade_tombstones_canonical_while_intake_is_paused(monkeypatch, canonical_db):
     uid = "uid-canonical-ws-j"
     conversation_id = "conv-cascade"
     content = "Fact sourced from conversation"
@@ -660,7 +660,10 @@ def test_conversation_delete_cascade_tombstones_canonical_and_emits_durable_dele
     )
 
     write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
-    retract_result = retract_conversation_sourced_memories(uid, conversation_id, db_client=canonical_db)
+    monkeypatch.setenv("MEMORY_MODE", "off")
+    service = MemoryService(db_client=canonical_db)
+    service.history.all_live = MagicMock(return_value=[])
+    retract_result = service.retract_conversation_memories(uid, conversation_id)
 
     assert retract_result["retracted_memory_ids"] == [memory_id]
     tombstoned = canonical_db.docs[f"users/{uid}/memory_items/{memory_id}"]

--- a/backend/tests/unit/test_ws_m_atom_keyword_index.py
+++ b/backend/tests/unit/test_ws_m_atom_keyword_index.py
@@ -737,7 +737,7 @@ class TestPurgeAndRebuild:
             lambda uid, db_client=None: control,
         )
         monkeypatch.setattr(
-            "utils.memory.canonical_memory_adapter.replace_conversation_source_firestore",
+            "utils.memory.canonical_memory_adapter.retract_conversation_source_firestore",
             lambda **_: types.SimpleNamespace(
                 control_state=committed_control,
                 retracted_memory_ids=[item.memory_id],
@@ -751,7 +751,9 @@ class TestPurgeAndRebuild:
             lambda uid, memory_ids, db_client=None: 0,
         )
 
-        retract_conversation_sourced_memories(CANONICAL_UID, "conv-1", db_client=MagicMock())
+        db_client = MagicMock()
+        db_client.document.return_value.get.return_value.exists = False
+        retract_conversation_sourced_memories(CANONICAL_UID, "conv-1", db_client=db_client)
         assert _provider_id(item) not in docs_store
 
     def test_rebuild_reconstructs_index_count_verified(self, mock_typesense, monkeypatch):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -33,6 +33,7 @@ from database.memory_apply_store import (
     ConversationSourceReplacementConflict,
     apply_long_term_patch_firestore,
     replace_conversation_source_firestore,
+    retract_conversation_source_firestore,
     tombstone_memory_items_firestore,
     transactional,
 )
@@ -1309,6 +1310,7 @@ def replace_conversation_sourced_memories(
     items: List[Dict[str, Any]],
     *,
     db_client: Any = None,
+    allow_paused_retraction: bool = False,
 ) -> Dict[str, Any]:
     """Atomically replace one conversation's complete canonical memory set."""
     client = db_client if db_client is not None else default_db_client
@@ -1405,18 +1407,33 @@ def replace_conversation_sourced_memories(
             writes.append(write)
             planning_control = preview.control_state
         try:
-            result = replace_conversation_source_firestore(
-                uid=uid,
-                conversation_id=conversation_id,
-                replacement_id=replacement_id,
-                replacement_digest=replacement_digest,
-                replacement_operation=replacement_operation,
-                observed_control=observed_control,
-                expected_source_items=expected_source_items,
-                expected_reactivation_items=expected_reactivation_items,
-                writes=writes,
-                db_client=client,
-            )
+            if allow_paused_retraction:
+                if items:
+                    raise ValueError("paused source retraction cannot write replacement memories")
+                result = retract_conversation_source_firestore(
+                    uid=uid,
+                    conversation_id=conversation_id,
+                    replacement_id=replacement_id,
+                    replacement_digest=replacement_digest,
+                    replacement_operation=replacement_operation,
+                    observed_control=observed_control,
+                    expected_source_items=expected_source_items,
+                    expected_reactivation_items=expected_reactivation_items,
+                    db_client=client,
+                )
+            else:
+                result = replace_conversation_source_firestore(
+                    uid=uid,
+                    conversation_id=conversation_id,
+                    replacement_id=replacement_id,
+                    replacement_digest=replacement_digest,
+                    replacement_operation=replacement_operation,
+                    observed_control=observed_control,
+                    expected_source_items=expected_source_items,
+                    expected_reactivation_items=expected_reactivation_items,
+                    writes=writes,
+                    db_client=client,
+                )
             break
         except ConversationSourceReplacementConflict as exc:
             last_conflict = exc
@@ -2163,6 +2180,7 @@ def retract_conversation_sourced_memories(uid: str, conversation_id: str, *, db_
         conversation_id,
         [],
         db_client=db_client,
+        allow_paused_retraction=True,
     )
 
 

--- a/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+DataLoading.swift
@@ -187,13 +187,12 @@ extension AppState {
     conversationRepository.cancelSearch()
   }
 
-  func deleteConversation(_ conversationId: String) async -> Bool {
+  func deleteConversation(_ conversationId: String) async throws {
     do {
       try await conversationRepository.delete(id: conversationId)
-      return true
     } catch {
       logError("Conversations: Failed to delete conversation", error: error)
-      return false
+      throw error
     }
   }
 

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -2240,9 +2240,7 @@ final class DesktopAutomationActionRegistry {
         return ["error": "missing 'id'"]
       }
       if let appState = await MainActor.run(body: { AppState.current }) {
-        guard await appState.deleteConversation(id) else {
-          throw APIError.invalidResponse
-        }
+        try await appState.deleteConversation(id)
       } else {
         try await APIClient.shared.deleteConversation(id: id)
         NotificationCenter.default.post(

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -28,6 +28,7 @@ struct ConversationRowView: View {
   @State private var isDeleting = false
   @State private var isUpdatingTitle = false
   @State private var isCopyingLink = false
+  @State private var deleteError: String?
 
   /// The timestamp to display (prefer startedAt, fall back to createdAt)
   private var displayDate: Date {
@@ -148,8 +149,11 @@ struct ConversationRowView: View {
     guard !isDeleting else { return }
     isDeleting = true
 
-    if await appState.deleteConversation(conversation.id) {
+    do {
+      try await appState.deleteConversation(conversation.id)
       log("Deleted conversation \(conversation.id)")
+    } catch {
+      deleteError = UserFacingErrorPresentation.message(for: error, while: .conversationDeletion)
     }
 
     isDeleting = false
@@ -510,6 +514,17 @@ struct ConversationRowView: View {
       }
     } message: {
       Text("Are you sure you want to delete this conversation? This action cannot be undone.")
+    }
+    .alert(
+      "Couldn't Delete Conversation",
+      isPresented: Binding(
+        get: { deleteError != nil },
+        set: { if !$0 { deleteError = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(deleteError ?? "")
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/UserFacingErrorPresentation.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/UserFacingErrorPresentation.swift
@@ -11,6 +11,7 @@ enum UserFacingErrorPresentation {
     case dashboard
     case chatSessions
     case conversations
+    case conversationDeletion
     case conversationSearch
     case conversationMerge
     case tasks
@@ -34,6 +35,7 @@ enum UserFacingErrorPresentation {
       case .dashboard: return "refresh the dashboard"
       case .chatSessions: return "load chats"
       case .conversations: return "load conversations"
+      case .conversationDeletion: return "delete this conversation"
       case .conversationSearch: return "search conversations"
       case .conversationMerge: return "merge conversations"
       case .tasks: return "update tasks"

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -47,6 +47,7 @@ struct ConversationDetailView: View {
   @State private var editedTitle = ""
   @State private var isUpdatingTitle = false
   @State private var isDeleting = false
+  @State private var deleteError: String?
 
   // Speaker naming state
   @State private var selectedSegmentForNaming: TranscriptSegment? = nil
@@ -253,6 +254,17 @@ struct ConversationDetailView: View {
         onDismiss: { showAppSelector = false }
       )
       .frame(width: 400, height: 500)
+    }
+    .alert(
+      "Couldn't Delete Conversation",
+      isPresented: Binding(
+        get: { deleteError != nil },
+        set: { if !$0 { deleteError = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(deleteError ?? "")
     }
     .dismissableSheet(item: $selectedSegmentForNaming) { segment in
       NameSpeakerSheet(
@@ -542,11 +554,18 @@ struct ConversationDetailView: View {
     defer { isDeleting = false }
 
     let conversationId = conversation.id
-    if await AppState.current?.deleteConversation(conversationId) == true {
+    guard let appState = AppState.current else {
+      deleteError = UserFacingErrorPresentation.message(from: "", while: .conversationDeletion)
+      return
+    }
+    do {
+      try await appState.deleteConversation(conversationId)
       await MainActor.run {
         onDelete?()
         onBack()
       }
+    } catch {
+      deleteError = UserFacingErrorPresentation.message(for: error, while: .conversationDeletion)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -143,6 +143,7 @@ class MemoriesViewModel: ObservableObject {
   }
   @Published var hasMoreMemories = true
   @Published var errorMessage: String?
+  @Published var deletionErrorMessage: String?
   @Published var searchText = "" {
     didSet {
       if oldValue != searchText {
@@ -1423,6 +1424,7 @@ class MemoriesViewModel: ObservableObject {
   }
 
   func deleteMemory(_ memory: ServerMemory) async {
+    deletionErrorMessage = nil
     // Cancel any existing pending delete
     deleteTask?.cancel()
     if let existingPending = pendingDeleteMemory {
@@ -1534,6 +1536,7 @@ class MemoriesViewModel: ObservableObject {
       // undo window; decrementing earlier would re-fetch and duplicate it.
       rawBackendOffset = max(0, rawBackendOffset - 1)
     } catch {
+      deletionErrorMessage = UserFacingErrorPresentation.message(for: error, while: .memoryDeletion)
       logError("Failed to delete memory", error: error)
       do {
         try await MemoryStorage.shared.restoreMemory(surfacedId: memory.id)
@@ -1916,6 +1919,17 @@ struct MemoriesPage: View {
     }
     .overlay(alignment: .bottom) {
       undoDeleteToast
+    }
+    .alert(
+      "Couldn't Delete Memory",
+      isPresented: Binding(
+        get: { viewModel.deletionErrorMessage != nil },
+        set: { if !$0 { viewModel.deletionErrorMessage = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) {}
+    } message: {
+      Text(viewModel.deletionErrorMessage ?? "")
     }
     .overlay {
       // Loading overlay for conversation fetch. This page rides on `PageGlassLane`'s panel, so the

--- a/desktop/macos/Desktop/Tests/MemoryLocalIdentityMutationTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryLocalIdentityMutationTests.swift
@@ -68,6 +68,22 @@ final class MemoryLocalIdentityMutationTests: XCTestCase {
     XCTAssertEqual(backendRequestIDs, [server.id])
   }
 
+  func testFailedBackendDeleteRestoresMemoryAndSurfacesRecovery() async throws {
+    let server = makeMemory(id: "server-memory")
+    try await MemoryStorage.shared.syncServerMemories([server])
+    let viewModel = MemoriesViewModel(deleteMemoryRequest: { _ in
+      throw URLError(.notConnectedToInternet)
+    })
+
+    viewModel.memories = [server]
+    await viewModel.deleteMemory(server)
+    await viewModel.confirmDelete().value
+
+    XCTAssertEqual(viewModel.deletionErrorMessage, "Check your connection and try again.")
+    let restored = try await MemoryStorage.shared.getLocalMemories(limit: 100)
+    XCTAssertTrue(restored.contains { $0.id == server.id })
+  }
+
   private func insertLocalMemory(content: String) async throws -> MemoryRecord {
     try await MemoryStorage.shared.insertLocalMemory(MemoryRecord(content: content))
   }

--- a/desktop/macos/Desktop/Tests/UserFacingErrorPresentationTests.swift
+++ b/desktop/macos/Desktop/Tests/UserFacingErrorPresentationTests.swift
@@ -20,6 +20,16 @@ final class UserFacingErrorPresentationTests: XCTestCase {
     )
   }
 
+  func testProvidesConversationDeletionRecovery() {
+    XCTAssertEqual(
+      UserFacingErrorPresentation.message(
+        for: APIError.httpError(statusCode: 500, detail: "canonical memory retraction failed"),
+        while: .conversationDeletion
+      ),
+      "Omi's service is unavailable right now. Try again."
+    )
+  }
+
   func testHidesDecodingDiagnostics() {
     let decodingError = DecodingError.keyNotFound(
       CodingKeys.example,

--- a/desktop/macos/changelog/unreleased/20260816-deletion-feedback.json
+++ b/desktop/macos/changelog/unreleased/20260816-deletion-feedback.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved feedback when deleting a conversation or memory does not complete"
+}


### PR DESCRIPTION
## Summary

- Let conversation deletion retract existing canonical memory while canonical intake is paused.
- Keep failed mobile and macOS deletions visible and recoverable instead of presenting them as success.

## Root cause

The deletion path used the same intake fence as canonical memory creation, so conversations with existing canonical memory could not be deleted while intake was paused.

## Validation

- `backend/.venv/bin/pytest backend/tests/unit/test_ws_j_delete_privacy.py backend/tests/unit/test_memory_apply_store.py -q`
- `backend/.venv/bin/python backend/scripts/scan_async_blockers.py`
- `backend/scripts/typecheck.sh`
- `bash app/test.sh`
- Focused macOS deletion XCTest, Swift formatting, and test-quality checks
- `make preflight`

## Product invariant

- `INV-MEM-1`: preserves the canonical memory collection and existing tier policy while allowing only zero-write retractions.

Failure-Class: none

Line-Count-Exception: backend/database/memory_apply_store.py | 1932 -> 1961 | A dedicated transaction preserves the paused-intake boundary for ordinary writes while allowing only zero-write retraction.
Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 2388 -> 2406 | The adapter selects the dedicated zero-write retraction path without changing normal canonical replacement behavior.
Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift | 3468 -> 3482 | The existing page owns optimistic deletion state, restoration, and its user-visible failure alert.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

