### PR TITLE
fix(backend): declare opposite-direction Firestore list-scan indexes + converge cascade-retract CAS (#11684, #11726)

### DIFF
--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -351,8 +351,9 @@ CANONICAL_MEMORY_ATLAS_READ_QUERY = FirestoreQuerySpec(
 # Collection-scoped newest-first scan for universal mixed list cursor paging.
 # Equality filters are intentionally empty: access/device/pending/archive are
 # applied after each bounded raw page so filtered rows still advance the keyset.
-# Firestore manages the single-field updated_at index (plus automatic __name__
-# tie-break) itself — this spec records the serving query contract only.
+# Firestore auto single-field indexes only cover field+__name__ in the *same*
+# direction (DESC+DESC / ASC+ASC). updated_at DESC + __name__ ASC is a real
+# composite and must be declared (#11684).
 UNIVERSAL_CANONICAL_LIST_SCAN_QUERY = FirestoreQuerySpec(
     identifier='memory_items_universal_list_scan',
     collection_group='memory_items',
@@ -363,8 +364,8 @@ UNIVERSAL_CANONICAL_LIST_SCAN_QUERY = FirestoreQuerySpec(
 
 # Historical dual-stream keysets for effective updated_at-or-created_at order.
 # Docs with updated_at ride the updated stream; created stream skips those
-# duplicates in Python so each document is emitted once. Single-field+__name__
-# indexes stay out of the composite manifest.
+# duplicates in Python so each document is emitted once. Opposite-direction
+# __name__ tie-breaks need composite indexes (same class as #11684).
 UNIVERSAL_HISTORICAL_UPDATED_LIST_SCAN_QUERY = FirestoreQuerySpec(
     identifier='memories_universal_list_scan_updated_at',
     collection_group='memories',
@@ -614,12 +615,36 @@ QUERY_SPECS = (
 _INDEX_ONLY_REQUIREMENT_SIGNATURES = frozenset(requirement.signature for requirement in INDEX_ONLY_REQUIREMENTS)
 
 
+def _index_fields_need_composite_manifest(index_fields: tuple[FirestoreIndexField, ...]) -> bool:
+    """Return True when Firestore will not serve this order from automatic indexes.
+
+    Automatic single-field indexes cover ``field ASC, __name__ ASC`` and
+    ``field DESC, __name__ DESC`` only. A lone ordered field with an opposite
+    ``__name__`` direction is a composite Firestore must be given explicitly
+    (#11684). Multi-field orders always need the composite manifest.
+    Array-contains (+ ``__name__``) stays out of the composite manifest — the
+    existing unified-memory index contract keeps those automatic.
+    """
+
+    non_name = [field for field in index_fields if field.field_path != '__name__']
+    name_fields = [field for field in index_fields if field.field_path == '__name__']
+    if len(non_name) > 1:
+        return True
+    if len(non_name) != 1 or len(name_fields) != 1:
+        return False
+    ordered = non_name[0]
+    name = name_fields[0]
+    if ordered.order is None or name.order is None:
+        return False
+    return ordered.order != name.order
+
+
 def _query_spec_index_requirements() -> tuple[FirestoreIndexRequirement, ...]:
     """One composite index per signature, even when two serving queries share it."""
     seen = set(_INDEX_ONLY_REQUIREMENT_SIGNATURES)
     requirements: list[FirestoreIndexRequirement] = []
     for spec in QUERY_SPECS:
-        if len([field for field in spec.index_fields if field.field_path != '__name__']) <= 1:
+        if not _index_fields_need_composite_manifest(spec.index_fields):
             continue
         signature = spec.index_requirement.signature
         if signature in seen:

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -48,6 +48,7 @@ from utils.conversations.process_conversation import process_conversation, retri
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, llm_executor, postprocess_executor, run_blocking, submit_with_context
 from utils.memory.memory_service import MemoryService
+from utils.memory.retraction_scope import retraction_can_be_skipped
 from utils.memory.canonical_memory_adapter import ConversationReplacementConflictError
 from utils import byok
 from utils.conversations.search import (

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -48,7 +48,7 @@ from utils.conversations.process_conversation import process_conversation, retri
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, llm_executor, postprocess_executor, run_blocking, submit_with_context
 from utils.memory.memory_service import MemoryService
-from utils.memory.retraction_scope import retraction_can_be_skipped
+from utils.memory.canonical_memory_adapter import ConversationReplacementConflictError
 from utils import byok
 from utils.conversations.search import (
     ConversationSearchUnavailableError,
@@ -792,7 +792,18 @@ def delete_conversation(
         # the fence is closed; anything real still raises rather than orphaning
         # live memories against a deleted conversation.
         if not retraction_can_be_skipped(uid, conversation_id, memory_service=memory_service, db_client=db_client):
-            memory_service.retract_conversation_memories(uid, conversation_id)
+            try:
+                memory_service.retract_conversation_memories(uid, conversation_id)
+            except ConversationReplacementConflictError as error:
+                logger.exception('cascade retraction conflicted uid=%s conversation_id=%s', uid, conversation_id)
+                # Concurrent same-account memory writes kept winning the
+                # account-global control CAS. Nothing has been deleted yet, so
+                # fail closed with a retryable answer instead of an opaque 500;
+                # the retraction is idempotent, a retried delete is safe (#11726).
+                raise HTTPException(
+                    status_code=503,
+                    detail='Conversation memory retraction is busy, please retry',
+                ) from error
 
         action_items_db.delete_action_items_for_conversation(uid, conversation_id)
         background_tasks.add_task(delete_conversation_audio_files, uid, conversation_id)

--- a/backend/tests/unit/test_cascade_retract_convergence.py
+++ b/backend/tests/unit/test_cascade_retract_convergence.py
@@ -1,0 +1,209 @@
+"""Cascade retraction converges under account-global control CAS races (#11726).
+
+Concurrent same-uid canonical writes — parallel ``DELETE
+/v1/conversations/{id}?cascade=true``, extractions, merges — all bump the one
+``memory_state/apply_control`` document. ``replace_conversation_sourced_memories``
+answers those races with ``ConversationSourceReplacementConflict`` and, after
+three immediate attempts, ``RuntimeError`` → unhandled HTTP 500, while the
+Flutter client retried the same conversation up to 12× and kept the storm fed.
+
+These tests pin the convergence contract on the retraction entry
+(``retract_conversation_sourced_memories``), the only path cascade delete and
+merge use:
+
+* injected control-change conflicts are retried with bounded backoff and
+  converge instead of raising;
+* a source whose retraction was already committed elsewhere — including the
+  stale-receipt shape after another conversation's replacement advanced the
+  generation — returns the committed-empty result instead of livelocking on
+  ``source replacement operation already exists``;
+* a source that still has live items after every bounded round keeps raising,
+  so the caller fails closed with the conversation and its memories intact
+  (the #11627 fence must not regress).
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.unit.memory_import_isolation import (
+    ensure_utils_memory_packages_importable,
+    install_database_client_stub,
+    install_ws_j_heavy_import_stubs,
+    restore_sys_modules,
+    snapshot_sys_modules,
+)
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cascade_retract_import_isolation():
+    saved = snapshot_sys_modules(["database._client", "firebase_admin", "utils.subscription", "database.users"])
+    install_database_client_stub()
+    install_ws_j_heavy_import_stubs()
+    yield
+    restore_sys_modules(saved)
+
+
+ensure_utils_memory_packages_importable(str(BACKEND_DIR))
+from database.memory_apply_store import ConversationSourceReplacementConflict  # noqa: E402
+from models.memory_apply import MemoryControlState  # noqa: E402
+from models.product_memory import MemoryItemStatus  # noqa: E402
+from utils.memory.canonical_memory_adapter import ConversationReplacementConflictError  # noqa: E402
+from tests.unit.fixtures.canonical_memory_fakes import (  # noqa: E402
+    _FakeDb,
+    _sample_memory_payload,
+    _trusted_account_generation,
+)
+
+UID = "uid-cascade-retract"
+
+
+@pytest.fixture(autouse=True)
+def _reset_universal_memory_env(monkeypatch):
+    from tests.unit.universal_memory_test_helpers import reset_universal_memory_fixture
+
+    canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+    globals()["retract_conversation_sourced_memories"] = canonical_adapter.retract_conversation_sourced_memories
+    globals()["write_canonical_extraction_memory"] = canonical_adapter.write_canonical_extraction_memory
+    monkeypatch.setattr(
+        canonical_adapter,
+        "read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    reset_universal_memory_fixture(monkeypatch)
+
+
+def _cascade_db() -> _FakeDb:
+    return _FakeDb(
+        {
+            f"users/{UID}/memory_state/apply_control": MemoryControlState(
+                uid=UID,
+                head_commit_id="head0",
+                account_generation=1,
+                source_generation=1,
+            ).model_dump(mode="json"),
+        }
+    )
+
+
+class _ConflictInjector:
+    """Wraps the adapter's store boundary with deterministic CAS races.
+
+    Raises ``ConversationSourceReplacementConflict`` — the exact class the
+    Firestore transaction fence raises when the account-global control moved —
+    for the first ``conflicts`` calls (``None`` = every call), then delegates
+    to the real store.
+    """
+
+    def __init__(self, conflicts: int | None):
+        self.conflicts = conflicts
+        self.calls = 0
+        canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+        self._real = canonical_adapter.replace_conversation_source_firestore
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        if self.conflicts is None or self.calls <= self.conflicts:
+            raise ConversationSourceReplacementConflict("memory control changed during conversation replacement")
+        return self._real(*args, **kwargs)
+
+
+def _write_source_item(db: _FakeDb, conversation_id: str, content: str) -> str:
+    payload = _sample_memory_payload(uid=UID, conversation_id=conversation_id, content=content)
+    # The shared fixture hardcodes one evidence id; distinct sources need
+    # distinct evidence docs or retraction's staleness fence trips on the
+    # overwritten peer (ws_j does the same re-keying).
+    payload["evidence"][0]["evidence_id"] = f"ev_{conversation_id}"
+    write_canonical_extraction_memory(UID, payload, db_client=db)
+    return payload["id"]
+
+
+def _record_retract_backoff(monkeypatch) -> list[float]:
+    sleeps: list[float] = []
+    canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+    monkeypatch.setattr(canonical_adapter, "time", SimpleNamespace(sleep=sleeps.append))
+    return sleeps
+
+
+def test_injected_control_change_conflicts_converge_instead_of_raising(monkeypatch):
+    db = _cascade_db()
+    conversation_id = "conv-converge"
+    memory_id = _write_source_item(db, conversation_id, "User enjoys hiking")
+    sleeps = _record_retract_backoff(monkeypatch)
+
+    injector = _ConflictInjector(conflicts=3)  # one full internal exhaustion round
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.replace_conversation_source_firestore",
+        injector,
+    )
+
+    result = retract_conversation_sourced_memories(UID, conversation_id, db_client=db)
+
+    assert result["retracted_memory_ids"] == [memory_id]
+    assert db.docs[f"users/{UID}/memory_items/{memory_id}"]["status"] == MemoryItemStatus.tombstoned.value
+    assert db.docs[f"users/{UID}/memory_state/apply_control"]["source_generation"] == 2
+    assert injector.calls == 4  # 3 conflicted rounds, then the converged commit
+    assert sleeps == [0.05]  # bounded backoff between outer rounds only
+
+
+def test_repeat_retract_with_stale_receipt_returns_already_retracted(monkeypatch):
+    db = _cascade_db()
+    first_conversation = "conv-retracted-first"
+    second_conversation = "conv-retracted-second"
+    first_id = _write_source_item(db, first_conversation, "User enjoys hiking")
+    second_id = _write_source_item(db, second_conversation, "User keeps a journal")
+
+    assert retract_conversation_sourced_memories(UID, first_conversation, db_client=db)["retracted_memory_ids"] == [
+        first_id
+    ]
+    # Another conversation's replacement advances source_generation, which
+    # makes the first conversation's committed receipt stale: the deterministic
+    # operation replans and hits "source replacement operation already exists".
+    assert retract_conversation_sourced_memories(UID, second_conversation, db_client=db)["retracted_memory_ids"] == [
+        second_id
+    ]
+    control = db.docs[f"users/{UID}/memory_state/apply_control"]
+    assert control["source_generation"] == 3
+
+    sleeps = _record_retract_backoff(monkeypatch)
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.replace_conversation_source_firestore",
+        _ConflictInjector(conflicts=None),  # the CAS never wins again
+    )
+
+    result = retract_conversation_sourced_memories(UID, first_conversation, db_client=db)
+
+    assert result["retracted_memory_ids"] == []
+    assert result["committed_memory_ids"] == []
+    assert result["source_generation"] == 3
+    assert sleeps == []  # converged on the post-conflict completion check
+    # The peer conversation's retracted state is untouched.
+    assert db.docs[f"users/{UID}/memory_items/{second_id}"]["status"] == MemoryItemStatus.tombstoned.value
+
+
+def test_exhausted_conflicts_with_live_items_fail_closed(monkeypatch):
+    db = _cascade_db()
+    conversation_id = "conv-live-under-storm"
+    memory_id = _write_source_item(db, conversation_id, "User climbs on weekends")
+    sleeps = _record_retract_backoff(monkeypatch)
+
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.replace_conversation_source_firestore",
+        _ConflictInjector(conflicts=None),
+    )
+
+    with pytest.raises(ConversationReplacementConflictError):
+        retract_conversation_sourced_memories(UID, conversation_id, db_client=db)
+
+    # Bounded retry budget: one backoff sleep per non-final outer round.
+    assert sleeps == [0.05, 0.1, 0.25, 0.5]
+    # Nothing was retracted — the caller must keep the conversation and its
+    # live memories intact (#11627 fence).
+    assert db.docs[f"users/{UID}/memory_items/{memory_id}"]["status"] == MemoryItemStatus.active.value
+    assert db.docs[f"users/{UID}/memory_state/apply_control"]["source_generation"] == 1

--- a/backend/tests/unit/test_conversation_events_bounds.py
+++ b/backend/tests/unit/test_conversation_events_bounds.py
@@ -102,6 +102,16 @@ def router():
     retraction_scope = ModuleType("utils.memory.retraction_scope")
     setattr(retraction_scope, "retraction_can_be_skipped", MagicMock(return_value=False))
 
+    # The router imports the typed conflict raised by exhausted cascade-retract
+    # CAS retries (#11726); expose it as a real RuntimeError subclass so the
+    # except-clause in delete_conversation binds to something concrete.
+    canonical_adapter = ModuleType("utils.memory.canonical_memory_adapter")
+
+    class _ConversationReplacementConflictError(RuntimeError):
+        pass
+
+    setattr(canonical_adapter, "ConversationReplacementConflictError", _ConversationReplacementConflictError)
+
     request_validation = ModuleType("utils.request_validation")
     setattr(request_validation, "NonNegativeOffset", int)
     setattr(request_validation, "PositiveLimit", int)
@@ -168,6 +178,7 @@ def router():
         "utils.memory.memory_system": memory_system,
         "utils.memory.canonical_activation": canonical_activation,
         "utils.memory.retraction_scope": retraction_scope,
+        "utils.memory.canonical_memory_adapter": canonical_adapter,
         "utils.retrieval": _pkg("utils.retrieval"),
         "utils.retrieval.tools": _pkg("utils.retrieval.tools"),
         "utils.retrieval.tools.calendar_tools": _pkg("utils.retrieval.tools.calendar_tools"),

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -184,6 +184,19 @@ _retraction_scope_stub = ModuleType('utils.memory.retraction_scope')
 setattr(_retraction_scope_stub, 'retraction_can_be_skipped', MagicMock(return_value=False))
 _register_module('utils.memory.retraction_scope', _retraction_scope_stub)
 
+# The router imports the typed conflict raised by exhausted cascade-retract CAS
+# retries (#11726); expose it as a real RuntimeError subclass so the
+# except-clause in delete_conversation binds to something concrete.
+_canonical_adapter_stub = ModuleType('utils.memory.canonical_memory_adapter')
+
+
+class _ConversationReplacementConflictError(RuntimeError):
+    pass
+
+
+setattr(_canonical_adapter_stub, 'ConversationReplacementConflictError', _ConversationReplacementConflictError)
+_register_module('utils.memory.canonical_memory_adapter', _canonical_adapter_stub)
+
 _apps_stub = ModuleType('utils.apps')
 setattr(_apps_stub, 'get_available_app_by_id_with_reviews', MagicMock())
 setattr(_apps_stub, 'get_is_user_paid_app', MagicMock(return_value=False))

--- a/backend/tests/unit/test_conversations_date_range_validation.py
+++ b/backend/tests/unit/test_conversations_date_range_validation.py
@@ -75,6 +75,16 @@ def conv():
     retraction_scope_stub = ModuleType("utils.memory.retraction_scope")
     retraction_scope_stub.retraction_can_be_skipped = MagicMock(return_value=False)
 
+    # The router imports the typed conflict raised by exhausted cascade-retract
+    # CAS retries (#11726); expose it as a real RuntimeError subclass so the
+    # except-clause in delete_conversation binds to something concrete.
+    canonical_adapter_stub = ModuleType("utils.memory.canonical_memory_adapter")
+
+    class _ConversationReplacementConflictError(RuntimeError):
+        pass
+
+    setattr(canonical_adapter_stub, "ConversationReplacementConflictError", _ConversationReplacementConflictError)
+
     # utils.request_validation — route param annotations; plain int keeps the direct-call path simple.
     request_validation_stub = ModuleType("utils.request_validation")
     request_validation_stub.NonNegativeOffset = int
@@ -125,6 +135,7 @@ def conv():
         "utils.memory.memory_system": memory_system_stub,
         "utils.memory.canonical_activation": canonical_activation_stub,
         "utils.memory.retraction_scope": retraction_scope_stub,
+        "utils.memory.canonical_memory_adapter": canonical_adapter_stub,
         # utils.request_validation
         "utils.request_validation": request_validation_stub,
     }

--- a/backend/tests/unit/test_delete_conversation_cascade_retraction_fence.py
+++ b/backend/tests/unit/test_delete_conversation_cascade_retraction_fence.py
@@ -54,7 +54,27 @@ def test_the_retraction_call_is_inside_the_guard():
     # gate the call would satisfy the ordering check above but fix nothing.
     body = _delete_conversation_source()
     guarded = re.search(
-        r"if not retraction_can_be_skipped\([^)]*\):\s*\n\s+memory_service\.retract_conversation_memories\(",
+        r"if not retraction_can_be_skipped\([^)]*\):\s*\n"
+        r"\s+try:\s*\n\s+memory_service\.retract_conversation_memories\(",
         body,
     )
     assert guarded, "retraction must be inside the `if not retraction_can_be_skipped(...)` branch"
+
+
+def test_exhausted_replacement_conflict_maps_to_retryable_503_before_any_delete():
+    # #11726: concurrent same-uid deletes raced the account-global memory
+    # control CAS into an unhandled RuntimeError → 500. The exhausted conflict
+    # is retryable (retraction is idempotent), and nothing has been deleted
+    # yet at that point, so the route must answer 503 while the conversation
+    # and its live memories stay intact.
+    body = _delete_conversation_source()
+    mapped = re.search(
+        r"try:\s*\n\s+memory_service\.retract_conversation_memories\([^)]*\)\s*\n"
+        r"\s+except ConversationReplacementConflictError[^:]*:\s*\n"
+        r"((?:\s+.*\n)*?)\s+raise HTTPException\(\s*\n\s+status_code=503,",
+        body,
+    )
+    assert mapped, "the retract call must map ConversationReplacementConflictError to a 503"
+    assert (
+        "conversations_db.delete_conversation" in body.split("except ConversationReplacementConflictError")[1]
+    ), "the conversation document delete must stay in the post-retract success path"

--- a/backend/tests/unit/test_firestore_index_config.py
+++ b/backend/tests/unit/test_firestore_index_config.py
@@ -27,13 +27,57 @@ def test_firestore_config_declares_memory_items_canary_read_index():
     )
 
 
-def test_firestore_config_does_not_declare_single_field_composite_indexes():
-    # Firestore manages single-field indexes itself. A declared index with only
-    # one real field plus the document-id tie breaker is rejected at deploy
-    # time as redundant (HTTP 400: configure using single field index controls).
+def test_firestore_config_does_not_declare_same_direction_single_field_composites():
+    # Firestore auto-serves field+__name__ when both orders match (ASC+ASC /
+    # DESC+DESC). Declaring those is rejected as redundant. Opposite-direction
+    # pairs (e.g. updated_at DESC + __name__ ASC) are real composites and must
+    # stay in the manifest (#11684).
     for index in _index_specs():
-        indexed_fields = [field for field, _ in _fields(index) if field != '__name__']
-        assert len(indexed_fields) > 1, index
+        fields = _fields(index)
+        non_name = [(path, order) for path, order in fields if path != '__name__']
+        name = [(path, order) for path, order in fields if path == '__name__']
+        if len(non_name) != 1 or len(name) != 1:
+            continue
+        (_, field_order), (_, name_order) = non_name[0], name[0]
+        if field_order is None or name_order is None:
+            continue
+        assert field_order != name_order, index
+
+
+def test_firestore_config_declares_opposite_direction_universal_list_scans():
+    # Prod GET /v3/memories 503ed because these were omitted from the manifest.
+    required = [
+        (
+            'memory_items',
+            'COLLECTION',
+            (('updated_at', 'DESCENDING'), ('__name__', 'ASCENDING')),
+        ),
+        (
+            'memories',
+            'COLLECTION',
+            (('updated_at', 'DESCENDING'), ('__name__', 'ASCENDING')),
+        ),
+        (
+            'memories',
+            'COLLECTION',
+            (('created_at', 'DESCENDING'), ('__name__', 'ASCENDING')),
+        ),
+        (
+            'memory_review_queue',
+            'COLLECTION',
+            (('status', 'ASCENDING'), ('__name__', 'DESCENDING')),
+        ),
+    ]
+    specs = {
+        (
+            index.get('collectionGroup'),
+            index.get('queryScope'),
+            tuple(_fields(index)),
+        )
+        for index in _index_specs()
+    }
+    for collection, scope, fields in required:
+        assert (collection, scope, fields) in specs
 
 
 def test_firestore_config_declares_mcp_conversation_category_filter_index():

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
@@ -97,6 +98,11 @@ Payload = Dict[str, Any]
 SortKey = tuple[int, datetime | int]
 UserMutationPatchBuilder = Callable[[MemoryItem, datetime], Tuple[Payload, Payload]]
 
+# Concurrent same-account canonical writes race the account-global control
+# CAS inside the conversation source replacement. Retraction — the delete and
+# merge path — converges across those races instead of failing (#11726).
+_RETRACT_CONFLICT_ATTEMPTS = 5
+_RETRACT_CONFLICT_BACKOFF_SECONDS = (0.05, 0.1, 0.25, 0.5)
 _SETTLED_PROMOTION_FIELDS = frozenset(
     {
         "route",
@@ -124,6 +130,16 @@ class CanonicalBatchMutationLimitError(ValueError):
 
 class CanonicalMemoryNotFoundError(ValueError):
     """Raised when an item is absent or already tombstoned during an atomic batch read."""
+
+
+class ConversationReplacementConflictError(RuntimeError):
+    """Conversation source replacement exhausted its bounded conflict retries.
+
+    Subclasses :class:`RuntimeError` so pre-existing callers keep their
+    ``except RuntimeError`` contract. Callers that can retry the operation —
+    cascade delete, merge — get a typed signal instead of an opaque 500
+    (#11726).
+    """
 
 
 def _payload_or_empty(value: object) -> Payload:
@@ -1421,7 +1437,9 @@ def replace_conversation_sourced_memories(
         except ConversationSourceReplacementConflict as exc:
             last_conflict = exc
     else:
-        raise RuntimeError("canonical conversation replacement conflicted repeatedly") from last_conflict
+        raise ConversationReplacementConflictError(
+            "canonical conversation replacement conflicted repeatedly"
+        ) from last_conflict
 
     committed_ids = set(result.committed_memory_ids)
     for memory_id in result.retracted_memory_ids:
@@ -2156,14 +2174,99 @@ def _non_tombstoned_lineage_memory_ids(
     )
 
 
+def _retracted_source_completion_control(
+    uid: str,
+    conversation_id: str,
+    *,
+    db_client: Any,
+) -> Optional[MemoryControlState]:
+    """Control state proving this source has nothing left to retract.
+
+    Mirrors the double-read fence the replacement loop itself uses: the cohort
+    scan only counts when the account-global control did not move while it
+    ran. ``None`` means completion is unproven — callers must keep retrying
+    the real replacement instead of treating the source as retracted.
+    """
+    before = _read_replacement_control(uid, db_client=db_client)
+    live_source_items = [
+        item
+        for item in fetch_authoritative_product_memory_items_for_source(
+            uid,
+            conversation_id,
+            db_client=db_client,
+        )
+        if item.status != MemoryItemStatus.tombstoned and _item_sourced_from_conversation(item, conversation_id)
+    ]
+    if live_source_items:
+        return None
+    after = _read_replacement_control(uid, db_client=db_client)
+    if (
+        before.head_commit_id != after.head_commit_id
+        or before.account_generation != after.account_generation
+        or before.source_generation != after.source_generation
+        or before.commit_sequence != after.commit_sequence
+    ):
+        return None
+    return after
+
+
+def _already_retracted_result(control: MemoryControlState) -> Dict[str, Any]:
+    """The committed-empty-replacement shape, without fighting the CAS for it."""
+    return {
+        "retracted_memory_ids": [],
+        "committed_memory_ids": [],
+        "reactivated_memory_ids": [],
+        "vector_delete_ids": [],
+        "tombstoned_evidence_ids": [],
+        "source_generation": control.source_generation,
+    }
+
+
 def retract_conversation_sourced_memories(uid: str, conversation_id: str, *, db_client: Any = None) -> Dict[str, Any]:
-    """Atomically replace one conversation's complete source set with nothing."""
-    return replace_conversation_sourced_memories(
-        uid,
-        conversation_id,
-        [],
-        db_client=db_client,
-    )
+    """Atomically replace one conversation's complete source set with nothing.
+
+    Concurrent same-account canonical writes — parallel cascade deletes,
+    extractions, merges — all race the account-global control CAS inside
+    :func:`replace_conversation_sourced_memories`, whose three immediate
+    attempts exhaust under sustained contention (#11726). A retraction
+    converges instead of failing: after each conflict round it re-checks,
+    under the same double-read control fence, whether the source is already
+    empty. That covers both a peer worker that committed this retraction and
+    a repeat delete whose committed receipt went stale after another
+    conversation's replacement advanced the generation. A source that still
+    has live items after every bounded round keeps raising, so callers fail
+    closed with the conversation and its memories intact.
+    """
+    client = db_client if db_client is not None else default_db_client
+    last_conflict: Optional[ConversationReplacementConflictError] = None
+    for attempt in range(_RETRACT_CONFLICT_ATTEMPTS):
+        try:
+            return replace_conversation_sourced_memories(
+                uid,
+                conversation_id,
+                [],
+                db_client=client,
+            )
+        except ConversationReplacementConflictError as exc:
+            last_conflict = exc
+            try:
+                completed_control = _retracted_source_completion_control(uid, conversation_id, db_client=client)
+            except Exception:
+                # A rescue-check read failure must not reintroduce the 500
+                # storm this loop exists to end — keep converging instead.
+                logger.exception(
+                    "canonical retraction completion check failed uid=%s conversation_id=%s",
+                    uid,
+                    conversation_id,
+                )
+                completed_control = None
+            if completed_control is not None:
+                return _already_retracted_result(completed_control)
+            if attempt + 1 < _RETRACT_CONFLICT_ATTEMPTS:
+                time.sleep(_RETRACT_CONFLICT_BACKOFF_SECONDS[min(attempt, len(_RETRACT_CONFLICT_BACKOFF_SECONDS) - 1)])
+    raise ConversationReplacementConflictError(
+        "canonical conversation retraction conflicted repeatedly"
+    ) from last_conflict
 
 
 def delete_canonical_memory(uid: str, memory_id: str, *, db_client: Any = None) -> None:

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -409,6 +409,20 @@
       ]
     },
     {
+      "collectionGroup": "memory_review_queue",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "memory_items",
       "queryScope": "COLLECTION",
       "fields": [
@@ -541,6 +555,48 @@
         {
           "fieldPath": "__name__",
           "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "memory_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "memories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "memories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "created_at",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
         }
       ]
     },


### PR DESCRIPTION
## What changed and why

Two production 5xx classes from the 2026-08-17 incident window (watchdog `75afe342f6f8`, serving SHA `6316415` = merged #11627), fixed in two independent commits:

1. **Missing opposite-direction Firestore list-scan indexes → 503 (#11684).** Serving queries order `updated_at DESC, __name__ ASC` (`read_canonical_scan_page`, plus the historical dual-stream scans and the review-queue status scan). Firestore automatic single-field indexes only cover `field+__name__` in the *same* direction, so these need real composites — but `_query_spec_index_requirements()` dropped every spec with ≤1 non-`__name__` field. Prod answered `FailedPrecondition: The query requires an index`, mapped to 503 `Canonical memory unavailable` / `Historical memory unavailable` on `GET /v3/memories` and the cascade-delete skip-guard scan. Fix: the predicate now declares exactly the opposite-direction pairs and regenerates the manifest with the four missing indexes (`memory_items` `updated_at DESC`+`__name__ ASC`; `memories` `updated_at DESC`+`__name__ ASC`; `memories` `created_at DESC`+`__name__ ASC`; `memory_review_queue` `status ASC`+`__name__ DESC`). Same-direction singles and array-contains pairs stay out (deploy rejects those as redundant).

2. **Cascade-retract CAS exhaustion → 500 (#11726).** Concurrent same-uid canonical writes all bump the one account-global `memory_state/apply_control` document. `replace_conversation_sourced_memories`' three *immediate* CAS attempts exhausted under that contention and raised an unhandled `RuntimeError` → `DELETE /v1/conversations/{id}?cascade=true` returned 500 while the Flutter client retried one conversation up to 12× and kept the storm fed. A repeat delete whose committed receipt went stale (another conversation's replacement advanced `source_generation`) livelocked on `source replacement operation already exists` the same way. Fix on the retract entry only (cascade delete + merge; the extraction replace path keeps its existing contract): bounded backoff retry (5 rounds, 0.05→0.5s), and after each conflict an epoch-guarded empty-cohort check — the same double-read control fence the replacement loop uses — returns the committed-empty result when a peer already retracted the source. Exhaustion raises typed `ConversationReplacementConflictError` (a `RuntimeError` subclass, so existing callers are unchanged), which `delete_conversation` maps to a retryable **503** *before anything is deleted*: the #11627 never-orphan-live-memories fence holds, and a retried delete is idempotent (receipt replay / already-retracted short-circuit).

Closes #11684
Closes #11726

## Relationship to open work

- **Supersedes #11687** (aryanorastar's index fix). That branch conflicts with current main — main refactored the predicate into `_query_spec_index_requirements()` — so this PR re-expresses the same semantic change there, ports its test fix verbatim (`test_firestore_config_does_not_declare_same_direction_single_field_composites` + the four-tuple declaration test), and regenerates the manifest through the generator rather than hand-patched JSON hunks. Credit for the measured predicate direction belongs to #11684/#11687.
- **Does not replace #11727** (draft: zero-write retraction while intake is paused). That PR targets the fenced-intake path; this PR converges the open-intake CAS path. Whichever lands second will need a small rebase; the touched regions barely overlap.
- Out of scope, per #11726: #11685/#11688 extract abort, MEMORY_MODE/cohort/control-schema redesign, client-only backoff.

## Merge sequencing (required)

`firestore_readiness` runs `reconcile_firestore_indexes.py --check-only` on backend deploys and **fails closed until every manifest index is READY**. Merge only after a human runs `Reconcile Firestore Indexes` → `prod` → `APPLY_FIRESTORE_INDEXES` (dev first is fine) — that APPLY alone stops the 503s even before this PR merges. Split-merging (declaration after APPLY lands separately) is a later human decision; nobody should run APPLY from this PR.

## How it was verified

- `pytest tests/unit/test_firestore_index_config.py tests/unit/test_firestore_indexes.py tests/unit/test_reconcile_firestore_indexes.py tests/unit/test_firestore_query_contract.py` → **62 passed** (was 61 on the wrong predicate; the renamed same-direction test no longer codifies the bug and the new opposite-direction declaration test pins all four indexes).
- `python3 backend/scripts/generate_firestore_indexes.py --write` then read-mode → `firestore.indexes.json matches the Firestore index registry`; diff adds exactly the 4 entries (+56 lines, same shape as #11687).
- `python3 backend/scripts/firestore_query_coverage.py --check-ratchet` → exit 0 (coverage keys on query signatures; QUERY_SPECS unchanged → no baseline drift).
- `pytest tests/unit/test_cascade_retract_convergence.py tests/unit/test_delete_conversation_cascade_retraction_fence.py` → **7 passed**: injected `ConversationSourceReplacementConflict` rounds converge with bounded backoff; repeat retract with a stale receipt returns already-retracted instead of livelocking; exhausted conflicts with live items still raise (conversation + memories intact, #11627 fence); route maps the typed conflict to 503 before any delete.
- Affected memory suites: `pytest tests/unit/test_ws_i_hardening.py tests/unit/test_ws_j_delete_privacy.py tests/unit/test_memory_apply_store.py tests/unit/test_memory_replace_policy.py tests/unit/test_merge_conversations_canonical_delete.py tests/unit/test_merge_skips_retraction_without_canonical_memories.py tests/unit/test_universal_memory_service.py tests/unit/test_atomicity_lifecycle_regressions.py` → **173 passed**.
- Scan-read/fake-contract: `pytest tests/unit/test_bounded_firestore_list_reads.py tests/unit/test_firestore_fake_contract.py` → **12 passed**.
- `scripts/pr-preflight --suggest` → INV-MEM-1 required; failure-class protocol honored below.

Not verified here: live Firestore behavior (no APPLY, no prod/dev writes — the four indexes must be provisioned by a human via the workflow above).

## Tests

- Index half regression: `backend/tests/unit/test_firestore_index_config.py::test_firestore_config_declares_opposite_direction_universal_list_scans` (fails on main's manifest) and the renamed same-direction test (fails if the predicate over-declares).
- CAS half regression: `backend/tests/unit/test_cascade_retract_convergence.py` (three behavioral tests: convergence under injected conflicts, stale-receipt idempotency, fail-closed exhaustion) + `test_delete_conversation_cascade_retraction_fence.py::test_exhausted_replacement_conflict_maps_to_retryable_503_before_any_delete`.

## Product invariants affected

INV-MEM-1

## Failure class (fixes)

Failure-Class: FC-undeclared-serving-query-index

(That class covers the index half exactly — a serving query's composite index missing from the registry manifest. The CAS half has no existing class in the registry; it is a candidate for a new class — "account-global CAS exhaustion surfaced as an unhandled 500 on a retryable, idempotent operation" — to be registered separately per the transition-narrative protocol, not inline in this fix PR.)

Line-Count-Exception: backend/routers/conversations.py | 1515 -> 1527 | retryable-503 mapping for the cascade-retract conflict (#11726) is a few lines inside the existing delete route; splitting the router is out of scope for an incident fix
Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 2388 -> 2491 | retract convergence loop + epoch-guarded completion check + typed conflict error live with the CAS loop they wrap (#11726); extraction into a new module would split the replace/retract boundary mid-incident

## Residual risk

- The 503-after-exhaustion path is still a 5xx by design — but only after 5 backoff rounds *and* a proven-non-empty source, with nothing deleted and a safe client retry; the incident's unbounded 12×-retry 500 loop is gone (converges or fails closed).
- The already-retracted short-circuit trusts the same double-read fence the replacement loop uses; it cannot skip a retract that still has live items (live items → keep retrying → raise).
- Multi-instance Cloud Run: the backoff converges cross-instance via the control CAS itself; there is no cross-instance lock (deliberately — the smallest shape #11726 sanctioned).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


