### PR TITLE
fix(backend): report undecodable listen streams instead of dropping them silently (#11732)

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -67,6 +67,7 @@ from utils.transcribe_decisions import (
 )
 from utils.log_sanitizer import sanitize
 from utils.listen_audio import ChannelConfig, mix_n_channel_buffers, resample_pcm
+from utils.observability.fallback import record_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,10 @@ STT_DEATH_POLL_INTERVAL_SECONDS = 1.0
 
 # Longest frame the Opus format can carry, in milliseconds.
 OPUS_MAX_FRAME_MS = 120
+
+# Consecutive undecodable frames that mean the session's whole stream is unusable rather
+# than one corrupt packet: 1 s of audio at the 20 ms cadence omi clients encode with.
+DECODE_FAILURE_STREAK_ALERT = 50
 
 
 def opus_decode_capacity(sample_rate: int) -> int:
@@ -117,6 +122,8 @@ class ListenReceiver:
         self.vad_gate: Any = None
         self.image_chunks: OrderedDict[str, Dict[str, Any]] = OrderedDict()
         self.last_image_chunk_cleanup = 0.0
+        self.decode_failure_streak = 0
+        self.decode_stream_reported = False
 
     def _capture(self, method: str, *args: Any) -> None:
         """Keep optional dev capture out of the production audio failure domain."""
@@ -127,6 +134,39 @@ class ListenReceiver:
             capture(*args)
         except Exception as error:
             logger.warning('Listen parity capture failed method=%s type=%s', method, type(error).__name__)
+
+    def _record_decode_failure(
+        self, codec: str, error: BaseException, payload_len: int, channel: Optional[int] = None
+    ) -> None:
+        """Report an undecodable audio frame with enough detail to act on it.
+
+        Dropping the frame keeps the socket alive, so an undecodable stream is a fail-open
+        branch: the user records a whole session and gets no transcript, no ring buffer, and
+        no mixed audio, while the only trace is one `type=OpusError` line per frame. That name
+        cannot tell a corrupt client stream from a decoder the receiver sized wrong (#10701),
+        so carry the codec's own message and the payload size, and once the streak proves the
+        entire stream is failing, report it as the silent mic it is.
+        """
+        self.decode_failure_streak += 1
+        logger.warning(
+            'Listen audio frame decode failed codec=%s channel=%s type=%s bytes=%s streak=%s detail=%s',
+            codec,
+            channel,
+            type(error).__name__,
+            payload_len,
+            self.decode_failure_streak,
+            sanitize(error)[:120],
+        )
+        if self.decode_stream_reported or self.decode_failure_streak < DECODE_FAILURE_STREAK_ALERT:
+            return
+        self.decode_stream_reported = True
+        record_fallback(
+            component='silent_mic',
+            from_mode=codec,
+            to_mode='none',
+            reason='capability_mismatch',
+            outcome='exhausted',
+        )
 
     def _serving_provider(self) -> str:
         """Resolve the provider actually serving this session, read at use time.
@@ -426,12 +466,9 @@ class ListenReceiver:
                     bytes(audio), opus_decode_capacity(request.sample_rate)
                 )
             except Exception as error:
-                logger.warning(
-                    'Listen audio frame decode failed codec=opus channel=%s type=%s',
-                    channel_index,
-                    type(error).__name__,
-                )
+                self._record_decode_failure('opus', error, len(audio), channel=channel_index)
                 return
+            self.decode_failure_streak = 0
             if not audio:
                 return
         pcm = resample_pcm(bytes(audio), request.sample_rate, TARGET_SAMPLE_RATE)
@@ -590,10 +627,9 @@ class ListenReceiver:
                         elif request.codec == 'pcm8':
                             decoded = audioop.lin2lin(audioop.bias(data, 1, -128), 1, 2)
                     except Exception as error:
-                        logger.warning(
-                            'Listen audio frame decode failed codec=%s type=%s', request.codec, type(error).__name__
-                        )
+                        self._record_decode_failure(request.codec, error, len(data))
                         continue
+                    self.decode_failure_streak = 0
                     if not decoded:
                         continue
                     self._capture('capture_client_audio', decoded)

--- a/backend/tests/unit/test_listen_receiver_decode_failure_report.py
+++ b/backend/tests/unit/test_listen_receiver_decode_failure_report.py
@@ -1,0 +1,163 @@
+"""An undecodable listen stream must report itself, not just drop frames silently.
+
+Dropping a frame keeps the socket alive, so a stream the decoder cannot read is a fail-open
+branch: the user records a whole session and gets no transcript, no ring buffer, and no mixed
+audio. Prod logged only `Listen audio frame decode failed codec=opus type=OpusError`, one line
+per frame — a name that cannot separate a corrupt client stream (`corrupted stream`) from a
+decoder the receiver sized wrong (`buffer too small`, the #10701 regression), and no metric to
+alert on. The receiver now carries the codec's own message plus the payload size, and reports
+the session once the streak proves the whole stream is failing.
+"""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from routers.listen import receiver as receiver_module
+from routers.listen.receiver import DECODE_FAILURE_STREAK_ALERT, ListenReceiver
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+class _OpusError(Exception):
+    """Stands in for opuslib.OpusError, whose str() is the libopus message."""
+
+
+class _ScriptedDecoder:
+    """Raises for the frames named in `fail_on`, decodes the rest."""
+
+    def __init__(self, fail_on):
+        self.fail_on = set(fail_on)
+
+    def decode(self, data: bytes, frame_size: int = 0, **_kwargs) -> bytes:
+        if data in self.fail_on:
+            raise _OpusError("b'corrupted stream'")
+        return b'\x01\x02' * 320
+
+
+class _FramesWebSocket:
+    def __init__(self, frames):
+        self.frames = iter(frames)
+
+    async def receive(self):
+        return next(self.frames)
+
+
+def _host(websocket):
+    return SimpleNamespace(
+        request=SimpleNamespace(websocket=websocket, codec='opus', sample_rate=16000),
+        state=SimpleNamespace(
+            active=True,
+            close_code=1001,
+            last_audio_received_time=None,
+            last_activity_time=None,
+            first_audio_byte_timestamp=None,
+            last_usage_record_timestamp=None,
+            audio_ring_buffer=None,
+        ),
+        limits=SimpleNamespace(ws_receive_timeout=1.0),
+        is_multi_channel=False,
+        use_custom_stt=True,
+        audio_bytes_send=None,
+        transcripts=SimpleNamespace(enqueue=lambda _segments: None),
+        start_live_transcription=lambda: None,
+    )
+
+
+def _receiver(frames, decoder):
+    websocket = _FramesWebSocket(list(frames) + [{'type': 'websocket.disconnect', 'code': 1000}])
+    instance = ListenReceiver(_host(websocket), [], {})
+    instance.opus_decoder = decoder
+    return instance
+
+
+@pytest.fixture
+def recorded_fallbacks(monkeypatch):
+    calls = []
+    monkeypatch.setattr(receiver_module, 'record_fallback', lambda **kwargs: calls.append(kwargs))
+    return calls
+
+
+@pytest.mark.anyio
+async def test_decode_failure_log_names_the_codec_message_and_payload_size(caplog, recorded_fallbacks):
+    frame = b'\xff\xff\xff'
+    receiver = _receiver([{'bytes': frame}], _ScriptedDecoder({frame}))
+
+    with caplog.at_level(logging.WARNING, logger=receiver_module.__name__):
+        await receiver.receive_data()
+
+    (message,) = [record.getMessage() for record in caplog.records if 'decode failed' in record.getMessage()]
+    assert 'codec=opus' in message
+    assert 'type=_OpusError' in message
+    assert f'bytes={len(frame)}' in message
+    assert 'corrupted stream' in message
+    assert 'streak=1' in message
+
+
+@pytest.mark.anyio
+async def test_whole_stream_undecodable_reports_a_silent_mic_once(recorded_fallbacks):
+    frame = b'\xff\xff\xff'
+    frames = [{'bytes': frame}] * (DECODE_FAILURE_STREAK_ALERT + 3)
+    receiver = _receiver(frames, _ScriptedDecoder({frame}))
+
+    await receiver.receive_data()
+
+    assert receiver.decode_failure_streak == DECODE_FAILURE_STREAK_ALERT + 3
+    assert recorded_fallbacks == [
+        {
+            'component': 'silent_mic',
+            'from_mode': 'opus',
+            'to_mode': 'none',
+            'reason': 'capability_mismatch',
+            'outcome': 'exhausted',
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_a_corrupt_packet_among_good_frames_never_reports(recorded_fallbacks):
+    bad, good = b'\xff\xff\xff', b'opus-frame'
+    frames = [{'bytes': bad}, {'bytes': good}] * (DECODE_FAILURE_STREAK_ALERT + 3)
+    receiver = _receiver(frames, _ScriptedDecoder({bad}))
+
+    await receiver.receive_data()
+
+    assert receiver.decode_failure_streak == 0
+    assert recorded_fallbacks == []
+
+
+@pytest.mark.anyio
+async def test_multi_channel_decode_failure_names_its_channel(caplog, recorded_fallbacks):
+    frame = b'\xff\xff\xff'
+    receiver = _receiver([], _ScriptedDecoder({frame}))
+    receiver.host.is_multi_channel = True
+    receiver.channel_id_to_index = {7: 1}
+    receiver.multi_opus_decoders = [None, _ScriptedDecoder({frame})]
+
+    with caplog.at_level(logging.WARNING, logger=receiver_module.__name__):
+        await receiver._handle_multi_channel_audio(bytes([7]) + frame)
+
+    (message,) = [record.getMessage() for record in caplog.records if 'decode failed' in record.getMessage()]
+    assert 'channel=1' in message
+    assert f'bytes={len(frame)}' in message
+    assert receiver.decode_failure_streak == 1
+
+
+@pytest.mark.skipif(receiver_module.opuslib is None, reason='opuslib/libopus unavailable')
+@pytest.mark.anyio
+async def test_real_libopus_rejection_is_reported_with_its_own_message(caplog, recorded_fallbacks):
+    # libopus decodes most arbitrary bytes; b'\xff\xff\xff' is a packet it actually rejects,
+    # which is how prod's storm looked from the inside.
+    frame = b'\xff\xff\xff'
+    receiver = _receiver([{'bytes': frame}], receiver_module.opuslib.Decoder(16000, 1))
+
+    with caplog.at_level(logging.WARNING, logger=receiver_module.__name__):
+        await receiver.receive_data()
+
+    (message,) = [record.getMessage() for record in caplog.records if 'decode failed' in record.getMessage()]
+    assert 'type=OpusError' in message
+    assert 'corrupted stream' in message


### PR DESCRIPTION
## Bug

An audio frame the decoder rejects is dropped so the socket survives — a fail-open branch. When *every* frame of a session fails, the user records the whole session and gets no transcript, no ring buffer, and no mixed audio, while the only trace is one line per frame:

```
WARNING:routers.listen.receiver:Listen audio frame decode failed codec=opus type=OpusError
```

Prod is doing exactly that right now (#11732): one `dg-canary` session on the current image (`6316415`) dropped **5,000+ consecutive frames at a flat ~100 ms cadence over 10 minutes**, 06:45:22–06:53:47Z, while that lane logged 0 failures in each of the four preceding hours.

## Root cause of the *diagnosis* gap

`type(error).__name__` collapses failures libopus itself distinguishes by message. Verified locally against real `opuslib` 3.0.1 + libopus:

| payload | libopus |
|---|---|
| `b'\xff\xff\xff'` | `OpusError: b'corrupted stream'` — client stream is undecodable |
| valid packet, `frame_size=10` | `OpusError: b'buffer too small'` — receiver-side sizing, i.e. the #10701 regression |
| 320 arbitrary bytes | decodes fine |

So `type=OpusError` cannot tell "the client is sending something that isn't an opus packet" from "we sized the decoder wrong" — the two have completely different owners. The payload size and whether one packet or the whole stream failed were also discarded, and the branch emitted **no metric**, although `docs/agents/fallback-telemetry.md` requires `record_fallback` on exactly this shape (fail-open, correctness changed).

## Fix

- `_record_decode_failure` (shared by the single- and multi-channel paths) logs `codec=… channel=… type=… bytes=… streak=… detail=<libopus message>`, sanitized and truncated.
- After `DECODE_FAILURE_STREAK_ALERT = 50` consecutive drops (1 s at the 20 ms cadence omi clients encode with) it reports the session once via `record_fallback(component='silent_mic', from_mode=<codec>, to_mode='none', reason='capability_mismatch', outcome='exhausted')` — an alertable signal for "this user's mic went nowhere".
- A successful decode resets the streak, so an isolated corrupt packet never reports; the telemetry fires at most once per session.

Behavior is otherwise unchanged: frames are still dropped, the session still survives.

## Tested

- `backend/test.sh` over the listen/receiver files — `tests/unit/test_listen_receiver_decode_failure_report.py`, `test_listen_receiver_opus_frame_capacity.py`, `test_listen_receiver_frame_recovery.py`, `test_listen_pipeline.py`, `test_listen_runtime_regressions.py`, `tests/unit/utils/test_listen_pusher_session.py` — 6 files, all green, no duration-guard offenders.
- New regression tests drive `ListenReceiver.receive_data()` end to end: the detail fields land in the log; a fully undecodable stream records exactly one `silent_mic` fallback; a corrupt packet among good frames records none; the multi-channel path names its channel.
- One test drives the receiver with a **real** `opuslib.Decoder(16000, 1)` and asserts the warning now carries `corrupted stream` (passes locally with libopus on the loader path; skips where libopus is absent).

## Not fixed here

Why that client's `opus_fs320` stream is undecodable stays open in #11732 — the new `detail=`/`bytes=` fields are what will answer it on the next occurrence.

Failure-Class: FC-typed-failure-collapsed-to-generic

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

