### PR TITLE
SCA-323: restore company-paid Flash onto Vertex PT

### DIFF
--- a/.github/scripts/check-desktop-backend-release-policy.py
+++ b/.github/scripts/check-desktop-backend-release-policy.py
@@ -50,6 +50,9 @@ def _validate_production_python_runtime(text: str, *, workflow: str) -> list[str
         "--format='none'",
         "SERVICE_ACCOUNT_JSON",
         "GOOGLE_APPLICATION_CREDENTIALS=/secrets/firebase/service-account.json",
+        "USE_VERTEX_AI=true",
+        "GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}",
+        "GCP_LOCATION=us-central1",
         "/secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest",
         "AGENT_GCS_BUCKET: ${{ vars.AGENT_GCS_BUCKET }}",
         "AGENT_GCS_BUCKET=${{ env.AGENT_GCS_BUCKET }}",
@@ -180,7 +183,9 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             workflow=workflow,
         )
     )
-    request_step = "Deploy production candidate at zero traffic" if production else "Deploy desktop-backend to Cloud Run"
+    request_step = (
+        "Deploy production candidate at zero traffic" if production else "Deploy desktop-backend to Cloud Run"
+    )
     errors.extend(_validate_private_agent_vm_readiness(text, workflow=workflow, request_step=request_step))
     # Static workflow tripwire: deploy-cloudrun's parseFlags splits an unquoted
     # --args=-m,... token, making Python treat -m as a gcloud flag instead of a
@@ -226,6 +231,8 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             "FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
             "FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}",
             "GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}",
+            "USE_VERTEX_AI=true",
+            "GCP_LOCATION=us-central1",
             "/secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest",
             "FIREBASE_API_KEY=FIREBASE_API_KEY:latest",
             "${{ secrets.GCP_SERVICE_ACCOUNT }}",
@@ -277,6 +284,10 @@ def validate_deploy_workflow(text: str, *, production: bool) -> list[str]:
             for line in desktop_block.splitlines()
         ):
             errors.append(f"{workflow}: desktop candidate must isolate Firebase auth credentials from dev ADC")
+        if desktop_block is not None:
+            for env_var in ("USE_VERTEX_AI=true", "GCP_LOCATION=us-central1"):
+                if not any(line.strip() == env_var for line in desktop_block.splitlines()):
+                    errors.append(f"{workflow}: desktop candidate missing Vertex PT runtime env {env_var!r}")
     return errors
 
 

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -270,6 +270,8 @@ jobs:
             FIREBASE_AUTH_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
             FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
             GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}
+            USE_VERTEX_AI=true
+            GCP_LOCATION=us-central1
             FIREBASE_AUTH_CREDENTIALS_PATH=/secrets/firebase/service-account.json
             BASE_API_URL=${{ steps.desktop-base-api-url.outputs.base_api_url }}
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.candidate-identity.outputs.source_sha }}

--- a/.github/workflows/desktop_backend_prod.yml
+++ b/.github/workflows/desktop_backend_prod.yml
@@ -352,6 +352,9 @@ jobs:
             --remove-secrets=PINECONE_API_KEY,PINECONE_HOST
           env_vars: |
             FIREBASE_PROJECT_ID=${{ env.FIREBASE_AUTH_PROJECT_ID }}
+            USE_VERTEX_AI=true
+            GOOGLE_CLOUD_PROJECT=${{ vars.GCP_PROJECT_ID }}
+            GCP_LOCATION=us-central1
             GOOGLE_APPLICATION_CREDENTIALS=/secrets/firebase/service-account.json
             BASE_API_URL=${{ env.PRODUCTION_DESKTOP_BACKEND_URL }}
             OMI_DESKTOP_BACKEND_RELEASE_SHA=${{ steps.admitted-source.outputs.source_sha }}

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -334,6 +334,14 @@ environments:
           X_OAUTH_REDIRECT_URI:
             source: environment
     region: us-central1
+    desktop_backend:
+      env:
+        USE_VERTEX_AI:
+          value: 'true'
+        GOOGLE_CLOUD_PROJECT:
+          value: based-hardware-dev
+        GCP_LOCATION:
+          value: us-central1
     cloud_run:
       network:
         flags:
@@ -1238,6 +1246,14 @@ environments:
           SYNC_TASKS_INVOKER_SA:
             source: environment
     region: us-central1
+    desktop_backend:
+      env:
+        USE_VERTEX_AI:
+          value: 'true'
+        GOOGLE_CLOUD_PROJECT:
+          value: based-hardware
+        GCP_LOCATION:
+          value: us-central1
     cloud_run:
       network:
         flags:

--- a/backend/deploy/runtime_env/_base.yaml
+++ b/backend/deploy/runtime_env/_base.yaml
@@ -150,6 +150,16 @@ environment_shared:
             key: MCP_RESOURCE_URL
       values_file: backend/charts/backend-listen/{env}_omi_backend_listen_values.yaml
   region: us-central1
+  # Separate Cloud Run release vector from gcp_backend.yml. Compose + tests pin
+  # Vertex PT; desktop_backend_*.yml is what actually deploys these env vars.
+  desktop_backend:
+    env:
+      USE_VERTEX_AI:
+        value: 'true'
+      GOOGLE_CLOUD_PROJECT:
+        value: '{compute_project}'
+      GCP_LOCATION:
+        value: us-central1
   cloud_run:
     network:
       flags:

--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -1,0 +1,66 @@
+# Vertex Provisioned Throughput for Gemini 2.5 Flash
+
+We bought **5 GSU Provisioned Throughput** for `gemini-2.5-flash` in
+`us-central1` so company-paid Flash text is reserved and cheaper than Gemini
+API list price.
+
+**Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28.**
+
+- SKU: `Vertex AI: Provisioned Throughput 1 Year`
+- Cap: 13,450 tok/s
+- First billing row: 2026-05-28
+- **Expires ~2027-05-28** (1-year SKU; confirm in Cloud Console → Vertex →
+  Provisioned Throughput — Commerce API was disabled, so do not invent a more
+  precise date)
+- Flat ~$290.32/day even when traffic is elsewhere
+
+PT and EDP apply **only on Vertex publisher**, not AI Studio
+(`generativelanguage.googleapis.com`).
+
+## Never send company-paid Flash to AI Studio
+
+Server-paid `gemini-2.5-flash` `generateContent` / `streamGenerateContent` must
+go to:
+
+`{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/gemini-2.5-flash:generateContent`
+
+using ADC / Workload Identity. **Never** `generativelanguage.googleapis.com`
+and **never** `?key=` for that path. Missing `GOOGLE_CLOUD_PROJECT` must fail
+closed — that omission is what moved Flash off Vertex on 2026-08-04 and
+double-paid (reservation + API list).
+
+The model pin is `VERTEX_PT_MODEL = 'gemini-2.5-flash'` in
+`backend/routers/desktop_proxy.py`. Changing the company-paid Flash default to
+Lite / 3.1 without updating that pin, this note, and the contract tests in the
+same commit is the regression.
+
+BYOK Gemini stays on the user's key / AI Studio.
+
+## Durable runtime env
+
+`desktop-backend` compose (`backend/deploy/runtime_env/_base.yaml` →
+`desktop_backend`) and the Cloud Run deploy workflows must keep:
+
+- `USE_VERTEX_AI=true`
+- `GOOGLE_CLOUD_PROJECT` = `based-hardware` (prod) / `based-hardware-dev` (dev)
+- `GCP_LOCATION=us-central1`
+
+`GEMINI_API_KEY` remains only for BYOK / emergency leftover surfaces.
+
+## Out of scope leftovers
+
+Realtime token mint (`desktop_realtime.py`) and the omni Live websocket
+(`omni_relay.py`) still use AI Studio. Vertex Live is not wired. Those are not
+the high-volume Flash text bill.
+
+Single `embedContent` uses Vertex `:predict` when a project is set.
+`batchEmbedContents` stays on AI Studio (incompatible Vertex batch shape).
+
+## How to verify after deploy
+
+- Cloud Monitoring `consumed_token_throughput{request_type=dedicated, model=gemini-2.5-flash}` should move
+- Gemini API Flash daily $ should drop
+- PT SKU stays flat (~$290/day)
+- Proxy logs: `provider_route=vertex_ai`, not `ai_studio`, for server-paid Flash
+
+Incident: 2026-08-04 cutover. GitHub #6935 / SCA-323.

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -41,6 +41,13 @@ _VERTEX_MODELS = frozenset({'gemini-2.5-flash', 'gemini-2.5-flash-lite', 'gemini
 # Keep the provider decision explicit instead of silently trying one API shape on
 # another provider.
 _VERTEX_ACTIONS = frozenset({'generateContent', 'streamGenerateContent', 'embedContent'})
+# Company-paid Flash text is reserved on Vertex PT. Changing this pin without
+# updating the matching tests and backend/docs/vertex-pt-flash.md is the
+# 2026-08-04 AI Studio double-pay regression.
+VERTEX_PT_MODEL = 'gemini-2.5-flash'
+VERTEX_PT_LOCATION = 'us-central1'
+VERTEX_PT_EXPIRES = '~2027-05-28'
+VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28'
 _MAX_BODY_BYTES = 5 * 1024 * 1024
 _MAX_OUTPUT_TOKENS = 8192
 _DEFAULT_THINKING_BUDGET = 1024
@@ -254,7 +261,7 @@ def _size_bucket(size: int) -> str:
 
 
 def _path_parts(path: str) -> tuple[str, str, str]:
-    path = path.replace('gemini-3-flash-preview', 'gemini-2.5-flash')
+    path = path.replace('gemini-3-flash-preview', VERTEX_PT_MODEL)
     prefix, separator, action = path.partition(':')
     model = prefix.removeprefix('models/') if separator and prefix.startswith('models/') else ''
     if action not in _ALLOWED_ACTIONS or model not in _ALLOWED_MODELS:
@@ -337,11 +344,25 @@ def _sanitize(body: bytes, action: str) -> bytes:
     return json.dumps(payload, separators=(',', ':')).encode()
 
 
+def _use_vertex_ai() -> bool:
+    return os.getenv('USE_VERTEX_AI', '').strip().lower() in {'1', 'true', 'yes'}
+
+
+def _server_paid_flash_text(model: str, action: str) -> bool:
+    return model == VERTEX_PT_MODEL and action in {'generateContent', 'streamGenerateContent'}
+
+
+def _vertex_required(model: str, action: str) -> bool:
+    if action not in _VERTEX_ACTIONS or model not in _VERTEX_MODELS:
+        return False
+    return _server_paid_flash_text(model, action) or _use_vertex_ai()
+
+
 def _vertex_url(model: str, action: str) -> str | None:
     project = os.getenv('GOOGLE_CLOUD_PROJECT', '').strip()
     if model not in _VERTEX_MODELS or action not in _VERTEX_ACTIONS or not project:
         return None
-    location = os.getenv('GCP_LOCATION', 'us-central1').strip()
+    location = os.getenv('GCP_LOCATION', VERTEX_PT_LOCATION).strip() or VERTEX_PT_LOCATION
     return f'https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:{action}'
 
 
@@ -385,7 +406,15 @@ async def _upstream(path: str, model: str, action: str, query: dict[str, str]) -
             query,
             'vertex_ai',
             'application_default_credentials',
-            os.getenv('GCP_LOCATION', 'us-central1').strip(),
+            os.getenv('GCP_LOCATION', VERTEX_PT_LOCATION).strip() or VERTEX_PT_LOCATION,
+        )
+    if _vertex_required(model, action):
+        # Missing GOOGLE_CLOUD_PROJECT is the 2026-08-04 production bug: Flash
+        # fell through to GEMINI_API_KEY / AI Studio and bypassed Vertex PT.
+        raise RoutingFailure(
+            code='routing_vertex_not_configured',
+            message=f'Gemini Vertex route is required. {VERTEX_PT_CONTRACT}',
+            phase='routing',
         )
     server_key = os.getenv('GEMINI_API_KEY', '').strip()
     if not server_key:
@@ -432,10 +461,13 @@ async def _meter_server_request(uid: str, path: str, model: str, action: str) ->
             reason='quota',
             outcome='degraded',
         )
-        return f'models/gemini-2.5-flash:{action}'
+        return f'models/{VERTEX_PT_MODEL}:{action}'
     return path
 
 
+# gemini-embedding-001 single embed uses Vertex :predict when a project is
+# configured (~$278/30d). batchEmbedContents stays on AI Studio because the
+# Vertex batch wire shape is not compatible.
 def _vertex_embedding_request(body: bytes) -> bytes:
     payload = json.loads(body)
     try:

--- a/backend/routers/desktop_realtime.py
+++ b/backend/routers/desktop_realtime.py
@@ -20,6 +20,8 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _OPENAI_CLIENT_SECRETS_URL = "https://api.openai.com/v1/realtime/client_secrets"
+# Leftover AI Studio Live token mint. Vertex Live is not wired here; this is
+# not the $1k/day Flash text bill. See backend/docs/vertex-pt-flash.md.
 _GEMINI_AUTH_TOKENS_URL = "https://generativelanguage.googleapis.com/v1alpha/auth_tokens"
 _OPENAI_REALTIME_MODEL = "gpt-realtime-2"
 _GEMINI_LIVE_MODEL = "models/gemini-3.1-flash-live-preview"

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 # Protocol is provider-native and opaque to the relay — the desktop speaks raw
 # OpenAI Realtime / Gemini Live JSON; we just forward bytes both ways.
 
+# Leftover AI Studio Live websocket. Vertex Live is not wired here; this is
+# not the $1k/day Flash text bill. See backend/docs/vertex-pt-flash.md.
 GEMINI_URL = (
     "wss://generativelanguage.googleapis.com/ws/"
     "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key={key}"

--- a/backend/scripts/render_backend_runtime_env.py
+++ b/backend/scripts/render_backend_runtime_env.py
@@ -48,6 +48,10 @@ def main() -> int:
     rendered_outputs.append(('cloud_run_flags', _render_flags(_as_config_dict(network.get('flags')) or {})))
     services = _as_config_dict(cloud_run.get('services')) or {}
     if not args.job:
+        desktop_backend = _as_config_dict(env_config.get('desktop_backend')) or {}
+        desktop_env = _as_config_dict(desktop_backend.get('env')) or {}
+        if desktop_env:
+            rendered_outputs.append(('desktop_backend_env_vars', _render_env_vars(desktop_env)))
         for service, raw_service_config in services.items():
             service_config = _as_config_dict(raw_service_config)
             if service_config is None:

--- a/backend/scripts/runtime_env_validation/manifest.py
+++ b/backend/scripts/runtime_env_validation/manifest.py
@@ -609,6 +609,31 @@ def _validate_sync_ledger_fence_mode(env_config: ConfigDict, cloud_run_state: Co
     return errors
 
 
+VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28'
+_DESKTOP_BACKEND_VERTEX_PT_ENV = {
+    'USE_VERTEX_AI': 'true',
+    'GCP_LOCATION': 'us-central1',
+}
+
+
+def _validate_desktop_backend_vertex_pt_contract(env: str, env_config: ConfigDict) -> list[ValidationError]:
+    expected_project = 'based-hardware' if env == 'prod' else 'based-hardware-dev'
+    desktop = _as_config_dict(env_config.get('desktop_backend')) or {}
+    env_map = _as_config_dict(desktop.get('env')) or {}
+    required = {**_DESKTOP_BACKEND_VERTEX_PT_ENV, 'GOOGLE_CLOUD_PROJECT': expected_project}
+    errors: list[ValidationError] = []
+    for name, expected in required.items():
+        actual = _manifest_literal_env_value(env_map, name)
+        if actual != expected:
+            errors.append(
+                ValidationError(
+                    f'{env}/desktop_backend',
+                    f'{name} must be {expected!r} so company-paid Flash consumes Vertex PT. {VERTEX_PT_CONTRACT}',
+                )
+            )
+    return errors
+
+
 def validate_runtime_env(
     *,
     env: str,
@@ -626,6 +651,7 @@ def validate_runtime_env(
     if errors:
         return errors
 
+    errors.extend(_validate_desktop_backend_vertex_pt_contract(env, env_config))
     errors.extend(_validate_gke(env_config, strict_provisional=strict_provisional))
     errors.extend(_validate_stt_serving_model_policy(env, env_config))
     errors.extend(validate_parakeet_admission_contract(env, env_config))

--- a/backend/tests/unit/test_backend_runtime_env_validator.py
+++ b/backend/tests/unit/test_backend_runtime_env_validator.py
@@ -1792,6 +1792,32 @@ def test_memory_maintenance_job_contract_passes_for_repo_manifest():
     assert validator.validate_runtime_env(env='prod') == []
 
 
+@pytest.mark.parametrize('env', ['dev', 'prod'])
+def test_desktop_backend_compose_requires_vertex_pt_env(env):
+    validator = load_validator()
+    errors = validator.validate_runtime_env(env=env)
+    assert errors == []
+    manifest = validator._load_yaml(ROOT / 'deploy/runtime_env.yaml')
+    desktop_env = manifest['environments'][env]['desktop_backend']['env']
+    expected_project = 'based-hardware' if env == 'prod' else 'based-hardware-dev'
+    assert desktop_env['USE_VERTEX_AI']['value'] == 'true'
+    assert desktop_env['GOOGLE_CLOUD_PROJECT']['value'] == expected_project
+    assert desktop_env['GCP_LOCATION']['value'] == 'us-central1'
+
+
+def test_desktop_backend_vertex_pt_omission_fails_loud(tmp_path):
+    validator = load_validator()
+    manifest = copy.deepcopy(validator._load_yaml(ROOT / 'deploy/runtime_env.yaml'))
+    del manifest['environments']['prod']['desktop_backend']
+    path = tmp_path / 'runtime_env.yaml'
+    write_yaml(path, manifest)
+
+    errors = validator.validate_runtime_env(env='prod', manifest_path=path)
+    messages = [error.message for error in errors if error.scope == 'prod/desktop_backend']
+    assert messages
+    assert any('Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28' in message for message in messages)
+
+
 def test_memory_maintenance_contract_rejects_retired_promotion_envs_when_new_contract_is_present():
     validator = load_validator()
     retired = {

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -297,6 +297,81 @@ async def test_proxy_marks_daily_quota_exhaustion_non_retryable_and_preserves_re
 
 
 @pytest.mark.asyncio
+async def test_server_paid_flash_fails_closed_without_project(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.setenv("USE_VERTEX_AI", "true")
+    monkeypatch.setenv("GEMINI_API_KEY", "must-not-be-used")
+
+    with pytest.raises(desktop_proxy.RoutingFailure) as error:
+        await desktop_proxy._upstream(
+            "models/gemini-2.5-flash:generateContent",
+            "gemini-2.5-flash",
+            "generateContent",
+            {},
+        )
+
+    assert error.value.code == "routing_vertex_not_configured"
+    assert desktop_proxy.VERTEX_PT_CONTRACT in error.value.message
+    assert desktop_proxy.VERTEX_PT_MODEL == "gemini-2.5-flash"
+    assert desktop_proxy.VERTEX_PT_EXPIRES == "~2027-05-28"
+
+
+@pytest.mark.asyncio
+async def test_server_paid_flash_uses_vertex_never_studio_or_key(monkeypatch):
+    async def token():
+        return "adc-token"
+
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy._vertex_tokens, "get_access_token", token)
+    monkeypatch.setenv("USE_VERTEX_AI", "true")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+    monkeypatch.setenv("GEMINI_API_KEY", "must-not-be-used")
+
+    for action in ("generateContent", "streamGenerateContent"):
+        route = await desktop_proxy._upstream(
+            f"models/{desktop_proxy.VERTEX_PT_MODEL}:{action}",
+            desktop_proxy.VERTEX_PT_MODEL,
+            action,
+            {"alt": "sse"} if action == "streamGenerateContent" else {},
+        )
+        assert route.provider == "vertex_ai"
+        assert "aiplatform.googleapis.com" in route.url
+        assert "us-central1" in route.url
+        assert "generativelanguage.googleapis.com" not in route.url
+        assert "key" not in route.params
+        assert route.params.get("key") is None
+
+
+@pytest.mark.asyncio
+async def test_byok_flash_stays_on_ai_studio(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: "user-key")
+    monkeypatch.setenv("USE_VERTEX_AI", "true")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+
+    route = await desktop_proxy._upstream(
+        "models/gemini-2.5-flash:generateContent",
+        "gemini-2.5-flash",
+        "generateContent",
+        {},
+    )
+
+    assert route.provider == "ai_studio_byok"
+    assert route.params["key"] == "user-key"
+    assert "generativelanguage.googleapis.com" in route.url
+
+
+def test_vertex_pt_model_pin_points_at_the_docs():
+    docs = BACKEND_DIR / "docs" / "vertex-pt-flash.md"
+    text = docs.read_text(encoding="utf-8")
+    assert desktop_proxy.VERTEX_PT_MODEL in text
+    assert desktop_proxy.VERTEX_PT_EXPIRES in text
+    assert desktop_proxy.VERTEX_PT_CONTRACT.split(",")[0] in text
+    assert "generativelanguage.googleapis.com" in text
+
+
+@pytest.mark.asyncio
 async def test_vertex_credentials_fail_closed_without_studio_fallback(monkeypatch):
     async def unavailable():
         raise RuntimeError("credential detail must not escape")

--- a/backend/tests/unit/test_render_backend_runtime_env.py
+++ b/backend/tests/unit/test_render_backend_runtime_env.py
@@ -365,3 +365,23 @@ def test_backend_service_deploys_remove_retired_canonical_memory_env_vars():
         job = manifest[env]['cloud_run']['jobs']['memory-maintenance-job']
         job_flags = _MODULE['_render_flags'](job['flags'])
         assert f'--remove-env-vars={retired}' in job_flags, f'memory-maintenance-job for {env} must strip {retired}'
+
+
+VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28'
+
+
+@pytest.mark.parametrize(
+    ('env', 'project'),
+    [
+        ('dev', 'based-hardware-dev'),
+        ('prod', 'based-hardware'),
+    ],
+)
+def test_desktop_backend_compose_pins_vertex_pt(env, project):
+    desktop = _MANIFEST['environments'][env]['desktop_backend']
+    rendered = _MODULE['_render_env_vars'](desktop['env'])
+    assert 'USE_VERTEX_AI=true' in rendered, VERTEX_PT_CONTRACT
+    assert f'GOOGLE_CLOUD_PROJECT={project}' in rendered, VERTEX_PT_CONTRACT
+    assert 'GCP_LOCATION=us-central1' in rendered, VERTEX_PT_CONTRACT
+    docs = Path(__file__).resolve().parents[2] / 'docs' / 'vertex-pt-flash.md'
+    assert VERTEX_PT_CONTRACT.split(',')[0] in docs.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary

Restore company-paid `gemini-2.5-flash` generateContent / streamGenerateContent onto Vertex Provisioned Throughput so desktop-backend stops billing Gemini API / AI Studio.

On 2026-08-04, Flash left the Vertex publisher path (where the 1-year 5 GSU PT applies) and started hitting `generativelanguage.googleapis.com`. PT still billed ~$290/day; Gemini API Flash jumped to ~$1,100/day. Live prod `desktop-backend` had `GEMINI_API_KEY` but not `USE_VERTEX_AI` / `GOOGLE_CLOUD_PROJECT`, so `_vertex_url` was None and every server-paid Flash call used AI Studio.

This PR:

- Fails closed when server-paid Flash text has no `GOOGLE_CLOUD_PROJECT` (no `?key=` / AI Studio fallback)
- Pins `VERTEX_PT_MODEL = gemini-2.5-flash` (expires ~2027-05-28)
- Adds durable `desktop-backend` compose + prod/dev Cloud Run env: `USE_VERTEX_AI=true`, `GOOGLE_CLOUD_PROJECT`, `GCP_LOCATION=us-central1`
- Documents the PT contract in `backend/docs/vertex-pt-flash.md`
- Leaves realtime / omni Live on AI Studio (not the Flash text bill); BYOK stays on the user key

Closes #6935
Closes SCA-323

## RCA

| Date | What happened | $ |
|---|---|---|
| 2026-05-28 | First PT billing row (1-year SKU, inferred expiry ~2027-05-28) | 5 GSU, us-central1, 13,450 tok/s |
| Jul 18–Aug 3 | Vertex Flash dedicated ~93% of cap + spillover | Vertex on-demand Flash ~$420–645/day + PT $290/day |
| Aug 4 | Vertex Flash $645 → $30 → ~$0; dedicated/spillover series stop | Gemini API Flash $8 → $1,100/day; PT still $290/day |
| 2026-08-17 | Live desktop-backend missing Vertex env, `credential_source=server_key`, `provider_route=ai_studio` | Double-pay: reservation + API list |

## Files

- `backend/routers/desktop_proxy.py` — fail-closed Vertex route + PT pin
- `backend/deploy/runtime_env/_base.yaml` + composed `runtime_env.yaml` — desktop-backend Vertex env
- `.github/workflows/desktop_backend_prod.yml` / `desktop_backend_auto_dev.yml` — deploy the env
- `backend/docs/vertex-pt-flash.md` — durable agent note
- Contract tests in `test_desktop_proxy.py`, `test_render_backend_runtime_env.py`, `test_backend_runtime_env_validator.py`

## Test plan

- [x] `pytest backend/tests/unit/test_desktop_proxy.py` — Vertex URL + ADC; missing project fail-closed; no `generativelanguage.googleapis.com` / `?key=` for server-paid Flash; BYOK unchanged
- [x] `pytest backend/tests/unit/test_render_backend_runtime_env.py` + `test_backend_runtime_env_validator.py` — prod/dev desktop-backend compose contains Vertex PT env; omission names **Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28**
- [x] Gateway Vertex tests stay green (`test_llm_gateway_vertex_provider.py`)
- [ ] After deploy: Cloud Monitoring `consumed_token_throughput{request_type=dedicated, model=gemini-2.5-flash}` moves; Gemini API Flash daily $ drops; PT SKU stays flat

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

