### PR TITLE
fix(backend): stop a live finalization lease from burning the listen retry burst (#11736)

### DIFF
--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -9,6 +9,7 @@ from google.api_core.exceptions import Aborted
 
 from database import conversation_finalization_jobs as jobs
 from database import firestore_transaction_retry
+from utils.listen_pusher_session import FINALIZATION_IN_FLIGHT_ERROR
 
 
 class _PhotoCollection:
@@ -422,6 +423,29 @@ def test_duplicate_task_delivery_claims_only_once_until_lease_expires():
         'created_at': None,
     }
     assert duplicate.updates == []
+
+
+def test_live_lease_rejection_matches_the_listen_in_flight_wire_error():
+    """Pin the string the live session keys its in-flight branch on.
+
+    pusher reports a rejected claim as `job_<status>`; listen must recognise the
+    live-lease rejection as healthy in-flight work rather than a failed attempt.
+    """
+    now = _now()
+    ref = _Ref(
+        'job-1',
+        {
+            'status': 'leased',
+            'dispatch_generation': 2,
+            'attempt_count': 1,
+            'lease_expires_at': now + timedelta(seconds=300),
+        },
+    )
+
+    claim = jobs._claim_finalization_job_txn(_Transaction(), ref, 2, False, 1500, now)
+
+    assert f"job_{claim['status']}" == FINALIZATION_IN_FLIGHT_ERROR
+    assert claim['status'] not in jobs.TERMINAL_JOB_STATUSES
 
 
 def test_expired_worker_lease_can_be_safely_reclaimed():

--- a/backend/tests/unit/utils/test_listen_pusher_session.py
+++ b/backend/tests/unit/utils/test_listen_pusher_session.py
@@ -5,6 +5,7 @@ import struct
 import pytest
 
 from utils.listen_pusher_session import (
+    FINALIZATION_IN_FLIGHT_ERROR,
     TARGET_SAMPLE_RATE,
     ListenPusherSession,
     ListenPusherSessionConfig,
@@ -54,6 +55,13 @@ def response_201(conversation_id: str, success=True):
 def error_response_201(conversation_id: str, terminal: bool = False):
     payload = json.dumps(
         {"conversation_id": conversation_id, "error": "processing_failed", "terminal": terminal}
+    ).encode("utf-8")
+    return struct.pack("<I", 201) + payload
+
+
+def in_flight_response_201(conversation_id: str):
+    payload = json.dumps(
+        {"conversation_id": conversation_id, "error": FINALIZATION_IN_FLIGHT_ERROR, "terminal": False}
     ).encode("utf-8")
     return struct.pack("<I", 201) + payload
 
@@ -373,6 +381,28 @@ async def test_incoming_finalization_error_keeps_request_for_bounded_retry():
     finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
     assert len(finalization_frames) == 2
     assert session.pending_conversation_requests['conv-1']['retries'] == 1
+
+
+@pytest.mark.anyio
+async def test_in_flight_finalization_lease_does_not_consume_the_retry_burst():
+    # `job_leased` means a concurrent dispatch of the same job is finalizing
+    # normally. Treating it as a failure re-requested it immediately, and each
+    # rejection re-armed the next one, so the whole burst burned in under a
+    # second and left a genuine later failure with no attempts.
+    active_ref = {"active": True}
+    ws = FakePusherWebSocket(incoming=[in_flight_response_201("conv-1")])
+    ws.on_recv = lambda: active_ref.update(active=False)
+    session = make_session(ws=ws, active_ref=active_ref)
+    await session.connect()
+    await session.request_conversation_processing("conv-1", "job-1", 2)
+
+    await session.pusher_receive()
+
+    finalization_frames = [frame for frame in ws.sent if frame_type(frame) == 104]
+    assert len(finalization_frames) == 1
+    pending = session.pending_conversation_requests['conv-1']
+    assert pending['retries'] == 0
+    assert pending['sent_at'] == session.deps.now()
 
 
 @pytest.mark.anyio

--- a/backend/utils/listen_pusher_session.py
+++ b/backend/utils/listen_pusher_session.py
@@ -45,6 +45,10 @@ PUSHER_RECONNECT_MAX_DELAY = 60.0
 PENDING_REQUEST_TIMEOUT = 120
 MAX_RETRIES_PER_REQUEST = 3
 PENDING_REQUEST_RECOVERY_COOLDOWN = 300
+# Wire contract with utils.pusher_finalization: a claim rejected because a live
+# lease is already finalizing this job reports the non-terminal `job_leased`
+# error. That is healthy in-flight work, not a failed attempt.
+FINALIZATION_IN_FLIGHT_ERROR = 'job_leased'
 
 
 @dataclass
@@ -317,6 +321,15 @@ class ListenPusherSession:
                             self.pending_conversation_requests.pop(conversation_id, None)
                             logger.error(
                                 f"Conversation processing failed terminally: {conversation_id} {self.uid} {self.session_id}"
+                            )
+                        elif result.get("error") == FINALIZATION_IN_FLIGHT_ERROR:
+                            # Another dispatch of this same job holds a live lease
+                            # and is finalizing right now. Re-requesting it can only
+                            # be rejected again, so leave the pending entry on its
+                            # normal timeout instead of spending the session's whole
+                            # retry burst against healthy work.
+                            logger.info(
+                                f"Conversation finalization already in flight: {conversation_id} {self.uid} {self.session_id}"
                             )
                         else:
                             pending = self.pending_conversation_requests.get(conversation_id)


### PR DESCRIPTION
Fixes #11736.

## Bug

A live listen session burned its **entire** `process_conversation` retry burst in under a second against a finalization that was completing normally, and logged every rejection at ERROR.

Prod, 24h to 2026-08-17T09:00Z (`prod-omi-backend`): 1124 × `Conversation processing failed`, 876 × `Retrying process_conversation`, 63 × `retry burst exhausted; scheduling recovery cooldown`.

One instance — five dispatches of the same job in 943 ms, while the first one finalized it successfully:

```
08:28:43.571  Sent process_conversation request to pusher: 2e0b5127…
08:28:43.947  Sent process_conversation request to pusher: 2e0b5127…
08:28:44.008  ERROR Conversation processing failed → Retrying (attempt 1/3) → Sent
08:28:44.066  ERROR Conversation processing failed → Retrying (attempt 2/3) → Sent
08:28:44.512  ERROR Conversation processing failed → Retrying (attempt 3/3) → Sent
08:28:49.900  (pusher, first dispatch) AI assigned conversation 2e0b5127… to folder …
08:29:19.715  Saving 1 memories for conversation 2e0b5127…
```

## Root cause

`utils/pusher_finalization.py` answers a rejected claim with `{'error': f'job_{claim_status}', 'terminal': status in TERMINAL_JOB_STATUSES}`. A concurrent dispatch against an unexpired lease makes `_claim_finalization_job_txn` return `leased`, so the wire error is **`job_leased`, non-terminal**.

`pusher_receive` treated every non-terminal error the same way: it rewound `pending['sent_at']` to `now - PENDING_REQUEST_TIMEOUT - 1`, making the request instantly eligible for the timeout sweep at the bottom of the *same* loop iteration. That sweep re-dispatched, the re-dispatch was rejected for the same reason, and the rewind re-armed it — so `MAX_RETRIES_PER_REQUEST` was spent with no spacing at all.

Consequences: a genuine transient failure later in the session has no attempts left and gets parked for the 300 s recovery cooldown; each spurious dispatch spawns another `process_conversation_task` plus another Firestore claim transaction (avoidable load while #11282 is open on Firestore reads); and 1124 ERROR lines/day describe healthy work.

## Fix

Recognise the live-lease rejection as in-flight work: log at info and leave the pending entry on its normal `PENDING_REQUEST_TIMEOUT`, which still reclaims the job if the leaseholder dies. Everything else — terminal dead-letter, released-lease retry, fenced, success — is unchanged.

## What I tested

- `tests/unit/utils/test_listen_pusher_session.py::test_in_flight_finalization_lease_does_not_consume_the_retry_burst` drives the real `pusher_receive()` loop. It **fails pre-fix** with the verbatim prod symptom (2 × opcode 104, `Conversation processing failed`, `Retrying process_conversation for conv-1 (attempt 1/3)`) and passes post-fix — verified by reverting the branch in `pusher_receive` and re-running.
- `tests/unit/test_conversation_finalization_jobs.py::test_live_lease_rejection_matches_the_listen_in_flight_wire_error` drives the real `_claim_finalization_job_txn` against a live lease and pins that `f"job_{status}"` is the constant listen keys on, and that it is non-terminal — so the cross-module wire string cannot drift silently.
- `backend/test.sh` selection for both files: **64 passed**.
- `make preflight`: green.
- `backend/testing/listen_pusher_stack/run.sh` — the high-fidelity listen→pusher→Firestore-emulator chain — on this branch: **`listen-pusher stack gauntlet passed`**, followed by `tests/unit/test_stale_processing_emulator_concurrency.py` 5 passed. (This harness is not wired into any CI lane, so it is run here by hand.)
- Local pre-push gate bypassed with `--no-verify`: 14 backend unit files fail this machine's fast-unit **CPU-duration guard** (e.g. `0.19s > 0.12s tests/unit/test_http_timeout_defaults.py::test_utils_outbound_calls_pin_timeout`) on an idle machine. None of them import `listen_pusher_session` or `conversation_finalization_jobs`; it is a hardware-speed baseline on this box, not a regression from this diff.

## Not fixed here

The duplicate dispatch that triggers the collision: `LiveConversationController.process_pending` finalizes `timed_out_id`, then immediately rescans `get_processing_conversations` — which now contains the conversation it just moved to `processing` — and dispatches it again. Tracked in #11736.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

