### PR TITLE
feat(desktop): port mobile General Summary app picker to conversation detail

### DIFF
--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -80,6 +80,10 @@ enum DefaultsKey: String {
   case onboardingChatGPTImportedMemories = "onboardingChatGPTImportedMemoriesCount"
   case gmailSelectedCookiePath = "gmailSelectedCookiePath"
   case gmailSelectedAccountLabel = "gmailSelectedAccountLabel"
+  /// Preferred summarization app for conversation summaries; locally mirrored
+  /// (the backend exposes no GET) and pushed via
+  /// `PUT /v1/users/preferences/app`. Same name mobile uses in SharedPreferences.
+  case preferredSummarizationAppId = "preferredSummarizationAppId"
   case disableSystemAudioCapture = "disableSystemAudioCapture"
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationAppSelectorSheet.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationAppSelectorSheet.swift
@@ -1,0 +1,165 @@
+import OmiTheme
+import SwiftUI
+
+// MARK: - App Selector Sheet
+
+struct AppSelectorSheet: View {
+  let apps: [OmiApp]
+  let isLoading: Bool
+  /// App behind the current primary summary (apps_results[0]); the row shows a
+  /// checkmark so the picker opens on the active summarization app.
+  var selectedAppId: String? = nil
+  /// Locally mirrored preferred app; its row is badged "Default".
+  var preferredAppId: String? = nil
+  let onSelect: (OmiApp) -> Void
+  var onSetPreferred: ((OmiApp) -> Void)? = nil
+  let onDismiss: () -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      // Header
+      HStack {
+        Text("Select App")
+          .scaledFont(size: OmiType.subheading, weight: .semibold)
+          .foregroundColor(Ink.primary)
+
+        Spacer()
+
+        Button(action: onDismiss) {
+          Image(systemName: "xmark.circle.fill")
+            .scaledFont(size: OmiType.heading)
+            .foregroundColor(Ink.secondary)
+        }
+        .buttonStyle(.plain)
+      }
+      .padding()
+
+      Divider()
+        .background(Ink.rowFillHover)
+
+      // Apps list
+      if apps.isEmpty {
+        VStack(spacing: OmiSpacing.md) {
+          Image(systemName: "square.grid.2x2")
+            .scaledFont(size: OmiType.hero)
+            .foregroundColor(Ink.secondary)
+
+          Text("No Apps Available")
+            .scaledFont(size: OmiType.body, weight: .medium)
+            .foregroundColor(Ink.secondary)
+
+          Text("Enable apps with memory capability to reprocess conversations")
+            .scaledFont(size: OmiType.caption)
+            .foregroundColor(Ink.secondary)
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+      } else {
+        ScrollView {
+          LazyVStack(spacing: OmiSpacing.hairline) {
+            ForEach(apps) { app in
+              AppSelectorRow(
+                app: app,
+                isSelected: selectedAppId == app.id,
+                isPreferred: preferredAppId == app.id,
+                isLoading: isLoading && selectedAppId == app.id,
+                onSelect: { onSelect(app) },
+                onSetPreferred: onSetPreferred == nil ? nil : { onSetPreferred?(app) }
+              )
+            }
+          }
+          .padding(.horizontal, OmiSpacing.sm)
+          .padding(.vertical, OmiSpacing.sm)
+        }
+      }
+    }
+    .frame(width: 320, height: 400)
+    .background(Ink.surface)
+  }
+}
+
+struct AppSelectorRow: View {
+  let app: OmiApp
+  let isSelected: Bool
+  var isPreferred: Bool = false
+  let isLoading: Bool
+  let onSelect: () -> Void
+  var onSetPreferred: (() -> Void)? = nil
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: onSelect) {
+      HStack(spacing: OmiSpacing.md) {
+        AsyncImage(url: URL(string: app.image)) { phase in
+          switch phase {
+          case .success(let image):
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+          default:
+            RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+              .fill(Ink.rowFillHover)
+          }
+        }
+        .frame(width: 44, height: 44)
+        .clipShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius))
+
+        VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
+          Text(app.name)
+            .scaledFont(size: OmiType.body, weight: .medium)
+          HStack(spacing: OmiSpacing.xxs) {
+            Text(app.author)
+              .scaledFont(size: OmiType.caption)
+              .foregroundColor(Ink.secondary)
+
+            if isPreferred {
+              Image(systemName: "star.fill")
+                .scaledFont(size: OmiType.micro)
+                .foregroundColor(PageGlass.starred)
+              Text("Default")
+                .scaledFont(size: OmiType.micro)
+                .foregroundColor(Ink.secondary)
+            }
+          }
+        }
+
+        Spacer()
+
+        if isLoading {
+          ProgressView()
+            .scaleEffect(0.7)
+        } else if isSelected {
+          Image(systemName: "checkmark.circle.fill")
+            .scaledFont(size: OmiType.heading)
+            .foregroundColor(Ink.primary)
+        }
+      }
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.vertical, OmiSpacing.sm)
+      .background(
+        RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
+          .fill(isSelected || isHovering ? Ink.rowFillHover : Color.clear)
+      )
+    }
+    .buttonStyle(.plain)
+    .disabled(isLoading)
+    .onHover { isHovering = $0 }
+    // macOS analog of mobile's swipe-to-set-default: right-click a row to pin
+    // the preferred summarization app for future conversations.
+    .contextMenu {
+      if let onSetPreferred {
+        Button {
+          onSetPreferred()
+        } label: {
+          Label(
+            isPreferred ? "Default App" : "Set as Default",
+            systemImage: isPreferred ? "star.fill" : "star"
+          )
+        }
+        .disabled(isPreferred)
+      }
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -27,6 +27,9 @@ struct ConversationDetailView: View {
   @State private var showAppSelector = false
   @State private var isReprocessing = false
   @State private var selectedAppForReprocess: OmiApp?
+  /// Locally mirrored preferred summarization app (mobile keeps the same key
+  /// in SharedPreferences; the backend exposes no GET for it).
+  @State private var preferredSummaryAppId: String?
 
   // Transcript presentation state. Summary and transcript are exclusive panes so neither one is
   // compressed into an unreadable split view at the minimum window width.
@@ -199,6 +202,8 @@ struct ConversationDetailView: View {
       showTranscriptDrawer = true
     }
     .task {
+      preferredSummaryAppId =
+        UserDefaults.standard.string(forKey: .preferredSummarizationAppId).flatMap { $0.isEmpty ? nil : $0 }
       await appProvider.fetchApps()
       await onFetchPeople?()
       AnalyticsManager.shared.conversationDetailOpened(conversationId: conversation.id)
@@ -244,11 +249,16 @@ struct ConversationDetailView: View {
       AppSelectorSheet(
         apps: appProvider.apps.filter { $0.capabilities.contains("memories") },
         isLoading: isReprocessing,
+        selectedAppId: ConversationSummarySelection.primarySummary(for: displayConversation).appId,
+        preferredAppId: preferredSummaryAppId,
         onSelect: { app in
           selectedAppForReprocess = app
           Task {
             await reprocessWithApp(app)
           }
+        },
+        onSetPreferred: { app in
+          setPreferredSummaryApp(app)
         },
         onDismiss: { showAppSelector = false }
       )
@@ -581,16 +591,18 @@ struct ConversationDetailView: View {
 
   @ViewBuilder
   private var summaryContent: some View {
-    // Overview section
-    if !displayConversation.overview.isEmpty {
+    let selection = ConversationSummarySelection.primarySummary(for: displayConversation)
+
+    // Overview section (selected app result, or the structured fallback)
+    if !selection.content.isEmpty {
       overviewSection
     }
 
     // Metadata chips
     metadataSection
 
-    // App Results section
-    if !displayConversation.appsResults.isEmpty {
+    // App Results section (insights beyond the promoted primary summary)
+    if !ConversationSummarySelection.secondaryResults(for: displayConversation).isEmpty {
       appResultsSection
     }
 
@@ -835,7 +847,10 @@ struct ConversationDetailView: View {
   // MARK: - Overview Section
 
   private var overviewSection: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+    let selection = ConversationSummarySelection.primarySummary(for: displayConversation)
+    let primaryApp = selection.appId.flatMap { id in appProvider.apps.first { $0.id == id } }
+
+    return VStack(alignment: .leading, spacing: OmiSpacing.sm) {
       HStack(spacing: OmiSpacing.xs) {
         Image(systemName: "star.fill")
           .scaledFont(size: OmiType.body)
@@ -844,6 +859,34 @@ struct ConversationDetailView: View {
         Text("Summary")
           .scaledFont(size: OmiType.body, weight: .semibold)
           .foregroundColor(Ink.secondary)
+
+        // The selected summarization app owns this section; say which one.
+        if let primaryApp {
+          Text(primaryApp.name)
+            .scaledFont(size: OmiType.caption, weight: .medium)
+            .foregroundColor(Ink.secondary)
+            .padding(.horizontal, OmiSpacing.sm)
+            .padding(.vertical, OmiSpacing.xxs)
+            .background(
+              Capsule()
+                .fill(Ink.rowFillHover)
+            )
+        }
+
+        Spacer()
+
+        Button(action: { showAppSelector = true }) {
+          HStack(spacing: OmiSpacing.xxs) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+              .scaledFont(size: OmiType.caption)
+            Text(primaryApp == nil ? "Summary App" : "Change")
+              .scaledFont(size: OmiType.caption, weight: .medium)
+          }
+          .foregroundColor(Ink.secondary)
+        }
+        .buttonStyle(.plain)
+        .disabled(isReprocessing)
+        .help("Choose the app that summarizes this conversation")
       }
 
       // No `colorScheme` override here. This section used to force `.dark` so the markdown would
@@ -851,7 +894,7 @@ struct ConversationDetailView: View {
       // whole summary — the longest prose in the app — in near-white on a near-white ground. The
       // page is `glassContent()`, which already pins the panel's light appearance, and the markdown
       // inherits it.
-      OmiMarkdown(text: displayConversation.overview, sender: .ai)
+      OmiMarkdown(text: selection.content, sender: .ai)
         .textSelection(.enabled)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -940,7 +983,7 @@ struct ConversationDetailView: View {
         .disabled(isReprocessing)
       }
 
-      ForEach(displayConversation.appsResults) { result in
+      ForEach(ConversationSummarySelection.secondaryResults(for: displayConversation)) { result in
         AppResultCard(
           result: result,
           app: appProvider.apps.first { $0.id == result.appId }
@@ -961,15 +1004,11 @@ struct ConversationDetailView: View {
         Spacer()
       }
 
-      let memoryApps = appProvider.apps.filter { app in
-        // Name the outer element: inside the inner closure a bare `$0`
-        // shadows it, so `$0.appId == $0.id` compared an appsResults entry
-        // to itself (always true for any entry with a non-nil app_id, since
-        // AppResponse.id == appId ?? uuid), which excluded every app and
-        // left this section perpetually empty.
-        app.capabilities.contains("memories")
-          && !displayConversation.appsResults.contains(where: { $0.appId == app.id })
-      }.prefix(4)
+      // The $0-shadow exclusion that kept this section empty now lives (and is
+      // tested) in ConversationSummarySelection.suggestedApps.
+      let memoryApps = ConversationSummarySelection.suggestedApps(
+        appProvider.apps, results: displayConversation.appsResults
+      ).prefix(4)
 
       if memoryApps.isEmpty && !appProvider.isLoading {
         Text("Enable apps with memory capability to get additional insights")
@@ -1015,13 +1054,37 @@ struct ConversationDetailView: View {
     // Track reprocess
     AnalyticsManager.shared.conversationReprocessed(conversationId: conversation.id, appId: app.id)
 
+    // Mobile parity: the backend resolves reprocess targets from the enabled
+    // slice (plus defaults), so a not-yet-enabled pick is enabled first —
+    // otherwise it silently clears apps_results and produces no summary.
+    if !app.enabled {
+      await appProvider.enableApp(app)
+    }
+
     do {
-      try await APIClient.shared.reprocessConversation(
+      // The route returns the updated conversation; adopting it repaints the
+      // summary pane with the selected app as primary.
+      let updated = try await APIClient.shared.reprocessConversation(
         conversationId: conversation.id,
         appId: app.id
       )
+      loadedConversation = updated
     } catch {
       logError("Failed to reprocess conversation", error: error)
+    }
+  }
+
+  /// Persists the preferred summarization app locally (the backend has no GET
+  /// for it) and server-side, where future conversation processing keys on it.
+  private func setPreferredSummaryApp(_ app: OmiApp) {
+    preferredSummaryAppId = app.id
+    UserDefaults.standard.set(app.id, forKey: .preferredSummarizationAppId)
+    Task {
+      do {
+        try await APIClient.shared.setPreferredSummarizationApp(appId: app.id)
+      } catch {
+        logError("Failed to set preferred summarization app", error: error)
+      }
     }
   }
 
@@ -1277,139 +1340,6 @@ struct SuggestedAppCard: View {
       .background(
         RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
           .fill(isHovering ? Ink.rowFillHover : Ink.rowFill)
-      )
-    }
-    .buttonStyle(.plain)
-    .disabled(isLoading)
-    .onHover { isHovering = $0 }
-  }
-}
-
-// MARK: - App Selector Sheet
-
-struct AppSelectorSheet: View {
-  let apps: [OmiApp]
-  let isLoading: Bool
-  let onSelect: (OmiApp) -> Void
-  let onDismiss: () -> Void
-
-  @State private var selectedAppId: String?
-
-  var body: some View {
-    VStack(spacing: 0) {
-      // Header
-      HStack {
-        Text("Select App")
-          .scaledFont(size: OmiType.subheading, weight: .semibold)
-          .foregroundColor(Ink.primary)
-
-        Spacer()
-
-        Button(action: onDismiss) {
-          Image(systemName: "xmark.circle.fill")
-            .scaledFont(size: OmiType.heading)
-            .foregroundColor(Ink.secondary)
-        }
-        .buttonStyle(.plain)
-      }
-      .padding()
-
-      Divider()
-        .background(Ink.rowFillHover)
-
-      // Apps list
-      if apps.isEmpty {
-        VStack(spacing: OmiSpacing.md) {
-          Image(systemName: "square.grid.2x2")
-            .scaledFont(size: OmiType.hero)
-            .foregroundColor(Ink.secondary)
-
-          Text("No Apps Available")
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.secondary)
-
-          Text("Enable apps with memory capability to reprocess conversations")
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-            .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding()
-      } else {
-        ScrollView {
-          LazyVStack(spacing: OmiSpacing.hairline) {
-            ForEach(apps) { app in
-              AppSelectorRow(
-                app: app,
-                isSelected: selectedAppId == app.id,
-                isLoading: isLoading && selectedAppId == app.id
-              ) {
-                selectedAppId = app.id
-                onSelect(app)
-              }
-            }
-          }
-          .padding(.horizontal, OmiSpacing.sm)
-          .padding(.vertical, OmiSpacing.sm)
-        }
-      }
-    }
-    .frame(width: 320, height: 400)
-    .background(Ink.surface)
-  }
-}
-
-struct AppSelectorRow: View {
-  let app: OmiApp
-  let isSelected: Bool
-  let isLoading: Bool
-  let onSelect: () -> Void
-
-  @State private var isHovering = false
-
-  var body: some View {
-    Button(action: onSelect) {
-      HStack(spacing: OmiSpacing.md) {
-        AsyncImage(url: URL(string: app.image)) { phase in
-          switch phase {
-          case .success(let image):
-            image
-              .resizable()
-              .aspectRatio(contentMode: .fill)
-          default:
-            RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
-              .fill(Ink.rowFillHover)
-          }
-        }
-        .frame(width: 44, height: 44)
-        .clipShape(RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius))
-
-        VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
-          Text(app.name)
-            .scaledFont(size: OmiType.body, weight: .medium)
-            .foregroundColor(Ink.primary)
-
-          Text(app.author)
-            .scaledFont(size: OmiType.caption)
-            .foregroundColor(Ink.secondary)
-        }
-
-        Spacer()
-
-        if isLoading {
-          ProgressView()
-            .scaleEffect(0.7)
-        } else if isSelected {
-          Image(systemName: "checkmark.circle.fill")
-            .scaledFont(size: OmiType.heading)
-            .foregroundColor(Ink.primary)
-        }
-      }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.vertical, OmiSpacing.sm)
-      .background(
-        RoundedRectangle(cornerRadius: OmiChrome.smallControlRadius)
-          .fill(isSelected || isHovering ? Ink.rowFillHover : Color.clear)
       )
     }
     .buttonStyle(.plain)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationSummarySelection.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationSummarySelection.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Pure selection policy for the conversation detail summary pane.
+///
+/// Mobile parity (`ConversationDetailProvider.getSummarizedApp`): the backend's
+/// `_trigger_apps` clears `apps_results` and appends exactly the app it ran, so
+/// the first result with usable content *is* the selected summarization app's
+/// output. When no app produced a usable result, the pane falls back to the
+/// first-party `structured.overview`.
+enum ConversationSummarySelection {
+  /// The markdown the summary pane renders as primary, plus the app that
+  /// produced it (`nil` = first-party structured overview).
+  struct Primary: Equatable {
+    let content: String
+    let appId: String?
+  }
+
+  static func primarySummary(for conversation: ServerConversation) -> Primary {
+    if let result = conversation.appsResults.first(where: { !$0.content.isEmpty }) {
+      return Primary(content: result.content, appId: result.appId)
+    }
+    return Primary(content: conversation.overview, appId: nil)
+  }
+
+  /// "App Insights" keeps only results that are not the primary summary. With
+  /// no usable result there is no primary to promote, so every row stays.
+  static func secondaryResults(for conversation: ServerConversation) -> [AppResponse] {
+    guard let primaryResult = conversation.appsResults.first(where: { !$0.content.isEmpty }) else {
+      return conversation.appsResults
+    }
+    return conversation.appsResults.filter { $0.id != primaryResult.id }
+  }
+
+  /// Suggested "Try with Apps" rows: memories-capable apps that have not
+  /// produced a result for this conversation yet.
+  ///
+  /// Regression note: the inline closure this replaces compared `$0.appId == $0.id`
+  /// inside `contains(where:)` — the inner `$0` shadowed the outer app, every
+  /// appsResults entry compared to itself, and the section was always empty.
+  static func suggestedApps(_ apps: [OmiApp], results: [AppResponse]) -> [OmiApp] {
+    let resultAppIds = Set(results.compactMap(\.appId))
+    return apps.filter { app in
+      app.capabilities.contains("memories") && !resultAppIds.contains(app.id)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Apps.swift
@@ -452,17 +452,57 @@ extension APIClient {
 
   // MARK: - Conversation Reprocessing
 
-  /// Reprocess a conversation with a specific app
-  func reprocessConversation(conversationId: String, appId: String) async throws {
+  /// Reprocess a conversation with a specific app.
+  ///
+  /// The route returns the updated conversation (backend
+  /// `response_model=Conversation`); the caller adopts it so the summary pane
+  /// re-renders with the reprocessed app as primary. Decoding a synthetic
+  /// `{success, message}` envelope here used to throw on every successful call.
+  func reprocessConversation(conversationId: String, appId: String) async throws -> ServerConversation {
     struct ReprocessRequest: Encodable {
-      let app_id: String
+      let appId: String
+      enum CodingKeys: String, CodingKey {
+        case appId = "app_id"
+      }
     }
-    struct ReprocessResponse: Decodable {
-      let success: Bool
-      let message: String
+    let body = ReprocessRequest(appId: appId)
+    return try await post("v1/conversations/\(conversationId)/reprocess", body: body)
+  }
+
+  /// Sets the user's preferred summarization app; the backend keys future
+  /// conversation processing on it (mobile uses the same route).
+  func setPreferredSummarizationApp(appId: String) async throws {
+    struct StatusResponse: Decodable {
+      let status: String?
+      let message: String?
     }
-    let body = ReprocessRequest(app_id: appId)
-    let _: ReprocessResponse = try await post(
-      "v1/conversations/\(conversationId)/reprocess", body: body)
+    let _: StatusResponse = try await put("v1/users/preferences/app?app_id=\(appId)")
+  }
+
+  /// Bodyless PUT counterpart of the `post`/`patch` helpers, kept in this
+  /// extension so the oversized core transport file stays net-neutral.
+  func put<T: Decodable>(
+    _ endpoint: String,
+    requireAuth: Bool = true,
+    customBaseURL: String? = nil,
+    expectedOwnerId: String? = nil,
+    authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
+  ) async throws -> T {
+    let authPolicy = try resolvedRequestAuthPolicy(
+      expectedOwnerId: expectedOwnerId,
+      authorizationSnapshot: authorizationSnapshot)
+    let authOwnerId = authPolicy.expectedAuthOwnerId
+    try validateExpectedOwner(authPolicy)
+    let base = customBaseURL ?? baseURL
+    guard let url = URL(string: base + endpoint) else {
+      throw APIError.invalidResponse
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "PUT"
+    request.allHTTPHeaderFields = try await buildHeaders(
+      requireAuth: requireAuth,
+      expectedAuthOwnerId: authOwnerId)
+    try validateExpectedOwner(authPolicy)
+    return try await performRequest(request, authPolicy: authPolicy)
   }
 }

--- a/desktop/macos/Desktop/Tests/ConversationSummarySelectionTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationSummarySelectionTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Behavioral coverage for the conversation summary pane's selection policy:
+/// primary summary promotion (mobile `getSummarizedApp` parity), the
+/// structured-overview fallback, secondary "App Insights" rows, and the
+/// suggested-apps exclusion that the `$0` shadow used to break.
+final class ConversationSummarySelectionTests: XCTestCase {
+  private func conversation(
+    appResults: [AppResponse],
+    overview: String = "First-party overview"
+  ) -> ServerConversation {
+    ServerConversation(
+      id: "conversation-1",
+      createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+      updatedAt: nil,
+      startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+      finishedAt: Date(timeIntervalSince1970: 1_700_000_060),
+      structured: Structured(
+        title: "Title",
+        overview: overview,
+        emoji: "💬",
+        category: "other",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: [],
+      transcriptSegmentsIncluded: false,
+      geolocation: nil,
+      photos: [],
+      appsResults: appResults,
+      source: .desktop,
+      language: "en",
+      status: .completed,
+      discarded: false,
+      deleted: false,
+      isLocked: false,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil
+    )
+  }
+
+  private func appResponse(appId: String?, content: String) throws -> AppResponse {
+    let appIdJSON = appId.map { "\"\($0)\"" } ?? "null"
+    let json = #"{"app_id": \#(appIdJSON), "content": "\#(content)"}"#
+    return try JSONDecoder().decode(AppResponse.self, from: Data(json.utf8))
+  }
+
+  private func app(id: String, capabilities: [String] = ["memories"]) throws -> OmiApp {
+    let capabilitiesJSON = capabilities.map { "\"\($0)\"" }.joined(separator: ",")
+    let json = #"{"id": "\#(id)", "name": "\#(id)", "capabilities": [\#(capabilitiesJSON)]}"#
+    return try JSONDecoder().decode(OmiApp.self, from: Data(json.utf8))
+  }
+
+  // MARK: - Primary summary
+
+  func testPrimarySummaryPromotesTheFirstAppResult() throws {
+    let result = try appResponse(appId: "general-summary", content: "App-produced summary")
+    let conversation = conversation(appResults: [result])
+
+    let primary = ConversationSummarySelection.primarySummary(for: conversation)
+
+    XCTAssertEqual(primary.content, "App-produced summary")
+    XCTAssertEqual(primary.appId, "general-summary")
+  }
+
+  func testPrimarySummaryFallsBackToStructuredOverviewWithoutAppResults() {
+    let conversation = conversation(appResults: [])
+
+    let primary = ConversationSummarySelection.primarySummary(for: conversation)
+
+    XCTAssertEqual(primary.content, "First-party overview")
+    XCTAssertNil(primary.appId)
+  }
+
+  func testPrimarySummaryFallsBackToStructuredOverviewWhenAppResultIsBlank() throws {
+    let blank = try appResponse(appId: "general-summary", content: "")
+    let conversation = conversation(appResults: [blank])
+
+    let primary = ConversationSummarySelection.primarySummary(for: conversation)
+
+    XCTAssertEqual(primary.content, "First-party overview")
+    XCTAssertNil(primary.appId)
+  }
+
+  func testPrimarySummarySkipsBlankLeadingResultsToTheNextUsableOne() throws {
+    let blank = try appResponse(appId: "app-a", content: "")
+    let usable = try appResponse(appId: "app-b", content: "B content")
+    let conversation = conversation(appResults: [blank, usable])
+
+    let primary = ConversationSummarySelection.primarySummary(for: conversation)
+
+    XCTAssertEqual(primary.content, "B content")
+    XCTAssertEqual(primary.appId, "app-b")
+  }
+
+  // MARK: - Secondary (App Insights) rows
+
+  func testSecondaryResultsExcludeThePromotedPrimary() throws {
+    let first = try appResponse(appId: "app-a", content: "a")
+    let second = try appResponse(appId: "app-b", content: "b")
+    let conversation = conversation(appResults: [first, second])
+
+    let secondary = ConversationSummarySelection.secondaryResults(for: conversation)
+
+    XCTAssertEqual(secondary.map(\.appId), ["app-b"])
+  }
+
+  func testSecondaryResultsKeepEverythingWhenNoResultIsUsable() throws {
+    let blank = try appResponse(appId: "app-a", content: "")
+    let conversation = conversation(appResults: [blank])
+
+    let secondary = ConversationSummarySelection.secondaryResults(for: conversation)
+
+    XCTAssertEqual(secondary.map(\.appId), ["app-a"])
+  }
+
+  // MARK: - Suggested apps ($0-shadow regression)
+
+  func testSuggestedAppsExcludeAppsThatAlreadyProducedResults() throws {
+    let produced = try app(id: "app-a")
+    let fresh = try app(id: "app-b")
+    let chatOnly = try app(id: "app-c", capabilities: ["chat"])
+    let result = try appResponse(appId: "app-a", content: "a")
+
+    let suggested = ConversationSummarySelection.suggestedApps([produced, fresh, chatOnly], results: [result])
+
+    XCTAssertEqual(suggested.map(\.id), ["app-b"])
+  }
+
+  func testSuggestedAppsRegressionInnerShadowComparedAResultToItself() throws {
+    // The replaced inline closure compared `$0.appId == $0.id` on the
+    // appsResults entry — always true — so ANY existing result emptied the
+    // section. Here app-b never produced a result and must still be offered.
+    let fresh = try app(id: "app-b")
+    let unrelatedResult = try appResponse(appId: "app-a", content: "a")
+
+    let suggested = ConversationSummarySelection.suggestedApps([fresh], results: [unrelatedResult])
+
+    XCTAssertEqual(suggested.map(\.id), ["app-b"])
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260817-summary-app-picker.json
+++ b/desktop/macos/changelog/unreleased/20260817-summary-app-picker.json
@@ -1,0 +1,3 @@
+{
+  "change": "Conversation summaries now show the selected summarization app's output (e.g. General Summary) as the main summary, with a picker to switch apps and set your default — falling back to Omi's own summary when no app result is available"
+}

--- a/desktop/macos/e2e/flows/conversation-detail.yaml
+++ b/desktop/macos/e2e/flows/conversation-detail.yaml
@@ -5,6 +5,8 @@ description: Hermetic conversation detail open + full-width transcript pane via 
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationAppSelectorSheet.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationSummarySelection.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsPage.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
   - desktop/macos/Desktop/Sources/MainWindow/ConversationDetailAutomationState.swift


### PR DESCRIPTION
## Summary

Ports the mobile conversation-summary app picker behavior to desktop:

- **Primary summary = the selected summarization app's output.** The summary pane promotes the first usable `apps_results` entry (mobile `getSummarizedApp()` parity — the backend's `_trigger_apps` replaces `apps_results` with exactly the app it ran), and falls back to `structured.overview` when no usable app result exists.
- **Picker.** The summary header names the producing app and opens the existing `AppSelectorSheet`, which now marks the active app, and offers **Set as Default** (right-click) — persisting via the existing `PUT /v1/users/preferences/app?app_id=` plus a local mirror under `DefaultsKey.preferredSummarizationAppId` (the backend exposes no GET; mobile keeps the same key in SharedPreferences).
- **Switch + reprocess.** Picking an app reprocesses the conversation and adopts the response, so the new app's result renders as the primary summary immediately. Not-yet-enabled picks are enabled first (mobile parity; the backend resolves reprocess targets from the enabled slice).
- **Bug fix required by the port:** `reprocessConversation` decoded a synthetic `{success, message}` envelope, but the route returns the full `Conversation` — so every successful reprocess threw a `DecodingError` client-side and the view never refreshed. It now decodes `ServerConversation`.
- **`$0`-shadow regression locked in:** the "Try with Apps" exclusion moved from an inline closure into the new `ConversationSummarySelection` policy with behavioral coverage.
- Action items, transcript drawer, speaker assignment, and share link are untouched.

## Implementation notes

- New pure policy `ConversationSummarySelection` (`primarySummary`, `secondaryResults`, `suggestedApps`) extracted from the view; `AppSelectorSheet`/`AppSelectorRow` moved to their own file, keeping `ConversationDetailView.swift` under its #9838 frozen baseline (1419 → 1349).
- Bodyless `PUT` helper lives in `APIClient+Apps.swift` so the oversized core transport file stays untouched.

## Testing

- `ConversationSummarySelectionTests` (8 tests): primary promotion, structured-overview fallback (empty and blank results), blank-skipping, secondary exclusion, and two suggested-apps cases including the exact `$0`-shadow shape — all green.
- Adjacent suites (`AppResponseIdentityTests`, `ConversationDetailAutomationStateTests`) green.
- `xcrun swift build -c debug` green; pinned swift-format lint clean on changed files (net −1 pre-existing violation in `APIClient+Apps.swift`); full SwiftLint scope 0 violations; `check_desktop_test_quality.py` OK; e2e flow coverage for all changed Swift files via `conversation-detail.yaml` (et al.).
- Named-bundle QA path exercised: `omi-summary-picker` built, ad-hoc signed, installed, launched; automation bridge healthy, Conversations tab reachable, no signing/dyld failures. Signed-in end-to-end summary switching was not exercisable on this machine (no Omi Dev auth seed and no Apple signing identity available); the selection behavior is covered by the hermetic unit suite instead.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

