### PR TITLE
Windows search: find anything across conversations, memories, tasks and screen

### DIFF
--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -29,6 +29,7 @@ import { registerCaptureBridge } from './ipc/captureBridge'
 import { registerSoak } from './soak'
 import { createCaptureWindow, getCaptureWindow, getCaptureWc } from './captureWindow'
 import { registerFileIndexHandlers } from './ipc/fileIndex'
+import { registerSearchHandlers } from './ipc/search'
 import { cancelStartupRescan } from './fileIndex/indexer'
 import { registerMemoryImportHandlers } from './ipc/memoryImport'
 import { registerMemoryExportHandlers } from './ipc/memoryExport'
@@ -855,6 +856,7 @@ app.whenReady().then(async () => {
   // byte counters to userData/soak.jsonl for the 8h idle-soak verification.
   registerSoak()
   registerFileIndexHandlers()
+  registerSearchHandlers()
   registerLocalGraphHandlers()
   registerMemoryImportHandlers()
   registerMemoryExportHandlers()

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -8,6 +8,12 @@ import { addColumnIfMissing as ensureColumn, runMigrations } from './dbMigration
 import { applyRewindEmbeddingSchema } from './rewindEmbeddingSchema'
 import { LOCAL_CONVERSATION_SCHEMA } from './localConversationSchema'
 import {
+  MEMORY_SEARCH_SCHEMA,
+  searchMemoriesFts,
+  type MemorySearchDb,
+  type MemorySearchRow
+} from '../search/memorySearchStore'
+import {
   clearCorruptionFlags,
   isCorruptionError,
   isCorruptionSuspected,
@@ -656,6 +662,12 @@ function get(): Database.Database {
     );
     CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
   `)
+  // Full-text index over the memories just created. DDL lives in
+  // search/memorySearchStore.ts so prod and the node:sqlite tests run the same
+  // SQL; the index is external-content + trigger-maintained, so it is
+  // deliberately absent from USER_DATA_TABLES (see dbWipe.ts) and is backfilled
+  // for existing installs by migration v3.
+  db.exec(MEMORY_SEARCH_SCHEMA)
   // Track 3 local task storage (action_items + staged_tasks + their FTS indexes).
   // DDL lives in taskStore.ts so prod and the node:sqlite CRUD tests run the same
   // SQL; both tables are user-scoped (see USER_DATA_TABLES in dbWipe.ts).
@@ -702,7 +714,12 @@ function get(): Database.Database {
     // Rebuild every external-content FTS index from its recovered base rows (salvage
     // skips virtual tables, leaving the shadow tables empty). Same 'rebuild' idiom as
     // migration v2. Each is independent — one failing must not skip the others.
-    for (const fts of ['rewind_frames_fts', 'action_items_fts', 'staged_tasks_fts']) {
+    for (const fts of [
+      'rewind_frames_fts',
+      'action_items_fts',
+      'staged_tasks_fts',
+      'memories_fts'
+    ]) {
       try {
         db.exec(`INSERT INTO ${fts}(${fts}) VALUES('rebuild')`)
       } catch (e) {
@@ -1475,6 +1492,15 @@ export function listRewindFramesSampled(
     const step = rewindSampleStep(n, target)
     return d.prepare(buildRewindSampledSql(REWIND_COLUMNS)).all(from, to, step) as RewindFrame[]
   })
+}
+
+/** BM25-ranked memories for an already-built FTS5 MATCH expression. Thin
+ *  get()-bound wrapper over search/memorySearchStore.ts, which owns the SQL so
+ *  production and the node:sqlite tests run the same statement. */
+export function searchMemories(match: string, limit = 50): MemorySearchRow[] {
+  return timed('searchMemories', () =>
+    searchMemoriesFts(get() as unknown as MemorySearchDb, match, limit)
+  )
 }
 
 // --- Track 4: Rewind FTS5 search ---

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -7,12 +7,9 @@ import { buildRewindFtsMatch } from '../rewind/rewindSearchQuery'
 import { addColumnIfMissing as ensureColumn, runMigrations } from './dbMigrations'
 import { applyRewindEmbeddingSchema } from './rewindEmbeddingSchema'
 import { LOCAL_CONVERSATION_SCHEMA } from './localConversationSchema'
-import {
-  MEMORY_SEARCH_SCHEMA,
-  searchMemoriesFts,
-  type MemorySearchDb,
-  type MemorySearchRow
-} from '../search/memorySearchStore'
+import { MEMORY_SEARCH_SCHEMA } from '../search/memorySearchStore'
+import { searchAllCorpora, type SearchDb } from '../search/desktopSearch'
+import type { DesktopSearchResult } from '../../shared/types'
 import {
   clearCorruptionFlags,
   isCorruptionError,
@@ -1494,12 +1491,12 @@ export function listRewindFramesSampled(
   })
 }
 
-/** BM25-ranked memories for an already-built FTS5 MATCH expression. Thin
- *  get()-bound wrapper over search/memorySearchStore.ts, which owns the SQL so
- *  production and the node:sqlite tests run the same statement. */
-export function searchMemories(match: string, limit = 50): MemorySearchRow[] {
-  return timed('searchMemories', () =>
-    searchMemoriesFts(get() as unknown as MemorySearchDb, match, limit)
+/** One search over every local corpus. Thin get()-bound wrapper over
+ *  search/desktopSearch.ts, which owns the SQL so production and the node:sqlite
+ *  tests run the same statements. */
+export function searchDesktopCorpora(query: string, limit?: number): DesktopSearchResult {
+  return timed('searchDesktopCorpora', () =>
+    searchAllCorpora(get() as unknown as SearchDb, query, limit)
   )
 }
 

--- a/desktop/windows/src/main/ipc/dbMigrations.test.ts
+++ b/desktop/windows/src/main/ipc/dbMigrations.test.ts
@@ -9,7 +9,14 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { MIGRATIONS, getUserVersion, runMigrations, type Migration, type MigrationDb } from './dbMigrations'
+import {
+  MIGRATIONS,
+  getUserVersion,
+  runMigrations,
+  type Migration,
+  type MigrationDb
+} from './dbMigrations'
+import { MEMORY_SEARCH_SCHEMA } from '../search/memorySearchStore'
 
 // The local_conversation schema as it shipped BEFORE the sync outbox (verbatim
 // from db.ts as of feat/windows-capture — kind/messages/title already present).
@@ -29,7 +36,10 @@ const OLD_SCHEMA = `
 const tempFiles: string[] = []
 
 function makeOldDbFile(): { file: string; db: DatabaseSync } {
-  const file = path.join(os.tmpdir(), `omi-mig-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`)
+  const file = path.join(
+    os.tmpdir(),
+    `omi-mig-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  )
   tempFiles.push(file)
   const db = new DatabaseSync(file)
   db.exec(OLD_SCHEMA)
@@ -68,7 +78,9 @@ describe('runMigrations', () => {
     }
     // Pre-existing data survives and gets the defaults.
     const row = db
-      .prepare('SELECT id, transcript, title, sync_state, sync_attempts, cloud_id FROM local_conversation')
+      .prepare(
+        'SELECT id, transcript, title, sync_state, sync_attempts, cloud_id FROM local_conversation'
+      )
       .get() as Record<string, unknown>
     expect(row.id).toBe('conv-1')
     expect(row.transcript).toBe('You: hello')
@@ -102,6 +114,53 @@ describe('runMigrations', () => {
     expect(() => runMigrations(d, bad)).toThrow(/migration 1 .*boom/)
     expect(getUserVersion(d)).toBe(0)
     expect(columns(db, 'local_conversation')).not.toContain('doomed')
+  })
+
+  it('v3 backfills the memories index so an existing install can find its own memories', () => {
+    const { file, db } = makeOldDbFile()
+    // An install that predates the index: memories exist, the index does not.
+    db.exec(`CREATE TABLE memories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      content TEXT NOT NULL,
+      category TEXT NOT NULL,
+      source_app TEXT NOT NULL DEFAULT '',
+      window_title TEXT NOT NULL DEFAULT '',
+      context_summary TEXT NOT NULL DEFAULT '',
+      confidence REAL,
+      screenshot_id INTEGER,
+      backend_id TEXT,
+      backend_synced INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    );`)
+    db.prepare('INSERT INTO memories (content, category, created_at) VALUES (?, ?, ?)').run(
+      'Signed the lease in March',
+      'personal',
+      1000
+    )
+    // db.ts's bootstrap block creates the index before runMigrations, so the
+    // triggers exist but never fired for the row above.
+    db.exec(MEMORY_SEARCH_SCHEMA)
+    expect(
+      db.prepare("SELECT COUNT(*) AS n FROM memories_fts WHERE memories_fts MATCH 'lease*'").get()
+    ).toEqual({ n: 0 })
+
+    runMigrations(db as unknown as MigrationDb)
+
+    expect(
+      db.prepare("SELECT COUNT(*) AS n FROM memories_fts WHERE memories_fts MATCH 'lease*'").get()
+    ).toEqual({ n: 1 })
+    expect(getUserVersion(db as unknown as MigrationDb)).toBe(MIGRATIONS.length)
+    db.close()
+    expect(file).toBeTruthy()
+  })
+
+  it('v3 skips cleanly when the memories index is not there', () => {
+    // A migration-only harness seeds local_conversation alone; the guard must not
+    // turn that into a hard failure that blocks every later migration.
+    const { db } = makeOldDbFile()
+    expect(() => runMigrations(db as unknown as MigrationDb)).not.toThrow()
+    expect(getUserVersion(db as unknown as MigrationDb)).toBe(MIGRATIONS.length)
+    db.close()
   })
 
   it('rejects a non-contiguous migration list (append-only discipline)', () => {

--- a/desktop/windows/src/main/ipc/dbMigrations.ts
+++ b/desktop/windows/src/main/ipc/dbMigrations.ts
@@ -89,6 +89,23 @@ export const MIGRATIONS: Migration[] = [
       if (!hasFts) return
       d.exec("INSERT INTO rewind_frames_fts(rewind_frames_fts) VALUES('rebuild')")
     }
+  },
+  {
+    version: 3,
+    name: 'memories_fts_backfill',
+    up: (d) => {
+      // Same one-time backfill as v2, for the memories index added alongside it.
+      // memories_fts + its triggers are created in db.ts's bootstrap block, which
+      // runs BEFORE runMigrations, so the table exists here in production; the
+      // triggers only fire on new writes, so without this an existing install
+      // would search an empty index and quietly find none of its own memories.
+      // Guard on existence: a migration-only harness seeds only local_conversation.
+      const hasFts = d
+        .prepare("SELECT 1 AS x FROM sqlite_master WHERE type='table' AND name='memories_fts'")
+        .get() as { x: number } | undefined
+      if (!hasFts) return
+      d.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')")
+    }
   }
 ]
 

--- a/desktop/windows/src/main/ipc/search.test.ts
+++ b/desktop/windows/src/main/ipc/search.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const searchDesktopCorpora = vi.fn()
+
+vi.mock('electron', () => ({ ipcMain: { handle: vi.fn() } }))
+vi.mock('./db', () => ({ searchDesktopCorpora }))
+
+const { MAX_QUERY_CHARS, searchLocalCorpora } = await import('./search')
+const { PER_CORPUS_LIMIT } = await import('../search/desktopSearch')
+
+const RESULT = {
+  memories: { hits: [], total: 3 },
+  tasks: { hits: [], total: 0 },
+  screen: { hits: [], total: 0 }
+}
+const EMPTY = {
+  memories: { hits: [], total: 0 },
+  tasks: { hits: [], total: 0 },
+  screen: { hits: [], total: 0 }
+}
+
+beforeEach(() => {
+  searchDesktopCorpora.mockReset()
+  searchDesktopCorpora.mockReturnValue(RESULT)
+})
+
+describe('searchLocalCorpora', () => {
+  it('passes the query through and returns what the corpora gave', () => {
+    expect(searchLocalCorpora('lease')).toBe(RESULT)
+    expect(searchDesktopCorpora).toHaveBeenCalledWith('lease', PER_CORPUS_LIMIT)
+  })
+
+  it('ignores a non-string query instead of handing it to SQLite', () => {
+    for (const bad of [undefined, null, 42, {}, ['lease']]) {
+      expect(searchLocalCorpora(bad)).toEqual(EMPTY)
+    }
+    expect(searchDesktopCorpora).not.toHaveBeenCalled()
+  })
+
+  it('truncates a pasted-in query rather than refusing it', () => {
+    searchLocalCorpora('x'.repeat(MAX_QUERY_CHARS + 500))
+    // Refusing would make the box look broken; an unbounded string becomes an
+    // unbounded FTS expression running on every keystroke.
+    expect(searchDesktopCorpora.mock.calls[0][0].length).toBe(MAX_QUERY_CHARS)
+  })
+
+  it('clamps the limit to the per-corpus cap in both directions', () => {
+    searchLocalCorpora('lease', 5)
+    expect(searchDesktopCorpora.mock.calls[0][1]).toBe(5)
+
+    searchLocalCorpora('lease', 9999)
+    expect(searchDesktopCorpora.mock.calls[1][1]).toBe(PER_CORPUS_LIMIT)
+
+    searchLocalCorpora('lease', 0)
+    expect(searchDesktopCorpora.mock.calls[2][1]).toBe(1)
+
+    searchLocalCorpora('lease', Number.NaN)
+    expect(searchDesktopCorpora.mock.calls[3][1]).toBe(PER_CORPUS_LIMIT)
+  })
+
+  it('degrades to no local results instead of throwing at the renderer', () => {
+    searchDesktopCorpora.mockImplementation(() => {
+      throw new Error('database is locked')
+    })
+    // A search box must never take the window down, and the server-side
+    // conversation search the renderer runs alongside this still works.
+    expect(searchLocalCorpora('lease')).toEqual(EMPTY)
+  })
+})

--- a/desktop/windows/src/main/ipc/search.ts
+++ b/desktop/windows/src/main/ipc/search.ts
@@ -1,0 +1,47 @@
+// Renderer-facing surface for local search.
+//
+// Reads only, so it is not gated to the main window: every UI window is allowed
+// to search the corpora the signed-in user already sees, and there is nothing
+// here to mutate. The write-side surfaces (starring, completing a task) keep
+// their own existing channels and guards.
+
+import { ipcMain } from 'electron'
+import { searchDesktopCorpora } from './db'
+import { PER_CORPUS_LIMIT } from '../search/desktopSearch'
+import type { DesktopSearchResult } from '../../shared/types'
+
+const EMPTY: DesktopSearchResult = {
+  memories: { hits: [], total: 0 },
+  tasks: { hits: [], total: 0 },
+  screen: { hits: [], total: 0 }
+}
+
+/** Longest query text accepted. A search box can be pasted into; an unbounded
+ *  string becomes an unbounded FTS expression and a slow query on every
+ *  keystroke. Long queries are truncated rather than refused, because refusing
+ *  would make the box look broken. */
+export const MAX_QUERY_CHARS = 200
+
+export function searchLocalCorpora(query: unknown, limit?: unknown): DesktopSearchResult {
+  if (typeof query !== 'string') return EMPTY
+  const text = query.slice(0, MAX_QUERY_CHARS)
+  const bounded =
+    typeof limit === 'number' && Number.isFinite(limit)
+      ? Math.max(1, Math.min(Math.floor(limit), PER_CORPUS_LIMIT))
+      : PER_CORPUS_LIMIT
+  try {
+    return searchDesktopCorpora(text, bounded)
+  } catch (e) {
+    // A search box must never take the window down. An unusable index (mid
+    // recovery, mid migration) degrades to "no local results" while the
+    // server-side conversation search the renderer runs in parallel still works.
+    console.error('[search] local search failed', e)
+    return EMPTY
+  }
+}
+
+export function registerSearchHandlers(): void {
+  ipcMain.handle('omi-search:local', (_e, query: unknown, limit?: unknown) =>
+    searchLocalCorpora(query, limit)
+  )
+}

--- a/desktop/windows/src/main/search/desktopSearch.test.ts
+++ b/desktop/windows/src/main/search/desktopSearch.test.ts
@@ -1,0 +1,239 @@
+// Unified local search, proven against a REAL SQLite database via node:sqlite
+// (better-sqlite3 here is built for Electron's ABI and won't load under
+// plain-node vitest).
+//
+// The memories and task schemas are IMPORTED from the modules that own them, so
+// a column rename there fails this suite rather than shipping a search that
+// silently returns nothing. The rewind_frames block is copied from db.ts, whose
+// DDL is inline in its bootstrap exec and has no exported form.
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it } from 'vitest'
+import { MEMORY_SEARCH_SCHEMA } from './memorySearchStore'
+import { TASK_TABLES_SCHEMA } from '../ipc/taskStore'
+import { PER_CORPUS_LIMIT, searchAllCorpora, type SearchDb } from './desktopSearch'
+
+/** Copied from db.ts's bootstrap block (rewind_frames + its FTS mirror). */
+const REWIND_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS rewind_frames (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    app TEXT NOT NULL DEFAULT '',
+    window_title TEXT NOT NULL DEFAULT '',
+    ocr_text TEXT NOT NULL DEFAULT '',
+    width INTEGER NOT NULL DEFAULT 0,
+    height INTEGER NOT NULL DEFAULT 0,
+    indexed INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE VIRTUAL TABLE IF NOT EXISTS rewind_frames_fts USING fts5(
+    ocr_text, window_title, app,
+    content='rewind_frames', content_rowid='id', tokenize='unicode61'
+  );
+  CREATE TRIGGER IF NOT EXISTS rewind_frames_ai AFTER INSERT ON rewind_frames BEGIN
+    INSERT INTO rewind_frames_fts(rowid, ocr_text, window_title, app)
+    VALUES (new.id, new.ocr_text, new.window_title, new.app);
+  END;
+`
+
+const MEMORIES_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS memories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    category TEXT NOT NULL,
+    source_app TEXT NOT NULL DEFAULT '',
+    window_title TEXT NOT NULL DEFAULT '',
+    context_summary TEXT NOT NULL DEFAULT '',
+    confidence REAL,
+    screenshot_id INTEGER,
+    backend_id TEXT,
+    backend_synced INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+  );
+`
+
+const EPOCH = 1_723_800_000_000
+
+const open = (): SearchDb & { exec: (s: string) => void } => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(MEMORIES_SCHEMA)
+  db.exec(MEMORY_SEARCH_SCHEMA)
+  db.exec(TASK_TABLES_SCHEMA)
+  db.exec(REWIND_SCHEMA)
+  return db as unknown as SearchDb & { exec: (s: string) => void }
+}
+
+const addMemory = (db: SearchDb, content: string, at = EPOCH, summary = ''): void => {
+  db.prepare(
+    `INSERT INTO memories (content, category, context_summary, created_at) VALUES (?, 'personal', ?, ?)`
+  ).all(content, summary, at)
+}
+
+const addAction = (
+  db: SearchDb,
+  description: string,
+  over: { completed?: boolean; deleted?: boolean; at?: number } = {}
+): void => {
+  db.prepare(
+    `INSERT INTO action_items (description, completed, deleted, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`
+  ).all(
+    description,
+    over.completed ? 1 : 0,
+    over.deleted ? 1 : 0,
+    over.at ?? EPOCH,
+    over.at ?? EPOCH
+  )
+}
+
+const addStaged = (db: SearchDb, description: string, at = EPOCH): void => {
+  db.prepare(`INSERT INTO staged_tasks (description, created_at, updated_at) VALUES (?, ?, ?)`).all(
+    description,
+    at,
+    at
+  )
+}
+
+const addFrame = (
+  db: SearchDb,
+  over: { ocr?: string; title?: string; app?: string; at?: number } = {}
+): void => {
+  db.prepare(
+    `INSERT INTO rewind_frames (ts, path, app, window_title, ocr_text) VALUES (?, ?, ?, ?, ?)`
+  ).all(over.at ?? EPOCH, 'C:/frames/f.jpg', over.app ?? 'Chrome', over.title ?? '', over.ocr ?? '')
+}
+
+describe('searchAllCorpora', () => {
+  it('finds the same word across memories, tasks and screen text in one call', () => {
+    const db = open()
+    addMemory(db, 'Prefers the lease renewed annually')
+    addAction(db, 'Send the lease to legal')
+    addStaged(db, 'Review lease clause 7')
+    addFrame(db, { ocr: 'lease agreement draft', title: 'Docs' })
+
+    const out = searchAllCorpora(db, 'lease')
+    expect(out.memories.hits.map((h) => h.title)).toEqual(['Prefers the lease renewed annually'])
+    expect(out.tasks.hits.map((h) => h.title).sort()).toEqual([
+      'Review lease clause 7',
+      'Send the lease to legal'
+    ])
+    expect(out.screen.hits.length).toBe(1)
+  })
+
+  it('narrows as more words are typed rather than widening', () => {
+    const db = open()
+    addMemory(db, 'budget review with finance')
+    addMemory(db, 'budget approved')
+
+    // Tokens are AND-joined: the second word must also match.
+    expect(searchAllCorpora(db, 'budget').memories.hits.length).toBe(2)
+    expect(searchAllCorpora(db, 'budget finance').memories.hits.length).toBe(1)
+  })
+
+  it('matches a prefix so results appear while the word is still being typed', () => {
+    const db = open()
+    addMemory(db, 'Renewed the insurance policy')
+    expect(searchAllCorpora(db, 'insur').memories.hits.length).toBe(1)
+  })
+
+  it('treats punctuation as literal text instead of query syntax', () => {
+    const db = open()
+    addMemory(db, 'Ship v2 of the API')
+    // A bare `"` or `*` reaching FTS5 is a syntax error thrown out of SQLite,
+    // which would surface as a crash on a keystroke.
+    expect(() => searchAllCorpora(db, 'api "')).not.toThrow()
+    expect(() => searchAllCorpora(db, '***')).not.toThrow()
+    expect(() => searchAllCorpora(db, 'api AND OR NOT')).not.toThrow()
+  })
+
+  it('returns empty slices for a query with nothing searchable in it', () => {
+    const db = open()
+    addMemory(db, 'anything')
+    const out = searchAllCorpora(db, '   ')
+    expect(out).toEqual({
+      memories: { hits: [], total: 0 },
+      tasks: { hits: [], total: 0 },
+      screen: { hits: [], total: 0 }
+    })
+  })
+
+  it('reports the true total so the UI never implies it showed everything', () => {
+    const db = open()
+    for (let i = 0; i < 30; i += 1) addMemory(db, `standup note ${i}`, EPOCH + i)
+
+    const out = searchAllCorpora(db, 'standup')
+    expect(out.memories.hits.length).toBe(PER_CORPUS_LIMIT)
+    // 30 matched; 20 are shown. A slice that reported 20 would read as "that is
+    // everything you have".
+    expect(out.memories.total).toBe(30)
+  })
+
+  it('searches both accepted and suggested tasks, and counts both', () => {
+    const db = open()
+    addAction(db, 'invoice Acme')
+    addStaged(db, 'invoice Globex')
+
+    const out = searchAllCorpora(db, 'invoice')
+    expect(out.tasks.total).toBe(2)
+    expect(out.tasks.hits.map((h) => h.id.split(':')[0]).sort()).toEqual(['action', 'staged'])
+    expect(out.tasks.hits.find((h) => h.id.startsWith('staged'))?.detail).toBe('Suggested')
+  })
+
+  it('keeps completed tasks findable but drops deleted ones', () => {
+    const db = open()
+    addAction(db, 'renew the domain', { completed: true })
+    addAction(db, 'renew the certificate', { deleted: true })
+
+    const out = searchAllCorpora(db, 'renew')
+    // "What did I decide about X" is usually a question about finished work.
+    expect(out.tasks.hits.map((h) => h.title)).toEqual(['renew the domain'])
+    expect(out.tasks.hits[0].detail).toBe('Done')
+    expect(out.tasks.total).toBe(1)
+  })
+
+  it('orders merged task results by recency, not by two incomparable scores', () => {
+    const db = open()
+    addAction(db, 'ship the report', { at: EPOCH })
+    addStaged(db, 'ship the deck', EPOCH + 5_000)
+    addAction(db, 'ship the notes', { at: EPOCH + 10_000 })
+
+    expect(searchAllCorpora(db, 'ship').tasks.hits.map((h) => h.title)).toEqual([
+      'ship the notes',
+      'ship the deck',
+      'ship the report'
+    ])
+  })
+
+  it('labels a screen hit by its window title and falls back to the app', () => {
+    const db = open()
+    addFrame(db, { ocr: 'quarterly figures', title: 'Q3 Plan - Google Docs', app: 'Chrome' })
+    addFrame(db, { ocr: 'quarterly figures', title: '', app: 'Excel', at: EPOCH - 1 })
+
+    const hits = searchAllCorpora(db, 'quarterly').screen.hits
+    expect(hits.map((h) => h.title).sort()).toEqual(['Excel', 'Q3 Plan - Google Docs'])
+  })
+
+  it('finds a memory by its context summary as well as its content', () => {
+    const db = open()
+    addMemory(db, 'Ships on Fridays', EPOCH, 'agreed during the release sync')
+    expect(searchAllCorpora(db, 'release').memories.hits.length).toBe(1)
+  })
+
+  it('never matches a memory on its raw window title', () => {
+    const db = open()
+    db.prepare(
+      `INSERT INTO memories (content, category, window_title, created_at)
+       VALUES (?, 'personal', ?, ?)`
+    ).all('Prefers async standups', 'MyChart - Lab Results', EPOCH)
+    expect(searchAllCorpora(db, 'mychart').memories.hits).toEqual([])
+  })
+
+  it('splits a camelCase query word so it still matches the spaced-out text', () => {
+    const db = open()
+    addMemory(db, 'Owns the data pipeline rewrite')
+    // The expansion is on the QUERY side: "DataPipeline" becomes
+    // ("DataPipeline"* OR "Data"* OR "Pipeline"*), so a name copied out of code
+    // still finds the prose that describes it. The FTS tokenizer does not split
+    // the indexed text, so the reverse does not hold.
+    expect(searchAllCorpora(db, 'DataPipeline').memories.hits.length).toBe(1)
+  })
+})

--- a/desktop/windows/src/main/search/desktopSearch.ts
+++ b/desktop/windows/src/main/search/desktopSearch.ts
@@ -1,0 +1,193 @@
+// One search over everything this machine holds: memories, tasks, and captured
+// screen text.
+//
+// Windows had no way to search any of it. Rewind had a frame-only search box and
+// Settings had a settings-only one; a memory or a task could be found by
+// scrolling and no other way. This module is the query half of that gap
+// (conversations are searched server-side by the renderer, which is the only
+// place the full history exists — see searchAllCorpora's doc comment).
+//
+// Two rules the shape of this file exists to enforce:
+//
+// 1. ONE matcher for the whole surface. `buildRewindFtsMatch` is already the
+//    app's tuned user-facing FTS5 matcher (quoted phrase terms so punctuation can
+//    never become query syntax, trailing `*` for prefix search, camelCase and
+//    digit sub-parts expanded, tokens AND-joined so typing more narrows). Reusing
+//    it means one query behaves the same way against every corpus, instead of the
+//    three differently-tuned matchers the codebase already has for other jobs
+//    (taskStore's sanitizeFtsQuery is exact-AND for agent tool calls;
+//    toolBackends' buildFtsQuery is prefix-OR for dedup recall). It lives under
+//    rewind/ for historical reasons; it is not rewind-specific.
+//
+// 2. NEVER interleave BM25 scores across corpora. A score from memories_fts and
+//    one from rewind_frames_fts are computed over different document
+//    populations, so comparing them is meaningless and would silently order
+//    results by which index happens to have shorter documents. Results are
+//    grouped per corpus and ranked inside it, and the caller decides presentation
+//    order.
+
+import { buildRewindFtsMatch } from '../rewind/rewindSearchQuery'
+import { countMemoriesFts, searchMemoriesFts, type MemorySearchDb } from './memorySearchStore'
+// The result shape crosses the IPC boundary, so shared/types.ts is its one
+// definition and both sides import it from there.
+import type { CorpusHit, CorpusSlice, DesktopSearchResult } from '../../shared/types'
+
+/** Minimal DB surface — satisfied structurally by better-sqlite3 (production)
+ *  and node:sqlite's DatabaseSync (tests). Positional `?` params only. */
+export interface SearchDb {
+  prepare(sql: string): {
+    all: (...params: unknown[]) => unknown[]
+    get: (...params: unknown[]) => unknown
+  }
+}
+
+/** Hits returned per corpus. Deliberately small: the surface shows a few strong
+ *  results per corpus and reports the true total next to them. */
+export const PER_CORPUS_LIMIT = 20
+
+const EMPTY: DesktopSearchResult = {
+  memories: { hits: [], total: 0 },
+  tasks: { hits: [], total: 0 },
+  screen: { hits: [], total: 0 }
+}
+
+/**
+ * Searches every local corpus for `query`.
+ *
+ * Returns empty slices (never throws) when the query has no indexable content,
+ * so a search box can call this on every keystroke without guarding.
+ *
+ * Conversations are absent on purpose. Only the last 200 are cached locally, so
+ * a local conversation search would quietly cover a fraction of someone's
+ * history and present it as a search of all of it. The renderer searches them
+ * through `POST /v1/conversations/search`, which covers the full history.
+ */
+export function searchAllCorpora(
+  db: SearchDb,
+  query: string,
+  limit = PER_CORPUS_LIMIT
+): DesktopSearchResult {
+  const match = buildRewindFtsMatch(query)
+  if (match === null) return EMPTY
+  return {
+    memories: searchMemorySlice(db, match, limit),
+    tasks: searchTaskSlice(db, match, limit),
+    screen: searchScreenSlice(db, match, limit)
+  }
+}
+
+function countMatches(db: SearchDb, sql: string, match: string): number {
+  const row = db.prepare(sql).get(match) as { n: number } | undefined
+  return row?.n ?? 0
+}
+
+function searchMemorySlice(db: SearchDb, match: string, limit: number): CorpusSlice {
+  // The memories SQL lives in memorySearchStore.ts next to the schema it reads,
+  // so the index definition and its query can never drift apart.
+  const store = db as unknown as MemorySearchDb
+  return {
+    hits: searchMemoriesFts(store, match, limit).map((r) => ({
+      kind: 'memory' as const,
+      id: String(r.id),
+      title: r.content,
+      detail: r.contextSummary ?? '',
+      timestamp: r.createdAt
+    })),
+    total: countMemoriesFts(store, match)
+  }
+}
+
+/**
+ * Tasks span two tables: `action_items` (accepted) and `staged_tasks` (proposed
+ * but not yet accepted). Both are things the user would call a task, so both are
+ * searched and the results are merged.
+ *
+ * The merge orders by recency rather than by score: the two tables are separate
+ * FTS indexes, so interleaving their BM25 scores would be the cross-corpus
+ * comparison this module refuses to make everywhere else.
+ *
+ * Deleted rows are excluded from both, and completed action items are kept:
+ * "what did I decide about the lease" is usually a question about finished work.
+ */
+function searchTaskSlice(db: SearchDb, match: string, limit: number): CorpusSlice {
+  const actions = db
+    .prepare(
+      `SELECT a.id AS id, a.description AS description, a.completed AS completed,
+              a.created_at AS ts
+         FROM action_items a JOIN action_items_fts ON a.id = action_items_fts.rowid
+        WHERE action_items_fts MATCH ? AND a.deleted = 0
+        ORDER BY bm25(action_items_fts) ASC
+        LIMIT ?`
+    )
+    .all(match, limit) as { id: number; description: string; completed: number; ts: number }[]
+  const staged = db
+    .prepare(
+      `SELECT s.id AS id, s.description AS description, s.created_at AS ts
+         FROM staged_tasks s JOIN staged_tasks_fts ON s.id = staged_tasks_fts.rowid
+        WHERE staged_tasks_fts MATCH ? AND s.completed = 0 AND s.deleted = 0
+        ORDER BY bm25(staged_tasks_fts) ASC
+        LIMIT ?`
+    )
+    .all(match, limit) as { id: number; description: string; ts: number }[]
+
+  const hits: CorpusHit[] = [
+    ...actions.map((r) => ({
+      kind: 'task' as const,
+      id: `action:${r.id}`,
+      title: r.description,
+      detail: r.completed ? 'Done' : '',
+      timestamp: r.ts
+    })),
+    ...staged.map((r) => ({
+      kind: 'task' as const,
+      id: `staged:${r.id}`,
+      title: r.description,
+      detail: 'Suggested',
+      timestamp: r.ts
+    }))
+  ]
+  hits.sort((a, b) => b.timestamp - a.timestamp)
+
+  const total =
+    countMatches(
+      db,
+      `SELECT COUNT(*) AS n FROM action_items a JOIN action_items_fts ON a.id = action_items_fts.rowid
+        WHERE action_items_fts MATCH ? AND a.deleted = 0`,
+      match
+    ) +
+    countMatches(
+      db,
+      `SELECT COUNT(*) AS n FROM staged_tasks s JOIN staged_tasks_fts ON s.id = staged_tasks_fts.rowid
+        WHERE staged_tasks_fts MATCH ? AND s.completed = 0 AND s.deleted = 0`,
+      match
+    )
+  return { hits: hits.slice(0, limit), total }
+}
+
+function searchScreenSlice(db: SearchDb, match: string, limit: number): CorpusSlice {
+  const rows = db
+    .prepare(
+      `SELECT f.id AS id, f.window_title AS windowTitle, f.app AS app, f.ts AS ts
+         FROM rewind_frames f JOIN rewind_frames_fts ON f.id = rewind_frames_fts.rowid
+        WHERE rewind_frames_fts MATCH ?
+        ORDER BY bm25(rewind_frames_fts) ASC, f.ts DESC
+        LIMIT ?`
+    )
+    .all(match, limit) as { id: number; windowTitle: string; app: string; ts: number }[]
+  return {
+    hits: rows.map((r) => ({
+      kind: 'screen' as const,
+      id: String(r.id),
+      // The window title is what a person recognizes a moment by; the app name
+      // alone ("Chrome") identifies nothing.
+      title: r.windowTitle || r.app || 'Screen',
+      detail: r.windowTitle ? r.app : '',
+      timestamp: r.ts
+    })),
+    total: countMatches(
+      db,
+      `SELECT COUNT(*) AS n FROM rewind_frames_fts WHERE rewind_frames_fts MATCH ?`,
+      match
+    )
+  }
+}

--- a/desktop/windows/src/main/search/memorySearchStore.test.ts
+++ b/desktop/windows/src/main/search/memorySearchStore.test.ts
@@ -7,7 +7,12 @@
 // 3 block; the last test pins what actually happens when the two drift.
 import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, it } from 'vitest'
-import { MEMORY_SEARCH_SCHEMA, searchMemoriesFts, type MemorySearchDb } from './memorySearchStore'
+import {
+  MEMORY_SEARCH_SCHEMA,
+  countMemoriesFts,
+  searchMemoriesFts,
+  type MemorySearchDb
+} from './memorySearchStore'
 
 /** Verbatim from db.ts's `CREATE TABLE IF NOT EXISTS memories` block. */
 const MEMORIES_SCHEMA = `
@@ -111,11 +116,18 @@ describe('memories full-text index', () => {
     const db = open()
     const id = insert(db, { content: 'Allergic to penicillin' })
     expect(searchMemoriesFts(db, 'penicillin*').length).toBe(1)
+    expect(countMemoriesFts(db, 'penicillin*')).toBe(1)
 
     db.prepare('DELETE FROM memories WHERE id = ?').run(id)
-    // The delete trigger is what makes memories_fts safe to leave out of
-    // USER_DATA_TABLES: an account switch deletes the rows and the index follows.
     expect(searchMemoriesFts(db, 'penicillin*')).toEqual([])
+    // The COUNT is the assertion that actually exercises the delete trigger.
+    // searchMemoriesFts JOINs `memories`, so a deleted row is filtered out by
+    // the join whether or not the index was updated - the hit list alone cannot
+    // tell a working trigger from a broken one. The count reads memories_fts
+    // directly, so a stale index shows up here as a total that overstates what
+    // the user actually has. This is also what makes memories_fts safe to leave
+    // out of USER_DATA_TABLES: the account-switch DELETE empties it too.
+    expect(countMemoriesFts(db, 'penicillin*')).toBe(0)
   })
 
   it('follows an edit rather than keeping the old text findable', () => {

--- a/desktop/windows/src/main/search/memorySearchStore.test.ts
+++ b/desktop/windows/src/main/search/memorySearchStore.test.ts
@@ -1,0 +1,179 @@
+// Proven against a REAL SQLite database via node:sqlite — better-sqlite3 in this
+// repo is built for Electron's ABI and won't load under plain-node vitest (same
+// reason dbMigrations.test.ts / dbWipe.test.ts use node:sqlite).
+//
+// MEMORY_SEARCH_SCHEMA is IMPORTED, not re-declared, so this exercises the exact
+// DDL production runs. The base `memories` table below is a copy of db.ts's Track
+// 3 block; `keeps the base-table contract` guards the columns the triggers depend
+// on so a rename in db.ts cannot silently stop the index updating.
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it } from 'vitest'
+import { MEMORY_SEARCH_SCHEMA, searchMemoriesFts, type MemorySearchDb } from './memorySearchStore'
+
+/** Verbatim from db.ts's `CREATE TABLE IF NOT EXISTS memories` block. */
+const MEMORIES_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS memories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL,
+    category TEXT NOT NULL,
+    source_app TEXT NOT NULL DEFAULT '',
+    window_title TEXT NOT NULL DEFAULT '',
+    context_summary TEXT NOT NULL DEFAULT '',
+    confidence REAL,
+    screenshot_id INTEGER,
+    backend_id TEXT,
+    backend_synced INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at);
+`
+
+const EPOCH = 1_723_800_000_000
+
+interface Seed {
+  content: string
+  category?: string
+  sourceApp?: string
+  windowTitle?: string
+  contextSummary?: string
+  createdAt?: number
+}
+
+const open = (): MemorySearchDb & { close: () => void } => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(MEMORIES_SCHEMA)
+  db.exec(MEMORY_SEARCH_SCHEMA)
+  return db as unknown as MemorySearchDb & { close: () => void }
+}
+
+const insert = (db: MemorySearchDb, seed: Seed): number => {
+  db.prepare(
+    `INSERT INTO memories
+       (content, category, source_app, window_title, context_summary, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(
+    seed.content,
+    seed.category ?? 'personal',
+    seed.sourceApp ?? 'Slack',
+    seed.windowTitle ?? '',
+    seed.contextSummary ?? '',
+    seed.createdAt ?? EPOCH
+  )
+  const row = db.prepare('SELECT last_insert_rowid() AS id').get() as { id: number }
+  return row.id
+}
+
+describe('memories full-text index', () => {
+  it('finds a memory by a word in its content', () => {
+    const db = open()
+    insert(db, { content: 'Prefers oat milk in coffee' })
+    insert(db, { content: 'Runs on Tuesday mornings' })
+
+    const hits = searchMemoriesFts(db, 'coffee*')
+    expect(hits.map((h) => h.content)).toEqual(['Prefers oat milk in coffee'])
+    expect(hits[0]).toMatchObject({ category: 'personal', sourceApp: 'Slack', createdAt: EPOCH })
+  })
+
+  it('searches the context summary as well as the content', () => {
+    const db = open()
+    insert(db, { content: 'Ships on Fridays', contextSummary: 'discussed during the release sync' })
+    expect(searchMemoriesFts(db, 'release*').length).toBe(1)
+  })
+
+  it('never matches on the raw window title', () => {
+    const db = open()
+    insert(db, {
+      content: 'Prefers async standups',
+      windowTitle: 'MyChart - Lab Results'
+    })
+    // Window titles are unfiltered PII that memory/persist.ts deliberately keeps
+    // local. Indexing them would make that PII reachable by typing a fragment of
+    // it into a search box.
+    expect(searchMemoriesFts(db, 'mychart*')).toEqual([])
+    expect(searchMemoriesFts(db, 'lab*')).toEqual([])
+    // The curated content is still findable.
+    expect(searchMemoriesFts(db, 'standups*').length).toBe(1)
+  })
+
+  it('breaks equal relevance ties newest first', () => {
+    const db = open()
+    insert(db, { content: 'budget review', createdAt: EPOCH })
+    insert(db, { content: 'budget review', createdAt: EPOCH + 60_000 })
+    insert(db, { content: 'budget review', createdAt: EPOCH + 30_000 })
+
+    expect(searchMemoriesFts(db, 'budget*').map((h) => h.createdAt)).toEqual([
+      EPOCH + 60_000,
+      EPOCH + 30_000,
+      EPOCH
+    ])
+  })
+
+  it('drops a memory from the index when it is deleted', () => {
+    const db = open()
+    const id = insert(db, { content: 'Allergic to penicillin' })
+    expect(searchMemoriesFts(db, 'penicillin*').length).toBe(1)
+
+    db.prepare('DELETE FROM memories WHERE id = ?').run(id)
+    // The delete trigger is what makes memories_fts safe to leave out of
+    // USER_DATA_TABLES: an account switch deletes the rows and the index follows.
+    expect(searchMemoriesFts(db, 'penicillin*')).toEqual([])
+  })
+
+  it('follows an edit rather than keeping the old text findable', () => {
+    const db = open()
+    const id = insert(db, { content: 'Drinks decaf' })
+    db.prepare('UPDATE memories SET content = ? WHERE id = ?').run('Drinks espresso', id)
+
+    expect(searchMemoriesFts(db, 'decaf*')).toEqual([])
+    expect(searchMemoriesFts(db, 'espresso*').length).toBe(1)
+  })
+
+  it('indexes memories that already existed when the index was created', () => {
+    // The triggers only fire on new writes, so an existing install needs the
+    // one-time rebuild that migration v3 runs.
+    const db = new DatabaseSync(':memory:') as unknown as MemorySearchDb
+    db.exec(MEMORIES_SCHEMA)
+    insert(db, { content: 'Signed the lease in March' })
+    db.exec(MEMORY_SEARCH_SCHEMA)
+    expect(searchMemoriesFts(db, 'lease*')).toEqual([])
+
+    db.exec("INSERT INTO memories_fts(memories_fts) VALUES('rebuild')")
+    expect(searchMemoriesFts(db, 'lease*').length).toBe(1)
+  })
+
+  it('respects the result limit', () => {
+    const db = open()
+    for (let i = 0; i < 10; i += 1) insert(db, { content: `standup note ${i}` })
+    expect(searchMemoriesFts(db, 'standup*', 4).length).toBe(4)
+  })
+
+  it('returns nothing for an empty match rather than scanning', () => {
+    const db = open()
+    insert(db, { content: 'anything' })
+    expect(searchMemoriesFts(db, '')).toEqual([])
+  })
+
+  it('fails loudly on the first write if the base table drifts', () => {
+    // The triggers read new.content / new.context_summary / new.source_app off
+    // `memories`. SQLite does NOT resolve those columns when the trigger is
+    // created, so a rename in db.ts installs cleanly and then throws on the next
+    // memory insert. Pinned because that makes a rename break memory WRITES, not
+    // just search: whoever renames the column needs to see this test, not a
+    // silently empty search box.
+    const db = new DatabaseSync(':memory:')
+    db.exec(`CREATE TABLE memories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      body TEXT NOT NULL,
+      category TEXT NOT NULL,
+      source_app TEXT NOT NULL DEFAULT '',
+      context_summary TEXT NOT NULL DEFAULT '',
+      created_at INTEGER NOT NULL
+    );`)
+    expect(() => db.exec(MEMORY_SEARCH_SCHEMA)).not.toThrow()
+    expect(() =>
+      db
+        .prepare(`INSERT INTO memories (body, category, created_at) VALUES (?, ?, ?)`)
+        .run('drifted', 'personal', EPOCH)
+    ).toThrow(/no such column: new\.content/)
+  })
+})

--- a/desktop/windows/src/main/search/memorySearchStore.test.ts
+++ b/desktop/windows/src/main/search/memorySearchStore.test.ts
@@ -4,8 +4,7 @@
 //
 // MEMORY_SEARCH_SCHEMA is IMPORTED, not re-declared, so this exercises the exact
 // DDL production runs. The base `memories` table below is a copy of db.ts's Track
-// 3 block; `keeps the base-table contract` guards the columns the triggers depend
-// on so a rename in db.ts cannot silently stop the index updating.
+// 3 block; the last test pins what actually happens when the two drift.
 import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, it } from 'vitest'
 import { MEMORY_SEARCH_SCHEMA, searchMemoriesFts, type MemorySearchDb } from './memorySearchStore'

--- a/desktop/windows/src/main/search/memorySearchStore.ts
+++ b/desktop/windows/src/main/search/memorySearchStore.ts
@@ -66,8 +66,9 @@ export interface MemorySearchRow {
 
 /**
  * BM25-ranked memories for an FTS5 MATCH expression. `match` is already-built
- * FTS5 syntax (see corpusQuery.ts) — callers must never interpolate raw user
- * text, which would let a stray `"` or `*` throw a syntax error out of SQLite.
+ * FTS5 syntax (desktopSearch.ts builds it) — callers must never interpolate raw
+ * user text, which would let a stray `"` or `*` throw a syntax error out of
+ * SQLite on a keystroke.
  *
  * Ties break on recency, matching searchRewindFrames: two memories that mention
  * the query equally often are most usefully ordered newest-first.
@@ -92,4 +93,16 @@ export function searchMemoriesFts(
       ORDER BY bm25(memories_fts) ASC, memories.created_at DESC
       LIMIT ?`
   ).all(match, limit) as MemorySearchRow[]
+}
+
+/** Total memories matching `match`, before any limit. Separate from
+ *  searchMemoriesFts so a caller can show how much it is not displaying without
+ *  fetching every row to count it. */
+export function countMemoriesFts(db: MemorySearchDb, match: string): number {
+  if (match.length === 0) return 0
+  const row = cachedStmt(
+    db,
+    `SELECT COUNT(*) AS n FROM memories_fts WHERE memories_fts MATCH ?`
+  ).get(match) as { n: number } | undefined
+  return row?.n ?? 0
 }

--- a/desktop/windows/src/main/search/memorySearchStore.ts
+++ b/desktop/windows/src/main/search/memorySearchStore.ts
@@ -1,0 +1,95 @@
+// Full-text search over the local `memories` table.
+//
+// Both the schema (MEMORY_SEARCH_SCHEMA) and the query live here so production
+// (db.ts) and the tests run byte-identical SQL — a re-declared test copy drifts
+// silently, which has happened twice in this program (see the header of
+// taskStore.ts). db.ts execs the schema and re-exports a get()-bound wrapper;
+// the tests import these same symbols.
+//
+// Shape follows `rewind_frames_fts` exactly: an external-content FTS5 index
+// mirroring the base table's rowid, kept in sync by AFTER INSERT/DELETE/UPDATE
+// triggers, so a search is a BM25-ranked index read rather than a LIKE scan over
+// every memory ever extracted. Because the index is external-content and
+// trigger-maintained, `memories_fts` is deliberately NOT in USER_DATA_TABLES:
+// `DELETE FROM memories` on account switch empties it through the delete
+// trigger, exactly as rewind_frames_fts / action_items_fts already do.
+//
+// Indexed columns are the CURATED ones only. `memories.window_title` is
+// deliberately excluded: memory/persist.ts:26-31 keeps raw window titles local
+// precisely because they are unfiltered PII ("Chase - Log in", "MyChart - Lab
+// Results"), and the curated content/context_summary/source_app are what
+// represent the memory everywhere else. Indexing the raw title would make that
+// PII reachable by typing a fragment of it into a search box.
+
+import { cachedStmt } from '../ipc/stmtCache'
+
+/** Minimal DB surface — satisfied structurally by better-sqlite3 (production)
+ *  and node:sqlite's DatabaseSync (tests). Positional `?` params only. */
+export interface MemorySearchDb {
+  exec(sql: string): void
+  prepare(sql: string): {
+    all: (...params: unknown[]) => unknown[]
+    get: (...params: unknown[]) => unknown
+    run: (...params: unknown[]) => unknown
+  }
+}
+
+export const MEMORY_SEARCH_SCHEMA = `
+  CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+    content, context_summary, source_app,
+    content='memories', content_rowid='id', tokenize='unicode61'
+  );
+  CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+    INSERT INTO memories_fts(rowid, content, context_summary, source_app)
+    VALUES (new.id, new.content, new.context_summary, new.source_app);
+  END;
+  CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content, context_summary, source_app)
+    VALUES ('delete', old.id, old.content, old.context_summary, old.source_app);
+  END;
+  CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+    INSERT INTO memories_fts(memories_fts, rowid, content, context_summary, source_app)
+    VALUES ('delete', old.id, old.content, old.context_summary, old.source_app);
+    INSERT INTO memories_fts(rowid, content, context_summary, source_app)
+    VALUES (new.id, new.content, new.context_summary, new.source_app);
+  END;
+`
+
+export interface MemorySearchRow {
+  id: number
+  content: string
+  category: string
+  sourceApp: string
+  contextSummary: string
+  createdAt: number
+}
+
+/**
+ * BM25-ranked memories for an FTS5 MATCH expression. `match` is already-built
+ * FTS5 syntax (see corpusQuery.ts) — callers must never interpolate raw user
+ * text, which would let a stray `"` or `*` throw a syntax error out of SQLite.
+ *
+ * Ties break on recency, matching searchRewindFrames: two memories that mention
+ * the query equally often are most usefully ordered newest-first.
+ */
+export function searchMemoriesFts(
+  db: MemorySearchDb,
+  match: string,
+  limit = 50
+): MemorySearchRow[] {
+  if (match.length === 0) return []
+  return cachedStmt(
+    db,
+    `SELECT memories.id AS id,
+            memories.content AS content,
+            memories.category AS category,
+            memories.source_app AS sourceApp,
+            memories.context_summary AS contextSummary,
+            memories.created_at AS createdAt
+       FROM memories
+       JOIN memories_fts ON memories.id = memories_fts.rowid
+      WHERE memories_fts MATCH ?
+      ORDER BY bm25(memories_fts) ASC, memories.created_at DESC
+      LIMIT ?`
+  ).all(match, limit) as MemorySearchRow[]
+}

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -351,6 +351,11 @@ const omi: OmiBridgeApi = {
     return () => ipcRenderer.removeListener('rewind:captured', listener)
   },
   rewindSearch: (query: string) => ipcRenderer.invoke('rewind:search', query),
+  /** One search over every local corpus (memories, tasks, captured screen text).
+   *  Conversations are searched separately by the renderer against the backend,
+   *  which is the only place the full history lives. */
+  searchLocal: (query: string, limit?: number) =>
+    ipcRenderer.invoke('omi-search:local', query, limit),
   // --- Track 4 (Rewind semantic search) --- Phase 2 of a search: the same results
   // with semantic hits merged in, pushed if/when the embedding round-trip lands.
   // Keyword results are already on screen by then — see the rewind:search handler.

--- a/desktop/windows/src/renderer/src/hooks/useSearch.ts
+++ b/desktop/windows/src/renderer/src/hooks/useSearch.ts
@@ -1,0 +1,77 @@
+// Search state for the page: debounce, run, and keep the answer that belongs to
+// what is in the box.
+//
+// The debounce is what stops a request per keystroke; SearchRunner is what stops
+// an earlier answer landing on top of a later one when the debounce still lets
+// two through (a paste, then a keystroke). Both are needed - a debounce alone
+// still races, and a runner alone still floods.
+//
+// `searching` is DERIVED, not stored: it is simply "the results on screen do not
+// belong to the text in the box". Storing it would mean setting state from the
+// effect that starts the search, and any path that forgot to clear it would
+// leave a permanent spinner over perfectly good results.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  SearchRunner,
+  isSearchable,
+  type SearchDeps,
+  type SearchResults
+} from '../lib/search/runSearch'
+
+/** Quiet period before a search runs. Long enough that ordinary typing produces
+ *  one request rather than one per letter, short enough that the results feel
+ *  like they follow the keystroke. */
+export const SEARCH_DEBOUNCE_MS = 180
+
+export interface UseSearch {
+  input: string
+  setInput: (value: string) => void
+  results: SearchResults | null
+  searching: boolean
+  /** Clears the box and everything on screen. */
+  clear: () => void
+}
+
+export function useSearch(deps?: SearchDeps): UseSearch {
+  const [input, setInput] = useState('')
+  const [results, setResults] = useState<SearchResults | null>(null)
+  const runner = useMemo(() => new SearchRunner(deps), [deps])
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      runner.cancel()
+    }
+  }, [runner])
+
+  const trimmed = input.trim()
+
+  useEffect(() => {
+    if (!isSearchable(trimmed)) {
+      // Nothing to run. Anything in flight belongs to a longer query that is no
+      // longer on screen, so it is dropped rather than allowed to land.
+      runner.cancel()
+      return
+    }
+    const timer = setTimeout(() => {
+      void runner.run(trimmed, (r) => {
+        if (mounted.current) setResults(r)
+      })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [trimmed, runner])
+
+  const clear = useCallback(() => {
+    runner.cancel()
+    setInput('')
+    setResults(null)
+  }, [runner])
+
+  // Searching means the visible results were computed from different text.
+  const searching = isSearchable(trimmed) && results?.query !== trimmed
+
+  return { input, setInput, results, searching, clear }
+}

--- a/desktop/windows/src/renderer/src/lib/search/runSearch.test.ts
+++ b/desktop/windows/src/renderer/src/lib/search/runSearch.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MIN_QUERY_LENGTH,
+  SearchRunner,
+  conversationSlice,
+  conversationTimestamp,
+  conversationTitle,
+  isSearchable,
+  runSearch,
+  type SearchDeps,
+  type SearchResults
+} from './runSearch'
+import type { Conversation, SearchConversationsResponse } from '../omiApi.generated'
+import type { DesktopSearchResult } from '../../../../shared/types'
+
+const EPOCH_ISO = '2026-08-15T10:00:00Z'
+const EPOCH_MS = Date.parse(EPOCH_ISO)
+
+const conversation = (over: Partial<Conversation> = {}): Conversation =>
+  ({
+    id: 'c1',
+    created_at: EPOCH_ISO,
+    started_at: EPOCH_ISO,
+    finished_at: EPOCH_ISO,
+    structured: { title: 'Lease renewal', overview: 'We agreed to renew' },
+    ...over
+  }) as Conversation
+
+const localResult = (over: Partial<DesktopSearchResult> = {}): DesktopSearchResult => ({
+  memories: { hits: [], total: 0 },
+  tasks: { hits: [], total: 0 },
+  screen: { hits: [], total: 0 },
+  ...over
+})
+
+const deps = (over: Partial<SearchDeps> = {}): SearchDeps => ({
+  searchLocal: async () => localResult(),
+  searchConversations: async () => ({
+    items: [conversation()],
+    current_page: 1,
+    per_page: 20,
+    total_pages: 1
+  }),
+  ...over
+})
+
+const signal = (): AbortSignal => new AbortController().signal
+
+describe('isSearchable', () => {
+  it('needs more than a character before it will search', () => {
+    expect(isSearchable('a')).toBe(false)
+    expect(isSearchable('  a  ')).toBe(false)
+    expect(isSearchable('ab')).toBe(true)
+    expect(MIN_QUERY_LENGTH).toBe(2)
+  })
+})
+
+describe('conversationTitle', () => {
+  it('prefers the title, falls back to the overview, then to a label', () => {
+    expect(conversationTitle(conversation())).toBe('Lease renewal')
+    expect(
+      conversationTitle(conversation({ structured: { title: '  ', overview: 'Just an overview' } }))
+    ).toBe('Just an overview')
+    // An untitled conversation is normal before processing finishes; a blank row
+    // would look like a broken result.
+    expect(conversationTitle(conversation({ structured: {} }))).toBe('Untitled conversation')
+  })
+
+  it('truncates a long overview used as a title', () => {
+    const long = 'x'.repeat(200)
+    const title = conversationTitle(conversation({ structured: { overview: long } }))
+    expect(title.length).toBe(90)
+    expect(title.endsWith('…')).toBe(true)
+  })
+})
+
+describe('conversationTimestamp', () => {
+  it('uses the capture time, falling back to creation', () => {
+    expect(conversationTimestamp(conversation())).toBe(EPOCH_MS)
+    expect(conversationTimestamp(conversation({ started_at: null }))).toBe(EPOCH_MS)
+  })
+
+  it('survives an unparseable date instead of producing NaN', () => {
+    // NaN would sort unpredictably and render as "Invalid Date".
+    expect(conversationTimestamp(conversation({ started_at: 'not a date', created_at: '' }))).toBe(
+      0
+    )
+  })
+})
+
+describe('conversationSlice', () => {
+  it('counts a single page exactly', () => {
+    const slice = conversationSlice({
+      items: [conversation(), conversation({ id: 'c2' })],
+      current_page: 1,
+      per_page: 20,
+      total_pages: 1
+    })
+    expect(slice.total).toBe(2)
+    expect(slice.atLeast).toBe(false)
+    expect(slice.hits.map((h) => h.kind)).toEqual(['conversation', 'conversation'])
+  })
+
+  it('reports a multi-page result as an at-least, never as an exact count', () => {
+    // The endpoint reports pages, not rows. Three pages of 20 means "at least
+    // 41" — claiming 60 would invent up to 19 conversations.
+    const slice = conversationSlice({
+      items: Array.from({ length: 20 }, (_v, i) => conversation({ id: `c${i}` })),
+      current_page: 1,
+      per_page: 20,
+      total_pages: 3
+    })
+    expect(slice.total).toBe(41)
+    // A page count cannot say how full the last page is, so 41 is a floor.
+    expect(slice.atLeast).toBe(true)
+  })
+
+  it('survives a malformed response instead of throwing at the page', () => {
+    const slice = conversationSlice({} as SearchConversationsResponse)
+    expect(slice).toEqual({ hits: [], total: 0, failed: false, atLeast: false })
+  })
+})
+
+describe('runSearch', () => {
+  it('searches both sources and labels every corpus', async () => {
+    const out = await runSearch(
+      'lease',
+      signal(),
+      deps({
+        searchLocal: async () =>
+          localResult({
+            memories: {
+              hits: [
+                { kind: 'memory', id: '1', title: 'Prefers the lease', detail: '', timestamp: 1 }
+              ],
+              total: 4
+            }
+          })
+      })
+    )
+    expect(out.query).toBe('lease')
+    expect(out.conversations.hits.length).toBe(1)
+    expect(out.memories.total).toBe(4)
+    expect([out.conversations, out.memories, out.tasks, out.screen].every((s) => !s.failed)).toBe(
+      true
+    )
+  })
+
+  it('still shows local results when the conversation search fails', async () => {
+    const out = await runSearch(
+      'lease',
+      signal(),
+      deps({
+        searchConversations: async () => {
+          throw new Error('offline')
+        },
+        searchLocal: async () => localResult({ tasks: { hits: [], total: 7 } })
+      })
+    )
+    // A blank page, or an empty list that reads as "you have nothing about
+    // that", would both be wrong.
+    expect(out.conversations.failed).toBe(true)
+    expect(out.tasks.failed).toBe(false)
+    expect(out.tasks.total).toBe(7)
+  })
+
+  it('still shows conversations when the local index is unusable', async () => {
+    const out = await runSearch(
+      'lease',
+      signal(),
+      deps({
+        searchLocal: async () => {
+          throw new Error('database is locked')
+        }
+      })
+    )
+    expect(out.conversations.hits.length).toBe(1)
+    expect(out.memories.failed).toBe(true)
+    expect(out.tasks.failed).toBe(true)
+    expect(out.screen.failed).toBe(true)
+  })
+
+  it('marks every local corpus failed together, since one call serves all three', async () => {
+    const out = await runSearch(
+      'lease',
+      signal(),
+      deps({
+        searchLocal: async () => {
+          throw new Error('nope')
+        }
+      })
+    )
+    expect([out.memories.failed, out.tasks.failed, out.screen.failed]).toEqual([true, true, true])
+  })
+
+  it('does not search a query that is too short', async () => {
+    const searchLocal = vi.fn()
+    const searchConversations = vi.fn()
+    const out = await runSearch('a', signal(), deps({ searchLocal, searchConversations }))
+    expect(searchLocal).not.toHaveBeenCalled()
+    expect(searchConversations).not.toHaveBeenCalled()
+    expect(out.query).toBe('a')
+  })
+
+  it('searches the trimmed text and echoes back what it searched', async () => {
+    const searchLocal = vi.fn(async () => localResult())
+    const out = await runSearch('  lease  ', signal(), deps({ searchLocal }))
+    expect(searchLocal).toHaveBeenCalledWith('lease')
+    // The page renders "nothing for X" from this, never from the live input, so
+    // the message can never name a different word than the one searched.
+    expect(out.query).toBe('lease')
+  })
+})
+
+describe('SearchRunner', () => {
+  const resolvable = (): {
+    promise: Promise<SearchConversationsResponse>
+    resolve: (r: SearchConversationsResponse) => void
+  } => {
+    let resolve!: (r: SearchConversationsResponse) => void
+    const promise = new Promise<SearchConversationsResponse>((r) => {
+      resolve = r
+    })
+    return { promise, resolve }
+  }
+
+  it('drops a slow answer that lands after a newer one', async () => {
+    const slow = resolvable()
+    const fast = resolvable()
+    const queue = [slow.promise, fast.promise]
+    const runner = new SearchRunner(
+      deps({
+        searchConversations: async () => queue.shift() as Promise<SearchConversationsResponse>
+      })
+    )
+
+    const delivered: SearchResults[] = []
+    const first = runner.run('le', (r) => delivered.push(r))
+    const second = runner.run('lease', (r) => delivered.push(r))
+
+    // The newer query answers first, then the older one finally arrives.
+    fast.resolve({
+      items: [conversation({ id: 'new' })],
+      current_page: 1,
+      per_page: 20,
+      total_pages: 1
+    })
+    await second
+    slow.resolve({
+      items: [conversation({ id: 'old' })],
+      current_page: 1,
+      per_page: 20,
+      total_pages: 1
+    })
+    await first
+
+    // Typing "lease" fires a request per keystroke; "le" resolving last must not
+    // put its results back on screen.
+    expect(delivered.length).toBe(1)
+    expect(delivered[0].query).toBe('lease')
+  })
+
+  it('delivers results for a single run', async () => {
+    const runner = new SearchRunner(deps())
+    const delivered: SearchResults[] = []
+    await runner.run('lease', (r) => delivered.push(r))
+    expect(delivered.map((d) => d.query)).toEqual(['lease'])
+  })
+
+  it('aborts the request still in flight when a newer search starts', async () => {
+    const aborted: string[] = []
+    const first = resolvable()
+    const queue = [first.promise]
+    const runner = new SearchRunner(
+      deps({
+        searchConversations: async (q, s) => {
+          s.addEventListener('abort', () => aborted.push(q))
+          const queued = queue.shift()
+          if (queued) return queued
+          return { items: [], current_page: 1, per_page: 20, total_pages: 1 }
+        }
+      })
+    )
+    // Deliberately NOT awaited: the point is that the first request is still
+    // open when the second starts, which is what typing produces.
+    const pending = runner.run('lea', () => undefined)
+    await runner.run('lease', () => undefined)
+    expect(aborted).toEqual(['lea'])
+
+    first.resolve({ items: [], current_page: 1, per_page: 20, total_pages: 1 })
+    await pending
+  })
+
+  it('cancel stops a pending run from delivering', async () => {
+    const pending = resolvable()
+    const runner = new SearchRunner(deps({ searchConversations: async () => pending.promise }))
+    const delivered: SearchResults[] = []
+    const run = runner.run('lease', (r) => delivered.push(r))
+    runner.cancel()
+    pending.resolve({ items: [], current_page: 1, per_page: 20, total_pages: 1 })
+    await run
+    expect(delivered).toEqual([])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/search/runSearch.ts
+++ b/desktop/windows/src/renderer/src/lib/search/runSearch.ts
@@ -1,0 +1,241 @@
+// One query, four corpora, two very different sources.
+//
+// Memories, tasks and captured screen text are indexed on this machine and come
+// back from main in a millisecond. Conversations live only in the cloud (the
+// local cache holds the last 200), so they are searched through
+// `POST /v1/conversations/search`, which covers the whole history.
+//
+// Three properties this module exists to hold:
+//
+// 1. THE TWO SOURCES ARE INDEPENDENT. A failed conversation request must still
+//    show local results, and an unusable local index must still show
+//    conversations. Each corpus reports its own `failed`, so the UI can say which
+//    part is missing instead of showing a blank page or, worse, an empty result
+//    list that reads as "you have nothing about that".
+//
+// 2. A SLOW ANSWER NEVER OVERWRITES A NEWER ONE. Typing "lease" fires a request
+//    per keystroke; "l" can easily resolve after "lease". Every run carries a
+//    monotonic sequence number and the caller drops anything that is not the
+//    latest, so the results on screen always belong to the text in the box.
+//
+// 3. THE QUERY IS ECHOED BACK. The caller renders "no results for X" from the
+//    query the results were computed FROM, never from the current input, so the
+//    message can never name a different word than the one that was searched.
+
+import { omiApi } from '../apiClient'
+import type { Conversation, SearchConversationsResponse } from '../omiApi.generated'
+import type { CorpusHit, CorpusSlice, DesktopSearchResult } from '../../../../shared/types'
+
+export type SearchCorpus = 'conversations' | 'memories' | 'tasks' | 'screen'
+
+export interface SearchSlice extends CorpusSlice {
+  /** True when this corpus could not be searched at all. Distinct from an empty
+   *  slice, which means "searched, found nothing". */
+  failed: boolean
+  /** True when `total` is a lower bound rather than an exact count. The
+   *  conversation endpoint reports pages, not rows, so a multi-page result is
+   *  only known to a page's granularity and must be shown as "41+", never "41". */
+  atLeast: boolean
+}
+
+export interface SearchResults {
+  /** The text these results were computed from. */
+  query: string
+  conversations: SearchSlice
+  memories: SearchSlice
+  tasks: SearchSlice
+  screen: SearchSlice
+}
+
+/** Conversations requested per search. Matches the local per-corpus limit so no
+ *  corpus visually dominates the page just by being fetched deeper. */
+export const CONVERSATION_PAGE_SIZE = 20
+
+/** Shortest query that is searched. One or two characters match a large fraction
+ *  of everything and produce a result list that is noise, plus a request per
+ *  keystroke that is never useful. */
+export const MIN_QUERY_LENGTH = 2
+
+const emptySlice = (): SearchSlice => ({ hits: [], total: 0, failed: false, atLeast: false })
+const failedSlice = (): SearchSlice => ({ hits: [], total: 0, failed: true, atLeast: false })
+
+export const emptyResults = (query = ''): SearchResults => ({
+  query,
+  conversations: emptySlice(),
+  memories: emptySlice(),
+  tasks: emptySlice(),
+  screen: emptySlice()
+})
+
+/** True when a query is worth sending. Exported so the UI shows its prompt state
+ *  from the same rule the search uses, instead of a second copy that can drift. */
+export function isSearchable(query: string): boolean {
+  return query.trim().length >= MIN_QUERY_LENGTH
+}
+
+/** A conversation's display title, falling back through the fields that are
+ *  actually populated. An untitled conversation is common (it is titled after
+ *  processing), so it must not render as a blank row. */
+export function conversationTitle(c: Conversation): string {
+  const title = c.structured?.title?.trim()
+  if (title) return title
+  const overview = c.structured?.overview?.trim()
+  if (overview) return overview.length > 90 ? `${overview.slice(0, 89)}…` : overview
+  return 'Untitled conversation'
+}
+
+/** Epoch ms for ordering. `started_at` is the capture time and is what every
+ *  other conversation surface sorts by; `created_at` is the fallback for rows
+ *  that never got one. */
+export function conversationTimestamp(c: Conversation): number {
+  const raw = c.started_at ?? c.created_at
+  const ms = raw ? Date.parse(raw) : Number.NaN
+  return Number.isFinite(ms) ? ms : 0
+}
+
+export function conversationToHit(c: Conversation): CorpusHit {
+  return {
+    kind: 'conversation',
+    id: c.id,
+    title: conversationTitle(c),
+    detail: c.structured?.overview?.trim() ?? '',
+    timestamp: conversationTimestamp(c)
+  }
+}
+
+/** Maps a search response onto a slice. `total_pages` is what the endpoint
+ *  reports, so the true total is only known to a page's granularity: a result
+ *  set of 3 pages is "more than 40", not "60". The caller renders that as an
+ *  at-least, never as an exact count. */
+export function conversationSlice(res: SearchConversationsResponse): SearchSlice {
+  const items = Array.isArray(res?.items) ? res.items : []
+  const pages = Number.isFinite(res?.total_pages) ? Math.max(1, res.total_pages) : 1
+  const perPage = Number.isFinite(res?.per_page) && res.per_page > 0 ? res.per_page : items.length
+  return {
+    hits: items.map(conversationToHit),
+    // Everything before the last page is full; the last page holds at least one.
+    total: pages > 1 ? (pages - 1) * perPage + 1 : items.length,
+    failed: false,
+    atLeast: pages > 1
+  }
+}
+
+export interface SearchDeps {
+  searchLocal: (query: string) => Promise<DesktopSearchResult>
+  searchConversations: (query: string, signal: AbortSignal) => Promise<SearchConversationsResponse>
+}
+
+/** Production dependencies. Split out so tests drive the orchestration without
+ *  Electron or the network. */
+export const defaultDeps: SearchDeps = {
+  searchLocal: async (query) => {
+    const api = window.omi
+    if (!api?.searchLocal) throw new Error('local search unavailable')
+    return api.searchLocal(query)
+  },
+  searchConversations: async (query, signal) => {
+    const res = await omiApi.post<SearchConversationsResponse>(
+      '/v1/conversations/search',
+      { query, page: 1, per_page: CONVERSATION_PAGE_SIZE },
+      { signal }
+    )
+    return res.data
+  }
+}
+
+/**
+ * Runs one search. Never rejects: a corpus that fails comes back with
+ * `failed: true` so the page can name what is missing.
+ *
+ * `signal` aborts the conversation request; the local search is synchronous on
+ * the main side and completes either way, which costs nothing.
+ */
+export async function runSearch(
+  query: string,
+  signal: AbortSignal,
+  deps: SearchDeps = defaultDeps
+): Promise<SearchResults> {
+  const text = query.trim()
+  if (!isSearchable(text)) return emptyResults(text)
+
+  const [local, conversations] = await Promise.all([
+    deps
+      .searchLocal(text)
+      .then((r) => ({ ok: true as const, r }))
+      .catch(() => ({ ok: false as const, r: null })),
+    deps
+      .searchConversations(text, signal)
+      .then((r) => ({ ok: true as const, r }))
+      .catch(() => ({ ok: false as const, r: null }))
+  ])
+
+  const localSlice = (pick: (r: DesktopSearchResult) => CorpusSlice): SearchSlice =>
+    local.ok && local.r !== null
+      ? { ...pick(local.r), failed: false, atLeast: false }
+      : failedSlice()
+
+  return {
+    query: text,
+    conversations:
+      conversations.ok && conversations.r !== null
+        ? conversationSlice(conversations.r)
+        : failedSlice(),
+    memories: localSlice((r) => r.memories),
+    tasks: localSlice((r) => r.tasks),
+    screen: localSlice((r) => r.screen)
+  }
+}
+
+/**
+ * Serialises searches so a slow answer can never replace a newer one.
+ *
+ * Every call bumps a sequence number and aborts the previous request. A result
+ * is delivered only if its sequence is still the latest, so the list on screen
+ * always belongs to the text that produced it.
+ */
+export class SearchRunner {
+  private seq = 0
+  private inFlight: AbortController | null = null
+
+  constructor(private readonly deps: SearchDeps = defaultDeps) {}
+
+  /** Cancels anything in flight. Delivered results stay on screen. */
+  cancel(): void {
+    this.inFlight?.abort()
+    this.inFlight = null
+    this.seq += 1
+  }
+
+  /**
+   * Runs `query` and calls `onResults` only when this run is still the newest.
+   * Returns the sequence number used, for tests and diagnostics.
+   */
+  async run(query: string, onResults: (results: SearchResults) => void): Promise<number> {
+    this.inFlight?.abort()
+    const controller = new AbortController()
+    this.inFlight = controller
+    this.seq += 1
+    const mine = this.seq
+
+    const results = await runSearch(query, controller.signal, this.deps)
+    if (mine !== this.seq) return mine
+    this.inFlight = null
+    onResults(results)
+    return mine
+  }
+}
+
+/** Corpora in the order the page presents them. Conversations lead because they
+ *  are what people search for most and the only corpus covering all of history. */
+export const CORPUS_ORDER: SearchCorpus[] = ['conversations', 'memories', 'tasks', 'screen']
+
+export const CORPUS_LABELS: Record<SearchCorpus, string> = {
+  conversations: 'Conversations',
+  memories: 'Memories',
+  tasks: 'Tasks',
+  screen: 'Screen'
+}
+
+export function sliceFor(results: SearchResults, corpus: SearchCorpus): SearchSlice {
+  return results[corpus]
+}

--- a/desktop/windows/src/renderer/src/lib/search/searchCopy.test.ts
+++ b/desktop/windows/src/renderer/src/lib/search/searchCopy.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COPY,
+  corpusCountLabel,
+  failedCorpora,
+  isEmptyResult,
+  isTotalFailure,
+  searchPhase
+} from './searchCopy'
+import { CORPUS_LABELS, emptyResults, type SearchResults, type SearchSlice } from './runSearch'
+
+const slice = (over: Partial<SearchSlice> = {}): SearchSlice => ({
+  hits: [],
+  total: 0,
+  failed: false,
+  atLeast: false,
+  ...over
+})
+
+const hits = (n: number): SearchSlice['hits'] =>
+  Array.from({ length: n }, (_v, i) => ({
+    kind: 'memory' as const,
+    id: String(i),
+    title: `hit ${i}`,
+    detail: '',
+    timestamp: i
+  }))
+
+const results = (over: Partial<SearchResults> = {}): SearchResults => ({
+  ...emptyResults('lease'),
+  ...over
+})
+
+describe('corpusCountLabel', () => {
+  it('says nothing matched when nothing did', () => {
+    expect(corpusCountLabel(slice())).toBe('No matches')
+  })
+
+  it('names a failure instead of showing it as an empty result', () => {
+    // An empty list here would read as "you have nothing about that", which is a
+    // different and much worse claim than "this could not be searched".
+    expect(corpusCountLabel(slice({ failed: true }))).toBe('Could not be searched')
+  })
+
+  it('gives the exact count when everything is on screen', () => {
+    expect(corpusCountLabel(slice({ hits: hits(1), total: 1 }))).toBe('1 match')
+    expect(corpusCountLabel(slice({ hits: hits(4), total: 4 }))).toBe('4 matches')
+  })
+
+  it('says how much it is not showing when the list is capped', () => {
+    expect(corpusCountLabel(slice({ hits: hits(20), total: 300 }))).toBe('Showing 20 of 300')
+  })
+
+  it('marks a lower-bound total so it is never read as exact', () => {
+    // The conversation endpoint reports pages, not rows, so this total is a
+    // floor and must not be presented as a count.
+    expect(corpusCountLabel(slice({ hits: hits(20), total: 41, atLeast: true }))).toBe(
+      'Showing 20 of 41+'
+    )
+  })
+
+  it('groups thousands so a large number stays readable', () => {
+    expect(corpusCountLabel(slice({ hits: hits(20), total: 3741 }))).toBe('Showing 20 of 3,741')
+  })
+
+  it('never claims fewer matches than the hits it is showing', () => {
+    // A stale or wrong total must not produce "Showing 20 of 3".
+    expect(corpusCountLabel(slice({ hits: hits(20), total: 3 }))).toBe('20 matches')
+  })
+})
+
+describe('result predicates', () => {
+  it('treats a result with no hits anywhere as empty', () => {
+    expect(isEmptyResult(results())).toBe(true)
+    expect(isEmptyResult(results({ tasks: slice({ hits: hits(1), total: 1 }) }))).toBe(false)
+  })
+
+  it('does not call a result empty when a corpus failed', () => {
+    // Something might well match in the corpus that could not be reached.
+    expect(isEmptyResult(results({ conversations: slice({ failed: true }) }))).toBe(false)
+  })
+
+  it('recognises a total failure and lists which corpora failed', () => {
+    const all = results({
+      conversations: slice({ failed: true }),
+      memories: slice({ failed: true }),
+      tasks: slice({ failed: true }),
+      screen: slice({ failed: true })
+    })
+    expect(isTotalFailure(all)).toBe(true)
+    expect(failedCorpora(all)).toEqual(['conversations', 'memories', 'tasks', 'screen'])
+
+    const partial = results({ conversations: slice({ failed: true }) })
+    expect(isTotalFailure(partial)).toBe(false)
+    expect(failedCorpora(partial)).toEqual(['conversations'])
+  })
+})
+
+describe('searchPhase', () => {
+  const base = { input: '', searching: false, results: null as SearchResults | null }
+
+  it('prompts on an empty box', () => {
+    expect(searchPhase(base)).toEqual({ kind: 'prompt' })
+    expect(searchPhase({ ...base, input: '   ' })).toEqual({ kind: 'prompt' })
+  })
+
+  it('asks for more characters before searching', () => {
+    expect(searchPhase({ ...base, input: 'l' })).toEqual({ kind: 'tooShort' })
+  })
+
+  it('shows searching while a request is open', () => {
+    expect(searchPhase({ ...base, input: 'lease', searching: true })).toEqual({ kind: 'searching' })
+  })
+
+  it('keeps showing searching until the first result arrives', () => {
+    // results === null means nothing has come back yet. Rendering "nothing
+    // found" here would tell someone their data is missing when it simply has
+    // not arrived.
+    expect(searchPhase({ ...base, input: 'lease', searching: false })).toEqual({
+      kind: 'searching'
+    })
+  })
+
+  it('prefers searching over empty when a newer request is open', () => {
+    expect(searchPhase({ input: 'lease', searching: true, results: results() })).toEqual({
+      kind: 'searching'
+    })
+  })
+
+  it('reports empty against the text that was searched, not the live input', () => {
+    // The box may already say "leaseh" while these results are for "lease".
+    expect(
+      searchPhase({ input: 'leaseh', searching: false, results: results({ query: 'lease' }) })
+    ).toEqual({ kind: 'empty', query: 'lease' })
+  })
+
+  it('calls it unavailable when nothing could be searched', () => {
+    const dead = results({
+      conversations: slice({ failed: true }),
+      memories: slice({ failed: true }),
+      tasks: slice({ failed: true }),
+      screen: slice({ failed: true })
+    })
+    expect(searchPhase({ input: 'lease', searching: false, results: dead })).toEqual({
+      kind: 'unavailable'
+    })
+  })
+
+  it('shows results when any corpus has one', () => {
+    expect(
+      searchPhase({
+        input: 'lease',
+        searching: false,
+        results: results({ memories: slice({ hits: hits(2), total: 2 }) })
+      })
+    ).toEqual({ kind: 'results' })
+  })
+})
+
+describe('COPY', () => {
+  it('names the searched text in the empty message', () => {
+    expect(COPY.empty('lease')).toBe('Nothing matches “lease”.')
+  })
+
+  it('names every corpus that failed in the partial warning', () => {
+    expect(COPY.partial(['conversations'], CORPUS_LABELS)).toBe(
+      'Conversations could not be searched, so these results are incomplete.'
+    )
+    expect(COPY.partial(['conversations', 'screen'], CORPUS_LABELS)).toBe(
+      'Conversations and Screen could not be searched, so these results are incomplete.'
+    )
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/search/searchCopy.ts
+++ b/desktop/windows/src/renderer/src/lib/search/searchCopy.ts
@@ -1,0 +1,91 @@
+// Every string the search page shows, as pure functions.
+//
+// They live here rather than inline in JSX for one reason: the count line is the
+// only thing telling someone whether they are looking at all of their matches or
+// a slice of them, so each branch of it is worth a test. A count that quietly
+// reads "20" when 300 matched is the search-box equivalent of losing data — the
+// person stops looking, believing they have seen everything.
+
+import type { SearchCorpus, SearchResults, SearchSlice } from './runSearch'
+import { CORPUS_ORDER, MIN_QUERY_LENGTH } from './runSearch'
+
+const formatCount = (n: number): string => n.toLocaleString()
+
+/**
+ * The line under a corpus heading.
+ *
+ * - failed          -> names the failure, so an empty list is never mistaken for
+ *                      "you have nothing about that"
+ * - nothing matched -> "No matches"
+ * - all shown       -> the exact count
+ * - some shown      -> "Showing N of M", with a trailing `+` when M is a floor
+ */
+export function corpusCountLabel(slice: SearchSlice): string {
+  if (slice.failed) return 'Could not be searched'
+  if (slice.total === 0 && slice.hits.length === 0) return 'No matches'
+  const shown = slice.hits.length
+  const total = Math.max(slice.total, shown)
+  const totalText = `${formatCount(total)}${slice.atLeast ? '+' : ''}`
+  if (shown >= total && !slice.atLeast) {
+    return shown === 1 ? '1 match' : `${formatCount(shown)} matches`
+  }
+  return `Showing ${formatCount(shown)} of ${totalText}`
+}
+
+/** True when every corpus came back empty and none of them failed. */
+export function isEmptyResult(results: SearchResults): boolean {
+  return CORPUS_ORDER.every((c) => results[c].hits.length === 0 && !results[c].failed)
+}
+
+/** True when no corpus could be searched at all. */
+export function isTotalFailure(results: SearchResults): boolean {
+  return CORPUS_ORDER.every((c) => results[c].failed)
+}
+
+/** Corpora that could not be searched, in presentation order. */
+export function failedCorpora(results: SearchResults): SearchCorpus[] {
+  return CORPUS_ORDER.filter((c) => results[c].failed)
+}
+
+export type SearchPhase =
+  | { kind: 'prompt' }
+  | { kind: 'tooShort' }
+  | { kind: 'searching' }
+  | { kind: 'unavailable' }
+  | { kind: 'empty'; query: string }
+  | { kind: 'results' }
+
+/**
+ * Which state the page is in. Kept as one function so the page cannot render two
+ * states at once, and so the precedence is written down instead of emerging from
+ * the order of JSX conditionals.
+ *
+ * `searching` wins over `empty`: showing "nothing found" while a request is
+ * still open tells someone their data is missing when it simply has not arrived.
+ */
+export function searchPhase(args: {
+  input: string
+  searching: boolean
+  results: SearchResults | null
+}): SearchPhase {
+  const trimmed = args.input.trim()
+  if (trimmed.length === 0) return { kind: 'prompt' }
+  if (trimmed.length < MIN_QUERY_LENGTH) return { kind: 'tooShort' }
+  if (args.searching) return { kind: 'searching' }
+  if (args.results === null) return { kind: 'searching' }
+  if (isTotalFailure(args.results)) return { kind: 'unavailable' }
+  if (isEmptyResult(args.results)) return { kind: 'empty', query: args.results.query }
+  return { kind: 'results' }
+}
+
+export const COPY = {
+  placeholder: 'Search conversations, memories, tasks and screen',
+  prompt: 'Search everything Omi has kept for you.',
+  tooShort: `Type at least ${MIN_QUERY_LENGTH} characters.`,
+  searching: 'Searching…',
+  unavailable: 'Search is unavailable right now. Check your connection and try again.',
+  /** Named after the text that was actually searched, not the live input. */
+  empty: (query: string): string => `Nothing matches “${query}”.`,
+  partial: (corpora: SearchCorpus[], labels: Record<SearchCorpus, string>): string =>
+    `${corpora.map((c) => labels[c]).join(' and ')} could not be searched, so these results are incomplete.`
+} as const

--- a/desktop/windows/src/renderer/src/pages/Search.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Search.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+//
+// The Search page drives window.omi.searchLocal plus the conversation search
+// endpoint. These tests mock both and assert the behaviors that decide whether
+// someone trusts the result list: that a capped list says so, that an
+// unreachable corpus is named rather than shown as empty, that "nothing matches"
+// names the text that was searched, and that Escape does not strand the page.
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, waitFor, fireEvent, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { DesktopSearchResult } from '../../../shared/types'
+
+const searchLocal = vi.fn()
+const post = vi.fn()
+const navigate = vi.fn()
+
+vi.mock('../lib/apiClient', () => ({ omiApi: { post: (...a: unknown[]) => post(...a) } }))
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+const { Search } = await import('./Search')
+
+const EPOCH = Date.parse('2026-08-15T10:00:00Z')
+
+const local = (over: Partial<DesktopSearchResult> = {}): DesktopSearchResult => ({
+  memories: { hits: [], total: 0 },
+  tasks: { hits: [], total: 0 },
+  screen: { hits: [], total: 0 },
+  ...over
+})
+
+const memoryHits = (n: number): DesktopSearchResult['memories']['hits'] =>
+  Array.from({ length: n }, (_v, i) => ({
+    kind: 'memory' as const,
+    id: String(i),
+    title: `memory ${i}`,
+    detail: '',
+    timestamp: EPOCH
+  }))
+
+const conversationsResponse = (
+  items: Array<{ id: string; title: string }>,
+  totalPages = 1
+): { data: unknown } => ({
+  data: {
+    items: items.map((i) => ({
+      id: i.id,
+      created_at: '2026-08-15T10:00:00Z',
+      started_at: '2026-08-15T10:00:00Z',
+      finished_at: null,
+      structured: { title: i.title, overview: '' }
+    })),
+    current_page: 1,
+    per_page: 20,
+    total_pages: totalPages
+  }
+})
+
+beforeEach(() => {
+  searchLocal.mockReset().mockResolvedValue(local())
+  post.mockReset().mockResolvedValue(conversationsResponse([]))
+  navigate.mockReset()
+  ;(window as unknown as { omi: unknown }).omi = { searchLocal }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+const mount = (): void => {
+  render(
+    <MemoryRouter>
+      <Search />
+    </MemoryRouter>
+  )
+}
+
+const type = (text: string): void => {
+  fireEvent.change(screen.getByLabelText('Search'), { target: { value: text } })
+}
+
+describe('Search page', () => {
+  it('prompts before anything is typed and does not search', async () => {
+    mount()
+    expect(screen.getByText('Search everything Omi has kept for you.')).toBeTruthy()
+    expect(searchLocal).not.toHaveBeenCalled()
+  })
+
+  it('asks for more characters instead of searching a single letter', async () => {
+    mount()
+    type('l')
+    await waitFor(() => expect(screen.getByText('Type at least 2 characters.')).toBeTruthy())
+    expect(searchLocal).not.toHaveBeenCalled()
+  })
+
+  it('shows results grouped by corpus', async () => {
+    post.mockResolvedValue(conversationsResponse([{ id: 'c1', title: 'Lease renewal' }]))
+    searchLocal.mockResolvedValue(local({ memories: { hits: memoryHits(2), total: 2 } }))
+    mount()
+    type('lease')
+
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+    expect(screen.getByText('Conversations')).toBeTruthy()
+    expect(screen.getByText('Memories')).toBeTruthy()
+    // Tasks and Screen had nothing and did not fail, so they are left out
+    // entirely rather than shown as empty headings.
+    expect(screen.queryByText('Tasks')).toBeNull()
+  })
+
+  it('says how much of a capped corpus it is showing', async () => {
+    searchLocal.mockResolvedValue(local({ memories: { hits: memoryHits(20), total: 300 } }))
+    mount()
+    type('standup')
+    // Showing 20 while 300 matched, without saying so, would stop someone
+    // looking any further.
+    await waitFor(() => expect(screen.getByText('Showing 20 of 300')).toBeTruthy())
+  })
+
+  it('marks a multi-page conversation total as a lower bound', async () => {
+    post.mockResolvedValue(
+      conversationsResponse(
+        Array.from({ length: 20 }, (_v, i) => ({ id: `c${i}`, title: `conv ${i}` })),
+        3
+      )
+    )
+    mount()
+    type('lease')
+    await waitFor(() => expect(screen.getByText('Showing 20 of 41+')).toBeTruthy())
+  })
+
+  it('names an unreachable corpus rather than showing it as empty', async () => {
+    post.mockRejectedValue(new Error('offline'))
+    searchLocal.mockResolvedValue(local({ tasks: { hits: memoryHits(1), total: 1 } }))
+    mount()
+    type('lease')
+
+    await waitFor(() => expect(screen.getByText('Could not be searched')).toBeTruthy())
+    // The distinction that matters: "could not be searched" is not the same
+    // claim as "you have nothing about that".
+    expect(
+      screen.getByText('Conversations could not be searched, so these results are incomplete.')
+    ).toBeTruthy()
+  })
+
+  it('reports search as unavailable when nothing at all could be searched', async () => {
+    post.mockRejectedValue(new Error('offline'))
+    searchLocal.mockRejectedValue(new Error('database is locked'))
+    mount()
+    type('lease')
+    await waitFor(() => expect(screen.getByText('Search unavailable')).toBeTruthy())
+  })
+
+  it('names the searched text when nothing matches', async () => {
+    mount()
+    type('quarterly')
+    await waitFor(() => expect(screen.getByText('Nothing matches “quarterly”.')).toBeTruthy())
+  })
+
+  it('opens a conversation result at its detail route', async () => {
+    post.mockResolvedValue(conversationsResponse([{ id: 'abc123', title: 'Lease renewal' }]))
+    mount()
+    type('lease')
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+
+    fireEvent.click(screen.getByText('Lease renewal'))
+    expect(navigate).toHaveBeenCalledWith('/conversations/abc123')
+  })
+
+  it('clears the box on Escape, and leaves the page on a second Escape', async () => {
+    mount()
+    const box = screen.getByLabelText('Search') as HTMLInputElement
+    type('lease')
+    await waitFor(() => expect(box.value).toBe('lease'))
+
+    fireEvent.keyDown(box, { key: 'Escape' })
+    await waitFor(() => expect(box.value).toBe(''))
+    expect(navigate).not.toHaveBeenCalled()
+
+    // useKeyboardNav ignores keys pressed inside an input, so without the page
+    // handling this an empty box would swallow Escape and strand the page.
+    fireEvent.keyDown(box, { key: 'Escape' })
+    expect(navigate).toHaveBeenCalledWith('/home')
+  })
+
+  it('sends one search for a burst of typing, not one per letter', async () => {
+    mount()
+    type('l')
+    type('le')
+    type('lea')
+    type('lease')
+    await waitFor(() => expect(searchLocal).toHaveBeenCalled())
+    expect(searchLocal).toHaveBeenCalledTimes(1)
+    expect(searchLocal).toHaveBeenCalledWith('lease')
+  })
+
+  it('keeps showing the searching state until the first answer arrives', async () => {
+    let release!: (v: unknown) => void
+    post.mockReturnValue(
+      new Promise((r) => {
+        release = r
+      })
+    )
+    mount()
+    type('lease')
+    await waitFor(() => expect(screen.getByText('Searching…')).toBeTruthy())
+    // Rendering "nothing found" here would claim the data is missing when it
+    // simply has not arrived.
+    expect(screen.queryByText('No matches')).toBeNull()
+    release(conversationsResponse([]))
+  })
+})

--- a/desktop/windows/src/renderer/src/pages/Search.tsx
+++ b/desktop/windows/src/renderer/src/pages/Search.tsx
@@ -1,0 +1,200 @@
+// Search: one box over conversations, memories, tasks and captured screen text.
+//
+// Before this page the only search inputs in the app were Rewind's (frames only)
+// and Settings' (settings only), so a conversation, a memory or a task could be
+// found by scrolling and no other way.
+//
+// Results are grouped by corpus rather than interleaved. The scores behind them
+// come from separate indexes and a remote endpoint, so a single ranked list
+// would be ordering by numbers that are not comparable; grouping keeps the
+// ordering honest and makes "where would this have been?" answerable.
+
+import { useEffect, useMemo, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { MessagesSquare, Brain, ListChecks, Monitor, SearchIcon, X } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { HOME_PATH } from '../routes/manifest'
+import { PageHeader } from '../components/layout/PageHeader'
+import { EmptyState } from '../components/ui/EmptyState'
+import { useSearch } from '../hooks/useSearch'
+import {
+  CORPUS_LABELS,
+  CORPUS_ORDER,
+  type SearchCorpus,
+  type SearchSlice
+} from '../lib/search/runSearch'
+import { COPY, corpusCountLabel, failedCorpora, searchPhase } from '../lib/search/searchCopy'
+import type { CorpusHit } from '../../../shared/types'
+
+const CORPUS_ICONS: Record<SearchCorpus, LucideIcon> = {
+  conversations: MessagesSquare,
+  memories: Brain,
+  tasks: ListChecks,
+  screen: Monitor
+}
+
+/** Where a result takes you. Only conversations have a detail route to land on;
+ *  the rest open their own page, which is where the item lives. Deep-linking to
+ *  one memory, task or frame needs a target that does not exist yet. */
+const CORPUS_DESTINATIONS: Record<SearchCorpus, (hit: CorpusHit) => string> = {
+  conversations: (hit) => `/conversations/${hit.id}`,
+  memories: () => '/memories',
+  tasks: () => '/tasks',
+  screen: () => '/rewind'
+}
+
+function formatWhen(ts: number): string {
+  if (!ts) return ''
+  const d = new Date(ts)
+  const sameYear = d.getFullYear() === new Date().getFullYear()
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' })
+  })
+}
+
+function ResultRow(props: { hit: CorpusHit; onOpen: () => void }): React.JSX.Element {
+  const { hit, onOpen } = props
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-start justify-between gap-4 rounded-lg px-3 py-2.5 text-left hover:bg-white/[0.06]"
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm text-white/90">{hit.title}</span>
+        {hit.detail && (
+          <span className="mt-0.5 block truncate text-xs text-white/40">{hit.detail}</span>
+        )}
+      </span>
+      <span className="shrink-0 pt-0.5 text-xs tabular-nums text-white/35">
+        {formatWhen(hit.timestamp)}
+      </span>
+    </button>
+  )
+}
+
+function CorpusSection(props: {
+  corpus: SearchCorpus
+  slice: SearchSlice
+  onOpen: (hit: CorpusHit) => void
+}): React.JSX.Element | null {
+  const { corpus, slice, onOpen } = props
+  // A corpus with nothing to say is left out entirely; a failed one stays so its
+  // absence is stated rather than silent.
+  if (slice.hits.length === 0 && !slice.failed) return null
+  const Icon = CORPUS_ICONS[corpus]
+  return (
+    <section className="mb-6">
+      <header className="mb-1.5 flex items-center gap-2 px-3">
+        <Icon className="h-3.5 w-3.5 text-white/40" strokeWidth={1.8} />
+        <h2 className="text-xs font-medium uppercase tracking-wide text-white/55">
+          {CORPUS_LABELS[corpus]}
+        </h2>
+        <span className="text-xs text-white/30">{corpusCountLabel(slice)}</span>
+      </header>
+      {slice.hits.map((hit) => (
+        <ResultRow key={`${corpus}:${hit.id}`} hit={hit} onOpen={() => onOpen(hit)} />
+      ))}
+    </section>
+  )
+}
+
+export function Search(): React.JSX.Element {
+  const navigate = useNavigate()
+  const { input, setInput, results, searching, clear } = useSearch()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // The page exists to be typed into, so it takes focus on arrival.
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const phase = useMemo(
+    () => searchPhase({ input, searching, results }),
+    [input, searching, results]
+  )
+  const partial = useMemo(
+    () => (results && phase.kind === 'results' ? failedCorpora(results) : []),
+    [results, phase.kind]
+  )
+
+  const open = (corpus: SearchCorpus, hit: CorpusHit): void => {
+    navigate(CORPUS_DESTINATIONS[corpus](hit))
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader title="Search" subtitle="Everything Omi has kept for you" />
+
+      <div className="px-6">
+        <div className="glass flex items-center gap-2 rounded-xl px-3 py-2">
+          <SearchIcon className="h-4 w-4 shrink-0 text-white/40" strokeWidth={1.8} />
+          <input
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key !== 'Escape') return
+              // The whole Escape ladder has to live here. useKeyboardNav ignores
+              // any key pressed inside an INPUT, so its escape-to-home never
+              // fires while this box has focus - without the second branch an
+              // empty box would swallow Escape and strand the page.
+              e.preventDefault()
+              if (input.length > 0) clear()
+              else navigate(HOME_PATH)
+            }}
+            placeholder={COPY.placeholder}
+            aria-label="Search"
+            spellCheck={false}
+            className="w-full bg-transparent text-sm text-white/90 outline-none placeholder:text-white/30"
+          />
+          {input.length > 0 && (
+            <button
+              type="button"
+              onClick={clear}
+              aria-label="Clear search"
+              className="shrink-0 rounded p-0.5 text-white/40 hover:text-white/80"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pt-5">
+        {phase.kind === 'prompt' && (
+          <EmptyState icon={SearchIcon} title="Search" description={COPY.prompt} />
+        )}
+        {phase.kind === 'tooShort' && <p className="px-3 text-sm text-white/40">{COPY.tooShort}</p>}
+        {phase.kind === 'searching' && (
+          <p className="px-3 text-sm text-white/40">{COPY.searching}</p>
+        )}
+        {phase.kind === 'unavailable' && (
+          <EmptyState icon={SearchIcon} title="Search unavailable" description={COPY.unavailable} />
+        )}
+        {phase.kind === 'empty' && (
+          <EmptyState icon={SearchIcon} title="No matches" description={COPY.empty(phase.query)} />
+        )}
+        {phase.kind === 'results' && results && (
+          <>
+            {partial.length > 0 && (
+              <p className="mb-4 px-3 text-xs text-amber-300/80">
+                {COPY.partial(partial, CORPUS_LABELS)}
+              </p>
+            )}
+            {CORPUS_ORDER.map((corpus) => (
+              <CorpusSection
+                key={corpus}
+                corpus={corpus}
+                slice={results[corpus]}
+                onOpen={(hit) => open(corpus, hit)}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/routes/manifest.test.ts
+++ b/desktop/windows/src/renderer/src/routes/manifest.test.ts
@@ -43,9 +43,19 @@ describe('nav model (macOS parity)', () => {
     expect(pathForShortcut(key)).toBe(path)
   })
 
+  // Ctrl+7 is a DELIBERATE divergence from the table above. macOS has no Search
+  // destination to bind: its search is the QueryShell that Home itself becomes
+  // when you type (MainWindow/QueryShell/QueryShellHome.swift), so there is
+  // nothing there for a seventh key to open. Windows has no QueryShell, so
+  // search is its own destination and needs its own key. Everything else stays
+  // pinned to macOS.
+  it('binds Ctrl+7 to Search, which macOS has no equivalent destination for', () => {
+    expect(pathForShortcut('7')).toBe('/search')
+  })
+
   it('binds no other keys', () => {
-    expect(pathForShortcut('7')).toBeUndefined()
-    expect(pathForShortcut('k')).toBeUndefined() // macOS has no command palette
+    expect(pathForShortcut('8')).toBeUndefined()
+    expect(pathForShortcut('k')).toBeUndefined() // still no command palette
   })
 
   // DesktopHomeView.swift:1037-1044 — Esc goes Home from these four ONLY.
@@ -117,14 +127,17 @@ describe('route manifest', () => {
     expect(resolveRoute('/nope')).toBeUndefined()
   })
 
-  it('navRoutes are Home, Conversations, Tasks, Rewind, Apps, Insights in nav order', () => {
+  it('navRoutes are Home, Conversations, Tasks, Rewind, Apps, Insights, Search in nav order', () => {
+    // Search is appended rather than placed near Home so the existing rail order
+    // is unchanged for anyone already used to it.
     expect(navRoutes().map((e) => e.id)).toEqual([
       'home',
       'conversations',
       'tasks',
       'rewind',
       'apps',
-      'insights'
+      'insights',
+      'search'
     ])
   })
 
@@ -138,7 +151,8 @@ describe('route manifest', () => {
       'goals',
       'apps',
       'rewind',
-      'insights'
+      'insights',
+      'search'
     ])
   })
 

--- a/desktop/windows/src/renderer/src/routes/manifest.ts
+++ b/desktop/windows/src/renderer/src/routes/manifest.ts
@@ -1,7 +1,15 @@
 import { memo, createElement } from 'react'
 import type { ComponentType, ReactElement } from 'react'
 import type { LucideIcon } from 'lucide-react'
-import { House, GanttChartSquare, ListChecks, History, LayoutGrid, Lightbulb } from 'lucide-react'
+import {
+  House,
+  GanttChartSquare,
+  ListChecks,
+  History,
+  LayoutGrid,
+  Lightbulb,
+  Search as SearchIcon
+} from 'lucide-react'
 import { Home } from '../pages/Home'
 import { Conversations } from '../pages/Conversations'
 import { Memories } from '../pages/Memories'
@@ -12,6 +20,7 @@ import { Goals } from '../pages/Goals'
 import { Apps } from '../pages/Apps'
 import { Rewind } from '../pages/Rewind'
 import { Insights } from '../pages/Insights'
+import { Search } from '../pages/Search'
 import { LiveConversation } from '../pages/LiveConversation'
 import { KnowledgeGraph } from '../pages/KnowledgeGraph'
 import { CONVERSATIONS_PATH } from '../lib/conversations/conversationsPanelActivity'
@@ -79,6 +88,7 @@ const GoalsPanel = memo(Goals)
 const AppsPanel = memo(Apps)
 const RewindPanel = memo(Rewind)
 const InsightsPanel = memo(Insights)
+const SearchPanel = memo(Search)
 
 // Shared path constants — keep panel activity predicates and the manifest in sync.
 export const HOME_PATH = '/home'
@@ -184,6 +194,17 @@ export const routeManifest: RouteEntry[] = [
     path: '/insights',
     Component: InsightsPanel,
     nav: { label: 'Insights', Icon: Lightbulb, order: 5 },
+    escapeToHome: true
+  },
+  {
+    // Appended rather than placed near Home so the existing rail order is
+    // unchanged; '7' is the next free shortcut after Insights.
+    id: 'search',
+    kind: 'panel',
+    path: '/search',
+    Component: SearchPanel,
+    nav: { label: 'Search', Icon: SearchIcon, order: 6 },
+    shortcut: '7',
     escapeToHome: true
   }
 ]

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -2058,8 +2058,10 @@ export type RewindFrame = {
   indexed: number // 0 = not yet OCR'd, 1 = OCR done
 }
 
-/** Which corpus a local search hit came from. */
-export type CorpusKind = 'memory' | 'task' | 'screen'
+/** Which corpus a search hit came from. `conversation` is produced only in the
+ *  renderer: conversations live in the cloud, so they are searched against the
+ *  backend rather than the local index. */
+export type CorpusKind = 'conversation' | 'memory' | 'task' | 'screen'
 
 export type CorpusHit = {
   kind: CorpusKind

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -127,7 +127,12 @@ export type ChatMessage = {
  * See lib/sync/outbox.ts for the transition rules and dedupe strategy.
  */
 export type ConversationSyncState =
-  'local_only' | 'pending' | 'posting' | 'done' | 'failed' | 'unconfirmed'
+  | 'local_only'
+  | 'pending'
+  | 'posting'
+  | 'done'
+  | 'failed'
+  | 'unconfirmed'
 
 /** One transcript segment in the `/v1/conversations/from-segments` request shape
  * (snake_case matches the wire verbatim). `start`/`end` are WALL-CLOCK
@@ -990,6 +995,10 @@ export type OmiBridgeApi = {
   /** Phase 1 of a Rewind search: KEYWORD (FTS5/BM25) results, immediately. Never
    *  waits on the network — semantic hits follow on `onRewindSearchResults`. */
   rewindSearch: (query: string) => Promise<RewindSearchGroup[]>
+  /** One search over every local corpus. Conversations are absent: only the last
+   *  200 are cached locally, so the renderer searches them against the backend,
+   *  which is the only place the full history lives. */
+  searchLocal: (query: string, limit?: number) => Promise<DesktopSearchResult>
   /** Phase 2: the same result list with semantic hits merged in, delivered if and
    *  when the embedding round-trip lands. Never fires when semantic search is
    *  unavailable (signed out, backend down, nothing indexed) — the keyword results
@@ -1709,7 +1718,13 @@ export type MemoryExportResult = {
 }
 
 export type IndexedFileType =
-  'document' | 'code' | 'image' | 'media' | 'archive' | 'application' | 'other'
+  | 'document'
+  | 'code'
+  | 'image'
+  | 'media'
+  | 'archive'
+  | 'application'
+  | 'other'
 
 export type IndexedFileRecord = {
   path: string
@@ -1803,7 +1818,14 @@ export type RebuildResult = {
 // the macOS-parity local graph synthesized from indexed_files + memories and
 // consumed by the chat pre-step. Never conflate the two mechanisms.
 export type LocalKGNodeType =
-  'project' | 'app' | 'technology' | 'person' | 'org' | 'interest' | 'file_group' | 'card' // background-synthesized natural-language overview served to the chat floor
+  | 'project'
+  | 'app'
+  | 'technology'
+  | 'person'
+  | 'org'
+  | 'interest'
+  | 'file_group'
+  | 'card' // background-synthesized natural-language overview served to the chat floor
 
 export type LocalKGNode = {
   id: string // `${slug(label)}:${nodeType}` — stable across re-synthesis
@@ -2034,6 +2056,32 @@ export type RewindFrame = {
   width: number
   height: number
   indexed: number // 0 = not yet OCR'd, 1 = OCR done
+}
+
+/** Which corpus a local search hit came from. */
+export type CorpusKind = 'memory' | 'task' | 'screen'
+
+export type CorpusHit = {
+  kind: CorpusKind
+  /** Stable within a corpus; not unique across corpora. */
+  id: string
+  title: string
+  detail: string
+  /** Epoch ms. */
+  timestamp: number
+}
+
+export type CorpusSlice = {
+  hits: CorpusHit[]
+  /** Matches in the whole corpus, before the per-corpus limit, so the UI can say
+   *  how much it is not showing. */
+  total: number
+}
+
+export type DesktopSearchResult = {
+  memories: CorpusSlice
+  tasks: CorpusSlice
+  screen: CorpusSlice
 }
 
 export type RewindSearchGroup = {


### PR DESCRIPTION
You could not search your own data on Windows. This adds a search that covers all of it.

## The gap

The only two search inputs in the whole Windows app were `components/rewind/RewindSearchBar.tsx` (28 lines, frames only) and `components/settings/SettingsSearchProvider.tsx` (37 lines, settings only). A conversation, a memory or a task could be found by scrolling and no other way.

The capability was partly there and unreachable. `POST /v1/conversations/search` exists, and the generated client already has `search_conversations_endpoint_v1_conversations_search_post` in `omiApi.generated.ts` - nothing in the UI ever called it. Memories had no index at all, while rewind frames, action items and staged tasks each had one.

macOS solves this with QueryShell (`MainWindow/QueryShell/`, ~2,900 lines): Home itself becomes a search over rows it has already hydrated into memory. That works there because macOS mirrors everything locally in GRDB. Windows has no local mirror of cloud conversations, so the same design would have searched a fraction of someone's history and presented it as all of it. This uses full-text indexes and the server endpoint instead, which is a deliberate divergence and is why the shape differs.

## What is searched, and from where

| Corpus | Source | Coverage |
|---|---|---|
| Conversations | `POST /v1/conversations/search` | Full history |
| Memories | new `memories_fts` index | Everything on this machine |
| Tasks | existing `action_items_fts` + `staged_tasks_fts` | Everything on this machine |
| Screen | existing `rewind_frames_fts` | Everything on this machine |

One matcher runs all of it. `buildRewindFtsMatch` was already the app's tuned user-facing FTS5 matcher: quoted phrase terms so punctuation can never become query syntax, a trailing star for prefix search, camelCase and digit sub-parts expanded, tokens AND-joined so typing more narrows. Using it everywhere means one query behaves the same way against every corpus, rather than adding a fourth matcher next to the two the codebase already has for other jobs (exact-AND for agent tool calls, prefix-OR for dedup recall).

## Three things the design refuses to do

**Never interleave BM25 scores across corpora.** Scores from two indexes are computed over different document populations, so comparing them is meaningless and would silently order results by which index happens to hold shorter documents. Each corpus is ranked inside itself and shown in its own group.

**Never let a capped list read as a complete one.** Every slice carries the true total next to the hits it is showing, so the page says "Showing 20 of 300" instead of "20". A search that silently truncates makes someone stop looking, believing they have seen everything. Conversation totals come from a page count rather than a row count, so they are shown as a lower bound ("41+") rather than a number that would invent up to nineteen conversations.

**Never show an unreachable corpus as an empty one.** The two sources fail independently: a conversation request that times out still shows local results, and an unusable local index still shows conversations. Each corpus carries its own failure state, because "could not be searched" and "you have nothing about that" are different claims and only one of them is about the user's data.

## Privacy

The memories index covers content, context summary and source app, and deliberately not `window_title`. `assistants/memory/persist.ts` keeps raw window titles local precisely because they are unfiltered PII ("Chase - Log in", "MyChart - Lab Results"); indexing them would make that PII reachable by typing a fragment of it into a search box. A test asserts it stays unsearchable.

## Races

Typing fires a request per keystroke and a two-letter query can easily resolve after a five-letter one. Every run takes a sequence number, aborts its predecessor, and delivers only while it is still the latest, so the list on screen always belongs to the text in the box. Results also carry the text they were computed from, so "nothing matches X" can never name a different word than the one that was searched.

## Divergence: Ctrl+7

`manifest.test.ts` pins the Windows shortcut table to macOS's `OmiApp.swift:163-214` (Cmd+1..6 and Cmd+,) and asserted that no seventh key was bound. That test is updated, and the reason belongs in the record: macOS has no Search destination to bind, because its search is the QueryShell that Home becomes when you type. Windows has no QueryShell, so search is its own destination and needs its own key. Nothing else in the table moved, and Search is appended to the rail rather than placed near Home so the existing order is untouched.

## Migration

`memories_fts` is external-content and trigger-maintained, following `rewind_frames_fts` exactly, so it stays out of `USER_DATA_TABLES`: the account-switch `DELETE FROM memories` empties it through the delete trigger. Migration v3 runs the one-time rebuild for installs whose memories predate the index, and the index is added to the post-recovery rebuild list alongside the other three.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,293 passed, 18 skipped, 547 files. 85 of those are this feature, run against a real SQLite database via node:sqlite and a real jsdom render of the page.
- `npx tsc --noEmit` on both `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint` on every touched file - 0 problems.
- `npx electron-vite build` - built in 17.14s.
- `check_lifecycle_headers.py`, `check_brand_ui.py`, `check_arch_guardrails.py` - all pass.

## Mutation audit

24 regressions seeded into the source, each confirmed to turn the suite red:

- memories index also covers the raw window title
- memory delete trigger dropped, leaving deleted content in the index
- memories ranked oldest-first on a tie
- existing memories never backfilled into the index
- deleted tasks become findable again
- completed tasks dropped from search
- suggested tasks not searched at all
- total reports only what is shown, hiding truncation
- a malformed query passed straight to FTS5
- IPC accepts a non-string query
- IPC lets a database failure reach the renderer
- IPC does not bound a pasted query
- a local failure blanks the conversation results too
- a conversation failure blanks the local results too
- a stale answer overwrites a newer one
- a newer search does not abort the one in flight
- a multi-page conversation total presented as exact
- a one-letter query is searched
- results echo the live input instead of what was searched
- an unreachable corpus renders as no matches
- the count line hides that the list is capped
- a failed corpus counts as an empty result
- empty is shown while a search is still running
- no results yet is reported as nothing found

Two of these were caught only after a test was strengthened. The delete-trigger test could not fail as first written: `searchMemoriesFts` joins `memories`, so a deleted row is filtered out by the join whether or not the index was updated. Asserting on the count, which reads the index directly, is what actually exercises the trigger.

## What is not here

The Activity spine (macOS `MainWindow/Spine/`, ~3,000 lines) is the other half of the macOS surface and is not in this PR. Deep links to a single memory, task or frame are also absent: those pages have no per-item route to land on yet, so a result opens the page the item lives on. Memories are searched from the local index, which covers memories extracted on this machine; there is no server-side memory search endpoint to complement it the way conversations have one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

