### PR TITLE
test(agent-vm): arm the offload hang guard at block time, not before setup (#11744)

### DIFF
--- a/backend/tests/unit/test_agent_vm_protocol.py
+++ b/backend/tests/unit/test_agent_vm_protocol.py
@@ -46,6 +46,15 @@ def read_database_value(path: Path, table: str) -> str:
         connection.close()
 
 
+# The offload tests below release a blocked worker through a hang guard. The guard is a
+# deadlock rescue, not a latency bound: it is armed from inside the worker once that
+# worker is actually blocking, so upload setup (payload stream, disk write, two fsync
+# thread hops) stays outside its window, and it fires only if the event loop never
+# resumes. The blocked worker outwaits the guard so the guard is always the rescue.
+HANG_GUARD_SECONDS = 2.0
+BLOCKED_WORKER_TIMEOUT_SECONDS = 10.0
+
+
 def test_health_requires_vm_token_and_reports_database_state(tmp_path: Path) -> None:
     app, _ = load_app(tmp_path)
     with TestClient(app) as client:
@@ -151,7 +160,8 @@ def test_database_integrity_check_does_not_block_event_loop(tmp_path: Path, monk
         nonlocal worker
         worker = threading.current_thread()
         started.set()
-        assert release.wait(2)
+        timer.start()
+        assert release.wait(BLOCKED_WORKER_TIMEOUT_SECONDS)
         return ["ok"]
 
     monkeypatch.setattr(module, "validate_database_integrity", slow_validation)
@@ -166,10 +176,8 @@ def test_database_integrity_check_does_not_block_event_loop(tmp_path: Path, monk
         upload_task = asyncio.create_task(module.upload_database(Request()))
         assert await asyncio.to_thread(started.wait, 1)
         await asyncio.sleep(0.01)
-        elapsed = time.monotonic() - started_at
         release.set()
-        result = await upload_task
-        return elapsed, result
+        return await upload_task
 
     timer_fired = False
 
@@ -178,22 +186,18 @@ def test_database_integrity_check_does_not_block_event_loop(tmp_path: Path, monk
         timer_fired = True
         release.set()
 
-    timer = threading.Timer(0.2, hang_guard)
-    started_at = time.monotonic()
-    timer.start()
+    timer = threading.Timer(HANG_GUARD_SECONDS, hang_guard)
     try:
-        elapsed, result = asyncio.run(run_upload())
+        result = asyncio.run(run_upload())
     finally:
         release.set()
         timer.cancel()
         module.runtime.close_database()
 
-    # The upload must release through its own path, not the 0.2 s hang guard:
-    # if the offloaded work never resumed, only the timer unblocks the await
-    # and the guard flag is set. The elapsed bound is deliberately generous —
-    # the precise signal is whether the guard fired, not a wall-clock race.
+    # The upload must release through its own path, not the hang guard: if validation
+    # ran on the event loop the loop can never reach release.set(), so only the guard
+    # unblocks the await and the flag is set.
     assert not timer_fired
-    assert elapsed < 2.0
     assert worker is not threading.main_thread()
     assert result == (len(payload), len(payload))
 
@@ -212,7 +216,8 @@ def test_database_upload_fsync_does_not_block_event_loop(tmp_path: Path, monkeyp
         if calls == 1:
             worker = threading.current_thread()
             started.set()
-            assert release.wait(2)
+            timer.start()
+            assert release.wait(BLOCKED_WORKER_TIMEOUT_SECONDS)
 
     monkeypatch.setattr(module, "fsync_file", slow_fsync)
 
@@ -226,10 +231,8 @@ def test_database_upload_fsync_does_not_block_event_loop(tmp_path: Path, monkeyp
         upload_task = asyncio.create_task(module.upload_database(Request()))
         assert await asyncio.to_thread(started.wait, 1)
         await asyncio.sleep(0.01)
-        elapsed = time.monotonic() - started_at
         release.set()
-        result = await upload_task
-        return elapsed, result
+        return await upload_task
 
     timer_fired = False
 
@@ -238,11 +241,9 @@ def test_database_upload_fsync_does_not_block_event_loop(tmp_path: Path, monkeyp
         timer_fired = True
         release.set()
 
-    timer = threading.Timer(0.2, hang_guard)
-    started_at = time.monotonic()
-    timer.start()
+    timer = threading.Timer(HANG_GUARD_SECONDS, hang_guard)
     try:
-        elapsed, result = asyncio.run(run_upload())
+        result = asyncio.run(run_upload())
     finally:
         release.set()
         timer.cancel()
@@ -250,7 +251,6 @@ def test_database_upload_fsync_does_not_block_event_loop(tmp_path: Path, monkeyp
 
     # See the sibling test: the precise signal is the hang guard, not the wall clock.
     assert not timer_fired
-    assert elapsed < 2.0
     assert worker is not threading.main_thread()
     assert result == (len(payload), len(payload))
 
@@ -274,7 +274,8 @@ def test_database_installation_is_offloaded_and_serialized_with_db_use(tmp_path:
         if not install_started.is_set():
             install_thread = threading.current_thread()
             install_started.set()
-            assert release_install.wait(2)
+            timer.start()
+            assert release_install.wait(BLOCKED_WORKER_TIMEOUT_SECONDS)
         return original_close()
 
     def tracked_execute_sql(query):
@@ -309,9 +310,7 @@ def test_database_installation_is_offloaded_and_serialized_with_db_use(tmp_path:
         timer_fired = True
         release_install.set()
 
-    timer = threading.Timer(0.2, hang_guard)
-    started_at = time.monotonic()
-    timer.start()
+    timer = threading.Timer(HANG_GUARD_SECONDS, hang_guard)
     try:
         query_blocked, result, query_result = asyncio.run(run_upload())
     finally:
@@ -321,10 +320,8 @@ def test_database_installation_is_offloaded_and_serialized_with_db_use(tmp_path:
 
     # The install must release through its own path: if the query serialized
     # behind the database install (the deadlock this test guards), only the
-    # 0.2 s hang guard unblocks it. The wall-clock bound is intentionally
-    # generous; the precise signal is whether the guard fired.
+    # hang guard unblocks it.
     assert not timer_fired
-    assert time.monotonic() - started_at < 2.0
     assert install_thread is not threading.main_thread()
     assert query_blocked
     assert result == (len(payload), len(payload))


### PR DESCRIPTION
Fixes #11744.

## Bug

`Backend Unit Tests` is red on `main` at 81bcd25ca3 ([run 32020219616](https://github.com/BasedHardware/omi/actions/runs/32020219616)):

```
FAILED tests/unit/test_agent_vm_protocol.py::test_database_integrity_check_does_not_block_event_loop - assert not True
```

Not a code regression: the last green run is bc296efee3, and everything between it and 81bcd25ca3 touches only `.github/`, `backend/scripts/`, docs and new tests — nothing under `backend/agent_vm/`.

## Root cause

The three offload tests release a blocked worker through `threading.Timer(0.2, hang_guard)` and assert `not timer_fired`. The timer is armed **before** `asyncio.run(...)`, so its window covers the whole upload setup that precedes the blocking call: `upload_database` streams the payload, writes it to disk, then makes two `run_thread_operation` hops (`fsync_file`, `fsync_directory`) before it ever reaches the monkeypatched blocker (`backend/agent_vm/main.py:414-438`). The backend runner starts one pytest process per test file, so on a loaded runner that setup alone outlasts the 0.2 s window, the guard fires, and the test reds with the property under test intact.

`9c9a2d5893` already de-flaked these same three tests once, swapping a 0.15 s wall-clock bound for this 0.2 s guard. That moved the race rather than removing it.

## Fix

- Arm the timer **from inside the worker**, once it is actually blocking, so setup latency falls outside the guard window.
- Size the guard as the deadlock rescue it is (2 s), with the blocked worker outwaiting it (10 s) so the guard is always what releases a genuinely stuck loop.
- Drop the `elapsed < 2.0` assertions. With the guard armed at block time they only measure setup speed — the machine load that caused the flake — and `assert not timer_fired` is now the precise signal.

Test-only change; no production code touched.

## What I tested

- **Deterministic repro of the flake.** Injecting 0.5 s of setup latency ahead of the blocker fires the old guard while the offload property still holds — `timer_fired=True`, `worker off main thread=True`, `VERDICT: FAIL (false red)`. The new form passes with 1.5 s of injected setup latency.
- **Mutation check — the guard still catches its regression.** Patching `run_thread_operation` to run inline on the event loop fails all three tests under the new form (plus `test_cancelled_database_upload_waits_for_install_before_reusing_temp_path`), so the assertion was not neutered. Reverted after the run.
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/fl.txt bash test.sh` over `tests/unit/test_agent_vm_protocol.py`: **24 passed**.
- 10 repeats of the three tests under 40 concurrent CPU burners: **0 failures**.
- `make preflight`: **24 checks passed**. `scripts/pr-preflight --suggest`: no product invariants affected, no failure-class declaration required. Pre-push gate passed against the canonical `backend/.venv`.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

