### PR TITLE
Windows Activity: one day-grouped stream of conversations, memories, tasks and screen

### DIFF
--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -29,6 +29,7 @@ import { registerCaptureBridge } from './ipc/captureBridge'
 import { registerSoak } from './soak'
 import { createCaptureWindow, getCaptureWindow, getCaptureWc } from './captureWindow'
 import { registerFileIndexHandlers } from './ipc/fileIndex'
+import { registerSpineHandlers } from './ipc/spine'
 import { cancelStartupRescan } from './fileIndex/indexer'
 import { registerMemoryImportHandlers } from './ipc/memoryImport'
 import { registerMemoryExportHandlers } from './ipc/memoryExport'
@@ -855,6 +856,7 @@ app.whenReady().then(async () => {
   // byte counters to userData/soak.jsonl for the 8h idle-soak verification.
   registerSoak()
   registerFileIndexHandlers()
+  registerSpineHandlers()
   registerLocalGraphHandlers()
   registerMemoryImportHandlers()
   registerMemoryExportHandlers()

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -8,6 +8,12 @@ import { addColumnIfMissing as ensureColumn, runMigrations } from './dbMigration
 import { applyRewindEmbeddingSchema } from './rewindEmbeddingSchema'
 import { LOCAL_CONVERSATION_SCHEMA } from './localConversationSchema'
 import {
+  projectScreenDay,
+  screenDaysWithCapture,
+  type ScreenDayProjection,
+  type ScreenIndexDb
+} from '../spine/screenIndex'
+import {
   clearCorruptionFlags,
   isCorruptionError,
   isCorruptionSuspected,
@@ -1475,6 +1481,19 @@ export function listRewindFramesSampled(
     const step = rewindSampleStep(n, target)
     return d.prepare(buildRewindSampledSql(REWIND_COLUMNS)).all(from, to, step) as RewindFrame[]
   })
+}
+
+/** Activity spine screen projections. Thin get()-bound wrappers over
+ *  spine/screenIndex.ts, which owns the SQL so production and the node:sqlite
+ *  tests run the same statements. */
+export function spineScreenDays(limit: number): number[] {
+  return timed('spineScreenDays', () =>
+    screenDaysWithCapture(get() as unknown as ScreenIndexDb, limit)
+  )
+}
+
+export function spineScreenDay(dayId: number): ScreenDayProjection {
+  return timed('spineScreenDay', () => projectScreenDay(get() as unknown as ScreenIndexDb, dayId))
 }
 
 // --- Track 4: Rewind FTS5 search ---

--- a/desktop/windows/src/main/ipc/spine.ts
+++ b/desktop/windows/src/main/ipc/spine.ts
@@ -1,0 +1,56 @@
+// Renderer-facing surface for the Activity spine's screen data.
+//
+// Reads only, so it is not gated to the main window: this returns the same
+// capture the Rewind page already shows. Two channels rather than one, because
+// the two answers have very different sizes - the day list is a handful of
+// numbers and is needed immediately, while a day projection carries up to a few
+// hundred frames and is only worth fetching for days actually on screen.
+
+import { ipcMain } from 'electron'
+import { spineScreenDay, spineScreenDays } from './db'
+import type { ScreenDayProjection } from '../spine/screenIndex'
+
+/** Most days offered to the spine at once. The stream pages further back by
+ *  conversation and memory, which are cheap; screen days are not. */
+export const MAX_SCREEN_DAYS = 30
+
+const emptyDay = (dayId: number): ScreenDayProjection => ({
+  dayId,
+  total: 0,
+  hourCounts: new Array<number>(24).fill(0),
+  sampled: []
+})
+
+export function listScreenDays(limit?: unknown): number[] {
+  const bounded =
+    typeof limit === 'number' && Number.isFinite(limit)
+      ? Math.max(1, Math.min(Math.floor(limit), MAX_SCREEN_DAYS))
+      : MAX_SCREEN_DAYS
+  try {
+    return spineScreenDays(bounded)
+  } catch (e) {
+    // A timeline that cannot read screen capture still has conversations,
+    // memories and tasks to show; failing the whole page over this would be a
+    // worse answer than a timeline with no screen rows in it.
+    console.error('[spine] screen day list failed', e)
+    return []
+  }
+}
+
+export function readScreenDay(dayId: unknown): ScreenDayProjection | null {
+  if (typeof dayId !== 'number' || !Number.isFinite(dayId)) return null
+  const day = Math.floor(dayId)
+  try {
+    return spineScreenDay(day)
+  } catch (e) {
+    console.error('[spine] screen day projection failed', e)
+    // A zeroed day, not null: the caller asked and got an answer, so the rail
+    // shows 0 rather than sitting on "counting" forever.
+    return emptyDay(day)
+  }
+}
+
+export function registerSpineHandlers(): void {
+  ipcMain.handle('omi-spine:screen-days', (_e, limit?: unknown) => listScreenDays(limit))
+  ipcMain.handle('omi-spine:screen-day', (_e, dayId: unknown) => readScreenDay(dayId))
+}

--- a/desktop/windows/src/main/spine/screenIndex.test.ts
+++ b/desktop/windows/src/main/spine/screenIndex.test.ts
@@ -71,12 +71,23 @@ describe('bucketByLocalHour', () => {
 
 describe('endOfLocalDay', () => {
   it('ends one calendar day later, not 24 hours later', () => {
-    // Adding 86_400_000 would land an hour early or late across a DST boundary
-    // and drop or double-count the frames in that hour.
     const end = endOfLocalDay(DAY_15)
     const d = new Date(end)
     expect([d.getHours(), d.getMinutes()]).toEqual([0, 0])
     expect(d.getDate()).toBe(16)
+  })
+
+  it('lands on local midnight for every day of a year', () => {
+    // Adding a fixed 86_400_000 lands an hour early or late on the two DST
+    // transition days, dropping or double-counting the frames in that hour. In a
+    // timezone that observes DST this loop fails for the fixed-constant version;
+    // in UTC (which CI uses) no day transitions, so this asserts the property
+    // holds everywhere it can be observed rather than proving the DST case.
+    for (let i = 0; i < 365; i += 1) {
+      const day = startOfLocalDay(new Date(2026, 0, 1 + i, 12).getTime())
+      const end = new Date(endOfLocalDay(day))
+      expect([end.getHours(), end.getMinutes(), end.getSeconds()]).toEqual([0, 0, 0])
+    }
   })
 })
 

--- a/desktop/windows/src/main/spine/screenIndex.test.ts
+++ b/desktop/windows/src/main/spine/screenIndex.test.ts
@@ -1,0 +1,211 @@
+// Proven against a REAL SQLite database via node:sqlite — better-sqlite3 here is
+// built for Electron's ABI and won't load under plain-node vitest.
+//
+// Timestamps are built with the LOCAL Date constructor so the local-hour
+// bucketing under test is deterministic in whatever timezone the runner uses.
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, it } from 'vitest'
+import {
+  SCREEN_SAMPLE_TARGET,
+  bucketByLocalHour,
+  endOfLocalDay,
+  projectScreenDay,
+  sampleStep,
+  screenDaysWithCapture,
+  startOfLocalDay,
+  type ScreenIndexDb
+} from './screenIndex'
+
+/** Copied from db.ts's bootstrap block. */
+const REWIND_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS rewind_frames (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts INTEGER NOT NULL,
+    path TEXT NOT NULL,
+    app TEXT NOT NULL DEFAULT '',
+    window_title TEXT NOT NULL DEFAULT '',
+    ocr_text TEXT NOT NULL DEFAULT '',
+    width INTEGER NOT NULL DEFAULT 0,
+    height INTEGER NOT NULL DEFAULT 0,
+    indexed INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE INDEX IF NOT EXISTS idx_rewind_frames_ts ON rewind_frames(ts);
+`
+
+const at = (day: number, hour: number, minute = 0): number =>
+  new Date(2026, 7, day, hour, minute, 0, 0).getTime()
+
+const DAY_15 = startOfLocalDay(at(15, 12))
+
+const open = (): ScreenIndexDb => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(REWIND_SCHEMA)
+  return db as unknown as ScreenIndexDb
+}
+
+const addFrame = (
+  db: ScreenIndexDb,
+  ts: number,
+  over: { app?: string; title?: string; path?: string } = {}
+): void => {
+  db.prepare(`INSERT INTO rewind_frames (ts, path, app, window_title) VALUES (?, ?, ?, ?)`).all(
+    ts,
+    over.path ?? 'C:/frames/f.jpg',
+    over.app ?? 'Chrome',
+    over.title ?? 'Docs'
+  )
+}
+
+describe('bucketByLocalHour', () => {
+  it('counts into the local hour, not UTC', () => {
+    const counts = bucketByLocalHour([at(15, 9), at(15, 9, 30), at(15, 14)])
+    expect(counts[9]).toBe(2)
+    expect(counts[14]).toBe(1)
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(3)
+  })
+
+  it('always returns 24 buckets', () => {
+    expect(bucketByLocalHour([]).length).toBe(24)
+  })
+})
+
+describe('endOfLocalDay', () => {
+  it('ends one calendar day later, not 24 hours later', () => {
+    // Adding 86_400_000 would land an hour early or late across a DST boundary
+    // and drop or double-count the frames in that hour.
+    const end = endOfLocalDay(DAY_15)
+    const d = new Date(end)
+    expect([d.getHours(), d.getMinutes()]).toEqual([0, 0])
+    expect(d.getDate()).toBe(16)
+  })
+})
+
+describe('sampleStep', () => {
+  it('takes every row when the day is under the target', () => {
+    expect(sampleStep(50, 240)).toBe(1)
+    expect(sampleStep(240, 240)).toBe(1)
+  })
+
+  it('steps far enough to land under the target', () => {
+    expect(sampleStep(480, 240)).toBe(2)
+    expect(sampleStep(1000, 240)).toBe(5)
+    expect(Math.ceil(1000 / sampleStep(1000, 240))).toBeLessThanOrEqual(240)
+  })
+})
+
+describe('projectScreenDay', () => {
+  it('reports an exact total and an exact histogram', () => {
+    const db = open()
+    addFrame(db, at(15, 9))
+    addFrame(db, at(15, 9, 30))
+    addFrame(db, at(15, 21))
+    // A frame on the next day must not leak into this one.
+    addFrame(db, at(16, 9))
+
+    const p = projectScreenDay(db, DAY_15)
+    expect(p.total).toBe(3)
+    expect(p.hourCounts[9]).toBe(2)
+    expect(p.hourCounts[21]).toBe(1)
+    expect(p.sampled.length).toBe(3)
+  })
+
+  it('returns a read-but-empty projection for a day with no capture', () => {
+    const db = open()
+    addFrame(db, at(16, 9))
+    const p = projectScreenDay(db, DAY_15)
+    // Zeroed, not absent: "read, and there was nothing" is a real answer and is
+    // what lets the rail show 0 rather than "counting".
+    expect(p).toEqual({
+      dayId: DAY_15,
+      total: 0,
+      hourCounts: new Array<number>(24).fill(0),
+      sampled: []
+    })
+  })
+
+  it('samples a busy day down while still counting all of it', () => {
+    const db = open()
+    for (let i = 0; i < 600; i += 1) addFrame(db, at(15, 8) + i * 60_000)
+
+    const p = projectScreenDay(db, DAY_15, 100)
+    expect(p.total).toBe(600)
+    expect(p.sampled.length).toBeLessThanOrEqual(100)
+    expect(p.sampled.length).toBeGreaterThan(0)
+    // The histogram is built from every timestamp, not the sample, so a busy
+    // hour still reads as busy.
+    expect(p.hourCounts.reduce((a, b) => a + b, 0)).toBe(600)
+  })
+
+  it('spreads the sample across the day instead of clustering it', () => {
+    const db = open()
+    for (let i = 0; i < 600; i += 1) addFrame(db, at(15, 8) + i * 60_000)
+
+    const p = projectScreenDay(db, DAY_15, 100)
+    const first = p.sampled[0].timestamp
+    const last = p.sampled[p.sampled.length - 1].timestamp
+    // A sample taken only from the start of the day would make the afternoon
+    // look like it never happened.
+    expect(last - first).toBeGreaterThan(500 * 60_000)
+  })
+
+  it('keeps sampling stable when retention has deleted earlier frames', () => {
+    const db = open()
+    for (let i = 0; i < 300; i += 1) addFrame(db, at(15, 8) + i * 60_000)
+    const before = projectScreenDay(db, DAY_15, 50).sampled.map((m) => m.timestamp)
+    // Retention deletes a chunk from an EARLIER day, leaving a rowid gap.
+    db.prepare('DELETE FROM rewind_frames WHERE id <= 0').all()
+    const after = projectScreenDay(db, DAY_15, 50).sampled.map((m) => m.timestamp)
+    // Sampling on a row number over the day's own ordering, rather than on
+    // rowid, is what keeps this stable.
+    expect(after).toEqual(before)
+  })
+
+  it('carries the fields a strip renders and nothing more', () => {
+    const db = open()
+    addFrame(db, at(15, 9), { app: 'Excel', title: 'Q3 Plan', path: 'C:/frames/9.jpg' })
+    const [m] = projectScreenDay(db, DAY_15).sampled
+    expect(m).toEqual({
+      id: expect.any(Number),
+      timestamp: at(15, 9),
+      appName: 'Excel',
+      windowTitle: 'Q3 Plan',
+      imagePath: 'C:/frames/9.jpg'
+    })
+  })
+
+  it('reports an absent window title as null rather than an empty string', () => {
+    const db = open()
+    addFrame(db, at(15, 9), { title: '' })
+    // The row falls back to the app name, which it can only do if the absence
+    // is distinguishable.
+    expect(projectScreenDay(db, DAY_15).sampled[0].windowTitle).toBeNull()
+  })
+
+  it('uses a default sample target when none is given', () => {
+    expect(SCREEN_SAMPLE_TARGET).toBe(240)
+  })
+})
+
+describe('screenDaysWithCapture', () => {
+  it('lists the days holding capture, newest first', () => {
+    const db = open()
+    addFrame(db, at(13, 9))
+    addFrame(db, at(15, 9))
+    expect(screenDaysWithCapture(db)).toEqual([
+      startOfLocalDay(at(15, 9)),
+      startOfLocalDay(at(14, 9)),
+      startOfLocalDay(at(13, 9))
+    ])
+  })
+
+  it('returns nothing when there is no capture at all', () => {
+    expect(screenDaysWithCapture(open())).toEqual([])
+  })
+
+  it('stops at the limit rather than walking the whole history', () => {
+    const db = open()
+    addFrame(db, at(1, 9))
+    addFrame(db, at(28, 9))
+    expect(screenDaysWithCapture(db, 5).length).toBe(5)
+  })
+})

--- a/desktop/windows/src/main/spine/screenIndex.ts
+++ b/desktop/windows/src/main/spine/screenIndex.ts
@@ -1,0 +1,164 @@
+// Per-day screen capture, projected for the Activity spine.
+//
+// One day of capture is thousands of frames; the spine shows at most eight per
+// strip and a 24-bar histogram. So this reads three different things at three
+// different resolutions rather than shipping the day across IPC and letting the
+// renderer throw most of it away:
+//
+//   total       exact COUNT over the day
+//   hourCounts  exact, from the day's timestamps alone (one INTEGER per row)
+//   sampled     a bounded, evenly-spaced sample of whole frames
+//
+// Hour bucketing is done in JS from the epoch-ms timestamp, deliberately not in
+// SQL. SQLite's date functions would need an explicit 'localtime' modifier and
+// would still bucket against the server-style UTC day; doing it here means the
+// histogram matches the local calendar the spine groups days by, including on a
+// DST-transition day where one local hour has twice the frames and another has
+// none.
+
+import { cachedStmt } from '../ipc/stmtCache'
+
+/** Minimal DB surface — satisfied structurally by better-sqlite3 (production)
+ *  and node:sqlite's DatabaseSync (tests). Positional `?` params only. */
+export interface ScreenIndexDb {
+  prepare(sql: string): {
+    all: (...params: unknown[]) => unknown[]
+    get: (...params: unknown[]) => unknown
+  }
+}
+
+export interface ScreenMoment {
+  id: number
+  timestamp: number
+  appName: string
+  windowTitle: string | null
+  imagePath: string | null
+}
+
+export interface ScreenDayProjection {
+  /** Local midnight, epoch ms. */
+  dayId: number
+  /** Exact frame count for the day. */
+  total: number
+  /** 24 entries, index = local hour. Exact, never sampled. */
+  hourCounts: number[]
+  sampled: ScreenMoment[]
+}
+
+/** Frames carried across IPC per day. The strip shows 8; the surplus is what
+ *  lets a cluster split on a gap and still have frames on both sides. */
+export const SCREEN_SAMPLE_TARGET = 240
+
+export function startOfLocalDay(ts: number): number {
+  const d = new Date(ts)
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+}
+
+/** Exclusive end of the local day starting at `dayId`. Computed by adding one
+ *  calendar day rather than 24 hours, so a DST day is 23 or 25 hours long and
+ *  no frame falls into a gap between two days. */
+export function endOfLocalDay(dayId: number): number {
+  const d = new Date(dayId)
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1).getTime()
+}
+
+/** Buckets timestamps into 24 local-hour counts. Exported for its own test:
+ *  this is the part a UTC-based implementation gets wrong. */
+export function bucketByLocalHour(timestamps: number[]): number[] {
+  const counts = new Array<number>(24).fill(0)
+  for (const ts of timestamps) {
+    const hour = new Date(ts).getHours()
+    if (hour >= 0 && hour < 24) counts[hour] += 1
+  }
+  return counts
+}
+
+/** Evenly-spaced sample indices for `n` rows down to at most `target`. Keeping
+ *  the step as an integer means the sample is spread across the whole day rather
+ *  than clustered at one end. */
+export function sampleStep(n: number, target: number): number {
+  if (n <= target || target <= 0) return 1
+  return Math.max(1, Math.ceil(n / target))
+}
+
+interface FrameRow {
+  id: number
+  ts: number
+  app: string
+  window_title: string
+  path: string
+}
+
+const toMoment = (row: FrameRow): ScreenMoment => ({
+  id: row.id,
+  timestamp: row.ts,
+  appName: row.app,
+  windowTitle: row.window_title.length > 0 ? row.window_title : null,
+  imagePath: row.path.length > 0 ? row.path : null
+})
+
+/**
+ * Projects one local day. Returns a zeroed projection for a day with no
+ * capture, which is a real answer ("read, and there was nothing") and distinct
+ * from the caller never asking.
+ */
+export function projectScreenDay(
+  db: ScreenIndexDb,
+  dayId: number,
+  target = SCREEN_SAMPLE_TARGET
+): ScreenDayProjection {
+  const from = dayId
+  const to = endOfLocalDay(dayId)
+
+  const stamps = (
+    cachedStmt(db, `SELECT ts FROM rewind_frames WHERE ts >= ? AND ts < ? ORDER BY ts`).all(
+      from,
+      to
+    ) as { ts: number }[]
+  ).map((r) => r.ts)
+
+  if (stamps.length === 0) {
+    return { dayId, total: 0, hourCounts: new Array<number>(24).fill(0), sampled: [] }
+  }
+
+  const step = sampleStep(stamps.length, target)
+  // The modulo is applied to a row number over the day's own ordering, so the
+  // sample is stable for a given day rather than depending on rowid gaps left
+  // by retention deleting frames.
+  const rows = cachedStmt(
+    db,
+    `SELECT id, ts, app, window_title, path FROM (
+       SELECT id, ts, app, window_title, path,
+              ROW_NUMBER() OVER (ORDER BY ts) - 1 AS n
+         FROM rewind_frames WHERE ts >= ? AND ts < ?
+     ) WHERE n % ? = 0 ORDER BY ts`
+  ).all(from, to, step) as FrameRow[]
+
+  return {
+    dayId,
+    total: stamps.length,
+    hourCounts: bucketByLocalHour(stamps),
+    sampled: rows.map(toMoment)
+  }
+}
+
+/** The local days that hold any capture at all, newest first. */
+export function screenDaysWithCapture(db: ScreenIndexDb, limit = 30): number[] {
+  const bounds = cachedStmt(
+    db,
+    `SELECT MIN(ts) AS min, MAX(ts) AS max FROM rewind_frames`
+  ).get() as { min: number | null; max: number | null } | undefined
+  if (!bounds || bounds.min === null || bounds.max === null) return []
+
+  const days: number[] = []
+  let cursor = startOfLocalDay(bounds.max)
+  const earliest = startOfLocalDay(bounds.min)
+  // Walked one calendar day at a time rather than by a fixed 86.4e6 step, so a
+  // DST transition cannot skip or repeat a day.
+  while (cursor >= earliest && days.length < limit) {
+    days.push(cursor)
+    const d = new Date(cursor)
+    cursor = new Date(d.getFullYear(), d.getMonth(), d.getDate() - 1).getTime()
+  }
+  return days
+}

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -351,6 +351,10 @@ const omi: OmiBridgeApi = {
     return () => ipcRenderer.removeListener('rewind:captured', listener)
   },
   rewindSearch: (query: string) => ipcRenderer.invoke('rewind:search', query),
+  /** Local days holding screen capture, newest first (Activity spine). */
+  spineScreenDays: (limit?: number) => ipcRenderer.invoke('omi-spine:screen-days', limit),
+  /** One local day's exact totals plus a bounded sample of its frames. */
+  spineScreenDay: (dayId: number) => ipcRenderer.invoke('omi-spine:screen-day', dayId),
   // --- Track 4 (Rewind semantic search) --- Phase 2 of a search: the same results
   // with semantic hits merged in, pushed if/when the embedding round-trip lands.
   // Keyword results are already on screen by then — see the rewind:search handler.

--- a/desktop/windows/src/renderer/src/components/spine/SpineHourRail.tsx
+++ b/desktop/windows/src/renderer/src/components/spine/SpineHourRail.tsx
@@ -1,0 +1,63 @@
+// The 24-hour density rail beside a day. The maths lives in spineRailModel.ts.
+
+import { formatHourLabel } from '../../lib/spine/spineModel'
+import {
+  HOT_THRESHOLD,
+  LABELLED_HOURS,
+  RENDERED_HOURS,
+  hourDensity,
+  railFooter,
+  railHeadline
+} from './spineRailModel'
+
+export function SpineHourRail(props: {
+  hourCounts: number[]
+  momentCount: number | null
+  dayTitle: string
+  conversationCount: number
+  currentHour: number | null
+}): React.JSX.Element {
+  const density = hourDensity(props.hourCounts)
+  const headline = railHeadline(props.momentCount)
+  return (
+    <aside className="w-[154px] shrink-0 px-3 py-4" aria-label={`${props.dayTitle} activity`}>
+      <p className="truncate text-2xl font-semibold text-white/90">{headline.value}</p>
+      <p className="text-[11px] text-white/40">{headline.caption}</p>
+      <p className="mt-0.5 truncate text-[11px] text-white/30">{props.dayTitle}</p>
+
+      <div className="mt-3 flex flex-col gap-[1px]">
+        {RENDERED_HOURS.map((hour) => {
+          const weight = density[hour] ?? 0
+          const isCurrent = props.currentHour === hour
+          const isHot = weight >= HOT_THRESHOLD
+          const labelled = LABELLED_HOURS.has(hour) || isCurrent
+          return (
+            <div key={hour} className="flex h-[7px] items-center gap-1.5">
+              <span
+                className="block rounded-full bg-white"
+                style={{
+                  width: `${14 + weight * 78}px`,
+                  height: isCurrent ? 6 : 5,
+                  opacity: isCurrent ? 0.85 : isHot ? 0.42 : 0.2
+                }}
+              />
+              {labelled && (
+                <span
+                  className={`text-[9px] tabular-nums ${
+                    isCurrent ? 'font-semibold text-white/60' : 'text-white/25'
+                  }`}
+                >
+                  {formatHourLabel(hour)}
+                </span>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {railFooter(props.conversationCount) !== null && (
+        <p className="mt-3 text-[11px] text-white/30">{railFooter(props.conversationCount)}</p>
+      )}
+    </aside>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/spine/SpineRow.tsx
+++ b/desktop/windows/src/renderer/src/components/spine/SpineRow.tsx
@@ -47,54 +47,50 @@ export function SpineRowView(props: {
       <Gutter time={row.isAttached ? null : formatRowTime(row.anchor)} />
       <div className={`min-w-0 flex-1 ${nested ? 'pl-7' : 'pl-4'}`}>
         {row.content.type === 'conversation' && (
-          <button
-            type="button"
-            onClick={() =>
-              props.onOpenConversation(
-                row.content.type === 'conversation' ? row.content.conversation.id : ''
-              )
-            }
-            className="group flex w-full items-center gap-3 rounded-xl bg-white/[0.04] px-4 py-3 text-left hover:bg-white/[0.07]"
-          >
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-lg">
-              {row.content.conversation.emoji}
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block truncate text-sm text-white/90">
-                {row.content.conversation.title || 'Untitled conversation'}
+          <div className="group flex w-full items-center gap-3 rounded-xl bg-white/[0.04] pr-2 hover:bg-white/[0.07]">
+            <button
+              type="button"
+              onClick={() =>
+                props.onOpenConversation(
+                  row.content.type === 'conversation' ? row.content.conversation.id : ''
+                )
+              }
+              className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-lg">
+                {row.content.conversation.emoji}
               </span>
-              <span className="block truncate text-xs text-white/40">
-                {row.content.conversation.overview}
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm text-white/90">
+                  {row.content.conversation.title || 'Untitled conversation'}
+                </span>
+                <span className="block truncate text-xs text-white/40">
+                  {row.content.conversation.overview}
+                </span>
               </span>
-            </span>
-            <span
-              role="button"
-              tabIndex={0}
+            </button>
+            {/* A sibling of the open button, not nested inside it: an interactive
+                element inside another is unreachable by keyboard in the order a
+                reader expects, and it needed stopPropagation to work at all. */}
+            <button
+              type="button"
               aria-label={row.content.conversation.starred ? 'Unstar' : 'Star'}
-              onClick={(e) => {
-                e.stopPropagation()
-                if (row.content.type !== 'conversation') return
-                props.onToggleStar(row.content.conversation.id, row.content.conversation.starred)
-              }}
-              onKeyDown={(e) => {
-                if (e.key !== 'Enter' && e.key !== ' ') return
-                e.preventDefault()
-                e.stopPropagation()
+              onClick={() => {
                 if (row.content.type !== 'conversation') return
                 props.onToggleStar(row.content.conversation.id, row.content.conversation.starred)
               }}
               className={`shrink-0 rounded p-1 ${
                 row.content.conversation.starred
                   ? 'text-amber-300'
-                  : 'text-white/35 opacity-0 group-hover:opacity-100'
+                  : 'text-white/35 opacity-0 focus:opacity-100 group-hover:opacity-100'
               }`}
             >
               <Star
                 className="h-3.5 w-3.5"
                 fill={row.content.conversation.starred ? 'currentColor' : 'none'}
               />
-            </span>
-          </button>
+            </button>
+          </div>
         )}
 
         {row.content.type === 'memories' && (

--- a/desktop/windows/src/renderer/src/components/spine/SpineRow.tsx
+++ b/desktop/windows/src/renderer/src/components/spine/SpineRow.tsx
@@ -1,0 +1,169 @@
+// One row of the Activity stream.
+//
+// Every row draws the same gutter so the day reads as a single timeline rather
+// than five stacked lists. Only unattached rows print their time: an attached
+// row belongs to the conversation above it and repeating the clock beside it
+// implies it happened separately.
+
+import { MessagesSquare, Brain, ListChecks, Monitor, Network, Star } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { formatRowTime, type SpineRow as Row } from '../../lib/spine/spineModel'
+
+const KIND_ICONS: Record<string, LucideIcon> = {
+  conversations: MessagesSquare,
+  memories: Brain,
+  tasks: ListChecks,
+  screen: Monitor
+}
+
+function Gutter(props: { time: string | null }): React.JSX.Element {
+  return (
+    <div className="relative w-[68px] shrink-0 border-r border-white/10 pr-3 text-right">
+      {props.time !== null && (
+        <>
+          <span className="text-[11px] tabular-nums text-white/35">{props.time}</span>
+          <span className="absolute -right-[3px] top-1.5 block h-[5px] w-[5px] rounded-full bg-white/30" />
+        </>
+      )}
+    </div>
+  )
+}
+
+export function SpineRowView(props: {
+  row: Row
+  /** Attached rows indent only in the unfiltered view; inside a single-kind
+   *  filter there is no parent on screen to indent under. */
+  showIndent: boolean
+  onOpenConversation: (id: string) => void
+  onToggleStar: (id: string, starred: boolean) => void
+  onOpenKind: (kind: Row['kind']) => void
+}): React.JSX.Element {
+  const { row } = props
+  const nested = row.isAttached && props.showIndent
+  const Icon = KIND_ICONS[row.kind] ?? Monitor
+
+  return (
+    <div className={`flex items-start ${nested ? 'pt-2' : 'pt-5'}`}>
+      <Gutter time={row.isAttached ? null : formatRowTime(row.anchor)} />
+      <div className={`min-w-0 flex-1 ${nested ? 'pl-7' : 'pl-4'}`}>
+        {row.content.type === 'conversation' && (
+          <button
+            type="button"
+            onClick={() =>
+              props.onOpenConversation(
+                row.content.type === 'conversation' ? row.content.conversation.id : ''
+              )
+            }
+            className="group flex w-full items-center gap-3 rounded-xl bg-white/[0.04] px-4 py-3 text-left hover:bg-white/[0.07]"
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/[0.06] text-lg">
+              {row.content.conversation.emoji}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm text-white/90">
+                {row.content.conversation.title || 'Untitled conversation'}
+              </span>
+              <span className="block truncate text-xs text-white/40">
+                {row.content.conversation.overview}
+              </span>
+            </span>
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label={row.content.conversation.starred ? 'Unstar' : 'Star'}
+              onClick={(e) => {
+                e.stopPropagation()
+                if (row.content.type !== 'conversation') return
+                props.onToggleStar(row.content.conversation.id, row.content.conversation.starred)
+              }}
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return
+                e.preventDefault()
+                e.stopPropagation()
+                if (row.content.type !== 'conversation') return
+                props.onToggleStar(row.content.conversation.id, row.content.conversation.starred)
+              }}
+              className={`shrink-0 rounded p-1 ${
+                row.content.conversation.starred
+                  ? 'text-amber-300'
+                  : 'text-white/35 opacity-0 group-hover:opacity-100'
+              }`}
+            >
+              <Star
+                className="h-3.5 w-3.5"
+                fill={row.content.conversation.starred ? 'currentColor' : 'none'}
+              />
+            </span>
+          </button>
+        )}
+
+        {row.content.type === 'memories' && (
+          <ul className="space-y-1.5">
+            {row.content.memories.map((memory) => (
+              <li key={memory.id} className="flex items-start gap-2">
+                <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-white/30" strokeWidth={1.8} />
+                <span className="text-sm leading-snug text-white/75">{memory.text}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {row.content.type === 'tasks' && (
+          <ul className="space-y-1.5">
+            {row.content.tasks.map((task) => (
+              <li key={task.id} className="flex items-start gap-2">
+                <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-white/30" strokeWidth={1.8} />
+                <span
+                  className={`text-sm leading-snug ${
+                    task.completed ? 'text-white/35 line-through' : 'text-white/75'
+                  }`}
+                >
+                  {task.text}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {row.content.type === 'moments' && (
+          <div>
+            <div className="flex flex-wrap gap-1.5">
+              {row.content.shown.map((moment) => (
+                <span
+                  key={moment.id}
+                  title={moment.windowTitle ?? moment.appName}
+                  className="max-w-[180px] truncate rounded-md bg-white/[0.05] px-2 py-1 text-xs text-white/55"
+                >
+                  {moment.windowTitle ?? moment.appName}
+                </span>
+              ))}
+            </div>
+            {row.content.total > row.content.shown.length && (
+              // The strip says how much it is not showing rather than implying
+              // these were the only frames captured.
+              <p className="mt-1 text-[11px] text-white/30">
+                {`Showing ${row.content.shown.length} of ${row.content.total.toLocaleString()} screen moments`}
+              </p>
+            )}
+          </div>
+        )}
+
+        {row.content.type === 'brainMap' && (
+          <button
+            type="button"
+            onClick={() => props.onOpenKind('memories')}
+            className="flex w-full items-center gap-3 rounded-xl border border-white/10 px-4 py-3 text-left hover:bg-white/[0.05]"
+          >
+            <Network className="h-4 w-4 shrink-0 text-white/40" strokeWidth={1.8} />
+            <span className="min-w-0 flex-1">
+              <span className="block text-sm text-white/85">Brain map</span>
+              <span className="block text-xs text-white/40">
+                {`How the day’s ${row.content.memoryCount === 1 ? 'memory connects' : `${row.content.memoryCount} memories connect`}`}
+              </span>
+            </span>
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/components/spine/spineRailModel.test.ts
+++ b/desktop/windows/src/renderer/src/components/spine/spineRailModel.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  HOT_THRESHOLD,
+  LABELLED_HOURS,
+  RENDERED_HOURS,
+  hourDensity,
+  railFooter,
+  railHeadline
+} from './spineRailModel'
+
+describe('RENDERED_HOURS', () => {
+  it('runs the same direction as the newest-first list', () => {
+    // 23 at the top, 0 at the bottom. Reversed, the eye would travel backwards
+    // through the day while the list beside it travels forwards.
+    expect(RENDERED_HOURS[0]).toBe(23)
+    expect(RENDERED_HOURS[RENDERED_HOURS.length - 1]).toBe(0)
+    expect(RENDERED_HOURS.length).toBe(24)
+  })
+})
+
+describe('hourDensity', () => {
+  it('normalises against the day, not the account', () => {
+    const counts = new Array<number>(24).fill(0)
+    counts[9] = 50
+    counts[14] = 100
+    const density = hourDensity(counts)
+    // A quiet day and a busy day both use their own peak, so an ordinary day
+    // does not render as a blank column next to one all-night capture session.
+    expect(density[14]).toBe(1)
+    expect(density[9]).toBe(0.5)
+    expect(density[3]).toBe(0)
+  })
+
+  it('returns a flat column for a day with no capture instead of dividing by zero', () => {
+    expect(hourDensity(new Array<number>(24).fill(0))).toEqual(new Array<number>(24).fill(0))
+  })
+
+  it('marks an hour hot only at or above the threshold', () => {
+    const counts = new Array<number>(24).fill(0)
+    counts[9] = 6
+    counts[10] = 5
+    counts[11] = 10
+    const density = hourDensity(counts)
+    expect(density[9] >= HOT_THRESHOLD).toBe(true)
+    expect(density[10] >= HOT_THRESHOLD).toBe(false)
+  })
+})
+
+describe('railHeadline', () => {
+  it('shows an em dash and counting for a day not read yet', () => {
+    // Rendering 0 here would claim the user captured nothing on a day that is
+    // still being counted.
+    expect(railHeadline(null)).toEqual({ value: '—', caption: 'counting screen moments' })
+  })
+
+  it('shows zero for a day that was read and held nothing', () => {
+    expect(railHeadline(0)).toEqual({ value: '0', caption: 'screen moments' })
+  })
+
+  it('agrees with itself on the singular', () => {
+    expect(railHeadline(1)).toEqual({ value: '1', caption: 'screen moment' })
+  })
+
+  it('groups thousands so a busy day stays readable', () => {
+    expect(railHeadline(4213).value).toBe('4,213')
+  })
+})
+
+describe('railFooter', () => {
+  it('is absent when the day held no conversation', () => {
+    expect(railFooter(0)).toBeNull()
+  })
+
+  it('reads naturally at one and many', () => {
+    expect(railFooter(1)).toBe('1 conversation')
+    expect(railFooter(12)).toBe('12 conversations')
+  })
+})
+
+describe('LABELLED_HOURS', () => {
+  it('labels the quarters of the day', () => {
+    expect([...LABELLED_HOURS].sort((a, b) => a - b)).toEqual([0, 6, 12, 18])
+  })
+})

--- a/desktop/windows/src/renderer/src/components/spine/spineRailModel.ts
+++ b/desktop/windows/src/renderer/src/components/spine/spineRailModel.ts
@@ -1,0 +1,48 @@
+// Pure rail maths, split out of SpineHourRail.tsx so that file only exports a
+// component (the fast-refresh rule) and so these rules can be tested directly.
+
+/** Rendered top to bottom: 23, 22, ... 0 - the same direction as the
+ *  newest-first list beside it. A rail running the other way would make the eye
+ *  travel backwards through the day while the list travels forwards. */
+export const RENDERED_HOURS: number[] = Array.from({ length: 24 }, (_v, i) => 23 - i)
+
+/** An hour at or above this share of the day's peak reads as busy. */
+export const HOT_THRESHOLD = 0.6
+
+/** Hours that always carry a label; the current hour is added to these. */
+export const LABELLED_HOURS = new Set([0, 6, 12, 18])
+
+/**
+ * Per-hour share of the day's own peak, in 0..1.
+ *
+ * Normalised against THAT DAY's busiest hour, never against the account:
+ * normalising globally would flatten every ordinary day into a blank column
+ * next to the one week someone left capture running overnight.
+ *
+ * All zeroes when the day has no capture, which renders as a flat column rather
+ * than dividing by zero.
+ */
+export function hourDensity(hourCounts: number[]): number[] {
+  const peak = hourCounts.reduce((max, n) => Math.max(max, n), 0)
+  if (peak <= 0) return new Array<number>(24).fill(0)
+  return hourCounts.map((n) => n / peak)
+}
+
+/** The headline number and the caption that has to agree with it. */
+export function railHeadline(momentCount: number | null): { value: string; caption: string } {
+  // null is "not read yet" and must never render as 0: a day still being
+  // counted would otherwise claim the user captured nothing.
+  if (momentCount === null) return { value: '—', caption: 'counting screen moments' }
+  return {
+    value: momentCount.toLocaleString(),
+    caption: momentCount === 1 ? 'screen moment' : 'screen moments'
+  }
+}
+
+/** "1 conversation" / "4 conversations", or null when there were none. */
+export function railFooter(conversationCount: number): string | null {
+  if (conversationCount <= 0) return null
+  return conversationCount === 1
+    ? '1 conversation'
+    : `${conversationCount.toLocaleString()} conversations`
+}

--- a/desktop/windows/src/renderer/src/hooks/useSpine.ts
+++ b/desktop/windows/src/renderer/src/hooks/useSpine.ts
@@ -1,0 +1,188 @@
+// Loads the four sources the Activity spine composes, and holds the view state
+// that is deliberately NOT persisted.
+//
+// Screen days are fetched separately from the rest, because they are the only
+// source whose cost scales with how much the user captured. The day list is one
+// cheap call; each day's projection is another. A day that has not been
+// projected yet is absent from `screen` AND from `loadedScreenDays`, which is
+// what lets the rail say "counting" instead of claiming the day held nothing.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { omiApi } from '../lib/apiClient'
+import type { Conversation, MemoryDB } from '../lib/omiApi.generated'
+import type { SpineScreenDay } from '../../../shared/types'
+import {
+  composeSpine,
+  filterSpine,
+  type SpineDay,
+  type SpineDayScreen,
+  type SpineKind
+} from '../lib/spine/spineModel'
+import {
+  compact,
+  toScreenMap,
+  toSpineConversation,
+  toSpineMemory,
+  toSpineTask
+} from '../lib/spine/spineSources'
+
+/** Conversations and memories pulled for the stream. Deep enough to cover a
+ *  couple of weeks for an ordinary account without paging on first paint. */
+export const CONVERSATION_LIMIT = 200
+export const MEMORY_LIMIT = 300
+export const TASK_LIMIT = 300
+/** Screen days projected up front. The rest report a null count until asked. */
+export const SCREEN_DAYS = 14
+
+export interface UseSpine {
+  days: SpineDay[]
+  /** Unfiltered, for counts that should not move when a chip is pressed. */
+  allDays: SpineDay[]
+  loading: boolean
+  /** True when a source failed; the stream still shows whatever loaded. */
+  degraded: boolean
+  kind: SpineKind | null
+  setKind: (kind: SpineKind | null) => void
+  query: string
+  setQuery: (query: string) => void
+  folded: ReadonlySet<number>
+  toggleFold: (dayId: number) => void
+  reload: () => void
+}
+
+async function loadConversations(): Promise<Conversation[] | null> {
+  try {
+    const r = await omiApi.get<Conversation[]>('/v1/conversations', {
+      params: { limit: CONVERSATION_LIMIT, offset: 0 }
+    })
+    return Array.isArray(r.data) ? r.data : []
+  } catch {
+    return null
+  }
+}
+
+async function loadMemories(): Promise<MemoryDB[] | null> {
+  try {
+    const r = await omiApi.get<MemoryDB[]>('/v3/memories', {
+      params: { limit: MEMORY_LIMIT, offset: 0 }
+    })
+    return Array.isArray(r.data) ? r.data : []
+  } catch {
+    return null
+  }
+}
+
+async function loadTasks(): Promise<ReturnType<typeof toSpineTask>[] | null> {
+  const api = window.omi
+  if (!api?.tasksListIncomplete) return null
+  try {
+    const [incomplete, completed] = await Promise.all([
+      api.tasksListIncomplete({ limit: TASK_LIMIT }),
+      api.tasksListCompleted?.({ limit: TASK_LIMIT }) ?? Promise.resolve([])
+    ])
+    // Completed tasks belong in a timeline: the point of looking back at a day
+    // is often to see what got finished in it.
+    return [...incomplete, ...completed].map(toSpineTask)
+  } catch {
+    return null
+  }
+}
+
+async function loadScreen(): Promise<{
+  screen: Record<number, SpineDayScreen>
+  loaded: Set<number>
+} | null> {
+  const api = window.omi
+  if (!api?.spineScreenDays || !api?.spineScreenDay) return null
+  try {
+    const dayIds = await api.spineScreenDays(SCREEN_DAYS)
+    const projections = await Promise.all(dayIds.map((id) => api.spineScreenDay(id)))
+    const present = projections.filter((p): p is SpineScreenDay => p !== null)
+    return { screen: toScreenMap(present), loaded: new Set(present.map((p) => p.dayId)) }
+  } catch {
+    return null
+  }
+}
+
+export function useSpine(): UseSpine {
+  // One piece of state for the whole load, null until the first answer arrives.
+  // `loading` is DERIVED from it rather than stored, so there is no path that
+  // leaves a spinner up over results that already loaded.
+  const [result, setResult] = useState<{ days: SpineDay[]; degraded: boolean } | null>(null)
+  const [kind, setKind] = useState<SpineKind | null>(null)
+  const [query, setQuery] = useState('')
+  // Fold state is keyed by the day's own identity, never by index, so paging
+  // older days in cannot move which day is folded. Session-only on purpose: a
+  // day folded last week should not still be hidden today.
+  const [folded, setFolded] = useState<ReadonlySet<number>>(() => new Set())
+  const [nonce, setNonce] = useState(0)
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      const [conversations, memories, tasks, screen] = await Promise.all([
+        loadConversations(),
+        loadMemories(),
+        loadTasks(),
+        loadScreen()
+      ])
+      if (cancelled || !mounted.current) return
+      // Any source may be null; the stream shows what did load and says so,
+      // because a timeline missing one source is far more useful than none.
+      setResult({
+        degraded: conversations === null || memories === null || tasks === null || screen === null,
+        days: composeSpine({
+          conversations: compact((conversations ?? []).map(toSpineConversation)),
+          memories: compact((memories ?? []).map(toSpineMemory)),
+          tasks: compact(tasks ?? []),
+          screen: screen?.screen ?? {},
+          loadedScreenDays: screen?.loaded ?? new Set()
+        })
+      })
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [nonce])
+
+  // Memoised so the identity is stable across renders; without it the filter
+  // below would recompute on every render even when nothing changed.
+  const days = useMemo(() => result?.days ?? [], [result])
+  const filtered = useMemo(() => filterSpine(days, kind, query), [days, kind, query])
+
+  const toggleFold = useCallback((dayId: number) => {
+    setFolded((prev) => {
+      const next = new Set(prev)
+      if (next.has(dayId)) next.delete(dayId)
+      else next.add(dayId)
+      return next
+    })
+  }, [])
+
+  const reload = useCallback(() => {
+    setResult(null)
+    setNonce((n) => n + 1)
+  }, [])
+
+  return {
+    days: filtered,
+    allDays: days,
+    loading: result === null,
+    degraded: result?.degraded ?? false,
+    kind,
+    setKind,
+    query,
+    setQuery,
+    folded,
+    toggleFold,
+    reload
+  }
+}

--- a/desktop/windows/src/renderer/src/lib/spine/spineModel.test.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineModel.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MOMENTS_PER_STRIP,
   attachMoments,
+  compareRows,
   clusterMoments,
   composeSpine,
   countRows,
@@ -125,6 +126,14 @@ describe('composeSpine day bucketing', () => {
     )
     expect(days.map((d) => d.id)).toEqual([DAY_14])
     expect(days[0].rows.map((r) => r.id)).toContain('conv-mem:c1')
+  })
+
+  it('collapses a conversation that arrived on two overlapping pages', () => {
+    // Both upstream stores page by offset against a server-resorted list, so the
+    // same record legitimately arrives twice; rendering it twice would look like
+    // the user had the same conversation two times.
+    const days = composeSpine(input({ conversations: [conversation(), conversation()] }), NOW)
+    expect(rowIds(days)).toEqual(['conv:c1'])
   })
 
   it('titles days Today, Yesterday, then by name', () => {
@@ -336,6 +345,40 @@ describe('composeSpine ordering', () => {
       NOW
     )
     expect(rowIds(days).slice(0, 3)).toEqual(['mem:later', 'conv:c1', 'conv-mem:c1'])
+  })
+})
+
+describe('compareRows', () => {
+  const row = (over: Partial<SpineRow>): SpineRow => ({
+    id: 'r',
+    anchor: 0,
+    kind: 'memories',
+    isAttached: false,
+    content: { type: 'memories', memories: [memory()] },
+    searchText: '',
+    ...over
+  })
+
+  it('orders newest first', () => {
+    expect(compareRows(row({ anchor: 2 }), row({ anchor: 1 }))).toBeLessThan(0)
+    expect(compareRows(row({ anchor: 1 }), row({ anchor: 2 }))).toBeGreaterThan(0)
+  })
+
+  it('puts a conversation first at an identical anchor, whichever side it is on', () => {
+    // Tested directly rather than through composeSpine: rows are emitted
+    // conversation-first and Array.prototype.sort is stable, so the current emit
+    // order already produces this and a composed test could not tell the rule
+    // from the accident.
+    const conv = row({ anchor: 5, kind: 'conversations' })
+    const mem = row({ anchor: 5, kind: 'memories' })
+    expect(compareRows(conv, mem)).toBeLessThan(0)
+    expect(compareRows(mem, conv)).toBeGreaterThan(0)
+  })
+
+  it('leaves two non-conversation rows at the same anchor alone', () => {
+    expect(compareRows(row({ anchor: 5, kind: 'tasks' }), row({ anchor: 5, kind: 'screen' }))).toBe(
+      0
+    )
   })
 })
 

--- a/desktop/windows/src/renderer/src/lib/spine/spineModel.test.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineModel.test.ts
@@ -1,0 +1,438 @@
+// Composition rules for the Activity spine.
+//
+// Timestamps are built with the LOCAL Date constructor so day bucketing is
+// deterministic in any timezone the suite runs in - a UTC literal would land on
+// a different local day depending on the runner's offset, which is the exact
+// class of bug the model buckets locally to avoid.
+import { describe, expect, it } from 'vitest'
+import {
+  MOMENTS_PER_STRIP,
+  attachMoments,
+  clusterMoments,
+  composeSpine,
+  countRows,
+  filterSpine,
+  formatDayTitle,
+  formatHourLabel,
+  ownerIdOf,
+  reseatAttachments,
+  startOfLocalDay,
+  uniqueById,
+  type SpineConversation,
+  type SpineDayScreen,
+  type SpineInput,
+  type SpineMemory,
+  type SpineMoment,
+  type SpineRow,
+  type SpineTask
+} from './spineModel'
+
+const at = (day: number, hour: number, minute = 0): number =>
+  new Date(2026, 7, day, hour, minute, 0, 0).getTime()
+
+const NOW = at(15, 18)
+const DAY_15 = startOfLocalDay(at(15, 12))
+const DAY_14 = startOfLocalDay(at(14, 12))
+
+const conversation = (over: Partial<SpineConversation> = {}): SpineConversation => ({
+  id: 'c1',
+  title: 'Lease renewal',
+  overview: 'We agreed to renew',
+  category: 'personal',
+  emoji: '🏠',
+  startedAt: at(15, 10),
+  finishedAt: at(15, 11),
+  starred: false,
+  ...over
+})
+
+const memory = (over: Partial<SpineMemory> = {}): SpineMemory => ({
+  id: 'm1',
+  text: 'Prefers oat milk',
+  timestamp: at(15, 10, 30),
+  conversationId: null,
+  ...over
+})
+
+const task = (over: Partial<SpineTask> = {}): SpineTask => ({
+  id: 't1',
+  text: 'Send the lease',
+  timestamp: at(15, 10, 45),
+  conversationId: null,
+  completed: false,
+  sourceLabel: 'Slack',
+  ...over
+})
+
+const moment = (over: Partial<SpineMoment> = {}): SpineMoment => ({
+  id: 1,
+  timestamp: at(15, 10, 15),
+  appName: 'Chrome',
+  windowTitle: 'Docs',
+  imagePath: 'C:/f/1.jpg',
+  ...over
+})
+
+const screenDay = (moments: SpineMoment[], total = moments.length): SpineDayScreen => ({
+  total,
+  hourCounts: new Array<number>(24).fill(0),
+  sampled: moments
+})
+
+const input = (over: Partial<SpineInput> = {}): SpineInput => ({
+  conversations: [],
+  memories: [],
+  tasks: [],
+  screen: {},
+  ...over
+})
+
+const rowIds = (days: ReturnType<typeof composeSpine>): string[] =>
+  days.flatMap((d) => d.rows.map((r) => r.id))
+
+describe('uniqueById', () => {
+  it('keeps the first sighting and the original order', () => {
+    // Both upstream stores page by offset against a server-resorted list, so
+    // overlapping pages are normal rather than exceptional.
+    const out = uniqueById([{ id: 'a' }, { id: 'b' }, { id: 'a' }, { id: 'c' }])
+    expect(out.map((x) => x.id)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('composeSpine day bucketing', () => {
+  it('orders days newest first', () => {
+    const days = composeSpine(
+      input({
+        conversations: [
+          conversation({ id: 'old', startedAt: at(14, 9), finishedAt: at(14, 10) }),
+          conversation({ id: 'new', startedAt: at(15, 9), finishedAt: at(15, 10) })
+        ]
+      }),
+      NOW
+    )
+    expect(days.map((d) => d.id)).toEqual([DAY_15, DAY_14])
+  })
+
+  it('files an attached memory under its conversation day, not its own', () => {
+    // A conversation that runs past midnight can produce a memory stamped the
+    // next day; it belongs with the conversation that produced it.
+    const days = composeSpine(
+      input({
+        conversations: [conversation({ startedAt: at(14, 23, 30), finishedAt: at(15, 0, 30) })],
+        memories: [memory({ timestamp: at(15, 0, 15), conversationId: 'c1' })]
+      }),
+      NOW
+    )
+    expect(days.map((d) => d.id)).toEqual([DAY_14])
+    expect(days[0].rows.map((r) => r.id)).toContain('conv-mem:c1')
+  })
+
+  it('titles days Today, Yesterday, then by name', () => {
+    expect(formatDayTitle(DAY_15, NOW)).toBe('Today')
+    expect(formatDayTitle(DAY_14, NOW)).toBe('Yesterday')
+    expect(formatDayTitle(startOfLocalDay(at(10, 12)), NOW)).toMatch(/August/)
+  })
+})
+
+describe('composeSpine attachment', () => {
+  it('attaches a memory and a task to their conversation', () => {
+    const days = composeSpine(
+      input({
+        conversations: [conversation()],
+        memories: [memory({ conversationId: 'c1' })],
+        tasks: [task({ conversationId: 'c1' })]
+      }),
+      NOW
+    )
+    expect(rowIds(days)).toEqual(['conv:c1', 'conv-mem:c1', 'conv-task:c1', 'map:' + DAY_15])
+    const conv = days[0].rows[0]
+    expect(conv.content).toMatchObject({ type: 'conversation', memoryCount: 1, taskCount: 1 })
+  })
+
+  it('keeps a memory whose conversation is not loaded as its own row', () => {
+    // Dropping it would silently hide the user's data behind a paging boundary.
+    const days = composeSpine(input({ memories: [memory({ conversationId: 'not-loaded' })] }), NOW)
+    expect(rowIds(days)).toEqual(['mem:m1', 'map:' + DAY_15])
+  })
+
+  it('batches attached memories into one row but gives each loose one its own', () => {
+    const days = composeSpine(
+      input({
+        conversations: [conversation()],
+        memories: [
+          memory({ id: 'a', conversationId: 'c1' }),
+          memory({ id: 'b', conversationId: 'c1' }),
+          memory({ id: 'c', timestamp: at(15, 14) }),
+          memory({ id: 'd', timestamp: at(15, 15) })
+        ]
+      }),
+      NOW
+    )
+    const ids = rowIds(days)
+    expect(ids.filter((i) => i.startsWith('conv-mem'))).toEqual(['conv-mem:c1'])
+    expect(ids.filter((i) => i.startsWith('mem:'))).toEqual(['mem:d', 'mem:c'])
+  })
+
+  it('sorts attached memories newest first inside their row', () => {
+    const days = composeSpine(
+      input({
+        conversations: [conversation()],
+        memories: [
+          memory({ id: 'early', timestamp: at(15, 10, 10), conversationId: 'c1' }),
+          memory({ id: 'late', timestamp: at(15, 10, 50), conversationId: 'c1' })
+        ]
+      }),
+      NOW
+    )
+    const row = days[0].rows.find((r) => r.id === 'conv-mem:c1')
+    expect(row?.content.type === 'memories' && row.content.memories.map((m) => m.id)).toEqual([
+      'late',
+      'early'
+    ])
+  })
+})
+
+describe('attachMoments (the two-pointer merge)', () => {
+  it('attaches a frame captured inside a conversation', () => {
+    const c = conversation()
+    const m = moment({ timestamp: at(15, 10, 30) })
+    const { momentsByConversation, looseMoments } = attachMoments([c], [m])
+    expect(momentsByConversation.get('c1')?.length).toBe(1)
+    expect(looseMoments).toEqual([])
+  })
+
+  it('leaves a frame outside every conversation loose', () => {
+    const { momentsByConversation, looseMoments } = attachMoments(
+      [conversation()],
+      [moment({ timestamp: at(15, 15) })]
+    )
+    expect(momentsByConversation.size).toBe(0)
+    expect(looseMoments.length).toBe(1)
+  })
+
+  it('a frame newer than every conversation does not orphan the ones behind it', () => {
+    // The regression macOS pins by name. If the cursor advanced on finishedAt,
+    // this one future frame would consume the whole list and every conversation
+    // after it would lose its frames.
+    const newer = conversation({ id: 'newer', startedAt: at(15, 14), finishedAt: at(15, 15) })
+    const older = conversation({ id: 'older', startedAt: at(15, 9), finishedAt: at(15, 10) })
+    const { momentsByConversation, looseMoments } = attachMoments(
+      [newer, older],
+      [
+        moment({ id: 1, timestamp: at(15, 17) }), // after everything
+        moment({ id: 2, timestamp: at(15, 9, 30) }) // inside `older`
+      ]
+    )
+    expect(looseMoments.map((m) => m.id)).toEqual([1])
+    expect(momentsByConversation.get('older')?.map((m) => m.id)).toEqual([2])
+  })
+
+  it('attaches at both boundaries of a conversation', () => {
+    const c = conversation()
+    const { looseMoments } = attachMoments(
+      [c],
+      [moment({ id: 1, timestamp: c.startedAt }), moment({ id: 2, timestamp: c.finishedAt })]
+    )
+    expect(looseMoments).toEqual([])
+  })
+})
+
+describe('clusterMoments', () => {
+  it('splits only on a gap strictly greater than 45 minutes', () => {
+    const runs = clusterMoments([
+      moment({ id: 1, timestamp: at(15, 9, 0) }),
+      moment({ id: 2, timestamp: at(15, 9, 45) }), // exactly 45m after 1: same run
+      moment({ id: 3, timestamp: at(15, 10, 31) }) // 46m after 2: new run
+    ])
+    expect(runs.map((r) => r.map((m) => m.id))).toEqual([[3], [2, 1]])
+  })
+
+  it('keeps runs and their contents newest first', () => {
+    const runs = clusterMoments([
+      moment({ id: 1, timestamp: at(15, 9) }),
+      moment({ id: 2, timestamp: at(15, 9, 10) })
+    ])
+    expect(runs).toEqual([[expect.objectContaining({ id: 2 }), expect.objectContaining({ id: 1 })]])
+  })
+})
+
+describe('composeSpine screen rows', () => {
+  it('caps a strip at eight frames but reports the whole cluster', () => {
+    const moments = Array.from({ length: 20 }, (_v, i) =>
+      moment({ id: i, timestamp: at(15, 14, i) })
+    )
+    const days = composeSpine(input({ screen: { [DAY_15]: screenDay(moments) } }), NOW)
+    const row = days[0].rows.find((r) => r.content.type === 'moments')
+    expect(row?.content.type === 'moments' && row.content.shown.length).toBe(MOMENTS_PER_STRIP)
+    // A strip that reported 8 would claim the other 12 do not exist.
+    expect(row?.content.type === 'moments' && row.content.total).toBe(20)
+  })
+
+  it('reports a null moment count for a day whose screen was never read', () => {
+    const days = composeSpine(
+      input({ conversations: [conversation()], screen: {}, loadedScreenDays: new Set() }),
+      NOW
+    )
+    // null is "not read yet"; 0 is "read, and there was nothing". Collapsing
+    // them makes an unread day claim the user captured nothing.
+    expect(days[0].momentCount).toBeNull()
+  })
+
+  it('reports zero for a day that was read and had nothing', () => {
+    const days = composeSpine(
+      input({
+        conversations: [conversation()],
+        screen: { [DAY_15]: screenDay([], 0) },
+        loadedScreenDays: new Set([DAY_15])
+      }),
+      NOW
+    )
+    expect(days[0].momentCount).toBe(0)
+  })
+
+  it('carries the exact per-day total, not the sample size', () => {
+    const days = composeSpine(input({ screen: { [DAY_15]: screenDay([moment()], 4213) } }), NOW)
+    expect(days[0].momentCount).toBe(4213)
+  })
+})
+
+describe('composeSpine ordering', () => {
+  it('orders rows by anchor, newest first', () => {
+    const days = composeSpine(
+      input({
+        memories: [
+          memory({ id: 'early', timestamp: at(15, 9) }),
+          memory({ id: 'late', timestamp: at(15, 17) })
+        ]
+      }),
+      NOW
+    )
+    expect(rowIds(days).slice(0, 2)).toEqual(['mem:late', 'mem:early'])
+  })
+
+  it('puts a conversation above anything else sharing its anchor', () => {
+    const days = composeSpine(
+      input({
+        conversations: [conversation()],
+        memories: [memory({ id: 'tie', timestamp: at(15, 10) })]
+      }),
+      NOW
+    )
+    expect(rowIds(days).slice(0, 2)).toEqual(['conv:c1', 'mem:tie'])
+  })
+
+  it('re-seats an attachment under its owner even when the anchors interleave', () => {
+    // The attached memory is older than a later standalone one, so pure anchor
+    // ordering would put an unrelated row between the conversation and its own
+    // memory.
+    const days = composeSpine(
+      input({
+        conversations: [conversation()],
+        memories: [
+          memory({ id: 'attached', timestamp: at(15, 10, 30), conversationId: 'c1' }),
+          memory({ id: 'later', timestamp: at(15, 16) })
+        ]
+      }),
+      NOW
+    )
+    expect(rowIds(days).slice(0, 3)).toEqual(['mem:later', 'conv:c1', 'conv-mem:c1'])
+  })
+})
+
+describe('reseatAttachments', () => {
+  const row = (id: string, attached: boolean, content: SpineRow['content']): SpineRow => ({
+    id,
+    anchor: 0,
+    kind: 'memories',
+    isAttached: attached,
+    content,
+    searchText: ''
+  })
+
+  it('keeps an attachment whose owner is missing rather than dropping it', () => {
+    const orphan = row('conv-mem:gone', true, { type: 'memories', memories: [memory()] })
+    expect(reseatAttachments([orphan]).map((r) => r.id)).toEqual(['conv-mem:gone'])
+  })
+
+  it('parses the owner id off the row id', () => {
+    expect(ownerIdOf('conv-mem:abc:123')).toBe('abc:123')
+    expect(ownerIdOf('nocolon')).toBe('')
+  })
+})
+
+describe('composeSpine brain map card', () => {
+  it('appends it last on a day that has memories', () => {
+    const days = composeSpine(input({ memories: [memory()] }), NOW)
+    const last = days[0].rows[days[0].rows.length - 1]
+    expect(last.id).toBe(`map:${DAY_15}`)
+    expect(last.content).toEqual({ type: 'brainMap', memoryCount: 1 })
+  })
+
+  it('is absent on a day with no memories', () => {
+    const days = composeSpine(input({ conversations: [conversation()] }), NOW)
+    expect(rowIds(days).some((i) => i.startsWith('map:'))).toBe(false)
+  })
+
+  it('counts as a memories row so soloing Conversations drops a memories-only day', () => {
+    const days = composeSpine(input({ memories: [memory()] }), NOW)
+    // Otherwise the day would survive the filter carrying nothing but an orphan
+    // map card.
+    expect(filterSpine(days, 'conversations', '')).toEqual([])
+    expect(filterSpine(days, 'memories', '').length).toBe(1)
+  })
+})
+
+describe('filterSpine', () => {
+  const days = (): ReturnType<typeof composeSpine> =>
+    composeSpine(
+      input({
+        conversations: [conversation()],
+        memories: [memory({ id: 'loose', text: 'Prefers oat milk', timestamp: at(15, 16) })],
+        tasks: [task({ id: 'loose-task', timestamp: at(15, 17) })]
+      }),
+      NOW
+    )
+
+  it('returns everything unchanged with no kind and no query', () => {
+    const all = days()
+    expect(filterSpine(all, null, '')).toBe(all)
+  })
+
+  it('keeps only the chosen kind and drops days left empty', () => {
+    const out = filterSpine(days(), 'tasks', '')
+    expect(out.length).toBe(1)
+    expect(out[0].rows.map((r) => r.id)).toEqual(['task:loose-task'])
+  })
+
+  it('matches the query case-insensitively against the row text', () => {
+    expect(filterSpine(days(), null, 'OAT MILK').flatMap((d) => d.rows).length).toBe(1)
+    // Both the conversation title and the task text contain "lease", and the
+    // task is the newer row.
+    expect(filterSpine(days(), null, 'lease').flatMap((d) => d.rows.map((r) => r.id))).toEqual([
+      'task:loose-task',
+      'conv:c1'
+    ])
+  })
+
+  it('drops every day when nothing matches', () => {
+    expect(filterSpine(days(), null, 'zzz')).toEqual([])
+  })
+
+  it('counts rows across days without regard to folding', () => {
+    expect(countRows(days())).toBe(countRows(days()))
+    expect(countRows(filterSpine(days(), 'conversations', ''))).toBe(1)
+  })
+})
+
+describe('formatHourLabel', () => {
+  it('reads as a clock, not a number', () => {
+    expect([0, 6, 9, 12, 18, 23].map(formatHourLabel)).toEqual([
+      '12 AM',
+      '6 AM',
+      '9 AM',
+      '12 PM',
+      '6 PM',
+      '11 PM'
+    ])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/spine/spineModel.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineModel.ts
@@ -1,0 +1,505 @@
+// The Activity spine: conversations, memories, tasks and captured screen moments
+// composed into one reverse-chronological stream, grouped by day.
+//
+// Ported from macOS `MainWindow/Spine/SpineModel.swift`. Everything here is pure
+// so the composition rules can be tested without a database, a network or a
+// renderer - which matters, because almost every rule below exists to stop a
+// specific wrong-looking timeline rather than to produce a right-looking one.
+//
+// Timestamps are epoch milliseconds throughout (the Windows convention; macOS
+// uses Date). Day and hour bucketing is done in JS against the LOCAL calendar
+// and never in SQL, for the reason the macOS file header gives: local-time
+// bucketing is what makes a DST-transition day come out right, and a UTC-keyed
+// GROUP BY silently shifts every row near midnight into the wrong day.
+
+/** The one filter axis. "Everything" is the absence of a filter, modelled as
+ *  `null` rather than a member, so a row can never claim to be it. */
+export type SpineKind = 'conversations' | 'memories' | 'tasks' | 'screen'
+
+export interface SpineMoment {
+  id: number
+  timestamp: number
+  appName: string
+  windowTitle: string | null
+  imagePath: string | null
+}
+
+export interface SpineMemory {
+  id: string
+  text: string
+  timestamp: number
+  /** Set when the memory came out of a conversation. */
+  conversationId: string | null
+}
+
+export interface SpineTask {
+  id: string
+  text: string
+  timestamp: number
+  conversationId: string | null
+  completed: boolean
+  sourceLabel: string
+}
+
+export interface SpineConversation {
+  id: string
+  title: string
+  overview: string
+  category: string
+  emoji: string
+  startedAt: number
+  finishedAt: number
+  starred: boolean
+}
+
+/** What one day's screen capture looks like to the spine: an exact total and
+ *  per-hour histogram, plus a bounded sample of frames to actually show. */
+export interface SpineDayScreen {
+  total: number
+  /** 24 entries, index = local hour. Exact counts, not sampled. */
+  hourCounts: number[]
+  sampled: SpineMoment[]
+}
+
+export type SpineRowContent =
+  | {
+      type: 'conversation'
+      conversation: SpineConversation
+      memoryCount: number
+      taskCount: number
+      momentCount: number
+    }
+  | { type: 'memories'; memories: SpineMemory[] }
+  | { type: 'tasks'; tasks: SpineTask[] }
+  | { type: 'moments'; shown: SpineMoment[]; total: number }
+  | { type: 'brainMap'; memoryCount: number }
+
+export interface SpineRow {
+  /** `"<prefix>:<recordId>"`. The prefix is an identity CONTRACT, not a
+   *  convention: the re-seat pass parses the owner id back out of it. */
+  id: string
+  /** The only value the stream is ordered by. */
+  anchor: number
+  kind: SpineKind
+  /** True when this row was produced by the conversation directly above it. */
+  isAttached: boolean
+  content: SpineRowContent
+  /** Lowercased haystack a typed query is matched against. */
+  searchText: string
+}
+
+export interface SpineDay {
+  /** Local midnight, epoch ms. The day's identity everywhere. */
+  id: number
+  title: string
+  rows: SpineRow[]
+  /** null means "this day's screen capture has not been read yet", which is a
+   *  different statement from 0 and must never be collapsed into it. */
+  momentCount: number | null
+  conversationCount: number
+  taskCount: number
+  hourCounts: number[]
+}
+
+/** Frames shown in one strip. The row still reports the full cluster size, so a
+ *  strip can honestly say it is showing 8 of 184. */
+export const MOMENTS_PER_STRIP = 8
+
+/** A gap longer than this splits a run of loose frames into two clusters. */
+export const MOMENT_CLUSTER_GAP_MS = 45 * 60 * 1000
+
+/** Local midnight for a timestamp, as epoch ms. */
+export function startOfLocalDay(ts: number): number {
+  const d = new Date(ts)
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+}
+
+/** Local hour (0-23) for a timestamp. */
+export function localHour(ts: number): number {
+  return new Date(ts).getHours()
+}
+
+/** Dedupe by id keeping the FIRST sighting and the original order. Load-bearing:
+ *  both conversations and memories page by offset against a list the server
+ *  re-sorts, so overlapping pages are normal rather than exceptional. */
+export function uniqueById<T extends { id: string | number }>(items: T[]): T[] {
+  const seen = new Set<string | number>()
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false
+    seen.add(item.id)
+    return true
+  })
+}
+
+/** Splits loose frames into runs, newest first, splitting on a gap strictly
+ *  greater than 45 minutes. Frames inside each run stay newest-first. */
+export function clusterMoments(moments: SpineMoment[]): SpineMoment[][] {
+  const ordered = [...moments].sort((a, b) => b.timestamp - a.timestamp)
+  const runs: SpineMoment[][] = []
+  let current: SpineMoment[] = []
+  for (const moment of ordered) {
+    const previous = current[current.length - 1]
+    if (previous !== undefined && previous.timestamp - moment.timestamp > MOMENT_CLUSTER_GAP_MS) {
+      runs.push(current)
+      current = []
+    }
+    current.push(moment)
+  }
+  if (current.length > 0) runs.push(current)
+  return runs
+}
+
+const lower = (parts: Array<string | null | undefined>): string =>
+  parts
+    .filter((p): p is string => typeof p === 'string' && p.length > 0)
+    .join(' ')
+    .toLowerCase()
+
+function conversationRow(
+  conversation: SpineConversation,
+  memoryCount: number,
+  taskCount: number,
+  momentCount: number
+): SpineRow {
+  return {
+    id: `conv:${conversation.id}`,
+    anchor: conversation.startedAt,
+    kind: 'conversations',
+    isAttached: false,
+    content: { type: 'conversation', conversation, memoryCount, taskCount, momentCount },
+    searchText: lower([conversation.title, conversation.overview, conversation.category])
+  }
+}
+
+const memoriesRow = (id: string, memories: SpineMemory[], attached: boolean): SpineRow => ({
+  id,
+  anchor: Math.max(...memories.map((m) => m.timestamp)),
+  kind: 'memories',
+  isAttached: attached,
+  content: { type: 'memories', memories },
+  searchText: lower(memories.map((m) => m.text))
+})
+
+const tasksRow = (id: string, tasks: SpineTask[], attached: boolean): SpineRow => ({
+  id,
+  anchor: Math.max(...tasks.map((t) => t.timestamp)),
+  kind: 'tasks',
+  isAttached: attached,
+  content: { type: 'tasks', tasks },
+  searchText: lower(tasks.flatMap((t) => [t.text, t.sourceLabel]))
+})
+
+const momentsRow = (id: string, moments: SpineMoment[], attached: boolean): SpineRow => ({
+  id,
+  anchor: Math.max(...moments.map((m) => m.timestamp)),
+  kind: 'screen',
+  isAttached: attached,
+  content: { type: 'moments', shown: moments.slice(0, MOMENTS_PER_STRIP), total: moments.length },
+  searchText: lower(moments.flatMap((m) => [m.appName, m.windowTitle]))
+})
+
+/** Fixed presentation order for the rows attached to one conversation. */
+const ATTACHMENT_ORDER: Record<SpineKind, number> = {
+  conversations: 0,
+  memories: 1,
+  tasks: 2,
+  screen: 3
+}
+
+/** The owner conversation id encoded in an attached row's id: everything after
+ *  the first colon. */
+export function ownerIdOf(rowId: string): string {
+  const at = rowId.indexOf(':')
+  return at < 0 ? '' : rowId.slice(at + 1)
+}
+
+export interface SpineInput {
+  conversations: SpineConversation[]
+  memories: SpineMemory[]
+  tasks: SpineTask[]
+  /** Keyed by local-midnight epoch ms. */
+  screen: Record<number, SpineDayScreen>
+  /** Days whose screen capture has been read. A day absent from this reports a
+   *  null moment count, which the rail renders as "counting" rather than zero. */
+  loadedScreenDays?: Set<number>
+}
+
+/**
+ * Composes everything into days, newest first.
+ *
+ * `now` is injected so day titles are deterministic in tests; production passes
+ * Date.now().
+ */
+export function composeSpine(input: SpineInput, now: number = Date.now()): SpineDay[] {
+  const conversations = uniqueById(input.conversations)
+  const memories = uniqueById(input.memories)
+  const tasks = uniqueById(input.tasks)
+
+  // Attach by conversation id, but only to a conversation that is actually
+  // loaded. A memory pointing at a conversation that has not been paged in yet
+  // becomes a standalone row - it is never dropped, because the alternative is
+  // silently hiding the user's data behind a paging boundary.
+  const loaded = new Set(conversations.map((c) => c.id))
+  const attachedMemories = new Map<string, SpineMemory[]>()
+  const looseMemories: SpineMemory[] = []
+  for (const memory of memories) {
+    const owner = memory.conversationId
+    if (owner !== null && loaded.has(owner)) push(attachedMemories, owner, memory)
+    else looseMemories.push(memory)
+  }
+  const attachedTasks = new Map<string, SpineTask[]>()
+  const looseTasks: SpineTask[] = []
+  for (const task of tasks) {
+    const owner = task.conversationId
+    if (owner !== null && loaded.has(owner)) push(attachedTasks, owner, task)
+    else looseTasks.push(task)
+  }
+
+  const conversationsByDay = new Map<number, SpineConversation[]>()
+  for (const c of conversations) push(conversationsByDay, startOfLocalDay(c.startedAt), c)
+  const memoriesByDay = new Map<number, SpineMemory[]>()
+  for (const m of looseMemories) push(memoriesByDay, startOfLocalDay(m.timestamp), m)
+  const tasksByDay = new Map<number, SpineTask[]>()
+  for (const t of looseTasks) push(tasksByDay, startOfLocalDay(t.timestamp), t)
+
+  const dayIds = new Set<number>([
+    ...conversationsByDay.keys(),
+    ...memoriesByDay.keys(),
+    ...tasksByDay.keys(),
+    ...Object.keys(input.screen).map(Number)
+  ])
+
+  return [...dayIds]
+    .sort((a, b) => b - a)
+    .map((dayId) =>
+      composeDay({
+        dayId,
+        now,
+        conversations: conversationsByDay.get(dayId) ?? [],
+        looseMemories: memoriesByDay.get(dayId) ?? [],
+        looseTasks: tasksByDay.get(dayId) ?? [],
+        screen: input.screen[dayId],
+        attachedMemories,
+        attachedTasks,
+        screenLoaded: input.loadedScreenDays?.has(dayId) ?? input.screen[dayId] !== undefined
+      })
+    )
+}
+
+function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const existing = map.get(key)
+  if (existing === undefined) map.set(key, [value])
+  else existing.push(value)
+}
+
+function composeDay(args: {
+  dayId: number
+  now: number
+  conversations: SpineConversation[]
+  looseMemories: SpineMemory[]
+  looseTasks: SpineTask[]
+  screen: SpineDayScreen | undefined
+  attachedMemories: Map<string, SpineMemory[]>
+  attachedTasks: Map<string, SpineTask[]>
+  screenLoaded: boolean
+}): SpineDay {
+  const ordered = [...args.conversations].sort((a, b) => b.startedAt - a.startedAt)
+  const { momentsByConversation, looseMoments } = attachMoments(ordered, args.screen?.sampled ?? [])
+
+  const rows: SpineRow[] = []
+  for (const conversation of ordered) {
+    const mems = (args.attachedMemories.get(conversation.id) ?? []).sort(
+      (a, b) => b.timestamp - a.timestamp
+    )
+    const tsks = (args.attachedTasks.get(conversation.id) ?? []).sort(
+      (a, b) => b.timestamp - a.timestamp
+    )
+    const moments = momentsByConversation.get(conversation.id) ?? []
+    rows.push(conversationRow(conversation, mems.length, tsks.length, moments.length))
+    if (mems.length > 0) rows.push(memoriesRow(`conv-mem:${conversation.id}`, mems, true))
+    if (tsks.length > 0) rows.push(tasksRow(`conv-task:${conversation.id}`, tsks, true))
+    if (moments.length > 0) rows.push(momentsRow(`conv-shot:${conversation.id}`, moments, true))
+  }
+
+  // One row per loose memory and per loose task; only attached ones are batched.
+  for (const memory of [...args.looseMemories].sort((a, b) => b.timestamp - a.timestamp)) {
+    rows.push(memoriesRow(`mem:${memory.id}`, [memory], false))
+  }
+  for (const task of [...args.looseTasks].sort((a, b) => b.timestamp - a.timestamp)) {
+    rows.push(tasksRow(`task:${task.id}`, [task], false))
+  }
+  for (const cluster of clusterMoments(looseMoments)) {
+    rows.push(momentsRow(`shot:${cluster[0].id}`, cluster, false))
+  }
+
+  rows.sort((a, b) => {
+    if (a.anchor !== b.anchor) return b.anchor - a.anchor
+    // At an identical anchor a conversation leads, so its own attachments never
+    // appear above it before the re-seat pass runs.
+    if (a.kind === 'conversations' && b.kind !== 'conversations') return -1
+    if (b.kind === 'conversations' && a.kind !== 'conversations') return 1
+    return 0
+  })
+
+  const seated = reseatAttachments(rows)
+
+  const memoryCount = seated.reduce(
+    (n, r) => n + (r.content.type === 'memories' ? r.content.memories.length : 0),
+    0
+  )
+  const taskCount = seated.reduce(
+    (n, r) => n + (r.content.type === 'tasks' ? r.content.tasks.length : 0),
+    0
+  )
+  // The brain-map card is appended AFTER the sort and after re-seating, so it
+  // sits at the foot of the day regardless of its anchor.
+  if (memoryCount > 0) {
+    seated.push({
+      id: `map:${args.dayId}`,
+      anchor: args.dayId,
+      // Deliberately `memories`: soloing Conversations on a memories-only day
+      // should drop the day entirely rather than leave an orphan map card.
+      kind: 'memories',
+      isAttached: false,
+      content: { type: 'brainMap', memoryCount },
+      searchText: 'brain map how the day’s memories connect'
+    })
+  }
+
+  return {
+    id: args.dayId,
+    title: formatDayTitle(args.dayId, args.now),
+    rows: seated,
+    momentCount: args.screenLoaded ? (args.screen?.total ?? 0) : null,
+    conversationCount: ordered.length,
+    taskCount,
+    hourCounts: args.screen?.hourCounts ?? new Array<number>(24).fill(0)
+  }
+}
+
+/**
+ * Single-pass two-pointer merge that decides which conversation, if any, each
+ * frame belongs to. Both lists are newest-first.
+ *
+ * The cursor advances only past conversations that START AFTER the frame.
+ * Advancing on `finishedAt` instead is a real bug: one frame newer than every
+ * conversation would consume the whole list and orphan every conversation
+ * behind it. macOS regression-tests exactly that
+ * (`testAFrameNewerThanEveryConversationDoesNotOrphanTheOnesBehindIt`).
+ */
+export function attachMoments(
+  conversationsNewestFirst: SpineConversation[],
+  sampled: SpineMoment[]
+): { momentsByConversation: Map<string, SpineMoment[]>; looseMoments: SpineMoment[] } {
+  const momentsByConversation = new Map<string, SpineMoment[]>()
+  const looseMoments: SpineMoment[] = []
+  let cursor = 0
+  for (const moment of [...sampled].sort((a, b) => b.timestamp - a.timestamp)) {
+    while (
+      cursor < conversationsNewestFirst.length &&
+      conversationsNewestFirst[cursor].startedAt > moment.timestamp
+    ) {
+      cursor += 1
+    }
+    const candidate = conversationsNewestFirst[cursor]
+    if (candidate !== undefined && moment.timestamp <= candidate.finishedAt) {
+      push(momentsByConversation, candidate.id, moment)
+    } else {
+      looseMoments.push(moment)
+    }
+  }
+  return { momentsByConversation, looseMoments }
+}
+
+/**
+ * Pulls every attached row out and re-inserts it directly under its owner
+ * conversation. This deliberately defeats the pure-anchor ordering: a memory
+ * recorded mid-conversation would otherwise interleave with unrelated rows and
+ * read as though it came from somewhere else.
+ */
+export function reseatAttachments(rows: SpineRow[]): SpineRow[] {
+  const attachedByOwner = new Map<string, SpineRow[]>()
+  const trunk: SpineRow[] = []
+  for (const row of rows) {
+    if (row.isAttached) push(attachedByOwner, ownerIdOf(row.id), row)
+    else trunk.push(row)
+  }
+  // Attachments sit under their conversation in a FIXED order - memories, then
+  // tasks, then moments - rather than by anchor. Anchor order is right for the
+  // trunk, where it means "what happened next", but under a conversation it
+  // would put the memory row above the task row on one card and below it on the
+  // next depending on which happened to be recorded last, so the same card reads
+  // differently every time.
+  for (const attached of attachedByOwner.values()) {
+    attached.sort((a, b) => ATTACHMENT_ORDER[a.kind] - ATTACHMENT_ORDER[b.kind])
+  }
+  const out: SpineRow[] = []
+  for (const row of trunk) {
+    out.push(row)
+    if (row.content.type !== 'conversation') continue
+    const attached = attachedByOwner.get(row.content.conversation.id)
+    if (attached !== undefined) {
+      out.push(...attached)
+      attachedByOwner.delete(row.content.conversation.id)
+    }
+  }
+  // An attachment whose owner is not in this day's trunk would otherwise vanish.
+  for (const orphans of attachedByOwner.values()) out.push(...orphans)
+  return out
+}
+
+/**
+ * Keeps only the rows matching a kind and a query, and drops days left empty.
+ *
+ * Filtering is presentation over an already-composed stream, so a row's
+ * attachment and ordering never depend on what is filtered.
+ */
+export function filterSpine(days: SpineDay[], kind: SpineKind | null, query: string): SpineDay[] {
+  const needle = query.trim().toLowerCase()
+  if (kind === null && needle.length === 0) return days
+  const out: SpineDay[] = []
+  for (const day of days) {
+    const rows = day.rows.filter((row) => {
+      if (kind !== null && row.kind !== kind) return false
+      if (needle.length === 0) return true
+      return row.searchText.includes(needle)
+    })
+    if (rows.length > 0) out.push({ ...day, rows })
+  }
+  return out
+}
+
+/** Rows across every day, for a match count that does not depend on folding. */
+export function countRows(days: SpineDay[]): number {
+  return days.reduce((n, day) => n + day.rows.length, 0)
+}
+
+// --- formatting --------------------------------------------------------------
+
+/** `"Today"`, `"Yesterday"`, `"Wednesday 6 August"`, or `"Wednesday 30 September 2026"`. */
+export function formatDayTitle(dayId: number, now: number): string {
+  const today = startOfLocalDay(now)
+  if (dayId === today) return 'Today'
+  const yesterday = startOfLocalDay(today - 12 * 60 * 60 * 1000)
+  if (dayId === yesterday) return 'Yesterday'
+  const d = new Date(dayId)
+  const sameYear = d.getFullYear() === new Date(now).getFullYear()
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    ...(sameYear ? {} : { year: 'numeric' })
+  })
+}
+
+/** `"9:41 AM"`. */
+export function formatRowTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+}
+
+/** `"12 AM"`, `"9 AM"`, `"12 PM"`, `"9 PM"`. */
+export function formatHourLabel(hour: number): string {
+  if (hour === 0) return '12 AM'
+  if (hour === 12) return '12 PM'
+  return hour < 12 ? `${hour} AM` : `${hour - 12} PM`
+}

--- a/desktop/windows/src/renderer/src/lib/spine/spineModel.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineModel.ts
@@ -332,14 +332,7 @@ function composeDay(args: {
     rows.push(momentsRow(`shot:${cluster[0].id}`, cluster, false))
   }
 
-  rows.sort((a, b) => {
-    if (a.anchor !== b.anchor) return b.anchor - a.anchor
-    // At an identical anchor a conversation leads, so its own attachments never
-    // appear above it before the re-seat pass runs.
-    if (a.kind === 'conversations' && b.kind !== 'conversations') return -1
-    if (b.kind === 'conversations' && a.kind !== 'conversations') return 1
-    return 0
-  })
+  rows.sort(compareRows)
 
   const seated = reseatAttachments(rows)
 
@@ -375,6 +368,24 @@ function composeDay(args: {
     taskCount,
     hourCounts: args.screen?.hourCounts ?? new Array<number>(24).fill(0)
   }
+}
+
+/**
+ * Stream order: newest anchor first, and at an identical anchor a conversation
+ * leads so its own attachments never appear above it before the re-seat pass.
+ *
+ * The kind tie-break is defence in depth rather than the thing that produces
+ * today's order: rows are emitted conversation-first and Array.prototype.sort is
+ * stable, so it is already correct without it. It is written out so that
+ * changing the emit order cannot silently reorder a conversation under its own
+ * memory, and it is exported so the rule can be tested rather than inferred from
+ * whatever the emit order happens to be.
+ */
+export function compareRows(a: SpineRow, b: SpineRow): number {
+  if (a.anchor !== b.anchor) return b.anchor - a.anchor
+  if (a.kind === 'conversations' && b.kind !== 'conversations') return -1
+  if (b.kind === 'conversations' && a.kind !== 'conversations') return 1
+  return 0
 }
 
 /**

--- a/desktop/windows/src/renderer/src/lib/spine/spineSources.test.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineSources.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compact,
+  parseWireTime,
+  toScreenMap,
+  toSpineConversation,
+  toSpineMemory,
+  toSpineTask
+} from './spineSources'
+import type { Conversation, MemoryDB } from '../omiApi.generated'
+import type { ActionItemRecord, SpineScreenDay } from '../../../../shared/types'
+
+const ISO = '2026-08-15T10:00:00Z'
+const MS = Date.parse(ISO)
+
+const conversation = (over: Partial<Conversation> = {}): Conversation =>
+  ({
+    id: 'c1',
+    created_at: ISO,
+    started_at: ISO,
+    finished_at: '2026-08-15T11:00:00Z',
+    structured: {
+      title: 'Lease renewal',
+      overview: 'We agreed',
+      category: 'personal',
+      emoji: '🏠'
+    },
+    ...over
+  }) as Conversation
+
+const memoryDb = (over: Partial<MemoryDB> = {}): MemoryDB =>
+  ({ id: 'm1', content: 'Prefers oat milk', created_at: ISO, ...over }) as MemoryDB
+
+const taskRecord = (over: Partial<ActionItemRecord> = {}): ActionItemRecord =>
+  ({
+    id: 7,
+    description: 'Send the lease',
+    completed: false,
+    conversationId: null,
+    createdAt: MS,
+    source: 'conversation',
+    sourceApp: null,
+    ...over
+  }) as ActionItemRecord
+
+describe('parseWireTime', () => {
+  it('reads an ISO string', () => {
+    expect(parseWireTime(ISO)).toBe(MS)
+  })
+
+  it('returns null for anything unreadable', () => {
+    for (const bad of ['', 'not a date', null, undefined]) {
+      expect(parseWireTime(bad)).toBeNull()
+    }
+  })
+})
+
+describe('toSpineConversation', () => {
+  it('maps the fields the stream renders', () => {
+    expect(toSpineConversation(conversation())).toEqual({
+      id: 'c1',
+      title: 'Lease renewal',
+      overview: 'We agreed',
+      category: 'personal',
+      emoji: '🏠',
+      startedAt: MS,
+      finishedAt: Date.parse('2026-08-15T11:00:00Z'),
+      starred: false
+    })
+  })
+
+  it('falls back to the creation time when there is no start', () => {
+    expect(toSpineConversation(conversation({ started_at: null }))?.startedAt).toBe(MS)
+  })
+
+  it('keeps an unfinished conversation open at its start', () => {
+    // Treating a null finish as zero would stop every frame captured during a
+    // live conversation from attaching to it.
+    const c = toSpineConversation(conversation({ finished_at: null }))
+    expect(c?.finishedAt).toBe(c?.startedAt)
+  })
+
+  it('never lets the finish precede the start', () => {
+    const c = toSpineConversation(
+      conversation({ started_at: ISO, finished_at: '2026-08-15T09:00:00Z' })
+    )
+    // An inverted range would make the attachment window empty and silently
+    // orphan every frame in it.
+    expect(c?.finishedAt).toBe(c?.startedAt)
+  })
+
+  it('drops a conversation that cannot be placed in time', () => {
+    // Showing it at epoch zero would claim the user had a conversation in 1970.
+    expect(toSpineConversation(conversation({ started_at: null, created_at: '' }))).toBeNull()
+  })
+
+  it('supplies a default emoji rather than rendering a blank circle', () => {
+    expect(toSpineConversation(conversation({ structured: {} }))?.emoji).toBe('💬')
+  })
+})
+
+describe('toSpineMemory', () => {
+  it('maps a memory and its conversation link', () => {
+    expect(toSpineMemory(memoryDb({ conversation_id: 'c1' }))).toEqual({
+      id: 'm1',
+      text: 'Prefers oat milk',
+      timestamp: MS,
+      conversationId: 'c1'
+    })
+  })
+
+  it('drops an untimed or empty memory', () => {
+    expect(toSpineMemory(memoryDb({ created_at: '' }))).toBeNull()
+    expect(toSpineMemory(memoryDb({ content: '   ' }))).toBeNull()
+  })
+})
+
+describe('toSpineTask', () => {
+  it('maps a task and prefers the app it came from as its label', () => {
+    expect(toSpineTask(taskRecord({ sourceApp: 'Slack' }))).toMatchObject({
+      id: '7',
+      text: 'Send the lease',
+      timestamp: MS,
+      sourceLabel: 'Slack'
+    })
+  })
+
+  it('falls back to the source when no app is recorded', () => {
+    expect(toSpineTask(taskRecord())?.sourceLabel).toBe('conversation')
+  })
+
+  it('drops an untimed or empty task', () => {
+    expect(toSpineTask(taskRecord({ createdAt: 0 }))).toBeNull()
+    expect(toSpineTask(taskRecord({ description: '' }))).toBeNull()
+  })
+})
+
+describe('toScreenMap', () => {
+  const day = (over: Partial<SpineScreenDay> = {}): SpineScreenDay => ({
+    dayId: 1_723_680_000_000,
+    total: 12,
+    hourCounts: new Array<number>(24).fill(0),
+    sampled: [
+      { id: 1, timestamp: MS, appName: 'Chrome', windowTitle: 'Docs', imagePath: 'C:/f/1.jpg' }
+    ],
+    ...over
+  })
+
+  it('keys days by their local midnight', () => {
+    const map = toScreenMap([day()])
+    expect(map[1_723_680_000_000]).toMatchObject({ total: 12 })
+  })
+
+  it('replaces a malformed histogram rather than rendering a short rail', () => {
+    const map = toScreenMap([day({ hourCounts: [1, 2] })])
+    expect(map[1_723_680_000_000].hourCounts.length).toBe(24)
+  })
+})
+
+describe('compact', () => {
+  it('drops the nulls the mappers produced', () => {
+    expect(compact([1, null, 2, null])).toEqual([1, 2])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/spine/spineSources.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineSources.ts
@@ -1,0 +1,96 @@
+// Maps the app's four data sources onto the spine model.
+//
+// Kept apart from spineModel.ts on purpose: the model is pure composition rules
+// and should stay testable without knowing that a conversation arrives as an
+// ISO string from the cloud while a task arrives as epoch milliseconds from
+// SQLite. Every wire quirk is absorbed here.
+//
+// The one rule worth stating: a record that cannot be placed in time is
+// DROPPED, not shown at epoch zero. A row with a broken timestamp sorts to the
+// bottom of the oldest day and claims the user did something in 1970.
+
+import type { Conversation, MemoryDB } from '../omiApi.generated'
+import type { ActionItemRecord, SpineScreenDay } from '../../../../shared/types'
+import type { SpineConversation, SpineDayScreen, SpineMemory, SpineTask } from './spineModel'
+
+/** Epoch ms, or null when the value cannot be read as a time. */
+export function parseWireTime(raw: string | null | undefined): number | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  const ms = Date.parse(raw)
+  return Number.isFinite(ms) ? ms : null
+}
+
+/** A conversation the spine can place, or null when it cannot be timed. */
+export function toSpineConversation(c: Conversation): SpineConversation | null {
+  const startedAt = parseWireTime(c.started_at) ?? parseWireTime(c.created_at)
+  if (startedAt === null) return null
+  // An in-progress conversation has no finish time yet. Treating it as
+  // zero-length would stop every frame captured during it from attaching, so it
+  // stays open at its start instant until the server closes it.
+  const finishedAt = parseWireTime(c.finished_at) ?? startedAt
+  return {
+    id: c.id,
+    title: c.structured?.title?.trim() ?? '',
+    overview: c.structured?.overview?.trim() ?? '',
+    category: c.structured?.category ?? '',
+    emoji: c.structured?.emoji ?? '💬',
+    startedAt,
+    finishedAt: Math.max(finishedAt, startedAt),
+    starred: c.starred === true
+  }
+}
+
+export function toSpineMemory(m: MemoryDB): SpineMemory | null {
+  const timestamp = parseWireTime(m.created_at)
+  if (timestamp === null) return null
+  const text = (m.content ?? '').trim()
+  if (text.length === 0) return null
+  return {
+    id: m.id,
+    text,
+    timestamp,
+    conversationId: m.conversation_id ?? null
+  }
+}
+
+export function toSpineTask(t: ActionItemRecord): SpineTask | null {
+  const text = (t.description ?? '').trim()
+  if (text.length === 0) return null
+  if (!Number.isFinite(t.createdAt) || t.createdAt <= 0) return null
+  return {
+    id: String(t.id),
+    text,
+    timestamp: t.createdAt,
+    conversationId: t.conversationId,
+    completed: t.completed,
+    // What produced the task, for the row's second line and its search text.
+    sourceLabel: t.sourceApp ?? t.source ?? ''
+  }
+}
+
+/** Screen projections from main, keyed by local-midnight epoch ms. */
+export function toScreenMap(days: SpineScreenDay[]): Record<number, SpineDayScreen> {
+  const out: Record<number, SpineDayScreen> = {}
+  for (const day of days) {
+    out[day.dayId] = {
+      total: day.total,
+      hourCounts:
+        Array.isArray(day.hourCounts) && day.hourCounts.length === 24
+          ? day.hourCounts
+          : new Array<number>(24).fill(0),
+      sampled: day.sampled.map((m) => ({
+        id: m.id,
+        timestamp: m.timestamp,
+        appName: m.appName,
+        windowTitle: m.windowTitle,
+        imagePath: m.imagePath
+      }))
+    }
+  }
+  return out
+}
+
+/** Drops the nulls a mapper produced, keeping the callers free of the filter. */
+export function compact<T>(items: Array<T | null>): T[] {
+  return items.filter((item): item is T => item !== null)
+}

--- a/desktop/windows/src/renderer/src/lib/spine/spineSources.ts
+++ b/desktop/windows/src/renderer/src/lib/spine/spineSources.ts
@@ -24,10 +24,11 @@ export function parseWireTime(raw: string | null | undefined): number | null {
 export function toSpineConversation(c: Conversation): SpineConversation | null {
   const startedAt = parseWireTime(c.started_at) ?? parseWireTime(c.created_at)
   if (startedAt === null) return null
-  // An in-progress conversation has no finish time yet. Treating it as
-  // zero-length would stop every frame captured during it from attaching, so it
-  // stays open at its start instant until the server closes it.
-  const finishedAt = parseWireTime(c.finished_at) ?? startedAt
+  // An in-progress conversation has no finish time yet, and a bad one can carry
+  // a finish before its start. Either would make the attachment window empty and
+  // silently orphan every frame captured during the conversation, so the window
+  // is clamped to at least the start instant.
+  const finishedAt = Math.max(parseWireTime(c.finished_at) ?? startedAt, startedAt)
   return {
     id: c.id,
     title: c.structured?.title?.trim() ?? '',
@@ -35,7 +36,7 @@ export function toSpineConversation(c: Conversation): SpineConversation | null {
     category: c.structured?.category ?? '',
     emoji: c.structured?.emoji ?? '💬',
     startedAt,
-    finishedAt: Math.max(finishedAt, startedAt),
+    finishedAt,
     starred: c.starred === true
   }
 }

--- a/desktop/windows/src/renderer/src/pages/Activity.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Activity.test.tsx
@@ -179,18 +179,28 @@ describe('Activity page', () => {
     expect(navigate).toHaveBeenCalledWith('/conversations/c1')
   })
 
-  it('stars a conversation without opening it', async () => {
+  it('stars a conversation with the query param the endpoint requires', async () => {
     mount()
     await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
 
     fireEvent.click(screen.getByRole('button', { name: 'Star' }))
+    // The endpoint's parameter is named `starred` (backend/routers/
+    // conversations.py, set_conversation_starred(conversation_id, starred:
+    // bool)). This asserted `value` before, so every star tap failed validation
+    // and the test enshrined the wrong contract rather than catching it.
     await waitFor(() =>
       expect(patch).toHaveBeenCalledWith('/v1/conversations/c1/starred', null, {
-        params: { value: true }
+        params: { starred: true }
       })
     )
-    // The star sits inside the row button; without stopPropagation it would also
-    // navigate away from the page it was pressed on.
+  })
+
+  it('does not open the conversation when the star is pressed', async () => {
+    mount()
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Star' }))
+    // The star is a sibling of the open button rather than nested inside it, so
+    // this holds without any event-propagation handling.
     expect(navigate).not.toHaveBeenCalled()
   })
 

--- a/desktop/windows/src/renderer/src/pages/Activity.test.tsx
+++ b/desktop/windows/src/renderer/src/pages/Activity.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+//
+// The Activity page composes four sources into one stream. These tests mock all
+// four and assert the behaviors that decide whether the timeline can be trusted:
+// that a day still renders when a source is down, that folding is per day and
+// survives another day folding, that an unread day says "counting" rather than
+// zero, and that a capped strip says how much it is hiding.
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, waitFor, fireEvent, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const get = vi.fn()
+const patch = vi.fn()
+const tasksListIncomplete = vi.fn()
+const tasksListCompleted = vi.fn()
+const spineScreenDays = vi.fn()
+const spineScreenDay = vi.fn()
+const navigate = vi.fn()
+
+vi.mock('../lib/apiClient', () => ({
+  omiApi: { get: (...a: unknown[]) => get(...a), patch: (...a: unknown[]) => patch(...a) }
+}))
+vi.mock('../lib/toast', () => ({ toast: vi.fn() }))
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigate }
+})
+
+const { Activity } = await import('./Activity')
+
+const at = (day: number, hour: number, minute = 0): Date =>
+  new Date(2026, 7, day, hour, minute, 0, 0)
+const iso = (d: Date): string => d.toISOString()
+const startOfDay = (d: Date): number =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+
+const conversation = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: 'c1',
+  created_at: iso(at(15, 10)),
+  started_at: iso(at(15, 10)),
+  finished_at: iso(at(15, 11)),
+  structured: { title: 'Lease renewal', overview: 'We agreed', category: 'personal', emoji: '🏠' },
+  starred: false,
+  ...over
+})
+
+const memory = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: 'm1',
+  content: 'Prefers oat milk',
+  created_at: iso(at(15, 12)),
+  ...over
+})
+
+const screenDay = (dayId: number, over: Record<string, unknown> = {}): Record<string, unknown> => ({
+  dayId,
+  total: 3,
+  hourCounts: new Array<number>(24).fill(0),
+  sampled: [],
+  ...over
+})
+
+beforeEach(() => {
+  navigate.mockReset()
+  patch.mockReset().mockResolvedValue({ data: {} })
+  tasksListIncomplete.mockReset().mockResolvedValue([])
+  tasksListCompleted.mockReset().mockResolvedValue([])
+  spineScreenDays.mockReset().mockResolvedValue([])
+  spineScreenDay.mockReset().mockResolvedValue(null)
+  get.mockReset().mockImplementation((path: string) => {
+    if (path === '/v1/conversations') return Promise.resolve({ data: [conversation()] })
+    if (path === '/v3/memories') return Promise.resolve({ data: [memory()] })
+    return Promise.resolve({ data: [] })
+  })
+  ;(window as unknown as { omi: unknown }).omi = {
+    tasksListIncomplete,
+    tasksListCompleted,
+    spineScreenDays,
+    spineScreenDay
+  }
+})
+
+afterEach(() => cleanup())
+
+const mount = (): void => {
+  render(
+    <MemoryRouter>
+      <Activity />
+    </MemoryRouter>
+  )
+}
+
+describe('Activity page', () => {
+  it('composes the sources into a day with a header', async () => {
+    mount()
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+    expect(screen.getByText('Prefers oat milk')).toBeTruthy()
+    // The day header names the day, and the day is today's date in the fixture
+    // only if the suite runs on that date - so assert the header exists by role.
+    expect(screen.getAllByRole('button', { name: /Collapse|Expand/ }).length).toBeGreaterThan(0)
+  })
+
+  it('still renders the stream when a source is unavailable', async () => {
+    get.mockImplementation((path: string) => {
+      if (path === '/v3/memories') return Promise.reject(new Error('offline'))
+      if (path === '/v1/conversations') return Promise.resolve({ data: [conversation()] })
+      return Promise.resolve({ data: [] })
+    })
+    mount()
+
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+    // A timeline missing one source is far more useful than no timeline, but it
+    // has to say so rather than implying the missing records never existed.
+    expect(
+      screen.getByText('Some of your history could not be loaded, so this day may be incomplete.')
+    ).toBeTruthy()
+  })
+
+  it('folds one day without touching another', async () => {
+    get.mockImplementation((path: string) => {
+      if (path === '/v1/conversations') {
+        return Promise.resolve({
+          data: [
+            conversation(),
+            conversation({
+              id: 'c2',
+              started_at: iso(at(14, 10)),
+              created_at: iso(at(14, 10)),
+              finished_at: iso(at(14, 11)),
+              structured: { title: 'Standup', overview: '', category: '', emoji: '📅' }
+            })
+          ]
+        })
+      }
+      return Promise.resolve({ data: [] })
+    })
+    mount()
+    await waitFor(() => expect(screen.getByText('Standup')).toBeTruthy())
+
+    const headers = screen.getAllByRole('button', { name: /Collapse/ })
+    fireEvent.click(headers[0])
+
+    await waitFor(() => expect(screen.queryByText('Lease renewal')).toBeNull())
+    // Folding is keyed by the day's own identity, so the other day is untouched.
+    expect(screen.getByText('Standup')).toBeTruthy()
+  })
+
+  it('filters to one kind and drops the days left empty', async () => {
+    mount()
+    await waitFor(() => expect(screen.getByText('Prefers oat milk')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tasks' }))
+    await waitFor(() => expect(screen.queryByText('Prefers oat milk')).toBeNull())
+    expect(screen.getByText('Tasks you add or Omi extracts appear here.')).toBeTruthy()
+  })
+
+  it('says counting for a day whose screen capture was never read', async () => {
+    mount()
+    // No screen day was projected, so the rail must not claim zero moments.
+    await waitFor(() => expect(screen.getByText('counting screen moments')).toBeTruthy())
+    // The headline is an em dash rather than a number, for the same reason.
+    expect(screen.getByText('—')).toBeTruthy()
+    expect(screen.queryByText('0')).toBeNull()
+  })
+
+  it('says zero for a day that was read and held nothing', async () => {
+    const day = startOfDay(at(15, 10))
+    spineScreenDays.mockResolvedValue([day])
+    spineScreenDay.mockResolvedValue(screenDay(day, { total: 0 }))
+    mount()
+
+    await waitFor(() => expect(screen.getByText('0')).toBeTruthy())
+    expect(screen.queryByText('counting screen moments')).toBeNull()
+  })
+
+  it('opens a conversation from its row', async () => {
+    mount()
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+    fireEvent.click(screen.getByText('Lease renewal'))
+    expect(navigate).toHaveBeenCalledWith('/conversations/c1')
+  })
+
+  it('stars a conversation without opening it', async () => {
+    mount()
+    await waitFor(() => expect(screen.getByText('Lease renewal')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Star' }))
+    await waitFor(() =>
+      expect(patch).toHaveBeenCalledWith('/v1/conversations/c1/starred', null, {
+        params: { value: true }
+      })
+    )
+    // The star sits inside the row button; without stopPropagation it would also
+    // navigate away from the page it was pressed on.
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('shows the empty state when nothing loaded at all', async () => {
+    get.mockResolvedValue({ data: [] })
+    mount()
+    await waitFor(() => expect(screen.getByText('Nothing here yet')).toBeTruthy())
+    expect(
+      screen.getByText(
+        'Conversations, memories, tasks and screen moments appear here as they happen.'
+      )
+    ).toBeTruthy()
+  })
+})

--- a/desktop/windows/src/renderer/src/pages/Activity.tsx
+++ b/desktop/windows/src/renderer/src/pages/Activity.tsx
@@ -1,0 +1,165 @@
+// Activity: one reverse-chronological stream of everything Omi kept, grouped by
+// day, with an hour rail beside each day.
+//
+// Windows had four separate lists (Conversations, Memories, Tasks, Rewind) and
+// no way to see a day. This is the same records composed into one timeline, so
+// "what happened on Tuesday" is one screen rather than four cross-referenced
+// ones.
+//
+// Ported from macOS MainWindow/Spine. The composition rules live in
+// lib/spine/spineModel.ts; this file is presentation over their output.
+
+import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronDown, GanttChartSquare } from 'lucide-react'
+import { PageHeader } from '../components/layout/PageHeader'
+import { EmptyState } from '../components/ui/EmptyState'
+import { SpineHourRail } from '../components/spine/SpineHourRail'
+import { SpineRowView } from '../components/spine/SpineRow'
+import { useSpine } from '../hooks/useSpine'
+import { countRows, localHour, startOfLocalDay, type SpineKind } from '../lib/spine/spineModel'
+import { omiApi } from '../lib/apiClient'
+import { toast } from '../lib/toast'
+
+const CHIPS: Array<{ id: SpineKind | null; label: string }> = [
+  { id: null, label: 'All' },
+  { id: 'conversations', label: 'Conversations' },
+  { id: 'memories', label: 'Memories' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'screen', label: 'Screen' }
+]
+
+const EMPTY_DETAIL: Record<string, string> = {
+  all: 'Conversations, memories, tasks and screen moments appear here as they happen.',
+  conversations: 'Conversations appear here once Omi has heard one.',
+  memories: 'Memories appear here as Omi learns things worth keeping.',
+  tasks: 'Tasks you add or Omi extracts appear here.',
+  screen: 'Screen moments appear here while screen capture is on.'
+}
+
+export function Activity(): React.JSX.Element {
+  const navigate = useNavigate()
+  const spine = useSpine()
+  // Read once, at mount. `now` is impure, so it is pinned in state rather than
+  // recomputed on every render - which also keeps the "current hour" marker from
+  // jittering while the list is being scrolled.
+  const [now] = useState(() => Date.now())
+  const today = useMemo(() => startOfLocalDay(now), [now])
+  const currentHour = useMemo(() => localHour(now), [now])
+  const matches = useMemo(() => countRows(spine.days), [spine.days])
+
+  const toggleStar = async (id: string, starred: boolean): Promise<void> => {
+    try {
+      await omiApi.patch(`/v1/conversations/${id}/starred`, null, { params: { value: !starred } })
+      spine.reload()
+    } catch {
+      toast('Could not update that conversation.', { tone: 'warn' })
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeader
+        title="Activity"
+        subtitle="Everything Omi kept, in the order it happened"
+        actions={
+          spine.query.length > 0 || spine.kind !== null ? (
+            <span className="text-xs text-white/40">
+              {matches === 1 ? '1 result' : `${matches.toLocaleString()} results`}
+            </span>
+          ) : undefined
+        }
+      />
+
+      <div className="flex items-center gap-1.5 px-6 pb-1">
+        {CHIPS.map((chip) => {
+          const active = spine.kind === chip.id
+          return (
+            <button
+              key={chip.label}
+              type="button"
+              onClick={() => spine.setKind(chip.id)}
+              aria-pressed={active}
+              className={`rounded-full px-3 py-1 text-xs ${
+                active ? 'bg-white/15 text-white/90' : 'text-white/45 hover:bg-white/[0.06]'
+              }`}
+            >
+              {chip.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {spine.degraded && (
+        <p className="px-6 pt-2 text-xs text-amber-300/80">
+          Some of your history could not be loaded, so this day may be incomplete.
+        </p>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pt-3">
+        {spine.loading && spine.days.length === 0 && (
+          <p className="px-6 text-sm text-white/40">Reading your day…</p>
+        )}
+
+        {!spine.loading && spine.days.length === 0 && (
+          <EmptyState
+            icon={GanttChartSquare}
+            title="Nothing here yet"
+            description={EMPTY_DETAIL[spine.kind ?? 'all']}
+          />
+        )}
+
+        {spine.days.map((day) => {
+          const isFolded = spine.folded.has(day.id)
+          return (
+            <section key={day.id} className="mb-2">
+              <button
+                type="button"
+                onClick={() => spine.toggleFold(day.id)}
+                aria-expanded={!isFolded}
+                aria-label={`${isFolded ? 'Expand' : 'Collapse'} ${day.title}`}
+                className="sticky top-0 z-10 flex w-full items-center gap-2 rounded-lg border border-white/10 bg-neutral-900/80 px-3 py-2 text-left backdrop-blur"
+              >
+                <ChevronDown
+                  className={`h-3.5 w-3.5 text-white/40 transition-transform ${
+                    isFolded ? '-rotate-90' : ''
+                  }`}
+                />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-white/70">
+                  {day.title}
+                </span>
+                <span className="text-[11px] text-white/30">
+                  {day.rows.length === 1 ? '1 entry' : `${day.rows.length} entries`}
+                </span>
+              </button>
+
+              {!isFolded && (
+                <div className="flex gap-2 pb-4">
+                  <div className="min-w-0 flex-1">
+                    {day.rows.map((row) => (
+                      <SpineRowView
+                        key={row.id}
+                        row={row}
+                        showIndent={spine.kind === null}
+                        onOpenConversation={(id) => navigate(`/conversations/${id}`)}
+                        onToggleStar={(id, starred) => void toggleStar(id, starred)}
+                        onOpenKind={() => navigate('/knowledge-graph')}
+                      />
+                    ))}
+                  </div>
+                  <SpineHourRail
+                    hourCounts={day.hourCounts}
+                    momentCount={day.momentCount}
+                    dayTitle={day.title}
+                    conversationCount={day.conversationCount}
+                    currentHour={day.id === today ? currentHour : null}
+                  />
+                </div>
+              )}
+            </section>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/desktop/windows/src/renderer/src/pages/Activity.tsx
+++ b/desktop/windows/src/renderer/src/pages/Activity.tsx
@@ -18,7 +18,7 @@ import { SpineHourRail } from '../components/spine/SpineHourRail'
 import { SpineRowView } from '../components/spine/SpineRow'
 import { useSpine } from '../hooks/useSpine'
 import { countRows, localHour, startOfLocalDay, type SpineKind } from '../lib/spine/spineModel'
-import { omiApi } from '../lib/apiClient'
+import { setConversationStarred } from '../lib/conversations/mutations'
 import { toast } from '../lib/toast'
 
 const CHIPS: Array<{ id: SpineKind | null; label: string }> = [
@@ -50,7 +50,10 @@ export function Activity(): React.JSX.Element {
 
   const toggleStar = async (id: string, starred: boolean): Promise<void> => {
     try {
-      await omiApi.patch(`/v1/conversations/${id}/starred`, null, { params: { value: !starred } })
+      // Through the shared mutation rather than a hand-rolled request: the
+      // endpoint names its query param `starred`, and a second call site
+      // spelling it itself is how that gets out of step with the backend.
+      await setConversationStarred(id, !starred)
       spine.reload()
     } catch {
       toast('Could not update that conversation.', { tone: 'warn' })

--- a/desktop/windows/src/renderer/src/routes/manifest.test.ts
+++ b/desktop/windows/src/renderer/src/routes/manifest.test.ts
@@ -117,14 +117,17 @@ describe('route manifest', () => {
     expect(resolveRoute('/nope')).toBeUndefined()
   })
 
-  it('navRoutes are Home, Conversations, Tasks, Rewind, Apps, Insights in nav order', () => {
+  it('navRoutes are Home, Conversations, Tasks, Rewind, Apps, Insights, Activity in nav order', () => {
+    // Activity is appended rather than placed near Home so the existing rail
+    // order is unchanged for anyone already used to it.
     expect(navRoutes().map((e) => e.id)).toEqual([
       'home',
       'conversations',
       'tasks',
       'rewind',
       'apps',
-      'insights'
+      'insights',
+      'activity'
     ])
   })
 
@@ -138,7 +141,8 @@ describe('route manifest', () => {
       'goals',
       'apps',
       'rewind',
-      'insights'
+      'insights',
+      'activity'
     ])
   })
 

--- a/desktop/windows/src/renderer/src/routes/manifest.ts
+++ b/desktop/windows/src/renderer/src/routes/manifest.ts
@@ -1,7 +1,15 @@
 import { memo, createElement } from 'react'
 import type { ComponentType, ReactElement } from 'react'
 import type { LucideIcon } from 'lucide-react'
-import { House, GanttChartSquare, ListChecks, History, LayoutGrid, Lightbulb } from 'lucide-react'
+import {
+  House,
+  GanttChartSquare,
+  ListChecks,
+  History,
+  LayoutGrid,
+  Lightbulb,
+  Activity as ActivityIcon
+} from 'lucide-react'
 import { Home } from '../pages/Home'
 import { Conversations } from '../pages/Conversations'
 import { Memories } from '../pages/Memories'
@@ -12,6 +20,7 @@ import { Goals } from '../pages/Goals'
 import { Apps } from '../pages/Apps'
 import { Rewind } from '../pages/Rewind'
 import { Insights } from '../pages/Insights'
+import { Activity } from '../pages/Activity'
 import { LiveConversation } from '../pages/LiveConversation'
 import { KnowledgeGraph } from '../pages/KnowledgeGraph'
 import { CONVERSATIONS_PATH } from '../lib/conversations/conversationsPanelActivity'
@@ -79,6 +88,7 @@ const GoalsPanel = memo(Goals)
 const AppsPanel = memo(Apps)
 const RewindPanel = memo(Rewind)
 const InsightsPanel = memo(Insights)
+const ActivityPanel = memo(Activity)
 
 // Shared path constants — keep panel activity predicates and the manifest in sync.
 export const HOME_PATH = '/home'
@@ -184,6 +194,18 @@ export const routeManifest: RouteEntry[] = [
     path: '/insights',
     Component: InsightsPanel,
     nav: { label: 'Insights', Icon: Lightbulb, order: 5 },
+    escapeToHome: true
+  },
+  {
+    // Appended rather than placed near Home so the existing rail order is
+    // unchanged. Deliberately no Ctrl+N: macOS reaches this surface as a tab
+    // inside the Memory hub rather than as a destination, so it binds no key
+    // there either, and the rail item is the discovery path here.
+    id: 'activity',
+    kind: 'panel',
+    path: '/activity',
+    Component: ActivityPanel,
+    nav: { label: 'Activity', Icon: ActivityIcon, order: 6 },
     escapeToHome: true
   }
 ]

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -127,12 +127,7 @@ export type ChatMessage = {
  * See lib/sync/outbox.ts for the transition rules and dedupe strategy.
  */
 export type ConversationSyncState =
-  | 'local_only'
-  | 'pending'
-  | 'posting'
-  | 'done'
-  | 'failed'
-  | 'unconfirmed'
+  'local_only' | 'pending' | 'posting' | 'done' | 'failed' | 'unconfirmed'
 
 /** One transcript segment in the `/v1/conversations/from-segments` request shape
  * (snake_case matches the wire verbatim). `start`/`end` are WALL-CLOCK
@@ -1719,13 +1714,7 @@ export type MemoryExportResult = {
 }
 
 export type IndexedFileType =
-  | 'document'
-  | 'code'
-  | 'image'
-  | 'media'
-  | 'archive'
-  | 'application'
-  | 'other'
+  'document' | 'code' | 'image' | 'media' | 'archive' | 'application' | 'other'
 
 export type IndexedFileRecord = {
   path: string
@@ -1819,14 +1808,7 @@ export type RebuildResult = {
 // the macOS-parity local graph synthesized from indexed_files + memories and
 // consumed by the chat pre-step. Never conflate the two mechanisms.
 export type LocalKGNodeType =
-  | 'project'
-  | 'app'
-  | 'technology'
-  | 'person'
-  | 'org'
-  | 'interest'
-  | 'file_group'
-  | 'card' // background-synthesized natural-language overview served to the chat floor
+  'project' | 'app' | 'technology' | 'person' | 'org' | 'interest' | 'file_group' | 'card' // background-synthesized natural-language overview served to the chat floor
 
 export type LocalKGNode = {
   id: string // `${slug(label)}:${nodeType}` — stable across re-synthesis

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -127,7 +127,12 @@ export type ChatMessage = {
  * See lib/sync/outbox.ts for the transition rules and dedupe strategy.
  */
 export type ConversationSyncState =
-  'local_only' | 'pending' | 'posting' | 'done' | 'failed' | 'unconfirmed'
+  | 'local_only'
+  | 'pending'
+  | 'posting'
+  | 'done'
+  | 'failed'
+  | 'unconfirmed'
 
 /** One transcript segment in the `/v1/conversations/from-segments` request shape
  * (snake_case matches the wire verbatim). `start`/`end` are WALL-CLOCK
@@ -990,6 +995,11 @@ export type OmiBridgeApi = {
   /** Phase 1 of a Rewind search: KEYWORD (FTS5/BM25) results, immediately. Never
    *  waits on the network — semantic hits follow on `onRewindSearchResults`. */
   rewindSearch: (query: string) => Promise<RewindSearchGroup[]>
+  /** Local days holding screen capture, newest first (Activity spine). */
+  spineScreenDays: (limit?: number) => Promise<number[]>
+  /** One local day's exact totals plus a bounded sample of its frames. Null when
+   *  the day id is not a number; a zeroed projection when the read failed. */
+  spineScreenDay: (dayId: number) => Promise<SpineScreenDay | null>
   /** Phase 2: the same result list with semantic hits merged in, delivered if and
    *  when the embedding round-trip lands. Never fires when semantic search is
    *  unavailable (signed out, backend down, nothing indexed) — the keyword results
@@ -1709,7 +1719,13 @@ export type MemoryExportResult = {
 }
 
 export type IndexedFileType =
-  'document' | 'code' | 'image' | 'media' | 'archive' | 'application' | 'other'
+  | 'document'
+  | 'code'
+  | 'image'
+  | 'media'
+  | 'archive'
+  | 'application'
+  | 'other'
 
 export type IndexedFileRecord = {
   path: string
@@ -1803,7 +1819,14 @@ export type RebuildResult = {
 // the macOS-parity local graph synthesized from indexed_files + memories and
 // consumed by the chat pre-step. Never conflate the two mechanisms.
 export type LocalKGNodeType =
-  'project' | 'app' | 'technology' | 'person' | 'org' | 'interest' | 'file_group' | 'card' // background-synthesized natural-language overview served to the chat floor
+  | 'project'
+  | 'app'
+  | 'technology'
+  | 'person'
+  | 'org'
+  | 'interest'
+  | 'file_group'
+  | 'card' // background-synthesized natural-language overview served to the chat floor
 
 export type LocalKGNode = {
   id: string // `${slug(label)}:${nodeType}` — stable across re-synthesis
@@ -2034,6 +2057,25 @@ export type RewindFrame = {
   width: number
   height: number
   indexed: number // 0 = not yet OCR'd, 1 = OCR done
+}
+
+/** One local day of screen capture as the Activity spine consumes it. */
+export type SpineScreenMoment = {
+  id: number
+  timestamp: number
+  appName: string
+  windowTitle: string | null
+  imagePath: string | null
+}
+
+export type SpineScreenDay = {
+  /** Local midnight, epoch ms. */
+  dayId: number
+  /** Exact frame count for the day, not the sample size. */
+  total: number
+  /** 24 entries, index = local hour. Exact, never sampled. */
+  hourCounts: number[]
+  sampled: SpineScreenMoment[]
 }
 
 export type RewindSearchGroup = {


### PR DESCRIPTION
Windows had four separate lists and no way to see a day. This composes them into one.

## The gap

Answering "what happened on Tuesday" meant opening Conversations, Memories, Tasks and Rewind and cross-referencing them by hand, because nothing on Windows put a day's records next to each other. macOS has had this for a while as the Activity tab of the Memory hub (`MainWindow/Spine/`, ~3,000 lines). The survey of remaining macOS-only surfaces ranked it the largest gap with no platform blocker, and it is the other half of the surface #11743 started.

This is a port of that model: conversations, memories, tasks and captured screen moments composed into one reverse-chronological stream, grouped by day, with a 24-hour density rail beside each day and chips to solo a kind.

## The rules that carry the weight

Almost every rule in `spineModel.ts` exists to stop a specific wrong-looking timeline rather than to produce a right-looking one. The four worth reading the diff for:

**Frames attach to conversations through a two-pointer merge whose cursor advances only past conversations that START after the frame.** Advancing on the finish time instead lets one frame newer than everything consume the whole list and orphan every conversation behind it. macOS regression-tests this by name (`testAFrameNewerThanEveryConversationDoesNotOrphanTheOnesBehindIt`); the test here is the same case.

**Attached rows are re-seated directly under their conversation**, deliberately defeating the pure-anchor ordering. A memory recorded mid-conversation would otherwise interleave with unrelated rows and read as though it came from somewhere else. They sit in a fixed order (memories, tasks, screen) rather than by anchor, so the same card does not reorder itself depending on which attachment happened to be recorded last.

**A memory pointing at a conversation that is not loaded becomes its own row.** Hiding the user's data behind a paging boundary is worse than showing it unattached.

**A day's moment count is null when its capture has not been read and 0 when it was read and held nothing.** Collapsing the two makes an unread day claim the user captured nothing. The rail renders the first as an em dash and "counting screen moments".

## Local time, deliberately

Days and hours are bucketed in JS against the local calendar and never in SQL. A UTC-keyed `GROUP BY` shifts every row near midnight into the wrong day, and SQLite's date functions would need an explicit `localtime` modifier and still bucket against a UTC day, so the histogram would disagree with the day grouping beside it.

For the same reason the day boundary is computed by adding one calendar day rather than 24 hours, and the day walk steps by calendar day: a DST transition must not drop, duplicate or misplace an hour.

## Reading a day without shipping it

A busy day is thousands of frames and the stream shows eight per strip, so `screenIndex.ts` reads a day at three resolutions: an exact count, an exact 24-bucket histogram built from the day's timestamps alone, and a bounded evenly-spaced sample of whole frames. The histogram is built from every timestamp rather than from the sample, so a busy hour still reads as busy.

The sample is taken on a row number over the day's own ordering rather than on rowid, so retention deleting older frames does not reshuffle which frames a day shows.

## Degradation

Any of the four sources may fail. The stream shows whatever loaded and says the day may be incomplete, because a timeline missing one source is far more useful than no timeline and much better than one that quietly implies the missing records never existed.

Fold state is keyed by the day's own identity, so paging older days in cannot move which day is folded, and is session-only, so a day folded last week is not still hidden today.

## Divergences from macOS, stated

- **No Ctrl+N.** macOS reaches this as a tab inside the Memory hub rather than as a destination, so it binds no key there either. Windows has no Memory hub with destination tabs, so Activity is its own panel route; taking a number would also collide with the Search page in #11743. The `manifest.test.ts` shortcut pin is untouched.
- **No video frames.** macOS moments carry a video chunk path and frame offset; Windows Rewind is screenshot-only (`grep -riE "videoChunk|mp4|h264|ffmpeg"` across `desktop/windows/src` returns 0), so the moment model carries the five fields a strip actually renders.
- **The row comparator's kind tie-break cannot be observed through the composer.** Rows are emitted conversation-first and `Array.prototype.sort` is stable, so the order is already right without it; macOS needs it because Swift's `sort` is not stable. It is kept as an explicit invariant against a future change to the emit order, and exported so it is tested directly rather than inferred.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,301 passed, 18 skipped, 546 files. 105 of those are this feature, including a real SQLite database via node:sqlite for the screen index and a jsdom render of the page.
- `npx tsc --noEmit` on both `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint` on every touched file - 0 problems.
- `npx electron-vite build` - built in 21.47s.
- `check_lifecycle_headers.py`, `check_brand_ui.py` - pass.

## Mutation audit

28 regressions seeded into the source, each confirmed to turn the suite red:

- frame cursor advances on finish instead of start, orphaning conversations
- a frame exactly at a conversation's end no longer attaches
- a memory whose conversation is not loaded is dropped
- attachments are not re-seated under their conversation
- an attachment whose owner is missing is dropped
- attachments order by anchor instead of a fixed type order
- rows order oldest first
- days order oldest first
- a conversation no longer wins a tie against its own attachment
- overlapping pages produce duplicate rows
- cluster splits at exactly 45 minutes instead of beyond it
- a strip reports only what it shows
- the brain map card counts as a conversation row
- a brain map card appears on a day with no memories
- an attached record is filed under its own day, not its conversation's
- a day that has not been read reports zero moments
- filtering keeps days that matched nothing
- the query is matched case-sensitively
- an untimed conversation is shown at epoch zero
- an unfinished conversation is treated as zero length
- an inverted conversation range is kept
- the day ends 24 hours later instead of one calendar day
- the histogram is built from the sample instead of every timestamp
- the sample is taken from the start of the day only
- a day with no capture is indistinguishable from one never read
- the rail runs oldest hour first
- density normalises against a fixed ceiling rather than the day
- the rail headline loses its not-read-yet branch

Four of these escaped on the first pass and produced the last commit. Two were tests that could not fail: the ordering tie-break was masked by a stable sort plus a conversation-first emit order, and the conversation time window had two overlapping guards so neither could be shown to matter alone. The other two were simply missing cases.

One coverage limit worth stating rather than hiding: the "24 hours instead of one calendar day" mutation is only observable in a timezone that observes DST. The test asserts the property across every day of a year, so it catches the mutation on a developer machine in such a zone, but CI runs in UTC where no day transitions.

## What is not here

Paging further back than the first load (200 conversations, 300 memories, 14 screen days), and thumbnails on the screen strips - the strip shows window titles, and rendering frame images needs the same decode path Rewind uses. macOS's `SpineHydrator` background paging is the natural follow-up.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

