### PR TITLE
fix(desktop): derive launcher-test discovery skips so test.sh reaches its Python and Swift sections (#11747)

### DIFF
--- a/desktop/macos/scripts/check-launcher-test-skips.py
+++ b/desktop/macos/scripts/check-launcher-test-skips.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Static checker: launcher-test discovery skips are derived, not hand-listed.
+
+`test.sh` and the "Desktop launcher script tests" step in
+`.github/workflows/desktop-swift-ci.yml` both discover every
+`desktop/macos/tests/test-*.sh` instead of listing them, so a new test runs in
+both places automatically. A few discovered scripts cannot run under that loop —
+they need a running app's automation token, or an installed named bundle path —
+and each declares that in its own header with a `# discovery-skip:` line.
+`test.sh` derives its skips from that marker; the CI step carries a hand list
+because the loop is inlined in YAML.
+
+#11747: the CI step skipped `test-mounted-navigation-latency.sh` and
+`test-named-bundle-resources.sh` while `test.sh` skipped nothing, so `test.sh`
+aborted on them under `set -e` and never reached its Python or Swift sections.
+The membership was hand-listed in one loop and absent from the other
+(FC-hand-listed-test-isolation-membership), so this checker holds the two loops
+to the marked set:
+
+1. every script declaring `# discovery-skip:` is in the CI step's hand list;
+2. the CI step's hand list contains nothing else;
+3. `test.sh` still derives its skips from the marker;
+4. every script named in either place exists;
+5. a script that requires a positional argument declares the marker — the
+   property that made #11747 reachable, so a new one cannot repeat it silently.
+
+This is a static checker over source, not behavioral coverage of the loops.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+MACOS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = MACOS_DIR.parent.parent
+RUNNER = MACOS_DIR / "test.sh"
+WORKFLOW = REPO_ROOT / ".github/workflows/desktop-swift-ci.yml"
+TESTS_DIR = MACOS_DIR / "tests"
+
+MARKER = "# discovery-skip:"
+# A `case` pattern line listing one or more discovered tests, e.g.
+#   tests/test-a.sh|tests/test-b.sh)
+CASE_PATTERN = re.compile(r"^\s*(tests/test-[^)]*)\)\s*$")
+# A guard that rejects a missing positional argument, e.g. `if [[ $# -ne 1 ]]`.
+ARGUMENT_GUARD = re.compile(r"\$#\s*(-ne|-lt|-eq|==|!=)\s*\d")
+NONZERO_EXIT = re.compile(r"\bexit\s+[1-9]")
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def marked_tests() -> set[str]:
+    """Scripts that declare they cannot run under the discovery loop."""
+    return {
+        f"tests/{path.name}"
+        for path in sorted(TESTS_DIR.glob("test-*.sh"))
+        if MARKER in path.read_text()
+    }
+
+
+def requires_argument(path: Path) -> bool:
+    """True when the script bails out non-zero on a missing positional argument.
+
+    An argument count guard alone is not enough — a script may compare `$#` to
+    default an optional argument. The property that breaks the discovery loop is
+    the guard exiting non-zero, so require both.
+    """
+    lines = path.read_text().splitlines()
+    return any(
+        ARGUMENT_GUARD.search(line) and any(NONZERO_EXIT.search(nxt) for nxt in lines[index + 1 : index + 6])
+        for index, line in enumerate(lines)
+    )
+
+
+def workflow_skips() -> set[str]:
+    """The hand list the inlined CI loop carries."""
+    matches = [
+        match.group(1) for line in WORKFLOW.read_text().splitlines() if (match := CASE_PATTERN.match(line))
+    ]
+    if len(matches) > 1:
+        raise SystemExit(
+            f"FAIL: found {len(matches)} launcher-test skip lists in {rel(WORKFLOW)}. Keep the step's "
+            "skips in one `case` pattern line so this checker can compare them."
+        )
+    return {name.strip() for name in matches[0].split("|") if name.strip()} if matches else set()
+
+
+def main() -> int:
+    marked = marked_tests()
+    workflow = workflow_skips()
+    failures = []
+
+    if MARKER not in RUNNER.read_text():
+        failures.append(
+            f"{rel(RUNNER)} no longer derives its launcher-test skips from `{MARKER}`. Without the "
+            "derivation a marked script runs in the loop that cannot supply its prerequisite and "
+            "aborts the runner under `set -e` (#11747)."
+        )
+
+    unlisted = sorted(marked - workflow)
+    if unlisted:
+        failures.append(
+            f"declared `{MARKER}` but not skipped by the CI step in {rel(WORKFLOW)}: {unlisted}. "
+            "Add them to that step's `case` pattern line — the CI loop is inlined in YAML and cannot "
+            "read the marker."
+        )
+
+    unmarked = sorted(workflow - marked)
+    if unmarked:
+        failures.append(
+            f"skipped by the CI step in {rel(WORKFLOW)} but not declared with `{MARKER}`: {unmarked}. "
+            f"Either declare the prerequisite in the script's header so {rel(RUNNER)} skips it too, or "
+            "drop it from the CI step's list."
+        )
+
+    for name in sorted(marked | workflow):
+        if not (MACOS_DIR / name).is_file():
+            failures.append(f"skipped script does not exist: {name} (stale skip after a rename?)")
+
+    for path in sorted(TESTS_DIR.glob("test-*.sh")):
+        name = f"tests/{path.name}"
+        if name not in marked and requires_argument(path):
+            failures.append(
+                f"{name} requires a positional argument the discovery loop cannot supply but does not "
+                f"declare `{MARKER}`. It fails on every machine and aborts the runner (#11747)."
+            )
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+
+    print(f"launcher-test discovery skips are derived and agree ({len(marked)} skipped: {', '.join(sorted(marked))})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/macos/test.sh
+++ b/desktop/macos/test.sh
@@ -10,8 +10,22 @@ cd "$SCRIPT_DIR"
 # Discovery, not a hardcoded list — a hardcoded list already orphaned one test
 # (test-prepare-desktop-bundle-native-deps.sh ran nowhere). Every tests/test-*.sh
 # runs, mirroring swift-test-suites.sh's auto-discovery of Swift suites.
+#
+# A few discovered scripts need something this loop cannot supply — a running
+# app's automation token, an installed named bundle path. Each declares that in
+# its own header with `# discovery-skip: <reason>`, so it opts out where it lives
+# and this runner derives the set. #11747: the CI step in
+# .github/workflows/desktop-swift-ci.yml hand-listed those two scripts and this
+# runner listed nothing, so `set -e` aborted here and the Python and Swift
+# sections below never ran. scripts/check-launcher-test-skips.py holds both loops
+# to the marked set.
 for t in tests/test-*.sh; do
   echo "== $t"
+  skip_reason="$(sed -n '1,10s/^# discovery-skip: *//p' "$t" | head -1)"
+  if [[ -n "$skip_reason" ]]; then
+    echo "  skip: $skip_reason"
+    continue
+  fi
   bash "$t"
 done
 python3 scripts/check-e2e-flow-coverage.py --strict

--- a/desktop/macos/tests/test-launcher-test-skips.sh
+++ b/desktop/macos/tests/test-launcher-test-skips.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/../scripts/check-launcher-test-skips.py"

--- a/desktop/macos/tests/test-mounted-navigation-latency.sh
+++ b/desktop/macos/tests/test-mounted-navigation-latency.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# discovery-skip: needs a running app's automation token — run it directly against a live app
 set -euo pipefail
 
 PORT="${1:-${OMI_AUTOMATION_PORT:-47777}}"

--- a/desktop/macos/tests/test-named-bundle-resources.sh
+++ b/desktop/macos/tests/test-named-bundle-resources.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# discovery-skip: needs an installed named bundle path — run it directly with the .app
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then


### PR DESCRIPTION
Fixes #11747.

## Bug

`desktop/macos/test.sh` — `desktop/macos/README.md:47` calls it "the full component/PR suite", and it is the desktop answer to Definition-of-Done item 2 — cannot reach its Python or Swift sections on any machine. It aborts inside its first section.

## Root cause

The launcher-test loop is deliberately discovery-based (`for t in tests/test-*.sh`), but two discovered scripts need something the loop cannot supply:

- `tests/test-mounted-navigation-latency.sh` — a running app's automation token → `FAIL: automation token is unavailable for port 47777`, exit 1.
- `tests/test-named-bundle-resources.sh` — an installed named bundle path → `usage: ... /Applications/your-named-omi.app`, exit 64. With no argument it can never pass.

`test.sh` runs under `set -euo pipefail`, so the first of the two kills the run and `=== Python Desktop Backend Tests ===` / `=== Swift App Tests ===` never execute. CI does not hit this because the "Desktop launcher script tests" step in `.github/workflows/desktop-swift-ci.yml:183` has a `case`/`continue` skipping exactly those two. The membership was hand-listed in one loop and absent from the other.

## Fix

Derived, not hand-listed — the canonical prevention for `FC-hand-listed-test-isolation-membership`, whose existing guard artifact covers `swift-test-suites.sh` and did not generalize to this second discovery loop:

1. Each script that cannot run under the loop declares `# discovery-skip: <reason>` in its own header, so it opts out where it lives rather than in a remote list.
2. `test.sh` derives its skips from that marker and prints a visible `skip: <reason>` line — no silent drop, no second list to keep in sync.
3. New `scripts/check-launcher-test-skips.py` (run by `tests/test-launcher-test-skips.sh`, so both discovery loops execute it) holds the two loops to the marked set: every marked script is in the CI step's hand list, that list contains nothing else, `test.sh` still derives from the marker, every named script exists, and a script whose `$#` guard exits non-zero must carry the marker — the property that made this reachable.

The CI step's inlined list is unchanged; it is now verified rather than authoritative.

## Verification

Ran the real runner, `bash test.sh`, on this branch (`python3` = 3.12; `backend/.venv` synced):

- Launcher section completes: every discovered test passes, the two marked ones print `skip: <reason>`. Previously it died here.
- `=== Python Desktop Backend Tests ===` — reached for the first time: **196 passed in 11.14s**.
- `=== Swift App Tests ===` — reached and executing the per-suite isolated run.

Guard proven against the pre-fix state, not just asserted (each run reproduced on a scratch copy so the real tree stayed intact):

| Scenario | Result |
|---|---|
| `test.sh` as on `main` — no skips, CI list intact | `FAIL: launcher-test skip lists diverge — only in desktop-swift-ci.yml: [both scripts]` |
| Partial divergence — one script skipped, one not | `FAIL: ... only in desktop-swift-ci.yml: [test-mounted-navigation-latency.sh]` |
| Stale skip naming a deleted script | `FAIL: skipped script does not exist: ...` |
| Marker removed from `test.sh`'s loop | `FAIL: desktop/macos/test.sh no longer derives its launcher-test skips from '# discovery-skip:'` |
| This branch | `launcher-test discovery skips are derived and agree (2 skipped: ...)` |

The `$#`-guard rule produced no false positives across the 40+ existing `tests/test-*.sh`. Lane selection confirmed with `scripts/pre_push_ci_prediction.py`: this diff selects `desktop-swift-tests`, so CI runs the new checker.

Not fixed here, unrelated to this diff: `tests/test-context-bucket-benchmark.sh` crashes under Python 3.9 (`exc.read()` on an `HTTPError` with `fp=None` raises `KeyError` from the `tempfile` wrapper, outside the caught exception tuple). It passes on 3.10+, which is what CI runs.

Failure-Class: FC-hand-listed-test-isolation-membership

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

