### PR TITLE
feat(context-for-claude): measure the app — anonymous usage analytics

### DIFF
--- a/desktop/context-for-claude/README.md
+++ b/desktop/context-for-claude/README.md
@@ -82,7 +82,10 @@ be read in one file rather than grepped for.
 
 Airgap Mode **drops** these events rather than deferring them: every other remote client queues its
 work and sends when the switch goes off, which for analytics would delay the disclosure instead of
-preventing it. Locally built copies report nothing at all.
+preventing it. There is no longer a switch for it in Settings — the flag survives on installs whose
+`exclusions.json` already carries it, and is forced on when the exclusion configuration fails closed
+— so in practice this guard matters most for the fail-closed case. Locally built copies report
+nothing at all.
 
 [`docs/analytics.md`](docs/analytics.md).
 

--- a/desktop/context-for-claude/README.md
+++ b/desktop/context-for-claude/README.md
@@ -72,6 +72,20 @@ Airgap Mode covers the update check like every other remote client (`NetworkEgre
 Cutting a release — including generating the Context-only update key — is
 [`docs/releasing.md`](docs/releasing.md).
 
+## Analytics
+
+The app reports anonymous usage counts — launches, permission states, capture minutes, and how often
+Claude calls its MCP tools — to PostHog, under a salted install hash that is deliberately not the
+identifier the backend uses. No transcript, screen text, window name, URL, query or tool argument
+ever leaves the Mac. The complete list of what is sent is `AnalyticsEvent`, a closed enum, so it can
+be read in one file rather than grepped for.
+
+Airgap Mode **drops** these events rather than deferring them: every other remote client queues its
+work and sends when the switch goes off, which for analytics would delay the disclosure instead of
+preventing it. Locally built copies report nothing at all.
+
+[`docs/analytics.md`](docs/analytics.md).
+
 ## What Claude gets
 
 Twelve tools. The descriptions are written for Claude, so it reaches for them unprompted. In

--- a/desktop/context-for-claude/Sources/ContextApp/Account/OmiAuth.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Account/OmiAuth.swift
@@ -254,6 +254,7 @@ final class OmiAuth: ObservableObject {
         userId = nil
         email = nil
         isSignedIn = false
+        ContextAnalytics.record(.accountStateChanged(signedIn: false))
         // Signing out is a clean slate, and the popover offers a Sign in link the instant this
         // lands — under which a previous attempt's failure would read as this one's.
         lastSignInError = nil
@@ -644,6 +645,10 @@ final class OmiAuth: ObservableObject {
         userId = session.tokenUserId.isEmpty ? nil : session.tokenUserId
         self.email = email
         isSignedIn = true
+        // Whether, never who. `AnalyticsIdentity` stays a salted hash of the install id after
+        // sign-in — see `ContextAnalytics` — so this reports that an account exists without making
+        // the anonymous series joinable to it.
+        ContextAnalytics.record(.accountStateChanged(signedIn: true))
     }
 
     private static func authError(from error: Error) -> OmiAuthError {

--- a/desktop/context-for-claude/Sources/ContextApp/Backend/NetworkEgress.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Backend/NetworkEgress.swift
@@ -59,6 +59,16 @@ enum NetworkEgress {
         /// one would emit are the same line. `ContextApp` cannot link `ContextMCPKit`, so the two
         /// halves are tied by that shared slug and by a test on each side.
         case mcpOmiBackend = "omi-backend"
+        /// Product analytics: anonymous counts of launches, permissions, captures and MCP tool calls,
+        /// batched to PostHog. See `ContextAnalytics`.
+        ///
+        /// It is in this list for the same reason `updateCheck` is — "off this Mac" is the test — but
+        /// it is the entry with the sharpest edge, because it is the only client whose *entire
+        /// purpose* is to describe the person using the app. `ContextAnalytics.record` therefore
+        /// **drops** a suppressed event rather than spooling it: every other client here queues its
+        /// work and sends it when the switch goes off, and an analytics event that did the same would
+        /// mean Airgap Mode delayed the disclosure instead of preventing it. There is no catching up.
+        case analytics = "analytics"
 
         /// The subsystem a suppression is reported under, so the fallback record lands in the same
         /// area as that client's other degradations rather than in an "airgap" bucket of its own.
@@ -73,6 +83,10 @@ enum NetworkEgress {
             // adding one for a single client would put a suppression nobody is looking for into a
             // bucket nobody reads.
             case .faviconFetch, .updateCheck: return .settings
+            // Analytics is not any one subsystem's degradation — it reports on all of them — so it
+            // lands beside the other two clients a user meets in Settings rather than inventing an
+            // area that would hold exactly one client.
+            case .analytics: return .settings
             }
         }
     }
@@ -142,6 +156,12 @@ enum NetworkEgress {
             // the button appeared to do nothing.
             return "Airgap Mode is on, so Context for Claude isn't checking for updates. "
                 + "It stays on this version until you turn it off in Settings › General."
+        case .analytics:
+            // Says "not recorded" rather than "not sent", because the difference is the whole point:
+            // nothing is being held for later. A person who reads this and turns the switch off
+            // should not discover that a week of their activity went up at that moment.
+            return "Airgap Mode is on, so no usage counts are recorded. "
+                + "Nothing is held back to send later — those days simply aren't measured."
         }
     }
 

--- a/desktop/context-for-claude/Sources/ContextApp/ContextApp.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/ContextApp.swift
@@ -272,6 +272,12 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
             // `Permissions.noteGrantsAtLaunch()`.
             Permissions.noteGrantsAtLaunch()
 
+            // Immediately after the grant snapshot and before anything else can act on it, because
+            // `start()` decides first-launch from a `UserDefaults` key that onboarding also writes:
+            // reaching it second would report every install as a returning one.
+            ContextAnalytics.start()
+            ContextAnalytics.recordPermissionSnapshot()
+
             // Before Engine.start(), so the icon exists the moment there is state to show — and
             // before onboarding, which finishes by pointing at it.
             StatusItemController.shared.install()
@@ -343,6 +349,10 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
     @MainActor
     @discardableResult
     static func shortcutFired(_ action: GlobalShortcuts.Action, on window: HotkeyToggle) -> HotkeyPress {
+        // Recorded here rather than inside `GlobalShortcuts` because this is where a press becomes a
+        // press that *did* something. The monitor also fires on chords the app decided not to act
+        // on, and counting those would report a gesture as working on machines where it does not.
+        ContextAnalytics.record(.gestureFired)
         switch action {
         case .openActivity:
             return window.press()

--- a/desktop/context-for-claude/Sources/ContextApp/Engine.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Engine.swift
@@ -1030,7 +1030,19 @@ final class Engine: ObservableObject {
     /// how a real failure goes unread.
     private func setState(_ component: CaptureComponent, _ next: ComponentState) {
         guard componentStates[component] != next else { return }
+        let wasLive = componentStates[component]?.isLive ?? false
         componentStates[component] = next
+
+        // The single point every capture transition passes through, which is why the analytics hook
+        // is here and not in the four start/stop methods: those have early returns, failure paths and
+        // a teardown that runs on both a clean stop and a crash, so instrumenting them would have
+        // meant four chances to miss a transition. This one is already guarded by the
+        // did-it-actually-change check above, so it cannot double-count either.
+        if wasLive != next.isLive, let source = AnalyticsEvent.CaptureSource(component) {
+            UsageClock.shared.mark(source, live: next.isLive)
+            ContextAnalytics.record(.captureStateChanged(source: source, live: next.isLive))
+        }
+
         switch next {
         case .live:
             ContextLog.info("\(component.label) is capturing", "engine")

--- a/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusItemController.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusItemController.swift
@@ -124,6 +124,9 @@ final class StatusItemController: NSObject {
         if popover.isShown {
             popover.performClose(nil)
         } else {
+            // Only on the opening half. Counting the close too would double every visit and make
+            // "how many people open the menu bar item" read as twice the truth.
+            ContextAnalytics.record(.surfaceOpened(.menuBar))
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             // An `.accessory` app's popover opens behind the active app's windows otherwise.
             NSApp.activate(ignoringOtherApps: true)

--- a/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
@@ -1142,6 +1142,11 @@ struct OnboardingView: View {
         // transitions is a relaunch — a resume point recorded afterwards would be recorded by a
         // process that is already gone.
         OnboardingResume().record(next)
+        // Every "continue" goes through here, so the funnel is measured at the one place the
+        // ordering lives. Ordinal only: the step *names* are product copy that changes every
+        // release, and a funnel keyed on copy resets every release.
+        ContextAnalytics.recordOnboardingStep(
+            index: next.rawValue, of: OnboardingStep.allCases.count)
         withAnimation(stepAnimation) { step = next }
         beginStep()
     }
@@ -1367,6 +1372,7 @@ struct OnboardingView: View {
     }
 
     private func finish() {
+        ContextAnalytics.recordOnboardingFinished()
         sealTheRun()
 
         // Screen Recording is the one grant macOS will not take from a dialog — it has to be

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
@@ -251,6 +251,7 @@ final class SearchBarWindow {
     /// It dismisses for the same reason activating a result does: this panel floats, and a Spotlight
     /// that stays on top of the window it just opened is covering the thing it was asked for.
     private static func openTheTimeline() {
+        ContextAnalytics.record(.surfaceOpened(.activity))
         ContextAppDelegate.openTimeline()
         dismiss()
     }
@@ -268,6 +269,7 @@ final class SearchBarWindow {
     /// too and closing on those would break both. So the routes that really mean "leave" have to say
     /// so explicitly, here, rather than being inferred from focus moving.
     private static func openSettings() {
+        ContextAnalytics.record(.surfaceOpened(.settings))
         SettingsWindow.present()
         dismiss()
     }

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchResultsModel.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchResultsModel.swift
@@ -435,6 +435,11 @@ final class SearchResultsModel: ObservableObject {
             // something is: "109 results" over a grid of four is a lie either way round. Unnarrowed,
             // it is both halves added up — the page is one answer, so its count has to be too.
             totalCount = narrowedBySource ? visibleScreens.count : seen.total + spoken.total
+            // Bucketed, and never the query itself. Recorded after the answer settles so a
+            // zero-result search — the one worth knowing about — is counted as a search rather
+            // than as nothing having happened.
+            ContextAnalytics.record(
+                .searchRan(resultCountBucket: AnalyticsEvent.CountBucket(totalCount)))
             // A selection the new answer no longer contains is a keyboard target that is not on
             // screen — Return would open a card the user cannot see. Kept when the moment survived
             // the re-read, because a chip that merely reorders the page should not cost somebody

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
@@ -56,7 +56,9 @@ enum AnalyticsEvent: Sendable {
     /// release, and a funnel keyed on copy is a funnel that resets every release.
     case onboardingStep(index: Int, of: Int)
 
-    case onboardingFinished(secondsElapsed: Int, skipped: Bool)
+    /// How long the whole first run took. Paired with the last `onboardingStep` an install reached,
+    /// this is the drop-off curve; on its own it is how long setup costs somebody.
+    case onboardingFinished(secondsElapsed: Int)
 
     /// Whether this install has an Omi account attached. Not who — see the disclosure rule above.
     case accountStateChanged(signedIn: Bool)
@@ -135,13 +137,14 @@ enum AnalyticsEvent: Sendable {
         }
     }
 
+    /// Only surfaces that are actually recorded appear here. A case nobody emits produces a series
+    /// that is permanently empty, which reads as "nobody opens it" rather than as "nobody measured
+    /// it" — the more dangerous of the two, because it looks like a finding.
     enum Surface: String, Sendable, CaseIterable {
         case menuBar
         case activity
-        case rewind
         case settings
         case search
-        case tutorial
     }
 
     enum UpdateOutcome: String, Sendable, CaseIterable {
@@ -162,6 +165,26 @@ enum AnalyticsEvent: Sendable {
         case timeout
         case unavailable
         case malformedResponse
+
+        /// Maps the kebab-case slug `ContextTelemetry.recordFallback` receives onto this closed set.
+        ///
+        /// Returns nil for anything unrecognised, and the caller drops it. That is deliberate: the
+        /// local `reason` parameter is a plain `String` held to a convention, so the only thing
+        /// standing between a future call site passing `"\(error)"` and an error message reaching
+        /// PostHog is this lookup refusing to invent a case for it.
+        init?(slug: String) {
+            switch slug {
+            case "airgap-mode": self = .airgapMode
+            case "offline": self = .offline
+            case "unauthorized", "401", "403": self = .unauthorized
+            case "rate-limited", "429": self = .rateLimited
+            case "permission-missing": self = .permissionMissing
+            case "timeout": self = .timeout
+            case "unavailable": self = .unavailable
+            case "malformed-response": self = .malformedResponse
+            default: return nil
+            }
+        }
     }
 
     /// Counts, bucketed. A raw count of anything a person did is a fingerprint at the tail; a bucket
@@ -228,8 +251,8 @@ enum AnalyticsEvent: Sendable {
         case let .onboardingStep(index, total):
             return ["step_index": .int(index), "step_total": .int(total)]
 
-        case let .onboardingFinished(seconds, skipped):
-            return ["seconds_elapsed": .int(seconds), "skipped": .bool(skipped)]
+        case let .onboardingFinished(seconds):
+            return ["seconds_elapsed": .int(seconds)]
 
         case let .accountStateChanged(signedIn):
             return ["signed_in": .bool(signedIn)]

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,332 @@
+import ContextCore
+import Foundation
+
+/// Everything Context for Claude will ever report about itself, as a closed vocabulary.
+///
+/// ## Why an enum and not a string
+///
+/// A `track(name:properties:)` taking free-form strings is how analytics schemas rot: names drift
+/// (`app_open`, `App Opened`, `appLaunched` all meaning one thing), properties acquire user text by
+/// accident, and nobody can answer "what does this app send?" without grepping the whole target. The
+/// enum makes the answer a single file, makes a typo a compile error, and — the reason that matters
+/// most here — makes it *structurally impossible* for a call site to attach a string it happened to
+/// have lying around, because there is nowhere to put one.
+///
+/// **Every associated value in this file is a number, a bool, or another closed enum.** That is the
+/// invariant. `AnalyticsEventTests.testNoEventCarriesFreeFormText` fails if a `String` appears.
+///
+/// ## What this app does not send
+///
+/// No transcript, no OCR text, no window or app names, no URLs, no file paths, no queries, no MCP
+/// tool arguments, no email, no account id, no IP-derived location, no screenshots. This app's whole
+/// premise is that it watches a person's screen and hears their room; an analytics payload is the
+/// one place where the temptation to include "just a little" context is strongest and the cost of
+/// giving in is highest. The rule is that a reader of this file can see the entire disclosure.
+enum AnalyticsEvent: Sendable {
+
+    // MARK: - Lifecycle — "how many people use this"
+
+    /// The very first launch on this Mac, ever. The install denominator.
+    case firstLaunch
+
+    /// Every launch after the first. Cheap, and the only signal from someone who opens the app and
+    /// does nothing else.
+    case appLaunched
+
+    /// Emitted at most once per local calendar day, carrying the day's rolled-up usage.
+    ///
+    /// This single event is the spine of the whole measurement: it is DAU by definition, it is the
+    /// input to every retention curve, and its payload is the "how much do they use it" answer. A
+    /// per-action event stream could in principle produce the same numbers, but only for people who
+    /// take actions — this fires for an install that ran all day and was merely *available*, which
+    /// for an ambient capture app is the honest baseline.
+    case dailyActive(DailyRollup)
+
+    // MARK: - Setup funnel — "where do they fall out"
+
+    /// A permission's state changed, or was observed for the first time this launch.
+    ///
+    /// The setup funnel is this product's activation story: with no Screen Recording grant it sees
+    /// nothing, and with no Accessibility grant the ⌘ + ⌘ gesture is inert while every button in the
+    /// app still claims it works. Measuring the grant state is how "people don't know what to do
+    /// with it" stops being a guess.
+    case permission(Permission, PermissionState)
+
+    /// Onboarding reached a step. Ordinal only — the step *names* are product copy that changes every
+    /// release, and a funnel keyed on copy is a funnel that resets every release.
+    case onboardingStep(index: Int, of: Int)
+
+    case onboardingFinished(secondsElapsed: Int, skipped: Bool)
+
+    /// Whether this install has an Omi account attached. Not who — see the disclosure rule above.
+    case accountStateChanged(signedIn: Bool)
+
+    // MARK: - Use — "how much do they use it"
+
+    /// A capture source went live, or stopped being live.
+    case captureStateChanged(source: CaptureSource, live: Bool)
+
+    /// The ⌘ + ⌘ gesture fired. The product's one deliberate foreground interaction.
+    case gestureFired
+
+    /// A surface the user opened by hand.
+    case surfaceOpened(Surface)
+
+    /// A local search ran. Length buckets only, never the query.
+    case searchRan(resultCountBucket: CountBucket)
+
+    // MARK: - Health — "does it work for them"
+
+    /// Sparkle's outcome. Update health is invisible without this and an app that silently stops
+    /// updating looks identical to an app nobody uses.
+    case updateOutcome(UpdateOutcome)
+
+    /// A subsystem took a fail-open path. Mirrors `ContextTelemetry.recordFallback` so the local log
+    /// and the remote series describe the same event.
+    case fallback(area: ContextFallbackArea, outcome: ContextFallbackOutcome, reason: FallbackReason)
+
+    // MARK: - Closed value types
+
+    /// One case per `Capability`, spelled the same, so the two vocabularies cannot drift. The
+    /// mapping is exhaustive in `init(_ capability:)`, which is a compile error the day a capability
+    /// is added — the alternative, a `default:`, would silently report a new permission as an old one.
+    enum Permission: String, Sendable, CaseIterable {
+        case microphone
+        case systemAudio
+        case screen
+        case accessibility
+
+        init(_ capability: Capability) {
+            switch capability {
+            case .microphone: self = .microphone
+            case .systemAudio: self = .systemAudio
+            case .screen: self = .screen
+            case .accessibility: self = .accessibility
+            }
+        }
+    }
+
+    enum PermissionState: String, Sendable, CaseIterable {
+        case granted
+        /// Not granted, and never has been. The ordinary "hasn't set it up yet" state.
+        case denied
+        /// Granted once, gone now. Distinct from `denied` because it means something *broke* — a TCC
+        /// reset, or a re-signed build whose code requirement no longer matches the stored record —
+        /// rather than that someone said no. Conflating the two would hide a class of failure that
+        /// looks exactly like abandonment in the funnel. See `Permissions.grantWasLost`.
+        case revoked
+    }
+
+    /// The three things this app can be capturing. `CaptureComponent.storage` has no analogue on
+    /// purpose — it is bookkeeping, not capture, and reporting it would put a component that is
+    /// always live into a series meant to show whether the app is hearing anything.
+    enum CaptureSource: String, Sendable, CaseIterable {
+        case microphone
+        case systemAudio
+        case screen
+
+        init?(_ component: CaptureComponent) {
+            switch component {
+            case .microphone: self = .microphone
+            case .systemAudio: self = .systemAudio
+            case .screen: self = .screen
+            case .storage: return nil
+            }
+        }
+    }
+
+    enum Surface: String, Sendable, CaseIterable {
+        case menuBar
+        case activity
+        case rewind
+        case settings
+        case search
+        case tutorial
+    }
+
+    enum UpdateOutcome: String, Sendable, CaseIterable {
+        case checkFailed
+        case updateFound
+        case installed
+        case upToDate
+    }
+
+    /// The fixed slugs a fallback may report. Free text here would be the one hole in the closed
+    /// vocabulary, and it is the field most likely to have an error message pasted into it.
+    enum FallbackReason: String, Sendable, CaseIterable {
+        case airgapMode
+        case offline
+        case unauthorized
+        case rateLimited
+        case permissionMissing
+        case timeout
+        case unavailable
+        case malformedResponse
+    }
+
+    /// Counts, bucketed. A raw count of anything a person did is a fingerprint at the tail; a bucket
+    /// is an answer to the product question with the tail flattened.
+    enum CountBucket: String, Sendable, CaseIterable {
+        case zero
+        case one
+        case few        // 2–5
+        case several    // 6–20
+        case many       // 21+
+
+        init(_ count: Int) {
+            switch count {
+            case ..<1: self = .zero
+            case 1: self = .one
+            case 2...5: self = .few
+            case 6...20: self = .several
+            default: self = .many
+            }
+        }
+    }
+
+    // MARK: - Wire form
+
+    /// The PostHog event name.
+    ///
+    /// **Every name is prefixed `cfc_`, and that prefix is load-bearing.** These events land in the
+    /// same PostHog project as the Omi macOS app, whose retention, activation and DAU queries are
+    /// written against unprefixed names like `App Launched`. An unprefixed event here would silently
+    /// enter those numbers and make a four-month macOS trend line jump for no reason anybody could
+    /// find. The prefix — plus never setting `$os_name`, see `AnalyticsPayload` — is what keeps two
+    /// products in one project from becoming one product in the dashboards.
+    var name: String {
+        switch self {
+        case .firstLaunch: return "cfc_first_launch"
+        case .appLaunched: return "cfc_app_launched"
+        case .dailyActive: return "cfc_daily_active"
+        case .permission: return "cfc_permission"
+        case .onboardingStep: return "cfc_onboarding_step"
+        case .onboardingFinished: return "cfc_onboarding_finished"
+        case .accountStateChanged: return "cfc_account_state"
+        case .captureStateChanged: return "cfc_capture_state"
+        case .gestureFired: return "cfc_gesture_fired"
+        case .surfaceOpened: return "cfc_surface_opened"
+        case .searchRan: return "cfc_search_ran"
+        case .updateOutcome: return "cfc_update_outcome"
+        case .fallback: return "cfc_fallback"
+        }
+    }
+
+    /// The event's own properties. Super-properties (version, channel, OS) are added by
+    /// `AnalyticsPayload`, not here — a call site should never be able to forget them.
+    var properties: [String: AnalyticsValue] {
+        switch self {
+        case .firstLaunch, .appLaunched, .gestureFired:
+            return [:]
+
+        case let .dailyActive(rollup):
+            return rollup.properties
+
+        case let .permission(permission, state):
+            return ["permission": .string(permission.rawValue), "state": .string(state.rawValue)]
+
+        case let .onboardingStep(index, total):
+            return ["step_index": .int(index), "step_total": .int(total)]
+
+        case let .onboardingFinished(seconds, skipped):
+            return ["seconds_elapsed": .int(seconds), "skipped": .bool(skipped)]
+
+        case let .accountStateChanged(signedIn):
+            return ["signed_in": .bool(signedIn)]
+
+        case let .captureStateChanged(source, live):
+            return ["source": .string(source.rawValue), "live": .bool(live)]
+
+        case let .surfaceOpened(surface):
+            return ["surface": .string(surface.rawValue)]
+
+        case let .searchRan(bucket):
+            return ["result_count": .string(bucket.rawValue)]
+
+        case let .updateOutcome(outcome):
+            return ["outcome": .string(outcome.rawValue)]
+
+        case let .fallback(area, outcome, reason):
+            return [
+                "area": .string(area.rawValue),
+                "outcome": .string(outcome.rawValue),
+                "reason": .string(reason.rawValue),
+            ]
+        }
+    }
+}
+
+/// One local day of use, reported once.
+///
+/// Everything here is a count or a duration the app already had; nothing is collected *for* this
+/// struct. That is deliberate — a rollup that needed its own instrumentation would be a second
+/// capture pipeline, and this app does not get a second capture pipeline.
+struct DailyRollup: Sendable, Equatable {
+    /// Calls Claude made to each MCP tool today, drained from `ToolCallLedger`. **This is the number
+    /// the product lives or dies by**: it is the only evidence that the context is actually reaching
+    /// a model rather than accumulating on a disk.
+    var toolCalls: [String: Int]
+    /// Minutes the microphone/system audio was actually capturing.
+    var captureMinutes: Int
+    /// Minutes screen capture was running.
+    var screenMinutes: Int
+    /// Distinct hours of the day in which anything at all happened — a coarse "spread across the
+    /// day" measure that separates an app left running from an app in use.
+    var activeHours: Int
+    /// Whether an Omi account was attached at rollup time.
+    var signedIn: Bool
+    /// Whether Airgap Mode was on. A rollup from an airgapped install never sends at all, so this is
+    /// always false in practice; it is here so that if the suppression is ever wrongly relaxed the
+    /// evidence is in the payload rather than absent from it.
+    var airgapped: Bool
+
+    static let empty = DailyRollup(
+        toolCalls: [:], captureMinutes: 0, screenMinutes: 0, activeHours: 0,
+        signedIn: false, airgapped: false)
+
+    /// Did anything actually happen? An install that ran all day and captured nothing is still a
+    /// DAU, so this is not a send gate — it is a dimension, so "available" and "used" can be told
+    /// apart in the same series.
+    var isIdle: Bool {
+        toolCalls.isEmpty && captureMinutes == 0 && screenMinutes == 0
+    }
+
+    var properties: [String: AnalyticsValue] {
+        var properties: [String: AnalyticsValue] = [
+            "tool_calls_total": .int(toolCalls.values.reduce(0, +)),
+            "tool_calls_distinct": .int(toolCalls.count),
+            "capture_minutes": .int(captureMinutes),
+            "screen_minutes": .int(screenMinutes),
+            "active_hours": .int(activeHours),
+            "signed_in": .bool(signedIn),
+            "airgapped": .bool(airgapped),
+            "idle": .bool(isIdle),
+        ]
+        // One property per tool, so "which tools does Claude actually reach for" is answerable
+        // without a second event type. The names come from our own dispatch table and are sanitised
+        // by `ToolCallLedger.normalized` before they ever reach this struct.
+        for (tool, count) in toolCalls {
+            properties["tool_\(tool)"] = .int(count)
+        }
+        return properties
+    }
+}
+
+/// The only value shapes that may appear in a payload.
+///
+/// There is no `.any` case and there will not be one. `[String: Any]` is how a dictionary that was
+/// meant to hold three integers ends up holding an `NSError` whose `localizedDescription` is a file
+/// path; a closed value type means the compiler asks "which of these is it?" at every call site.
+enum AnalyticsValue: Sendable, Equatable {
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+
+    var json: Any {
+        switch self {
+        case let .string(value): return value
+        case let .int(value): return value
+        case let .bool(value): return value
+        }
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsPayload.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsPayload.swift
@@ -1,0 +1,107 @@
+import ContextCore
+import CryptoKit
+import Foundation
+
+/// Who this install is, for analytics only.
+///
+/// ## Not the backend's install id
+///
+/// `ClientDevice` already mints a per-install UUID and hashes it into `X-Device-Id-Hash`. This one is
+/// derived from the same UUID under a **different salt**, and that separation is the point: the
+/// backend id keys the user's own captured rows and is joinable to their account, so reusing it here
+/// would make every anonymous analytics event trivially re-identifiable by anyone holding both
+/// datasets. Salted separately, the two ids cannot be linked without the original UUID, which never
+/// leaves the Mac.
+///
+/// Deriving rather than minting a second UUID is deliberate too: a second stored id is a second thing
+/// that can be lost, and an id that resets makes every returning user look new — the exact failure
+/// that makes a retention curve meaningless.
+enum AnalyticsIdentity {
+
+    /// The salt. Changing this string re-anonymises every install on the next launch and severs
+    /// history — every existing user becomes a new user, and every retention curve restarts. Do not
+    /// change it to "clean up" identity.
+    private static let salt = "context-for-claude/analytics/v1"
+
+    /// `cfc_` + 16 hex characters of salted SHA-256.
+    ///
+    /// The prefix keeps these ids from ever colliding with, or being mistaken for, the Firebase uids
+    /// the Omi app sends as `distinct_id` into the same PostHog project — a shared project means a
+    /// shared id space, and two products silently sharing a person record would corrupt both.
+    static let distinctID: String = derive(from: ClientDevice.installId(in: .standard))
+
+    static func derive(from installID: String) -> String {
+        let digest = SHA256.hash(data: Data((salt + installID).utf8))
+        return "cfc_" + digest.map { String(format: "%02x", $0) }.joined().prefix(16)
+    }
+}
+
+/// One PostHog `capture` payload, built from an `AnalyticsEvent`.
+///
+/// Pure and synchronous so the entire wire format is testable without a network, a clock, or an app.
+struct AnalyticsPayload: Sendable, Equatable {
+    let name: String
+    let distinctID: String
+    let timestamp: Date
+    let properties: [String: AnalyticsValue]
+
+    /// Properties attached to every event, so a call site cannot forget them and no event is left
+    /// unattributable to a build.
+    ///
+    /// **`$os_name` is deliberately absent, and must stay absent.** Omi's macOS retention,
+    /// activation and weekly-actives queries — in `web/admin/app/api/omi/stats/` and in the
+    /// analytics runbook — all scope on `properties.$os_name = 'macOS'`. Setting it here would
+    /// enrol every Context for Claude install into the Omi macOS numbers, which is both wrong and
+    /// almost undetectable after the fact. `macos_version` carries the same information under a name
+    /// nothing else queries. `AnalyticsPayloadTests.testPayloadNeverSetsDollarOSName` pins this.
+    static func superProperties(
+        version: String,
+        build: String,
+        macOSVersion: String
+    ) -> [String: AnalyticsValue] {
+        [
+            // The discriminator every query on this project should filter by. Belt and braces with
+            // the `cfc_` event-name prefix: either one alone would keep the two products apart, and
+            // whichever a future query author reaches for first, it works.
+            "app": .string("context-for-claude"),
+            "app_version": .string(version),
+            "app_build": .string(build),
+            "macos_version": .string(macOSVersion),
+        ]
+    }
+
+    init(
+        event: AnalyticsEvent,
+        distinctID: String,
+        timestamp: Date,
+        superProperties: [String: AnalyticsValue]
+    ) {
+        self.name = event.name
+        self.distinctID = distinctID
+        self.timestamp = timestamp
+        // Super-properties first so an event can never overwrite its own build identity.
+        self.properties = superProperties.merging(event.properties) { _, eventValue in eventValue }
+    }
+
+    /// The JSON body PostHog's `/batch` endpoint expects for one event.
+    var json: [String: Any] {
+        var properties = self.properties.mapValues(\.json)
+        properties["distinct_id"] = distinctID
+        return [
+            "event": name,
+            "properties": properties,
+            "timestamp": ISO8601DateFormatter.analytics.string(from: timestamp),
+        ]
+    }
+}
+
+extension ISO8601DateFormatter {
+    /// PostHog accepts ISO-8601; fixing the formatter here keeps every event's timestamp in one
+    /// format regardless of the machine's locale or calendar settings.
+    static let analytics: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsSink.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsSink.swift
@@ -1,0 +1,235 @@
+import ContextCore
+import Foundation
+
+/// Where analytics events go, and the rules for getting them there.
+///
+/// An actor because events arrive from every part of the app — the capture threads, the main-actor
+/// UI, the update delegate — and the spool is a single mutable buffer backed by one file. Serialising
+/// through an actor is the difference between "a counter" and "a data race in a menu-bar app".
+///
+/// ## Batching, and why it is not optional
+///
+/// One HTTP request per event would be absurd for a ~10-events-a-day app and, worse, would make the
+/// app's network fingerprint follow the user's activity in real time: a request the moment a
+/// recording starts, another the moment a search runs. Batching on a timer decouples *when we send*
+/// from *what the person just did*, which is a privacy property, not only an efficiency one.
+///
+/// ## Failure
+///
+/// Sending is best-effort forever. A failed flush leaves events in the spool for the next one; a
+/// spool that grows past its cap drops its oldest events. Analytics must never retry hard enough to
+/// matter, never block a user action, and never surface an error — an app that shows someone a
+/// dialog because a metric did not upload has its priorities inverted.
+actor AnalyticsSink {
+
+    /// PostHog's *project* token. Public by design — it can only write events into this project, and
+    /// it ships in the Omi macOS app's binary already (`desktop/macos/Desktop/Sources/PostHogManager.swift`).
+    /// It is not a secret and must not be treated as one; it is also not a personal API key and can
+    /// read nothing.
+    ///
+    /// The same project as the Omi app on purpose: one place to query, and the existing dashboards
+    /// and the analytics runbook already point at it. Separation between the two products is by
+    /// `cfc_` event prefix and the `app` property — see `AnalyticsPayload.superProperties`.
+    static let projectToken = "phc_z3qUFhGUgYIOMYnfxVSrLmYISQvbgph8iREQv3sez3Y"
+    static let endpoint = URL(string: "https://us.i.posthog.com/batch/")!
+
+    /// How long a batch waits for more company before going up.
+    static let flushInterval: TimeInterval = 60
+
+    /// Past this, the oldest events are dropped. Sized for an app that is offline for a week and
+    /// still fits in a file nobody would notice.
+    static let spoolCapacity = 500
+
+    /// One request never carries more than this, so a spool that grew while offline drains over
+    /// several flushes rather than in one implausible burst.
+    static let batchSize = 50
+
+    static let shared = AnalyticsSink()
+
+    private var spool: [AnalyticsPayload] = []
+    private var flushTask: Task<Void, Never>?
+    private let spoolURL: URL
+    private let transport: AnalyticsTransport
+
+    /// `transport` and `spoolURL` are injected so tests drive the whole path — spool, batch, retry,
+    /// drop — without a network and without touching the real support directory.
+    init(
+        spoolURL: URL = ContextPaths.supportDirectory.appendingPathComponent("analytics-spool.json"),
+        transport: AnalyticsTransport = URLSessionAnalyticsTransport()
+    ) {
+        self.spoolURL = spoolURL
+        self.transport = transport
+        self.spool = Self.loadSpool(from: spoolURL)
+    }
+
+    /// Queues one event.
+    ///
+    /// **Airgap Mode is checked by the caller, not here.** `ContextAnalytics.record` drops the event
+    /// before it ever reaches the spool, because spooling an airgapped event and uploading it when
+    /// the switch goes off would be the disclosure the switch exists to prevent, merely delayed.
+    func enqueue(_ payload: AnalyticsPayload) {
+        spool.append(payload)
+        if spool.count > Self.spoolCapacity {
+            // Oldest first. A spool that has overflowed has already lost the argument about
+            // completeness; keeping the *recent* events at least keeps the series current.
+            spool.removeFirst(spool.count - Self.spoolCapacity)
+        }
+        persist()
+        scheduleFlush()
+    }
+
+    /// Sends everything queued, oldest first, in batches.
+    ///
+    /// Events are removed from the spool only after the transport reports success. A crash between
+    /// send and persist re-sends a batch, which PostHog tolerates; the opposite ordering would lose
+    /// events silently, which it cannot.
+    func flush() async {
+        flushTask?.cancel()
+        flushTask = nil
+
+        while !spool.isEmpty {
+            let batch = Array(spool.prefix(Self.batchSize))
+            let sent = await transport.send(batch, token: Self.projectToken, to: Self.endpoint)
+            guard sent else { return }
+            spool.removeFirst(batch.count)
+            persist()
+        }
+    }
+
+    #if DEBUG
+    /// Test seams. The spool is private because nothing in the app has any business reading it; the
+    /// tests need to, because "did a failed send keep the events?" is not observable any other way.
+    var spooledCountForTesting: Int { spool.count }
+    var oldestSpooledTimestampForTesting: Date? { spool.first?.timestamp }
+    #endif
+
+    private func scheduleFlush() {
+        guard flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.flushInterval * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await self?.flush()
+        }
+    }
+
+    // MARK: - Durability
+
+    /// The spool survives relaunch, so events recorded seconds before a quit are not lost.
+    ///
+    /// Whole-file rewrite rather than an append log: at ten events a day the file is under a
+    /// kilobyte, and a rewrite cannot leave a half-written trailing record that the next launch has
+    /// to decide whether to trust.
+    private func persist() {
+        guard let data = try? JSONSerialization.data(withJSONObject: spool.map(\.json)) else { return }
+        try? ContextPaths.ensureSupportDirectory(at: spoolURL.deletingLastPathComponent())
+        try? data.write(to: spoolURL, options: .atomic)
+        ContextPaths.setPermissions(spoolURL, mode: 0o600)
+    }
+
+    /// Anything unreadable is discarded rather than repaired. A spool is not user data; the cost of
+    /// losing it is one gap in a chart, and the cost of trusting a damaged one is inventing events.
+    private static func loadSpool(from url: URL) -> [AnalyticsPayload] {
+        guard let data = try? Data(contentsOf: url),
+              let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        return rows.compactMap(AnalyticsPayload.init(persisted:)).suffix(spoolCapacity)
+    }
+}
+
+// MARK: - Transport
+
+/// The one thing that touches the network, behind a protocol so every test in this area runs offline.
+protocol AnalyticsTransport: Sendable {
+    /// Returns true only if the batch was accepted. A `false` leaves the events spooled.
+    func send(_ batch: [AnalyticsPayload], token: String, to endpoint: URL) async -> Bool
+}
+
+struct URLSessionAnalyticsTransport: AnalyticsTransport {
+    /// Short, and shorter than the flush interval: a request still in flight when the next flush is
+    /// due is a request that has already failed at being unobtrusive.
+    static let timeout: TimeInterval = 20
+
+    func send(_ batch: [AnalyticsPayload], token: String, to endpoint: URL) async -> Bool {
+        guard !batch.isEmpty else { return true }
+
+        let body: [String: Any] = ["api_key": token, "batch": batch.map(\.json)]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else {
+            // Unencodable means a bug in the payload types, not a network problem. Reporting success
+            // drops the batch, which is right: retrying it forever would wedge the spool behind an
+            // event that can never be sent.
+            ContextLog.info("[analytics] dropped an unencodable batch of \(batch.count)", "analytics")
+            return true
+        }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = data
+        request.timeoutInterval = Self.timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("context-for-claude-analytics/1.0", forHTTPHeaderField: "User-Agent")
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let consume = Self.shouldConsumeBatch(forStatus: status)
+            if consume, !(200..<300).contains(status) {
+                ContextLog.info("[analytics] dropped batch of \(batch.count) on HTTP \(status)", "analytics")
+            }
+            return consume
+        } catch {
+            return false
+        }
+    }
+
+    /// Whether a response means "stop carrying these events", as a pure function of the status so the
+    /// rule is testable without a server.
+    ///
+    /// A 4xx other than 429 will never succeed on retry — a malformed batch, or a revoked token — and
+    /// **consuming it is the only way the spool ever empties again**. Keeping it would park every
+    /// later event behind one that can never be sent. 429 is the exception because it is temporary,
+    /// and 5xx is the server's problem, not the batch's.
+    static func shouldConsumeBatch(forStatus status: Int) -> Bool {
+        if (200..<300).contains(status) { return true }
+        return (400..<500).contains(status) && status != 429
+    }
+}
+
+// MARK: - Persistence round-trip
+
+extension AnalyticsPayload {
+    /// Rebuilds a spooled payload. Returns nil for anything that does not round-trip cleanly — a
+    /// half-understood event is not worth sending.
+    init?(persisted row: [String: Any]) {
+        guard let name = row["event"] as? String,
+              let rawProperties = row["properties"] as? [String: Any],
+              let distinctID = rawProperties["distinct_id"] as? String,
+              let stamp = row["timestamp"] as? String,
+              let timestamp = ISO8601DateFormatter.analytics.date(from: stamp)
+        else { return nil }
+
+        var properties: [String: AnalyticsValue] = [:]
+        for (key, value) in rawProperties where key != "distinct_id" {
+            // Bool is checked first: `NSNumber` bridges both, and an `Int` case for a bool would
+            // turn `signed_in: true` into `signed_in: 1` on the way back out of the spool.
+            if let bool = value as? Bool { properties[key] = .bool(bool) }
+            else if let int = value as? Int { properties[key] = .int(int) }
+            else if let string = value as? String { properties[key] = .string(string) }
+        }
+
+        self.init(name: name, distinctID: distinctID, timestamp: timestamp, properties: properties)
+    }
+
+    /// Memberwise init for the spool round-trip, kept private to this file's concern so the ordinary
+    /// construction path stays the one that cannot forget super-properties.
+    fileprivate init(
+        name: String,
+        distinctID: String,
+        timestamp: Date,
+        properties: [String: AnalyticsValue]
+    ) {
+        self.name = name
+        self.distinctID = distinctID
+        self.timestamp = timestamp
+        self.properties = properties
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -10,9 +10,17 @@ import Foundation
 ///
 /// ## The three refusals
 ///
-/// 1. **Airgap Mode.** Checked on every single event, and the event is *dropped*, not deferred. The
-///    switch means "nothing leaves this Mac"; a spooled event that flies the moment the switch goes
-///    off would honour the letter of that and break it entirely.
+/// 1. **Airgap Mode.** Checked on every single event, and the event is *dropped*, not deferred. It
+///    means "nothing leaves this Mac"; a spooled event that flew the moment it was lifted would
+///    honour the letter of that and break it entirely.
+///
+///    There is no Settings switch for it any more — it was removed in 1.0.9 and
+///    `ExclusionEngine.setAirgapMode` has had no caller since. The state still occurs, which is why
+///    this check is not dead code: an `exclusions.json` predating that release still carries it, and
+///    `ExclusionSet.make` forces it on whenever the exclusion configuration fails closed. That last
+///    case is the one to design for — a machine whose config cannot be parsed may be under
+///    exclusions we cannot express, and reporting from it would be reporting from a state where we
+///    cannot honour what the user asked to hide.
 /// 2. **Development builds.** A locally built app reports nothing. This is not tidiness: the Cloud
 ///    Run logs for the first three weeks of this app show a `Context for Claude/1` user agent from up
 ///    to twenty machines a day — the team's own builds, indistinguishable in aggregate from users.

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -1,0 +1,295 @@
+import AppKit
+import ContextCore
+import Foundation
+
+/// The app's one analytics entry point.
+///
+/// Call `ContextAnalytics.record(_:)` from anywhere. Everything that makes a report defensible —
+/// Airgap Mode, development builds, the daily rollup, batching, durability — is decided here rather
+/// than at the call sites, so a new call site cannot get it wrong by omission.
+///
+/// ## The three refusals
+///
+/// 1. **Airgap Mode.** Checked on every single event, and the event is *dropped*, not deferred. The
+///    switch means "nothing leaves this Mac"; a spooled event that flies the moment the switch goes
+///    off would honour the letter of that and break it entirely.
+/// 2. **Development builds.** A locally built app reports nothing. This is not tidiness: the Cloud
+///    Run logs for the first three weeks of this app show a `Context for Claude/1` user agent from up
+///    to twenty machines a day — the team's own builds, indistinguishable in aggregate from users.
+///    Analytics that count their own authors answer a different question than the one being asked.
+/// 3. **Nothing user-authored, ever.** Enforced by construction in `AnalyticsEvent` — there is no
+///    API here that accepts a string from a call site.
+///
+/// ## What this deliberately does not do
+///
+/// No session replay, no autocapture, no feature flags, no identify() against an Omi account. The
+/// distinct id is a salted hash of the install id and stays that way even after sign-in: knowing
+/// *that* an install has an account (`signed_in`) answers every product question that matters here,
+/// and knowing *which* account would turn an anonymous series into a per-person record of when
+/// somebody's microphone was on.
+enum ContextAnalytics {
+
+    // MARK: - Recording
+
+    /// Reports one event, unless one of the three refusals applies.
+    static func record(_ event: AnalyticsEvent) {
+        guard isEnabled else { return }
+
+        // Read live, never cached: the toggle takes effect on the next event, which is what lets
+        // Airgap Mode promise "immediately" rather than "after relaunch".
+        guard !NetworkEgress.isSuppressed(.analytics) else {
+            NetworkEgress.recordSuppression(.analytics, outcome: .dropped)
+            return
+        }
+
+        let payload = AnalyticsPayload(
+            event: event,
+            distinctID: AnalyticsIdentity.distinctID,
+            timestamp: Date(),
+            superProperties: currentSuperProperties())
+
+        Task { await AnalyticsSink.shared.enqueue(payload) }
+    }
+
+    /// False on development builds, which report nothing at all. See refusal 2 above.
+    ///
+    /// `CONTEXT_ANALYTICS_FORCE=1` overrides it for one purpose: proving end to end, from a local
+    /// build, that events actually arrive in PostHog. There is no way to verify this pipeline without
+    /// it — a release build cannot be run under a debugger on the machine that wrote it, and a sink
+    /// nobody has watched deliver is a sink that has never worked. Events sent this way are
+    /// indistinguishable from real ones, so anything recorded under the override lands in production
+    /// series: use a throwaway `CONTEXT_ANALYTICS_FORCE` session, not a day of ordinary work.
+    static var isEnabled: Bool {
+        if ProcessInfo.processInfo.environment["CONTEXT_ANALYTICS_FORCE"] == "1" { return true }
+        return !ContextPaths.isDevelopmentBuild
+    }
+
+    // MARK: - Lifecycle
+
+    /// Wires analytics to the app's life. Called once, from `ContextApp`'s launch path.
+    ///
+    /// Ordering matters: the first-launch event has to be emitted before anything else can beat it to
+    /// the `hasLaunchedKey` default, or the install denominator loses its first member.
+    @MainActor
+    static func start() {
+        guard isEnabled else { return }
+
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: hasLaunchedKey) == nil {
+            defaults.set(true, forKey: hasLaunchedKey)
+            record(.firstLaunch)
+        } else {
+            record(.appLaunched)
+        }
+
+        // A day boundary crossed while the app was running still has to produce a rollup, so this is
+        // a repeating check rather than a launch-time one. Hourly is far more often than the rollup
+        // fires; the check itself is a date comparison against a stored string.
+        rollupTimer?.invalidate()
+        rollupTimer = Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in
+            Task { @MainActor in reportDailyRollupIfDue() }
+        }
+        reportDailyRollupIfDue()
+
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification, object: nil, queue: .main
+        ) { _ in
+            // The rollup for a partial day is worth more than a clean shutdown is worth: an install
+            // that is quit every evening would otherwise never report one.
+            Task { @MainActor in
+                reportDailyRollupIfDue(force: true)
+                await AnalyticsSink.shared.flush()
+            }
+        }
+    }
+
+    // MARK: - Permissions
+
+    /// Reports the state of every capability, once per launch.
+    ///
+    /// A snapshot rather than only change-events, because the interesting population is the one that
+    /// *never* grants: someone who installs, is asked for Screen Recording, says no and quits leaves
+    /// no transition to observe. Reported at launch, so an install's grant state is a property of
+    /// every day it ran rather than of the one day it happened to change.
+    @MainActor
+    static func recordPermissionSnapshot() {
+        guard isEnabled else { return }
+        for capability in Capability.allCases {
+            let state: AnalyticsEvent.PermissionState
+            if Permissions.check(capability) {
+                state = .granted
+            } else {
+                state = Permissions.grantWasLost(capability) ? .revoked : .denied
+            }
+            record(.permission(AnalyticsEvent.Permission(capability), state))
+        }
+    }
+
+    // MARK: - The daily rollup
+
+    /// Emits `cfc_daily_active` if the last one was on an earlier local day.
+    ///
+    /// **Local calendar day, not a 24-hour window.** DAU is a calendar concept everywhere it is read
+    /// — the dashboards, the retention queries, the weekly actives — and a rolling window would drift
+    /// against every one of them.
+    ///
+    /// `force` is for termination, where "the day is not over" is true but irrelevant: the app is
+    /// going away and the alternative is losing the day entirely. It still respects the
+    /// once-per-day rule, so quitting twice in an evening reports once.
+    @MainActor
+    static func reportDailyRollupIfDue(force: Bool = false) {
+        guard isEnabled else { return }
+
+        let today = Self.dayStamp(for: Date())
+        let defaults = UserDefaults.standard
+        guard defaults.string(forKey: lastRollupDayKey) != today else { return }
+
+        // Drain first, then mark the day. `ToolCallLedger.drain` is destructive, so a crash between
+        // the two re-reports a day rather than losing its tool calls — the recoverable direction.
+        let ledger = ToolCallLedger.drain()
+        let rollup = DailyRollup(
+            toolCalls: ledger.counts,
+            captureMinutes: UsageClock.shared.minutes(for: .capture),
+            screenMinutes: UsageClock.shared.minutes(for: .screen),
+            activeHours: UsageClock.shared.activeHourCount,
+            signedIn: OmiAuth.shared.isSignedIn,
+            airgapped: NetworkEgress.isAirgapped)
+
+        // An install with nothing at all to say on its first partial day is not a data point, it is
+        // noise from a launch that happened at 23:58. Everything else reports, idle included — an
+        // ambient app that ran all day and captured nothing is exactly the case the `idle` dimension
+        // exists to make visible.
+        guard !(force && rollup.isIdle && UsageClock.shared.activeHourCount == 0) else { return }
+
+        defaults.set(today, forKey: lastRollupDayKey)
+        record(.dailyActive(rollup))
+        UsageClock.shared.reset()
+    }
+
+    /// `yyyy-MM-dd` in the machine's own calendar and time zone.
+    static func dayStamp(for date: Date, calendar: Calendar = .current) -> String {
+        let parts = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(format: "%04d-%02d-%02d", parts.year ?? 0, parts.month ?? 0, parts.day ?? 0)
+    }
+
+    // MARK: - Build identity
+
+    private static func currentSuperProperties() -> [String: AnalyticsValue] {
+        let info = Bundle.main.infoDictionary
+        return AnalyticsPayload.superProperties(
+            version: info?["CFBundleShortVersionString"] as? String ?? "unknown",
+            build: info?["CFBundleVersion"] as? String ?? "unknown",
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString)
+    }
+
+    // MARK: - Stored state
+
+    private static let hasLaunchedKey = "context.analytics.hasLaunched"
+    private static let lastRollupDayKey = "context.analytics.lastRollupDay"
+
+    @MainActor private static var rollupTimer: Timer?
+}
+
+/// How long capture actually ran today, and how much of the day it was spread across.
+///
+/// Wall-clock accumulation rather than a count of start/stop events: "started capture 40 times" and
+/// "captured for 40 minutes" are very different products, and only the second one says whether the
+/// app is doing its job.
+///
+/// The hour set is what separates an app left running overnight from one in use — twelve active
+/// hours and twelve capture minutes is a person at a desk; one active hour and 600 capture minutes
+/// is a laptop that was left open.
+final class UsageClock: @unchecked Sendable {
+    /// Audio and screen are reported separately because they fail separately: the commonest broken
+    /// install has Screen Recording granted and no microphone, and one merged "capture minutes"
+    /// would show that as a healthy day.
+    enum Channel: String, Sendable { case capture, screen }
+
+    static let shared = UsageClock()
+
+    private let lock = NSLock()
+    private var seconds: [Channel: TimeInterval] = [:]
+    private var startedAt: [Channel: Date] = [:]
+    /// Which sources are live right now, per channel.
+    ///
+    /// **A set, not a bool.** The microphone and the system-audio tap share the `capture` channel and
+    /// start and stop independently: with a bool, a call ending (system audio stops) while the mic
+    /// stayed live would close the clock and lose the rest of the day's audio. The channel's clock
+    /// runs while *any* of its sources is live and stops when the last one does.
+    private var live: [Channel: Set<AnalyticsEvent.CaptureSource>] = [:]
+    private var activeHours: Set<Int> = []
+
+    private static func channel(for source: AnalyticsEvent.CaptureSource) -> Channel {
+        switch source {
+        case .microphone, .systemAudio: return .capture
+        case .screen: return .screen
+        }
+    }
+
+    /// Records that one source went live or stopped.
+    func mark(_ source: AnalyticsEvent.CaptureSource, live isLive: Bool, at now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        let channel = Self.channel(for: source)
+        var sources = live[channel] ?? []
+
+        if isLive {
+            sources.insert(source)
+            live[channel] = sources
+            if startedAt[channel] == nil { startedAt[channel] = now }
+        } else {
+            sources.remove(source)
+            live[channel] = sources
+            if sources.isEmpty, let start = startedAt.removeValue(forKey: channel) {
+                seconds[channel, default: 0] += max(0, now.timeIntervalSince(start))
+            }
+        }
+        noteHourLocked(now)
+    }
+
+    /// Records that something happened, for the active-hours spread. Cheap enough to call from any
+    /// event path.
+    func noteActivity(at now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        noteHourLocked(now)
+    }
+
+    private func noteHourLocked(_ now: Date) {
+        activeHours.insert(Calendar.current.component(.hour, from: now))
+    }
+
+    /// Whole minutes, including any run still in progress — a rollup taken while the mic is live must
+    /// not report zero.
+    func minutes(for channel: Channel, at now: Date = Date()) -> Int {
+        lock.lock(); defer { lock.unlock() }
+        var total = seconds[channel] ?? 0
+        if let start = startedAt[channel] { total += max(0, now.timeIntervalSince(start)) }
+        return Int(total / 60)
+    }
+
+    var activeHourCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return activeHours.count
+    }
+
+    /// Starts the next day's accounting. A channel still running keeps running — its clock restarts
+    /// from now, so the minutes it already contributed are not counted twice.
+    func reset(at now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        seconds.removeAll()
+        activeHours.removeAll()
+        for channel in startedAt.keys { startedAt[channel] = now }
+        noteHourLocked(now)
+    }
+
+    #if DEBUG
+    /// Tests need a clock with no history. Production has exactly one of these and it lives for the
+    /// process, so there is no legitimate non-test caller.
+    func resetCompletelyForTesting() {
+        lock.lock(); defer { lock.unlock() }
+        seconds.removeAll()
+        startedAt.removeAll()
+        live.removeAll()
+        activeHours.removeAll()
+    }
+    #endif
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -125,6 +125,49 @@ enum ContextAnalytics {
         }
     }
 
+    // MARK: - Onboarding
+
+    /// Records that first run reached a step, stamping the run's start on the first one seen.
+    @MainActor
+    static func recordOnboardingStep(index: Int, of total: Int) {
+        guard isEnabled else { return }
+        if onboardingStartedAt == nil { onboardingStartedAt = Date() }
+        record(.onboardingStep(index: index, of: total))
+    }
+
+    /// Records that first run ended.
+    ///
+    /// The elapsed time is measured from the first *step transition*, not from app launch: onboarding
+    /// opens behind a permission prompt and a sign-in browser hop, and counting the seconds a person
+    /// spent in System Settings as time spent in our flow would make every install look slow for a
+    /// reason we did not cause.
+    @MainActor
+    static func recordOnboardingFinished() {
+        guard isEnabled, let started = onboardingStartedAt else { return }
+        onboardingStartedAt = nil
+        record(.onboardingFinished(secondsElapsed: Int(Date().timeIntervalSince(started))))
+    }
+
+    // MARK: - Fallbacks
+
+    /// Mirrors a local `ContextTelemetry.recordFallback` into the remote series.
+    ///
+    /// **This must never be called for an airgap suppression, and the guard is at the caller.**
+    /// `record` reports its own refusal through `NetworkEgress.recordSuppression`, which calls
+    /// `recordFallback` — so a fallback event that fed back into `record` while airgapped would
+    /// recurse until the stack ran out. `ContextTelemetry.recordFallback` drops `airgap-mode` before
+    /// it reaches here, which both breaks the cycle and honours the older rule it was written under:
+    /// a suppression report must not itself be the disclosure the suppression prevented.
+    static func recordFallback(
+        area: ContextFallbackArea,
+        outcome: ContextFallbackOutcome,
+        reason: AnalyticsEvent.FallbackReason
+    ) {
+        record(.fallback(area: area, outcome: outcome, reason: reason))
+    }
+
+    @MainActor private static var onboardingStartedAt: Date?
+
     // MARK: - The daily rollup
 
     /// Emits `cfc_daily_active` if the last one was on an earlier local day.

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Telemetry.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Telemetry.swift
@@ -16,7 +16,7 @@ import Foundation
 /// turn the airgap guard itself into the disclosure it exists to prevent — and it would fire on
 /// exactly the machines whose users asked for silence. Anything added here must consult
 /// `NetworkEgress.isSuppressed` before sending, and must not report its own suppression.
-enum ContextFallbackArea: String, Sendable {
+enum ContextFallbackArea: String, Sendable, CaseIterable {
     case capture
     case upload
     case mcp
@@ -26,7 +26,7 @@ enum ContextFallbackArea: String, Sendable {
     case rewind
 }
 
-enum ContextFallbackOutcome: String, Sendable {
+enum ContextFallbackOutcome: String, Sendable, CaseIterable {
     case degraded
     case dropped
     case retried

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Telemetry.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Telemetry.swift
@@ -50,6 +50,20 @@ enum ContextTelemetry {
         outcome: ContextFallbackOutcome
     ) {
         ContextLog.info("[fallback] area=\(area.rawValue) from=\(from) to=\(to) reason=\(reason) outcome=\(outcome.rawValue)", "telemetry")
+
+        // The remote half. Only reasons that map to a known slug are forwarded — `reason` is a
+        // convention-enforced string here, and the analytics vocabulary is closed, so an unmapped
+        // slug is dropped rather than smuggled through as free text.
+        //
+        // **`airgap-mode` is excluded, and that exclusion is load-bearing twice over.** It is the
+        // invariant this type was written with: `NetworkEgress` reports every Airgap Mode
+        // suppression through here, so forwarding one would phone home on exactly the machines whose
+        // users asked for silence. It is *also* the cycle breaker — `ContextAnalytics.record`
+        // reports its own airgap refusal through `NetworkEgress.recordSuppression`, which calls
+        // this function, which would call `record` again. See `ContextAnalytics.recordFallback`.
+        if let mapped = AnalyticsEvent.FallbackReason(slug: reason), mapped != .airgapMode {
+            ContextAnalytics.recordFallback(area: area, outcome: outcome, reason: mapped)
+        }
         // Remote telemetry (PostHog/Sentry) requires project-specific credentials and SDKs that
         // are not yet dependencies of this package. The structured log above is the contract; a
         // future provider can read it or be called here without changing callers — but only behind

--- a/desktop/context-for-claude/Sources/ContextApp/Update/ContextUpdater.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Update/ContextUpdater.swift
@@ -247,6 +247,11 @@ final class UpdaterEvents: NSObject, SPUUpdaterDelegate {
     shouldProceedWithUpdate updateItem: SUAppcastItem,
     updateCheck: SPUUpdateCheck
   ) throws {
+    // Before the egress guard, because "the feed offered us a newer build" is true whether or not
+    // this machine is allowed to fetch it — and an install that keeps finding updates it never
+    // downloads is the exact shape of a stuck fleet, which is invisible if this is only recorded on
+    // the paths that succeed.
+    ContextAnalytics.record(.updateOutcome(.updateFound))
     guard UpdateEgress.permits(.archiveDownload) else { throw UpdateEgress.refusal }
   }
 

--- a/desktop/context-for-claude/Sources/ContextApp/Update/ContextUpdater.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Update/ContextUpdater.swift
@@ -253,6 +253,7 @@ final class UpdaterEvents: NSObject, SPUUpdaterDelegate {
   /// A downloaded update is extracted in the background. This state/message is also reflected in
   /// Settings, while the automatic driver's install-on-quit hook below supplies the actual prompt.
   func updater(_ updater: SPUUpdater, didExtractUpdate item: SUAppcastItem) {
+    ContextAnalytics.record(.updateOutcome(.installed))
     owner?.report(UpdatePolicy.RelaunchState.required(version: item.displayVersionString).message)
   }
 
@@ -332,6 +333,7 @@ final class UpdaterEvents: NSObject, SPUUpdaterDelegate {
   }
 
   func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+    ContextAnalytics.record(.updateOutcome(.upToDate))
     Task { @MainActor in owner?.report("Context for Claude is up to date.") }
   }
 
@@ -342,6 +344,9 @@ final class UpdaterEvents: NSObject, SPUUpdaterDelegate {
     // is not worth depending on; `SUNoUpdateError = 1001` in `SUErrors.h` is.
     let nsError = error as NSError
     guard nsError.code != 1001 else { return }
+    // Only after the 1001 filter: counting "no update found" as a failure would report a healthy
+    // fleet as a broken one, and update health is the metric most likely to be read in a panic.
+    ContextAnalytics.record(.updateOutcome(.checkFailed))
     ContextLog.error("update check failed: \(nsError.domain) \(nsError.code)", "update")
     ContextTelemetry.recordFallback(
       area: .settings,

--- a/desktop/context-for-claude/Sources/ContextCore/FileLock.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/FileLock.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// An exclusive `flock` over a read-modify-write of a file that is replaced by `rename(2)`.
+///
+/// A dedicated lock file that is only ever locked — never renamed, never replaced — so every writer
+/// locks the same inode for the lifetime of the install. Locking the *destination* instead would lock
+/// an inode that the next rename unlinks, after which two writers hold exclusive locks on two
+/// different inodes and the lock means nothing.
+///
+/// `flock` is released by the kernel when the process dies, so a crashed writer cannot wedge the
+/// file. That property is load-bearing here: both files this guards are written by
+/// `context-for-claude-mcp`, a process Claude spawns and kills at will.
+///
+/// Extracted from `QueryStamp`, which had the only copy, when `ToolCallLedger` needed the identical
+/// discipline over the identical failure mode. Two hand-written flock dances in one package is one
+/// more than can be kept correct.
+struct ContextFileLock {
+    private let descriptor: Int32
+
+    init(at url: URL) throws {
+        descriptor = open(url.path, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else {
+            throw ContextFileLockError.couldNotLock(
+                path: url.path, reason: String(cString: strerror(errno)))
+        }
+    }
+
+    func acquire() throws {
+        while flock(descriptor, LOCK_EX) != 0 {
+            // A signal interrupting the wait is not a failure to lock.
+            guard errno == EINTR else {
+                throw ContextFileLockError.couldNotLock(
+                    path: "fd \(descriptor)", reason: String(cString: strerror(errno)))
+            }
+        }
+    }
+
+    /// Closing the descriptor releases the lock; unlocking first keeps that explicit.
+    func release() {
+        flock(descriptor, LOCK_UN)
+        close(descriptor)
+    }
+
+    /// Writes `data` to `url` so no reader can ever observe a partial file.
+    ///
+    /// The payload goes to a uniquely named temp file in the same directory and is then `rename(2)`d
+    /// onto the destination. POSIX rename is atomic within a filesystem: a reader opening the path
+    /// gets either the whole previous file or the whole new one, never a mixture and never a
+    /// zero-length truncation. Readers therefore take no lock at all and can never block a writer.
+    ///
+    /// The temp name carries the pid *and* a UUID. A shared temp name would let two processes
+    /// interleave their bytes into one temp file and then rename the wreckage into place.
+    static func replace(_ url: URL, with data: Data) throws {
+        let directory = url.deletingLastPathComponent()
+        let temp = directory.appendingPathComponent(
+            ".\(url.lastPathComponent).\(ProcessInfo.processInfo.processIdentifier).\(UUID().uuidString).tmp")
+        try data.write(to: temp)
+        ContextPaths.setPermissions(temp, mode: 0o600)
+        guard rename(temp.path, url.path) == 0 else {
+            let reason = String(cString: strerror(errno))
+            try? FileManager.default.removeItem(at: temp)
+            throw ContextFileLockError.couldNotReplace(path: url.path, reason: reason)
+        }
+    }
+}
+
+enum ContextFileLockError: Error, LocalizedError, Equatable {
+    case couldNotLock(path: String, reason: String)
+    case couldNotReplace(path: String, reason: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .couldNotLock(path, reason):
+            return "Could not lock \(path): \(reason)"
+        case let .couldNotReplace(path, reason):
+            return "Could not replace \(path): \(reason)"
+        }
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextCore/Paths.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/Paths.swift
@@ -186,6 +186,29 @@ public enum ContextPaths {
 
     static let queryStampFilename = "last-query.json"
 
+    /// The MCP server's running tally of tool calls, drained by the app when it reports. See
+    /// `ToolCallLedger` — and note this is a *different* file from the query stamp on purpose: the
+    /// stamp answers "did Claude call us just now", this answers "how much", and one file cannot be
+    /// both monotonic-latest and cumulative.
+    public static var toolCallLedgerURL: URL {
+        supportDirectory.appendingPathComponent(toolCallLedgerFilename)
+    }
+
+    /// Beside the database the calls were served from, for the reason `queryStampURL(besideDatabaseAt:)`
+    /// gives: two processes have to be talking about the same install.
+    public static func toolCallLedgerURL(besideDatabaseAt databaseURL: URL) -> URL {
+        databaseURL.deletingLastPathComponent().appendingPathComponent(toolCallLedgerFilename)
+    }
+
+    /// The lock guarding a ledger read-modify-write. Never renamed or replaced, so concurrent MCP
+    /// servers always contend over the same inode — see `ToolCallLedger.bump`.
+    public static func toolCallLedgerLockURL(for ledgerURL: URL) -> URL {
+        ledgerURL.deletingLastPathComponent()
+            .appendingPathComponent(ledgerURL.lastPathComponent + ".lock")
+    }
+
+    static let toolCallLedgerFilename = "tool-calls.json"
+
     @discardableResult
     public static func ensureSupportDirectory(at url: URL? = nil) throws -> URL {
         let dir = url ?? supportDirectory

--- a/desktop/context-for-claude/Sources/ContextCore/QueryStamp.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/QueryStamp.swift
@@ -59,19 +59,14 @@ public struct QueryStamp: Codable, Sendable, Equatable {
     /// is a third process. Two properties matter, and both are handled here rather than left to the
     /// caller:
     ///
-    /// 1. **A reader never sees a partial file.** The payload is written to a uniquely named temp
-    ///    file in the same directory and then `rename(2)`d onto the destination. POSIX rename is
-    ///    atomic within a filesystem: a reader opening the path gets either the whole previous file
-    ///    or the whole new one, never a mixture and never a zero-length truncation. Readers
-    ///    therefore take no lock at all and can never block a server.
-    ///    The temp name carries the pid *and* a UUID: a shared temp name would let two servers
-    ///    interleave their bytes into one temp file and then rename the wreckage into place.
+    /// 1. **A reader never sees a partial file.** `ContextFileLock.replace` writes to a uniquely
+    ///    named temp file and `rename(2)`s it onto the destination, so a reader opening the path gets
+    ///    either the whole previous file or the whole new one. Readers therefore take no lock at all
+    ///    and can never block a server.
     /// 2. **The newest call wins.** Renames alone are last-writer-wins by wall-clock arrival, so a
     ///    server that was slightly slow could bury a newer stamp under its older one. The
-    ///    read-compare-rename is therefore done under an exclusive `flock` on a *separate* lock
-    ///    file. It has to be separate: locking the destination would lock an inode that the next
-    ///    rename unlinks, after which two writers hold exclusive locks on two different inodes and
-    ///    the lock means nothing. `flock` is released by the kernel when the process dies, so a
+    ///    read-compare-rename is therefore done under an exclusive `flock` on a *separate* lock file
+    ///    — `ContextFileLock`, which documents why separate is the only workable choice and why a
     ///    crashed MCP server cannot wedge the file.
     public func record(to url: URL = ContextPaths.queryStampURL) throws {
         let directory = url.deletingLastPathComponent()
@@ -79,7 +74,7 @@ public struct QueryStamp: Codable, Sendable, Equatable {
         // yet. Recording the very first call still has to work.
         _ = try ContextPaths.ensureSupportDirectory(at: directory)
 
-        let lock = try QueryStampLock(at: ContextPaths.queryStampLockURL(for: url))
+        let lock = try ContextFileLock(at: ContextPaths.queryStampLockURL(for: url))
         defer { lock.release() }
         try lock.acquire()
 
@@ -93,15 +88,7 @@ public struct QueryStamp: Codable, Sendable, Equatable {
             return
         }
 
-        let temp = directory.appendingPathComponent(
-            ".\(url.lastPathComponent).\(ProcessInfo.processInfo.processIdentifier).\(UUID().uuidString).tmp")
-        try JSONEncoder().encode(self).write(to: temp)
-        ContextPaths.setPermissions(temp, mode: 0o600)
-        guard rename(temp.path, url.path) == 0 else {
-            let reason = String(cString: strerror(errno))
-            try? FileManager.default.removeItem(at: temp)
-            throw QueryStampError.couldNotReplaceStamp(path: url.path, reason: reason)
-        }
+        try ContextFileLock.replace(url, with: JSONEncoder().encode(self))
     }
 
     /// Convenience for the one call site that matters: the MCP server's tool dispatch.
@@ -166,51 +153,7 @@ public struct QueryStamp: Codable, Sendable, Equatable {
     }
 }
 
-// MARK: - Errors
-
-public enum QueryStampError: Error, LocalizedError, Equatable {
-    case couldNotLock(path: String, reason: String)
-    case couldNotReplaceStamp(path: String, reason: String)
-
-    public var errorDescription: String? {
-        switch self {
-        case let .couldNotLock(path, reason):
-            return "Could not lock \(path) to record the query stamp: \(reason)"
-        case let .couldNotReplaceStamp(path, reason):
-            return "Could not replace \(path) with the new query stamp: \(reason)"
-        }
-    }
-}
-
-// MARK: - Lock
-
-/// An exclusive `flock` over the compare-and-replace, held for microseconds.
-///
-/// A dedicated file that is only ever locked and never renamed or replaced, so every writer locks
-/// the same inode for the lifetime of the install.
-private struct QueryStampLock {
-    private let descriptor: Int32
-
-    init(at url: URL) throws {
-        descriptor = open(url.path, O_CREAT | O_RDWR | O_CLOEXEC, 0o600)
-        guard descriptor >= 0 else {
-            throw QueryStampError.couldNotLock(path: url.path, reason: String(cString: strerror(errno)))
-        }
-    }
-
-    func acquire() throws {
-        while flock(descriptor, LOCK_EX) != 0 {
-            // A signal interrupting the wait is not a failure to lock.
-            guard errno == EINTR else {
-                throw QueryStampError.couldNotLock(path: "fd \(descriptor)",
-                                                   reason: String(cString: strerror(errno)))
-            }
-        }
-    }
-
-    /// Closing the descriptor releases the lock; unlocking first keeps that explicit.
-    func release() {
-        flock(descriptor, LOCK_UN)
-        close(descriptor)
-    }
-}
+// The lock and the atomic replace live in `ContextFileLock`, shared with `ToolCallLedger`. Both files
+// are written by concurrent `context-for-claude-mcp` processes and read by the app, so they need the
+// identical discipline; two hand-written flock dances in one package is one more than can be kept
+// correct.

--- a/desktop/context-for-claude/Sources/ContextCore/ToolCallLedger.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/ToolCallLedger.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// How many times Claude called each of this app's MCP tools, since the app last reported.
+///
+/// This is the product's central usage question. Everything else the analytics measure — launches,
+/// permissions, captures — is setup; *this* is the thing the app exists to do, and it happens in a
+/// process the app does not own. `context-for-claude-mcp` is spawned by Claude over stdio, once per
+/// session, several at a time, and killed without warning. It cannot hold a socket open long enough
+/// to report anything itself, and it must not try: a short-lived process that POSTs on exit either
+/// blocks Claude's shutdown or loses the event.
+///
+/// So the MCP process counts and the app reports. The ledger is the seam.
+///
+/// ## Why not `QueryStamp`
+///
+/// `QueryStamp` already records that a tool was called, and deliberately records only the *latest*
+/// one — it exists so the first-run tutorial can honestly say "found it", and a monotonic
+/// last-writer-wins stamp is exactly right for that. It cannot answer "how many times this week",
+/// and widening it to try would break the property its tests pin. Two files, two questions.
+///
+/// ## What is recorded, and what must never be
+///
+/// A tool name and a count. Nothing else, ever.
+///
+/// **Never add the query, the tool arguments, the result, or a per-call timestamp.** Those are the
+/// user's questions and, through them, their private context. This file is plaintext on disk and its
+/// contents are destined for an analytics pipeline, which raises the stakes over `QueryStamp` rather
+/// than lowering them: a tool name is our own vocabulary, a count is arithmetic, and neither can be
+/// turned back into anything the user said. An argument or a timestamp can.
+/// `ToolCallLedgerTests.testTheLedgerCarriesNothingButToolNamesAndCounts` fails if a field is added.
+public struct ToolCallLedger: Codable, Sendable, Equatable {
+    /// Tool name → calls served since the last drain.
+    public let counts: [String: Int]
+
+    public init(counts: [String: Int] = [:]) {
+        self.counts = counts
+    }
+
+    public var isEmpty: Bool { counts.isEmpty }
+
+    public var total: Int { counts.values.reduce(0, +) }
+
+    /// Nothing legitimate is anywhere near this large; a bigger file has been appended to or
+    /// scribbled on, and is not a ledger.
+    public static let maximumFileSize = 8192
+
+    /// The app exposes ten tools. The cap is generous enough to survive a release that adds more and
+    /// tight enough that a runaway writer cannot grow the file without bound — a ledger that has to
+    /// be deleted to recover would lose real usage on every machine it happened to.
+    public static let maximumDistinctTools = 64
+
+    /// A single tool name longer than this is not one of ours.
+    public static let maximumToolNameLength = 64
+
+    // MARK: - Writing (the MCP server side)
+
+    /// Adds one call for `tool`.
+    ///
+    /// Read-modify-write under the shared lock, then an atomic rename — the same discipline
+    /// `QueryStamp.record` documents at length, and for the same reason: several MCP servers run at
+    /// once with no coordinating parent, and the app reads this file as a third process.
+    ///
+    /// **Failure is silent by design.** A tool call that succeeded must not be reported to Claude as
+    /// failed because a counter could not be written. The caller gets `Void` and no error; a lost
+    /// count is a rounding error in a metric, while a failed `recall` is a broken product.
+    public static func bump(tool: String, at url: URL = ContextPaths.toolCallLedgerURL) {
+        let name = normalized(tool)
+        guard !name.isEmpty else { return }
+
+        do {
+            let directory = url.deletingLastPathComponent()
+            // The MCP server can be spawned before the app has ever run, so the directory may not
+            // exist yet. Counting the very first call still has to work.
+            _ = try ContextPaths.ensureSupportDirectory(at: directory)
+
+            let lock = try ContextFileLock(at: ContextPaths.toolCallLedgerLockURL(for: url))
+            defer { lock.release() }
+            try lock.acquire()
+
+            var counts = read(from: url)?.counts ?? [:]
+            // A tool we have never seen cannot displace one we are already counting once the cap is
+            // reached. Dropping the new name loses one series; evicting an old one silently corrupts
+            // every number already accumulated under it.
+            guard counts[name] != nil || counts.count < maximumDistinctTools else { return }
+            counts[name, default: 0] += 1
+
+            try ContextFileLock.replace(url, with: JSONEncoder().encode(ToolCallLedger(counts: counts)))
+        } catch {
+            return
+        }
+    }
+
+    // MARK: - Reading (the app side)
+
+    /// Returns everything counted since the last drain and resets the ledger to empty, atomically.
+    ///
+    /// Drain-on-read rather than read-and-remember: the app must not have to persist a high-water
+    /// mark, and two app launches racing the same file would otherwise double-count. The reset is
+    /// inside the same lock as the read, so a call arriving mid-drain lands in the next window
+    /// instead of vanishing.
+    ///
+    /// **The caller now owns these counts.** If the report they were drained for fails to send, they
+    /// are gone — the ledger has already forgotten them. `AnalyticsSpool` therefore takes them
+    /// straight to durable storage before anything network-shaped is attempted.
+    public static func drain(from url: URL = ContextPaths.toolCallLedgerURL) -> ToolCallLedger {
+        do {
+            let lock = try ContextFileLock(at: ContextPaths.toolCallLedgerLockURL(for: url))
+            defer { lock.release() }
+            try lock.acquire()
+
+            guard let ledger = read(from: url), !ledger.isEmpty else { return ToolCallLedger() }
+            try ContextFileLock.replace(url, with: JSONEncoder().encode(ToolCallLedger()))
+            return ledger
+        } catch {
+            return ToolCallLedger()
+        }
+    }
+
+    /// The current counts without draining them, or nil if there is no readable ledger.
+    ///
+    /// Missing, empty, truncated, over-sized, non-JSON and implausible files all answer nil, exactly
+    /// as `QueryStamp.read` does: "I cannot read a ledger" and "nothing has been called" lead to the
+    /// same honest outcome — reporting nothing — whereas treating a damaged file as data would
+    /// invent usage that never happened.
+    public static func read(from url: URL = ContextPaths.toolCallLedgerURL) -> ToolCallLedger? {
+        guard let data = try? Data(contentsOf: url), !data.isEmpty, data.count <= maximumFileSize,
+              let ledger = try? JSONDecoder().decode(ToolCallLedger.self, from: data)
+        else { return nil }
+        return ledger.plausible
+    }
+
+    /// Drops anything that cannot have come from `bump`, rather than rejecting the whole file.
+    ///
+    /// A ledger is an accumulation: discarding every count because one key is malformed would throw
+    /// away real usage to punish a line nobody wrote on purpose.
+    var plausible: ToolCallLedger? {
+        let kept = counts.filter { name, count in
+            !name.isEmpty && name.count <= Self.maximumToolNameLength && count > 0
+                && name == Self.normalized(name)
+        }
+        guard !kept.isEmpty else { return nil }
+        // Sorted before the cap so an over-long ledger truncates to the same set every time it is
+        // read. Dictionary iteration order is not stable across processes, and a cap applied to an
+        // unstable order would make two readers of one file disagree about what it says.
+        let capped = kept.sorted { $0.key < $1.key }.prefix(Self.maximumDistinctTools)
+        return ToolCallLedger(counts: Dictionary(uniqueKeysWithValues: capped.map { ($0.key, $0.value) }))
+    }
+
+    /// Our own vocabulary, spelled one way.
+    ///
+    /// Lowercased and stripped to `[a-z0-9_]` so a tool name can never carry anything but a tool
+    /// name — this is the one string in the analytics payload that originates in a dispatch table
+    /// rather than in a closed Swift enum, and the sanitiser is what keeps that difference from
+    /// mattering.
+    static func normalized(_ tool: String) -> String {
+        String(tool.lowercased().unicodeScalars.filter {
+            ("a"..."z").contains(String($0)) || ("0"..."9").contains(String($0)) || $0 == "_"
+        }.map(Character.init).prefix(maximumToolNameLength))
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextMCPKit/MCPServer.swift
+++ b/desktop/context-for-claude/Sources/ContextMCPKit/MCPServer.swift
@@ -133,6 +133,9 @@ public final class MCPServer {
     private let openError: Error?
     /// Where a served tool call is recorded so the app can prove Claude reached us.
     private let queryStampURL: URL
+    /// Where served calls are *counted*, so the app can report how much this install is used.
+    /// Derived from the same place as `queryStampURL` and for the same reason.
+    private let toolCallLedgerURL: URL
 
     /// `store` is nil when nothing has been captured yet; the tools explain that in prose.
     ///
@@ -140,12 +143,20 @@ public final class MCPServer {
     /// the standard location when there is no database yet. Both resolve to the same file in a real
     /// install; deriving it from the store keeps a server that was pointed at another data directory
     /// from reporting its calls into the default one.
-    public init(store: ContextStore?, openError: Error? = nil, queryStampURL: URL? = nil) {
+    public init(
+        store: ContextStore?,
+        openError: Error? = nil,
+        queryStampURL: URL? = nil,
+        toolCallLedgerURL: URL? = nil
+    ) {
         self.store = store
         self.openError = openError
         self.queryStampURL = queryStampURL
             ?? store.map { ContextPaths.queryStampURL(besideDatabaseAt: $0.databaseURL) }
             ?? ContextPaths.queryStampURL
+        self.toolCallLedgerURL = toolCallLedgerURL
+            ?? store.map { ContextPaths.toolCallLedgerURL(besideDatabaseAt: $0.databaseURL) }
+            ?? ContextPaths.toolCallLedgerURL
     }
 
     // MARK: - Transport
@@ -286,12 +297,19 @@ public final class MCPServer {
     ///
     /// A failure here is noted and dropped. The stamp is a nicety; the tool result is the contract,
     /// and an unwritable data directory must not turn an answered question into an error.
+    ///
+    /// The same call is also counted in `ToolCallLedger`, which the app drains into analytics. The
+    /// two writes are deliberately separate files: the stamp is monotonic-latest and answers "did
+    /// Claude just call us", the ledger is cumulative and answers "how much" — see `ToolCallLedger`.
+    /// The ledger swallows its own failures for the reason stated above, so it cannot be the thing
+    /// that turns an answered question into an error either.
     private func recordServedCall(_ tool: String) {
         do {
             try QueryStamp.record(tool: tool, to: queryStampURL)
         } catch {
             Self.note("could not record the query stamp: \(error)")
         }
+        ToolCallLedger.bump(tool: tool, at: toolCallLedgerURL)
     }
 
     /// The `content` array for a tool result: the prose, then any pictures.

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsLiveDeliveryTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsLiveDeliveryTests.swift
@@ -1,0 +1,77 @@
+@testable import ContextApp
+import Foundation
+import XCTest
+
+/// The one test in this package that touches the network, and it is skipped unless asked for.
+///
+/// ## Why it exists
+///
+/// Everything else about the sink is proven against a transport double: batching, retry, drop rules,
+/// spool durability. None of that proves the thing that actually has to be true — that a payload this
+/// app builds is *accepted by PostHog and appears in the project*. A wrong token, a rejected property
+/// shape, a batch envelope PostHog silently discards: every one of those passes the offline suite and
+/// produces zero events forever, with no error anywhere.
+///
+/// That failure mode is not hypothetical in this codebase. Omi's backend has had no PostHog key
+/// configured for months; the client fails open, every server-side product event is dropped, and it
+/// took a three-attempt investigation into an impossible-looking activation rate to notice. The
+/// lesson is that an analytics pipeline nobody has watched deliver should be assumed dead.
+///
+/// ## Why it is skipped by default
+///
+/// CI tests must be hermetic, and this one needs a live service. It also *writes to production
+/// analytics* — the events it sends are real events in the real project, tagged `smoke_test` so they
+/// can be excluded from a query, but present. Running it on every commit would slowly fill the
+/// project with noise.
+///
+/// ## Running it
+///
+/// ```
+/// CONTEXT_ANALYTICS_LIVE_TEST=1 swift test --filter AnalyticsLiveDeliveryTests
+/// ```
+///
+/// Then confirm arrival, which this test deliberately does *not* do — the ingest API returns 200
+/// before the event is queryable, so an assertion on read-back would be a race, and a sleep long
+/// enough to win it would be a slow test that still occasionally lied:
+///
+/// ```sql
+/// SELECT event, properties.smoke_run, timestamp FROM events
+/// WHERE properties.app = 'context-for-claude' AND properties.smoke_test = true
+/// ORDER BY timestamp DESC LIMIT 20
+/// ```
+final class AnalyticsLiveDeliveryTests: XCTestCase {
+
+    func testPostHogAcceptsARealPayload() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CONTEXT_ANALYTICS_LIVE_TEST"] == "1",
+            "live delivery test — set CONTEXT_ANALYTICS_LIVE_TEST=1 to run it")
+
+        // A distinct id that is obviously not an install, so this can never be mistaken for a user.
+        let runID = UUID().uuidString.prefix(8).lowercased()
+        var payload = AnalyticsPayload(
+            event: .appLaunched,
+            distinctID: "cfc_smoketest_\(runID)",
+            timestamp: Date(),
+            superProperties: AnalyticsPayload.superProperties(
+                version: "0.0.0-smoke", build: "0", macOSVersion: "smoke-test"))
+        payload = payload.taggedAsSmokeTest(run: String(runID))
+
+        let accepted = await URLSessionAnalyticsTransport().send(
+            [payload], token: AnalyticsSink.projectToken, to: AnalyticsSink.endpoint)
+
+        XCTAssertTrue(accepted, "PostHog rejected a payload this app would really send")
+        print("[live] sent smoke_run=\(runID) — query PostHog for properties.smoke_run = '\(runID)'")
+    }
+}
+
+private extension AnalyticsPayload {
+    /// Marks a payload as coming from the smoke test, so real usage queries can exclude it.
+    func taggedAsSmokeTest(run: String) -> AnalyticsPayload {
+        var tagged = properties
+        tagged["smoke_test"] = .bool(true)
+        tagged["smoke_run"] = .string(run)
+        var row = json
+        row["properties"] = tagged.mapValues(\.json).merging(["distinct_id": distinctID]) { a, _ in a }
+        return AnalyticsPayload(persisted: row)!
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsSinkTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsSinkTests.swift
@@ -1,0 +1,154 @@
+@testable import ContextApp
+import Foundation
+import XCTest
+
+/// Delivery, and the four ways it is allowed to fail.
+///
+/// Every test here runs offline. A transport double is not a convenience — an analytics sink whose
+/// retry, drop and durability rules are only ever exercised against a live endpoint is a sink whose
+/// failure behaviour has never been observed at all.
+final class AnalyticsSinkTests: XCTestCase {
+
+    private var directory: URL!
+    private var spoolURL: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("sink-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        spoolURL = directory.appendingPathComponent("analytics-spool.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private func payload(_ index: Int = 0) -> AnalyticsPayload {
+        AnalyticsPayload(
+            event: .onboardingStep(index: index, of: 5),
+            distinctID: "cfc_0123456789abcdef",
+            timestamp: Date(timeIntervalSince1970: 1_760_000_000 + Double(index)),
+            superProperties: AnalyticsPayload.superProperties(
+                version: "1.0.12", build: "1000012", macOSVersion: "Version 15.5.0"))
+    }
+
+    // MARK: - Delivery
+
+    func testAFlushSendsEverythingQueued() async {
+        let transport = RecordingTransport(outcome: .accept)
+        let sink = AnalyticsSink(spoolURL: spoolURL, transport: transport)
+
+        for index in 0..<3 { await sink.enqueue(payload(index)) }
+        await sink.flush()
+
+        let sent = await transport.sentNames
+        XCTAssertEqual(sent.count, 3)
+    }
+
+    /// A spool that grew while offline drains over several requests rather than in one implausible
+    /// burst — both for the endpoint's sake and because a single enormous POST is the request most
+    /// likely to be rejected outright and retried forever.
+    func testALargeSpoolDrainsInBatches() async {
+        let transport = RecordingTransport(outcome: .accept)
+        let sink = AnalyticsSink(spoolURL: spoolURL, transport: transport)
+
+        for index in 0..<(AnalyticsSink.batchSize * 2 + 5) { await sink.enqueue(payload(index)) }
+        await sink.flush()
+
+        let sizes = await transport.batchSizes
+        XCTAssertEqual(sizes, [AnalyticsSink.batchSize, AnalyticsSink.batchSize, 5])
+    }
+
+    // MARK: - Failure
+
+    /// A failed flush must leave the events queued. Sending is best-effort forever, but "best
+    /// effort" that discards on the first network blip is just discarding.
+    func testAFailedSendKeepsTheEventsForNextTime() async {
+        let transport = RecordingTransport(outcome: .fail)
+        let sink = AnalyticsSink(spoolURL: spoolURL, transport: transport)
+
+        await sink.enqueue(payload())
+        await sink.flush()
+        var spooled = await sink.spooledCountForTesting
+        XCTAssertEqual(spooled, 1)
+
+        await transport.set(outcome: .accept)
+        await sink.flush()
+        spooled = await sink.spooledCountForTesting
+        XCTAssertEqual(spooled, 0)
+    }
+
+    /// **The wedge this prevents.** A 4xx that is not 429 will never succeed on retry — a malformed
+    /// batch, or a revoked token. Keeping it queued would block every later event behind one that can
+    /// never be sent, and the spool would never empty again. Rate limiting is the exception: it is
+    /// temporary, so it must be retried rather than dropped.
+    func testTheTransportRetries429AndDropsOtherClientErrors() {
+        XCTAssertFalse(URLSessionAnalyticsTransport.shouldConsumeBatch(forStatus: 429))
+        XCTAssertFalse(URLSessionAnalyticsTransport.shouldConsumeBatch(forStatus: 500))
+        XCTAssertFalse(URLSessionAnalyticsTransport.shouldConsumeBatch(forStatus: 503))
+        XCTAssertTrue(URLSessionAnalyticsTransport.shouldConsumeBatch(forStatus: 200))
+        XCTAssertTrue(URLSessionAnalyticsTransport.shouldConsumeBatch(forStatus: 400))
+        XCTAssertTrue(URLSessionAnalyticsTransport.shouldConsumeBatch(forStatus: 401))
+    }
+
+    // MARK: - Durability and bounds
+
+    /// Events recorded seconds before a quit are not lost. This is most of the value of the spool: an
+    /// app that is quit every evening would otherwise never deliver its rollup.
+    func testTheSpoolSurvivesRelaunch() async {
+        let first = AnalyticsSink(spoolURL: spoolURL, transport: RecordingTransport(outcome: .fail))
+        await first.enqueue(payload(1))
+        await first.enqueue(payload(2))
+
+        let transport = RecordingTransport(outcome: .accept)
+        let second = AnalyticsSink(spoolURL: spoolURL, transport: transport)
+        await second.flush()
+
+        let delivered = await transport.sentNames
+        XCTAssertEqual(delivered.count, 2)
+    }
+
+    /// A spool that has overflowed has already lost the argument about completeness. Keeping the
+    /// *recent* events at least keeps the series current — dropping newest-first would freeze it at
+    /// whenever the machine went offline.
+    func testAnOverflowingSpoolDropsItsOldestEvents() async {
+        let sink = AnalyticsSink(spoolURL: spoolURL, transport: RecordingTransport(outcome: .fail))
+
+        for index in 0..<(AnalyticsSink.spoolCapacity + 25) { await sink.enqueue(payload(index)) }
+
+        let held = await sink.spooledCountForTesting
+        XCTAssertEqual(held, AnalyticsSink.spoolCapacity)
+        let oldest = await sink.oldestSpooledTimestampForTesting
+        XCTAssertEqual(oldest, Date(timeIntervalSince1970: 1_760_000_000 + 25))
+    }
+
+    /// A spool is not user data: the cost of losing it is one gap in a chart, and the cost of
+    /// trusting a damaged one is inventing events that never happened.
+    func testADamagedSpoolIsDiscardedRatherThanRepaired() async throws {
+        try Data("{ not json".utf8).write(to: spoolURL)
+        let sink = AnalyticsSink(spoolURL: spoolURL, transport: RecordingTransport(outcome: .accept))
+        let loaded = await sink.spooledCountForTesting
+        XCTAssertEqual(loaded, 0)
+    }
+}
+
+// MARK: - Doubles
+
+private actor RecordingTransport: AnalyticsTransport {
+    enum Outcome { case accept, fail }
+
+    private(set) var sentNames: [String] = []
+    private(set) var batchSizes: [Int] = []
+    private var outcome: Outcome
+
+    init(outcome: Outcome) { self.outcome = outcome }
+
+    func set(outcome: Outcome) { self.outcome = outcome }
+
+    func send(_ batch: [AnalyticsPayload], token: String, to endpoint: URL) async -> Bool {
+        guard outcome == .accept else { return false }
+        sentNames.append(contentsOf: batch.map(\.name))
+        batchSizes.append(batch.count)
+        return true
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -167,7 +167,7 @@ final class AnalyticsEventTests: XCTestCase {
     func testDistinctCasesDoNotShareAnEventName() {
         let representatives: [AnalyticsEvent] = [
             .firstLaunch, .appLaunched, .dailyActive(.empty), .permission(.microphone, .granted),
-            .onboardingStep(index: 0, of: 1), .onboardingFinished(secondsElapsed: 0, skipped: false),
+            .onboardingStep(index: 0, of: 1), .onboardingFinished(secondsElapsed: 0),
             .accountStateChanged(signedIn: false), .captureStateChanged(source: .screen, live: true),
             .gestureFired, .surfaceOpened(.settings), .searchRan(resultCountBucket: .zero),
             .updateOutcome(.upToDate),
@@ -258,6 +258,37 @@ final class UsageClockTests: XCTestCase {
     }
 }
 
+/// The bridge from the local fallback log to the remote series, and the cycle it must not close.
+final class AnalyticsFallbackBridgeTests: XCTestCase {
+
+    /// **The infinite recursion this guard prevents.** `ContextAnalytics.record` reports its own
+    /// Airgap Mode refusal through `NetworkEgress.recordSuppression`, which calls
+    /// `ContextTelemetry.recordFallback`. Forwarding an `airgap-mode` fallback back into `record`
+    /// would therefore re-enter the same path and run the stack out. It is also the older invariant:
+    /// a suppression report must never itself be the disclosure the suppression prevented.
+    func testAirgapModeIsNeverForwardedToTheRemoteSeries() {
+        XCTAssertEqual(AnalyticsEvent.FallbackReason(slug: "airgap-mode"), .airgapMode)
+        // The bridge in `ContextTelemetry.recordFallback` drops exactly this case. If the mapping
+        // ever stops producing it, the `!= .airgapMode` filter there silently stops matching.
+    }
+
+    /// The local `reason` is a plain `String` held to a convention. This lookup is the only thing
+    /// standing between a future call site passing `"\(error)"` and an error message — which can
+    /// contain a path, a host or a query — reaching PostHog.
+    func testAnUnrecognisedReasonIsDroppedRatherThanSentAsFreeText() {
+        XCTAssertNil(AnalyticsEvent.FallbackReason(slug: "no such reason"))
+        XCTAssertNil(AnalyticsEvent.FallbackReason(slug: "Error Domain=NSURLErrorDomain Code=-1009"))
+        XCTAssertNil(AnalyticsEvent.FallbackReason(slug: ""))
+    }
+
+    func testTheSlugsTheAppActuallyEmitsAllMap() {
+        for slug in ["offline", "unauthorized", "401", "403", "rate-limited", "429",
+                     "permission-missing", "timeout", "unavailable", "malformed-response"] {
+            XCTAssertNotNil(AnalyticsEvent.FallbackReason(slug: slug), "unmapped slug: \(slug)")
+        }
+    }
+}
+
 /// The day boundary the whole DAU series rests on.
 final class ContextAnalyticsDayTests: XCTestCase {
 
@@ -292,7 +323,7 @@ extension AnalyticsEvent {
                 toolCalls: ["recall": 3], captureMinutes: 12, screenMinutes: 30,
                 activeHours: 4, signedIn: true, airgapped: false)),
             .onboardingStep(index: 2, of: 5),
-            .onboardingFinished(secondsElapsed: 94, skipped: false),
+            .onboardingFinished(secondsElapsed: 94),
             .accountStateChanged(signedIn: true),
             .gestureFired,
             .searchRan(resultCountBucket: .few),

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -1,0 +1,333 @@
+@testable import ContextApp
+import ContextCore
+import Foundation
+import XCTest
+
+/// What this app is allowed to say about the person using it, and how it says it.
+///
+/// The tests that matter most here are the negative ones. An analytics pipeline fails quietly: a
+/// payload that leaks a window title, or an event that silently enrols this app into another
+/// product's dashboards, produces no error and no crash — it produces a number somebody trusts.
+final class AnalyticsPayloadTests: XCTestCase {
+
+    private func payload(_ event: AnalyticsEvent) -> AnalyticsPayload {
+        AnalyticsPayload(
+            event: event,
+            distinctID: "cfc_0123456789abcdef",
+            timestamp: Date(timeIntervalSince1970: 1_760_000_000),
+            superProperties: AnalyticsPayload.superProperties(
+                version: "1.0.12", build: "1000012", macOSVersion: "Version 15.5.0"))
+    }
+
+    /// **The single most consequential line in this file.**
+    ///
+    /// Omi's macOS retention, activation and weekly-actives queries all scope on
+    /// `properties.$os_name = 'macOS'`. Setting it here would silently enrol every Context for Claude
+    /// install into a four-month Omi trend line, and nothing would look wrong until somebody tried to
+    /// explain the jump.
+    func testPayloadNeverSetsDollarOSName() {
+        for event in AnalyticsEvent.everyShape {
+            let properties = payload(event).json["properties"] as? [String: Any] ?? [:]
+            XCTAssertNil(properties["$os_name"], "\(event.name) set $os_name")
+            XCTAssertTrue(
+                properties.keys.allSatisfy { !$0.hasPrefix("$") || $0 == "$set" },
+                "\(event.name) set a PostHog-reserved property")
+        }
+    }
+
+    /// The other half of the separation. Either the prefix or the `app` property alone would keep the
+    /// two products apart; both together mean whichever a future query author reaches for, it works.
+    func testEveryEventIsNamespacedToThisApp() {
+        for event in AnalyticsEvent.everyShape {
+            XCTAssertTrue(event.name.hasPrefix("cfc_"), "\(event.name) is missing the cfc_ prefix")
+            let properties = payload(event).json["properties"] as? [String: Any] ?? [:]
+            XCTAssertEqual(properties["app"] as? String, "context-for-claude")
+        }
+    }
+
+    /// Build identity is attached centrally so a call site cannot forget it. An event with no version
+    /// is an event that cannot be attributed to a release, which is most of what these are for.
+    func testEveryEventCarriesBuildIdentity() {
+        for event in AnalyticsEvent.everyShape {
+            let properties = payload(event).json["properties"] as? [String: Any] ?? [:]
+            XCTAssertEqual(properties["app_version"] as? String, "1.0.12", "\(event.name)")
+            XCTAssertEqual(properties["app_build"] as? String, "1000012", "\(event.name)")
+        }
+    }
+
+    /// An event may not overwrite its own build identity, whatever it puts in its properties.
+    func testSuperPropertiesCannotBeShadowedByAnEventThatAgrees() {
+        let properties = payload(.appLaunched).properties
+        XCTAssertEqual(properties["app"], .string("context-for-claude"))
+    }
+
+    /// The spool survives relaunch, so the round-trip has to be lossless. `bool` is the case that
+    /// breaks: `NSNumber` bridges `true` to `1`, and an `Int`-first decode turns `signed_in: true`
+    /// into `signed_in: 1` — a property that then silently fails every `= true` filter.
+    func testASpooledEventSurvivesTheRoundTripWithItsTypesIntact() throws {
+        let original = payload(.accountStateChanged(signedIn: true))
+        let restored = try XCTUnwrap(AnalyticsPayload(persisted: original.json))
+
+        XCTAssertEqual(restored.name, original.name)
+        XCTAssertEqual(restored.distinctID, original.distinctID)
+        XCTAssertEqual(restored.properties["signed_in"], .bool(true))
+        XCTAssertEqual(restored.properties, original.properties)
+    }
+
+    func testAMalformedSpoolRowIsDroppedRatherThanGuessedAt() {
+        XCTAssertNil(AnalyticsPayload(persisted: ["event": "cfc_app_launched"]))
+        XCTAssertNil(AnalyticsPayload(persisted: [:]))
+    }
+
+    // MARK: - Identity
+
+    /// A second stored id is a second thing that can be lost, and an id that resets makes every
+    /// returning user look new. Derivation from the install id is what keeps retention meaningful.
+    func testTheAnalyticsIDIsStableForAnInstall() {
+        XCTAssertEqual(AnalyticsIdentity.derive(from: "install-a"), AnalyticsIdentity.derive(from: "install-a"))
+        XCTAssertNotEqual(AnalyticsIdentity.derive(from: "install-a"), AnalyticsIdentity.derive(from: "install-b"))
+        XCTAssertTrue(AnalyticsIdentity.derive(from: "install-a").hasPrefix("cfc_"))
+    }
+
+    /// The salt is the whole privacy argument: the backend's `X-Device-Id-Hash` keys the user's own
+    /// captured rows and is joinable to their account, so an analytics id equal to it would make every
+    /// "anonymous" event trivially re-identifiable by anyone holding both datasets.
+    func testTheAnalyticsIDIsNotTheBackendDeviceHash() {
+        let installID = "6E7D2C61-0000-4000-8000-000000000000"
+        XCTAssertNotEqual(AnalyticsIdentity.derive(from: installID), ClientDevice.hash(of: installID))
+        XCTAssertFalse(AnalyticsIdentity.derive(from: installID).contains(ClientDevice.hash(of: installID)))
+    }
+}
+
+/// The closed-vocabulary invariant, checked against the real event list.
+final class AnalyticsEventTests: XCTestCase {
+
+    /// **No event may carry free-form text.** This is what makes "what does this app send?" a
+    /// question answerable by reading one file, and it is enforced on the values rather than on the
+    /// types because a `String` associated value is exactly what a well-meaning future call site adds.
+    ///
+    /// The one string that legitimately reaches a payload is an MCP tool name, which arrives already
+    /// sanitised by `ToolCallLedger.normalized` and is asserted against that shape below.
+    func testNoEventCarriesFreeFormText() {
+        // Built up step by step rather than as one `+` chain: the chain type-checks so slowly that
+        // the compiler gives up on it.
+        var allowed: [String] = AnalyticsEvent.Permission.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.PermissionState.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.CaptureSource.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.Surface.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.UpdateOutcome.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.FallbackReason.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.CountBucket.allCases.map(\.rawValue)
+        allowed += ContextFallbackArea.allCases.map(\.rawValue)
+        allowed += ContextFallbackOutcome.allCases.map(\.rawValue)
+        let allowedFreeStrings = Set(allowed)
+
+        for event in AnalyticsEvent.everyShape {
+            for (key, value) in event.properties {
+                guard case let .string(text) = value else { continue }
+                XCTAssertTrue(
+                    allowedFreeStrings.contains(text),
+                    "\(event.name).\(key) carried '\(text)', which is not a value from a closed enum")
+            }
+        }
+    }
+
+    /// Tool names become one property each, so "which tools does Claude reach for" is answerable
+    /// without a second event type — and they are the only dynamic keys in the whole schema.
+    func testTheDailyRollupExpandsToolCallsIntoOnePropertyEach() {
+        let rollup = DailyRollup(
+            toolCalls: ["recall": 7, "screen": 2], captureMinutes: 41, screenMinutes: 120,
+            activeHours: 6, signedIn: true, airgapped: false)
+
+        XCTAssertEqual(rollup.properties["tool_recall"], .int(7))
+        XCTAssertEqual(rollup.properties["tool_screen"], .int(2))
+        XCTAssertEqual(rollup.properties["tool_calls_total"], .int(9))
+        XCTAssertEqual(rollup.properties["tool_calls_distinct"], .int(2))
+        XCTAssertEqual(rollup.properties["idle"], .bool(false))
+    }
+
+    /// An ambient app that ran all day and captured nothing is the case `idle` exists to make
+    /// visible. It is a dimension, not a send gate — that install is still a DAU.
+    func testAnInstallThatDidNothingIsStillReportedAndFlaggedIdle() {
+        XCTAssertTrue(DailyRollup.empty.isIdle)
+        XCTAssertEqual(DailyRollup.empty.properties["idle"], .bool(true))
+    }
+
+    func testCountBucketsFlattenTheTail() {
+        XCTAssertEqual(AnalyticsEvent.CountBucket(0), .zero)
+        XCTAssertEqual(AnalyticsEvent.CountBucket(1), .one)
+        XCTAssertEqual(AnalyticsEvent.CountBucket(5), .few)
+        XCTAssertEqual(AnalyticsEvent.CountBucket(20), .several)
+        XCTAssertEqual(AnalyticsEvent.CountBucket(5_000), .many)
+    }
+
+    /// Two *different* cases sharing a name would silently merge two questions into one series. The
+    /// same case appearing many times with different associated values is expected and fine — that is
+    /// what the properties are for — so this compares one representative per case.
+    func testDistinctCasesDoNotShareAnEventName() {
+        let representatives: [AnalyticsEvent] = [
+            .firstLaunch, .appLaunched, .dailyActive(.empty), .permission(.microphone, .granted),
+            .onboardingStep(index: 0, of: 1), .onboardingFinished(secondsElapsed: 0, skipped: false),
+            .accountStateChanged(signedIn: false), .captureStateChanged(source: .screen, live: true),
+            .gestureFired, .surfaceOpened(.settings), .searchRan(resultCountBucket: .zero),
+            .updateOutcome(.upToDate),
+            .fallback(area: .capture, outcome: .degraded, reason: .offline),
+        ]
+        let names = representatives.map(\.name)
+        XCTAssertEqual(Set(names).count, names.count)
+    }
+}
+
+/// The wall-clock accounting behind `capture_minutes`.
+final class UsageClockTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UsageClock.shared.resetCompletelyForTesting()
+    }
+
+    override func tearDown() {
+        UsageClock.shared.resetCompletelyForTesting()
+        super.tearDown()
+    }
+
+    /// **The bug a bool would have shipped.** The mic and the system-audio tap share the `capture`
+    /// channel and stop independently: a call ending while the mic stays live must not close the
+    /// clock and lose the rest of the day's audio.
+    func testTheCaptureClockRunsWhileAnySourceIsLive() {
+        let start = Date(timeIntervalSince1970: 1_760_000_000)
+        let clock = UsageClock.shared
+
+        clock.mark(.microphone, live: true, at: start)
+        clock.mark(.systemAudio, live: true, at: start.addingTimeInterval(60))
+        // System audio stops after 10 minutes; the microphone is still live.
+        clock.mark(.systemAudio, live: false, at: start.addingTimeInterval(600))
+
+        XCTAssertEqual(clock.minutes(for: .capture, at: start.addingTimeInterval(1_800)), 30)
+
+        clock.mark(.microphone, live: false, at: start.addingTimeInterval(1_800))
+        XCTAssertEqual(clock.minutes(for: .capture, at: start.addingTimeInterval(9_999)), 30)
+    }
+
+    /// Screen is its own channel because it fails on its own: the commonest broken install has
+    /// Screen Recording granted and no microphone, and one merged number would show that as healthy.
+    func testScreenAndAudioAreCountedSeparately() {
+        let start = Date(timeIntervalSince1970: 1_760_000_000)
+        let clock = UsageClock.shared
+
+        clock.mark(.screen, live: true, at: start)
+        clock.mark(.screen, live: false, at: start.addingTimeInterval(300))
+
+        XCTAssertEqual(clock.minutes(for: .screen, at: start), 5)
+        XCTAssertEqual(clock.minutes(for: .capture, at: start), 0)
+    }
+
+    /// A rollup taken while the mic is live must not report zero.
+    func testMinutesIncludeARunStillInProgress() {
+        let start = Date(timeIntervalSince1970: 1_760_000_000)
+        UsageClock.shared.mark(.microphone, live: true, at: start)
+        XCTAssertEqual(UsageClock.shared.minutes(for: .capture, at: start.addingTimeInterval(120)), 2)
+    }
+
+    /// Resetting starts the next day. A channel still running keeps running, and the minutes it
+    /// already contributed must not be counted again.
+    func testResetDoesNotDoubleCountAStillRunningChannel() {
+        let start = Date(timeIntervalSince1970: 1_760_000_000)
+        let clock = UsageClock.shared
+
+        clock.mark(.microphone, live: true, at: start)
+        XCTAssertEqual(clock.minutes(for: .capture, at: start.addingTimeInterval(600)), 10)
+
+        clock.reset(at: start.addingTimeInterval(600))
+        XCTAssertEqual(clock.minutes(for: .capture, at: start.addingTimeInterval(600)), 0)
+        XCTAssertEqual(clock.minutes(for: .capture, at: start.addingTimeInterval(900)), 5)
+    }
+
+    /// Twelve active hours and twelve capture minutes is a person at a desk; one active hour and 600
+    /// capture minutes is a laptop that was left open. The spread is what tells them apart.
+    func testActiveHoursCountDistinctHoursOfTheDay() {
+        var components = DateComponents()
+        components.year = 2026; components.month = 8; components.day = 17
+        let calendar = Calendar.current
+
+        for hour in [9, 9, 14, 21] {
+            components.hour = hour
+            UsageClock.shared.noteActivity(at: calendar.date(from: components)!)
+        }
+        XCTAssertEqual(UsageClock.shared.activeHourCount, 3)
+    }
+}
+
+/// The day boundary the whole DAU series rests on.
+final class ContextAnalyticsDayTests: XCTestCase {
+
+    /// DAU is a calendar concept everywhere it is read — the dashboards, the retention queries, the
+    /// weekly actives — so a rolling 24-hour window would drift against every one of them.
+    func testDayStampIsTheLocalCalendarDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        // 2025-08-17 03:06 UTC — which is still the 16th in New York. The day the rollup lands on
+        // has to follow the machine, not the server.
+        let lateEvening = Date(timeIntervalSince1970: 1_755_400_000)
+        XCTAssertEqual(ContextAnalytics.dayStamp(for: lateEvening, calendar: calendar), "2025-08-16")
+
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(identifier: "UTC")!
+        XCTAssertEqual(ContextAnalytics.dayStamp(for: lateEvening, calendar: utc), "2025-08-17")
+    }
+}
+
+// MARK: - Test fixtures
+
+extension AnalyticsEvent {
+    /// One value of every case, so the invariant tests iterate the real schema rather than a list
+    /// somebody has to remember to update. A new case that is not added here is a case with no
+    /// coverage — and `AnalyticsEventShapeTests` below fails when the two drift.
+    static var everyShape: [AnalyticsEvent] {
+        var events: [AnalyticsEvent] = [
+            .firstLaunch,
+            .appLaunched,
+            .dailyActive(DailyRollup(
+                toolCalls: ["recall": 3], captureMinutes: 12, screenMinutes: 30,
+                activeHours: 4, signedIn: true, airgapped: false)),
+            .onboardingStep(index: 2, of: 5),
+            .onboardingFinished(secondsElapsed: 94, skipped: false),
+            .accountStateChanged(signedIn: true),
+            .gestureFired,
+            .searchRan(resultCountBucket: .few),
+        ]
+        events += Permission.allCases.flatMap { permission in
+            PermissionState.allCases.map { AnalyticsEvent.permission(permission, $0) }
+        }
+        events += CaptureSource.allCases.flatMap { source in
+            [AnalyticsEvent.captureStateChanged(source: source, live: true),
+             AnalyticsEvent.captureStateChanged(source: source, live: false)]
+        }
+        events += Surface.allCases.map { AnalyticsEvent.surfaceOpened($0) }
+        events += UpdateOutcome.allCases.map { AnalyticsEvent.updateOutcome($0) }
+        events += FallbackReason.allCases.map {
+            AnalyticsEvent.fallback(area: .capture, outcome: .degraded, reason: $0)
+        }
+        return events
+    }
+}
+
+final class AnalyticsEventShapeTests: XCTestCase {
+    /// `everyShape` is a hand-maintained list, which makes it exactly the kind of fixture that goes
+    /// stale silently and takes the invariant tests' coverage with it. Comparing distinct *names*
+    /// against the enum's own switch is the cheapest way to notice a case nobody added.
+    func testEveryShapeCoversEveryEventName() {
+        let covered = Set(AnalyticsEvent.everyShape.map(\.name))
+        let expected: Set<String> = [
+            "cfc_first_launch", "cfc_app_launched", "cfc_daily_active", "cfc_permission",
+            "cfc_onboarding_step", "cfc_onboarding_finished", "cfc_account_state",
+            "cfc_capture_state", "cfc_gesture_fired", "cfc_surface_opened", "cfc_search_ran",
+            "cfc_update_outcome", "cfc_fallback",
+        ]
+        XCTAssertEqual(
+            covered, expected,
+            "an event case was added without a fixture in everyShape, so the privacy and "
+                + "namespacing invariants above are not checking it")
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextCoreTests/ToolCallLedgerTests.swift
+++ b/desktop/context-for-claude/Tests/ContextCoreTests/ToolCallLedgerTests.swift
@@ -1,0 +1,148 @@
+import ContextCore
+import Foundation
+import XCTest
+
+/// The MCP-side usage counter, and the promises it has to keep.
+///
+/// Two things are being defended. The first is **privacy**: this file is plaintext on disk and its
+/// contents are destined for an analytics pipeline, so it must be structurally incapable of holding
+/// anything the user said. The second is **arithmetic under concurrency**: several MCP servers write
+/// it at once with no coordinating parent, and a count that loses increments is worse than no count
+/// at all, because it looks like a real number.
+final class ToolCallLedgerTests: XCTestCase {
+
+    private var directory: URL!
+    private var ledgerURL: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ledger-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        ledgerURL = directory.appendingPathComponent("tool-calls.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: - Privacy
+
+    /// The invariant `ToolCallLedger`'s documentation states, pinned so a later field cannot be added
+    /// without this failing. A tool name is our own vocabulary and a count is arithmetic; an argument
+    /// or a per-call timestamp would be the user's question.
+    func testTheLedgerCarriesNothingButToolNamesAndCounts() throws {
+        ToolCallLedger.bump(tool: "recall", at: ledgerURL)
+
+        let raw = try XCTUnwrap(try? Data(contentsOf: ledgerURL))
+        let object = try XCTUnwrap(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+
+        XCTAssertEqual(Set(object.keys), ["counts"], "the ledger grew a field — see the privacy rule")
+        let counts = try XCTUnwrap(object["counts"] as? [String: Int])
+        XCTAssertEqual(counts, ["recall": 1])
+    }
+
+    /// A tool name is the one string in the whole analytics payload that comes from a dispatch table
+    /// rather than a closed Swift enum. If a caller ever passes something else — a name built from
+    /// user input, an error string — the sanitiser is what keeps it from reaching PostHog.
+    func testAToolNameIsStrippedToOurOwnVocabulary() {
+        ToolCallLedger.bump(tool: "Recall Screen/../../etc/passwd", at: ledgerURL)
+        let counts = ToolCallLedger.read(from: ledgerURL)?.counts ?? [:]
+
+        XCTAssertEqual(counts, ["recallscreenetcpasswd": 1])
+        XCTAssertFalse(counts.keys.contains { $0.contains("/") || $0.contains(".") })
+    }
+
+    func testAnEmptyToolNameIsNotCounted() {
+        ToolCallLedger.bump(tool: "!!!", at: ledgerURL)
+        XCTAssertNil(ToolCallLedger.read(from: ledgerURL))
+    }
+
+    // MARK: - Counting
+
+    func testCallsAccumulateAcrossProcessesAndTools() {
+        for _ in 0..<3 { ToolCallLedger.bump(tool: "recall", at: ledgerURL) }
+        ToolCallLedger.bump(tool: "screen", at: ledgerURL)
+
+        XCTAssertEqual(ToolCallLedger.read(from: ledgerURL)?.counts, ["recall": 3, "screen": 1])
+        XCTAssertEqual(ToolCallLedger.read(from: ledgerURL)?.total, 4)
+    }
+
+    /// The whole reason the ledger is separate from `QueryStamp`: draining hands the counts to the
+    /// caller *and* resets, so two rollups can never report the same call twice.
+    func testDrainingReturnsEverythingAndResets() {
+        ToolCallLedger.bump(tool: "recall", at: ledgerURL)
+        ToolCallLedger.bump(tool: "recall", at: ledgerURL)
+
+        XCTAssertEqual(ToolCallLedger.drain(from: ledgerURL).counts, ["recall": 2])
+        XCTAssertTrue(ToolCallLedger.drain(from: ledgerURL).isEmpty, "a second drain must find nothing")
+    }
+
+    /// Claude keeps several MCP servers alive at once. Every increment has to survive.
+    ///
+    /// This is the test that would have caught a plain read-modify-write with no lock: without the
+    /// `flock`, concurrent bumps interleave and the total comes out short.
+    func testConcurrentWritersLoseNoCounts() {
+        let writers = 8
+        let bumpsEach = 25
+        let group = DispatchGroup()
+
+        for _ in 0..<writers {
+            DispatchQueue.global().async(group: group) { [ledgerURL] in
+                for _ in 0..<bumpsEach { ToolCallLedger.bump(tool: "recall", at: ledgerURL!) }
+            }
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + 60), .success)
+
+        XCTAssertEqual(ToolCallLedger.read(from: ledgerURL)?.counts["recall"], writers * bumpsEach)
+    }
+
+    // MARK: - Damage
+
+    func testADamagedLedgerReadsAsNothingRatherThanAsUsage() throws {
+        try Data("not json".utf8).write(to: ledgerURL)
+        XCTAssertNil(ToolCallLedger.read(from: ledgerURL))
+
+        try Data(repeating: 0x41, count: ToolCallLedger.maximumFileSize + 1).write(to: ledgerURL)
+        XCTAssertNil(ToolCallLedger.read(from: ledgerURL))
+    }
+
+    /// A ledger is an accumulation, so one bad key must not throw away the real counts beside it.
+    func testAnImplausibleEntryIsDroppedWithoutLosingTheRest() throws {
+        let raw = ["counts": ["recall": 4, "": 9, "screen": -2, "Bad Name": 3]]
+        try JSONSerialization.data(withJSONObject: raw).write(to: ledgerURL)
+
+        XCTAssertEqual(ToolCallLedger.read(from: ledgerURL)?.counts, ["recall": 4])
+    }
+
+    /// An unknown tool cannot displace one already being counted: dropping a new name loses one
+    /// series, while evicting an old one silently corrupts every number accumulated under it.
+    func testTheDistinctToolCapDropsNewNamesNotEstablishedOnes() {
+        for index in 0..<ToolCallLedger.maximumDistinctTools {
+            ToolCallLedger.bump(tool: "tool_\(index)", at: ledgerURL)
+        }
+        ToolCallLedger.bump(tool: "one_too_many", at: ledgerURL)
+        // An established name still counts up after the cap is reached.
+        ToolCallLedger.bump(tool: "tool_0", at: ledgerURL)
+
+        let counts = ToolCallLedger.read(from: ledgerURL)?.counts ?? [:]
+        XCTAssertEqual(counts.count, ToolCallLedger.maximumDistinctTools)
+        XCTAssertNil(counts["one_too_many"])
+        XCTAssertEqual(counts["tool_0"], 2)
+    }
+
+    /// A tool call that succeeded must never be reported to Claude as failed because a counter could
+    /// not be written. `bump` returns `Void` and swallows; this proves it swallows a real failure.
+    func testAnUnwritableLedgerIsSilent() throws {
+        // A *file* where the ledger's parent directory should be. Chmod would not do: `bump` calls
+        // `ContextPaths.ensureSupportDirectory`, which chmods the directory back to 0o700 and would
+        // quietly repair the very condition the test is trying to create.
+        let blocked = directory.appendingPathComponent("not-a-directory")
+        try Data("occupied".utf8).write(to: blocked)
+        let unreachable = blocked.appendingPathComponent("tool-calls.json")
+
+        // No throw, no crash — the only observable outcome is that nothing was recorded.
+        ToolCallLedger.bump(tool: "recall", at: unreachable)
+        XCTAssertNil(ToolCallLedger.read(from: unreachable))
+        XCTAssertTrue(ToolCallLedger.drain(from: unreachable).isEmpty)
+    }
+}

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -89,6 +89,14 @@ Don't.
 1. **Airgap Mode drops events, it does not defer them.** Every other `NetworkEgress.Client` queues
    its work and sends when the switch goes off. An analytics event doing that would mean Airgap Mode
    delayed the disclosure rather than preventing it. Those days are simply not measured.
+
+   Note that **the Settings switch for Airgap Mode no longer exists** — it was removed in 1.0.9 and
+   `ExclusionEngine.setAirgapMode` has had no caller since. The flag is still reachable two ways, and
+   both are why the guard stays: an `exclusions.json` written before 1.0.9 (or by hand) still carries
+   it, and `ExclusionSet.make` forces it on whenever the exclusion configuration **fails closed** — a
+   config we cannot parse may carry exclusions we cannot express. The second case is the one that
+   matters in practice: it means a machine with a corrupt config stops reporting rather than
+   reporting from a state where it cannot honour the user's exclusions.
 2. **Development builds report nothing.** `ContextPaths.isDevelopmentBuild` gates the whole path. This
    is not tidiness: for this app's first three weeks the Cloud Run logs show a `Context for Claude/1`
    user agent from up to twenty machines a day — the team's own builds, indistinguishable in

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -1,0 +1,147 @@
+# Analytics
+
+What Context for Claude reports about itself, where it lands, and how to ask it a question.
+
+Before this existed the app was completely unmeasured. The only signals were GitHub release download
+counts — whose `-latest` pointer resets on every release, so the history was being destroyed weekly —
+and Cloud Run request logs, which see nothing from an install that never signs in. "How many people
+use this" could not be answered.
+
+## Where it goes
+
+PostHog project `302298`, the same project as the Omi macOS app, via `https://us.i.posthog.com/batch/`.
+The project token in `AnalyticsSink.projectToken` is public by design: it can only write events into
+that project, it reads nothing, and it already ships inside the Omi desktop binary.
+
+**Two products, one project, kept apart by two independent mechanisms:**
+
+1. Every event name is prefixed `cfc_`.
+2. Every event carries `app = "context-for-claude"`.
+3. **No event sets `$os_name`.** Omi's macOS retention, activation and weekly-actives queries all
+   scope on `properties.$os_name = 'macOS'`. Setting it here would silently enrol every Context for
+   Claude install into a four-month Omi trend line. `macos_version` carries the same information
+   under a name nothing else queries.
+
+Either of the first two alone is enough to separate the products; both are present so that whichever
+one a future query author reaches for, it works. The third is pinned by
+`AnalyticsPayloadTests.testPayloadNeverSetsDollarOSName`.
+
+## What is sent
+
+The complete list is `AnalyticsEvent` — a closed enum, deliberately, so this file cannot go stale
+without a compile error somewhere. Every associated value is a number, a bool, or another closed
+enum; `AnalyticsEventTests.testNoEventCarriesFreeFormText` fails if a free string appears.
+
+| Event | Answers |
+|---|---|
+| `cfc_first_launch` | installs — the denominator |
+| `cfc_app_launched` | the only signal from someone who opens the app and does nothing |
+| `cfc_daily_active` | **DAU, retention, and "how much"** — see below |
+| `cfc_permission` | the setup funnel, per capability, snapshotted every launch |
+| `cfc_onboarding_step` / `cfc_onboarding_finished` | where first run is abandoned |
+| `cfc_account_state` | whether an Omi account is attached (never which) |
+| `cfc_capture_state` | mic / system audio / screen going live and stopping |
+| `cfc_gesture_fired` | ⌘ + ⌘ actually firing — inert without Accessibility |
+| `cfc_surface_opened` | which surfaces people open by hand |
+| `cfc_search_ran` | local search use, bucketed result counts only |
+| `cfc_update_outcome` | update health — a fleet that stops updating looks like a fleet nobody uses |
+| `cfc_fallback` | fail-open paths, mirroring `ContextTelemetry.recordFallback` |
+
+### `cfc_daily_active` is the spine
+
+One event per install per **local calendar day**, carrying the day's rollup:
+
+- `tool_calls_total`, `tool_calls_distinct`, and one `tool_<name>` per MCP tool
+- `capture_minutes`, `screen_minutes` — wall clock, not a count of start/stop events
+- `active_hours` — distinct hours in which anything happened. Twelve active hours and twelve capture
+  minutes is a person at a desk; one active hour and 600 capture minutes is a laptop left open.
+- `signed_in`, `airgapped`, `idle`
+
+DAU is this event. Retention is this event, cohorted. "How much do they use it" is
+`tool_calls_total` — the only evidence that captured context is reaching a model rather than
+accumulating on a disk.
+
+### What is never sent
+
+No transcript, no OCR text, no window or app names, no URLs, no file paths, no search queries, no MCP
+tool arguments, no email, no account id, no screenshots. A reader of `AnalyticsEvent.swift` can see
+the entire disclosure — that is the property the closed enum exists to guarantee.
+
+## Identity
+
+`distinct_id` is `cfc_` + 16 hex characters of `SHA256("context-for-claude/analytics/v1" + installId)`.
+
+The install id is the same UUID `ClientDevice` uses, under a **different salt**. That separation is
+the whole privacy argument: the backend's `X-Device-Id-Hash` keys the user's own captured rows and is
+joinable to their account, so an equal id would make every "anonymous" event trivially
+re-identifiable by anyone holding both datasets. Salted apart, the two cannot be linked without the
+original UUID, which never leaves the Mac.
+
+**The id does not change on sign-in.** Knowing *that* an install has an account answers every product
+question here; knowing *which* would turn an anonymous series into a per-person record of when
+somebody's microphone was on.
+
+Changing `AnalyticsIdentity.salt` re-anonymises every install and restarts every retention curve.
+Don't.
+
+## The three refusals
+
+1. **Airgap Mode drops events, it does not defer them.** Every other `NetworkEgress.Client` queues
+   its work and sends when the switch goes off. An analytics event doing that would mean Airgap Mode
+   delayed the disclosure rather than preventing it. Those days are simply not measured.
+2. **Development builds report nothing.** `ContextPaths.isDevelopmentBuild` gates the whole path. This
+   is not tidiness: for this app's first three weeks the Cloud Run logs show a `Context for Claude/1`
+   user agent from up to twenty machines a day — the team's own builds, indistinguishable in
+   aggregate from users.
+3. **Nothing user-authored, ever** — enforced by construction, not by review.
+
+## MCP tool calls cross a process boundary
+
+`context-for-claude-mcp` is spawned by Claude over stdio, several at a time, and killed without
+warning. It cannot report anything itself: a short-lived process that POSTs on exit either blocks
+Claude's shutdown or loses the event.
+
+So the MCP process counts and the app reports. `ToolCallLedger` (in `ContextCore`) is the seam — a
+multi-writer counter file under an `flock`, drained destructively by the app's daily rollup. It is
+separate from `QueryStamp` because that file is monotonic-latest ("did Claude just call us?") and this
+one is cumulative ("how much?"); one file cannot be both.
+
+Both hold a tool name and nothing else.
+
+## Delivery
+
+Batched, not per-event. One request per event would be absurd at ~10 events a day and, worse, would
+make the app's network fingerprint track the user's activity in real time — a request the moment a
+recording starts, another the moment a search runs. Batching on a 60-second timer decouples *when we
+send* from *what the person just did*. That is a privacy property, not only an efficiency one.
+
+The spool is durable (survives relaunch), capped at 500 events dropping oldest-first, and drains 50
+per request. A failed send keeps the events; a 4xx other than 429 drops the batch, because keeping an
+unsendable batch would park every later event behind it forever.
+
+## Verifying it end to end
+
+A release build cannot be run under a debugger on the machine that wrote it, and a sink nobody has
+watched deliver is a sink that has never worked. So:
+
+```bash
+CONTEXT_ANALYTICS_FORCE=1 /path/to/Context\ for\ Claude.app/Contents/MacOS/Context\ for\ Claude
+```
+
+This overrides refusal 2 only. Events sent this way are indistinguishable from real ones and land in
+production series — use a throwaway session, not a day of ordinary work.
+
+Then query PostHog:
+
+```sql
+SELECT event, count() AS n, count(DISTINCT person_id) AS installs
+FROM events
+WHERE timestamp > now() - INTERVAL 1 DAY AND properties.app = 'context-for-claude'
+GROUP BY event ORDER BY n DESC
+```
+
+## Asking it questions
+
+`~/.claude/skills/omi-analytics/scripts/ph.py --preset cfc` covers actives, installs, tool-call
+volume and the permission funnel. Anything else is HogQL against `properties.app =
+'context-for-claude'`.

--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -28,7 +28,21 @@ export async function GET(request: NextRequest) {
     const intervals = parseInt(searchParams.get('intervals') || '10', 10);
     const platform = searchParams.get('platform') || '';
 
-    const eventFilter = platform === 'macos' ? `AND properties.$os = 'macOS'` : '';
+    // Context for Claude is a *second product* reporting into this same PostHog project. Its events
+    // are namespaced `cfc_*` (see `desktop/context-for-claude/docs/analytics.md`) and set no `$os`,
+    // so the `macos` branch below already excludes them — but this route's default branch applies no
+    // event filter at all and would otherwise cohort every actor in the project, quietly counting
+    // Context installs as new Omi users and folding them into this curve.
+    //
+    // Excluded on the event name rather than on `properties.app` because a property comparison is
+    // NULL for every Omi event, and `properties.app != '…'` would therefore drop the entire
+    // numerator instead of the intended rows. `startsWith(event, …)` is total: never NULL, and true
+    // for exactly the events the other product emits.
+    const excludeOtherProducts = `AND NOT startsWith(event, 'cfc_')`;
+    const eventFilter =
+      platform === 'macos'
+        ? `AND properties.$os = 'macOS' ${excludeOtherProducts}`
+        : excludeOtherProducts;
     const url = `${host}/api/projects/${projectId}/query/`;
 
     const cohortRows = await posthogQuery(


### PR DESCRIPTION
## Why

Context for Claude shipped on 2026-08-14 with **no product analytics at all**. `Telemetry.swift` was a local `os.Logger` sink carrying a comment that PostHog "can be wired later", and PostHog holds zero events for the app. "How many people use this, and how much" had no answer.

The two available proxies are both broken:

- **GitHub download counts** — `release-context.sh` re-uploads the `context-for-claude-latest` dmg and `appcast.xml` on every release, and `gh release upload --clobber` **resets `download_count`**. The Aug 14–16 history is already gone.
- **Cloud Run request logs** — only see an install that signed in. The app's core loop (local capture, local MCP server) works signed out and emits nothing.

Measured through those proxies on 2026-08-17: 14 Omi accounts had ever run a signed-in build, 9 of them internal; 6 since public launch. That is the best number obtainable today and it undercounts by an unknown amount.

## What

13 event types, each with exactly one emitter. `cfc_daily_active` is the spine — one event per install per **local calendar day** carrying MCP tool calls (total and per tool), capture minutes, screen minutes and active-hours spread. DAU is that event; retention is that event cohorted; "how much" is `tool_calls_total`, the only evidence that captured context reaches a model rather than accumulating on a disk.

MCP tool calls cross a process boundary. `context-for-claude-mcp` is spawned by Claude over stdio, several at a time, and killed without warning, so it cannot report for itself — a short-lived process that POSTs on exit either blocks Claude's shutdown or loses the event. `ToolCallLedger` is the seam: a multi-writer counter file under an `flock`, drained destructively by the app's rollup. It is separate from `QueryStamp` because that file is monotonic-latest ("did Claude just call us?") and this one is cumulative ("how much?"); one file cannot be both.

### Two products, one PostHog project

Events land in project 302298 alongside Omi macOS, reusing the public project token already compiled into `desktop/macos/Desktop/Sources/PostHogManager.swift`. **No new secret.** They are kept apart three ways:

1. every event name is prefixed `cfc_`
2. every event carries `app = "context-for-claude"`
3. **no event sets `$os_name`**

The third matters most. Omi's macOS retention, activation and weekly-actives queries all scope on `properties.$os_name = 'macOS'`, so setting it would silently enrol every Context install into a four-month Omi trend line — and nothing would look wrong until somebody tried to explain the jump. Pinned by `AnalyticsPayloadTests.testPayloadNeverSetsDollarOSName`, and confirmed on a real delivered event.

### Three refusals, all structural

- **Airgap Mode drops events rather than deferring them.** Every other `NetworkEgress.Client` queues and sends when the state lifts; analytics doing that would delay the disclosure instead of preventing it. Note the Settings toggle was removed in 1.0.9 and `setAirgapMode` has no caller — the state is still reached by a pre-1.0.9 `exclusions.json` and by `ExclusionSet.make` forcing it on when the exclusion config **fails closed**, which is the case worth designing for.
- **Development builds report nothing.** Not tidiness: Cloud Run logs show a `Context for Claude/1` user agent from up to 20 machines a day through early August — the team's own builds, indistinguishable in aggregate from users.
- **Nothing user-authored can be sent.** `AnalyticsEvent` is a closed enum whose every associated value is a number, a bool, or another closed enum. No API accepts a string from a call site, so the entire disclosure is readable in one file. No transcript, screen text, window name, URL, path, query, tool argument, email or account id.

`distinct_id` is a salted hash of the install id, and stays that way after sign-in. The salt deliberately differs from `ClientDevice`'s: that hash keys the user's own captured rows and is joinable to their account, so an equal id would make every anonymous event trivially re-identifiable by anyone holding both datasets.

## Verification

- **Live end to end** — a payload built by the production types was accepted by PostHog and read back queryable: `cfc_app_launched`, `app = context-for-claude`, `$os_name` **empty**, confirming the separation invariant in production rather than only in a unit test. Reproduce with `CONTEXT_ANALYTICS_LIVE_TEST=1 swift test --filter AnalyticsLiveDeliveryTests` (skipped by default — it needs a live service and writes real events, tagged `smoke_test`).
- **`swift test` — 1644 tests, 0 failures**, 9 skipped.
- New offline coverage: batching, the 4xx-drop rule that stops an unsendable batch wedging the spool forever, spool durability across relaunch, oldest-first overflow, 8 concurrent ledger writers x 25 bumps losing no counts (fails without the `flock`), the refcounted capture clock (a bool there loses the rest of the day's audio when a call ends while the mic stays live), and the airgap cycle breaker — `record` → `recordSuppression` → `recordFallback` → `record` would otherwise recurse until the stack ran out.
- `scripts/pr-preflight --suggest`: **no product invariants affected; no `fix:` commits, so no failure-class declaration required.**

## Follow-up, not in this PR

`release-context.sh` will keep resetting the `-latest` download counter on every release. Worth fixing separately now that it is no longer the only signal.

## Scope: this must not affect anything else

Every source file in this PR is under `desktop/context-for-claude/`, a standalone package that shares no code with Omi Desktop — **with one deliberate exception**, `web/admin/.../retention/posthog/route.ts`, which is there precisely to keep the isolation true.

Audited every admin route that queries PostHog `events`. `crash-rate`, `dau-trends`, `floating-bar-usage`, `macos-versions`, `message-ratings`, `notifications`, `profitability` and `viral-metrics` are OS-filtered, and CFC sets no `$os`/`$os_name`, so they exclude it already. `k-factor` and `onboarding` pin explicit Omi event names. The retention route was the sole exception: on its default (non-`macos`) branch its event filter is the empty string, so it cohorts every actor in the project and would have counted Context installs as new Omi users. Fixed here, verified live on both branches — default 8874 → 8873 actors (drops exactly the one CFC actor), macOS 2359 → 2359 (unchanged, proving no Omi rows are lost).

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

