### PR TITLE
Windows memory atlas: the brain map as named regions instead of hidden nodes

### DIFF
--- a/desktop/windows/src/renderer/src/components/graph/KnowledgeGraphViewer.tsx
+++ b/desktop/windows/src/renderer/src/components/graph/KnowledgeGraphViewer.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { ArrowLeft, Brain, Loader2, RefreshCw } from 'lucide-react'
 import type { KnowledgeGraph } from '../../../../shared/types'
 import { BrainGraph } from './LazyBrainGraph'
+import { MemoryAtlas } from './MemoryAtlas'
 import { EmptyState } from '../ui/EmptyState'
 import { capGraph, isCapped, DEFAULT_NODE_CAP, DEFAULT_LABEL_TOPK } from '../../lib/graphDisplay'
 
@@ -38,6 +39,11 @@ export function KnowledgeGraphViewer(props: {
   // showAll (4 states) — all labels of the key nodes, or all labels of the full
   // graph. Component state (not durable), matching showAll above.
   const [showAllLabels, setShowAllLabels] = useState(false)
+  // Two ways of reading the same graph. The graph hides nodes to stay legible;
+  // the map hides none and groups them into named regions instead. Component
+  // state, like the two toggles above, so neither view is imposed on a return
+  // visit.
+  const [view, setView] = useState<'graph' | 'map'>('graph')
 
   // The full graph stays reachable: showAll lifts the cap entirely (capGraph
   // returns the same graph ref, so the sim re-lays out the complete set). When
@@ -57,7 +63,8 @@ export function KnowledgeGraphViewer(props: {
     // blurred surface pins the GPU re-blending on every unrelated repaint (same
     // reason the Memories card uses a solid tint).
     <div className="relative h-full w-full overflow-hidden bg-black/40">
-      {hasGraph ? (
+      {hasGraph && view === 'map' && <MemoryAtlas graph={graph} centerNodeId={centerNodeId} />}
+      {hasGraph && view === 'graph' ? (
         <BrainGraph
           interactive
           graph={visibleGraph}
@@ -69,7 +76,7 @@ export function KnowledgeGraphViewer(props: {
           frameLoop="demand"
           labelMode={showAllLabels ? 'all' : 'declutter'}
         />
-      ) : (
+      ) : hasGraph ? null : (
         <div className="flex h-full w-full items-center justify-center">
           <EmptyState
             icon={Brain}
@@ -113,7 +120,21 @@ export function KnowledgeGraphViewer(props: {
           </span>
         </div>
         <div className="pointer-events-auto flex items-center gap-2">
-          {hasGraph && capsBite && (
+          {hasGraph && (
+            <button
+              onClick={() => setView((v) => (v === 'graph' ? 'map' : 'graph'))}
+              className="btn-ghost px-3 py-2"
+              title={
+                view === 'graph'
+                  ? 'Group your memories into named regions instead of hiding nodes'
+                  : 'Back to the connection graph'
+              }
+              aria-pressed={view === 'map'}
+            >
+              {view === 'graph' ? 'Map' : 'Graph'}
+            </button>
+          )}
+          {hasGraph && view === 'graph' && capsBite && (
             <button
               onClick={() => setShowAll((v) => !v)}
               className="btn-ghost px-3 py-2"
@@ -127,7 +148,7 @@ export function KnowledgeGraphViewer(props: {
               {showAll ? `Show key ${DEFAULT_NODE_CAP}` : `Show all ${graph.nodes.length}`}
             </button>
           )}
-          {hasGraph && labelsBite && (
+          {hasGraph && view === 'graph' && labelsBite && (
             <button
               onClick={() => setShowAllLabels((v) => !v)}
               className="btn-ghost px-3 py-2"

--- a/desktop/windows/src/renderer/src/components/graph/MemoryAtlas.test.tsx
+++ b/desktop/windows/src/renderer/src/components/graph/MemoryAtlas.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+//
+// The atlas draws to a 2D canvas, which jsdom does not implement, so the context
+// is a recording stub. That is enough to assert what matters here: that the map
+// is built from the graph and that the right things reach the canvas in the
+// right order - regions under entities, captions over both.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, screen, fireEvent } from '@testing-library/react'
+import type { KGEdge, KGNode, KnowledgeGraph } from '../../../../shared/types'
+
+const calls: Array<{ op: string; args: unknown[] }> = []
+
+const stubContext = (): unknown => {
+  const record =
+    (op: string) =>
+    (...args: unknown[]): void => {
+      calls.push({ op, args })
+    }
+  return {
+    setTransform: record('setTransform'),
+    clearRect: record('clearRect'),
+    beginPath: record('beginPath'),
+    moveTo: record('moveTo'),
+    lineTo: record('lineTo'),
+    closePath: record('closePath'),
+    arc: record('arc'),
+    fill: record('fill'),
+    stroke: record('stroke'),
+    fillText: record('fillText'),
+    set fillStyle(v: unknown) {
+      calls.push({ op: 'fillStyle', args: [v] })
+    },
+    set strokeStyle(v: unknown) {
+      calls.push({ op: 'strokeStyle', args: [v] })
+    },
+    set lineWidth(v: unknown) {
+      calls.push({ op: 'lineWidth', args: [v] })
+    },
+    set font(v: unknown) {
+      calls.push({ op: 'font', args: [v] })
+    },
+    set textAlign(v: unknown) {
+      calls.push({ op: 'textAlign', args: [v] })
+    },
+    set textBaseline(v: unknown) {
+      calls.push({ op: 'textBaseline', args: [v] })
+    }
+  }
+}
+
+const { MemoryAtlas } = await import('./MemoryAtlas')
+
+const node = (id: string, label: string, memoryIds: string[] = []): KGNode => ({
+  id,
+  label,
+  nodeType: 'topic',
+  aliases: [],
+  memoryIds
+})
+const edge = (a: string, b: string, memoryIds: string[] = []): KGEdge => ({
+  id: `${a}-${b}`,
+  sourceId: a,
+  targetId: b,
+  label: '',
+  memoryIds
+})
+
+const threeWorlds = (): KnowledgeGraph => {
+  const nodes: KGNode[] = []
+  const edges: KGEdge[] = []
+  for (const [prefix, hub] of [
+    ['w', 'Acme'],
+    ['h', 'Lease'],
+    ['t', 'Travel']
+  ] as const) {
+    for (let i = 0; i < 10; i += 1) {
+      nodes.push(node(`${prefix}${i}`, i === 0 ? hub : `${prefix} thing ${i}`, [`${prefix}m`]))
+    }
+    for (let i = 0; i < 10; i += 1) {
+      for (let j = i + 1; j < 10; j += 1) {
+        edges.push(edge(`${prefix}${i}`, `${prefix}${j}`, [`${prefix}m`]))
+      }
+    }
+  }
+  edges.push(edge('w0', 'h0'))
+  edges.push(edge('h0', 't0'))
+  return { nodes, edges }
+}
+
+beforeEach(() => {
+  calls.length = 0
+  HTMLCanvasElement.prototype.getContext = vi.fn(stubContext) as never
+  // jsdom reports every element as zero-sized; the atlas skips drawing at zero,
+  // so the canvas is given a size the way a real layout would.
+  Object.defineProperty(HTMLCanvasElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 800
+  })
+  Object.defineProperty(HTMLCanvasElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 600
+  })
+})
+
+afterEach(() => cleanup())
+
+const textDrawn = (): string[] =>
+  calls.filter((c) => c.op === 'fillText').map((c) => String(c.args[0]))
+
+describe('MemoryAtlas', () => {
+  it('names the regions it found in its accessible label', () => {
+    render(<MemoryAtlas graph={threeWorlds()} />)
+    expect(screen.getByRole('img', { name: 'Memory atlas with 3 regions' })).toBeTruthy()
+  })
+
+  it('draws a caption for every region, in upper case', () => {
+    render(<MemoryAtlas graph={threeWorlds()} />)
+    const text = textDrawn()
+    // Uppercased at draw time only; the stored caption keeps its own casing so
+    // nothing downstream inherits the shouting.
+    expect(text).toContain('ACME')
+    expect(text).toContain('LEASE')
+    expect(text).toContain('TRAVEL')
+  })
+
+  it('fills regions with the even-odd rule so an enclave stays a hole', () => {
+    render(<MemoryAtlas graph={threeWorlds()} />)
+    expect(calls.some((c) => c.op === 'fill' && c.args[0] === 'evenodd')).toBe(true)
+  })
+
+  it('draws regions first and captions last', () => {
+    render(<MemoryAtlas graph={threeWorlds()} />)
+    const firstFill = calls.findIndex((c) => c.op === 'fill' && c.args[0] === 'evenodd')
+    const firstDot = calls.findIndex((c) => c.op === 'arc')
+    const lastCaption = calls.map((c) => c.op).lastIndexOf('fillText')
+    // A caption under its own region is unreadable, and an entity under a
+    // region fill disappears.
+    expect(firstFill).toBeLessThan(firstDot)
+    expect(lastCaption).toBeGreaterThan(firstDot)
+  })
+
+  it('renders an empty graph without drawing anything', () => {
+    render(<MemoryAtlas graph={{ nodes: [], edges: [] }} />)
+    expect(screen.getByRole('img', { name: 'Memory atlas with 0 regions' })).toBeTruthy()
+    expect(textDrawn()).toEqual([])
+  })
+
+  it('hides nothing: every entity reaches the canvas', () => {
+    render(<MemoryAtlas graph={threeWorlds()} />)
+    // The point of the map is that it does not solve legibility by dropping
+    // nodes the way the graph view does.
+    expect(calls.filter((c) => c.op === 'arc').length).toBe(30)
+  })
+
+  it('redraws when the camera moves', () => {
+    render(<MemoryAtlas graph={threeWorlds()} />)
+    const before = calls.length
+    fireEvent.wheel(screen.getByRole('img'), { deltaY: -100 })
+    expect(calls.length).toBeGreaterThan(before)
+  })
+})

--- a/desktop/windows/src/renderer/src/components/graph/MemoryAtlas.tsx
+++ b/desktop/windows/src/renderer/src/components/graph/MemoryAtlas.tsx
@@ -1,0 +1,247 @@
+// The memory atlas: the knowledge graph drawn as a map.
+//
+// The existing brain map keeps a large graph legible by HIDING nodes - a default
+// cap on the most connected, with a "show all" escape hatch. Its own header
+// records why: a real account measures ~188 nodes and ~474 edges with one
+// 226-degree hub, and drawn whole it is an unreadable hairball.
+//
+// This takes the opposite approach to the same problem. Nothing is hidden;
+// instead the entities are grouped into named regions, so the shape of the map
+// carries the structure and the labels say what each part is about. Detail
+// arrives as you zoom in rather than being thrown away up front.
+//
+// Canvas 2D rather than WebGL: this draws filled polygons and text, which canvas
+// does natively, and it means the map renders in a plain jsdom test.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { KnowledgeGraph } from '../../../../shared/types'
+import { buildAtlas, type Atlas } from '../../lib/atlas/buildAtlas'
+import { territoryAt, type Territory } from '../../lib/atlas/territories'
+import {
+  MINIMUM_ZOOM,
+  detailBudget,
+  maximumZoom,
+  panPreservingCenter,
+  zoomToEnter
+} from '../../lib/atlas/zoomPolicy'
+import type { AtlasPoint } from '../../lib/atlas/islands'
+
+/** Inset so a region touching the edge of the field still has margin on screen. */
+const PADDING = 24
+
+interface Camera {
+  zoom: number
+  panX: number
+  panY: number
+}
+
+const IDENTITY: Camera = { zoom: 1, panX: 0, panY: 0 }
+
+/** Atlas space (0..1) to canvas pixels. */
+function project(
+  point: AtlasPoint,
+  camera: Camera,
+  width: number,
+  height: number
+): { x: number; y: number } {
+  const span = Math.min(width, height) - PADDING * 2
+  return {
+    x: width / 2 + (point.x - 0.5) * span * camera.zoom + camera.panX,
+    // Atlas y runs up; canvas y runs down.
+    y: height / 2 - (point.y - 0.5) * span * camera.zoom - camera.panY
+  }
+}
+
+/** Canvas pixels back to atlas space, for hit testing. */
+function unproject(
+  x: number,
+  y: number,
+  camera: Camera,
+  width: number,
+  height: number
+): AtlasPoint {
+  const span = Math.min(width, height) - PADDING * 2
+  return {
+    x: (x - width / 2 - camera.panX) / (span * camera.zoom) + 0.5,
+    y: -(y - height / 2 + camera.panY) / (span * camera.zoom) + 0.5
+  }
+}
+
+function drawTerritory(
+  ctx: CanvasRenderingContext2D,
+  territory: Territory,
+  camera: Camera,
+  width: number,
+  height: number,
+  highlighted: boolean
+): void {
+  ctx.beginPath()
+  for (const ring of territory.rings) {
+    if (ring.length < 3) continue
+    ring.forEach((point, i) => {
+      const p = project(point, camera, width, height)
+      if (i === 0) ctx.moveTo(p.x, p.y)
+      else ctx.lineTo(p.x, p.y)
+    })
+    ctx.closePath()
+  }
+  // Even-odd so a ring enclosed by another reads as a hole, matching the
+  // containment test the rest of the atlas uses.
+  ctx.fillStyle = highlighted ? 'rgba(255,255,255,0.10)' : 'rgba(255,255,255,0.045)'
+  ctx.fill('evenodd')
+  ctx.strokeStyle = highlighted ? 'rgba(255,255,255,0.34)' : 'rgba(255,255,255,0.16)'
+  ctx.lineWidth = 1
+  ctx.stroke()
+}
+
+export interface MemoryAtlasProps {
+  graph: KnowledgeGraph
+  centerNodeId?: string
+  /** Reports what the user is looking at, so a host can show it as chrome. */
+  onFocusTerritory?: (territory: Territory | null) => void
+}
+
+export function MemoryAtlas(props: MemoryAtlasProps): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const [camera, setCamera] = useState<Camera>(IDENTITY)
+  const [hovered, setHovered] = useState<Territory | null>(null)
+  const drag = useRef<{ x: number; y: number; panX: number; panY: number } | null>(null)
+
+  const atlas: Atlas = useMemo(
+    () => buildAtlas(props.graph, props.centerNodeId),
+    [props.graph, props.centerNodeId]
+  )
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (canvas === null) return
+    const ctx = canvas.getContext('2d')
+    if (ctx === null) return
+
+    const ratio = window.devicePixelRatio || 1
+    const width = canvas.clientWidth
+    const height = canvas.clientHeight
+    if (width === 0 || height === 0) return
+    canvas.width = Math.floor(width * ratio)
+    canvas.height = Math.floor(height * ratio)
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0)
+    ctx.clearRect(0, 0, width, height)
+
+    const budget = detailBudget(camera.zoom, atlas.nodes.length)
+
+    for (const territory of atlas.territories) {
+      drawTerritory(ctx, territory, camera, width, height, territory === hovered)
+    }
+
+    // Entities: most connected first, so a cap keeps the structural hubs.
+    const ranked = [...atlas.nodes].sort((a, b) => b.degree - a.degree)
+    const shown = ranked.slice(0, budget.maxNodes)
+    for (const node of shown) {
+      const p = project(node.position, camera, width, height)
+      ctx.beginPath()
+      ctx.arc(p.x, p.y, node.community === -1 ? 4 : 2.5, 0, Math.PI * 2)
+      ctx.fillStyle = node.community === -1 ? 'rgba(255,255,255,0.85)' : 'rgba(255,255,255,0.45)'
+      ctx.fill()
+    }
+
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    for (const node of shown.slice(0, budget.maxLabels)) {
+      const p = project(node.position, camera, width, height)
+      ctx.font = '11px system-ui, sans-serif'
+      ctx.fillStyle = 'rgba(255,255,255,0.62)'
+      ctx.fillText(node.label, p.x, p.y - 9)
+    }
+
+    // Region captions last, so they sit above everything they name.
+    for (const territory of atlas.territories) {
+      const p = project(territory.center, camera, width, height)
+      ctx.font = '600 10px system-ui, sans-serif'
+      ctx.fillStyle = 'rgba(255,255,255,0.78)'
+      // Uppercased at draw time only; the stored caption keeps its own casing.
+      ctx.fillText(territory.caption.toUpperCase(), p.x, p.y)
+    }
+  }, [atlas, camera, hovered])
+
+  useEffect(() => {
+    draw()
+  }, [draw])
+
+  useEffect(() => {
+    const onResize = (): void => draw()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [draw])
+
+  const pointFor = (e: React.MouseEvent<HTMLCanvasElement>): AtlasPoint | null => {
+    const canvas = canvasRef.current
+    if (canvas === null) return null
+    const rect = canvas.getBoundingClientRect()
+    return unproject(
+      e.clientX - rect.left,
+      e.clientY - rect.top,
+      camera,
+      canvas.clientWidth,
+      canvas.clientHeight
+    )
+  }
+
+  return (
+    <canvas
+      ref={canvasRef}
+      role="img"
+      aria-label={`Memory atlas with ${atlas.territories.length} regions`}
+      className="h-full w-full cursor-grab active:cursor-grabbing"
+      onWheel={(e) => {
+        const next = Math.min(
+          Math.max(camera.zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1), MINIMUM_ZOOM),
+          maximumZoom(atlas.nodes.length, false)
+        )
+        setCamera((c) => ({
+          zoom: next,
+          panX: panPreservingCenter(c.panX, c.zoom, next),
+          panY: panPreservingCenter(c.panY, c.zoom, next)
+        }))
+      }}
+      onMouseDown={(e) => {
+        drag.current = { x: e.clientX, y: e.clientY, panX: camera.panX, panY: camera.panY }
+      }}
+      onMouseUp={() => {
+        drag.current = null
+      }}
+      onMouseLeave={() => {
+        drag.current = null
+        setHovered(null)
+        props.onFocusTerritory?.(null)
+      }}
+      onMouseMove={(e) => {
+        const dragging = drag.current
+        if (dragging !== null) {
+          setCamera((c) => ({
+            ...c,
+            panX: dragging.panX + (e.clientX - dragging.x),
+            panY: dragging.panY - (e.clientY - dragging.y)
+          }))
+          return
+        }
+        const point = pointFor(e)
+        const found = point === null ? null : territoryAt(atlas.territories, point)
+        if (found !== hovered) {
+          setHovered(found)
+          props.onFocusTerritory?.(found)
+        }
+      }}
+      onDoubleClick={(e) => {
+        const point = pointFor(e)
+        const found = point === null ? null : territoryAt(atlas.territories, point)
+        if (found === null) {
+          setCamera(IDENTITY)
+          return
+        }
+        // Frame the region rather than jumping to a fixed magnification, so a
+        // small region fills the same share of the viewport as a large one.
+        setCamera({ zoom: zoomToEnter(found.radius, atlas.nodes.length), panX: 0, panY: 0 })
+      }}
+    />
+  )
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/ARCHITECTURE.md
+++ b/desktop/windows/src/renderer/src/lib/atlas/ARCHITECTURE.md
@@ -1,0 +1,100 @@
+# Memory atlas
+
+LIFECYCLE: permanent
+
+Draws the knowledge graph as a map: entities grouped into named regions with
+coastlines, rather than a node-link ball. Ported from macOS
+`MainWindow/Pages/MemoryGraph/`.
+
+## The problem it answers
+
+`components/graph/KnowledgeGraphViewer.tsx` states the measurement in its own
+header: a real account is around 188 nodes and 474 edges with one 226-degree hub
+and roughly 40% degree-1 leaves, and drawn whole it is an unreadable, laggy
+hairball.
+
+The existing graph view keeps that legible by **hiding** nodes: a default cap on
+the most connected, with a "Show all" escape hatch. The atlas takes the opposite
+approach to the same problem. It hides nothing, and instead groups entities into
+regions whose names say what each part of the map is about. Both views ship; the
+Brain Map page toggles between them.
+
+## Pipeline
+
+```
+relatedness  ->  communities  ->  layout  ->  coastlines  ->  territories
+```
+
+| Module | Answers |
+|---|---|
+| `relatedness.ts` | How strongly are two entities related? |
+| `communities.ts` | Which entities belong together? |
+| `atlasLayout.ts` | Where does each entity go? |
+| `islands.ts` | What shape is a group's land? |
+| `territories.ts` | Which groups are places, and what are they called? |
+| `zoomPolicy.ts` | What is visible at this magnification? |
+| `buildAtlas.ts` | Runs the above, in this order. |
+
+Communities are detected **before** positions are computed, which is the reverse
+of the obvious order. The layout needs them: see below.
+
+## The rules that carry the weight
+
+**Relatedness is two signals.** Edges the graph states outright, weighted
+logarithmically in the memories behind them, plus entities that keep appearing in
+the same memory. Each memory divides one unit of relatedness among its
+participants, and each participant is weighted by how rare it is, so two entities
+that only ever co-occur inside one ubiquitous entity's memories are not treated
+as related. A memory naming more than 20 entities is skipped: it relates
+everything to everything, which is the same information as relating nothing.
+
+**A community must be denser than the map to have land.** A coastline is drawn
+where a community's own scalar field beats the sea level. This is why
+`atlasLayout.ts` exists rather than reusing the app's `computeLayout`: that
+layout spreads entities evenly, which is right for a node-link graph and fatal
+here. Wired to it, two of three obvious clusters produced no land at all.
+
+**Three constants shape every coastline.** The sea level sits above 1 because a
+lone entity's bump peaks at exactly 1, so one entity can never mint a territory.
+The decisive margin means a cell only belongs to the leader if it beats the
+runner-up by a quarter, so contested ground stays water. Reach is not an absolute
+distance but the map's own median nearest-neighbour spacing times 2.5, because
+the same spacing means "tight" on a dense map and "scattered" on a sparse one.
+
+**Marching squares stitches by integer edge identity**, not by coordinate.
+Comparing interpolated coordinates leaves hairline gaps wherever two cells
+disagree in the last bit, and a ring with a gap cannot be filled.
+
+**A region the map cannot name is not drawn.** An unnamed shape is noise, and the
+entities inside it are still drawn as entities.
+
+**Determinism is a contract.** Every traversal that can affect an output walks a
+sorted array, a tied Louvain candidate cannot pull a node, and the layout seeds
+from a phyllotaxis spiral by index with a fixed tick count. The graph is merged
+from an onboarding floor plus a server fetch whose interleaving is not fixed, so
+without this the map would rearrange itself between runs for no visible reason.
+
+## Deliberate divergences from macOS
+
+| Divergence | Why |
+|---|---|
+| One added force on the existing d3 engine, not a 1,600-line bespoke relaxation | The bespoke layout exists to pack communities; one community-attraction force achieves what the island algorithm needs. |
+| A purity floor is **enforced**, not just asserted | macOS asserts in tests that every drawn region holds its own members, because its relaxation packs tightly enough that it is always true. Here it can fail, and a region drawn over ground none of its entities stand on is worse than no region. |
+| No playback | Playback replays the map growing over time, and `graphDisplay.ts` records that the server graph carries no per-node timestamp. Deriving one from each node's memories is possible but is its own change. |
+| No render-plan or snapshot cache | Those exist for a 4,000-line SwiftUI canvas under continuous camera motion; this redraws a few hundred shapes. |
+| `ForceDirectedSimulation.swift` not ported | It is the legacy 3D engine for the old page, has no Atlas references, and uses a random source, which would break determinism. |
+
+## Guards that cannot be observed in the output
+
+Two rules here are defence in depth rather than load-bearing today, and the code
+says so where they sit:
+
+- Island ownership ties resolve to the lowest group id. A cell where two
+  communities peak identically has `best == runnerUp`, so it fails the decisive
+  margin and becomes water whichever community owns it.
+- The eager-versus-lazy edge crossing in marching squares. The two cells sharing
+  an edge read the same corner values, so they always agree on whether the
+  contour crosses it, and a NaN for a non-crossing edge is never referenced.
+
+Both are kept so that a later change to the surrounding rule cannot silently
+start depending on the wrong behaviour.

--- a/desktop/windows/src/renderer/src/lib/atlas/atlasLayout.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/atlasLayout.ts
@@ -1,0 +1,160 @@
+// Positions for the atlas.
+//
+// This is NOT the app's existing `computeLayout`, and the difference is the
+// whole reason it exists. That layout spreads entities evenly, which is right
+// for a node-link graph. The island algorithm needs the opposite: a community
+// has to be denser than the map average, because a coastline is drawn where a
+// community's own field beats the sea level, and a community spread as thinly as
+// everything else never clears it.
+//
+// macOS solves this with a bespoke 1,600-line relaxation. Rather than port a
+// second force engine, this adds one force to the one already in the tree: every
+// entity is pulled toward its community's centre of mass. That is the minimum
+// needed to make the ported island algorithm produce land, and it leaves the
+// existing brain map untouched.
+//
+// Determinism: seeds are a phyllotaxis spiral by index, tick count is fixed, and
+// no force here consults a random source - d3 only reaches for Math.random when
+// a node arrives without coordinates, which is why the seeds are set first.
+
+import {
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  forceX,
+  forceY,
+  type SimulationNodeDatum
+} from 'd3-force'
+import type { AtlasLink } from './relatedness'
+
+/** Ticks run before the positions are read. Fixed rather than run-to-convergence
+ *  so the same graph always lands in the same place. */
+export const LAYOUT_TICKS = 300
+/** How hard entities push each other apart. */
+export const CHARGE_STRENGTH = -140
+/** How hard a community pulls its own members together. Strong enough to make a
+ *  community denser than the map, gentle enough that the links still shape it. */
+export const COMMUNITY_PULL = 0.22
+/** Keeps entities from stacking, so a community has interior rather than a spike. */
+export const COLLIDE_RADIUS = 12
+/** Nominal space the simulation runs in; the result is normalised afterwards. */
+export const LAYOUT_EXTENT = 1000
+
+interface LayoutNode extends SimulationNodeDatum {
+  id: string
+  community: number
+}
+
+export interface LaidOutAtlasNode {
+  id: string
+  x: number
+  y: number
+}
+
+/**
+ * Seed positions: a phyllotaxis spiral per community, with communities
+ * themselves placed on a spiral. Deterministic, and it starts communities apart
+ * so the simulation separates them rather than having to tear them apart.
+ */
+export function seedPositions(
+  ids: string[],
+  membership: Map<string, number>
+): Map<string, { x: number; y: number }> {
+  const golden = 2.399963229728653
+  const byCommunity = new Map<number, string[]>()
+  for (const id of [...ids].sort()) {
+    const group = membership.get(id) ?? -1
+    const existing = byCommunity.get(group)
+    if (existing === undefined) byCommunity.set(group, [id])
+    else existing.push(id)
+  }
+
+  const out = new Map<string, { x: number; y: number }>()
+  const groups = [...byCommunity.keys()].sort((a, b) => a - b)
+  groups.forEach((group, groupIndex) => {
+    const members = byCommunity.get(group) ?? []
+    const groupAngle = groupIndex * golden
+    const groupRadius = LAYOUT_EXTENT * (0.12 + 0.06 * groupIndex)
+    const cx = LAYOUT_EXTENT / 2 + groupRadius * Math.cos(groupAngle)
+    const cy = LAYOUT_EXTENT / 2 + groupRadius * Math.sin(groupAngle)
+    members.forEach((id, i) => {
+      const angle = i * golden
+      const radius = LAYOUT_EXTENT * 0.05 * Math.sqrt((i + 0.5) / Math.max(members.length, 1))
+      out.set(id, { x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) })
+    })
+  })
+  return out
+}
+
+/**
+ * Lays the graph out with communities packed.
+ *
+ * `membership` decides which entities pull together; an entity with no community
+ * (the anchor) is pulled to the centre instead, which is where it belongs.
+ */
+export function layoutAtlas(
+  ids: string[],
+  links: AtlasLink[],
+  membership: Map<string, number>
+): LaidOutAtlasNode[] {
+  if (ids.length === 0) return []
+  const seeds = seedPositions(ids, membership)
+  const nodes: LayoutNode[] = [...ids].sort().map((id) => ({
+    id,
+    community: membership.get(id) ?? -1,
+    x: seeds.get(id)?.x ?? LAYOUT_EXTENT / 2,
+    y: seeds.get(id)?.y ?? LAYOUT_EXTENT / 2
+  }))
+
+  // Community centres, recomputed each tick so a community that drifts takes its
+  // members with it rather than being stretched back to where it started.
+  const centres = new Map<number, { x: number; y: number }>()
+  const recentreCommunities = (): void => {
+    const sums = new Map<number, { x: number; y: number; n: number }>()
+    for (const node of nodes) {
+      const acc = sums.get(node.community) ?? { x: 0, y: 0, n: 0 }
+      acc.x += node.x ?? 0
+      acc.y += node.y ?? 0
+      acc.n += 1
+      sums.set(node.community, acc)
+    }
+    centres.clear()
+    for (const [group, acc] of sums) centres.set(group, { x: acc.x / acc.n, y: acc.y / acc.n })
+  }
+  recentreCommunities()
+
+  const simulation = forceSimulation(nodes)
+    .force('charge', forceManyBody().strength(CHARGE_STRENGTH))
+    .force(
+      'link',
+      forceLink<LayoutNode, { source: string; target: string; weight: number }>(
+        links.map((l) => ({ source: l.a, target: l.b, weight: l.weight }))
+      )
+        .id((n) => n.id)
+        .distance(60)
+        .strength(0.4)
+    )
+    .force('collide', forceCollide(COLLIDE_RADIUS))
+    // The community pull. An entity with no community is drawn to the middle.
+    .force(
+      'communityX',
+      forceX<LayoutNode>((n) => centres.get(n.community)?.x ?? LAYOUT_EXTENT / 2).strength(
+        COMMUNITY_PULL
+      )
+    )
+    .force(
+      'communityY',
+      forceY<LayoutNode>((n) => centres.get(n.community)?.y ?? LAYOUT_EXTENT / 2).strength(
+        COMMUNITY_PULL
+      )
+    )
+    .stop()
+
+  for (let i = 0; i < LAYOUT_TICKS; i += 1) {
+    recentreCommunities()
+    simulation.tick()
+  }
+
+  return nodes.map((n) => ({ id: n.id, x: n.x ?? 0, y: n.y ?? 0 }))
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/buildAtlas.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/buildAtlas.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+import { buildAtlas, normalisePositions } from './buildAtlas'
+import type { KGEdge, KGNode, KnowledgeGraph } from '../../../../shared/types'
+
+const node = (id: string, label: string, memoryIds: string[] = []): KGNode => ({
+  id,
+  label,
+  nodeType: 'topic',
+  aliases: [],
+  memoryIds
+})
+
+const edge = (a: string, b: string, memoryIds: string[] = []): KGEdge => ({
+  id: `${a}-${b}`,
+  sourceId: a,
+  targetId: b,
+  label: '',
+  memoryIds
+})
+
+/**
+ * Three topic clusters joined by thin edges. Each cluster is fully connected,
+ * which is what a real topic cluster looks like: the entities in one subject are
+ * related to each other, not strung out in a chain.
+ */
+const threeWorlds = (perCluster = 10): KnowledgeGraph => {
+  const nodes: KGNode[] = []
+  const edges: KGEdge[] = []
+  for (const [prefix, hub] of [
+    ['w', 'Acme'],
+    ['h', 'Lease'],
+    ['t', 'Travel']
+  ] as const) {
+    for (let i = 0; i < perCluster; i += 1) {
+      nodes.push(node(`${prefix}${i}`, i === 0 ? hub : `${prefix} thing ${i}`, [`${prefix}m`]))
+    }
+    for (let i = 0; i < perCluster; i += 1) {
+      for (let j = i + 1; j < perCluster; j += 1) {
+        edges.push(edge(`${prefix}${i}`, `${prefix}${j}`, [`${prefix}m`]))
+      }
+    }
+  }
+  edges.push(edge('w0', 'h0'))
+  edges.push(edge('h0', 't0'))
+  return { nodes, edges }
+}
+
+describe('normalisePositions', () => {
+  it('maps a layout into the unit square', () => {
+    const out = normalisePositions([
+      { id: 'a', x: 100, y: 200 },
+      { id: 'b', x: 300, y: 400 }
+    ])
+    for (const p of out.values()) {
+      expect(p.x).toBeGreaterThanOrEqual(0)
+      expect(p.x).toBeLessThanOrEqual(1)
+      expect(p.y).toBeGreaterThanOrEqual(0)
+      expect(p.y).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('uses one scale for both axes so the map is not stretched', () => {
+    // A wide, short layout must stay wide and short; scaling each axis to fill
+    // the square would distort every region's shape.
+    const out = normalisePositions([
+      { id: 'a', x: 0, y: 0 },
+      { id: 'b', x: 100, y: 10 }
+    ])
+    const a = out.get('a') as { x: number; y: number }
+    const b = out.get('b') as { x: number; y: number }
+    expect(b.x - a.x).toBeCloseTo(1, 6)
+    expect(b.y - a.y).toBeCloseTo(0.1, 6)
+  })
+
+  it('centres a degenerate layout rather than dividing by zero', () => {
+    const out = normalisePositions([
+      { id: 'a', x: 5, y: 5 },
+      { id: 'b', x: 5, y: 5 }
+    ])
+    expect(out.get('a')).toEqual({ x: 0.5, y: 0.5 })
+  })
+
+  it('handles an empty layout', () => {
+    expect(normalisePositions([]).size).toBe(0)
+  })
+})
+
+describe('buildAtlas', () => {
+  it('returns nothing for an empty graph', () => {
+    expect(buildAtlas({ nodes: [], edges: [] })).toEqual({
+      nodes: [],
+      territories: [],
+      unnamedCommunities: 0
+    })
+  })
+
+  it('places every node and gives each a community', () => {
+    const atlas = buildAtlas(threeWorlds())
+    expect(atlas.nodes.length).toBe(30)
+    for (const n of atlas.nodes) {
+      expect(Number.isFinite(n.position.x)).toBe(true)
+      expect(Number.isFinite(n.position.y)).toBe(true)
+      expect(n.community).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('separates the two worlds into different communities', () => {
+    const atlas = buildAtlas(threeWorlds())
+    const communityOf = (id: string): number =>
+      atlas.nodes.find((n) => n.id === id)?.community as number
+    expect(communityOf('w0')).toBe(communityOf('w5'))
+    expect(communityOf('h0')).toBe(communityOf('h5'))
+    expect(communityOf('w0')).not.toBe(communityOf('h0'))
+  })
+
+  it('draws a named region for each world', () => {
+    const atlas = buildAtlas(threeWorlds())
+    // The hubs carry every edge in their cluster, so they are what the regions
+    // are about. Asserted unconditionally: a guard here would hide a pipeline
+    // that had stopped producing regions at all.
+    expect(atlas.territories.map((t) => t.caption).sort()).toEqual(['Acme', 'Lease', 'Travel'])
+    expect(atlas.unnamedCommunities).toBe(0)
+  })
+
+  it('keeps a region over its own members', () => {
+    const atlas = buildAtlas(threeWorlds())
+    for (const territory of atlas.territories) {
+      // A region whose members stand outside it is drawn over the wrong ground.
+      expect(territory.purity).toBeGreaterThan(0.5)
+    }
+  })
+
+  it('never puts the account holder in a region', () => {
+    const graph = threeWorlds()
+    graph.nodes.push(node('me', 'Zach'))
+    for (const n of graph.nodes) {
+      if (n.id !== 'me') graph.edges.push(edge('me', n.id))
+    }
+    const atlas = buildAtlas(graph, 'me')
+    // The anchor touches everything, so including it would merge the whole map
+    // into one region and could name that region after the user.
+    expect(atlas.nodes.find((n) => n.id === 'me')?.community).toBe(-1)
+    expect(atlas.territories.some((t) => t.memberIds.includes('me'))).toBe(false)
+    expect(atlas.territories.some((t) => t.caption === 'Zach')).toBe(false)
+  })
+
+  it('gives the same atlas for the same graph', () => {
+    const first = buildAtlas(threeWorlds())
+    const second = buildAtlas(threeWorlds())
+    expect(second.territories.map((t) => t.caption)).toEqual(
+      first.territories.map((t) => t.caption)
+    )
+    expect(second.nodes.map((n) => n.community)).toEqual(first.nodes.map((n) => n.community))
+  })
+
+  it('survives a graph with no edges at all', () => {
+    const graph: KnowledgeGraph = {
+      nodes: Array.from({ length: 12 }, (_v, i) => node(`n${i}`, `Thing ${i}`)),
+      edges: []
+    }
+    const atlas = buildAtlas(graph)
+    expect(atlas.nodes.length).toBe(12)
+    // Nothing is related to anything, so there are no regions to draw - but the
+    // entities are still placed and still shown.
+    expect(atlas.territories).toEqual([])
+  })
+
+  it('counts a community that holds land but could not be named', () => {
+    // Every member is blank, so the community wins land and then has nothing to
+    // call itself. Reported rather than silently dropped, so a caller can say
+    // how much of the map is unlabelled instead of pretending it is not there.
+    const graph = threeWorlds()
+    for (const n of graph.nodes) {
+      if (n.id.startsWith('t')) n.label = '   '
+    }
+    const atlas = buildAtlas(graph)
+    expect(atlas.territories.map((t) => t.caption).sort()).toEqual(['Acme', 'Lease'])
+    expect(atlas.unnamedCommunities).toBe(1)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/atlas/buildAtlas.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/buildAtlas.ts
@@ -1,0 +1,148 @@
+// The whole atlas, from a knowledge graph to something drawable.
+//
+//   relatedness  ->  communities  ->  positions  ->  coastlines  ->  territories
+//
+// Communities are detected BEFORE positions are computed, because the layout
+// needs them: an island is drawn where a community's own field beats the sea
+// level, and a community spread as thinly as the rest of the map never clears
+// it. See atlasLayout.ts for why that is its own layout rather than the app's
+// existing one.
+
+import type { KnowledgeGraph } from '../../../../shared/types'
+import { nodeDegrees } from '../graphDisplay'
+import { layoutAtlas } from './atlasLayout'
+import { atlasLinks, neighboursOf } from './relatedness'
+import { detectCommunities, membersByCommunity } from './communities'
+import { coastlines, type AtlasPoint } from './islands'
+import { buildTerritories, type AtlasMember, type Territory } from './territories'
+
+export interface AtlasNode {
+  id: string
+  label: string
+  nodeType: string
+  /** Normalised atlas space, 0..1 on both axes. */
+  position: AtlasPoint
+  degree: number
+  community: number
+}
+
+export interface Atlas {
+  nodes: AtlasNode[]
+  territories: Territory[]
+  /** Communities that hold land but could not be named, so a caller can say how
+   *  much of the map is unlabelled rather than silently omitting it. */
+  unnamedCommunities: number
+}
+
+const EMPTY: Atlas = { nodes: [], territories: [], unnamedCommunities: 0 }
+
+/**
+ * Rescales laid-out coordinates into the unit square the island field expects.
+ *
+ * The field is a fixed 128x128 grid with a margin, so a layout in pixel space
+ * would land almost entirely in one cell. Normalising by the actual extent
+ * rather than by the nominal viewport keeps the map filling the field however
+ * tightly or loosely the layout happened to settle.
+ */
+export function normalisePositions(
+  points: Array<{ id: string; x: number; y: number }>
+): Map<string, AtlasPoint> {
+  const out = new Map<string, AtlasPoint>()
+  if (points.length === 0) return out
+  const xs = points.map((p) => p.x)
+  const ys = points.map((p) => p.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+  // A degenerate extent (every node stacked) would divide by zero; centring them
+  // is the only sensible answer and produces no land, which is correct.
+  const spanX = maxX - minX
+  const spanY = maxY - minY
+  const span = Math.max(spanX, spanY)
+  if (span <= 0) {
+    for (const p of points) out.set(p.id, { x: 0.5, y: 0.5 })
+    return out
+  }
+  // One scale for both axes so the map is not stretched; the shorter axis is
+  // centred in what is left.
+  const offsetX = (span - spanX) / 2
+  const offsetY = (span - spanY) / 2
+  for (const p of points) {
+    out.set(p.id, { x: (p.x - minX + offsetX) / span, y: (p.y - minY + offsetY) / span })
+  }
+  return out
+}
+
+/**
+ * Builds the atlas.
+ *
+ * `anchorId` is the account holder's node when the graph has one. It is excluded
+ * from every community, so a region can never end up named after the user.
+ */
+export function buildAtlas(graph: KnowledgeGraph, anchorId?: string): Atlas {
+  if (graph.nodes.length === 0) return EMPTY
+
+  const anchor = anchorId ?? null
+  const links = atlasLinks(graph, anchor)
+  const neighbours = neighboursOf(links)
+  const degrees = nodeDegrees(graph)
+
+  // The anchor is left out of community detection entirely: it touches
+  // everything, so including it merges the whole map into one region.
+  const groupedIds = graph.nodes.map((n) => n.id).filter((id) => id !== anchor)
+  const membership = detectCommunities(groupedIds, neighbours)
+
+  const laidOut = layoutAtlas(
+    graph.nodes.map((n) => n.id),
+    links,
+    membership
+  )
+  const positions = normalisePositions(laidOut)
+
+  const nodes: AtlasNode[] = graph.nodes.map((node) => ({
+    id: node.id,
+    label: node.label,
+    nodeType: node.nodeType,
+    position: positions.get(node.id) ?? { x: 0.5, y: 0.5 },
+    degree: degrees.get(node.id) ?? 0,
+    // -1 marks the anchor: it belongs to no region by construction.
+    community: membership.get(node.id) ?? -1
+  }))
+
+  const byGroup = membersByCommunity(membership)
+  const pointsByGroup = new Map<number, AtlasPoint[]>()
+  const membersByGroup = new Map<number, AtlasMember[]>()
+  for (const group of [...byGroup.keys()].sort((a, b) => a - b)) {
+    const ids = byGroup.get(group) ?? []
+    const members: AtlasMember[] = ids.map((id) => {
+      const node = nodes.find((n) => n.id === id)
+      return {
+        id,
+        label: node?.label ?? '',
+        degree: node?.degree ?? 0,
+        position: node?.position ?? { x: 0.5, y: 0.5 }
+      }
+    })
+    membersByGroup.set(group, members)
+    pointsByGroup.set(
+      group,
+      members.map((m) => m.position)
+    )
+  }
+
+  // Every community competes for land, including ones that will never be named.
+  // Leaving one out hands its ground to whichever named neighbour is closest,
+  // which draws a territory over entities that do not belong to it.
+  const ringsByGroup = coastlines(pointsByGroup)
+  const territories = buildTerritories({
+    membersByGroup,
+    ringsByGroup,
+    allPositions: nodes.map((n) => n.position)
+  })
+
+  const named = new Set(territories.map((t) => t.group))
+  const unnamedCommunities = [...ringsByGroup.keys()].filter((g) => !named.has(g)).length
+
+  return { nodes, territories, unnamedCommunities }
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/communities.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/communities.test.ts
@@ -58,6 +58,38 @@ describe('mergeByModularity', () => {
     expect(mergeByModularity([], [])).toEqual([])
   })
 
+  it('leaves a node where it is when two candidates tie exactly', () => {
+    // `a` is pulled equally by `b` and `c`. Moving on a tie makes the winner
+    // whichever candidate is compared last, so the partition depends on
+    // iteration order and oscillates between sweeps; refusing to move on a tie
+    // is what makes it settle.
+    const membership = detectCommunities(
+      ['a', 'b', 'c'],
+      neighbours([
+        ['a', 'b', 1],
+        ['a', 'c', 1]
+      ])
+    )
+    const groupOf = (id: string): number => membership.get(id) as number
+    // b and c are symmetric, so a must not end up merged with exactly one of
+    // them on the strength of a tie.
+    expect(groupOf('b') === groupOf('c') || groupOf('a') !== groupOf('b')).toBe(true)
+    expect(groupOf('b') === groupOf('c') || groupOf('a') !== groupOf('c')).toBe(true)
+  })
+
+  it('ignores a self-edge, so it cannot look like evidence of grouping', () => {
+    // A node linked only to itself has no reason to join anyone.
+    const membership = detectCommunities(
+      ['a', 'b', 'c'],
+      neighbours([
+        ['a', 'a', 99],
+        ['b', 'c', 5]
+      ])
+    )
+    expect(membership.get('a')).not.toBe(membership.get('b'))
+    expect(membership.get('b')).toBe(membership.get('c'))
+  })
+
   it('leaves a node where it is when a candidate only ties', () => {
     // A node pulled by an equal-scoring candidate makes the partition oscillate
     // and never settle, so the map would reorganise itself on every run.

--- a/desktop/windows/src/renderer/src/lib/atlas/communities.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/communities.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LOUVAIN_EPSILON,
+  denseRelabel,
+  detectCommunities,
+  membersByCommunity,
+  mergeByModularity
+} from './communities'
+import { atlasLinks, neighboursOf } from './relatedness'
+import type { KnowledgeGraph } from '../../../../shared/types'
+
+const neighbours = (
+  pairs: Array<[string, string, number]>
+): Map<string, Array<{ id: string; weight: number }>> => {
+  const out = new Map<string, Array<{ id: string; weight: number }>>()
+  const add = (from: string, to: string, weight: number): void => {
+    const existing = out.get(from)
+    if (existing === undefined) out.set(from, [{ id: to, weight }])
+    else existing.push({ id: to, weight })
+  }
+  for (const [a, b, w] of pairs) {
+    add(a, b, w)
+    add(b, a, w)
+  }
+  return out
+}
+
+/** Two triangles joined by one thin edge - the textbook case for community
+ *  detection, and the shape a real graph's regions approximate. */
+const TWO_CLIQUES: Array<[string, string, number]> = [
+  ['a1', 'a2', 5],
+  ['a2', 'a3', 5],
+  ['a3', 'a1', 5],
+  ['b1', 'b2', 5],
+  ['b2', 'b3', 5],
+  ['b3', 'b1', 5],
+  ['a1', 'b1', 0.1]
+]
+
+describe('denseRelabel', () => {
+  it('renumbers in first-seen order', () => {
+    expect(denseRelabel([7, 7, 3, 9, 3])).toEqual([0, 0, 1, 2, 1])
+  })
+
+  it('leaves an already dense labelling alone', () => {
+    expect(denseRelabel([0, 1, 2])).toEqual([0, 1, 2])
+  })
+})
+
+describe('mergeByModularity', () => {
+  it('returns the identity partition for a graph with no weight', () => {
+    // Inventing groups for an empty graph would draw territories over nothing.
+    const adjacency = [new Map<number, number>(), new Map<number, number>()]
+    expect(mergeByModularity(adjacency, [0, 0])).toEqual([0, 1])
+  })
+
+  it('handles an empty graph', () => {
+    expect(mergeByModularity([], [])).toEqual([])
+  })
+
+  it('leaves a node where it is when a candidate only ties', () => {
+    // A node pulled by an equal-scoring candidate makes the partition oscillate
+    // and never settle, so the map would reorganise itself on every run.
+    const adjacency = [
+      new Map([
+        [1, 1],
+        [2, 1]
+      ]),
+      new Map([[0, 1]]),
+      new Map([[0, 1]])
+    ]
+    const first = mergeByModularity(adjacency, [0, 0, 0])
+    const second = mergeByModularity(adjacency, [0, 0, 0])
+    expect(first).toEqual(second)
+    expect(LOUVAIN_EPSILON).toBeGreaterThan(0)
+  })
+})
+
+describe('detectCommunities', () => {
+  it('separates two dense clusters joined by a thin edge', () => {
+    const membership = detectCommunities(
+      ['a1', 'a2', 'a3', 'b1', 'b2', 'b3'],
+      neighbours(TWO_CLIQUES)
+    )
+    const groupOf = (id: string): number => membership.get(id) as number
+    expect(groupOf('a1')).toBe(groupOf('a2'))
+    expect(groupOf('a2')).toBe(groupOf('a3'))
+    expect(groupOf('b1')).toBe(groupOf('b2'))
+    expect(groupOf('b2')).toBe(groupOf('b3'))
+    expect(groupOf('a1')).not.toBe(groupOf('b1'))
+  })
+
+  it('gives the same answer whatever order the ids arrive in', () => {
+    // The graph is merged from an onboarding floor plus a server fetch, whose
+    // interleaving is not fixed, so a partition that depended on arrival order
+    // would rearrange the map for no reason the user can see.
+    const ids = ['a1', 'a2', 'a3', 'b1', 'b2', 'b3']
+    const forward = detectCommunities(ids, neighbours(TWO_CLIQUES))
+    const reversed = detectCommunities([...ids].reverse(), neighbours(TWO_CLIQUES))
+
+    const shape = (m: Map<string, number>): string =>
+      [...m.keys()]
+        .sort()
+        .map((id) => {
+          const same = [...m.keys()].filter((other) => m.get(other) === m.get(id)).sort()
+          return `${id}:${same.join(',')}`
+        })
+        .join('|')
+    expect(shape(reversed)).toBe(shape(forward))
+  })
+
+  it('gives every id a community, including ones with no links', () => {
+    const membership = detectCommunities(['a1', 'a2', 'lonely'], neighbours([['a1', 'a2', 1]]))
+    // A node dropped here vanishes from the map entirely, which is worse than
+    // showing it alone.
+    expect(membership.size).toBe(3)
+    expect(membership.get('lonely')).toBeDefined()
+    expect(membership.get('lonely')).not.toBe(membership.get('a1'))
+  })
+
+  it('ignores a self-edge, which says nothing about grouping', () => {
+    const membership = detectCommunities(['a', 'b'], neighbours([['a', 'a', 99]]))
+    expect(membership.get('a')).not.toBe(membership.get('b'))
+  })
+
+  it('is stable across repeated runs', () => {
+    const ids = ['a1', 'a2', 'a3', 'b1', 'b2', 'b3']
+    const once = detectCommunities(ids, neighbours(TWO_CLIQUES))
+    const twice = detectCommunities(ids, neighbours(TWO_CLIQUES))
+    expect([...twice.entries()]).toEqual([...once.entries()])
+  })
+
+  it('handles an empty graph', () => {
+    expect(detectCommunities([], new Map()).size).toBe(0)
+  })
+})
+
+describe('membersByCommunity', () => {
+  it('lists members in sorted id order', () => {
+    const membership = new Map([
+      ['z', 0],
+      ['a', 0],
+      ['m', 1]
+    ])
+    const groups = membersByCommunity(membership)
+    expect(groups.get(0)).toEqual(['a', 'z'])
+    expect(groups.get(1)).toEqual(['m'])
+  })
+})
+
+describe('end to end from a knowledge graph', () => {
+  const graph: KnowledgeGraph = {
+    nodes: [
+      { id: 'work1', label: 'Acme', nodeType: 'org', aliases: [], memoryIds: ['m1', 'm2'] },
+      { id: 'work2', label: 'Q3 Plan', nodeType: 'topic', aliases: [], memoryIds: ['m1'] },
+      { id: 'work3', label: 'Dana', nodeType: 'person', aliases: [], memoryIds: ['m2'] },
+      { id: 'home1', label: 'Lease', nodeType: 'topic', aliases: [], memoryIds: ['m9'] },
+      { id: 'home2', label: 'Landlord', nodeType: 'person', aliases: [], memoryIds: ['m9'] }
+    ],
+    edges: [
+      { id: 'e1', sourceId: 'work1', targetId: 'work2', label: '', memoryIds: ['m1'] },
+      { id: 'e2', sourceId: 'work1', targetId: 'work3', label: '', memoryIds: ['m2'] },
+      { id: 'e3', sourceId: 'work2', targetId: 'work3', label: '', memoryIds: ['m1'] },
+      { id: 'e4', sourceId: 'home1', targetId: 'home2', label: '', memoryIds: ['m9'] }
+    ]
+  }
+
+  it('finds the work group and the home group', () => {
+    const links = atlasLinks(graph, null)
+    const membership = detectCommunities(
+      graph.nodes.map((n) => n.id),
+      neighboursOf(links)
+    )
+    expect(membership.get('work1')).toBe(membership.get('work2'))
+    expect(membership.get('home1')).toBe(membership.get('home2'))
+    expect(membership.get('work1')).not.toBe(membership.get('home1'))
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/atlas/communities.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/communities.ts
@@ -1,0 +1,177 @@
+// Louvain community detection over the relatedness graph.
+//
+// Ported from macOS `MemoryAtlasForceLayout.swift:790-915`. This is what turns a
+// hairball into regions: the map cannot draw a named territory until it knows
+// which entities belong together, and "belong together" here means densely
+// connected to each other relative to the rest of the graph.
+//
+// Determinism, as everywhere in this package: candidate groups are walked in
+// sorted order and a move needs to beat the incumbent by more than a tolerance,
+// so a tie leaves a node exactly where it was. Without both, the same graph
+// produces different regions on different runs and the map appears to reorganise
+// itself for no reason.
+
+/** Weighted undirected adjacency: `adjacency[i]` maps a neighbour index to a weight. */
+type Adjacency = Array<Map<number, number>>
+
+/** Levels of coarsening attempted before giving up. */
+export const LOUVAIN_LEVELS = 10
+/** Local-move sweeps per level. */
+export const LOUVAIN_ROUNDS = 20
+/** A candidate must beat the incumbent by more than this to win the node. */
+export const LOUVAIN_EPSILON = 1e-12
+
+/**
+ * One pass of local moving: repeatedly move each node to the neighbouring
+ * community that most improves modularity, until nothing moves or the sweep
+ * budget runs out. Returns a dense, first-seen relabelling.
+ */
+export function mergeByModularity(
+  adjacency: Adjacency,
+  selfLoops: number[],
+  rounds = LOUVAIN_ROUNDS
+): number[] {
+  const n = adjacency.length
+  const community = Array.from({ length: n }, (_v, i) => i)
+  if (n === 0) return community
+
+  const degree = adjacency.map((neighbours, i) => {
+    let total = 0
+    for (const weight of neighbours.values()) total += weight
+    return total + 2 * (selfLoops[i] ?? 0)
+  })
+  const twiceTotal = degree.reduce((sum, d) => sum + d, 0)
+  // A graph with no weight has no communities to find; the identity partition is
+  // the honest answer rather than an arbitrary grouping.
+  if (twiceTotal <= 0) return community
+
+  const totalDegree = [...degree]
+
+  for (let round = 0; round < rounds; round += 1) {
+    let moved = false
+    for (let i = 0; i < n; i += 1) {
+      const current = community[i]
+      // Weight from i into each candidate community.
+      const shared = new Map<number, number>()
+      for (const [j, weight] of adjacency[i]) {
+        if (j === i) continue
+        shared.set(community[j], (shared.get(community[j]) ?? 0) + weight)
+      }
+
+      // Remove i from its own community before scoring, so it is not compared
+      // against a total that still includes itself.
+      totalDegree[current] -= degree[i]
+      const currentShared = shared.get(current) ?? 0
+      let bestCommunity = current
+      let bestGain = currentShared - (totalDegree[current] * degree[i]) / twiceTotal
+
+      for (const candidate of [...shared.keys()].sort((x, y) => x - y)) {
+        if (candidate === current) continue
+        const gain =
+          (shared.get(candidate) ?? 0) - (totalDegree[candidate] * degree[i]) / twiceTotal
+        // Strictly greater by more than the tolerance: an equal-scoring
+        // candidate must not be able to pull the node, or the partition
+        // oscillates and never settles.
+        if (gain > bestGain + LOUVAIN_EPSILON) {
+          bestGain = gain
+          bestCommunity = candidate
+        }
+      }
+
+      totalDegree[bestCommunity] += degree[i]
+      if (bestCommunity !== current) {
+        community[i] = bestCommunity
+        moved = true
+      }
+    }
+    if (!moved) break
+  }
+
+  return denseRelabel(community)
+}
+
+/** Renumbers labels to 0..k-1 in first-seen order, so the ids a level produces
+ *  do not depend on how large the original index space was. */
+export function denseRelabel(labels: number[]): number[] {
+  const seen = new Map<number, number>()
+  return labels.map((label) => {
+    const existing = seen.get(label)
+    if (existing !== undefined) return existing
+    const next = seen.size
+    seen.set(label, next)
+    return next
+  })
+}
+
+/**
+ * Assigns every id a community.
+ *
+ * `neighbours` is the weighted adjacency from relatedness.ts. Ids with no
+ * neighbours still get a community of their own, so nothing is silently lost
+ * between here and the map.
+ */
+export function detectCommunities(
+  ids: string[],
+  neighbours: Map<string, Array<{ id: string; weight: number }>>,
+  levels = LOUVAIN_LEVELS
+): Map<string, number> {
+  const indexOf = new Map<string, number>()
+  ids.forEach((id, i) => indexOf.set(id, i))
+
+  let adjacency: Adjacency = ids.map(() => new Map<number, number>())
+  for (let i = 0; i < ids.length; i += 1) {
+    for (const neighbour of neighbours.get(ids[i]) ?? []) {
+      const j = indexOf.get(neighbour.id)
+      // Self-edges carry no information about which group a node belongs to.
+      if (j === undefined || j === i) continue
+      adjacency[i].set(j, (adjacency[i].get(j) ?? 0) + neighbour.weight)
+    }
+  }
+  let selfLoops = new Array<number>(ids.length).fill(0)
+  // Membership of the ORIGINAL nodes, rewritten at each level of coarsening.
+  let membership = ids.map((_id, i) => i)
+
+  for (let level = 0; level < levels; level += 1) {
+    const groups = mergeByModularity(adjacency, selfLoops)
+    const groupCount = new Set(groups).size
+    // Nothing merged, so no coarser level can either.
+    if (groupCount >= adjacency.length) break
+
+    membership = membership.map((g) => groups[g])
+
+    const collapsed: Adjacency = Array.from({ length: groupCount }, () => new Map<number, number>())
+    const collapsedSelf = new Array<number>(groupCount).fill(0)
+    for (let i = 0; i < adjacency.length; i += 1) {
+      collapsedSelf[groups[i]] += selfLoops[i]
+      for (const [j, weight] of adjacency[i]) {
+        if (groups[i] === groups[j]) {
+          // Each undirected edge is seen once from each end, so half of it lands
+          // in the group's self-loop from each side.
+          collapsedSelf[groups[i]] += weight / 2
+        } else {
+          const key = groups[j]
+          collapsed[groups[i]].set(key, (collapsed[groups[i]].get(key) ?? 0) + weight)
+        }
+      }
+    }
+    adjacency = collapsed
+    selfLoops = collapsedSelf
+  }
+
+  const out = new Map<string, number>()
+  const dense = denseRelabel(membership)
+  ids.forEach((id, i) => out.set(id, dense[i]))
+  return out
+}
+
+/** Members per community, each list in sorted id order. */
+export function membersByCommunity(membership: Map<string, number>): Map<number, string[]> {
+  const out = new Map<number, string[]>()
+  for (const id of [...membership.keys()].sort()) {
+    const group = membership.get(id) as number
+    const existing = out.get(group)
+    if (existing === undefined) out.set(group, [id])
+    else existing.push(id)
+  }
+  return out
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/communities.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/communities.ts
@@ -52,9 +52,12 @@ export function mergeByModularity(
     for (let i = 0; i < n; i += 1) {
       const current = community[i]
       // Weight from i into each candidate community.
+      // Self-edges are excluded where the adjacency is BUILT (both in
+      // detectCommunities and in the collapse below), so there is no second
+      // check here: two guards for one invariant means neither can be shown to
+      // matter on its own.
       const shared = new Map<number, number>()
       for (const [j, weight] of adjacency[i]) {
-        if (j === i) continue
         shared.set(community[j], (shared.get(community[j]) ?? 0) + weight)
       }
 

--- a/desktop/windows/src/renderer/src/lib/atlas/islands.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/islands.test.ts
@@ -1,0 +1,312 @@
+// Coastline extraction.
+//
+// Clusters are generated from a deterministic sequence, never Math.random: the
+// module's contract is that the same input gives the same rings, and a test that
+// fed it noise could not tell a real regression from a different roll.
+import { describe, expect, it } from 'vitest'
+import {
+  DECISIVE_MARGIN,
+  MAX_REACH,
+  SEA_LEVEL,
+  blur,
+  coastlineContains,
+  coastlines,
+  influenceReach,
+  makeStencil,
+  ringArea,
+  traceRings,
+  type AtlasPoint
+} from './islands'
+
+/** Deterministic points around a centre: a phyllotaxis spiral, so the spread is
+ *  even and reproducible without a random source. */
+const cluster = (cx: number, cy: number, count: number, spread: number): AtlasPoint[] =>
+  Array.from({ length: count }, (_v, i) => {
+    const angle = i * 2.399963229728653
+    const radius = spread * Math.sqrt((i + 0.5) / count)
+    return { x: cx + radius * Math.cos(angle), y: cy + radius * Math.sin(angle) }
+  })
+
+const groups = (entries: Array<[number, AtlasPoint[]]>): Map<number, AtlasPoint[]> =>
+  new Map(entries)
+
+describe('influenceReach', () => {
+  it('is relative to how spread out the map already is', () => {
+    // The same absolute spacing means "tight" on a dense map and "scattered" on
+    // a sparse one, so reach cannot be an absolute distance.
+    const dense = influenceReach(groups([[0, cluster(0.5, 0.5, 60, 0.05)]]))
+    const sparse = influenceReach(groups([[0, cluster(0.5, 0.5, 8, 0.4)]]))
+    expect(sparse).toBeGreaterThan(dense)
+  })
+
+  it('falls back to the widest reach for a map with one point', () => {
+    expect(influenceReach(groups([[0, [{ x: 0.5, y: 0.5 }]]]))).toBe(MAX_REACH)
+  })
+
+  it('is not collapsed to zero by two entities at the same coordinate', () => {
+    // Nearest-neighbour uses value inequality, so a duplicate does not report a
+    // spacing of zero and shrink the reach for the entire map.
+    const duplicated = [
+      { x: 0.3, y: 0.3 },
+      { x: 0.3, y: 0.3 },
+      { x: 0.7, y: 0.7 }
+    ]
+    expect(influenceReach(groups([[0, duplicated]]))).toBeGreaterThan(0)
+  })
+
+  it('stays inside its clamp however tightly packed the map is', () => {
+    const reach = influenceReach(groups([[0, cluster(0.5, 0.5, 200, 0.001)]]))
+    expect(reach).toBeGreaterThanOrEqual(0.006)
+    expect(reach).toBeLessThanOrEqual(MAX_REACH)
+  })
+})
+
+describe('makeStencil', () => {
+  it('peaks at exactly one in the centre', () => {
+    // SEA_LEVEL is calibrated against this: it sits above 1 precisely so a lone
+    // entity's peak cannot clear it.
+    const stencil = makeStencil(0.05)
+    expect(stencil.values[stencil.radius * stencil.span + stencil.radius]).toBeCloseTo(1, 12)
+    expect(SEA_LEVEL).toBeGreaterThan(1)
+  })
+
+  it('falls away from the centre', () => {
+    const stencil = makeStencil(0.05)
+    const centre = stencil.values[stencil.radius * stencil.span + stencil.radius]
+    expect(stencil.values[0]).toBeLessThan(centre)
+  })
+})
+
+describe('blur', () => {
+  it('spreads a single lit cell into its neighbours', () => {
+    const mask = new Array<number>(128 * 128).fill(0)
+    mask[64 * 128 + 64] = 1
+    const out = blur(mask)
+    expect(out[64 * 128 + 64]).toBeGreaterThan(0)
+    expect(out[64 * 128 + 65]).toBeGreaterThan(0)
+    expect(out[64 * 128 + 70]).toBe(0)
+  })
+
+  it('treats out-of-bounds neighbours as empty rather than wrapping', () => {
+    const mask = new Array<number>(128 * 128).fill(0)
+    mask[0] = 1
+    const out = blur(mask)
+    // Wrapping would light the opposite corner, drawing land across the map.
+    expect(out[127 * 128 + 127]).toBe(0)
+  })
+})
+
+describe('ringArea', () => {
+  it('measures a square', () => {
+    const square = [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+      { x: 0, y: 2 }
+    ]
+    expect(Math.abs(ringArea(square))).toBe(4)
+  })
+
+  it('is zero for anything with fewer than three points', () => {
+    expect(ringArea([{ x: 0, y: 0 }])).toBe(0)
+  })
+})
+
+describe('traceRings', () => {
+  it('finds nothing in an empty field', () => {
+    expect(traceRings(new Array<number>(128 * 128).fill(0))).toEqual([])
+  })
+
+  it('discards a chain too short to be a region', () => {
+    // Two lit cells at the corner trace an open three-point chain. Keeping it
+    // would put a sliver on the map with no interior to fill.
+    const mask = new Array<number>(128 * 128).fill(0)
+    mask[0] = 1
+    mask[1] = 1
+    expect(traceRings(mask)).toEqual([])
+  })
+
+  it('closes a ring around a solid block', () => {
+    const mask = new Array<number>(128 * 128).fill(0)
+    for (let r = 40; r < 60; r += 1) for (let c = 40; c < 60; c += 1) mask[r * 128 + c] = 1
+    const rings = traceRings(mask)
+    expect(rings.length).toBe(1)
+    expect(rings[0].length).toBeGreaterThanOrEqual(4)
+    expect(Math.abs(ringArea(rings[0]))).toBeGreaterThan(100)
+  })
+})
+
+describe('coastlines', () => {
+  it('gives one community in two places two rings, with sea between them', () => {
+    const lobes = [...cluster(0.2, 0.5, 30, 0.06), ...cluster(0.8, 0.5, 30, 0.06)]
+    const rings = coastlines(groups([[0, lobes]])).get(0)
+    expect(rings?.length).toBe(2)
+    // An archipelago is the correct answer for a community that lives in two
+    // places; a hull would swallow everything between them.
+    expect(coastlineContains(rings ?? [], { x: 0.2, y: 0.5 })).toBe(true)
+    expect(coastlineContains(rings ?? [], { x: 0.8, y: 0.5 })).toBe(true)
+    expect(coastlineContains(rings ?? [], { x: 0.5, y: 0.5 })).toBe(false)
+  })
+
+  it('leaves contested ground as water when two communities interleave', () => {
+    const blob = cluster(0.5, 0.5, 40, 0.08)
+    const even = blob.filter((_p, i) => i % 2 === 0)
+    const odd = blob.filter((_p, i) => i % 2 === 1)
+    const result = coastlines(
+      groups([
+        [0, even],
+        [1, odd]
+      ])
+    )
+    for (const probe of [
+      { x: 0.5, y: 0.5 },
+      { x: 0.46, y: 0.52 },
+      { x: 0.54, y: 0.48 }
+    ]) {
+      // Neither community is decisive here, so neither owns it. Awarding it to
+      // one would draw a territory over the other's entities.
+      expect(coastlineContains(result.get(0) ?? [], probe)).toBe(false)
+      expect(coastlineContains(result.get(1) ?? [], probe)).toBe(false)
+    }
+  })
+
+  it('gives each community its own centre once they are pulled apart', () => {
+    const result = coastlines(
+      groups([
+        [0, cluster(0.28, 0.5, 20, 0.05)],
+        [1, cluster(0.72, 0.5, 20, 0.05)]
+      ])
+    )
+    expect(coastlineContains(result.get(0) ?? [], { x: 0.28, y: 0.5 })).toBe(true)
+    expect(coastlineContains(result.get(1) ?? [], { x: 0.72, y: 0.5 })).toBe(true)
+    expect(coastlineContains(result.get(0) ?? [], { x: 0.5, y: 0.5 })).toBe(false)
+    expect(coastlineContains(result.get(1) ?? [], { x: 0.5, y: 0.5 })).toBe(false)
+  })
+
+  it('gives a lone entity no land at all', () => {
+    // A single bump peaks at exactly 1 and the sea level is above it, so one
+    // entity can never mint a territory.
+    expect(coastlines(groups([[0, [{ x: 0.5, y: 0.5 }]]])).get(0)).toBeUndefined()
+  })
+
+  it('gives scattered entities no land, but a cluster on the same map does get some', () => {
+    const scattered = Array.from({ length: 8 }, (_v, i) => ({
+      x: 0.1 + 0.1 * i,
+      y: 0.15 + 0.09 * i
+    }))
+    const result = coastlines(
+      groups([
+        [0, scattered],
+        [1, cluster(0.75, 0.3, 20, 0.04)]
+      ])
+    )
+    // "Scattered" is relative to the map's own spacing, which is why both are
+    // measured on the same map rather than in isolation.
+    expect(result.get(0)).toBeUndefined()
+    expect(result.get(1)).toBeDefined()
+  })
+
+  it('drops an island too small to be worth drawing', () => {
+    // Two entities almost on top of each other do clear the sea level together,
+    // but the land they make is a speck; the area floor is what keeps specks off
+    // the map. The wider pair, on the same map, survives it.
+    const pair = (gap: number): Map<number, AtlasPoint[]> =>
+      groups([
+        [
+          0,
+          [
+            { x: 0.5 - gap / 2, y: 0.5 },
+            { x: 0.5 + gap / 2, y: 0.5 }
+          ]
+        ]
+      ])
+    expect(coastlines(pair(0.006)).get(0)).toBeUndefined()
+    expect(coastlines(pair(0.01)).get(0)).toBeDefined()
+  })
+
+  it('returns exactly the same rings for the same input', () => {
+    const input = (): Map<number, AtlasPoint[]> =>
+      groups([
+        [0, cluster(0.3, 0.3, 25, 0.06)],
+        [1, cluster(0.7, 0.7, 25, 0.06)]
+      ])
+    expect(coastlines(input())).toEqual(coastlines(input()))
+  })
+
+  it('does not depend on the order communities were inserted in', () => {
+    const a = cluster(0.3, 0.3, 25, 0.06)
+    const b = cluster(0.7, 0.7, 25, 0.06)
+    const forward = coastlines(
+      groups([
+        [0, a],
+        [1, b]
+      ])
+    )
+    const backward = coastlines(
+      groups([
+        [1, b],
+        [0, a]
+      ])
+    )
+    expect(backward.get(0)).toEqual(forward.get(0))
+    expect(backward.get(1)).toEqual(forward.get(1))
+  })
+
+  it('never gives one point to two communities', () => {
+    const result = coastlines(
+      groups([
+        [0, cluster(0.25, 0.25, 25, 0.07)],
+        [1, cluster(0.75, 0.25, 25, 0.07)],
+        [2, cluster(0.5, 0.75, 25, 0.07)]
+      ])
+    )
+    // Territories must tile. A point owned twice draws two labels over the same
+    // ground and makes the map unreadable.
+    for (let i = 0; i <= 40; i += 1) {
+      for (let j = 0; j <= 40; j += 1) {
+        const probe = { x: i / 40, y: j / 40 }
+        const owners = [...result.values()].filter((rings) => coastlineContains(rings, probe))
+        expect(owners.length).toBeLessThanOrEqual(1)
+      }
+    }
+  })
+
+  it('skips a community with no members rather than giving it an empty entry', () => {
+    const result = coastlines(
+      groups([
+        [0, cluster(0.5, 0.5, 25, 0.06)],
+        [1, []]
+      ])
+    )
+    expect(result.has(1)).toBe(false)
+  })
+
+  it('needs a decisive margin, not just a lead', () => {
+    expect(DECISIVE_MARGIN).toBeGreaterThan(1)
+  })
+})
+
+describe('coastlineContains', () => {
+  const square = (x: number, y: number, size: number): AtlasPoint[] => [
+    { x, y },
+    { x: x + size, y },
+    { x: x + size, y: y + size },
+    { x, y: y + size }
+  ]
+
+  it('reads a ring inside another as a hole', () => {
+    // Even-odd, not nonzero: an enclave belongs to whoever is inside it, not to
+    // the territory that surrounds it.
+    const withHole = [square(0, 0, 10), square(3, 3, 4)]
+    expect(coastlineContains(withHole, { x: 1, y: 5 })).toBe(true)
+    expect(coastlineContains(withHole, { x: 5, y: 5 })).toBe(false)
+  })
+
+  it('is false outside every ring', () => {
+    expect(coastlineContains([square(0, 0, 2)], { x: 9, y: 9 })).toBe(false)
+  })
+
+  it('ignores a degenerate ring', () => {
+    expect(coastlineContains([[{ x: 0, y: 0 }]], { x: 0, y: 0 })).toBe(false)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/atlas/islands.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/islands.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest'
 import {
   DECISIVE_MARGIN,
   MAX_REACH,
+  MIN_REACH,
   SEA_LEVEL,
   blur,
   coastlineContains,
@@ -43,15 +44,18 @@ describe('influenceReach', () => {
     expect(influenceReach(groups([[0, [{ x: 0.5, y: 0.5 }]]]))).toBe(MAX_REACH)
   })
 
-  it('is not collapsed to zero by two entities at the same coordinate', () => {
+  it('is not collapsed by two entities at the same coordinate', () => {
     // Nearest-neighbour uses value inequality, so a duplicate does not report a
-    // spacing of zero and shrink the reach for the entire map.
-    const duplicated = [
-      { x: 0.3, y: 0.3 },
+    // spacing of zero. Identity comparison would let the duplicate through, the
+    // median gap would fall to zero, and the reach would clamp to its floor -
+    // shrinking every territory on the map because two entities coincided.
+    const spaced = [
       { x: 0.3, y: 0.3 },
       { x: 0.7, y: 0.7 }
     ]
-    expect(influenceReach(groups([[0, duplicated]]))).toBeGreaterThan(0)
+    const withDuplicate = [{ x: 0.3, y: 0.3 }, ...spaced]
+    expect(influenceReach(groups([[0, withDuplicate]]))).toBe(influenceReach(groups([[0, spaced]])))
+    expect(influenceReach(groups([[0, withDuplicate]]))).toBeGreaterThan(MIN_REACH)
   })
 
   it('stays inside its clamp however tightly packed the map is', () => {
@@ -91,7 +95,10 @@ describe('blur', () => {
     const mask = new Array<number>(128 * 128).fill(0)
     mask[0] = 1
     const out = blur(mask)
-    // Wrapping would light the opposite corner, drawing land across the map.
+    // Wrapping would light the far end of the same row and the far end of the
+    // same column, drawing land across the map from one lit corner cell.
+    expect(out[0 * 128 + 127]).toBe(0)
+    expect(out[127 * 128 + 0]).toBe(0)
     expect(out[127 * 128 + 127]).toBe(0)
   })
 })
@@ -222,6 +229,26 @@ describe('coastlines', () => {
       ])
     expect(coastlines(pair(0.006)).get(0)).toBeUndefined()
     expect(coastlines(pair(0.01)).get(0)).toBeDefined()
+  })
+
+  it('never puts a NaN in a coastline', () => {
+    // Every crossing point must come from an edge the contour actually crosses.
+    // An edge whose ends sit on the same side divides by zero, and one NaN
+    // reachable from the neighbouring cell moves a whole coastline off the map.
+    const result = coastlines(
+      groups([
+        [0, cluster(0.3, 0.3, 30, 0.07)],
+        [1, cluster(0.7, 0.7, 30, 0.07)]
+      ])
+    )
+    for (const rings of result.values()) {
+      for (const ring of rings) {
+        for (const point of ring) {
+          expect(Number.isFinite(point.x)).toBe(true)
+          expect(Number.isFinite(point.y)).toBe(true)
+        }
+      }
+    }
   })
 
   it('returns exactly the same rings for the same input', () => {

--- a/desktop/windows/src/renderer/src/lib/atlas/islands.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/islands.ts
@@ -167,9 +167,14 @@ export function traceRings(mask: number[]): Ring[] {
 
       // Each crossing point is created ONLY for an edge the contour actually
       // crosses. Computing all four up front divides by zero on an edge whose
-      // ends are on the same side of the level, and the resulting NaN is then
-      // reachable by the neighbouring cell that shares that edge id - which
-      // silently puts a coastline nowhere near the entities it belongs to.
+      // ends sit on the same side of the level.
+      //
+      // That NaN turns out to be unreachable rather than dangerous: the two
+      // cells sharing an edge read the same two corner values for it, so they
+      // always agree on whether the contour crosses it, and a case never
+      // references an edge its own corners say is uncrossed. Kept lazy anyway,
+      // because a map holding NaN that nothing happens to read is one refactor
+      // away from being a map holding NaN that something does.
       const bottom = (): number => {
         const id = horizontalEdge(r, c)
         if (!points.has(id)) points.set(id, { x: c + cross(bl, br), y: r })

--- a/desktop/windows/src/renderer/src/lib/atlas/islands.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/islands.ts
@@ -1,0 +1,361 @@
+// Turning a set of positioned entities into coastlines.
+//
+// Ported from macOS `MemoryAtlasIslands.swift`. Each community's members are
+// splatted as Gaussian bumps into a shared 128x128 scalar field; a cell belongs
+// to whichever community peaks highest there, provided the peak is decisive; the
+// resulting mask is blurred and traced with marching squares into closed rings.
+//
+// That indirection is the whole point. A convex hull round a community's members
+// would swallow every other community standing between them; a field lets two
+// interleaved communities own nothing in the contested middle, which is the
+// honest answer.
+//
+// Three constants carry most of the behaviour:
+//
+//   seaLevel 1.1        A single entity's bump peaks at exactly 1.0, so a lone
+//                       entity can never mint a territory. Above 1 is deliberate.
+//   decisiveMargin 1.25 A cell only belongs to the leader if it beats the runner
+//                       up by a quarter, so contested ground stays water.
+//   reach               NOT an absolute distance: the median nearest-neighbour
+//                       distance of the whole map times 2.5. "Spread out" is
+//                       relative to how spread out everything else is.
+
+/** A point in normalised atlas space, roughly 0..1 on both axes. */
+export interface AtlasPoint {
+  x: number
+  y: number
+}
+
+/** A closed ring of points in normalised atlas space. */
+export type Ring = AtlasPoint[]
+
+export const FIELD_RESOLUTION = 128
+export const FIELD_MARGIN = 0.08
+/** A lone entity peaks at exactly 1.0, so this being above 1 is what stops one
+ *  entity from minting a territory of its own. */
+export const SEA_LEVEL = 1.1
+/** The leader must beat the runner up by this factor to own a cell. */
+export const DECISIVE_MARGIN = 1.25
+/** Rings smaller than this share of the field are dropped. */
+export const SMALLEST_ISLAND = 0.0008
+/** Reach is clamped into this band however tightly or loosely packed the map is. */
+export const MIN_REACH = 0.006
+export const MAX_REACH = 0.2
+/** Nearest-neighbour samples taken when measuring the map's typical spacing. */
+export const REACH_SAMPLES = 300
+
+const CELLS = FIELD_RESOLUTION * FIELD_RESOLUTION
+const SCALE = (FIELD_RESOLUTION - 1) / (1 + 2 * FIELD_MARGIN)
+
+const column = (x: number): number => Math.round((x + FIELD_MARGIN) * SCALE)
+const row = (y: number): number => Math.round((y + FIELD_MARGIN) * SCALE)
+const unscale = (grid: number): number => grid / SCALE - FIELD_MARGIN
+
+/**
+ * The map's own sense of "close": the median distance from a point to its
+ * nearest other point, times 2.5, clamped.
+ *
+ * Relative rather than absolute because a map of eight entities and a map of
+ * eight hundred are laid out in the same unit square. An absolute radius would
+ * make the first all sea and the second all land.
+ */
+export function influenceReach(pointsByGroup: Map<number, AtlasPoint[]>): number {
+  const points: AtlasPoint[] = []
+  for (const group of [...pointsByGroup.keys()].sort((a, b) => a - b)) {
+    points.push(...(pointsByGroup.get(group) ?? []))
+  }
+  if (points.length <= 1) return MAX_REACH
+
+  const stride = Math.max(1, Math.floor(points.length / REACH_SAMPLES))
+  const gaps: number[] = []
+  for (let i = 0; i < points.length; i += stride) {
+    let nearest = Number.POSITIVE_INFINITY
+    for (const other of points) {
+      // Value inequality, not identity: exact duplicates are skipped, so two
+      // entities at the same coordinate do not report a spacing of zero and
+      // collapse the reach for the whole map.
+      if (other.x === points[i].x && other.y === points[i].y) continue
+      const dx = other.x - points[i].x
+      const dy = other.y - points[i].y
+      const distance = Math.sqrt(dx * dx + dy * dy)
+      if (distance < nearest) nearest = distance
+    }
+    if (Number.isFinite(nearest)) gaps.push(nearest)
+  }
+  if (gaps.length === 0) return MAX_REACH
+  gaps.sort((a, b) => a - b)
+  const typical = gaps[Math.floor(gaps.length / 2)] * 2.5
+  return Math.min(Math.max(typical, MIN_REACH), MAX_REACH)
+}
+
+interface Stencil {
+  radius: number
+  span: number
+  values: number[]
+}
+
+/** The Gaussian bump one entity contributes, precomputed once. Its centre value
+ *  is exactly 1, which is what SEA_LEVEL is calibrated against. */
+export function makeStencil(reach: number): Stencil {
+  const radius = Math.max(1, Math.round(3 * reach * SCALE))
+  const span = 2 * radius + 1
+  const values = new Array<number>(span * span).fill(0)
+  for (let r = 0; r < span; r += 1) {
+    for (let c = 0; c < span; c += 1) {
+      const dx = (c - radius) / SCALE
+      const dy = (r - radius) / SCALE
+      values[r * span + c] = Math.exp(-(dx * dx + dy * dy) / (2 * reach * reach))
+    }
+  }
+  return { radius, span, values }
+}
+
+/** Separable [1,2,1]/4 blur. Out-of-bounds neighbours count as zero, so the
+ *  field falls off at the edge rather than wrapping. */
+export function blur(mask: number[]): number[] {
+  const pass = new Array<number>(CELLS).fill(0)
+  const out = new Array<number>(CELLS).fill(0)
+  for (let r = 0; r < FIELD_RESOLUTION; r += 1) {
+    for (let c = 0; c < FIELD_RESOLUTION; c += 1) {
+      const left = c > 0 ? mask[r * FIELD_RESOLUTION + c - 1] : 0
+      const right = c < FIELD_RESOLUTION - 1 ? mask[r * FIELD_RESOLUTION + c + 1] : 0
+      pass[r * FIELD_RESOLUTION + c] = (left + 2 * mask[r * FIELD_RESOLUTION + c] + right) / 4
+    }
+  }
+  for (let r = 0; r < FIELD_RESOLUTION; r += 1) {
+    for (let c = 0; c < FIELD_RESOLUTION; c += 1) {
+      const below = r > 0 ? pass[(r - 1) * FIELD_RESOLUTION + c] : 0
+      const above = r < FIELD_RESOLUTION - 1 ? pass[(r + 1) * FIELD_RESOLUTION + c] : 0
+      out[r * FIELD_RESOLUTION + c] = (below + 2 * pass[r * FIELD_RESOLUTION + c] + above) / 4
+    }
+  }
+  return out
+}
+
+const horizontalEdge = (r: number, c: number): number => r * FIELD_RESOLUTION + c
+const verticalEdge = (r: number, c: number): number => CELLS + r * FIELD_RESOLUTION + c
+
+/**
+ * Marching squares at 0.5.
+ *
+ * Edge identity is an INTEGER, not a coordinate. Stitching segments by integer
+ * equality is what closes a ring exactly; comparing interpolated coordinates
+ * leaves hairline gaps wherever two cells disagree in the last bit.
+ */
+export function traceRings(mask: number[]): Ring[] {
+  const points = new Map<number, AtlasPoint>()
+  const links = new Map<number, number[]>()
+  const connect = (p: number, q: number): void => {
+    const a = links.get(p)
+    if (a === undefined) links.set(p, [q])
+    else a.push(q)
+    const b = links.get(q)
+    if (b === undefined) links.set(q, [p])
+    else b.push(p)
+  }
+  const cross = (a: number, b: number): number => (0.5 - a) / (b - a)
+
+  for (let r = 0; r < FIELD_RESOLUTION - 1; r += 1) {
+    for (let c = 0; c < FIELD_RESOLUTION - 1; c += 1) {
+      const bl = mask[r * FIELD_RESOLUTION + c]
+      const br = mask[r * FIELD_RESOLUTION + c + 1]
+      const tr = mask[(r + 1) * FIELD_RESOLUTION + c + 1]
+      const tl = mask[(r + 1) * FIELD_RESOLUTION + c]
+      const code =
+        (bl >= 0.5 ? 1 : 0) | (br >= 0.5 ? 2 : 0) | (tr >= 0.5 ? 4 : 0) | (tl >= 0.5 ? 8 : 0)
+      if (code === 0 || code === 15) continue
+
+      const bottom = horizontalEdge(r, c)
+      const top = horizontalEdge(r + 1, c)
+      const left = verticalEdge(r, c)
+      const right = verticalEdge(r, c + 1)
+      if (!points.has(bottom)) points.set(bottom, { x: c + cross(bl, br), y: r })
+      if (!points.has(top)) points.set(top, { x: c + cross(tl, tr), y: r + 1 })
+      if (!points.has(left)) points.set(left, { x: c, y: r + cross(bl, tl) })
+      if (!points.has(right)) points.set(right, { x: c + 1, y: r + cross(br, tr) })
+
+      switch (code) {
+        case 1:
+        case 14:
+          connect(left, bottom)
+          break
+        case 2:
+        case 13:
+          connect(bottom, right)
+          break
+        case 3:
+        case 12:
+          connect(left, right)
+          break
+        case 4:
+        case 11:
+          connect(right, top)
+          break
+        case 6:
+        case 9:
+          connect(bottom, top)
+          break
+        case 7:
+        case 8:
+          connect(left, top)
+          break
+        case 5:
+          // Ambiguous: the cell's average decides which way the two strands run,
+          // so neighbouring saddles agree and the rings stay closed.
+          if ((bl + br + tr + tl) / 4 >= 0.5) {
+            connect(left, top)
+            connect(bottom, right)
+          } else {
+            connect(left, bottom)
+            connect(right, top)
+          }
+          break
+        case 10:
+          if ((bl + br + tr + tl) / 4 >= 0.5) {
+            connect(left, bottom)
+            connect(right, top)
+          } else {
+            connect(left, top)
+            connect(bottom, right)
+          }
+          break
+        default:
+          break
+      }
+    }
+  }
+
+  const visited = new Set<number>()
+  const rings: Ring[] = []
+  for (const start of [...links.keys()].sort((a, b) => a - b)) {
+    if (visited.has(start)) continue
+    const ring: Ring = []
+    let current: number | undefined = start
+    let previous: number | undefined
+    while (current !== undefined && !visited.has(current)) {
+      visited.add(current)
+      const point = points.get(current)
+      if (point !== undefined) ring.push(point)
+      const next: number | undefined = (links.get(current) ?? []).find(
+        (candidate) => candidate !== previous && !visited.has(candidate)
+      )
+      previous = current
+      current = next
+    }
+    // Fewer than four points is a sliver, not a region.
+    if (ring.length >= 4) rings.push(ring)
+  }
+  return rings
+}
+
+/** Shoelace area over grid coordinates. Sign carries winding, so callers take
+ *  the absolute value. */
+export function ringArea(ring: Ring): number {
+  if (ring.length < 3) return 0
+  let total = 0
+  for (let i = 0; i < ring.length; i += 1) {
+    const a = ring[i]
+    const b = ring[(i + 1) % ring.length]
+    total += a.x * b.y - b.x * a.y
+  }
+  return total / 2
+}
+
+/**
+ * Coastlines per community.
+ *
+ * EVERY competing community must be passed in, including ones the map will never
+ * name. Omitting one hands its land to whichever named community is nearest,
+ * which draws a territory over entities that do not belong to it.
+ *
+ * A community with no surviving ring gets no entry at all; the caller drops it.
+ */
+export function coastlines(pointsByGroup: Map<number, AtlasPoint[]>): Map<number, Ring[]> {
+  const groups = [...pointsByGroup.keys()].sort((a, b) => a - b)
+  const reach = influenceReach(pointsByGroup)
+  const stencil = makeStencil(reach)
+
+  const best = new Array<number>(CELLS).fill(0)
+  const runnerUp = new Array<number>(CELLS).fill(0)
+  const owner = new Array<number>(CELLS).fill(-1)
+  const field = new Array<number>(CELLS).fill(0)
+
+  for (const group of groups) {
+    const members = pointsByGroup.get(group)
+    if (members === undefined || members.length === 0) continue
+    const touched: number[] = []
+    for (const member of members) {
+      const centreCol = column(member.x)
+      const centreRow = row(member.y)
+      for (let r = 0; r < stencil.span; r += 1) {
+        const gridRow = centreRow - stencil.radius + r
+        if (gridRow < 0 || gridRow >= FIELD_RESOLUTION) continue
+        for (let c = 0; c < stencil.span; c += 1) {
+          const gridCol = centreCol - stencil.radius + c
+          if (gridCol < 0 || gridCol >= FIELD_RESOLUTION) continue
+          const index = gridRow * FIELD_RESOLUTION + gridCol
+          if (field[index] === 0) touched.push(index)
+          field[index] += stencil.values[r * stencil.span + c]
+        }
+      }
+    }
+    for (const index of touched) {
+      const value = field[index]
+      // Strict `>` plus the sorted group walk means the LOWEST group id wins a
+      // tie. That rule cannot be observed in the output today: a cell where two
+      // communities peak at exactly the same value has best == runnerUp, so it
+      // fails the decisive margin below and becomes water whichever community is
+      // recorded as its owner. It is written this way so the ownership array is
+      // still well defined, and so relaxing the margin later cannot silently
+      // start awarding tied ground to whichever community happened to be
+      // processed last.
+      if (value > best[index]) {
+        runnerUp[index] = best[index]
+        best[index] = value
+        owner[index] = group
+      } else if (value > runnerUp[index]) {
+        runnerUp[index] = value
+      }
+      field[index] = 0
+    }
+  }
+
+  const floor = SMALLEST_ISLAND * CELLS
+  const result = new Map<number, Ring[]>()
+  for (const group of groups) {
+    const members = pointsByGroup.get(group)
+    if (members === undefined || members.length === 0) continue
+    const mask = new Array<number>(CELLS).fill(0)
+    for (let i = 0; i < CELLS; i += 1) {
+      mask[i] =
+        owner[i] === group && best[i] >= SEA_LEVEL && best[i] >= runnerUp[i] * DECISIVE_MARGIN
+          ? 1
+          : 0
+    }
+    const rings = traceRings(blur(mask))
+      .filter((ring) => Math.abs(ringArea(ring)) >= floor)
+      .map((ring) => ring.map((p) => ({ x: unscale(p.x), y: unscale(p.y) })))
+    if (rings.length > 0) result.set(group, rings)
+  }
+  return result
+}
+
+/**
+ * Even-odd ray cast across ALL rings of a territory, so a ring enclosed by
+ * another reads as a hole rather than as more land.
+ */
+export function coastlineContains(rings: Ring[], point: AtlasPoint): boolean {
+  let inside = false
+  for (const ring of rings) {
+    if (ring.length < 3) continue
+    for (let i = 0; i < ring.length; i += 1) {
+      const current = ring[i]
+      const previous = ring[(i + ring.length - 1) % ring.length]
+      if (current.y > point.y !== previous.y > point.y) {
+        const t = (point.y - current.y) / (previous.y - current.y)
+        if (point.x < current.x + t * (previous.x - current.x)) inside = !inside
+      }
+    }
+  }
+  return inside
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/islands.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/islands.ts
@@ -165,58 +165,75 @@ export function traceRings(mask: number[]): Ring[] {
         (bl >= 0.5 ? 1 : 0) | (br >= 0.5 ? 2 : 0) | (tr >= 0.5 ? 4 : 0) | (tl >= 0.5 ? 8 : 0)
       if (code === 0 || code === 15) continue
 
-      const bottom = horizontalEdge(r, c)
-      const top = horizontalEdge(r + 1, c)
-      const left = verticalEdge(r, c)
-      const right = verticalEdge(r, c + 1)
-      if (!points.has(bottom)) points.set(bottom, { x: c + cross(bl, br), y: r })
-      if (!points.has(top)) points.set(top, { x: c + cross(tl, tr), y: r + 1 })
-      if (!points.has(left)) points.set(left, { x: c, y: r + cross(bl, tl) })
-      if (!points.has(right)) points.set(right, { x: c + 1, y: r + cross(br, tr) })
+      // Each crossing point is created ONLY for an edge the contour actually
+      // crosses. Computing all four up front divides by zero on an edge whose
+      // ends are on the same side of the level, and the resulting NaN is then
+      // reachable by the neighbouring cell that shares that edge id - which
+      // silently puts a coastline nowhere near the entities it belongs to.
+      const bottom = (): number => {
+        const id = horizontalEdge(r, c)
+        if (!points.has(id)) points.set(id, { x: c + cross(bl, br), y: r })
+        return id
+      }
+      const top = (): number => {
+        const id = horizontalEdge(r + 1, c)
+        if (!points.has(id)) points.set(id, { x: c + cross(tl, tr), y: r + 1 })
+        return id
+      }
+      const left = (): number => {
+        const id = verticalEdge(r, c)
+        if (!points.has(id)) points.set(id, { x: c, y: r + cross(bl, tl) })
+        return id
+      }
+      const right = (): number => {
+        const id = verticalEdge(r, c + 1)
+        if (!points.has(id)) points.set(id, { x: c + 1, y: r + cross(br, tr) })
+        return id
+      }
 
       switch (code) {
         case 1:
         case 14:
-          connect(left, bottom)
+          connect(left(), bottom())
           break
         case 2:
         case 13:
-          connect(bottom, right)
+          connect(bottom(), right())
           break
         case 3:
         case 12:
-          connect(left, right)
+          connect(left(), right())
           break
         case 4:
         case 11:
-          connect(right, top)
+          connect(right(), top())
           break
         case 6:
         case 9:
-          connect(bottom, top)
+          connect(bottom(), top())
           break
         case 7:
         case 8:
-          connect(left, top)
+          connect(left(), top())
           break
         case 5:
           // Ambiguous: the cell's average decides which way the two strands run,
           // so neighbouring saddles agree and the rings stay closed.
           if ((bl + br + tr + tl) / 4 >= 0.5) {
-            connect(left, top)
-            connect(bottom, right)
+            connect(left(), top())
+            connect(bottom(), right())
           } else {
-            connect(left, bottom)
-            connect(right, top)
+            connect(left(), bottom())
+            connect(right(), top())
           }
           break
         case 10:
           if ((bl + br + tr + tl) / 4 >= 0.5) {
-            connect(left, bottom)
-            connect(right, top)
+            connect(left(), bottom())
+            connect(right(), top())
           } else {
-            connect(left, top)
-            connect(bottom, right)
+            connect(left(), top())
+            connect(bottom(), right())
           }
           break
         default:

--- a/desktop/windows/src/renderer/src/lib/atlas/relatedness.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/relatedness.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ANCHOR_TETHER,
+  MAX_MEMORY_PARTICIPANTS,
+  NEIGHBOUR_LIMIT,
+  atlasLinks,
+  coOccurrenceLinks,
+  explicitLinks,
+  linkKey,
+  makeLink,
+  mergeLinks,
+  neighboursOf,
+  strongestPerNode
+} from './relatedness'
+import type { KGNode, KnowledgeGraph } from '../../../../shared/types'
+
+const node = (id: string, memoryIds: string[] = []): KGNode => ({
+  id,
+  label: id,
+  nodeType: 'topic',
+  aliases: [],
+  memoryIds
+})
+
+const graph = (nodes: KGNode[], edges: Array<[string, string, string[]]>): KnowledgeGraph => ({
+  nodes,
+  edges: edges.map(([sourceId, targetId, memoryIds], i) => ({
+    id: `e${i}`,
+    sourceId,
+    targetId,
+    label: '',
+    memoryIds
+  }))
+})
+
+describe('linkKey', () => {
+  it('is the same whichever end the pair is seen from', () => {
+    expect(linkKey('a', 'b')).toBe(linkKey('b', 'a'))
+  })
+
+  it('cannot be forged by an id containing the separator', () => {
+    // The separator is U+0001, which an entity id cannot contain, so "ab" + "c"
+    // can never collide with "a" + "bc".
+    expect(linkKey('ab', 'c')).not.toBe(linkKey('a', 'bc'))
+  })
+
+  it('orders endpoints canonically', () => {
+    expect(makeLink('z', 'a', 1)).toEqual({ a: 'a', b: 'z', weight: 1 })
+  })
+})
+
+describe('mergeLinks', () => {
+  it('sums duplicates and drops self-links', () => {
+    const merged = mergeLinks([makeLink('a', 'b', 1), makeLink('b', 'a', 2), makeLink('c', 'c', 9)])
+    expect(merged).toEqual([{ a: 'a', b: 'b', weight: 3 }])
+  })
+
+  it('preserves first-seen order', () => {
+    // The weights are floating point, so a different addition order gives a
+    // different last bit and the layout stops being reproducible.
+    const merged = mergeLinks([makeLink('m', 'n', 1), makeLink('a', 'b', 1)])
+    expect(merged.map((l) => l.a)).toEqual(['m', 'a'])
+  })
+})
+
+describe('explicitLinks', () => {
+  it('weights a link by its memories, but logarithmically', () => {
+    const [one] = explicitLinks(graph([node('a'), node('b')], [['a', 'b', ['m1']]]))
+    const [many] = explicitLinks(
+      graph([node('a'), node('b')], [['a', 'b', ['m1', 'm2', 'm3', 'm4', 'm5']]])
+    )
+    // The fifth memory about a pair says much less than the second.
+    expect(many.weight).toBeGreaterThan(one.weight)
+    expect(many.weight).toBeLessThan(one.weight * 3)
+    expect(one.weight).toBeCloseTo(1 + Math.log1p(1), 12)
+  })
+
+  it('drops a self-edge', () => {
+    expect(explicitLinks(graph([node('a')], [['a', 'a', ['m1']]]))).toEqual([])
+  })
+
+  it('merges parallel edges between the same pair', () => {
+    const links = explicitLinks(
+      graph(
+        [node('a'), node('b')],
+        [
+          ['a', 'b', []],
+          ['b', 'a', []]
+        ]
+      )
+    )
+    expect(links.length).toBe(1)
+    expect(links[0].weight).toBe(2)
+  })
+})
+
+describe('coOccurrenceLinks', () => {
+  it('relates two entities that share a memory', () => {
+    const links = coOccurrenceLinks([node('a', ['m1']), node('b', ['m1'])], null)
+    expect(links.map((l) => [l.a, l.b])).toEqual([['a', 'b']])
+    expect(links[0].weight).toBeGreaterThan(0)
+  })
+
+  it('ignores a memory nobody shares', () => {
+    expect(coOccurrenceLinks([node('a', ['m1']), node('b', ['m2'])], null)).toEqual([])
+  })
+
+  it('skips a memory shared by a crowd', () => {
+    // A memory naming everyone relates everything to everything, which carries
+    // the same information as relating nothing.
+    const many = Array.from({ length: MAX_MEMORY_PARTICIPANTS + 1 }, (_v, i) =>
+      node(`n${i}`, ['crowd'])
+    )
+    expect(coOccurrenceLinks(many, null)).toEqual([])
+  })
+
+  it('weights a rare entity above a ubiquitous one', () => {
+    // `hub` appears in every memory, so co-occurring with it says little; `rare`
+    // appears once, so co-occurring with it says a lot.
+    const nodes = [
+      node('hub', ['m1', 'm2', 'm3']),
+      node('rare', ['m1']),
+      node('common', ['m1', 'm2', 'm3'])
+    ]
+    const links = coOccurrenceLinks(nodes, null)
+    const weightOf = (a: string, b: string): number =>
+      links.find((l) => linkKey(l.a, l.b) === linkKey(a, b))?.weight ?? 0
+    expect(weightOf('hub', 'rare')).toBeGreaterThan(0)
+    expect(weightOf('hub', 'rare')).toBeGreaterThan(weightOf('hub', 'common') / 3)
+  })
+
+  it('excludes the anchor so the account holder does not co-occur with everything', () => {
+    const links = coOccurrenceLinks(
+      [node('me', ['m1']), node('a', ['m1']), node('b', ['m1'])],
+      'me'
+    )
+    expect(links.some((l) => l.a === 'me' || l.b === 'me')).toBe(false)
+    expect(links.length).toBe(1)
+  })
+})
+
+describe('strongestPerNode', () => {
+  it('keeps a link that matters to either endpoint', () => {
+    // The hub ranks this link last, but it is the leaf's only link; dropping it
+    // would strand the leaf.
+    const hubLinks = Array.from({ length: NEIGHBOUR_LIMIT }, (_v, i) =>
+      makeLink('hub', `strong${i}`, 10)
+    )
+    const kept = strongestPerNode([...hubLinks, makeLink('hub', 'leaf', 0.001)], NEIGHBOUR_LIMIT)
+    expect(kept.some((l) => l.a === 'leaf' || l.b === 'leaf')).toBe(true)
+  })
+
+  it('breaks weight ties on the key so the result does not depend on input order', () => {
+    const links = [makeLink('n', 'z', 1), makeLink('n', 'a', 1)]
+    const forward = strongestPerNode(links, 1).map((l) => linkKey(l.a, l.b))
+    const reversed = strongestPerNode([...links].reverse(), 1).map((l) => linkKey(l.a, l.b))
+    expect(new Set(reversed)).toEqual(new Set(forward))
+  })
+})
+
+describe('atlasLinks', () => {
+  it('weakens the anchor so it does not pull the map into one blob', () => {
+    const g = graph([node('me'), node('a')], [['me', 'a', ['m1']]])
+    const untethered = atlasLinks(g, null)[0].weight
+    const tethered = atlasLinks(g, 'me')[0].weight
+    expect(tethered).toBeCloseTo(untethered * ANCHOR_TETHER, 12)
+  })
+
+  it('combines both signals for the same pair', () => {
+    const g = graph([node('a', ['m1']), node('b', ['m1'])], [['a', 'b', ['m1']]])
+    const [link] = atlasLinks(g, null)
+    // The pair is both stated by an edge and observed in a shared memory.
+    expect(link.weight).toBeGreaterThan(1 + Math.log1p(1))
+  })
+})
+
+describe('neighboursOf', () => {
+  it('lists both directions, strongest first', () => {
+    const map = neighboursOf([makeLink('a', 'b', 1), makeLink('a', 'c', 5)])
+    expect(map.get('a')?.map((n) => n.id)).toEqual(['c', 'b'])
+    expect(map.get('b')?.map((n) => n.id)).toEqual(['a'])
+  })
+
+  it('breaks a weight tie on id so the order is not input order', () => {
+    const map = neighboursOf([makeLink('a', 'z', 1), makeLink('a', 'b', 1)])
+    expect(map.get('a')?.map((n) => n.id)).toEqual(['b', 'z'])
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/atlas/relatedness.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/relatedness.ts
@@ -1,0 +1,197 @@
+// How strongly two entities in the knowledge graph are related.
+//
+// Ported from macOS `MemoryAtlasForceLayout.swift`. Two signals are combined:
+// the edges the graph states outright, and the memories two entities keep
+// turning up in together.
+//
+// THE DETERMINISM RULE, which governs this whole package: every traversal that
+// can affect an output walks a SORTED array. macOS needs that because Swift
+// seeds string hashing per process, so dictionary order is not stable across
+// launches; JS object and Map iteration order is insertion-ordered and therefore
+// stable, but the sorts are kept anyway. They are what make the output a
+// function of the graph rather than of the order the graph happened to arrive
+// in, and the graph arrives from two merged sources (an onboarding floor plus a
+// server fetch) whose interleaving is not fixed.
+
+import type { KnowledgeGraph, KGNode } from '../../../../shared/types'
+
+/** Canonical undirected link. Endpoints are ordered so `a <= b`, which is what
+ *  makes the key stable regardless of which end an edge was seen from. */
+export interface AtlasLink {
+  a: string
+  b: string
+  weight: number
+}
+
+/** U+0001, constructed rather than written literally: it cannot occur in an id,
+ *  so the key is unambiguous, and building it means no editor, formatter or copy
+ *  through a terminal can silently eat the control character. */
+const SEP = String.fromCharCode(1)
+
+/** Canonical key for an undirected pair. */
+export function linkKey(a: string, b: string): string {
+  return a <= b ? `${a}${SEP}${b}` : `${b}${SEP}${a}`
+}
+
+export function makeLink(x: string, y: string, weight: number): AtlasLink {
+  return x <= y ? { a: x, b: y, weight } : { a: y, b: x, weight }
+}
+
+/** Strongest links kept per node. */
+export const NEIGHBOUR_LIMIT = 6
+/** A memory shared by more than this many entities says nothing about any pair
+ *  of them, so it is skipped entirely rather than diluted. */
+export const MAX_MEMORY_PARTICIPANTS = 20
+/** Links touching the anchor are weakened so the account holder does not pull
+ *  the whole map into one blob. */
+export const ANCHOR_TETHER = 0.1
+
+/**
+ * Sums duplicate links, drops self-links, and preserves first-seen key order.
+ * Order preservation matters: the sum is floating point, so a different
+ * addition order gives a different last bit, and the layout that consumes these
+ * is asserted to be bit-identical run to run.
+ */
+export function mergeLinks(links: AtlasLink[]): AtlasLink[] {
+  const byKey = new Map<string, AtlasLink>()
+  for (const link of links) {
+    if (link.a === link.b) continue
+    const key = linkKey(link.a, link.b)
+    const existing = byKey.get(key)
+    if (existing === undefined) byKey.set(key, { ...link })
+    else existing.weight += link.weight
+  }
+  return [...byKey.values()]
+}
+
+/** Explicit graph edges. A link's weight grows with the memories behind it, but
+ *  logarithmically: the tenth memory about a pair says much less than the second. */
+export function explicitLinks(graph: KnowledgeGraph): AtlasLink[] {
+  const links: AtlasLink[] = []
+  for (const edge of graph.edges) {
+    if (edge.sourceId === edge.targetId) continue
+    const memoryCount = Math.max(edge.memoryIds?.length ?? 0, 0)
+    links.push(makeLink(edge.sourceId, edge.targetId, 1 + Math.log1p(memoryCount)))
+  }
+  return mergeLinks(links)
+}
+
+/**
+ * Links inferred from entities appearing in the same memory.
+ *
+ * Each memory divides one unit of relatedness among its participants, and each
+ * participant is weighted by how rare it is across all memories (inverse
+ * document frequency), so two entities that only ever co-occur inside one very
+ * common entity's memories are not treated as related to each other.
+ */
+export function coOccurrenceLinks(nodes: KGNode[], anchorId: string | null): AtlasLink[] {
+  const memoryIdsByNode = new Map<string, string[]>()
+  for (const node of nodes) {
+    if (node.id === anchorId) continue
+    memoryIdsByNode.set(node.id, node.memoryIds ?? [])
+  }
+
+  const nodeIdsByMemory = new Map<string, string[]>()
+  for (const nodeId of [...memoryIdsByNode.keys()].sort()) {
+    for (const memoryId of memoryIdsByNode.get(nodeId) ?? []) {
+      const existing = nodeIdsByMemory.get(memoryId)
+      if (existing === undefined) nodeIdsByMemory.set(memoryId, [nodeId])
+      else existing.push(nodeId)
+    }
+  }
+
+  const totalMemories = Math.max(nodeIdsByMemory.size, 1)
+  const evidence = new Map<string, number>()
+  for (const nodeId of [...memoryIdsByNode.keys()].sort()) {
+    const appearances = new Set(memoryIdsByNode.get(nodeId) ?? []).size
+    if (appearances === 0) continue
+    evidence.set(nodeId, Math.log(1 + totalMemories / appearances))
+  }
+
+  const weights = new Map<string, AtlasLink>()
+  for (const memoryId of [...nodeIdsByMemory.keys()].sort()) {
+    const participants = [...new Set(nodeIdsByMemory.get(memoryId) ?? [])].sort()
+    // A memory about one entity relates nothing; a memory about a crowd relates
+    // everything to everything, which is the same as relating nothing.
+    if (participants.length < 2 || participants.length > MAX_MEMORY_PARTICIPANTS) continue
+    const share = 1 / (participants.length - 1)
+    for (let i = 0; i < participants.length; i += 1) {
+      for (let j = i + 1; j < participants.length; j += 1) {
+        const specific =
+          share * (evidence.get(participants[i]) ?? 1) * (evidence.get(participants[j]) ?? 1)
+        const key = linkKey(participants[i], participants[j])
+        const existing = weights.get(key)
+        if (existing === undefined) {
+          weights.set(key, makeLink(participants[i], participants[j], specific))
+        } else {
+          existing.weight += specific
+        }
+      }
+    }
+  }
+  return strongestPerNode([...weights.values()], NEIGHBOUR_LIMIT)
+}
+
+/**
+ * Keeps a link when EITHER endpoint ranks it among its strongest. A link that
+ * matters to a leaf but not to the hub it hangs off survives, which is what
+ * stops sparsification from stranding small entities.
+ */
+export function strongestPerNode(links: AtlasLink[], limit: number): AtlasLink[] {
+  const byNode = new Map<string, AtlasLink[]>()
+  const add = (id: string, link: AtlasLink): void => {
+    const existing = byNode.get(id)
+    if (existing === undefined) byNode.set(id, [link])
+    else existing.push(link)
+  }
+  for (const link of links) {
+    add(link.a, link)
+    add(link.b, link)
+  }
+
+  const kept = new Set<string>()
+  for (const nodeId of [...byNode.keys()].sort()) {
+    const ranked = [...(byNode.get(nodeId) ?? [])].sort((x, y) => {
+      if (y.weight !== x.weight) return y.weight - x.weight
+      const kx = linkKey(x.a, x.b)
+      const ky = linkKey(y.a, y.b)
+      return kx < ky ? -1 : kx > ky ? 1 : 0
+    })
+    for (const link of ranked.slice(0, limit)) kept.add(linkKey(link.a, link.b))
+  }
+  return links.filter((link) => kept.has(linkKey(link.a, link.b)))
+}
+
+/** Both signals, merged, with the anchor's own links weakened. */
+export function atlasLinks(graph: KnowledgeGraph, anchorId: string | null): AtlasLink[] {
+  const merged = mergeLinks([...explicitLinks(graph), ...coOccurrenceLinks(graph.nodes, anchorId)])
+  if (anchorId === null) return merged
+  return merged.map((link) =>
+    link.a === anchorId || link.b === anchorId
+      ? { ...link, weight: link.weight * ANCHOR_TETHER }
+      : link
+  )
+}
+
+/** Weighted adjacency, each neighbour list sorted by weight desc then id asc. */
+export function neighboursOf(
+  links: AtlasLink[]
+): Map<string, Array<{ id: string; weight: number }>> {
+  const out = new Map<string, Array<{ id: string; weight: number }>>()
+  const add = (from: string, to: string, weight: number): void => {
+    const existing = out.get(from)
+    if (existing === undefined) out.set(from, [{ id: to, weight }])
+    else existing.push({ id: to, weight })
+  }
+  for (const link of links) {
+    add(link.a, link.b, link.weight)
+    add(link.b, link.a, link.weight)
+  }
+  for (const list of out.values()) {
+    list.sort((x, y) => {
+      if (y.weight !== x.weight) return y.weight - x.weight
+      return x.id < y.id ? -1 : x.id > y.id ? 1 : 0
+    })
+  }
+  return out
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/territories.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/territories.test.ts
@@ -180,7 +180,7 @@ describe('buildTerritories', () => {
     const built = buildTerritories({
       membersByGroup: new Map([[0, members('work', 3, 0.3, 0.3)]]),
       ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
-      allPositions: []
+      allPositions: members('work', 3, 0.3, 0.3).map((m) => m.position)
     })
     expect(built).toEqual([])
   })
@@ -192,7 +192,7 @@ describe('buildTerritories', () => {
     const built = buildTerritories({
       membersByGroup: new Map([[0, unnamed]]),
       ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
-      allPositions: []
+      allPositions: unnamed.map((m) => m.position)
     })
     expect(built).toEqual([])
   })
@@ -207,7 +207,10 @@ describe('buildTerritories', () => {
         [0, [square(0.1, 0.1, 0.2)]],
         [1, [square(0.7, 0.7, 0.2)]]
       ]),
-      allPositions: []
+      allPositions: [
+        ...members('small', 6, 0.2, 0.2).map((m) => m.position),
+        ...members('big', 12, 0.8, 0.8).map((m) => m.position)
+      ]
     })
     expect(built.map((t) => t.caption)).toEqual(['big hub', 'small hub'])
   })
@@ -220,7 +223,7 @@ describe('territoryAt', () => {
         [0, Array.from({ length: 8 }, (_v, i) => member(`n${i}`, 'Acme', 1, 0.3, 0.3))]
       ]),
       ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
-      allPositions: []
+      allPositions: Array.from({ length: 8 }, () => ({ x: 0.3, y: 0.3 }))
     })
     expect(territoryAt(territories, { x: 0.3, y: 0.3 })?.caption).toBe('Acme')
     expect(territoryAt(territories, { x: 0.9, y: 0.9 })).toBeNull()

--- a/desktop/windows/src/renderer/src/lib/atlas/territories.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/territories.test.ts
@@ -176,6 +176,32 @@ describe('buildTerritories', () => {
     expect(built).toEqual([])
   })
 
+  it('drops a region drawn over ground none of its members stand on', () => {
+    // The coastline can form on a ridge BETWEEN a community's members, leaving
+    // them all outside it. A region nothing of its own stands in is worse than
+    // no region.
+    const work = members('work', 8, 0.3, 0.3)
+    const built = buildTerritories({
+      membersByGroup: new Map([[0, work]]),
+      // Land nowhere near the members.
+      ringsByGroup: new Map([[0, [square(0.8, 0.8, 0.15)]]]),
+      allPositions: work.map((m) => m.position)
+    })
+    expect(built).toEqual([])
+  })
+
+  it('drops a community whose coastline came back empty', () => {
+    const work = members('work', 8, 0.3, 0.3)
+    const built = buildTerritories({
+      membersByGroup: new Map([[0, work]]),
+      // An empty array, not a missing key: the difference matters because
+      // coastlines() can return either.
+      ringsByGroup: new Map([[0, []]]),
+      allPositions: work.map((m) => m.position)
+    })
+    expect(built).toEqual([])
+  })
+
   it('drops a community too small to be a region', () => {
     const built = buildTerritories({
       membersByGroup: new Map([[0, members('work', 3, 0.3, 0.3)]]),

--- a/desktop/windows/src/renderer/src/lib/atlas/territories.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/territories.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CAPTION_CEILING,
+  TERRITORY_MIN_MEMBERS,
+  buildTerritories,
+  captionFor,
+  centerOf,
+  purityOf,
+  radiusOf,
+  rankMembers,
+  territoryAt,
+  territorySizeFloor,
+  type AtlasMember
+} from './territories'
+import type { AtlasPoint, Ring } from './islands'
+
+const member = (id: string, label: string, degree: number, x = 0.5, y = 0.5): AtlasMember => ({
+  id,
+  label,
+  degree,
+  position: { x, y }
+})
+
+const square = (x: number, y: number, size: number): Ring => [
+  { x, y },
+  { x: x + size, y },
+  { x: x + size, y: y + size },
+  { x, y: y + size }
+]
+
+describe('territorySizeFloor', () => {
+  it('never lets a pair of entities become a region', () => {
+    expect(territorySizeFloor(10)).toBe(TERRITORY_MIN_MEMBERS)
+    expect(territorySizeFloor(0)).toBe(TERRITORY_MIN_MEMBERS)
+  })
+
+  it('scales with the map so a big map does not fill with tiny regions', () => {
+    expect(territorySizeFloor(1000)).toBe(15)
+  })
+})
+
+describe('captionFor', () => {
+  it('prefers a short unwordy label', () => {
+    expect(captionFor(['A rather long-winded description of things', 'Acme'])).toBe('Acme')
+  })
+
+  it('takes the first ranked candidate, not the shortest', () => {
+    // Ranking is by connectedness; the best-connected entity is what the region
+    // is about, and picking the shortest name instead would label a region after
+    // an incidental member.
+    expect(captionFor(['Acme', 'Bob'])).toBe('Acme')
+  })
+
+  it('falls back to a short but wordy label when nothing tidier exists', () => {
+    expect(captionFor(['the third quarter plan'])).toBe('the third quarter plan')
+  })
+
+  it('truncates a label too long to be a name', () => {
+    const long = 'Something far too long to sit on a map as a place name'
+    const caption = captionFor([long]) as string
+    expect(caption.length).toBeLessThanOrEqual(CAPTION_CEILING)
+    expect(caption.endsWith('…')).toBe(true)
+    expect(caption.startsWith('Something far too long')).toBe(true)
+  })
+
+  it('does not leave a dangling space before the ellipsis', () => {
+    // "Quarterly planning" is 18 characters and the cut falls at 25, landing in
+    // the run of spaces after it; without the trim the caption would read
+    // "Quarterly planning       …".
+    expect(captionFor(['Quarterly planning       review of everything'])).toBe(
+      'Quarterly planning…'
+    )
+  })
+
+  it('keeps a truncation that lands mid-word rather than inventing a break', () => {
+    // Cutting back to the previous word boundary would sometimes lose the only
+    // distinguishing part of the label, so the cut is where it falls.
+    expect(captionFor(['Quarterly planning and review notes'])).toBe('Quarterly planning and re…')
+  })
+
+  it('returns null when there is nothing to call the place', () => {
+    expect(captionFor([])).toBeNull()
+    expect(captionFor(['', '   '])).toBeNull()
+  })
+})
+
+describe('rankMembers', () => {
+  it('ranks the best connected first', () => {
+    const ranked = rankMembers([member('a', 'Alpha', 1), member('b', 'Beta', 9)])
+    expect(ranked.map((m) => m.id)).toEqual(['b', 'a'])
+  })
+
+  it('breaks a degree tie on the label, case-insensitively', () => {
+    const ranked = rankMembers([member('a', 'zeta', 5), member('b', 'Alpha', 5)])
+    expect(ranked.map((m) => m.label)).toEqual(['Alpha', 'zeta'])
+  })
+
+  it('breaks a full tie on id so the name does not depend on input order', () => {
+    const forward = rankMembers([member('z', 'Same', 1), member('a', 'Same', 1)])
+    const reversed = rankMembers([member('a', 'Same', 1), member('z', 'Same', 1)])
+    expect(reversed.map((m) => m.id)).toEqual(forward.map((m) => m.id))
+    expect(forward.map((m) => m.id)).toEqual(['a', 'z'])
+  })
+})
+
+describe('centerOf and radiusOf', () => {
+  it('centres on the mean', () => {
+    expect(
+      centerOf([
+        { x: 0, y: 0 },
+        { x: 1, y: 1 }
+      ])
+    ).toEqual({ x: 0.5, y: 0.5 })
+  })
+
+  it('ignores one far-flung member when measuring reach', () => {
+    const tight: AtlasPoint[] = Array.from({ length: 10 }, (_v, i) => ({
+      x: 0.5 + i * 0.001,
+      y: 0.5
+    }))
+    const withOutlier = [...tight, { x: 0.99, y: 0.99 }]
+    // An 80th-percentile radius keeps the label over the body of the region
+    // rather than halfway to a stray member.
+    expect(radiusOf({ x: 0.5, y: 0.5 }, withOutlier)).toBeLessThan(0.1)
+  })
+
+  it('floors the radius so a tight cluster still has room for a label', () => {
+    expect(radiusOf({ x: 0.5, y: 0.5 }, [{ x: 0.5, y: 0.5 }])).toBe(0.01)
+  })
+})
+
+describe('purityOf', () => {
+  it('is one when only the community stands inside its own coastline', () => {
+    const rings = [square(0, 0, 1)]
+    const members = [{ x: 0.5, y: 0.5 }]
+    expect(purityOf(rings, members, [...members, { x: 5, y: 5 }])).toBe(1)
+  })
+
+  it('falls when the coastline swallows other entities', () => {
+    const rings = [square(0, 0, 1)]
+    const members = [{ x: 0.2, y: 0.2 }]
+    const everyone = [...members, { x: 0.8, y: 0.8 }]
+    expect(purityOf(rings, members, everyone)).toBe(0.5)
+  })
+
+  it('is zero when nothing is inside at all', () => {
+    expect(purityOf([square(0, 0, 1)], [], [{ x: 9, y: 9 }])).toBe(0)
+  })
+})
+
+describe('buildTerritories', () => {
+  const members = (group: string, count: number, x: number, y: number): AtlasMember[] =>
+    Array.from({ length: count }, (_v, i) =>
+      member(`${group}${i}`, i === 0 ? `${group} hub` : `${group}${i}`, i === 0 ? 9 : 1, x, y)
+    )
+
+  it('builds a named territory from a big enough community with land', () => {
+    const built = buildTerritories({
+      membersByGroup: new Map([[0, members('work', 8, 0.3, 0.3)]]),
+      ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
+      allPositions: members('work', 8, 0.3, 0.3).map((m) => m.position)
+    })
+    expect(built.length).toBe(1)
+    expect(built[0].caption).toBe('work hub')
+    expect(built[0].memberIds.length).toBe(8)
+    expect(built[0].purity).toBe(1)
+  })
+
+  it('drops a community with no coastline', () => {
+    // No land, no place. The entities are still drawn; only the region is not.
+    const built = buildTerritories({
+      membersByGroup: new Map([[0, members('work', 8, 0.3, 0.3)]]),
+      ringsByGroup: new Map(),
+      allPositions: []
+    })
+    expect(built).toEqual([])
+  })
+
+  it('drops a community too small to be a region', () => {
+    const built = buildTerritories({
+      membersByGroup: new Map([[0, members('work', 3, 0.3, 0.3)]]),
+      ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
+      allPositions: []
+    })
+    expect(built).toEqual([])
+  })
+
+  it('drops a community nothing in it can name', () => {
+    // An unnamed shape on a map is noise; the entities inside it are still
+    // visible as entities.
+    const unnamed = Array.from({ length: 8 }, (_v, i) => member(`n${i}`, '   ', 1, 0.3, 0.3))
+    const built = buildTerritories({
+      membersByGroup: new Map([[0, unnamed]]),
+      ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
+      allPositions: []
+    })
+    expect(built).toEqual([])
+  })
+
+  it('orders the biggest region first', () => {
+    const built = buildTerritories({
+      membersByGroup: new Map([
+        [0, members('small', 6, 0.2, 0.2)],
+        [1, members('big', 12, 0.8, 0.8)]
+      ]),
+      ringsByGroup: new Map([
+        [0, [square(0.1, 0.1, 0.2)]],
+        [1, [square(0.7, 0.7, 0.2)]]
+      ]),
+      allPositions: []
+    })
+    expect(built.map((t) => t.caption)).toEqual(['big hub', 'small hub'])
+  })
+})
+
+describe('territoryAt', () => {
+  it('finds the region a point falls in', () => {
+    const territories = buildTerritories({
+      membersByGroup: new Map([
+        [0, Array.from({ length: 8 }, (_v, i) => member(`n${i}`, 'Acme', 1, 0.3, 0.3))]
+      ]),
+      ringsByGroup: new Map([[0, [square(0.2, 0.2, 0.2)]]]),
+      allPositions: []
+    })
+    expect(territoryAt(territories, { x: 0.3, y: 0.3 })?.caption).toBe('Acme')
+    expect(territoryAt(territories, { x: 0.9, y: 0.9 })).toBeNull()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/atlas/territories.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/territories.ts
@@ -1,0 +1,183 @@
+// Which communities become named territories, and what they are called.
+//
+// Ported from macOS `MemoryAtlasLayoutEngine` and
+// `MemoryAtlasNeighbourhoodLabels`. Two decisions live here:
+//
+//   Which communities get drawn at all. A community too small to matter, or one
+//   whose coastline came back empty, is not a place.
+//
+//   What a place is called. One name, not a list: a region labelled with four
+//   entities reads as a list of entities rather than as somewhere.
+//
+// An island the map cannot name is not drawn. That is the contract rather than a
+// bug: an unnamed shape on a map is noise, and the entities inside it are still
+// visible as entities.
+
+import { coastlineContains, type AtlasPoint, type Ring } from './islands'
+
+/** Longest caption before it is truncated. */
+export const CAPTION_CEILING = 26
+/** A candidate name may not be wordier than this. */
+export const CAPTION_MAX_WORDS = 3
+/** Share of the map a community must hold to be a contender for a territory. */
+export const TERRITORY_SIZE_SHARE = 0.015
+/** ...and never fewer members than this, however small the map is. */
+export const TERRITORY_MIN_MEMBERS = 6
+
+export interface AtlasMember {
+  id: string
+  label: string
+  /** Distinct neighbours in the relatedness graph. Drives which member names the
+   *  region: the best-connected entity is the one the region is about. */
+  degree: number
+  position: AtlasPoint
+}
+
+export interface Territory {
+  group: number
+  caption: string
+  rings: Ring[]
+  memberIds: string[]
+  center: AtlasPoint
+  radius: number
+  /** Share of everything standing inside this territory that actually belongs to
+   *  it. A low value means the coastline swallowed other communities' entities. */
+  purity: number
+}
+
+/** Communities large enough to be worth drawing. Everything above the floor is a
+ *  contender, INCLUDING communities that will never be captioned: they still
+ *  compete for land, and leaving one out hands its ground to a named neighbour. */
+export function territorySizeFloor(totalPlacements: number): number {
+  return Math.max(TERRITORY_MIN_MEMBERS, Math.floor(totalPlacements * TERRITORY_SIZE_SHARE))
+}
+
+const wordCount = (label: string): number => label.trim().split(/\s+/).filter(Boolean).length
+
+/**
+ * The name for a region, chosen from its members in three tiers.
+ *
+ * Members arrive ranked by degree desc, then label case-insensitively. A short
+ * unwordy label is a name; a short but wordy one is a fallback; a long one is
+ * truncated. Returns null when there is nothing to call the place.
+ */
+export function captionFor(rankedLabels: string[]): string | null {
+  const cleaned = rankedLabels.map((l) => l.trim()).filter((l) => l.length > 0)
+
+  const names = cleaned.filter(
+    (l) => l.length <= CAPTION_CEILING && wordCount(l) <= CAPTION_MAX_WORDS
+  )
+  if (names.length > 0) return names[0]
+
+  const shortButWordy = cleaned.filter((l) => l.length <= CAPTION_CEILING)
+  if (shortButWordy.length > 0) return shortButWordy[0]
+
+  const long = cleaned.find((l) => l.length > CAPTION_CEILING)
+  if (long === undefined) return null
+  // One character short of the ceiling, then the ellipsis, so the result is
+  // never wider than a name that fit.
+  return `${long.slice(0, CAPTION_CEILING - 1).trimEnd()}…`
+}
+
+/** Members ranked for captioning: best connected first, then by label so the
+ *  choice does not depend on the order members were collected in. */
+export function rankMembers(members: AtlasMember[]): AtlasMember[] {
+  return [...members].sort((a, b) => {
+    if (b.degree !== a.degree) return b.degree - a.degree
+    const la = a.label.toLocaleLowerCase()
+    const lb = b.label.toLocaleLowerCase()
+    if (la !== lb) return la < lb ? -1 : 1
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
+}
+
+/** Arithmetic mean of the members' positions. */
+export function centerOf(points: AtlasPoint[]): AtlasPoint {
+  if (points.length === 0) return { x: 0.5, y: 0.5 }
+  let x = 0
+  let y = 0
+  for (const p of points) {
+    x += p.x
+    y += p.y
+  }
+  return { x: x / points.length, y: y / points.length }
+}
+
+/**
+ * How far the region reaches: the 80th-percentile distance from its centre, so a
+ * single far-flung member does not inflate it. Floored so a tight cluster still
+ * has somewhere to put a label.
+ */
+export function radiusOf(center: AtlasPoint, points: AtlasPoint[]): number {
+  if (points.length === 0) return 0.01
+  const distances = points
+    .map((p) => Math.hypot(p.x - center.x, p.y - center.y))
+    .sort((a, b) => a - b)
+  const index = Math.min(distances.length - 1, Math.floor(distances.length * 0.8))
+  return Math.max(distances[index], 0.01)
+}
+
+/**
+ * Share of everything standing inside a coastline that belongs to the community
+ * that owns it. Zero when nothing at all is inside.
+ */
+export function purityOf(rings: Ring[], members: AtlasPoint[], everyone: AtlasPoint[]): number {
+  const inside = everyone.filter((p) => coastlineContains(rings, p)).length
+  if (inside === 0) return 0
+  return members.filter((p) => coastlineContains(rings, p)).length / inside
+}
+
+export interface BuildTerritoriesInput {
+  /** Members per community, each list in sorted id order. */
+  membersByGroup: Map<number, AtlasMember[]>
+  /** Coastlines per community; a community absent here has no land. */
+  ringsByGroup: Map<number, Ring[]>
+  /** Every placed entity on the map, for the purity measure. */
+  allPositions: AtlasPoint[]
+}
+
+/**
+ * Territories, largest first.
+ *
+ * A community is dropped when it is too small, when it has no coastline, or when
+ * nothing in it can name the place.
+ */
+export function buildTerritories(input: BuildTerritoriesInput): Territory[] {
+  const floor = territorySizeFloor(input.allPositions.length)
+  const out: Territory[] = []
+
+  for (const group of [...input.membersByGroup.keys()].sort((a, b) => a - b)) {
+    const members = input.membersByGroup.get(group) ?? []
+    if (members.length < floor) continue
+    const rings = input.ringsByGroup.get(group)
+    // No land, no place. The entities are still drawn; only the region is not.
+    if (rings === undefined || rings.length === 0) continue
+    const caption = captionFor(rankMembers(members).map((m) => m.label))
+    if (caption === null) continue
+
+    const points = members.map((m) => m.position)
+    const center = centerOf(points)
+    out.push({
+      group,
+      caption,
+      rings,
+      memberIds: members.map((m) => m.id).sort(),
+      center,
+      radius: radiusOf(center, points),
+      purity: purityOf(rings, points, input.allPositions)
+    })
+  }
+
+  return out.sort((a, b) => {
+    if (b.memberIds.length !== a.memberIds.length) return b.memberIds.length - a.memberIds.length
+    return a.group - b.group
+  })
+}
+
+/** The territory a point falls in, or null. Territories tile, so at most one. */
+export function territoryAt(territories: Territory[], point: AtlasPoint): Territory | null {
+  for (const territory of territories) {
+    if (coastlineContains(territory.rings, point)) return territory
+  }
+  return null
+}

--- a/desktop/windows/src/renderer/src/lib/atlas/territories.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/territories.ts
@@ -23,6 +23,18 @@ export const CAPTION_MAX_WORDS = 3
 export const TERRITORY_SIZE_SHARE = 0.015
 /** ...and never fewer members than this, however small the map is. */
 export const TERRITORY_MIN_MEMBERS = 6
+/**
+ * Least share of what stands inside a coastline that must belong to it.
+ *
+ * A DIVERGENCE from macOS, which asserts this holds rather than enforcing it:
+ * its bespoke relaxation packs a community tightly enough that the ridge of land
+ * always covers its members. Windows reuses the app's existing d3-force layout,
+ * which can leave a community ringed around its hub, and then the field clears
+ * the sea level on the ridge BETWEEN members while the members themselves sit
+ * just outside it. The region that comes out is drawn over ground none of its
+ * entities stand on, which is worse than no region at all.
+ */
+export const MIN_PURITY = 0.5
 
 export interface AtlasMember {
   id: string
@@ -156,6 +168,9 @@ export function buildTerritories(input: BuildTerritoriesInput): Territory[] {
     if (caption === null) continue
 
     const points = members.map((m) => m.position)
+    const purity = purityOf(rings, points, input.allPositions)
+    // A region nothing of its own stands in is not a place.
+    if (purity < MIN_PURITY) continue
     const center = centerOf(points)
     out.push({
       group,
@@ -164,7 +179,7 @@ export function buildTerritories(input: BuildTerritoriesInput): Territory[] {
       memberIds: members.map((m) => m.id).sort(),
       center,
       radius: radiusOf(center, points),
-      purity: purityOf(rings, points, input.allPositions)
+      purity
     })
   }
 

--- a/desktop/windows/src/renderer/src/lib/atlas/zoomPolicy.test.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/zoomPolicy.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DETAIL_ZOOM,
+  FOCUS_ZOOM,
+  INSPECT_ZOOM,
+  MINIMUM_ZOOM,
+  NEIGHBOURHOOD_ZOOM,
+  SMALL_ATLAS_CEILING,
+  canvasLabelZoom,
+  departureZoom,
+  detailBudget,
+  detailLevel,
+  fullyLabelledZoom,
+  maximumZoom,
+  panPreservingCenter,
+  zoomToEnter
+} from './zoomPolicy'
+
+describe('detailLevel', () => {
+  it('climbs through the bands as the camera goes in', () => {
+    expect(detailLevel(0.5)).toBe('overview')
+    expect(detailLevel(NEIGHBOURHOOD_ZOOM)).toBe('neighbourhood')
+    expect(detailLevel(DETAIL_ZOOM)).toBe('detail')
+    expect(detailLevel(FOCUS_ZOOM)).toBe('focus')
+    expect(detailLevel(INSPECT_ZOOM)).toBe('inspect')
+    expect(detailLevel(1000)).toBe('inspect')
+  })
+
+  it('has no hysteresis, so the same zoom always shows the same thing', () => {
+    // A level that depended on which direction you arrived from would make the
+    // map look different at the same magnification.
+    const justBelow = NEIGHBOURHOOD_ZOOM - 1e-9
+    expect(detailLevel(justBelow)).toBe('overview')
+    expect(detailLevel(NEIGHBOURHOOD_ZOOM)).toBe('neighbourhood')
+    expect(detailLevel(justBelow)).toBe('overview')
+  })
+})
+
+describe('detailBudget', () => {
+  it('shows more of everything the further in the camera goes', () => {
+    const out = detailBudget(0.5, 500)
+    const inspect = detailBudget(20, 500)
+    expect(inspect.maxNodes).toBeGreaterThan(out.maxNodes)
+    expect(inspect.maxEdges).toBeGreaterThan(out.maxEdges)
+    expect(inspect.maxLabels).toBeGreaterThan(out.maxLabels)
+  })
+
+  it('does not cap labels on a map small enough to read whole', () => {
+    // Capping labels on a twelve-entity graph hides things for no reason.
+    const budget = detailBudget(0.5, 12)
+    expect(budget.maxLabels).toBe(12)
+    expect(budget.labelsPerTerritory).toBe(12)
+    expect(SMALL_ATLAS_CEILING).toBe(60)
+  })
+
+  it('lifts every limit once the camera is past the fully-labelled zoom', () => {
+    const nodeCount = 400
+    const budget = detailBudget(fullyLabelledZoom(nodeCount), nodeCount)
+    expect(budget.maxNodes).toBe(nodeCount)
+    expect(budget.maxLabels).toBe(nodeCount)
+  })
+})
+
+describe('fullyLabelledZoom', () => {
+  it('matches the values macOS pins', () => {
+    // From MemoryAtlasPerformanceHarnessTests: these are the measured points the
+    // ladder was tuned against, so they are the contract rather than a guess.
+    expect(fullyLabelledZoom(1)).toBe(16)
+    expect(fullyLabelledZoom(1946)).toBe(160)
+    expect(fullyLabelledZoom(2400)).toBe(180)
+    expect(fullyLabelledZoom(10000)).toBe(360)
+  })
+
+  it('never goes below its floor, even for an empty map', () => {
+    expect(fullyLabelledZoom(0)).toBe(16)
+  })
+
+  it('grows with the square root of the map, not linearly', () => {
+    // Four times the entities needs twice the magnification, not four times.
+    expect(fullyLabelledZoom(10000) / fullyLabelledZoom(2500)).toBeCloseTo(2, 1)
+  })
+})
+
+describe('canvasLabelZoom', () => {
+  it('matches the values macOS pins', () => {
+    expect(canvasLabelZoom(1)).toBe(7.5)
+    expect(canvasLabelZoom(1946)).toBe(40)
+    expect(canvasLabelZoom(2400)).toBe(45)
+    expect(canvasLabelZoom(10000)).toBe(90)
+  })
+})
+
+describe('maximumZoom', () => {
+  it('is tight in the compact card and generous full screen', () => {
+    expect(maximumZoom(2400, true)).toBe(NEIGHBOURHOOD_ZOOM)
+    expect(maximumZoom(2400, false)).toBe(180)
+  })
+})
+
+describe('panPreservingCenter', () => {
+  it('keeps the point under the middle of the viewport fixed', () => {
+    expect(panPreservingCenter(100, 1, 2)).toBe(200)
+    expect(panPreservingCenter(200, 2, 1)).toBe(100)
+  })
+
+  it('round-trips', () => {
+    const there = panPreservingCenter(37, 1.2, 4.4)
+    expect(panPreservingCenter(there, 4.4, 1.2)).toBeCloseTo(37, 4)
+  })
+
+  it('does not divide by a zoom below the floor', () => {
+    expect(Number.isFinite(panPreservingCenter(10, 0, 2))).toBe(true)
+  })
+})
+
+describe('zoomToEnter', () => {
+  it('frames a small region closely and a large one loosely', () => {
+    expect(zoomToEnter(0.05, 400)).toBeGreaterThan(zoomToEnter(0.3, 400))
+  })
+
+  it('never asks for more magnification than the map allows', () => {
+    expect(zoomToEnter(0.0001, 400)).toBeLessThanOrEqual(maximumZoom(400, false))
+    expect(zoomToEnter(0.0001, 400, true)).toBeLessThanOrEqual(NEIGHBOURHOOD_ZOOM)
+  })
+
+  it('never asks to zoom out past the floor', () => {
+    expect(zoomToEnter(10, 400)).toBeGreaterThanOrEqual(MINIMUM_ZOOM)
+  })
+})
+
+describe('departureZoom', () => {
+  it('sits below the zoom you entered at, so a nudge does not eject you', () => {
+    const entered = 1.35
+    const leave = departureZoom(entered) as number
+    expect(leave).toBeLessThan(entered)
+    expect(leave).toBeCloseTo(1.35 * 0.85, 12)
+  })
+
+  it('is capped at the neighbourhood band however far in you entered', () => {
+    expect(departureZoom(50)).toBeCloseTo(NEIGHBOURHOOD_ZOOM * 0.85, 12)
+  })
+
+  it('reports no exit rather than one below the floor', () => {
+    // Entering at a very low zoom leaves no room to zoom out; inventing a
+    // threshold under the minimum would make it unreachable and the region
+    // impossible to leave.
+    expect(departureZoom(0.8)).toBeNull()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/atlas/zoomPolicy.ts
+++ b/desktop/windows/src/renderer/src/lib/atlas/zoomPolicy.ts
@@ -1,0 +1,120 @@
+// What the atlas shows at each zoom.
+//
+// Ported from macOS `MemoryAtlasZoomPolicy.swift` and the detail ladder in
+// `CanonicalMemoryAtlasView`. The map holds far more than can be drawn legibly at
+// once, so the answer to "what is on screen" is a function of how far in the
+// camera is: territories and a handful of hubs when zoomed out, every entity and
+// every label when zoomed all the way in.
+//
+// There is deliberately NO hysteresis on the bands. They are plain comparisons
+// against the live zoom, so the same zoom always shows the same thing - a level
+// that depended on which direction you arrived from would make the map look
+// different at the same magnification.
+
+export type DetailLevel = 'overview' | 'neighbourhood' | 'detail' | 'focus' | 'inspect'
+
+/** Band boundaries. A zoom below the first is overview; at or above the last is
+ *  inspect. */
+export const NEIGHBOURHOOD_ZOOM = 1.35
+export const DETAIL_ZOOM = 1.9
+export const FOCUS_ZOOM = 3.2
+export const INSPECT_ZOOM = 7.5
+export const MINIMUM_ZOOM = 0.75
+/** A map this small is legible whole, so it skips the density limits. */
+export const SMALL_ATLAS_CEILING = 60
+
+export function detailLevel(zoom: number): DetailLevel {
+  if (zoom < NEIGHBOURHOOD_ZOOM) return 'overview'
+  if (zoom < DETAIL_ZOOM) return 'neighbourhood'
+  if (zoom < FOCUS_ZOOM) return 'detail'
+  if (zoom < INSPECT_ZOOM) return 'focus'
+  return 'inspect'
+}
+
+export interface DetailBudget {
+  /** Entities drawn. */
+  maxNodes: number
+  /** Connections drawn. */
+  maxEdges: number
+  /** Labels per territory. */
+  labelsPerTerritory: number
+  /** Labels on screen in total. */
+  maxLabels: number
+}
+
+const BUDGETS: Record<DetailLevel, DetailBudget> = {
+  overview: { maxNodes: 1200, maxEdges: 2000, labelsPerTerritory: 3, maxLabels: 12 },
+  neighbourhood: { maxNodes: 1600, maxEdges: 2400, labelsPerTerritory: 7, maxLabels: 24 },
+  detail: { maxNodes: 2400, maxEdges: 3000, labelsPerTerritory: 11, maxLabels: 36 },
+  focus: { maxNodes: 3200, maxEdges: 3600, labelsPerTerritory: 24, maxLabels: 72 },
+  inspect: { maxNodes: 3200, maxEdges: 4200, labelsPerTerritory: 96, maxLabels: 96 }
+}
+
+/**
+ * What may be drawn at this zoom.
+ *
+ * A map small enough to read whole gets no label limits at all: capping labels
+ * on a twelve-entity graph hides things for no reason.
+ */
+export function detailBudget(zoom: number, nodeCount: number): DetailBudget {
+  const level = detailLevel(zoom)
+  const budget = BUDGETS[level]
+  if (nodeCount <= SMALL_ATLAS_CEILING) {
+    return { ...budget, labelsPerTerritory: nodeCount, maxLabels: nodeCount }
+  }
+  if (zoom >= fullyLabelledZoom(nodeCount)) {
+    return { ...budget, maxNodes: nodeCount, labelsPerTerritory: nodeCount, maxLabels: nodeCount }
+  }
+  return budget
+}
+
+/**
+ * The zoom at which everything is labelled, scaled by how much there is.
+ *
+ * Denser maps need more magnification before every label fits, so this grows
+ * with the square root of the entity count rather than being a fixed number.
+ */
+export function fullyLabelledZoom(nodeCount: number): number {
+  return Math.max(16, Math.ceil((Math.sqrt(Math.max(nodeCount, 1)) * 3.6) / 5) * 5)
+}
+
+/** Beyond this, labels are cheaper drawn straight onto the canvas than as
+ *  individually laid out elements. */
+export function canvasLabelZoom(nodeCount: number): number {
+  return Math.max(7.5, Math.ceil(fullyLabelledZoom(nodeCount) * 0.25 * 2) / 2)
+}
+
+/** How far the camera may go in. */
+export function maximumZoom(nodeCount: number, compact: boolean): number {
+  return compact ? NEIGHBOURHOOD_ZOOM : fullyLabelledZoom(nodeCount)
+}
+
+/** Keeps the point under the centre of the viewport fixed while zooming. */
+export function panPreservingCenter(pan: number, currentZoom: number, nextZoom: number): number {
+  return pan * (nextZoom / Math.max(currentZoom, MINIMUM_ZOOM))
+}
+
+/** Share of the viewport a territory fills when you enter it. */
+export const ENTERED_COVERAGE = 0.62
+
+/** The zoom that frames a territory of this radius. */
+export function zoomToEnter(radius: number, nodeCount: number, compact = false): number {
+  const extent = Math.max(radius * 2, 0.02)
+  const desired = ENTERED_COVERAGE / extent
+  return Math.min(Math.max(desired, MINIMUM_ZOOM), maximumZoom(nodeCount, compact))
+}
+
+/**
+ * The zoom at which leaving a territory takes effect, or null when there is no
+ * zoom-out that exits it.
+ *
+ * This is the one piece of stickiness in the whole policy: without it, nudging
+ * the camera a hair past the band boundary would drop you out of the region you
+ * just entered.
+ */
+export function departureZoom(enteredZoom: number): number | null {
+  const threshold = Math.min(enteredZoom, NEIGHBOURHOOD_ZOOM) * 0.85
+  // Below the floor there is nothing to zoom out TO, so there is no exit rather
+  // than an exit nobody can reach.
+  return threshold < MINIMUM_ZOOM ? null : threshold
+}


### PR DESCRIPTION
The brain map keeps a large graph legible by hiding nodes. This adds a view that hides none.

## The problem, as the codebase already states it

`KnowledgeGraphViewer.tsx` records the measurement in its own header:

> a real account's graph is large (measured: ~188 nodes / ~474 edges, one 226-degree hub, ~40% degree-1 leaves) - drawn whole it is an unreadable, laggy hairball

Its answer is a default node cap plus label declutter, with a "Show all" escape hatch. That is a reasonable answer, and it is the only one Windows has.

macOS answers the same problem the other way, in `MainWindow/Pages/MemoryGraph/` (9,463 lines against Windows' ~1,500): group the entities into regions, give each region a name, and let detail arrive with magnification instead of throwing it away up front. This ports that.

Both views ship. The Brain Map page gains a Map/Graph toggle; the existing scene is untouched, which matters because onboarding mounts it too.

## Pipeline

```
relatedness  ->  communities  ->  layout  ->  coastlines  ->  territories
```

Communities are detected **before** positions are computed, which is the reverse of the obvious order, and the reason is the most interesting thing in the diff. See "what building it taught me" below.

## The rules that carry the weight

**Relatedness is two signals.** Edges the graph states outright, weighted logarithmically in the memories behind them, plus entities that keep turning up in the same memory. Each memory divides one unit of relatedness among its participants, each weighted by how rare it is, so two entities that only ever co-occur inside one ubiquitous entity's memories are not treated as related. A memory naming more than twenty entities is skipped entirely: it relates everything to everything, which carries the same information as relating nothing.

**Coastlines are a scalar field, not a hull.** Each community's members are splatted as Gaussian bumps into a shared 128x128 field; a cell belongs to whichever community peaks highest, provided the peak is decisive; the mask is blurred and traced with marching squares. A hull would swallow every other community standing between a community's members. A field lets two interleaved communities own nothing in the contested middle, and lets a community that lives in two places come out as two islands rather than one region spanning the gap.

**Three constants shape every coastline.** The sea level sits above 1 because a lone entity's bump peaks at exactly 1, so one entity can never mint a territory. The decisive margin means a cell only belongs to the leader if it beats the runner-up by a quarter. Reach is not an absolute distance but the map's own median nearest-neighbour spacing times 2.5, because the same spacing means "tight" on a dense map and "scattered" on a sparse one.

**Marching squares stitches by integer edge identity**, not by coordinate. Comparing interpolated coordinates leaves hairline gaps wherever two cells disagree in the last bit, and a ring with a gap cannot be filled.

**A region the map cannot name is not drawn.** An unnamed shape is noise; the entities inside it are still drawn as entities.

**Determinism is a contract.** Every traversal that can affect an output walks a sorted array, a tied Louvain candidate cannot pull a node, and the layout seeds from a phyllotaxis spiral by index with a fixed tick count. The graph is merged from an onboarding floor plus a server fetch whose interleaving is not fixed, so without this the map would rearrange itself between runs for no reason a user could see.

## What building it taught me

Wired to the app's existing `computeLayout`, the ported island algorithm produced almost nothing: two of three obvious clusters had no land at all, and the third produced a ridge running BETWEEN its members with none of them standing inside it.

That is why macOS carries its own force layout, and it is not incidental. The existing layout spreads entities evenly, which is right for a node-link graph. A coastline is drawn where a community's own field beats the sea level, and a community spread as thinly as the rest of the map never clears it.

Rather than port a second 1,600-line relaxation, this adds one force to the engine already in the tree: every entity is pulled toward its community's centre of mass, recomputed each tick. That is the minimum needed, and it is why communities have to be detected first.

## Deliberate divergences from macOS

| Divergence | Why |
|---|---|
| One added force on the existing d3 engine, not a bespoke relaxation | The bespoke layout exists to pack communities; one community-attraction force achieves what the island algorithm needs, and leaves the existing brain map untouched. |
| A purity floor is **enforced**, not just asserted | macOS asserts in its tests that every drawn region holds its own members, because its relaxation packs tightly enough that it is always true. Here it can fail, and a region drawn over ground none of its entities stand on is worse than no region. |
| No playback | Playback replays the map growing over time, and `graphDisplay.ts` records that the server graph carries no per-node timestamp. Deriving one from each node's memories is possible but is its own change. |
| No render-plan or snapshot cache | Those exist for a 4,000-line SwiftUI canvas under continuous camera motion; this redraws a few hundred shapes. |
| `ForceDirectedSimulation.swift` not ported | It is the legacy 3D engine for the old page, has no Atlas references, and uses a random source, which would break the determinism contract. |

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,339 passed, 18 skipped, 548 files. 127 of those are this feature; the branch point was 5,212.
- `npx tsc --noEmit` on both `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint` on every touched file - 0 problems.
- `npx electron-vite build` - built in 22.58s.
- `check_lifecycle_headers.py`, `check_brand_ui.py`, `check_arch_guardrails.py` - pass.

The component test records what reaches the canvas and asserts regions are drawn under entities, captions over both, the fill uses the even-odd rule matching the containment test, and every one of the thirty entities is drawn rather than capped.

The four fully-labelled zoom values are the ones macOS pins in its own performance harness tests (1 -> 16, 1946 -> 160, 2400 -> 180, 10000 -> 360), so they are a cited contract rather than a guess.

## Mutation audit

33 regressions seeded, **32 caught**. They cover every constant and guard in the package: the sea level, the decisive margin, relative reach, the area floor, the ring-vertex floor, even-odd containment, the caption tiers and truncation, the size floor, the purity floor, every zoom band and ceiling, the anchor exclusion, the community pull, and the deterministic seeds.

Two things worth reporting rather than burying.

**One escape is real, and it means an earlier commit in this branch was wrong.** That commit claimed the eager edge-crossing computation was a bug and that a NaN from a non-crossing edge was reachable from the neighbouring cell. The audit showed otherwise: making all four crossings eager again fails no test, and it cannot, because the two cells sharing an edge read the same two corner values and always agree on whether the contour crosses it. The misplaced coastlines that change was credited with fixing were caused entirely by the layout, which the same commit also changed. There is a commit correcting the record, and the lazy version stays as hygiene rather than as a fix.

**Several guards genuinely cannot be observed in the output**, and the code says so where they sit rather than pretending a test covers them: island ownership ties (a tied cell fails the decisive margin either way), the weightless-graph guard in Louvain (the gains become NaN and no node moves regardless), and the final dense relabelling (membership is already dense by then). They are kept so a later change to the surrounding rule cannot silently start depending on the wrong behaviour.

One redundancy the audit did find and fix: the self-edge guard existed both where the adjacency is built and again inside the modularity loop, so neither could be shown to matter. It is now in one place.

## What is not here

Playback, the caches, and macOS's label-dodging placement pass, which re-places region labels twice so they avoid each other. Labels currently sit at their region's centre.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

