### PR TITLE
fix(dev-harness): name `make dev-init` when the harness venv is unprovisioned

### DIFF
--- a/scripts/dev-harness/_resolve_python.sh
+++ b/scripts/dev-harness/_resolve_python.sh
@@ -88,3 +88,24 @@ dev_harness_pythonpath() {
   fi
   printf '%s\n' "$value"
 }
+
+# Name the provisioning step instead of letting an import traceback stand in for
+# it. The harness's own prerequisite check lives inside the Python CLI, so an
+# interpreter without backend/requirements.txt installed dies at
+# `import dev_harness.cli` before that check can report anything.
+dev_harness_require_cli() {
+  local python_bin="$1"
+  local pythonpath="$2"
+  local probe
+
+  if probe="$(PYTHONPATH="$pythonpath" "$python_bin" -c 'import dev_harness.cli' 2>&1)"; then
+    return 0
+  fi
+
+  {
+    echo "Omi dev harness is not provisioned: $python_bin cannot import dev_harness.cli"
+    printf '%s\n' "$probe" | tail -n 1 | sed 's/^/  /'
+    echo "Run \`make dev-init\` first (creates backend/.venv and installs backend/requirements.txt)."
+  } >&2
+  return 1
+}

--- a/scripts/dev-harness/dev-check.sh
+++ b/scripts/dev-harness/dev-check.sh
@@ -10,4 +10,6 @@ if git ls-files --error-unmatch backend/.env.local-dev >/dev/null 2>&1; then
   exit 1
 fi
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli check
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli check

--- a/scripts/dev-harness/dev-down.sh
+++ b/scripts/dev-harness/dev-down.sh
@@ -6,4 +6,6 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli down
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli down

--- a/scripts/dev-harness/dev-logs.sh
+++ b/scripts/dev-harness/dev-logs.sh
@@ -6,4 +6,6 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli logs
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli logs

--- a/scripts/dev-harness/dev-reset.sh
+++ b/scripts/dev-harness/dev-reset.sh
@@ -6,4 +6,6 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli reset
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli reset

--- a/scripts/dev-harness/dev-status.sh
+++ b/scripts/dev-harness/dev-status.sh
@@ -6,4 +6,6 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli status
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli status

--- a/scripts/dev-harness/dev-summary.sh
+++ b/scripts/dev-harness/dev-summary.sh
@@ -6,4 +6,6 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli summary
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli summary

--- a/scripts/dev-harness/dev-up.sh
+++ b/scripts/dev-harness/dev-up.sh
@@ -6,4 +6,6 @@ source "$(dirname "$0")/_source_local_dev_env.sh"
 source "$(dirname "$0")/_resolve_python.sh"
 cd "$(dirname "$0")/../.."
 PYTHON_BIN="$(dev_harness_python)"
-PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)" "$PYTHON_BIN" -m dev_harness.cli up
+HARNESS_PYTHONPATH="$(dev_harness_pythonpath "$PYTHON_BIN" scripts/dev-harness)"
+dev_harness_require_cli "$PYTHON_BIN" "$HARNESS_PYTHONPATH"
+PYTHONPATH="$HARNESS_PYTHONPATH" "$PYTHON_BIN" -m dev_harness.cli up

--- a/scripts/dev-harness/tests/test_dev_wrappers.py
+++ b/scripts/dev-harness/tests/test_dev_wrappers.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HARNESS_ROOT = Path(__file__).resolve().parents[1]
+SHARED_SOURCES = ("_resolve_python.sh", "_source_local_dev_env.sh")
+# Every wrapper that hands control to the Python CLI, with the subcommand it runs.
+CLI_WRAPPERS = (
+    ("dev-up.sh", "up"),
+    ("dev-down.sh", "down"),
+    ("dev-status.sh", "status"),
+    ("dev-summary.sh", "summary"),
+    ("dev-reset.sh", "reset"),
+    ("dev-logs.sh", "logs"),
+    ("dev-check.sh", "check"),
+)
+
+PROVISIONED_CLI = "import sys\nprint('cli', *sys.argv[1:])\n"
+# python-dotenv and friends live in backend/requirements.txt, so an unprovisioned
+# interpreter fails at import time exactly like this.
+UNPROVISIONED_CLI = "import omi_missing_third_party_dep\n" + PROVISIONED_CLI
+
+
+def _bash() -> str:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("Bash is required for dev-harness wrapper tests")
+    return bash
+
+
+def _fixture_repo(root: Path, wrapper: str, cli_body: str) -> Path:
+    """A checkout carrying one wrapper plus a stand-in dev_harness package."""
+    repo = root / "repo"
+    harness = repo / "scripts/dev-harness"
+    harness.mkdir(parents=True)
+    for name in (wrapper, *SHARED_SOURCES):
+        shutil.copy2(HARNESS_ROOT / name, harness / name)
+
+    package = harness / "dev_harness"
+    package.mkdir()
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "cli.py").write_text(cli_body, encoding="utf-8")
+    return repo
+
+
+def _run_wrapper(repo: Path, wrapper: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    # The resolver appends an inherited PYTHONPATH, and the fixture package must
+    # be the only importable dev_harness.
+    env.pop("PYTHONPATH", None)
+    env["PYTHON"] = sys.executable
+    return subprocess.run(
+        [_bash(), f"scripts/dev-harness/{wrapper}"],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("wrapper,subcommand", CLI_WRAPPERS)
+def test_wrapper_names_dev_init_when_the_harness_is_unprovisioned(
+    tmp_path: Path, wrapper: str, subcommand: str
+) -> None:
+    """The harness's own prerequisite check lives inside the Python CLI, so an
+    unprovisioned venv used to die at `import dev_harness.cli` first — the
+    contributor saw `ModuleNotFoundError: No module named 'dotenv'` and a
+    traceback naming neither the venv nor `make dev-init` (issue #11533).
+    """
+    repo = _fixture_repo(tmp_path, wrapper, UNPROVISIONED_CLI)
+
+    result = _run_wrapper(repo, wrapper)
+
+    assert result.returncode != 0, result.stdout
+    assert "make dev-init" in result.stdout, result.stdout
+    assert "omi_missing_third_party_dep" in result.stdout, result.stdout
+    assert "Traceback" not in result.stdout, result.stdout
+    assert f"cli {subcommand}" not in result.stdout, result.stdout
+
+
+@pytest.mark.parametrize("wrapper,subcommand", CLI_WRAPPERS)
+def test_wrapper_runs_the_cli_when_the_harness_imports(tmp_path: Path, wrapper: str, subcommand: str) -> None:
+    repo = _fixture_repo(tmp_path, wrapper, PROVISIONED_CLI)
+
+    result = _run_wrapper(repo, wrapper)
+
+    assert result.returncode == 0, result.stdout
+    assert f"cli {subcommand}" in result.stdout, result.stdout
+    assert "make dev-init" not in result.stdout, result.stdout


### PR DESCRIPTION
## What

`make dev-up` (and `dev-status`/`dev-down`/`dev-logs`/`dev-reset`/`dev-summary`/`dev-check`) now fail with the provisioning step to run when the resolved interpreter has no harness dependencies, instead of a Python traceback.

```
Omi dev harness is not provisioned: python3 cannot import dev_harness.cli
  ModuleNotFoundError: No module named 'dotenv'
Run `make dev-init` first (creates backend/.venv and installs backend/requirements.txt).
```

## Why

From #11533 — the contributor followed the documented onboarding path on macOS, ended up with an unprovisioned venv, and got:

```
Traceback (most recent call last):
  File "scripts/dev-harness/dev_harness/cli.py", line 21, in <module>
    from . import config, providers, qualification, safety, memory_scenarios
  File "scripts/dev-harness/dev_harness/config.py", line 10, in <module>
    from dotenv import dotenv_values
ModuleNotFoundError: No module named 'dotenv'
make[2]: *** [dev-up] Error 1
```

Nothing in that output names the venv or `make dev-init`. The reporter's own correction narrowed the defect precisely: the harness *does* have a good prerequisite check (it names missing `redis-server`/`docker` and offers an alternative runtime) — but that check lives **inside** the Python CLI, so it cannot run when the import that reaches it fails. "the ordering and the reachability of the preflight are the whole problem."

The issue's headline half (`.git/hooks` in a linked worktree) already landed in #11542; this is the remaining half. `backend/requirements.txt` needs nothing added — `dotenv` is its only third-party module imported at `dev_harness.cli` import time, and it is already listed there.

## How

- `dev_harness_require_cli` in `scripts/dev-harness/_resolve_python.sh` probes `import dev_harness.cli` with the interpreter and PYTHONPATH the wrapper is about to use, and on failure prints the resolved interpreter, the underlying import error, and `make dev-init`.
- All seven wrappers that hand control to the CLI call it first, so every `make dev-*` entry point answers the same way rather than only `dev-up`.

Not changed: the reporter's second suggestion (install hooks before `pip install`). Since #11542 the hook step resolves `git rev-parse --git-path hooks` and no longer fails in a worktree, so reordering would trade one partial-run shape for another with no defect behind it.

## Tested

Verified in a worktree whose resolved interpreter genuinely lacks the harness dependencies (`python3` → Xcode 3.9, no `dotenv`) — i.e. the issue's exact condition, not a simulation:

| | `make dev-up` |
|---|---|
| before (this diff stashed) | the traceback above, `make: *** [dev-up] Error 1` |
| after | the 3-line message above, exit 1, no traceback |

- Happy path with a provisioned interpreter (fresh venv + `python-dotenv`): `PYTHON=<venv>/bin/python make dev-status` passes the preflight, reaches the **real** `dev_harness.cli`, prints harness status, exit 0.
- New regression tests `scripts/dev-harness/tests/test_dev_wrappers.py` — behavioral, parametrized over all seven wrappers: unprovisioned → non-zero exit, `make dev-init` named, underlying import error named, no traceback, CLI never runs; provisioned → CLI runs with the wrapper's own subcommand.
- `make preflight`: **13/13 checks pass**, including the `dev-harness-unit-tests` lane (86 passed, 7 skipped) and `failure-class-protocol` against this body.
- `shellcheck` on the touched scripts: no findings beyond the pre-existing informational SC1091 `source` notes.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

The violated contract — a prerequisite check must be reachable without the dependency it exists to report on — has one fixed instance and no recurrence evidence, so it is declared as an instance rather than minted into the registry. If the sibling onboarding-diagnosability reports (#11534) resolve the same way, that is the point to open a class with two evidence PRs behind it.

fixes #11533

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

