### PR TITLE
fix(backend): stop reporting an immediately-rejected STT fallback as recovered (#11752)

### DIFF
--- a/backend/tests/unit/test_deepgram_connection_fallback.py
+++ b/backend/tests/unit/test_deepgram_connection_fallback.py
@@ -16,7 +16,7 @@ import pytest
 
 from routers.listen import receiver as receiver_mod
 from routers.listen.receiver import ListenReceiver
-from utils.stt import streaming
+from utils.stt import provider_resilience, streaming
 from utils.stt.streaming import STTService
 
 
@@ -180,6 +180,61 @@ async def test_the_deepgram_and_parakeet_circuits_stay_independent():
 
     parakeet_circuit.record_failure.assert_not_called()
     parakeet_circuit.allow_request.assert_not_called()
+
+
+class _RejectedSocket:
+    """Velma's over-quota shape: the upgrade succeeds, then the stream is refused."""
+
+    def __init__(self, reason: str = 'modulate error: Monthly usage limit reached.') -> None:
+        self.death_reason = reason
+        self.finished = False
+
+    @property
+    def is_connection_dead(self) -> bool:
+        return True
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+@pytest.mark.anyio
+async def test_a_fallback_that_is_already_dead_is_not_reported_as_recovered():
+    """Regression (#11752): an over-quota Modulate connect is an exhausted chain, not a heal."""
+    rejected = _RejectedSocket()
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback') as record,
+        pytest.raises(RuntimeError, match='Monthly usage limit reached'),
+    ):
+        await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.parakeet,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=rejected),
+        )
+
+    assert record.call_args.kwargs['outcome'] == 'exhausted'
+    assert rejected.finished, 'the rejected socket must be released, not leaked'
+
+
+@pytest.mark.anyio
+async def test_a_live_fallback_socket_still_serves_the_session():
+    """The liveness check must not fail a healthy fallback that simply has no audio yet."""
+    live_socket = SimpleNamespace(is_connection_dead=False, death_reason=None)
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback') as record,
+    ):
+        socket, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.parakeet,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=live_socket),
+        )
+
+    assert socket is live_socket
+    assert service == STTService.modulate
+    assert record.call_args.kwargs['outcome'] == 'recovered'
 
 
 @pytest.mark.anyio

--- a/backend/utils/stt/provider_resilience.py
+++ b/backend/utils/stt/provider_resilience.py
@@ -6,11 +6,53 @@ latency optimization for each listener process, not a fleet-wide coordinator.
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import os
 import threading
 import time
-from typing import Callable
+from typing import Any, Callable, Final
+
+logger = logging.getLogger(__name__)
 
 EXPECTED_REJECTIONS = frozenset({'capacity_full', 'allocation_rejected'})
+
+# A provider accepts the WebSocket upgrade before it applies account state, so the
+# window has to outlast that rejection round trip (prod measured ~150ms).
+STT_FALLBACK_LIVENESS_GRACE_SECONDS: Final[float] = float(os.getenv('STT_FALLBACK_LIVENESS_GRACE_SECONDS', '0.3'))
+_FALLBACK_LIVENESS_POLL_SECONDS: Final[float] = 0.02
+
+
+async def fallback_socket_is_serving(socket: Any) -> bool:
+    """Return whether a freshly connected fallback socket is actually serving.
+
+    Velma accepts the upgrade and only then rejects the stream — an over-quota
+    account answers ``{"type":"error","error":"Monthly usage limit reached."}``
+    about 150ms later, which the socket surfaces as ``is_connection_dead``.
+    Treating that connect as a heal reports ``outcome='recovered'`` for a session
+    that dies moments afterwards, so the outage never reaches ops (#11752).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + STT_FALLBACK_LIVENESS_GRACE_SECONDS
+    while True:
+        if getattr(socket, 'is_connection_dead', False):
+            return False
+        if loop.time() >= deadline:
+            return True
+        await asyncio.sleep(_FALLBACK_LIVENESS_POLL_SECONDS)
+
+
+def close_rejected_socket(socket: Any) -> None:
+    """Release a fallback socket that never served.
+
+    Deliberately the sync close and not the awaited tail drain: a rejected stream
+    transcribed nothing, and the drain path is allowed to wait on a provider that
+    has already gone away — which would stall session setup instead of failing it.
+    """
+    try:
+        socket.finish()
+    except Exception:
+        logger.warning('Failed to close a rejected STT fallback socket')
 
 
 class ProviderCircuitBreaker:

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -33,7 +33,12 @@ from utils.metrics import OMI_LIVE_STT_MISALIGNED_FRAMES_TOTAL
 from utils.http_client import get_stt_client, get_stt_semaphore
 from utils.stt.safe_socket import SafeDeepgramSocket  # noqa: F401 — re-exported for backward compat
 from utils.stt.socket import STTSocket
-from utils.stt.provider_resilience import EXPECTED_REJECTIONS, ProviderCircuitBreaker
+from utils.stt.provider_resilience import (
+    EXPECTED_REJECTIONS,
+    ProviderCircuitBreaker,
+    close_rejected_socket,
+    fallback_socket_is_serving,
+)
 from utils.stt.speaker_embedding import (
     SPEAKER_MATCH_THRESHOLD,
     async_extract_embedding_from_bytes,
@@ -132,6 +137,10 @@ async def connect_stt_socket_with_fallback(
         fallback_socket = await connect_modulate()
         if fallback_socket is None:
             raise RuntimeError('Modulate returned no socket')
+        if not await fallback_socket_is_serving(fallback_socket):
+            detail = getattr(fallback_socket, 'death_reason', None) or 'stream rejected'
+            close_rejected_socket(fallback_socket)
+            raise RuntimeError(f'Modulate rejected the stream: {detail}')
     except Exception:
         record_fallback(
             component='stt_selection',


### PR DESCRIPTION
## Bug

`connect_stt_socket_with_fallback` treated "`connect_modulate()` returned a socket" as proof the failover healed the session. Velma accepts the WebSocket upgrade *before* it applies account state, so an over-quota account connects and only then answers `{"type":"error","error":"Monthly usage limit reached."}` — about 150ms later, which `SafeModulateSocket` surfaces as `is_connection_dead`.

The session therefore recorded a heal that never happened:

```
omi_fallback_event component=stt_selection from=parakeet to=modulate reason=timeout outcome=recovered
```

and then died on the STT death monitor. Prod is in exactly that state right now — Deepgram rejecting every live connect with HTTP 402 (#11695) and Modulate over its monthly cap (#11752): 20 `outcome=recovered` failovers to Modulate between 17:13Z and 17:16Z on `prod-omi-backend-listen`, alongside 17 `Modulate streaming error: Monthly usage limit reached.` stream errors in the same window.

`docs/agents/fallback-telemetry.md` states the contract this violates: **silent UX healing is allowed; silent ops is not.** `omi_fallback_total` is what an operator reads to see a provider outage, and during a total two-provider outage it was reading `recovered`.

## Root cause

The fallback stage checked only `socket is not None`. A socket that connected and was refused a moment later is indistinguishable from a healthy one at that instant, so the chain recorded `outcome='recovered'`, returned the doomed socket, and let the session fail later through the death monitor instead of at initialization.

## Fix

Confirm the fallback socket is not already dead before claiming it serves, within a bounded grace that outlasts the provider's rejection round trip (`STT_FALLBACK_LIVENESS_GRACE_SECONDS`, default 0.3s — spent only on a session that already lost its primary; healthy primary paths are untouched). The check lives with the other STT resilience primitives in `utils/stt/provider_resilience.py`, next to the circuit breaker. A rejected socket is released with the sync close, never the awaited tail drain (which is allowed to wait on a provider that has already gone away), and the chain records `outcome='exhausted'` and raises — so the client receives its typed terminal live-STT status at init instead of a socket that silently stops transcribing.

**This does not restore transcription.** With Deepgram at 402 and Modulate over quota, streaming Parakeet is en-only (`nvidia/parakeet-rnnt-1.1b` → `frozenset({'en'})`), so a `multi` session has no eligible provider left; remediation for the outage itself is vendor capacity. This change makes the loss visible and terminal instead of a false heal.

## What I tested

- `backend/.venv/bin/python -m pytest tests/unit/test_deepgram_connection_fallback.py` → **11 passed**. Both new regression tests **fail on clean `origin/main`** (verified by stashing the `streaming.py` hunk).
- `tests/unit/test_modulate_stt.py test_live_stt_failure.py test_listen_stt_death_monitor.py test_transcribe_teardown_flush.py test_listen_parity_runtime.py test_desktop_transcribe.py` → 182 passed, 4 failed; the same 4 `TestLanguageRouting` tests fail identically on clean `origin/main` in this local env (pre-existing).
- `make preflight` → passes under Python 3.11 with the exception declared below (the system `python3` on this machine is 3.9 and cannot import `.github/scripts/git_bash.py`).
- The production shape is already covered: `test_modulate_stt.py` proves a real `SafeModulateSocket` marks itself dead on `{"type":"error"}`.

Line-Count-Exception: backend/utils/stt/streaming.py | 1556 -> 1565 | the liveness check and its constants live in utils/stt/provider_resilience.py; the 9 lines added here are the call site and its import, and splitting this frozen module is not in scope for an incident fix

Failure-Class: FC-recoverable-provider-failure-terminal

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

