### PR TITLE
SCA-324: stop idle RUNNING omi-agent VMs in the reconciler

### DIFF
--- a/.github/failure-classes/FC-agent-vm-idle-running-unstopped.json
+++ b/.github/failure-classes/FC-agent-vm-idle-running-unstopped.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "FC-agent-vm-idle-running-unstopped",
+  "violated_contract": "A healthy RUNNING omi-agent GCE instance with no unexpired session lease must be stopped after a documented idle TTL so the TERMINATED reaper can delete it; guest self-stop is fail-silent and is not a fleet backstop.",
+  "canonical_prevention": "In the fleet reconciler, persist idleSince on first zero-session observation of a no-drift RUNNING VM and stop it after AGENT_VM_IDLE_STOP_SECONDS. Never fold idle into drift_reasons, which would stop then restart. Keep the reaper TERMINATED-only.",
+  "canonical_prevention_artifact": [
+    "backend/jobs/agent_vm_reconciler.py",
+    "backend/tests/unit/test_agent_vm_reconciler_job.py"
+  ],
+  "evidence_prs": [
+    7596,
+    10390
+  ],
+  "scope_hints": [
+    "backend/jobs/agent_vm_reconciler.py",
+    "backend/scripts/agent_vm_reaper.py",
+    "backend/agent_vm/main.py",
+    "backend/charts/agent-vm-reaper/**"
+  ],
+  "status": "open"
+}

--- a/backend/agent_vm/main.py
+++ b/backend/agent_vm/main.py
@@ -3,6 +3,7 @@ import base64
 import copy
 import hashlib
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -130,6 +131,7 @@ class Runtime:
 
 
 runtime = Runtime()
+logger = logging.getLogger("agent-vm")
 
 
 @asynccontextmanager
@@ -178,6 +180,7 @@ async def stop_instance() -> None:
     audience = os.environ.get("AGENT_VM_STOP_AUDIENCE", "").strip()
     backend_url = runtime.backend_url.rstrip("/")
     if not audience or not backend_url:
+        logger.warning("idle-stop skipped: AGENT_VM_STOP_AUDIENCE or BACKEND_URL unset")
         return
     try:
         identity = await metadata(
@@ -189,7 +192,8 @@ async def stop_instance() -> None:
                 headers={"Authorization": f"Bearer {identity}"},
             )
             response.raise_for_status()
-    except (httpx.HTTPError, OSError):
+    except (httpx.HTTPError, OSError) as exc:
+        logger.warning("idle-stop broker call failed: %s", type(exc).__name__)
         return
 
 

--- a/backend/charts/agent-vm-reaper/README.md
+++ b/backend/charts/agent-vm-reaper/README.md
@@ -14,7 +14,7 @@ desktop agent leaves a permanent disk (~$5/mo).
 | Target | Rule (defaults) |
 |--------|-----------------|
 | `TERMINATED` | `lastStopTimestamp` older than **12h** |
-| `RUNNING` | `creationTimestamp` older than **2d** |
+| `RUNNING` | **Never deleted here.** The fleet reconciler is the RUNNING authority: a healthy VM with no session lease past `AGENT_VM_IDLE_STOP_SECONDS` (default 1h) is stopped; this reaper then deletes the TERMINATED leftover. Do not reap RUNNING by creation age — that would delete live sessions (review #10390). |
 
 After a TERMINATED VM is deleted, `GET /v2/agent/status` sees `NOT_FOUND`,
 demotes the client-facing status to `updating`, records `reconcile.state=missing`
@@ -40,11 +40,14 @@ kubectl -n prod-omi-backend logs -l job-name --tail=200   # or logs job/<name>
 AGENT_VM_REAPER_APPLY=1 AGENT_VM_REAPER_LIVE=1 bash backend/scripts/apply-agent-vm-reaper.sh
 ```
 
-Local inventory dry-run (no cluster mutation):
+Local inventory (no deletes; lists by status, including RUNNING that the reconciler must stop first):
 
 ```bash
+python3 backend/scripts/agent_vm_reaper.py --inventory
 python3 backend/scripts/agent_vm_reaper.py --dry-run
 ```
+
+Ownerless RUNNING VMs (no Firestore `users.agentVm.vmName`) are outside the reconciler and need operator cleanup. Join the inventory names against Firestore before any one-shot delete.
 
 ## Related
 

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -89,6 +89,8 @@ OWNER_FALLBACK_SCAN_LIMIT = 1_000
 FAILED_JOB_STATES = {"retry", "quarantined", "missing", "stale", "recreate_required"}
 DEFAULT_MISSING_CLEANUP_GRACE_SECONDS = 24 * 60 * 60
 MIN_MISSING_CLEANUP_GRACE_SECONDS = 60
+DEFAULT_IDLE_STOP_SECONDS = 60 * 60
+MIN_IDLE_STOP_SECONDS = 30 * 60
 _IMMUTABLE_BOOT_IMAGE = re.compile(r"^projects/[^/]+/global/images/[^/]+$")
 _MIGRATION_ID = re.compile(r"^[0-9a-f]{24}$")
 
@@ -391,6 +393,41 @@ def _missing_cleanup_grace_seconds() -> int:
     if value < MIN_MISSING_CLEANUP_GRACE_SECONDS:
         raise ValueError(f"AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS must be at least {MIN_MISSING_CLEANUP_GRACE_SECONDS}")
     return value
+
+
+def _idle_stop_seconds() -> int:
+    raw = os.getenv("AGENT_VM_IDLE_STOP_SECONDS")
+    if raw is None or not raw.strip():
+        return DEFAULT_IDLE_STOP_SECONDS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError("AGENT_VM_IDLE_STOP_SECONDS must be an integer") from exc
+    if value < MIN_IDLE_STOP_SECONDS:
+        raise ValueError(f"AGENT_VM_IDLE_STOP_SECONDS must be at least {MIN_IDLE_STOP_SECONDS}")
+    return value
+
+
+def idle_stop_due(
+    *,
+    status: str,
+    reasons: Sequence[str],
+    start_requested: bool,
+    active_sessions: int,
+    idle_since: float | None,
+    now: float,
+    idle_stop_seconds: int,
+) -> bool:
+    """True only for a healthy RUNNING VM with no live session past the idle TTL.
+
+    Idle must never be folded into drift ``reasons``: that path stops, rewrites
+    metadata, then restarts. This predicate is a terminal-for-this-run outcome.
+    """
+    if reasons or start_requested or active_sessions != 0:
+        return False
+    if status != "RUNNING" or idle_since is None:
+        return False
+    return idle_since <= now - idle_stop_seconds
 
 
 def _canonical_image_ref(value: str) -> str:
@@ -1220,6 +1257,7 @@ async def reconcile_one(
     project: str,
     dry_run: bool = False,
     missing_cleanup_grace_seconds: int | None = None,
+    idle_stop_seconds: int | None = None,
     boot_image_migration: BootImageMigrationPlan | None = None,
 ) -> ReconcileResult:
     vm_name = str(vm["vmName"])
@@ -1265,6 +1303,7 @@ async def reconcile_one(
     missing_cleanup_grace_seconds = (
         _missing_cleanup_grace_seconds() if missing_cleanup_grace_seconds is None else missing_cleanup_grace_seconds
     )
+    idle_stop_seconds = _idle_stop_seconds() if idle_stop_seconds is None else idle_stop_seconds
     failed_candidate: dict[str, str] = {}
     try:
         instance = await api.get_instance(vm_name)
@@ -1510,6 +1549,8 @@ async def reconcile_one(
                     return ReconcileResult(uid, "stale", "owner lease lost while deferring drain")
                 return ReconcileResult(uid, "deferred", f"{active} active session(s)")
         status = str(instance.get("status") or "UNKNOWN")
+        idle_since_raw = reconcile_state.get("idleSince")
+        idle_since = float(idle_since_raw) if isinstance(idle_since_raw, (int, float)) else None
         if not reasons and status in {"TERMINATED", "STOPPED"} and not start_requested:
             if not await _update_reconcile(
                 uid,
@@ -1526,6 +1567,7 @@ async def reconcile_one(
                     "lastError": None,
                     "retryAt": None,
                     "missingSince": DELETE_FIELD,
+                    "idleSince": DELETE_FIELD,
                     **clear_vm_reconcile_lease_fields(),
                 },
                 vm_fields={
@@ -1536,6 +1578,61 @@ async def reconcile_one(
             ):
                 return ReconcileResult(uid, "stale", "owner lease lost while recording stopped VM")
             return ReconcileResult(uid, "ready", "stopped; idle self-stop preserved")
+        if not reasons and status == "RUNNING" and not start_requested:
+            active = await asyncio.to_thread(active_session_count, uid, vm_name)
+            if idle_stop_due(
+                status=status,
+                reasons=reasons,
+                start_requested=start_requested,
+                active_sessions=active,
+                idle_since=idle_since,
+                now=now,
+                idle_stop_seconds=idle_stop_seconds,
+            ):
+                if not await asyncio.to_thread(renew_vm_lease, uid, vm_name, auth_token, owner):
+                    return ReconcileResult(uid, "stale", "owner lease lost before idle stop")
+                await api.stop(vm_name)
+                if not await _update_reconcile(
+                    uid,
+                    vm_name,
+                    auth_token,
+                    owner,
+                    {
+                        "state": "ready",
+                        "observedRelease": release.release_id,
+                        "observedImageDigest": release.image_digest,
+                        "observedStartupSha256": release.startup_sha256,
+                        "lastSuccessAt": time.time(),
+                        "retryCount": 0,
+                        "lastError": None,
+                        "retryAt": None,
+                        "missingSince": DELETE_FIELD,
+                        "idleSince": DELETE_FIELD,
+                        **clear_vm_reconcile_lease_fields(),
+                    },
+                    vm_fields={
+                        "status": "stopped",
+                        **({"stateDisk": state_disk_info} if state_disk_info else {}),
+                    },
+                    consume_start_request_at=observed_start_request_at,
+                ):
+                    return ReconcileResult(uid, "stale", "owner lease lost while recording idle stop")
+                return ReconcileResult(uid, "ready", "stopped; idle TTL elapsed")
+            if active == 0:
+                recorded_idle_since = idle_since if idle_since is not None else now
+                if not await _update_reconcile(
+                    uid,
+                    vm_name,
+                    auth_token,
+                    owner,
+                    {
+                        "state": "ready",
+                        "idleSince": recorded_idle_since,
+                        **clear_vm_reconcile_lease_fields(),
+                    },
+                ):
+                    return ReconcileResult(uid, "stale", "owner lease lost while recording idleSince")
+                return ReconcileResult(uid, "ready", "idle; waiting for TTL")
         if status == "RUNNING" and reasons:
             if not await asyncio.to_thread(renew_vm_lease, uid, vm_name, auth_token, owner):
                 return ReconcileResult(uid, "stale", "owner lease lost before stop")
@@ -1589,6 +1686,7 @@ async def reconcile_one(
                 "lastError": None,
                 "retryAt": None,
                 "missingSince": DELETE_FIELD,
+                "idleSince": DELETE_FIELD,
                 **clear_vm_reconcile_lease_fields(),
             },
             vm_fields={

--- a/backend/scripts/agent_vm_reaper.py
+++ b/backend/scripts/agent_vm_reaper.py
@@ -90,7 +90,7 @@ def list_agent_vms(project: str) -> list[dict[str, Any]]:
             "list",
             f"--project={project}",
             f"--filter=name~^{NAME_PREFIX}",
-            "--format=json(name,zone,status,creationTimestamp,lastStopTimestamp,disks)",
+            "--format=json(name,zone,status,creationTimestamp,lastStartTimestamp,lastStopTimestamp,disks)",
         ],
         check=True,
         capture_output=True,
@@ -150,7 +150,35 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--instances-json",
         help="Optional path to a gcloud instances JSON list (skips live list; for tests/fixtures).",
     )
+    parser.add_argument(
+        "--inventory",
+        action="store_true",
+        help="List omi-agent VMs by status and exit. No deletes. Ownerless VMs (no Firestore owner) are outside the reconciler and need operator cleanup.",
+    )
     return parser.parse_args(argv)
+
+
+def format_inventory(instances: list[dict[str, Any]]) -> str:
+    """Group-list VMs by status for operator review. Does not decide reapability."""
+    by_status: dict[str, list[str]] = {}
+    for inst in instances:
+        name = str(inst.get("name") or "")
+        if not name.startswith(NAME_PREFIX):
+            continue
+        status = str(inst.get("status") or "UNKNOWN")
+        created = str(inst.get("creationTimestamp") or "")
+        started = str(inst.get("lastStartTimestamp") or "")
+        by_status.setdefault(status, []).append(f"{name} created={created} lastStart={started}")
+    lines = [f"inventory {sum(len(v) for v in by_status.values())} omi-agent VMs"]
+    for status in sorted(by_status):
+        rows = by_status[status]
+        lines.append(f"{status}: {len(rows)}")
+        lines.extend(f"  {row}" for row in rows)
+    lines.append(
+        "Ownerless RUNNING VMs (GCE name not in users.agentVm.vmName) are unreachable "
+        "by the reconciler idle-stop path and need operator cleanup."
+    )
+    return "\n".join(lines)
 
 
 def live_deletes_allowed(*, dry_run: bool, live_flag: bool) -> bool:
@@ -180,6 +208,10 @@ def main(argv: list[str] | None = None) -> int:
             instances = json.load(handle)
     else:
         instances = list_agent_vms(args.project)
+
+    if args.inventory:
+        print(format_inventory(instances if isinstance(instances, list) else []))
+        return 0
 
     targets = select_reapable(
         instances,

--- a/backend/tests/unit/test_agent_vm_protocol.py
+++ b/backend/tests/unit/test_agent_vm_protocol.py
@@ -100,6 +100,35 @@ def test_http_protocol_requires_vm_token(tmp_path: Path) -> None:
         assert client.post("/ping?token=test-token").json() == {"status": "ok"}
 
 
+def test_stop_instance_is_observable_when_audience_missing(tmp_path: Path, monkeypatch, caplog) -> None:
+    import logging
+
+    _, module = load_app(tmp_path)
+    monkeypatch.delenv("AGENT_VM_STOP_AUDIENCE", raising=False)
+    module.runtime.backend_url = "https://api.example.test"
+    with caplog.at_level(logging.WARNING, logger="agent-vm"):
+        asyncio.run(module.stop_instance())
+    assert "idle-stop skipped" in caplog.text
+
+
+def test_stop_instance_is_observable_when_broker_fails(tmp_path: Path, monkeypatch, caplog) -> None:
+    import logging
+
+    import httpx
+
+    _, module = load_app(tmp_path)
+    monkeypatch.setenv("AGENT_VM_STOP_AUDIENCE", "https://api.example.test")
+    module.runtime.backend_url = "https://api.example.test"
+
+    async def boom(_path: str) -> str:
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(module, "metadata", boom)
+    with caplog.at_level(logging.WARNING, logger="agent-vm"):
+        asyncio.run(module.stop_instance())
+    assert "idle-stop broker call failed" in caplog.text
+
+
 def test_invalid_database_upload_preserves_open_database(tmp_path: Path) -> None:
     app, module = load_app(tmp_path)
     connection = sqlite3.connect(module.runtime.db_path)

--- a/backend/tests/unit/test_agent_vm_reaper.py
+++ b/backend/tests/unit/test_agent_vm_reaper.py
@@ -244,6 +244,42 @@ def test_apply_script_refuses_without_gate():
     assert "REFUSED" in proc.stderr
 
 
+def test_readme_does_not_reap_running_by_creation_age():
+    readme = (ROOT / "backend" / "charts" / "agent-vm-reaper" / "README.md").read_text(encoding="utf-8")
+    assert "creationTimestamp older than **2d**" not in readme
+    assert "Never deleted here" in readme
+    assert "reconciler" in readme.lower()
+
+
+def test_inventory_lists_running_without_selecting_them(reaper):
+    instances = [
+        _inst("omi-agent-old", "RUNNING", created_hours_ago=49),
+        _inst("omi-agent-aged", "TERMINATED", created_hours_ago=40, stopped_hours_ago=13),
+        _inst("other-vm", "RUNNING", created_hours_ago=49),
+    ]
+    text = reaper.format_inventory(instances)
+    assert "RUNNING: 1" in text
+    assert "omi-agent-old" in text
+    assert "other-vm" not in text
+    assert "Ownerless" in text
+    assert reaper.select_reapable(instances, now=NOW, terminated_min_age_hours=12)[0]["name"] == "omi-agent-aged"
+
+
+def test_cli_inventory_does_not_delete(tmp_path, monkeypatch, reaper):
+    import json
+
+    fixture = tmp_path / "instances.json"
+    fixture.write_text(
+        json.dumps([_inst("omi-agent-old", "RUNNING", created_hours_ago=49)]),
+        encoding="utf-8",
+    )
+    deleted = []
+    monkeypatch.setattr(reaper, "delete_instance", lambda *_a, **_k: deleted.append(True))
+    rc = reaper.main(["--instances-json", str(fixture), "--inventory"])
+    assert rc == 0
+    assert deleted == []
+
+
 def test_cronjob_manifest_defaults_are_safe():
     docs = list(yaml.safe_load_all(MANIFEST.read_text(encoding="utf-8")))
     cron = next(d for d in docs if d and d.get("kind") == "CronJob")

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -90,6 +90,220 @@ def test_reconcile_preserves_a_healthy_stopped_vm(monkeypatch):
     assert updates[-1]["vm_fields"] == {"status": "stopped"}
 
 
+class IdleRunningApi:
+    stops = 0
+    starts = 0
+    metadata_writes = 0
+
+    def __init__(self, _project: str, _zone: str) -> None:
+        self.instance = {
+            "status": "RUNNING",
+            "metadata": {},
+            "serviceAccounts": [],
+            "disks": [{"boot": True, "source": "projects/project/zones/us-central1-a/disks/omi-agent-user"}],
+            "networkInterfaces": [{"networkIP": "10.128.0.9", "accessConfigs": [{"natIP": "34.1.2.3"}]}],
+        }
+
+    async def get_instance(self, _vm_name: str) -> dict[str, Any]:
+        return self.instance
+
+    async def request(self, _method: str, _url: str) -> Any:
+        class Response:
+            @staticmethod
+            def raise_for_status() -> None:
+                return None
+
+            @staticmethod
+            def json() -> dict[str, str]:
+                return {"sourceImage": "projects/project/global/images/omi-agent-20260805"}
+
+        return Response()
+
+    async def stop(self, _vm_name: str) -> None:
+        type(self).stops += 1
+        self.instance["status"] = "TERMINATED"
+
+    async def start(self, _vm_name: str) -> None:
+        type(self).starts += 1
+
+    async def set_metadata(self, *_args: Any) -> None:
+        type(self).metadata_writes += 1
+
+    async def set_service_account(self, *_args: Any) -> None:
+        type(self).metadata_writes += 1
+
+    def private_instance_ip(self, _instance: dict[str, Any]) -> str:
+        return "10.128.0.9"
+
+    def instance_ip(self, _instance: dict[str, Any]) -> str:
+        return "34.1.2.3"
+
+    async def runtime_is_current(self, *_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+    async def wait_for_runtime(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _patch_idle_reconcile(monkeypatch, *, sessions: int = 0):
+    updates: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    IdleRunningApi.stops = 0
+    IdleRunningApi.starts = 0
+    IdleRunningApi.metadata_writes = 0
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", IdleRunningApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "renew_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: [])
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: sessions)
+    monkeypatch.setattr(
+        reconciler, "update_vm_reconcile", lambda *args, **kwargs: updates.append((args, kwargs)) or True
+    )
+    return updates
+
+
+def test_idle_running_vm_past_ttl_is_stopped_without_restart(monkeypatch):
+    updates = _patch_idle_reconcile(monkeypatch)
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "reconcile": {"idleSince": now - 7200},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            idle_stop_seconds=3600,
+        )
+    )
+
+    assert result.state == "ready"
+    assert result.detail == "stopped; idle TTL elapsed"
+    assert IdleRunningApi.stops == 1
+    assert IdleRunningApi.starts == 0
+    assert IdleRunningApi.metadata_writes == 0
+    fields = updates[-1][0][4]
+    assert fields["state"] == "ready"
+    assert fields["idleSince"] is lifecycle.DELETE_FIELD
+    assert updates[-1][1]["vm_fields"]["status"] == "stopped"
+
+
+def test_idle_running_vm_with_active_session_is_not_stopped(monkeypatch):
+    updates = _patch_idle_reconcile(monkeypatch, sessions=1)
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "reconcile": {"idleSince": now - 7200},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            idle_stop_seconds=3600,
+        )
+    )
+
+    assert result.state == "ready"
+    assert IdleRunningApi.stops == 0
+    assert IdleRunningApi.starts == 0
+    fields = updates[-1][0][4]
+    assert fields["state"] == "ready"
+    assert fields["idleSince"] is lifecycle.DELETE_FIELD
+    assert updates[-1][1]["vm_fields"]["status"] == "ready"
+
+
+def test_idle_running_vm_with_start_request_starts_not_stops(monkeypatch):
+    updates = _patch_idle_reconcile(monkeypatch)
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "reconcile": {"startRequested": True, "startRequestedAt": now, "idleSince": now - 7200},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            idle_stop_seconds=3600,
+        )
+    )
+
+    assert result.state == "ready"
+    assert IdleRunningApi.stops == 0
+    fields = updates[-1][0][4]
+    assert fields["idleSince"] is lifecycle.DELETE_FIELD
+    assert updates[-1][1]["vm_fields"]["status"] == "ready"
+
+
+def test_idle_ttl_not_reached_persists_idle_since_without_stop(monkeypatch):
+    updates = _patch_idle_reconcile(monkeypatch)
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "reconcile": {"idleSince": now - 10},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+            idle_stop_seconds=3600,
+        )
+    )
+
+    assert result.state == "ready"
+    assert result.detail == "idle; waiting for TTL"
+    assert IdleRunningApi.stops == 0
+    assert IdleRunningApi.starts == 0
+    fields = updates[-1][0][4]
+    assert fields["idleSince"] == now - 10
+
+
+def test_idle_is_never_a_drift_reason():
+    assert "idle" not in lifecycle.drift_reasons(
+        {
+            "serviceAccounts": [{"email": RELEASE.service_account}],
+            "metadata": {"items": []},
+        },
+        RELEASE,
+    )
+    assert not reconciler.idle_stop_due(
+        status="RUNNING",
+        reasons=["runtime"],
+        start_requested=False,
+        active_sessions=0,
+        idle_since=0.0,
+        now=10_000.0,
+        idle_stop_seconds=3600,
+    )
+    assert reconciler.idle_stop_due(
+        status="RUNNING",
+        reasons=[],
+        start_requested=False,
+        active_sessions=0,
+        idle_since=0.0,
+        now=10_000.0,
+        idle_stop_seconds=3600,
+    )
+
+
 def test_reconcile_starts_a_current_vm_only_after_fenced_start_request(monkeypatch):
     class StartRequestedApi:
         starts = 0
@@ -3439,6 +3653,25 @@ def test_missing_cleanup_grace_rejects_unsafe_configuration(monkeypatch, value):
     monkeypatch.setenv("AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS", value)
     with pytest.raises(ValueError, match="AGENT_VM_MISSING_CLEANUP_GRACE_SECONDS"):
         reconciler._missing_cleanup_grace_seconds()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, reconciler.DEFAULT_IDLE_STOP_SECONDS), ("1800", 1800)],
+)
+def test_idle_stop_seconds_uses_a_safe_default_or_valid_override(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("AGENT_VM_IDLE_STOP_SECONDS", raising=False)
+    else:
+        monkeypatch.setenv("AGENT_VM_IDLE_STOP_SECONDS", value)
+    assert reconciler._idle_stop_seconds() == expected
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "1799"])
+def test_idle_stop_seconds_rejects_unsafe_configuration(monkeypatch, value):
+    monkeypatch.setenv("AGENT_VM_IDLE_STOP_SECONDS", value)
+    with pytest.raises(ValueError, match="AGENT_VM_IDLE_STOP_SECONDS"):
+        reconciler._idle_stop_seconds()
 
 
 @pytest.mark.parametrize("state", ["quarantined", "missing", "stale", "recreate_required"])

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -25,6 +25,14 @@ before acceptance, so an unaccepted candidate cannot escape the staged gate.
    Agent VM subnet and set `AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc`; it
    refuses to send the bearer token over a NAT address. A healthy
    stopped VM with no drift remains stopped so idle self-stop is preserved.
+   A healthy RUNNING VM with no start demand and zero session leases records
+   `agentVm.reconcile.idleSince` on first observation and is stopped after
+   `AGENT_VM_IDLE_STOP_SECONDS` (default 1h, minimum 30m). Idle is never a
+   drift reason: the drift path would stop-then-restart and leak again. The
+   TERMINATED reaper remains the delete backstop. Ownerless VMs (no Firestore
+   owner) are unreachable here — inventory them with
+   `python3 backend/scripts/agent_vm_reaper.py --inventory` and clean up
+   out-of-band.
 4. A provider-confirmed missing VM is recorded with `missingSince`. The
    reconciler selects that terminal record independently of the rollout cohort
    and deletes only its Firestore `agentVm` pointer after the configured grace


### PR DESCRIPTION
Line-Count-Exception: backend/jobs/agent_vm_reconciler.py | 1814 -> 1912 | idle-stop predicate and no-drift RUNNING path stay next to the existing stop/preserve CAS; splitting would hide the stop-vs-restart invariant

## What changed and why

Idle RUNNING `omi-agent-*` VMs had no server-side stop path: guest idle-stop is fail-silent, the reconciler only stopped on drift (then restarted), and the reaper deletes TERMINATED only. The reconciler now records `idleSince` on a healthy no-session RUNNING VM and stops it after `AGENT_VM_IDLE_STOP_SECONDS` (default 1h). The existing TERMINATED reaper remains the delete backstop.

Closes SCA-324
Closes #6611

#7326's public-IP residual is out of scope (firewall still `applyEnabled: false`). This PR covers the cost half only.

## Product invariants affected

none

## How it was verified

Ran the agent-vm unit files after `make setup`:

```text
BACKEND_UNIT_TEST_FILE_LIST=... ./test.sh
138 passed
```

including the new leak matrix (RUNNING+stale stops once and does not restart; RUNNING+lease and start-demand do not stop; TTL-not-reached persists `idleSince`; idle is never a drift reason; README no longer claims RUNNING>2d; guest `stop_instance()` failures are logged).

Did not exercise live GCE or the prod CronJob. Existing 1,151 prod VMs are operator cleanup after merge; ownerless VMs are unreachable by this path (`python3 backend/scripts/agent_vm_reaper.py --inventory`).

## Tests

- `test_idle_running_vm_past_ttl_is_stopped_without_restart` — the leak itself
- `test_idle_running_vm_with_active_session_is_not_stopped`
- `test_idle_running_vm_with_start_request_starts_not_stops`
- `test_idle_ttl_not_reached_persists_idle_since_without_stop`
- `test_idle_is_never_a_drift_reason`
- `test_readme_does_not_reap_running_by_creation_age`
- `test_stop_instance_is_observable_when_audience_missing`
- `test_stop_instance_is_observable_when_broker_fails`

## Failure class (fixes)

Failure-Class: new

## Failure-class transition narrative (only when needed)

Violated contract: a healthy RUNNING `omi-agent-*` VM with no unexpired session lease must be stopped after a documented idle TTL so the TERMINATED reaper can delete it. The guest 30-minute self-stop is fail-silent and is not a fleet backstop.

Canonical guard: `idle_stop_due()` in `backend/jobs/agent_vm_reconciler.py`, used only on the no-drift RUNNING path (never folded into `drift_reasons`, which would stop-then-restart). Tests in `backend/tests/unit/test_agent_vm_reconciler_job.py` pin stop-once / lease-defer / start-demand / TTL-wait / not-a-drift-reason.

Registry lifecycle for the new class is a follow-up PR after this instance fix merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

