### PR TITLE
fix(backend): continue the live-STT fallback chain past Modulate to Parakeet (#11752)

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -50,6 +50,7 @@ from utils.stt.streaming import (
     connect_stt_socket_with_fallback,
     make_stream_callback,
     modulate_is_configured_fallback,
+    parakeet_is_configured_fallback,
     process_audio_dg,
     process_audio_modulate,
     process_audio_parakeet,
@@ -238,6 +239,18 @@ class ListenReceiver:
 
             if not modulate_is_configured_fallback(self.host.stt_language):
                 return await connect_deepgram()
+
+            def connect_parakeet() -> Any:
+                return process_audio_parakeet(
+                    callback,
+                    self.host.stt_language,
+                    sample_rate,
+                    1,
+                    model='parakeet',
+                    keywords=keywords,
+                    is_active=lambda: self.host.state.active,
+                )
+
             socket, actual_service = await connect_stt_socket_with_fallback(
                 primary_service=STTService.deepgram,
                 connect_primary=connect_deepgram,
@@ -246,10 +259,15 @@ class ListenReceiver:
                     sample_rate,
                     self.host.stt_language,
                 ),
+                connect_parakeet=(
+                    connect_parakeet if parakeet_is_configured_fallback(self.host.stt_language) else None
+                ),
             )
             self.host.stt_service = actual_service
             if actual_service == STTService.modulate:
                 self.host.stt_model = 'velma-2'
+            elif actual_service == STTService.parakeet:
+                self.host.stt_model = 'parakeet'
             return socket
         raise RuntimeError(f'Unsupported serving STT provider {self.host.stt_service!r}')
 

--- a/backend/tests/unit/test_deepgram_connection_fallback.py
+++ b/backend/tests/unit/test_deepgram_connection_fallback.py
@@ -238,6 +238,140 @@ async def test_a_live_fallback_socket_still_serves_the_session():
 
 
 @pytest.mark.anyio
+async def test_the_chain_continues_to_parakeet_when_modulate_cannot_serve():
+    """Regression (#11752): Deepgram 402 + Modulate rejection must not end the chain.
+
+    ``STT_SERVICE_MODELS`` lists Parakeet behind both of them, so a healthy
+    Parakeet deployment has to take the session instead of it being terminalized.
+    """
+    parakeet_socket = SimpleNamespace(is_connection_dead=False, death_reason=None)
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback') as record,
+    ):
+        socket, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.deepgram,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=_RejectedSocket()),
+            connect_parakeet=AsyncMock(return_value=parakeet_socket),
+        )
+
+    assert socket is parakeet_socket
+    assert service == STTService.parakeet
+    modulate_leg, parakeet_leg = [call.kwargs for call in record.call_args_list]
+    assert (modulate_leg['from_mode'], modulate_leg['to_mode'], modulate_leg['outcome']) == (
+        'deepgram',
+        'modulate',
+        'exhausted',
+    )
+    assert (parakeet_leg['from_mode'], parakeet_leg['to_mode'], parakeet_leg['outcome']) == (
+        'modulate',
+        'parakeet',
+        'recovered',
+    )
+    # The over-quota Modulate rejection is why the session moved on, not Deepgram's 402.
+    assert parakeet_leg['reason'] == 'quota'
+
+
+@pytest.mark.anyio
+async def test_an_exhausted_chain_still_raises_after_parakeet_also_fails():
+    rejected_modulate = _RejectedSocket()
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback') as record,
+        pytest.raises(RuntimeError, match='parakeet returned no socket'),
+    ):
+        await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.deepgram,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=rejected_modulate),
+            connect_parakeet=AsyncMock(return_value=None),
+        )
+
+    assert [call.kwargs['outcome'] for call in record.call_args_list] == ['exhausted', 'exhausted']
+    assert rejected_modulate.finished
+
+
+@pytest.mark.anyio
+async def test_a_parakeet_primary_never_falls_back_to_itself():
+    """The chain must not retry the provider that just failed as its own fallback."""
+    connect_parakeet = AsyncMock()
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        _, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.parakeet,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(return_value=SimpleNamespace(is_connection_dead=False, death_reason=None)),
+            connect_parakeet=connect_parakeet,
+        )
+
+    assert service == STTService.modulate
+    connect_parakeet.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_the_deepgram_session_serves_from_parakeet_when_modulate_is_down():
+    """End of the receiver path: the session survives on Parakeet, labelled as Parakeet."""
+    receiver = _deepgram_receiver()
+    parakeet_socket = SimpleNamespace(is_connection_dead=False, death_reason=None)
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=None)),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=_RejectedSocket())),
+        patch.object(receiver_mod, 'process_audio_parakeet', new=AsyncMock(return_value=parakeet_socket)) as parakeet,
+        patch.object(receiver_mod, 'modulate_is_configured_fallback', return_value=True),
+        patch.object(receiver_mod, 'parakeet_is_configured_fallback', return_value=True),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    parakeet.assert_awaited_once()
+    assert socket is parakeet_socket
+    assert receiver.host.stt_service == STTService.parakeet
+    assert receiver.host.stt_model == 'parakeet'
+
+
+@pytest.mark.anyio
+async def test_a_language_parakeet_cannot_serve_is_not_offered_to_it():
+    receiver = _deepgram_receiver()
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=None)),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=_RejectedSocket())),
+        patch.object(receiver_mod, 'process_audio_parakeet', new=AsyncMock()) as parakeet,
+        patch.object(receiver_mod, 'modulate_is_configured_fallback', return_value=True),
+        patch.object(receiver_mod, 'parakeet_is_configured_fallback', return_value=False),
+        patch.object(streaming, 'record_fallback'),
+        pytest.raises(RuntimeError, match='modulate rejected the stream'),
+    ):
+        await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    parakeet.assert_not_awaited()
+
+
+def test_parakeet_is_a_configured_fallback_only_when_the_deployment_can_serve_it():
+    with (
+        patch.object(streaming, 'stt_service_models', ['dg-nova-3', ' modulate-velma-2', 'parakeet']),
+        patch.dict('os.environ', {'HOSTED_PARAKEET_API_URL': 'ws://parakeet.omi.me/v3/stream'}),
+    ):
+        assert streaming.parakeet_is_configured_fallback('en') is True
+        # Parakeet has no multilingual live mode, so a `multi` session must not move to it.
+        assert streaming.parakeet_is_configured_fallback('multi') is False
+    with (
+        patch.object(streaming, 'stt_service_models', ['dg-nova-3', 'modulate-velma-2']),
+        patch.dict('os.environ', {'HOSTED_PARAKEET_API_URL': 'ws://parakeet.omi.me/v3/stream'}),
+    ):
+        assert streaming.parakeet_is_configured_fallback('en') is False
+
+
+@pytest.mark.anyio
 async def test_modulate_primary_is_still_rejected():
     with pytest.raises(ValueError, match='modulate'):
         await streaming.connect_stt_socket_with_fallback(

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -91,19 +91,46 @@ def _circuit_for_primary(primary_service: STTService) -> ProviderCircuitBreaker:
     raise ValueError(f'connection fallback is not defined for a {primary_service.value} primary')
 
 
+def _fallback_failure_reason(error: BaseException) -> str:
+    """Classify why a fallback provider could not serve, for the next leg's telemetry."""
+    if isinstance(error, (asyncio.TimeoutError, TimeoutError)):
+        return 'timeout'
+    detail = str(error).lower()
+    if 'limit' in detail or 'quota' in detail:
+        return 'quota'
+    return 'provider_5xx'
+
+
+async def _connect_serving_fallback(
+    connect: Callable[[], Awaitable[Optional[STTSocket]]], service: STTService
+) -> STTSocket:
+    """Connect a fallback provider and prove it is actually serving before adopting it."""
+    socket = await connect()
+    if socket is None:
+        raise RuntimeError(f'{service.value} returned no socket')
+    if not await fallback_socket_is_serving(socket):
+        detail = getattr(socket, 'death_reason', None) or 'stream rejected'
+        close_rejected_socket(socket)
+        raise RuntimeError(f'{service.value} rejected the stream: {detail}')
+    return socket
+
+
 async def connect_stt_socket_with_fallback(
     *,
     primary_service: STTService,
     connect_primary: Callable[[], Awaitable[Optional[STTSocket]]],
     connect_modulate: Callable[[], Awaitable[Optional[STTSocket]]],
+    connect_parakeet: Optional[Callable[[], Awaitable[Optional[STTSocket]]]] = None,
 ) -> Tuple[STTSocket, STTService]:
-    """Connect the selected primary before audio starts, falling back once to Modulate.
+    """Connect the selected primary before audio starts, walking the configured fallbacks.
 
     ``STT_SERVICE_MODELS`` states an ordered preference, so a primary that
     cannot open a socket must advance to the next configured provider instead
     of failing the session — a Deepgram account rejecting every connect with
     HTTP 402 otherwise takes the whole deployment's live transcription down
-    (#11695).
+    (#11695). The chain must not stop at Modulate either: with Deepgram at HTTP
+    402 and Modulate answering 500/over quota, an English session died while a
+    healthy Parakeet deployment sat idle behind them in the same list (#11752).
 
     The circuit is deliberately process-local and never owns capacity. The
     Parakeet service rejects excess streams at its GPU boundary; this helper
@@ -133,32 +160,40 @@ async def connect_stt_socket_with_fallback(
             reason = 'provider_5xx'
             circuit.record_failure()
 
-    try:
-        fallback_socket = await connect_modulate()
-        if fallback_socket is None:
-            raise RuntimeError('Modulate returned no socket')
-        if not await fallback_socket_is_serving(fallback_socket):
-            detail = getattr(fallback_socket, 'death_reason', None) or 'stream rejected'
-            close_rejected_socket(fallback_socket)
-            raise RuntimeError(f'Modulate rejected the stream: {detail}')
-    except Exception:
+    candidates: List[Tuple[STTService, Callable[[], Awaitable[Optional[STTSocket]]]]] = [
+        (STTService.modulate, connect_modulate)
+    ]
+    if connect_parakeet is not None and primary_service != STTService.parakeet:
+        candidates.append((STTService.parakeet, connect_parakeet))
+
+    from_mode = primary_service.value
+    for service, connect in candidates:
+        try:
+            fallback_socket = await _connect_serving_fallback(connect, service)
+        except Exception as error:
+            record_fallback(
+                component='stt_selection',
+                from_mode=from_mode,
+                to_mode=service.value,
+                reason=reason,
+                outcome='exhausted',
+            )
+            if service == candidates[-1][0]:
+                raise
+            from_mode = service.value
+            reason = _fallback_failure_reason(error)
+            continue
+
         record_fallback(
             component='stt_selection',
-            from_mode=primary_service.value,
-            to_mode=STTService.modulate.value,
+            from_mode=from_mode,
+            to_mode=service.value,
             reason=reason,
-            outcome='exhausted',
+            outcome='recovered',
         )
-        raise
+        return fallback_socket, service
 
-    record_fallback(
-        component='stt_selection',
-        from_mode=primary_service.value,
-        to_mode=STTService.modulate.value,
-        reason=reason,
-        outcome='recovered',
-    )
-    return fallback_socket, STTService.modulate
+    raise RuntimeError('No STT fallback provider was configured')
 
 
 async def drain_stt_socket(socket: STTSocket) -> None:
@@ -302,6 +337,22 @@ def modulate_is_configured_fallback(language: Optional[str]) -> bool:
         'modulate-velma-2' in (model.strip() for model in stt_service_models)
         and provider_is_enabled(MODULATE_PROVIDER, STTServingSurface.STREAMING)
         and modulate_supports_language(language)
+    )
+
+
+def parakeet_is_configured_fallback(language: Optional[str]) -> bool:
+    """Return whether Parakeet may take over a session whose earlier providers failed.
+
+    Same contract as ``modulate_is_configured_fallback``, one provider further
+    down the ordered ``STT_SERVICE_MODELS`` preference: the deployment must list
+    Parakeet, the policy must serve it, its endpoint must be configured, and it
+    must support the session's resolved provider language.
+    """
+    return (
+        STTService.parakeet.value in (model.strip() for model in stt_service_models)
+        and provider_is_enabled(PARAKEET_PROVIDER, STTServingSurface.STREAMING)
+        and bool(os.getenv('HOSTED_PARAKEET_API_URL'))
+        and parakeet_supports_language(STTServingSurface.STREAMING, language or 'en')
     )
 
 


### PR DESCRIPTION
## Bug

`STT_SERVICE_MODELS` states an **ordered** preference — prod's listen deployment runs `dg-nova-3,modulate-velma-2,parakeet` — but `connect_stt_socket_with_fallback` only ever made **one** hop. A primary that could not connect got exactly one Modulate attempt, and a Modulate that could not serve ended the session, with Parakeet never asked.

That is prod right now:

```
WebSocketException in ListenWebSocketClient.start: server rejected WebSocket connection: HTTP 402   (#11695, continuous)
ERROR:utils.stt.streaming:Modulate streaming error: Internal server error                            (36 in the last hour)
INFO:utils.stt.streaming:Parakeet WS connected successfully                                          (25 in the same hour — healthy)
```

So an `en` session whose Deepgram connect is refused (402) and whose Modulate leg is then refused (over quota / 500) is terminalized while the Parakeet deployment listed *behind both of them in the same preference list* is serving other sessions in the same process. `en` is exactly the case that loses here: selection puts Deepgram first for every Deepgram-supported language, so a plain English session never reaches Parakeet on its own.

## Root cause

The fallback chain was one hardcoded hop (`connect_primary` → `connect_modulate`) rather than a walk of the configured preference list. `modulate_is_configured_fallback` already encoded "may this provider take over a failed session"; nothing encoded the same question for the next provider, and nothing continued after Modulate raised.

## Fix

Walk the remaining configured providers instead of a single hop.

- `connect_stt_socket_with_fallback` takes an optional `connect_parakeet` leg and iterates its candidates. Each leg still proves the socket is actually serving before it is adopted (`_connect_serving_fallback`, the liveness check added in #11754), so a socket that connects and is refused 150ms later is not counted as a heal.
- Telemetry stays legible per leg: the leg that failed records `outcome='exhausted'`, and the leg that served records `outcome='recovered'` with the reason the previous provider was left (`quota` for an over-quota Velma rejection). Exhausting the whole chain raises exactly as before, so the client still receives its typed terminal live-STT status at init.
- `parakeet_is_configured_fallback` mirrors `modulate_is_configured_fallback`: Parakeet is offered only when the deployment lists it in `STT_SERVICE_MODELS`, the serving policy enables it, `HOSTED_PARAKEET_API_URL` is configured, and its streaming capability covers the session language. Streaming Parakeet is en-only, so a `multi` session is **not** offered it and its behavior is unchanged.
- A Parakeet primary is never offered itself as its own fallback.

Scope: the healthy-primary path is untouched — a primary that connects returns before any of this runs.

**This does not fix the outage itself** (#11695 Deepgram HTTP 402, #11752 Modulate capacity — both vendor billing). It stops a two-provider vendor failure from taking down sessions a third, healthy, already-configured provider can serve.

## What I tested

- `backend/.venv/bin/python -m pytest tests/unit/test_deepgram_connection_fallback.py` → **17 passed**. All **6 new tests fail on clean `origin/main`** (verified by stashing the `streaming.py` + `receiver.py` hunks: 6 failed, 1 passed).
- `pytest tests/unit/test_parakeet_connection_fallback.py test_transcribe_teardown_flush.py test_modulate_stt.py test_desktop_transcribe.py test_stt_provider_policy.py` → 213 passed, 4 failed; the same 4 `TestLanguageRouting` tests fail identically on clean `origin/main` in this local env (pre-existing, `DEEPGRAM_API_KEY` present locally).
- **Exercised the real path, not only mocks**: drove `ListenReceiver.initialize_stt()` with `process_audio_dg` returning `None` (the real 402 shape — `start()` returns False) and a **real `SafeModulateSocket`** over a WebSocket that answers Velma's actual `{"type":"error","error":"Monthly usage limit reached."}`, so the death latch flips through production code. Result: session **not** terminalized, `stt_service=parakeet`, `stt_model=parakeet`, 32,000 bytes of PCM delivered to the Parakeet socket through `_flush_stt_buffer`, and the transcript segment reached the session's transcript queue. Emitted telemetry:
  ```
  omi_fallback_event component=stt_selection from=deepgram to=modulate reason=config_incomplete outcome=exhausted
  omi_fallback_event component=stt_selection from=modulate to=parakeet reason=quota   outcome=recovered
  ```
- `make preflight` → passes under Python 3.11 with the line-count exception declared below (the system `python3` on this machine is 3.9 and cannot import `.github/scripts/git_bash.py`).

Line-Count-Exception: backend/utils/stt/streaming.py | 1565 -> 1616 | the chain walk replaces the single hardcoded hop in place; splitting this frozen module is a separate refactor and not in scope for an incident fix

Failure-Class: FC-recoverable-provider-failure-terminal

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

