### PR TITLE
SCA-328: do not create Agent VM on every launch warmup

### DIFF
--- a/desktop/macos/Desktop/Sources/AgentVMService.swift
+++ b/desktop/macos/Desktop/Sources/AgentVMService.swift
@@ -59,8 +59,10 @@ actor AgentVMService {
     log("AgentVMService: Cancelled owner-bound lifecycle work")
   }
 
-  /// Check backend for existing VM — if none exists, run the full pipeline.
-  /// Call this on every app launch for signed-in users.
+  /// Adopt an existing agent VM on signed-in launch warmup.
+  /// Never creates a VM: missing status or a status-check failure returns
+  /// without calling `provisionAgentVM` / `runPipeline`. Use `startPipeline()`
+  /// for onboarding and other explicit first-agent-use paths.
   func ensureProvisioned() {
     startOwnerBoundPipeline(checkExisting: true)
   }
@@ -98,31 +100,60 @@ actor AgentVMService {
     }
   }
 
+  enum WarmupAction: Equatable {
+    case adoptReady
+    case pollUntilReady
+    case skip
+  }
+
+  /// Launch warmup may only reconnect to an existing VM. A missing box, an
+  /// unrecognized status, or a failed status check must not create one.
+  static func warmupAction(
+    status: String?,
+    ip: String?,
+    statusCheckFailed: Bool = false
+  ) -> WarmupAction {
+    if statusCheckFailed {
+      return .skip
+    }
+    switch status {
+    case "ready":
+      return ip == nil ? .pollUntilReady : .adoptReady
+    case "provisioning", "stopped":
+      return .pollUntilReady
+    default:
+      return .skip
+    }
+  }
+
   private func ensureExistingOrProvision(ownerID: String, generation: UInt64) async {
+    let status: APIClient.AgentStatusResponse?
     do {
-      let status = try await APIClient.shared.getAgentStatus()
-      guard isCurrent(ownerID: ownerID, generation: generation) else { return }
-      if let status, status.status == "ready", let ip = status.ip {
-        await prepareReadyVM(status, ip: ip, ownerID: ownerID, generation: generation)
-        return
-      }
-      if let status, status.status == "provisioning" || status.status == "stopped" {
-        if let result = await pollUntilReady(
-          maxAttempts: 75,
-          intervalSeconds: 5,
-          ownerID: ownerID,
-          generation: generation),
-          let ip = result.ip
-        {
-          await prepareReadyVM(result, ip: ip, ownerID: ownerID, generation: generation)
-        }
-        return
-      }
+      status = try await APIClient.shared.getAgentStatus()
     } catch {
       guard isCurrent(ownerID: ownerID, generation: generation) else { return }
-      log("AgentVMService: Status check failed — \(error.localizedDescription), will provision")
+      log("AgentVMService: Status check failed — \(error.localizedDescription), not provisioning")
+      return
     }
-    await runPipeline(ownerID: ownerID, generation: generation)
+    guard isCurrent(ownerID: ownerID, generation: generation) else { return }
+
+    switch Self.warmupAction(status: status?.status, ip: status?.ip) {
+    case .adoptReady:
+      guard let status, let ip = status.ip else { return }
+      await prepareReadyVM(status, ip: ip, ownerID: ownerID, generation: generation)
+    case .pollUntilReady:
+      if let result = await pollUntilReady(
+        maxAttempts: 75,
+        intervalSeconds: 5,
+        ownerID: ownerID,
+        generation: generation),
+        let ip = result.ip
+      {
+        await prepareReadyVM(result, ip: ip, ownerID: ownerID, generation: generation)
+      }
+    case .skip:
+      log("AgentVMService: No adoptable VM on warmup — not provisioning")
+    }
   }
 
   private func runPipeline(ownerID: String, generation: UInt64) async {

--- a/desktop/macos/Desktop/Tests/AgentVMWarmupAdoptionTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentVMWarmupAdoptionTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class AgentVMWarmupAdoptionTests: XCTestCase {
+  func testWarmupAdoptsAReadyVMWithAnIP() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "ready", ip: "203.0.113.10"),
+      .adoptReady)
+  }
+
+  func testWarmupPollsAReadyVMUntilItHasAnIP() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "ready", ip: nil),
+      .pollUntilReady)
+  }
+
+  func testWarmupPollsProvisioningAndStoppedVMs() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "provisioning", ip: nil),
+      .pollUntilReady)
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "stopped", ip: "203.0.113.10"),
+      .pollUntilReady)
+  }
+
+  func testWarmupDoesNotCreateWhenStatusIsMissing() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: nil, ip: nil),
+      .skip)
+  }
+
+  func testWarmupDoesNotCreateWhenStatusCheckFails() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "ready", ip: "203.0.113.10", statusCheckFailed: true),
+      .skip)
+  }
+
+  func testWarmupDoesNotCreateForUnrecognizedOrErrorStatus() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "error", ip: nil),
+      .skip)
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: "terminated", ip: nil),
+      .skip)
+  }
+
+  func testStartPipelineStillCreatesWhileWarmupOnlyAdopts() {
+    XCTAssertEqual(
+      AgentVMService.warmupAction(status: nil, ip: nil),
+      .skip,
+      "launch warmup must not treat a missing VM as a create")
+    XCTAssertNotEqual(
+      AgentVMService.warmupAction(status: "ready", ip: "203.0.113.10"),
+      .skip)
+  }
+
+  func testLaunchWarmupNeverCallsTheCreatePipeline() throws {
+    let service = try sourceFile("AgentVMService.swift")
+    let adoptBody = try XCTUnwrap(
+      swiftFunctionBody(in: service, named: "ensureExistingOrProvision"),
+      "ensureExistingOrProvision must remain the launch-warmup adopt path")
+    XCTAssertFalse(
+      adoptBody.contains("runPipeline"),
+      "launch warmup must not fall through to runPipeline")
+    XCTAssertFalse(
+      adoptBody.contains("provisionAgentVM"),
+      "launch warmup must not call provisionAgentVM")
+    XCTAssertTrue(
+      adoptBody.contains("warmupAction("),
+      "launch warmup must decide adopt/skip through warmupAction")
+
+    let ensureBody = try XCTUnwrap(swiftFunctionBody(in: service, named: "ensureProvisioned"))
+    XCTAssertTrue(ensureBody.contains("checkExisting: true"))
+    XCTAssertFalse(ensureBody.contains("checkExisting: false"))
+
+    let startBody = try XCTUnwrap(swiftFunctionBody(in: service, named: "startPipeline"))
+    XCTAssertTrue(
+      startBody.contains("checkExisting: false"),
+      "startPipeline must still create via the full pipeline")
+
+    let ownerBound = try XCTUnwrap(swiftFunctionBody(in: service, named: "startOwnerBoundPipeline"))
+    XCTAssertTrue(ownerBound.contains("await runPipeline("))
+    XCTAssertTrue(ownerBound.contains("await ensureExistingOrProvision("))
+
+    let home = try sourceFile("MainWindow/DesktopHomeView.swift")
+    XCTAssertTrue(home.contains("AgentVMService.shared.ensureProvisioned()"))
+    XCTAssertFalse(home.contains("AgentVMService.shared.startPipeline()"))
+
+    let onboarding = try sourceFile("Onboarding/OnboardingView.swift")
+    XCTAssertTrue(
+      onboarding.contains("AgentVMService.shared.startPipeline()"),
+      "onboarding must remain the explicit create path")
+  }
+
+  private func sourceFile(_ relativePath: String) throws -> String {
+    let sourceURL = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources")
+      .appendingPathComponent(relativePath)
+    // omi-test-quality: source-inspection -- static contract: launch warmup must only adopt an existing VM; create stays on startPipeline
+    return try String(contentsOf: sourceURL, encoding: .utf8)
+  }
+
+  private func swiftFunctionBody(in source: String, named name: String) -> String? {
+    let signature = "func \(name)("
+    guard let start = source.range(of: signature),
+      let openBrace = source[start.upperBound...].firstIndex(of: "{")
+    else { return nil }
+    var depth = 0
+    var index = openBrace
+    while index < source.endIndex {
+      let character = source[index]
+      if character == "{" { depth += 1 }
+      if character == "}" {
+        depth -= 1
+        if depth == 0 {
+          return String(source[openBrace...index])
+        }
+      }
+      index = source.index(after: index)
+    }
+    return nil
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260818-no-launch-warmup-agent-vm-create.json
+++ b/desktop/macos/changelog/unreleased/20260818-no-launch-warmup-agent-vm-create.json
@@ -1,0 +1,3 @@
+{
+  "change": "Stopped creating a new cloud agent computer on every app launch"
+}


### PR DESCRIPTION
## What changed and why

Signed-in macOS launch warmup (`ensureProvisioned`) now only adopts an existing Agent VM (`ready` / `stopped` / `provisioning`). A missing VM or a failed status check logs and returns instead of falling through to `provisionAgentVM` / `runPipeline`. Onboarding still calls `startPipeline()` for explicit first create. There is no first-open Agent chat/tool path that assumed a VM already exists, so no extra create site was added.

Closes SCA-328

Please merge with a regular merge commit (do not squash).

This is the low-hanging create-rate cut. Do not duplicate #11755 (idle-stop in the reconciler, already merged). Reaper LIVE / public IP / #7326 / provision architecture are out of scope.

## Product invariants affected

none

## How it was verified

Focused desktop Swift tests after a clean package build:

```text
./scripts/dev-feedback.py --once swift 'AgentVMWarmupAdoptionTests|AgentVMLifecycleFenceTests|AgentVMCompressionRatioTests'
Executed 14 tests, with 0 failures
Iteration 1: PASS
```

`python3 scripts/check_desktop_test_quality.py` stayed at the source-inspection baseline (54 files / 147 sites). Did not exercise a live GCE provision; the production create call is now unreachable from the warmup path.

## Tests

- `testWarmupAdoptsAReadyVMWithAnIP` / `testWarmupPollsProvisioningAndStoppedVMs` — adopt-only happy path
- `testWarmupDoesNotCreateWhenStatusIsMissing` — missing VM on warmup does not create
- `testWarmupDoesNotCreateWhenStatusCheckFails` — status error never provisions
- `testWarmupDoesNotCreateForUnrecognizedOrErrorStatus`
- `testStartPipelineStillCreatesWhileWarmupOnlyAdopts` — create stays off the warmup decision
- `testLaunchWarmupNeverCallsTheCreatePipeline` — static contract: `ensureExistingOrProvision` never calls `runPipeline` / `provisionAgentVM`; home warmup still calls `ensureProvisioned`; onboarding still calls `startPipeline`

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

