### PR TITLE
fix(windows): stop full action-item hydrate on every local read

### DIFF
--- a/.github/failure-classes/FC-unthrottled-read-revalidation.json
+++ b/.github/failure-classes/FC-unthrottled-read-revalidation.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-unthrottled-read-revalidation",
+  "violated_contract": "A local-first read served from a local cache must not re-derive its full backing dataset from the backend on every read. Background revalidation must be bounded in time and volume (one time-throttled, in-flight-deduped entry point that every trigger funnels through), because UI read frequency is unbounded: a store-change broadcast that makes the UI re-read turns per-read revalidation into a self-feeding loop, and a per-read full scan multiplies backend cost by UI event frequency instead of data-change frequency.",
+  "canonical_prevention": "Route reads, timers, and focus events through a single throttled revalidation entry point; revalidate by cheap id census plus per-item fetch of only new/changed items; reserve full scans for one-time versioned population and explicit user refresh; and broadcast store-change events only when a sync actually changed a row so the read-to-sync-to-broadcast cycle cannot self-feed.",
+  "canonical_prevention_artifact": [
+    "desktop/windows/src/main/tasks/taskSyncEngine.ts",
+    "desktop/windows/src/main/tasks/taskSyncEngine.test.ts"
+  ],
+  "evidence_prs": [9891],
+  "scope_hints": [
+    "desktop/windows/src/main/tasks/**",
+    "desktop/macos/Desktop/Sources/Stores/TasksStore.swift"
+  ],
+  "status": "open"
+}

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -107,9 +107,13 @@ import { registerScreenSynthHandlers } from './ipc/screenSynth'
 import { registerAiUserProfileHandlers } from './ipc/aiUserProfile'
 import { registerTaskHandlers } from './ipc/tasks'
 import { registerBackendDegradedIpc, resetBackendDegraded } from './observability/backendDegraded'
-import { resetPendingDeletes } from './tasks/taskSyncEngine'
+import {
+  resetPendingDeletes,
+  scheduleBackgroundSync,
+  setTaskDeletionListener,
+  startTaskBackgroundSync
+} from './tasks/taskSyncEngine'
 import { onSessionReset } from './assistants/core/session'
-import { setTaskDeletionListener } from './tasks/taskSyncEngine'
 import { removeFromIndex as removeTaskFromEmbeddingIndex } from './tasks/taskEmbeddingService'
 import { createGlowWindow, registerGlowIpc, destroyGlow } from './glow/glowWindow'
 import { maybeGenerateOnStartup as maybeGenerateAiProfileOnStartup } from './assistants/aiUserProfile/service'
@@ -968,8 +972,8 @@ app.whenReady().then(async () => {
   // startup check + daily timer are wired at ready-to-show below.
   registerAiUserProfileHandlers()
   // Track 3 (task sync engine): local-first Tasks list. Cheap handler registration;
-  // the engine reads the shared backend session (relayed by the renderer) and syncs
-  // on demand when a list/reconcile channel is invoked.
+  // the engine reads the shared backend session (relayed by the renderer), reads
+  // stay SQLite-only, and freshness comes from the throttled census sync below.
   registerTaskHandlers()
   // 429-storm degraded-mode: pull channel so a window that mounts mid-storm can sync
   // the current state (the transitions themselves broadcast on `backend:degraded`).
@@ -985,6 +989,16 @@ app.whenReady().then(async () => {
   // returned ids here so their vectors are evicted. DI seam, no hard import either way.
   setTaskDeletionListener((deleted) => {
     for (const { source, id } of deleted) removeTaskFromEmbeddingIndex(source, id)
+  })
+  // The Firestore-read fix: the task engine's background reconcile (ID census, ≤1
+  // per 5 min) runs on this interval instead of on every local read, which used to
+  // full-list `GET /v1/action-items?limit=500` per Tasks/dashboard read (billing
+  // RCA 2026-08: ~61-73 RPS from omi-windows). Ticks are session-gated no-ops
+  // until the renderer relays a session. Window focus asks for a sync too — the
+  // shared 5-min throttle caps it, so focus spam can't restore the storm.
+  startTaskBackgroundSync()
+  app.on('browser-window-focus', () => {
+    void scheduleBackgroundSync()
   })
   // Track 3 (focus halo): the click-through ring the Focus assistant fires around
   // the active window (red = distracted, green = refocused). Handler registration

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -45,6 +45,7 @@ import {
   hardDeleteAbsentTasksOn,
   hardDeleteAbsentCompletedTasksOn,
   getUnsyncedActionItemsOn,
+  getSyncedActionItemIdsOn,
   getAllActionItemEmbeddingsOn,
   updateActionItemEmbeddingOn,
   getActionItemsMissingEmbeddingsOn,
@@ -2186,6 +2187,12 @@ export function getUnsyncedActionItems(opts?: {
     includeRecent: opts?.includeRecent,
     now: opts?.now ?? Date.now()
   })
+}
+
+/** Backend ids + completion buckets of every synced, non-deleted local row —
+ *  the local half of the sync engine's ID-census diff. */
+export function getSyncedActionItemIds(): { backendId: string; completed: boolean }[] {
+  return getSyncedActionItemIdsOn(taskStoreDb())
 }
 
 export function getAllActionItemEmbeddings(): { id: number; embedding: Float32Array }[] {

--- a/desktop/windows/src/main/ipc/dbTasks.test.ts
+++ b/desktop/windows/src/main/ipc/dbTasks.test.ts
@@ -25,6 +25,7 @@ import {
   hardDeleteAbsentTasksOn,
   hardDeleteAbsentCompletedTasksOn,
   getUnsyncedActionItemsOn,
+  getSyncedActionItemIdsOn,
   getAllActionItemEmbeddingsOn,
   updateActionItemEmbeddingOn,
   getActionItemsMissingEmbeddingsOn,
@@ -457,6 +458,28 @@ describe('hardDeleteAbsentCompletedTasks (completed-phantom convergence)', () =>
       db.prepare('SELECT id FROM action_items ORDER BY id').all() as { id: number }[]
     ).map((r) => r.id)
     expect(remaining).toEqual([incompleteAbsent.id, unsynced.id, recent])
+  })
+})
+
+describe('getSyncedActionItemIds (census diff input)', () => {
+  it('returns backend ids + buckets for synced visible rows only', () => {
+    const active = insertLocalActionItemOn(db, ai({ description: 'a', backendId: 'ba' }))
+    markSyncedActionItemOn(db, active.id, 'ba', 1000)
+    const done = insertLocalActionItemOn(
+      db,
+      ai({ description: 'c', backendId: 'bc', completed: true })
+    )
+    markSyncedActionItemOn(db, done.id, 'bc', 1000)
+    insertLocalActionItemOn(db, ai({ description: 'unsynced' })) // no backend_id
+    const deleted = insertLocalActionItemOn(db, ai({ description: 'd', backendId: 'bd' }))
+    markSyncedActionItemOn(db, deleted.id, 'bd', 1000)
+    deleteActionItemByBackendIdOn(db, 'bd', 'user') // hard-deleted rows leave the census
+
+    const ids = getSyncedActionItemIdsOn(db)
+    expect(ids).toEqual([
+      { backendId: 'ba', completed: false },
+      { backendId: 'bc', completed: true }
+    ])
   })
 })
 

--- a/desktop/windows/src/main/ipc/taskStore.ts
+++ b/desktop/windows/src/main/ipc/taskStore.ts
@@ -890,6 +890,23 @@ export function getUnsyncedActionItemsOn(
   return rows.map(mapAction)
 }
 
+/** Backend ids of every SYNCED, non-deleted local row with its completion bucket —
+ *  the local half of the ID-census diff the sync engine runs (backend half:
+ *  GET /v1/action-items/ids). Deliberately minimal: no row mapping, no FTS, just
+ *  the two columns the diff needs, so it stays cheap at any store size. `completed`
+ *  is coerced to a real boolean — SQLite stores 0/1, and the engine's strict
+ *  bucket comparison (`!== false`) would misclassify a 0 as a bucket move. */
+export function getSyncedActionItemIdsOn(
+  d: TaskStoreDb
+): { backendId: string; completed: boolean }[] {
+  const rows = cachedStmt(
+    d,
+    `SELECT backend_id AS backendId, completed FROM action_items
+         WHERE deleted = 0 AND backend_id IS NOT NULL AND backend_synced = 1`
+  ).all() as { backendId: string; completed: number }[]
+  return rows.map((r) => ({ backendId: r.backendId, completed: r.completed === 1 }))
+}
+
 /** All action-item embeddings for loading the in-memory index. */
 export function getAllActionItemEmbeddingsOn(d: TaskStoreDb): TaskEmbeddingRow[] {
   const rows = cachedStmt(

--- a/desktop/windows/src/main/ipc/tasks.ts
+++ b/desktop/windows/src/main/ipc/tasks.ts
@@ -26,10 +26,12 @@
 // │                        the renderer re-fetches. Subscribe via onTasksChanged│
 // └───────────────────────────────────────────────────────────────────────────┘
 //
-// Reads are LOCAL-FIRST: they return the local rows instantly and kick a background
-// sync, then fire `tasks:changed` when the store updates. The engine reads the
-// SHARED backend session (assistants/core/session.ts, relayed by the renderer); no
-// session is passed per call.
+// Reads are LOCAL-FIRST and stay that way: they return the local rows instantly
+// and never talk to the backend. Freshness is the engine's throttled background
+// sync (≤1 census reconcile per 5 min, plus the interval/focus triggers wired in
+// main); `tasks:changed` fires when a background sync or optimistic write lands.
+// The engine reads the SHARED backend session (assistants/core/session.ts,
+// relayed by the renderer); no session is passed per call.
 import { ipcMain, type IpcMainInvokeEvent } from 'electron'
 import {
   createTask,

--- a/desktop/windows/src/main/tasks/parityWire.test.ts
+++ b/desktop/windows/src/main/tasks/parityWire.test.ts
@@ -19,7 +19,7 @@ vi.mock('electron', () => ({
 vi.mock('../ipc/db', () => ({
   getLocalActionItems: vi.fn(() => []),
   getFilteredActionItems: vi.fn(() => []),
-  getUnsyncedActionItems: vi.fn(() => []),
+  getSyncedActionItemIds: vi.fn(() => []),
   insertLocalActionItem: vi.fn(),
   updateCompletionStatus: vi.fn(),
   updateActionItemFields: vi.fn(),
@@ -41,7 +41,12 @@ vi.mock('../observability/backendDegraded', () => ({
 
 import { mapBackendItem } from './taskSyncEngine'
 
-type WireExpectation = { parses: boolean; description?: string; completed?: boolean; due_utc?: string | null }
+type WireExpectation = {
+  parses: boolean
+  description?: string
+  completed?: boolean
+  due_utc?: string | null
+}
 type WireCase = {
   name: string
   payload: Record<string, unknown>
@@ -58,11 +63,14 @@ type WireCase = {
 const SYNC_NOW = Date.parse('2026-08-15T00:00:00Z')
 
 describe('action item wire decode (parity contract)', () => {
-  const path = fileURLToPath(new URL('../../../../../contracts/parity/wire_action_item.json', import.meta.url))
+  const path = fileURLToPath(
+    new URL('../../../../../contracts/parity/wire_action_item.json', import.meta.url)
+  )
   const { cases } = JSON.parse(readFileSync(path, 'utf8')) as { cases: WireCase[] }
   it.each(cases)('$name', (c) => {
     const expected = c.expected_by_model ? c.expected_by_model.tolerant_decode : c.expected
-    if (!expected) throw new Error(`${c.name}: fixture case has neither expected nor expected_by_model`)
+    if (!expected)
+      throw new Error(`${c.name}: fixture case has neither expected nor expected_by_model`)
     const mapped = mapBackendItem(c.payload as never, SYNC_NOW)
     expect(expected.parses).toBe(true)
     expect(mapped.description).toBe(expected.description)

--- a/desktop/windows/src/main/tasks/taskSyncEngine.test.ts
+++ b/desktop/windows/src/main/tasks/taskSyncEngine.test.ts
@@ -2,9 +2,9 @@
 // BrowserWindow) and the storage wrappers (`../ipc/db`, a native better-sqlite3
 // module that can't load under plain-node vitest) are mocked; the REAL
 // core/session drives the epoch guard. Covers the ported Mac behaviors: local-first
-// hydration → sync, reconcile hard-delete (+ empty-guard + 5-min throttle),
-// optimistic create/toggle/update/delete (markSynced / revert / keep-local), the
-// FIX-ii deletion listener, and retryUnsynced.
+// reads → throttled census-based background sync, reconcile hard-delete (+
+// empty-guard + throttle), optimistic create/toggle/update/delete (markSynced /
+// revert / keep-local), the FIX-ii deletion listener, and retryUnsynced.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActionItemRecord } from '../../shared/types'
 
@@ -15,14 +15,24 @@ const h = vi.hoisted(() => {
     status,
     json: async () => data
   })
+  // Mutable app_meta store keyed by flag name. A holder object (not a reassigned
+  // binding) so the getAppMeta implementation below always reads the current
+  // values across tests.
+  const appMeta = { values: { tasksFullSyncCompleted_v2_u1: '1' } as Record<string, string> }
   return {
     jsonResponse,
     // Routed by HTTP method; individual tests override for failures/echoes.
     serverItems: [] as unknown[],
+    // The ID census (GET /v1/action-items/ids?completed=…) per bucket.
+    censusIncomplete: [] as string[],
+    censusCompleted: [] as string[],
+    // Per-id document store for GET /v1/action-items/{id} (census diff fetches).
+    itemsById: {} as Record<string, Record<string, unknown>>,
     netFetch: vi.fn(),
     // storage wrappers
     getLocalActionItems: vi.fn((): ActionItemRecord[] => []),
     getFilteredActionItems: vi.fn((): ActionItemRecord[] => []),
+    getSyncedActionItemIds: vi.fn((): { backendId: string; completed: boolean }[] => []),
     getUnsyncedActionItems: vi.fn((): ActionItemRecord[] => []),
     insertLocalActionItem: vi.fn(),
     updateCompletionStatus: vi.fn(),
@@ -32,7 +42,8 @@ const h = vi.hoisted(() => {
     syncTaskActionItems: vi.fn(() => ({ skipped: 0, adopted: 0, inserted: 0, updated: 0 })),
     hardDeleteAbsentTasks: vi.fn((): number[] => []),
     hardDeleteAbsentCompletedTasks: vi.fn((): number[] => []),
-    getAppMeta: vi.fn((): string | null => '1'), // full-sync flag set → skip full sync by default
+    appMeta,
+    getAppMeta: vi.fn((key: string): string | null => appMeta.values[key] ?? null),
     setAppMeta: vi.fn(),
     // Event-driven promotion trigger (create.ts) — mocked so the engine's toggle/
     // delete promote calls are observable without pulling create's real deps.
@@ -54,6 +65,7 @@ vi.mock('electron', () => ({
 vi.mock('../ipc/db', () => ({
   getLocalActionItems: h.getLocalActionItems,
   getFilteredActionItems: h.getFilteredActionItems,
+  getSyncedActionItemIds: h.getSyncedActionItemIds,
   getUnsyncedActionItems: h.getUnsyncedActionItems,
   insertLocalActionItem: h.insertLocalActionItem,
   updateCompletionStatus: h.updateCompletionStatus,
@@ -97,17 +109,49 @@ function backendItem(over: Record<string, unknown> = {}): Record<string, unknown
   }
 }
 
-// Default net.fetch: GET returns h.serverItems, writes echo a plausible item.
+// Default net.fetch: GET serves the census buckets, per-id documents, and the
+// legacy full listing; writes echo a plausible item.
 function defaultRoute(): void {
-  h.netFetch.mockImplementation(async (_url: string, init?: { method?: string }) => {
+  h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
     const method = init?.method ?? 'GET'
-    if (method === 'GET') return h.jsonResponse({ action_items: h.serverItems, has_more: false })
+    const u = String(url)
+    if (method === 'GET') {
+      if (u.includes('/v1/action-items/ids')) {
+        return h.jsonResponse({
+          ids: u.includes('completed=true') ? h.censusCompleted : h.censusIncomplete
+        })
+      }
+      const byId = u.match(/\/v1\/action-items\/([^/?]+)$/)
+      if (byId) {
+        const item = h.itemsById[byId[1]]
+        return item ? h.jsonResponse(item) : h.jsonResponse({ detail: 'nf' }, false, 404)
+      }
+      return h.jsonResponse({ action_items: h.serverItems, has_more: false })
+    }
     if (method === 'POST') return h.jsonResponse(backendItem({ id: 'srv-new' }))
     if (method === 'PATCH') return h.jsonResponse(backendItem({ completed: true }))
     if (method === 'DELETE') return h.jsonResponse({}, true, 204)
     return h.jsonResponse({})
   })
 }
+
+// Request classifiers shared by the cost-guard tests.
+type Call = [url: string, init: { method?: string } | undefined]
+const asCalls = (calls: unknown[][]): Call[] => calls as Call[]
+const methodOf = (c: Call): string => c[1]?.method ?? 'GET'
+const urlOf = (c: Call): string => String(c[0])
+const listingCalls = (): Call[] =>
+  asCalls(h.netFetch.mock.calls).filter(
+    (c) => methodOf(c) === 'GET' && urlOf(c).includes('/v1/action-items?')
+  )
+const censusCalls = (): Call[] =>
+  asCalls(h.netFetch.mock.calls).filter(
+    (c) => methodOf(c) === 'GET' && urlOf(c).includes('/v1/action-items/ids')
+  )
+const byIdCalls = (): Call[] =>
+  asCalls(h.netFetch.mock.calls).filter(
+    (c) => methodOf(c) === 'GET' && /\/v1\/action-items\/[^/?]+$/.test(urlOf(c))
+  )
 
 // Each test gets a fresh engine + session module pair (module-scoped state:
 // lastReconcileAt, retrying, in-flight promises, deletionListener).
@@ -125,8 +169,12 @@ async function freshEngine(): Promise<{
 beforeEach(() => {
   vi.clearAllMocks()
   h.serverItems = [backendItem()]
-  h.getAppMeta.mockReturnValue('1')
+  h.censusIncomplete = []
+  h.censusCompleted = []
+  h.itemsById = {}
+  h.appMeta.values = { tasksFullSyncCompleted_v2_u1: '1' } // full-sync flag set by default
   h.getLocalActionItems.mockReturnValue([])
+  h.getSyncedActionItemIds.mockReturnValue([])
   h.hardDeleteAbsentTasks.mockReturnValue([])
   h.hardDeleteAbsentCompletedTasks.mockReturnValue([])
   h.isBackendDegraded.mockReturnValue(false)
@@ -137,10 +185,12 @@ beforeEach(() => {
 
 afterEach(() => vi.restoreAllMocks())
 
-describe('hydration (local-first)', () => {
-  it('listIncomplete returns local rows immediately, then background-syncs the backend page', async () => {
+describe('reads + throttled background sync (local-first)', () => {
+  it('listIncomplete returns local rows immediately, then the background sync lands new backend rows', async () => {
     const local = [{ id: 1, description: 'local' } as unknown as ActionItemRecord]
     h.getLocalActionItems.mockReturnValue(local)
+    h.censusIncomplete = ['b1']
+    h.itemsById = { b1: backendItem({ id: 'b1' }) }
     const { engine } = await freshEngine()
 
     const rows = engine.listIncomplete()
@@ -151,7 +201,9 @@ describe('hydration (local-first)', () => {
       offset: undefined
     })
 
-    await engine.hydrateIncomplete() // await the background run
+    await engine.scheduleBackgroundSync() // await the background run
+    // Census diff: b1 is new locally → per-id GET → synced.
+    expect(byIdCalls().map((c) => urlOf(c))).toEqual(['https://api.example/v1/action-items/b1'])
     expect(h.syncTaskActionItems).toHaveBeenCalledTimes(1)
     const items = (h.syncTaskActionItems.mock.calls[0] as unknown[])[0]
     expect(items).toEqual([
@@ -164,159 +216,184 @@ describe('hydration (local-first)', () => {
     session.setBackendSession(null)
 
     engine.listIncomplete()
-    await engine.hydrateIncomplete()
+    await engine.scheduleBackgroundSync()
 
     expect(h.netFetch).not.toHaveBeenCalled()
     expect(h.syncTaskActionItems).not.toHaveBeenCalled()
   })
 
-  // Regression: a hydrate that changes nothing MUST NOT emit `tasks:changed`. The
-  // renderer re-reads on that event, and every read kicks another hydrate — an
-  // unconditional broadcast turns steady state into an unbounded backend-poll loop.
-  it('a no-op hydrate stays silent (no tasks:changed broadcast)', async () => {
+  // Regression: a sync that changes nothing MUST NOT emit `tasks:changed`. The
+  // renderer re-reads on that event, and pre-fix every read kicked another sync —
+  // an unconditional broadcast turns steady state into an unbounded polling loop.
+  it('a steady-state no-op sync fetches no documents and stays silent', async () => {
+    h.censusIncomplete = ['b1']
+    h.getSyncedActionItemIds.mockReturnValue([{ backendId: 'b1', completed: false }])
     const { engine } = await freshEngine()
-    // Defaults: syncTaskActionItems → all-zero counts, hardDeleteAbsentTasks → [].
-    await engine.hydrateIncomplete()
-    expect(h.syncTaskActionItems).toHaveBeenCalledTimes(1)
+
+    await engine.scheduleBackgroundSync()
+
+    expect(byIdCalls()).toHaveLength(0) // matching census → zero document reads
+    expect(h.syncTaskActionItems).not.toHaveBeenCalled()
     expect(h.send).not.toHaveBeenCalledWith('tasks:changed')
   })
 
   it('broadcasts tasks:changed when the sync actually changes a row', async () => {
+    h.censusIncomplete = ['b1']
+    h.itemsById = { b1: backendItem({ id: 'b1' }) }
     h.syncTaskActionItems.mockReturnValue({ skipped: 0, adopted: 0, inserted: 1, updated: 0 })
     const { engine } = await freshEngine()
-    await engine.hydrateIncomplete()
+    await engine.scheduleBackgroundSync()
     expect(h.send).toHaveBeenCalledWith('tasks:changed')
+  })
+
+  it('throttles: one background sync per 5-minute window however many reads ask', async () => {
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    h.censusIncomplete = ['b1']
+    h.getSyncedActionItemIds.mockReturnValue([{ backendId: 'b1', completed: false }])
+    const { engine } = await freshEngine()
+
+    engine.listIncomplete()
+    engine.listCompleted()
+    engine.dashboardSlices()
+    await engine.scheduleBackgroundSync()
+    expect(censusCalls()).toHaveLength(2) // exactly one census round (one per bucket)
+
+    nowSpy.mockReturnValue(t0 + 60_000) // +1 min: reads are throttled away
+    engine.listIncomplete()
+    engine.listCompleted()
+    await engine.scheduleBackgroundSync()
+    expect(censusCalls()).toHaveLength(2)
+
+    nowSpy.mockReturnValue(t0 + 5 * 60_000 + 1) // past the window
+    await engine.scheduleBackgroundSync()
+    expect(censusCalls()).toHaveLength(4) // second round
+  })
+
+  it('dedupes: concurrent schedule calls share the one in-flight run', async () => {
+    h.censusIncomplete = ['b1']
+    h.itemsById = { b1: backendItem({ id: 'b1' }) }
+    const { engine } = await freshEngine()
+    const a = engine.scheduleBackgroundSync()
+    const b = engine.scheduleBackgroundSync()
+    await Promise.all([a, b])
+    expect(censusCalls()).toHaveLength(2)
   })
 })
 
-describe('reconcile (hardDeleteAbsentTasks)', () => {
-  it('hard-deletes tasks absent from the backend listing and evicts them (FIX ii)', async () => {
+describe('reconcile (hardDeleteAbsentTasks, census-driven)', () => {
+  it('hard-deletes tasks absent from the census and evicts them (FIX ii)', async () => {
+    h.censusIncomplete = ['b1']
+    h.getSyncedActionItemIds.mockReturnValue([
+      { backendId: 'b1', completed: false },
+      { backendId: 'gone', completed: false }
+    ])
     h.hardDeleteAbsentTasks.mockReturnValue([42])
     const { engine } = await freshEngine()
     const evicted: unknown[] = []
     engine.setTaskDeletionListener((d) => evicted.push(...d))
 
-    await engine.hydrateIncomplete()
+    await engine.scheduleBackgroundSync()
 
     expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['b1'])
     expect(evicted).toEqual([{ source: 'action_item', id: 42 }])
   })
 
   it('empty-guard: when the store deletes nothing, the deletion listener is not called', async () => {
+    h.censusIncomplete = ['b1']
     h.hardDeleteAbsentTasks.mockReturnValue([])
     const { engine } = await freshEngine()
     const listener = vi.fn()
     engine.setTaskDeletionListener(listener)
 
-    await engine.hydrateIncomplete()
+    await engine.scheduleBackgroundSync()
 
     expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['b1'])
     expect(listener).not.toHaveBeenCalled()
   })
 
-  it('throttles reconcile to once per 5 minutes', async () => {
-    const t0 = 1_700_000_000_000
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+  it('empty census never wipes local rows (the storage empty-guard holds)', async () => {
+    // Local rows exist; both census buckets come back empty. The reconcile must
+    // not hand storage an empty sweep that could drop everything.
+    h.getSyncedActionItemIds.mockReturnValue([{ backendId: 'b1', completed: false }])
     const { engine } = await freshEngine()
 
-    await engine.hydrateIncomplete()
-    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledTimes(1)
+    await engine.scheduleBackgroundSync()
 
-    nowSpy.mockReturnValue(t0 + 60_000) // +1 min, within throttle
-    await engine.hydrateIncomplete()
-    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledTimes(1)
-
-    nowSpy.mockReturnValue(t0 + 6 * 60_000) // +6 min, past throttle
-    await engine.hydrateIncomplete()
-    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledTimes(2)
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith([]) // storage no-ops on []
+    expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledWith([], expect.any(Number))
+    expect(h.deleteActionItemByBackendId).not.toHaveBeenCalled()
   })
 })
 
-describe('completed-phantom reconcile (hardDeleteAbsentCompletedTasks)', () => {
-  it('hydrateCompleted reconciles a completed row absent from the backend completed list + evicts it', async () => {
+describe('completed-phantom reconcile (hardDeleteAbsentCompletedTasks, census-driven)', () => {
+  it('reconciles a completed row absent from the completed census + evicts it', async () => {
+    h.censusCompleted = ['b1']
     h.hardDeleteAbsentCompletedTasks.mockReturnValue([77])
     const { engine } = await freshEngine()
     const evicted: unknown[] = []
     engine.setTaskDeletionListener((d) => evicted.push(...d))
 
-    await engine.hydrateCompleted()
+    await engine.scheduleBackgroundSync()
 
-    // Called with the backend's completed ids (the fetched list), and its deletions
-    // are evicted from the embedding index + broadcast.
+    // Called with the census's completed ids; its deletions are evicted from
+    // the embedding index + broadcast.
     expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledWith(['b1'], expect.any(Number))
     expect(evicted).toEqual([{ source: 'action_item', id: 77 }])
     expect(h.send).toHaveBeenCalledWith('tasks:changed')
   })
 
   it('empty-guard: a deletion of nothing does not fire the listener or broadcast', async () => {
+    h.censusCompleted = ['b1']
     h.hardDeleteAbsentCompletedTasks.mockReturnValue([])
     const { engine } = await freshEngine()
     const listener = vi.fn()
     engine.setTaskDeletionListener(listener)
 
-    await engine.hydrateCompleted()
+    await engine.scheduleBackgroundSync()
 
     expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledWith(['b1'], expect.any(Number))
     expect(listener).not.toHaveBeenCalled()
     expect(h.send).not.toHaveBeenCalledWith('tasks:changed')
   })
 
-  // The mass-flip guard: a 429 storm can return a thin/partial completed list, so the
+  // The mass-flip guard: a 429 storm can return a thin/partial list, so the
   // delete-by-absence sweep MUST be skipped entirely while degraded.
   it('SKIPS the completed reconcile in the 429-degraded state', async () => {
+    h.censusCompleted = ['b1']
     h.isBackendDegraded.mockReturnValue(true)
     h.hardDeleteAbsentCompletedTasks.mockReturnValue([77]) // would delete if it ran
     const { engine } = await freshEngine()
     const listener = vi.fn()
     engine.setTaskDeletionListener(listener)
 
-    await engine.hydrateCompleted()
+    await engine.scheduleBackgroundSync()
 
     expect(h.hardDeleteAbsentCompletedTasks).not.toHaveBeenCalled()
     expect(listener).not.toHaveBeenCalled()
   })
 
-  // THE mass-flip regression: the sweep must NEVER run against a partial completed
-  // list. A multi-page fetch whose 2nd page rejects (500/429) makes fetchAll throw,
-  // so doHydrateCompleted's catch skips the reconcile entirely — no delete-by-absence
-  // off a truncated snapshot. This guards the invariant (fetchPage throws on !ok →
-  // fetchAll propagates) a refactor could silently break with an otherwise-green suite.
-  it('mass-flip guard: a page-2 failure in the completed fetch skips the reconcile (no delete)', async () => {
+  // THE fail-closed regression: the sweep must NEVER run off an incomplete
+  // picture of the backend. A census request that fails (500/429) makes the
+  // whole round abort — no sync, no delete-by-absence off a partial census.
+  it('fail-closed: a failed census aborts the round (no sync, no reconcile, no wipe)', async () => {
     h.hardDeleteAbsentCompletedTasks.mockReturnValue([99]) // would delete a real row if ever called
+    h.hardDeleteAbsentTasks.mockReturnValue([98])
     h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
       if ((init?.method ?? 'GET') !== 'GET') return h.jsonResponse({})
-      // Page 1 (offset=0): a page that signals more. Page 2 (offset=500): reject.
-      if (String(url).includes('offset=0'))
-        return h.jsonResponse({ action_items: [backendItem({ id: 'b1' })], has_more: true })
-      return h.jsonResponse({}, false, 500)
+      if (String(url).includes('/v1/action-items/ids')) return h.jsonResponse({}, false, 500)
+      return h.jsonResponse({ action_items: [backendItem()], has_more: false })
     })
     const { engine } = await freshEngine()
     const listener = vi.fn()
     engine.setTaskDeletionListener(listener)
 
-    await engine.hydrateCompleted() // swallows the fetch error
+    await engine.scheduleBackgroundSync() // swallows the census error
 
-    // fetchAll threw on page 2 → neither the sync nor the reconcile is reached.
+    expect(h.hardDeleteAbsentTasks).not.toHaveBeenCalled()
     expect(h.hardDeleteAbsentCompletedTasks).not.toHaveBeenCalled()
     expect(h.syncTaskActionItems).not.toHaveBeenCalled()
     expect(listener).not.toHaveBeenCalled()
-  })
-
-  it('throttles the completed reconcile to once per 5 minutes', async () => {
-    const t0 = 1_700_000_000_000
-    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
-    const { engine } = await freshEngine()
-
-    await engine.hydrateCompleted()
-    expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledTimes(1)
-
-    nowSpy.mockReturnValue(t0 + 60_000) // within throttle
-    await engine.hydrateCompleted()
-    expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledTimes(1)
-
-    nowSpy.mockReturnValue(t0 + 6 * 60_000) // past throttle
-    await engine.hydrateCompleted()
-    expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledTimes(2)
   })
 })
 
@@ -411,18 +488,20 @@ describe('optimistic delete', () => {
     expect(h.insertLocalActionItem).not.toHaveBeenCalled()
   })
 
-  it('a hydrate during an in-flight delete does not resurrect the row (passes the tombstone guard)', async () => {
+  it('a background sync during an in-flight delete does not resurrect the row (passes the tombstone guard)', async () => {
     h.deleteActionItemByBackendId.mockReturnValue([9])
-    // DELETE never resolves → the tombstone stays set while the hydrate runs.
-    h.netFetch.mockImplementation(async (_u: string, init?: { method?: string }) => {
+    // DELETE never resolves → the tombstone stays set while the sync runs.
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
       const method = init?.method ?? 'GET'
+      const u = String(url)
       if (method === 'DELETE') return new Promise(() => {}) // hang forever
-      return h.jsonResponse({ action_items: [backendItem({ id: 'b1' })], has_more: false })
+      if (u.includes('/v1/action-items/ids')) return h.jsonResponse({ ids: ['b1'] })
+      return h.jsonResponse(backendItem({ id: 'b1' })) // the per-id census fetch
     })
     const { engine } = await freshEngine()
     engine.deleteTask('b1') // sets the tombstone
-    await engine.hydrateIncomplete()
-    // The hydrate's sync call carries a guard that reports the deleted id as pending,
+    await engine.scheduleBackgroundSync()
+    // The sync's item fetch carries a guard that reports the deleted id as pending,
     // so the storage insert branch skips it (proven against a real DB in dbTasks.test).
     const lastSync = h.syncTaskActionItems.mock.calls.at(-1) as unknown as
       | [unknown, { isTombstoned?: (id: string) => boolean }]
@@ -629,18 +708,459 @@ describe('event-driven promotion (Mac TasksStore complete/delete triggers)', () 
 })
 
 describe('one-time full sync (versioned flag)', () => {
-  it('pages everything once when the flag is unset, then persists the flag', async () => {
-    h.getAppMeta.mockReturnValue(null) // not yet done
+  it('pages everything once when the flag is unset, then persists the flag (sweeps census-capped)', async () => {
+    h.appMeta.values = {} // flag unset → full populate due
+    h.censusIncomplete = ['b1']
+    h.censusCompleted = []
     const { engine } = await freshEngine()
 
-    await engine.hydrateIncomplete()
+    await engine.scheduleBackgroundSync()
 
-    expect(h.setAppMeta).toHaveBeenCalledWith('tasksFullSyncCompleted_v1_u1', '1')
-    // Both completed=false and completed=true pages were fetched during the full sync.
-    const gets = h.netFetch.mock.calls
-      .filter((c) => ((c[1] as { method?: string })?.method ?? 'GET') === 'GET')
-      .map((c) => String(c[0]))
-    expect(gets.some((u) => u.includes('completed=true'))).toBe(true)
-    expect(gets.some((u) => u.includes('completed=false'))).toBe(true)
+    expect(h.setAppMeta).toHaveBeenCalledWith('tasksFullSyncCompleted_v2_u1', '1')
+    // Both completed=false and completed=true pages were fetched for content…
+    const urls = listingCalls().map(urlOf)
+    expect(urls.some((u) => u.includes('completed=true'))).toBe(true)
+    expect(urls.some((u) => u.includes('completed=false'))).toBe(true)
+    // …and the forced sweeps took their keep-set from the (uncapped) census.
+    expect(censusCalls()).toHaveLength(2)
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['b1'])
+  })
+
+  it('full-sync sweeps keep listing-capped tail rows (census is the uncapped authority)', async () => {
+    // A >2000-doc account: the listing is hard-capped server-side and reports
+    // has_more=false, so the listing ids must NEVER drive the forced sweeps.
+    h.appMeta.values = {}
+    h.censusIncomplete = ['tail1', 'tail2'] // census sees past the cap
+    h.censusCompleted = []
+    h.serverItems = [] // the (capped) listing delivered nothing
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['tail1', 'tail2'])
+    expect(h.deleteActionItemByBackendId).not.toHaveBeenCalled()
+  })
+
+  it('re-runs once for existing installs after the v1 → v2 bump (drift repair)', async () => {
+    // v1 flag set by a pre-fix install, v2 unset → one more full populate.
+    h.appMeta.values = { tasksFullSyncCompleted_v1_u1: '1' }
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    expect(h.setAppMeta).toHaveBeenCalledWith('tasksFullSyncCompleted_v2_u1', '1')
+    expect(listingCalls().length).toBeGreaterThan(0)
+  })
+})
+
+describe('census diff (the steady-state cut)', () => {
+  it('fetches ONLY new and bucket-moved ids — unchanged ids cost zero document reads', async () => {
+    h.censusIncomplete = ['a', 'b'] // a is known-incomplete, b is new
+    h.censusCompleted = ['c', 'd'] // c is known-completed, d is new
+    h.getSyncedActionItemIds.mockReturnValue([
+      { backendId: 'a', completed: false },
+      { backendId: 'c', completed: true }
+    ])
+    h.itemsById = {
+      b: backendItem({ id: 'b' }),
+      d: backendItem({ id: 'd', completed: true })
+    }
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    expect(
+      byIdCalls()
+        .map((c) => urlOf(c))
+        .sort()
+    ).toEqual(['https://api.example/v1/action-items/b', 'https://api.example/v1/action-items/d'])
+    const synced = (h.syncTaskActionItems.mock.calls[0] as unknown[])[0] as {
+      backendId: string
+    }[]
+    expect(synced.map((i) => i.backendId).sort()).toEqual(['b', 'd'])
+  })
+
+  it('a remotely toggled id (bucket move) is fetched, flipped, and kept by the UNION keep-set', async () => {
+    // b1 was incomplete locally; the backend moved it to completed.
+    h.censusIncomplete = []
+    h.censusCompleted = ['b1']
+    h.getSyncedActionItemIds.mockReturnValue([{ backendId: 'b1', completed: false }])
+    h.itemsById = { b1: backendItem({ id: 'b1', completed: true }) }
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    // The authoritative doc landed with the remote bucket…
+    const synced = (h.syncTaskActionItems.mock.calls[0] as unknown[])[0] as {
+      backendId: string
+      completed: boolean
+    }[]
+    expect(synced).toEqual([expect.objectContaining({ backendId: 'b1', completed: true })])
+    // …and BOTH sweeps ran against the census UNION, so the (now flipped) row is
+    // in the keep-set either way — never delete-by-absence'd by its old bucket.
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['b1'])
+    expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledWith(['b1'], expect.any(Number))
+  })
+
+  // Swarm must-fix regression: a mover whose per-id GET failed (or was cut by
+  // MAX_CENSUS_LOOKUPS) is PROVEN LIVE by the other bucket's census — the union
+  // keep-set must hold it for the next tick instead of letting its old bucket's
+  // sweep hard-delete it (which would destroy local-only fields on re-insert).
+  it('a bucket-moved row whose per-id GET FAILS is kept (union keep-set), not deleted', async () => {
+    h.censusIncomplete = ['x'] // non-empty old bucket — the dangerous case
+    h.censusCompleted = ['b1'] // b1 moved here remotely
+    h.getSyncedActionItemIds.mockReturnValue([
+      { backendId: 'b1', completed: false },
+      { backendId: 'x', completed: false }
+    ])
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const u = String(url)
+      if ((init?.method ?? 'GET') === 'GET') {
+        if (u.includes('completed=true')) return h.jsonResponse({ ids: h.censusCompleted })
+        if (u.includes('/v1/action-items/ids')) return h.jsonResponse({ ids: h.censusIncomplete })
+        if (u.endsWith('/b1')) return h.jsonResponse({}, false, 503) // the flip fails
+        return h.jsonResponse(backendItem({ id: 'x' }))
+      }
+      return h.jsonResponse({})
+    })
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    // The sweep keep-set is the UNION: b1 is present in the completed census, so
+    // the active-row sweep must NOT see it as absent.
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['x', 'b1'])
+    expect(h.hardDeleteAbsentCompletedTasks).toHaveBeenCalledWith(['x', 'b1'], expect.any(Number))
+  })
+
+  it('a mover cut by MAX_CENSUS_LOOKUPS is kept the same way (no delete past the cap)', async () => {
+    // 201 rows all moved buckets remotely; only 200 per-id GETs are allowed.
+    const movers = Array.from({ length: 201 }, (_, i) => `m${i}`)
+    h.censusIncomplete = []
+    h.censusCompleted = movers
+    h.getSyncedActionItemIds.mockReturnValue(
+      movers.map((id) => ({ backendId: id, completed: false }))
+    )
+    h.itemsById = Object.fromEntries(movers.map((id) => [id, backendItem({ id, completed: true })]))
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    expect(byIdCalls()).toHaveLength(200) // the cap
+    // …but the sweep keep-set still carries every mover id (union), so the one
+    // un-flipped row survives to the next tick.
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(expect.arrayContaining(movers))
+  })
+
+  it('a 404 on a census-fetched id is skipped (the reconciles handle absence)', async () => {
+    h.censusIncomplete = ['gone']
+    // No itemsById entry → per-id GET 404s.
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    expect(h.syncTaskActionItems).not.toHaveBeenCalled()
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['gone']) // absent → sweep decides
+  })
+
+  // Swarm should-fix regression: a LOCKED item (backend 402 'paid plan required'
+  // on the per-id GET) must not become a per-round zombie that re-bills forever
+  // and starves MAX_CENSUS_LOOKUPS — it is negative-cached until its TTL.
+  it('a 402 (locked) per-id GET is skipped on subsequent syncs until its TTL', async () => {
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    let lockedGets = 0
+    h.censusIncomplete = ['locked', 'fresh']
+    h.getSyncedActionItemIds.mockReturnValue([]) // both ids are new locally
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const u = String(url)
+      if ((init?.method ?? 'GET') === 'GET') {
+        if (u.includes('completed=true')) return h.jsonResponse({ ids: [] })
+        if (u.includes('/v1/action-items/ids')) return h.jsonResponse({ ids: h.censusIncomplete })
+        if (u.endsWith('/locked')) {
+          lockedGets++
+          return h.jsonResponse({ detail: 'paid plan required' }, false, 402)
+        }
+        return h.jsonResponse(backendItem({ id: 'fresh' }))
+      }
+      return h.jsonResponse({})
+    })
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+    expect(lockedGets).toBe(1) // tried once…
+    expect(h.syncTaskActionItems).toHaveBeenCalledTimes(1) // …and the fresh id still synced
+
+    nowSpy.mockReturnValue(t0 + 5 * 60_000 + 1) // next window: still inside the TTL
+    await engine.scheduleBackgroundSync()
+    expect(lockedGets).toBe(1) // not re-billed
+
+    nowSpy.mockReturnValue(t0 + 61 * 60_000) // TTL expired (plan may have changed)
+    await engine.scheduleBackgroundSync()
+    expect(lockedGets).toBe(2) // retried
+  })
+
+  it('one unreadable id does not abort the round — the rest still sync', async () => {
+    h.censusIncomplete = ['bad', 'ok']
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const u = String(url)
+      if ((init?.method ?? 'GET') === 'GET') {
+        if (u.includes('completed=true')) return h.jsonResponse({ ids: [] })
+        if (u.includes('/v1/action-items/ids')) return h.jsonResponse({ ids: h.censusIncomplete })
+        if (u.endsWith('/bad')) return h.jsonResponse({}, false, 500)
+        return h.jsonResponse(backendItem({ id: 'ok' }))
+      }
+      return h.jsonResponse({})
+    })
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+
+    const synced = (h.syncTaskActionItems.mock.calls[0] as unknown[])[0] as {
+      backendId: string
+    }[]
+    expect(synced.map((i) => i.backendId)).toEqual(['ok'])
+  })
+
+  it('caps per-sync lookups and converges the remainder on the next window', async () => {
+    const ids = Array.from({ length: 201 }, (_, i) => `n${i}`)
+    h.censusIncomplete = ids
+    h.itemsById = Object.fromEntries(ids.map((id) => [id, backendItem({ id })]))
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync()
+    expect(byIdCalls()).toHaveLength(200) // MAX_CENSUS_LOOKUPS
+
+    // Storage has now absorbed the first 200 (this test plays storage's role);
+    // only the 1 leftover is still "new" for the next window's diff.
+    h.getSyncedActionItemIds.mockReturnValue(
+      ids.slice(0, 200).map((id) => ({ backendId: id, completed: false }))
+    )
+    nowSpy.mockReturnValue(t0 + 5 * 60_000 + 1)
+    await engine.scheduleBackgroundSync()
+    expect(byIdCalls()).toHaveLength(201) // 200 + the 1 leftover picked up
+  })
+})
+
+describe('failure retry floor + timer', () => {
+  it('a sync that got NO backend response (offline) retries after 30s; a served one waits the window', async () => {
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    let offline = true
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const u = String(url)
+      if ((init?.method ?? 'GET') === 'GET' && u.includes('/v1/action-items/ids') && offline) {
+        throw new TypeError('net offline') // NO response — nothing billed
+      }
+      if ((init?.method ?? 'GET') === 'GET' && u.includes('/v1/action-items/ids')) {
+        return h.jsonResponse({ ids: [] })
+      }
+      return h.jsonResponse({ action_items: [], has_more: false })
+    })
+    const { engine } = await freshEngine()
+
+    await engine.scheduleBackgroundSync() // offline: fails with no response
+    nowSpy.mockReturnValue(t0 + 31_000)
+    offline = false
+    await engine.scheduleBackgroundSync() // within the 5-min window but past the retry floor
+    expect(censusCalls()).toHaveLength(3) // 1 offline attempt + the online round's 2
+
+    // Served-response failure: the reads are already billed, so the SAME 30s
+    // shortcut must NOT re-buy a round (a partially-failing backend would be
+    // re-scanned every 30s).
+    let secondCensusFails = false
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const u = String(url)
+      if ((init?.method ?? 'GET') === 'GET' && u.includes('/v1/action-items/ids')) {
+        if (u.includes('completed=true') && secondCensusFails) {
+          return h.jsonResponse({}, false, 500) // a RESPONSE — billed
+        }
+        return h.jsonResponse({ ids: [] })
+      }
+      return h.jsonResponse({ action_items: [], has_more: false })
+    })
+    nowSpy.mockReturnValue(t0 + 331_000) // fresh window (online round stamped at +31s)
+    secondCensusFails = true
+    await engine.scheduleBackgroundSync() // census #1 served, census #2 500s
+    expect(censusCalls()).toHaveLength(5) // 3 + 2 in the failed round
+    nowSpy.mockReturnValue(t0 + 363_000) // 30s later — inside the window
+    secondCensusFails = false
+    await engine.scheduleBackgroundSync()
+    expect(censusCalls()).toHaveLength(5) // NO 30s re-buy after a served response
+  })
+
+  // Swarm note regression: a sync that fails BECAUSE the session went away (the
+  // abort lands in the catch) must not re-stamp the throttle window — sign-out
+  // zeroed it via the session reset, and re-stamping would defer the NEXT
+  // account's first sync (leaving it reading the previous account's rows).
+  it('a sign-out mid-failed sync does not defer the next account’s first sync', async () => {
+    h.netFetch.mockImplementation(
+      async (url: string, init?: { method?: string; signal?: AbortSignal }) => {
+        if ((init?.method ?? 'GET') === 'GET' && String(url).includes('/v1/action-items/ids')) {
+          // Hang until the session abort kills the request (like real net.fetch).
+          const { promise, reject } = Promise.withResolvers<unknown>()
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')))
+          return promise
+        }
+        return h.jsonResponse({ action_items: [], has_more: false })
+      }
+    )
+    const { engine, session } = await freshEngine()
+    const pending = engine.scheduleBackgroundSync()
+    // Sign-out: epoch bump + the app-wired reset (index.ts onSessionReset →
+    // resetPendingDeletes) zeroes the throttle stamps.
+    session.setBackendSession(null)
+    engine.resetPendingDeletes()
+    await pending.catch(() => {})
+
+    // The next account signs in and reads: its first sync must run immediately.
+    session.setBackendSession(SESSION)
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      if ((init?.method ?? 'GET') === 'GET' && String(url).includes('/v1/action-items/ids')) {
+        return h.jsonResponse({ ids: [] })
+      }
+      return h.jsonResponse({ action_items: [], has_more: false })
+    })
+    await engine.scheduleBackgroundSync()
+    expect(censusCalls()).toHaveLength(2) // the new account's round ran NOW
+  })
+
+  it('startTaskBackgroundSync ticks a throttled census; a signed-out app stays idle', async () => {
+    const fresh = await freshEngine()
+    vi.useFakeTimers()
+    try {
+      fresh.engine.startTaskBackgroundSync()
+
+      // No session → the tick no-ops.
+      fresh.session.setBackendSession(null)
+      await vi.advanceTimersByTimeAsync(5 * 60_000)
+      expect(h.netFetch).not.toHaveBeenCalled()
+
+      fresh.session.setBackendSession(SESSION)
+      await vi.advanceTimersByTimeAsync(5 * 60_000)
+      expect(censusCalls()).toHaveLength(2) // one round per tick
+      await vi.advanceTimersByTimeAsync(5 * 60_000)
+      expect(censusCalls()).toHaveLength(4)
+    } finally {
+      fresh.engine.__stopTaskBackgroundSyncForTest()
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('explicit reconcile (strong path, tasks:reconcile)', () => {
+  it('full-lists both buckets, force-reconciles against the census, and restarts the throttle window', async () => {
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    h.getSyncedActionItemIds.mockReturnValue([{ backendId: 'b1', completed: false }])
+    h.censusIncomplete = ['b1']
+    const { engine } = await freshEngine()
+
+    await engine.reconcile()
+
+    // The strong path pages both full listings for content…
+    expect(listingCalls().length).toBeGreaterThanOrEqual(2)
+    // …censuses for the sweep keep-set (uncapped, unlike the 2000-doc listing
+    // cap), and its reconciles are forced (run even at t0, where a throttled
+    // call would have skipped).
+    expect(censusCalls()).toHaveLength(2)
+    expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['b1'])
+
+    // Fresh data just landed: the background window restarts, so an immediate
+    // scheduleBackgroundSync is throttled away instead of censusing over it.
+    nowSpy.mockReturnValue(t0 + 10_000)
+    await engine.scheduleBackgroundSync()
+    expect(censusCalls()).toHaveLength(2)
+  })
+
+  it('dedupes concurrent reconciles', async () => {
+    const { engine } = await freshEngine()
+    const a = engine.reconcile()
+    const b = engine.reconcile()
+    await Promise.all([a, b])
+    expect(listingCalls()).toHaveLength(2) // one run's worth (incomplete + completed)
+  })
+})
+
+// The deterministic cost guard. The script mirrors what the renderer actually
+// does over 5 minutes of Tasks use (mount reads; every `tasks:changed` broadcast
+// re-reads from the Tasks page, the Hub stats hook, and the Quick Task widget;
+// then a toggle, a create, and a rename). Under origin/main EVERY one of these
+// reads kicked a paged `GET /v1/action-items?limit=500` hydrate — measured by
+// running the identical flushed script against an origin/main worktree:
+// 22 listing requests / 500 listing documents / 25 requests total, vs 0 / 0 / 5
+// on this branch (see the PR body's before/after request log).
+describe('steady-state cost guard (scripted 5-min UI session)', () => {
+  it('makes ZERO full-listing requests and ≤2 census requests; only mutations hit the backend', async () => {
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    h.insertLocalActionItem.mockReturnValue({ id: 99 } as unknown as ActionItemRecord)
+    // Populated steady state: 30 incomplete + 10 completed synced rows, census
+    // buckets matching exactly (no remote changes during the window).
+    const local = [
+      ...Array.from({ length: 30 }, (_, i) => ({ backendId: `i${i}`, completed: false })),
+      ...Array.from({ length: 10 }, (_, i) => ({ backendId: `c${i}`, completed: true }))
+    ]
+    h.getSyncedActionItemIds.mockReturnValue(local)
+    h.censusIncomplete = local.filter((r) => !r.completed).map((r) => r.backendId)
+    h.censusCompleted = local.filter((r) => r.completed).map((r) => r.backendId)
+    const { engine } = await freshEngine()
+
+    // --- the script (renderer-faithful read/mutation pattern) ---
+    // Mount: Tasks page (incomplete + completed), Hub stats (incomplete +
+    // completed), Quick Task widget (incomplete).
+    engine.listIncomplete()
+    engine.listCompleted()
+    engine.dashboardSlices()
+    await flush()
+    // User: view incomplete, switch to completed, open the dashboard.
+    engine.listIncomplete()
+    engine.listCompleted()
+    engine.dashboardSlices()
+    await flush()
+    // Toggle → broadcast → the three subscribers re-read.
+    engine.toggleTask('i0', true)
+    await flush()
+    for (let i = 0; i < 5; i++) {
+      engine.listIncomplete()
+      engine.listCompleted()
+    }
+    // Create → broadcast → re-reads.
+    engine.createTask({ description: 'new task' })
+    await flush()
+    for (let i = 0; i < 5; i++) {
+      engine.listIncomplete()
+      engine.listCompleted()
+    }
+    // Rename → broadcast → re-reads.
+    engine.updateTask('i1', { description: 'renamed' })
+    await flush()
+    for (let i = 0; i < 5; i++) {
+      engine.listIncomplete()
+      engine.listCompleted()
+    }
+    // The window ends just before the timer's second tick.
+    nowSpy.mockReturnValue(t0 + 5 * 60_000 - 1)
+    engine.listIncomplete()
+    await flush()
+    // --- end of script ---
+
+    // The cut: zero full listings in the whole window…
+    expect(listingCalls()).toHaveLength(0)
+    // …exactly one census round (2 requests, one per bucket)…
+    expect(censusCalls()).toHaveLength(2)
+    // …zero per-id document fetches (the census matched the local store)…
+    expect(byIdCalls()).toHaveLength(0)
+    // …and the only other backend traffic is the three mutation writes
+    // (toggle PATCH + create POST + rename PATCH), which are user-caused.
+    const methods = h.netFetch.mock.calls.map((c) => c[1]?.method ?? 'GET')
+    expect(methods.filter((m) => m === 'GET')).toHaveLength(2) // the census
+    expect(methods.filter((m) => m === 'PATCH')).toHaveLength(2) // toggle + rename
+    expect(methods.filter((m) => m === 'POST')).toHaveLength(1) // create
+
+    // The reads stayed instant and local throughout.
+    expect(h.getLocalActionItems).toHaveBeenCalled()
   })
 })

--- a/desktop/windows/src/main/tasks/taskSyncEngine.ts
+++ b/desktop/windows/src/main/tasks/taskSyncEngine.ts
@@ -19,11 +19,20 @@
 //
 // OPTIMISTIC WRITE-THROUGH (Mac behavior, ported verbatim):
 //   - create : insert local (unsynced) → POST → markSynced on success; on failure
-//              stays unsynced (retried at next hydrate). NEVER reverted.
+//              stays unsynced (retried at next sync). NEVER reverted.
 //   - toggle : flip local → PATCH; on success absorb the server echo; on failure
 //              REVERT the local completion.
 //   - update : edit local → PATCH; on failure keep-local (next sync reconciles).
 //   - delete : HARD-delete local → DELETE; on failure keep-local-deleted.
+//
+// SYNC MODEL (the Firestore-read fix): local reads NEVER trigger a backend
+// listing. A single throttled background sync (≤1 per 5 min + in-flight dedup)
+// reconciles via the cheap ID census (`GET /v1/action-items/ids?completed=`),
+// fetching per-id documents only for ids that are new or moved buckets — a
+// steady state with no remote changes costs two census requests and ZERO
+// document transfers. Full paged listings are reserved for the one-time
+// per-account populate (versioned flag) and the explicit user reconcile
+// (`tasks:reconcile`), so the every-read `?limit=500` listing storm is gone.
 //
 // FIX (ii) — embedding eviction via DEPENDENCY INJECTION (no hard import of the
 // embedding service): `setTaskDeletionListener` wires a callback that every
@@ -35,6 +44,7 @@ import {
   getAppMeta,
   getFilteredActionItems,
   getLocalActionItems,
+  getSyncedActionItemIds,
   getUnsyncedActionItems,
   hardDeleteAbsentTasks,
   hardDeleteAbsentCompletedTasks,
@@ -70,8 +80,17 @@ import { promoteIfNeeded } from '../assistants/tasks/create'
 // reconcile), but a thin/partial list must never drive a delete-by-absence.
 import { isBackendDegraded } from '../observability/backendDegraded'
 
-// --- Tunables ---------------------------------------------------------------
 const REQUEST_TIMEOUT_MS = 15_000
+// Background sync cadence: ONE census-based reconcile per 5 minutes max, however
+// many local reads / focus events ask for one. This single number is what kills
+// the every-read listing storm (billing RCA 2026-08: ~61-73 RPS of
+// `GET /v1/action-items?limit=500` from omi-windows). Mac's TasksStore uses the
+// same 5-minute reconcile bound.
+const SYNC_THROTTLE_MS = 5 * 60_000
+// A FAILED background sync retries at most this often (not the full 5-min window)
+// so an offline-then-online user isn't locked out of freshness, while a 429 storm
+// still only sees ≤2 sync attempts per minute instead of the old per-read storm.
+const SYNC_RETRY_MS = 30_000
 // Reconcile (hard-delete tasks absent from the backend) at most once per 5 min —
 // Mac's `lastReconcileAt` throttle. Prevents an every-keystroke reconcile sweep.
 const RECONCILE_THROTTLE_MS = 5 * 60_000
@@ -79,7 +98,10 @@ const RECONCILE_THROTTLE_MS = 5 * 60_000
 const PAGE_LIMIT = 500
 // Hard ceiling on paging so a runaway `has_more` can never loop forever.
 const MAX_PAGES = 200
-
+// Per-id document lookups one background sync may issue (new / bucket-moved ids).
+// Bounds the repair burst after a mass remote change; the remainder stays
+// "missing" in the next tick's census diff and converges on later ticks.
+const MAX_CENSUS_LOOKUPS = 200
 // --- FIX (ii): the embedding-eviction DI seam --------------------------------
 
 /** One locally hard-deleted task, handed to the deletion listener so the caller
@@ -110,8 +132,18 @@ function emitDeletions(ids: number[]): void {
 let lastReconcileAt = 0
 let lastCompletedReconcileAt = 0
 let retrying = false
-let hydrateIncompleteInFlight: Promise<void> | null = null
-let hydrateCompletedInFlight: Promise<void> | null = null
+// The throttled background sync (census-based). `lastSyncAt` stamps at sync START
+// (after the session check) so a run in flight can't be double-scheduled; a
+// FAILED run relaxes the stamp by SYNC_RETRY_MS so freshness retries are bounded
+// but frequent enough to heal an offline→online transition.
+let lastSyncAt = 0
+let backgroundSyncInFlight: Promise<void> | null = null
+let reconcileInFlight: Promise<void> | null = null
+let syncTimer: NodeJS.Timeout | null = null
+// True once the CURRENT round served any listing/census response — those reads
+// are already billed, so the failure-retry floor must not buy another round at
+// 30s (that would re-bill full scans every 30s on a partially-failing backend).
+let roundServedBackendRead = false
 
 // --- Pending-delete tombstones ----------------------------------------------
 // A user delete is a HARD local delete + a fire-and-forget backend DELETE. Without
@@ -145,12 +177,18 @@ function isTombstoned(backendId: string): boolean {
   return true
 }
 
-/** Drop all pending-delete tombstones. Called on sign-out so one account's in-flight
- *  deletes never gate another account's hydrate (cross-account hygiene). */
+/** Drop all per-session sync state: pending-delete tombstones plus the sync /
+ *  reconcile throttle stamps. Called on sign-out (core/session reset listener) so
+ *  one account's in-flight deletes or throttle windows never gate the next
+ *  account — a fresh sign-in syncs immediately and reconciles against its own
+ *  baseline (cross-account hygiene). */
 export function resetPendingDeletes(): void {
   pendingDeletes.clear()
+  lockedItemSkips.clear()
+  lastSyncAt = 0
+  lastReconcileAt = 0
+  lastCompletedReconcileAt = 0
 }
-/** Test-only alias. */
 export function __resetTombstonesForTest(): void {
   resetPendingDeletes()
 }
@@ -276,9 +314,11 @@ async function apiFetch(
 
 /** Stable request key for the 429-storm tracker's distinct-path rule: method +
  *  path with the query dropped and any trailing action-item id collapsed to :id,
- *  so all deletes/patches share one key while list vs create vs by-id stay distinct. */
+ *  so all deletes/patches share one key while list vs census vs create vs by-id
+ *  stay distinct. The static `ids` segment must NOT collapse (it is the census
+ *  endpoint, not an action-item id). */
 function rateLimitKey(method: string, path: string): string {
-  const pathname = path.split('?')[0].replace(/(\/v1\/action-items)\/[^/]+$/, '$1/:id')
+  const pathname = path.split('?')[0].replace(/(\/v1\/action-items)\/(?!ids$)[^/]+$/, '$1/:id')
   return `${method} ${pathname}`
 }
 
@@ -292,6 +332,7 @@ async function fetchPage(
   const q = new URLSearchParams({ limit: String(PAGE_LIMIT), offset: String(offset) })
   if (completed !== undefined) q.set('completed', String(completed))
   const res = await apiFetch('GET', `/v1/action-items?${q.toString()}`, undefined, external)
+  roundServedBackendRead = true // a response arrived — its reads are billed
   if (!res.ok) throw new HttpError(res.status)
   const json = (await res.json()) as { action_items?: BackendActionItem[]; has_more?: boolean }
   return {
@@ -301,7 +342,11 @@ async function fetchPage(
 }
 
 /** Page an entire listing (until has_more is false). Bails if the session epoch
- *  moved mid-paging. */
+ *  moved mid-paging. NOT used on any hot path — only the one-time versioned full
+ *  sync and the explicit user reconcile. NOTE: the backend hard-caps a listing at
+ *  2000 docs and reports has_more=false AT the cap, so a "complete" fetchAll can
+ *  silently be truncated on large accounts — which is exactly why runFullSync's
+ *  delete sweeps take their keep-set from the (uncapped) census, not the listing. */
 async function fetchAll(
   completed: boolean | undefined,
   epoch: number,
@@ -317,6 +362,59 @@ async function fetchAll(
     offset += PAGE_LIMIT
   }
   return out
+}
+
+/** One bucket of the ID census: `GET /v1/action-items/ids?completed=<bucket>`.
+ *  Returns the NON-deleted ids in that completion bucket (backend
+ *  `get_visible_action_item_ids` — an un-paged, uncapped select-projection
+ *  stream: no document bodies cross the wire, and a single response can't be
+ *  "thin", which is what makes census-driven delete-by-absence safe. COST: the
+ *  scan is billed 1 Firestore Read Op per collection doc per call (projection
+ *  trims payload, not Read Ops), so a round = 2 collection scans — see the
+ *  SYNC_MODEL note above. Throws on !ok so a failed census aborts the whole
+ *  sync (fail closed — never reconcile off a partial). */
+async function fetchIdCensus(completed: boolean, external?: AbortSignal): Promise<string[]> {
+  const res = await apiFetch(
+    'GET',
+    `/v1/action-items/ids?completed=${completed}`,
+    undefined,
+    external
+  )
+  roundServedBackendRead = true // a response arrived — its reads are billed
+  if (!res.ok) throw new HttpError(res.status)
+  const json = (await res.json()) as { ids?: unknown }
+  return Array.isArray(json.ids) ? (json.ids as string[]) : []
+}
+
+// Ids whose per-id GET returned 402 (backend: locked behind a paid plan — the
+// document is listed truncated but never readable by id). Re-fetching such an id
+// every round is a permanent zombie that also starves MAX_CENSUS_LOOKUPS, so
+// skip it for a TTL; a plan change re-enables it, and a sign-out clears the
+// cache entirely.
+const LOCKED_SKIP_TTL_MS = 60 * 60_000
+const lockedItemSkips = new Map<string, number>()
+
+/** Fetch one action item by id (authoritative doc for a census-new or
+ *  bucket-moved id). Returns null on 404 (gone — the reconciles handle absence)
+ *  and on 402 (locked: negative-cached so the round stops paying for it).
+ *  Rethrows other failures so the caller can skip that id without aborting. */
+async function fetchItemById(
+  backendId: string,
+  external?: AbortSignal
+): Promise<BackendActionItem | null> {
+  const res = await apiFetch(
+    'GET',
+    `/v1/action-items/${encodeURIComponent(backendId)}`,
+    undefined,
+    external
+  )
+  if (res.status === 404) return null
+  if (res.status === 402) {
+    lockedItemSkips.set(backendId, Date.now() + LOCKED_SKIP_TTL_MS)
+    return null
+  }
+  if (!res.ok) throw new HttpError(res.status)
+  return (await res.json()) as BackendActionItem
 }
 
 // --- Renderer notification ---------------------------------------------------
@@ -424,141 +522,196 @@ function uidFromToken(token: string): string | null {
   }
 }
 
-/** Once per (user, schema version): page EVERYTHING (incomplete + completed) so the
- *  local store starts fully populated, then reconcile once. The flag lives in
- *  app_meta (survives sign-out, keyed per uid) so it runs exactly once per install
- *  per account. */
+/** Page EVERYTHING (incomplete + completed) for CONTENT, sync it, then force
+ *  both reconciles against the CENSUS keep-set. Shared by the one-time versioned
+ *  populate and the explicit user reconcile — the only two paths that still move
+ *  full documents. Returns the changed-row count for the caller's broadcast
+ *  decision. Epoch-guarded: fetchAll re-checks per page, and the post-fetch
+ *  checks drop the whole result on a session change (never write one account's
+ *  data into the next account's DB).
+ *
+ *  Why the sweeps census even though we just listed everything: the backend
+ *  hard-caps a listing at 2000 docs and reports has_more=false AT the cap, so
+ *  listing ids can never drive delete-by-absence for a large account (the
+ *  forced sweep would hard-delete every local row past the cap, then the
+ *  background census would re-add them — a mass-delete/re-add flap on every
+ *  explicit refresh). The census is uncapped, so its union is the authoritative
+ *  keep-set; listing-truncated tail rows simply stay "new" in the next
+ *  background diff and backfill via per-id fetches. */
+async function runFullSync(epoch: number, external?: AbortSignal): Promise<number> {
+  const incomplete = await fetchAll(false, epoch, external)
+  const completed = await fetchAll(true, epoch, external)
+  if (getSessionEpoch() !== epoch) return 0
+  const now = Date.now()
+  const res = syncTaskActionItems(
+    [...incomplete, ...completed].map((i) => mapBackendItem(i, now)),
+    { now, isTombstoned }
+  )
+  const censusKeep = await fetchCensusKeep(external)
+  if (getSessionEpoch() !== epoch) return 0
+  // Force both reconciles regardless of the 5-min throttle: this caller holds
+  // authoritative data, so the sweeps are safe and also clear completed
+  // phantoms the throttled path leaves for later.
+  maybeReconcile(censusKeep, now, true)
+  maybeReconcileCompleted(censusKeep, now, true)
+  return res.inserted + res.updated + res.adopted
+}
+
+/** Both census buckets, deduped — the authoritative "live remotely" keep-set. */
+async function fetchCensusKeep(external?: AbortSignal): Promise<string[]> {
+  const incompleteIds = await fetchIdCensus(false, external)
+  const completedIds = await fetchIdCensus(true, external)
+  return [...new Set([...incompleteIds, ...completedIds])]
+}
+
+/** Once per (user, schema version): full-populate the local store, then reconcile.
+ *  The flag lives in app_meta (survives sign-out, keyed per uid) so it runs exactly
+ *  once per install per account. Returns true when the populate ran (the caller
+ *  skips the census that round — the full sync is itself the authoritative
+ *  reconcile). v2: the sync model changed from every-read full listings to the ID
+ *  census, and census buckets cannot see in-place content edits — so every
+ *  existing install re-populates ONCE after updating (repairing drift accumulated
+ *  under v1); content afterwards flows through mutations, the census, and the
+ *  explicit reconcile. */
 async function maybeFullSync(
   session: BackendSession,
   epoch: number,
   external?: AbortSignal
-): Promise<void> {
+): Promise<boolean> {
   const uid = uidFromToken(session.token)
-  if (!uid) return
-  const key = `tasksFullSyncCompleted_v1_${uid}`
-  if (getAppMeta(key)) return
-  const incomplete = await fetchAll(false, epoch, external)
-  const completed = await fetchAll(true, epoch, external)
-  if (getSessionEpoch() !== epoch) return
-  const now = Date.now()
-  syncTaskActionItems(
-    [...incomplete, ...completed].map((i) => mapBackendItem(i, now)),
-    {
-      now,
-      isTombstoned
-    }
-  )
-  // The one-time full sync forces a reconcile regardless of the 5-min throttle —
-  // both the incomplete (active) and completed sweeps, so the initial populate also
-  // clears any completed phantom left by a prior install's dropped write.
-  maybeReconcile(
-    incomplete.map((i) => i.id),
-    now,
-    true
-  )
-  maybeReconcileCompleted(
-    completed.map((i) => i.id),
-    now,
-    true
-  )
+  if (!uid) return false
+  const key = `tasksFullSyncCompleted_v2_${uid}`
+  if (getAppMeta(key)) return false
+  const changed = await runFullSync(epoch, external)
+  if (getSessionEpoch() !== epoch) return false
   setAppMeta(key, '1')
-  broadcastTasksChanged()
+  if (changed > 0) broadcastTasksChanged()
+  return true
 }
 
-// --- Hydration (local-first) -------------------------------------------------
+// --- Background sync (throttled, census-based) --------------------------------
 
-/** Sync the incomplete list from the backend, then reconcile. Deduped: concurrent
- *  callers share the one in-flight run. On the first run per account it also drains
- *  unsynced creates and does the one-time full sync. Errors are swallowed (logged
- *  name-only) — hydration is best-effort over the always-available local read. */
-export function hydrateIncomplete(): Promise<void> {
-  if (hydrateIncompleteInFlight) return hydrateIncompleteInFlight
-  hydrateIncompleteInFlight = doHydrateIncomplete().finally(() => {
-    hydrateIncompleteInFlight = null
+/** The ONE background sync entry point. Throttled to SYNC_THROTTLE_MS and deduped
+ *  (concurrent callers share the in-flight run), so local reads, the periodic
+ *  timer, and window focus all funnel here without any of them being able to
+ *  restore the old every-read full-listing storm. Errors are swallowed (logged
+ *  name-only) — the sync is best-effort over the always-available local read. */
+export function scheduleBackgroundSync(): Promise<void> {
+  if (backgroundSyncInFlight) return backgroundSyncInFlight
+  if (Date.now() - lastSyncAt < SYNC_THROTTLE_MS) return Promise.resolve()
+  backgroundSyncInFlight = doBackgroundSync().finally(() => {
+    backgroundSyncInFlight = null
   })
-  return hydrateIncompleteInFlight
+  return backgroundSyncInFlight
 }
 
-async function doHydrateIncomplete(): Promise<void> {
+async function doBackgroundSync(): Promise<void> {
   const session = getBackendSession()
   if (!session) return // local-only until a session is relayed
+  lastSyncAt = Date.now() // stamp at START: this run's requests are committed
+  roundServedBackendRead = false
   const epoch = getSessionEpoch()
   const external = getAbortSignal()
   try {
     await retryUnsynced()
-    await maybeFullSync(session, epoch, external)
     if (getSessionEpoch() !== epoch) return
-    const items = await fetchAll(false, epoch, external)
+    // First run per (user, version) pages everything once. Its sweeps already
+    // run against the census keep-set (see runFullSync), and its content pages
+    // cover everything the per-id path would fetch — no separate diff needed.
+    if (await maybeFullSync(session, epoch, external)) return
     if (getSessionEpoch() !== epoch) return
+    // ID census, one request per completion bucket. A failure throws and aborts
+    // the whole round (fail closed): with no complete census there is no safe
+    // delete-by-absence. The census is a single un-paged response, so it can
+    // never be "thin" the way a truncated page run can.
+    const incompleteIds = await fetchIdCensus(false, external)
+    const completedIds = await fetchIdCensus(true, external)
+    if (getSessionEpoch() !== epoch) return
+    // Diff the census against the local synced rows: fetch documents ONLY for
+    // ids that are new locally or moved buckets (a remote toggle). Unchanged
+    // ids cost nothing beyond the census itself — that is the steady-state cut.
+    const local = new Map(getSyncedActionItemIds().map((r) => [r.backendId, r.completed]))
+    const toFetch: string[] = []
+    for (const id of incompleteIds) if (local.get(id) !== false) toFetch.push(id)
+    for (const id of completedIds) if (local.get(id) !== true) toFetch.push(id)
+    const items: BackendActionItem[] = []
+    // Slice AFTER dropping TTL-active locked skips, so a locked id can never
+    // occupy one of the MAX_CENSUS_LOOKUPS slots and starve genuine new ids.
+    const now0 = Date.now()
+    const lookupQueue = toFetch.filter((id) => {
+      const skipUntil = lockedItemSkips.get(id)
+      if (skipUntil === undefined) return true
+      if (skipUntil > now0) return false
+      lockedItemSkips.delete(id)
+      return true
+    })
+    for (const id of lookupQueue.slice(0, MAX_CENSUS_LOOKUPS)) {
+      try {
+        const item = await fetchItemById(id, external)
+        if (item) items.push(item)
+      } catch (e) {
+        // One unreadable document must not abort the round (Mac's stale-row
+        // resolution behaves the same); the id stays "changed" in the next
+        // tick's diff and is retried then.
+        console.warn('[tasks] census item fetch failed (will retry next sync):', errName(e))
+      }
+      if (getSessionEpoch() !== epoch) return
+    }
+    let changed = false
+    if (items.length > 0) {
+      const now = Date.now()
+      const res = syncTaskActionItems(
+        items.map((i) => mapBackendItem(i, now)),
+        { now, isTombstoned }
+      )
+      changed = res.inserted + res.updated + res.adopted > 0
+    }
+    // Census-driven delete-by-absence, AFTER the per-id syncs. The keep-set for
+    // BOTH sweeps is the UNION of the two census buckets: an id present in
+    // EITHER bucket is proven live remotely, so a bucket-moved row whose per-id
+    // GET failed (or was cut by MAX_CENSUS_LOOKUPS) is KEPT and retried next
+    // tick — only an id absent from both buckets is genuinely deleted remotely.
+    // Per-bucket keep-sets would delete a mover from its old bucket the moment
+    // its flip didn't land, destroying local-only fields (score/tags/priority)
+    // on the later re-insert. Empty censuses no-op inside storage (never wipe
+    // on an empty or failed census). maybeReconcile* broadcast on their own iff
+    // they delete something.
     const now = Date.now()
-    const res = syncTaskActionItems(
-      items.map((i) => mapBackendItem(i, now)),
-      { now, isTombstoned }
-    )
-    // maybeReconcile broadcasts on its own iff it hard-deletes something. Here we
-    // broadcast only when the sync actually changed a row — a no-op hydrate MUST
-    // stay silent, else the renderer (which re-reads on `tasks:changed`, and every
-    // read kicks another hydrate) spins in an unbounded backend-polling loop.
-    maybeReconcile(
-      items.map((i) => i.id),
-      now
-    )
-    if (res.inserted + res.updated + res.adopted > 0) broadcastTasksChanged()
+    const censusKeep = [...new Set([...incompleteIds, ...completedIds])]
+    maybeReconcile(censusKeep, now)
+    maybeReconcileCompleted(censusKeep, now)
+    // A no-op sync MUST stay silent: the renderer re-reads on `tasks:changed`,
+    // and before this throttle every read kicked another sync — an unconditional
+    // broadcast recreates that polling loop even with the throttle in place.
+    if (changed) broadcastTasksChanged()
   } catch (e) {
-    console.warn('[tasks] hydrateIncomplete failed:', errName(e))
+    console.warn('[tasks] background sync failed:', errName(e))
+    // Failure retry floor: allow another attempt after SYNC_RETRY_MS, not the
+    // full window, so a fully-offline round heals quickly — while a 429 storm
+    // still only sees ≤2 attempts/min instead of the old per-read storm. Two
+    // guards: never re-stamp after a sign-out (the session reset already zeroed
+    // the stamp for the next account), and never re-stamp once this round
+    // SERVED a listing/census response — those reads are already billed, and a
+    // 30s re-buy would re-bill the full scans on a partially-failing backend.
+    if (getSessionEpoch() === epoch && !roundServedBackendRead) {
+      lastSyncAt = Date.now() - SYNC_THROTTLE_MS + SYNC_RETRY_MS
+    }
   }
 }
 
-/** Sync the completed list (no reconcile — hardDeleteAbsentTasks only ever touches
- *  active rows, so a completed listing must never drive it). Deduped. */
-export function hydrateCompleted(): Promise<void> {
-  if (hydrateCompletedInFlight) return hydrateCompletedInFlight
-  hydrateCompletedInFlight = doHydrateCompleted().finally(() => {
-    hydrateCompletedInFlight = null
-  })
-  return hydrateCompletedInFlight
-}
+// --- Reads (local-first: SQLite only; freshness is the throttled sync's job) ---
 
-async function doHydrateCompleted(): Promise<void> {
-  const session = getBackendSession()
-  if (!session) return
-  const epoch = getSessionEpoch()
-  const external = getAbortSignal()
-  try {
-    const items = await fetchAll(true, epoch, external)
-    if (getSessionEpoch() !== epoch) return
-    const now = Date.now()
-    const res = syncTaskActionItems(
-      items.map((i) => mapBackendItem(i, now)),
-      { now, isTombstoned }
-    )
-    // Reconcile completed phantoms: a locally-completed row absent from the backend's
-    // full completed listing was deleted server-side and must be dropped locally.
-    // maybeReconcileCompleted broadcasts on its own iff it deletes something.
-    maybeReconcileCompleted(
-      items.map((i) => i.id),
-      now
-    )
-    // Broadcast only on an actual change — see doHydrateIncomplete for why a silent
-    // no-op hydrate is mandatory (renderer re-read → hydrate → broadcast loop).
-    if (res.inserted + res.updated + res.adopted > 0) broadcastTasksChanged()
-  } catch (e) {
-    console.warn('[tasks] hydrateCompleted failed:', errName(e))
-  }
-}
-
-// --- Reads (local-first: return local instantly, kick background hydration) ---
-
-/** Incomplete tasks — returns the LOCAL rows instantly and kicks a background sync
+/** Incomplete tasks — the LOCAL rows, instantly. Freshness comes from the
+ *  throttled background sync (≤1 per 5 min); a read never talks to the backend
  *  (subscribe to `tasks:changed` to re-fetch). */
 export function listIncomplete(opts?: { limit?: number; offset?: number }): ActionItemRecord[] {
-  void hydrateIncomplete()
+  void scheduleBackgroundSync()
   return getLocalActionItems({ completed: false, limit: opts?.limit, offset: opts?.offset })
 }
 
-/** Completed tasks — local-first, kicks a background completed sync. */
+/** Completed tasks — local-first, same throttled-sync contract. */
 export function listCompleted(opts?: { limit?: number; offset?: number }): ActionItemRecord[] {
-  void hydrateCompleted()
+  void scheduleBackgroundSync()
   return getLocalActionItems({ completed: true, limit: opts?.limit, offset: opts?.offset })
 }
 
@@ -573,9 +726,10 @@ export function listDeleted(_opts?: { limit?: number; offset?: number }): Action
 }
 
 /** Dashboard slices for the Tasks home: overdue / due-today / no-due — all active
- *  tasks, read from local (getFilteredActionItems), with a background sync kicked. */
+ *  tasks, read from local (getFilteredActionItems); the throttled background sync
+ *  keeps the store fresh. */
 export function dashboardSlices(): TaskDashboardSlices {
-  void hydrateIncomplete()
+  void scheduleBackgroundSync()
   const start = new Date()
   start.setHours(0, 0, 0, 0)
   const startToday = start.getTime()
@@ -590,10 +744,9 @@ export function dashboardSlices(): TaskDashboardSlices {
 }
 
 // --- Optimistic write-through ------------------------------------------------
-
 /** Create a task: insert locally (unsynced) and return the row immediately; POST in
  *  the background. On success stamp it synced with the backend id. On FAILURE it
- *  stays unsynced (retried at the next hydrate) — never reverted. */
+ *  stays unsynced (retried at the next background sync) — never reverted. */
 export function createTask(fields: TaskCreateFields): ActionItemRecord {
   const now = Date.now()
   const rec = insertLocalActionItem({
@@ -836,7 +989,7 @@ function scheduleDeleteReVerify(
 
 /** Re-POST every unsynced local create (a create whose background POST never
  *  landed — offline at creation, or app killed before markSynced). Guarded against
- *  re-entry. Called at the start of each incomplete hydrate. */
+ *  re-entry. Called at the start of each background sync and explicit reconcile. */
 export async function retryUnsynced(): Promise<void> {
   if (retrying) return
   const session = getBackendSession()
@@ -880,8 +1033,58 @@ export async function retryUnsynced(): Promise<void> {
 
 // --- Public reconcile (IPC `tasks:reconcile`) --------------------------------
 
-/** Run a throttled reconcile: page the incomplete list, sync it, and hard-delete
- *  local tasks the backend no longer has (respecting the 5-min throttle). */
+/** EXPLICIT user refresh (the Tasks page refresh button): the strong path — full
+ *  paged listings of both buckets with forced reconciles. Rare by construction
+ *  (a user action), so the full-document cost is acceptable here and ONLY here;
+ *  it is also the one path that reliably picks up in-place remote EDITS (renames,
+ *  due-date changes) the ID census cannot see. Deduped and epoch-guarded like the
+ *  background sync. */
 export function reconcile(): Promise<void> {
-  return hydrateIncomplete()
+  if (reconcileInFlight) return reconcileInFlight
+  reconcileInFlight = doReconcile().finally(() => {
+    reconcileInFlight = null
+  })
+  return reconcileInFlight
+}
+
+async function doReconcile(): Promise<void> {
+  const session = getBackendSession()
+  if (!session) return
+  const epoch = getSessionEpoch()
+  const external = getAbortSignal()
+  try {
+    await retryUnsynced()
+    if (getSessionEpoch() !== epoch) return
+    const changed = await runFullSync(epoch, external)
+    if (getSessionEpoch() !== epoch) return
+    // Fresh data just landed under the user's eyes: restart the background
+    // window so the timer doesn't immediately census over it.
+    lastSyncAt = Date.now()
+    if (changed > 0) broadcastTasksChanged()
+  } catch (e) {
+    console.warn('[tasks] reconcile failed:', errName(e))
+  }
+}
+
+// --- Periodic timer ------------------------------------------------------------
+
+/** Start the background-sync interval (idempotent). Wired once at app startup;
+ *  ticks are session-gated and throttled, so a signed-out app does nothing. The
+ *  interval IS the remote-change visibility bound: adds / deletes / toggles made
+ *  on other surfaces appear within one interval; in-place edits appear on the
+ *  explicit reconcile. */
+export function startTaskBackgroundSync(): void {
+  if (syncTimer) return
+  syncTimer = setInterval(() => {
+    void scheduleBackgroundSync()
+  }, SYNC_THROTTLE_MS)
+}
+
+/** Test-only: stop and clear the interval so a timer started in one test never
+ *  leaks across a module reset. */
+export function __stopTaskBackgroundSyncForTest(): void {
+  if (syncTimer) {
+    clearInterval(syncTimer)
+    syncTimer = null
+  }
 }


### PR DESCRIPTION
fix(windows): stop full action-item hydrate on every local read

## Why

Billing RCA (2026-08-17, coordinator-verified): Windows Desktop fired `GET /v1/action-items?limit=500` on **~61–73 RPS** (Cloud Logging 30s sample: 1,825 requests, 99% `omi-windows`, 99% `limit=500`, ~2:1 completed:true/false). Every local Tasks read (`listIncomplete` / `listCompleted` / `dashboardSlices`) kicked an **unthrottled** paged `fetchAll`, and every `tasks:changed` broadcast made the renderer re-read (Tasks page + Hub stats + Quick Task widget) — a self-feeding listing storm. Firestore Read Ops SKU: **$3,285.95 → $9,862.43/mo** (10.42B → 21.39B ops), live QUERY ~10.5–12k reads/s. Related: #9889 (open; not closed by this PR), #9891 (merged, did not drop cash).

## What changed (Windows client only; backend untouched)

`desktop/windows/src/main/tasks/taskSyncEngine.ts` + storage reader + main wiring:

- **Reads are SQLite-only.** `listIncomplete` / `listCompleted` / `dashboardSlices` never talk to the backend.
- **One throttled background sync** (`scheduleBackgroundSync`): ≤1 per 5 min + in-flight dedup; reads, a 5-min interval (`startTaskBackgroundSync`, wired at startup), and window focus all funnel through the same gate, so no trigger can restore the storm. A 30s failure-retry floor heals offline→online, and only when the failed round served **no** backend read response (a served response is already billed — no 30s re-scans of a partially-failing backend), never after sign-out (epoch-guarded).
- **ID-census reconcile**: `GET /v1/action-items/ids?completed=false|true` (existing endpoint), diffed against local synced ids (`getSyncedActionItemIds`, new minimal storage reader); per-id document GETs only for ids that are **new or moved buckets** (remote toggles), capped at 200/sync with convergence on later ticks. Steady state with no remote changes = **2 census requests, 0 document transfers**.
- **Delete-by-absence safety**: keep-set for both sweeps is the **union of both census buckets** — an id present in either bucket is proven live remotely, so a bucket-moved row whose flip didn't land is kept and retried, never deleted by its old bucket's sweep. Failed census = fail-closed round (no sweep at all). Empty censuses no-op in storage. Epoch + tombstone guards unchanged; offline/401 never wipes the local store.
- **Full paged listings only** in the one-time versioned populate (flag `v1 → v2`: every existing install re-populates once, repairing drift the census can't see) and the explicit reconcile (`tasks:reconcile` — the Tasks-page refresh button). Both take their sweep keep-sets from the **uncapped census**, because the backend hard-caps listings at 2,000 docs and reports `has_more=false` at the cap — listing ids must never drive forced delete-by-absence on large accounts.
- **Locked items (402)**: per-id GETs that return 402 (paid-plan lock; the doc is listed truncated but never readable by id) are negative-cached for 1h so they can't re-bill every round or starve the lookup cap; they appear via the explicit reconcile's listing, matching pre-fix behavior.
- No-op syncs stay silent (no `tasks:changed`), so the read → sync → broadcast → re-read loop cannot self-feed.

## Cost evidence (deterministic, same script on both trees)

Identical scripted 5-min UI session (mount reads; browse; toggle/create/rename; renderer-faithful re-reads after every broadcast), run against an `origin/main` worktree and this branch (temporary harness, not committed; the committed `steady-state cost guard` test pins the after-side):

| | requests | full listings | listing docs | census | per-id | writes |
|---|---|---|---|---|---|---|
| origin/main | 25 | **22** | **500** | 0 | 0 | 3 |
| this branch | 5 | **0** | **0** | 2 | 0 | 3 |

- **Listing-scan volume (the acceptance metric): −100%** (22→0 requests, 500→0 docs). Deterministically pinned by `taskSyncEngine.test.ts › steady-state cost guard`.
- **Honest strictest accounting**: each census call is a select-projection stream over the whole collection = **1 Firestore Read Op per doc per call** (projection trims payload, not Read Ops; verified in `backend/database/action_items.py get_visible_action_item_ids`), so a round costs 2N read-ops where N = total tasks. In the single-user test window that is 80 vs 500 (**−84%**); in production the old path billed R×N per window at 61–73 RPS aggregate (≥3 orders of magnitude above 2N/5min). The cut comes from the 5-min throttle + per-id fetching, **not** per-call read magic. A per-call read-ops cut needs a backend `updated_at` watermark/index — deliberately out of scope here.
- New steady-state floor per signed-in client: 2N read-ops per 5 min (the ≤5-min remote-visibility bound). Cadence is the only client-side lever; a slower bound would cut it linearly.

## UX

- Lists paint **instantly from SQLite** on every read (unchanged local-first contract; create/complete/edit/delete stay optimistic write-through with revert-on-failure semantics).
- **Remote adds / deletes / completion toggles appear within ≤5 minutes** (census cadence) or immediately on the explicit refresh.
- **In-place remote edits (rename, due-date) appear on explicit refresh** (`tasks:reconcile`, full listing) or the one-time v2 re-populate — the census is ids-only and cannot see content edits. This is the stated bound; a watermark endpoint would tighten it.
- Locked (paid-plan) items: background sync skips their docs for 1h at a time; the explicit refresh still shows them (truncated), as before.

## Swarm review (before `gh pr create`)

Two independent reviewer lanes ran on the unpushed branch (data-loss/correctness + cost-refuter):

- **DataLossReviewer — must-fix (fixed)**: per-bucket sweep keep-sets hard-deleted a bucket-moved row whose per-id GET failed (429/5xx) or was cut by the 200-lookup cap — destroying local-only fields (score/tags/priority) on re-insert; deterministic repro via 300 remote bulk-completes. **Fix**: union keep-set for both sweeps + regression tests (failed-flip keeper, cap keeper).
- **DataLossReviewer — note (fixed)**: sign-out mid-failed-sync re-stamped the throttle window, deferring the next account's first sync ≤30s. **Fix**: epoch-guarded re-stamp + regression test.
- **CostRefuter — should-fix (fixed)**: 402 locked-item ids became permanent per-round re-fetch zombies starving the lookup cap → negative-cached (1h TTL, cleared on sign-out); 30s retry floor re-billed served census scans on partially-failing backends → relax now gated on "no backend read response served" (also bounds degraded-mode v2-populate retries to the 5-min cadence); forced full-sync sweeps used the 2,000-capped listing ids (mass-delete/re-add flap on refresh for >2k-task accounts) → census keep-set.
- **CostRefuter — disclosure (addressed in this body)**: census costs 2 full-collection scans per round (2N read-ops) and introduces an idle-polling cost class the old read-driven code didn't have; numbers above state it plainly.
- Confirmed by both lanes: no steady-state full-listing path with the v2 flag set, no hydrate-broadcast loop, epoch/tombstone/empty-set invariants hold, fail-closed on failed/partial census.

**Verification round**: both lanes re-reviewed the fixed tree — DataLossReviewer: *"correct, no remaining findings from my lane"* (all previously-traced invariants re-checked); CostRefuter: *"all three should-fix findings are fixed as claimed"* with one P3 residual (locked skips occupying lookup slots before the slice) — also fixed: the lookup queue filters locked skips **before** the `MAX_CENSUS_LOOKUPS` slice. Residual trade-offs both lanes accepted: an intermittent-5xx backend retries freshness at the 5-min window instead of 30s (fail-closed, no data risk); the explicit reconcile costs 2 listings + 2 censuses per click (user-action rate); a 401 response counts as "served" and blocks that round's 30s retry (over-conservative, harmless).

## Tests

Focused suites in `desktop/windows` (vitest): throttle/dedup, census diff (new/moved/404/402/500-skip/cap+converge), union keep-set keepers, fail-closed census, empty-census no-wipe, no-op silence, timer + signed-out idle, explicit reconcile strong path, v2 re-populate + capped-tail survival, sign-out stamp hygiene, storage reader contract vs real SQLite (`dbTasks.test.ts`). Verified locally: `vitest run src/main` (2,551 passed) + Tasks/home/voice renderer suites (3,057 passed across the task-adjacent surface), `tsc` node+web clean, eslint clean. Full-suite runs on this machine show unrelated renderer flakes under parallel load that pass in isolation on both clean and patched trees.

Refs #9889 (not closed — backend QUERY residual remains).

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

