### PR TITLE
feat(agent-vm): minimum spend — delete undemanded capacity, read-only status, opt-in provisioning

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -306,6 +306,7 @@ jobs:
             AGENT_VM_IMAGE_DIGEST=${{ steps.agent-vm-release.outputs.image_digest }}
             AGENT_VM_STARTUP_SHA256=${{ steps.agent-vm-release.outputs.startup_sha256 }}
             AGENT_VM_STOP_AUDIENCE=${{ steps.desktop-base-api-url.outputs.base_api_url }}
+            AGENT_VM_PROVISIONING_ENABLED=true
           secrets: |
             /secrets/firebase/service-account.json=SERVICE_ACCOUNT_JSON:latest
             GEMINI_API_KEY=GEMINI_API_KEY:latest

--- a/backend/charts/agent-vm-reaper/README.md
+++ b/backend/charts/agent-vm-reaper/README.md
@@ -14,13 +14,14 @@ desktop agent leaves a permanent disk (~$5/mo).
 | Target | Rule (defaults) |
 |--------|-----------------|
 | `TERMINATED` | `lastStopTimestamp` older than **12h** |
-| `RUNNING` | **Never deleted here.** The fleet reconciler is the RUNNING authority: a healthy VM with no session lease past `AGENT_VM_IDLE_STOP_SECONDS` (default 1h) is stopped; this reaper then deletes the TERMINATED leftover. Do not reap RUNNING by creation age — that would delete live sessions (review #10390). |
+| `RUNNING` | **Never deleted here.** The fleet reconciler is the RUNNING authority: a healthy VM with no session lease past `AGENT_VM_IDLE_TEARDOWN_SECONDS` (default 30m) is **deleted** by the reconciler itself (disks reclaimed via `autoDelete`); this reaper covers TERMINATED leftovers the reconciler cannot reach (e.g. ownerless records). Do not reap RUNNING by creation age — that would delete live sessions (review #10390). |
 
 After a TERMINATED VM is deleted, `GET /v2/agent/status` sees `NOT_FOUND`,
-demotes the client-facing status to `updating`, records `reconcile.state=missing`
-(when no reconciler lease/quarantine owns the pointer), and queues fenced
-reconciler demand. Desktop `ensureExistingOrProvision` can then claim a
-replacement immediately because missing pointers are replaceable; the
+demotes the client-facing status to `updating`, and records
+`reconcile.state=missing` (when no reconciler lease/quarantine owns the
+pointer). Status never queues reconciler demand — waking a VM requires a real
+session or an explicit ensure call. Desktop `ensureExistingOrProvision` can
+claim a replacement immediately because missing pointers are replaceable; the
 reconciler's grace/session clear remains the backstop when the request path
 does not replace first.
 

--- a/backend/jobs/agent_vm_reconciler.py
+++ b/backend/jobs/agent_vm_reconciler.py
@@ -89,8 +89,8 @@ OWNER_FALLBACK_SCAN_LIMIT = 1_000
 FAILED_JOB_STATES = {"retry", "quarantined", "missing", "stale", "recreate_required"}
 DEFAULT_MISSING_CLEANUP_GRACE_SECONDS = 24 * 60 * 60
 MIN_MISSING_CLEANUP_GRACE_SECONDS = 60
-DEFAULT_IDLE_STOP_SECONDS = 60 * 60
-MIN_IDLE_STOP_SECONDS = 30 * 60
+DEFAULT_IDLE_TEARDOWN_SECONDS = 30 * 60
+MIN_IDLE_TEARDOWN_SECONDS = 30 * 60
 _IMMUTABLE_BOOT_IMAGE = re.compile(r"^projects/[^/]+/global/images/[^/]+$")
 _MIGRATION_ID = re.compile(r"^[0-9a-f]{24}$")
 
@@ -395,20 +395,20 @@ def _missing_cleanup_grace_seconds() -> int:
     return value
 
 
-def _idle_stop_seconds() -> int:
-    raw = os.getenv("AGENT_VM_IDLE_STOP_SECONDS")
+def _idle_teardown_seconds() -> int:
+    raw = os.getenv("AGENT_VM_IDLE_TEARDOWN_SECONDS")
     if raw is None or not raw.strip():
-        return DEFAULT_IDLE_STOP_SECONDS
+        return DEFAULT_IDLE_TEARDOWN_SECONDS
     try:
         value = int(raw)
     except ValueError as exc:
-        raise ValueError("AGENT_VM_IDLE_STOP_SECONDS must be an integer") from exc
-    if value < MIN_IDLE_STOP_SECONDS:
-        raise ValueError(f"AGENT_VM_IDLE_STOP_SECONDS must be at least {MIN_IDLE_STOP_SECONDS}")
+        raise ValueError("AGENT_VM_IDLE_TEARDOWN_SECONDS must be an integer") from exc
+    if value < MIN_IDLE_TEARDOWN_SECONDS:
+        raise ValueError(f"AGENT_VM_IDLE_TEARDOWN_SECONDS must be at least {MIN_IDLE_TEARDOWN_SECONDS}")
     return value
 
 
-def idle_stop_due(
+def idle_teardown_due(
     *,
     status: str,
     reasons: Sequence[str],
@@ -416,18 +416,19 @@ def idle_stop_due(
     active_sessions: int,
     idle_since: float | None,
     now: float,
-    idle_stop_seconds: int,
+    idle_teardown_seconds: int,
 ) -> bool:
     """True only for a healthy RUNNING VM with no live session past the idle TTL.
 
-    Idle must never be folded into drift ``reasons``: that path stops, rewrites
-    metadata, then restarts. This predicate is a terminal-for-this-run outcome.
+    Idle must never be folded into drift ``reasons``: that path stops and
+    rewrites metadata. This predicate is a terminal-for-this-run outcome: the
+    VM is deleted (disks reclaimed via ``autoDelete``), not stopped-and-kept.
     """
     if reasons or start_requested or active_sessions != 0:
         return False
     if status != "RUNNING" or idle_since is None:
         return False
-    return idle_since <= now - idle_stop_seconds
+    return idle_since <= now - idle_teardown_seconds
 
 
 def _canonical_image_ref(value: str) -> str:
@@ -1248,6 +1249,55 @@ async def _update_reconcile(
     )
 
 
+async def _teardown_undemanded_vm(
+    uid: str,
+    vm_name: str,
+    auth_token: str,
+    *,
+    api: GceAgentVmClient,
+    owner: str,
+    instance: Mapping[str, Any],
+    now: float,
+    observed_start_request_at: float | None,
+    detail: str,
+) -> ReconcileResult:
+    """Delete a VM that no session demands; cost policy owns undemanded capacity.
+
+    The caller has already verified: owner lease held, zero active session
+    leases, no start demand, and no active boot-image migration. Deletion
+    reclaims the boot and state disks through their ``autoDelete`` attachments;
+    the SQLite database on the state disk is a client-uploaded copy and the
+    Chrome profile is a tmpfs, so no unique data exists on the instance. The
+    owner record is marked ``missing`` so desktop provisioning can claim a
+    replacement immediately and terminal cleanup erases the record after grace.
+    """
+    instance_id = str(instance.get("id") or "")
+    if not instance_id:
+        raise RuntimeError("undemanded VM teardown identity is unavailable")
+    if not await asyncio.to_thread(renew_vm_lease, uid, vm_name, auth_token, owner):
+        return ReconcileResult(uid, "stale", "owner lease lost before teardown")
+    if not await api.delete_instance(vm_name, instance_id):
+        return ReconcileResult(uid, "stale", "instance identity changed before teardown")
+    if not await _update_reconcile(
+        uid,
+        vm_name,
+        auth_token,
+        owner,
+        {
+            "state": "missing",
+            "lastError": "undemanded VM torn down",
+            "missingSince": now,
+            "idleSince": DELETE_FIELD,
+            **clear_vm_reconcile_lease_fields(),
+        },
+        consume_start_request_at=observed_start_request_at,
+    ):
+        # The instance is already gone; the next run observes the provider 404
+        # and records missing itself.
+        return ReconcileResult(uid, "ready", f"{detail}; owner record update deferred")
+    return ReconcileResult(uid, "ready", detail)
+
+
 async def reconcile_one(
     uid: str,
     vm: Mapping[str, Any],
@@ -1257,7 +1307,7 @@ async def reconcile_one(
     project: str,
     dry_run: bool = False,
     missing_cleanup_grace_seconds: int | None = None,
-    idle_stop_seconds: int | None = None,
+    idle_teardown_seconds: int | None = None,
     boot_image_migration: BootImageMigrationPlan | None = None,
 ) -> ReconcileResult:
     vm_name = str(vm["vmName"])
@@ -1303,7 +1353,7 @@ async def reconcile_one(
     missing_cleanup_grace_seconds = (
         _missing_cleanup_grace_seconds() if missing_cleanup_grace_seconds is None else missing_cleanup_grace_seconds
     )
-    idle_stop_seconds = _idle_stop_seconds() if idle_stop_seconds is None else idle_stop_seconds
+    idle_teardown_seconds = _idle_teardown_seconds() if idle_teardown_seconds is None else idle_teardown_seconds
     failed_candidate: dict[str, str] = {}
     try:
         instance = await api.get_instance(vm_name)
@@ -1410,6 +1460,31 @@ async def reconcile_one(
             retirement = await _retire_soaked_boot_image_predecessor(uid, vm, owner=owner, api=api, release=release)
             if retirement is not None:
                 return retirement
+        # Cost policy: a stopped VM without session demand is deleted, never
+        # preserved or repaired. This runs before drift/boot-image handling on
+        # purpose — an undemanded VM is not worth converging to the release.
+        # Boot-image migration allowlists and active migration journals keep
+        # their instances.
+        if (
+            str(instance.get("status") or "") in {"TERMINATED", "STOPPED"}
+            and not start_requested
+            and boot_image_migration is None
+            and not _active_migration_candidate(vm)
+        ):
+            active = await asyncio.to_thread(active_session_count, uid, vm_name)
+            if active == 0:
+                await _active_state_disk_info(api, uid, vm, instance)
+                return await _teardown_undemanded_vm(
+                    uid,
+                    vm_name,
+                    auth_token,
+                    api=api,
+                    owner=owner,
+                    instance=instance,
+                    now=now,
+                    observed_start_request_at=observed_start_request_at,
+                    detail="deleted stopped VM; no session demand",
+                )
         boot_drift = await _boot_image_drift(api, instance, release)
         if boot_drift:
             reason, actual = boot_drift
@@ -1478,6 +1553,15 @@ async def reconcile_one(
                 )
                 if migration.state != "recreate_required":
                     return migration
+            # Cost policy: never leave an undemanded RUNNING VM billing behind a
+            # terminal recreate_required record. Stop it now; the next run's
+            # stopped-teardown gate deletes it and reclaims the disks.
+            if str(instance.get("status") or "") == "RUNNING" and not start_requested:
+                active = await asyncio.to_thread(active_session_count, uid, vm_name)
+                if active == 0:
+                    if not await asyncio.to_thread(renew_vm_lease, uid, vm_name, auth_token, owner):
+                        return ReconcileResult(uid, "stale", "owner lease lost before boot-drift stop")
+                    await api.stop(vm_name)
             if not await _update_reconcile(
                 uid,
                 vm_name,
@@ -1580,44 +1664,26 @@ async def reconcile_one(
             return ReconcileResult(uid, "ready", "stopped; idle self-stop preserved")
         if not reasons and status == "RUNNING" and not start_requested:
             active = await asyncio.to_thread(active_session_count, uid, vm_name)
-            if idle_stop_due(
+            if idle_teardown_due(
                 status=status,
                 reasons=reasons,
                 start_requested=start_requested,
                 active_sessions=active,
                 idle_since=idle_since,
                 now=now,
-                idle_stop_seconds=idle_stop_seconds,
-            ):
-                if not await asyncio.to_thread(renew_vm_lease, uid, vm_name, auth_token, owner):
-                    return ReconcileResult(uid, "stale", "owner lease lost before idle stop")
-                await api.stop(vm_name)
-                if not await _update_reconcile(
+                idle_teardown_seconds=idle_teardown_seconds,
+            ) and not _active_migration_candidate(vm):
+                return await _teardown_undemanded_vm(
                     uid,
                     vm_name,
                     auth_token,
-                    owner,
-                    {
-                        "state": "ready",
-                        "observedRelease": release.release_id,
-                        "observedImageDigest": release.image_digest,
-                        "observedStartupSha256": release.startup_sha256,
-                        "lastSuccessAt": time.time(),
-                        "retryCount": 0,
-                        "lastError": None,
-                        "retryAt": None,
-                        "missingSince": DELETE_FIELD,
-                        "idleSince": DELETE_FIELD,
-                        **clear_vm_reconcile_lease_fields(),
-                    },
-                    vm_fields={
-                        "status": "stopped",
-                        **({"stateDisk": state_disk_info} if state_disk_info else {}),
-                    },
-                    consume_start_request_at=observed_start_request_at,
-                ):
-                    return ReconcileResult(uid, "stale", "owner lease lost while recording idle stop")
-                return ReconcileResult(uid, "ready", "stopped; idle TTL elapsed")
+                    api=api,
+                    owner=owner,
+                    instance=instance,
+                    now=now,
+                    observed_start_request_at=observed_start_request_at,
+                    detail="deleted idle VM; idle TTL elapsed",
+                )
             if active == 0:
                 recorded_idle_since = idle_since if idle_since is not None else now
                 if not await _update_reconcile(
@@ -1638,6 +1704,23 @@ async def reconcile_one(
                 return ReconcileResult(uid, "stale", "owner lease lost before stop")
             await api.stop(vm_name)
             status = "TERMINATED"
+            # Cost policy: only session demand justifies repairing and
+            # restarting a drifted VM. Without demand the drained instance is
+            # deleted here rather than converged back to RUNNING — this is what
+            # retires the stop-rewrite-restart loop on permanently broken
+            # guests.
+            if not start_requested and not _active_migration_candidate(vm):
+                return await _teardown_undemanded_vm(
+                    uid,
+                    vm_name,
+                    auth_token,
+                    api=api,
+                    owner=owner,
+                    instance=instance,
+                    now=now,
+                    observed_start_request_at=observed_start_request_at,
+                    detail="deleted drifted VM; no session demand",
+                )
         if status not in {"TERMINATED", "STOPPED"} and reasons:
             raise RuntimeError(f"provider status {status}")
         if reasons:

--- a/backend/routers/desktop_agent_vm.py
+++ b/backend/routers/desktop_agent_vm.py
@@ -28,7 +28,6 @@ from services.agent_vm_lifecycle import (
     STATE_SOURCE_REQUIRED_METADATA,
     claim_vm_lease,
     clear_vm_reconcile_lease_fields,
-    request_vm_start,
     startup_wrapper,
     update_vm_reconcile,
 )
@@ -102,6 +101,17 @@ class ProvisionAgentResponse(BaseModel):
 
 def _agent_disabled() -> bool:
     return os.getenv("ENVIRONMENT") == "local-dev-harness"
+
+
+def _provisioning_enabled() -> bool:
+    """Creating (or replacing) Agent VMs is explicit opt-in per deployment.
+
+    Dark by default: an environment that does not set
+    ``AGENT_VM_PROVISIONING_ENABLED=true`` serves existing VM owners but never
+    creates new capacity. Cost policy 2026-08-17: the fleet billed
+    ~$3.7k/week against zero successful sessions in the trailing four days.
+    """
+    return os.getenv("AGENT_VM_PROVISIONING_ENABLED", "").strip().lower() in {"1", "true", "on"}
 
 
 async def _authorized_desktop_user(uid: str = Depends(get_current_user_uid)) -> str:
@@ -809,6 +819,15 @@ async def provision_agent_vm(
 ) -> ProvisionAgentResponse:
     if _agent_disabled():
         raise HTTPException(status_code=503, detail="Agent VM provisioning is disabled")
+    if not _provisioning_enabled():
+        # Creation is gated, not the whole endpoint: an existing live owner
+        # record still takes the idempotent "exists" path below. Without one
+        # (no record, or a provider-confirmed missing record that a claim
+        # would replace with a new VM), refuse to create.
+        existing = await run_blocking(db_executor, _get_vm, uid)
+        existing_reconcile = existing.get("reconcile") if isinstance(existing, dict) else None
+        if existing is None or (isinstance(existing_reconcile, dict) and existing_reconcile.get("state") == "missing"):
+            raise HTTPException(status_code=503, detail="agent_vm_provisioning_disabled")
     try:
         project = _project()
         source_image = _source_image(project)
@@ -905,8 +924,8 @@ async def get_agent_status(
                 str(vm.get("authToken") or ""),
             )
         except Exception as exc:
-            # Marker persistence is best-effort; still queue start demand so the
-            # reconciler can observe the 404 and persist missing itself.
+            # Marker persistence is best-effort; the reconciler observes the
+            # 404 on its next pass and persists missing itself.
             logger.warning(
                 "Agent VM missing-state marker failed for uid=%s: %s",
                 uid,
@@ -915,31 +934,11 @@ async def get_agent_status(
             record_fallback(
                 component="other",
                 from_mode="missing_marker",
-                to_mode="reconciler_demand",
+                to_mode="reconciler_observation",
                 reason="other",
                 outcome="degraded",
             )
-    if decision.queue_start:
-        # Provider 404 / stopped / repairable running: queue fenced reconciler
-        # demand. Status also records ``missing`` (when allowed) so desktop
-        # provision can replace immediately; the reconciler still owns
-        # lease/quarantine fences and grace-period terminal cleanup as backstop.
-        requested = await run_blocking(
-            db_executor,
-            request_vm_start,
-            uid,
-            str(vm["vmName"]),
-            str(vm.get("authToken") or ""),
-        )
-        if not requested:
-            latest = await run_blocking(db_executor, _get_vm, uid)
-            if not latest:
-                return None
-            if str(latest.get("vmName") or "") != str(vm.get("vmName") or "") or str(
-                latest.get("authToken") or ""
-            ) != str(vm.get("authToken") or ""):
-                return _response(latest)
-            # Same owner lost the race (deletion fence / concurrent claim): still
-            # demote the confirmed-stale ready view for this generation.
-            return _response(apply_agent_vm_read_decision(latest, decision))
+    # Status is read-only: it never queues reconciler start demand. Waking or
+    # repairing a VM requires a real session (agent-proxy connect) or an
+    # explicit ensure call — status polling must not keep undemanded VMs alive.
     return _response(apply_agent_vm_read_decision(vm, decision))

--- a/backend/services/agent_vm_lifecycle.py
+++ b/backend/services/agent_vm_lifecycle.py
@@ -1947,6 +1947,25 @@ class GceAgentVmClient:
             body,
         )
 
+    async def delete_instance(self, vm_name: str, expected_instance_id: str) -> bool:
+        """Delete only the numeric-ID-matched instance (undemanded teardown).
+
+        The caller must hold the owner lease and have observed zero active
+        session leases. The numeric instance ID fences against a same-named
+        replacement created between the caller's observation and this delete.
+        ``autoDelete`` disk attachments are reclaimed by the provider with the
+        instance.
+        """
+        if not expected_instance_id:
+            return False
+        instance = await self.get_instance(vm_name)
+        if instance is None:
+            return True
+        if str(instance.get("id") or "") != expected_instance_id:
+            return False
+        await self._mutate("DELETE", self.instance_url(vm_name))
+        return True
+
     async def delete_replacement(self, vm_name: str, expected_instance_id: str, migration_id: str) -> bool:
         """Delete only the labelled, numeric-ID-matched predecessor/candidate."""
         instance = await self.get_instance(vm_name)

--- a/backend/services/agent_vm_read.py
+++ b/backend/services/agent_vm_read.py
@@ -51,10 +51,17 @@ class AgentVmProviderObservation:
 
 @dataclass(frozen=True)
 class AgentVmReadDecision:
-    """Shared status/read decision for desktop, tools, and proxy paths."""
+    """Shared status/read decision for desktop, tools, and proxy paths.
+
+    Read paths are observational: they may demote a stale ``ready`` cache and
+    record a provider-confirmed 404, but they never queue reconciler start
+    demand. Only a real session (agent-proxy connect) or an explicit ensure
+    call may wake or repair a VM — status polling must not keep undemanded
+    VMs alive (measured wake-on-open: 135 status-driven restart attempts in
+    24h against zero successful sessions, 2026-08-17).
+    """
 
     client_status: str
-    queue_start: bool
     preserve_owner: bool
     clear_cached_ip: bool = False
     record_missing: bool = False
@@ -92,16 +99,17 @@ def decide_agent_vm_read(
     Behavior contract:
     - Reconciler already owns the record → demote to ``updating``, do not probe
       demand again from this helper (callers skip provider lookups first).
-    - Provider ``NOT_FOUND`` → demote to ``updating``, queue reconciler demand,
-      and record ``missing`` so provisioning can claim a replacement.
+    - Provider ``NOT_FOUND`` → demote to ``updating`` and record ``missing`` so
+      provisioning can claim a replacement. No start demand is queued.
     - Provider API blip (``unknown``) → preserve the owner pointer and status.
     - Provider running with a healthy ready cache → leave unchanged.
+    - Stopped/unhealthy instances are never woken from a read path; the proxy
+      queues demand when a real session connects.
     """
     stored = str(vm.get("status") or "provisioning")
     if reconcile_in_progress(vm, now):
         return AgentVmReadDecision(
             client_status="updating",
-            queue_start=False,
             preserve_owner=True,
             clear_cached_ip=True,
         )
@@ -110,33 +118,28 @@ def decide_agent_vm_read(
             if usable_cached_ip is False:
                 return AgentVmReadDecision(
                     client_status="updating",
-                    queue_start=True,
                     preserve_owner=True,
                     clear_cached_ip=True,
                 )
             return AgentVmReadDecision(
                 client_status="ready",
-                queue_start=False,
                 preserve_owner=True,
                 clear_cached_ip=False,
             )
         return AgentVmReadDecision(
             client_status=stored,
-            queue_start=False,
             preserve_owner=True,
             clear_cached_ip=False,
         )
     if observation.kind == "unknown":
         return AgentVmReadDecision(
             client_status=stored,
-            queue_start=False,
             preserve_owner=True,
             clear_cached_ip=False,
         )
     if observation.kind == "not_found":
         return AgentVmReadDecision(
             client_status="updating",
-            queue_start=True,
             preserve_owner=True,
             clear_cached_ip=True,
             record_missing=True,
@@ -144,7 +147,6 @@ def decide_agent_vm_read(
     if observation.kind == "stopped":
         return AgentVmReadDecision(
             client_status="updating",
-            queue_start=True,
             preserve_owner=True,
             clear_cached_ip=True,
         )
@@ -153,13 +155,11 @@ def decide_agent_vm_read(
         if needs_repair:
             return AgentVmReadDecision(
                 client_status="updating",
-                queue_start=True,
                 preserve_owner=True,
                 clear_cached_ip=True,
             )
         return AgentVmReadDecision(
             client_status=stored,
-            queue_start=False,
             preserve_owner=True,
             clear_cached_ip=False,
         )
@@ -168,13 +168,11 @@ def decide_agent_vm_read(
     if stored == "ready":
         return AgentVmReadDecision(
             client_status="updating",
-            queue_start=False,
             preserve_owner=True,
             clear_cached_ip=True,
         )
     return AgentVmReadDecision(
         client_status=stored,
-        queue_start=False,
         preserve_owner=True,
         clear_cached_ip=False,
     )

--- a/backend/tests/unit/test_agent_vm_read_decision.py
+++ b/backend/tests/unit/test_agent_vm_read_decision.py
@@ -1,4 +1,12 @@
-"""Shared Agent VM status/read decisions for stale ready vs provider state."""
+"""Shared Agent VM status/read decisions for stale ready vs provider state.
+
+Read decisions are observational only: no field of ``AgentVmReadDecision`` may
+queue reconciler start demand (wake-on-open retired 2026-08-17; measured 135
+status-driven restart attempts in 24h against zero successful sessions).
+"""
+
+import dataclasses
+
 
 from services.agent_vm_read import (
     apply_agent_vm_read_decision,
@@ -15,13 +23,12 @@ READY_VM = {
 }
 
 
-def test_ready_plus_missing_instance_demotes_and_queues_reprovision_demand():
+def test_ready_plus_missing_instance_demotes_and_records_missing_without_demand():
     observation = classify_provider_observation(gce_status="NOT_FOUND")
     decision = decide_agent_vm_read(READY_VM, observation)
 
     assert observation.kind == "not_found"
     assert decision.client_status == "updating"
-    assert decision.queue_start is True
     assert decision.record_missing is True
     assert decision.preserve_owner is True
     assert apply_agent_vm_read_decision(READY_VM, decision) == {
@@ -37,7 +44,6 @@ def test_ready_plus_api_error_preserves_owner_and_ready_status():
 
     assert observation.kind == "unknown"
     assert decision.client_status == "ready"
-    assert decision.queue_start is False
     assert decision.preserve_owner is True
     assert apply_agent_vm_read_decision(READY_VM, decision)["status"] == "ready"
     assert apply_agent_vm_read_decision(READY_VM, decision)["ip"] == "34.1.2.3"
@@ -49,7 +55,6 @@ def test_ready_plus_running_instance_is_unchanged():
 
     assert observation.kind == "running"
     assert decision.client_status == "ready"
-    assert decision.queue_start is False
     assert decision.preserve_owner is True
     assert apply_agent_vm_read_decision(READY_VM, decision) == dict(READY_VM)
 
@@ -60,7 +65,6 @@ def test_ready_plus_transitional_gce_state_is_demoted():
 
     assert observation.kind == "other"
     assert decision.client_status == "updating"
-    assert decision.queue_start is False
     assert apply_agent_vm_read_decision(READY_VM, decision)["ip"] is None
 
 
@@ -68,7 +72,6 @@ def test_ready_with_unusable_cached_ip_demotes_without_provider_probe():
     decision = decide_agent_vm_read(READY_VM, usable_cached_ip=False)
 
     assert decision.client_status == "updating"
-    assert decision.queue_start is True
 
 
 def test_missing_reconcile_state_demotes_without_extra_demand():
@@ -79,5 +82,12 @@ def test_missing_reconcile_state_demotes_without_extra_demand():
     decision = decide_agent_vm_read(vm)
 
     assert decision.client_status == "updating"
-    assert decision.queue_start is False
     assert apply_agent_vm_read_decision(vm, decision)["ip"] is None
+
+
+def test_read_decision_has_no_demand_channel():
+    """Wake-on-open stays retired: read decisions carry no start-demand field."""
+    from services.agent_vm_read import AgentVmReadDecision
+
+    field_names = {field.name for field in dataclasses.fields(AgentVmReadDecision)}
+    assert field_names == {"client_status", "preserve_owner", "clear_cached_ip", "record_missing"}

--- a/backend/tests/unit/test_agent_vm_reconciler_authority.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_authority.py
@@ -40,10 +40,20 @@ def test_proxy_and_tools_have_no_direct_compute_control_plane_path():
         assert "request_vm_start" in source
 
 
-def test_desktop_status_requests_reconciliation_without_direct_power_mutation():
+def test_desktop_status_is_read_only_without_power_mutation_or_start_demand():
+    """Status polling must never wake or mutate VMs (static tripwire).
+
+    Contract change 2026-08-17 (minimum-spend): wake-on-open is retired.
+    Measured basis: prod agent-proxy logs for the trailing 24h showed 135
+    status-driven restart/queue attempts (99 "not reachable", 90 "RUNNING but
+    unhealthy, resetting", 36 "no VM") against zero successful sessions, while
+    the read path kept an undemanded fleet billing. Only a real session
+    (agent-proxy connect) or an explicit ensure call may queue start demand.
+    """
     status = _function(BACKEND_DIR / "routers/desktop_agent_vm.py", "get_agent_status")
     calls = _called_names(status)
     blocking_targets = _run_blocking_targets(status)
 
-    assert "request_vm_start" in blocking_targets
+    assert "request_vm_start" not in blocking_targets
+    assert "request_vm_start" not in calls
     assert not {"_start_vm", "_stop_vm", "_set_service_account", "_delete_vm"} & calls

--- a/backend/tests/unit/test_agent_vm_reconciler_job.py
+++ b/backend/tests/unit/test_agent_vm_reconciler_job.py
@@ -30,6 +30,7 @@ RELEASE = AgentVmRelease.from_mapping(
 class FakeApi:
     instances: dict[str, dict[str, Any]] = {
         "omi-agent-user": {
+            "id": "8080706050",
             "status": "STOPPED",
             "metadata": {},
             "serviceAccounts": [],
@@ -37,12 +38,22 @@ class FakeApi:
         }
     }
     starts = 0
+    deletes = 0
 
     def __init__(self, _project: str, _zone: str) -> None:
         pass
 
     async def get_instance(self, vm_name: str) -> dict[str, Any] | None:
         return self.instances.get(vm_name)
+
+    async def delete_instance(self, vm_name: str, expected_instance_id: str) -> bool:
+        instance = self.instances.get(vm_name)
+        if instance is None:
+            return True
+        if str(instance.get("id") or "") != expected_instance_id:
+            return False
+        type(self).deletes += 1
+        return True
 
     async def request(self, _method: str, _url: str) -> Any:
         class Response:
@@ -66,13 +77,56 @@ class FakeApi:
         self.starts += 1
 
 
-def test_reconcile_preserves_a_healthy_stopped_vm(monkeypatch):
-    updates: list[dict[str, Any]] = []
+def test_reconcile_deletes_a_stopped_vm_without_session_demand(monkeypatch):
+    """Cost policy: undemanded stopped capacity is deleted, never preserved or repaired.
+
+    Drift reasons are present on purpose — the teardown gate runs before drift
+    handling so a drifted stopped VM is deleted instead of being metadata-repaired
+    and restarted (the August 2026 resurrection loop).
+    """
+    updates: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
     FakeApi.starts = 0
+    FakeApi.deletes = 0
     monkeypatch.setattr(reconciler, "GceAgentVmClient", FakeApi)
     monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "renew_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 0)
+    monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: ["metadata"])
+    monkeypatch.setattr(
+        reconciler, "update_vm_reconcile", lambda *args, **kwargs: updates.append((args, kwargs)) or True
+    )
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {"vmName": "omi-agent-user", "authToken": "token"},
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "ready"
+    assert result.detail == "deleted stopped VM; no session demand"
+    assert FakeApi.starts == 0
+    assert FakeApi.deletes == 1
+    fields = updates[-1][0][4]
+    assert fields["state"] == "missing"
+    assert fields["lastError"] == "undemanded VM torn down"
+    assert updates[-1][1].get("vm_fields") is None
+
+
+def test_reconcile_preserves_a_stopped_vm_with_an_active_session(monkeypatch):
+    updates: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    FakeApi.starts = 0
+    FakeApi.deletes = 0
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", FakeApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 1)
     monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: [])
-    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *_args, **kwargs: updates.append(kwargs) or True)
+    monkeypatch.setattr(
+        reconciler, "update_vm_reconcile", lambda *args, **kwargs: updates.append((args, kwargs)) or True
+    )
 
     result = asyncio.run(
         reconciler.reconcile_one(
@@ -87,22 +141,60 @@ def test_reconcile_preserves_a_healthy_stopped_vm(monkeypatch):
     assert result.state == "ready"
     assert "idle self-stop preserved" in result.detail
     assert FakeApi.starts == 0
-    assert updates[-1]["vm_fields"] == {"status": "stopped"}
+    assert FakeApi.deletes == 0
+    assert updates[-1][1]["vm_fields"] == {"status": "stopped"}
+
+
+def test_stopped_teardown_stale_on_identity_fence_change(monkeypatch):
+    class FencedApi(FakeApi):
+        async def delete_instance(self, _vm_name: str, _expected_instance_id: str) -> bool:
+            return False
+
+    FakeApi.starts = 0
+    FakeApi.deletes = 0
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", FencedApi)
+    monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "renew_vm_lease", lambda *_args: True)
+    monkeypatch.setattr(reconciler, "active_session_count", lambda *_args: 0)
+    monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: [])
+    monkeypatch.setattr(reconciler, "update_vm_reconcile", lambda *_args, **_kwargs: True)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {"vmName": "omi-agent-user", "authToken": "token"},
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "stale"
+    assert result.detail == "instance identity changed before teardown"
+    assert FakeApi.deletes == 0
 
 
 class IdleRunningApi:
     stops = 0
     starts = 0
+    deletes = 0
     metadata_writes = 0
 
     def __init__(self, _project: str, _zone: str) -> None:
         self.instance = {
+            "id": "9090807060",
             "status": "RUNNING",
             "metadata": {},
             "serviceAccounts": [],
             "disks": [{"boot": True, "source": "projects/project/zones/us-central1-a/disks/omi-agent-user"}],
             "networkInterfaces": [{"networkIP": "10.128.0.9", "accessConfigs": [{"natIP": "34.1.2.3"}]}],
         }
+
+    async def delete_instance(self, _vm_name: str, expected_instance_id: str) -> bool:
+        if str(self.instance.get("id") or "") != expected_instance_id:
+            return False
+        type(self).deletes += 1
+        return True
 
     async def get_instance(self, _vm_name: str) -> dict[str, Any]:
         return self.instance
@@ -149,6 +241,7 @@ def _patch_idle_reconcile(monkeypatch, *, sessions: int = 0):
     updates: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
     IdleRunningApi.stops = 0
     IdleRunningApi.starts = 0
+    IdleRunningApi.deletes = 0
     IdleRunningApi.metadata_writes = 0
     monkeypatch.setattr(reconciler, "GceAgentVmClient", IdleRunningApi)
     monkeypatch.setattr(reconciler, "claim_vm_lease", lambda *_args: True)
@@ -161,7 +254,7 @@ def _patch_idle_reconcile(monkeypatch, *, sessions: int = 0):
     return updates
 
 
-def test_idle_running_vm_past_ttl_is_stopped_without_restart(monkeypatch):
+def test_idle_running_vm_past_ttl_is_deleted_without_restart(monkeypatch):
     updates = _patch_idle_reconcile(monkeypatch)
     now = 1_700_000_000.0
     monkeypatch.setattr(reconciler.time, "time", lambda: now)
@@ -177,22 +270,118 @@ def test_idle_running_vm_past_ttl_is_stopped_without_restart(monkeypatch):
             RELEASE,
             owner="worker",
             project="project",
-            idle_stop_seconds=3600,
+            idle_teardown_seconds=3600,
         )
     )
 
     assert result.state == "ready"
-    assert result.detail == "stopped; idle TTL elapsed"
-    assert IdleRunningApi.stops == 1
+    assert result.detail == "deleted idle VM; idle TTL elapsed"
+    assert IdleRunningApi.stops == 0
     assert IdleRunningApi.starts == 0
+    assert IdleRunningApi.deletes == 1
     assert IdleRunningApi.metadata_writes == 0
     fields = updates[-1][0][4]
-    assert fields["state"] == "ready"
+    assert fields["state"] == "missing"
+    assert fields["missingSince"] == now
     assert fields["idleSince"] is lifecycle.DELETE_FIELD
-    assert updates[-1][1]["vm_fields"]["status"] == "stopped"
+    assert updates[-1][1].get("vm_fields") is None
 
 
-def test_idle_running_vm_with_active_session_is_not_stopped(monkeypatch):
+def test_drifted_running_vm_without_demand_is_drained_and_deleted(monkeypatch):
+    """The drift path repairs and restarts only on demand; otherwise it deletes."""
+    updates = _patch_idle_reconcile(monkeypatch)
+    monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: ["runtime"])
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {"vmName": "omi-agent-user", "authToken": "token"},
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "ready"
+    assert result.detail == "deleted drifted VM; no session demand"
+    assert IdleRunningApi.stops == 1
+    assert IdleRunningApi.deletes == 1
+    assert IdleRunningApi.starts == 0
+    assert IdleRunningApi.metadata_writes == 0
+    drain_fields = updates[0][0][4]
+    assert drain_fields["state"] == "draining"
+    fields = updates[-1][0][4]
+    assert fields["state"] == "missing"
+
+
+def test_drifted_running_vm_with_start_demand_is_repaired_and_restarted(monkeypatch):
+    updates = _patch_idle_reconcile(monkeypatch)
+    monkeypatch.setattr(reconciler, "drift_reasons", lambda *_args: ["metadata"])
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {
+                "vmName": "omi-agent-user",
+                "authToken": "token",
+                "reconcile": {"startRequested": True, "startRequestedAt": now},
+            },
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "ready"
+    assert IdleRunningApi.stops == 1
+    assert IdleRunningApi.deletes == 0
+    assert IdleRunningApi.starts == 1
+    assert IdleRunningApi.metadata_writes == 2
+    assert updates[-1][1]["vm_fields"]["status"] == "ready"
+
+
+def test_boot_drift_without_demand_stops_the_running_vm_before_recreate_required(monkeypatch):
+    class BootDriftApi(IdleRunningApi):
+        async def request(self, _method: str, _url: str) -> Any:
+            class Response:
+                @staticmethod
+                def raise_for_status() -> None:
+                    return None
+
+                @staticmethod
+                def json() -> dict[str, str]:
+                    return {"sourceImage": "projects/project/global/images/omi-agent-older"}
+
+            return Response()
+
+    updates = _patch_idle_reconcile(monkeypatch)
+    monkeypatch.setattr(reconciler, "GceAgentVmClient", BootDriftApi)
+    now = 1_700_000_000.0
+    monkeypatch.setattr(reconciler.time, "time", lambda: now)
+
+    result = asyncio.run(
+        reconciler.reconcile_one(
+            "user",
+            {"vmName": "omi-agent-user", "authToken": "token"},
+            RELEASE,
+            owner="worker",
+            project="project",
+        )
+    )
+
+    assert result.state == "recreate_required"
+    assert BootDriftApi.stops == 1
+    assert BootDriftApi.starts == 0
+    assert BootDriftApi.deletes == 0
+    fields = updates[-1][0][4]
+    assert fields["state"] == "recreate_required"
+
+
+def test_idle_running_vm_with_active_session_is_not_torn_down(monkeypatch):
     updates = _patch_idle_reconcile(monkeypatch, sessions=1)
     now = 1_700_000_000.0
     monkeypatch.setattr(reconciler.time, "time", lambda: now)
@@ -208,7 +397,7 @@ def test_idle_running_vm_with_active_session_is_not_stopped(monkeypatch):
             RELEASE,
             owner="worker",
             project="project",
-            idle_stop_seconds=3600,
+            idle_teardown_seconds=3600,
         )
     )
 
@@ -221,7 +410,7 @@ def test_idle_running_vm_with_active_session_is_not_stopped(monkeypatch):
     assert updates[-1][1]["vm_fields"]["status"] == "ready"
 
 
-def test_idle_running_vm_with_start_request_starts_not_stops(monkeypatch):
+def test_idle_running_vm_with_start_request_is_not_torn_down(monkeypatch):
     updates = _patch_idle_reconcile(monkeypatch)
     now = 1_700_000_000.0
     monkeypatch.setattr(reconciler.time, "time", lambda: now)
@@ -237,7 +426,7 @@ def test_idle_running_vm_with_start_request_starts_not_stops(monkeypatch):
             RELEASE,
             owner="worker",
             project="project",
-            idle_stop_seconds=3600,
+            idle_teardown_seconds=3600,
         )
     )
 
@@ -264,7 +453,7 @@ def test_idle_ttl_not_reached_persists_idle_since_without_stop(monkeypatch):
             RELEASE,
             owner="worker",
             project="project",
-            idle_stop_seconds=3600,
+            idle_teardown_seconds=3600,
         )
     )
 
@@ -284,23 +473,23 @@ def test_idle_is_never_a_drift_reason():
         },
         RELEASE,
     )
-    assert not reconciler.idle_stop_due(
+    assert not reconciler.idle_teardown_due(
         status="RUNNING",
         reasons=["runtime"],
         start_requested=False,
         active_sessions=0,
         idle_since=0.0,
         now=10_000.0,
-        idle_stop_seconds=3600,
+        idle_teardown_seconds=3600,
     )
-    assert reconciler.idle_stop_due(
+    assert reconciler.idle_teardown_due(
         status="RUNNING",
         reasons=[],
         start_requested=False,
         active_sessions=0,
         idle_since=0.0,
         now=10_000.0,
-        idle_stop_seconds=3600,
+        idle_teardown_seconds=3600,
     )
 
 
@@ -376,7 +565,7 @@ def test_reconcile_starts_a_current_vm_only_after_fenced_start_request(monkeypat
     assert updates[-1][1]["vm_fields"] == {"status": "ready", "privateIp": "10.128.0.9", "ip": "34.1.2.3"}
 
 
-def test_boot_image_drift_requires_operator_recreate_without_mutating_vm(monkeypatch):
+def test_boot_image_drift_on_a_demanded_vm_requires_operator_recreate_without_mutating_vm(monkeypatch):
     class DriftApi(FakeApi):
         mutated = False
 
@@ -412,7 +601,9 @@ def test_boot_image_drift_requires_operator_recreate_without_mutating_vm(monkeyp
     result = asyncio.run(
         reconciler.reconcile_one(
             "user",
-            {"vmName": "omi-agent-user", "authToken": "token"},
+            # A start demand keeps the stopped VM out of the undemanded-teardown
+            # gate; boot-image drift must then fail closed without mutation.
+            {"vmName": "omi-agent-user", "authToken": "token", "reconcile": {"startRequested": True}},
             RELEASE,
             owner="worker",
             project="project",
@@ -421,6 +612,7 @@ def test_boot_image_drift_requires_operator_recreate_without_mutating_vm(monkeyp
 
     assert result.state == "recreate_required"
     assert "operator must recreate" in result.detail
+    assert DriftApi.mutated is False
     assert updates[-1]["state"] == "recreate_required"
     assert updates[-1]["observedBootImage"].endswith("/omi-agent-old")
     assert not DriftApi.mutated
@@ -3657,21 +3849,21 @@ def test_missing_cleanup_grace_rejects_unsafe_configuration(monkeypatch, value):
 
 @pytest.mark.parametrize(
     ("value", "expected"),
-    [(None, reconciler.DEFAULT_IDLE_STOP_SECONDS), ("1800", 1800)],
+    [(None, reconciler.DEFAULT_IDLE_TEARDOWN_SECONDS), ("1800", 1800)],
 )
-def test_idle_stop_seconds_uses_a_safe_default_or_valid_override(monkeypatch, value, expected):
+def test_idle_teardown_seconds_uses_a_safe_default_or_valid_override(monkeypatch, value, expected):
     if value is None:
-        monkeypatch.delenv("AGENT_VM_IDLE_STOP_SECONDS", raising=False)
+        monkeypatch.delenv("AGENT_VM_IDLE_TEARDOWN_SECONDS", raising=False)
     else:
-        monkeypatch.setenv("AGENT_VM_IDLE_STOP_SECONDS", value)
-    assert reconciler._idle_stop_seconds() == expected
+        monkeypatch.setenv("AGENT_VM_IDLE_TEARDOWN_SECONDS", value)
+    assert reconciler._idle_teardown_seconds() == expected
 
 
 @pytest.mark.parametrize("value", ["not-a-number", "1799"])
-def test_idle_stop_seconds_rejects_unsafe_configuration(monkeypatch, value):
-    monkeypatch.setenv("AGENT_VM_IDLE_STOP_SECONDS", value)
-    with pytest.raises(ValueError, match="AGENT_VM_IDLE_STOP_SECONDS"):
-        reconciler._idle_stop_seconds()
+def test_idle_teardown_seconds_rejects_unsafe_configuration(monkeypatch, value):
+    monkeypatch.setenv("AGENT_VM_IDLE_TEARDOWN_SECONDS", value)
+    with pytest.raises(ValueError, match="AGENT_VM_IDLE_TEARDOWN_SECONDS"):
+        reconciler._idle_teardown_seconds()
 
 
 @pytest.mark.parametrize("state", ["quarantined", "missing", "stale", "recreate_required"])

--- a/backend/tests/unit/test_desktop_agent_vm.py
+++ b/backend/tests/unit/test_desktop_agent_vm.py
@@ -16,6 +16,75 @@ os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7
 from routers import desktop_agent_vm
 
 
+@pytest.fixture(autouse=True)
+def _agent_vm_provisioning_enabled(monkeypatch):
+    """Creation is dark by default; most tests exercise the enabled path."""
+    monkeypatch.setenv("AGENT_VM_PROVISIONING_ENABLED", "true")
+
+
+@pytest.mark.asyncio
+async def test_provision_refuses_to_create_when_provisioning_is_dark(monkeypatch):
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.delenv("AGENT_VM_PROVISIONING_ENABLED", raising=False)
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await desktop_agent_vm.provision_agent_vm(BackgroundTasks(), "user")
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "agent_vm_provisioning_disabled"
+
+
+@pytest.mark.asyncio
+async def test_provision_refuses_to_replace_a_missing_pointer_when_dark(monkeypatch):
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    vm = {
+        "vmName": "omi-agent-user",
+        "authToken": "omi-token",
+        "status": "ready",
+        "reconcile": {"state": "missing", "missingSince": 1.0},
+    }
+    monkeypatch.delenv("AGENT_VM_PROVISIONING_ENABLED", raising=False)
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await desktop_agent_vm.provision_agent_vm(BackgroundTasks(), "user")
+
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "agent_vm_provisioning_disabled"
+
+
+@pytest.mark.asyncio
+async def test_provision_still_serves_an_existing_live_owner_when_dark(monkeypatch):
+    """Legacy principal: released desktops with a live VM keep working un-flagged."""
+    vm = {"vmName": "omi-agent-user", "ip": "1.2.3.4", "authToken": "omi-token", "status": "ready"}
+
+    async def run_blocking(_, function, *args):
+        return function(*args)
+
+    monkeypatch.delenv("AGENT_VM_PROVISIONING_ENABLED", raising=False)
+    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
+    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
+    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
+    monkeypatch.setattr(desktop_agent_vm, "_source_image", lambda _project: "image")
+    monkeypatch.setattr(desktop_agent_vm, "_gcs_bucket", lambda: "bucket")
+    monkeypatch.setattr(desktop_agent_vm, "_service_account", lambda: "service-account")
+    monkeypatch.setattr(desktop_agent_vm, "_claim_vm_if_allowed", lambda _uid, _candidate: (vm, False))
+    tasks = BackgroundTasks()
+
+    response = await desktop_agent_vm.provision_agent_vm(tasks, "user")
+
+    assert response.status == "exists"
+    assert response.agent_status == "ready"
+    assert not tasks.tasks
+
+
 def test_vm_publish_transaction_refuses_deletion_admitted_before_commit():
     deletion = type('Snapshot', (), {'exists': True, 'to_dict': lambda self: {'wipe_status': 'running'}})()
 
@@ -178,36 +247,6 @@ def test_record_provider_missing_rejects_quarantined_state():
     assert marked is False
     assert database.rows[("users", "uid")]["agentVm"]["reconcile"]["state"] == "quarantined"
     assert database.transactions[-1].updates == []
-
-
-@pytest.mark.asyncio
-async def test_status_keeps_demotion_when_start_request_loses_same_owner_race(monkeypatch):
-    vm = {
-        "vmName": "omi-agent-stale",
-        "zone": "us-central1-a",
-        "ip": "34.1.2.3",
-        "authToken": "old-token",
-        "status": "ready",
-        "createdAt": "2026-07-26T00:00:00Z",
-    }
-
-    async def run_blocking(_, function, *args):
-        return function(*args)
-
-    async def not_found(*_args):
-        return "NOT_FOUND", None
-
-    monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
-    monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
-    monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
-    monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
-    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *_args: False)
-    monkeypatch.setattr(desktop_agent_vm, "record_provider_missing_if_current", lambda *_args: True)
-
-    response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
-
-    assert response.status == "updating"
-    assert response.ip is None
 
 
 @pytest.mark.asyncio
@@ -462,7 +501,13 @@ def test_instance_address_parser_never_returns_unknown_placeholder():
 
 
 @pytest.mark.asyncio
-async def test_status_requests_reconciler_start_for_stopped_vm(monkeypatch):
+async def test_status_demotes_a_stopped_vm_without_waking_it(monkeypatch):
+    """Wake-on-open retired 2026-08-17: status polling must not restart VMs.
+
+    Measured basis: 135 status/poll-driven restart attempts in the trailing
+    24h of prod agent-proxy logs against zero successful sessions. A real
+    session connect (agent-proxy) is the only wake path.
+    """
     vm = {
         "vmName": "omi-agent-user",
         "zone": "us-central1-a",
@@ -471,23 +516,23 @@ async def test_status_requests_reconciler_start_for_stopped_vm(monkeypatch):
         "status": "ready",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    requests = []
+    writes = []
 
     async def run_blocking(_, function, *args):
-        return function(*args)
+        return writes.append(function) or function(*args)
 
     monkeypatch.setattr(desktop_agent_vm, "run_blocking", run_blocking)
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", lambda *args: _stopped_instance())
-    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
     tasks = BackgroundTasks()
 
     response = await desktop_agent_vm.get_agent_status(tasks, "user")
 
     assert response.status == "updating"
     assert response.ip is None
-    assert requests == [("user", "omi-agent-user", "omi-token")]
+    # The only offloaded work is the owner-record read: no demand write.
+    assert writes == [desktop_agent_vm._get_vm]
     assert not tasks.tasks
 
 
@@ -555,7 +600,6 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
         "status": "ready",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    requests = []
     marked = []
 
     async def run_blocking(_, function, *args):
@@ -568,7 +612,6 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
-    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
     monkeypatch.setattr(
         desktop_agent_vm, "record_provider_missing_if_current", lambda *args: marked.append(args) or True
     )
@@ -577,12 +620,11 @@ async def test_status_defers_missing_gce_pointer_to_the_fenced_reconciler(monkey
 
     assert response.status == "updating"
     assert response.ip is None
-    assert requests == [("uid", "omi-agent-stale", "old-token")]
     assert marked == [("uid", "omi-agent-stale", "us-central1-a", "old-token")]
 
 
 @pytest.mark.asyncio
-async def test_status_queues_start_when_missing_marker_raises(monkeypatch):
+async def test_status_records_fallback_when_missing_marker_raises(monkeypatch):
     vm = {
         "vmName": "omi-agent-stale",
         "zone": "us-central1-a",
@@ -591,7 +633,6 @@ async def test_status_queues_start_when_missing_marker_raises(monkeypatch):
         "status": "ready",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    requests = []
     fallbacks = []
 
     async def run_blocking(_, function, *args):
@@ -607,7 +648,6 @@ async def test_status_queues_start_when_missing_marker_raises(monkeypatch):
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", not_found)
-    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
     monkeypatch.setattr(desktop_agent_vm, "record_provider_missing_if_current", boom)
     monkeypatch.setattr(desktop_agent_vm, "record_fallback", lambda **fields: fallbacks.append(fields))
 
@@ -615,7 +655,6 @@ async def test_status_queues_start_when_missing_marker_raises(monkeypatch):
 
     assert response.status == "updating"
     assert response.ip is None
-    assert requests == [("uid", "omi-agent-stale", "old-token")]
     assert fallbacks and fallbacks[0]["from_mode"] == "missing_marker"
 
 
@@ -640,9 +679,6 @@ async def test_status_preserves_ready_when_gce_probe_fails(monkeypatch):
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", probe_failed)
-    monkeypatch.setattr(
-        desktop_agent_vm, "request_vm_start", lambda *_args: pytest.fail("API blip must preserve ownership")
-    )
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
@@ -671,9 +707,6 @@ async def test_status_leaves_ready_running_instance_unchanged(monkeypatch):
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", running)
-    monkeypatch.setattr(
-        desktop_agent_vm, "request_vm_start", lambda *_args: pytest.fail("healthy ready VM must not queue repair")
-    )
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
@@ -705,7 +738,7 @@ async def test_status_does_not_probe_a_missing_record_while_reconciler_cleanup_i
 
 
 @pytest.mark.asyncio
-async def test_status_defers_running_vm_without_usable_ip_to_reconciler(monkeypatch):
+async def test_status_demotes_running_vm_without_usable_ip_without_demand(monkeypatch):
     vm = {
         "vmName": "omi-agent-unreachable",
         "zone": "us-central1-a",
@@ -714,7 +747,6 @@ async def test_status_defers_running_vm_without_usable_ip_to_reconciler(monkeypa
         "status": "error",
         "createdAt": "2026-07-26T00:00:00Z",
     }
-    requests = []
 
     async def run_blocking(_, function, *args):
         return function(*args)
@@ -726,13 +758,11 @@ async def test_status_defers_running_vm_without_usable_ip_to_reconciler(monkeypa
     monkeypatch.setattr(desktop_agent_vm, "_get_vm", lambda _uid: vm)
     monkeypatch.setattr(desktop_agent_vm, "_project", lambda: "project")
     monkeypatch.setattr(desktop_agent_vm, "_instance", running_without_ip)
-    monkeypatch.setattr(desktop_agent_vm, "request_vm_start", lambda *args: requests.append(args) or True)
 
     response = await desktop_agent_vm.get_agent_status(BackgroundTasks(), "uid")
 
     assert response.status == "updating"
     assert response.ip is None
-    assert requests == [("uid", "omi-agent-unreachable", "current-token")]
 
 
 @pytest.mark.asyncio

--- a/docs/runbooks/agent-vm-fleet-reconciler.md
+++ b/docs/runbooks/agent-vm-fleet-reconciler.md
@@ -19,18 +19,27 @@ before acceptance, so an unaccepted candidate cannot escape the staged gate.
    metadata, release identity, image digest, or runtime health identity.
 3. A drifted running VM is marked `draining`. Agent Proxy rejects new sessions
    and existing sessions retain a 90-second renewable lease. A VM is stopped
-   only after the lease set is empty; stopped VMs are prepared without booting,
-   then started and verified against `/health` with the owner token over the
-   private VM network. The reconciler job must use direct VPC egress to the
-   Agent VM subnet and set `AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc`; it
-   refuses to send the bearer token over a NAT address. A healthy
-   stopped VM with no drift remains stopped so idle self-stop is preserved.
-   A healthy RUNNING VM with no start demand and zero session leases records
-   `agentVm.reconcile.idleSince` on first observation and is stopped after
-   `AGENT_VM_IDLE_STOP_SECONDS` (default 1h, minimum 30m). Idle is never a
-   drift reason: the drift path would stop-then-restart and leak again. The
-   TERMINATED reaper remains the delete backstop. Ownerless VMs (no Firestore
-   owner) are unreachable here — inventory them with
+   only after the lease set is empty. Repair (metadata rewrite, restart, and
+   `/health` verification with the owner token over the private VM network)
+   happens only when a fenced start request demands it; the reconciler job
+   must use direct VPC egress to the Agent VM subnet and set
+   `AGENT_VM_TRUSTED_HEALTH_CHANNEL=private-vpc` — it refuses to send the
+   bearer token over a NAT address. **Undemanded capacity is deleted, not
+   preserved** (minimum-spend policy, 2026-08-17): a stopped VM with no start
+   demand, no session lease, and no active boot-image migration is deleted
+   (its `autoDelete` boot and state disks are reclaimed with it), and a
+   drained drifted VM without demand is deleted in the same run instead of
+   being restarted. A healthy RUNNING VM with no start demand and zero
+   session leases records `agentVm.reconcile.idleSince` on first observation
+   and is deleted after `AGENT_VM_IDLE_TEARDOWN_SECONDS` (default and minimum
+   30m). Idle is never a drift reason. Deletion writes
+   `reconcile.state=missing`, so desktop provisioning can claim a replacement
+   immediately and terminal cleanup erases the record after grace. The state
+   disk holds only a client-uploaded SQLite copy (the Chrome profile is a
+   tmpfs), so teardown loses no unique data — the next session re-uploads.
+   The TERMINATED reaper remains the delete backstop for records the
+   reconciler cannot reach. Ownerless VMs (no Firestore owner) are
+   unreachable here — inventory them with
    `python3 backend/scripts/agent_vm_reaper.py --inventory` and clean up
    out-of-band.
 4. A provider-confirmed missing VM is recorded with `missingSince`. The

--- a/docs/superpowers/specs/2026-08-17-agent-vm-minimum-spend-design.md
+++ b/docs/superpowers/specs/2026-08-17-agent-vm-minimum-spend-design.md
@@ -1,0 +1,177 @@
+# Agent VM minimum spend
+
+- Date: 2026-08-17
+- Status: Prescribed; code half implemented in this PR. Live-infrastructure
+  actions require explicit operator execution and are NOT performed by any code
+  in this repository.
+- Decision owner: Agent runtime / cost policy
+- Operator instruction: "Have Fable prescribe the best cost savings approach
+  that gets us down to minimum spend … Be aggressive in savings, ok with
+  degrading UX a little bit."
+
+## Measured situation (2026-08-17)
+
+Demand, from prod agent-proxy logs (`connecting to vm=` is emitted exactly once
+per successful session):
+
+- 761 successful sessions in 30 days across 41 distinct users.
+- Six sessions in the last 7 days, all one user. **Zero since 2026-08-13.**
+- Last 24h: 135 WebSocket attempts from 43 users, **zero** reached a VM
+  (99 "not reachable", 90 "RUNNING but unhealthy, resetting", 36 "no VM").
+
+Cost:
+
+- Last closed 7 days: **$3,725/week** ($2,050 VM + $964 disk + $711 external
+  IP) — a ~$16k/month run rate.
+- The operator mass-stopped the RUNNING fleet (1,153 → 0) at 19:41 UTC. Stop
+  does not delete disks: **1,208 pd-balanced disks / 60,400 GB ≈ $6,040/month
+  (~$199/day) keep billing.** Disks are now the dominant cost.
+- Within an hour, 10 VMs were RUNNING again via wake-on-open and reconciler
+  restarts. Without code changes the stop is a one-shot, not a steady state.
+
+Mechanism (confirmed, sibling evidence in the knowledge base): the 2026-08-04
+Python cutover dropped the old guest's `sudo shutdown -h now` fallback on
+service-account-less VMs, so VMs stopped dying. August cohort retention 97.6%
+vs July ~22%. Creation was *lower* in August than July. Ownerless fraction: 0.
+
+The root allocation error: the design pays `O(registered users × 24h)` for
+demand that is `O(concurrent sessions × session length)` — a ~1,000× gap at
+the July peak and an ∞ gap today.
+
+## Prescription
+
+**A VM (and its disks) may exist only around a session. Everything without
+session demand is deleted, not stopped. New capacity is explicit opt-in.**
+
+### Target steady state
+
+| Line | Today (run rate) | Target | How |
+| --- | ---: | ---: | --- |
+| Disks (standing) | ~$6,040/mo | ~$0 | Operator deletes the stopped fleet; code deletes instead of stopping from then on (`autoDelete` reclaims both disks with the instance) |
+| VM compute | ~$8,800/mo pre-stop | ~$0 standing | Provisioning dark in prod; undemanded VMs deleted ≤35 min after last session |
+| External IPs | ~$3,050/mo pre-stop | ~$0 standing | IP billing follows VM-hours; dies with the fleet |
+| **Total** | **~$16k/mo** | **≤ $25/mo** at current demand | Session-scaled residual only |
+
+If July-peak demand ever returns (~50 sessions/day), the same code yields
+roughly 50 × ~1.5 VM-hours/day ≈ $2–4/day ≈ **$60–120/month** — still ~100×
+below the August run rate, with no further intervention.
+
+### What UX is spent (quantified, per the operator's "a little")
+
+1. **The feature goes dark in prod for new/returning users** until an operator
+   sets `AGENT_VM_PROVISIONING_ENABLED=true`. Measured regression today:
+   **zero** — no user has completed a session since Aug 13; the 43 users/day
+   who try currently get an error anyway. When the flag is off they get an
+   honest 503 instead of a broken spinner.
+2. **Cold start replaces warm start.** A VM idle ≥30 min is deleted. The next
+   session is a full provision (~2–5 min incl. readiness) plus desktop DB
+   re-upload, instead of a ~60–90 s restart. Affected population at current
+   demand: ~1 user.
+3. **App launch/status polling no longer resurrects VMs.** Only a real session
+   connect (agent-proxy) or an explicit ensure call wakes anything. A user who
+   only opens the app never pays for a VM again.
+4. **No state persists between sessions.** The state disk held only a
+   client-uploaded SQLite copy (the guest literally errors "Upload omi.db
+   first"); the Chrome profile has always been a tmpfs and never persisted.
+   Deleting the disk loses nothing unique — it re-uploads on next session.
+
+### Ranked actions — dollars saved per unit of risk, in execution order
+
+#### Operator actions (live infrastructure; David authorizes and executes; NOT in this PR)
+
+1. **Delete every `omi-agent-*` instance, then sweep orphaned `omi-agent-*`
+   disks.** ~$6,040/month, effective immediately (~$199/day while deferred).
+   Risk: destroys re-uploadable SQLite copies; there are zero in-flight
+   sessions to kill. This is the single highest-value action and it is
+   independent of any deploy. `autoDelete` is set, so instance delete cascades
+   to disks; the disk sweep catches any orphans.
+2. **Bake this PR on dev, then promote to prod** (desktop-backend +
+   `agent-vm-reconciler` job via `desktop_backend_prod.yml`). This is what
+   makes action 1 stick: without it, wake-on-open and drift-restarts regrow
+   the fleet. Note the prod deploy also turns provisioning dark (the flag is
+   deliberately absent from the prod workflow env).
+3. **Optional backstop: install/flip the reaper live** (`DRY_RUN=false`,
+   TERMINATED >12h). With the reconciler deleting undemanded VMs itself, the
+   reaper only covers records the reconciler cannot reach; ownerless count is
+   0 today. Low value, low risk — fine to skip.
+4. **Decide the feature's future explicitly.** Zero successful sessions since
+   Aug 13 is a *reliability* failure this prescription does not fix. Re-enable
+   provisioning only when someone commits to fixing the runtime; a feature
+   with zero working users should stay dark until then.
+
+#### Code (this PR)
+
+1. **Reconciler: undemanded ⇒ deleted.**
+   - A stopped VM with no start demand, no session lease, and no active
+     boot-image migration is deleted (identity-fenced by numeric instance ID),
+     and its owner record is marked `missing` so provisioning can replace it
+     instantly. This also auto-drains any future stopped pile.
+   - Idle RUNNING VMs are deleted after `AGENT_VM_IDLE_TEARDOWN_SECONDS`
+     (default lowered 1h → 30m, the floor) instead of stopped.
+   - The drift path repairs-and-restarts **only on demand**; a drained drifted
+     VM without demand is deleted in the same run. This retires the
+     stop-rewrite-restart loop that was resurrecting broken guests ~90×/day.
+   - Undemanded RUNNING VMs behind a `recreate_required` boot-image record are
+     stopped so the next run deletes them, instead of billing forever behind a
+     terminal marker.
+2. **Wake-on-open removed.** `GET /v2/agent/status` (and the shared read
+   decision used by tools status) is strictly read-only: it may demote a stale
+   `ready` cache and record a provider 404, but never queues reconciler start
+   demand. The agent-proxy connect path keeps `request_vm_start` — real
+   sessions still wake stopped VMs.
+3. **Provisioning dark by default.** `POST /v2/agent/provision` refuses to
+   *create* (or replace a missing pointer) unless
+   `AGENT_VM_PROVISIONING_ENABLED=true`; existing live owners keep the
+   idempotent "exists" path so released desktops degrade gracefully (the
+   desktop already logs-and-continues on provision failure). Dev sets the flag
+   for dogfood; prod does not.
+
+### Considered and rejected
+
+- **Smaller machines / Spot / smaller or pd-standard disks.** These cut unit
+  price; the actual cost lives in *lifetime*. After delete-on-idle, total
+  fleet-hours ≈ session-hours and all of these save <$5/month combined — not
+  worth the review or breakage risk (boot image size constraints, Spot
+  preemption mid-session). Revisit only if sustained demand returns.
+- **Public IP removal / proxy over `privateIp` (#7326).** Once VM-hours ≈ 0,
+  the external-IP line follows to ≈ $0, so this is now a *security* item
+  (bearer token over plaintext public HTTP), not a cost item. It needs Cloud
+  NAT for guest egress plus an agent-proxy change; sequence it with any
+  feature revival, not here.
+- **Relying on #11755 idle-*stop* alone.** Stop preserves disks. At one VM per
+  registered user that is the $6k/month disk line forever. Stop is the wrong
+  terminal state for state that is a copy.
+- **Waiting for the Cloud Run session runtime**
+  (`feat/agent-vm-session-scaled-runtime`). That ADR reaches the same
+  economics by replacing the runtime; this PR reaches them with ~200 net lines
+  against the existing reconciler, and the branch is currently red and saves
+  $0 until fully landed. **This prescription supersedes it in priority**: keep
+  the ADR as the long-term shape *if* the feature earns users again; spend
+  nothing more on it while demand is zero.
+
+### Risks and honest caveats
+
+- **Teardown is destructive by design.** Fences: owner lease + zero session
+  leases + no start demand + numeric-instance-ID-fenced delete + idleSince
+  persisted across ≥30 min of runs (for the idle path). The worst realistic
+  failure is deleting a VM a user reconnects to minutes later — cost: one cold
+  provision.
+- **Reconciler-driven cleanup of a large stopped fleet is slow** (rollout
+  cohort phasing, 5-min ticks). The operator mass-delete is the primary
+  mechanism; the reconciler handles stragglers and the future.
+- **Stale `missing` records linger up to the cleanup grace** (24h prod) and
+  show as "updating" to status polls. Cosmetic; provision replaces them
+  immediately on demand (when the flag allows).
+- **A prod deploy of this PR changes prod behavior** (dark provisioning,
+  deletion policy). That is intended and called out; the prod deploy itself
+  remains a manually approved operator action.
+
+### Sequencing after this PR
+
+1. Operator actions 1–2 above (delete fleet; bake + promote).
+2. If the feature is revived: fix the runtime (agent-vm-reliability track),
+   re-enable the flag env-by-env, then take #7326 (private IP + Cloud NAT)
+   and create-on-first-use in the desktop client as the next code cuts.
+3. If it is not revived within a quarter: delete the feature surface
+   (reconciler, reaper, charts, broker) rather than maintaining a zero-user
+   control plane.


### PR DESCRIPTION
# Agent VM minimum spend: delete undemanded capacity, read-only status, opt-in provisioning

Implements the code half of the minimum-spend prescription
(`docs/superpowers/specs/2026-08-17-agent-vm-minimum-spend-design.md`, in this
PR). Operator instruction: aggressive savings, small UX degradation accepted.

## Why

Measured on 2026-08-17 (prod agent-proxy logs + billing export):

- **Zero successful agent sessions since Aug 13**; 761 sessions / 41 users in
  30 days. Last 24h: 135 attempts from 43 users, none reached a VM.
- Run rate before the operator's mass-stop: **$3,725/week** ($2,050 VM +
  $964 disk + $711 IP). After the stop, **1,208 stopped-fleet disks keep
  billing ~$6,040/month** — stop preserves disks; only delete reclaims them
  (`autoDelete`).
- Within an hour of the stop, 10 VMs were RUNNING again via wake-on-open and
  reconciler drift-restarts. Without these changes the stop is a one-shot.

Root allocation error: cost is `O(registered users × 24h)`, demand is
`O(concurrent sessions × session length)`.

## What changes

1. **Reconciler: undemanded ⇒ deleted, never stopped-and-kept**
   (`backend/jobs/agent_vm_reconciler.py`, `services/agent_vm_lifecycle.py`).
   - Stopped VM with no start demand, no session lease, no active boot-image
     migration → identity-fenced `delete_instance` + owner record marked
     `missing` (provision can replace immediately; terminal cleanup erases the
     record after the existing grace).
   - Idle RUNNING VM → deleted after `AGENT_VM_IDLE_TEARDOWN_SECONDS`
     (renamed from `AGENT_VM_IDLE_STOP_SECONDS`, which no deployment sets;
     default lowered 1h → 30m, floor unchanged at 30m).
   - Drift path repairs-and-restarts **only on start demand**; a drained
     drifted VM without demand is deleted in the same run (retires the
     stop-rewrite-restart loop resurrecting broken guests ~90×/day).
   - Undemanded RUNNING VM behind `recreate_required` boot-image drift is
     stopped so the next run deletes it, instead of billing forever behind a
     terminal marker.
   - No unique data is lost: the state disk holds a client-uploaded SQLite
     copy (guest errors `Upload omi.db first` without it) and the Chrome
     profile is a Docker tmpfs that never persisted.
2. **Wake-on-open retired** (`services/agent_vm_read.py`,
   `routers/desktop_agent_vm.py`): `GET /v2/agent/status` and the shared read
   decision are strictly observational — they demote stale `ready` caches and
   record provider 404s but never queue reconciler start demand.
   `AgentVmReadDecision.queue_start` is removed. Real wake paths unchanged:
   agent-proxy connect and `POST /v1/agent/vm-ensure` still call
   `request_vm_start`.
3. **Provisioning dark by default** (`routers/desktop_agent_vm.py`,
   `.github/workflows/desktop_backend_auto_dev.yml`): creating a VM (or
   replacing a provider-confirmed `missing` pointer) requires
   `AGENT_VM_PROVISIONING_ENABLED=true`. Existing live owners keep the
   idempotent `exists` path (legacy-principal test included), so released
   desktops hit their existing provision-failed logging and continue. Dev
   auto-deploy sets the flag (dogfood); **prod deliberately does not — the
   next prod deploy of this SHA turns new-VM creation off in prod.**

Docs updated in the same PR: fleet-reconciler runbook, reaper chart README,
and the prescription spec (targets, quantified UX cost, ranked
operator-vs-code actions, rejected options, sequencing).

## UX spent (accepted by the operator)

- Prod feature is dark for users without a live VM until the flag is set.
  Measured regression today: zero (no user completes a session now; they get
  an honest 503 instead of a broken spinner).
- Warm start (~60–90s) becomes cold provision (~2–5 min + DB re-upload) after
  ≥30 min idle. Affected population at current demand: ~1 user.
- App launch / status polling never resurrects a VM; only a real connect does.

## Test-rewrite justification (AGENTS.md rule)

`test_desktop_status_*` (authority tripwire) and the wake-on-open tests assert
the inverted contract. External basis cited in the tests: prod agent-proxy
measurement (135 status-driven restart attempts in 24h, zero successful
sessions) and the 2026-08-17 operator cost directive.

## Explicitly NOT in this PR

- No live GCE/GCS/Cloud Run mutation. Deleting the 1,208-disk stopped fleet,
  promoting to prod, and (optionally) flipping the reaper live are operator
  actions listed in the prescription doc.
- No machine-type/disk/Spot changes, no #7326 public-IP removal (now a
  security item, ~$0 cost after teardown), no Cloud Run runtime migration
  (superseded in priority; see prescription).

## Verification

Interpreter: `backend/.venv` (repo test runner env; the older `backend/venv`
lacks pytest-asyncio and fails at baseline).

- `pytest tests/unit/test_agent_vm_reconciler_job.py -q` → **104 passed**
- `pytest tests/unit/test_desktop_agent_vm.py tests/unit/test_agent_vm_read_decision.py tests/unit/test_agent_vm_reconciler_authority.py -q` → **52 passed**
- Adjacent suites (`test_agent_vm_reconciler.py`, `test_agent_vm_reaper.py`,
  `test_tools_agent_route_response_shape.py`, `test_agent_vm_account_cleanup.py`,
  …) → **56 passed**; second batch (async/protocol/firewall/health/reaped-
  record/deploy-scripts/scheduler) → **83 passed**
- Post-format re-run of the four changed suites → **156 passed**
- `scripts/scan_async_blockers.py --dirs routers` → 0 findings
- Pre-existing, unrelated: `tests/unit/test_agent_vm_startup.py` fails
  identically (21F) on unmodified `main` in this environment.
- Not exercised live: reconcile-vs-GCE deletion on a real instance (no live
  mutations allowed in this task); covered by fenced unit tests + dev bake.

Line-Count-Exception: backend/jobs/agent_vm_reconciler.py | 1912 -> 1995 | teardown policy lives beside the drift/idle branches it replaces; splitting the reconciler mid-policy-change would be the unreviewable migration AGENTS.md forbids
Line-Count-Exception: backend/services/agent_vm_lifecycle.py | 2126 -> 2145 | one identity-fenced delete_instance next to the existing fenced delete_replacement it mirrors

## Rollout

Dev bake via auto-deploy (reconciler job + desktop-backend), watch:
teardown results in reconciler logs, no deletion of leased VMs, provision 503
absent on dev (flag on). Prod promote is the operator's call and is what
activates dark provisioning + fleet-regrowth prevention in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

