### PR TITLE
fix(backend): import PlanLimits so BYOK users can read their subscription (#11762)

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -74,6 +74,7 @@ from models.users import (
     Subscription,
     SubscriptionPlan,
     SubscriptionStatus,
+    PlanLimits,
     PlanType,
     PricingOption,
     PhoneCallQuota,

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -468,3 +468,27 @@ def test_update_person_name_existing_returns_ok():
 
     assert result == {'status': 'ok'}
     update_person.assert_called_once_with('uid1', 'p1', 'Alice')
+
+
+def test_byok_subscription_endpoint_returns_unlimited_plan():
+    # `PlanLimits` was used in this module without being imported, so every BYOK
+    # user's GET /v1/users/me/subscription raised NameError -> 500 in prod.
+    with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=True)), patch.object(
+        users_router, 'has_byok_keys', MagicMock(return_value=True)
+    ):
+        response = users_router.get_user_subscription_endpoint(uid='uid1')
+
+    assert response.subscription.plan == users_router.PlanType.unlimited
+    assert response.subscription.features == ['byok']
+    assert response.subscription.limits.transcription_seconds is None
+
+
+def test_marketplace_reviewer_subscription_endpoint_returns_unlimited_plan():
+    # Same missing import on the reviewer branch (routers/users.py:1193).
+    with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=False)), patch.dict(
+        users_router.os.environ, {'MARKETPLACE_APP_REVIEWERS': 'reviewer-uid'}
+    ):
+        response = users_router.get_user_subscription_endpoint(uid='reviewer-uid')
+
+    assert response.subscription.plan == users_router.PlanType.unlimited
+    assert response.subscription.limits.words_transcribed is None


### PR DESCRIPTION
Fixes #11762.

## Bug

`GET /v1/users/me/subscription` answers **500** for every BYOK-active user in prod:

```
File "/app/routers/users.py", line 1177, in get_user_subscription_endpoint
  subscription=_byok_unlimited_subscription(),
File "/app/routers/users.py", line 1151, in _byok_unlimited_subscription
  limits=PlanLimits(
NameError: name 'PlanLimits' is not defined
```

22 occurrences in a 4-hour prod sample (2026-08-17T18:00Z onward), still firing at 21:33:46Z.

## Root cause

`backend/routers/users.py` constructs `PlanLimits` twice — `_byok_unlimited_subscription()` (`:1150`) and the `MARKETPLACE_APP_REVIEWERS` branch of `get_user_subscription_endpoint` (`:1193`) — but the `from models.users import (...)` block never listed it, and `from database.users import *` does not re-export it. Broken since 60769ab903 ("Add BYOK endpoint + subscription bypass", 2026-04-19): neither branch had a test, so nothing executed the name.

The endpoint exists precisely so "broken-BYOK users must still see their plan so they can recover" (its own comment) — it was the one thing that 500'd.

## Fix

One-line import, plus regression tests that drive the real endpoint through both branches.

## Verification

- Reproduced on clean `origin/main` (b339c7a056): `python -c "import routers.users as u; u._byok_unlimited_subscription()"` → `NameError: name 'PlanLimits' is not defined`.
- Both new tests fail on clean main with the prod NameError at `routers/users.py:1150` and `:1193`; both pass with the import.
- `pytest tests/routers/test_users.py tests/unit/test_byok_security.py` → **108 passed**.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged

Line-Count-Exception: backend/routers/users.py | 2175 -> 2176 | one import line for a name the file already constructs twice; splitting an oversized router is out of scope for a crash fix


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

