### PR TITLE
Fit desktop Gemini demand under the Vertex PT cap: evict low-value lanes to Flash-Lite, fix the Pro demotion, cap server-paid output

### DIFF
--- a/.github/failure-classes/FC-degraded-fallback-consumes-protected-budget.json
+++ b/.github/failure-classes/FC-degraded-fallback-consumes-protected-budget.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-degraded-fallback-consumes-protected-budget",
+  "violated_contract": "A quota or degradation fallback must not route work onto the scarce, budgeted resource the quota exists to protect. The demotion destination is part of the quota's contract: a limit that dumps its overflow onto the protected budget converts a per-user ceiling into unmetered consumption of the shared reservation.",
+  "canonical_prevention": "Name the fallback destination as an explicit constant next to the protected resource's pin, with a behavioral test asserting the two can never be equal, so re-pointing either one fails the guard instead of silently landing degraded traffic on the protected budget.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_desktop_proxy.py"
+  ],
+  "evidence_prs": [
+    10686
+  ],
+  "scope_hints": [
+    "backend/routers/desktop_proxy.py"
+  ],
+  "status": "open"
+}

--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -36,6 +36,24 @@ same commit is the regression.
 
 BYOK Gemini stays on the user's key / AI Studio.
 
+## Keeping the reservation for work that must be Flash
+
+The 13,450 tok/s cap is oversubscribed, so the proxy actively keeps low-value
+work off `gemini-2.5-flash`:
+
+- **Over-quota Pro demotes to `gemini-2.5-flash-lite`**
+  (`_QUOTA_DEMOTION_MODEL`), which is `shared`/on-demand on Vertex and never
+  burns the PT. Demoting to `gemini-2.5-flash` instead was the 2026-08-17
+  defect that silently dumped the Insight tool loop (~11% of the reservation)
+  onto the saturated PT lane.
+
+The desktop clients pin the low-value lanes (memory extraction, LiveNotes,
+goals, task dedup/prioritization, home suggestions, Windows insight) to
+`gemini-2.5-flash-lite` directly — see `ModelQoS.Gemini.lightweight`
+(macOS) and the Windows assistant model pins. Task extraction stays on
+`gemini-2.5-flash`: Flash-Lite measurably fails its prompt contract there
+(omi-knowledge-base, vertex-pt-flash-spend, 2026-08-17 overflow bakeoff).
+
 ## Durable runtime env
 
 `desktop-backend` compose (`backend/deploy/runtime_env/_base.yaml` →

--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -46,6 +46,13 @@ work off `gemini-2.5-flash`:
   burns the PT. Demoting to `gemini-2.5-flash` instead was the 2026-08-17
   defect that silently dumped the Insight tool loop (~11% of the reservation)
   onto the saturated PT lane.
+- **Server-paid requests are capped at 2048 output tokens**
+  (`_SERVER_PAID_MAX_OUTPUT_TOKENS`). No shipped desktop client sends
+  `maxOutputTokens`, so everything used to inherit the 8192 default while
+  output burns down the reservation at 9x. Realistic per-lane budgets are
+  64–1024 visible tokens plus a thinking budget of up to 1024 (thinking counts
+  toward the output limit on 2.5 models). BYOK requests keep the 8192
+  default/clamp.
 
 The desktop clients pin the low-value lanes (memory extraction, LiveNotes,
 goals, task dedup/prioritization, home suggestions, Windows insight) to

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -54,7 +54,17 @@ VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~20
 # omi-knowledge-base vertex-pt-flash-spend 2026-08-17 workload value ranking.
 _QUOTA_DEMOTION_MODEL = 'gemini-2.5-flash-lite'
 _MAX_BODY_BYTES = 5 * 1024 * 1024
+# Absolute ceiling; also the default for BYOK traffic, which keeps its
+# historical behavior.
 _MAX_OUTPUT_TOKENS = 8192
+# Server-paid requests get a smaller default and clamp. No shipped desktop
+# client can emit maxOutputTokens (macOS GenerationConfig has no such field;
+# Windows sends none), so every request used to take the 8192 default while the
+# largest realistic per-lane budget is ~1024 visible tokens plus a thinking
+# budget of up to 1024 (thinking counts toward the output limit on 2.5 models).
+# Mean measured output is ~241 tokens — this bounds the paid tail, it does not
+# change the mean.
+_SERVER_PAID_MAX_OUTPUT_TOKENS = 2048
 _DEFAULT_THINKING_BUDGET = 1024
 _MAX_CONTENT_ITEMS = 128
 _MAX_CONTENT_PARTS = 512
@@ -286,7 +296,7 @@ def _as_nonnegative_int(value: Any) -> int | None:
     return None
 
 
-def _sanitize(body: bytes, action: str) -> bytes:
+def _sanitize(body: bytes, action: str, *, max_output_tokens: int = _MAX_OUTPUT_TOKENS) -> bytes:
     try:
         payload = json.loads(body)
     except (TypeError, ValueError) as exc:
@@ -327,7 +337,7 @@ def _sanitize(body: bytes, action: str) -> bytes:
         ]
         if not generation_configs:
             payload['generationConfig'] = {
-                'maxOutputTokens': _MAX_OUTPUT_TOKENS,
+                'maxOutputTokens': max_output_tokens,
                 'thinkingConfig': {'thinkingBudget': _DEFAULT_THINKING_BUDGET},
             }
         for config in generation_configs:
@@ -340,13 +350,19 @@ def _sanitize(body: bytes, action: str) -> bytes:
                 value = _as_nonnegative_int(config.get(key))
                 if value is not None:
                     output_key_present = True
-                    if value > _MAX_OUTPUT_TOKENS:
-                        config[key] = _MAX_OUTPUT_TOKENS
+                    if value > max_output_tokens:
+                        config[key] = max_output_tokens
             if not output_key_present:
-                config['maxOutputTokens'] = _MAX_OUTPUT_TOKENS
+                config['maxOutputTokens'] = max_output_tokens
             if 'thinking_config' not in config and 'thinkingConfig' not in config:
                 config['thinkingConfig'] = {'thinkingBudget': _DEFAULT_THINKING_BUDGET}
     return json.dumps(payload, separators=(',', ':')).encode()
+
+
+def _output_token_cap() -> int:
+    """BYOK traffic keeps its historical 8192 ceiling; server-paid requests are
+    bounded at 2048 because output burns the PT reservation down at 9x."""
+    return _MAX_OUTPUT_TOKENS if get_byok_key('gemini') else _SERVER_PAID_MAX_OUTPUT_TOKENS
 
 
 def _use_vertex_ai() -> bool:
@@ -762,7 +778,7 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
         _, model, action = _path_parts(path)
         telemetry.model = model
         telemetry.action = action
-        body = _sanitize(body, action)
+        body = _sanitize(body, action, max_output_tokens=_output_token_cap())
         telemetry.shape = _payload_shape(body)
     except HTTPException as exc:
         outcome = 'rate_limited' if exc.status_code == 429 else 'validation_rejected'

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -48,6 +48,11 @@ VERTEX_PT_MODEL = 'gemini-2.5-flash'
 VERTEX_PT_LOCATION = 'us-central1'
 VERTEX_PT_EXPIRES = '~2027-05-28'
 VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28'
+# Over-quota Pro demotes to Flash-Lite (`shared`, on-demand), never to the PT
+# model: demoting to `gemini-2.5-flash` silently dumped the Insight tool loop
+# (~11% of the reservation) onto the saturated PT lane. Evidence:
+# omi-knowledge-base vertex-pt-flash-spend 2026-08-17 workload value ranking.
+_QUOTA_DEMOTION_MODEL = 'gemini-2.5-flash-lite'
 _MAX_BODY_BYTES = 5 * 1024 * 1024
 _MAX_OUTPUT_TOKENS = 8192
 _DEFAULT_THINKING_BUDGET = 1024
@@ -457,11 +462,11 @@ async def _meter_server_request(uid: str, path: str, model: str, action: str) ->
         record_fallback(
             component='gemini_model',
             from_mode='pro',
-            to_mode='flash',
+            to_mode='flash_lite',
             reason='quota',
             outcome='degraded',
         )
-        return f'models/{VERTEX_PT_MODEL}:{action}'
+        return f'models/{_QUOTA_DEMOTION_MODEL}:{action}'
     return path
 
 

--- a/backend/tests/fast_unit_duration_allowlist.txt
+++ b/backend/tests/fast_unit_duration_allowlist.txt
@@ -12,6 +12,9 @@
 # so imports are paid once per worker instead of per file, or (b) raise BACKEND_FAST_UNIT_FAIL_SECONDS.
 # Genuinely non-unit tests (real asyncio sleeps, network, stress, codebase greps, full-app wiring,
 # per-test fresh module reload) are marked `slow`/`integration` and are NOT listed here.
+# One full _proxy round trip (metering -> sanitize -> dispatch -> terminal telemetry) with an
+# in-process capturing client; hermetic, but the end-to-end path costs ~0.15-0.19s CPU.
+tests/unit/test_desktop_proxy.py::test_proxy_dispatches_server_paid_bodies_with_the_2048_cap
 # Renders all eight first-party charts in dev and prod; still hermetic and required in the unit lane.
 tests/unit/test_llm_gateway_deploy_contract.py::test_gateway_deploy_workflows_bind_identity_and_gate_serving_static_contract
 tests/unit/test_rendered_deployment_contract.py::test_repository_charts_render_the_full_contract_when_helm_is_available

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -502,6 +502,75 @@ async def test_proxy_dispatches_once_and_classifies_read_timeout(monkeypatch):
     assert response.headers["x-omi-retryable"] == "false"
 
 
+def test_output_token_cap_follows_byok(monkeypatch):
+    """Server-paid requests are bounded at 2048 output tokens; BYOK keeps 8192."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    assert desktop_proxy._output_token_cap() == 2048
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: "user-key")
+    assert desktop_proxy._output_token_cap() == 8192
+
+
+def test_sanitize_applies_the_requested_output_cap():
+    """No desktop client sets maxOutputTokens, so the cap passed by the caller is
+    both the injected default and the clamp; smaller explicit values pass through."""
+    absent = json.loads(desktop_proxy._sanitize(b'{"generationConfig": {}}', "generateContent", max_output_tokens=2048))
+    assert absent["generationConfig"]["maxOutputTokens"] == 2048
+    oversized = json.loads(
+        desktop_proxy._sanitize(
+            b'{"generationConfig": {"maxOutputTokens": 9000}}', "generateContent", max_output_tokens=2048
+        )
+    )
+    assert oversized["generationConfig"]["maxOutputTokens"] == 2048
+    smaller = json.loads(
+        desktop_proxy._sanitize(
+            b'{"generationConfig": {"maxOutputTokens": 512}}', "generateContent", max_output_tokens=2048
+        )
+    )
+    assert smaller["generationConfig"]["maxOutputTokens"] == 512
+    byok = json.loads(
+        desktop_proxy._sanitize(
+            b'{"generationConfig": {"maxOutputTokens": 9000}}', "generateContent", max_output_tokens=8192
+        )
+    )
+    assert byok["generationConfig"]["maxOutputTokens"] == 8192
+
+
+@pytest.mark.asyncio
+async def test_proxy_dispatches_server_paid_bodies_with_the_2048_cap(monkeypatch):
+    """End-to-end wiring: a server-paid request leaves the proxy carrying the
+    2048 default (regression for every request inheriting the 8192 default)."""
+    dispatched: list[bytes] = []
+
+    class CapturingClient:
+        async def post(self, url, *, params, content, headers):
+            dispatched.append(content)
+            return httpx.Response(200, request=httpx.Request("POST", url), json={"ok": True})
+
+    async def route(path, _model, _action, _query):
+        return desktop_proxy.UpstreamRoute("https://provider.invalid", {}, {}, "vertex_ai", "adc", "us-central1")
+
+    async def meter(_uid, path, _model, _action):
+        return path
+
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy, "_meter_server_request", meter)
+    monkeypatch.setattr(desktop_proxy, "_upstream", route)
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_client", lambda: CapturingClient())
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: asyncio.Semaphore(1))
+
+    response = await desktop_proxy._proxy(
+        make_request(),
+        "models/gemini-2.5-flash:generateContent",
+        False,
+        "user",
+    )
+
+    assert response.status_code == 200
+    assert len(dispatched) == 1
+    config = json.loads(dispatched[0])["generationConfig"]
+    assert config["maxOutputTokens"] == 2048
+
+
 @pytest.mark.asyncio
 async def test_disconnect_cancels_in_flight_provider_call():
     disconnected = asyncio.Event()

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -202,17 +202,26 @@ async def test_server_gemini_meter_downgrades_pro_after_the_soft_limit(monkeypat
         await desktop_proxy._meter_server_request(
             "user", "models/gemini-2.5-pro:generateContent", "gemini-2.5-pro", "generateContent"
         )
-        == "models/gemini-2.5-flash:generateContent"
+        == "models/gemini-2.5-flash-lite:generateContent"
     )
     assert fallbacks == [
         {
             "component": "gemini_model",
             "from_mode": "pro",
-            "to_mode": "flash",
+            "to_mode": "flash_lite",
             "reason": "quota",
             "outcome": "degraded",
         }
     ]
+
+
+def test_quota_demotion_never_targets_the_pt_model():
+    """Regression: over-quota Pro used to demote onto `gemini-2.5-flash`, silently
+    dumping the Insight tool loop (~11% of the reservation) onto the saturated
+    Vertex PT lane. The demotion target must stay a `shared`/on-demand model."""
+    assert desktop_proxy._QUOTA_DEMOTION_MODEL != desktop_proxy.VERTEX_PT_MODEL
+    assert desktop_proxy._QUOTA_DEMOTION_MODEL in desktop_proxy._ALLOWED_MODELS
+    assert desktop_proxy._QUOTA_DEMOTION_MODEL in desktop_proxy._VERTEX_MODELS
 
 
 @pytest.mark.asyncio

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
@@ -73,7 +73,7 @@ class LiveNotesMonitor: ObservableObject {
 
   private convenience init() {
     self.init(
-      noteGeneratorFactory: { try GeminiClient() },
+      noteGeneratorFactory: { try GeminiClient(model: ModelQoS.Gemini.lightweight) },
       noteStorage: NoteStorage.shared,
       subscribeToTranscript: true
     )

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
@@ -308,7 +308,7 @@ struct GeminiHomeSuggestionGenerator: HomeSuggestionGenerating {
       - Return an empty list if the context doesn't contain enough real, current material.
       """
 
-    let client = try GeminiClient()
+    let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
     let responseText = try await client.sendRequest(
       prompt: prompt,
       systemPrompt:

--- a/desktop/macos/Desktop/Sources/ModelQoS.swift
+++ b/desktop/macos/Desktop/Sources/ModelQoS.swift
@@ -87,14 +87,28 @@ struct ModelQoS {
 
     /// Insight generation.
     ///
-    /// Pro on both tiers, deliberately. Insight ran on `gemini-pro-latest` for everyone until
-    /// this dropped to Flash at the premium tier, and the click-through fell with it: 2.34%
-    /// in the week of 2026-04-12 (39.8k sent, 336 distinct clickers) against 0.7–0.96%
-    /// through July. Unlike the other proactive assistants this one is cheap to run well —
-    /// a 10-minute timer caps it at ~6 analyses/hour no matter how much the user switches
-    /// windows — and its whole job is finding the one non-obvious thing, which is exactly
-    /// where the weaker model stops earning its interruption.
+    /// Pro on both tiers, deliberately. A 10-minute timer caps it at ~6 analyses/hour no
+    /// matter how much the user switches windows, so it is cheap to run well — and its whole
+    /// job is finding the one non-obvious thing, which is exactly where the weaker model
+    /// stops earning its interruption. Measured (PostHog, 30d to 2026-08-17, macOS): insight
+    /// CTR 1.162% against a 0.68% fleet average — the best-performing high-volume lane.
+    /// (An earlier revision cited "2.34% in the week of 2026-04-12, 39.8k sent, 336
+    /// clickers"; that tuple reproduces from no PostHog slice and was removed.)
+    /// After 30 Pro calls/user/day the backend proxy demotes this lane to Flash-Lite —
+    /// never to Flash, which would burn the Vertex PT reservation.
     static var insight: String { "gemini-2.5-pro" }
+
+    /// Low-value / schema-bounded lanes evicted from the Vertex PT Flash reservation
+    /// (2026-08-17 workload value ranking + overflow bakeoff, omi-knowledge-base
+    /// vertex-pt-flash-spend): memory extraction, LiveNotes, goals, task dedup,
+    /// task prioritization, home suggestions. Flash-Lite is `shared`/on-demand on
+    /// Vertex — it never competes with task extraction for the 13,450 tok/s PT cap —
+    /// and measured ~0.27x Flash's cost. On the memory lane it is also *more*
+    /// prompt-compliant than Flash (fires 5/12 vs Flash's 8/8 against a prompt that
+    /// says most screens should return nothing). Task extraction must NOT use this
+    /// pin: Flash-Lite measurably extracts from chat sidebars and drops second
+    /// commitments on that lane.
+    static var lightweight: String { "gemini-2.5-flash-lite" }
 
     /// Live notch suggestions.
     ///

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift
@@ -28,7 +28,7 @@ actor GoalsAIService {
     guard APIKeyService.keysAvailable || !geminiClientInitAttempted else { return nil }
     geminiClientInitAttempted = true
     do {
-      let client = try GeminiClient()
+      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
       geminiClient = client
       return client
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -76,7 +76,7 @@ actor InsightAssistant: ProactiveAssistant {
 
   init(apiKey: String? = nil) throws {
     self.geminiClient = try GeminiClient(
-      apiKey: apiKey, model: ModelQoS.Gemini.insight, fallbackModel: "gemini-2.5-flash")
+      apiKey: apiKey, model: ModelQoS.Gemini.insight, fallbackModel: ModelQoS.Gemini.lightweight)
 
     let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
     self.frameSignal = stream

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -73,8 +73,9 @@ actor MemoryAssistant: ProactiveAssistant {
   // MARK: - Initialization
 
   init(apiKey: String? = nil) throws {
-    // Use Gemini Flash for memory extraction (text+vision, no tool loop — Flash-safe)
-    self.geminiClient = try GeminiClient(apiKey: apiKey)
+    // Flash-Lite: vision-capable, off the Vertex PT reservation, and measurably more
+    // prompt-compliant than Flash on this lane (see ModelQoS.Gemini.lightweight).
+    self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.lightweight)
     self.extractionOverride = nil
     self.durabilityPipeline = MemoryAssistantDurabilityPipeline(
       runner: MemoryAssistantProductionDurability(operations: MemoryAssistantLiveDurabilityOperations())

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistantSettings.swift
@@ -17,7 +17,11 @@ class MemoryAssistantSettings {
   // MARK: - Default Values
 
   private let defaultEnabled = true
-  private let defaultExtractionInterval: TimeInterval = 600.0  // 10 minutes
+  // 30 minutes. Was 10; memory extraction measured the worst value of any proactive
+  // lane (50.5% of macOS notification volume at 0.240% CTR, ~53 calls per stored
+  // memory), so its default cadence carries a 3x cut. Users can still pick a faster
+  // interval in Settings — 1800 is an existing step on the interval ladder.
+  private let defaultExtractionInterval: TimeInterval = 1800.0
   private let defaultMinConfidence: Double = 0.7
   private let defaultNotificationsEnabled = false
 

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
@@ -44,7 +44,7 @@ actor TaskDeduplicationService {
     guard APIKeyService.keysAvailable || !geminiClientInitAttempted else { return nil }
     geminiClientInitAttempted = true
     do {
-      let client = try GeminiClient()
+      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
       geminiClient = client
       return client
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
@@ -63,7 +63,7 @@ actor TaskPrioritizationService {
     guard APIKeyService.keysAvailable || !geminiClientInitAttempted else { return nil }
     geminiClientInitAttempted = true
     do {
-      let client = try GeminiClient()
+      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
       geminiClient = client
       return client
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -967,11 +967,11 @@ public class ProactiveAssistantsPlugin: NSObject {
 
         frameCount += 1
         let captureTime = Date()
-        // A full-screen `CGImage` redrawn into a 9x8 grayscale context — a real decode and
-        // downscale, and it was on the main actor for every captured frame. `CGImage` is immutable,
-        // and the hash is a pure function of it, so nothing about this needed the main thread.
+        // Off the main actor on purpose: `CGImage` is immutable and the hash is a pure function.
+        // Hashed at preview scale: this enters the same history the ≤80px preview grabs are
+        // compared against, and a full-resolution dHash aliases differently (see previewScaleDHash).
         let fullHash = await Task.detached(priority: .userInitiated) {
-          RewindOCRService.dHash(of: cgImage)
+          RewindOCRService.previewScaleDHash(of: cgImage)
         }.value
         captureTrigger.markCaptured(
           app: appName, windowTitle: currentWindowTitle, at: captureTime, frameHash: fullHash)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -192,6 +192,36 @@ actor RewindOCRService {
     return hash
   }
 
+  /// dHash computed through an intermediate downscale to the preview-capture envelope.
+  ///
+  /// The proactive capture pipeline compares hashes of ≤80px preview grabs against a
+  /// history that also receives the hash of every full capture. Hashing a
+  /// full-resolution frame straight into dHash's 9x8 grid aliases differently than
+  /// hashing an 80px preview of the same screen, so cross-scale comparisons read as
+  /// "changed", defeat the preview-similarity skip, and trigger unnecessary full
+  /// captures (and the Gemini calls behind them). Downscaling to the same ≤80px
+  /// envelope first keeps both sides of the comparison in one representation.
+  static func previewScaleDHash(of cgImage: CGImage, maxSize: Int = 80) -> UInt64 {
+    let width = cgImage.width
+    let height = cgImage.height
+    guard width > maxSize || height > maxSize else { return dHash(of: cgImage) }
+    let scale = Double(maxSize) / Double(max(width, height))
+    let w = max(1, Int((Double(width) * scale).rounded()))
+    let h = max(1, Int((Double(height) * scale).rounded()))
+    guard
+      let ctx = CGContext(
+        data: nil, width: w, height: h,
+        bitsPerComponent: 8, bytesPerRow: w,
+        space: CGColorSpaceCreateDeviceGray(),
+        bitmapInfo: CGImageAlphaInfo.none.rawValue
+      )
+    else { return dHash(of: cgImage) }
+    ctx.interpolationQuality = .medium
+    ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: w, height: h))
+    guard let downscaled = ctx.makeImage() else { return dHash(of: cgImage) }
+    return dHash(of: downscaled)
+  }
+
   /// Check if a frame should skip OCR because it's perceptually identical to the previous frame.
   /// Uses dHash with Hamming distance — small changes (cursor blink, spinners) produce
   /// distance 1-4 and are skipped, while real content changes produce distance 10+ and trigger OCR.

--- a/desktop/macos/Desktop/Tests/ModelQoSTests.swift
+++ b/desktop/macos/Desktop/Tests/ModelQoSTests.swift
@@ -73,12 +73,23 @@ final class ModelQoSTests: XCTestCase {
     XCTAssertEqual(ModelQoS.Gemini.taskExtraction, "gemini-2.5-flash")
   }
 
-  /// Insight is Pro on every tier by design — the timer caps it at ~6 analyses/hour, and the
-  /// premium-tier drop to Flash tracked a click-through fall from 2.34% to under 1%.
+  /// Insight is Pro on every tier by design — the timer caps it at ~6 analyses/hour, and it is
+  /// the best-performing high-volume notification lane (PostHog 30d to 2026-08-17: 1.162% CTR
+  /// vs 0.68% fleet average).
   func testInsightIsProOnEveryTier() {
     for tier in ModelTier.allCases {
       ModelQoS.activeTier = tier
       XCTAssertEqual(ModelQoS.Gemini.insight, "gemini-2.5-pro")
+    }
+  }
+
+  /// The PT-eviction pin. Lanes routed through `lightweight` must stay off `gemini-2.5-flash`:
+  /// that model burns the saturated Vertex PT reservation, which is reserved for task
+  /// extraction (2026-08-17 vertex-pt-flash-spend evidence). Tier-independent on purpose.
+  func testLightweightPinIsFlashLiteOnEveryTier() {
+    for tier in ModelTier.allCases {
+      ModelQoS.activeTier = tier
+      XCTAssertEqual(ModelQoS.Gemini.lightweight, "gemini-2.5-flash-lite")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/PreviewScaleDHashTests.swift
+++ b/desktop/macos/Desktop/Tests/PreviewScaleDHashTests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for the preview-hash representation bug: `markCaptured` used to
+/// store a full-resolution dHash into the same history the ≤80px preview grabs are
+/// compared against. A hash of a full frame and a hash of a small preview of the same
+/// screen must land close enough to clear the strictest preview-similarity threshold,
+/// or every preview reads as "changed" and the preview-skip never fires.
+final class PreviewScaleDHashTests: XCTestCase {
+
+  /// Renders the same synthetic "desktop window" scene at an arbitrary pixel size.
+  /// Vector drawing in normalized coordinates, so every size shows identical content.
+  private func renderScene(width: Int, height: Int) throws -> CGImage {
+    let ctx = try XCTUnwrap(
+      CGContext(
+        data: nil, width: width, height: height,
+        bitsPerComponent: 8, bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      ))
+    ctx.scaleBy(x: CGFloat(width), y: CGFloat(height))
+    // Background, title bar, sidebar, and a column of "text lines" with varying
+    // gray levels — enough horizontal luminance structure to exercise all 64 bits.
+    ctx.setFillColor(CGColor(gray: 0.95, alpha: 1))
+    ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+    ctx.setFillColor(CGColor(gray: 0.20, alpha: 1))
+    ctx.fill(CGRect(x: 0, y: 0.92, width: 1, height: 0.08))
+    ctx.setFillColor(CGColor(gray: 0.75, alpha: 1))
+    ctx.fill(CGRect(x: 0, y: 0, width: 0.22, height: 0.92))
+    for row in 0..<9 {
+      let shade = 0.30 + 0.05 * Double(row % 4)
+      ctx.setFillColor(CGColor(gray: shade, alpha: 1))
+      let y = 0.06 + Double(row) * 0.09
+      let lineWidth = 0.45 + 0.25 * Double((row * 7) % 3) / 2.0
+      ctx.fill(CGRect(x: 0.26, y: y, width: lineWidth, height: 0.035))
+    }
+    ctx.setFillColor(CGColor(gray: 0.55, alpha: 1))
+    ctx.fill(CGRect(x: 0.03, y: 0.10, width: 0.16, height: 0.55))
+    return try XCTUnwrap(ctx.makeImage())
+  }
+
+  private func hammingDistance(_ a: UInt64, _ b: UInt64) -> Int {
+    (a ^ b).nonzeroBitCount
+  }
+
+  func testFullCaptureHashMatchesPreviewHashOfTheSameScreen() throws {
+    // Production shapes: a typical full window capture and the 80px preview grab.
+    let full = try renderScene(width: 1638, height: 1072)
+    let preview = try renderScene(width: 80, height: 52)
+
+    let fullHash = RewindOCRService.previewScaleDHash(of: full)
+    let previewHash = RewindOCRService.dHash(of: preview)
+
+    // The strictest threshold in PreviewSimilarityThresholdPolicy is 0.99 (notes),
+    // i.e. at most 1 differing bit would still skip. Same-representation hashing of
+    // identical content must comfortably clear the default 0.95 tier (≤3 bits).
+    XCTAssertLessThanOrEqual(
+      hammingDistance(fullHash, previewHash), 3,
+      "full-capture hash diverged from the preview hash of identical content — "
+        + "cross-scale hashing defeats the preview-similarity skip")
+  }
+
+  func testPreviewScaleDHashIsAPassThroughAtOrBelowPreviewSize() throws {
+    let preview = try renderScene(width: 80, height: 52)
+    XCTAssertEqual(
+      RewindOCRService.previewScaleDHash(of: preview),
+      RewindOCRService.dHash(of: preview),
+      "images already inside the preview envelope must hash identically on both paths")
+  }
+
+  func testPreviewScaleDHashIsDeterministic() throws {
+    let full = try renderScene(width: 1638, height: 1072)
+    XCTAssertEqual(
+      RewindOCRService.previewScaleDHash(of: full),
+      RewindOCRService.previewScaleDHash(of: full))
+  }
+}

--- a/desktop/macos/Desktop/Tests/SettingsAssistantControlsTests.swift
+++ b/desktop/macos/Desktop/Tests/SettingsAssistantControlsTests.swift
@@ -151,9 +151,11 @@ final class SettingsAssistantControlsTests: XCTestCase {
     XCTAssertEqual(InsightAssistantSettings.shared.extractionInterval, 600)
     XCTAssertEqual(UserDefaults.standard.double(forKey: insightIntervalDefaultsKey), 600)
 
+    // Memory's default is 1800 (30 min), not 600: 2026-08-17 measured value ranking —
+    // worst CTR of any proactive lane at half the notification volume — cut its cadence 3x.
     MemoryAssistantSettings.shared.extractionInterval = 0
-    XCTAssertEqual(MemoryAssistantSettings.shared.extractionInterval, 600)
-    XCTAssertEqual(UserDefaults.standard.double(forKey: memoryIntervalDefaultsKey), 600)
+    XCTAssertEqual(MemoryAssistantSettings.shared.extractionInterval, 1800)
+    XCTAssertEqual(UserDefaults.standard.double(forKey: memoryIntervalDefaultsKey), 1800)
 
     AssistantSettings.shared.analysisDelay = -1
     XCTAssertEqual(AssistantSettings.shared.analysisDelay, 60)

--- a/desktop/macos/changelog/unreleased/20260817-gemini-cost-lane-tuning.json
+++ b/desktop/macos/changelog/unreleased/20260817-gemini-cost-lane-tuning.json
@@ -1,0 +1,3 @@
+{
+  "change": "Tuned which AI model each background assistant uses and slowed the memory-extraction timer to reduce noise; fixed a screen-change detector bug that caused unnecessary captures"
+}

--- a/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
+++ b/desktop/macos/e2e/flows/context-buckets-dogfood.yaml
@@ -11,6 +11,7 @@ app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/ScreenCandidateAdapter.swift
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin+RewindCapture.swift
   - desktop/macos/Desktop/Sources/ProactiveAssistants/Core/CandidateSink.swift

--- a/desktop/macos/e2e/flows/rewind.yaml
+++ b/desktop/macos/e2e/flows/rewind.yaml
@@ -4,6 +4,7 @@ tier: manual
 description: Rewind overlay — open via View menu (⌘⌥R), verify permission gate, search, date picker (v0.12.119+ redesign — Rewind is no longer in top nav)
 app: com.omi.computer-macos
 covers:
+  - desktop/macos/Desktop/Sources/Rewind/Core/RewindOCRService.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindViewModel.swift
   - desktop/macos/Desktop/Sources/Rewind/UI/RewindSearchBar.swift

--- a/desktop/windows/src/main/assistants/focus/gemini.ts
+++ b/desktop/windows/src/main/assistants/focus/gemini.ts
@@ -14,7 +14,9 @@ import { net } from 'electron'
 import { getAbortSignal, type BackendSession } from '../core/session'
 import { FOCUS_RESPONSE_SCHEMA, parseScreenAnalysis, type ScreenAnalysis } from './models'
 
-const MODEL = 'gemini-2.5-flash'
+// Focus stays on the PT model: small payloads, and the lane earns its cost
+// (CTR 1.275%, one of the best) — see modelPins.test.ts for the reservation ratchet.
+export const MODEL = 'gemini-2.5-flash'
 const REQUEST_TIMEOUT_MS = 30_000
 /** 3 attempts total. Mac's backoff, exactly: 2s then 8s. */
 const RETRY_DELAYS_MS = [2_000, 8_000]

--- a/desktop/windows/src/main/assistants/goals/generate.ts
+++ b/desktop/windows/src/main/assistants/goals/generate.ts
@@ -25,7 +25,9 @@ import { getAppSettings, setAppSettings } from '../../appSettings'
 import { fetchGoalContext, hasSufficientContext, type GoalContextData } from './context'
 import { GOAL_SYSTEM_PROMPT, GOAL_SUGGESTION_SCHEMA, fillPrompt } from './prompt'
 
-const MODEL = 'gemini-2.5-flash'
+// Flash-Lite: text-only, schema-bounded, nobody waiting — no business on the Vertex
+// Flash PT reservation. Mirrors Mac's ModelQoS.Gemini.lightweight goals pin.
+export const MODEL = 'gemini-2.5-flash-lite'
 const REQUEST_TIMEOUT_MS = 30_000
 /** 3 attempts total. Mac's backoff, exactly: 2s then 8s. */
 const RETRY_DELAYS_MS = [2_000, 8_000]

--- a/desktop/windows/src/main/assistants/insight/gemini.ts
+++ b/desktop/windows/src/main/assistants/insight/gemini.ts
@@ -30,8 +30,12 @@ import {
   type ToolCall
 } from './models'
 
-export const MODEL = 'gemini-2.5-flash'
-export const FALLBACK_MODEL = 'gemini-2.5-flash'
+// Flash-Lite, deliberately: Windows used to pin Insight straight onto
+// `gemini-2.5-flash`, which burns the saturated Vertex PT reservation that is kept
+// for task extraction (Mac pins Insight to Pro; the proxy demotes over-quota Pro to
+// Flash-Lite as well). Flash-Lite is `shared`/on-demand on Vertex.
+export const MODEL = 'gemini-2.5-flash-lite'
+export const FALLBACK_MODEL = 'gemini-2.5-flash-lite'
 export const THINKING_BUDGET = 1024
 const REQUEST_TIMEOUT_MS = 120_000
 /** 3 attempts total per model. Mac's backoff, exactly: 2s then 8s. */

--- a/desktop/windows/src/main/assistants/memory/gemini.ts
+++ b/desktop/windows/src/main/assistants/memory/gemini.ts
@@ -13,7 +13,10 @@ import {
   type MemoryExtractionResult
 } from './models'
 
-const MODEL = 'gemini-2.5-flash'
+// Flash-Lite, deliberately: vision-capable, `shared`/on-demand on Vertex (never burns
+// the saturated Flash PT reservation), and measurably more prompt-compliant than Flash
+// on this lane (2026-08-17 overflow bakeoff). Mirrors Mac's ModelQoS.Gemini.lightweight.
+export const MODEL = 'gemini-2.5-flash-lite'
 const REQUEST_TIMEOUT_MS = 30_000
 /** 3 attempts total. Mac's backoff, exactly: 2s then 8s. */
 const RETRY_DELAYS_MS = [2_000, 8_000]

--- a/desktop/windows/src/main/assistants/modelPins.test.ts
+++ b/desktop/windows/src/main/assistants/modelPins.test.ts
@@ -1,0 +1,45 @@
+// Which assistant lane may burn the Vertex PT Flash reservation — a ratchet.
+//
+// Company-paid `gemini-2.5-flash` in us-central1 burns a saturated, prepaid
+// Provisioned Throughput reservation (13,450 tok/s) that is kept for task
+// extraction — the one lane Flash-Lite measurably fails (sidebar false-extraction
+// at confidence 0.9; silently dropped second commitment). Everything else runs on
+// `gemini-2.5-flash-lite`, which is `shared`/on-demand on Vertex and never
+// competes with task extraction for the reservation. Evidence: omi-knowledge-base,
+// vertex-pt-flash-spend, 2026-08-17 workload value ranking + overflow bakeoff.
+//
+// Re-pinning a lane onto `gemini-2.5-flash` is a cost regression on a saturated
+// reservation, not a free upgrade: change this test only with new lane-level
+// evidence, in the same PR as the pin change.
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
+vi.mock('../core/session', () => ({ getAbortSignal: () => undefined }))
+
+import { TASK_MODEL, TASK_FALLBACK_MODEL } from './tasks/geminiWire'
+import { MODEL as FOCUS_MODEL } from './focus/gemini'
+import { MODEL as MEMORY_MODEL } from './memory/gemini'
+import { MODEL as INSIGHT_MODEL, FALLBACK_MODEL as INSIGHT_FALLBACK_MODEL } from './insight/gemini'
+
+const PT_MODEL = 'gemini-2.5-flash'
+const OFF_PT_MODEL = 'gemini-2.5-flash-lite'
+
+describe('assistant model pins vs the Vertex PT reservation', () => {
+  it('task extraction keeps the reservation (nowhere cheaper to go)', () => {
+    expect(TASK_MODEL).toBe(PT_MODEL)
+    expect(TASK_FALLBACK_MODEL).toBe(PT_MODEL)
+  })
+
+  it('focus keeps the reservation (small payloads, best-performing lane)', () => {
+    expect(FOCUS_MODEL).toBe(PT_MODEL)
+  })
+
+  it('memory extraction is evicted to Flash-Lite (worst CTR of any lane)', () => {
+    expect(MEMORY_MODEL).toBe(OFF_PT_MODEL)
+  })
+
+  it('insight never lands on the PT model, fallback included', () => {
+    expect(INSIGHT_MODEL).toBe(OFF_PT_MODEL)
+    expect(INSIGHT_FALLBACK_MODEL).toBe(OFF_PT_MODEL)
+  })
+})


### PR DESCRIPTION
# Aggressive Gemini spend reduction: fit desktop demand under the Vertex PT cap

## Why

The 5 GSU `gemini-2.5-flash` Vertex Provisioned Throughput reservation (13,450 tok/s, $290.32/day, sunk to ~2027-05-28) is saturated 24/7: measured desktop demand is **18,431 tok/s = 137% of the cap**, and the 27.4% that spills over is billed at PayGo Flash list price — the only avoidable Gemini-Flash cash. There is no overnight trough to defer into (0 of 408 measured hours below cap), downscaling screenshots saves exactly zero tokens (measured, 12/12 frames), and halving every output token in the fleet still would not fit. The only thing that fits is moving whole low-value workloads onto `gemini-2.5-flash-lite`, which is `shared`/on-demand on Vertex (measured `trafficType=ON_DEMAND`, 44/44 calls) and never competes with the reservation.

Evidence base (omi-knowledge-base, `projects/vertex-pt-flash-spend/evidence/`): `2026-08-17-workload-value-ranking.md` (rev 2), `2026-08-17-overflow-destination-bakeoff.md` (210 measured calls), `2026-08-17-cache-optimization-analysis.md`, `2026-08-17-screenshot-resolution-experiment.md`, RCA. The decision record for this PR: `2026-08-17-aggressive-savings-prescription.md`.

## What

One commit per surface:

1. **fix(backend): over-quota Pro demotes to Flash-Lite, not Flash.** The 30/day Pro soft limit rewrote Insight onto `gemini-2.5-flash`, silently dumping the most expensive tool loop (~11% of the reservation) onto the saturated PT lane within the first hour of use. New `_QUOTA_DEMOTION_MODEL` constant + regression test that the demotion target can never be the PT pin.
2. **feat(backend): server-paid output cap 8192 → 2048** (default and clamp). No shipped desktop client can send `maxOutputTokens`, so every request inherited 8192 while output burns the reservation at 9×; realistic per-lane budgets are 64–1024 visible tokens + thinking ≤1024 (thinking counts toward the limit on 2.5 models). Mean output is ~241 tokens — this bounds the paid tail, not typical behavior. **BYOK keeps the 8192 default/clamp unchanged.**
3. **feat(desktop/windows): memory, insight (model+fallback), goals → Flash-Lite**; tasks and focus stay on Flash. `modelPins.test.ts` ratchets the reservation boundary.
4. **feat(desktop/macos): evict low-value lanes to Flash-Lite** via a new `ModelQoS.Gemini.lightweight` pin: memory extraction, LiveNotes, Goals (generate/progress/insight), task dedup, task prioritization, HomeSuggestions; Insight's client-side transient fallback follows. Also corrects the `ModelQoS` insight comment whose 2.34% CTR tuple reproduces from no PostHog slice (measured 30d: insight 1.162% vs 0.68% fleet).
5. **feat(desktop/macos): memory extraction default cadence 600s → 1800s.** Worst-value lane on both fleet instruments (50.5% of notification volume at 0.240% CTR; ~53 calls per stored memory). User-chosen intervals are respected; 1800 is an existing ladder step.
6. **fix(desktop/macos): hash full captures at preview scale.** `markCaptured` stored a full-resolution dHash into the history that ≤80px preview hashes are compared against; cross-scale aliasing reads as "changed", defeating the preview-skip and triggering unnecessary full captures and the Gemini calls behind them. New `previewScaleDHash` + behavioral test.
7. Docs move with the code: `backend/docs/vertex-pt-flash.md` gains a "keeping the reservation for work that must be Flash" section.

**Kept on the reservation, deliberately:** task extraction (60% of burndown) — the bakeoff measured Flash-Lite extracting from a chat sidebar at confidence 0.9 against an explicit prompt ban and silently dropping one of two commitments; it has nowhere cheaper to go. Windows focus (small, best lane CTR). macOS Insight's first 30/day stay on Pro. **No task-lane cadence cuts**: once demand fits under the cap, on-reservation tokens are marginally free — degrading the flagship lane would save $0.

## Projected effect

Set #6 arithmetic from the value ranking: PT demand **18,431 → ~10,514 tok/s (78.2% of cap)** — PayGo Flash spillover → ~0 at current demand, with headroom for the observed 1.15× intraday peak. Net Gemini cash reduction roughly **$100–200/day** at current volumes (evicted lanes cost 0.27× on Lite on-demand), plus the memory-lane cadence cut. Absolute $ inherits the RCA's uncertainty; the tok/s arithmetic and cost ratios are measured.

## Expected UX degradation (accepted, per David's mandate)

- Insight after the 30/day Pro quota runs on Flash-Lite (the largest quality risk here — the bakeoff did not exercise Lite on the insight tool loop specifically).
- Fewer memories: Lite fires ~42% as often as Flash on that lane (measured as prompt-compliant restraint, but genuine coverage will drop) and the timer is 3× slower.
- Dedup slightly worse (Lite missed 1 of 3 duplicate pairs).
- Possible extreme-tail truncation at 2048 output tokens; the mean (~241) is unaffected.
- LiveNotes/prioritization/HomeSuggestions/goals: no detectable delta measured; LiveNotes gets faster.

## Verification

- `backend/.venv/bin/pytest tests/unit/test_desktop_proxy.py` — **42 passed** (includes the new demotion regression test and the 5-case server-paid/BYOK output-cap matrix driven through `_proxy` with a capturing client).
- Windows: `pnpm test` (vitest, Node 22) — **5205 passed, 29 skipped**, including the new `modelPins.test.ts`.
- macOS: `xcrun swift build -c debug --package-path Desktop` — clean (Build complete, 258s); `xcrun swift test --filter 'ModelQoSTests|PreviewScaleDHashTests|SettingsAssistantControlsTests'` — all suites passed (ModelQoSTests 18, PreviewScaleDHashTests 3, SettingsAssistantControlsTests full suite; 0 failures).
- `make preflight` — **PASS, 34 checks** (including swift-format lint, SwiftLint, e2e flow coverage, failure-class protocol, product invariants, changelog contract).
- `scripts/failure-class validate` — OK (`declaration=new`, definition added in this PR).
- Formatting: black (backend), swift-format wrapper (macOS), prettier (windows) — all clean.
- Not exercised live: real Vertex traffic shift (requires deploy, out of scope for this PR per the task boundary — do not deploy, do not merge).

## Follow-ups (named, not in this diff)

- **Task extraction → `gpt-5.6-luna`**: measurably better than Flash (10/10 vs 9/10, −81% output) but needs the legacy tool-loop contract ported onto the proactivity route; decision gate is a 50-labelled-frame bakeoff (~$1 of calls).
- Thinking-budget cut (1024 → 256) once the billing export passes the 08-17 restore and the fleet reasoning share is measurable.
- 2304px defensive resolution cap for external-display captures (~145 tok/s, INFERRED).
- Prefix-cache restructuring (the byte-identical 4,211-token block; stranded static chars at `TaskAssistant.swift:965-975`).
- Dead-code removals: `focus_sessions` (no writer, still synced/queried) and `PTTTranscriptCleanupService.cleanup` (zero callers).
- Windows memory-cadence parity (its default lives in `appSettings` and is a separate testable surface).
- `usageMetadata` + `x-omi-workload` proxy instrumentation to replace the evidence base's inference layer with measurement.

Failure-Class: new

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

