### PR TITLE
perf(desktop): extend task extraction cache prefix

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -163,6 +163,59 @@ actor TaskAssistant: ProactiveAssistant {
     }
   }
 
+  /// This policy is identical for every task-extraction request. Keep it in the
+  /// system instruction so Gemini can include it in the reusable implicit-cache
+  /// prefix instead of stranding it after per-frame context in the user turn.
+  static let cacheStableCapturePolicy = """
+    Analyze this screenshot. If you see a potential request, search for duplicates first.
+    If there is clearly no request on screen (~90% of screenshots), call no_task_found immediately.
+
+    CANONICAL CAPTURE POLICY (overrides older/custom duplicate instructions):
+    - A matching active task is evidence, not a reason to discard the observation.
+    - Exact duplicate with useful new evidence: call extract_task with duplicate_of set to its task id.
+    - A follow-up that changes an active task: call extract_task with refines_task set to its task id.
+    - Evidence that an active task was completed: call extract_task with capture_kind already_done and refines_task set to its task id.
+    - Use reject_task only for a previously rejected/deleted item or a true no-op with no useful new evidence.
+    """
+
+  static func requestPrompts(
+    baseSystemPrompt: String,
+    appName: String,
+    today: String,
+    profileText: String?,
+    contextEvidence: String
+  ) -> (system: String, user: String) {
+    var userPrompt =
+      "Screenshot from \(appName). Today is \(today). Analyze this screenshot for any unaddressed request directed at the user.\n\n"
+
+    let messagingApps: Set<String> = ["Telegram", "WhatsApp", "\u{200E}WhatsApp", "Messages", "Slack", "Discord"]
+    if messagingApps.contains(appName) {
+      userPrompt += """
+        REMINDER — THIS IS A MESSAGING APP:
+        - If this screenshot shows a chat sidebar/conversation list rather than an open conversation, SKIP entirely.
+        - If it shows an open conversation, read the FULL conversation flow between the user and the other person.
+        - LEFT-SIDE messages = from the other person. RIGHT-SIDE/colored = from the user.
+        - PRIORITY: Look for where the user AGREED or COMMITTED to doing something the other person asked.
+          Example: Other person says "Can you send me the report?" → User replies "Sure, will do" → Extract task: "Send [person] the report"
+        - ALSO: Look for incoming requests the user hasn't responded to yet.
+        - The task title should describe what was asked for, naming the other person in the conversation.
+
+        """
+    }
+
+    if let profileText {
+      userPrompt += "USER PROFILE (who this user is — use for context, not as a task source):\n"
+      userPrompt += profileText + "\n\n"
+    }
+
+    userPrompt += contextEvidence
+
+    return (
+      system: baseSystemPrompt + "\n\n" + cacheStableCapturePolicy,
+      user: userPrompt
+    )
+  }
+
   /// Get the extraction interval from settings
   private var extractionInterval: TimeInterval {
     get async {
@@ -935,44 +988,15 @@ actor TaskAssistant: ProactiveAssistant {
     dateFormatter.dateFormat = "yyyy-MM-dd (EEEE)"
     let todayStr = dateFormatter.string(from: Date())
 
-    var prompt =
-      "Screenshot from \(appName). Today is \(todayStr). Analyze this screenshot for any unaddressed request directed at the user.\n\n"
-
-    // For messaging apps, add an extra reminder about conversation analysis
-    let messagingApps: Set<String> = ["Telegram", "WhatsApp", "\u{200E}WhatsApp", "Messages", "Slack", "Discord"]
-    if messagingApps.contains(appName) {
-      prompt += """
-        REMINDER — THIS IS A MESSAGING APP:
-        - If this screenshot shows a chat sidebar/conversation list rather than an open conversation, SKIP entirely.
-        - If it shows an open conversation, read the FULL conversation flow between the user and the other person.
-        - LEFT-SIDE messages = from the other person. RIGHT-SIDE/colored = from the user.
-        - PRIORITY: Look for where the user AGREED or COMMITTED to doing something the other person asked.
-          Example: Other person says "Can you send me the report?" → User replies "Sure, will do" → Extract task: "Send [person] the report"
-        - ALSO: Look for incoming requests the user hasn't responded to yet.
-        - The task title should describe what was asked for, naming the other person in the conversation.
-
-        """
-    }
-
-    // Inject AI user profile for context
-    if let profile = await AIUserProfileService.shared.getLatestProfile() {
-      prompt += "USER PROFILE (who this user is — use for context, not as a task source):\n"
-      prompt += profile.profileText + "\n\n"
-    }
-
-    prompt += Self.contextEvidencePrompt(context)
-
-    prompt += """
-      Analyze this screenshot. If you see a potential request, search for duplicates first.
-      If there is clearly no request on screen (~90% of screenshots), call no_task_found immediately.
-
-      CANONICAL CAPTURE POLICY (overrides older/custom duplicate instructions):
-      - A matching active task is evidence, not a reason to discard the observation.
-      - Exact duplicate with useful new evidence: call extract_task with duplicate_of set to its task id.
-      - A follow-up that changes an active task: call extract_task with refines_task set to its task id.
-      - Evidence that an active task was completed: call extract_task with capture_kind already_done and refines_task set to its task id.
-      - Use reject_task only for a previously rejected/deleted item or a true no-op with no useful new evidence.
-      """
+    let profileText = await AIUserProfileService.shared.getLatestProfile()?.profileText
+    let currentSystemPrompt = await systemPrompt
+    let prompts = Self.requestPrompts(
+      baseSystemPrompt: currentSystemPrompt,
+      appName: appName,
+      today: todayStr,
+      profileText: profileText,
+      contextEvidence: Self.contextEvidencePrompt(context)
+    )
 
     // 3. Define 5 tools
     let tools = GeminiTool(functionDeclarations: [
@@ -1093,10 +1117,7 @@ actor TaskAssistant: ProactiveAssistant {
       ),
     ])
 
-    // 4. Get system prompt
-    let currentSystemPrompt = await systemPrompt
-
-    // 5. Build initial contents
+    // 4. Build initial contents
     // Wrap base64 encoding in autoreleasepool — Swift concurrency doesn't
     // drain autorelease pools, causing bridged NSString objects to accumulate.
     var contents: [GeminiImageToolRequest.Content] = autoreleasepool {
@@ -1105,14 +1126,14 @@ actor TaskAssistant: ProactiveAssistant {
         GeminiImageToolRequest.Content(
           role: "user",
           parts: [
-            GeminiImageToolRequest.Part(text: prompt),
+            GeminiImageToolRequest.Part(text: prompts.user),
             GeminiImageToolRequest.Part(mimeType: "image/jpeg", data: base64Data),
           ]
         )
       ]
     }
 
-    // 6. Tool-calling loop (max 8 iterations — enough headroom for 2-3 distinct
+    // 5. Tool-calling loop (max 8 iterations — enough headroom for 2-3 distinct
     // commitments per frame each doing search + extract).
     var searchCount = 0
     var extractedResults: [TaskExtractionResult] = []
@@ -1122,7 +1143,7 @@ actor TaskAssistant: ProactiveAssistant {
     toolLoop: for iteration in 0..<8 {
       let result = try await geminiClient.sendImageToolLoop(
         contents: contents,
-        systemPrompt: currentSystemPrompt,
+        systemPrompt: prompts.system,
         tools: [tools],
         forceToolCall: iteration == 0,
         thinkingBudget: 1024

--- a/desktop/macos/Desktop/Tests/TaskAssistantPromptTests.swift
+++ b/desktop/macos/Desktop/Tests/TaskAssistantPromptTests.swift
@@ -3,6 +3,38 @@ import XCTest
 @testable import Omi_Computer
 
 final class TaskAssistantPromptTests: XCTestCase {
+  func testRequestPromptsPutStableCapturePolicyBeforeVolatileFrameContext() {
+    let prompts = TaskAssistant.requestPrompts(
+      baseSystemPrompt: "custom detector rules",
+      appName: "Slack",
+      today: "2026-08-17 (Monday)",
+      profileText: "Works on Omi",
+      contextEvidence: "ACTIVE TASKS:\n- Ship cache change"
+    )
+
+    XCTAssertTrue(prompts.system.hasPrefix("custom detector rules\n\n"))
+    XCTAssertTrue(prompts.system.hasSuffix(TaskAssistant.cacheStableCapturePolicy))
+    XCTAssertFalse(prompts.user.contains(TaskAssistant.cacheStableCapturePolicy))
+    XCTAssertTrue(prompts.user.contains("Screenshot from Slack. Today is 2026-08-17 (Monday)."))
+    XCTAssertTrue(prompts.user.contains("REMINDER — THIS IS A MESSAGING APP:"))
+    XCTAssertTrue(prompts.user.contains("Works on Omi"))
+    XCTAssertTrue(prompts.user.hasSuffix("ACTIVE TASKS:\n- Ship cache change"))
+  }
+
+  func testRequestPromptsPreserveNonMessagingFrameContextWithoutProfile() {
+    let prompts = TaskAssistant.requestPrompts(
+      baseSystemPrompt: "detector rules",
+      appName: "Safari",
+      today: "2026-08-17 (Monday)",
+      profileText: nil,
+      contextEvidence: ""
+    )
+
+    XCTAssertEqual(prompts.system, "detector rules\n\n" + TaskAssistant.cacheStableCapturePolicy)
+    XCTAssertFalse(prompts.user.contains("REMINDER — THIS IS A MESSAGING APP:"))
+    XCTAssertFalse(prompts.user.contains("USER PROFILE"))
+  }
+
   func testBrowserKeywordMatchingUsesUserLocaleRules() {
     XCTAssertTrue(
       TaskAssistantSettings.windowTitle("Résumé – Safari", matchesAny: ["resume"])

--- a/desktop/macos/changelog/unreleased/20260817-task-extraction-prompt-cache.json
+++ b/desktop/macos/changelog/unreleased/20260817-task-extraction-prompt-cache.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved the efficiency of automatic task extraction without changing which tasks are captured"
+}


### PR DESCRIPTION
## Summary

- Move the unchanged 182-token canonical task-capture policy from the volatile per-frame user prompt into Gemini's system instruction.
- Keep app/date/profile/context and the screenshot in the user turn, so repeated requests now begin with a larger identical prefix.
- Preserve the tool schema, prompt wording, and backend removal of client-supplied `cachedContent` handles.

## Cache-prefix measurement

Using Google's local tokenizer for `gemini-2.5-flash`, the moved policy is 182 tokens. Against the issue's 4,211-token stable text baseline, the stable prefix becomes 4,393 tokens: +182 tokens / +4.32%.

Including the measured 1,806 image tokens, the stable share of model input rises from 70.0% (4,211 / 6,017) to 73.0% (4,393 / 6,017). Against the issue's full 6,735-token request total (including thinking/output), it rises from 62.5% to 65.2%. Total prompt content is unchanged.

This is a modelled prefix improvement, not a claim that the observed 46% production hit rate has already moved. The direct desktop Gemini proxy does not yet expose `usageMetadata.cachedContentTokenCount`; confirmation requires repeated production traffic within the implicit-cache TTL after cache telemetry reaches this path. Confidence is high that the cache-eligible prefix grew, but the real hit-rate effect still depends on traffic timing and provider behavior.

The backend sanitizer helps the reordering: it promotes legacy `system` messages into Gemini `systemInstruction` while leaving native `system_instruction` in place. It also continues stripping client-controlled `cached_content` / `cachedContent` handles before forwarding.

Google documents that system instructions are processed before prompts and are appropriate for repeated instructions, and that Gemini 2.5 supports implicit caching:

- https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instruction-introduction
- https://cloud.google.com/blog/products/ai-machine-learning/vertex-ai-context-caching

## Behavioral safety

The canonical policy text is byte-for-byte unchanged and still explicitly overrides custom extraction guidance. Only its message placement changes. The screenshot remains the final user content part, the contextual fields remain per-frame, and the task tool declaration is unchanged. Tests cover both messaging and non-messaging frames, with and without profile text.

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift | 1792 -> 1814 | the prompt-construction helper keeps the cache boundary explicit and directly testable without changing task-extraction behavior

## Validation

- `xcrun swift test -c debug --package-path Desktop --filter TaskAssistantPromptTests` — 4 passed
- `backend/.venv/bin/pytest backend/tests/unit/test_desktop_proxy.py -q` — 40 passed
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- `make preflight` — passed
- Isolated `com.omi.omi-cache-prefix` bundle — launched signed-in and reported healthy
- `agent-continuity-gauntlet.sh --suite prompts` — unrelated live-model P3 style probe failed because the unknown-person answer was too long and used “recorded conversations”; evidence captured under the gauntlet harness
- Full Desktop Swift suite — 5,437 tests executed, 1 skipped, with one unrelated order-dependent `RewindCaptureExclusionGenerationTests` failure; the failing test passed when rerun alone

Closes SCA-331.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


