### PR TITLE
SCA-333: Windows memory extraction default cadence 600s → 1800s

### DIFF
--- a/desktop/windows/src/main/appSettings.test.ts
+++ b/desktop/windows/src/main/appSettings.test.ts
@@ -43,6 +43,17 @@ describe('appSettings', () => {
     expect(s.recordHotkey).toBe('Ctrl+Space')
   })
 
+  it('keeps an explicit memory extraction interval when the default changes', () => {
+    // A user (or a prior full-object write) who already has 10 minutes on disk
+    // must keep 10 after we raised the absent-key default to 30. This is a
+    // default change, not a migration.
+    setAppSettings({ memoryExtractionIntervalMin: 10 })
+    setAppSettings({ closeToTrayNoticeShown: true })
+    _resetForTests()
+    expect(getAppSettings().memoryExtractionIntervalMin).toBe(10)
+    expect(getAppSettings().closeToTrayNoticeShown).toBe(true)
+  })
+
   it('round-trips a patched flag and preserves untouched fields', () => {
     setAppSettings({ closeToTrayNoticeShown: true })
     // Drop the cache so the assertion proves the value persisted to disk.
@@ -138,7 +149,7 @@ describe('appSettings', () => {
       notificationsEnabled: true,
       notificationFrequency: 0,
       memoryEnabled: false,
-      memoryExtractionIntervalMin: 10,
+      memoryExtractionIntervalMin: 30,
       memoryMinConfidence: 0.7,
       memoryExcludedApps: [],
       taskEnabled: true,
@@ -220,14 +231,24 @@ describe('appSettings', () => {
       []
     )
     // Memory: master flag opt-OUT; interval reuses the cooldown sanitizer (positive
-    // integer minutes, junk → 10); min-confidence clamps to [0,1] (junk → 0.7).
+    // integer minutes, junk/absent → 30); min-confidence clamps to [0,1] (junk → 0.7).
+    // External source for the 30-min default: 2026-08-17 workload value ranking
+    // (PostHog 30d) — worst CTR of any proactive lane; Mac already shipped 1800s.
     expect(sanitizeAppSettings({ memoryEnabled: false }).memoryEnabled).toBe(false)
+    expect(sanitizeAppSettings(null).memoryExtractionIntervalMin).toBe(30)
+    expect(sanitizeAppSettings({} as never).memoryExtractionIntervalMin).toBe(30)
+    // An already-persisted explicit interval survives, including the old 10-min
+    // default a user (or a prior write of the full settings object) has on disk.
+    // Changing the fallback is not a migration of existing settings.
+    expect(
+      sanitizeAppSettings({ memoryExtractionIntervalMin: 10 }).memoryExtractionIntervalMin
+    ).toBe(10)
     expect(
       sanitizeAppSettings({ memoryExtractionIntervalMin: 15 }).memoryExtractionIntervalMin
     ).toBe(15)
     expect(
       sanitizeAppSettings({ memoryExtractionIntervalMin: 0 }).memoryExtractionIntervalMin
-    ).toBe(10)
+    ).toBe(30)
     expect(sanitizeAppSettings({ memoryMinConfidence: 0.85 }).memoryMinConfidence).toBe(0.85)
     expect(sanitizeAppSettings({ memoryMinConfidence: 2 }).memoryMinConfidence).toBe(1)
     expect(sanitizeAppSettings({ memoryMinConfidence: -1 }).memoryMinConfidence).toBe(0)

--- a/desktop/windows/src/main/appSettings.ts
+++ b/desktop/windows/src/main/appSettings.ts
@@ -99,7 +99,10 @@ export type AppSettings = {
    *  "may I send screenshots to Gemini" lever remains `screenAnalysisEnabled`. */
   memoryEnabled: boolean
   /** Track 3 (Memory): minutes between extraction attempts, Mac's
-   *  `memoryExtractionInterval` (600s = 10 min). Default 10. */
+   *  `memoryExtractionInterval` (1800s = 30 min). Default 30. Was 10; memory
+   *  extraction measured the worst value of any proactive lane (50.5% of macOS
+   *  notification volume at 0.240% CTR), so its default cadence carries a 3x
+   *  cut. An already-persisted user value is kept as-is. */
   memoryExtractionIntervalMin: number
   /** Track 3 (Memory): minimum confidence an extracted memory must clear to be
    *  kept, Mac's `memoryMinConfidence`. Default 0.7. */
@@ -202,11 +205,13 @@ function sanitizeFrequency(raw: unknown): number {
   return raw
 }
 
-// Cooldown minutes: a positive integer, else Mac's default 10. Zero/negative/
-// junk falls back rather than disabling the cooldown (which would let a
-// distracted user be re-billed for a Gemini call every few seconds).
-function sanitizeCooldownMinutes(raw: unknown): number {
-  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0) return 10
+// Cooldown / extraction-interval minutes: a positive integer, else `fallback`
+// (Focus/Task default 10; Memory default 30). Zero/negative/junk falls back
+// rather than disabling the timer (which would let a distracted user be
+// re-billed for a Gemini call every few seconds). An already-persisted
+// positive integer is kept — changing `fallback` is not a migration.
+function sanitizeCooldownMinutes(raw: unknown, fallback = 10): number {
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw <= 0) return fallback
   return Math.min(raw, 24 * 60) // a day is already absurd; cap the blast radius.
 }
 
@@ -290,8 +295,10 @@ export function sanitizeAppSettings(raw: Partial<AppSettings> | null | undefined
     notificationFrequency: sanitizeFrequency(r.notificationFrequency),
     memoryEnabled: r.memoryEnabled === true,
     // Reuses the cooldown sanitizer: same contract (positive integer minutes,
-    // default 10, capped at a day). A junk interval falls back to 10, never 0.
-    memoryExtractionIntervalMin: sanitizeCooldownMinutes(r.memoryExtractionIntervalMin),
+    // capped at a day). Default 30 (1800s) to match Mac. A junk/absent interval
+    // falls back to 30, never 0. An explicit persisted value (including the
+    // old 10-minute default a user already has on disk) is kept.
+    memoryExtractionIntervalMin: sanitizeCooldownMinutes(r.memoryExtractionIntervalMin, 30),
     memoryMinConfidence: sanitizeMinConfidence(r.memoryMinConfidence),
     memoryExcludedApps: sanitizeExcludedApps(r.memoryExcludedApps),
     // Default ON (!== false, same idiom as screenAnalysisEnabled), matching Mac's

--- a/desktop/windows/src/main/assistants/memory/memoryAssistant.test.ts
+++ b/desktop/windows/src/main/assistants/memory/memoryAssistant.test.ts
@@ -9,7 +9,7 @@ import type { MemoryToPersist } from './persist'
 const h = vi.hoisted(() => ({
   settings: {
     memoryEnabled: true,
-    memoryExtractionIntervalMin: 10,
+    memoryExtractionIntervalMin: 30,
     memoryMinConfidence: 0.7,
     memoryExcludedApps: [] as string[]
   },
@@ -71,7 +71,7 @@ function result(over: Partial<MemoryExtractionResult> = {}): MemoryExtractionRes
 
 beforeEach(() => {
   h.settings.memoryEnabled = true
-  h.settings.memoryExtractionIntervalMin = 10
+  h.settings.memoryExtractionIntervalMin = 30
   h.settings.memoryMinConfidence = 0.7
   h.settings.memoryExcludedApps = []
   vi.clearAllMocks()
@@ -106,10 +106,10 @@ describe('isEnabled — gated solely by memoryEnabled', () => {
 })
 
 describe('shouldAnalyze — the fixed extraction interval', () => {
-  it('runs only once the interval has elapsed (10 min default → 600000 ms)', () => {
+  it('runs only once the interval has elapsed (30 min default → 1800000 ms)', () => {
     const a = new MemoryAssistant()
-    expect(a.shouldAnalyze(0, 599_999)).toBe(false)
-    expect(a.shouldAnalyze(0, 600_000)).toBe(true)
+    expect(a.shouldAnalyze(0, 1_799_999)).toBe(false)
+    expect(a.shouldAnalyze(0, 1_800_000)).toBe(true)
   })
 
   it('honours a custom interval from settings', () => {

--- a/desktop/windows/src/main/assistants/memory/memoryAssistant.ts
+++ b/desktop/windows/src/main/assistants/memory/memoryAssistant.ts
@@ -55,10 +55,10 @@ export class MemoryAssistant implements ProactiveAssistant {
   }
 
   /** Memory's only cadence control: the fixed extraction interval (Mac's
-   *  `memoryExtractionInterval`, 600s / 10 min default). */
+   *  `memoryExtractionInterval`, 1800s / 30 min default). */
   private effectiveIntervalMs(): number {
     const min = getAppSettings().memoryExtractionIntervalMin
-    return Math.max(1, Number.isFinite(min) ? min : 10) * 60_000
+    return Math.max(1, Number.isFinite(min) ? min : 30) * 60_000
   }
 
   shouldAnalyze(_frameNumber: number, timeSinceLastAnalysisMs: number): boolean {


### PR DESCRIPTION
## Summary

- Raise the Windows memory-extraction **default** interval from 10 minutes (600s) to 30 minutes (1800s), matching the macOS change that already landed in #11764 (`feat(desktop/macos): memory extraction default cadence 600s -> 1800s`).
- This is a default change, not a migration: an already-persisted `memoryExtractionIntervalMin` (including a user who still has the old 10) is kept as-is. Junk/absent values fall back to 30.
- Windows does not surface this interval in Settings (Notifications only has the memory **toggle**), so there is no picker ladder to extend. 30 is a valid positive-integer minute under the existing sanitizer.

Closes SCA-333

## Why

Memory extraction is the worst-value proactive lane on every instrument that exists: 50.5% of macOS notification volume at 0.240% CTR (5× worse than the next-worst lane), ~1.9% dogfood yield (8 stored memories from ~420 calls). Windows is a meaningful share of desktop Gemini traffic (~23% of flash `generateContent` calls). Tripling the default interval is a deliberate coverage/cost trade.

External source for the rewritten expected default: 2026-08-17 workload value ranking (PostHog 30d), same measurement that shipped the macOS 1800s default.

## What

- `sanitizeCooldownMinutes` now takes an optional fallback (Focus/Task stay at 10; Memory uses 30).
- `memoryAssistant.effectiveIntervalMs` defensive fallback follows the new default.
- Tests: absent/junk → 30; explicit 10 and 15 survive sanitize; disk round-trip of an explicit 10 survives an unrelated later write; assistant cadence uses 30 min → 1_800_000 ms.

## Test plan

- [x] `pnpm exec vitest run src/main/appSettings.test.ts src/main/assistants/memory/memoryAssistant.test.ts` — 29 passed
- [x] `pnpm test` (Node 22.21.1) — 5220 passed, 33 skipped
- [x] `make preflight` — 11 checks passed
- [ ] Could not exercise the real Windows Settings UI (this run is on macOS). The interval is not shown in the Notifications tab; only the memory toggle is. Confirm on a Windows build that a fresh profile extracts every 30 min and a profile with `memoryExtractionIntervalMin: 10` already on disk stays at 10.

## Commands run

```
export PATH="/opt/homebrew/opt/node@22/bin:$PATH"   # v22.21.1
pnpm install --ignore-scripts --frozen-lockfile
pnpm exec vitest run src/main/appSettings.test.ts src/main/assistants/memory/memoryAssistant.test.ts
# Test Files  2 passed (2) / Tests  29 passed (29)

pnpm test
# Test Files  542 passed | 6 skipped (548)
# Tests  5220 passed | 33 skipped (5253)

make setup
make preflight
# PR preflight passed: 11 checks in 196.25s
scripts/pr-preflight --suggest
# Product invariants affected: none
# No fix: commits; no Failure-Class declaration required
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

