### PR TITLE
fix(ci): admit desktop-backend traffic on lineage, not branch recency

### DIFF
--- a/.github/checks-manifest.yaml
+++ b/.github/checks-manifest.yaml
@@ -695,6 +695,11 @@ checks:
     triggers: [".github/workflows/desktop_backend_auto_dev.yml", ".github/workflows/desktop_backend_prod.yml", ".github/workflows/desktop_backend_recover_prod.yml", ".github/workflows/desktop_promote_prod.yml", ".github/scripts/verify_desktop_backend_image_lineage.py", ".github/scripts/check-desktop-backend-release-policy.py", ".github/scripts/test_check_desktop_backend_release_policy.py", "backend/scripts/preflight_agent_vm_reconciler_deploy_identity.py", "backend/Dockerfile.desktop_backend", "backend/**/*.py", "backend/pylock.runtime.toml", "desktop/macos/pi-mono-extension/index.ts", ".github/checks-manifest.yaml"]
     lanes: ["local", "ci"]
     reason: "mutation fixtures reject traffic-before-proof, missing reconciler actAs preflight, mutable/stale/wrong-platform images, automatic production deploys, baked runtime credentials, and chat-contract drift"
+  - id: desktop-backend-traffic-lineage-fixtures
+    command: ["python3", ".github/scripts/test_check_desktop_backend_traffic_regression.py"]
+    triggers: [".github/workflows/desktop_backend_auto_dev.yml", ".github/scripts/check_desktop_backend_traffic_regression.py", ".github/scripts/test_check_desktop_backend_traffic_regression.py", ".github/checks-manifest.yaml"]
+    lanes: ["local", "ci"]
+    reason: "a traffic promotion gate must refuse only backwards promotions; refusing on branch recency discards candidates whose build and acceptance are already paid for"
   - id: desktop-backend-candidate-probe-fixtures
     command: ["python3", ".github/scripts/test_desktop_backend_candidate_probe.py"]
     triggers: [".github/scripts/desktop_backend_candidate_probe.py", ".github/scripts/test_desktop_backend_candidate_probe.py", "backend/**/*.py", "backend/pylock.runtime.toml", ".github/checks-manifest.yaml"]
@@ -727,6 +732,8 @@ exempt:
     reason: "deployment concurrency policy full-tree check, not diff-scoped"
   - path: ".github/scripts/check_admin_deploy_scope.py"
     reason: "runtime classifier invoked by gcp_admin.yml; contract and fixtures are admin-deploy-scope*"
+  - path: ".github/scripts/check_desktop_backend_traffic_regression.py"
+    reason: "runtime promotion gate invoked by desktop_backend_auto_dev.yml; contract and fixtures are desktop-backend-traffic-lineage-fixtures"
   - path: ".github/scripts/check_isinstance_return_ratchet.py"
     reason: "typed error flow-control ratchet uses a committed baseline, not diff-scoped triggers"
   - path: "backend/scripts/check_app_client_openapi_compatibility.py"

--- a/.github/failure-classes/FC-promotion-gate-admits-on-recency-not-lineage.json
+++ b/.github/failure-classes/FC-promotion-gate-admits-on-recency-not-lineage.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-promotion-gate-admits-on-recency-not-lineage",
+  "violated_contract": "A gate standing between an accepted deploy candidate and its traffic promotion may refuse only when promoting would regress the serving surface — the candidate does not descend from what is serving. It must not refuse merely because the branch advanced while the candidate was building. Recency is not a safety property once ordering is already guaranteed by a serialized, non-cancelling concurrency group; conflating the two makes admission depend on whether anyone else merged during the build, so sustained merge pressure discards every candidate after its build and acceptance are already paid for.",
+  "canonical_prevention": "Gate the traffic mutation on commit lineage between the candidate and the release SHA recorded on the revision currently serving 100% traffic, admitting descendants and unprovable lineage while refusing ancestors and divergent histories. Keep recency checks upstream of the build, where they can still prevent work rather than discard it.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check_desktop_backend_traffic_regression.py",
+    ".github/scripts/test_check_desktop_backend_traffic_regression.py"
+  ],
+  "evidence_prs": [11768],
+  "scope_hints": [
+    ".github/workflows/desktop_backend_auto_dev.yml",
+    ".github/scripts/check_desktop_backend_traffic_regression.py"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check_desktop_backend_traffic_regression.py
+++ b/.github/scripts/check_desktop_backend_traffic_regression.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Admit a desktop-backend traffic promotion unless it would move the service backwards.
+
+The deploy pipeline serialises runs on one concurrency group and never cancels
+in progress (``desktop-backend-auto-dev``). That ordering already prevents a
+newer run from routing while an older one holds the lock, so the property worth
+enforcing before ``update-traffic`` is *lineage*, not *recency*: the candidate
+must not be an ancestor of whatever is serving today.
+
+Comparing the candidate against ``origin/main`` instead fails whenever any
+commit lands during the build, which under sustained merge pressure is every
+run. That check discards builds that already passed acceptance without
+preventing a single Cloud Build, because the build is long finished by the time
+traffic is routed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    allowed: bool
+    reason: str
+
+
+#: Returned when the serving revision predates SHA-stamped revisions, or its
+#: commit is not reachable in the checkout. Lineage is unprovable, so it is not
+#: evidence that the promotion regresses anything.
+UNKNOWN_LINEAGE = "unknown-lineage"
+
+
+def evaluate_traffic_promotion(
+    *,
+    candidate_sha: str,
+    serving_sha: str | None,
+    is_ancestor: Callable[[str, str], bool | None],
+) -> PromotionDecision:
+    """Decide whether ``candidate_sha`` may take 100% traffic from ``serving_sha``.
+
+    ``is_ancestor(a, b)`` reports whether commit ``a`` is an ancestor of commit
+    ``b``, or ``None`` when either commit is unresolvable.
+    """
+    if not candidate_sha:
+        raise ValueError("candidate SHA is required to evaluate a traffic promotion")
+
+    if not serving_sha:
+        return PromotionDecision(
+            allowed=True,
+            reason=(
+                f"{UNKNOWN_LINEAGE}: serving revision records no release SHA; "
+                "cannot prove the promotion moves traffic backwards"
+            ),
+        )
+
+    if serving_sha == candidate_sha:
+        return PromotionDecision(
+            allowed=True,
+            reason="serving revision is already this candidate's commit; promotion is idempotent",
+        )
+
+    ancestry = is_ancestor(serving_sha, candidate_sha)
+    if ancestry is None:
+        return PromotionDecision(
+            allowed=True,
+            reason=(
+                f"{UNKNOWN_LINEAGE}: {serving_sha} is not reachable in this checkout; "
+                "cannot prove the promotion moves traffic backwards"
+            ),
+        )
+    if ancestry:
+        return PromotionDecision(
+            allowed=True,
+            reason=f"candidate {candidate_sha} descends from serving {serving_sha}",
+        )
+
+    return PromotionDecision(
+        allowed=False,
+        reason=(
+            f"candidate {candidate_sha} does not descend from serving {serving_sha}; "
+            "routing it would move desktop-backend backwards"
+        ),
+    )
+
+
+def _git_is_ancestor(repo_ancestor: str, repo_descendant: str) -> bool | None:
+    for commit in (repo_ancestor, repo_descendant):
+        resolved = subprocess.run(
+            ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
+            capture_output=True,
+        )
+        if resolved.returncode != 0:
+            return None
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", repo_ancestor, repo_descendant],
+        capture_output=True,
+    )
+    if completed.returncode == 0:
+        return True
+    if completed.returncode == 1:
+        return False
+    stderr = completed.stderr.decode("utf-8", "replace").strip()
+    raise RuntimeError(f"git merge-base --is-ancestor failed: {stderr}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument(
+        "--serving-release-sha",
+        default="",
+        help="Release SHA recorded on the revision serving 100% traffic; empty when unknown.",
+    )
+    args = parser.parse_args(argv)
+
+    decision = evaluate_traffic_promotion(
+        candidate_sha=args.candidate_sha,
+        serving_sha=args.serving_release_sha.strip() or None,
+        is_ancestor=_git_is_ancestor,
+    )
+    if not decision.allowed:
+        print(f"ERROR: {decision.reason}; traffic remains unchanged.", file=sys.stderr)
+        return 1
+    if decision.reason.startswith(UNKNOWN_LINEAGE):
+        print(f"::warning title=Unproven traffic lineage::{decision.reason}")
+    print(decision.reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_desktop_backend_traffic_regression.py
+++ b/.github/scripts/test_check_desktop_backend_traffic_regression.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check_desktop_backend_traffic_regression.py")
+SPEC = importlib.util.spec_from_file_location("desktop_backend_traffic_regression", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def _ancestry(pairs: dict[tuple[str, str], bool | None]):
+    def is_ancestor(ancestor: str, descendant: str) -> bool | None:
+        return pairs[(ancestor, descendant)]
+
+    return is_ancestor
+
+
+class EvaluateTrafficPromotionTests(unittest.TestCase):
+    def test_admits_a_candidate_built_before_main_advanced(self) -> None:
+        """The regression this file exists for: a merge during the build is not staleness."""
+        decision = MODULE.evaluate_traffic_promotion(
+            candidate_sha="cafe1",
+            serving_sha="beef0",
+            is_ancestor=_ancestry({("beef0", "cafe1"): True}),
+        )
+
+        self.assertTrue(decision.allowed)
+        self.assertIn("descends from serving", decision.reason)
+
+    def test_refuses_a_candidate_the_serving_revision_already_descends_from(self) -> None:
+        decision = MODULE.evaluate_traffic_promotion(
+            candidate_sha="beef0",
+            serving_sha="cafe1",
+            is_ancestor=_ancestry({("cafe1", "beef0"): False}),
+        )
+
+        self.assertFalse(decision.allowed)
+        self.assertIn("would move desktop-backend backwards", decision.reason)
+
+    def test_refuses_a_candidate_on_a_divergent_history(self) -> None:
+        decision = MODULE.evaluate_traffic_promotion(
+            candidate_sha="fork1",
+            serving_sha="fork2",
+            is_ancestor=_ancestry({("fork2", "fork1"): False}),
+        )
+
+        self.assertFalse(decision.allowed)
+
+    def test_admits_an_idempotent_reroute_of_the_same_commit(self) -> None:
+        decision = MODULE.evaluate_traffic_promotion(
+            candidate_sha="cafe1",
+            serving_sha="cafe1",
+            is_ancestor=_ancestry({}),
+        )
+
+        self.assertTrue(decision.allowed)
+        self.assertIn("idempotent", decision.reason)
+
+    def test_admits_when_the_serving_revision_records_no_release_sha(self) -> None:
+        """Legacy revisions predate SHA stamping; refusing would deadlock the pipeline."""
+        decision = MODULE.evaluate_traffic_promotion(
+            candidate_sha="cafe1",
+            serving_sha=None,
+            is_ancestor=_ancestry({}),
+        )
+
+        self.assertTrue(decision.allowed)
+        self.assertTrue(decision.reason.startswith(MODULE.UNKNOWN_LINEAGE))
+
+    def test_admits_when_the_serving_commit_is_unreachable(self) -> None:
+        decision = MODULE.evaluate_traffic_promotion(
+            candidate_sha="cafe1",
+            serving_sha="gone0",
+            is_ancestor=_ancestry({("gone0", "cafe1"): None}),
+        )
+
+        self.assertTrue(decision.allowed)
+        self.assertTrue(decision.reason.startswith(MODULE.UNKNOWN_LINEAGE))
+
+    def test_rejects_a_missing_candidate_sha(self) -> None:
+        with self.assertRaises(ValueError):
+            MODULE.evaluate_traffic_promotion(
+                candidate_sha="",
+                serving_sha="beef0",
+                is_ancestor=_ancestry({}),
+            )
+
+
+class GitAncestryTests(unittest.TestCase):
+    """Exercise the real git seam the workflow runs, not a stub of it."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = Path(self._tmp.name)
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", *args],
+                cwd=self.repo,
+                env=env,
+                capture_output=True,
+                check=True,
+            ).stdout.decode()
+
+        git("init", "-q", "-b", "main")
+        (self.repo / "f").write_text("1")
+        git("add", "f")
+        git("commit", "-qm", "first")
+        self.first = git("rev-parse", "HEAD").strip()
+        (self.repo / "f").write_text("2")
+        git("commit", "-qam", "second")
+        self.second = git("rev-parse", "HEAD").strip()
+
+        self._cwd = os.getcwd()
+        os.chdir(self.repo)
+        self.addCleanup(os.chdir, self._cwd)
+
+    def test_reports_ancestry_in_both_directions(self) -> None:
+        self.assertTrue(MODULE._git_is_ancestor(self.first, self.second))
+        self.assertFalse(MODULE._git_is_ancestor(self.second, self.first))
+
+    def test_reports_none_for_a_commit_absent_from_the_checkout(self) -> None:
+        absent = "0" * 40
+        self.assertIsNone(MODULE._git_is_ancestor(absent, self.second))
+
+    def test_cli_admits_a_descendant_and_refuses_an_ancestor(self) -> None:
+        self.assertEqual(
+            MODULE.main(["--candidate-sha", self.second, "--serving-release-sha", self.first]),
+            0,
+        )
+        self.assertEqual(
+            MODULE.main(["--candidate-sha", self.first, "--serving-release-sha", self.second]),
+            1,
+        )
+
+    def test_cli_admits_an_empty_serving_sha(self) -> None:
+        self.assertEqual(
+            MODULE.main(["--candidate-sha", self.second, "--serving-release-sha", ""]),
+            0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -446,12 +446,30 @@ jobs:
           REVISION: ${{ steps.candidate-identity.outputs.revision }}
         run: |
           set -euo pipefail
+          # Refuse only promotions that would move the service backwards in history.
+          # Requiring origin/main to be unchanged fails whenever any commit lands
+          # during the build, which discards an accepted candidate without saving a
+          # single Cloud Build. Run ordering is already guaranteed by the
+          # desktop-backend-auto-dev concurrency group (cancel-in-progress: false).
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          current_main="$(git rev-parse 'origin/main^{commit}')"
-          if [[ "$current_main" != "${{ steps.candidate-identity.outputs.source_sha }}" ]]; then
-            echo "ERROR: candidate is stale because origin/main advanced to $current_main; traffic remains unchanged." >&2
-            exit 1
+          git fetch --no-tags --deepen=200 origin main 2>/dev/null || true
+          serving_revision="$(gcloud run services describe "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --format=json 2>/dev/null \
+            | python3 .github/scripts/extract_single_cloud_run_traffic_revision.py 2>/dev/null || true)"
+          serving_release_sha=""
+          if [[ -n "$serving_revision" ]]; then
+            serving_release_sha="$(gcloud run revisions describe "$serving_revision" \
+              --project="$PROJECT_ID" \
+              --region="$REGION" \
+              --format=json 2>/dev/null \
+              | jq -r '[.spec.containers[]?.env[]? | select(.name == "OMI_DESKTOP_BACKEND_RELEASE_SHA") | .value] | first // ""' \
+              || true)"
           fi
+          python3 .github/scripts/check_desktop_backend_traffic_regression.py \
+            --candidate-sha="${{ steps.candidate-identity.outputs.source_sha }}" \
+            --serving-release-sha="$serving_release_sha"
           python3 backend/scripts/resolve_cloud_run_tagged_url.py \
             --project="$PROJECT_ID" \
             --region="$REGION" \


### PR DESCRIPTION
## Problem

The dev desktop-backend deploy refuses to route traffic whenever `origin/main` advances during the build:

```
ERROR: candidate is stale because origin/main advanced to
015172400b775fe897f2ea9158bfbeb59907372d; traffic remains unchanged.
```

A desktop-backend deploy takes ~5 minutes. When commits land faster than that, every run is pre-empted at the last step — *after* Cloud Build and the acceptance probes have already run. The check cannot prevent a build; by the time it fires, the build is finished. All it can do is discard it.

Three consecutive runs failed this way on 2026-08-17:

| Run | main@ | Outcome |
| --- | --- | --- |
| [32059345833](https://github.com/BasedHardware/omi/actions/runs/32059345833) | `4f8da45f` | failed (project/URL resolution — different cause) |
| [32074024600](https://github.com/BasedHardware/omi/actions/runs/32074024600) | `fc458ef3` | stale: main advanced to `a7ff90a4` |
| [32074869094](https://github.com/BasedHardware/omi/actions/runs/32074869094) | `03f50eb1` | stale: main advanced to `01517240` |

The failure mode is worse than a stuck pipeline. Prod promotes the last **dev-accepted** candidate, so with dev unable to accept anything since 19:06, the prod run at 22:11 reported **success** while re-shipping the `34bd15da` image. #11764 is merged, built, and sitting in an unrouted revision — while the dashboard reads green.

It is also self-reinforcing: the more the team merges, the less likely any deploy ever lands.

## Why the check was redundant

The two protections it appeared to provide are both already in place elsewhere, and they fight each other:

- **Ordering** is guaranteed by the `desktop-backend-auto-dev` concurrency group with `cancel-in-progress: false`. A newer run cannot route while an older one holds the lock. But holding that lock for the full build is *exactly* what guarantees `main` has moved by the time the older run reaches the traffic step — a queued run behind it has its commit on `main` by definition.
- **Debounce against stacked Cloud Builds** is the entry guard in `Resolve immutable candidate identity` ([:68](https://github.com/BasedHardware/omi/blob/main/.github/workflows/desktop_backend_auto_dev.yml#L68)), which exits before Google Auth and before any build is spent. **This PR does not touch it.** Superseded commits still bail out early; a burst of three merges still builds only the newest.

Re-asking the same question after the build could only throw away finished work.

## Change

Gate the promotion on **lineage** rather than recency: refuse only when the candidate does not descend from the release SHA recorded on the revision currently serving 100% traffic. That preserves the real safety property — never move desktop-backend backwards — without requiring that nobody merged during the build.

Unknown lineage (a legacy revision with no recorded SHA, or a commit unreachable in the checkout) warns and admits. Dev is currently serving `desktop-backend-00461-qiy`, a pre-SHA revision, so refusing on unknown lineage would deadlock the pipeline on the very next run.

Scoped to the dev workflow. `desktop_backend_prod.yml` admits via `admitted-source` and never carried this guard.

## Verification

```
python3 -m pytest .github/scripts/test_check_desktop_backend_traffic_regression.py -q   # 11 passed
python3 .github/scripts/check-desktop-backend-release-policy.py                          # OK
python3 .github/scripts/check-deployment-concurrency.py                                  # OK
python3 -m pytest .github/scripts/test_check_desktop_backend_release_policy.py -q         # 27 passed
make preflight
```

**Replayed the three real failures** against the SHA prod actually serves (`34bd15da`):

| Candidate | Old guard | New guard |
| --- | --- | --- |
| `03f50eb1` (#11764) | refused | **admitted** — descends from serving |
| `fc458ef3` | refused | **admitted** |
| `a7ff90a4` (#11760) | refused | **admitted** |
| `34bd15da` vs serving `03f50eb1` | admitted | **refused** — would move backwards |
| serving SHA empty (dev today) | n/a | **admitted** with `::warning` |

**Exercised the live discovery path** against the prod service: `extract_single_cloud_run_traffic_revision.py` resolved `desktop-backend-34bd15da499c-32074856543-1`, and the `jq` expression read `OMI_DESKTOP_BACKEND_RELEASE_SHA=34bd15da499cbfe314f1b5d9014b79611f91736c` off it. The dev project was not reachable from the read-only bot (`run.services.get` denied), so that half runs first in CI.

The unit tests cover the decision function through an injected ancestry oracle, and the `git` seam itself against a real temporary repository — including the unreachable-commit path — rather than stubbing it.

## Risk

Traffic shifts become more frequent, because builds that pass acceptance now actually ship instead of being discarded. That is the intent. If churn needs bounding, the correct lever is the entry-side debounce, not discarding completed work at the exit.

Failure-Class: new

Adds `FC-promotion-gate-admits-on-recency-not-lineage` — a gate between an accepted candidate and its traffic promotion may refuse only backwards promotions, never merely because the branch advanced during the build. Guard artifact is the checked-in decision function and its fixtures.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

