### PR TITLE
fix(backend): an ungrounded memory extraction must not abort conversation finalization (#11769)

### DIFF
--- a/backend/tests/unit/test_memory_replace_policy.py
+++ b/backend/tests/unit/test_memory_replace_policy.py
@@ -216,12 +216,12 @@ def test_canonical_capture_preserves_prior_state_when_candidate_has_any_unground
         ],
     )
 
-    with pytest.raises(
-        ValueError,
-        match="evidence without a unique source binding",
-    ):
-        pc._extract_memories_canonical("uid-quote-grounding", conversation, db_client=MagicMock())
+    result = pc._extract_memories_canonical("uid-quote-grounding", conversation, db_client=MagicMock())
 
+    # No replacement is submitted, so the source keeps the memories it already
+    # has — and finalization still returns, so the caller's action items, audio
+    # files and created webhook are not collateral of an extraction verdict.
+    assert result.count == 0
     mock_service.replace_conversation_memories.assert_not_called()
 
 

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -18,7 +18,7 @@ import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from fastapi import HTTPException
@@ -1355,6 +1355,77 @@ def test_app_summary_results_reach_the_database(monkeypatch):
     assert results[0]['app_id'] == 'app-1'
     assert results[0]['content'] == 'APP SUMMARY'
     assert written.get('suggested_summarization_apps') == ['app-1']
+
+
+def test_finalization_survives_an_extraction_run_with_no_grounded_candidates(monkeypatch):
+    """Regression: when every L1 candidate failed grounding, canonical extraction
+    raised and took the rest of finalization with it — action items, goal
+    progress, audio files and the created webhook never ran, and the caller
+    (developer conversation intake, sync enrichment) returned 500. Grounding is
+    a verdict on the memories only: the replacement is skipped, finalization
+    continues."""
+    from models.transcript_segment import TranscriptSegment
+
+    completed_conversation = Conversation(
+        id='conversation-ungrounded',
+        created_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        started_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 7, 21, 0, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title='Title', overview='Overview'),
+        transcript_segments=[
+            TranscriptSegment(
+                text='We discussed ordinary weekend plans and a grocery list.',
+                speaker='SPEAKER_00',
+                is_user=True,
+                start=0.0,
+                end=4.0,
+            )
+        ],
+        status=ConversationStatus.completed,
+        discarded=False,
+    )
+
+    memory_service = MagicMock()
+    submitted = MagicMock()
+
+    input_conversation = MagicMock()
+    input_conversation.source = 'omi'
+    input_conversation.get_person_ids.return_value = []
+
+    monkeypatch.setattr(process_conversation, '_get_structured', lambda *a, **k: (MagicMock(), False))
+    monkeypatch.setattr(process_conversation, '_get_conversation_obj', lambda *a, **k: completed_conversation)
+    monkeypatch.setattr(process_conversation.lifecycle_service, 'persist_processed_conversation', lambda *a, **k: True)
+    monkeypatch.setattr(process_conversation.lifecycle_service, 'create_completed_conversation', lambda *a, **k: True)
+    monkeypatch.setattr(process_conversation, '_trigger_apps', lambda *a, **k: None)
+    monkeypatch.setattr(process_conversation, 'submit_with_context', submitted)
+    monkeypatch.setattr(process_conversation.conversations_db, 'update_conversation', lambda *a, **k: None)
+    monkeypatch.setattr(process_conversation, 'MemoryService', lambda db_client: memory_service)
+    monkeypatch.setattr(process_conversation.users_db, 'get_user_language_preference', lambda uid: 'en')
+    monkeypatch.setattr(
+        process_conversation,
+        'extract_canonical_l1_memory_candidates',
+        MagicMock(
+            return_value=[
+                SimpleNamespace(
+                    content='The user was diagnosed with condition X.',
+                    evidence_quotes=['I was diagnosed with condition X'],
+                    speaker_label='SPEAKER_00',
+                    speaker_scope='session-local',
+                    about='the user',
+                    risk_flags=[],
+                    archive_class='general',
+                )
+            ]
+        ),
+    )
+
+    process_conversation.process_conversation('uid', 'en', input_conversation)
+
+    # Nothing is written or retracted for the source ...
+    memory_service.replace_conversation_memories.assert_not_called()
+    # ... and the effects sequenced after extraction still ran.
+    assert '_save_action_items' in {getattr(call.args[1], '__name__', '') for call in submitted.call_args_list}
 
 
 def test_dedup_candidates_exclude_own_and_merge_source_items():

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -954,10 +954,27 @@ def _extract_memories_canonical(
         if seen_candidates and not capture_candidates:
             # Every candidate failed grounding: the run itself is untrustworthy,
             # so it must not submit the empty replacement that would retract the
-            # source's existing memories. Count what the loop actually yielded —
-            # the extractor's return value is only known to be iterable, so its
-            # truthiness is not a statement about how many candidates it holds.
-            raise ValueError("canonical memory extraction returned evidence without a unique source binding")
+            # source's existing memories. Skipping the replacement is the whole
+            # verdict — it leaves prior memories intact. Raising instead would
+            # abort the caller's finalization and additionally drop that
+            # conversation's action items, goal progress, audio files and
+            # created webhook, which this extraction has no standing to decide.
+            # Count what the loop actually yielded — the extractor's return
+            # value is only known to be iterable, so its truthiness is not a
+            # statement about how many candidates it holds.
+            logger.warning(
+                "canonical memory extraction skipped replacement: all %s candidates ungrounded conversation=%s",
+                seen_candidates,
+                conversation.id,
+            )
+            record_fallback(
+                component='other',
+                from_mode='canonical_memory_extraction',
+                to_mode='replacement_skipped',
+                reason='other',
+                outcome='degraded',
+            )
+            return ConversationMemoryExtractionResult(count=0, source=source, path=PATH_CANONICAL)
         if ungrounded_candidates:
             logger.warning(
                 "canonical memory extraction dropped %s of %s ungrounded candidates conversation=%s",


### PR DESCRIPTION
Fixes #11769.

## Bug

Since **2026-08-17 18:41 UTC** prod raises, at a sustained ~500/hour:

```
File "/app/utils/conversations/process_conversation.py", line 918, in _extract_memories_canonical
    raise ValueError("canonical memory extraction returned evidence without a unique source binding")
```

| hour (UTC) | raises |
|---|---|
| 08-15 all day / 08-16 all day / 08-17 00:00–18:40 | 0 |
| 18:41 (first) → 19:00 | 72 |
| 20:00 | 928 |
| 21:00 | 407 |
| 22:00 | 535 |

No deploy sits at that boundary — prod has been on `commit-sha=6316415534` (deployed 08-15 15:36) throughout. The onset is behavioral: the L1 extractor's `evidence_quotes` stopped being verbatim spans of a single transcript segment, so nothing grounds. In the same window there are **zero** `"dropped N of M ungrounded candidates"` warnings — grounding never fails partially, which is the signature of a provider/routing change rather than per-candidate model noise. **That root cause is not fixed here** (tracked in #11769); this PR fixes what the failure is allowed to destroy.

## Root cause of the blast radius

The guard (from #11685 → #11688 → #11702) exists so an all-ungrounded run does not submit the empty replacement that would retract the source's existing memories. **Skipping the replacement achieves that on its own.** Raising was the part with no standing: `_extract_memories` runs inside `_emit_derived_effects` *ahead of* `_save_action_items`, `_update_goal_progress`, `create_audio_files_from_chunks` (+ the playback artifact build) and `conversation_created_webhook`.

So each of those ~500/hour conversations also lost its action items, goal progress, audio files and created webhook — and the caller returned 500 (`routers/developer.py::create_conversation_from_segments{,_user}`, `routers/conversations.py::_run_enrichment`) for a conversation that had **already been durably written**, which is a duplicate-retry hazard for the client.

## Fix

When every candidate is ungrounded: skip `replace_conversation_memories` (nothing written, nothing retracted — the fence is intact), log the count, `record_fallback(..., to_mode='replacement_skipped', outcome='degraded')` so the residual rate stays visible, and return a zero-count result so finalization completes. Grounding stays a verdict on the memories, not on the conversation.

## Tested

```
cd backend
: > /tmp/f.txt
echo tests/unit/test_memory_replace_policy.py >> /tmp/f.txt
echo tests/unit/test_process_conversation_usage_context.py >> /tmp/f.txt
BACKEND_UNIT_TEST_FILE_LIST=/tmp/f.txt bash test.sh
```

- after: `test_memory_replace_policy.py` **16 passed**, `test_process_conversation_usage_context.py` **31 passed**
- **the new test executes production behavior through the real seam**: `test_finalization_survives_an_extraction_run_with_no_grounded_candidates` calls `process_conversation.process_conversation(...)` with an extractor whose one candidate quotes text absent from the transcript, then asserts `replace_conversation_memories` was never called *and* that `_save_action_items` — the effect sequenced immediately after extraction — was still submitted.
- **proven to catch the regression**: `git stash push utils/conversations/process_conversation.py` (test changes only) → `test_finalization_survives_an_extraction_run_with_no_grounded_candidates` FAILED and `test_canonical_capture_preserves_prior_state_when_candidate_has_any_ungrounded_quote` FAILED; restoring the hunk makes both pass.
- `make preflight` green (run with a Python 3.12 `python3`; the repo scripts use `str | None`, which the mac's system 3.9 cannot parse)

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 1810 -> 1827 | the raise becomes a skip: a warning, a `record_fallback` call and the zero-count return, plus the comment recording why an extraction verdict must not cancel the caller's finalization

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

