### PR TITLE
SCA-334: defensive 2304px capture cap for high-DPI displays

### DIFF
--- a/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenCaptureService.swift
@@ -5,7 +5,19 @@ import ImageIO
 import ScreenCaptureKit
 
 final class ScreenCaptureService: Sendable {
-  private static let maxSize: CGFloat = 3000
+  /// Long-edge cap for ScreenCaptureKit stream config and the screencapture fallback.
+  ///
+  /// `SCWindow.frame` is in points; `SCStreamConfiguration.width/height` are in
+  /// pixels. On a typical Mac the clamp never fires — the largest production
+  /// frame across 400 sampled chunks was 1710×1072. It *can* fire on an
+  /// external 5K/6K display at "More Space" scaling.
+  ///
+  /// 2304 = 3×768, the next Gemini tile-grid step below 3000. Measured token
+  /// cost on high-DPI sources drops 22–46% at 2304 vs 3000, with quality
+  /// indistinguishable from 3000. Do not lower this to 1536: that rung saves
+  /// nothing further on landscape sources and starts silently confabulating
+  /// on-screen text (measured on a retina terminal capture).
+  static let maxSize: CGFloat = 2304
   private let jpegQuality: CGFloat = 0.8
   private static let activeWindowResolveTimeoutNs: UInt64 = 500_000_000  // 500ms
   private static let activeWindowCacheTTL: TimeInterval = 2

--- a/desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenCaptureDimensionsTests.swift
@@ -10,7 +10,11 @@ import XCTest
 /// from the background screen-capture loop. Sizing is now a pure function that refuses
 /// degenerate frames; these tests pin that.
 final class ScreenCaptureDimensionsTests: XCTestCase {
-  private let maxSize: CGFloat = 3000
+  private let maxSize = ScreenCaptureService.maxSize
+
+  func testProductionMaxSizeIs2304() {
+    XCTAssertEqual(ScreenCaptureService.maxSize, 2304)
+  }
 
   func testPreservesAspectRatioForNormalWindow() {
     let size = ScreenCaptureService.captureDimensions(width: 1440, height: 900, maxSize: maxSize)
@@ -19,17 +23,28 @@ final class ScreenCaptureDimensionsTests: XCTestCase {
   }
 
   func testClampsOversizedWindowToMaxSize() {
-    // 6000x3000 → width clamps to 3000, height follows the 2:1 aspect ratio.
-    let size = ScreenCaptureService.captureDimensions(width: 6000, height: 3000, maxSize: maxSize)
-    XCTAssertEqual(size?.width, 3000)
-    XCTAssertEqual(size?.height, 1500)
+    // 4608x2304 → width clamps to 2304, height follows the 2:1 aspect ratio.
+    let size = ScreenCaptureService.captureDimensions(width: 4608, height: 2304, maxSize: maxSize)
+    XCTAssertEqual(size?.width, 2304)
+    XCTAssertEqual(size?.height, 1152)
   }
 
   func testClampsTallWindowByHeight() {
-    // 1000x9000 → height clamps to 3000, width follows the 1:9 aspect ratio.
+    // 1000x9000 → height clamps to 2304, width follows the 1:9 aspect ratio.
     let size = ScreenCaptureService.captureDimensions(width: 1000, height: 9000, maxSize: maxSize)
-    XCTAssertEqual(size?.height, 3000)
-    XCTAssertEqual(size?.width, 333)
+    XCTAssertEqual(size?.height, 2304)
+    XCTAssertEqual(size?.width, 256)
+  }
+
+  func testClampsMeasuredHighDPILandscapeAndPreservesAspect() {
+    // 2874×1710 is a measured high-DPI landscape source (aspect ≈ 1.68).
+    let size = ScreenCaptureService.captureDimensions(width: 2874, height: 1710, maxSize: maxSize)
+    XCTAssertEqual(size?.width, 2304)
+    XCTAssertEqual(size?.height, 1370)
+    guard let size else {
+      return
+    }
+    XCTAssertEqual(Double(size.width) / Double(size.height), 2874.0 / 1710.0, accuracy: 0.01)
   }
 
   /// The crash: width 0 produced NaN, and `Int(NaN)` traps.

--- a/desktop/macos/changelog/unreleased/20260818-defensive-2304px-capture-cap.json
+++ b/desktop/macos/changelog/unreleased/20260818-defensive-2304px-capture-cap.json
@@ -1,0 +1,3 @@
+{
+  "change": "Capped very large window captures so high-resolution external displays send smaller images to the assistant"
+}


### PR DESCRIPTION
## Summary

- Lower `ScreenCaptureService.maxSize` from 3000 to 2304 (3×768). This is a defensive cap: on current hardware the clamp never fires because `SCWindow.frame` is in points while `SCStreamConfiguration.width/height` are in pixels (largest observed production frame across 400 chunks: 1710×1072). It exists so an external 5K/6K display at "More Space" scaling does not send a 2560–2874px image into Gemini.
- 2304 is the first tile-grid step that actually saves tokens on high-DPI *image sources* (−22% to −46% vs 3000). Quality at 2304 was indistinguishable from 3000. 1536 buys nothing further on landscape sources and starts silently confabulating on-screen text. Do not "optimize" this down.
- Estimated value is small (~145 tok/s against a 13,450 tok/s reservation). No-op on typical Macs.

Closes SCA-334

## Honest limitation

The token table was measured on high-DPI *image sources* on one machine (M4 Air, 2880×1864 panel). This change was **not** verified against a real ScreenCaptureKit capture on an external 5K/6K monitor at "More Space" scaling — which is the only configuration where the clamp binds.

## Caller audit

- `ScreenCaptureService.maxSize` is the default for `captureConfiguration` and `captureWindowCGImage` only.
- `ProactiveAssistantsPlugin.swift` still passes `maxSize: 80` for the preview-hash path — left alone.
- No other caller depended on the 3000 value.

## Changelog

Unreleased fragment: `desktop/macos/changelog/unreleased/20260818-defensive-2304px-capture-cap.json`. Internal on typical Macs; the note is for the rare 5K/6K "More Space" case where the clamp can fire.

## Test plan

- [x] `xcrun swift build -c debug --package-path Desktop` — clean
- [x] `xcrun swift test -c debug --package-path Desktop --filter ScreenCaptureDimensionsTests` — 9 tests, 0 failures (clamps at 2304, preserves aspect, refuses degenerate frames)
- [ ] Real 5K/6K "More Space" capture — not available on this machine


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

