### PR TITLE
feat: expose Gemini usage by desktop workload

### DIFF
--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 import time
-from collections.abc import AsyncIterator, Awaitable
+from collections.abc import AsyncIterator, Awaitable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from database import redis_db
+from llm_gateway.gateway.accounting import vertex_usage_from_response
 from llm_gateway.gateway.providers import VertexAccessTokenSupplier
 from utils.byok import get_byok_key
 from utils.executors import critical_executor, db_executor, run_blocking
@@ -71,6 +72,8 @@ _MAX_CONTENT_PARTS = 512
 _MAX_INLINE_MEDIA_PARTS = 16
 _BURST_LIMIT = 30
 _DAILY_HARD_LIMIT = 1500
+_ALLOWED_WORKLOADS = frozenset({'interactive', 'extraction', 'maintenance'})
+_ALLOWED_TRAFFIC_TYPES = frozenset({'PROVISIONED_THROUGHPUT', 'ON_DEMAND'})
 
 # The deployed Rust proxy originally used a 70/75-second attempt/logical
 # contract. A later blind expansion to 235/240 seconds exactly matches the
@@ -147,6 +150,14 @@ class ProxyTelemetry:
         self.region = 'none'
         self.model = 'unknown'
         self.action = 'unknown'
+        supplied_workload = request.headers.get('x-omi-workload', '').strip().lower()
+        self.workload_class = supplied_workload if supplied_workload in _ALLOWED_WORKLOADS else 'unknown'
+        self.prompt_token_count: int | None = None
+        self.candidates_token_count: int | None = None
+        self.total_token_count: int | None = None
+        self.cached_content_token_count: int | None = None
+        self.thoughts_token_count: int | None = None
+        self.traffic_type = 'unknown'
         self.phase = 'validation'
         self.shape = PayloadShape('unknown', 'unknown', 'unknown')
         self.started = time.monotonic()
@@ -156,6 +167,20 @@ class ProxyTelemetry:
         self.provider = route.provider
         self.credential_source = route.credential_source
         self.region = route.region
+
+    def observe_gemini_response(self, response: Mapping[str, Any]) -> None:
+        """Retain only bounded billing metadata from a Gemini response."""
+        metadata = vertex_usage_from_response(response)
+        if metadata.traffic_type in _ALLOWED_TRAFFIC_TYPES:
+            self.traffic_type = metadata.traffic_type
+        if metadata.usage is None:
+            return
+        usage = metadata.usage
+        self.prompt_token_count = usage.prompt_tokens
+        self.candidates_token_count = usage.output_tokens
+        self.total_token_count = usage.total_tokens
+        self.cached_content_token_count = usage.cached_input_tokens
+        self.thoughts_token_count = usage.reasoning_tokens
 
     def complete(
         self,
@@ -185,6 +210,8 @@ class ProxyTelemetry:
             'model': self.model if self.model in _ALLOWED_MODELS else 'unknown',
             'region': _safe_region(self.region),
             'action': self.action if self.action in _ALLOWED_ACTIONS else 'unknown',
+            'workload_class': self.workload_class,
+            'traffic_type': self.traffic_type,
             'attempt': 1,
             'phase': phase,
             'outcome': outcome,
@@ -197,6 +224,16 @@ class ProxyTelemetry:
             'inline_media_parts_bucket': self.shape.inline_media_bucket,
             'elapsed_ms': round((time.monotonic() - self.started) * 1000),
         }
+        if self.prompt_token_count is not None:
+            event.update(
+                {
+                    'prompt_token_count': self.prompt_token_count,
+                    'candidates_token_count': self.candidates_token_count,
+                    'total_token_count': self.total_token_count,
+                    'cached_content_token_count': self.cached_content_token_count,
+                    'thoughts_token_count': self.thoughts_token_count,
+                }
+            )
         project = os.getenv('GOOGLE_CLOUD_PROJECT', '').strip()
         if self.trace_id and project:
             event['logging.googleapis.com/trace'] = f'projects/{project}/traces/{self.trace_id}'
@@ -683,6 +720,38 @@ def _stream_error_event(*, code: str, phase: str, telemetry: ProxyTelemetry) -> 
     return f'data: {json.dumps(event, separators=(",", ":"))}\n\n'.encode()
 
 
+class _StreamingUsageObserver:
+    """Incrementally inspect SSE data fields without retaining response content."""
+
+    def __init__(self, telemetry: ProxyTelemetry) -> None:
+        self.telemetry = telemetry
+        self.buffer = bytearray()
+
+    def feed(self, chunk: bytes) -> None:
+        self.buffer.extend(chunk)
+        self.buffer = bytearray(bytes(self.buffer).replace(b'\r\n', b'\n'))
+        while b'\n\n' in self.buffer:
+            event, _, remainder = self.buffer.partition(b'\n\n')
+            self.buffer = bytearray(remainder)
+            self._observe_event(bytes(event))
+
+    def finish(self) -> None:
+        if self.buffer:
+            self._observe_event(bytes(self.buffer))
+            self.buffer.clear()
+
+    def _observe_event(self, event: bytes) -> None:
+        data_lines = [line[5:].lstrip() for line in event.splitlines() if line.startswith(b'data:')]
+        if not data_lines:
+            return
+        try:
+            payload = json.loads(b'\n'.join(data_lines))
+        except (TypeError, ValueError):
+            return
+        if isinstance(payload, dict):
+            self.telemetry.observe_gemini_response(payload)
+
+
 async def _stream_provider(
     request: Request,
     route: UpstreamRoute,
@@ -694,6 +763,7 @@ async def _stream_provider(
     context: Any | None = None
     acquired = False
     opened = False
+    usage_observer = _StreamingUsageObserver(telemetry)
     try:
         async with asyncio.timeout(_TOTAL_TIMEOUT_SECONDS):
             telemetry.phase = 'pool'
@@ -716,7 +786,9 @@ async def _stream_provider(
             yield f'data: {json.dumps(event, separators=(",", ":"))}\n\n'.encode()
             return
         async for chunk in upstream.aiter_bytes():
+            usage_observer.feed(chunk)
             yield chunk
+        usage_observer.finish()
         telemetry.complete(outcome='success', status_code=upstream.status_code, retryable=False, phase='body')
     except ClientDisconnected:
         telemetry.complete(outcome='client_cancelled', status_code=499, retryable=False, phase='client_disconnect')
@@ -901,6 +973,13 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
         if route.provider == 'vertex_ai' and action == 'embedContent'
         else response.content
     )
+    if action == 'generateContent':
+        try:
+            response_payload = json.loads(response.content)
+        except (TypeError, ValueError):
+            response_payload = None
+        if isinstance(response_payload, dict):
+            telemetry.observe_gemini_response(response_payload)
     telemetry.complete(
         outcome='success',
         status_code=response.status_code,

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -24,6 +24,7 @@ def make_request(
     body: bytes = b'{"contents":[{"parts":[{"text":"hello"}]}]}',
     *,
     query_string: bytes = b"",
+    workload: str | None = None,
 ) -> Request:
     sent = False
     pending = asyncio.Event()
@@ -35,13 +36,16 @@ def make_request(
             return {"type": "http.request", "body": body, "more_body": False}
         await pending.wait()
 
+    headers = [(b"x-omi-request-id", b"request-12345678")]
+    if workload is not None:
+        headers.append((b"x-omi-workload", workload.encode()))
     return Request(
         {
             "type": "http",
             "method": "POST",
             "path": "/v1/proxy/gemini/models/gemini-2.5-flash:generateContent",
             "query_string": query_string,
-            "headers": [(b"x-omi-request-id", b"request-12345678")],
+            "headers": headers,
         },
         receive,
     )
@@ -544,7 +548,20 @@ async def test_proxy_dispatches_server_paid_bodies_with_the_2048_cap(monkeypatch
     class CapturingClient:
         async def post(self, url, *, params, content, headers):
             dispatched.append(content)
-            return httpx.Response(200, request=httpx.Request("POST", url), json={"ok": True})
+            return httpx.Response(
+                200,
+                request=httpx.Request("POST", url),
+                json={
+                    "usageMetadata": {
+                        "promptTokenCount": 120,
+                        "cachedContentTokenCount": 80,
+                        "candidatesTokenCount": 14,
+                        "thoughtsTokenCount": 6,
+                        "totalTokenCount": 140,
+                    },
+                    "trafficType": "PROVISIONED_THROUGHPUT",
+                },
+            )
 
     async def route(path, _model, _action, _query):
         return desktop_proxy.UpstreamRoute("https://provider.invalid", {}, {}, "vertex_ai", "adc", "us-central1")
@@ -552,6 +569,8 @@ async def test_proxy_dispatches_server_paid_bodies_with_the_2048_cap(monkeypatch
     async def meter(_uid, path, _model, _action):
         return path
 
+    output = io.StringIO()
+    monkeypatch.setattr(desktop_proxy.sys, "stdout", output)
     monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
     monkeypatch.setattr(desktop_proxy, "_meter_server_request", meter)
     monkeypatch.setattr(desktop_proxy, "_upstream", route)
@@ -559,7 +578,7 @@ async def test_proxy_dispatches_server_paid_bodies_with_the_2048_cap(monkeypatch
     monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: asyncio.Semaphore(1))
 
     response = await desktop_proxy._proxy(
-        make_request(),
+        make_request(workload="extraction"),
         "models/gemini-2.5-flash:generateContent",
         False,
         "user",
@@ -569,6 +588,30 @@ async def test_proxy_dispatches_server_paid_bodies_with_the_2048_cap(monkeypatch
     assert len(dispatched) == 1
     config = json.loads(dispatched[0])["generationConfig"]
     assert config["maxOutputTokens"] == 2048
+    event = json.loads(output.getvalue())
+    assert event["workload_class"] == "extraction"
+    assert event["traffic_type"] == "PROVISIONED_THROUGHPUT"
+    assert event["prompt_token_count"] == 120
+    assert event["cached_content_token_count"] == 80
+    assert event["candidates_token_count"] == 14
+    assert event["thoughts_token_count"] == 6
+    assert event["total_token_count"] == 140
+
+
+def test_missing_usage_and_unknown_workload_are_safely_bucketed(monkeypatch):
+    output = io.StringIO()
+    monkeypatch.setattr(desktop_proxy.sys, "stdout", output)
+    missing_usage = desktop_proxy.ProxyTelemetry(make_request(), streaming=False)
+    missing_usage.observe_gemini_response({"candidates": []})
+    missing_usage.complete(outcome="success", status_code=200, retryable=False, phase="body")
+    event = json.loads(output.getvalue())
+    assert event["workload_class"] == "unknown"
+    assert event["traffic_type"] == "unknown"
+    assert "prompt_token_count" not in event
+    assert (
+        desktop_proxy.ProxyTelemetry(make_request(workload="private-feature-name"), streaming=False).workload_class
+        == "unknown"
+    )
 
 
 @pytest.mark.asyncio
@@ -743,13 +786,19 @@ async def test_proxy_bounds_concurrency_pool_wait_and_labels_phase(monkeypatch):
 async def test_streaming_defers_resource_acquisition_until_body_iteration(monkeypatch):
     streams_opened = 0
     streams_closed = 0
-    chunk = b'data: {"ok":true}\n\n'
+    chunks = [
+        b'data: {"candidates":[{"content":{"parts":[{"text":"ok"}]}}],',
+        b'"usageMetadata":{"promptTokenCount":10,"cachedContentTokenCount":4,',
+        b'"candidatesTokenCount":2,"thoughtsTokenCount":1,"totalTokenCount":13},',
+        b'"trafficType":"ON_DEMAND"}\r\n\r\n',
+    ]
 
     class UpstreamResponse:
         status_code = 200
 
         async def aiter_bytes(self):
-            yield chunk
+            for chunk in chunks:
+                yield chunk
 
     class StreamContext:
         async def __aenter__(self):
@@ -779,12 +828,24 @@ async def test_streaming_defers_resource_acquisition_until_body_iteration(monkey
     monkeypatch.setattr(desktop_proxy, "_cancel_on_disconnect", await_upstream)
     monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_stream_client", lambda: Client())
     monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: asyncio.Semaphore(1))
+    output = io.StringIO()
+    monkeypatch.setattr(desktop_proxy.sys, "stdout", output)
 
-    response = await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:streamGenerateContent", True, "user")
+    response = await desktop_proxy._proxy(
+        make_request(workload="interactive"), "models/gemini-2.5-flash:streamGenerateContent", True, "user"
+    )
 
     assert response.status_code == 200
     assert streams_opened == 0
-    chunks = [chunk async for chunk in response.body_iterator]
-    assert chunks == [chunk]
+    received = [chunk async for chunk in response.body_iterator]
+    assert received == chunks
     assert streams_opened == 1
     assert streams_closed == 1
+    event = json.loads(output.getvalue())
+    assert event["workload_class"] == "interactive"
+    assert event["traffic_type"] == "ON_DEMAND"
+    assert event["prompt_token_count"] == 10
+    assert event["cached_content_token_count"] == 4
+    assert event["candidates_token_count"] == 2
+    assert event["thoughts_token_count"] == 1
+    assert event["total_token_count"] == 13

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift
@@ -409,7 +409,7 @@ actor PTTTranscriptCleanupService {
 
     do {
       let response = try await withTimeout(seconds: 2) {
-        let client = try GeminiClient(model: ModelQoS.Gemini.proactive)
+        let client = try GeminiClient(model: ModelQoS.Gemini.proactive, workload: .interactive)
         return try await client.sendTextRequest(
           prompt: prompt,
           systemPrompt: "You clean up short voice ASR transcripts. Return only the corrected transcript.",

--- a/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
+++ b/desktop/macos/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
@@ -73,7 +73,7 @@ class LiveNotesMonitor: ObservableObject {
 
   private convenience init() {
     self.init(
-      noteGeneratorFactory: { try GeminiClient(model: ModelQoS.Gemini.lightweight) },
+      noteGeneratorFactory: { try GeminiClient(model: ModelQoS.Gemini.lightweight, workload: .extraction) },
       noteStorage: NoteStorage.shared,
       subscribeToTranscript: true
     )

--- a/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Dashboard/HomeSuggestionsStore.swift
@@ -308,7 +308,7 @@ struct GeminiHomeSuggestionGenerator: HomeSuggestionGenerating {
       - Return an empty list if the context doesn't contain enough real, current material.
       """
 
-    let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
+    let client = try GeminiClient(model: ModelQoS.Gemini.lightweight, workload: .maintenance)
     let responseText = try await client.sendRequest(
       prompt: prompt,
       systemPrompt:

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingChatView.swift
@@ -1226,7 +1226,7 @@ struct OnboardingChatView: View {
 
     // Send to Gemini
     do {
-      let gemini = try GeminiClient()
+      let gemini = try GeminiClient(workload: .interactive)
       let prompt =
         "The user needs to grant \(permLabel) permission to the Omi app. Look at the screenshot. Tell them exactly where to click in ONE short sentence, max 15 words."
       let systemPrompt =

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift
@@ -28,7 +28,7 @@ actor GoalsAIService {
     guard APIKeyService.keysAvailable || !geminiClientInitAttempted else { return nil }
     geminiClientInitAttempted = true
     do {
-      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
+      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight, workload: .interactive)
       geminiClient = client
       return client
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -76,7 +76,10 @@ actor InsightAssistant: ProactiveAssistant {
 
   init(apiKey: String? = nil) throws {
     self.geminiClient = try GeminiClient(
-      apiKey: apiKey, model: ModelQoS.Gemini.insight, fallbackModel: ModelQoS.Gemini.lightweight)
+      apiKey: apiKey,
+      model: ModelQoS.Gemini.insight,
+      fallbackModel: ModelQoS.Gemini.lightweight,
+      workload: .extraction)
 
     let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
     self.frameSignal = stream

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -75,7 +75,8 @@ actor MemoryAssistant: ProactiveAssistant {
   init(apiKey: String? = nil) throws {
     // Flash-Lite: vision-capable, off the Vertex PT reservation, and measurably more
     // prompt-compliant than Flash on this lane (see ModelQoS.Gemini.lightweight).
-    self.geminiClient = try GeminiClient(apiKey: apiKey, model: ModelQoS.Gemini.lightweight)
+    self.geminiClient = try GeminiClient(
+      apiKey: apiKey, model: ModelQoS.Gemini.lightweight, workload: .extraction)
     self.extractionOverride = nil
     self.durabilityPipeline = MemoryAssistantDurabilityPipeline(
       runner: MemoryAssistantProductionDurability(operations: MemoryAssistantLiveDurabilityOperations())

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -96,7 +96,8 @@ actor SuggestionAssistant: ProactiveAssistant {
     self.geminiClient = try GeminiClient(
       apiKey: apiKey,
       model: model,
-      fallbackModel: "gemini-2.5-flash"
+      fallbackModel: "gemini-2.5-flash",
+      workload: .maintenance
     )
     telemetryModel = SuggestionAssistantTelemetry.Model(configuredModel: model)
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -153,7 +153,6 @@ actor TaskAssistant: ProactiveAssistant {
     let startOfDay = calendar.startOfDay(for: Date())
     return calendar.date(bySettingHour: 23, minute: 59, second: 0, of: startOfDay) ?? startOfDay
   }
-
   /// Get the current system prompt from settings (accessed on MainActor for thread safety)
   private var systemPrompt: String {
     get async {
@@ -162,7 +161,6 @@ actor TaskAssistant: ProactiveAssistant {
       }
     }
   }
-
   /// Get the extraction interval from settings
   private var extractionInterval: TimeInterval {
     get async {
@@ -171,7 +169,6 @@ actor TaskAssistant: ProactiveAssistant {
       }
     }
   }
-
   /// Get the minimum confidence threshold from settings
   private var minConfidence: Double {
     get async {
@@ -185,7 +182,10 @@ actor TaskAssistant: ProactiveAssistant {
 
   init(apiKey: String? = nil) throws {
     self.geminiClient = try GeminiClient(
-      apiKey: apiKey, model: ModelQoS.Gemini.taskExtraction, fallbackModel: "gemini-2.5-flash")
+      apiKey: apiKey,
+      model: ModelQoS.Gemini.taskExtraction,
+      fallbackModel: "gemini-2.5-flash",
+      workload: .extraction)
 
     let (stream, continuation) = AsyncStream.makeStream(of: TriggerEvent.self, bufferingPolicy: .bufferingNewest(1))
     self.triggerStream = stream

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
@@ -44,7 +44,7 @@ actor TaskDeduplicationService {
     guard APIKeyService.keysAvailable || !geminiClientInitAttempted else { return nil }
     geminiClientInitAttempted = true
     do {
-      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
+      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight, workload: .maintenance)
       geminiClient = client
       return client
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
@@ -63,7 +63,7 @@ actor TaskPrioritizationService {
     guard APIKeyService.keysAvailable || !geminiClientInitAttempted else { return nil }
     geminiClientInitAttempted = true
     do {
-      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight)
+      let client = try GeminiClient(model: ModelQoS.Gemini.lightweight, workload: .maintenance)
       geminiClient = client
       return client
     } catch {

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+enum GeminiWorkloadClass: String {
+  case interactive
+  case extraction
+  case maintenance
+}
+
 // MARK: - Thinking Budget Configuration
 
 /// Controls how many tokens Gemini 2.5 spends on internal reasoning.
@@ -182,6 +188,7 @@ struct GeminiResponse: Decodable {
 /// the Gemini API key server-side. Auth uses Firebase Bearer token.
 actor GeminiClient {
   private let model: String
+  private let workload: GeminiWorkloadClass
 
   /// Backend proxy base URL resolved through the identity-bound endpoint policy.
   /// Do not read OMI_DESKTOP_API_URL directly: Beta must remain on its fixed
@@ -347,7 +354,12 @@ actor GeminiClient {
   /// (e.g. Pro overloaded → fall back to Flash). Nil or equal-to-primary = no fallback.
   private let fallbackModel: String?
 
-  init(apiKey: String? = nil, model: String = ModelQoS.Gemini.proactive, fallbackModel: String? = nil) throws {
+  init(
+    apiKey: String? = nil,
+    model: String = ModelQoS.Gemini.proactive,
+    fallbackModel: String? = nil,
+    workload: GeminiWorkloadClass
+  ) throws {
     // BREAKING CHANGE (issue #5861): apiKey parameter is ignored.
     // All Gemini requests now route through the backend proxy which supplies
     // the key server-side. Defaults to production when OMI_DESKTOP_API_URL is absent
@@ -357,6 +369,7 @@ actor GeminiClient {
     }
     self.model = model
     self.fallbackModel = fallbackModel
+    self.workload = workload
     // Which model a proactive assistant actually runs on is a product decision with a
     // measurable click-through cost, and until now it was invisible at runtime — the model
     // appears only inside the request URL, so a tier change could not be confirmed on a
@@ -555,6 +568,7 @@ actor GeminiClient {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue(try await authHeader(), forHTTPHeaderField: "Authorization")
+        urlRequest.setValue(workload.rawValue, forHTTPHeaderField: "X-Omi-Workload")
         urlRequest.timeoutInterval = 300
         urlRequest.httpBody = requestBody
 
@@ -630,6 +644,7 @@ actor GeminiClient {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue(try await authHeader(), forHTTPHeaderField: "Authorization")
+        urlRequest.setValue(workload.rawValue, forHTTPHeaderField: "X-Omi-Workload")
         urlRequest.timeoutInterval = timeout
         urlRequest.httpBody = try JSONEncoder().encode(request)
 
@@ -702,6 +717,7 @@ actor GeminiClient {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue(try await authHeader(), forHTTPHeaderField: "Authorization")
+        urlRequest.setValue(workload.rawValue, forHTTPHeaderField: "X-Omi-Workload")
         urlRequest.timeoutInterval = 300
         urlRequest.httpBody = try JSONEncoder().encode(request)
 
@@ -1007,6 +1023,7 @@ extension GeminiClient {
           urlRequest.httpMethod = "POST"
           urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
           urlRequest.setValue(try await authHeader(), forHTTPHeaderField: "Authorization")
+          urlRequest.setValue(workload.rawValue, forHTTPHeaderField: "X-Omi-Workload")
           urlRequest.timeoutInterval = 300
           urlRequest.httpBody = requestBody
 

--- a/desktop/macos/changelog/unreleased/20260817-gemini-usage-workload-telemetry.json
+++ b/desktop/macos/changelog/unreleased/20260817-gemini-usage-workload-telemetry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Improved internal Gemini usage reporting so AI capacity and costs can be tracked by workload without collecting request content"
+}


### PR DESCRIPTION
## Summary

- record Gemini `usageMetadata` billing counters and `trafficType` on desktop proxy terminal events for both JSON and fragmented SSE responses
- validate `X-Omi-Workload` into the closed `interactive`, `extraction`, and `maintenance` buckets, with absent or unknown values reported as `unknown`
- label every macOS `GeminiClient` call site and send the workload header on all request paths

## Billing and capacity evidence

The terminal event now exposes `prompt_token_count`, `cached_content_token_count`, `candidates_token_count`, `thoughts_token_count`, and `total_token_count` when Gemini reports usage. It also exposes bounded `traffic_type` and `workload_class` dimensions. This is sufficient to filter a UTC day by workload lane, sum input/cache/output/reasoning units for daily cost, and compare reservation demand and burndown between `PROVISIONED_THROUGHPUT` and `ON_DEMAND` traffic without logging request bodies.

## Privacy

The parser retains only normalized integer counters and closed-enum labels. It does not emit prompts, response text, provider payloads, headers, credentials, user identifiers, or arbitrary client-supplied feature names. Unknown header and traffic values collapse to `unknown`.

## Product invariants affected

- INV-CHAT-1: streaming bytes are forwarded unchanged while a side observer incrementally reads only complete SSE `data:` JSON events; the existing timeout, cancellation, and error behavior remains intact.

## Validation

- `BACKEND_UNIT_TEST_FILE_LIST=... bash backend/test.sh` — 41 passed with the fast-unit CPU guard enabled
- `xcrun swift build -c debug --package-path Desktop` — passed
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` — passed
- `OMI_PR_BODY_FILE=pr-body.md make preflight` — 32 checks passed
- `xcrun swift test --package-path Desktop` — 5,435 tests executed; one unrelated suite-order failure in `RewindCaptureExclusionGenerationTests.testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase`; the failing test passes in isolation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

