### PR TITLE
fix(backend): a memory-extractor provider failure must not abort conversation finalization (#11777)

### DIFF
--- a/backend/models/memory_contracts.py
+++ b/backend/models/memory_contracts.py
@@ -12,6 +12,30 @@ from models.product_memory import MemoryTier
 DURABLE_MEMORY_PATCH_FACT_SOURCE = "durable_memory_patch"
 
 
+class MemoryExtractionError(RuntimeError):
+    """A strict memory extraction failed before producing a valid batch.
+
+    This is the extraction boundary's own contract, not the provider stack's:
+    callers decide what an absent batch means for their write, and they must be
+    able to catch it without importing an LLM client.
+    """
+
+    def __init__(self, extractor: str, message: Optional[str] = None):
+        self.extractor = extractor
+        super().__init__(message or f"{extractor} failed before producing a valid extraction result")
+
+
+class WorkingObservationExtractionError(MemoryExtractionError):
+    """A strict L1 extraction failed before producing a valid batch."""
+
+    def __init__(self, stage: str):
+        self.stage = stage
+        super().__init__(
+            "working_observation_extractor",
+            f"working observation extraction failed during {stage}",
+        )
+
+
 class LifecycleState(str, Enum):
     working = "working"
     active = "active"

--- a/backend/tests/unit/test_memory_replace_policy.py
+++ b/backend/tests/unit/test_memory_replace_policy.py
@@ -225,6 +225,88 @@ def test_canonical_capture_preserves_prior_state_when_candidate_has_any_unground
     mock_service.replace_conversation_memories.assert_not_called()
 
 
+def test_canonical_capture_preserves_prior_state_when_the_extractor_never_returns_a_batch(monkeypatch):
+    """A provider failure is not a verdict on the source's existing memories.
+
+    ``strict=True`` makes the extractor raise instead of returning an empty
+    batch that would retract them. Skipping the replacement is that whole
+    protection; propagating the raise additionally aborts the caller's
+    finalization.
+    """
+    pc = _load_process_conversation()
+    from models.conversation import Conversation
+    from models.conversation_enums import CategoryEnum, ConversationSource
+    from models.structured import Structured
+    from models.transcript_segment import TranscriptSegment
+    from models.memory_contracts import WorkingObservationExtractionError
+
+    mock_service = MagicMock()
+    monkeypatch.setattr(pc, "MemoryService", lambda db_client: mock_service)
+    monkeypatch.setattr(
+        pc,
+        "extract_canonical_l1_memory_candidates",
+        MagicMock(side_effect=WorkingObservationExtractionError("invoke")),
+    )
+    monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
+
+    conversation = Conversation(
+        id="conv-extractor-unavailable",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title="Test", overview="Overview", category=CategoryEnum.personal),
+        transcript_segments=[
+            TranscriptSegment(
+                text="We discussed ordinary weekend plans and a grocery list.",
+                speaker="SPEAKER_00",
+                is_user=True,
+                start=0.0,
+                end=4.0,
+            )
+        ],
+    )
+
+    result = pc._extract_memories_canonical("uid-extractor-unavailable", conversation, db_client=MagicMock())
+
+    assert result.count == 0
+    mock_service.replace_conversation_memories.assert_not_called()
+
+
+def test_canonical_capture_survives_an_external_text_extractor_failure(monkeypatch):
+    """External-integration intake has the same extractor-failure boundary."""
+    pc = _load_process_conversation()
+    from models.conversation import Conversation
+    from models.conversation_enums import CategoryEnum, ConversationSource
+    from models.structured import Structured
+    from models.memory_contracts import MemoryExtractionError
+
+    mock_service = MagicMock()
+    monkeypatch.setattr(pc, "MemoryService", lambda db_client: mock_service)
+    monkeypatch.setattr(
+        pc,
+        "extract_memories_from_text",
+        MagicMock(side_effect=MemoryExtractionError("external_text_memory_extractor")),
+    )
+    monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
+
+    conversation = Conversation(
+        id="conv-external-extractor-unavailable",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+        source=ConversationSource.external_integration,
+        external_data={"text": "A long enough external note to reach the extractor.", "text_source": "other"},
+        structured=Structured(title="Test", overview="Overview", category=CategoryEnum.personal),
+        transcript_segments=[],
+    )
+
+    result = pc._extract_memories_canonical("uid-external-extractor", conversation, db_client=MagicMock())
+
+    assert result.count == 0
+    mock_service.replace_conversation_memories.assert_not_called()
+
+
 def test_canonical_capture_drops_only_the_ungrounded_candidate(monkeypatch):
     """One ungrounded candidate must not discard its grounded siblings."""
     pc = _load_process_conversation()

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -1428,6 +1428,65 @@ def test_finalization_survives_an_extraction_run_with_no_grounded_candidates(mon
     assert '_save_action_items' in {getattr(call.args[1], '__name__', '') for call in submitted.call_args_list}
 
 
+def test_finalization_survives_an_unavailable_memory_extractor(monkeypatch):
+    """Regression: an LLM invoke failure inside canonical extraction (prod:
+    openai.APITimeoutError -> WorkingObservationExtractionError) propagated out
+    of finalization, so the conversation also lost its action items, goal
+    progress, audio files and created webhook and the caller returned 500. A
+    provider that did not answer is a verdict on the memories only."""
+    from models.transcript_segment import TranscriptSegment
+    from models.memory_contracts import WorkingObservationExtractionError
+
+    completed_conversation = Conversation(
+        id='conversation-extractor-unavailable',
+        created_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        started_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 7, 21, 0, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title='Title', overview='Overview'),
+        transcript_segments=[
+            TranscriptSegment(
+                text='We discussed ordinary weekend plans and a grocery list.',
+                speaker='SPEAKER_00',
+                is_user=True,
+                start=0.0,
+                end=4.0,
+            )
+        ],
+        status=ConversationStatus.completed,
+        discarded=False,
+    )
+
+    memory_service = MagicMock()
+    submitted = MagicMock()
+
+    input_conversation = MagicMock()
+    input_conversation.source = 'omi'
+    input_conversation.get_person_ids.return_value = []
+
+    monkeypatch.setattr(process_conversation, '_get_structured', lambda *a, **k: (MagicMock(), False))
+    monkeypatch.setattr(process_conversation, '_get_conversation_obj', lambda *a, **k: completed_conversation)
+    monkeypatch.setattr(process_conversation.lifecycle_service, 'persist_processed_conversation', lambda *a, **k: True)
+    monkeypatch.setattr(process_conversation.lifecycle_service, 'create_completed_conversation', lambda *a, **k: True)
+    monkeypatch.setattr(process_conversation, '_trigger_apps', lambda *a, **k: None)
+    monkeypatch.setattr(process_conversation, 'submit_with_context', submitted)
+    monkeypatch.setattr(process_conversation.conversations_db, 'update_conversation', lambda *a, **k: None)
+    monkeypatch.setattr(process_conversation, 'MemoryService', lambda db_client: memory_service)
+    monkeypatch.setattr(process_conversation.users_db, 'get_user_language_preference', lambda uid: 'en')
+    monkeypatch.setattr(
+        process_conversation,
+        'extract_canonical_l1_memory_candidates',
+        MagicMock(side_effect=WorkingObservationExtractionError("invoke")),
+    )
+
+    process_conversation.process_conversation('uid', 'en', input_conversation)
+
+    # Prior memories are neither replaced nor retracted ...
+    memory_service.replace_conversation_memories.assert_not_called()
+    # ... and the effects sequenced after extraction still ran.
+    assert '_save_action_items' in {getattr(call.args[1], '__name__', '') for call in submitted.call_args_list}
+
+
 def test_dedup_candidates_exclude_own_and_merge_source_items():
     """Regression: on reprocess/merge, the conversation's own previous action
     items (and the merge sources') came back as dedup candidates — the LLM

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -70,6 +70,7 @@ from utils.llm.gateway_error_contract import conversation_processing_http_except
 from utils.llm.conversation_folder import assign_conversation_to_folder
 from utils.analytics import record_usage
 from utils.llm.usage_tracker import track_usage, Features
+from models.memory_contracts import MemoryExtractionError
 from utils.llm.memories import (
     extract_canonical_l1_memory_candidates,
     extract_memories_from_text,
@@ -862,6 +863,33 @@ def _canonical_conversation_write_payload(
     return payload
 
 
+def _canonical_extraction_unavailable(
+    conversation: Conversation, source: Any, exc: Exception
+) -> ConversationMemoryExtractionResult:
+    """The extractor never produced a batch, so this run has no verdict to apply.
+
+    ``strict=True`` exists so a provider failure cannot be mistaken for "no
+    memories" and submit the empty replacement that would retract the source's
+    existing memories. Skipping the replacement achieves that on its own;
+    raising additionally cancels the caller's finalization, which also drops
+    that conversation's action items, goal progress, audio files and created
+    webhook — an outcome a timed-out LLM call has no standing to decide.
+    """
+    logger.warning(
+        "canonical memory extraction skipped replacement: extractor unavailable conversation=%s reason=%s",
+        conversation.id,
+        type(exc).__name__,
+    )
+    record_fallback(
+        component='other',
+        from_mode='canonical_memory_extraction',
+        to_mode='replacement_skipped',
+        reason='provider_5xx',
+        outcome='degraded',
+    )
+    return ConversationMemoryExtractionResult(count=0, source=source, path=PATH_CANONICAL)
+
+
 def _extract_memories_canonical(
     uid: str, conversation: Conversation, *, db_client: Any, parity_capture: SurfaceParityCapture | None = None
 ) -> ConversationMemoryExtractionResult:
@@ -887,9 +915,8 @@ def _extract_memories_canonical(
         text_content = ext_data.get('text')
         if text_content and len(text_content) > 0:
             text_source = ext_data.get('text_source', 'other')
-            capture_candidates = [
-                (memory, [], "unknown", [], False)
-                for memory in extract_memories_from_text(
+            try:
+                extracted_memories = extract_memories_from_text(
                     uid,
                     text_content,
                     text_source,
@@ -897,18 +924,23 @@ def _extract_memories_canonical(
                     content_date=content_date,
                     strict=True,
                 )
-            ]
+            except MemoryExtractionError as exc:
+                return _canonical_extraction_unavailable(conversation, source, exc)
+            capture_candidates = [(memory, [], "unknown", [], False) for memory in extracted_memories]
     else:
         raw_user_name = get_user_name(uid)
         user_name = raw_user_name.strip() if isinstance(raw_user_name, str) and raw_user_name.strip() else "the user"
-        extracted_candidates = extract_canonical_l1_memory_candidates(
-            uid,
-            conversation.id,
-            conversation.transcript_segments,
-            user_name=user_name,
-            language=language,
-            strict=True,
-        )
+        try:
+            extracted_candidates = extract_canonical_l1_memory_candidates(
+                uid,
+                conversation.id,
+                conversation.transcript_segments,
+                user_name=user_name,
+                language=language,
+                strict=True,
+            )
+        except MemoryExtractionError as exc:
+            return _canonical_extraction_unavailable(conversation, source, exc)
         ungrounded_candidates = 0
         seen_candidates = 0
         for candidate in extracted_candidates:

--- a/backend/utils/llm/memories.py
+++ b/backend/utils/llm/memories.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from database import users as users_db
 from models.memories import Memory, MemoryCategory
-from models.memory_contracts import L1MemoryArchiveClass
+from models.memory_contracts import L1MemoryArchiveClass, MemoryExtractionError
 from models.other import Person
 from models.transcript_segment import TranscriptSegment
 from database.users import get_user_language_preference
@@ -86,14 +86,6 @@ class CanonicalL1MemoryCandidate(BaseModel):
     about: str = ""
     confidence: str = "medium"
     risk_flags: List[str] = Field(default_factory=list)
-
-
-class MemoryExtractionError(RuntimeError):
-    """A strict memory extraction failed before producing a valid batch."""
-
-    def __init__(self, extractor: str):
-        self.extractor = extractor
-        super().__init__(f"{extractor} failed before producing a valid extraction result")
 
 
 class MemoriesByTexts(BaseModel):

--- a/backend/utils/llm/working_observations.py
+++ b/backend/utils/llm/working_observations.py
@@ -10,7 +10,11 @@ from database.memory_non_active_routes import (
     NonActiveRouteOutcome,
     persist_non_active_route_outcome,
 )
-from models.memory_contracts import WorkingObservationArchiveItem, deterministic_contract_id
+from models.memory_contracts import (
+    WorkingObservationArchiveItem,
+    WorkingObservationExtractionError,
+    deterministic_contract_id,
+)
 from utils.llm.usage_tracker import Features, track_usage
 
 GetLlm = Callable[[str], object]
@@ -55,14 +59,6 @@ class WorkingObservationBatch(BaseModel):
 
 # Backward-compatible alias for callers/tests that still use the L1 name.
 L1MemoryArchiveItems = WorkingObservationBatch
-
-
-class WorkingObservationExtractionError(RuntimeError):
-    """A strict L1 extraction failed before producing a valid batch."""
-
-    def __init__(self, stage: str):
-        self.stage = stage
-        super().__init__(f"working observation extraction failed during {stage}")
 
 
 def _source_type_instructions(source_type: str, user_name: str) -> str:


### PR DESCRIPTION
Fixes #11777.

## Bug

Prod (`backend`) raises ~150 tracebacks/hour that end conversation finalization with a 500:

```
File "/app/routers/developer.py", line 1642, in _create_conversation_from_segments
File "/app/utils/conversations/process_conversation.py", line 1532, in _emit_derived_effects
File "/app/utils/conversations/process_conversation.py", line 904, in _extract_memories_canonical
File "/app/utils/llm/working_observations.py", line 270, in extract_l1_memory_archive_items_from_text
    raise WorkingObservationExtractionError("invoke") from exc
utils.llm.working_observations.WorkingObservationExtractionError: working observation extraction failed during invoke
```

The chained cause is `openai.APITimeoutError: Request timed out.`

## Root cause

`_extract_memories` runs inside `_emit_derived_effects` **ahead of** `_save_action_items`, `_update_goal_progress`, `create_audio_files_from_chunks` and the created webhook. One timed-out extractor call therefore also cost that conversation its action items, goal progress and audio files, and returned 500 to the caller (developer conversation intake, sync enrichment) for a conversation that was already durably written.

`strict=True` exists so a provider failure cannot be mistaken for "no memories" and submit the empty replacement that would retract the source's existing memories. Skipping the replacement is that whole protection; propagating the raise is what took finalization with it — the same collateral #11771 removed for ungrounded candidates, left in place on the provider-failure path.

## Fix

- Catch the typed extraction failure at both extractor call sites (transcript and external-integration text), skip the replacement, `record_fallback(... to_mode='replacement_skipped', reason='provider_5xx', outcome='degraded')`, and return a zero-count result so finalization completes. Prior memories are neither written nor retracted.
- Untyped exceptions keep propagating, so the existing fail-closed invariant (`test_universal_reextract_failure_preserves_existing_memories`) is unchanged.
- Both extraction-failure types move to `models.memory_contracts`, with `WorkingObservationExtractionError` under `MemoryExtractionError`. The extraction boundary's failure contract belongs with the contract module: callers must be able to catch it without importing the LLM provider stack, which `utils.llm.memories` cannot offer wherever that module is import-stubbed.

## Tested

- `BACKEND_UNIT_TEST_FILE_LIST` run of `tests/unit/test_memory_replace_policy.py` (18 passed), `tests/unit/test_process_conversation_usage_context.py` (32 passed) and `tests/unit/test_working_observations_extractor.py` (15 passed) via `backend/test.sh`.
- All three new tests fail on this branch with only `process_conversation.py` reverted to `a5c7455bb4`: the two `_extract_memories_canonical` tests raise the extraction error instead of returning, and `test_finalization_survives_an_unavailable_memory_extractor` propagates it out of `process_conversation` — i.e. they reproduce the prod 500.
- Full backend unit suite (868 files, the selector's requirement for a `models/` change) run locally with `backend/test.sh`.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 1827 -> 1859 | the fix adds one shared skip-the-replacement helper plus two guarded call sites in the function that owns canonical extraction; moving it out would split the canonical write path across files

Failure-Class: FC-recoverable-provider-failure-terminal

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

