### PR TITLE
fix(ci): stop re-enforcing the diff-scoped desktop changelog gate on the push lane (#11710)

### DIFF
--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Require desktop user-facing PRs to add an unreleased changelog fragment."""
+"""Require desktop user-facing PRs to add an unreleased changelog fragment.
+
+Lane semantics: the pull_request/local lanes enforce the diff-scoped rule (the
+no-changelog-needed label is visible there). On the post-merge push lane PR
+labels are invisible, so the rule was already enforced by the PR lane and is
+skipped; the release lane's tree-fragment contract still applies (#11710).
+"""
 
 from __future__ import annotations
 
@@ -125,6 +131,19 @@ def tree_has_unreleased_fragment(head_ref: str) -> bool:
     return bool(fragment_paths)
 
 
+def is_push_lane() -> bool:
+    """Whether this run is the post-merge push lane, where PR labels are invisible.
+
+    main is merge-protected, so every push is a merge whose pull_request lane
+    already gated the diff-scoped rule with full no-changelog-needed label
+    context. Re-running that rule here — where labels cannot be read — only
+    false-reds main (#11710: the first internal-only desktop PR after a release
+    consolidation empties unreleased/). The release lane keeps its own
+    tree-fragment contract via --accept-tree-fragments.
+    """
+    return os.getenv("GITHUB_EVENT_NAME") == "push"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", required=True, help="Base git ref, usually origin/main")
@@ -156,12 +175,25 @@ def main() -> int:
         print("No desktop changes require a changelog entry.")
         return 0
 
-    if has_new_unreleased_fragment(args.base, args.head):
+    if not is_push_lane() and has_new_unreleased_fragment(args.base, args.head):
         print("Desktop changelog fragment found.")
         return 0
 
+    # The release lane passes when the NEXT RELEASE has notes — a valid fragment
+    # already in the tree — regardless of which push landed it (#11373).
     if args.accept_tree_fragments and tree_has_unreleased_fragment(args.head):
         print("Release lane: unreleased changelog fragments already present in the tree.")
+        return 0
+
+    if is_push_lane() and not args.accept_tree_fragments:
+        # Hygiene double-enforcement: the pull_request lane already evaluated
+        # this diff with full no-changelog-needed label context, and main is
+        # merge-protected, so a label-blind re-run here can only false-red
+        # (#11710). The release lane above still asserts the tree contract.
+        print(
+            "Push lane: the pull_request lane already enforced the diff-scoped "
+            "changelog gate (PR labels are invisible here)."
+        )
         return 0
 
     print("FAIL: desktop changes require an unreleased changelog fragment.", file=sys.stderr)

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -11,6 +11,8 @@ on every platform.
 from __future__ import annotations
 
 import importlib.util
+import os
+import sys
 import tempfile
 import unittest
 import unittest.mock
@@ -125,6 +127,77 @@ class ChangelogRequirementTests(unittest.TestCase):
         with unittest.mock.patch.object(checker, "run_git", side_effect=fake_git):
             with self.assertRaises(SystemExit):
                 checker.tree_has_unreleased_fragment("HEAD")
+
+
+class PushLaneTests(unittest.TestCase):
+    """Regression coverage for #11710: the post-merge push lane reddened main.
+
+    On main pushes, GITHUB_EVENT_NAME == "push" and the merged PR's
+    no-changelog-needed label is invisible, so re-running the diff-scoped rule
+    is a blind evaluation that only false-reds (the first internal-only desktop
+    PR after a release consolidation empties unreleased/). The pull_request lane
+    already gated the diff with real label context, and the release lane keeps
+    its own tree-fragment contract.
+    """
+
+    def _git_runner(self, tree_fragment: str = "") -> object:
+        def fake_git(args: list[str]) -> str:
+            if args[0] == "diff" and "--name-status" in args:
+                return ""
+            if args[0] == "diff" and "--name-only" in args:
+                return "desktop/macos/Desktop/Sources/AppDelegate.swift\n"
+            if args[0] == "ls-tree":
+                return tree_fragment
+            if args[0] == "show":
+                return '{"change": "Fixed a thing"}'
+            raise AssertionError(f"unexpected git invocation: {args}")
+
+        return fake_git
+
+    def _run_main(self, *, event_name: str, accept_tree_fragments: bool) -> int:
+        env = {"GITHUB_EVENT_NAME": event_name}
+        if accept_tree_fragments:
+            env["DESKTOP_CHANGELOG_ACCEPT_TREE_FRAGMENTS"] = "1"
+        argv = [
+            ".github/scripts/check-desktop-changelog.py",
+            "--base",
+            "BASE",
+            "--head",
+            "HEAD",
+        ]
+        with (
+            unittest.mock.patch.object(sys, "argv", argv),
+            unittest.mock.patch.dict(os.environ, env),
+        ):
+            return checker.main()
+
+    def test_push_lane_skips_diff_scoped_rule_when_labels_are_invisible(self) -> None:
+        # Regression for #11710: a no-changelog-needed desktop-source PR merge
+        # reddened main on the Hygiene push lane because the label is invisible
+        # there. The pull_request lane already enforced the rule; the push run
+        # must pass even with no new fragment and no tree fragment.
+        with unittest.mock.patch.object(checker, "run_git", side_effect=self._git_runner()):
+            self.assertEqual(
+                self._run_main(event_name="push", accept_tree_fragments=False), 0
+            )
+
+    def test_push_lane_release_contract_still_requires_a_tree_fragment(self) -> None:
+        # The release lane (DESKTOP_CHANGELOG_ACCEPT_TREE_FRAGMENTS=1) must keep
+        # asserting the NEXT RELEASE has notes even on push: an empty
+        # unreleased/ dir still blocks the release proof (#11710).
+        with unittest.mock.patch.object(checker, "run_git", side_effect=self._git_runner()):
+            self.assertEqual(
+                self._run_main(event_name="push", accept_tree_fragments=True), 1
+            )
+
+    def test_pr_lane_still_enforces_the_diff_scoped_rule(self) -> None:
+        # The push-lane exemption must not leak into the pull_request lane: a
+        # user-facing desktop change without a fragment (or no-changelog-needed
+        # label) still fails there.
+        with unittest.mock.patch.object(checker, "run_git", side_effect=self._git_runner()):
+            self.assertEqual(
+                self._run_main(event_name="pull_request", accept_tree_fragments=False), 1
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix(ci): stop re-enforcing the diff-scoped desktop changelog gate on the push lane (#11710)

## Summary

`desktop-changelog-entry` (`.github/scripts/check-desktop-changelog.py`) also
ran on the post-merge push lane, where the merged PR's `no-changelog-needed`
label is invisible. A label-exempt desktop-source PR merge therefore reddened
main on the Hygiene push lane (`repo-checks.yml` step "Run deterministic check
manifest on main pushes") even though the pull_request lane had already
approved the diff with full label context. #11705 is the instance: flag-gated
production sources changed under
`desktop/macos/Desktop/Sources/ProactiveAssistants/Core/` that ship with the
application, so they cannot be exempted by path (the
`EXEMPT_DESKTOP_PATH_PREFIXES` approach #11040 used). The first internal-only
desktop PR after a release consolidation always trips it.

Implement the issue's option 2: `main` is merge-protected, so every push is a
merge the pull_request lane already gated; re-running the label-blind
diff-scoped rule on the push lane can only produce false reds.
`check-desktop-changelog.py` now detects `GITHUB_EVENT_NAME == "push"` and, on
that lane, skips the diff-scoped rule. The release lane is untouched: Release
Eligibility sets `DESKTOP_CHANGELOG_ACCEPT_TREE_FRAGMENTS`, and the tree
contract ("next release has notes", #11373) still binds — an empty
`unreleased/` dir still blocks the release proof.

## Verified (real #11705 merge push, base `ba973e1859d1` head `1d7de40b45`)

- Hygiene push lane (`GITHUB_EVENT_NAME=push`): before exit 1, after exit 0
- Release lane empty tree (`GITHUB_EVENT_NAME=push` + `DESKTOP_CHANGELOG_ACCEPT_TREE_FRAGMENTS=1`): exit 1 (contract preserved)
- Release lane tree with a fragment: exit 0
- PR lane without label (`GITHUB_EVENT_NAME=pull_request`): exit 1 (unchanged)

`.github/scripts/test_desktop_changelog.py` -> Ran 10 tests, OK (3 new
`PushLaneTests` regression cases). `make preflight` -> 11/11 pass.

## Caller audit

- `desktop-changelog-entry` manifest check (`run_checks.py`): PR lane and local
  preflight keep enforcing (label visible / `--skip` honored); push-lane runs on
  main now pass through the PR-lane decision.
- `desktop-swift-ci.yml` passes `--skip-changelog` on `pull_request`: unchanged.
- `.github/actions/release-eligibility` sets `DESKTOP_CHANGELOG_ACCEPT_TREE_FRAGMENTS=1`:
  tree-fragment contract still enforced on push.

## Invariant citations

None — no locked product-invariant path globs are touched
(`scripts/pr-preflight --suggest`).

## Test plan

- [x] `python3 .github/scripts/test_desktop_changelog.py` — 10 tests, OK
- [x] `make preflight` — 11 deterministic checks pass (with body)
- [x] Real-commit reproduction above

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

