### PR TITLE
fix(backend): restore the per-account knowledge-graph mutation gate

### DIFF
--- a/.github/failure-classes/FC-derived-state-gate-without-legacy-source-path.json
+++ b/.github/failure-classes/FC-derived-state-gate-without-legacy-source-path.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "id": "FC-derived-state-gate-without-legacy-source-path",
+  "violated_contract": "When a route is repointed from a legacy store to derived canonical state, every principal whose canonical state is not yet provisioned must keep a served path, on the read side and the mutation side alike. A gate that assumes the derived state exists for all principals denies the feature to every unprovisioned account, and the denial reaches the user as an error.",
+  "canonical_prevention": "Gate on a per-account probe of whether the derived state is actually established rather than on a deployment-wide constant, and keep the pre-migration source path served for accounts that fail that probe until a backfill provisions them. Prove both directions at the route boundary with a legacy-principal test.",
+  "canonical_prevention_artifact": [
+    "backend/routers/knowledge_graph.py",
+    "backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py",
+    "backend/tests/unit/test_knowledge_graph_legacy_fallback.py"
+  ],
+  "evidence_prs": [
+    11623,
+    11783
+  ],
+  "scope_hints": [
+    "backend/routers/knowledge_graph.py",
+    "backend/utils/memory/canonical_graph.py",
+    "backend/database/memory_apply_store.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -6,13 +6,18 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Callable, Optional, cast
 
 from database import knowledge_graph as kg_db
+from database._client import db as firestore_db
 from database.auth import get_user_name
 from utils.memory import canonical_graph as canonical_graph_service
+from utils.memory.memory_service import MemoryService
 from utils.executors import db_executor, llm_executor, run_blocking
 from utils.other import endpoints as auth
 from utils.subscription import is_trial_paywalled
 
 router = APIRouter()
+Payload = Dict[str, Any]
+MemoryPayloads = List[Payload]
+RebuildKnowledgeGraph = Callable[[str, MemoryPayloads, str], Payload]
 RateLimitFactory = Callable[[Any, str], Any]
 with_rate_limit: RateLimitFactory = cast(RateLimitFactory, getattr(auth, "with_rate_limit"))
 CANONICAL_GRAPH_MUTATION_CONFLICT = (
@@ -24,9 +29,38 @@ def _knowledge_graph_llm_module() -> Any:
     return sys.modules.get("utils.llm.knowledge_graph") or importlib.import_module("utils.llm.knowledge_graph")
 
 
-def _is_assertion_backed_graph_account(uid: str) -> bool:
-    """All authenticated accounts use assertion-backed graph semantics."""
+def _run_rebuild_knowledge_graph(uid: str, memories: MemoryPayloads, user_name: str) -> Payload:
+    rebuild_knowledge_graph = cast(
+        RebuildKnowledgeGraph, getattr(_knowledge_graph_llm_module(), "rebuild_knowledge_graph")
+    )
+    return rebuild_knowledge_graph(uid, memories, user_name)
+
+
+def _has_canonical_graph_state(uid: str) -> bool:
+    """Whether canonical graph state is actually established for this account.
+
+    Canonical graph reads are fenced on ``users/{uid}/memory_state/head``, which
+    only the canonical apply transaction writes. The convergence shipped no
+    backfill, so an account that has never committed through canonical apply has
+    no derived state at all.
+    """
+    try:
+        canonical_graph_service.get_canonical_knowledge_graph(uid, limit=1, cursor=None)
+    except canonical_graph_service.CanonicalGraphReadUnavailable:
+        return False
     return True
+
+
+def _is_assertion_backed_graph_account(uid: str) -> bool:
+    """Whether this account's graph is derived state owned by canonical apply.
+
+    This must stay a real per-account probe. Answering ``True`` unconditionally
+    protects derived state that does not exist and denies every account the
+    legacy rebuild/delete their graph still needs.
+    """
+    if _has_canonical_graph_state(uid):
+        return True
+    return kg_db.has_stored_memory_graph_assertions(uid, db_client=firestore_db)
 
 
 def _require_legacy_graph_mutation(uid: str) -> None:
@@ -186,12 +220,27 @@ def get_canonical_knowledge_graph(
     )
 
 
+def _rebuild_graph_task(uid: str, user_name: str) -> None:
+    if _is_assertion_backed_graph_account(uid):
+        return
+    memories: MemoryPayloads = [
+        {"id": memory.id, "content": memory.content}
+        for memory in MemoryService(db_client=firestore_db).read(uid, limit=500)
+        if not getattr(memory, "is_locked", False)
+    ]
+    _run_rebuild_knowledge_graph(uid, memories, user_name)
+
+
 @router.post('/v1/knowledge-graph/rebuild', tags=['knowledge_graph'], response_model=RebuildResponse)
 def rebuild_graph(
     background_tasks: BackgroundTasks,
     uid: str = Depends(with_rate_limit(auth.get_current_user_uid, "knowledge_graph:rebuild")),
 ):
     _require_legacy_graph_mutation(uid)
+    user_name = get_user_name(uid) or ""
+    kg_db.delete_knowledge_graph(uid)
+    background_tasks.add_task(_rebuild_graph_task, uid, user_name)
+    return RebuildResponse(status="rebuilding", nodes_count=0, edges_count=0)
 
 
 @router.post(
@@ -236,4 +285,6 @@ async def extract_knowledge_graph(
 
 @router.delete('/v1/knowledge-graph', tags=['knowledge_graph'], response_model=DeleteKnowledgeGraphResponse)
 def delete_knowledge_graph(uid: str = Depends(auth.get_current_user_uid)):
-    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=CANONICAL_GRAPH_MUTATION_CONFLICT)
+    _require_legacy_graph_mutation(uid)
+    kg_db.delete_knowledge_graph(uid)
+    return DeleteKnowledgeGraphResponse(status="deleted")

--- a/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
@@ -1,27 +1,171 @@
-"""Universal graph routes preserve assertion-backed derived-state ownership."""
+"""Graph mutation routes must gate on real per-account canonical state.
 
-from fastapi import BackgroundTasks, HTTPException
+`165c041a93` gated rebuild/delete on a per-account predicate: canonical state
+established, or stored memory-graph assertions. `5724a10084` replaced that body
+with an unconditional `return True`, so every account got
+
+    409 Canonical knowledge graph state is derived from canonical memories and
+    cannot be deleted or rebuilt directly.
+
+including accounts with no `memory_state/head` at all — canonical intake is
+fenced in production, and the convergence shipped no backfill, so there was no
+derived state to protect. Mobile rendered the 409 body straight to the screen.
+`fbb005c15b` restored the GET fallback; this suite covers the mutation side.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 
+from database import knowledge_graph as kg_db
 from routers import knowledge_graph as kg_router
+from utils.memory import canonical_graph as kg
+from utils.other import endpoints as auth
+
+UID = "uid-arbitrary-account"
 
 
-@pytest.mark.parametrize("uid", ["uid-former-cohort", "uid-arbitrary-account"])
-def test_graph_mutations_conflict_for_every_account_without_projection_mutation(uid):
-    background_tasks = BackgroundTasks()
-
-    with pytest.raises(HTTPException) as delete_error:
-        kg_router.delete_knowledge_graph(uid=uid)
-    with pytest.raises(HTTPException) as rebuild_error:
-        kg_router.rebuild_graph(background_tasks=background_tasks, uid=uid)
-
-    assert delete_error.value.status_code == 409
-    assert rebuild_error.value.status_code == 409
-    assert delete_error.value.detail == kg_router.CANONICAL_GRAPH_MUTATION_CONFLICT
-    assert rebuild_error.value.detail == kg_router.CANONICAL_GRAPH_MUTATION_CONFLICT
-    assert background_tasks.tasks == []
+class _Page:
+    nodes: List[Dict[str, Any]] = [{"id": "c1", "label": "Ada"}]
+    edges: List[Dict[str, Any]] = []
+    has_more = False
+    next_cursor = None
+    catalog_nodes: List[Dict[str, Any]] = []
 
 
-def test_all_accounts_use_assertion_backed_graph_semantics():
-    assert kg_router._is_assertion_backed_graph_account("uid-former-cohort") is True
-    assert kg_router._is_assertion_backed_graph_account("uid-arbitrary-account") is True
+def _canonical_unavailable(*_args: Any, **_kwargs: Any):
+    raise kg.CanonicalGraphReadUnavailable("missing_state_head")
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Rate limiting is not under test here and its counters leak across cases.
+    monkeypatch.setattr(auth, "_enforce_rate_limit", lambda *args, **kwargs: None)
+    app = FastAPI()
+    app.include_router(kg_router.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: UID
+    return TestClient(app)
+
+
+@pytest.fixture
+def deleted(monkeypatch):
+    """Record legacy graph deletions and keep them out of Firestore."""
+    calls: List[str] = []
+    monkeypatch.setattr(kg_db, "delete_knowledge_graph", lambda uid, **_kw: calls.append(uid))
+    monkeypatch.setattr(kg_router, "get_user_name", lambda uid: "Ada")
+    return calls
+
+
+def _legacy_principal(monkeypatch) -> None:
+    """No memory_state/head, no assertions — the unmigrated majority."""
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: False)
+
+
+def test_legacy_principal_can_rebuild(client, monkeypatch, deleted):
+    _legacy_principal(monkeypatch)
+    scheduled: List[Any] = []
+    # TestClient runs background tasks inline; the task itself has its own tests.
+    monkeypatch.setattr(kg_router, "_rebuild_graph_task", lambda uid, user_name: scheduled.append((uid, user_name)))
+
+    response = client.post("/v1/knowledge-graph/rebuild")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "rebuilding"
+    assert deleted == [UID]
+    assert scheduled == [(UID, "Ada")]
+
+
+def test_legacy_principal_can_delete(client, monkeypatch, deleted):
+    _legacy_principal(monkeypatch)
+
+    response = client.delete("/v1/knowledge-graph")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "deleted"
+    assert deleted == [UID]
+
+
+def test_established_canonical_state_still_conflicts(client, monkeypatch, deleted):
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", lambda *a, **k: _Page())
+
+    rebuild = client.post("/v1/knowledge-graph/rebuild")
+    delete = client.delete("/v1/knowledge-graph")
+
+    assert rebuild.status_code == 409
+    assert delete.status_code == 409
+    assert rebuild.json()["detail"] == kg_router.CANONICAL_GRAPH_MUTATION_CONFLICT
+    assert delete.json()["detail"] == kg_router.CANONICAL_GRAPH_MUTATION_CONFLICT
+    assert deleted == []
+
+
+def test_stored_assertions_still_conflict_without_a_state_head(client, monkeypatch, deleted):
+    # Assertion-backed graphs are derived state even when the canonical read
+    # cannot serve them; they must not be rebuilt or deleted through here.
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: True)
+
+    rebuild = client.post("/v1/knowledge-graph/rebuild")
+    delete = client.delete("/v1/knowledge-graph")
+
+    assert rebuild.status_code == 409
+    assert delete.status_code == 409
+    assert deleted == []
+
+
+def test_predicate_is_per_account_not_a_constant(monkeypatch):
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    monkeypatch.setattr(
+        kg_db,
+        "has_stored_memory_graph_assertions",
+        lambda uid, **_kw: uid == "uid-assertion-backed",
+    )
+
+    assert kg_router._is_assertion_backed_graph_account("uid-assertion-backed") is True
+    assert kg_router._is_assertion_backed_graph_account("uid-arbitrary-account") is False
+
+
+def test_rebuild_task_feeds_unlocked_memories_to_the_legacy_rebuild(monkeypatch):
+    _legacy_principal(monkeypatch)
+
+    class _Memory:
+        def __init__(self, memory_id: str, content: str, is_locked: bool = False):
+            self.id = memory_id
+            self.content = content
+            self.is_locked = is_locked
+
+    class _Service:
+        def __init__(self, **_kwargs: Any):
+            pass
+
+        def read(self, uid: str, **_kwargs: Any):
+            return [_Memory("m1", "one"), _Memory("m2", "locked", is_locked=True)]
+
+    captured: Dict[str, Any] = {}
+    monkeypatch.setattr(kg_router, "MemoryService", _Service)
+    monkeypatch.setattr(
+        kg_router,
+        "_run_rebuild_knowledge_graph",
+        lambda uid, memories, user_name: captured.update(uid=uid, memories=memories, user_name=user_name),
+    )
+
+    kg_router._rebuild_graph_task(UID, "Ada")
+
+    assert captured["memories"] == [{"id": "m1", "content": "one"}]
+    assert captured["user_name"] == "Ada"
+
+
+def test_rebuild_task_is_a_noop_for_an_assertion_backed_account(monkeypatch):
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: True)
+
+    def _must_not_run(*_args: Any, **_kwargs: Any):  # pragma: no cover - asserts absence
+        raise AssertionError("legacy rebuild ran for an assertion-backed account")
+
+    monkeypatch.setattr(kg_router, "_run_rebuild_knowledge_graph", _must_not_run)
+
+    kg_router._rebuild_graph_task(UID, "Ada")


### PR DESCRIPTION
## Problem

Every mobile user who opens the knowledge-graph page and taps rebuild gets the raw backend error rendered to their screen:

```
Exception: Failed to rebuild knowledge graph:
{"detail":"Canonical knowledge graph state is derived from canonical memories and cannot be deleted or rebuilt directly."}
```

`165c041a93` (2026-07-28) introduced the 409 on `POST /v1/knowledge-graph/rebuild` and `DELETE /v1/knowledge-graph` behind a **real per-account predicate**:

```python
def _is_assertion_backed_graph_account(uid: str) -> bool:
    if pin_memory_system(uid, db_client=firestore_db) == MemorySystem.CANONICAL:
        return True
    return kg_db.has_stored_memory_graph_assertions(uid, db_client=firestore_db)
```

`5724a10084` (2026-08-11, "converge universal memory and task authority") replaced that whole body with an unconditional `return True`. A correct per-account gate became a global one, so `_require_legacy_graph_mutation()` 409s **every** account — including accounts that have no canonical graph and therefore no derived state to protect.

Those accounts have no canonical graph because the canonical read is fenced on `users/{uid}/memory_state/head` (`backend/utils/memory/canonical_graph.py`), and that doc is written only inside the canonical apply transaction (`backend/database/memory_apply_store.py`). The convergence deliberately shipped no backfill. Memories survive this because their read path unions canonical + historical (`backend/utils/memory/memory_service.py`); the graph got the fence without the union.

This is the mutation half of #11623, which restored the same repoint's **read** half (GET falls back to the legacy graph on `CanonicalGraphReadUnavailable`). #11623 did not touch rebuild or delete.

## Fix

Repair the one predicate, which fixes rebuild and delete together rather than patching route by route (AGENTS.md: "Repair the Failure-Class Boundary"):

- `_is_assertion_backed_graph_account()` is a real per-account probe again: canonical graph state established (the canonical read succeeds for that uid), or stored memory-graph assertions present. `pin_memory_system` no longer exists after the convergence and is banned from public memory surfaces by `test_universal_memory_route_surfaces.py`, so establishment is probed through the canonical graph service itself instead of re-deriving the head fence in the router.
- `POST /v1/knowledge-graph/rebuild` performs the legacy delete + background rebuild again for accounts with no canonical state; the background task sources memories through `MemoryService.read`, whose read already unions canonical and historical memories.
- `DELETE /v1/knowledge-graph` performs the legacy delete again for those accounts.
- When canonical state **is** established (or assertions are stored), both routes keep the 409 and the existing message, unchanged. That behaviour is intended: derived state must not be mutated directly.

Style follows #11623: fall back to the legacy store when canonical is genuinely unavailable for that account; `/v1/knowledge-graph/canonical` still reports 503 because that caller asked for canonical specifically.

## Tests

`backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py` previously asserted the broken behaviour (409 for `"uid-arbitrary-account"`, and `_is_assertion_backed_graph_account(...) is True` for any uid). That was a static tripwire pinning the constant, not coverage of a contract, so it is corrected rather than kept. The suite is now behavioural, driven through the FastAPI route boundary with `TestClient`:

- **legacy-principal test** (AGENTS.md: "New fail-closed gates ship with a legacy-principal test"): no `memory_state/head`, no assertions → rebuild returns 200 `rebuilding` and schedules the rebuild task, delete returns 200 `deleted`, both after the legacy delete ran.
- converse: canonical read available → both routes 409 with `CANONICAL_GRAPH_MUTATION_CONFLICT` and no legacy mutation.
- stored assertions with no state head → still 409.
- the predicate answers differently for two different uids (it cannot be a constant again).
- the rebuild task filters locked memories and feeds the legacy rebuild; it is a no-op for an assertion-backed account.

## Verification

All commands run from `backend/` on this branch, `.venv` interpreter (Python 3.11).

```
python -m pytest tests/unit/test_knowledge_graph_canonical_mutation_routes.py -q
  -> 7 passed

git stash push -- routers/knowledge_graph.py   # revert the fix, keep the tests
python -m pytest tests/unit/test_knowledge_graph_canonical_mutation_routes.py -q
  -> 5 failed, 2 passed
     (legacy rebuild, legacy delete, per-account predicate, and both rebuild-task
      cases fail without the fix — the regression proof)
git stash pop

python -m pytest \
  tests/unit/test_knowledge_graph_canonical_mutation_routes.py \
  tests/unit/test_knowledge_graph_legacy_fallback.py \
  tests/unit/test_knowledge_graph_canonical_pagination.py \
  tests/unit/test_knowledge_graph_extract_helper.py \
  tests/unit/test_knowledge_graph_extract_route.py \
  tests/unit/test_memory_graph_assertion_read.py \
  tests/unit/test_historical_graph_enrichment.py \
  tests/unit/test_universal_memory_route_surfaces.py \
  tests/unit/test_universal_memory_task_authority.py \
  tests/unit/test_rate_limiting.py -q
  -> 162 passed, 1 skipped

python scripts/check_module_stub_pollution.py
  -> Checked 918 backend test file(s); 0 violation(s).

black --line-length 120 --skip-string-normalization routers/knowledge_graph.py \
  tests/unit/test_knowledge_graph_canonical_mutation_routes.py
  -> 2 files left unchanged

make preflight  (OMI_PR_BODY_FILE set to this body)
  -> see below
```

`test_universal_memory_route_surfaces.py` and `test_universal_memory_task_authority.py` are included deliberately: they are the ratchets that forbid `pin_memory_system` and direct historical-store imports in this router, and they constrain how the predicate could be rebuilt.

**Not verified:** the change was not exercised against a live backend or a Firestore emulator. Verification is route-boundary tests with the canonical graph service and `kg_db` stubbed; the Firestore reads themselves (`has_stored_memory_graph_assertions`, `kg_db.delete_knowledge_graph`, `MemoryService.read`) are pre-existing calls restored verbatim from `165c041a93`/the convergence and are not re-proved here. No mobile client was run against this branch.

## Failure class

Failure-Class: new

`FC-derived-state-gate-without-legacy-source-path` — when a route is repointed from a legacy store to derived canonical state, every principal whose canonical state is not yet provisioned must keep a served path, on the read side and the mutation side alike.

Why a new class and not an existing one:

- This is the **second** instance of the same cause in three weeks. #11623 repaired the read side of the very repoint whose mutation side this PR repairs. AGENTS.md: "If two or more recent fixes share the cause, add a reusable guard surface in the same PR." The reusable guard is the legacy-principal route-boundary suite named in `canonical_prevention_artifact`, alongside #11623's read-side suite.
- Near neighbours considered and rejected: `FC-gate-principal-outside-consolidated-entitlement` (about synthetic gate/CI principals dropped from a consolidated entitlement set, not about derived state that was never provisioned for real users); `FC-unestablished-capability-default` (a client rendering a not-yet-established capability's default value, not a server route denying on unprovisioned state); `FC-ship-before-required-route` (a client shipping ahead of a route's existence — the route exists here); `FC-denial-rendered-as-empty-success` (the opposite failure mode: this bug renders the denial loudly rather than hiding it as empty success); `FC-split-mutation-authority` (mutation authority is correctly single-owner here; the defect is that the gate protecting it has no per-account basis).

## Out of scope (follow-ups)

- **Mobile renders any non-200 as an empty memories list** — `app/lib/backend/http/api/memories.dart` returns `[]` for any non-200, and `backend/routers/memories.py` has a circular 503 fallback. Separate bug, separate PR.
- **Migrating clients off the rebuild endpoint** — Flutter `memory_graph_page.dart` and `onboarding/wrapper.dart`, macOS `MemoryGraphPage.swift`, Windows. Follow-up; this PR keeps the endpoint working for them.
- **Config split-brain** — GKE `backend-listen` runs `MEMORY_ENABLED=off` while Cloud Run `backend` runs `MEMORY_ENABLED=on`. Not touched here.

Per AGENTS.md: "Do not broaden a safe bug-fix PR into an unreviewable migration."


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

