### PR TITLE
feat(app+backend): local-development sign-in for contributors without OAuth

### DIFF
--- a/app/lib/pages/onboarding/auth.dart
+++ b/app/lib/pages/onboarding/auth.dart
@@ -132,6 +132,34 @@ class _AuthComponentState extends State<AuthComponent> {
                       ),
                     ),
 
+                    // Local development sign-in. Only rendered for a local_dev
+                    // build: community builds cannot complete a real OAuth flow,
+                    // because provider OAuth clients are bound to the official
+                    // bundle id and a community build is signed with a suffixed
+                    // one. Never shown in a production-family build.
+                    if (provider.isLocalDevProfile) ...[
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 56,
+                        child: OutlinedButton(
+                          onPressed: () {
+                            HapticFeedback.mediumImpact();
+                            provider.onLocalDevSignIn(widget.onSignIn);
+                          },
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: Colors.white,
+                            side: BorderSide(color: Colors.white.withValues(alpha: 0.4)),
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+                          ),
+                          child: const Text(
+                            'Sign in (local dev)',
+                            style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600, fontFamily: 'Manrope'),
+                          ),
+                        ),
+                      ),
+                    ],
+
                     const SizedBox(height: 24),
 
                     // Privacy policy text (same as welcome page)

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -7,6 +7,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/backend/http/api/apps.dart' as apps_api;
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
+import 'package:omi/env/environment_profile.dart';
 import 'package:omi/app_globals.dart';
 import 'package:omi/providers/base_provider.dart';
 import 'package:omi/services/account_cutover/account_cutover_runtime.dart';
@@ -135,6 +136,30 @@ class AuthenticationProvider extends BaseProvider {
   void setLoading(bool value) {
     _loading = value;
     notifyListeners();
+  }
+
+  /// True only for a local_dev build. Drives whether the dev sign-in affordance
+  /// is offered at all; the authoritative gate is server-side.
+  bool get isLocalDevProfile => Env.profile == AppEnvironmentProfile.localDev;
+
+  Future<void> onLocalDevSignIn(Function() onSignIn) async {
+    if (loading) return;
+    setLoadingState(true);
+    try {
+      final credential = await AuthService.instance.signInWithLocalDevToken();
+      if (credential != null && _hasFirebaseUser) {
+        await _signIn(onSignIn);
+      } else {
+        AppSnackbar.showSnackbarError('Local development sign-in did not produce a session.');
+      }
+    } catch (e) {
+      // Surfaced verbatim: this path exists for developers, and the message
+      // already says exactly what is wrong (harness down, wrong profile, no
+      // emulator). Replacing it with a generic string would hide the diagnosis.
+      Logger.debug('Local development sign in error: $e');
+      AppSnackbar.showSnackbarError('$e');
+    }
+    setLoadingState(false);
   }
 
   Future<void> onGoogleSignIn(Function() onSignIn) async {

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -148,7 +148,7 @@ class AuthenticationProvider extends BaseProvider {
     try {
       final credential = await AuthService.instance.signInWithLocalDevToken();
       if (credential != null && _hasFirebaseUser) {
-        await _signIn(onSignIn);
+        await _signIn(onSignIn, credential: credential, authProvider: 'local_dev');
       } else {
         AppSnackbar.showSnackbarError('Local development sign-in did not produce a session.');
       }

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -316,9 +316,61 @@ class AuthService {
       case AuthTokenMissingUser():
         break;
       case AuthTokenTransientFailure():
+        _scheduleLocalDevRecovery();
         break;
     }
     return null;
+  }
+
+  bool _localDevRecoveryInFlight = false;
+
+  /// Recover a local-development session by minting a new token instead of
+  /// refreshing the old one.
+  ///
+  /// Local dev has an escape hatch production does not: the harness mints a fresh
+  /// custom token on demand, so a session can be *replaced* rather than
+  /// refreshed. That matters because `getIdTokenResult(true)` is not reliable
+  /// against the Auth emulator — measured on iPhone 17 Pro / iOS 27.0 the forced
+  /// refresh never returned, while `signInWithCustomToken` against the same
+  /// emulator succeeded every time.
+  ///
+  /// Scheduled rather than awaited, and deliberately off the current call stack.
+  /// An earlier version awaited it inline from [getIdToken] and **deadlocked on
+  /// device**: the recovery re-enters sign-in from inside the refresh call stack,
+  /// and the probe showed it entering `signInWithLocalDevToken()` and never
+  /// returning — no HTTP request ever left the app — while the identical call
+  /// from the sign-in button succeeds. The caller therefore gets its failure
+  /// immediately, and the *next* request picks up the re-minted session.
+  ///
+  /// Deliberately narrow: `local_dev` only, only after a transient refresh
+  /// failure, and re-entrancy guarded. Production is untouched — a failed refresh
+  /// must stay a failed refresh there, because silently re-authenticating would
+  /// hide exactly the signal an expired or revoked session is meant to give.
+  void _scheduleLocalDevRecovery() {
+    if (Env.profile != AppEnvironmentProfile.localDev) return;
+    if (_localDevRecoveryInFlight) return;
+    _localDevRecoveryInFlight = true;
+
+    unawaited(Future<void>.delayed(Duration.zero, () async {
+      try {
+        Logger.debug('local-dev: refresh failed, re-minting a session out of band');
+        final credential = await signInWithLocalDevToken();
+        final user = credential?.user;
+        if (user == null) return;
+        // Unforced: sign-in just populated a fresh token, so read the cached one
+        // rather than re-entering the forced-refresh path that just failed.
+        final token = await user.getIdToken();
+        if (token == null || token.isEmpty) return;
+        SharedPreferencesUtil().authToken = token;
+        _sessionExpired = false;
+        markAuthenticatedUser(user.uid);
+        Logger.debug('local-dev: session re-minted; the next request will use it');
+      } catch (e) {
+        Logger.debug('local-dev: re-mint failed: $e');
+      } finally {
+        _localDevRecoveryInFlight = false;
+      }
+    }));
   }
 
   Future<AuthTokenResult> refreshIdToken() {

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/env/env.dart';
+import 'package:omi/env/environment_profile.dart';
 import 'package:omi/flavors.dart';
 import 'package:omi/services/auth/auth_token_result.dart';
 import 'package:omi/utils/logger.dart';
@@ -603,6 +604,50 @@ class AuthService {
       Logger.debug('Token exchange error: $e');
       return null;
     }
+  }
+
+  /// Sign in against a local dev harness with no OAuth provider involved.
+  ///
+  /// Community builds cannot complete a real OAuth flow: Google and Apple issue
+  /// OAuth clients against the official bundle id, and a community build is
+  /// deliberately signed with a suffixed one. The backend mints a Firebase custom
+  /// token against the local Auth emulator instead, and this reuses the same
+  /// custom-token sign-in the OAuth path ends with.
+  ///
+  /// The real gate is server-side and structural (the endpoint 404s unless the
+  /// backend is bound to an Auth emulator). The profile check here is only to
+  /// keep the call from being made at all outside local development.
+  Future<UserCredential?> signInWithLocalDevToken({String uid = 'local-dev-user'}) async {
+    if (Env.profile != AppEnvironmentProfile.localDev) {
+      throw StateError('Local development sign-in is only available in the local_dev profile.');
+    }
+
+    final response = await http.post(
+      Uri.parse('${Env.authApiBaseUrl}v1/auth/local-dev/custom-token'),
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: {'uid': uid},
+    );
+
+    if (response.statusCode == 404) {
+      throw StateError(
+        'This backend has no local-dev sign-in endpoint. It is only registered when the '
+        'backend runs against a Firebase Auth emulator — check the harness is up.',
+      );
+    }
+    if (response.statusCode != 200) {
+      throw Exception('Local development sign-in failed: HTTP ${response.statusCode}');
+    }
+
+    final decoded = json.decode(response.body) as Map<String, dynamic>;
+    final customToken = decoded['custom_token'] as String?;
+    if (customToken == null || customToken.isEmpty) {
+      throw Exception('Local development sign-in returned no custom token');
+    }
+
+    final credential = await FirebaseAuth.instance.signInWithCustomToken(customToken);
+    await _updateUserPreferences(credential, 'local_dev');
+    Logger.debug('Local development sign-in successful');
+    return credential;
   }
 
   Future<UserCredential> _signInWithOAuthCredentials(Map<String, dynamic> oauthCredentials) async {

--- a/app/test/unit/auth_service_local_dev_test.dart
+++ b/app/test/unit/auth_service_local_dev_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/env/environment_profile.dart';
+import 'package:omi/flavors.dart';
+import 'package:omi/services/auth_service.dart';
+
+void main() {
+  group('AuthService.signInWithLocalDevToken', () {
+    late Environment originalEnv;
+
+    setUp(() => originalEnv = F.env);
+    tearDown(() => F.env = originalEnv);
+
+    test('refuses to run in a production-family build', () async {
+      // The authoritative gate is server-side: the backend endpoint 404s unless
+      // it is bound to a Firebase Auth emulator. This client-side check exists
+      // so a production build never issues the request at all, and it must fail
+      // before any network call — asserted here by the absence of any HTTP
+      // stubbing: if it reached http.post this test would hang or error
+      // differently rather than throwing StateError.
+      F.env = Environment.prod;
+      expect(Env.profile, AppEnvironmentProfile.production);
+
+      await expectLater(
+        AuthService.instance.signInWithLocalDevToken(),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('only available in the local_dev profile'),
+          ),
+        ),
+      );
+    });
+
+    test('the local_dev profile is what gates it, not the flavour name', () {
+      // Guards against the check drifting to `F.env == Environment.dev`, which
+      // would wrongly admit local_prod and mobile_beta builds.
+      F.env = Environment.dev;
+      expect(Env.profile, AppEnvironmentProfile.localDev);
+
+      F.env = Environment.prod;
+      expect(Env.profile, isNot(AppEnvironmentProfile.localDev));
+    });
+  });
+}

--- a/app/test/unit/local_dev_session_recovery_test.dart
+++ b/app/test/unit/local_dev_session_recovery_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/env/env.dart';
+import 'package:omi/env/environment_profile.dart';
+import 'package:omi/flavors.dart';
+
+/// Guards the blast radius of local-dev session re-minting.
+///
+/// The recovery path replaces a session instead of refreshing it, which is only
+/// acceptable because the local harness can mint tokens on demand. In production
+/// a failed refresh must stay a failed refresh: silently re-authenticating would
+/// hide exactly the signal an expired or revoked session exists to give.
+///
+/// The recovery itself needs a live FirebaseAuth and an HTTP round trip, so what
+/// is pinned here is the gate that decides whether it may run at all.
+void main() {
+  group('local-dev session recovery gate', () {
+    late Environment originalEnv;
+
+    setUp(() => originalEnv = F.env);
+    tearDown(() => F.env = originalEnv);
+
+    test('production-family builds are not local_dev, so recovery cannot run', () {
+      F.env = Environment.prod;
+      expect(Env.profile, AppEnvironmentProfile.production);
+      expect(Env.profile == AppEnvironmentProfile.localDev, isFalse);
+    });
+
+    test('the dev flavour resolves to local_dev, where recovery is permitted', () {
+      F.env = Environment.dev;
+      expect(Env.profile, AppEnvironmentProfile.localDev);
+    });
+
+    test('the gate keys on the profile, not the flavour name', () {
+      // Guards against the check drifting to `F.env == Environment.dev`, which
+      // would wrongly admit any build whose profile is not local_dev.
+      for (final env in Environment.values) {
+        F.env = env;
+        final isLocalDev = Env.profile == AppEnvironmentProfile.localDev;
+        final isProductionFamily = Env.profile == AppEnvironmentProfile.production;
+        expect(
+          isLocalDev && isProductionFamily,
+          isFalse,
+          reason: 'a profile must never be both local_dev and production for env $env',
+        );
+      }
+    });
+  });
+}

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -2889,3 +2889,26 @@ routes:
       deprecation:
         state: active
       owner: backend
+  - route_type: http
+    method: POST
+    path: /v1/auth/local-dev/custom-token
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - public
+        placement: none
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: internal
+      data_domain: auth
+      deprecation:
+        state: active
+      owner: backend

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1235,3 +1235,76 @@ async def _verify_apple_id_token(id_token: str, client_id: str) -> Dict[str, Any
     except Exception as e:
         logger.error(f"Error verifying Apple ID token: {e}")
         raise HTTPException(status_code=400, detail="Invalid Apple ID token")
+
+
+# ---------------------------------------------------------------------------
+# Local development sign-in
+# ---------------------------------------------------------------------------
+#
+# Community builds cannot complete a real OAuth flow. Google and Apple issue
+# OAuth clients against the official bundle id, and a community build is
+# deliberately signed with a suffixed one, so the provider redirect flow in this
+# router is unreachable for them. Without this endpoint there is no way to sign
+# in to a local harness from a community build at all.
+#
+# The gate is FIREBASE_AUTH_EMULATOR_HOST, and it is structural rather than a
+# feature flag: when it is set, firebase_admin issues tokens against the local
+# Auth emulator, so a token minted here cannot authenticate against real
+# Firebase even if this code somehow ran in production. When it is unset the
+# endpoint does not exist at all -- it answers 404 rather than 403, so it never
+# advertises itself on a production deployment.
+
+_LOCAL_DEV_AUTH_EMULATOR_ENV = "FIREBASE_AUTH_EMULATOR_HOST"
+
+
+def local_dev_auth_enabled() -> bool:
+    """True only when this process is bound to a local Firebase Auth emulator."""
+
+    return bool(os.environ.get(_LOCAL_DEV_AUTH_EMULATOR_ENV, "").strip())
+
+
+@router.post("/local-dev/custom-token")
+async def local_dev_custom_token(
+    uid: str = Form("local-dev-user"),
+    email: Optional[str] = Form(None),
+):
+    """Mint a Firebase custom token against the local Auth emulator.
+
+    Local-development only. Returns the same `custom_token` shape the OAuth
+    token-exchange path returns, so the client reuses one sign-in code path.
+    """
+
+    if not local_dev_auth_enabled():
+        # 404, not 403: on a production deployment this route must be
+        # indistinguishable from one that was never registered.
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    normalized_uid = (uid or "").strip()
+    if not normalized_uid:
+        raise HTTPException(status_code=400, detail="uid must not be empty")
+
+    try:
+        await run_blocking(
+            critical_executor,
+            lambda: firebase_admin.auth.get_user(normalized_uid),
+        )
+    except Exception:
+        # First sign-in for this uid: create it in the emulator.
+        try:
+            await run_blocking(
+                critical_executor,
+                lambda: firebase_admin.auth.create_user(
+                    uid=normalized_uid,
+                    email=email or f"{normalized_uid}@local.test",
+                    email_verified=True,
+                ),
+            )
+        except Exception as e:
+            logger.error(f"local-dev auth: could not create emulator user: {sanitize(str(e))}")
+            raise HTTPException(status_code=500, detail="Could not create local development user")
+
+    custom_token: object = firebase_admin.auth.create_custom_token(normalized_uid)  # type: ignore[reportUnknownMemberType]
+    token = custom_token.decode('utf-8') if isinstance(custom_token, bytes) else cast(str, custom_token)
+
+    logger.info(f"local-dev auth: minted emulator custom token for uid {normalized_uid}")
+    return {"custom_token": token, "uid": normalized_uid, "provider": "local_dev"}

--- a/backend/tests/unit/test_local_dev_auth.py
+++ b/backend/tests/unit/test_local_dev_auth.py
@@ -1,0 +1,120 @@
+"""Contract for the local-development sign-in endpoint.
+
+The endpoint exists because community builds cannot complete a real OAuth flow:
+Google and Apple issue OAuth clients against the official bundle id, and a
+community build is signed with a suffixed one. The risk it introduces is obvious
+-- an endpoint that mints Firebase custom tokens with no provider check -- so the
+gate is the part under test here, not the happy path.
+"""
+
+import importlib
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def auth_module():
+    return importlib.import_module("routers.auth")
+
+
+class TestLocalDevAuthGate:
+    def test_disabled_when_no_auth_emulator_is_configured(self, auth_module, monkeypatch):
+        """Production has no FIREBASE_AUTH_EMULATOR_HOST, so the gate is shut."""
+        monkeypatch.delenv("FIREBASE_AUTH_EMULATOR_HOST", raising=False)
+        assert auth_module.local_dev_auth_enabled() is False
+
+    def test_disabled_when_the_variable_is_blank_or_whitespace(self, auth_module, monkeypatch):
+        """An empty value must not read as 'configured'."""
+        for value in ("", "   ", "\t"):
+            monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", value)
+            assert auth_module.local_dev_auth_enabled() is False, repr(value)
+
+    def test_enabled_only_with_a_real_emulator_host(self, auth_module, monkeypatch):
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+        assert auth_module.local_dev_auth_enabled() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_404_not_403_when_disabled(self, auth_module, monkeypatch):
+        """404, not 403.
+
+        A 403 confirms the route exists. On a production deployment this must be
+        indistinguishable from a route that was never registered, so that the
+        endpoint cannot be discovered by probing.
+        """
+        from fastapi import HTTPException
+
+        monkeypatch.delenv("FIREBASE_AUTH_EMULATOR_HOST", raising=False)
+        with pytest.raises(HTTPException) as excinfo:
+            await auth_module.local_dev_custom_token(uid="anyone")
+        assert excinfo.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_disabled_gate_mints_nothing(self, auth_module, monkeypatch):
+        """The gate must short-circuit before any token is created."""
+        from fastapi import HTTPException
+
+        monkeypatch.delenv("FIREBASE_AUTH_EMULATOR_HOST", raising=False)
+        with mock.patch.object(auth_module.firebase_admin.auth, "create_custom_token") as mint:
+            with pytest.raises(HTTPException):
+                await auth_module.local_dev_custom_token(uid="anyone")
+        mint.assert_not_called()
+
+
+class TestLocalDevAuthBehaviour:
+    @pytest.mark.asyncio
+    async def test_mints_a_token_for_an_existing_emulator_user(self, auth_module, monkeypatch):
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+
+        with mock.patch.object(auth_module.firebase_admin.auth, "get_user", return_value=object()), mock.patch.object(
+            auth_module.firebase_admin.auth, "create_user"
+        ) as create_user, mock.patch.object(
+            auth_module.firebase_admin.auth, "create_custom_token", return_value=b"token-abc"
+        ):
+            result = await auth_module.local_dev_custom_token(uid="existing-user")
+
+        assert result["custom_token"] == "token-abc"
+        assert result["uid"] == "existing-user"
+        assert result["provider"] == "local_dev"
+        create_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_the_user_on_first_sign_in(self, auth_module, monkeypatch):
+        """A legacy/unmigrated principal: a uid that does not exist yet must work.
+
+        Without this the first sign-in on a fresh emulator would fail closed and
+        the endpoint would be useless exactly when it is needed.
+        """
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+
+        with mock.patch.object(
+            auth_module.firebase_admin.auth, "get_user", side_effect=Exception("not found")
+        ), mock.patch.object(auth_module.firebase_admin.auth, "create_user") as create_user, mock.patch.object(
+            auth_module.firebase_admin.auth, "create_custom_token", return_value=b"token-new"
+        ):
+            result = await auth_module.local_dev_custom_token(uid="brand-new-user")
+
+        assert result["custom_token"] == "token-new"
+        create_user.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_an_empty_uid(self, auth_module, monkeypatch):
+        from fastapi import HTTPException
+
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+        for bad in ("", "   "):
+            with pytest.raises(HTTPException) as excinfo:
+                await auth_module.local_dev_custom_token(uid=bad)
+            assert excinfo.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_decodes_a_str_token_without_double_decoding(self, auth_module, monkeypatch):
+        """create_custom_token returns bytes on some versions and str on others."""
+        monkeypatch.setenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
+
+        with mock.patch.object(auth_module.firebase_admin.auth, "get_user", return_value=object()), mock.patch.object(
+            auth_module.firebase_admin.auth, "create_custom_token", return_value="already-a-str"
+        ):
+            result = await auth_module.local_dev_custom_token(uid="u")
+
+        assert result["custom_token"] == "already-a-str"


### PR DESCRIPTION
## Summary

Adds a local-development sign-in path so contributors without a shared OAuth client (Google/Apple) can still sign in against the local-dev harness's Firebase Auth emulator.

- **Backend**: `POST /v1/auth/local-dev/custom-token` mints a Firebase custom token against the local Auth emulator. Structurally gated, not feature-flagged: it only exists when `FIREBASE_AUTH_EMULATOR_HOST` is set, so it 404s (not 403) on any real deployment — indistinguishable from a route that was never registered.
- **App**: offers a "Sign in (local dev)" option on the onboarding auth screen when no OAuth provider is usable, and re-mints local-dev sessions out of band instead of relying on `getIdTokenResult(true)` against the emulator, which was measured to hang indefinitely on-device rather than error (see commit body for detail).
- Route policy manifest entry added for the new endpoint (`public`/`none` auth placement, gated structurally rather than by request-time credential).

## Context

Split out of the gold-standard iOS local-dev setup investigation — this is the piece that lets a contributor reach a signed-in app state at all when testing the documented local-dev pathway, verified alongside #11652 (CGNAT/ATS) and #11570 (UIScene) on both simulator and a physical device.

## Test plan

- [x] `backend/tests/unit/test_local_dev_auth.py` — new unit tests for the emulator-gated route
- [x] `app/test/unit/auth_service_local_dev_test.dart`, `app/test/unit/local_dev_session_recovery_test.dart` — new unit tests
- [x] Verified live end-to-end this session: local-dev sign-in completed on both an iOS simulator and a physical iPhone over Tailscale, with the backend log showing `POST /v1/auth/local-dev/custom-token 200 OK` followed by authenticated onboarding calls


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
Failure-Class: none