### PR TITLE
fix(backend): skip the empty replacement when strict memory extraction hits a provider failure (#11777)

### DIFF
--- a/backend/tests/unit/test_memory_replace_policy.py
+++ b/backend/tests/unit/test_memory_replace_policy.py
@@ -135,6 +135,98 @@ def test_universal_reextract_failure_preserves_existing_memories(monkeypatch):
     mock_service.replace_conversation_memories.assert_not_called()
 
 
+def test_universal_reextract_typed_failure_skips_replacement_and_finalizes(monkeypatch):
+    """A strict working-observation failure is not 'valid empty': skip the replacement (do not retract existing memories) and still finalize instead of raising."""
+    pc = _load_process_conversation()
+    from models.conversation import Conversation
+    from models.conversation_enums import CategoryEnum, ConversationSource
+    from models.structured import Structured
+    from utils.llm.working_observations import WorkingObservationExtractionError
+
+    mock_service = MagicMock()
+    monkeypatch.setattr(pc, "MemoryService", lambda db_client: mock_service)
+    fail_fallback = MagicMock()
+    monkeypatch.setattr(pc, "record_fallback", fail_fallback)
+    monkeypatch.setattr(
+        pc,
+        "extract_canonical_l1_memory_candidates",
+        MagicMock(side_effect=WorkingObservationExtractionError("invoke")),
+    )
+    monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
+
+    conversation = Conversation(
+        id="conv-canonical-typed-failure",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+        source=ConversationSource.omi,
+        structured=Structured(title="Test", overview="Overview", category=CategoryEnum.personal),
+        transcript_segments=[],
+    )
+
+    result = pc._extract_memories_inner("uid-canonical-typed-failure", conversation)
+
+    assert result.count == 0
+    assert result.path == pc.PATH_CANONICAL
+    mock_service.replace_conversation_memories.assert_not_called()
+    fail_fallback.assert_any_call(
+        component="other",
+        from_mode="canonical_memory_extraction",
+        to_mode="replacement_skipped",
+        reason="provider_5xx",
+        outcome="degraded",
+    )
+
+
+def test_universal_reextract_external_provider_failure_skips_replacement(monkeypatch):
+    """An external-integration extractor provider failure must skip the replacement the same way as the transcript path."""
+    pc = _load_process_conversation()
+    from models.conversation import Conversation
+    from models.conversation_enums import CategoryEnum, ConversationSource
+    from models.structured import Structured
+
+    class ExtractorProviderFailure(RuntimeError):
+        def __init__(self, extractor: str):
+            self.extractor = extractor
+            super().__init__(f"{extractor} failed before producing a valid extraction result")
+
+    mock_service = MagicMock()
+    monkeypatch.setattr(pc, "MemoryService", lambda db_client: mock_service)
+    monkeypatch.setattr(pc, "MemoryExtractionError", ExtractorProviderFailure)
+    fail_fallback = MagicMock()
+    monkeypatch.setattr(pc, "record_fallback", fail_fallback)
+    monkeypatch.setattr(
+        pc,
+        "extract_memories_from_text",
+        MagicMock(side_effect=ExtractorProviderFailure("external_text_memory_extractor")),
+    )
+    monkeypatch.setattr(pc.users_db, "get_user_language_preference", lambda uid: "en")
+
+    conversation = Conversation(
+        id="conv-canonical-external-failure",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 6, 1, 1, tzinfo=timezone.utc),
+        source=ConversationSource.external_integration,
+        structured=Structured(title="Test", overview="Overview", category=CategoryEnum.personal),
+        external_data={"text": "Product docs to memorize.", "text_source": "readme"},
+        transcript_segments=[],
+    )
+
+    result = pc._extract_memories_inner("uid-canonical-external-failure", conversation)
+
+    assert result.count == 0
+    assert result.path == pc.PATH_CANONICAL
+    mock_service.replace_conversation_memories.assert_not_called()
+    fail_fallback.assert_any_call(
+        component="other",
+        from_mode="canonical_memory_extraction",
+        to_mode="replacement_skipped",
+        reason="provider_5xx",
+        outcome="degraded",
+    )
+
+
 def test_universal_reextract_valid_empty_replaces_existing_source_state(monkeypatch):
     """A valid empty extraction is an authoritative source replacement."""
     pc = _load_process_conversation()

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -71,6 +71,7 @@ from utils.llm.conversation_folder import assign_conversation_to_folder
 from utils.analytics import record_usage
 from utils.llm.usage_tracker import track_usage, Features
 from utils.llm.memories import (
+    MemoryExtractionError,
     extract_canonical_l1_memory_candidates,
     extract_memories_from_text,
 )
@@ -887,9 +888,8 @@ def _extract_memories_canonical(
         text_content = ext_data.get('text')
         if text_content and len(text_content) > 0:
             text_source = ext_data.get('text_source', 'other')
-            capture_candidates = [
-                (memory, [], "unknown", [], False)
-                for memory in extract_memories_from_text(
+            try:
+                extracted_memories = extract_memories_from_text(
                     uid,
                     text_content,
                     text_source,
@@ -897,18 +897,58 @@ def _extract_memories_canonical(
                     content_date=content_date,
                     strict=True,
                 )
-            ]
+            except MemoryExtractionError as exc:
+                # Same verdict as the transcript path (#11777): a provider
+                # failure skips the replacement so existing memories survive and
+                # conversation finalization completes instead of raising.
+                logger.warning(
+                    "canonical memory extraction skipped replacement: external text provider failure "
+                    "conversation=%s extractor=%s",
+                    conversation.id,
+                    exc.extractor,
+                )
+                record_fallback(
+                    component='other',
+                    from_mode='canonical_memory_extraction',
+                    to_mode='replacement_skipped',
+                    reason='provider_5xx',
+                    outcome='degraded',
+                )
+                return ConversationMemoryExtractionResult(count=0, source=source, path=PATH_CANONICAL)
+            capture_candidates = [(memory, [], "unknown", [], False) for memory in extracted_memories]
     else:
         raw_user_name = get_user_name(uid)
         user_name = raw_user_name.strip() if isinstance(raw_user_name, str) and raw_user_name.strip() else "the user"
-        extracted_candidates = extract_canonical_l1_memory_candidates(
-            uid,
-            conversation.id,
-            conversation.transcript_segments,
-            user_name=user_name,
-            language=language,
-            strict=True,
-        )
+        from utils.llm.working_observations import WorkingObservationExtractionError
+
+        try:
+            extracted_candidates = extract_canonical_l1_memory_candidates(
+                uid,
+                conversation.id,
+                conversation.transcript_segments,
+                user_name=user_name,
+                language=language,
+                strict=True,
+            )
+        except WorkingObservationExtractionError as exc:
+            # A provider failure is not "no memories": submitting the empty
+            # replacement would retract the source's existing memories. Skipping
+            # the replacement is the verdict; returning (instead of raising)
+            # lets the caller's action items, goal progress, audio files and
+            # created webhook finish too (#11777).
+            logger.warning(
+                "canonical memory extraction skipped replacement: provider failure " "conversation=%s stage=%s",
+                conversation.id,
+                exc.stage,
+            )
+            record_fallback(
+                component='other',
+                from_mode='canonical_memory_extraction',
+                to_mode='replacement_skipped',
+                reason='provider_5xx',
+                outcome='degraded',
+            )
+            return ConversationMemoryExtractionResult(count=0, source=source, path=PATH_CANONICAL)
         ungrounded_candidates = 0
         seen_candidates = 0
         for candidate in extracted_candidates:


### PR DESCRIPTION
## Summary

Closes #11777 — when the strict canonical memory extractor hits a provider
failure (LLM 5xx) during conversation finalization, the failure was
indistinguishable from a genuinely-empty extraction and `_extract_memories_canonical`
submitted an empty source replacement, silently retracting the conversation's
existing memories.

Now a typed extraction failure skips the replacement (existing memories
survive) and returns a count-0 result so the rest of finalization (action
items, goal progress, audio files, created webhook) still runs. Telemetry
records the fallback as `provider_5xx` / `replacement_skipped`.

## Behavior change → test

- `test_universal_reextract_typed_failure_skips_replacement_and_finalizes`
  (transcript path, real `WorkingObservationExtractionError`).
- `test_universal_reextract_external_provider_failure_skips_replacement`
  (external-integration path, `MemoryExtractionError`).

Both assert `count == 0`, `replace_conversation_memories` not called, and the
`provider_5xx`/`replacement_skipped` fallback recorded.

## How I ran it

Full `uv pip sync pylock.toml` cannot resolve locally (locked `onnxruntime`
1.19.0 has no macOS arm64 wheel; CI is Linux), so I built a scoped venv and ran
the isolation suites that reload `process_conversation`:

- `pytest backend/tests/unit/test_memory_replace_policy.py` → 18 passed
- `pytest backend/tests/unit/test_upstream_boundary.py backend/tests/unit/test_universal_memory_task_authority.py` → 10 passed
- `scripts/check_module_stub_pollution.py` / `scan_import_time_side_effects.py` /
  `check_isinstance_return_ratchet.py` → clean
- `black --line-length 120 --skip-string-normalization` clean

Pyright lane runs on the Linux CI runner (partial local venv cannot resolve the
full type surface).

Failure-Class: FC-denial-rendered-as-empty-success

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 1827 -> 1867 | the two try/except skip-replacement handlers live inline at the exact extraction call sites they guard; extracting them into a helper would separate the provider-failure verdict from the replacement boundary it protects (#11777)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

