### PR TITLE
fix(dev-harness): let OMI_DEV_HOST make the harness actually reachable

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -47,8 +47,9 @@ Before getting started, make sure your device is connected and unlocked. If you'
 
    `bash setup.sh ios` is the safe local-development path: it uses the local
    API/emulator harness and the `demo-omi-local` Firebase project. For a real
-   iPhone, set `OMI_DEV_HOST` to the Mac's LAN address when the local harness is
-   reachable from the device.
+   iPhone, set `OMI_DEV_HOST` to the Mac's LAN or Tailscale address before
+   running both `setup.sh ios` and `make dev-up` (export it so both commands
+   see it) — the harness now binds there too, not just the app build.
 
    iOS setup requires macOS/Xcode, so Windows developers should use the Android setup path.
 

--- a/docs/doc/developer/AppSetup.mdx
+++ b/docs/doc/developer/AppSetup.mdx
@@ -149,8 +149,13 @@ data requires the explicit `beta` profile (see [Mobile beta](https://github.com/
 <Tip>
 The automatic setup runs entirely on your machine — local API, local emulators,
 no production data — making it the fastest way to start building apps and making
-changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN address so
-the device can reach the harness.
+changes. On a physical iPhone, set `OMI_DEV_HOST` to your Mac's LAN or Tailscale
+address before running both `setup.sh ios` and `make dev-up` (in the same shell,
+or exported so both commands see it) — this now makes the harness itself listen
+there too, not just the app you build. Only a private address works (LAN, e.g.
+`192.168.x.x`, or Tailscale/CGNAT, e.g. `100.x.x.x`); a public address is
+rejected. Use `OMI_DEV_BIND_HOST` instead if you want the harness to bind a
+different address than the one the app is compiled to reach.
 </Tip>
 
 ---
@@ -326,8 +331,11 @@ ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit
     Run `make dev-up` from the repo root first, and confirm with `make dev-status`.
 
     On a physical device, `127.0.0.1` is the phone — set `OMI_DEV_HOST` to your
-    Mac's LAN address before running `setup.sh` so the build points at your
-    machine. The Android emulator uses `10.0.2.2` by default.
+    Mac's LAN or Tailscale address before running **both** `setup.sh` (so the
+    build points at your machine) and `make dev-up` (so the harness actually
+    listens there — it defaults to loopback-only otherwise, which is why a
+    device build alone used to reach nothing). Export it in the same shell so
+    both commands see it. The Android emulator uses `10.0.2.2` by default.
   </Accordion>
   <Accordion title="Sign-in works but every request returns 401" icon="triangle-exclamation">
     The app and the backend are on **different Firebase projects**. Firebase ID

--- a/scripts/dev-harness/dev_harness/cli.py
+++ b/scripts/dev-harness/dev_harness/cli.py
@@ -372,6 +372,8 @@ def print_config(cfg: config.HarnessConfig) -> None:
     print(f"llm_gateway: {cfg.llm_gateway_url}")
     print(f"backend: {cfg.backend_url}")
     print(f"desktop_backend: {cfg.desktop_backend_url}")
+    if cfg.dev_bind_host != "127.0.0.1":
+        print(f"dev_bind_host: {cfg.dev_bind_host} (set via {config.DEV_BIND_HOST_ENV} or {config.APP_DEV_HOST_ENV})")
 
 
 def print_provider_status(cfg: config.HarnessConfig) -> providers.ProviderPreflight:
@@ -606,7 +608,10 @@ def _firebase_command(cfg: config.HarnessConfig) -> list[str]:
     emulators = payload.setdefault("emulators", {})
     for name, port in (("firestore", cfg.firestore_port), ("auth", cfg.auth_port)):
         emulator = emulators.setdefault(name, {})
-        emulator["host"] = "127.0.0.1"
+        # The Auth emulator is what a physical device's Firebase SDK connects to
+        # directly (not through the backend), so it must bind wherever the
+        # backend does for device reachability to work at all (#11774).
+        emulator["host"] = cfg.dev_bind_host
         emulator["port"] = port
     firestore = payload.setdefault("firestore", {})
     firestore["rules"] = str(cfg.repo_root / "firestore.rules")
@@ -753,7 +758,7 @@ def _start_app_services(cfg: config.HarnessConfig) -> None:
             "uvicorn",
             "llm_gateway.main:app",
             "--host",
-            "127.0.0.1",
+            cfg.dev_bind_host,
             "--port",
             str(cfg.llm_gateway_port),
         ],
@@ -764,7 +769,7 @@ def _start_app_services(cfg: config.HarnessConfig) -> None:
     _start_process(
         cfg,
         "backend",
-        [sys.executable, "-m", "uvicorn", "main:app", "--host", "127.0.0.1", "--port", str(cfg.backend_port)],
+        [sys.executable, "-m", "uvicorn", "main:app", "--host", cfg.dev_bind_host, "--port", str(cfg.backend_port)],
         cwd=cfg.repo_root / "backend",
         log_name="backend.log",
         port=cfg.backend_port,
@@ -778,7 +783,7 @@ def _start_app_services(cfg: config.HarnessConfig) -> None:
             "uvicorn",
             "desktop_backend:app",
             "--host",
-            "127.0.0.1",
+            cfg.dev_bind_host,
             "--port",
             str(cfg.desktop_backend_port),
         ],

--- a/scripts/dev-harness/dev_harness/config.py
+++ b/scripts/dev-harness/dev_harness/config.py
@@ -67,6 +67,7 @@ class HarnessConfig:
     redis_host: str = "127.0.0.1"
     redis_port: int = REDIS_PORT
     typesense_port: int = TYPESENSE_PORT
+    dev_bind_host: str = "127.0.0.1"
     llm_gateway_port: int = LLM_GATEWAY_PORT
 
     @property
@@ -118,6 +119,35 @@ def repo_root_from(path: Path) -> Path:
 
 def provider_mode_from_env(env: Mapping[str, str] | None = None) -> str:
     return providers.provider_mode_from_env(env)
+
+
+DEV_BIND_HOST_ENV = "OMI_DEV_BIND_HOST"
+# Falls back to OMI_DEV_HOST (app/setup.sh:53) so a contributor who follows the
+# documented physical-device setup — set OMI_DEV_HOST to the Mac's reachable
+# address — gets a harness that actually listens there too, not just an app
+# built to expect it (#11774). OMI_DEV_BIND_HOST exists for the narrower case
+# of wanting an asymmetric bind (e.g. a different advertise vs. listen address).
+APP_DEV_HOST_ENV = "OMI_DEV_HOST"
+
+
+def dev_bind_host_from_env(env: Mapping[str, str] | None = None) -> str:
+    """Resolve what the harness's HTTP services and Firebase emulators bind to.
+
+    Defaults to loopback-only, preserving today's behavior. Binds all
+    interfaces (0.0.0.0) when a private LAN/CGNAT address is requested, rather
+    than that literal address, so loopback callers (health checks, a booted
+    simulator) keep working alongside the newly reachable LAN/tailnet address.
+    Fails closed (SafetyError) on a publicly routable address.
+    """
+
+    source = os.environ if env is None else env
+    requested = source.get(DEV_BIND_HOST_ENV, "").strip() or source.get(APP_DEV_HOST_ENV, "").strip()
+    if not requested:
+        return "127.0.0.1"
+    safety.validate_dev_bind_host(requested, name=DEV_BIND_HOST_ENV)
+    if safety.is_loopback_host(requested):
+        return "127.0.0.1"
+    return "0.0.0.0"
 
 
 def _port_from_env(source: Mapping[str, str], name: str, default: int, offset: int) -> int:
@@ -240,6 +270,7 @@ def load_config(repo_root: Path, env: Mapping[str, str] | None = None, *, create
         else safety.layout_for_instance(repo_root, instance, source)
     )
     ports = harness_ports_from_env(source)
+    dev_bind_host = dev_bind_host_from_env(source)
     cfg = HarnessConfig(
         repo_root=repo_root.resolve(),
         instance=instance,
@@ -252,6 +283,7 @@ def load_config(repo_root: Path, env: Mapping[str, str] | None = None, *, create
         redis_port=ports["redis"],
         typesense_port=ports["typesense"],
         llm_gateway_port=ports["llm_gateway"],
+        dev_bind_host=dev_bind_host,
     )
     parsed = parse_secrets_file(cfg)
     if parsed.secrets.get("PROVIDER_MODE"):
@@ -268,6 +300,7 @@ def load_config(repo_root: Path, env: Mapping[str, str] | None = None, *, create
             redis_port=cfg.redis_port,
             typesense_port=cfg.typesense_port,
             llm_gateway_port=cfg.llm_gateway_port,
+            dev_bind_host=cfg.dev_bind_host,
         )
     safety.validate_harness_runtime_config(
         project_id=cfg.project_id,

--- a/scripts/dev-harness/dev_harness/safety.py
+++ b/scripts/dev-harness/dev_harness/safety.py
@@ -8,6 +8,7 @@ It does not start emulators or desktop apps.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import re
@@ -194,6 +195,48 @@ def is_loopback_host(value: str) -> bool:
 def validate_loopback_emulator_host(value: str, *, name: str = "emulator") -> str:
     if not is_loopback_host(value):
         raise SafetyError(f"{name} host must point to loopback, got {value!r}")
+    return value.strip()
+
+
+# Private ranges a LAN- or tailnet-reachable dev harness may bind to. Distinct
+# from the loopback-only guard above, which protects a different boundary: the
+# backend's own connection to its co-located emulators, which must never leave
+# loopback regardless of this setting. RFC 1918 covers ordinary LAN addresses;
+# 100.64.0.0/10 (RFC 6598 carrier-grade NAT) covers Tailscale, whose tailnet
+# addresses fall in that range and are the documented way a physical device
+# reaches this harness (see #11730/#11652).
+_PRIVATE_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+)
+
+
+def is_private_dev_host(value: str) -> bool:
+    """True for loopback or a non-public (LAN/CGNAT) address, never a public one."""
+
+    if is_loopback_host(value):
+        return True
+    host = _host_from_emulator_value(value)
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return any(addr in network for network in _PRIVATE_NETWORKS)
+
+
+def validate_dev_bind_host(value: str, *, name: str = "dev bind host") -> str:
+    """Fail closed unless the requested bind host is loopback or a private range.
+
+    Distinct from ``validate_loopback_emulator_host``: this guards what the
+    harness's own HTTP services and Firebase emulators may bind to when a
+    developer opts into LAN/tailnet reachability, never a publicly routable
+    address.
+    """
+
+    if not is_private_dev_host(value):
+        raise SafetyError(f"{name} must be loopback or a private (LAN/CGNAT) address, got {value!r}")
     return value.strip()
 
 

--- a/scripts/dev-harness/tests/test_cli.py
+++ b/scripts/dev-harness/tests/test_cli.py
@@ -127,6 +127,89 @@ def test_firebase_command_writes_the_configured_emulator_ports(monkeypatch: pyte
     assert payload["emulators"]["auth"]["port"] == 9420
 
 
+def test_dev_bind_host_defaults_to_loopback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("OMI_DEV_BIND_HOST", raising=False)
+    monkeypatch.delenv("OMI_DEV_HOST", raising=False)
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+
+    cfg = config.load_config(REPO_ROOT)
+
+    assert cfg.dev_bind_host == "127.0.0.1"
+
+
+def test_dev_bind_host_falls_back_to_app_dev_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # #11774: a contributor who follows the documented physical-device setup sets
+    # only OMI_DEV_HOST (the build-side var, app/setup.sh:53). The harness must
+    # pick that up too, or the app is built to expect a reachable harness that
+    # never actually listens anywhere but loopback.
+    monkeypatch.delenv("OMI_DEV_BIND_HOST", raising=False)
+    monkeypatch.setenv("OMI_DEV_HOST", "192.168.1.50")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+
+    cfg = config.load_config(REPO_ROOT)
+
+    # Binds all interfaces rather than the literal LAN address, so loopback
+    # callers (health checks, a booted simulator) keep working alongside it.
+    assert cfg.dev_bind_host == "0.0.0.0"
+
+
+def test_dev_bind_host_prefers_explicit_bind_host_over_app_dev_host(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("OMI_DEV_BIND_HOST", "100.64.1.2")
+    monkeypatch.setenv("OMI_DEV_HOST", "192.168.1.50")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+
+    cfg = config.load_config(REPO_ROOT)
+
+    assert cfg.dev_bind_host == "0.0.0.0"
+
+
+def test_dev_bind_host_rejects_a_public_address(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMI_DEV_HOST", "203.0.113.5")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+
+    with pytest.raises(safety.SafetyError, match="private"):
+        config.load_config(REPO_ROOT)
+
+
+def test_firebase_command_binds_emulators_to_the_resolved_dev_bind_host(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The Auth emulator is what a physical device's Firebase SDK connects to
+    # directly, so it must follow the same bind host as the backend (#11774).
+    monkeypatch.setenv("OMI_DEV_HOST", "192.168.1.50")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    cfg = config.load_config(REPO_ROOT, create_layout=True)
+
+    command = cli._firebase_command(cfg)
+
+    config_path = Path(command[command.index("--config") + 1])
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["emulators"]["firestore"]["host"] == "0.0.0.0"
+    assert payload["emulators"]["auth"]["host"] == "0.0.0.0"
+
+
+def test_app_services_bind_to_the_resolved_dev_bind_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("OMI_DEV_HOST", "192.168.1.50")
+    monkeypatch.setenv("OMI_LOCAL_STATE_ROOT", str(tmp_path / "state"))
+    cfg = config.load_config(REPO_ROOT, create_layout=True)
+
+    started: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        cli,
+        "_start_process",
+        lambda cfg, service, command, **kwargs: started.append((service, command)),
+    )
+
+    cli._start_app_services(cfg)
+
+    assert {service for service, _ in started} == {"llm-gateway", "backend", "desktop-backend"}
+    for service, command in started:
+        host_index = command.index("--host") + 1
+        assert command[host_index] == "0.0.0.0", f"{service} did not bind to the resolved dev_bind_host"
+
+
 def test_wait_health_returns_services_that_exhaust_their_deadlines(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/scripts/dev-harness/tests/test_safety.py
+++ b/scripts/dev-harness/tests/test_safety.py
@@ -64,6 +64,22 @@ def test_project_database_and_loopback_validation() -> None:
         safety.validate_loopback_emulator_host("firestore.googleapis.com:443")
 
 
+def test_private_dev_host_accepts_loopback_lan_and_tailnet_rejects_public() -> None:
+    # #11774: a physical device reaches the harness over a LAN or Tailscale
+    # (CGNAT, 100.64.0.0/10) address. This guard is deliberately separate from
+    # validate_loopback_emulator_host above, which protects a different thing
+    # (the backend's own connection to its co-located emulators) and must stay
+    # loopback-only regardless of this setting.
+    for host in ("127.0.0.1", "localhost", "10.1.2.3", "172.16.0.5", "192.168.1.42", "100.105.2.5"):
+        assert safety.is_private_dev_host(host) is True
+        assert safety.validate_dev_bind_host(host) == host
+
+    for host in ("8.8.8.8", "203.0.113.5", "1.1.1.1", "omi-relay.example.com"):
+        assert safety.is_private_dev_host(host) is False
+        with pytest.raises(safety.SafetyError, match="private"):
+            safety.validate_dev_bind_host(host)
+
+
 def test_child_environment_strips_cloud_defaults_and_offline_provider_secrets() -> None:
     parent = {
         "PATH": "/usr/bin",


### PR DESCRIPTION
## Summary

`OMI_DEV_HOST` only ever changed what the app was compiled to expect (`app/setup.sh:53`) — the harness bound `backend`, `llm-gateway`, `desktop-backend`, and the Firebase emulators to a hardcoded `127.0.0.1` regardless, so a physical device pointed at the documented LAN address reached nothing.

The harness now resolves a `dev_bind_host` from `OMI_DEV_BIND_HOST` (falls back to `OMI_DEV_HOST`, defaulting to loopback), fails closed via a new `validate_dev_bind_host` guard unless the requested address is loopback, RFC 1918 (LAN), or `100.64.0.0/10` (Tailscale CGNAT) — never public — and binds `0.0.0.0` rather than the literal address so loopback callers (health checks, a booted simulator) keep working alongside the newly reachable LAN/tailnet address.

This is deliberately a **new, separate** guard: `validate_loopback_emulator_host` protects a different boundary (the backend's own connection to its co-located emulators, which must always stay loopback) and is untouched.

## Testing

- New unit tests in `test_safety.py` (loopback/LAN/CGNAT accepted, public rejected) and `test_cli.py` (env resolution priority/fallback, public address rejected at `load_config`, `_firebase_command` and `_start_app_services` both actually bind to the resolved host) — 94 passed, 6 skipped (platform-gated).
- **Verified live end to end**, not just in unit tests: with `OMI_DEV_HOST` set to this Mac's Tailscale address, `make dev-up` brings up all seven services healthy, and `curl http://<tailscale-ip>:8000/` and `:9099/` both return `200` — mirroring the issue's own repro, which measured a refused connection on the LAN address before this fix.
- Along the way, found and worked around two testing artifacts that are **not** defects in this change: a leftover `tailscale serve` config from earlier work occupying the same tailnet address/port, and lingering Firebase emulator processes from rapid manual iteration that `lsof -sTCP:LISTEN` didn't surface but `netstat` did.

Failure-Class: none

Fixes #11774.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

