### PR TITLE
fix(backend): x-connector provider 5xx must not starve the remaining chunks in a cycle

### DIFF
--- a/backend/tests/unit/test_x_memory_extraction_retry.py
+++ b/backend/tests/unit/test_x_memory_extraction_retry.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
 
 from models.memories import Memory, MemoryCategory
+from models.memory_contracts import MemoryExtractionError
 from utils import x_connector
 
 
@@ -146,6 +147,52 @@ def test_scheduled_x_flex_deferral_remains_pending_without_acknowledgement(monke
         x_connector._extract_and_index('uid-1', [post], llm=object())
 
     assert acknowledgements == []
+
+
+def test_provider_5xx_skips_only_the_failed_chunk_and_leaves_it_pending(monkeypatch):
+    """A strict provider 5xx on one chunk cannot starve the batches behind it in the same cycle, and the failed chunk stays pending for the next sync."""
+    first_post = {'id': 'post-1', 'text': 'I prefer tea', 'created_at': '2026-07-14T00:00:00Z', 'kind': 'tweet'}
+    second_post = {'id': 'post-2', 'text': 'Second batch', 'created_at': '2026-07-14T00:00:00Z', 'kind': 'tweet'}
+
+    calls = []
+    acknowledgements = []
+    created_batches = []
+    recorded = []
+
+    def extract(*_args, **_kwargs):
+        chunk_text = _args[1]
+        calls.append(chunk_text)
+        if 'I prefer tea' in chunk_text:
+            raise MemoryExtractionError('external_text_memory_extractor')
+        return [Memory(content='Second batch memory', category=MemoryCategory.interesting)]
+
+    class RecordingMemoryService:
+        def __init__(self, **_kwargs):
+            pass
+
+        def create_external_memory_batch(self, _uid, memory_dbs, **_kwargs):
+            created_batches.append(memory_dbs)
+
+    monkeypatch.setattr(x_connector, 'MEMORY_BATCH_CHARS', 10)
+    monkeypatch.setattr(x_connector, 'extract_memories_from_text', extract)
+    monkeypatch.setattr(x_connector, 'MemoryService', RecordingMemoryService)
+    monkeypatch.setattr(x_connector, 'capture_memory_write', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        x_connector.x_posts_db,
+        'mark_memory_extraction_completed',
+        lambda _uid, post_ids: acknowledgements.append(post_ids),
+    )
+    monkeypatch.setattr(x_connector, 'record_fallback', lambda **kwargs: recorded.append(kwargs))
+
+    total = x_connector._extract_and_index('uid-1', [first_post, second_post], llm=object())
+
+    assert total == 1
+    assert len(calls) == 2, 'a 5xx chunk must not starve the batches behind it in the same cycle'
+    assert acknowledgements == [['post-2']], 'the failed chunk stays pending for the next sync'
+    assert len(created_batches) == 1 and len(created_batches[0]) == 1
+    assert recorded and recorded[0]['reason'] == 'provider_5xx'
+    assert recorded[0]['to_mode'] == 'chunk_deferred'
+    assert recorded[0]['outcome'] == 'degraded'
 
 
 async def _async_value(value):

--- a/backend/utils/x_connector.py
+++ b/backend/utils/x_connector.py
@@ -33,10 +33,12 @@ from database import x_posts as x_posts_db
 from database._client import db
 from database.vector_db import upsert_x_post_vectors_batch
 from models.memories import MemoryDB
+from models.memory_contracts import MemoryExtractionError
 from utils.llm.memories import extract_memories_from_text
 from utils.memory.memory_service import MemoryService
 from utils.memory.memory_system import MemorySystem
 from utils.memory.promotion_flex import PromotionFlexDeferred, PromotionFlexRunRouter
+from utils.observability.fallback import record_fallback
 from testing.parity_pack_v0.live_capture import capture_memory_write
 from utils.executors import db_executor, run_blocking
 from utils.log_sanitizer import sanitize
@@ -356,16 +358,37 @@ def _extract_and_index(
 
     total = 0
     for chunk, post_ids in chunks:
-        if llm is None:
-            extracted = extract_memories_from_text(uid, chunk, 'twitter_tweets')
-        else:
-            extracted = extract_memories_from_text(
+        try:
+            if llm is None:
+                extracted = extract_memories_from_text(uid, chunk, 'twitter_tweets')
+            else:
+                extracted = extract_memories_from_text(
+                    uid,
+                    chunk,
+                    'twitter_tweets',
+                    strict=True,
+                    llm=llm,
+                )
+        except MemoryExtractionError as exc:
+            # A provider 5xx on this chunk means the extractor never produced a
+            # batch — not "this chunk has no memories". Do not acknowledge the
+            # raw posts (they stay pending and the next sync replays this chunk),
+            # and keep extracting the remaining chunks so one provider blip does
+            # not starve the batches behind it in the same cycle.
+            logger.warning(
+                'x_connector: chunk skipped provider_5xx uid=%s posts=%d extractor=%s',
                 uid,
-                chunk,
-                'twitter_tweets',
-                strict=True,
-                llm=llm,
+                len(post_ids),
+                exc.extractor,
             )
+            record_fallback(
+                component='other',
+                from_mode='x_memory_extraction',
+                to_mode='chunk_deferred',
+                reason='provider_5xx',
+                outcome='degraded',
+            )
+            continue
         if result_guard is not None:
             result_guard()
         if extracted:


### PR DESCRIPTION
## Summary

Follow-up hardening for the same failure class fixed in #11780 (strict memory
extraction provider 5xx): in `x_connector._extract_and_index`, one chunk's
`MemoryExtractionError` (strict flex lane) previously aborted the whole
per-user sync, so the batches behind it had to wait for the next hourly cycle
even though the provider fault only hit the first chunk.

Now the typed extraction failure is caught per chunk: the failed raw posts are
**not acknowledged** (they stay pending and the next sync replays them — the
existing raw-owns-progress invariant is untouched), the remaining chunks still
extract in the same cycle, and the skip is recorded via `record_fallback`
(`provider_5xx` → `chunk_deferred` → `degraded`). `PromotionFlexDeferred` and
untyped exceptions still propagate unchanged (the deferral and fail-closed
invariants pinned by the existing tests are preserved).

## Behavior change → test

- `test_provider_5xx_skips_only_the_failed_chunk_and_leaves_it_pending`: two
  forced chunks; the first raises `MemoryExtractionError(query)`, the second
  still runs; asserts total == 1, only chunk 2 is acknowledged, chunk 1 is left
  pending for the next sync, and the fallback event fires with
  `provider_5xx`/`chunk_deferred`/`degraded`.

## How I ran it

- `pytest tests/unit/test_x_memory_extraction_retry.py` → 5 passed (incl. the
  new regression; the `PromotionFlexDeferred` propagation and strict+fenced ack
  tests are unchanged)
- `pytest tests/unit/test_x_posts_kind_filter_limit_before_sort.py
  tests/unit/test_x_posts_list_endpoint.py
  tests/unit/test_integration_sync_telemetry.py` → 16 passed
- `pytest tests/unit/test_universal_memory_task_authority.py
  tests/unit/test_universal_memory_route_surfaces.py` → 9 passed
- `scripts/check_module_stub_pollution.py` / `scan_import_time_side_effects.py`
  / `check_isinstance_return_ratchet.py` / `scan_async_blockers.py` → clean
- `scripts/check_fallback_instrumentation.py` → no warnings
- `black --line-length 120 --skip-string-normalization` clean

Same local constraint as before: the locked `onnxruntime 1.19.0` has no macOS
arm64 wheel, so the full `uv pip sync` (and the pyright lane) run on the Linux
CI runner.

## Failure class (fixes)

Failure-Class: FC-recoverable-provider-failure-terminal


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

