### PR TITLE
fix(backend): serve the memories first page when a keyset-scan index is building (#11791)

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -588,11 +588,16 @@ def get_memories(
             # First page must succeed whenever the legacy offset read can serve
             # it. The cursor path 503s on a missing cursor secret
             # ("Memory cursor unavailable"); the canonical keyset scan wraps any
-            # underlying failure as "Canonical memory unavailable". Both fall
-            # back to read(); unrelated errors (4xx, other 503s) propagate.
+            # underlying failure as "Canonical memory unavailable"; the
+            # historical keyset scan wraps its own as "Historical memory
+            # unavailable". The keyset scans order by (updated_at DESC,
+            # __name__) and so fail while that composite index is building,
+            # which the offset read's single-field order does not — so all three
+            # fall back to read(); unrelated errors (4xx, other 503s) propagate.
             if exc.status_code != 503 or exc.detail not in (
                 "Memory cursor unavailable",
                 "Canonical memory unavailable",
+                "Historical memory unavailable",
             ):
                 raise
         else:

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -222,6 +222,29 @@ def test_first_page_falls_back_to_offset_read_when_canonical_scan_unavailable():
     service.read.assert_called_once()
 
 
+def test_first_page_falls_back_to_offset_read_when_historical_scan_unavailable():
+    """Prod 2026-08-18: first page 503d for 5.5h while a composite index built.
+
+    ``read_page``'s historical keyset scan orders by (updated_at DESC,
+    __name__) and so returned FAILED_PRECONDITION for every request while the
+    matching ``memories`` composite index was still building, surfacing as this
+    detail. The offset ``read`` path orders by ``updated_at`` alone, does not
+    match that index, and could serve the page — so this detail must fall back
+    like the other two scan failures instead of failing the list endpoint.
+    """
+    from fastapi import HTTPException
+
+    service = MagicMock()
+    service.read_page.side_effect = HTTPException(status_code=503, detail="Historical memory unavailable")
+    service.read.return_value = ['memory-from-offset-read']
+
+    result = _get_first_page(service)
+
+    assert result == ['memory-from-offset-read']
+    service.read_page.assert_called_once()
+    service.read.assert_called_once()
+
+
 def test_first_page_propagates_unrelated_503_detail():
     from fastapi import HTTPException
 

--- a/backend/tests/unit/test_universal_memory_list_cursor.py
+++ b/backend/tests/unit/test_universal_memory_list_cursor.py
@@ -1276,3 +1276,32 @@ def test_canonical_scan_failure_logs_underlying_exception_and_503s(service_mod, 
     assert "canonical list scan page failed" in caplog.text
     assert "RuntimeError" in caplog.text
     assert "FAILED_PRECONDITION" in caplog.text
+
+
+def test_building_index_failure_is_the_historical_unavailable_detail(service_mod):
+    """Pin the detail the historical keyset scan raises while an index builds.
+
+    ``routers.memories`` matches this exact string to fall the first page back
+    to the legacy offset read (the 2026-08-18 5.5h GET /v3/memories outage), so
+    a rename here would silently reopen it. Drives the real adapter with the
+    Firestore error prod raised.
+    """
+    from fastapi import HTTPException
+    from google.api_core import exceptions as gcloud_exceptions
+
+    building_index = gcloud_exceptions.FailedPrecondition(
+        "400 The query requires an index. That index is currently building and cannot be used yet."
+    )
+    adapter = service_mod.HistoricalMemoryAdapter(db_client=_Db())
+    adapter_db = service_mod.memories_db
+    original = adapter_db.scan_memories_updated_at_page
+    adapter_db.scan_memories_updated_at_page = MagicMock(side_effect=building_index)
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            adapter.read_updated_scan_page("uid-test", limit=100)
+    finally:
+        adapter_db.scan_memories_updated_at_page = original
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Historical memory unavailable"
+    assert isinstance(exc_info.value.__cause__, gcloud_exceptions.FailedPrecondition)


### PR DESCRIPTION
Fixes #11791.

## Bug

`GET /v3/memories` returned **503 for 5.5 hours** in prod (2026-08-17 21:44:41Z → 2026-08-18 03:18:40Z): ~100 failures/min across 78+ distinct client IPs, ~33k failed memory-list reads, overwhelmingly the Windows desktop app (`omi-windows/1.0.0`). Users saw a broken Memories list for the whole window.

## Root cause

`read_page`'s historical keyset scan orders by `(updated_at DESC, __name__)`. Firestore fails a query with `FAILED_PRECONDITION` while a *matching* composite index is in `CREATING` state, so defining that index broke the live query until the build finished:

```
google.api_core.exceptions.FailedPrecondition: 400 The query requires an index.
That index is currently building and cannot be used yet.
  File "/app/utils/memory/memory_service.py", line 643, in read_updated_scan_page
  File "/app/database/memories.py", line 328, in _historical_scan_page
```

`routers/memories.py` already documents the guarantee this should have preserved — "First page must succeed whenever the legacy offset read can serve it" — and falls back to the legacy offset `read()` on a 503. But the whitelist only covered `Memory cursor unavailable` and `Canonical memory unavailable`. The historical scan raises `Historical memory unavailable` (`memory_service.py:650`), which was not listed, so it propagated and 503'd the endpoint.

The fallback would have served the page: `database/memories.py:get_memories` orders by `updated_at` alone and `created_at` alone, with no `__name__` tiebreak, so it does not match the building composite index.

## Fix

Add `Historical memory unavailable` to the first-page fallback whitelist, and record in the comment *why* the keyset scans fail where the offset read does not. One line of behavior; unrelated 503s still propagate unchanged.

## What I tested

- **Real route, real failure.** Drove `GET /v3/memories?limit=8&offset=0` through the actual FastAPI router with `scan_memories_updated_at_page` raising the exact `google.api_core.exceptions.FailedPrecondition` prod raised. On `origin/main`: `HTTP 503 {"detail":"Historical memory unavailable"}` — byte-identical to the prod response. With this change: `HTTP 200`. Index-READY control case is `HTTP 200` on both.
- **Regression test** `test_first_page_falls_back_to_offset_read_when_historical_scan_unavailable` fails on clean `origin/main` (1 failed, 7 passed) and passes here.
- **Contract test** `test_building_index_failure_is_the_historical_unavailable_detail` drives the real `HistoricalMemoryAdapter` with that Firestore error and pins the detail string the route matches on, so a rename cannot silently reopen this.
- `test.sh` on both changed test files (with the fast-unit timing guard): **8 passed** + **16 passed**. `pytest tests/unit/test_memory_visibility_export_fixes.py` also green.
- `make preflight` → **24 checks passed**.

## Product invariants affected

- INV-MEM-3
- INV-MEM-1

`INV-MEM-3` holds: the fallback is `MemoryService.read()`, not a direct legacy
reader, and it still runs the full canonical check (`_canonical_read` +
`canonical_statuses`). A failed *canonical* check still fails closed —
`Canonical memory unavailable` raised from `read()` propagates exactly as
before. The detail added here is raised only when the *historical* keyset scan
is unavailable, which is a read-input failure, not a bypassed authority check.
`INV-MEM-1` tier vocabulary is unchanged.

## Not fixed here

In the first phase of the outage the failing scan was the *canonical* one (`memory_service.py:1105` → `memory_items`), which raises the already-whitelisted `Canonical memory unavailable` — but `read()` calls `_canonical_read` → the same `memory_items` query, so the fallback re-raises. Serving a canonical-scan outage from history alone is a correctness decision, not a whitelist entry; left in #11791 rather than guessed at.

🤖 automated by hourly watchdog — tested and merged

Failure-Class: FC-recoverable-provider-failure-terminal


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

