### PR TITLE
fix(app): pin an iOS build destination and validate prerequisites

### DIFF
--- a/app/setup.sh
+++ b/app/setup.sh
@@ -235,16 +235,132 @@ function run_build_android() {
     && flutter run "${flutter_args[@]}"
 }
 
+# #####################################
+# iOS prerequisite and device selection
+# #####################################
+
+# True if $1 (a dotted version, e.g. "16.4") is >= $2. Relies on `sort -V`,
+# which Apple's /usr/bin/sort on macOS supports (verified; this is iOS-only
+# tooling, so a non-macOS sort is not a concern).
+function _version_at_least() {
+  local have="$1" want="$2"
+  [ "$(printf '%s\n%s\n' "$want" "$have" | sort -V | head -n1)" = "$want" ]
+}
+
+# Named checks with remedies, matching the harness's own pattern
+# (scripts/dev-harness's `Cannot start; missing prerequisites:` block) instead
+# of letting a missing/outdated tool surface as a confusing downstream failure
+# several minutes into a build.
+function check_ios_prerequisites() {
+  local missing=()
+
+  local flutter_version
+  flutter_version=$(flutter --version 2>/dev/null | grep -oE '^Flutter [0-9]+\.[0-9]+\.[0-9]+' | awk '{print $2}')
+  if [[ -z "$flutter_version" ]]; then
+    missing+=("Flutter SDK (v3.44.5 or later) — install from https://docs.flutter.dev/get-started/install")
+  elif ! _version_at_least "$flutter_version" "3.44.5"; then
+    missing+=("Flutter ${flutter_version} found, but v3.44.5 or later is required — run: flutter upgrade")
+  fi
+
+  if ! command -v xcodebuild &>/dev/null; then
+    missing+=("Xcode (v16.4 or later) — install from the App Store, then run: sudo xcode-select --switch /Applications/Xcode.app")
+  else
+    local xcode_version
+    xcode_version=$(xcodebuild -version 2>/dev/null | awk '/^Xcode/ {print $2; exit}')
+    if [[ -n "$xcode_version" ]] && ! _version_at_least "$xcode_version" "16.4"; then
+      missing+=("Xcode ${xcode_version} found, but v16.4 or later is required — update via the App Store")
+    fi
+  fi
+
+  if ! command -v pod &>/dev/null; then
+    missing+=("CocoaPods (v1.16.2 or later) — install with: sudo gem install cocoapods")
+  else
+    local pod_version
+    pod_version=$(pod --version 2>/dev/null)
+    if [[ -n "$pod_version" ]] && ! _version_at_least "$pod_version" "1.16.2"; then
+      missing+=("CocoaPods ${pod_version} found, but v1.16.2 or later is required — update with: sudo gem install cocoapods")
+    fi
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    missing+=("jq (used to select an iOS build destination) — install with: brew install jq")
+  fi
+
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    echo "❌ Cannot build for iOS; missing prerequisites:" >&2
+    local item
+    for item in "${missing[@]}"; do
+      echo "   - ${item}" >&2
+    done
+    return 1
+  fi
+}
+
+# Picks the iOS destination `flutter run -d` should target, instead of leaving
+# Flutter to fall back to whatever else it finds (macOS desktop, on a machine
+# with no simulator runtime and only a wirelessly-paired phone visible) and
+# reporting an error about a platform the developer never asked for.
+function select_ios_device() {
+  local devices_json
+  devices_json=$(flutter devices --machine 2>/dev/null) || {
+    echo "❌ Could not query connected devices (flutter devices --machine failed)." >&2
+    return 1
+  }
+
+  local ios_devices
+  ios_devices=$(echo "$devices_json" | jq -c '[.[] | select(.targetPlatform == "ios")]')
+  local count
+  count=$(echo "$ios_devices" | jq 'length')
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "❌ No iOS device or simulator found." >&2
+    echo "   Boot a simulator (open -a Simulator) or connect a physical device, then retry." >&2
+    return 1
+  fi
+
+  if [[ "$count" -eq 1 ]]; then
+    echo "$ios_devices" | jq -r '.[0].id'
+    return 0
+  fi
+
+  echo "⚠️  Multiple iOS destinations found. Choose one:" >&2
+  local i=0 line
+  while IFS= read -r line; do
+    i=$((i + 1))
+    echo "   $i) $line" >&2
+  done < <(echo "$ios_devices" | jq -r '.[] | "\(.name) (\(.id))"')
+
+  # Same reasoning as detect_apple_team_id's prompt: never block on read
+  # without a TTY, or a non-interactive run (CI, nested automation) hangs.
+  if [[ ! -t 0 ]]; then
+    echo "   ❌ No terminal available to choose a device." >&2
+    echo "      Disconnect the extras, or boot only the simulator you want, and re-run." >&2
+    return 1
+  fi
+
+  local choice
+  read -rp "   Enter number [1-${count}]: " choice
+  if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "$count" ]; then
+    echo "$ios_devices" | jq -r ".[$((choice - 1))].id"
+    return 0
+  fi
+  echo "❌ Invalid selection." >&2
+  return 1
+}
+
 # #########
 # Build iOS
 # #########
 function run_build_ios() {
   local flavor="${1:-dev}"
   shift || true
+  check_ios_prerequisites || return 1
+  local device_id
+  device_id=$(select_ios_device) || return 1
   flutter pub get \
     && pushd ios && pod install --repo-update && popd \
     && dart run build_runner build \
-    && flutter run --flavor "$flavor" "$@"
+    && flutter run --flavor "$flavor" -d "$device_id" "$@"
 }
 
 

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -267,7 +267,14 @@ function check_ios_prerequisites() {
   else
     local xcode_version
     xcode_version=$(xcodebuild -version 2>/dev/null | awk '/^Xcode/ {print $2; exit}')
-    if [[ -n "$xcode_version" ]] && ! _version_at_least "$xcode_version" "16.4"; then
+    if [[ -z "$xcode_version" ]]; then
+      # xcodebuild is on PATH but produced no version line — an unaccepted
+      # license or missing components, not a real "Xcode is fine" signal.
+      # Left unchecked, this passes the gate silently and surfaces as a
+      # confusing failure deep into the build, exactly what this check exists
+      # to prevent.
+      missing+=("xcodebuild is on PATH but not usable (license not accepted or components missing) — run: sudo xcodebuild -license accept && sudo xcodebuild -runFirstLaunch")
+    elif ! _version_at_least "$xcode_version" "16.4"; then
       missing+=("Xcode ${xcode_version} found, but v16.4 or later is required — update via the App Store")
     fi
   fi
@@ -278,7 +285,7 @@ function check_ios_prerequisites() {
     local pod_version
     pod_version=$(pod --version 2>/dev/null)
     if [[ -n "$pod_version" ]] && ! _version_at_least "$pod_version" "1.16.2"; then
-      missing+=("CocoaPods ${pod_version} found, but v1.16.2 or later is required — update with: sudo gem install cocoapods")
+      missing+=("CocoaPods ${pod_version} found, but v1.16.2 or later is required — update with: brew upgrade cocoapods (Homebrew) or sudo gem install cocoapods (gem)")
     fi
   fi
 
@@ -330,8 +337,8 @@ function select_ios_device() {
     echo "   $i) $line" >&2
   done < <(echo "$ios_devices" | jq -r '.[] | "\(.name) (\(.id))"')
 
-  # Same reasoning as detect_apple_team_id's prompt: never block on read
-  # without a TTY, or a non-interactive run (CI, nested automation) hangs.
+  # Never block on read without a TTY, or a non-interactive run (CI, nested
+  # automation) hangs indefinitely instead of failing with a usable message.
   if [[ ! -t 0 ]]; then
     echo "   ❌ No terminal available to choose a device." >&2
     echo "      Disconnect the extras, or boot only the simulator you want, and re-run." >&2

--- a/app/test/shell/ios_device_selection_test.sh
+++ b/app/test/shell/ios_device_selection_test.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Behavioral tests for select_ios_device() in app/setup.sh.
+#
+# Regression covered: run_build_ios() passed no `-d` to `flutter run`, so
+# Flutter picked a destination itself. On a machine with no iOS simulator
+# runtime installed and only a wirelessly-paired phone visible, it silently
+# built for macOS desktop instead and failed with an error about a platform
+# the developer never asked for, several minutes into pod install/build_runner.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SH="${SCRIPT_DIR}/../../setup.sh"
+
+if [[ ! -f "$SETUP_SH" ]]; then
+  echo "FAIL: cannot find setup.sh at $SETUP_SH" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "skip - select_ios_device tests need jq, not available on this host"
+  exit 0
+fi
+
+failures=0
+pass() { echo "  ok   - $1"; }
+fail() { echo "  FAIL - $1" >&2; failures=$((failures + 1)); }
+
+HARNESS="$(mktemp -t omi_ios_device_XXXXXX)"
+trap 'rm -f "$HARNESS"' EXIT
+
+extract_function() {
+  awk -v fn="function $1()" '
+    index($0, fn) == 1 { capture = 1 }
+    capture { print }
+    capture && $0 == "}" { exit }
+  ' "$SETUP_SH"
+}
+
+{
+  echo "set -uo pipefail"
+  extract_function select_ios_device
+} > "$HARNESS"
+
+if ! bash -n "$HARNESS"; then
+  echo "FAIL: extracted harness is not valid bash" >&2
+  exit 1
+fi
+
+# Stubs `flutter devices --machine` to return the given raw JSON array, plus
+# real jq/coreutils so the extracted function actually runs.
+stub_devices() {
+  local root="$1" devices_json="$2"
+  mkdir -p "$root/bin"
+  for real in bash sort grep awk printf head cat jq; do
+    ln -sf "$(command -v "$real")" "$root/bin/$real"
+  done
+  cat > "$root/bin/flutter" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "devices" ]]; then
+  cat <<'JSON'
+${devices_json}
+JSON
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$root/bin/flutter"
+}
+
+run_selection() {
+  local root="$1"; shift
+  PATH="$root/bin" bash -c "source '$HARNESS'; select_ios_device" "$@"
+}
+
+echo "select_ios_device:"
+
+# 1. Exactly one iOS destination: return it directly, no prompt.
+root=$(mktemp -d -t omi_ios_dev_one_XXXXXX)
+stub_devices "$root" '[
+  {"name":"iPhone 17 Pro","id":"SIM-ABC-123","isSupported":true,"targetPlatform":"ios","emulator":true},
+  {"name":"macOS","id":"macos","isSupported":true,"targetPlatform":"darwin","emulator":false}
+]'
+got=$(run_selection "$root" 2>/dev/null)
+rm -rf "$root"
+if [[ "$got" == "SIM-ABC-123" ]]; then
+  pass "returns the single iOS device's id, ignoring the non-iOS macOS entry"
+else
+  fail "expected 'SIM-ABC-123', got '${got}'"
+fi
+
+# 2. No iOS destination (only macOS): fail with a clear message, not a
+#    silent fallback to whatever flutter run would pick on its own.
+root=$(mktemp -d -t omi_ios_dev_none_XXXXXX)
+stub_devices "$root" '[
+  {"name":"macOS","id":"macos","isSupported":true,"targetPlatform":"darwin","emulator":false}
+]'
+out=$(run_selection "$root" 2>&1); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"No iOS device or simulator found"* ]]; then
+  pass "fails with a named error instead of silently picking macOS (the regression)"
+else
+  fail "expected a named no-iOS-device failure, got (rc=$rc): $out"
+fi
+
+# 3. Multiple iOS destinations, no TTY attached: fail fast rather than block
+#    on read, same reasoning as detect_apple_team_id's prompt.
+root=$(mktemp -d -t omi_ios_dev_multi_XXXXXX)
+stub_devices "$root" '[
+  {"name":"Revtim'"'"'s iPhone","id":"PHYS-1","isSupported":true,"targetPlatform":"ios","emulator":false},
+  {"name":"iPhone 17 Pro","id":"SIM-2","isSupported":true,"targetPlatform":"ios","emulator":true}
+]'
+rc=0
+run_selection "$root" </dev/null >/dev/null 2>&1 || rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]]; then
+  pass "fails fast (rc=$rc) instead of blocking on read without a TTY"
+else
+  fail "reported success despite multiple candidates and no way to choose"
+fi
+
+# 4. Empty device list entirely (flutter devices returned nothing at all).
+root=$(mktemp -d -t omi_ios_dev_empty_XXXXXX)
+stub_devices "$root" '[]'
+out=$(run_selection "$root" 2>&1); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"No iOS device or simulator found"* ]]; then
+  pass "fails with a named error when no devices are connected at all"
+else
+  fail "expected a named no-iOS-device failure, got (rc=$rc): $out"
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures shell test(s) failed" >&2
+  exit 1
+fi
+echo "all iOS device selection shell tests passed"

--- a/app/test/shell/ios_prerequisites_test.sh
+++ b/app/test/shell/ios_prerequisites_test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Behavioral tests for check_ios_prerequisites() and its _version_at_least()
+# helper in app/setup.sh.
+#
+# Regression covered: setup.sh printed a prerequisite list (Xcode, CocoaPods,
+# Flutter versions) but validated almost none of it, so a missing or outdated
+# tool surfaced as a confusing downstream failure several minutes into a
+# build instead of a named error with a remedy, unlike the harness's own
+# `Cannot start; missing prerequisites:` pattern.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SH="${SCRIPT_DIR}/../../setup.sh"
+
+if [[ ! -f "$SETUP_SH" ]]; then
+  echo "FAIL: cannot find setup.sh at $SETUP_SH" >&2
+  exit 1
+fi
+
+failures=0
+pass() { echo "  ok   - $1"; }
+fail() { echo "  FAIL - $1" >&2; failures=$((failures + 1)); }
+
+HARNESS="$(mktemp -t omi_ios_prereq_XXXXXX)"
+trap 'rm -f "$HARNESS"' EXIT
+
+extract_function() {
+  awk -v fn="function $1()" '
+    index($0, fn) == 1 { capture = 1 }
+    capture { print }
+    capture && $0 == "}" { exit }
+  ' "$SETUP_SH"
+}
+
+{
+  echo "set -uo pipefail"
+  extract_function _version_at_least
+  extract_function check_ios_prerequisites
+} > "$HARNESS"
+
+if ! bash -n "$HARNESS"; then
+  echo "FAIL: extracted harness is not valid bash" >&2
+  exit 1
+fi
+
+# Builds a stub bin/ directory reporting the given tool versions, plus real
+# coreutils (bash, sort, grep, awk, printf) so the harness itself still runs.
+stub_toolchain() {
+  local root="$1" flutter_version="$2" xcode_version="$3" pod_version="$4" have_jq="$5"
+  mkdir -p "$root/bin"
+  for real in bash sort grep awk printf head cat; do
+    ln -sf "$(command -v "$real")" "$root/bin/$real"
+  done
+  if [[ -n "$flutter_version" ]]; then
+    cat > "$root/bin/flutter" <<EOF
+#!/usr/bin/env bash
+[[ "\$1" == "--version" ]] && echo "Flutter ${flutter_version} • channel stable • https://github.com/flutter/flutter.git"
+exit 0
+EOF
+    chmod +x "$root/bin/flutter"
+  fi
+  if [[ -n "$xcode_version" ]]; then
+    cat > "$root/bin/xcodebuild" <<EOF
+#!/usr/bin/env bash
+[[ "\$1" == "-version" ]] && printf 'Xcode %s\nBuild version 0000000\n' "${xcode_version}"
+exit 0
+EOF
+    chmod +x "$root/bin/xcodebuild"
+  fi
+  if [[ -n "$pod_version" ]]; then
+    cat > "$root/bin/pod" <<EOF
+#!/usr/bin/env bash
+[[ "\$1" == "--version" ]] && echo "${pod_version}"
+exit 0
+EOF
+    chmod +x "$root/bin/pod"
+  fi
+  if [[ "$have_jq" == "yes" ]]; then
+    ln -sf "$(command -v jq)" "$root/bin/jq" 2>/dev/null || true
+  fi
+}
+
+run_with_toolchain() {
+  local root="$1"
+  PATH="$root/bin" bash -c "source '$HARNESS'; check_ios_prerequisites" 2>&1
+}
+
+echo "_version_at_least:"
+{
+  source "$HARNESS"
+  if _version_at_least "16.4" "16.4"; then pass "equal versions satisfy the minimum"; else fail "16.4 should satisfy a 16.4 minimum"; fi
+  if _version_at_least "17.0" "16.4"; then pass "newer major version satisfies an older minimum"; else fail "17.0 should satisfy a 16.4 minimum"; fi
+  if ! _version_at_least "16.3" "16.4"; then pass "older version fails a newer minimum"; else fail "16.3 should not satisfy a 16.4 minimum"; fi
+  if _version_at_least "1.16.2" "1.16.2"; then pass "three-component versions compare correctly"; else fail "1.16.2 should satisfy a 1.16.2 minimum"; fi
+}
+
+echo "check_ios_prerequisites:"
+
+root=$(mktemp -d -t omi_ios_prereq_all_ok_XXXXXX)
+stub_toolchain "$root" "3.44.9" "16.4" "1.16.2" "yes"
+out=$(run_with_toolchain "$root"); rc=$?
+rm -rf "$root"
+if [[ "$rc" -eq 0 ]]; then
+  pass "passes when every tool meets its minimum version"
+else
+  fail "expected success with all prerequisites met, got: $out"
+fi
+
+root=$(mktemp -d -t omi_ios_prereq_old_flutter_XXXXXX)
+stub_toolchain "$root" "3.40.0" "16.4" "1.16.2" "yes"
+out=$(run_with_toolchain "$root"); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"Flutter 3.40.0 found"* ]]; then
+  pass "names an outdated Flutter version with the found version and a remedy"
+else
+  fail "expected a named outdated-Flutter failure, got (rc=$rc): $out"
+fi
+
+root=$(mktemp -d -t omi_ios_prereq_no_xcode_XXXXXX)
+stub_toolchain "$root" "3.44.9" "" "1.16.2" "yes"
+out=$(run_with_toolchain "$root"); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"Xcode (v16.4 or later)"* ]]; then
+  pass "names a missing Xcode with a remedy"
+else
+  fail "expected a named missing-Xcode failure, got (rc=$rc): $out"
+fi
+
+root=$(mktemp -d -t omi_ios_prereq_old_pods_XXXXXX)
+stub_toolchain "$root" "3.44.9" "16.4" "1.10.0" "yes"
+out=$(run_with_toolchain "$root"); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"CocoaPods 1.10.0 found"* ]]; then
+  pass "names an outdated CocoaPods version with the found version and a remedy"
+else
+  fail "expected a named outdated-CocoaPods failure, got (rc=$rc): $out"
+fi
+
+root=$(mktemp -d -t omi_ios_prereq_no_jq_XXXXXX)
+stub_toolchain "$root" "3.44.9" "16.4" "1.16.2" "no"
+out=$(run_with_toolchain "$root"); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"jq (used to select"* ]]; then
+  pass "names missing jq with a remedy"
+else
+  fail "expected a named missing-jq failure, got (rc=$rc): $out"
+fi
+
+root=$(mktemp -d -t omi_ios_prereq_all_missing_XXXXXX)
+stub_toolchain "$root" "" "" "" "no"
+out=$(run_with_toolchain "$root"); rc=$?
+missing_count=$(printf '%s\n' "$out" | grep -c '^   - ')
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$missing_count" -eq 4 ]]; then
+  pass "names all four missing prerequisites at once, not just the first"
+else
+  fail "expected 4 named prerequisites, got $missing_count (rc=$rc): $out"
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures shell test(s) failed" >&2
+  exit 1
+fi
+echo "all iOS prerequisite shell tests passed"

--- a/app/test/shell/ios_prerequisites_test.sh
+++ b/app/test/shell/ios_prerequisites_test.sh
@@ -61,7 +61,16 @@ exit 0
 EOF
     chmod +x "$root/bin/flutter"
   fi
-  if [[ -n "$xcode_version" ]]; then
+  if [[ "$xcode_version" == "broken" ]]; then
+    # xcodebuild is on PATH but produces no "Xcode X.Y" line — an unaccepted
+    # license or missing components, matching the real command's behavior.
+    cat > "$root/bin/xcodebuild" <<'EOF'
+#!/usr/bin/env bash
+echo "xcodebuild: error: unable to build chip due to missing license agreement." >&2
+exit 1
+EOF
+    chmod +x "$root/bin/xcodebuild"
+  elif [[ -n "$xcode_version" ]]; then
     cat > "$root/bin/xcodebuild" <<EOF
 #!/usr/bin/env bash
 [[ "\$1" == "-version" ]] && printf 'Xcode %s\nBuild version 0000000\n' "${xcode_version}"
@@ -116,6 +125,16 @@ if [[ "$rc" -ne 0 ]] && [[ "$out" == *"Flutter 3.40.0 found"* ]]; then
   pass "names an outdated Flutter version with the found version and a remedy"
 else
   fail "expected a named outdated-Flutter failure, got (rc=$rc): $out"
+fi
+
+root=$(mktemp -d -t omi_ios_prereq_broken_xcode_XXXXXX)
+stub_toolchain "$root" "3.44.9" "broken" "1.16.2" "yes"
+out=$(run_with_toolchain "$root"); rc=$?
+rm -rf "$root"
+if [[ "$rc" -ne 0 ]] && [[ "$out" == *"xcodebuild is on PATH but not usable"* ]]; then
+  pass "names an unaccepted-license/broken Xcode install, not a silent pass"
+else
+  fail "expected a named broken-xcodebuild failure, got (rc=$rc): $out"
 fi
 
 root=$(mktemp -d -t omi_ios_prereq_no_xcode_XXXXXX)


### PR DESCRIPTION
## Summary

Two related gaps in `app/setup.sh`, both hit before any app code matters:

1. **`run_build_ios()` never pinned a target device.** With no `-d`, Flutter picked a destination itself. On a machine with no iOS simulator runtime installed and only a wirelessly-paired phone visible, it silently built for **macOS desktop** instead — after a full `pod install --repo-update` and `build_runner` pass — and failed with an unrelated "No macOS desktop project configured" error.
2. **`setup.sh` prints a prerequisite list but validates almost none of it.** Xcode v16.4, CocoaPods v1.16.2, Flutter v3.44.5 are documented in the script's own header, but the whole script has exactly one `command -v` check (for `fastlane`). A missing or outdated tool surfaces as a confusing downstream failure instead of a named error — unlike the dev harness's own `Cannot start; missing prerequisites:` pattern, which names each gap with a remedy.

## What changed

- `select_ios_device()` enumerates iOS-platform destinations from `flutter devices --machine` (via `jq`): returns the one candidate directly, prompts when there are several (failing fast without a TTY — same reasoning as `detect_apple_team_id`'s existing prompt), and fails with a named error instead of a silent fallback when there are none.
- `check_ios_prerequisites()` validates Flutter/Xcode/CocoaPods/`jq` against the versions the script already documents, listing every gap at once with a remedy, before any of the slow setup steps run.
- `run_build_ios()` now calls both before doing any real work, and passes the resolved `-d <device_id>` through to `flutter run`.

## Testing

- New shell tests: `app/test/shell/ios_device_selection_test.sh` (single device returns directly; zero devices fails named; multiple devices with no TTY fails fast, not hangs; empty device list fails named) and `app/test/shell/ios_prerequisites_test.sh` (`_version_at_least` comparisons; each of the four prerequisites individually missing/outdated with the correct remedy; all four missing at once).
- **Verified live, not just in the new tests** — ran the real `bash setup.sh ios` three ways:
  - Non-interactively with two real devices connected (a physical iPhone + a booted simulator) → correctly failed fast with the multi-device prompt rather than hang.
  - Through a real pty, feeding the interactive prompt "2" → correctly proceeded through `pod install`/`build_runner` and reached `Launching lib/main.dart on iPhone 17 Pro in debug mode...` — the exact device chosen.
  - With a stubbed toolchain reporting only a macOS destination → correctly failed with the named "No iOS device or simulator found" error instead of the original silent-fallback bug.

Failure-Class: none

Fixes #11775.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

