### PR TITLE
SCA-343: make no-changelog-needed survive the merge boundary

### DIFF
--- a/.github/failure-classes/FC-changelog-exemption-lost-at-merge.json
+++ b/.github/failure-classes/FC-changelog-exemption-lost-at-merge.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-changelog-exemption-lost-at-merge",
+  "violated_contract": "A desktop changelog exemption that makes the PR-run of check-desktop-changelog green must also make the post-merge push run green. GitHub PR labels are not visible on push, so they cannot be the sole exemption for production desktop paths.",
+  "canonical_prevention": "Exempt internal-only production desktop changes with an in-repo unreleased fragment of kind none. The no-changelog-needed label is not a skip for paths that require a changelog; PR and push evaluate the same tree/diff evidence.",
+  "canonical_prevention_artifact": [
+    ".github/scripts/check-desktop-changelog.py",
+    ".github/scripts/test_desktop_changelog.py"
+  ],
+  "evidence_prs": [11039, 11373, 11778],
+  "scope_hints": [
+    ".github/scripts/check-desktop-changelog.py",
+    ".github/scripts/pr_preflight.py",
+    "desktop/macos/changelog/unreleased/"
+  ],
+  "status": "open"
+}

--- a/.github/scripts/check-desktop-changelog.py
+++ b/.github/scripts/check-desktop-changelog.py
@@ -8,10 +8,12 @@ import json
 import os
 import subprocess
 import sys
+from typing import Literal
 
 UNRELEASED_CHANGELOG_PREFIX = "desktop/macos/changelog/unreleased/"
 CHANGELOG_PREFIX = "desktop/macos/changelog/"
 DESKTOP_PREFIX = "desktop/macos/"
+NONE_KIND = "none"
 EXEMPT_DESKTOP_PATHS = {
     "desktop/macos/CHANGELOG.json",
     "desktop/macos/AGENTS.md",
@@ -24,10 +26,10 @@ EXEMPT_DESKTOP_PATHS = {
     # launches the built app on CI builders, never ships inside it.
     "desktop/macos/scripts/smoke-signed-desktop-artifact.sh",
 }
-# Test and release-infra changes are likewise never user-facing app notes; the
-# `no-changelog-needed` PR label only satisfies the PR run, so post-merge push
-# runs of this gate must exempt these paths by path or they redden main
-# (internal-only desktop test/script edits have tripped tests/ on the merge push).
+# Test and release-infra changes are likewise never user-facing app notes.
+# `no-changelog-needed` is not an exemption for production desktop paths: the
+# label is invisible on the post-merge push run and would redden main. Internal
+# production edits use an in-repo `{"kind": "none"}` fragment instead.
 EXEMPT_DESKTOP_PATH_PREFIXES = (
     "desktop/macos/tests/",
     "desktop/macos/Desktop/Tests/",
@@ -43,6 +45,8 @@ EXEMPT_DESKTOP_PATH_PREFIXES = (
     # push for #11039.
     "desktop/macos/e2e/",
 )
+
+FragmentKind = Literal["none", "user_facing"]
 
 
 def run_git(args: list[str]) -> str:
@@ -71,7 +75,26 @@ def is_desktop_change_requiring_changelog(path: str) -> bool:
     return True
 
 
-def validate_unreleased_fragment(head_ref: str, path: str) -> None:
+def classify_fragment(data: object, path: str) -> FragmentKind:
+    if not isinstance(data, dict):
+        raise SystemExit(f"FAIL: {path} must contain a JSON object")
+
+    if data.get("kind") == NONE_KIND:
+        return "none"
+
+    if isinstance(data.get("change"), str) and data["change"].strip():
+        return "user_facing"
+    if isinstance(data.get("changes"), list) and any(
+        isinstance(entry, str) and entry.strip() for entry in data["changes"]
+    ):
+        return "user_facing"
+
+    raise SystemExit(
+        f"FAIL: {path} must contain a non-empty 'change' string, 'changes' list, " f"or 'kind': '{NONE_KIND}'"
+    )
+
+
+def load_fragment(head_ref: str, path: str) -> FragmentKind:
     try:
         raw = run_git(["show", f"{head_ref}:{path}"])
     except subprocess.CalledProcessError:
@@ -82,47 +105,91 @@ def validate_unreleased_fragment(head_ref: str, path: str) -> None:
     except json.JSONDecodeError as exc:
         raise SystemExit(f"FAIL: {path} is not valid JSON at {head_ref}: {exc}") from exc
 
-    if not isinstance(data, dict):
-        raise SystemExit(f"FAIL: {path} must contain a JSON object")
-
-    if isinstance(data.get("change"), str) and data["change"].strip():
-        return
-    if isinstance(data.get("changes"), list) and any(
-        isinstance(entry, str) and entry.strip() for entry in data["changes"]
-    ):
-        return
-
-    raise SystemExit(f"FAIL: {path} must contain a non-empty 'change' string or 'changes' list")
+    return classify_fragment(data, path)
 
 
-def has_new_unreleased_fragment(base_ref: str, head_ref: str) -> bool:
-    fragment_paths = [
+def validate_unreleased_fragment(head_ref: str, path: str) -> None:
+    load_fragment(head_ref, path)
+
+
+def added_unreleased_fragment_paths(base_ref: str, head_ref: str) -> list[str]:
+    return [
         path
         for path in added_files(base_ref, head_ref)
         if path.startswith(UNRELEASED_CHANGELOG_PREFIX) and path.endswith(".json")
     ]
+
+
+def has_new_unreleased_fragment(base_ref: str, head_ref: str) -> bool:
+    """Whether this diff added a valid exemption fragment (user-facing or kind none)."""
+    fragment_paths = added_unreleased_fragment_paths(base_ref, head_ref)
     for path in fragment_paths:
-        validate_unreleased_fragment(head_ref, path)
+        load_fragment(head_ref, path)
     return bool(fragment_paths)
 
 
 def tree_has_unreleased_fragment(head_ref: str) -> bool:
-    """Whether the tree at head carries at least one valid unreleased fragment.
+    """Whether the tree at head carries at least one user-facing unreleased fragment.
 
     The release lane (Release Eligibility on main pushes) cares that the NEXT
-    RELEASE will have notes, not that this particular push added them — PR
-    labels that exempted the merged PR are invisible on the push lane, and a
-    fragment landed by a sibling commit since the last tag satisfies the
-    release's contract. Per-PR enforcement stays with the diff-scoped check.
+    RELEASE will have notes, not that this particular push added them. A leftover
+    `kind: none` fragment is not notes — only user-facing fragments satisfy this.
     """
     try:
         output = run_git(["ls-tree", "-r", "--name-only", head_ref, UNRELEASED_CHANGELOG_PREFIX])
     except subprocess.CalledProcessError:
         return False
     fragment_paths = [path for path in output.splitlines() if path.endswith(".json")]
+    saw_user_facing = False
     for path in fragment_paths:
-        validate_unreleased_fragment(head_ref, path)
-    return bool(fragment_paths)
+        if load_fragment(head_ref, path) == "user_facing":
+            saw_user_facing = True
+    return saw_user_facing
+
+
+def evaluate_changelog_requirement(
+    *,
+    requiring_changelog: list[str],
+    skip: bool,
+    has_new_fragment: bool,
+    accept_tree_fragments: bool,
+    has_tree_user_facing_fragment: bool,
+) -> tuple[int, str]:
+    """Return (exit_code, stdout_or_stderr_message) for one gate evaluation.
+
+    `--skip` (the PR label, changelog/v branches, local hatches, the macOS CI
+    lane) is not an exemption when the diff touches production desktop paths.
+    Those paths need an in-repo fragment so the PR run and the post-merge push
+    run see the same evidence. #11778 / #11373 / #11039 all wedged main because
+    the label was invisible after merge.
+    """
+    if not requiring_changelog:
+        if skip:
+            return 0, "Desktop changelog check skipped: no production desktop paths require a fragment."
+        return 0, "No desktop changes require a changelog entry."
+
+    if has_new_fragment:
+        return 0, "Desktop changelog fragment found."
+
+    if accept_tree_fragments and has_tree_user_facing_fragment:
+        return 0, "Release lane: unreleased changelog fragments already present in the tree."
+
+    lines = [
+        "FAIL: desktop changes require an unreleased changelog fragment.",
+        "",
+        "Changed desktop files:",
+    ]
+    lines.extend(f"  - {path}" for path in requiring_changelog)
+    lines.extend(
+        [
+            "",
+            "Add a user-facing JSON fragment under desktop/macos/changelog/unreleased/, ",
+            f"or a {{\"kind\": \"{NONE_KIND}\"}} fragment for internal-only production edits.",
+            "The no-changelog-needed PR label is not an exemption: it is invisible after",
+            "merge and would redden main's Release Eligibility run.",
+        ]
+    )
+    return 1, "\n".join(lines)
 
 
 def main() -> int:
@@ -132,7 +199,10 @@ def main() -> int:
     parser.add_argument(
         "--skip",
         action="store_true",
-        help="Skip enforcement, used for PRs labeled no-changelog-needed",
+        help=(
+            "Legacy skip request (PR label, changelog/v, local hatch, macOS CI). "
+            "Ignored for production desktop paths; those need an in-repo fragment."
+        ),
     )
     parser.add_argument(
         "--accept-tree-fragments",
@@ -140,42 +210,30 @@ def main() -> int:
         default=os.getenv("DESKTOP_CHANGELOG_ACCEPT_TREE_FRAGMENTS") == "1",
         help=(
             "Release-lane mode: also pass when the tree at --head already carries a valid "
-            "unreleased fragment (set by Release Eligibility, where PR labels are invisible)"
+            "user-facing unreleased fragment (set by Release Eligibility)"
         ),
     )
     args = parser.parse_args()
 
-    if args.skip:
-        print("Desktop changelog check skipped by no-changelog-needed label.")
-        return 0
-
     files = changed_files(args.base, args.head)
     requiring_changelog = [path for path in files if is_desktop_change_requiring_changelog(path)]
-
-    if not requiring_changelog:
-        print("No desktop changes require a changelog entry.")
-        return 0
-
-    if has_new_unreleased_fragment(args.base, args.head):
-        print("Desktop changelog fragment found.")
-        return 0
-
-    if args.accept_tree_fragments and tree_has_unreleased_fragment(args.head):
-        print("Release lane: unreleased changelog fragments already present in the tree.")
-        return 0
-
-    print("FAIL: desktop changes require an unreleased changelog fragment.", file=sys.stderr)
-    print("", file=sys.stderr)
-    print("Changed desktop files:", file=sys.stderr)
-    for path in requiring_changelog:
-        print(f"  - {path}", file=sys.stderr)
-    print("", file=sys.stderr)
-    print(
-        "Add a one-line user-facing JSON fragment under desktop/macos/changelog/unreleased/, "
-        "or label the PR no-changelog-needed for internal-only changes.",
-        file=sys.stderr,
+    has_new_fragment = bool(requiring_changelog) and has_new_unreleased_fragment(args.base, args.head)
+    has_tree_user_facing_fragment = (
+        bool(requiring_changelog) and args.accept_tree_fragments and tree_has_unreleased_fragment(args.head)
     )
-    return 1
+
+    code, message = evaluate_changelog_requirement(
+        requiring_changelog=requiring_changelog,
+        skip=args.skip,
+        has_new_fragment=has_new_fragment,
+        accept_tree_fragments=args.accept_tree_fragments,
+        has_tree_user_facing_fragment=has_tree_user_facing_fragment,
+    )
+    if code:
+        print(message, file=sys.stderr)
+    else:
+        print(message)
+    return code
 
 
 if __name__ == "__main__":

--- a/.github/scripts/desktop-changelog.py
+++ b/.github/scripts/desktop-changelog.py
@@ -9,13 +9,13 @@ import sys
 from datetime import date
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 DESKTOP_DIR = ROOT / "desktop" / "macos"
 CHANGELOG_DIR = DESKTOP_DIR / "changelog"
 UNRELEASED_DIR = CHANGELOG_DIR / "unreleased"
 RELEASES_DIR = CHANGELOG_DIR / "releases"
 LEGACY_CHANGELOG_PATH = DESKTOP_DIR / "CHANGELOG.json"
+NONE_KIND = "none"
 
 
 class ChangelogError(Exception):
@@ -50,14 +50,20 @@ def normalize_changes(raw: object, path: Path) -> list[str]:
     return normalized
 
 
+def is_none_kind_fragment(data: object) -> bool:
+    return isinstance(data, dict) and data.get("kind") == NONE_KIND
+
+
 def read_unreleased_fragment(path: Path) -> list[str]:
     data = read_json(path)
+    if is_none_kind_fragment(data):
+        return []
     if isinstance(data, dict):
         if "change" in data:
             return normalize_changes(data["change"], path)
         if "changes" in data:
             return normalize_changes(data["changes"], path)
-    raise ChangelogError(f"{path} must contain a 'change' string or 'changes' list")
+    raise ChangelogError(f"{path} must contain a 'change' string, 'changes' list, or 'kind': '{NONE_KIND}'")
 
 
 def read_release_file(path: Path) -> dict[str, object]:
@@ -120,7 +126,9 @@ def release_entries() -> list[dict[str, object]]:
                     releases.append(normalized)
                     seen_versions.add(version)
 
-    return sorted(releases, key=lambda release: (str(release["date"]), version_sort_key(str(release["version"]))), reverse=True)
+    return sorted(
+        releases, key=lambda release: (str(release["date"]), version_sort_key(str(release["version"]))), reverse=True
+    )
 
 
 def legacy_changelog() -> dict[str, object]:

--- a/.github/scripts/pr_preflight.py
+++ b/.github/scripts/pr_preflight.py
@@ -254,7 +254,6 @@ def main() -> int:
         except RuntimeError as exc:
             print(f"FAIL: {exc}", file=sys.stderr)
             return 1
-        labels = metadata.labels if metadata else ()
         head_branch = args.head_branch or os.getenv("GITHUB_HEAD_REF", "")
         if not head_branch:
             head_branch = subprocess.run(
@@ -264,11 +263,7 @@ def main() -> int:
                 stdout=subprocess.PIPE,
                 text=True,
             ).stdout.strip()
-        skip_changelog = (
-            "no-changelog-needed" in labels
-            or head_branch.startswith("changelog/v")
-            or os.getenv("PRE_PUSH_SKIP_DESKTOP_CHANGELOG") == "1"
-        )
+        skip_changelog = head_branch.startswith("changelog/v") or os.getenv("PRE_PUSH_SKIP_DESKTOP_CHANGELOG") == "1"
         if metadata:
             print(f"PR metadata: {metadata.source}, updated_at={metadata.updated_at}")
         elif any(check.name == "product-invariants" for check in checks):

--- a/.github/scripts/test_desktop_changelog.py
+++ b/.github/scripts/test_desktop_changelog.py
@@ -16,9 +16,7 @@ import unittest
 import unittest.mock
 from pathlib import Path
 
-_SPEC = importlib.util.spec_from_file_location(
-    "desktop_changelog", Path(__file__).with_name("desktop-changelog.py")
-)
+_SPEC = importlib.util.spec_from_file_location("desktop_changelog", Path(__file__).with_name("desktop-changelog.py"))
 changelog = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(changelog)
 
@@ -125,6 +123,123 @@ class ChangelogRequirementTests(unittest.TestCase):
         with unittest.mock.patch.object(checker, "run_git", side_effect=fake_git):
             with self.assertRaises(SystemExit):
                 checker.tree_has_unreleased_fragment("HEAD")
+
+    def test_kind_none_is_a_valid_exemption_but_not_release_notes(self) -> None:
+        self.assertEqual(
+            checker.classify_fragment({"kind": "none"}, "desktop/macos/changelog/unreleased/none.json"),
+            "none",
+        )
+        self.assertEqual(
+            checker.classify_fragment({"change": "Fixed a thing"}, "desktop/macos/changelog/unreleased/fix.json"),
+            "user_facing",
+        )
+        with self.assertRaises(SystemExit):
+            checker.classify_fragment({}, "desktop/macos/changelog/unreleased/empty.json")
+
+    def test_release_lane_ignores_leftover_kind_none_fragments(self) -> None:
+        # A spent internal-only marker must not satisfy "the next release has notes".
+        def fake_git(args: list[str]) -> str:
+            if args[0] == "ls-tree":
+                return "desktop/macos/changelog/unreleased/20260818-dead-code.json"
+            if args[0] == "show":
+                return '{"kind": "none"}'
+            raise AssertionError(f"unexpected git invocation: {args}")
+
+        with unittest.mock.patch.object(checker, "run_git", side_effect=fake_git):
+            self.assertFalse(checker.tree_has_unreleased_fragment("HEAD"))
+
+
+PR_11778_SOURCES = (
+    "desktop/macos/Desktop/Sources/FloatingControlBar/PTTContextVocabularyProvider.swift",
+    "desktop/macos/Desktop/Sources/Rewind/Core/ProactiveModels.swift",
+    "desktop/macos/Desktop/Sources/Rewind/Core/ProactiveStorage.swift",
+    "desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift",
+)
+
+
+class MergeBoundaryAgreementTests(unittest.TestCase):
+    """#11778: a green PR-run must not be able to redden the post-merge push run."""
+
+    def test_11778_production_sources_require_a_changelog(self) -> None:
+        for path in PR_11778_SOURCES:
+            with self.subTest(path=path):
+                self.assertTrue(checker.is_desktop_change_requiring_changelog(path))
+
+    def test_11778_label_without_fragment_pr_and_push_both_fail(self) -> None:
+        requiring = list(PR_11778_SOURCES)
+        pr_code, pr_message = checker.evaluate_changelog_requirement(
+            requiring_changelog=requiring,
+            skip=True,
+            has_new_fragment=False,
+            accept_tree_fragments=False,
+            has_tree_user_facing_fragment=False,
+        )
+        push_code, push_message = checker.evaluate_changelog_requirement(
+            requiring_changelog=requiring,
+            skip=False,
+            has_new_fragment=False,
+            accept_tree_fragments=True,
+            has_tree_user_facing_fragment=False,
+        )
+        self.assertEqual(pr_code, push_code)
+        self.assertEqual(pr_code, 1)
+        self.assertIn("kind", pr_message)
+        self.assertIn("no-changelog-needed", pr_message)
+        self.assertIn("kind", push_message)
+
+    def test_11778_kind_none_fragment_pr_and_push_both_pass(self) -> None:
+        requiring = list(PR_11778_SOURCES)
+        pr_code, _ = checker.evaluate_changelog_requirement(
+            requiring_changelog=requiring,
+            skip=True,
+            has_new_fragment=True,
+            accept_tree_fragments=False,
+            has_tree_user_facing_fragment=False,
+        )
+        push_code, _ = checker.evaluate_changelog_requirement(
+            requiring_changelog=requiring,
+            skip=False,
+            has_new_fragment=True,
+            accept_tree_fragments=True,
+            has_tree_user_facing_fragment=False,
+        )
+        self.assertEqual(pr_code, push_code)
+        self.assertEqual(pr_code, 0)
+
+    def test_skip_still_passes_when_only_exempt_paths_changed(self) -> None:
+        code, message = checker.evaluate_changelog_requirement(
+            requiring_changelog=[],
+            skip=True,
+            has_new_fragment=False,
+            accept_tree_fragments=False,
+            has_tree_user_facing_fragment=False,
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("skipped", message)
+
+    def test_leftover_kind_none_does_not_satisfy_a_later_production_push(self) -> None:
+        code, _ = checker.evaluate_changelog_requirement(
+            requiring_changelog=list(PR_11778_SOURCES),
+            skip=False,
+            has_new_fragment=False,
+            accept_tree_fragments=True,
+            has_tree_user_facing_fragment=False,
+        )
+        self.assertEqual(code, 1)
+
+
+class NoneKindFragmentIOTests(unittest.TestCase):
+    def test_none_kind_fragment_contributes_no_release_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "20260818-dead-code.json"
+            changelog.write_json(path, {"kind": "none"})
+            self.assertEqual(changelog.read_unreleased_fragment(path), [])
+
+    def test_none_kind_is_valid_for_repository_wide_validate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "20260818-dead-code.json"
+            changelog.write_json(path, {"kind": "none"})
+            self.assertEqual(changelog.read_unreleased_fragment(path), [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -675,10 +675,27 @@ class SingleFlightTests(unittest.TestCase):
             self.assertEqual(status["phase"], "passed")
             self.assertTrue((temp / "test" / "preflight.log").exists())
 
+    def _hold_command(self, hold: Path) -> list[str]:
+        # A short sleep races the second runner on a loaded host: the first
+        # child can exit before the overlap is observed, so the second starts
+        # cleanly and the test expects 75 but gets 0. Hold a file instead.
+        script = (
+            "from pathlib import Path\n"
+            "import time\n"
+            f"hold = Path({str(hold)!r})\n"
+            "print('==> slow', flush=True)\n"
+            "deadline = time.monotonic() + 10\n"
+            "while hold.exists() and time.monotonic() < deadline:\n"
+            "    time.sleep(0.02)\n"
+        )
+        return [sys.executable, "-c", script]
+
     def test_different_input_is_rejected_while_active(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             temp = Path(tmp)
-            command = [sys.executable, "-c", "import time; print('==> slow', flush=True); time.sleep(.5)"]
+            hold = temp / "hold"
+            hold.write_text("1", encoding="utf-8")
+            command = self._hold_command(hold)
             first = self.run_runner(temp, command)
             assert first.stdin is not None
             first.stdin.write("first\n")
@@ -693,6 +710,7 @@ class SingleFlightTests(unittest.TestCase):
             if second.stdout:
                 second.stdout.close()
             self.assertIn("already running different input", second_output)
+            hold.unlink(missing_ok=True)
             if first.stdout:
                 first.stdout.read()
                 first.stdout.close()
@@ -719,7 +737,9 @@ class SingleFlightTests(unittest.TestCase):
     def test_different_pre_push_environment_is_not_joined(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             temp = Path(tmp)
-            command = [sys.executable, "-c", "import time; print('==> slow', flush=True); time.sleep(.5)"]
+            hold = temp / "hold"
+            hold.write_text("1", encoding="utf-8")
+            command = self._hold_command(hold)
             first = self.run_runner(temp, command, extra_env={"PRE_PUSH_SKIP_ACTIONLINT": "1"})
             assert first.stdin is not None
             first.stdin.close()
@@ -732,6 +752,7 @@ class SingleFlightTests(unittest.TestCase):
             self.assertIn("already running different input", second_output)
             if second.stdout:
                 second.stdout.close()
+            hold.unlink(missing_ok=True)
             if first.stdout:
                 first.stdout.read()
                 first.stdout.close()

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -646,12 +646,20 @@ class SingleFlightTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             temp = Path(tmp)
             counter = temp / "counter"
-            code = (
-                "from pathlib import Path; import time; "
-                f"p=Path({str(counter)!r}); p.write_text(p.read_text()+'x' if p.exists() else 'x'); "
-                "print('==> focused-tests', flush=True); time.sleep(.5)"
+            hold = temp / "hold"
+            hold.write_text("1", encoding="utf-8")
+            script = (
+                "from pathlib import Path\n"
+                "import time\n"
+                f"p = Path({str(counter)!r})\n"
+                f"hold = Path({str(hold)!r})\n"
+                "p.write_text(p.read_text() + 'x' if p.exists() else 'x')\n"
+                "print('==> focused-tests', flush=True)\n"
+                "deadline = time.monotonic() + 10\n"
+                "while hold.exists() and time.monotonic() < deadline:\n"
+                "    time.sleep(0.02)\n"
             )
-            command = [sys.executable, "-c", code]
+            command = [sys.executable, "-c", script]
             first = self.run_runner(temp, command)
             assert first.stdin is not None
             first.stdin.write("same\n")
@@ -661,6 +669,8 @@ class SingleFlightTests(unittest.TestCase):
             assert second.stdin is not None
             second.stdin.write("same\n")
             second.stdin.close()
+            time.sleep(0.3)
+            hold.unlink(missing_ok=True)
             first_output = first.stdout.read() if first.stdout else ""
             second_output = second.stdout.read() if second.stdout else ""
             self.assertEqual(first.wait(), 0, first_output)

--- a/.github/workflows/desktop-swift-ci.yml
+++ b/.github/workflows/desktop-swift-ci.yml
@@ -132,9 +132,10 @@ jobs:
         run: |
           MANIFEST_ARGS=()
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Repo Checks owns PR metadata enforcement and reruns it for label
-            # changes. This macOS-only lane has no live PR metadata, so it must
-            # not independently reject the supported no-changelog-needed label.
+            # Repo Checks owns PR-body metadata. This macOS-only lane still
+            # passes --skip-changelog so it does not depend on labels; the
+            # checker itself no longer treats that skip as an exemption for
+            # production desktop paths (SCA-343 / #11778).
             MANIFEST_ARGS+=(--skip-changelog)
           fi
           python3 .github/scripts/run_checks.py \

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -512,7 +512,8 @@ Guidelines:
 - Write from the user's perspective: "Fixed X", "Added Y", "Improved Z"
 - One sentence, no period at the end
 - Use a unique kebab-case filename so parallel PRs do not conflict
-- Skip internal-only changes (refactors, CI config, code cleanup)
+- Tests, generated Swift, e2e harness files, and listed release-infra paths are already exempt
+- Internal-only **production** edits (dead-code deletion, refactors in `Sources/`) need an in-repo marker, not the `no-changelog-needed` PR label — that label is invisible after merge and reddens main. Add `{"kind": "none"}` under `desktop/macos/changelog/unreleased/` instead
 - HTML is allowed for links: `<a href='...'>text</a>`
 - Do not edit `CHANGELOG.json` by hand; release automation regenerates it
 - Commit the fragment with your other changes (same commit is fine)


### PR DESCRIPTION
## Summary

Closes SCA-343.

The `no-changelog-needed` PR label greened the desktop changelog gate and then reddened main's Release Eligibility run, because push has no PR context. That is a trap: a green PR can poison a main SHA and block `gcp_backend.yml` deploys. Live instance: #11778. Same class as #11373 and #11039.

### Approach taken: (2) + (3)

**In-repo `{"kind": "none"}` fragment** as the durable internal exemption, **and reject the label as an exemption for production desktop paths**.

- A new unreleased fragment of `{"kind": "none"}` satisfies both the PR-run and the post-merge push-run. It lives in the diff, so both lanes see the same evidence.
- `--skip` / `no-changelog-needed` no longer passes when the diff touches production desktop paths. The PR-run and push-run therefore agree on the #11778 shape (both fail without a fragment; both pass with `kind: none`).
- Leftover `kind: none` fragments do **not** satisfy release-lane `--accept-tree-fragments`. That lane still requires real user-facing notes for the next release.
- Release consolidation ignores `kind: none` so it never becomes a user-facing changelog line.

### Why the others were rejected

1. **Resolve the PR from the merge commit and read labels via the API.** Closest to the old UI intent, but it adds a network dependency to a gate that is otherwise hermetic, and it must fail-closed on direct pushes and back-merges. A label would still be invisible to local `make preflight` / pre-push.
3. **Reject the label alone** (no in-repo marker). Smallest diff, but it forces a dishonest user-facing note for genuinely internal production edits such as dead-code deletion. Combined with (2), authors have an honest, durable escape.

The invariant: a PR that is green on this gate cannot redden `main` on the same gate.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

Registers `FC-changelog-exemption-lost-at-merge` with a reusable guard: `evaluate_changelog_requirement()` plus the #11778 regression in `.github/scripts/test_desktop_changelog.py`. Evidence PRs: #11039, #11373, #11778.

## Authors

Internal-only production desktop edits (for example dead-code deletion under `Desktop/Sources/`) now need:

```json
{"kind": "none"}
```

under `desktop/macos/changelog/unreleased/`. The `no-changelog-needed` label is not an exemption. Documented in `desktop/macos/AGENTS.md`.

## Test plan

- [x] `python3 .github/scripts/test_desktop_changelog.py` — 16 tests, including the #11778 PR-vs-push agreement cases
- [x] `python3 .github/scripts/desktop-changelog.py validate`
- [x] `python3 scripts/test_failure_class.py`
- [x] `scripts/pr-preflight --pr-body-file pr-body.md`
- [ ] Confirm CI `desktop-changelog-io-tests` and `desktop-changelog-entry` on this PR
- [ ] Confirm a follow-up internal Sources edit without a fragment fails both the PR lane and a simulated push lane (`--accept-tree-fragments`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

