### PR TITLE
fix(backend): only a genuinely absent state head may unlock the legacy knowledge-graph mutation

### DIFF
--- a/.github/failure-classes/FC-derived-state-gate-without-legacy-source-path.json
+++ b/.github/failure-classes/FC-derived-state-gate-without-legacy-source-path.json
@@ -6,7 +6,9 @@
   "canonical_prevention_artifact": [
     "backend/routers/knowledge_graph.py",
     "backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py",
-    "backend/tests/unit/test_knowledge_graph_legacy_fallback.py"
+    "backend/tests/unit/test_knowledge_graph_legacy_fallback.py",
+    "backend/utils/memory/canonical_graph.py",
+    "backend/tests/unit/test_canonical_graph_state_probe.py"
   ],
   "evidence_prs": [
     11623,

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from enum import Enum
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -11,6 +12,7 @@ from database.auth import get_user_name
 from utils.memory import canonical_graph as canonical_graph_service
 from utils.memory.memory_service import MemoryService
 from utils.executors import db_executor, llm_executor, run_blocking
+from utils.observability.fallback import record_fallback
 from utils.other import endpoints as auth
 from utils.subscription import is_trial_paywalled
 
@@ -22,6 +24,9 @@ RateLimitFactory = Callable[[Any, str], Any]
 with_rate_limit: RateLimitFactory = cast(RateLimitFactory, getattr(auth, "with_rate_limit"))
 CANONICAL_GRAPH_MUTATION_CONFLICT = (
     "Canonical knowledge graph state is derived from canonical memories and cannot be deleted or rebuilt directly."
+)
+CANONICAL_GRAPH_STATE_UNVERIFIED = (
+    "Knowledge graph state could not be verified right now, so it was left untouched. Please try again."
 )
 
 
@@ -36,39 +41,61 @@ def _run_rebuild_knowledge_graph(uid: str, memories: MemoryPayloads, user_name: 
     return rebuild_knowledge_graph(uid, memories, user_name)
 
 
-def _has_canonical_graph_state(uid: str) -> bool:
-    """Whether canonical graph state is actually established for this account.
+class LegacyGraphMutation(str, Enum):
+    """Whether the legacy rebuild/delete path may run for this account."""
 
-    Canonical graph reads are fenced on ``users/{uid}/memory_state/head``, which
-    only the canonical apply transaction writes. The convergence shipped no
-    backfill, so an account that has never committed through canonical apply has
-    no derived state at all.
+    ALLOWED = 'allowed'
+    #: Derived state exists and owns this graph — the legacy mutation is a conflict.
+    CONFLICT = 'conflict'
+    #: We could not establish whether derived state exists. Not the same as "it does not".
+    UNVERIFIED = 'unverified'
+
+
+def _legacy_graph_mutation_decision(uid: str) -> LegacyGraphMutation:
+    """Decide, per account, whether the legacy graph may still be rebuilt or deleted.
+
+    This must stay a real per-account probe. Answering ``CONFLICT`` unconditionally
+    protects derived state that does not exist and denies every account the legacy
+    rebuild/delete their graph still needs.
+
+    The probe is deliberately tri-state. ``GET`` may fail open on any unavailable
+    canonical read because the worst case is a stale view; these routes destroy the
+    legacy store, so only a *positive* "there is no state head" answer may unlock
+    them. A read timeout, a corrupt head, or an unsupported schema is an unanswered
+    question, and answering it as "unestablished" would let a transient Firestore
+    blip delete the graph.
     """
-    try:
-        canonical_graph_service.get_canonical_knowledge_graph(uid, limit=1, cursor=None)
-    except canonical_graph_service.CanonicalGraphReadUnavailable:
-        return False
-    return True
-
-
-def _is_assertion_backed_graph_account(uid: str) -> bool:
-    """Whether this account's graph is derived state owned by canonical apply.
-
-    This must stay a real per-account probe. Answering ``True`` unconditionally
-    protects derived state that does not exist and denies every account the
-    legacy rebuild/delete their graph still needs.
-    """
-    if _has_canonical_graph_state(uid):
-        return True
-    return kg_db.has_stored_memory_graph_assertions(uid, db_client=get_firestore_client())
+    state = canonical_graph_service.probe_canonical_graph_state(uid)
+    if state is canonical_graph_service.CanonicalGraphState.ESTABLISHED:
+        return LegacyGraphMutation.CONFLICT
+    if state is canonical_graph_service.CanonicalGraphState.INDETERMINATE:
+        return LegacyGraphMutation.UNVERIFIED
+    if kg_db.has_stored_memory_graph_assertions(uid, db_client=get_firestore_client()):
+        return LegacyGraphMutation.CONFLICT
+    return LegacyGraphMutation.ALLOWED
 
 
 def _require_legacy_graph_mutation(uid: str) -> None:
-    if _is_assertion_backed_graph_account(uid):
+    decision = _legacy_graph_mutation_decision(uid)
+    if decision is LegacyGraphMutation.CONFLICT:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=CANONICAL_GRAPH_MUTATION_CONFLICT,
         )
+    if decision is LegacyGraphMutation.UNVERIFIED:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=CANONICAL_GRAPH_STATE_UNVERIFIED,
+        )
+    # Fail-open path: this account has no canonical state, so the mutation is
+    # served by the pre-canonical store instead of the derived one.
+    record_fallback(
+        component='knowledge_graph',
+        from_mode='canonical_graph',
+        to_mode='legacy_graph',
+        reason='unmigrated_principal',
+        outcome='degraded',
+    )
 
 
 class KnowledgeNode(BaseModel):
@@ -221,7 +248,7 @@ def get_canonical_knowledge_graph(
 
 
 def _rebuild_graph_task(uid: str, user_name: str) -> None:
-    if _is_assertion_backed_graph_account(uid):
+    if _legacy_graph_mutation_decision(uid) is not LegacyGraphMutation.ALLOWED:
         return
     memories: MemoryPayloads = [
         {"id": memory.id, "content": memory.content}

--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Callable, Optional, cast
 
 from database import knowledge_graph as kg_db
-from database._client import db as firestore_db
+from database._client import get_firestore_client
 from database.auth import get_user_name
 from utils.memory import canonical_graph as canonical_graph_service
 from utils.memory.memory_service import MemoryService
@@ -60,7 +60,7 @@ def _is_assertion_backed_graph_account(uid: str) -> bool:
     """
     if _has_canonical_graph_state(uid):
         return True
-    return kg_db.has_stored_memory_graph_assertions(uid, db_client=firestore_db)
+    return kg_db.has_stored_memory_graph_assertions(uid, db_client=get_firestore_client())
 
 
 def _require_legacy_graph_mutation(uid: str) -> None:
@@ -225,7 +225,7 @@ def _rebuild_graph_task(uid: str, user_name: str) -> None:
         return
     memories: MemoryPayloads = [
         {"id": memory.id, "content": memory.content}
-        for memory in MemoryService(db_client=firestore_db).read(uid, limit=500)
+        for memory in MemoryService(db_client=get_firestore_client()).read(uid, limit=500)
         if not getattr(memory, "is_locked", False)
     ]
     _run_rebuild_knowledge_graph(uid, memories, user_name)

--- a/backend/tests/unit/test_canonical_graph_state_probe.py
+++ b/backend/tests/unit/test_canonical_graph_state_probe.py
@@ -1,0 +1,144 @@
+"""`probe_canonical_graph_state` answers three things, not two.
+
+Callers that destroy the pre-canonical store need the difference between "this
+account has no canonical state" and "we could not find out". The trusted head
+read collapses every exception into `READ_FAILED`, so a Firestore timeout looks
+identical to an absent document unless the reason is inspected by value.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from utils.memory import canonical_graph as kg
+from utils.memory.v3.account_generation_source import (
+    V3_TRUSTED_ACCOUNT_GENERATION_SCHEMA_VERSION,
+    V3_TRUSTED_ACCOUNT_GENERATION_SOURCE,
+    V3AccountGenerationFailureReason as Reason,
+    V3TrustedAccountGenerationResult as TrustedHead,
+)
+
+UID = "uid-probe"
+HEAD_PATH = f"users/{UID}/memory_state/head"
+
+
+def _head(monkeypatch, result: TrustedHead) -> None:
+    monkeypatch.setattr(kg, "read_memory_v3_trusted_account_generation", lambda **_kw: result)
+
+
+@pytest.fixture(autouse=True)
+def _no_firestore(monkeypatch):
+    monkeypatch.setattr(kg, "get_firestore_client", lambda: object())
+
+
+def test_a_committed_head_is_established(monkeypatch):
+    _head(
+        monkeypatch,
+        TrustedHead(
+            uid=UID,
+            source_path=HEAD_PATH,
+            account_generation=2,
+            head_commit_id="commit-1",
+            commit_sequence=5,
+            source=V3_TRUSTED_ACCOUNT_GENERATION_SOURCE,
+            schema_version=V3_TRUSTED_ACCOUNT_GENERATION_SCHEMA_VERSION,
+        ),
+    )
+
+    assert kg.probe_canonical_graph_state(UID) is kg.CanonicalGraphState.ESTABLISHED
+
+
+def test_an_absent_head_is_the_only_unestablished_answer(monkeypatch):
+    _head(monkeypatch, TrustedHead(uid=UID, source_path=HEAD_PATH, read_error_reason=Reason.MISSING_STATE_HEAD))
+
+    assert kg.probe_canonical_graph_state(UID) is kg.CanonicalGraphState.UNESTABLISHED
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        Reason.READ_FAILED,
+        Reason.MALFORMED_STATE_HEAD,
+        Reason.UNSUPPORTED_SCHEMA,
+        Reason.UID_MISMATCH,
+        Reason.SOURCE_MISMATCH,
+        Reason.MALFORMED_ACCOUNT_GENERATION,
+    ],
+    ids=lambda reason: reason.value,
+)
+def test_every_other_failure_reason_is_indeterminate(monkeypatch, reason):
+    _head(monkeypatch, TrustedHead(uid=UID, source_path=HEAD_PATH, read_error_reason=reason))
+
+    assert kg.probe_canonical_graph_state(UID) is kg.CanonicalGraphState.INDETERMINATE
+
+
+def test_a_head_without_a_usable_revision_fence_is_indeterminate(monkeypatch):
+    _head(
+        monkeypatch,
+        TrustedHead(uid=UID, source_path=HEAD_PATH, account_generation=2, head_commit_id="", commit_sequence=5),
+    )
+
+    assert kg.probe_canonical_graph_state(UID) is kg.CanonicalGraphState.INDETERMINATE
+
+
+def test_a_thrown_head_read_is_classified_as_read_failed_not_absent(monkeypatch):
+    """The probe's boundary is the real reader, not a hand-written enum value.
+
+    `read_memory_v3_trusted_account_generation` swallows every head-get
+    exception. Drive it with a client that raises so the probe is exercised
+    against the classification production actually produces.
+    """
+
+    class _Exploding:
+        def document(self, _path: str) -> Any:
+            raise TimeoutError("firestore deadline exceeded")
+
+    assert kg.probe_canonical_graph_state(UID, db_client=_Exploding()) is kg.CanonicalGraphState.INDETERMINATE
+
+
+def test_the_probe_needs_no_cursor_secret_and_no_atlas_query(monkeypatch):
+    """The probe reads one document; it must not depend on paging machinery.
+
+    The previous implementation materialized a whole canonical page just to
+    answer a boolean, which made the answer depend on `MEMORY_V3_CURSOR_SECRET`
+    and on the atlas composite index being present.
+    """
+    monkeypatch.delenv("MEMORY_V3_CURSOR_SECRET", raising=False)
+
+    def _must_not_page(*_args: Any, **_kwargs: Any):  # pragma: no cover - asserts absence
+        raise AssertionError("the state probe paged the canonical atlas")
+
+    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _must_not_page)
+    monkeypatch.setattr(kg, "_read_canonical_graph_page_once", _must_not_page)
+
+    reads: list[str] = []
+
+    class _Head:
+        exists = True
+
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "schema_version": V3_TRUSTED_ACCOUNT_GENERATION_SCHEMA_VERSION,
+                "uid": UID,
+                "source": V3_TRUSTED_ACCOUNT_GENERATION_SOURCE,
+                "account_generation": 2,
+                "head_commit_id": "commit-1",
+                "commit_sequence": 5,
+            }
+
+    class _Doc:
+        def get(self, **_kw: Any) -> _Head:
+            return _Head()
+
+    class _Client:
+        def document(self, path: str) -> _Doc:
+            reads.append(path)
+            return _Doc()
+
+        def collection(self, *_args: Any, **_kwargs: Any):  # pragma: no cover - asserts absence
+            raise AssertionError("the state probe ran a collection query")
+
+    assert kg.probe_canonical_graph_state(UID, db_client=_Client()) is kg.CanonicalGraphState.ESTABLISHED
+    assert reads == [HEAD_PATH]

--- a/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
@@ -11,6 +11,11 @@ including accounts with no `memory_state/head` at all — canonical intake is
 fenced in production, and the convergence shipped no backfill, so there was no
 derived state to protect. Mobile rendered the 409 body straight to the screen.
 `fbb005c15b` restored the GET fallback; this suite covers the mutation side.
+
+The gate is tri-state on purpose. `GET` may fail open on any unavailable
+canonical read; these routes delete the legacy store, so only a positive
+"there is no state head" answer may unlock them. Every other unavailable
+reason — a timed-out head read above all — must leave the graph alone.
 """
 
 from __future__ import annotations
@@ -24,21 +29,56 @@ import pytest
 from database import knowledge_graph as kg_db
 from routers import knowledge_graph as kg_router
 from utils.memory import canonical_graph as kg
+from utils.memory.v3.account_generation_source import (
+    V3_TRUSTED_ACCOUNT_GENERATION_SCHEMA_VERSION,
+    V3_TRUSTED_ACCOUNT_GENERATION_SOURCE,
+    V3AccountGenerationFailureReason as Reason,
+    V3TrustedAccountGenerationResult as TrustedHead,
+)
 from utils.other import endpoints as auth
 
 UID = "uid-arbitrary-account"
+HEAD_PATH = f"users/{UID}/memory_state/head"
+
+# Every way the trusted head read can fail other than "the document is absent".
+# None of these establishes that the account has no canonical state.
+INDETERMINATE_REASONS = [
+    Reason.READ_FAILED,
+    Reason.MALFORMED_STATE_HEAD,
+    Reason.UNSUPPORTED_SCHEMA,
+    Reason.UID_MISMATCH,
+    Reason.SOURCE_MISMATCH,
+    Reason.MALFORMED_ACCOUNT_GENERATION,
+]
 
 
-class _Page:
-    nodes: List[Dict[str, Any]] = [{"id": "c1", "label": "Ada"}]
-    edges: List[Dict[str, Any]] = []
-    has_more = False
-    next_cursor = None
-    catalog_nodes: List[Dict[str, Any]] = []
+def _established_head() -> TrustedHead:
+    """A well-formed state head: canonical apply has committed for this account."""
+    return TrustedHead(
+        uid=UID,
+        source_path=HEAD_PATH,
+        account_generation=3,
+        head_commit_id="commit-9",
+        commit_sequence=7,
+        source=V3_TRUSTED_ACCOUNT_GENERATION_SOURCE,
+        schema_version=V3_TRUSTED_ACCOUNT_GENERATION_SCHEMA_VERSION,
+    )
 
 
-def _canonical_unavailable(*_args: Any, **_kwargs: Any):
-    raise kg.CanonicalGraphReadUnavailable("missing_state_head")
+def _failed_head(reason: Reason) -> TrustedHead:
+    return TrustedHead(uid=UID, source_path=HEAD_PATH, read_error_reason=reason)
+
+
+def _head(monkeypatch, result: TrustedHead) -> None:
+    """Stub the one trusted head read the gate's probe performs."""
+    monkeypatch.setattr(kg, "read_memory_v3_trusted_account_generation", lambda **_kw: result)
+
+
+@pytest.fixture(autouse=True)
+def _no_firestore(monkeypatch):
+    # The probe resolves a client before reading; never build a real one here.
+    monkeypatch.setattr(kg, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(kg_router, "get_firestore_client", lambda: object())
 
 
 @pytest.fixture
@@ -60,13 +100,21 @@ def deleted(monkeypatch):
     return calls
 
 
+@pytest.fixture
+def fallbacks(monkeypatch):
+    """Record shared fallback telemetry emitted by the fail-open branch."""
+    calls: List[Dict[str, Any]] = []
+    monkeypatch.setattr(kg_router, "record_fallback", lambda **kwargs: calls.append(kwargs))
+    return calls
+
+
 def _legacy_principal(monkeypatch) -> None:
     """No memory_state/head, no assertions — the unmigrated majority."""
-    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    _head(monkeypatch, _failed_head(Reason.MISSING_STATE_HEAD))
     monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: False)
 
 
-def test_legacy_principal_can_rebuild(client, monkeypatch, deleted):
+def test_legacy_principal_can_rebuild(client, monkeypatch, deleted, fallbacks):
     _legacy_principal(monkeypatch)
     scheduled: List[Any] = []
     # TestClient runs background tasks inline; the task itself has its own tests.
@@ -80,7 +128,7 @@ def test_legacy_principal_can_rebuild(client, monkeypatch, deleted):
     assert scheduled == [(UID, "Ada")]
 
 
-def test_legacy_principal_can_delete(client, monkeypatch, deleted):
+def test_legacy_principal_can_delete(client, monkeypatch, deleted, fallbacks):
     _legacy_principal(monkeypatch)
 
     response = client.delete("/v1/knowledge-graph")
@@ -90,8 +138,41 @@ def test_legacy_principal_can_delete(client, monkeypatch, deleted):
     assert deleted == [UID]
 
 
-def test_established_canonical_state_still_conflicts(client, monkeypatch, deleted):
-    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", lambda *a, **k: _Page())
+def test_the_legacy_fail_open_reports_shared_fallback_telemetry(client, monkeypatch, deleted, fallbacks):
+    # AGENTS.md: a fail-open branch calls the shared record_fallback helper.
+    # Silent UX healing is fine; a silently degraded mutation path is not.
+    _legacy_principal(monkeypatch)
+
+    assert client.delete("/v1/knowledge-graph").status_code == 200
+
+    assert len(fallbacks) == 1
+    assert fallbacks[0]["component"] == "knowledge_graph"
+    assert fallbacks[0]["from_mode"] == "canonical_graph"
+    assert fallbacks[0]["to_mode"] == "legacy_graph"
+    assert fallbacks[0]["outcome"] == "degraded"
+
+
+def test_a_conflicting_account_reports_no_fallback(client, monkeypatch, deleted, fallbacks):
+    # The conflict is a hard refusal, not a degraded path; it must not inflate
+    # the fallback counter that measures how many accounts still run on legacy.
+    _head(monkeypatch, _established_head())
+
+    assert client.delete("/v1/knowledge-graph").status_code == 409
+
+    assert fallbacks == []
+
+
+def test_an_established_head_with_zero_assertions_still_conflicts(client, monkeypatch, deleted, fallbacks):
+    # The state head is the "canonical state established" signal, not whether a
+    # materialized page happens to carry assertions. An account mid-migration
+    # can have a committed head and zero graph assertions; its graph is still
+    # derived state, and rebuild/delete must not touch it.
+    _head(monkeypatch, _established_head())
+
+    def _must_not_be_consulted(*_args: Any, **_kwargs: Any) -> bool:  # pragma: no cover - asserts absence
+        raise AssertionError("an established head must decide the gate on its own")
+
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", _must_not_be_consulted)
 
     rebuild = client.post("/v1/knowledge-graph/rebuild")
     delete = client.delete("/v1/knowledge-graph")
@@ -103,10 +184,55 @@ def test_established_canonical_state_still_conflicts(client, monkeypatch, delete
     assert deleted == []
 
 
-def test_stored_assertions_still_conflict_without_a_state_head(client, monkeypatch, deleted):
-    # Assertion-backed graphs are derived state even when the canonical read
-    # cannot serve them; they must not be rebuilt or deleted through here.
-    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+@pytest.mark.parametrize("reason", INDETERMINATE_REASONS, ids=lambda reason: reason.value)
+def test_an_unanswered_canonical_probe_must_not_delete_the_legacy_graph(
+    client, monkeypatch, deleted, fallbacks, reason
+):
+    # A head read that timed out, or a head we cannot parse, does not establish
+    # that the account has no canonical state. Treating it as "unestablished"
+    # turns a transient Firestore blip into permanent loss of the legacy graph.
+    _head(monkeypatch, _failed_head(reason))
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: False)
+    scheduled: List[Any] = []
+    monkeypatch.setattr(kg_router, "_rebuild_graph_task", lambda uid, user_name: scheduled.append(uid))
+
+    rebuild = client.post("/v1/knowledge-graph/rebuild")
+    delete = client.delete("/v1/knowledge-graph")
+
+    assert deleted == []
+    assert scheduled == []
+    assert rebuild.status_code == 503
+    assert delete.status_code == 503
+    assert delete.json()["detail"] == kg_router.CANONICAL_GRAPH_STATE_UNVERIFIED
+
+
+def test_a_malformed_head_without_a_read_error_must_not_delete_the_legacy_graph(
+    client, monkeypatch, deleted, fallbacks
+):
+    # A head that reads cleanly but carries no commit sequence is not a usable
+    # revision fence, and it is not evidence of an unprovisioned account either.
+    _head(
+        monkeypatch,
+        TrustedHead(
+            uid=UID,
+            source_path=HEAD_PATH,
+            account_generation=3,
+            head_commit_id="commit-9",
+            commit_sequence=None,
+        ),
+    )
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: False)
+
+    delete = client.delete("/v1/knowledge-graph")
+
+    assert delete.status_code == 503
+    assert deleted == []
+
+
+def test_stored_assertions_still_conflict_without_a_state_head(client, monkeypatch, deleted, fallbacks):
+    # Assertion-backed graphs are derived state even when no state head exists;
+    # they must not be rebuilt or deleted through here.
+    _head(monkeypatch, _failed_head(Reason.MISSING_STATE_HEAD))
     monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: True)
 
     rebuild = client.post("/v1/knowledge-graph/rebuild")
@@ -117,16 +243,16 @@ def test_stored_assertions_still_conflict_without_a_state_head(client, monkeypat
     assert deleted == []
 
 
-def test_predicate_is_per_account_not_a_constant(monkeypatch):
-    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+def test_the_decision_is_per_account_not_a_constant(monkeypatch):
+    _head(monkeypatch, _failed_head(Reason.MISSING_STATE_HEAD))
     monkeypatch.setattr(
         kg_db,
         "has_stored_memory_graph_assertions",
         lambda uid, **_kw: uid == "uid-assertion-backed",
     )
 
-    assert kg_router._is_assertion_backed_graph_account("uid-assertion-backed") is True
-    assert kg_router._is_assertion_backed_graph_account("uid-arbitrary-account") is False
+    assert kg_router._legacy_graph_mutation_decision("uid-assertion-backed") is kg_router.LegacyGraphMutation.CONFLICT
+    assert kg_router._legacy_graph_mutation_decision("uid-arbitrary-account") is kg_router.LegacyGraphMutation.ALLOWED
 
 
 def test_rebuild_task_feeds_unlocked_memories_to_the_legacy_rebuild(monkeypatch):
@@ -160,12 +286,34 @@ def test_rebuild_task_feeds_unlocked_memories_to_the_legacy_rebuild(monkeypatch)
 
 
 def test_rebuild_task_is_a_noop_for_an_assertion_backed_account(monkeypatch):
-    monkeypatch.setattr(kg, "get_canonical_knowledge_graph", _canonical_unavailable)
+    _head(monkeypatch, _failed_head(Reason.MISSING_STATE_HEAD))
     monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: True)
 
     def _must_not_run(*_args: Any, **_kwargs: Any):  # pragma: no cover - asserts absence
         raise AssertionError("legacy rebuild ran for an assertion-backed account")
 
+    monkeypatch.setattr(kg_router, "_run_rebuild_knowledge_graph", _must_not_run)
+
+    kg_router._rebuild_graph_task(UID, "Ada")
+
+
+def test_rebuild_task_is_a_noop_when_the_canonical_probe_is_unanswered(monkeypatch):
+    # The task re-runs the decision after the route already deleted the graph.
+    # An unanswered probe must stop it there rather than rebuild blindly.
+    _head(monkeypatch, _failed_head(Reason.READ_FAILED))
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: False)
+
+    class _Service:
+        def __init__(self, **_kwargs: Any):
+            pass
+
+        def read(self, uid: str, **_kwargs: Any):
+            return []
+
+    def _must_not_run(*_args: Any, **_kwargs: Any):  # pragma: no cover - asserts absence
+        raise AssertionError("legacy rebuild ran while canonical state was unverified")
+
+    monkeypatch.setattr(kg_router, "MemoryService", _Service)
     monkeypatch.setattr(kg_router, "_run_rebuild_knowledge_graph", _must_not_run)
 
     kg_router._rebuild_graph_task(UID, "Ada")

--- a/backend/utils/memory/canonical_graph.py
+++ b/backend/utils/memory/canonical_graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from google.cloud import firestore
@@ -16,7 +17,11 @@ from database.firestore_index_registry import CANONICAL_MEMORY_ATLAS_READ_QUERY
 from database.memory_collections import MemoryCollections
 from models.memory_promotion import MemoryGraphAssertion
 from models.product_memory import RESTRICTED_SENSITIVITY_LABELS
-from utils.memory.v3.account_generation_source import read_memory_v3_trusted_account_generation
+from utils.memory.v3.account_generation_source import (
+    V3AccountGenerationFailureReason,
+    V3TrustedAccountGenerationResult,
+    read_memory_v3_trusted_account_generation,
+)
 from utils.memory.v3.cursor import (
     V3CursorContext,
     V3CursorError,
@@ -84,22 +89,67 @@ def _firestore_client(db_client: Any = None) -> Any:
     return db_client if db_client is not None else get_firestore_client()
 
 
-def _read_canonical_graph_revision(uid: str, *, db_client: Any) -> _CanonicalGraphRevision:
-    trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=db_client)
-    if trusted.read_error_reason is not None:
-        raise CanonicalGraphReadUnavailable(trusted.read_error_reason.value)
+def _revision_from_trusted(trusted: V3TrustedAccountGenerationResult) -> Optional[_CanonicalGraphRevision]:
+    """Build the revision fence from a trusted head read, or ``None`` if malformed."""
     if (
         trusted.account_generation is None
         or trusted.commit_sequence is None
         or not isinstance(trusted.head_commit_id, str)
         or not trusted.head_commit_id
     ):
-        raise CanonicalGraphReadUnavailable('malformed_memory_state_head')
+        return None
     return _CanonicalGraphRevision(
         account_generation=trusted.account_generation,
         commit_sequence=trusted.commit_sequence,
         head_commit_id=trusted.head_commit_id,
     )
+
+
+def _read_canonical_graph_revision(uid: str, *, db_client: Any) -> _CanonicalGraphRevision:
+    trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=db_client)
+    if trusted.read_error_reason is not None:
+        raise CanonicalGraphReadUnavailable(trusted.read_error_reason.value)
+    revision = _revision_from_trusted(trusted)
+    if revision is None:
+        raise CanonicalGraphReadUnavailable('malformed_memory_state_head')
+    return revision
+
+
+class CanonicalGraphState(str, Enum):
+    """Tri-state answer to "is canonical graph state established for this account?".
+
+    ``UNESTABLISHED`` is a positive answer: the state-head document is genuinely
+    absent, so no derived state exists. ``INDETERMINATE`` means the question was
+    not answered — a timed-out read, a corrupt head, a schema the reader does not
+    understand. A caller deciding whether derived state exists must never
+    collapse ``INDETERMINATE`` into ``UNESTABLISHED``: on a destructive path that
+    turns a transient Firestore blip into permanent data loss.
+    """
+
+    ESTABLISHED = 'established'
+    UNESTABLISHED = 'unestablished'
+    INDETERMINATE = 'indeterminate'
+
+
+def probe_canonical_graph_state(uid: str, *, db_client: Any = None) -> CanonicalGraphState:
+    """One-document probe of the canonical revision fence.
+
+    ``users/{uid}/memory_state/head`` is the fence every canonical graph read is
+    built on, and only the canonical apply transaction writes it. Its existence
+    — not whether a materialized page happens to carry assertions — is the
+    "canonical state is established" signal, so this reads the head directly
+    instead of paging the atlas. That also keeps the probe independent of
+    ``MEMORY_V3_CURSOR_SECRET`` and of the atlas composite index.
+    """
+    trusted = read_memory_v3_trusted_account_generation(uid=uid, db_client=_firestore_client(db_client))
+    reason = trusted.read_error_reason
+    if reason is V3AccountGenerationFailureReason.MISSING_STATE_HEAD:
+        return CanonicalGraphState.UNESTABLISHED
+    if reason is not None:
+        return CanonicalGraphState.INDETERMINATE
+    if _revision_from_trusted(trusted) is None:
+        return CanonicalGraphState.INDETERMINATE
+    return CanonicalGraphState.ESTABLISHED
 
 
 def _canonical_graph_cursor_secret() -> bytes:

--- a/backend/utils/observability/fallback.py
+++ b/backend/utils/observability/fallback.py
@@ -46,6 +46,7 @@ ALLOWED_REASONS = frozenset(
         'private_tool_output_in_context',
         'not_authorized',
         'authorization_unavailable',
+        'unmigrated_principal',
         'other',
         'none',
     }
@@ -69,6 +70,7 @@ ALLOWED_COMPONENTS = frozenset(
         'redis_ratelimit',
         'silent_mic',
         'firestore_read',
+        'knowledge_graph',
         'agent_tools',
         'agent_vm_reconciler',
         'other',


### PR DESCRIPTION
Hardens the per-account knowledge-graph mutation gate restored by #11783 before it ships (prod still serves `523d194333`). Findings from an adversarial review of that PR — "nothing blocking", four concrete fixes and one documented gap.

Failure-Class: FC-derived-state-gate-without-legacy-source-path

Product invariants touched (path-glob match): **INV-MEM-1**. The diff changes no tier vocabulary, no collection layout, and no default access policy — it only changes how one route classifies the *absence* of canonical state. Cited because `backend/utils/memory/canonical_graph.py` is inside the invariant's globs.

Failure-class rationale: the class's contract is "gate on a per-account probe of whether the derived state is actually established, and keep the pre-migration source path served for accounts that fail that probe". #11783 restored the probe; this PR fixes the probe's classification, which is the same contract. Registry edit is limited to appending two `canonical_prevention_artifact` paths (the probe and its test); no definition text, status, or evidence field was touched.

## 1. Mutation fail-open on a destructive path (SHOULD-FIX)

`_has_canonical_graph_state` called `get_canonical_knowledge_graph` and treated **every** `CanonicalGraphReadUnavailable` as "canonical state is not established". `read_memory_v3_trusted_account_generation` (`backend/utils/memory/v3/account_generation_source.py`) swallows every head-get exception into `READ_FAILED`, so a Firestore timeout or permission blip on `users/{uid}/memory_state/head` was indistinguishable from an absent document — and `POST /rebuild` / `DELETE /v1/knowledge-graph` then deleted the user's legacy `knowledge_nodes`/`knowledge_edges`.

`GET` may fail open on any unavailable canonical read (#11623): worst case is a stale view. These routes destroy the store `GET` would have shown. Copying the catch-all onto the mutation side was the miss.

New `canonical_graph.probe_canonical_graph_state` returns a tri-state keyed on the **typed** `V3AccountGenerationFailureReason` enum, not on strings:

| head read result | probe | route |
|---|---|---|
| valid head document | `ESTABLISHED` | 409 conflict |
| `MISSING_STATE_HEAD` | `UNESTABLISHED` | legacy mutation allowed |
| `READ_FAILED`, `MALFORMED_STATE_HEAD`, `UNSUPPORTED_SCHEMA`, `UID_MISMATCH`, `SOURCE_MISMATCH`, `MALFORMED_ACCOUNT_GENERATION` | `INDETERMINATE` | **503, nothing deleted** |
| head reads cleanly but carries no usable revision fence | `INDETERMINATE` | **503, nothing deleted** |

`_rebuild_graph_task` re-runs the same decision and stops on anything other than `ALLOWED`, so the background half cannot rebuild while the state is unverified either.

**Probe shape — took the reviewer's alternative.** The old probe materialized a whole canonical page (`limit=1`, plus the atlas query, plus the trailing revision re-read) to answer a boolean, which made the answer depend on `MEMORY_V3_CURSOR_SECRET` and on the atlas composite index — a missing cursor secret came back as `missing_cursor_secret`, i.e. "no canonical state", i.e. delete. The head document is the actual "canonical state exists" signal and only the canonical apply transaction writes it, so the probe now reads that one document. `_read_canonical_graph_revision` and the probe share `_revision_from_trusted` so the two cannot drift on what counts as a well-formed head. `test_the_probe_needs_no_cursor_secret_and_no_atlas_query` pins this: the fake client raises if anything calls `.collection()`.

Choice of 503 over 409: 409 asserts "derived state owns this graph", which is exactly the claim we could not verify. 503 is honest and retryable, and it does not reuse a message that mobile renders as a permanent refusal.

## 2. Tests now bind to the case they claim to protect (SHOULD-FIX)

The reviewer was right that `test_established_canonical_state_still_conflicts` stubbed a page with non-empty `nodes`, so a production body wrongly written as `return bool(page.nodes or page.edges)` would still have passed it. The whole suite now stubs the trusted head read — the real seam the gate depends on — instead of the page.

New tests:
- `test_an_established_head_with_zero_assertions_still_conflicts` — head exists, zero assertions. `has_stored_memory_graph_assertions` is replaced with a raiser, so the test fails if the gate consults it at all instead of deciding on the head.
- `test_an_unanswered_canonical_probe_must_not_delete_the_legacy_graph` — parametrized over all six non-`MISSING_STATE_HEAD` reasons; asserts nothing was deleted, no rebuild was scheduled, and both routes return 503.
- `test_a_malformed_head_without_a_read_error_must_not_delete_the_legacy_graph`.
- `test_rebuild_task_is_a_noop_when_the_canonical_probe_is_unanswered`.
- `test_the_legacy_fail_open_reports_shared_fallback_telemetry` / `test_a_conflicting_account_reports_no_fallback`.
- New file `tests/unit/test_canonical_graph_state_probe.py` covers the probe directly, including `test_a_thrown_head_read_is_classified_as_read_failed_not_absent`, which drives a client that raises `TimeoutError` so the classification comes from the real reader rather than a hand-written enum value.

The existing legacy-principal tests (`test_legacy_principal_can_rebuild` / `_can_delete`) are retained — the fail-closed arm still ships with its legacy-principal proof.

### Each new test proved to fail for its own specific reason

Not "5 of 7 fail once the function disappears". Six independent single-line mutations were applied to the shipped code, one at a time, restoring between each. Failure line reported by `pytest --tb=line`:

| Mutation | Test that failed | Assertion |
|---|---|---|
| A: probe collapses every unavailable reason into `UNESTABLISHED` (the pre-fix semantics) | `test_an_unanswered_canonical_probe_must_not_delete_the_legacy_graph[read_failed]` | `assert ['uid-arbitra...rary-account'] == []` |
| A | `test_rebuild_task_is_a_noop_when_the_canonical_probe_is_unanswered` | `AssertionError: legacy rebuild ran while canonical state was unverified` |
| A | `test_every_other_failure_reason_is_indeterminate[read_failed]` (+5 params) | `assert <CanonicalGraphState.UNESTABLISHED> is <CanonicalGraphState.INDETERMINATE>` |
| A | `test_a_thrown_head_read_is_classified_as_read_failed_not_absent` | same |
| B: an established head no longer short-circuits the gate | `test_an_established_head_with_zero_assertions_still_conflicts` | `AssertionError: an established head must decide the gate on its own` |
| C: fail-open branch stops calling `record_fallback` | `test_the_legacy_fail_open_reports_shared_fallback_telemetry` | `assert 0 == 1` |
| D: `record_fallback` fires on every call, conflicts included | `test_a_conflicting_account_reports_no_fallback` | `assert [{'component'...}] == []` |
| E: head with no usable revision fence treated as `ESTABLISHED` | `test_a_head_without_a_usable_revision_fence_is_indeterminate` | `assert <ESTABLISHED> is <INDETERMINATE>` |
| F: probe goes back to materializing a canonical page | `test_the_probe_needs_no_cursor_secret_and_no_atlas_query` | `AssertionError: the state probe paged the canonical atlas` |

Negative control: under mutation A, `test_an_established_head_with_zero_assertions_still_conflicts` and `test_the_legacy_fail_open_reports_shared_fallback_telemetry` both still **passed** — they do not bind to that line, which is what makes the table above meaningful rather than a blast radius.

## 3. Fallback telemetry (NIT, repo rule)

The fail-open to legacy mutation now calls the shared `record_fallback` (`component=knowledge_graph`, `from_mode=canonical_graph`, `to_mode=legacy_graph`, `reason=unmigrated_principal`, `outcome=degraded`) per `AGENTS.md` and `docs/agents/fallback-telemetry.md`. No new counter: `knowledge_graph` was added to `ALLOWED_COMPONENTS` and `unmigrated_principal` to `ALLOWED_REASONS` in `utils/observability/fallback.py`, so it lands on the existing `omi_fallback_total`. The conflict and unverified arms deliberately do not emit — those are hard refusals, and inflating the counter with them would destroy the "how many accounts still run on the legacy path" reading this exists to give.

## 4. Banned import (NIT)

`backend/AGENTS.md` (Service Map): `database._client.db` "remains a legacy lazy compatibility proxy only; do not use it in new code" — use `get_firestore_client()` at call time. #11783 reintroduced the proxy import; removed in its own commit (`chore(backend): stop the knowledge-graph router using the legacy Firestore proxy`). Behaviour-identical: `_LazyFirestoreClient.__getattr__` already delegates to `get_firestore_client()`.

## 5. Known gap, documented not fixed: rebuild deletes before it rebuilds

`POST /rebuild` calls `kg_db.delete_knowledge_graph(uid)` and returns 200 before the rebuild worker runs. If the worker dies the user is left with no graph, and `_rebuild_graph_task` re-checks the gate *after* the delete — an account that becomes assertion-backed (or whose head read starts timing out) in that window no-ops and the graph stays gone. This is the restored pre-`5724a10084` contract, not a hole introduced here, and it is deliberately **not** restructured in this PR. **There is no test coverage for "delete succeeded, rebuild failed."** Tracked: #11796.

Note that this PR slightly widens that window's failure modes — the new `UNVERIFIED` arm is another way the post-delete re-check can stop the rebuild. It also removes the far worse version of the same problem: before this PR, the transient failure deleted the graph in the first place.

## Verification

Branched from `origin/main` at `494edbb7f8` (contains #11783). Python 3.11.15.

```
$ backend/test.sh tests/unit/test_canonical_graph_state_probe.py \
    tests/unit/test_knowledge_graph_canonical_mutation_routes.py \
    tests/unit/test_knowledge_graph_legacy_fallback.py
tests/unit/test_canonical_graph_state_probe.py                       11 passed
tests/unit/test_knowledge_graph_canonical_mutation_routes.py         21 passed
tests/unit/test_knowledge_graph_legacy_fallback.py                   11 passed

$ pytest -q tests/unit/*canonical_graph* tests/unit/*knowledge_graph* \
    tests/unit/*fallback* tests/routers/*knowledge*
145 passed in 5.72s

$ OMI_PR_BODY_FILE=<this file> make preflight
Manifest checks passed: 25 check(s).
PR preflight passed: 25 checks in 104.94s.        # exit 0

$ scripts/failure-class validate --pr-body-file <this file>
"ok": true, "declaration": "FC-derived-state-gate-without-legacy-source-path"
```

`backend/test.sh` runs the whole unit tree, and on this machine it reported 16 unrelated files as failed — every one of them the **fast-unit CPU-duration guard** (`0.13s > 0.12s`, e.g. `test_desktop_transcribe.py`, `test_windows_rest_inventory.py` which itself logs `7 passed`), not an assertion failure. None of them are in this diff, and the three files above are not among them. `make preflight` — the actual gate — is green.

Mutation harness output for the table in section 2 is reproduced above verbatim from `pytest --tb=line`; the harness itself was a throwaway script and is not in the diff.

### Not verified

- **No live/staging exercise of the real user-facing path.** Every result here is hermetic unit tests against fakes. The 503 arm in particular has not been observed against a real Firestore timeout, and no client (mobile or desktop) was run against the new 503 to see how it renders — #11783's original defect was mobile printing a 409 body to the screen, so the new `CANONICAL_GRAPH_STATE_UNVERIFIED` string deserves a look from someone with the app in front of them.
- **No measurement of how often `INDETERMINATE` will actually fire in production.** If head reads flap, users will see 503s where they previously (silently, destructively) succeeded. The new `record_fallback` gives the denominator for the fail-open arm but not for the 503 arm.
- **`record_fallback` output not observed in a running service** — asserted at the call site only; the Prometheus counter itself was not scraped.
- Full `backend/test.sh` was not run end to end locally; selection above plus `make preflight` is the evidence.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

