### PR TITLE
fix(backend): bound the memory list page's suppressed-row walk (#11798)

### DIFF
--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -14,7 +14,12 @@ from database import review_queue
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.memory_imports import MemoryImportBatchRequest, MemoryImportBatchResponse
 from utils.apps import update_personas_async
-from utils.memory.memory_service import MemoryPayload, MemoryService, fetch_memory_dict
+from utils.memory.memory_service import (
+    MEMORY_LIST_SCAN_BUDGET_DETAIL,
+    MemoryPayload,
+    MemoryService,
+    fetch_memory_dict,
+)
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 from utils.memory.import_write_guard import (
     import_write_block_mode,
@@ -593,11 +598,18 @@ def get_memories(
             # unavailable". The keyset scans order by (updated_at DESC,
             # __name__) and so fail while that composite index is building,
             # which the offset read's single-field order does not — so all three
-            # fall back to read(); unrelated errors (4xx, other 503s) propagate.
+            # fall back to read(). The keyset scans also walk past every row they
+            # must not emit before they can fill the page, so an account whose
+            # historical set is fully suppressed by canonical exhausts the scan
+            # row budget ("Memory scan budget exceeded") — that walk is what took
+            # the first page past the 30s edge timeout in prod on 2026-08-18, and
+            # the offset read serves it without the walk.
+            # Unrelated errors (4xx, other 503s) propagate.
             if exc.status_code != 503 or exc.detail not in (
                 "Memory cursor unavailable",
                 "Canonical memory unavailable",
                 "Historical memory unavailable",
+                MEMORY_LIST_SCAN_BUDGET_DETAIL,
             ):
                 raise
         else:

--- a/backend/tests/unit/test_memories_pagination_clamp.py
+++ b/backend/tests/unit/test_memories_pagination_clamp.py
@@ -245,6 +245,28 @@ def test_first_page_falls_back_to_offset_read_when_historical_scan_unavailable()
     service.read.assert_called_once()
 
 
+def test_first_page_falls_back_to_offset_read_when_scan_row_budget_is_exhausted():
+    """Prod 2026-08-18: first pages 504'd at the 30s edge timeout (~100/h).
+
+    Once the ``memories`` composite indexes went READY the keyset scans actually
+    served, and an account whose historical set is fully suppressed by canonical
+    made ``read_page`` walk every historical row before it could emit anything.
+    The walk now stops at the scan row budget; the offset ``read`` path does not
+    walk suppressed rows, so the first page must fall back to it.
+    """
+    from fastapi import HTTPException
+
+    service = MagicMock()
+    service.read_page.side_effect = HTTPException(status_code=503, detail=mem_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL)
+    service.read.return_value = ['memory-from-offset-read']
+
+    result = _get_first_page(service)
+
+    assert result == ['memory-from-offset-read']
+    service.read_page.assert_called_once()
+    service.read.assert_called_once()
+
+
 def test_first_page_propagates_unrelated_503_detail():
     from fastapi import HTTPException
 

--- a/backend/tests/unit/test_universal_memory_list_cursor.py
+++ b/backend/tests/unit/test_universal_memory_list_cursor.py
@@ -395,6 +395,66 @@ def test_cursor_advances_through_suppressed_historical_prefix(service_mod):
     service_mod.read_canonical_memories.assert_not_called()
 
 
+def test_fully_suppressed_historical_set_stops_at_the_scan_row_budget(service_mod, monkeypatch):
+    """Prod 2026-08-18: GET /v3/memories 504'd at the 30s edge timeout.
+
+    An account whose historical rows are all suppressed by canonical makes the
+    first page walk the whole historical collection — 50 rows per Firestore
+    round trip, unbounded — before it can emit anything, so even ``limit=8``
+    ran past the edge timeout. The walk must stop at a bounded row count and
+    surface the detail the route falls back on, instead of hanging.
+    """
+    from fastapi import HTTPException
+    from models.product_memory import MemoryItemStatus
+
+    # The shipped bound is what keeps the walk inside the edge timeout; the test
+    # shrinks it so the mechanism is asserted without scanning thousands of rows.
+    assert service_mod.MEMORY_LIST_SCAN_ROW_BUDGET >= 1000
+    monkeypatch.setattr(service_mod, "MEMORY_LIST_SCAN_ROW_BUDGET", 100)
+
+    service = service_mod.MemoryService(db_client=_Db())
+    total = 400
+    historical = [_dated_historical(service_mod, f"h-{index:05d}", day=9000 - index) for index in range(total)]
+    statuses = {f"h-{index:05d}": MemoryItemStatus.tombstoned for index in range(total)}
+    _, updated_mock, _ = _install_streams(service, service_mod, canonical=[], historical=historical, statuses=statuses)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.read_page("uid-test", limit=8, cursor=None)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == service_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL
+    # The walk stopped at the budget instead of scanning every historical row.
+    scanned = sum(call.kwargs["limit"] for call in updated_mock.call_args_list)
+    assert scanned <= 150
+    assert scanned < total
+
+
+def test_suppressed_prefix_under_the_budget_still_serves_the_page(service_mod, monkeypatch):
+    """The budget bounds pathological accounts only — ordinary skips still page."""
+    from models.product_memory import MemoryItemStatus
+
+    monkeypatch.setattr(service_mod, "MEMORY_LIST_SCAN_ROW_BUDGET", 300)
+    service = service_mod.MemoryService(db_client=_Db())
+    suppressed_count = 200
+    suppressed = [
+        _dated_historical(service_mod, f"s-{index:05d}", day=9000 - index) for index in range(suppressed_count)
+    ]
+    visible = [_dated_historical(service_mod, f"visible-{index}", day=50 - index) for index in range(3)]
+    statuses = {f"s-{index:05d}": MemoryItemStatus.tombstoned for index in range(suppressed_count)}
+    _install_streams(
+        service,
+        service_mod,
+        canonical=[],
+        historical=suppressed + visible,
+        statuses=statuses,
+    )
+
+    page = service.read_page("uid-test", limit=2, cursor=None)
+
+    assert [memory.id for memory in page.memories] == ["visible-0", "visible-1"]
+    assert page.next_cursor
+
+
 def test_historical_status_suppression_batched_once_per_chunk(service_mod):
     from models.product_memory import MemoryItemStatus
 

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -839,6 +839,33 @@ class HistoricalMemoryAdapter:
             cls.cleanup(uid, memory_id, db_client=db_client)
 
 
+# A page walks past rows it must not emit (canonical-suppressed historical rows,
+# lineage-filtered canonical rows) before it can fill `limit`. That walk is
+# proportional to the account's skipped prefix, not to the page size: an account
+# whose whole historical set is suppressed by canonical scans every historical
+# document for a `limit=8` first page. In prod on 2026-08-18 that walk ran past
+# the 30s edge timeout and GET /v3/memories 504'd (~100/h, first pages only,
+# offset=0) once the `memories` composite indexes went READY and the keyset scans
+# actually started serving. Bound the skipped work per request so a page either
+# lands or fails fast into the route's offset-read fallback.
+MEMORY_LIST_SCAN_ROW_BUDGET = 4000
+MEMORY_LIST_SCAN_BUDGET_DETAIL = "Memory scan budget exceeded"
+
+
+class _ScanRowBudget:
+    """Bounds the rows one ``read_page`` call may skip without emitting."""
+
+    def __init__(self, limit: Optional[int] = None) -> None:
+        # Read the module constant at construction, not as a default argument,
+        # so the bound stays tunable in one place.
+        self._remaining = max(1, int(MEMORY_LIST_SCAN_ROW_BUDGET if limit is None else limit))
+
+    def charge(self) -> None:
+        self._remaining -= 1
+        if self._remaining < 0:
+            raise HTTPException(status_code=503, detail=MEMORY_LIST_SCAN_BUDGET_DETAIL)
+
+
 class _HistoricalRawStream:
     """Peekable keyset stream over one historical Firestore order field."""
 
@@ -852,12 +879,14 @@ class _HistoricalRawStream:
         exhausted: bool,
         device_scope_request: Optional[DeviceScopeRequest],
         page_limit: int,
+        budget: Optional[_ScanRowBudget] = None,
     ) -> None:
         self._service = service
         self._uid = uid
         self._kind = kind
         self.scan_keyset = scan
         self.exhausted = bool(exhausted)
+        self._budget = budget or _ScanRowBudget()
         self._device_scope_request = device_scope_request
         self._page_limit = max(1, int(page_limit or 100))
         self._peek: Optional[MemoryDB] = None
@@ -917,6 +946,7 @@ class _HistoricalRawStream:
                 return None
             record, scan_keyset = self._slots[self._slot_index]
             if record is None:
+                self._budget.charge()
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
@@ -927,11 +957,13 @@ class _HistoricalRawStream:
             )
             if reason == "canonical_identity":
                 self.identity_suppressed += 1
+                self._budget.charge()
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
             if reason == "canonical_state":
                 self.state_suppressed += 1
+                self._budget.charge()
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
@@ -977,9 +1009,11 @@ class _HistoricalCursorStream:
         created_exhausted: bool,
         device_scope_request: Optional[DeviceScopeRequest],
         page_limit: int,
+        budget: Optional[_ScanRowBudget] = None,
     ) -> None:
         self._service = service
         self.consumed_keyset = after
+        budget = budget or _ScanRowBudget()
         self._updated = _HistoricalRawStream(
             service=service,
             uid=uid,
@@ -988,6 +1022,7 @@ class _HistoricalCursorStream:
             exhausted=updated_exhausted,
             device_scope_request=device_scope_request,
             page_limit=page_limit,
+            budget=budget,
         )
         self._created = _HistoricalRawStream(
             service=service,
@@ -997,6 +1032,7 @@ class _HistoricalCursorStream:
             exhausted=created_exhausted,
             device_scope_request=device_scope_request,
             page_limit=page_limit,
+            budget=budget,
         )
         self._peek_source: Optional[str] = None
 
@@ -1077,12 +1113,14 @@ class _CanonicalCursorStream:
         include_archive: bool,
         now: Optional[datetime],
         page_limit: int,
+        budget: Optional[_ScanRowBudget] = None,
     ) -> None:
         self._service = service
         self._uid = uid
         self.emitted_keyset = emitted
         self.scan_keyset = scan
         self.exhausted = bool(exhausted)
+        self._budget = budget or _ScanRowBudget()
         self._device_scope_request = device_scope_request
         self._include_pending_processing = include_pending_processing
         self._include_archive = include_archive
@@ -1147,12 +1185,14 @@ class _CanonicalCursorStream:
             memory, scan_keyset = self._slots[self._slot_index]
             # Raw scan position advances for filtered rows too.
             if memory is None:
+                self._budget.charge()
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
             if self.emitted_keyset is not None and self._service.memory_cursor_sort_key(memory) <= (
                 self._service.keyset_sort_key(self.emitted_keyset)
             ):
+                self._budget.charge()
                 self.scan_keyset = scan_keyset
                 self._advance_raw_slot()
                 continue
@@ -1687,6 +1727,9 @@ class MemoryService:
                 historical_created_exhausted=False,
             )
 
+        # One budget per request, shared by both streams: the cost that has to
+        # stay bounded is the total skipped-row walk behind a single page.
+        budget = _ScanRowBudget()
         canonical = _CanonicalCursorStream(
             service=self,
             uid=uid,
@@ -1698,6 +1741,7 @@ class MemoryService:
             include_archive=include_archive,
             now=now,
             page_limit=bounded_limit,
+            budget=budget,
         )
         historical = _HistoricalCursorStream(
             service=self,
@@ -1709,6 +1753,7 @@ class MemoryService:
             created_exhausted=state.historical_created_exhausted,
             device_scope_request=device_scope_request,
             page_limit=bounded_limit,
+            budget=budget,
         )
 
         page: List[MemoryDB] = []


### PR DESCRIPTION
Fixes #11798.

## Bug

`GET /v3/memories` returned **504 at exactly 30.005s** in prod at ~100/hour from 2026-08-18T03:00Z (up ~10x from a ~10/hour baseline). Every one was a **first page** — `offset=0`, `limit=8`/`100`/`5000`, no cursor — from ~10 distinct client IPs an hour, overwhelmingly the Windows desktop app. Still reproducing on the current revision `backend-523d194-32102746612-1`, so not the stale image and not the #11791 503 outage (cleared 03:18:40Z). Successful requests on the same endpoint were at p95 11.79s.

## Root cause

`MemoryService.read_page` merges a canonical and a historical keyset stream. Both walk past every row they must not emit before they can fill the page: `_HistoricalRawStream.peek()` is a `while True` that refills 50 rows per Firestore round trip and skips each `canonical_identity` / `canonical_state` suppressed row, unbounded. For an account whose historical rows are all suppressed by canonical — the normal end state of the canonical migration — a `limit=8` first page scans the entire historical collection.

Measured against the real route: 8,000 suppressed rows = **161 sequential Firestore round trips**, so a ~30k-row account needs ~600 — past 30s at ordinary Firestore latency.

The walk only started serving on 2026-08-17T21:36Z, when the `memories` `(updated_at DESC, __name__ ASC)` composite index went READY. Before that the scan returned `FAILED_PRECONDITION`, `read_page` raised `Historical memory unavailable`, and the route fell back to the offset `read()` — which does not walk suppressed rows. That is why the 504 rate jumped the moment #11791's 503s cleared.

## Fix

One `_ScanRowBudget` per `read_page` call, shared by the canonical and historical streams and charged once per skipped row. Exhausting it raises the existing first-page fallback contract (`Memory scan budget exceeded`), so `routers/memories.py` serves the page from the offset `read()` instead of hanging until the edge timeout. Accounts under the budget are byte-for-byte unchanged.

## What I tested

- `backend/test.sh` over 83 memory-suite files (`tests/unit/test_*memor*` plus the two changed suites): **all green, exit 0**.
- All three new tests **fail on clean `origin/main`** (verified by stashing the two source hunks) and pass with the change.
- **Real user-facing path**: drove the actual FastAPI `get_memories` route with the real `MemoryService` over a fully suppressed 8,000-row account. `origin/main` takes 161 Firestore round trips and returns an empty list; with this change the walk stops at 81 round trips and the request is served by the offset read in 0.13s.
- `make preflight`: pass.

## Still true after this PR

The budget still allows ~80 sequential round trips (~4s) before falling back, so these accounts stay slow, just no longer past the timeout. The underlying shape — a merged list whose historical half is entirely suppressed — deserves a cleanup of the suppressed rows; tracked on #11798.

## Product invariants

- `INV-MEM-1` — tiering and default access policy are untouched; the budget only bounds how many rows a page may skip.
- `INV-MEM-3` — the universal authority still fails closed. Budget exhaustion raises a 503 through `MemoryService`, and the first page falls back to `MemoryService.read`, the same authority-owned offset path the three existing scan-failure details already fall back to. No direct legacy reader, no suppression check skipped. Guard suites `test_inv_mem_1_guard.py`, `test_universal_memory_service.py`, `test_universal_memory_task_authority.py`, `test_ws_l_surface_routing.py` all pass.

Line-Count-Exception: backend/utils/memory/memory_service.py | 2495 -> 2540 | scan row budget plus the incident comment that explains why the bound exists

Failure-Class: FC-bounded-read-exceeds-request-budget

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

