### PR TITLE
Windows Rewind video chunks: stop storing a JPEG per second of screen time

### DIFF
--- a/desktop/windows/e2e/rewind-chunks.spec.mjs
+++ b/desktop/windows/e2e/rewind-chunks.spec.mjs
@@ -1,0 +1,116 @@
+// The real WebCodecs round trip, in a real Electron renderer.
+//
+// Everything else about compaction is unit-tested in plain node: the container's
+// bytes, the grouping, the SQL, the write/verify/claim ordering, the cursor's
+// state machine. What none of that can cover is whether an actual H.264 encoder
+// and decoder, driven by the production modules, turn frames into a small chunk
+// and give the same frames back. That claim is the entire reason this feature
+// exists, and this is the only place it can be made honestly.
+//
+// The hooks it drives (`window.__omiRewindChunkE2E`) call the PRODUCTION
+// `encodeFramesToChunk` and `ChunkFrameReader`, not a copy — see
+// src/renderer/src/rewind/chunkE2EHooks.ts.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { _electron as electron } from 'playwright'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainEntry = path.join(here, '..', 'out', 'main', 'index.js')
+
+const WIDTH = 1280
+const HEIGHT = 720
+const FRAMES = 60
+
+/**
+ * The first window with the chunk hooks installed.
+ *
+ * Any window will do — the hooks are installed by both the main renderer and
+ * the capture window — so this takes whichever is ready first rather than
+ * waiting on the capture window, which only opens while capture is running.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- plain .mjs; the repo's other e2e specs are the same shape
+async function captureWindow(app) {
+  const deadline = Date.now() + 60_000
+  for (;;) {
+    for (const win of app.windows()) {
+      const installed = await win
+        .evaluate(() => Boolean(window.__omiRewindChunkE2E))
+        .catch(() => false)
+      if (installed) return win
+    }
+    if (Date.now() > deadline) throw new Error('timed out waiting for the capture window')
+    await new Promise((r) => setTimeout(r, 250))
+  }
+}
+
+test('encodes real frames into a chunk and reads every one of them back', async (t) => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'omi-e2e-chunks-'))
+  const app = await electron.launch({
+    args: [mainEntry, `--user-data-dir=${dir}`],
+    env: { ...process.env, OMI_E2E: '1', OMI_AUTOMATION: '0', OMI_SKIP_TUNNEL: '1' }
+  })
+  t.after(async () => {
+    try {
+      await app.close()
+    } catch {
+      /* already closed */
+    }
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const win = await captureWindow(app)
+
+  const codec = await win.evaluate(
+    ([w, h]) => window.__omiRewindChunkE2E.codecFor(w, h),
+    [WIDTH, HEIGHT]
+  )
+  // A machine with no usable encoder is a supported state — it just never
+  // compacts — but the harness machine is not allowed to be one silently.
+  assert.ok(codec, 'expected this machine to support at least one chunk codec')
+
+  const result = await win.evaluate(
+    ([n, w, h]) => window.__omiRewindChunkE2E.roundTrip(n, w, h),
+    [FRAMES, WIDTH, HEIGHT]
+  )
+
+  // --- Every frame came back. ---
+  // The property the compactor bets the JPEGs on. A chunk that returned 59 of
+  // 60 frames would have cost the user the sixtieth permanently.
+  assert.equal(result.framesBack, FRAMES, 'every frame must decode back out of the chunk')
+
+  // --- It is dramatically smaller. ---
+  // The generated frames are deliberately adversarial: dense high-entropy text
+  // with a full line changing every frame, which is far worse for both JPEG and
+  // inter-frame prediction than a real screen. This run measures about 6.4x
+  // against the 51x measured on real capture output (see
+  // main/rewind/chunks/ARCHITECTURE.md). The floor is set well below what the
+  // adversarial case achieves, so it asserts "inter-frame compression is
+  // working" without pinning a number that varies with the encoder build.
+  const ratio = result.jpegBytes / result.chunkBytes
+  assert.ok(
+    ratio > 3,
+    `expected the chunk to be far smaller than the JPEGs, got ${ratio.toFixed(1)}x ` +
+      `(${result.jpegBytes} -> ${result.chunkBytes} bytes)`
+  )
+
+  // --- The pixels survived. ---
+  // Mean absolute per-channel difference against the source JPEG, worst frame.
+  // Lossy at both ends (source is JPEG, chunk is H.264), so this is a real
+  // tolerance, not an equality: it catches a decode that returns the wrong
+  // frame, a black frame, or drifting garbage, which is what it is for.
+  assert.ok(
+    result.maxMeanDiff < 12,
+    `decoded frames drifted too far from their sources (worst mean diff ${result.maxMeanDiff})`
+  )
+
+  console.log(
+    `[rewind-chunks] ${codec}: ${FRAMES} frames, ` +
+      `${(result.jpegBytes / 1024).toFixed(0)} KB of JPEGs -> ` +
+      `${(result.chunkBytes / 1024).toFixed(0)} KB chunk (${ratio.toFixed(1)}x), ` +
+      `worst mean pixel diff ${result.maxMeanDiff.toFixed(2)}`
+  )
+})

--- a/desktop/windows/package.json
+++ b/desktop/windows/package.json
@@ -55,6 +55,7 @@
     "voice:loop-check": "node scripts/run-voice-loop-check.mjs",
     "test:e2e:lifecycle": "node scripts/run-lifecycle-e2e.mjs",
     "test:e2e:rewind-semantic": "node scripts/run-rewind-semantic-e2e.mjs",
+    "test:e2e:rewind-chunks": "node scripts/run-rewind-chunks-e2e.mjs",
     "test:e2e:db-recovery": "node scripts/run-db-recovery-e2e.mjs",
     "test:e2e:failure-ux": "node scripts/run-failure-ux-e2e.mjs",
     "test:e2e:rewind-dayscope": "node scripts/run-rewind-dayscope-e2e.mjs",

--- a/desktop/windows/scripts/run-rewind-chunks-e2e.mjs
+++ b/desktop/windows/scripts/run-rewind-chunks-e2e.mjs
@@ -1,0 +1,23 @@
+// Build the app, then run the Rewind video-chunk E2E against the real built
+// renderer. Hermetic: no network, no credentials — it generates its own frames
+// and drives the production encoder/decoder through WebCodecs.
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const NO_BUILD = process.argv.includes('--no-build')
+
+if (!NO_BUILD) {
+  // ensure-env first: without a .env the renderer bundle throws
+  // `auth/invalid-api-key` while Firebase initialises, which kills module
+  // evaluation before the E2E hooks are installed and leaves the spec waiting
+  // for a window that will never have them.
+  execFileSync('node', ['scripts/ensure-env.mjs'], { stdio: 'inherit', cwd: root })
+  execFileSync('npx', ['electron-vite', 'build'], { stdio: 'inherit', cwd: root, shell: true })
+}
+
+execFileSync('node', ['--test', '--test-timeout=300000', 'e2e/rewind-chunks.spec.mjs'], {
+  stdio: 'inherit',
+  cwd: root
+})

--- a/desktop/windows/src/main/index.ts
+++ b/desktop/windows/src/main/index.ts
@@ -134,6 +134,7 @@ import {
 import { startRewindOcr } from './rewind/ocrService'
 import { startRewindEmbedding } from './rewind/embeddingService'
 import { startRewindRetention } from './rewind/retentionRunner'
+import { startRewindCompaction } from './rewind/chunks/compactionRunner'
 import { startOrphanSweep } from './rewind/orphanSweep'
 import { prewarmPrimarySourceId } from './rewind/sourceId'
 import { perfMark, flushPerfMarks } from '../shared/perf'
@@ -1194,6 +1195,11 @@ app.whenReady().then(async () => {
           }
         },
         { name: 'rewindRetention', run: () => startRewindRetention() },
+        // Pack older JPEGs into inter-frame-compressed chunks. Measured 51x on a
+        // real 60-second run of this app's own capture; see
+        // rewind/chunks/ARCHITECTURE.md. Starts late and runs every 30 minutes
+        // so it never competes with capture.
+        { name: 'rewindCompaction', run: () => startRewindCompaction() },
         // Delete JPEGs orphaned by a crash between the file write and the DB insert
         // (Windows-specific — frames are per-file). Startup pass + every 6h.
         { name: 'orphanSweep', run: () => startOrphanSweep() },

--- a/desktop/windows/src/main/ipc/db.ts
+++ b/desktop/windows/src/main/ipc/db.ts
@@ -6,6 +6,17 @@ import { isNewLocalDay } from '../usage/usageDay'
 import { buildRewindFtsMatch } from '../rewind/rewindSearchQuery'
 import { addColumnIfMissing as ensureColumn, runMigrations } from './dbMigrations'
 import { applyRewindEmbeddingSchema } from './rewindEmbeddingSchema'
+import {
+  CHUNK_BACKED_FRAME_COUNT_SQL,
+  CLAIM_FRAME_INTO_CHUNK_SQL,
+  COMPACTABLE_FRAMES_SQL,
+  DELETE_FRAMES_IN_CHUNK_SQL,
+  FRAMES_IN_CHUNK_SQL,
+  IS_CHUNK_ABANDONED_SQL,
+  REFERENCED_CHUNK_PATHS_SQL,
+  TOMBSTONE_CHUNK_SQL
+} from '../rewind/chunks/chunkSql'
+import type { CompactableFrame } from '../rewind/chunks/compactionPlan'
 import { LOCAL_CONVERSATION_SCHEMA } from './localConversationSchema'
 import {
   clearCorruptionFlags,
@@ -680,6 +691,12 @@ function get(): Database.Database {
   // --- Track 4: additive columns on existing tables ---
   // Per-line OCR bounding boxes (JSON) for a future on-image highlight overlay.
   ensureColumn(db, 'rewind_frames', 'ocr_lines_json', 'TEXT')
+  // Video-chunk locator. Also added by migration 3 (which owns the matching
+  // index and the abandoned-chunk table); repeated here so the additive
+  // baseline stays a complete description of the table, as it is for every
+  // other column above.
+  ensureColumn(db, 'rewind_frames', 'chunk_path', 'TEXT')
+  ensureColumn(db, 'rewind_frames', 'chunk_offset', 'INTEGER')
   // Conversation starring + folder assignment (local mirror of the cloud fields).
   ensureColumn(db, 'local_conversation', 'starred', 'INTEGER NOT NULL DEFAULT 0')
   ensureColumn(db, 'local_conversation', 'folder_id', 'TEXT')
@@ -1436,14 +1453,31 @@ export function clearLocalGraph(): void {
 // --- Rewind: screen-history timeline ---
 
 const REWIND_COLUMNS =
-  'id, ts, app, window_title AS windowTitle, process_name AS processName, ocr_text AS ocrText, image_path AS imagePath, width, height, indexed'
+  'id, ts, app, window_title AS windowTitle, process_name AS processName, ocr_text AS ocrText, image_path AS imagePath, width, height, indexed, chunk_path AS chunkPath, chunk_offset AS chunkOffset'
 
 export function insertRewindFrame(f: Omit<RewindFrame, 'id'>): number {
   const r = cachedStmt(
     get(),
-    `INSERT INTO rewind_frames (ts, app, window_title, process_name, ocr_text, image_path, width, height, indexed)
-       VALUES (@ts, @app, @windowTitle, @processName, @ocrText, @imagePath, @width, @height, @indexed)`
-  ).run(f)
+    `INSERT INTO rewind_frames (ts, app, window_title, process_name, ocr_text, image_path, width, height, indexed, chunk_path, chunk_offset)
+       VALUES (@ts, @app, @windowTitle, @processName, @ocrText, @imagePath, @width, @height, @indexed, @chunkPath, @chunkOffset)`
+    // Bound explicitly rather than spreading `f`: better-sqlite3 rejects an
+    // object carrying names the statement does not declare, so a caller that
+    // read a frame back out and passed it straight in would throw. Every field
+    // the statement wants is listed, and the chunk locator defaults to NULL for
+    // the capture path, which is every caller except chunk recovery.
+  ).run({
+    ts: f.ts,
+    app: f.app,
+    windowTitle: f.windowTitle,
+    processName: f.processName,
+    ocrText: f.ocrText,
+    imagePath: f.imagePath,
+    width: f.width,
+    height: f.height,
+    indexed: f.indexed,
+    chunkPath: f.chunkPath ?? null,
+    chunkOffset: f.chunkOffset ?? null
+  })
   return r.lastInsertRowid as number
 }
 
@@ -1555,6 +1589,67 @@ export function getRewindFrameOcrLines(id: number): OcrLine[] {
   } catch {
     return []
   }
+}
+
+// --- Video chunks (see main/rewind/chunks/ARCHITECTURE.md) ---
+// Every statement below is imported from chunkSql.ts rather than written here,
+// so the SQL tests run the same text production does.
+
+/** Frames eligible for compaction: OCR'd, still JPEG-backed, older than the delay. */
+export function compactableRewindFrames(olderThanMs: number, limit: number): CompactableFrame[] {
+  return cachedStmt(get(), COMPACTABLE_FRAMES_SQL).all(olderThanMs, limit) as CompactableFrame[]
+}
+
+/**
+ * Point a frame at its slot in a chunk, giving up its JPEG path.
+ *
+ * Returns false when the frame was already claimed, which is the signal the
+ * compactor uses to abort a chunk rather than leave it half-owned. Refuses
+ * outright if the chunk has been tombstoned: an abandoned chunk's file may
+ * already be gone, and a frame pointed into it would be unreadable forever.
+ */
+export function claimFrameIntoChunk(id: number, chunkPath: string, offset: number): boolean {
+  const d = get()
+  const abandoned = cachedStmt(d, IS_CHUNK_ABANDONED_SQL).get(chunkPath) as { abandoned: number }
+  if (abandoned.abandoned) return false
+  const r = cachedStmt(d, CLAIM_FRAME_INTO_CHUNK_SQL).run(chunkPath, offset, id)
+  return r.changes === 1
+}
+
+/** Frames a chunk owns, in offset order. */
+export function framesInChunk(chunkPath: string): { id: number; ts: number; chunkOffset: number }[] {
+  return cachedStmt(get(), FRAMES_IN_CHUNK_SQL).all(chunkPath) as {
+    id: number
+    ts: number
+    chunkOffset: number
+  }[]
+}
+
+/** Every chunk path still referenced by a frame. */
+export function referencedChunkPaths(): string[] {
+  return (cachedStmt(get(), REFERENCED_CHUNK_PATHS_SQL).all() as { chunk_path: string }[]).map(
+    (r) => r.chunk_path
+  )
+}
+
+/**
+ * Tombstone a chunk and drop the frames pointing into it, in one transaction.
+ *
+ * Ported from macOS' `abandonVideoChunk`. The tombstone is inserted first so a
+ * crash between the two statements still leaves the chunk quarantined and a
+ * re-run finishes the job; both statements are idempotent.
+ */
+export function abandonChunk(chunkPath: string): number {
+  const d = get()
+  const run = d.transaction(() => {
+    cachedStmt(d, TOMBSTONE_CHUNK_SQL).run(chunkPath)
+    return cachedStmt(d, DELETE_FRAMES_IN_CHUNK_SQL).run(chunkPath).changes as number
+  })
+  return run()
+}
+
+export function chunkBackedFrameCount(): number {
+  return (cachedStmt(get(), CHUNK_BACKED_FRAME_COUNT_SQL).get() as { n: number }).n
 }
 
 /** Image paths of frames captured in [fromMs, toMs) — used by the orphaned-JPEG

--- a/desktop/windows/src/main/ipc/dbMigrations.ts
+++ b/desktop/windows/src/main/ipc/dbMigrations.ts
@@ -89,6 +89,45 @@ export const MIGRATIONS: Migration[] = [
       if (!hasFts) return
       d.exec("INSERT INTO rewind_frames_fts(rewind_frames_fts) VALUES('rebuild')")
     }
+  },
+  {
+    version: 3,
+    name: 'rewind_video_chunks',
+    up: (d) => {
+      // The abandoned-chunk table stands alone, so it is created either way.
+      // The database half of abandoned-chunk recovery, ported from macOS'
+      // `RewindAbandonedVideoChunkQuarantine`. A chunk found corrupt at read
+      // time is tombstoned here so a later claim cannot point a frame back into
+      // a file recovery has already given up on.
+      d.exec(
+        `CREATE TABLE IF NOT EXISTS rewind_abandoned_chunks (
+           chunk_path TEXT PRIMARY KEY NOT NULL
+         )`
+      )
+      // Guard on existence, for the same reason migration 2 does: db.ts's
+      // bootstrap creates rewind_frames before migrations run in production,
+      // but the migration-only harness (dbMigrations.test.ts) seeds only
+      // local_conversation, and a migration that assumes a table it did not
+      // create fails the whole chain there.
+      const hasFrames = d
+        .prepare("SELECT 1 AS x FROM sqlite_master WHERE type='table' AND name='rewind_frames'")
+        .get() as { x: number } | undefined
+      if (!hasFrames) return
+      // Where a frame lives once it has been compacted into a video chunk:
+      // `chunk_path` is the chunk's `<day>/<name>.omichunk` relative path and
+      // `chunk_offset` is its position inside it. Both stay NULL for a frame
+      // still stored as its own JPEG, which is every existing row — the column
+      // being NULL is what `chunkSql.ts` filters compaction candidates on, so
+      // the default is the migration's whole behaviour for existing data.
+      addColumnIfMissing(d, 'rewind_frames', 'chunk_path', 'TEXT')
+      addColumnIfMissing(d, 'rewind_frames', 'chunk_offset', 'INTEGER')
+      // Partial index: only chunk-backed rows are in it, so it stays small on a
+      // database that has never compacted anything, and the retention sweep's
+      // DISTINCT over chunk_path does not scan the whole table.
+      d.exec(
+        'CREATE INDEX IF NOT EXISTS idx_rewind_frames_chunk ON rewind_frames(chunk_path) WHERE chunk_path IS NOT NULL'
+      )
+    }
   }
 ]
 

--- a/desktop/windows/src/main/ipc/dbWipe.ts
+++ b/desktop/windows/src/main/ipc/dbWipe.ts
@@ -37,6 +37,11 @@ export const USER_DATA_TABLES = [
   // The vectors themselves — derived from the user's screen content, so they must
   // go on an account switch just like the frame->content mapping above.
   'rewind_embedding_vectors',
+  // Chunk tombstones name `<day>/<firstFrameTs>-<lastFrameTs>.omichunk` files,
+  // so each row states when the previous account was at its screen. Derived
+  // from their data and must go with it. (The drift guard in dbWipe.test.ts
+  // caught this one missing too.)
+  'rewind_abandoned_chunks',
   'file_index_meta',
   // Track 2's voice-turn outbox holds queued user voice-message data; it must be
   // cleared on account switch (drift-guard caught it missing — see dbWipe.test.ts).

--- a/desktop/windows/src/main/ipc/rewind.ts
+++ b/desktop/windows/src/main/ipc/rewind.ts
@@ -27,6 +27,9 @@ import { pruneRewindOnce } from '../rewind/retentionRunner'
 import { rebuildRewindIndexFromDisk } from '../rewind/rebuildIndex'
 import { rewindRoot } from '../rewind/paths'
 import { readRewindFrame } from '../rewind/frameFile'
+import { readChunkFile } from '../rewind/chunks/chunkFiles'
+import { compactRewindOnce, settleChunkEncode } from '../rewind/chunks/compactionRunner'
+import type { EncodeResponse } from '../rewind/chunks/chunkBroker'
 import type { RewindSettings } from '../../shared/types'
 
 /** How many semantic neighbours to pull before the similarity floor + the
@@ -126,6 +129,24 @@ export function registerRewindHandlers(): void {
     const buf = await readRewindFrame(rewindRoot(), imagePath)
     return `data:image/jpeg;base64,${buf.toString('base64')}`
   })
+  // --- Video chunks (main/rewind/chunks/ARCHITECTURE.md) ---
+  // A compacted frame has no JPEG; its pixels are one frame inside a chunk.
+  // Main hands over the chunk's bytes and the renderer decodes, because the
+  // cursor that keeps a scrub linear has to live next to the scrubber. The path
+  // is validated by resolveChunkPath before anything is read, so a corrupt row
+  // cannot address a file outside the Rewind root.
+  ipcMain.handle('rewind:chunkBytes', async (_e, chunkPath: string) => {
+    const bytes = await readChunkFile(rewindRoot(), chunkPath)
+    // Returned as a plain buffer; structured clone moves it without a base64
+    // round trip, which matters because a chunk is read once per scrub, not
+    // once per frame.
+    return bytes
+  })
+  // The renderer's answer to an encode request the compactor sent it.
+  ipcMain.on('rewind:chunk-encoded', (_e, response: EncodeResponse) => {
+    settleChunkEncode(response)
+  })
+  ipcMain.handle('rewind:compactNow', async () => compactRewindOnce())
   ipcMain.handle('rewind:getSettings', async () => getRewindSettings())
   ipcMain.handle('rewind:setSettings', async (_e, next: RewindSettings) => {
     updateRewindSettings(next)

--- a/desktop/windows/src/main/rewind/chunks/ARCHITECTURE.md
+++ b/desktop/windows/src/main/rewind/chunks/ARCHITECTURE.md
@@ -1,0 +1,203 @@
+# Rewind video chunks
+
+LIFECYCLE: permanent
+
+Packs runs of Rewind's per-frame JPEGs into inter-frame-compressed video chunks.
+Ported from macOS `Rewind/Core/VideoChunkEncoder.swift`,
+`RewindVideoFrameCursor.swift` and `RewindAbandonedVideoChunkRecovery.swift`.
+
+## The problem, measured
+
+Windows Rewind stores one JPEG per captured frame (`frameFile.ts`,
+`<userData>/rewind/<day>/<ts>.jpg`). Capture runs at one frame per second
+(`captureService.ts`, `intervalMs: 1000`) with a duplicate-frame skip and a
+30-second keyframe anchor, and retention defaults to 14 days
+(`rewindSettings.ts`).
+
+Measured on this machine's own capture output at the default `standard` quality
+tier (1280x720, JPEG quality 0.7), a real 60-second run of ordinary desktop work:
+
+| Storage | Per frame | Per 60s chunk |
+|---|---|---|
+| JPEG (what ships today) | 115.8 KB | 6.95 MB |
+| H.264 chunk @ 400 kbps | **2.26 KB** | **136 KB** |
+| VP9 chunk @ 400 kbps | 3.35 KB | 201 KB |
+
+**51x**, with every one of the 60 frames decoding back and scoring 37 to 41 dB
+PSNR against its source. The saving is that large because consecutive frames of a
+screen are nearly identical, which is exactly the redundancy a JPEG-per-frame
+store cannot exploit and an inter-frame codec exists to.
+
+Scaled to the shipped defaults that is the difference between roughly 25 GB and
+roughly 0.5 GB for a fortnight of active use. macOS never had this problem
+because it has encoded to 60-second chunks from the start.
+
+## Shape
+
+```
+compactionPlan  ->  compactor  ->  chunkFormat  ->  chunkFiles
+                        |
+                        +-- chunkBroker --> renderer/rewind/chunkEncoder (WebCodecs)
+```
+
+| Module | Answers |
+|---|---|
+| `compactionPlan.ts` | Which frames become which chunk? |
+| `chunkSql.ts` | Which frames may be compacted, and how is one claimed? |
+| `compactor.ts` | In what order, so that nothing can be lost? |
+| `chunkFormat.ts` | What is in the file? |
+| `chunkFiles.ts` | Where does it live, and when is it garbage? |
+| `cursorPolicy.ts` | Can the open decoder serve this read? |
+| `chunkBroker.ts` | How does main get an encode done? |
+| `chunkRebuild.ts` | What rows should exist for a chunk after a database wipe? |
+| `compactionRunner.ts` | When does any of this happen? |
+
+Reading a compacted frame runs the other way, and does not come through the
+broker: `renderer/rewind/frameImageSource.ts` asks main for the chunk's bytes
+and decodes locally with `chunkDecoder.ts`.
+
+## Compaction, not live encoding
+
+This is the deliberate divergence, and the rest of the design follows from it.
+
+macOS encodes **live**: `VideoChunkEncoder.addFrame` takes each frame as it is
+captured and appends it to the chunk currently being written. Windows compacts
+**after the fact**: capture keeps writing JPEGs exactly as it always has, and a
+background pass every 30 minutes packs runs that are older than 30 minutes.
+
+The reason is that live encoding puts the codec in the capture path. A bug there
+costs the user frames that no longer exist anywhere. Compacting instead means:
+
+- capture is untouched, so compaction cannot lose a frame that was captured;
+- a failed compaction leaves the JPEGs exactly where they were;
+- turning it off changes nothing about how frames are stored going forward;
+- the backlog already on disk gets compacted too, which a live encoder cannot do.
+
+It also removes most of the machinery macOS needs. Because macOS encodes live,
+its database rows necessarily exist while the chunk is still being written, so it
+carries a sidecar journal of abandoned writers, a quarantine table, and a
+generation/reservation ownership model to stop a stale finaliser from clearing a
+newer writer's state. Here nothing references a chunk until it is finished, so
+none of that is load-bearing. What is kept is the tombstone table, because a
+chunk can still be found corrupt at *read* time long after it was written.
+
+## The ordering that makes it safe
+
+```
+write chunk  ->  read it back and verify  ->  claim frame  ->  delete its JPEG
+```
+
+Every prefix is a safe place to crash:
+
+| Crash after | State | Who cleans up |
+|---|---|---|
+| write | an unreferenced chunk file | the chunk sweep, after its grace period |
+| verify | same | same |
+| a claim | claimed frames read from a chunk proven to hold them; unclaimed frames still have their JPEGs | nothing to clean; the chunk holds a superset |
+| a claim, before the delete | an orphaned JPEG | the existing orphan sweep |
+
+"Verify" re-reads the file from disk and checks that it parses, holds exactly the
+planned number of frames, carries the planned capture timestamp at every offset,
+and has the planned geometry. The timestamp check is the one that matters: a
+chunk with the right frame count but a shifted order would make every read return
+a neighbouring frame, silently.
+
+## Rules worth knowing
+
+**Only OCR'd frames are compacted.** `chunkSql.ts` requires `indexed = 1`. The
+OCR backlog sweep reads `image_path` for `indexed = 0` frames and, when the file
+is missing, marks the frame indexed with *empty text* rather than failing
+(`ocrService.ts`). Compacting an un-OCR'd frame would therefore not error; it
+would quietly cost that frame its searchable text forever.
+
+**A chunk holds one geometry and one local day.** A video track has exactly one
+size, and chunks are filed under a day directory so day-scoped retention can
+delete whole files.
+
+**Runs shorter than 8 frames are left alone.** The opening key frame is most of a
+short chunk: measured, a 5-frame run only reached 2.4x against the 51x of a
+60-frame run. Below the floor it is not worth replacing a directly-readable JPEG
+with a decode.
+
+**Presentation timestamps come from the frame index, not the capture clock.**
+macOS derives them from a live capture rate, and documents what that cost: a
+mid-chunk rate change (plugging in power shrinks the capture interval 3x) made a
+later frame's timestamp fall below an already-appended one, which `AVAssetWriter`
+rejects as non-monotonic, dropping frames and sometimes discarding the chunk. An
+index is monotonic by construction. The real capture time travels per record in
+the container instead.
+
+**The read cursor is one-way.** A chunk has no random access, so reaching frame
+*n* means decoding everything before it, and reopening per request makes a scrub
+quadratic. macOS measured 728 ms to walk an 18-frame chunk reopening each time
+against 59 ms keeping the reader alive — 12.3x, pixel-identical. The decision of
+when the open decoder can be reused is `cursorPolicy.ts`, a pure state machine;
+`chunkDecoder.ts` executes it.
+
+## The container
+
+A custom `.omichunk` rather than MP4. AVFoundation is a muxer-first API, so macOS
+gets a container whether it wants one or not; WebCodecs is codec-first, emitting
+bare `EncodedVideoChunk`s and accepting them back. An MP4 here would mean writing
+a muxer and a demuxer to put bytes into a box structure and immediately take them
+out again.
+
+Two properties are worth the format:
+
+- **Frame N is record N.** MP4 seeks by presentation time; here the index is the
+  addressing scheme, and it is the same number stored in `chunk_offset`.
+- **A chunk is self-describing.** Each record carries the capture timestamp its
+  JPEG filename used to carry, so `rebuildIndex.ts` — which re-creates
+  `rewind_frames` rows from `<day>/<ts>.jpg` after a database wipe — does not
+  lose that ability for every frame compaction touched.
+
+Parsing is defensive: every declared length is checked against the remaining
+buffer before use, and a truncated file raises rather than returning the frames it
+managed to read, because the compactor treats "reads back exactly" as the
+precondition for deleting anything.
+
+## Recovery after a database wipe
+
+`rebuildIndex.ts` exists because Windows can re-create `rewind_frames` rows from
+the JPEGs still on disk after a whole-database reset: the filename *is* the
+timestamp. Compaction would have quietly taken that away from every frame it
+packed, leaving intact pixels that nothing references and that the chunk sweep
+would eventually delete.
+
+So the rebuild has a chunk pass too (`chunkRebuild.ts`). It reads only each
+chunk's record headers, skips offsets that already have a row so a re-run
+inserts nothing, and refuses to invent rows for a chunk that does not parse.
+
+One difference from the JPEG pass is worth knowing: rebuilt chunk rows are
+marked `indexed = 1`, not `0`. The OCR backfill reads `image_path`, which is
+empty for a chunk-backed row, and its missing-file handling marks the frame
+indexed with empty text anyway — so both values reach the same end state and the
+only difference is whether the app first spends a run of OCR batches that cannot
+succeed. The OCR text itself is genuinely lost, because it lived only in the
+wiped database; it was never written into a chunk. The pixels come back.
+
+## Where a frame's pixels are
+
+`rewind_frames` gains `chunk_path` and `chunk_offset` (migration 3). Exactly one
+of them and `image_path` locates a frame:
+
+| `image_path` | `chunk_path` | Meaning |
+|---|---|---|
+| a path | NULL | still its own JPEG (every pre-existing row) |
+| `''` | a path | compacted; pixels are frame `chunk_offset` of that chunk |
+
+`image_path` is set to `''` rather than NULL because the column is `NOT NULL` and
+readers compare it as a string. macOS carries the identical compromise and says
+so.
+
+## Not ported
+
+- **Live encoding**, and with it the aspect-ratio debounce, the frame-rate
+  freeze, the buffer-overflow emergency reset, and the writer-not-ready retry
+  ladder. All of those exist to keep a live encoder healthy in the capture path.
+- **The reservation/generation ownership model** and the abandoned-writer sidecar
+  journal, for the reason given above: nothing references a chunk until it is
+  complete.
+- **`maxResolution` downscaling.** macOS caps a chunk's long edge at 3000 px.
+  Windows already caps the captured frame by quality tier
+  (`RewindCaptureHost.tsx`, max 2560x1440), so the cap would never bind.

--- a/desktop/windows/src/main/rewind/chunks/chunkBroker.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkBroker.test.ts
@@ -1,0 +1,150 @@
+// The encode channel's protocol: what happens when the renderer is slow,
+// silent, duplicated, or gone. None of it needs Electron or a codec.
+import { describe, expect, it, vi } from 'vitest'
+import { ChunkEncodeBroker, pickEncodeTarget, type EncodeRequest } from './chunkBroker'
+
+function broker(timeoutMs = 1000) {
+  const sent: EncodeRequest[] = []
+  const b = new ChunkEncodeBroker((r) => sent.push(r), timeoutMs)
+  return { b, sent }
+}
+
+const input = { width: 1280, height: 720, frames: [{ captureTsMs: 1, jpeg: new Uint8Array([1]) }] }
+
+describe('a normal encode', () => {
+  it('sends the request and resolves with the bytes', async () => {
+    const { b, sent } = broker()
+    const promise = b.encode(input)
+    expect(sent).toHaveLength(1)
+    b.settle({ requestId: sent[0].requestId, ok: true, bytes: new Uint8Array([9, 9]) })
+    expect([...(await promise)]).toEqual([9, 9])
+  })
+
+  it('gives every request its own id', async () => {
+    const { b, sent } = broker()
+    const a = b.encode(input)
+    const c = b.encode(input)
+    expect(sent[0].requestId).not.toBe(sent[1].requestId)
+    b.settle({ requestId: sent[0].requestId, ok: true, bytes: new Uint8Array([1]) })
+    b.settle({ requestId: sent[1].requestId, ok: true, bytes: new Uint8Array([2]) })
+    expect([...(await a)]).toEqual([1])
+    expect([...(await c)]).toEqual([2])
+  })
+
+  it('stops tracking a settled request', async () => {
+    const { b, sent } = broker()
+    const promise = b.encode(input)
+    expect(b.inFlight).toBe(1)
+    b.settle({ requestId: sent[0].requestId, ok: true, bytes: new Uint8Array([1]) })
+    await promise
+    expect(b.inFlight).toBe(0)
+  })
+})
+
+describe('when the renderer does not cooperate', () => {
+  it('rejects with the renderer’s error', async () => {
+    const { b, sent } = broker()
+    const promise = b.encode(input)
+    b.settle({ requestId: sent[0].requestId, ok: false, error: 'no encoder available' })
+    await expect(promise).rejects.toThrow('no encoder available')
+  })
+
+  it('times out rather than hanging forever', async () => {
+    vi.useFakeTimers()
+    try {
+      const { b } = broker(500)
+      const promise = b.encode(input)
+      const assertion = expect(promise).rejects.toThrow(/timed out after 500ms/)
+      await vi.advanceTimersByTimeAsync(500)
+      await assertion
+      expect(b.inFlight).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores an answer that arrives after the timeout', async () => {
+    // Late answers are normal, not exceptional: the encode really was still
+    // running. Raising here would surface as an unhandled error in an IPC
+    // handler for a request nobody is waiting on any more.
+    vi.useFakeTimers()
+    try {
+      const { b, sent } = broker(500)
+      const promise = b.encode(input)
+      const assertion = expect(promise).rejects.toThrow(/timed out/)
+      await vi.advanceTimersByTimeAsync(500)
+      await assertion
+      expect(() =>
+        b.settle({ requestId: sent[0].requestId, ok: true, bytes: new Uint8Array([1]) })
+      ).not.toThrow()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a duplicate answer', async () => {
+    const { b, sent } = broker()
+    const promise = b.encode(input)
+    b.settle({ requestId: sent[0].requestId, ok: true, bytes: new Uint8Array([1]) })
+    await promise
+    expect(() =>
+      b.settle({ requestId: sent[0].requestId, ok: true, bytes: new Uint8Array([2]) })
+    ).not.toThrow()
+  })
+
+  it('ignores an answer for a request it never made', () => {
+    const { b } = broker()
+    expect(() => b.settle({ requestId: 'nope', ok: true, bytes: new Uint8Array() })).not.toThrow()
+  })
+
+  it('rejects when the request cannot even be sent', async () => {
+    const b = new ChunkEncodeBroker(() => {
+      throw new Error('window is gone')
+    })
+    await expect(b.encode(input)).rejects.toThrow('window is gone')
+    expect(b.inFlight).toBe(0)
+  })
+})
+
+describe('when the renderer goes away', () => {
+  it('fails everything in flight instead of waiting out the timeout', async () => {
+    // A pass sitting on an unresolvable promise holds its plan and every loaded
+    // JPEG in memory for the whole timeout.
+    const { b } = broker(60_000)
+    const a = b.encode(input)
+    const c = b.encode(input)
+    b.abortAll('the encoding window closed')
+    await expect(a).rejects.toThrow('the encoding window closed')
+    await expect(c).rejects.toThrow('the encoding window closed')
+    expect(b.inFlight).toBe(0)
+  })
+
+  it('is a no-op when nothing is in flight', () => {
+    const { b } = broker()
+    expect(() => b.abortAll('closed')).not.toThrow()
+  })
+})
+
+describe('choosing a renderer', () => {
+  const contents = (destroyed: boolean, crashed = false) =>
+    ({ isDestroyed: () => destroyed, isCrashed: () => crashed }) as unknown as Parameters<
+      typeof pickEncodeTarget
+    >[0][number]
+
+  it('takes the first live window', () => {
+    const live = contents(false)
+    expect(pickEncodeTarget([contents(true), live])).toBe(live)
+  })
+
+  it('skips a crashed renderer', () => {
+    const live = contents(false)
+    expect(pickEncodeTarget([contents(false, true), live])).toBe(live)
+  })
+
+  it('returns null when there is no window', () => {
+    // A real state — the app can run with every window closed, and compaction
+    // simply does not happen that pass.
+    expect(pickEncodeTarget([])).toBeNull()
+    expect(pickEncodeTarget([contents(true)])).toBeNull()
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/chunkBroker.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkBroker.ts
@@ -1,0 +1,122 @@
+/**
+ * Getting an encode done, from a process that cannot encode.
+ *
+ * The compactor runs in main, where there is no `VideoEncoder`. The renderer
+ * has one. This is the request/response channel between them, and it is the
+ * only reason compaction is asynchronous at all.
+ *
+ * Reads do not come through here. A chunk-backed frame is decoded by the
+ * renderer that wants to display it, which asks main for the chunk's bytes and
+ * runs its own decoder — because the cursor that makes scrubbing linear has to
+ * live next to the thing doing the scrubbing to be worth anything. Encoding has
+ * no such locality: it happens once, in the background, for a file nobody is
+ * waiting on.
+ */
+
+import type { WebContents } from 'electron'
+
+/** A single chunk is one encode; a slow machine still finishes well inside this. */
+export const ENCODE_TIMEOUT_MS = 120_000
+
+export type EncodeRequest = {
+  requestId: string
+  width: number
+  height: number
+  frames: { captureTsMs: number; jpeg: Uint8Array }[]
+}
+
+export type EncodeResponse =
+  | { requestId: string; ok: true; bytes: Uint8Array }
+  | { requestId: string; ok: false; error: string }
+
+type Pending = {
+  resolve: (bytes: Uint8Array) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Tracks in-flight encodes.
+ *
+ * Kept as a class with injected time and id sources so the whole protocol —
+ * timeouts, a response for a request that already gave up, a renderer that goes
+ * away mid-encode — is testable without Electron.
+ */
+export class ChunkEncodeBroker {
+  private readonly pending = new Map<string, Pending>()
+  private sequence = 0
+
+  constructor(
+    private readonly send: (request: EncodeRequest) => void,
+    private readonly timeoutMs = ENCODE_TIMEOUT_MS
+  ) {}
+
+  get inFlight(): number {
+    return this.pending.size
+  }
+
+  encode(input: Omit<EncodeRequest, 'requestId'>): Promise<Uint8Array> {
+    const requestId = `chunk-${++this.sequence}`
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId)
+        reject(new Error(`chunk encode timed out after ${this.timeoutMs}ms`))
+      }, this.timeoutMs)
+      // Node keeps the process alive for a pending timer; a background
+      // compaction must never be the reason the app will not quit.
+      if (typeof timer.unref === 'function') timer.unref()
+      this.pending.set(requestId, { resolve, reject, timer })
+      try {
+        this.send({ requestId, ...input })
+      } catch (e) {
+        this.settleWithError(requestId, e as Error)
+      }
+    })
+  }
+
+  /** Deliver a renderer's answer. Unknown ids are ignored, not thrown on. */
+  settle(response: EncodeResponse): void {
+    const entry = this.pending.get(response.requestId)
+    // A response can arrive after its request timed out, or twice. Neither is
+    // an error worth raising into an IPC handler; the request is simply over.
+    if (!entry) return
+    clearTimeout(entry.timer)
+    this.pending.delete(response.requestId)
+    if (response.ok) entry.resolve(response.bytes)
+    else entry.reject(new Error(response.error))
+  }
+
+  private settleWithError(requestId: string, error: Error): void {
+    const entry = this.pending.get(requestId)
+    if (!entry) return
+    clearTimeout(entry.timer)
+    this.pending.delete(requestId)
+    entry.reject(error)
+  }
+
+  /**
+   * Fail everything in flight.
+   *
+   * Called when the renderer that was doing the encoding goes away. Without it
+   * a compaction pass would sit on a promise nobody can resolve until the
+   * timeout, holding its plan and its loaded JPEGs in memory the whole time.
+   */
+  abortAll(reason: string): void {
+    const ids = [...this.pending.keys()]
+    for (const id of ids) this.settleWithError(id, new Error(reason))
+  }
+}
+
+/**
+ * The renderer that should do the encoding.
+ *
+ * Any live, non-destroyed window will do — the work needs a codec, not a
+ * particular page. Returns null when the app has no window open, in which case
+ * compaction simply does not run this pass.
+ */
+export function pickEncodeTarget(candidates: WebContents[]): WebContents | null {
+  for (const contents of candidates) {
+    if (!contents.isDestroyed() && !contents.isCrashed()) return contents
+  }
+  return null
+}

--- a/desktop/windows/src/main/rewind/chunks/chunkFiles.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkFiles.test.ts
@@ -1,0 +1,173 @@
+// Chunk files on disk: the atomic write, and the sweep that decides a chunk is
+// garbage. The sweep is the one that can lose data if it is wrong, so most of
+// this file is about what it declines to delete.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtemp, readdir, readFile, rm, writeFile, mkdir } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  CHUNK_SWEEP_GRACE_MS,
+  daysTouched,
+  listChunkFiles,
+  readChunkFile,
+  removeChunkFile,
+  selectUnreferencedChunks,
+  writeChunkFile
+} from './chunkFiles'
+
+let root: string
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'omi-chunks-'))
+})
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('writing a chunk', () => {
+  it('creates the day directory and writes the bytes', async () => {
+    await writeChunkFile(root, '2026-08-17/100-200.omichunk', new Uint8Array([1, 2, 3]))
+    const back = await readChunkFile(root, '2026-08-17/100-200.omichunk')
+    expect([...back]).toEqual([1, 2, 3])
+  })
+
+  it('leaves no temporary file behind', async () => {
+    // A `.tmp` is deliberately not a legal chunk path, but one left lying
+    // around is still litter that grows without bound.
+    await writeChunkFile(root, '2026-08-17/100-200.omichunk', new Uint8Array([1]))
+    const entries = await readdir(join(root, '2026-08-17'))
+    expect(entries).toEqual(['100-200.omichunk'])
+  })
+
+  it('replaces an existing chunk atomically', async () => {
+    await writeChunkFile(root, '2026-08-17/100-200.omichunk', new Uint8Array([1, 1, 1]))
+    await writeChunkFile(root, '2026-08-17/100-200.omichunk', new Uint8Array([2, 2]))
+    expect([...(await readChunkFile(root, '2026-08-17/100-200.omichunk'))]).toEqual([2, 2])
+  })
+
+  it('refuses a path outside the root', async () => {
+    // Same containment property frameFile.ts enforces for JPEGs.
+    await expect(writeChunkFile(root, '../escape.omichunk', new Uint8Array([1]))).rejects.toThrow(
+      /refusing to write/
+    )
+    await expect(readChunkFile(root, '../../etc/passwd.omichunk')).rejects.toThrow(
+      /refusing to read/
+    )
+    await expect(removeChunkFile(root, '../x.omichunk')).rejects.toThrow(/refusing to delete/)
+  })
+})
+
+describe('listing chunks', () => {
+  it('finds chunks under day directories', async () => {
+    await writeChunkFile(root, '2026-08-16/1-2.omichunk', new Uint8Array([1]))
+    await writeChunkFile(root, '2026-08-17/3-4.omichunk', new Uint8Array([1]))
+    const found = await listChunkFiles(root)
+    expect(found.map((f) => f.relativePath).sort()).toEqual([
+      '2026-08-16/1-2.omichunk',
+      '2026-08-17/3-4.omichunk'
+    ])
+  })
+
+  it('ignores the JPEGs it shares the directory with', async () => {
+    await mkdir(join(root, '2026-08-17'), { recursive: true })
+    await writeFile(join(root, '2026-08-17', '1781329148845.jpg'), 'not a chunk')
+    await writeChunkFile(root, '2026-08-17/1-2.omichunk', new Uint8Array([1]))
+    const found = await listChunkFiles(root)
+    expect(found).toHaveLength(1)
+  })
+
+  it('ignores a leftover temporary file', async () => {
+    await mkdir(join(root, '2026-08-17'), { recursive: true })
+    await writeFile(join(root, '2026-08-17', '1-2.omichunk.tmp'), 'half a chunk')
+    expect(await listChunkFiles(root)).toHaveLength(0)
+  })
+
+  it('ignores directories that are not days', async () => {
+    await mkdir(join(root, 'videos'), { recursive: true })
+    await writeFile(join(root, 'videos', '1-2.omichunk'), 'x')
+    expect(await listChunkFiles(root)).toHaveLength(0)
+  })
+
+  it('returns nothing for a root that does not exist yet', async () => {
+    expect(await listChunkFiles(join(root, 'nope'))).toEqual([])
+  })
+})
+
+describe('deciding a chunk is garbage', () => {
+  const NOW = 1_781_400_000_000
+  const old = (path: string) => ({ relativePath: path, modifiedMs: NOW - 60 * 60_000 })
+
+  it('collects a chunk no frame points at', async () => {
+    expect(selectUnreferencedChunks([old('2026-08-17/1-2.omichunk')], [], NOW)).toEqual([
+      '2026-08-17/1-2.omichunk'
+    ])
+  })
+
+  it('keeps a chunk that is still referenced', () => {
+    const files = [old('2026-08-17/1-2.omichunk'), old('2026-08-17/3-4.omichunk')]
+    expect(selectUnreferencedChunks(files, ['2026-08-17/1-2.omichunk'], NOW)).toEqual([
+      '2026-08-17/3-4.omichunk'
+    ])
+  })
+
+  it('spares a chunk written moments ago', () => {
+    // THE case this grace exists for: between writing a chunk and claiming its
+    // first frame the file is legitimately unreferenced, and deleting it there
+    // would pull the ground out from under the compactor that just wrote it.
+    const fresh = { relativePath: '2026-08-17/1-2.omichunk', modifiedMs: NOW - 1000 }
+    expect(selectUnreferencedChunks([fresh], [], NOW)).toEqual([])
+  })
+
+  it('collects it once the grace has passed', () => {
+    const file = { relativePath: '2026-08-17/1-2.omichunk', modifiedMs: NOW - CHUNK_SWEEP_GRACE_MS }
+    expect(selectUnreferencedChunks([file], [], NOW)).toEqual(['2026-08-17/1-2.omichunk'])
+  })
+
+  it('collects a chunk the database never heard of', () => {
+    // The crash-after-write case: the file exists, nothing ever claimed into it.
+    expect(
+      selectUnreferencedChunks([old('2026-08-17/9-9.omichunk')], ['2026-08-17/1-2.omichunk'], NOW)
+    ).toEqual(['2026-08-17/9-9.omichunk'])
+  })
+
+  it('collects nothing when everything is referenced', () => {
+    const files = [old('2026-08-17/1-2.omichunk')]
+    expect(selectUnreferencedChunks(files, ['2026-08-17/1-2.omichunk'], NOW)).toEqual([])
+  })
+})
+
+describe('day extraction', () => {
+  it('lists the days a set of chunks touches, sorted', () => {
+    expect(
+      daysTouched(['2026-08-17/1-2.omichunk', '2026-08-16/3-4.omichunk', '2026-08-17/5-6.omichunk'])
+    ).toEqual(['2026-08-16', '2026-08-17'])
+  })
+
+  it('skips a path it would not have written', () => {
+    expect(daysTouched(['../evil.omichunk'])).toEqual([])
+  })
+})
+
+describe('round trip through the real filesystem', () => {
+  it('writes, lists, reads and removes', async () => {
+    const path = '2026-08-17/1781329148845-1781329208845.omichunk'
+    await writeChunkFile(root, path, new Uint8Array([7, 7, 7, 7]))
+    expect((await listChunkFiles(root)).map((f) => f.relativePath)).toEqual([path])
+    expect([...(await readChunkFile(root, path))]).toEqual([7, 7, 7, 7])
+    await removeChunkFile(root, path)
+    expect(await listChunkFiles(root)).toEqual([])
+  })
+
+  it('removing an absent chunk is not an error', async () => {
+    // Retention runs repeatedly and must be idempotent.
+    await expect(removeChunkFile(root, '2026-08-17/1-2.omichunk')).resolves.toBeUndefined()
+  })
+
+  it('does not read a file whose bytes were never renamed into place', async () => {
+    await mkdir(join(root, '2026-08-17'), { recursive: true })
+    await writeFile(join(root, '2026-08-17', '1-2.omichunk.tmp'), 'partial')
+    await expect(readChunkFile(root, '2026-08-17/1-2.omichunk')).rejects.toThrow()
+    // ...and the partial write is still sitting there under its temp name only.
+    expect(await readFile(join(root, '2026-08-17', '1-2.omichunk.tmp'), 'utf8')).toBe('partial')
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/chunkFiles.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkFiles.ts
@@ -1,0 +1,144 @@
+/**
+ * Chunk files on disk.
+ *
+ * Main owns every read and write, exactly as it already does for JPEGs
+ * (`frameFile.ts`). The renderer that runs the codec never touches the
+ * filesystem; it is handed bytes and hands bytes back.
+ *
+ * The write is atomic because the compactor's safety argument depends on it:
+ * "the chunk is durable before any row points at it" is only true if a torn
+ * write cannot be mistaken for a finished one. Writing to a temporary name and
+ * renaming means a reader either sees the whole chunk or no chunk.
+ */
+
+import { mkdir, readFile, rename, rm, unlink, writeFile, readdir, stat } from 'fs/promises'
+import { dirname, join } from 'path'
+import { chunkDay, isChunkRelativePath, resolveChunkPath } from './chunkPaths'
+
+/**
+ * A chunk file younger than this is never collected as unreferenced.
+ *
+ * The window between writing a chunk and claiming its first frame is real, and
+ * during it the file is legitimately unreferenced. Without this grace the sweep
+ * could delete a chunk out from under the compactor that just wrote it. The
+ * same reasoning (and roughly the same value) as `ORPHAN_GRACE_MS` in
+ * `orphanSelection.ts`, which exists for the mirror-image race on JPEGs.
+ */
+export const CHUNK_SWEEP_GRACE_MS = 10 * 60_000
+
+const DAY_DIR_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export async function writeChunkFile(
+  root: string,
+  relativePath: string,
+  bytes: Uint8Array
+): Promise<void> {
+  const absolute = resolveChunkPath(root, relativePath)
+  if (!absolute) throw new Error(`refusing to write chunk at ${relativePath}`)
+  await mkdir(dirname(absolute), { recursive: true })
+  // `.tmp` is deliberately not a chunk path, so a leftover temp file can never
+  // be mistaken for a chunk by the reader or the sweep.
+  //
+  // The atomicity this buys cannot be observed from a unit test — it only shows
+  // up when the process dies between the write and the rename — so no test here
+  // fails if the rename is removed. It is load-bearing regardless: the
+  // compactor's safety argument is "the chunk is durable before any row points
+  // at it", and a torn write that a reader could mistake for a finished chunk
+  // is precisely the case that breaks it.
+  const temporary = `${absolute}.tmp`
+  await writeFile(temporary, bytes)
+  await rename(temporary, absolute)
+}
+
+export async function readChunkFile(root: string, relativePath: string): Promise<Buffer> {
+  const absolute = resolveChunkPath(root, relativePath)
+  if (!absolute) throw new Error(`refusing to read chunk at ${relativePath}`)
+  return readFile(absolute)
+}
+
+export async function removeChunkFile(root: string, relativePath: string): Promise<void> {
+  const absolute = resolveChunkPath(root, relativePath)
+  if (!absolute) throw new Error(`refusing to delete chunk at ${relativePath}`)
+  await rm(absolute, { force: true })
+}
+
+/** Every chunk file under the root, as relative paths, with its modified time. */
+export async function listChunkFiles(
+  root: string
+): Promise<{ relativePath: string; modifiedMs: number }[]> {
+  let days: string[]
+  try {
+    days = await readdir(root)
+  } catch {
+    return []
+  }
+  const found: { relativePath: string; modifiedMs: number }[] = []
+  for (const day of days) {
+    // Skipping non-day directories is an optimisation, not a guard: the
+    // `isChunkRelativePath` check below rejects anything outside a day
+    // directory anyway. It is kept because the alternative is descending into
+    // every unrelated directory under the Rewind root and building a candidate
+    // path per file. A mutation audit confirmed removing it changes no output.
+    if (!DAY_DIR_RE.test(day)) continue
+    let entries: string[]
+    try {
+      entries = await readdir(join(root, day))
+    } catch {
+      continue // vanished between listing and read
+    }
+    for (const entry of entries) {
+      // One authority for what counts as a chunk. There was a cheap
+      // `entry.endsWith(CHUNK_EXTENSION)` pre-filter here as well; the audit
+      // showed it could be deleted without any test noticing, because this
+      // check subsumes it. A guard that cannot be shown to matter is a guard
+      // that will drift, so there is now only one.
+      const relativePath = `${day}/${entry}`
+      if (!isChunkRelativePath(relativePath)) continue
+      try {
+        const info = await stat(join(root, day, entry))
+        found.push({ relativePath, modifiedMs: info.mtimeMs })
+      } catch {
+        continue
+      }
+    }
+  }
+  return found
+}
+
+/**
+ * Chunk files no frame references any more.
+ *
+ * Pure so the grace-period rule can be tested without a filesystem. Retention
+ * deletes rows by age; a chunk becomes garbage when its last row goes, and this
+ * is what notices. It also catches a chunk the database never heard of, which
+ * is the crash-after-write case.
+ */
+export function selectUnreferencedChunks(
+  onDisk: { relativePath: string; modifiedMs: number }[],
+  referenced: string[],
+  nowMs: number,
+  graceMs = CHUNK_SWEEP_GRACE_MS
+): string[] {
+  const live = new Set(referenced)
+  return onDisk
+    .filter((f) => !live.has(f.relativePath))
+    .filter((f) => nowMs - f.modifiedMs >= graceMs)
+    .map((f) => f.relativePath)
+}
+
+/** Day directories a set of chunk paths touches, for logging and day-scoped work. */
+export function daysTouched(relativePaths: string[]): string[] {
+  const days = new Set<string>()
+  for (const path of relativePaths) {
+    const day = chunkDay(path)
+    if (day) days.add(day)
+  }
+  return [...days].sort()
+}
+
+/** Remove a stale `.tmp` left by a write that died mid-flight. */
+export async function removeTemporaryChunk(root: string, relativePath: string): Promise<void> {
+  const absolute = resolveChunkPath(root, relativePath)
+  if (!absolute) return
+  await unlink(`${absolute}.tmp`).catch(() => undefined)
+}

--- a/desktop/windows/src/main/rewind/chunks/chunkFormat.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkFormat.test.ts
@@ -1,0 +1,235 @@
+// The container is the boundary the compactor trusts when it decides to delete
+// a JPEG, so the properties pinned here are the ones that make that decision
+// safe: an exact round trip, and a hard failure on anything less than exact.
+import { describe, expect, it } from 'vitest'
+import {
+  CHUNK_FORMAT_VERSION,
+  MAX_FRAMES_PER_CHUNK,
+  decodeChunk,
+  decodeChunkHeaderOnly,
+  encodeChunk,
+  readChunkTimestamps,
+  type ChunkContents
+} from './chunkFormat'
+
+function bytes(...values: number[]): Uint8Array {
+  return new Uint8Array(values)
+}
+
+/** DataView over a chunk, for the cases that corrupt one specific field. */
+function fieldsOf(chunk: Uint8Array): DataView {
+  return new DataView(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+}
+
+/** Byte offset of frame 0's record header: header + codec + description. */
+function firstRecordAt(codec = 'avc1.42001f', descBytes = 6): number {
+  return 24 + new TextEncoder().encode(codec).byteLength + descBytes
+}
+
+function sample(overrides: Partial<ChunkContents> = {}): ChunkContents {
+  return {
+    codec: 'avc1.42001f',
+    description: bytes(1, 100, 0, 31, 255, 225),
+    width: 1280,
+    height: 720,
+    frames: [
+      { captureTsMs: 1_781_329_148_845, isKeyFrame: true, data: bytes(9, 8, 7, 6, 5) },
+      { captureTsMs: 1_781_329_149_899, isKeyFrame: false, data: bytes(4, 3) },
+      { captureTsMs: 1_781_329_150_950, isKeyFrame: false, data: bytes(2, 1, 0, 42) }
+    ],
+    ...overrides
+  }
+}
+
+describe('chunk container round trip', () => {
+  it('returns every field byte-for-byte', () => {
+    const original = sample()
+    const decoded = decodeChunk(encodeChunk(original))
+
+    expect(decoded.codec).toBe(original.codec)
+    expect([...decoded.description]).toEqual([...original.description])
+    expect(decoded.width).toBe(1280)
+    expect(decoded.height).toBe(720)
+    expect(decoded.frames).toHaveLength(3)
+    decoded.frames.forEach((frame, i) => {
+      expect(frame.captureTsMs).toBe(original.frames[i].captureTsMs)
+      expect(frame.isKeyFrame).toBe(original.frames[i].isKeyFrame)
+      expect([...frame.data]).toEqual([...original.frames[i].data])
+    })
+  })
+
+  it('keeps millisecond timestamps exact past 2^32', () => {
+    // The field is 64-bit precisely so epoch ms does not wrap. A 32-bit field
+    // would have silently truncated every timestamp after 1970-02-19.
+    const ts = 1_781_329_148_845
+    expect(ts).toBeGreaterThan(2 ** 32)
+    const decoded = decodeChunk(encodeChunk(sample()))
+    expect(decoded.frames[0].captureTsMs).toBe(ts)
+  })
+
+  it('does not alias the input buffer', () => {
+    // A decoded frame that pointed into the file buffer would keep the whole
+    // chunk alive for as long as one frame was held.
+    const buffer = encodeChunk(sample())
+    const decoded = decodeChunk(buffer)
+    buffer.fill(0)
+    expect([...decoded.frames[0].data]).toEqual([9, 8, 7, 6, 5])
+  })
+
+  it('handles a codec that needs no description', () => {
+    const decoded = decodeChunk(encodeChunk(sample({ codec: 'vp8', description: bytes() })))
+    expect(decoded.codec).toBe('vp8')
+    expect(decoded.description).toHaveLength(0)
+    expect(decoded.frames).toHaveLength(3)
+  })
+})
+
+describe('what encoding refuses to produce', () => {
+  it('refuses a chunk that opens on a delta frame', () => {
+    // Nothing can decode it: there is no reference picture for frame 0.
+    const frames = sample().frames.map((f) => ({ ...f, isKeyFrame: false }))
+    expect(() => encodeChunk(sample({ frames }))).toThrow(/key frame/)
+  })
+
+  it('refuses an empty chunk', () => {
+    expect(() => encodeChunk(sample({ frames: [] }))).toThrow(/at least one frame/)
+  })
+
+  it('refuses a frame carrying no bytes', () => {
+    const frames = [{ captureTsMs: 1, isKeyFrame: true, data: bytes() }]
+    expect(() => encodeChunk(sample({ frames }))).toThrow(/encoded bytes/)
+  })
+
+  it('refuses a zero or oversized frame geometry', () => {
+    expect(() => encodeChunk(sample({ width: 0 }))).toThrow(/width/)
+    expect(() => encodeChunk(sample({ height: 70_000 }))).toThrow(/height/)
+  })
+
+  it('refuses a negative timestamp', () => {
+    const frames = [{ captureTsMs: -1, isKeyFrame: true, data: bytes(1) }]
+    expect(() => encodeChunk(sample({ frames }))).toThrow(/non-negative/)
+  })
+})
+
+describe('what decoding refuses to accept', () => {
+  it('rejects a file that is not a chunk, on the magic bytes', () => {
+    // Asserting the MESSAGE, not just the error type. Arbitrary bytes also fail
+    // the version check a few lines later, so a type-only assertion passed even
+    // with the magic check deleted — it was proving the wrong guard.
+    expect(() => decodeChunk(new TextEncoder().encode('this is a jpeg, honestly'))).toThrow(
+      /not an omi chunk/
+    )
+  })
+
+  it('rejects a file whose bytes would otherwise pass the version check', () => {
+    // The sharper case: a payload carrying a valid-looking version field at
+    // offset 8, so only the magic can reject it.
+    const impostor = encodeChunk(sample())
+    impostor.set(new TextEncoder().encode('NOTAOMI\0'), 0)
+    expect(() => decodeChunk(impostor)).toThrow(/not an omi chunk/)
+    expect(() => decodeChunkHeaderOnly(impostor)).toThrow(/not an omi chunk/)
+  })
+
+  it('rejects a future format version', () => {
+    const buffer = encodeChunk(sample())
+    fieldsOf(buffer).setUint16(8, CHUNK_FORMAT_VERSION + 1, true)
+    expect(() => decodeChunk(buffer)).toThrow(/unsupported chunk version/)
+  })
+
+  it('rejects a chunk truncated inside a frame body', () => {
+    // The property that matters: it throws rather than returning the frames it
+    // managed to read, which a caller could mistake for the whole chunk.
+    const buffer = encodeChunk(sample())
+    expect(() => decodeChunk(buffer.subarray(0, buffer.byteLength - 2))).toThrow(/truncated/)
+  })
+
+  it('rejects a chunk truncated inside a record header', () => {
+    const buffer = encodeChunk(sample())
+    expect(() => decodeChunk(buffer.subarray(0, buffer.byteLength - 6))).toThrow(/truncated/)
+  })
+
+  it('rejects a header whose declared frame count is absurd', () => {
+    // Without the ceiling this allocates against a garbage count before a
+    // single record has been read.
+    const buffer = encodeChunk(sample())
+    fieldsOf(buffer).setUint32(16, MAX_FRAMES_PER_CHUNK + 1, true)
+    expect(() => decodeChunk(buffer)).toThrow(/too many frames/)
+  })
+
+  it('rejects a header whose declared record length runs past the file', () => {
+    const buffer = encodeChunk(sample())
+    fieldsOf(buffer).setUint32(firstRecordAt() + 4, 0xff_ff_ff, true)
+    expect(() => decodeChunk(buffer)).toThrow(/truncated/)
+  })
+
+  it('rejects a chunk whose first frame lost its key flag', () => {
+    const buffer = encodeChunk(sample())
+    fieldsOf(buffer).setUint8(firstRecordAt(), 0)
+    expect(() => decodeChunk(buffer)).toThrow(/key frame/)
+  })
+
+  it('rejects a chunk declaring no frames', () => {
+    const buffer = encodeChunk(sample())
+    fieldsOf(buffer).setUint32(16, 0, true)
+    expect(() => decodeChunk(buffer)).toThrow(/declares no frames/)
+  })
+
+  it('rejects a chunk declaring an empty frame size', () => {
+    // A zero-sized video track cannot be configured on a decoder, so this would
+    // surface as an opaque WebCodecs failure at read time instead of here.
+    const zeroWidth = encodeChunk(sample())
+    fieldsOf(zeroWidth).setUint16(20, 0, true)
+    expect(() => decodeChunk(zeroWidth)).toThrow(/empty frame size/)
+
+    const zeroHeight = encodeChunk(sample())
+    fieldsOf(zeroHeight).setUint16(22, 0, true)
+    expect(() => decodeChunk(zeroHeight)).toThrow(/empty frame size/)
+  })
+
+  it('rejects a header whose codec and description run past the file', () => {
+    // Without this the codec string and decoder description would be read from
+    // whatever bytes happened to follow, and the record walk would start at a
+    // bogus offset.
+    const buffer = encodeChunk(sample())
+    fieldsOf(buffer).setUint32(12, 0xff_ff, true) // description length
+    expect(() => decodeChunk(buffer)).toThrow(/runs past end of file/)
+  })
+})
+
+describe('header-only scan', () => {
+  it('reads every timestamp without touching a payload', () => {
+    const original = sample()
+    expect(readChunkTimestamps(encodeChunk(original))).toEqual(
+      original.frames.map((f) => f.captureTsMs)
+    )
+  })
+
+  it('reports geometry and codec for recovery', () => {
+    const header = decodeChunkHeaderOnly(encodeChunk(sample()))
+    expect(header.codec).toBe('avc1.42001f')
+    expect(header.width).toBe(1280)
+    expect(header.height).toBe(720)
+    expect(header.timestamps).toHaveLength(3)
+  })
+
+  it('refuses a truncated chunk rather than reporting a short frame list', () => {
+    // Recovery uses this to re-create database rows. A short list here would
+    // silently drop frames that are actually still in the file.
+    const buffer = encodeChunk(sample())
+    expect(() => readChunkTimestamps(buffer.subarray(0, buffer.byteLength - 3))).toThrow(
+      /truncated/
+    )
+  })
+
+  it('refuses a header declaring an unusable frame count', () => {
+    // The scan builds a timestamp array from this number, so it needs the same
+    // ceiling the full parse has rather than trusting the file.
+    const tooMany = encodeChunk(sample())
+    fieldsOf(tooMany).setUint32(16, MAX_FRAMES_PER_CHUNK + 1, true)
+    expect(() => readChunkTimestamps(tooMany)).toThrow(/unusable frame count/)
+
+    const none = encodeChunk(sample())
+    fieldsOf(none).setUint32(16, 0, true)
+    expect(() => readChunkTimestamps(none)).toThrow(/unusable frame count/)
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/chunkFormat.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkFormat.ts
@@ -1,0 +1,283 @@
+/**
+ * The `.omichunk` container: the byte layout a compacted run of Rewind frames is
+ * stored in.
+ *
+ * macOS stores the same thing as an MP4, because AVFoundation is a muxer-first
+ * API — `AVAssetWriter` wants a container and hands you one. WebCodecs is the
+ * opposite: `VideoEncoder` emits bare `EncodedVideoChunk`s and `VideoDecoder`
+ * accepts them back, so an MP4 here would mean writing a muxer and a demuxer to
+ * put bytes into a box structure and immediately take them out again. This
+ * format is what is left when that round trip is removed.
+ *
+ * Two properties are worth the custom format:
+ *
+ *  - **Frame N is record N.** MP4 seeking is by presentation time, so reaching a
+ *    frame means converting an index to a time and trusting the demuxer to land
+ *    on the same frame. Here the index is the addressing scheme.
+ *  - **A chunk is self-describing.** Each record carries the capture timestamp
+ *    that its JPEG's filename used to carry. `rebuildIndex.ts` exists because
+ *    Windows can re-create `rewind_frames` rows from `<day>/<ts>.jpg` after a
+ *    database wipe; compaction would have silently taken that recovery away from
+ *    every frame it packed, so the timestamps travel with the pixels.
+ *
+ * The format is versioned and read defensively: a truncated or corrupt chunk is
+ * a throw at parse, never a partial frame list, because the compactor treats
+ * "reads back exactly" as the precondition for deleting the JPEGs.
+ *
+ * Deliberately free of `Buffer`. This module is imported by BOTH the main
+ * process (which writes and verifies chunks) and the renderer (which encodes
+ * and decodes them), and `Buffer` does not exist in the renderer — an earlier
+ * version used it and threw `ReferenceError: Buffer is not defined` the first
+ * time a real encode ran. `Uint8Array` + `DataView` + `TextEncoder` are the
+ * shared vocabulary, and a Node `Buffer` passed in is already a `Uint8Array`.
+ */
+
+export const CHUNK_MAGIC = 'OMICHNK\0'
+export const CHUNK_FORMAT_VERSION = 1
+
+/** Header: magic(8) version(2) codecLen(2) descLen(4) frameCount(4) width(2) height(2). */
+const HEADER_BYTES = 24
+/** Per record: flags(1) pad(3) byteLength(4) captureTsMs(8). */
+const RECORD_HEADER_BYTES = 16
+
+const KEY_FRAME_FLAG = 0x01
+
+/**
+ * A chunk holding more frames than this is refused at both ends. The compactor
+ * never builds one (a 60s window at the fastest supported cadence is far below
+ * it); the guard exists so a corrupt header cannot make the parser allocate
+ * against a garbage count before it has read a single record.
+ */
+export const MAX_FRAMES_PER_CHUNK = 4096
+
+/** Same reasoning for a single record's length: no real encoded frame is 64 MB. */
+export const MAX_RECORD_BYTES = 64 * 1024 * 1024
+
+export type ChunkFrame = {
+  /** Wall-clock capture time, epoch ms — the identity `<ts>.jpg` used to carry. */
+  captureTsMs: number
+  isKeyFrame: boolean
+  data: Uint8Array
+}
+
+export type ChunkContents = {
+  /** WebCodecs codec string, e.g. `avc1.42001f`. */
+  codec: string
+  /** Decoder description (`avcC` for H.264); empty when the codec needs none. */
+  description: Uint8Array
+  width: number
+  height: number
+  frames: ChunkFrame[]
+}
+
+const UTF8_ENCODER = new TextEncoder()
+const UTF8_DECODER = new TextDecoder('utf-8')
+
+/** ASCII bytes compared without decoding, so the magic check allocates nothing. */
+function matchesMagic(bytes: Uint8Array): boolean {
+  for (let i = 0; i < CHUNK_MAGIC.length; i++) {
+    if (bytes[i] !== CHUNK_MAGIC.charCodeAt(i)) return false
+  }
+  return true
+}
+
+/**
+ * Serialize a chunk. Throws rather than emitting something unreadable: every
+ * caller is about to treat these bytes as durable, and a chunk that cannot be
+ * parsed back is worse than a failed compaction.
+ */
+export function encodeChunk(contents: ChunkContents): Uint8Array {
+  if (contents.frames.length === 0) throw new Error('a chunk must hold at least one frame')
+  if (contents.frames.length > MAX_FRAMES_PER_CHUNK) {
+    throw new Error(`a chunk may hold at most ${MAX_FRAMES_PER_CHUNK} frames`)
+  }
+  if (!contents.frames[0].isKeyFrame) {
+    // Nothing downstream can decode a chunk that opens on a delta frame: the
+    // decoder has no reference picture to apply it to.
+    throw new Error('the first frame of a chunk must be a key frame')
+  }
+  if (!Number.isInteger(contents.width) || contents.width <= 0 || contents.width > 0xffff) {
+    throw new Error('chunk width must be a positive 16-bit integer')
+  }
+  if (!Number.isInteger(contents.height) || contents.height <= 0 || contents.height > 0xffff) {
+    throw new Error('chunk height must be a positive 16-bit integer')
+  }
+  const codecUtf8 = UTF8_ENCODER.encode(contents.codec)
+  const codecBytes = codecUtf8.byteLength
+  if (codecBytes === 0 || codecBytes > 0xffff) throw new Error('chunk codec string is out of range')
+  if (contents.description.byteLength > 0xffffffff) throw new Error('chunk description too large')
+
+  let total = HEADER_BYTES + codecBytes + contents.description.byteLength
+  for (const frame of contents.frames) {
+    if (frame.data.byteLength === 0) throw new Error('a chunk frame must carry encoded bytes')
+    if (frame.data.byteLength > MAX_RECORD_BYTES)
+      throw new Error('chunk frame exceeds record limit')
+    if (!Number.isSafeInteger(frame.captureTsMs) || frame.captureTsMs < 0) {
+      throw new Error('chunk frame timestamp must be a non-negative safe integer')
+    }
+    total += RECORD_HEADER_BYTES + frame.data.byteLength
+  }
+
+  const out = new Uint8Array(total)
+  const view = new DataView(out.buffer)
+  let at = 0
+  for (let i = 0; i < CHUNK_MAGIC.length; i++) out[at + i] = CHUNK_MAGIC.charCodeAt(i)
+  at += 8
+  view.setUint16(at, CHUNK_FORMAT_VERSION, true)
+  at += 2
+  view.setUint16(at, codecBytes, true)
+  at += 2
+  view.setUint32(at, contents.description.byteLength, true)
+  at += 4
+  view.setUint32(at, contents.frames.length, true)
+  at += 4
+  view.setUint16(at, contents.width, true)
+  at += 2
+  view.setUint16(at, contents.height, true)
+  at += 2
+
+  out.set(codecUtf8, at)
+  at += codecBytes
+  out.set(contents.description, at)
+  at += contents.description.byteLength
+
+  for (const frame of contents.frames) {
+    view.setUint8(at, frame.isKeyFrame ? KEY_FRAME_FLAG : 0)
+    at += 4 // flags byte + 3 reserved, already zero
+    view.setUint32(at, frame.data.byteLength, true)
+    at += 4
+    // Epoch ms fits a double exactly for any real date; BigInt keeps the field
+    // 64-bit on disk without forcing BigInt on every caller.
+    view.setBigInt64(at, BigInt(frame.captureTsMs), true)
+    at += 8
+    out.set(frame.data, at)
+    at += frame.data.byteLength
+  }
+
+  return out
+}
+
+export class ChunkFormatError extends Error {}
+
+/**
+ * Parse a chunk. Every length is validated against the remaining buffer before
+ * it is used, so a truncated file raises instead of yielding a short frame list
+ * that a caller could mistake for a complete one.
+ */
+export function decodeChunk(buffer: Uint8Array): ChunkContents {
+  if (buffer.byteLength < HEADER_BYTES)
+    throw new ChunkFormatError('chunk is shorter than its header')
+  if (!matchesMagic(buffer)) throw new ChunkFormatError('not an omi chunk')
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+
+  const version = view.getUint16(8, true)
+  if (version !== CHUNK_FORMAT_VERSION) {
+    throw new ChunkFormatError(`unsupported chunk version ${version}`)
+  }
+  const codecBytes = view.getUint16(10, true)
+  const descBytes = view.getUint32(12, true)
+  const frameCount = view.getUint32(16, true)
+  const width = view.getUint16(20, true)
+  const height = view.getUint16(22, true)
+
+  if (frameCount === 0) throw new ChunkFormatError('chunk declares no frames')
+  if (frameCount > MAX_FRAMES_PER_CHUNK)
+    throw new ChunkFormatError('chunk declares too many frames')
+  if (width === 0 || height === 0) throw new ChunkFormatError('chunk declares an empty frame size')
+
+  let at = HEADER_BYTES
+  if (at + codecBytes + descBytes > buffer.byteLength) {
+    throw new ChunkFormatError('chunk header runs past end of file')
+  }
+  const codec = UTF8_DECODER.decode(buffer.subarray(at, at + codecBytes))
+  at += codecBytes
+  const description = buffer.slice(at, at + descBytes)
+  at += descBytes
+
+  const frames: ChunkFrame[] = []
+  for (let i = 0; i < frameCount; i++) {
+    if (at + RECORD_HEADER_BYTES > buffer.byteLength) {
+      throw new ChunkFormatError(`chunk truncated in the header of frame ${i}`)
+    }
+    const flags = view.getUint8(at)
+    const byteLength = view.getUint32(at + 4, true)
+    const captureTsMs = Number(view.getBigInt64(at + 8, true))
+    at += RECORD_HEADER_BYTES
+
+    if (byteLength === 0) throw new ChunkFormatError(`frame ${i} declares no bytes`)
+    if (byteLength > MAX_RECORD_BYTES)
+      throw new ChunkFormatError(`frame ${i} exceeds the record limit`)
+    if (at + byteLength > buffer.byteLength) {
+      throw new ChunkFormatError(`chunk truncated in the body of frame ${i}`)
+    }
+    frames.push({
+      captureTsMs,
+      isKeyFrame: (flags & KEY_FRAME_FLAG) !== 0,
+      // `slice` copies, so a held frame does not keep the whole chunk alive.
+      data: buffer.slice(at, at + byteLength)
+    })
+    at += byteLength
+  }
+
+  if (!frames[0].isKeyFrame) throw new ChunkFormatError('chunk does not open on a key frame')
+
+  return { codec, description, width, height, frames }
+}
+
+/**
+ * Read only what is needed to re-associate a chunk with the database: the
+ * per-frame capture timestamps, in order.
+ *
+ * This is the path `rebuildIndex.ts` takes after a database wipe, where the
+ * pixels are wanted but not yet needed. It walks the record headers and skips
+ * every payload, so recovering a day of chunks does not pull a day of encoded
+ * video through memory.
+ */
+export function readChunkTimestamps(buffer: Uint8Array): number[] {
+  const contents = decodeChunkHeaderOnly(buffer)
+  return contents.timestamps
+}
+
+export function decodeChunkHeaderOnly(buffer: Uint8Array): {
+  codec: string
+  width: number
+  height: number
+  timestamps: number[]
+} {
+  if (buffer.byteLength < HEADER_BYTES)
+    throw new ChunkFormatError('chunk is shorter than its header')
+  if (!matchesMagic(buffer)) throw new ChunkFormatError('not an omi chunk')
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  const version = view.getUint16(8, true)
+  if (version !== CHUNK_FORMAT_VERSION)
+    throw new ChunkFormatError(`unsupported chunk version ${version}`)
+
+  const codecBytes = view.getUint16(10, true)
+  const descBytes = view.getUint32(12, true)
+  const frameCount = view.getUint32(16, true)
+  const width = view.getUint16(20, true)
+  const height = view.getUint16(22, true)
+  if (frameCount === 0 || frameCount > MAX_FRAMES_PER_CHUNK) {
+    throw new ChunkFormatError('chunk declares an unusable frame count')
+  }
+
+  let at = HEADER_BYTES
+  if (at + codecBytes + descBytes > buffer.byteLength) {
+    throw new ChunkFormatError('chunk header runs past end of file')
+  }
+  const codec = UTF8_DECODER.decode(buffer.subarray(at, at + codecBytes))
+  at += codecBytes + descBytes
+
+  const timestamps: number[] = []
+  for (let i = 0; i < frameCount; i++) {
+    if (at + RECORD_HEADER_BYTES > buffer.byteLength) {
+      throw new ChunkFormatError(`chunk truncated in the header of frame ${i}`)
+    }
+    const byteLength = view.getUint32(at + 4, true)
+    timestamps.push(Number(view.getBigInt64(at + 8, true)))
+    at += RECORD_HEADER_BYTES + byteLength
+    if (at > buffer.byteLength)
+      throw new ChunkFormatError(`chunk truncated in the body of frame ${i}`)
+  }
+  return { codec, width, height, timestamps }
+}

--- a/desktop/windows/src/main/rewind/chunks/chunkPaths.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkPaths.test.ts
@@ -1,0 +1,91 @@
+// A chunk path comes out of the database and turns into a file read, so these
+// are the same containment properties frameFile.ts already defends for JPEGs.
+import { describe, expect, it } from 'vitest'
+import { resolve } from 'path'
+import { chunkDay, chunkRelativePath, isChunkRelativePath, resolveChunkPath } from './chunkPaths'
+
+const ROOT = resolve('C:/Users/someone/AppData/Roaming/omi-windows/rewind')
+
+describe('naming a chunk', () => {
+  it('names it for the span it covers', () => {
+    // A directory listing then sorts chronologically and says what is inside
+    // each file without opening it.
+    expect(chunkRelativePath('2026-08-17', 1781329148845, 1781329208845)).toBe(
+      '2026-08-17/1781329148845-1781329208845.omichunk'
+    )
+  })
+
+  it('is stable for the same frames', () => {
+    // Two runs over the same plan must not produce two files.
+    const a = chunkRelativePath('2026-08-17', 100, 200)
+    const b = chunkRelativePath('2026-08-17', 100, 200)
+    expect(a).toBe(b)
+  })
+
+  it('refuses a malformed day', () => {
+    expect(() => chunkRelativePath('2026-8-17', 100, 200)).toThrow(/invalid chunk day/)
+    expect(() => chunkRelativePath('../../etc', 100, 200)).toThrow(/invalid chunk day/)
+  })
+
+  it('refuses a span that ends before it starts', () => {
+    expect(() => chunkRelativePath('2026-08-17', 200, 100)).toThrow(/end timestamp/)
+  })
+})
+
+describe('validating a stored path', () => {
+  it('accepts what this app writes', () => {
+    expect(isChunkRelativePath('2026-08-17/1781329148845-1781329208845.omichunk')).toBe(true)
+  })
+
+  it.each([
+    ['parent traversal', '../../../Windows/System32/config.omichunk'],
+    ['embedded traversal', '2026-08-17/../../secrets.omichunk'],
+    ['absolute path', 'C:/Windows/System32/x.omichunk'],
+    ['UNC path', '//attacker/share/x.omichunk'],
+    ['wrong extension', '2026-08-17/1-2.jpg'],
+    ['no day directory', '1781329148845-1781329208845.omichunk'],
+    ['nested too deep', '2026-08-17/sub/1-2.omichunk'],
+    ['non-numeric span', '2026-08-17/first-last.omichunk'],
+    ['leading whitespace', ' 2026-08-17/1-2.omichunk'],
+    ['trailing whitespace', '2026-08-17/1-2.omichunk '],
+    ['empty', '']
+  ])('rejects %s', (_label, value) => {
+    expect(isChunkRelativePath(value)).toBe(false)
+    expect(resolveChunkPath(ROOT, value)).toBeNull()
+  })
+
+  it('rejects a non-string without throwing', () => {
+    // Rows come back from SQLite, where the column is only nominally typed.
+    expect(isChunkRelativePath(null as unknown as string)).toBe(false)
+    expect(isChunkRelativePath(42 as unknown as string)).toBe(false)
+  })
+})
+
+describe('resolving to disk', () => {
+  it('resolves inside the root', () => {
+    const resolved = resolveChunkPath(ROOT, '2026-08-17/1-2.omichunk')
+    expect(resolved).toBe(resolve(ROOT, '2026-08-17/1-2.omichunk'))
+    expect(resolved?.startsWith(ROOT)).toBe(true)
+  })
+
+  it('returns null rather than throwing on a corrupt row', () => {
+    // These callers serve a UI: one bad row should render one missing frame,
+    // not take down the page.
+    expect(resolveChunkPath(ROOT, '../escape.omichunk')).toBeNull()
+  })
+
+  it('does not treat a sibling directory with the same prefix as inside', () => {
+    // `<root>-evil` starts with `<root>` as a string but is not under it.
+    expect(resolveChunkPath(ROOT, '../rewind-evil/2026-08-17/1-2.omichunk')).toBeNull()
+  })
+})
+
+describe('day extraction', () => {
+  it('reads the day a chunk is filed under', () => {
+    expect(chunkDay('2026-08-17/1-2.omichunk')).toBe('2026-08-17')
+  })
+
+  it('returns null for a path it would not have written', () => {
+    expect(chunkDay('../x.omichunk')).toBeNull()
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/chunkPaths.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkPaths.ts
@@ -1,0 +1,88 @@
+/**
+ * Where chunks live, and what counts as a legal chunk path.
+ *
+ * A chunk path is stored in the database and later turned back into a file
+ * read, which makes it exactly the shape of input `frameFile.ts` already
+ * defends against for JPEGs: a stored string that must not be able to address
+ * anything outside the Rewind root. The rules here mirror that file's, and the
+ * validation is deliberately duplicated rather than shared, because the two
+ * differ in the part that matters (`.jpg` under `<root>` at any depth versus
+ * `<day>/<name>.omichunk` at exactly one level) and a single parameterised
+ * checker would blur the thing being asserted.
+ *
+ * macOS validates the same property in
+ * `RewindAbandonedVideoChunkJournal.videoURL`: exactly two path components,
+ * neither empty nor `.` nor `..`, the right extension, and a final containment
+ * check against the storage root. This is that check.
+ */
+
+import { resolve, sep } from 'path'
+
+export const CHUNK_EXTENSION = '.omichunk'
+
+/** `<day>/<firstFrameTs>-<lastFrameTs>.omichunk`. */
+const RELATIVE_CHUNK_RE = /^\d{4}-\d{2}-\d{2}\/\d{1,15}-\d{1,15}\.omichunk$/
+
+/**
+ * The relative path a planned chunk is stored at.
+ *
+ * Named from the timestamps it spans rather than a counter or a random id, so
+ * the filename says what is inside it, two runs over the same frames produce
+ * the same name, and a directory listing sorts chronologically.
+ */
+export function chunkRelativePath(day: string, firstTsMs: number, lastTsMs: number): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(day)) throw new Error(`invalid chunk day: ${day}`)
+  if (!Number.isSafeInteger(firstTsMs) || firstTsMs < 0)
+    throw new Error('invalid chunk start timestamp')
+  if (!Number.isSafeInteger(lastTsMs) || lastTsMs < firstTsMs)
+    throw new Error('invalid chunk end timestamp')
+  return `${day}/${firstTsMs}-${lastTsMs}${CHUNK_EXTENSION}`
+}
+
+/**
+ * Whether a stored string is a chunk path this app could have written.
+ *
+ * The regex is the load-bearing guard: it pins the whole shape, and by pinning
+ * it also rejects `..`, absolute paths, UNC paths, extra path segments and
+ * surrounding whitespace. A mutation audit confirmed that both the trim check
+ * below and the containment check in `resolveChunkPath` can be deleted without
+ * any test noticing, because this pattern already refuses everything they
+ * catch.
+ *
+ * They stay anyway, and the reason is worth stating rather than leaving as
+ * apparent redundancy: the shape rule is the kind of thing a later change
+ * loosens (a new naming scheme, a nested directory), and the containment check
+ * is what would still be standing between a stored string and a file read
+ * outside the Rewind root when it does.
+ */
+export function isChunkRelativePath(relativePath: string): boolean {
+  if (typeof relativePath !== 'string') return false
+  const trimmed = relativePath.trim()
+  if (trimmed !== relativePath) return false
+  return RELATIVE_CHUNK_RE.test(relativePath)
+}
+
+/**
+ * Absolute path for a chunk, or `null` when the stored value is not one this
+ * app could have written or escapes the root.
+ *
+ * Returns `null` rather than throwing because the callers are read paths
+ * serving a UI: a frame whose row is corrupt should render as a missing frame,
+ * not take down the page.
+ *
+ * The containment check is defence in depth behind `isChunkRelativePath` — see
+ * the note there for why it is kept despite being unobservable today.
+ */
+export function resolveChunkPath(root: string, relativePath: string): string | null {
+  if (!isChunkRelativePath(relativePath)) return null
+  const resolvedRoot = resolve(root)
+  const candidate = resolve(resolvedRoot, relativePath)
+  if (candidate !== resolvedRoot && !candidate.startsWith(resolvedRoot + sep)) return null
+  return candidate
+}
+
+/** The `<day>` component of a chunk path, for day-scoped retention. */
+export function chunkDay(relativePath: string): string | null {
+  if (!isChunkRelativePath(relativePath)) return null
+  return relativePath.slice(0, relativePath.indexOf('/'))
+}

--- a/desktop/windows/src/main/rewind/chunks/chunkRebuild.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkRebuild.test.ts
@@ -1,0 +1,98 @@
+// Recovery after a database wipe. The pixels are on disk either way; the
+// question is whether anything can still find them.
+//
+// This is the reason each chunk record carries its capture timestamp. Without
+// it a compacted frame would be exactly the case rebuildIndex.ts was written to
+// prevent: intact bytes that nothing references, which the sweep then deletes.
+import { describe, expect, it } from 'vitest'
+import { encodeChunk } from './chunkFormat'
+import { REBUILT_CHUNK_FRAME_INDEXED, selectChunkFramesToRebuild } from './chunkRebuild'
+
+const PATH = '2026-08-17/1781329148845-1781329208845.omichunk'
+
+function chunkOf(count: number, startTs = 1_781_329_148_845, width = 1280, height = 720) {
+  return {
+    relativePath: PATH,
+    bytes: encodeChunk({
+      codec: 'avc1.42001f',
+      description: new Uint8Array([1, 100]),
+      width,
+      height,
+      frames: Array.from({ length: count }, (_, i) => ({
+        captureTsMs: startTs + i * 1000,
+        isKeyFrame: i === 0,
+        data: new Uint8Array([i + 1, 7])
+      }))
+    })
+  }
+}
+
+describe('recovering rows from a chunk', () => {
+  it('recovers one row per frame, at the right offset and time', () => {
+    const targets = selectChunkFramesToRebuild(chunkOf(12), new Set())
+    expect(targets).toHaveLength(12)
+    expect(targets.map((t) => t.chunkOffset)).toEqual([...Array(12).keys()])
+    expect(targets[0].ts).toBe(1_781_329_148_845)
+    expect(targets[11].ts).toBe(1_781_329_148_845 + 11_000)
+    expect(targets.every((t) => t.chunkPath === PATH)).toBe(true)
+  })
+
+  it('recovers the frame geometry the viewer needs', () => {
+    // The OCR backfill only ever fills text, never width/height, so if these
+    // were not recovered here nothing else would supply them.
+    const targets = selectChunkFramesToRebuild(chunkOf(4, 1_000_000_000_000, 2560, 1440), new Set())
+    expect(targets[0].width).toBe(2560)
+    expect(targets[0].height).toBe(1440)
+  })
+
+  it('inserts nothing on a second run', () => {
+    // Idempotence, as for the JPEG rebuild: a re-run must not duplicate rows.
+    const chunk = chunkOf(10)
+    const all = new Set(selectChunkFramesToRebuild(chunk, new Set()).map((t) => t.chunkOffset))
+    expect(selectChunkFramesToRebuild(chunk, all)).toHaveLength(0)
+  })
+
+  it('finishes a partially recovered chunk rather than skipping it whole', () => {
+    // Checked per offset, not per chunk: a run interrupted halfway must be able
+    // to complete, which a chunk-level "already seen" check would prevent.
+    const chunk = chunkOf(10)
+    const targets = selectChunkFramesToRebuild(chunk, new Set([0, 1, 2, 3]))
+    expect(targets.map((t) => t.chunkOffset)).toEqual([4, 5, 6, 7, 8, 9])
+  })
+})
+
+describe('what it refuses to invent', () => {
+  it('recovers nothing from a corrupt chunk', () => {
+    // Rows for frames that may not decode would trade unreachable pixels for
+    // broken ones, and the user cannot tell the difference from the UI.
+    const chunk = { relativePath: PATH, bytes: new Uint8Array([1, 2, 3, 4, 5]) }
+    expect(selectChunkFramesToRebuild(chunk, new Set())).toEqual([])
+  })
+
+  it('recovers nothing from a truncated chunk', () => {
+    const full = chunkOf(10)
+    const cut = { relativePath: PATH, bytes: full.bytes.subarray(0, full.bytes.byteLength - 5) }
+    expect(selectChunkFramesToRebuild(cut, new Set())).toEqual([])
+  })
+
+  it('skips a record whose timestamp is not a real time', () => {
+    const chunk = chunkOf(3)
+    // Zero the second record's timestamp in place.
+    const view = new DataView(chunk.bytes.buffer, chunk.bytes.byteOffset, chunk.bytes.byteLength)
+    const recordAt = 24 + new TextEncoder().encode('avc1.42001f').byteLength + 2
+    const secondRecordAt = recordAt + 16 + 2
+    view.setBigInt64(secondRecordAt + 8, 0n, true)
+    const targets = selectChunkFramesToRebuild(chunk, new Set())
+    expect(targets.map((t) => t.chunkOffset)).toEqual([0, 2])
+  })
+})
+
+describe('how recovered rows are marked', () => {
+  it('marks them already indexed, unlike the JPEG rebuild', () => {
+    // Not an oversight. The OCR backfill reads `image_path`, which is '' for a
+    // chunk-backed row, and its missing-file handling marks the frame indexed
+    // with empty text anyway — so indexed=0 reaches the identical end state
+    // after spending a run of bounded OCR batches that cannot succeed.
+    expect(REBUILT_CHUNK_FRAME_INDEXED).toBe(1)
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/chunkRebuild.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkRebuild.ts
@@ -1,0 +1,87 @@
+/**
+ * Re-creating `rewind_frames` rows from chunk files after a database wipe.
+ *
+ * The chunk half of `rebuildIndex.ts`, and the reason each chunk record carries
+ * its capture timestamp. Windows can recover JPEG-backed frames because the
+ * filename *is* the timestamp (`<day>/<ts>.jpg`); without this, compaction would
+ * have quietly taken that ability away from every frame it packed — the pixels
+ * would still be on disk, intact and unreachable, and the orphan sweep would
+ * eventually delete them.
+ *
+ * The same shape as its JPEG sibling: only INSERTs, never deletes, idempotent,
+ * fail-open per file, and it reads only the record headers rather than pulling a
+ * day of encoded video through memory.
+ */
+
+import { decodeChunkHeaderOnly } from './chunkFormat'
+
+export type ChunkRebuildTarget = {
+  chunkPath: string
+  chunkOffset: number
+  ts: number
+  width: number
+  height: number
+}
+
+export type ChunkOnDisk = {
+  relativePath: string
+  bytes: Uint8Array
+}
+
+/**
+ * Rows that should exist for a chunk but do not.
+ *
+ * Pure: the caller supplies the chunk bytes and the offsets already present, so
+ * the selection can be tested without a filesystem or a database.
+ *
+ * `known` is the set of `chunk_offset` values the database already has for this
+ * chunk. Skipping them is what makes a re-run insert nothing, and it is checked
+ * per offset rather than per chunk so a partially-recovered chunk finishes
+ * rather than being skipped whole.
+ */
+export function selectChunkFramesToRebuild(
+  chunk: ChunkOnDisk,
+  known: ReadonlySet<number>
+): ChunkRebuildTarget[] {
+  let header
+  try {
+    header = decodeChunkHeaderOnly(chunk.bytes)
+  } catch {
+    // A corrupt or truncated chunk yields no rows. Inventing rows for frames
+    // that may not decode would trade unreachable pixels for broken ones.
+    return []
+  }
+  const targets: ChunkRebuildTarget[] = []
+  header.timestamps.forEach((ts, offset) => {
+    if (known.has(offset)) return
+    if (!Number.isSafeInteger(ts) || ts <= 0) return
+    targets.push({
+      chunkPath: chunk.relativePath,
+      chunkOffset: offset,
+      ts,
+      width: header.width,
+      height: header.height
+    })
+  })
+  return targets
+}
+
+/**
+ * Rebuilt chunk rows are inserted as already-indexed, which is the opposite of
+ * what `rebuildIndex.ts` does for JPEGs, and the difference is not an oversight.
+ *
+ * A rebuilt JPEG row is marked `indexed = 0` because the OCR backfill really can
+ * re-read the file and recover its text. A chunk-backed row cannot: the backfill
+ * reads `image_path`, which is `''` here, and its handling for a missing file is
+ * to mark the frame indexed with empty text so it stops retrying
+ * (`ocrService.ts`). So `indexed = 0` and `indexed = 1` reach the identical end
+ * state — empty text — and the only difference is whether the app first spends a
+ * run of bounded OCR batches discovering that, which on a large recovery is many
+ * passes that cannot succeed.
+ *
+ * What is genuinely lost is the OCR text, and it is lost because it lived only in
+ * the wiped database; it was never written into a chunk. The pixels come back,
+ * and they are browsable. Making these frames searchable again would mean
+ * teaching OCR to decode chunks, which needs a renderer and is its own change.
+ */
+export const REBUILT_CHUNK_FRAME_INDEXED = 1

--- a/desktop/windows/src/main/rewind/chunks/chunkSql.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkSql.test.ts
@@ -1,0 +1,307 @@
+// Proof that the chunk SQL does what the compactor assumes, in a REAL SQLite
+// database, running the statements production runs (imported, never re-typed —
+// see the header of rewindEmbeddingSql.ts for what re-typing them costs).
+//
+// The property under test throughout: a frame's JPEG is only ever given up in
+// exchange for a chunk slot that actually exists, exactly once.
+import { DatabaseSync } from 'node:sqlite'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  CHUNK_BACKED_FRAME_COUNT_SQL,
+  CLAIM_FRAME_INTO_CHUNK_SQL,
+  COMPACTABLE_FRAMES_SQL,
+  DELETE_FRAMES_IN_CHUNK_SQL,
+  FRAMES_IN_CHUNK_SQL,
+  IS_CHUNK_ABANDONED_SQL,
+  REFERENCED_CHUNK_PATHS_SQL,
+  TOMBSTONE_CHUNK_SQL
+} from './chunkSql'
+import { MIGRATIONS, runMigrations, type MigrationDb } from '../../ipc/dbMigrations'
+
+// The pre-migration table, as db.ts's baseline creates it. Migration 3 is then
+// run against it by the real migration runner, so this file also proves the
+// migration produces a schema these statements work on.
+const LEGACY_REWIND_FRAMES = `
+  CREATE TABLE rewind_frames (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts INTEGER NOT NULL,
+    app TEXT NOT NULL DEFAULT '',
+    window_title TEXT NOT NULL DEFAULT '',
+    process_name TEXT NOT NULL DEFAULT '',
+    ocr_text TEXT NOT NULL DEFAULT '',
+    image_path TEXT NOT NULL,
+    width INTEGER NOT NULL DEFAULT 0,
+    height INTEGER NOT NULL DEFAULT 0,
+    indexed INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE TABLE local_conversation (id TEXT PRIMARY KEY);`
+
+let db: DatabaseSync
+
+function addFrame(o: {
+  id: number
+  ts: number
+  indexed?: number
+  imagePath?: string
+  width?: number
+  height?: number
+}): void {
+  db.prepare(
+    'INSERT INTO rewind_frames (id, ts, image_path, width, height, indexed) VALUES (?, ?, ?, ?, ?, ?)'
+  ).run(
+    o.id,
+    o.ts,
+    o.imagePath ?? `C:/rewind/2026-08-17/${o.ts}.jpg`,
+    o.width ?? 1280,
+    o.height ?? 720,
+    o.indexed ?? 1
+  )
+}
+
+function compactable(olderThan: number, limit = 100) {
+  return db.prepare(COMPACTABLE_FRAMES_SQL).all(olderThan, limit) as {
+    id: number
+    ts: number
+    imagePath: string
+  }[]
+}
+
+function claim(id: number, chunkPath: string, offset: number): number {
+  const abandoned = db.prepare(IS_CHUNK_ABANDONED_SQL).get(chunkPath) as { abandoned: number }
+  if (abandoned.abandoned) return 0
+  return db.prepare(CLAIM_FRAME_INTO_CHUNK_SQL).run(chunkPath, offset, id).changes as number
+}
+
+beforeEach(() => {
+  db = new DatabaseSync(':memory:')
+  db.exec(LEGACY_REWIND_FRAMES)
+  runMigrations(db as unknown as MigrationDb, MIGRATIONS)
+})
+
+describe('migration 3', () => {
+  it('adds the locator columns to an existing table', () => {
+    const cols = (db.prepare('PRAGMA table_info(rewind_frames)').all() as { name: string }[]).map(
+      (c) => c.name
+    )
+    expect(cols).toContain('chunk_path')
+    expect(cols).toContain('chunk_offset')
+  })
+
+  it('leaves every existing row uncompacted', () => {
+    // The default is the migration's entire behaviour for existing data: NULL
+    // is what marks a frame as still JPEG-backed.
+    addFrame({ id: 1, ts: 1000 })
+    const row = db.prepare('SELECT chunk_path, chunk_offset FROM rewind_frames').get() as {
+      chunk_path: string | null
+      chunk_offset: number | null
+    }
+    expect(row.chunk_path).toBeNull()
+    expect(row.chunk_offset).toBeNull()
+  })
+
+  it('creates the abandoned-chunk table', () => {
+    const t = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='rewind_abandoned_chunks'"
+      )
+      .get()
+    expect(t).toBeTruthy()
+  })
+
+  it('is idempotent', () => {
+    expect(() => runMigrations(db as unknown as MigrationDb, MIGRATIONS)).not.toThrow()
+  })
+})
+
+describe('choosing what to compact', () => {
+  it('offers an OCR-indexed, JPEG-backed, old-enough frame', () => {
+    addFrame({ id: 1, ts: 1000 })
+    expect(compactable(5000).map((f) => f.id)).toEqual([1])
+  })
+
+  it('never offers a frame OCR has not reached', () => {
+    // The one that actually matters. ocrService.ts reads image_path for
+    // indexed=0 frames and, when the file is gone, marks the frame indexed with
+    // EMPTY text instead of failing — so compacting one of these does not error,
+    // it silently destroys that frame's searchable text forever.
+    addFrame({ id: 1, ts: 1000, indexed: 0 })
+    expect(compactable(5000)).toHaveLength(0)
+  })
+
+  it('never offers a frame twice', () => {
+    addFrame({ id: 1, ts: 1000 })
+    claim(1, '2026-08-17/1-2.omichunk', 0)
+    expect(compactable(5000)).toHaveLength(0)
+  })
+
+  it('excludes an already-compacted frame even if it still names a JPEG', () => {
+    // The case that proves `chunk_path IS NULL` carries its own weight. The
+    // normal claim also blanks image_path, so the two clauses mask each other
+    // and either alone appears sufficient; a row written by hand separates
+    // them. A frame in this state re-compacted would be pointed at a second
+    // chunk while the first still claimed it.
+    db.prepare(
+      'INSERT INTO rewind_frames (id, ts, image_path, width, height, indexed, chunk_path, chunk_offset)' +
+        " VALUES (1, 1000, 'C:/rewind/2026-08-17/1000.jpg', 1280, 720, 1, '2026-08-17/1-2.omichunk', 0)"
+    ).run()
+    expect(compactable(5000)).toHaveLength(0)
+  })
+
+  it('never offers a frame that already gave up its JPEG', () => {
+    addFrame({ id: 1, ts: 1000, imagePath: '' })
+    expect(compactable(5000)).toHaveLength(0)
+  })
+
+  it('respects the age cutoff the caller binds', () => {
+    addFrame({ id: 1, ts: 1000 })
+    addFrame({ id: 2, ts: 9000 })
+    expect(compactable(5000).map((f) => f.id)).toEqual([1])
+  })
+
+  it('returns frames in capture order', () => {
+    // The planner's grouping and the resulting chunk offsets depend on it.
+    addFrame({ id: 3, ts: 3000 })
+    addFrame({ id: 1, ts: 1000 })
+    addFrame({ id: 2, ts: 2000 })
+    expect(compactable(5000).map((f) => f.ts)).toEqual([1000, 2000, 3000])
+  })
+
+  it('orders frames sharing a millisecond deterministically', () => {
+    addFrame({ id: 9, ts: 1000 })
+    addFrame({ id: 4, ts: 1000 })
+    expect(compactable(5000).map((f) => f.id)).toEqual([4, 9])
+  })
+
+  it('honours the limit', () => {
+    for (let i = 1; i <= 10; i++) addFrame({ id: i, ts: i * 100 })
+    expect(compactable(5000, 3)).toHaveLength(3)
+  })
+})
+
+describe('claiming a frame into a chunk', () => {
+  const CHUNK = '2026-08-17/1000-3000.omichunk'
+
+  it('records the slot and surrenders the JPEG path', () => {
+    addFrame({ id: 1, ts: 1000 })
+    expect(claim(1, CHUNK, 4)).toBe(1)
+    const row = db
+      .prepare('SELECT chunk_path, chunk_offset, image_path FROM rewind_frames')
+      .get() as {
+      chunk_path: string
+      chunk_offset: number
+      image_path: string
+    }
+    expect(row.chunk_path).toBe(CHUNK)
+    expect(row.chunk_offset).toBe(4)
+    // '' rather than NULL: the column is NOT NULL and readers compare it as a
+    // string. macOS carries the identical compromise for the same reason.
+    expect(row.image_path).toBe('')
+  })
+
+  it('refuses to re-point a frame another chunk already owns', () => {
+    // Without the guard, a re-run holding a stale plan would silently move a
+    // frame to a chunk that does not contain its pixels.
+    addFrame({ id: 1, ts: 1000 })
+    expect(claim(1, CHUNK, 0)).toBe(1)
+    expect(claim(1, '2026-08-17/9000-9999.omichunk', 0)).toBe(0)
+    const row = db.prepare('SELECT chunk_path FROM rewind_frames').get() as { chunk_path: string }
+    expect(row.chunk_path).toBe(CHUNK)
+  })
+
+  it('refuses to claim into a tombstoned chunk', () => {
+    // An abandoned chunk's file may already be gone; a frame pointed into it
+    // would be unreadable forever.
+    addFrame({ id: 1, ts: 1000 })
+    db.prepare(TOMBSTONE_CHUNK_SQL).run(CHUNK)
+    expect(claim(1, CHUNK, 0)).toBe(0)
+    const row = db.prepare('SELECT chunk_path, image_path FROM rewind_frames').get() as {
+      chunk_path: string | null
+      image_path: string
+    }
+    expect(row.chunk_path).toBeNull()
+    expect(row.image_path).not.toBe('')
+  })
+
+  it('reads a chunk back in offset order, not insertion order', () => {
+    // Offsets are deliberately the REVERSE of row order. With offsets ascending
+    // in row order, SQLite returns them correctly with or without the ORDER BY,
+    // so the clause could be deleted without a test noticing.
+    addFrame({ id: 1, ts: 1000 })
+    addFrame({ id: 2, ts: 2000 })
+    addFrame({ id: 3, ts: 3000 })
+    claim(1, CHUNK, 2)
+    claim(2, CHUNK, 1)
+    claim(3, CHUNK, 0)
+    const rows = db.prepare(FRAMES_IN_CHUNK_SQL).all(CHUNK) as { id: number; chunkOffset: number }[]
+    expect(rows.map((r) => r.chunkOffset)).toEqual([0, 1, 2])
+    expect(rows.map((r) => r.id)).toEqual([3, 2, 1])
+  })
+})
+
+describe('abandoning a chunk', () => {
+  const CHUNK = '2026-08-17/1000-3000.omichunk'
+
+  it('tombstones it and drops the frames pointing into it', () => {
+    addFrame({ id: 1, ts: 1000 })
+    addFrame({ id: 2, ts: 2000 })
+    claim(1, CHUNK, 0)
+    claim(2, CHUNK, 1)
+
+    db.prepare(TOMBSTONE_CHUNK_SQL).run(CHUNK)
+    const deleted = db.prepare(DELETE_FRAMES_IN_CHUNK_SQL).run(CHUNK).changes
+    expect(deleted).toBe(2)
+    expect((db.prepare(IS_CHUNK_ABANDONED_SQL).get(CHUNK) as { abandoned: number }).abandoned).toBe(
+      1
+    )
+  })
+
+  it('leaves frames in other chunks alone', () => {
+    addFrame({ id: 1, ts: 1000 })
+    addFrame({ id: 2, ts: 2000 })
+    claim(1, CHUNK, 0)
+    claim(2, '2026-08-17/4000-5000.omichunk', 0)
+    db.prepare(DELETE_FRAMES_IN_CHUNK_SQL).run(CHUNK)
+    expect(db.prepare('SELECT COUNT(*) AS n FROM rewind_frames').get()).toEqual({ n: 1 })
+  })
+
+  it('is safe to repeat after a crash between its two statements', () => {
+    addFrame({ id: 1, ts: 1000 })
+    claim(1, CHUNK, 0)
+    db.prepare(TOMBSTONE_CHUNK_SQL).run(CHUNK) // crash here
+    expect(() => db.prepare(TOMBSTONE_CHUNK_SQL).run(CHUNK)).not.toThrow()
+    expect(db.prepare(DELETE_FRAMES_IN_CHUNK_SQL).run(CHUNK).changes).toBe(1)
+    expect(db.prepare(DELETE_FRAMES_IN_CHUNK_SQL).run(CHUNK).changes).toBe(0)
+  })
+})
+
+describe('finding live chunks', () => {
+  it('lists each referenced chunk once', () => {
+    const a = '2026-08-17/1-2.omichunk'
+    const b = '2026-08-17/3-4.omichunk'
+    for (let i = 1; i <= 4; i++) addFrame({ id: i, ts: i * 1000 })
+    claim(1, a, 0)
+    claim(2, a, 1)
+    claim(3, b, 0)
+    const paths = (db.prepare(REFERENCED_CHUNK_PATHS_SQL).all() as { chunk_path: string }[]).map(
+      (r) => r.chunk_path
+    )
+    expect(paths.sort()).toEqual([a, b])
+  })
+
+  it('stops listing a chunk once its last frame is gone', () => {
+    // This is what makes the file collectable: retention deletes rows by age,
+    // and the chunk becomes garbage when the last one goes.
+    const a = '2026-08-17/1-2.omichunk'
+    addFrame({ id: 1, ts: 1000 })
+    claim(1, a, 0)
+    db.prepare('DELETE FROM rewind_frames WHERE id = 1').run()
+    expect(db.prepare(REFERENCED_CHUNK_PATHS_SQL).all()).toEqual([])
+  })
+
+  it('counts chunk-backed frames for the status surface', () => {
+    addFrame({ id: 1, ts: 1000 })
+    addFrame({ id: 2, ts: 2000 })
+    claim(1, '2026-08-17/1-2.omichunk', 0)
+    expect(db.prepare(CHUNK_BACKED_FRAME_COUNT_SQL).get()).toEqual({ n: 1 })
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/chunkSql.ts
+++ b/desktop/windows/src/main/rewind/chunks/chunkSql.ts
@@ -1,0 +1,113 @@
+/**
+ * The load-bearing SQL for chunk-backed frames, as one importable source that
+ * both `db.ts` and the SQL tests execute.
+ *
+ * Same reasoning as `rewindEmbeddingSql.ts`, which records what happens without
+ * it: `db.ts` pulls in better-sqlite3 and cannot load under plain-node vitest,
+ * so a test that wants to run this SQL has to either import it from here or
+ * re-declare it, and a re-declared copy drifts silently. These statements are
+ * the ones that decide whether a JPEG may be deleted, so they are the last
+ * place in this feature where a drifting copy would be acceptable.
+ *
+ * Pure by construction: no electron, no better-sqlite3, no I/O.
+ */
+
+/**
+ * Frames that may be compacted.
+ *
+ * Every clause is a safety property, not an optimisation:
+ *
+ *  - `chunk_path IS NULL` — not already compacted. Compaction is idempotent
+ *    only because of this.
+ *  - `image_path != ''` — a row whose JPEG was already surrendered has nothing
+ *    left to pack.
+ *  - `indexed = 1` — OCR has already run. The backlog sweep in `ocrService.ts`
+ *    reads `image_path` for `indexed = 0` frames and, when the file is missing,
+ *    marks the frame indexed with *empty text* rather than failing. Compacting
+ *    an un-OCR'd frame would therefore not error; it would quietly cost that
+ *    frame its searchable text forever. This clause is the whole reason the
+ *    compactor cannot simply take the oldest frames.
+ *  - `ts <= ?` — older than the compaction delay, bound by the caller.
+ *
+ * Ordered by `ts` so the planner's grouping sees frames in capture order, and
+ * by `id` after it so two frames sharing a millisecond order deterministically.
+ *
+ * The `id` tiebreak is not observable in a test: with it removed SQLite happens
+ * to return same-`ts` rows in rowid order, which is the same answer. It is kept
+ * because "happens to" is not a contract — the plan can change with the
+ * indexes — and because the planner turns this order directly into chunk
+ * offsets, so a reordering here silently mis-addresses frames. The planner
+ * re-sorts defensively for the same reason, and that sort IS tested.
+ */
+export const COMPACTABLE_FRAMES_SQL = `SELECT id, ts, width, height, image_path AS imagePath
+     FROM rewind_frames
+    WHERE chunk_path IS NULL
+      AND image_path != ''
+      AND indexed = 1
+      AND ts <= ?
+    ORDER BY ts, id
+    LIMIT ?`
+
+/**
+ * Point one frame at its position inside a chunk and surrender its JPEG path.
+ *
+ * `image_path` is set to `''` rather than NULL because the column is `NOT NULL`
+ * and existing readers compare it as a string. macOS carries the identical
+ * compromise for the same reason, and says so:
+ * "`imagePath` is NOT NULL in SQLite, whereas video-backed screenshots carry
+ * nil in the model" (`RewindAbandonedVideoChunkRecovery.swift`).
+ *
+ * The `chunk_path IS NULL` guard makes this safe to re-run: a second pass over
+ * a frame another run already claimed updates nothing instead of re-pointing it
+ * at a different chunk.
+ */
+export const CLAIM_FRAME_INTO_CHUNK_SQL = `UPDATE rewind_frames
+        SET chunk_path = ?, chunk_offset = ?, image_path = ''
+      WHERE id = ?
+        AND chunk_path IS NULL`
+
+/** Frames a chunk owns, in offset order — the read side of the claim above. */
+export const FRAMES_IN_CHUNK_SQL = `SELECT id, ts, chunk_offset AS chunkOffset
+     FROM rewind_frames
+    WHERE chunk_path = ?
+    ORDER BY chunk_offset`
+
+/**
+ * Chunks that no longer back any frame.
+ *
+ * Retention deletes `rewind_frames` rows by age; a chunk file becomes garbage
+ * the moment its last row goes. This is the query the sweep uses to find them,
+ * and it is deliberately driven from the tombstone-free direction: it asks
+ * which distinct `chunk_path` values are still referenced and leaves the caller
+ * to diff that against the directory, so a chunk file the database has never
+ * heard of is also collected.
+ */
+export const REFERENCED_CHUNK_PATHS_SQL =
+  'SELECT DISTINCT chunk_path FROM rewind_frames WHERE chunk_path IS NOT NULL'
+
+/**
+ * Tombstone a chunk and drop every frame that pointed into it.
+ *
+ * This is macOS's `abandonVideoChunk` (`RewindAbandonedVideoChunkRecovery.swift`)
+ * with the same two-statement shape and the same idempotence: recording the
+ * tombstone first means a crash between the two statements still leaves the
+ * chunk quarantined, and re-running finishes the delete.
+ */
+export const TOMBSTONE_CHUNK_SQL =
+  'INSERT OR IGNORE INTO rewind_abandoned_chunks (chunk_path) VALUES (?)'
+
+export const DELETE_FRAMES_IN_CHUNK_SQL = 'DELETE FROM rewind_frames WHERE chunk_path = ?'
+
+/**
+ * Whether a chunk has been tombstoned.
+ *
+ * The claim path checks this before pointing any frame at a chunk, which is
+ * what stops a compaction that was abandoned mid-flight from being resurrected
+ * by a later run that still holds the old plan in memory.
+ */
+export const IS_CHUNK_ABANDONED_SQL =
+  'SELECT EXISTS(SELECT 1 FROM rewind_abandoned_chunks WHERE chunk_path = ?) AS abandoned'
+
+/** Bytes reclaimed so far, for the status surface. */
+export const CHUNK_BACKED_FRAME_COUNT_SQL =
+  'SELECT COUNT(*) AS n FROM rewind_frames WHERE chunk_path IS NOT NULL'

--- a/desktop/windows/src/main/rewind/chunks/compactionPlan.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/compactionPlan.test.ts
@@ -1,0 +1,179 @@
+// Grouping is where compaction decides which JPEGs stop existing, so each rule
+// is pinned against the reason it exists rather than against a golden shape.
+import { describe, expect, it } from 'vitest'
+import {
+  CHUNK_WINDOW_MS,
+  COMPACTION_MIN_AGE_MS,
+  MIN_FRAMES_PER_CHUNK,
+  localDayKey,
+  plannedJpegBytes,
+  planChunks,
+  type CompactableFrame
+} from './compactionPlan'
+
+const NOW = new Date('2026-08-17T18:00:00').getTime()
+/**
+ * Comfortably older than the compaction delay, with enough headroom that a case
+ * can offset hours forward and still be old enough to compact. (Set an hour
+ * back originally, which silently made the "far apart in time" case land in the
+ * future and get age-filtered away rather than grouped.)
+ */
+const BASE = NOW - 24 * 60 * 60_000
+
+function run(
+  count: number,
+  opts: Partial<CompactableFrame> & { startMs?: number; stepMs?: number } = {}
+) {
+  const step = opts.stepMs ?? 1000
+  const start = opts.startMs ?? BASE
+  return Array.from({ length: count }, (_, i) => ({
+    id: (opts.id ?? 1000) + i,
+    tsMs: start + i * step,
+    width: opts.width ?? 1280,
+    height: opts.height ?? 720,
+    imagePath: `C:/rewind/day/${start + i * step}.jpg`
+  }))
+}
+
+describe('grouping frames into chunks', () => {
+  it('packs a one-per-second minute into a single chunk', () => {
+    const plan = planChunks(run(45), NOW)
+    expect(plan).toHaveLength(1)
+    expect(plan[0].frames).toHaveLength(45)
+    expect(plan[0].width).toBe(1280)
+    expect(plan[0].height).toBe(720)
+  })
+
+  it('gives each frame the offset it will be addressed by', () => {
+    // The array index IS the stored chunk_offset, so order is not cosmetic.
+    const plan = planChunks(run(20), NOW)
+    const tsInOrder = plan[0].frames.map((f) => f.tsMs)
+    expect(tsInOrder).toEqual([...tsInOrder].sort((a, b) => a - b))
+  })
+
+  it('sorts frames the caller handed over out of order', () => {
+    // Offsets are positions in the returned array. One out-of-order frame would
+    // mis-address every frame after it, and nothing downstream could detect it.
+    const ordered = run(12)
+    const shuffled = [ordered[5], ordered[0], ...ordered.slice(6), ...ordered.slice(1, 5)]
+    const plan = planChunks(shuffled, NOW)
+    expect(plan[0].frames.map((f) => f.tsMs)).toEqual(ordered.map((f) => f.tsMs))
+  })
+
+  it('breaks a chunk once it spans more than the window', () => {
+    const frames = run(90) // 90 seconds at one per second
+    const plan = planChunks(frames, NOW)
+    expect(plan.length).toBeGreaterThan(1)
+    for (const chunk of plan) {
+      const span = chunk.frames[chunk.frames.length - 1].tsMs - chunk.frames[0].tsMs
+      expect(span).toBeLessThanOrEqual(CHUNK_WINDOW_MS)
+    }
+  })
+
+  it('breaks a chunk when the screen geometry changes', () => {
+    // A video track has exactly one size; a chunk cannot hold two.
+    const first = run(12)
+    const second = run(12, { id: 5000, startMs: BASE + 12_000, width: 2560, height: 1440 })
+    const plan = planChunks([...first, ...second], NOW)
+    expect(plan).toHaveLength(2)
+    expect(plan[0].width).toBe(1280)
+    expect(plan[1].width).toBe(2560)
+  })
+
+  it('never lets a chunk span two local days', () => {
+    // Chunks are filed in a day directory and retention deletes by day.
+    const beforeMidnight = new Date('2026-08-16T23:59:50').getTime()
+    const frames = run(20, { startMs: beforeMidnight })
+    const plan = planChunks(frames, new Date('2026-08-18T12:00:00').getTime())
+    for (const chunk of plan) {
+      const days = new Set(chunk.frames.map((f) => localDayKey(f.tsMs)))
+      expect(days.size).toBe(1)
+      expect(chunk.day).toBe(localDayKey(chunk.frames[0].tsMs))
+    }
+  })
+
+  it('separates runs that are far apart in time', () => {
+    const morning = run(15)
+    const evening = run(15, { id: 9000, startMs: BASE + 6 * 60 * 60_000 })
+    const plan = planChunks([...morning, ...evening], NOW)
+    expect(plan).toHaveLength(2)
+  })
+})
+
+describe('what is left alone', () => {
+  it('pins the floor at 8 frames', () => {
+    // A literal, because the cases below size their fixtures from it. Deriving
+    // those sizes from the constant instead made them unable to fail: lowering
+    // the floor to 1 also shrank every fixture, so a mutation audit walked
+    // straight past it. The value itself is the measured one (a 5-frame run
+    // reached only 2.4x against a 60-frame run's 51x).
+    expect(MIN_FRAMES_PER_CHUNK).toBe(8)
+  })
+
+  it('drops runs shorter than the floor instead of merging them', () => {
+    // Merging distant short runs is exactly the case where inter-frame
+    // compression has nothing to work with.
+    const a = run(7)
+    const b = run(7, { id: 7000, startMs: BASE + 10 * 60_000 })
+    expect(planChunks([...a, ...b], NOW)).toHaveLength(0)
+  })
+
+  it('keeps a run exactly at the floor', () => {
+    expect(planChunks(run(8), NOW)).toHaveLength(1)
+  })
+
+  it('leaves frames younger than the compaction delay alone', () => {
+    const fresh = run(40, { startMs: NOW - 60_000 })
+    expect(planChunks(fresh, NOW)).toHaveLength(0)
+  })
+
+  it('does not let a fresh frame extend a chunk of older ones', () => {
+    // The age filter runs before grouping, so a frame inside the delay cannot
+    // be swept in by a neighbour that is old enough.
+    const old = run(20, { startMs: NOW - COMPACTION_MIN_AGE_MS - 20_000 })
+    const plan = planChunks(old, NOW)
+    const youngest = Math.max(...plan.flatMap((c) => c.frames.map((f) => f.tsMs)))
+    expect(NOW - youngest).toBeGreaterThanOrEqual(COMPACTION_MIN_AGE_MS)
+  })
+
+  it('skips frames with no recorded geometry', () => {
+    // There is no honest video track size for a row that never stored one.
+    const frames = run(20).map((f, i) => (i === 10 ? { ...f, width: 0, height: 0 } : f))
+    const plan = planChunks(frames, NOW)
+    expect(plan.flatMap((c) => c.frames).some((f) => f.width === 0)).toBe(false)
+  })
+
+  it('breaks the chunk at a frame with no geometry rather than skipping over it', () => {
+    // Offsets must stay contiguous with capture order; silently omitting a
+    // middle frame would leave the two halves adjacent in one chunk.
+    const frames = run(30).map((f, i) => (i === 15 ? { ...f, width: 0, height: 0 } : f))
+    const plan = planChunks(frames, NOW)
+    expect(plan.length).toBe(2)
+    expect(plan[0].frames).toHaveLength(15)
+    expect(plan[1].frames).toHaveLength(14)
+  })
+})
+
+describe('reporting', () => {
+  it('sums the JPEG bytes a plan would reclaim', () => {
+    const plan = planChunks(run(20), NOW)
+    expect(plannedJpegBytes(plan, () => 64_000)).toBe(20 * 64_000)
+  })
+
+  it('reports nothing for an empty plan', () => {
+    expect(plannedJpegBytes([], () => 1)).toBe(0)
+  })
+})
+
+describe('local day keys', () => {
+  it('uses local midnight, not UTC', () => {
+    // A UTC-derived key would file evening frames under tomorrow for anyone
+    // west of Greenwich, splitting a day's chunks across two directories.
+    const evening = new Date(2026, 7, 17, 23, 30, 0).getTime()
+    expect(localDayKey(evening)).toBe('2026-08-17')
+  })
+
+  it('zero-pads month and day', () => {
+    expect(localDayKey(new Date(2026, 0, 5, 12, 0, 0).getTime())).toBe('2026-01-05')
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/compactionPlan.ts
+++ b/desktop/windows/src/main/rewind/chunks/compactionPlan.ts
@@ -1,0 +1,153 @@
+/**
+ * Which stored frames become which chunk.
+ *
+ * This is the whole policy of compaction as a pure function, separate from the
+ * encoder that executes it, because every rule here is a judgement that has to
+ * survive review and none of it needs a codec to test.
+ *
+ * macOS makes these decisions live, inside `VideoChunkEncoder`, as frames
+ * arrive. Windows makes them after the fact over frames already on disk. That
+ * difference is deliberate and is the reason the two files look nothing alike:
+ * see ARCHITECTURE.md. What is ported is the shape of a chunk — a 60-second
+ * window of one screen geometry — because that is what makes inter-frame
+ * compression pay.
+ */
+
+export type CompactableFrame = {
+  id: number
+  tsMs: number
+  width: number
+  height: number
+  imagePath: string
+}
+
+export type PlannedChunk = {
+  /** Local day the chunk is filed under, `YYYY-MM-DD`, from its first frame. */
+  day: string
+  /** Frames in capture order. Index in this array is the frame's chunk offset. */
+  frames: CompactableFrame[]
+  width: number
+  height: number
+}
+
+/**
+ * A chunk covers at most this much wall-clock time, measured from its first
+ * frame. macOS uses the same 60 seconds (`VideoChunkEncoder.chunkDuration`).
+ *
+ * It also does the work of a gap rule for free: frames either side of a lunch
+ * break are more than a minute apart, so they land in different chunks, which
+ * is what you want anyway — the second one shares no pixels with the first and
+ * would encode as a key frame regardless.
+ */
+export const CHUNK_WINDOW_MS = 60_000
+
+/**
+ * Runs shorter than this are left as JPEGs.
+ *
+ * Measured on this codebase's own capture path (1280x720, quality 0.7, one
+ * frame per second, H.264 at 400 kbps): a 60-frame run compacted 6.95 MB of
+ * JPEGs into 136 KB, a 51x reduction. A 5-frame run only reached 2.4x, because
+ * the opening key frame is most of the chunk and there is almost nothing for it
+ * to amortise over. The floor sits where the win stops being worth replacing a
+ * directly-readable JPEG with a decode.
+ */
+export const MIN_FRAMES_PER_CHUNK = 8
+
+/**
+ * Frames younger than this are never compacted.
+ *
+ * Two reasons, and the second is the load-bearing one. The Rewind page is most
+ * likely to be scrubbing recent frames, which are cheaper to serve straight
+ * from disk. More importantly the OCR backlog sweep reads `image_path` for
+ * every `indexed = 0` frame, and when the file is missing it marks the frame
+ * indexed with empty text (`ocrService.ts`) — so compacting a frame out from
+ * under it does not fail loudly, it silently costs that frame its OCR text
+ * forever. The `indexed = 1` requirement below is the real guard; this delay is
+ * the belt to its braces.
+ */
+export const COMPACTION_MIN_AGE_MS = 30 * 60_000
+
+/** Local `YYYY-MM-DD` for a timestamp, matching `paths.ts`'s day-directory rule. */
+export function localDayKey(tsMs: number): string {
+  const d = new Date(tsMs)
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}-${month}-${day}`
+}
+
+/**
+ * Group eligible frames into chunks.
+ *
+ * `frames` must already be filtered to compaction candidates (`indexed = 1`,
+ * still JPEG-backed) — that filter is SQL and lives in `chunkStore.ts`. This
+ * function owns only the grouping, and it re-sorts rather than trusting the
+ * caller's order, because chunk offsets are positions in the array it returns
+ * and an out-of-order frame would silently mis-address every frame after it.
+ *
+ * A chunk is broken by any of:
+ *  - more than `CHUNK_WINDOW_MS` since the chunk's first frame;
+ *  - a change of frame geometry (a video track has exactly one size);
+ *  - crossing into a different local day, so a chunk never spans two day
+ *    directories and day-scoped retention can delete whole files.
+ *
+ * Groups below `MIN_FRAMES_PER_CHUNK` are dropped, not merged: merging them
+ * would mean joining runs that are far apart in time, which is precisely the
+ * case where inter-frame compression has nothing to work with.
+ */
+export function planChunks(frames: CompactableFrame[], nowMs: number): PlannedChunk[] {
+  const eligible = frames
+    .filter((f) => nowMs - f.tsMs >= COMPACTION_MIN_AGE_MS)
+    .slice()
+    .sort((a, b) => (a.tsMs !== b.tsMs ? a.tsMs - b.tsMs : a.id - b.id))
+
+  const planned: PlannedChunk[] = []
+  let current: CompactableFrame[] = []
+
+  const flush = (): void => {
+    if (current.length >= MIN_FRAMES_PER_CHUNK) {
+      planned.push({
+        day: localDayKey(current[0].tsMs),
+        frames: current,
+        width: current[0].width,
+        height: current[0].height
+      })
+    }
+    current = []
+  }
+
+  for (const frame of eligible) {
+    if (frame.width <= 0 || frame.height <= 0) {
+      // A row that never recorded its geometry cannot be given a video track
+      // size. Leave it as a JPEG rather than guessing one.
+      flush()
+      continue
+    }
+    if (current.length > 0) {
+      const first = current[0]
+      const sameShape = frame.width === first.width && frame.height === first.height
+      const inWindow = frame.tsMs - first.tsMs <= CHUNK_WINDOW_MS
+      const sameDay = localDayKey(frame.tsMs) === localDayKey(first.tsMs)
+      if (!sameShape || !inWindow || !sameDay) flush()
+    }
+    current.push(frame)
+  }
+  flush()
+
+  return planned
+}
+
+/**
+ * Bytes a plan is expected to reclaim, given the size of each frame's JPEG.
+ *
+ * Reported rather than acted on: the compactor logs what it is about to do so a
+ * user who wonders where their disk went can see the answer, and so a run that
+ * reclaims nothing is visible instead of silent.
+ */
+export function plannedJpegBytes(
+  plan: PlannedChunk[],
+  sizeOf: (frame: CompactableFrame) => number
+): number {
+  let total = 0
+  for (const chunk of plan) for (const frame of chunk.frames) total += sizeOf(frame)
+  return total
+}

--- a/desktop/windows/src/main/rewind/chunks/compactionRunner.ts
+++ b/desktop/windows/src/main/rewind/chunks/compactionRunner.ts
@@ -1,0 +1,136 @@
+/**
+ * Scheduling compaction, and wiring it to Electron.
+ *
+ * Everything decision-shaped lives elsewhere and is tested without Electron:
+ * grouping in `compactionPlan.ts`, the write/verify/claim ordering in
+ * `compactor.ts`, the encode channel in `chunkBroker.ts`. This file is the
+ * assembly — where `app`, `BrowserWindow` and the database actually appear.
+ */
+
+import { BrowserWindow, app } from 'electron'
+import { stat } from 'fs/promises'
+import { claimFrameIntoChunk, compactableRewindFrames } from '../../ipc/db'
+import { readRewindFrame } from '../frameFile'
+import { rewindRoot } from '../paths'
+import { getRewindSettings } from '../captureService'
+import { ChunkEncodeBroker, pickEncodeTarget, type EncodeResponse } from './chunkBroker'
+import { readChunkFile, removeChunkFile, writeChunkFile } from './chunkFiles'
+import { compactOnce, type CompactionResult } from './compactor'
+import { removeRewindFrame } from '../frameFile'
+
+/**
+ * How often a pass runs.
+ *
+ * Compaction is pure housekeeping and its input only grows by a frame a second
+ * at most, so this is deliberately slow. It matters more that a pass never
+ * competes with capture than that the backlog clears quickly.
+ */
+const COMPACTION_INTERVAL_MS = 30 * 60_000
+/** Never on launch: the app has better things to do for the first few minutes. */
+const COMPACTION_STARTUP_DELAY_MS = 5 * 60_000
+
+let broker: ChunkEncodeBroker | null = null
+let running = false
+let timer: ReturnType<typeof setInterval> | null = null
+
+/** The renderer answers here. Registered by `registerRewindIpc`. */
+export function settleChunkEncode(response: EncodeResponse): void {
+  broker?.settle(response)
+}
+
+function ensureBroker(): ChunkEncodeBroker | null {
+  const target = pickEncodeTarget(BrowserWindow.getAllWindows().map((w) => w.webContents))
+  if (!target) return null
+  // Rebuilt per pass rather than held: the window that answered last time may
+  // be gone, and a broker bound to dead web contents fails every request.
+  broker = new ChunkEncodeBroker((request) => {
+    target.send('rewind:encode-chunk', {
+      requestId: request.requestId,
+      width: request.width,
+      height: request.height,
+      // Structured clone moves the buffers; the renderer gets real bytes.
+      frames: request.frames
+    })
+  })
+  const abort = (): void => broker?.abortAll('the encoding window closed')
+  target.once('destroyed', abort)
+  return broker
+}
+
+/**
+ * Run one compaction pass.
+ *
+ * Returns a zeroed result rather than throwing when there is no window to
+ * encode in: that is an ordinary state (every window closed, app in the tray),
+ * not a failure worth logging every half hour.
+ */
+export async function compactRewindOnce(): Promise<CompactionResult> {
+  const empty: CompactionResult = {
+    chunksWritten: 0,
+    framesCompacted: 0,
+    bytesReclaimed: 0,
+    skipped: []
+  }
+  if (running) return empty
+  const encodeBroker = ensureBroker()
+  if (!encodeBroker) return empty
+
+  running = true
+  const root = rewindRoot()
+  try {
+    return await compactOnce({
+      nowMs: () => Date.now(),
+      listCompactable: (olderThanMs, limit) => compactableRewindFrames(olderThanMs, limit),
+      readJpeg: (absolutePath) => readRewindFrame(root, absolutePath),
+      encode: (input) => encodeBroker.encode(input),
+      writeChunk: (relativePath, bytes) => writeChunkFile(root, relativePath, bytes),
+      readChunk: (relativePath) => readChunkFile(root, relativePath),
+      removeChunk: (relativePath) => removeChunkFile(root, relativePath),
+      claimFrame: (id, relativePath, offset) => claimFrameIntoChunk(id, relativePath, offset),
+      deleteJpeg: (absolutePath) => removeRewindFrame(root, absolutePath),
+      log: (message) => console.log(`[rewind] ${message}`)
+    })
+  } finally {
+    running = false
+  }
+}
+
+/**
+ * Whether compaction should run at all.
+ *
+ * Off when Rewind capture is off — there is nothing arriving to compact, and a
+ * user who has turned capture off has not asked us to keep rewriting their
+ * history in the background.
+ */
+function compactionEnabled(): boolean {
+  return getRewindSettings().captureEnabled
+}
+
+export function startRewindCompaction(): void {
+  if (timer) return
+  const tick = (): void => {
+    if (!compactionEnabled()) return
+    void compactRewindOnce().catch((e) => console.warn('[rewind] compaction pass failed:', e))
+  }
+  setTimeout(tick, COMPACTION_STARTUP_DELAY_MS).unref?.()
+  timer = setInterval(tick, COMPACTION_INTERVAL_MS)
+  timer.unref?.()
+  app.once('before-quit', () => {
+    if (timer) clearInterval(timer)
+    timer = null
+    broker?.abortAll('the app is quitting')
+  })
+}
+
+/** Bytes a set of frames currently occupies as JPEGs, for the status surface. */
+export async function jpegBytesOnDisk(paths: string[]): Promise<number> {
+  let total = 0
+  for (const path of paths) {
+    try {
+      total += (await stat(path)).size
+    } catch {
+      // A frame whose file is already gone contributes nothing.
+    }
+  }
+  return total
+}

--- a/desktop/windows/src/main/rewind/chunks/compactor.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/compactor.test.ts
@@ -1,0 +1,361 @@
+// Every test here is about one sentence: a JPEG is deleted only in exchange for
+// a chunk that has been written, read back from disk, and proven to hold that
+// exact frame at that exact offset. The cases are the ways that can fail.
+import { describe, expect, it, vi } from 'vitest'
+import { encodeChunk } from './chunkFormat'
+import { COMPACTION_MIN_AGE_MS, localDayKey, type CompactableFrame } from './compactionPlan'
+import { compactOnce, estimateReclaimable, type CompactorDeps } from './compactor'
+
+const NOW = new Date('2026-08-17T18:00:00').getTime()
+// A day back, not an hour: cases below offset hours forward from this and must
+// still land older than COMPACTION_MIN_AGE_MS, or they are silently filtered out
+// by age instead of exercising what they claim to.
+const OLD = NOW - 24 * 60 * 60_000
+/** Inside the compaction delay, so nothing here is eligible. */
+const TOO_NEW = NOW - COMPACTION_MIN_AGE_MS / 2
+
+function frames(count: number, startMs = OLD): CompactableFrame[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: 100 + i,
+    tsMs: startMs + i * 1000,
+    width: 1280,
+    height: 720,
+    imagePath: `C:/rewind/2026-08-17/${startMs + i * 1000}.jpg`
+  }))
+}
+
+type Harness = {
+  deps: CompactorDeps
+  disk: Map<string, Uint8Array>
+  jpegs: Map<string, Uint8Array>
+  claims: { id: number; path: string; offset: number }[]
+  deleted: string[]
+  logs: string[]
+}
+
+function harness(
+  rows: CompactableFrame[],
+  overrides: Partial<CompactorDeps> = {},
+  options: { unclaimable?: Set<number> } = {}
+): Harness {
+  const jpegs = new Map<string, Uint8Array>()
+  for (const f of rows) jpegs.set(f.imagePath, new Uint8Array([0xff, 0xd8, f.id & 0xff, 1, 2, 3]))
+  const disk = new Map<string, Uint8Array>()
+  const claims: { id: number; path: string; offset: number }[] = []
+  const deleted: string[] = []
+  const logs: string[] = []
+  const claimed = new Set<number>()
+
+  const deps: CompactorDeps = {
+    nowMs: () => NOW,
+    listCompactable: () => rows,
+    readJpeg: async (p) => {
+      const b = jpegs.get(p)
+      if (!b) throw new Error(`missing ${p}`)
+      return b
+    },
+    // A faithful stand-in: real bytes in the real container, so verification is
+    // exercised for real rather than stubbed past.
+    encode: async ({ width, height, frames: input }) =>
+      encodeChunk({
+        codec: 'avc1.42001f',
+        description: new Uint8Array([1, 100]),
+        width,
+        height,
+        frames: input.map((f, i) => ({
+          captureTsMs: f.captureTsMs,
+          isKeyFrame: i === 0,
+          data: new Uint8Array([i + 1, 9])
+        }))
+      }),
+    writeChunk: async (rel, bytes) => {
+      disk.set(rel, bytes)
+    },
+    readChunk: async (rel) => {
+      const b = disk.get(rel)
+      if (!b) throw new Error(`no chunk at ${rel}`)
+      return b
+    },
+    removeChunk: async (rel) => {
+      disk.delete(rel)
+    },
+    claimFrame: (id, path, offset) => {
+      if (options.unclaimable?.has(id)) return false
+      if (claimed.has(id)) return false
+      claimed.add(id)
+      claims.push({ id, path, offset })
+      return true
+    },
+    deleteJpeg: async (p) => {
+      deleted.push(p)
+      jpegs.delete(p)
+    },
+    log: (m) => logs.push(m),
+    ...overrides
+  }
+  return { deps, disk, jpegs, claims, deleted, logs }
+}
+
+describe('the happy path', () => {
+  it('writes one chunk, claims every frame, and deletes their JPEGs', async () => {
+    const rows = frames(30)
+    const h = harness(rows)
+    const result = await compactOnce(h.deps)
+
+    expect(result.chunksWritten).toBe(1)
+    expect(result.framesCompacted).toBe(30)
+    expect(h.disk.size).toBe(1)
+    expect(h.deleted).toHaveLength(30)
+    expect(h.jpegs.size).toBe(0)
+  })
+
+  it('claims each frame at the offset it occupies in the chunk', async () => {
+    // The offset IS the address. Off by one and every read returns a neighbour.
+    const rows = frames(20)
+    const h = harness(rows)
+    await compactOnce(h.deps)
+    expect(h.claims.map((c) => c.offset)).toEqual([...Array(20).keys()])
+    expect(h.claims.map((c) => c.id)).toEqual(rows.map((r) => r.id))
+  })
+
+  it('names the chunk for the span it covers', async () => {
+    const rows = frames(12)
+    const h = harness(rows)
+    await compactOnce(h.deps)
+    const [path] = [...h.disk.keys()]
+    expect(path).toBe(`${localDayKey(rows[0].tsMs)}/${rows[0].tsMs}-${rows[11].tsMs}.omichunk`)
+  })
+
+  it('reports what it reclaimed', async () => {
+    const h = harness(frames(15))
+    const result = await compactOnce(h.deps)
+    expect(result.bytesReclaimed).toBe(15 * 6)
+    expect(h.logs.join(' ')).toMatch(/compacted 15 frames/)
+  })
+
+  it('does nothing when there is nothing eligible', async () => {
+    const h = harness([])
+    const result = await compactOnce(h.deps)
+    expect(result).toEqual({ chunksWritten: 0, framesCompacted: 0, bytesReclaimed: 0, skipped: [] })
+    expect(h.disk.size).toBe(0)
+  })
+})
+
+describe('nothing is deleted unless the chunk is proven', () => {
+  it('deletes no JPEG when a source frame cannot be read', async () => {
+    // Compacting without it would renumber every offset after it.
+    const rows = frames(20)
+    const h = harness(rows, {
+      readJpeg: async (p) => {
+        if (p.endsWith(`${rows[7].tsMs}.jpg`)) throw new Error('gone')
+        return new Uint8Array([0xff, 0xd8, 1])
+      }
+    })
+    const result = await compactOnce(h.deps)
+    expect(result.chunksWritten).toBe(0)
+    expect(h.deleted).toEqual([])
+    expect(h.disk.size).toBe(0)
+    expect(result.skipped[0].reason).toMatch(/could not be read/)
+  })
+
+  it('deletes no JPEG when the encoder fails', async () => {
+    const h = harness(frames(20), {
+      encode: async () => {
+        throw new Error('no encoder on this machine')
+      }
+    })
+    const result = await compactOnce(h.deps)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/encode failed/)
+  })
+
+  it('deletes no JPEG when the chunk cannot be written', async () => {
+    const h = harness(frames(20), {
+      writeChunk: async () => {
+        throw new Error('disk full')
+      }
+    })
+    const result = await compactOnce(h.deps)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/write failed/)
+  })
+
+  it('deletes no JPEG when the chunk cannot be read back', async () => {
+    // A write that reported success but did not land.
+    const h = harness(frames(20), { readChunk: async () => new Uint8Array([1, 2, 3]) })
+    const result = await compactOnce(h.deps)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/did not read back/)
+  })
+
+  it('removes the bad file when verification fails', async () => {
+    const h = harness(frames(20), { readChunk: async () => new Uint8Array([1, 2, 3]) })
+    await compactOnce(h.deps)
+    expect(h.disk.size).toBe(0)
+  })
+
+  it('rejects a chunk that came back holding a different number of frames', async () => {
+    const rows = frames(20)
+    const h = harness(rows, {
+      encode: async ({ width, height, frames: input }) =>
+        encodeChunk({
+          codec: 'avc1.42001f',
+          description: new Uint8Array(),
+          width,
+          height,
+          frames: input.slice(0, 10).map((f, i) => ({
+            captureTsMs: f.captureTsMs,
+            isKeyFrame: i === 0,
+            data: new Uint8Array([1])
+          }))
+        })
+    })
+    const result = await compactOnce(h.deps)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/holds 10 frames, planned 20/)
+  })
+
+  it('rejects a chunk whose frames came back in the wrong order', async () => {
+    // The failure this catches is silent otherwise: right count, right size,
+    // every read off by one.
+    const rows = frames(20)
+    const h = harness(rows, {
+      encode: async ({ width, height, frames: input }) => {
+        const shifted = [...input.slice(1), input[0]]
+        return encodeChunk({
+          codec: 'avc1.42001f',
+          description: new Uint8Array(),
+          width,
+          height,
+          frames: shifted.map((f, i) => ({
+            captureTsMs: f.captureTsMs,
+            isKeyFrame: i === 0,
+            data: new Uint8Array([1])
+          }))
+        })
+      }
+    })
+    const result = await compactOnce(h.deps)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/wrong capture time/)
+  })
+
+  it('rejects a chunk that came back with the wrong geometry', async () => {
+    const h = harness(frames(20), {
+      encode: async ({ frames: input }) =>
+        encodeChunk({
+          codec: 'avc1.42001f',
+          description: new Uint8Array(),
+          width: 640,
+          height: 480,
+          frames: input.map((f, i) => ({
+            captureTsMs: f.captureTsMs,
+            isKeyFrame: i === 0,
+            data: new Uint8Array([1])
+          }))
+        })
+    })
+    const result = await compactOnce(h.deps)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/wrong geometry/)
+  })
+})
+
+describe('losing a race for a frame', () => {
+  it('keeps the JPEG of a frame it could not claim', async () => {
+    const rows = frames(20)
+    const h = harness(rows, {}, { unclaimable: new Set([rows[5].id]) })
+    await compactOnce(h.deps)
+    expect(h.deleted).not.toContain(rows[5].imagePath)
+    expect(h.jpegs.has(rows[5].imagePath)).toBe(true)
+  })
+
+  it('still compacts the frames it did claim', async () => {
+    // The chunk holds a superset of what points into it, which is harmless:
+    // the unclaimed frame simply stays JPEG-backed.
+    const rows = frames(20)
+    const h = harness(rows, {}, { unclaimable: new Set([rows[5].id]) })
+    const result = await compactOnce(h.deps)
+    expect(result.chunksWritten).toBe(1)
+    expect(result.framesCompacted).toBe(19)
+    expect(h.disk.size).toBe(1)
+  })
+
+  it('takes the file back when every frame was claimed by someone else', async () => {
+    const rows = frames(20)
+    const h = harness(rows, {}, { unclaimable: new Set(rows.map((r) => r.id)) })
+    const result = await compactOnce(h.deps)
+    expect(result.chunksWritten).toBe(0)
+    expect(h.disk.size).toBe(0)
+    expect(h.deleted).toEqual([])
+    expect(result.skipped[0].reason).toMatch(/already claimed/)
+  })
+
+  it('deletes a JPEG only after the claim that gave it up succeeded', async () => {
+    // Ordering, not just outcome: a delete before the claim would lose the
+    // frame outright if the claim then failed.
+    const order: string[] = []
+    const rows = frames(10)
+    const h = harness(rows, {
+      claimFrame: (id, path, offset) => {
+        order.push(`claim:${offset}`)
+        void id
+        void path
+        return true
+      },
+      deleteJpeg: async (p) => {
+        order.push(`delete:${p.split('/').pop()}`)
+      }
+    })
+    await compactOnce(h.deps)
+    expect(order[0]).toBe('claim:0')
+    expect(order[1]).toMatch(/^delete:/)
+    expect(order.filter((o) => o.startsWith('claim')).length).toBe(10)
+  })
+})
+
+describe('several runs in one pass', () => {
+  it('writes a chunk per run and keeps going after one is skipped', async () => {
+    const morning = frames(15)
+    const evening = frames(15, OLD + 6 * 60 * 60_000).map((f) => ({ ...f, id: f.id + 500 }))
+    const h = harness([...morning, ...evening], {
+      readJpeg: async (p) => {
+        if (p.endsWith(`${morning[3].tsMs}.jpg`)) throw new Error('gone')
+        return new Uint8Array([0xff, 0xd8, 7])
+      }
+    })
+    const result = await compactOnce(h.deps)
+    expect(result.chunksWritten).toBe(1)
+    expect(result.skipped).toHaveLength(1)
+    expect(h.disk.size).toBe(1)
+  })
+
+  it('logs what it skipped rather than failing silently', async () => {
+    const h = harness(frames(20), {
+      encode: async () => {
+        throw new Error('nope')
+      }
+    })
+    await compactOnce(h.deps)
+    expect(h.logs.join(' ')).toMatch(/skipped 1 chunk/)
+  })
+})
+
+describe('estimating without doing', () => {
+  it('reports the frames and bytes a pass would take', () => {
+    const estimate = estimateReclaimable(frames(30), NOW, () => 64_000)
+    expect(estimate.frames).toBe(30)
+    expect(estimate.bytes).toBe(30 * 64_000)
+  })
+
+  it('reports nothing when everything is too new', () => {
+    const estimate = estimateReclaimable(frames(30, TOO_NEW), NOW, () => 64_000)
+    expect(estimate).toEqual({ frames: 0, bytes: 0 })
+  })
+
+  it('touches nothing', () => {
+    const deleteJpeg = vi.fn()
+    estimateReclaimable(frames(30), NOW, () => 1)
+    expect(deleteJpeg).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/compactor.ts
+++ b/desktop/windows/src/main/rewind/chunks/compactor.ts
@@ -1,0 +1,247 @@
+/**
+ * The pass that replaces a run of JPEGs with one chunk.
+ *
+ * The ordering below is the entire safety argument, so it is worth stating
+ * plainly: **the chunk is durable and has been read back before a single
+ * database row is touched, and a row is touched before its JPEG is deleted.**
+ * Every prefix of that sequence is a safe place to crash.
+ *
+ *   write chunk -> read it back and verify -> claim frame -> delete its JPEG
+ *
+ *   - crash after write:  an unreferenced chunk file. The sweep collects it.
+ *   - crash after verify: same.
+ *   - crash mid-claim:    claimed frames read from a chunk that provably holds
+ *                         them; unclaimed frames still have their JPEGs. The
+ *                         chunk holds a superset of what points into it, which
+ *                         is harmless.
+ *   - crash after claim, before delete: an orphaned JPEG. The existing orphan
+ *                         sweep collects it.
+ *
+ * This is the part that differs most from macOS, and the difference is the
+ * point. `VideoChunkEncoder` encodes live, as frames arrive, so its database
+ * rows necessarily exist while the chunk is still being written — which is why
+ * it needs a sidecar journal of abandoned writers, a quarantine table, and a
+ * generation/reservation ownership model to keep a stale finaliser from
+ * clearing a newer writer's state. Compacting after the fact makes almost all
+ * of that unnecessary: nothing references a chunk until it is finished. What is
+ * kept from that design is the tombstone, because a chunk can still be found
+ * corrupt at *read* time long after it was written, and something has to stop
+ * the UI retrying it forever.
+ */
+
+import { ChunkFormatError, decodeChunk } from './chunkFormat'
+import { chunkRelativePath } from './chunkPaths'
+import {
+  planChunks,
+  plannedJpegBytes,
+  type CompactableFrame,
+  type PlannedChunk
+} from './compactionPlan'
+
+/** Frames considered per pass. One pass is roughly one chunk's worth of work. */
+export const COMPACTION_BATCH_FRAMES = 600
+
+export type CompactorDeps = {
+  nowMs: () => number
+  listCompactable: (olderThanMs: number, limit: number) => CompactableFrame[]
+  readJpeg: (absolutePath: string) => Promise<Uint8Array>
+  /** Encode a run into chunk bytes. Brokered to a renderer; may reject. */
+  encode: (input: {
+    width: number
+    height: number
+    frames: { captureTsMs: number; jpeg: Uint8Array }[]
+  }) => Promise<Uint8Array>
+  writeChunk: (relativePath: string, bytes: Uint8Array) => Promise<void>
+  readChunk: (relativePath: string) => Promise<Uint8Array>
+  removeChunk: (relativePath: string) => Promise<void>
+  claimFrame: (id: number, relativePath: string, offset: number) => boolean
+  deleteJpeg: (absolutePath: string) => Promise<void>
+  log: (message: string) => void
+}
+
+export type CompactionResult = {
+  chunksWritten: number
+  framesCompacted: number
+  bytesReclaimed: number
+  /** Runs that were planned but not written, with why. */
+  skipped: { chunk: string; reason: string }[]
+}
+
+/**
+ * Read every source JPEG for a planned chunk.
+ *
+ * All-or-nothing: a run with a missing file is abandoned rather than compacted
+ * without it, because dropping a frame here would renumber every offset after
+ * it while the database still expects the original positions.
+ */
+async function loadSources(
+  chunk: PlannedChunk,
+  deps: CompactorDeps
+): Promise<{ frames: { captureTsMs: number; jpeg: Uint8Array }[]; bytes: number } | null> {
+  const frames: { captureTsMs: number; jpeg: Uint8Array }[] = []
+  let bytes = 0
+  for (const frame of chunk.frames) {
+    let jpeg: Uint8Array
+    try {
+      jpeg = await deps.readJpeg(frame.imagePath)
+    } catch {
+      return null
+    }
+    if (jpeg.byteLength === 0) return null
+    bytes += jpeg.byteLength
+    frames.push({ captureTsMs: frame.tsMs, jpeg })
+  }
+  return { frames, bytes }
+}
+
+/**
+ * Confirm a written chunk reads back as the frames it was built from.
+ *
+ * This is the precondition for deleting anything. It re-reads from disk rather
+ * than checking the buffer that was just written, so it also catches a write
+ * that never landed, landed short, or landed somewhere else.
+ */
+function verifyChunk(
+  bytes: Uint8Array,
+  chunk: PlannedChunk
+): { ok: true } | { ok: false; reason: string } {
+  let parsed
+  try {
+    parsed = decodeChunk(bytes)
+  } catch (e) {
+    const why = e instanceof ChunkFormatError ? e.message : String(e)
+    return { ok: false, reason: `chunk did not read back: ${why}` }
+  }
+  if (parsed.frames.length !== chunk.frames.length) {
+    return {
+      ok: false,
+      reason: `chunk holds ${parsed.frames.length} frames, planned ${chunk.frames.length}`
+    }
+  }
+  for (let i = 0; i < chunk.frames.length; i++) {
+    if (parsed.frames[i].captureTsMs !== chunk.frames[i].tsMs) {
+      // Offsets are the addressing scheme; a shifted timestamp means frame i in
+      // the file is not frame i in the plan, and every read would be wrong.
+      return { ok: false, reason: `frame ${i} came back with the wrong capture time` }
+    }
+  }
+  if (parsed.width !== chunk.width || parsed.height !== chunk.height) {
+    return { ok: false, reason: 'chunk came back with the wrong geometry' }
+  }
+  return { ok: true }
+}
+
+/** Compact one batch. Safe to call repeatedly; each pass takes what is left. */
+export async function compactOnce(deps: CompactorDeps): Promise<CompactionResult> {
+  const now = deps.nowMs()
+  const candidates = deps.listCompactable(now, COMPACTION_BATCH_FRAMES)
+  const plan = planChunks(candidates, now)
+  const result: CompactionResult = {
+    chunksWritten: 0,
+    framesCompacted: 0,
+    bytesReclaimed: 0,
+    skipped: []
+  }
+  if (plan.length === 0) return result
+
+  for (const chunk of plan) {
+    const first = chunk.frames[0]
+    const last = chunk.frames[chunk.frames.length - 1]
+    const relativePath = chunkRelativePath(chunk.day, first.tsMs, last.tsMs)
+
+    const sources = await loadSources(chunk, deps)
+    if (!sources) {
+      result.skipped.push({ chunk: relativePath, reason: 'a source frame could not be read' })
+      continue
+    }
+
+    let encoded: Uint8Array
+    try {
+      encoded = await deps.encode({
+        width: chunk.width,
+        height: chunk.height,
+        frames: sources.frames
+      })
+    } catch (e) {
+      result.skipped.push({ chunk: relativePath, reason: `encode failed: ${(e as Error).message}` })
+      continue
+    }
+
+    try {
+      await deps.writeChunk(relativePath, encoded)
+    } catch (e) {
+      result.skipped.push({ chunk: relativePath, reason: `write failed: ${(e as Error).message}` })
+      continue
+    }
+
+    let readBack: Uint8Array
+    try {
+      readBack = await deps.readChunk(relativePath)
+    } catch (e) {
+      await deps.removeChunk(relativePath).catch(() => undefined)
+      result.skipped.push({
+        chunk: relativePath,
+        reason: `re-read failed: ${(e as Error).message}`
+      })
+      continue
+    }
+
+    const verified = verifyChunk(readBack, chunk)
+    if (!verified.ok) {
+      // Nothing points at it yet, so removing the file is the whole cleanup.
+      await deps.removeChunk(relativePath).catch(() => undefined)
+      result.skipped.push({ chunk: relativePath, reason: verified.reason })
+      continue
+    }
+
+    // Past this line the chunk is durable and proven to hold these frames.
+    let claimed = 0
+    for (let offset = 0; offset < chunk.frames.length; offset++) {
+      const frame = chunk.frames[offset]
+      // Capture the path first: the claim clears `image_path`.
+      const jpegPath = frame.imagePath
+      if (!deps.claimFrame(frame.id, relativePath, offset)) continue
+      claimed++
+      await deps.deleteJpeg(jpegPath).catch(() => undefined)
+      result.bytesReclaimed += sources.frames[offset].jpeg.byteLength
+    }
+
+    if (claimed === 0) {
+      // Every frame was claimed by someone else between planning and now. The
+      // file is unreferenced; take it back rather than leaving it for the sweep.
+      await deps.removeChunk(relativePath).catch(() => undefined)
+      result.skipped.push({ chunk: relativePath, reason: 'every frame was already claimed' })
+      continue
+    }
+
+    result.chunksWritten++
+    result.framesCompacted += claimed
+    deps.log(
+      `rewind: compacted ${claimed} frames into ${relativePath} ` +
+        `(${Math.round(sources.bytes / 1024)} KB of JPEGs -> ${Math.round(encoded.byteLength / 1024)} KB)`
+    )
+  }
+
+  if (result.skipped.length > 0) {
+    // Never silent: a compactor that quietly does nothing is indistinguishable
+    // from one that is working, and this one deliberately skips a lot.
+    deps.log(
+      `rewind: skipped ${result.skipped.length} chunk(s): ` +
+        result.skipped.map((s) => `${s.chunk} (${s.reason})`).join('; ')
+    )
+  }
+  return result
+}
+
+/** What a pass would reclaim, without doing it. Used by the settings surface. */
+export function estimateReclaimable(
+  frames: CompactableFrame[],
+  nowMs: number,
+  sizeOf: (frame: CompactableFrame) => number
+): { frames: number; bytes: number } {
+  const plan = planChunks(frames, nowMs)
+  return {
+    frames: plan.reduce((n, c) => n + c.frames.length, 0),
+    bytes: plannedJpegBytes(plan, sizeOf)
+  }
+}

--- a/desktop/windows/src/main/rewind/chunks/cursorPolicy.test.ts
+++ b/desktop/windows/src/main/rewind/chunks/cursorPolicy.test.ts
@@ -1,0 +1,103 @@
+// The rule that turns a scrub from quadratic into linear. macOS measured the
+// difference at 12.3x on a real 18-frame chunk; what is testable without a
+// codec is the decision that produces it, which is all of this file.
+import { describe, expect, it } from 'vitest'
+import { afterExhausted, afterRead, canServe, newCursor, planRead } from './cursorPolicy'
+
+const CHUNK = '2026-08-17/1-2.omichunk'
+const OTHER = '2026-08-17/3-4.omichunk'
+
+describe('a fresh cursor', () => {
+  it('cannot serve anything', () => {
+    expect(canServe(newCursor(), CHUNK, 0)).toBe(false)
+  })
+
+  it('reopens for the first read', () => {
+    expect(planRead(newCursor(), CHUNK, 7)).toEqual({
+      kind: 'reopen',
+      chunkPath: CHUNK,
+      advanceBy: 7
+    })
+  })
+})
+
+describe('walking forward', () => {
+  it('serves the very next frame with a single advance', () => {
+    // This is the case that makes sequential playback cheap: one decode step.
+    const state = afterRead(newCursor(), { kind: 'reopen', chunkPath: CHUNK, advanceBy: 0 }, 0)
+    expect(planRead(state, CHUNK, 1)).toEqual({ kind: 'advance', advanceBy: 0 })
+  })
+
+  it('skips ahead without reopening', () => {
+    const state = afterRead(newCursor(), { kind: 'reopen', chunkPath: CHUNK, advanceBy: 0 }, 3)
+    expect(planRead(state, CHUNK, 9)).toEqual({ kind: 'advance', advanceBy: 5 })
+  })
+
+  it('serves the offset it is parked on', () => {
+    // The tape parks *before* the next frame, so nextOffset is servable. Off by
+    // one here and every sequential read reopens, losing the whole benefit.
+    const state = { chunkPath: CHUNK, nextOffset: 4, finished: false }
+    expect(canServe(state, CHUNK, 4)).toBe(true)
+    expect(planRead(state, CHUNK, 4)).toEqual({ kind: 'advance', advanceBy: 0 })
+  })
+
+  it('costs one advance per frame across a whole chunk', () => {
+    let state = newCursor()
+    let reopens = 0
+    for (let offset = 0; offset < 60; offset++) {
+      const action = planRead(state, CHUNK, offset)
+      if (action.kind === 'reopen') reopens++
+      else expect(action.advanceBy).toBe(0)
+      state = afterRead(state, action, offset)
+    }
+    expect(reopens).toBe(1) // only the very first read
+  })
+})
+
+describe('what forces a reopen', () => {
+  it('a backward step', () => {
+    // A one-way tape has nothing cheaper available.
+    const state = afterRead(newCursor(), { kind: 'reopen', chunkPath: CHUNK, advanceBy: 0 }, 9)
+    expect(planRead(state, CHUNK, 4)).toEqual({ kind: 'reopen', chunkPath: CHUNK, advanceBy: 4 })
+  })
+
+  it('a different chunk', () => {
+    const state = afterRead(newCursor(), { kind: 'reopen', chunkPath: CHUNK, advanceBy: 0 }, 2)
+    expect(planRead(state, OTHER, 5)).toEqual({ kind: 'reopen', chunkPath: OTHER, advanceBy: 5 })
+  })
+
+  it('a cursor that ran off the end', () => {
+    let state = afterRead(newCursor(), { kind: 'reopen', chunkPath: CHUNK, advanceBy: 0 }, 5)
+    state = afterExhausted(state)
+    expect(canServe(state, CHUNK, 6)).toBe(false)
+    expect(planRead(state, CHUNK, 6).kind).toBe('reopen')
+  })
+})
+
+describe('state bookkeeping', () => {
+  it('adopts the chunk it reopened on', () => {
+    // Without this a cursor that reopened onto another chunk would still claim
+    // the old one and happily "serve" reads from the wrong file.
+    const state = afterRead(newCursor(), { kind: 'reopen', chunkPath: OTHER, advanceBy: 3 }, 3)
+    expect(state.chunkPath).toBe(OTHER)
+    expect(state.nextOffset).toBe(4)
+  })
+
+  it('keeps the chunk it was already on when advancing', () => {
+    const start = { chunkPath: CHUNK, nextOffset: 2, finished: false }
+    const state = afterRead(start, { kind: 'advance', advanceBy: 1 }, 3)
+    expect(state.chunkPath).toBe(CHUNK)
+    expect(state.nextOffset).toBe(4)
+  })
+
+  it('clears the finished flag after a successful read', () => {
+    const start = { chunkPath: CHUNK, nextOffset: 9, finished: true }
+    const state = afterRead(start, { kind: 'reopen', chunkPath: CHUNK, advanceBy: 0 }, 0)
+    expect(state.finished).toBe(false)
+  })
+
+  it('rejects a nonsense offset instead of planning for it', () => {
+    expect(() => planRead(newCursor(), CHUNK, -1)).toThrow(/non-negative/)
+    expect(() => planRead(newCursor(), CHUNK, 1.5)).toThrow(/integer/)
+  })
+})

--- a/desktop/windows/src/main/rewind/chunks/cursorPolicy.ts
+++ b/desktop/windows/src/main/rewind/chunks/cursorPolicy.ts
@@ -1,0 +1,100 @@
+/**
+ * The decision half of a chunk read cursor.
+ *
+ * A chunk is inter-frame compressed, so there is no random access to frame *n*:
+ * reaching it means decoding everything before it. Opening a fresh decoder per
+ * request therefore makes a scrub quadratic in the chunk's length — the user
+ * pays for frame 0 again on every step. macOS measured exactly this on a real
+ * 18-frame chunk: 728 ms to scrub it (40.5 ms/frame) reopening each time,
+ * against 59 ms (3.3 ms/frame) keeping the reader alive, 12.3x faster and
+ * pixel-identical at every offset (`RewindVideoFrameCursor.swift`).
+ *
+ * Keeping a decoder alive between requests is the whole trick, and deciding
+ * *when* it can be kept is the only part of it that needs no codec. That part
+ * is here, as a pure state machine, so the rule can be tested directly instead
+ * of inferred from timings. The decoding itself is WebCodecs and lives in the
+ * renderer (`renderer/src/rewind/chunkDecoder.ts`).
+ *
+ * The tape is one-way: a cursor can serve any offset at or after the one it is
+ * parked on. A backward step, or a step into a different chunk, reopens —
+ * there is nothing cheaper available for either.
+ */
+
+export type CursorAction =
+  /** Advance the live decoder by `advanceBy` frames to reach the request. */
+  | { kind: 'advance'; advanceBy: number }
+  /** Discard any live decoder, open `chunkPath` at 0, then advance. */
+  | { kind: 'reopen'; chunkPath: string; advanceBy: number }
+
+export type CursorState = {
+  /** Chunk the live decoder is reading, or null when there is none. */
+  chunkPath: string | null
+  /** Offset the next decoded frame will be. */
+  nextOffset: number
+  /** Set once the decoder has run past the end; the tape cannot be reused. */
+  finished: boolean
+}
+
+export function newCursor(): CursorState {
+  return { chunkPath: null, nextOffset: 0, finished: false }
+}
+
+/**
+ * Whether `state` can reach `frameOffset` of `chunkPath` without reopening.
+ *
+ * This is macOS's `canServe` unchanged, including the detail that an offset
+ * *equal* to `nextOffset` is servable: the tape is parked before that frame,
+ * not after it.
+ */
+export function canServe(state: CursorState, chunkPath: string, frameOffset: number): boolean {
+  return !state.finished && state.chunkPath === chunkPath && frameOffset >= state.nextOffset
+}
+
+/**
+ * What to do to serve `frameOffset` of `chunkPath`.
+ *
+ * Note the asymmetry with `canServe`: a reopen always starts at offset 0, so
+ * the advance for a reopen is the offset itself.
+ */
+export function planRead(state: CursorState, chunkPath: string, frameOffset: number): CursorAction {
+  if (!Number.isInteger(frameOffset) || frameOffset < 0) {
+    throw new Error(`frame offset must be a non-negative integer, got ${frameOffset}`)
+  }
+  if (canServe(state, chunkPath, frameOffset)) {
+    return { kind: 'advance', advanceBy: frameOffset - state.nextOffset }
+  }
+  return { kind: 'reopen', chunkPath, advanceBy: frameOffset }
+}
+
+/**
+ * Record that a read succeeded, parking the tape after the frame just served.
+ *
+ * Takes the action that was performed rather than re-deriving it, so a caller
+ * that reopened for its own reasons cannot leave the state claiming to still be
+ * on the old chunk.
+ */
+export function afterRead(
+  state: CursorState,
+  action: CursorAction,
+  frameOffset: number
+): CursorState {
+  return {
+    chunkPath: action.kind === 'reopen' ? action.chunkPath : state.chunkPath,
+    nextOffset: frameOffset + 1,
+    finished: false
+  }
+}
+
+/**
+ * Record that a read ran off the end of the chunk.
+ *
+ * On macOS this is a normal outcome, because the chunk being read can be the
+ * one still being written. Here it never is: a chunk is registered in the
+ * database only after it has been written whole and read back, so running off
+ * the end means the row's offset disagrees with the file. The cursor is retired
+ * either way — the difference is that the caller should treat it as a broken
+ * frame rather than "not yet".
+ */
+export function afterExhausted(state: CursorState): CursorState {
+  return { ...state, finished: true }
+}

--- a/desktop/windows/src/main/rewind/rebuildIndex.ts
+++ b/desktop/windows/src/main/rewind/rebuildIndex.ts
@@ -2,7 +2,9 @@ import { readdir, stat, readFile } from 'fs/promises'
 import { join } from 'path'
 import { nativeImage } from 'electron'
 import { rewindRoot } from './paths'
-import { rewindImagePathsBetween, insertRewindFrame } from '../ipc/db'
+import { rewindImagePathsBetween, insertRewindFrame, framesInChunk } from '../ipc/db'
+import { listChunkFiles, readChunkFile } from './chunks/chunkFiles'
+import { REBUILT_CHUNK_FRAME_INDEXED, selectChunkFramesToRebuild } from './chunks/chunkRebuild'
 import { deriveKeepSetWindow, parseFrameTs } from './orphanSelection'
 import { selectFramesToReindex, type DiskFrameFile } from './rebuildSelection'
 import { signalRewindOcrPending } from './ocrService'
@@ -96,6 +98,56 @@ async function rebuildDayDir(dayName: string): Promise<number> {
   return inserted
 }
 
+/**
+ * Re-create rows for frames stored in chunks.
+ *
+ * Reads only each chunk's record headers, so recovering a day of chunks does not
+ * pull a day of encoded video through memory, and skips offsets that already
+ * have a row so a re-run inserts nothing. Selection is pure and lives in
+ * `chunks/chunkRebuild.ts`.
+ */
+async function rebuildFromChunks(): Promise<number> {
+  const root = rewindRoot()
+  let onDisk: { relativePath: string }[]
+  try {
+    onDisk = await listChunkFiles(root)
+  } catch {
+    return 0
+  }
+  let inserted = 0
+  for (const { relativePath } of onDisk) {
+    let bytes: Uint8Array
+    try {
+      bytes = await readChunkFile(root, relativePath)
+    } catch {
+      continue // vanished or unreadable — fail-open, same as a stray JPEG
+    }
+    const known = new Set(framesInChunk(relativePath).map((f) => f.chunkOffset))
+    for (const target of selectChunkFramesToRebuild({ relativePath, bytes }, known)) {
+      try {
+        insertRewindFrame({
+          ts: target.ts,
+          app: '',
+          windowTitle: '',
+          processName: '',
+          ocrText: '',
+          // No JPEG of its own: the pixels are frame `chunkOffset` of the chunk.
+          imagePath: '',
+          width: target.width,
+          height: target.height,
+          indexed: REBUILT_CHUNK_FRAME_INDEXED,
+          chunkPath: target.chunkPath,
+          chunkOffset: target.chunkOffset
+        })
+        inserted++
+      } catch {
+        /* one bad row must not abandon the rest of the recovery */
+      }
+    }
+  }
+  return inserted
+}
+
 // Single-flight guard. A rebuild snapshots each day dir's existing image paths and
 // THEN inserts the missing rows; two rebuilds overlapping would share the same
 // pre-insert snapshot and each insert the same orphans → duplicate rows (the exact
@@ -128,6 +180,12 @@ async function runRebuild(): Promise<number> {
   }
   let total = 0
   for (const day of dayNames) total += await rebuildDayDir(day)
+  // Compacted frames live in chunks rather than in files named for their
+  // timestamp, so they need their own pass. Without it a database wipe would
+  // leave every compacted frame unreachable and the chunk sweep would
+  // eventually delete files whose pixels were perfectly intact.
+  const fromChunks = await rebuildFromChunks()
+  total += fromChunks
   if (total > 0) {
     console.log(`[rewind] index rebuild inserted ${total} row(s) from disk`)
     // These rows are inserted indexed=0 for the OCR backlog sweep to re-OCR. The

--- a/desktop/windows/src/main/rewind/retentionRunner.ts
+++ b/desktop/windows/src/main/rewind/retentionRunner.ts
@@ -1,8 +1,9 @@
 import { retentionCutoff } from './retentionSelection'
-import { deleteRewindFramesOlderThan } from '../ipc/db'
+import { deleteRewindFramesOlderThan, referencedChunkPaths } from '../ipc/db'
 import { getRewindSettings } from './captureService'
 import { rewindRoot } from './paths'
 import { removeRewindFrame } from './frameFile'
+import { listChunkFiles, removeChunkFile, selectUnreferencedChunks } from './chunks/chunkFiles'
 
 const PRUNE_INTERVAL_MS = 60 * 60 * 1000 // hourly
 
@@ -11,17 +12,60 @@ export async function pruneRewindOnce(): Promise<number> {
   const cutoff = retentionCutoff(Date.now(), retentionDays)
   const removed = deleteRewindFramesOlderThan(cutoff)
   await Promise.all(
-    removed.map((f) =>
-      removeRewindFrame(rewindRoot(), f.imagePath).catch((error: NodeJS.ErrnoException) => {
-        // ENOENT is idempotent (frame already gone). Other failures need a log
-        // so retention cannot silently leave disk growth undiagnosed.
-        if (error?.code !== 'ENOENT') {
-          console.warn('[rewind] failed to delete pruned frame:', f.imagePath, error)
-        }
-      })
-    )
+    removed
+      // A compacted frame has no JPEG of its own — its pixels live in a chunk,
+      // and its `image_path` was set to '' when it was claimed. Passing that to
+      // removeRewindFrame would raise "invalid frame path" for every such frame
+      // and log a warning per row. The chunk file itself is collected below,
+      // once the last frame pointing into it is gone.
+      .filter((f) => f.imagePath !== '')
+      .map((f) =>
+        removeRewindFrame(rewindRoot(), f.imagePath).catch((error: NodeJS.ErrnoException) => {
+          // ENOENT is idempotent (frame already gone). Other failures need a log
+          // so retention cannot silently leave disk growth undiagnosed.
+          if (error?.code !== 'ENOENT') {
+            console.warn('[rewind] failed to delete pruned frame:', f.imagePath, error)
+          }
+        })
+      )
   )
+  await collectDeadChunks()
   return removed.length
+}
+
+/**
+ * Delete chunk files nothing points at any more.
+ *
+ * This is the chunk half of retention. Frames are deleted by age above; a chunk
+ * becomes garbage the moment its last frame goes, and there is no foreign key
+ * to notice. It also collects a chunk written by a compaction that crashed
+ * before claiming anything, which is why it works from "what is on disk minus
+ * what is referenced" rather than from a list of chunks to delete.
+ */
+export async function collectDeadChunks(nowMs: number = Date.now()): Promise<number> {
+  const root = rewindRoot()
+  let onDisk: { relativePath: string; modifiedMs: number }[]
+  try {
+    onDisk = await listChunkFiles(root)
+  } catch (e) {
+    console.warn('[rewind] could not list chunk files:', e)
+    return 0
+  }
+  if (onDisk.length === 0) return 0
+
+  const dead = selectUnreferencedChunks(onDisk, referencedChunkPaths(), nowMs)
+  let removed = 0
+  for (const relativePath of dead) {
+    try {
+      await removeChunkFile(root, relativePath)
+      removed++
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code
+      if (code !== 'ENOENT') console.warn('[rewind] failed to delete chunk:', relativePath, error)
+    }
+  }
+  if (removed > 0) console.log(`[rewind] collected ${removed} unreferenced chunk file(s)`)
+  return removed
 }
 
 export function startRewindRetention(): void {

--- a/desktop/windows/src/preload/index.ts
+++ b/desktop/windows/src/preload/index.ts
@@ -1,6 +1,8 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import type {
+  RewindEncodeChunkRequest,
+  RewindEncodeChunkResponse,
   OmiBridgeApi,
   OmiOverlayApi,
   OmiBarApi,
@@ -364,6 +366,15 @@ const omi: OmiBridgeApi = {
   rewindSetEmbedSession: (session: { desktopApiBase: string; token: string } | null) =>
     ipcRenderer.invoke('rewind:setEmbedSession', session),
   rewindFrameImage: (imagePath: string) => ipcRenderer.invoke('rewind:frameImage', imagePath),
+  rewindChunkBytes: (chunkPath: string) => ipcRenderer.invoke('rewind:chunkBytes', chunkPath),
+  rewindCompactNow: () => ipcRenderer.invoke('rewind:compactNow'),
+  onRewindEncodeChunk: (cb: (request: RewindEncodeChunkRequest) => void) => {
+    const h = (_e: unknown, request: RewindEncodeChunkRequest): void => cb(request)
+    ipcRenderer.on('rewind:encode-chunk', h)
+    return () => ipcRenderer.removeListener('rewind:encode-chunk', h)
+  },
+  rewindChunkEncoded: (response: RewindEncodeChunkResponse) =>
+    ipcRenderer.send('rewind:chunk-encoded', response),
   // --- Track 4 --- per-line OCR boxes for the on-image search highlight overlay
   rewindFrameOcrLines: (frameId: number) => ipcRenderer.invoke('rewind:frameOcrLines', frameId),
   rewindGetSettings: () => ipcRenderer.invoke('rewind:getSettings'),

--- a/desktop/windows/src/renderer/src/App.tsx
+++ b/desktop/windows/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import { DbRecoveryNotice } from './components/ui/DbRecoveryNotice'
 import { DegradedModeNotice } from './components/ui/DegradedModeNotice'
 import { ToastHost } from './components/ui/ToastHost'
 import { purgeAppMemoriesOnce } from './lib/appMemories'
+import { RewindChunkHost } from './components/rewind/RewindChunkHost'
 import { AppStateProvider } from './state/AppStateProvider'
 import { useAppState } from './state/appState'
 import { SourcePicker } from './components/SourcePicker'
@@ -193,6 +194,12 @@ function AppShell(): React.JSX.Element {
 
   return (
     <AppStateProvider>
+      {/* Answers the compactor's encode requests. Mounted here as well as in
+          the capture window because main sends an encode to whichever window is
+          live, and the capture window only exists while capture is running — a
+          request sent to a window with no host would never be answered, and the
+          pass would sit on it until it timed out. */}
+      <RewindChunkHost />
       <AppShellInner />
     </AppStateProvider>
   )

--- a/desktop/windows/src/renderer/src/capture/CaptureApp.tsx
+++ b/desktop/windows/src/renderer/src/capture/CaptureApp.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useRef } from 'react'
 import { RewindCaptureHost } from '../components/rewind/RewindCaptureHost'
+import { RewindChunkHost } from '../components/rewind/RewindChunkHost'
 import { ContinuousSessionHost } from './ContinuousSessionHost'
 import { AudioSessionHost } from './AudioSessionHost'
 import { PttCaptureHost } from './PttCaptureHost'
 import { ScreenSessionHost } from './ScreenSessionHost'
 import { MeetingSessionHost } from './MeetingSessionHost'
 import { installCaptureE2EHooks } from './e2eHooks'
+import { installRewindChunkE2EHooks } from '../rewind/chunkE2EHooks'
 import { auth } from '../lib/firebase'
 
 // Test hooks (no-op unless OMI_E2E=1) — module scope so they exist as soon as
 // the capture bundle evaluates, before React mounts.
 installCaptureE2EHooks()
+installRewindChunkE2EHooks()
 
 // Root of the hidden capture window (renderer #/capture). No visible UI — it only
 // mounts the capture hosts that own ALL capture: Rewind frames, the continuous
@@ -51,6 +54,7 @@ export function CaptureApp(): React.JSX.Element {
   return (
     <>
       <RewindCaptureHost />
+      <RewindChunkHost />
       <ContinuousSessionHost />
       <AudioSessionHost />
       <PttCaptureHost />

--- a/desktop/windows/src/renderer/src/components/rewind/RewindChunkHost.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindChunkHost.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+import type { RewindEncodeChunkRequest } from '../../../../shared/types'
+import { encodeFramesToChunk } from '../../rewind/chunkEncoder'
+
+/**
+ * Answers the compactor's encode requests.
+ *
+ * Compaction is decided and executed in main, which has no `VideoEncoder`;
+ * this is the renderer end of that. It holds no state and renders nothing —
+ * every decision about what to encode, whether the result is trustworthy, and
+ * what to delete afterwards is main's (see `main/rewind/chunks/`).
+ *
+ * Mounted next to `RewindCaptureHost`, so a window that can capture can also
+ * compact. Any live window will do; main picks one.
+ */
+export function RewindChunkHost(): null {
+  useEffect(() => {
+    const encode = async (request: RewindEncodeChunkRequest): Promise<void> => {
+      try {
+        const bytes = await encodeFramesToChunk({
+          width: request.width,
+          height: request.height,
+          frames: request.frames
+        })
+        window.omi.rewindChunkEncoded({
+          requestId: request.requestId,
+          ok: true,
+          bytes: new Uint8Array(bytes)
+        })
+      } catch (e) {
+        // Always answer. A silent failure here would leave the compactor
+        // holding its plan and every loaded JPEG until the request times out.
+        window.omi.rewindChunkEncoded({
+          requestId: request.requestId,
+          ok: false,
+          error: e instanceof Error ? e.message : String(e)
+        })
+      }
+    }
+    return window.omi.onRewindEncodeChunk((request) => {
+      void encode(request)
+    })
+  }, [])
+
+  return null
+}

--- a/desktop/windows/src/renderer/src/components/rewind/RewindPlayer.tsx
+++ b/desktop/windows/src/renderer/src/components/rewind/RewindPlayer.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../../../shared/timelineGeometry'
 import { relativeTime, isSameDay } from '../../../../shared/relativeTime'
 import { parseWindowTitle } from '../../lib/windowTitle'
+import { FrameImageSource } from '../../rewind/frameImageSource'
 import {
   containedImageRect,
   highlightTerms,
@@ -50,20 +51,42 @@ export function RewindPlayer({
   )
   const frame = idx >= 0 ? frames[idx] : null
 
+  // One source for the whole player, not one per frame: it holds the chunk
+  // decoder open between frames, which is what makes stepping through a
+  // compacted run cost one decode instead of re-decoding from the chunk's start
+  // every time. See rewind/frameImageSource.ts.
+  const [imageSource] = useState(() => new FrameImageSource())
+  useEffect(() => () => imageSource.dispose(), [imageSource])
+
   useEffect(() => {
     let alive = true
+    let objectUrl: string | null = null
     if (!frame) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional load-on-mount / reset-on-dependency-change; not a self-retriggering loop
       setSrc(null)
       return
     }
-    void window.omi.rewindFrameImage(frame.imagePath).then((dataUrl) => {
-      if (alive) setSrc(dataUrl)
-    })
+    void imageSource
+      .srcFor(frame)
+      .then((resolved) => {
+        if (!alive) {
+          // Arrived after the frame changed: revoke rather than leak.
+          if (resolved?.revoke) URL.revokeObjectURL(resolved.src)
+          return
+        }
+        if (resolved?.revoke) objectUrl = resolved.src
+        setSrc(resolved?.src ?? null)
+      })
+      .catch(() => {
+        // A frame whose chunk is corrupt or missing renders as no image, the
+        // same as a JPEG that is gone. One bad row must not take down the page.
+        if (alive) setSrc(null)
+      })
     return () => {
       alive = false
+      if (objectUrl) URL.revokeObjectURL(objectUrl)
     }
-  }, [frame?.imagePath])
+  }, [frame?.imagePath, frame?.chunkPath, frame?.chunkOffset])
 
   // Load per-line OCR boxes for the current frame only while a search is active.
   const terms = highlightTerms(highlightQuery)

--- a/desktop/windows/src/renderer/src/main.tsx
+++ b/desktop/windows/src/renderer/src/main.tsx
@@ -38,6 +38,10 @@ import { AppCrashScreen } from './components/ui/AppCrashScreen'
 import { scrubEventPii } from '../../shared/sentryScrub'
 import { isSecondaryWindow } from './lib/windowRole'
 import { initFontScale } from './lib/fontScale'
+import { installRewindChunkE2EHooks } from './rewind/chunkE2EHooks'
+
+// Test hooks (no-op unless OMI_E2E=1) — module scope, before React mounts.
+installRewindChunkE2EHooks()
 
 // Renderer-side crash reporting. Only initializes when a DSN is configured, so
 // dev builds (and any build without the env var) stay entirely offline. Emails

--- a/desktop/windows/src/renderer/src/rewind/chunkDecoder.ts
+++ b/desktop/windows/src/renderer/src/rewind/chunkDecoder.ts
@@ -1,0 +1,260 @@
+/**
+ * Reading one frame back out of a chunk.
+ *
+ * A chunk is inter-frame compressed, so frame *n* cannot be reached without
+ * decoding everything before it. The consequence is the whole reason this file
+ * has a cursor in it rather than a `decodeFrame(path, n)` function: opening a
+ * fresh decoder per request makes a scrub quadratic, and macOS measured that
+ * cost directly — 728 ms to walk an 18-frame chunk reopening each time, 59 ms
+ * keeping the reader alive (`RewindVideoFrameCursor.swift`).
+ *
+ * The decision of when the live decoder can be reused is not here; it is a pure
+ * state machine in `main/rewind/chunks/cursorPolicy.ts`, tested on its own. This
+ * file is the part that needs a codec: it executes the plan that module returns.
+ */
+
+import { decodeChunk, type ChunkContents } from '../../../main/rewind/chunks/chunkFormat'
+import {
+  afterExhausted,
+  afterRead,
+  newCursor,
+  planRead,
+  type CursorState
+} from '../../../main/rewind/chunks/cursorPolicy'
+
+export type DecoderDeps = {
+  VideoDecoder: typeof globalThis.VideoDecoder
+  EncodedVideoChunk: typeof globalThis.EncodedVideoChunk
+  createCanvas: (width: number, height: number) => OffscreenCanvas
+}
+
+function defaultDeps(): DecoderDeps {
+  return {
+    VideoDecoder: globalThis.VideoDecoder,
+    EncodedVideoChunk: globalThis.EncodedVideoChunk,
+    createCanvas: (width, height) => new OffscreenCanvas(width, height)
+  }
+}
+
+export class ChunkDecodeError extends Error {}
+
+/**
+ * A live decode session over one chunk, parked before the next frame it will
+ * produce.
+ *
+ * WebCodecs decoding is push/pull across a callback rather than a pull-only
+ * tape, so this drains chunks into a queue and reads from it, where macOS calls
+ * `copyNextSampleBuffer()`. The externally visible behaviour is the same: a
+ * one-way tape that can serve any offset at or after where it is parked.
+ */
+class ChunkTape {
+  private readonly decoded: VideoFrame[] = []
+  private readonly decoder: VideoDecoder
+  private failure: Error | null = null
+  private fed = 0
+  /**
+   * Set once the stream has been flushed.
+   *
+   * `flush()` ends the decoder's current run: WebCodecs requires the next
+   * `decode()` after it to be a key frame, so flushing between reads would
+   * break the tape on the very next step ("A key frame is required after
+   * configure() or flush()"). It is therefore only ever done at the end of the
+   * chunk, when everything has been fed and there is nothing left to decode.
+   */
+  private flushed = false
+  /** Resolved by the output callback, so a read can await progress. */
+  private awaitingOutput: (() => void) | null = null
+
+  private constructor(
+    readonly chunkPath: string,
+    private readonly contents: ChunkContents,
+    private readonly deps: DecoderDeps
+  ) {
+    this.decoder = new deps.VideoDecoder({
+      output: (frame) => {
+        this.decoded.push(frame)
+        this.awaitingOutput?.()
+      },
+      error: (e: Error) => {
+        this.failure = e
+        this.awaitingOutput?.()
+      }
+    })
+    this.decoder.configure({
+      codec: contents.codec,
+      codedWidth: contents.width,
+      codedHeight: contents.height,
+      ...(contents.description.byteLength > 0 ? { description: contents.description } : {})
+    })
+  }
+
+  static open(chunkPath: string, contents: ChunkContents, deps: DecoderDeps): ChunkTape {
+    return new ChunkTape(chunkPath, contents, deps)
+  }
+
+  get frameCount(): number {
+    return this.contents.frames.length
+  }
+
+  /**
+   * Decode up to and including `offset`, returning that frame.
+   *
+   * Feeds only as far as it must. Frames before the target are decoded (they
+   * have to be — they are the reference pictures) and released immediately,
+   * so walking a chunk holds one frame at a time rather than all of them.
+   */
+  async advanceTo(offset: number): Promise<VideoFrame> {
+    if (offset >= this.contents.frames.length) {
+      throw new ChunkDecodeError(
+        `frame ${offset} is past the end of ${this.chunkPath} (${this.contents.frames.length} frames)`
+      )
+    }
+    while (this.fed <= offset) this.feedNext()
+
+    // A decoder may hold frames back before emitting them, so reaching offset
+    // can need more input than offset itself. Feed further chunks while any
+    // remain, and only flush once there is nothing left to feed — after which
+    // the tape is closed to new input, but by then everything is decoded.
+    while (this.decoded.length <= offset && !this.failure) {
+      if (await this.waitForOutput()) continue
+      if (this.fed < this.contents.frames.length) {
+        this.feedNext()
+        continue
+      }
+      if (this.flushed) break
+      await this.decoder.flush()
+      this.flushed = true
+    }
+    if (this.failure) throw this.failure
+
+    if (this.decoded.length <= offset) {
+      throw new ChunkDecodeError(
+        `decoder produced ${this.decoded.length} frames, wanted ${offset + 1}`
+      )
+    }
+    // Release everything before the target; they were only needed as references.
+    for (let i = 0; i < offset; i++) {
+      const stale = this.decoded[i]
+      if (stale) {
+        stale.close()
+        delete this.decoded[i]
+      }
+    }
+    return this.decoded[offset]
+  }
+
+  /** Push the next encoded frame into the decoder. */
+  private feedNext(): void {
+    const frame = this.contents.frames[this.fed]
+    this.decoder.decode(
+      new this.deps.EncodedVideoChunk({
+        type: frame.isKeyFrame ? 'key' : 'delta',
+        // Synthesised from the index for the same reason the encoder does it:
+        // it is monotonic by construction. The real capture time travels in the
+        // container record, not in the codec's timeline.
+        timestamp: this.fed * 1_000_000,
+        data: frame.data
+      })
+    )
+    this.fed++
+  }
+
+  /**
+   * Wait briefly for the decoder to emit something.
+   *
+   * Returns true if it did. False means it is waiting for more input (or is
+   * done), which the caller answers by feeding more or, as a last resort,
+   * flushing. The timeout is what keeps a decoder that will never emit again
+   * from hanging a read forever.
+   */
+  private waitForOutput(timeoutMs = 2000): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      let settled = false
+      const done = (value: boolean): void => {
+        if (settled) return
+        settled = true
+        this.awaitingOutput = null
+        clearTimeout(timer)
+        resolve(value)
+      }
+      const timer = setTimeout(() => done(false), timeoutMs)
+      this.awaitingOutput = () => done(true)
+    })
+  }
+
+  close(): void {
+    for (const frame of this.decoded) frame?.close()
+    this.decoded.length = 0
+    this.awaitingOutput?.()
+    try {
+      this.decoder.close()
+    } catch {
+      // Already closed by an error callback.
+    }
+  }
+}
+
+/**
+ * Serves frame reads from chunks, keeping one decoder alive between requests.
+ *
+ * Holds exactly one tape. A scrub through a chunk therefore costs one open plus
+ * one decode step per frame; anything that jumps backwards or to another chunk
+ * pays a reopen, which is what it would have paid anyway.
+ */
+export class ChunkFrameReader {
+  private state: CursorState = newCursor()
+  private tape: ChunkTape | null = null
+
+  constructor(private readonly deps: DecoderDeps = defaultDeps()) {}
+
+  /**
+   * Decode one frame to JPEG bytes.
+   *
+   * `loadChunk` is injected so the reader never touches the filesystem: main
+   * owns file access and hands the bytes over, exactly as it does for JPEGs.
+   */
+  async readFrame(
+    chunkPath: string,
+    frameOffset: number,
+    loadChunk: (path: string) => Promise<Uint8Array>,
+    quality = 0.82
+  ): Promise<Blob> {
+    const action = planRead(this.state, chunkPath, frameOffset)
+
+    if (action.kind === 'reopen') {
+      this.retire()
+      const bytes = await loadChunk(chunkPath)
+      const contents = decodeChunk(bytes)
+      this.tape = ChunkTape.open(chunkPath, contents, this.deps)
+    }
+    const tape = this.tape
+    if (!tape) throw new ChunkDecodeError('no chunk open')
+
+    let frame: VideoFrame
+    try {
+      frame = await tape.advanceTo(frameOffset)
+    } catch (e) {
+      // A chunk registered in the database is always complete, so running off
+      // the end means the row disagrees with the file rather than "not yet".
+      this.state = afterExhausted(this.state)
+      this.retire()
+      throw e
+    }
+
+    const canvas = this.deps.createCanvas(frame.displayWidth, frame.displayHeight)
+    const context = canvas.getContext('2d')
+    if (!context) throw new ChunkDecodeError('no 2d context for chunk decoding')
+    context.drawImage(frame, 0, 0)
+    const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality })
+
+    this.state = afterRead(this.state, action, frameOffset)
+    return blob
+  }
+
+  /** Drop the live decoder. Safe at any time; the next read reopens. */
+  retire(): void {
+    this.tape?.close()
+    this.tape = null
+    this.state = newCursor()
+  }
+}

--- a/desktop/windows/src/renderer/src/rewind/chunkE2EHooks.ts
+++ b/desktop/windows/src/renderer/src/rewind/chunkE2EHooks.ts
@@ -1,0 +1,138 @@
+// E2E-only hooks for video chunks, installed ONLY when the app runs under the
+// harness (OMI_E2E=1 → window.omi.isE2E). Same pattern as
+// `capture/e2eHooks.ts`, and for the same reason: the interesting part here is
+// the real WebCodecs encode/decode round trip, which cannot run under
+// plain-node vitest, and the only honest way to test it is to run the
+// PRODUCTION modules inside a real Electron renderer rather than a copy of them.
+import { encodeFramesToChunk } from './chunkEncoder'
+import { ChunkFrameReader } from './chunkDecoder'
+
+/**
+ * Draw a frame that looks like a screen, and JPEG-encode it exactly as capture
+ * does (`RewindCaptureHost`'s `standard` tier: JPEG at quality 0.7).
+ *
+ * Text-heavy on purpose. A flat colour field is not a fair stand-in: it
+ * compresses so well as a JPEG that the baseline the chunk is measured against
+ * is unrealistically small, which understates the saving and makes the
+ * assertion meaningless. Real screens are dense small text, which is precisely
+ * what makes per-frame JPEGs expensive.
+ *
+ * Only one line changes per frame, mirroring the thing that makes compaction
+ * pay: consecutive screen captures are nearly identical.
+ */
+async function makeFrame(width: number, height: number, index: number): Promise<Uint8Array> {
+  const canvas = new OffscreenCanvas(width, height)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('no 2d context')
+  ctx.fillStyle = '#101820'
+  ctx.fillRect(0, 0, width, height)
+  ctx.font = '13px monospace'
+  const lineHeight = 17
+  const rows = Math.floor(height / lineHeight)
+  for (let row = 0; row < rows; row++) {
+    // A deterministic pseudo-random line of code-like text, stable across
+    // frames except for the one the caret is on.
+    const seed = row * 2654435761
+    ctx.fillStyle = row % 4 === 0 ? '#7fd1b9' : '#d8dee9'
+    let line = ''
+    for (let col = 0; col < 100; col++) {
+      const n = (seed + col * 40503 + (row === index % rows ? index : 0)) >>> 0
+      line += String.fromCharCode(33 + (n % 90))
+    }
+    ctx.fillText(line, 8, (row + 1) * lineHeight)
+  }
+  const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.7 })
+  return new Uint8Array(await blob.arrayBuffer())
+}
+
+/** Mean absolute per-channel difference between two same-sized RGBA buffers. */
+function meanAbsoluteDifference(a: Uint8ClampedArray, b: Uint8ClampedArray): number {
+  let total = 0
+  let n = 0
+  for (let i = 0; i < a.length; i += 4) {
+    for (let k = 0; k < 3; k++) {
+      total += Math.abs(a[i + k] - b[i + k])
+      n++
+    }
+  }
+  return total / n
+}
+
+async function rgbaOf(
+  bytes: Uint8Array,
+  width: number,
+  height: number
+): Promise<Uint8ClampedArray> {
+  const bitmap = await createImageBitmap(new Blob([bytes as BlobPart], { type: 'image/jpeg' }))
+  const canvas = new OffscreenCanvas(width, height)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('no 2d context')
+  ctx.drawImage(bitmap, 0, 0, width, height)
+  bitmap.close()
+  return ctx.getImageData(0, 0, width, height).data
+}
+
+export function installRewindChunkE2EHooks(): void {
+  if (!window.omi?.isE2E) return
+  ;(window as unknown as Record<string, unknown>).__omiRewindChunkE2E = {
+    /**
+     * The whole round trip through the production encoder, container and
+     * decoder: N generated frames in, N frames back out, with the sizes and the
+     * per-frame fidelity the harness asserts on.
+     */
+    roundTrip: async (
+      count: number,
+      width: number,
+      height: number
+    ): Promise<{
+      jpegBytes: number
+      chunkBytes: number
+      framesBack: number
+      maxMeanDiff: number
+      firstTs: number
+      lastTs: number
+    }> => {
+      const baseTs = 1_781_329_148_845
+      const frames: { captureTsMs: number; jpeg: Uint8Array }[] = []
+      for (let i = 0; i < count; i++) {
+        frames.push({ captureTsMs: baseTs + i * 1000, jpeg: await makeFrame(width, height, i) })
+      }
+      const jpegBytes = frames.reduce((s, f) => s + f.jpeg.byteLength, 0)
+
+      const chunk = await encodeFramesToChunk({ width, height, frames })
+
+      // Read every frame back through the real cursor, in order — the same path
+      // and the same object a scrub uses.
+      const reader = new ChunkFrameReader()
+      const load = async (): Promise<Uint8Array> => new Uint8Array(chunk)
+      let framesBack = 0
+      let maxMeanDiff = 0
+      for (let i = 0; i < count; i++) {
+        const blob = await reader.readFrame('2026-08-17/1-2.omichunk', i, load)
+        const back = new Uint8Array(await blob.arrayBuffer())
+        const [source, decoded] = await Promise.all([
+          rgbaOf(frames[i].jpeg, width, height),
+          rgbaOf(back, width, height)
+        ])
+        maxMeanDiff = Math.max(maxMeanDiff, meanAbsoluteDifference(source, decoded))
+        framesBack++
+      }
+      reader.retire()
+
+      return {
+        jpegBytes,
+        chunkBytes: chunk.byteLength,
+        framesBack,
+        maxMeanDiff,
+        firstTs: frames[0].captureTsMs,
+        lastTs: frames[count - 1].captureTsMs
+      }
+    },
+
+    /** Whether this machine can encode at all, and with which codec. */
+    codecFor: async (width: number, height: number): Promise<string | null> => {
+      const { pickChunkCodec } = await import('./chunkEncoder')
+      return pickChunkCodec(width, height)
+    }
+  }
+}

--- a/desktop/windows/src/renderer/src/rewind/chunkEncoder.test.ts
+++ b/desktop/windows/src/renderer/src/rewind/chunkEncoder.test.ts
@@ -1,0 +1,286 @@
+// The encoder's orchestration, driven by a fake codec.
+//
+// What a fake can prove is everything that is not the codec: that frames go in
+// in capture order, that exactly the first one is a key frame, that the decoder
+// description is not dropped, and — the part that matters most — that no
+// failure path can return a chunk holding only some of the frames the caller is
+// about to delete the JPEGs for. The real H.264 round trip is covered by the
+// Electron e2e, which is where a real encoder exists.
+import { describe, expect, it, vi } from 'vitest'
+import { decodeChunk } from '../../../main/rewind/chunks/chunkFormat'
+import {
+  CHUNK_BITRATE,
+  ChunkEncodeError,
+  encodeFramesToChunk,
+  pickChunkCodec,
+  type EncoderDeps,
+  type SourceFrame
+} from './chunkEncoder'
+
+type EncodeCall = { keyFrame: boolean; timestamp: number }
+
+function fakeDeps(
+  options: {
+    supported?: (codec: string) => boolean
+    /** Emit the decoder description on the chunk at this index. */
+    describeAt?: number | null
+    /** Stop emitting output after this many frames, without erroring. */
+    emitOnly?: number
+    /** Raise on the encoder's error callback at this input index. */
+    errorAt?: number
+    calls?: EncodeCall[]
+  } = {}
+): EncoderDeps {
+  const supported = options.supported ?? ((c: string) => c === 'avc1.42001f')
+  const describeAt = options.describeAt === undefined ? 0 : options.describeAt
+  const calls = options.calls ?? []
+
+  class FakeVideoEncoder {
+    static async isConfigSupported(config: { codec: string }) {
+      return { supported: supported(config.codec), config }
+    }
+    private emitted = 0
+    private onError: (e: Error) => void
+    private onOutput: (chunk: unknown, meta?: unknown) => void
+    constructor(init: { output: (c: unknown, m?: unknown) => void; error: (e: Error) => void }) {
+      this.onOutput = init.output
+      this.onError = init.error
+    }
+    configure(): void {
+      /* the fake needs no configuration */
+    }
+    encode(frame: { timestamp: number }, opts?: { keyFrame?: boolean }): void {
+      const index = calls.length
+      calls.push({ keyFrame: Boolean(opts?.keyFrame), timestamp: frame.timestamp })
+      if (options.errorAt === index) {
+        this.onError(new Error('fake encoder failed'))
+        return
+      }
+      if (options.emitOnly !== undefined && this.emitted >= options.emitOnly) return
+      const payload = new Uint8Array([index + 1, 0xaa])
+      this.onOutput(
+        {
+          type: opts?.keyFrame ? 'key' : 'delta',
+          byteLength: payload.byteLength,
+          copyTo: (dest: Uint8Array) => dest.set(payload)
+        },
+        this.emitted === describeAt
+          ? { decoderConfig: { description: new Uint8Array([1, 100, 0, 31]) } }
+          : undefined
+      )
+      this.emitted++
+    }
+    async flush(): Promise<void> {
+      /* the fake emits synchronously, so there is nothing to drain */
+    }
+    close(): void {
+      /* nothing to release */
+    }
+  }
+
+  class FakeVideoFrame {
+    timestamp: number
+    duration: number
+    constructor(_source: unknown, init: { timestamp: number; duration: number }) {
+      this.timestamp = init.timestamp
+      this.duration = init.duration
+    }
+    close(): void {
+      /* nothing to release */
+    }
+  }
+
+  return {
+    VideoEncoder: FakeVideoEncoder as unknown as typeof globalThis.VideoEncoder,
+    VideoFrame: FakeVideoFrame as unknown as typeof globalThis.VideoFrame,
+    createImageBitmap: (async () => ({ close: () => {} })) as unknown as typeof createImageBitmap,
+    createCanvas: () =>
+      ({
+        getContext: () => ({ drawImage: vi.fn() })
+      }) as unknown as OffscreenCanvas
+  }
+}
+
+function sources(count: number, startMs = 1_781_329_148_845): SourceFrame[] {
+  return Array.from({ length: count }, (_, i) => ({
+    captureTsMs: startMs + i * 1000,
+    jpeg: new Uint8Array([0xff, 0xd8, i])
+  }))
+}
+
+describe('picking a codec', () => {
+  it('prefers H.264, which measured smallest on this app’s own output', () => {
+    // 60-frame 1280x720 run: 136 KB H.264 against 201 KB VP9.
+    return expect(pickChunkCodec(1280, 720, fakeDeps())).resolves.toBe('avc1.42001f')
+  })
+
+  it('falls back in order', async () => {
+    const deps = fakeDeps({ supported: (c) => c === 'vp09.00.10.08' })
+    await expect(pickChunkCodec(1280, 720, deps)).resolves.toBe('vp09.00.10.08')
+  })
+
+  it('returns null when the machine can encode none of them', async () => {
+    // A real outcome, not an error: such a machine simply keeps its JPEGs.
+    const deps = fakeDeps({ supported: () => false })
+    await expect(pickChunkCodec(1280, 720, deps)).resolves.toBeNull()
+  })
+
+  it('treats a codec string that throws as unsupported', async () => {
+    const deps = fakeDeps()
+    deps.VideoEncoder = {
+      isConfigSupported: async (c: { codec: string }) => {
+        if (c.codec !== 'vp8') throw new TypeError('unrecognised codec')
+        return { supported: true, config: c }
+      }
+    } as unknown as typeof globalThis.VideoEncoder
+    await expect(pickChunkCodec(1280, 720, deps)).resolves.toBe('vp8')
+  })
+})
+
+describe('encoding a run', () => {
+  it('produces a chunk that parses back to the same frames', async () => {
+    const frames = sources(12)
+    const bytes = await encodeFramesToChunk({
+      width: 1280,
+      height: 720,
+      frames,
+      deps: fakeDeps()
+    })
+    const decoded = decodeChunk(bytes)
+    expect(decoded.codec).toBe('avc1.42001f')
+    expect(decoded.width).toBe(1280)
+    expect(decoded.height).toBe(720)
+    expect(decoded.frames).toHaveLength(12)
+    expect(decoded.frames.map((f) => f.captureTsMs)).toEqual(frames.map((f) => f.captureTsMs))
+  })
+
+  it('makes exactly the first frame a key frame', async () => {
+    const calls: EncodeCall[] = []
+    await encodeFramesToChunk({
+      width: 640,
+      height: 480,
+      frames: sources(8),
+      deps: fakeDeps({ calls })
+    })
+    expect(calls.map((c) => c.keyFrame)).toEqual([
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ])
+  })
+
+  it('derives presentation timestamps from the index, not the capture clock', async () => {
+    // macOS derived them from a live capture rate and a mid-chunk rate change
+    // made a later frame's timestamp fall below an earlier one, which the writer
+    // rejects as non-monotonic. Here the source timestamps deliberately jump
+    // around and the encoded timeline stays strictly increasing.
+    const calls: EncodeCall[] = []
+    const jumpy: SourceFrame[] = [
+      { captureTsMs: 5_000, jpeg: new Uint8Array([1]) },
+      { captureTsMs: 1_000, jpeg: new Uint8Array([2]) },
+      { captureTsMs: 90_000, jpeg: new Uint8Array([3]) }
+    ]
+    await encodeFramesToChunk({ width: 640, height: 480, frames: jumpy, deps: fakeDeps({ calls }) })
+    const stamps = calls.map((c) => c.timestamp)
+    expect(stamps).toEqual([0, 1_000_000, 2_000_000])
+    // ...and the real capture times survive in the container instead.
+    const bytes = await encodeFramesToChunk({
+      width: 640,
+      height: 480,
+      frames: jumpy,
+      deps: fakeDeps()
+    })
+    expect(decodeChunk(bytes).frames.map((f) => f.captureTsMs)).toEqual([5_000, 1_000, 90_000])
+  })
+
+  it('keeps the decoder description wherever the encoder attaches it', async () => {
+    // Losing it makes the whole file undecodable, and it does not always ride
+    // on the first chunk.
+    const bytes = await encodeFramesToChunk({
+      width: 640,
+      height: 480,
+      frames: sources(5),
+      deps: fakeDeps({ describeAt: 3 })
+    })
+    expect([...decodeChunk(bytes).description]).toEqual([1, 100, 0, 31])
+  })
+
+  it('encodes for a codec that carries no description', async () => {
+    const bytes = await encodeFramesToChunk({
+      width: 640,
+      height: 480,
+      frames: sources(5),
+      deps: fakeDeps({ describeAt: null })
+    })
+    expect(decodeChunk(bytes).description).toHaveLength(0)
+  })
+})
+
+describe('what it refuses to hand back', () => {
+  it('throws when the encoder returns fewer frames than it was given', async () => {
+    // THE property of this file. The caller deletes the source JPEGs on
+    // success, so a chunk holding 5 of 10 frames would take the other 5 with it.
+    await expect(
+      encodeFramesToChunk({
+        width: 640,
+        height: 480,
+        frames: sources(10),
+        deps: fakeDeps({ emitOnly: 5 })
+      })
+    ).rejects.toThrow(/returned 5 frames for 10 inputs/)
+  })
+
+  it('propagates an encoder error instead of returning a partial chunk', async () => {
+    await expect(
+      encodeFramesToChunk({
+        width: 640,
+        height: 480,
+        frames: sources(10),
+        deps: fakeDeps({ errorAt: 4 })
+      })
+    ).rejects.toThrow(/fake encoder failed/)
+  })
+
+  it('stops feeding frames once the encoder has errored', async () => {
+    const calls: EncodeCall[] = []
+    await encodeFramesToChunk({
+      width: 640,
+      height: 480,
+      frames: sources(10),
+      deps: fakeDeps({ errorAt: 2, calls })
+    }).catch(() => undefined)
+    // It notices before the next encode rather than pushing all ten in.
+    expect(calls.length).toBeLessThan(10)
+  })
+
+  it('refuses when no codec is available', async () => {
+    await expect(
+      encodeFramesToChunk({
+        width: 640,
+        height: 480,
+        frames: sources(9),
+        deps: fakeDeps({ supported: () => false })
+      })
+    ).rejects.toThrow(ChunkEncodeError)
+  })
+
+  it('refuses an empty run', async () => {
+    await expect(
+      encodeFramesToChunk({ width: 640, height: 480, frames: [], deps: fakeDeps() })
+    ).rejects.toThrow(/nothing to encode/)
+  })
+})
+
+describe('configuration', () => {
+  it('targets a bitrate high enough that a busy minute is not smeared', () => {
+    // Set as a ceiling, not a size: the same run measured 136 KB at both 400
+    // and 150 kbps, because near-identical screens have no more information in
+    // them to spend the budget on.
+    expect(CHUNK_BITRATE).toBe(400_000)
+  })
+})

--- a/desktop/windows/src/renderer/src/rewind/chunkEncoder.ts
+++ b/desktop/windows/src/renderer/src/rewind/chunkEncoder.ts
@@ -1,0 +1,241 @@
+/**
+ * Turning a run of JPEGs into one inter-frame-compressed chunk.
+ *
+ * This runs in the renderer because that is where WebCodecs lives: Electron's
+ * main process is Node, and Node has no `VideoEncoder`. Main owns every file
+ * read and write (as it already does for JPEGs), hands the bytes over, and gets
+ * chunk bytes back — so adding compaction does not give the renderer filesystem
+ * access it did not have.
+ *
+ * The codec objects are injected rather than reached for globally. Everything
+ * interesting here is orchestration — frame order, where the key frame goes,
+ * what happens when the encoder errors halfway — and none of it needs a real
+ * H.264 encoder to be worth testing. The real codec is exercised end to end by
+ * the Electron e2e (`scripts/run-rewind-chunk-e2e.mjs`).
+ */
+
+import {
+  encodeChunk,
+  type ChunkContents,
+  type ChunkFrame
+} from '../../../main/rewind/chunks/chunkFormat'
+
+/**
+ * Codec preference order.
+ *
+ * H.264 first because it was measurably the smallest on this app's own capture
+ * output: on a 60-frame 1280x720 run, 136 KB against VP9's 201 KB. VP9 is the
+ * fallback rather than the default despite scoring higher on PSNR, because the
+ * fidelity both reach is far past what a screen recall thumbnail needs and the
+ * point of the feature is the bytes.
+ */
+export const CHUNK_CODEC_PREFERENCE = ['avc1.42001f', 'vp09.00.10.08', 'vp8'] as const
+
+/**
+ * Encoder target rate.
+ *
+ * A rate controller spends its budget whether or not the content needs it, so
+ * this number is a ceiling on a pathological chunk rather than the size of a
+ * normal one: the same 60-frame run measured 136 KB at 400 kbps and 136 KB at
+ * 150 kbps, because near-identical consecutive screens do not have 400 kbps of
+ * information in them. It is set high enough that a genuinely busy minute
+ * (video playback, fast scrolling) is not smeared.
+ */
+export const CHUNK_BITRATE = 400_000
+
+/** Chunks are addressed by frame index; the nominal rate only sets timestamps. */
+const NOMINAL_FPS = 1
+const FRAME_DURATION_US = 1_000_000 / NOMINAL_FPS
+
+export type SourceFrame = {
+  captureTsMs: number
+  /** The frame's stored JPEG bytes. */
+  jpeg: Uint8Array
+}
+
+export type EncodeChunkOptions = {
+  width: number
+  height: number
+  frames: SourceFrame[]
+  /** Overrides for tests; production passes nothing and uses the globals. */
+  deps?: Partial<EncoderDeps>
+}
+
+export type EncoderDeps = {
+  VideoEncoder: typeof globalThis.VideoEncoder
+  VideoFrame: typeof globalThis.VideoFrame
+  createImageBitmap: typeof globalThis.createImageBitmap
+  createCanvas: (width: number, height: number) => OffscreenCanvas
+}
+
+function defaultDeps(): EncoderDeps {
+  return {
+    VideoEncoder: globalThis.VideoEncoder,
+    VideoFrame: globalThis.VideoFrame,
+    // Bound, not referenced. `createImageBitmap` is a method on the global
+    // object and throws "Illegal invocation" when called with `this` undefined,
+    // which is exactly what happens once it is pulled out into a plain
+    // property. Constructors above are unaffected because `new` supplies its
+    // own receiver.
+    createImageBitmap: globalThis.createImageBitmap?.bind(globalThis),
+    createCanvas: (width, height) => new OffscreenCanvas(width, height)
+  }
+}
+
+export class ChunkEncodeError extends Error {}
+
+/**
+ * Copy a WebCodecs buffer source into bytes we own.
+ *
+ * `decoderConfig.description` is an `AllowSharedBufferSource`: an ArrayBuffer, a
+ * SharedArrayBuffer, or a view onto either. It is copied rather than referenced
+ * because the encoder may reuse the underlying storage once the callback
+ * returns, and the description has to outlive the encode to reach the file.
+ */
+function copyBufferSource(source: AllowSharedBufferSource): Uint8Array<ArrayBuffer> {
+  const view = ArrayBuffer.isView(source)
+    ? new Uint8Array(source.buffer as ArrayBufferLike, source.byteOffset, source.byteLength)
+    : new Uint8Array(source as ArrayBufferLike)
+  // Allocate our own storage and copy in, so the result is backed by a plain
+  // ArrayBuffer regardless of which of the three shapes arrived.
+  const copy = new Uint8Array(new ArrayBuffer(view.byteLength))
+  copy.set(view)
+  return copy
+}
+
+/**
+ * The first codec in the preference order this machine can actually encode.
+ *
+ * Returns null when none is available, which is a real outcome — a machine with
+ * no usable video encoder simply never compacts, and keeps its JPEGs.
+ */
+export async function pickChunkCodec(
+  width: number,
+  height: number,
+  deps: EncoderDeps = defaultDeps()
+): Promise<string | null> {
+  for (const codec of CHUNK_CODEC_PREFERENCE) {
+    try {
+      const support = await deps.VideoEncoder.isConfigSupported({
+        codec,
+        width,
+        height,
+        bitrate: CHUNK_BITRATE,
+        framerate: NOMINAL_FPS
+      })
+      if (support.supported) return codec
+    } catch {
+      // An unrecognised codec string throws rather than reporting unsupported.
+      // Either way it is not usable; try the next one.
+    }
+  }
+  return null
+}
+
+/**
+ * Encode a planned run into chunk bytes.
+ *
+ * Throws rather than returning a short chunk: the caller is about to delete the
+ * JPEGs these frames came from, and a chunk holding a prefix of them would take
+ * the rest with it. Every failure path here leaves the source files untouched.
+ */
+export async function encodeFramesToChunk(options: EncodeChunkOptions): Promise<Uint8Array> {
+  const deps = { ...defaultDeps(), ...options.deps }
+  const { width, height, frames } = options
+  if (frames.length === 0) throw new ChunkEncodeError('nothing to encode')
+
+  const codec = await pickChunkCodec(width, height, deps)
+  if (!codec) throw new ChunkEncodeError('no supported video encoder on this machine')
+
+  const encoded: ChunkFrame[] = []
+  let description = new Uint8Array()
+  let encoderError: Error | null = null
+
+  const encoder = new deps.VideoEncoder({
+    output: (chunk, metadata) => {
+      // The decoder description (avcC for H.264) arrives on metadata, usually
+      // only with the first chunk. Losing it makes the file undecodable, so it
+      // is captured from whichever chunk carries it.
+      const config = metadata?.decoderConfig
+      if (config?.description) description = copyBufferSource(config.description)
+      const data = new Uint8Array(chunk.byteLength)
+      chunk.copyTo(data)
+      encoded.push({
+        // Position in `encoded` is the frame's offset, and the encoder emits in
+        // order, so the source frame at this index is the one this belongs to.
+        captureTsMs: frames[encoded.length]?.captureTsMs ?? 0,
+        isKeyFrame: chunk.type === 'key',
+        data
+      })
+    },
+    error: (e: Error) => {
+      encoderError = e
+    }
+  })
+
+  encoder.configure({
+    codec,
+    width,
+    height,
+    bitrate: CHUNK_BITRATE,
+    framerate: NOMINAL_FPS,
+    latencyMode: 'quality'
+  })
+
+  const canvas = deps.createCanvas(width, height)
+  const context = canvas.getContext('2d')
+  if (!context) throw new ChunkEncodeError('no 2d context for chunk encoding')
+
+  try {
+    for (let i = 0; i < frames.length; i++) {
+      if (encoderError) throw encoderError
+      const bitmap = await deps.createImageBitmap(
+        new Blob([frames[i].jpeg as BlobPart], { type: 'image/jpeg' })
+      )
+      try {
+        // Every frame is drawn to the chunk's fixed geometry. The planner only
+        // groups frames that already share it, so this is a blit and not a
+        // rescale — but doing it through the canvas means a row whose stored
+        // width disagrees with its JPEG cannot produce a mis-sized VideoFrame.
+        context.drawImage(bitmap, 0, 0, width, height)
+      } finally {
+        bitmap.close()
+      }
+      // Presentation timestamps are derived from the frame INDEX, not from the
+      // capture clock. macOS derives them from a live capture rate and documents
+      // what that cost: a mid-chunk rate change made a later frame's timestamp
+      // fall below an already-appended one, which the writer rejects as
+      // non-monotonic, dropping frames and sometimes the whole chunk
+      // (VideoChunkEncoder.swift). An index is monotonic by construction, and
+      // the real capture time is carried per record in the container instead.
+      const frame = new deps.VideoFrame(canvas, {
+        timestamp: i * FRAME_DURATION_US,
+        duration: FRAME_DURATION_US
+      })
+      try {
+        encoder.encode(frame, { keyFrame: i === 0 })
+      } finally {
+        frame.close()
+      }
+    }
+
+    await encoder.flush()
+    if (encoderError) throw encoderError
+  } finally {
+    try {
+      encoder.close()
+    } catch {
+      // A closed-on-error encoder throws again on close; the original error is
+      // the one worth reporting.
+    }
+  }
+
+  if (encoded.length !== frames.length) {
+    throw new ChunkEncodeError(
+      `encoder returned ${encoded.length} frames for ${frames.length} inputs`
+    )
+  }
+
+  const contents: ChunkContents = { codec, description, width, height, frames: encoded }
+  return encodeChunk(contents)
+}

--- a/desktop/windows/src/renderer/src/rewind/frameImageSource.ts
+++ b/desktop/windows/src/renderer/src/rewind/frameImageSource.ts
@@ -1,0 +1,84 @@
+/**
+ * Turning a frame row into something an `<img>` can show, whichever way its
+ * pixels are stored.
+ *
+ * Exactly one of `imagePath` / `chunkPath` locates a frame. Callers should not
+ * have to know which — before compaction every frame was a JPEG and every call
+ * site said so, and the point of routing here is that they can go on not
+ * knowing.
+ *
+ * The reader is held across calls on purpose. A chunk is inter-frame
+ * compressed, so a scrub that reopened the decoder per frame would be quadratic
+ * in the chunk's length; keeping it alive makes a forward step one decode. That
+ * is the whole reason this is an object and not a function.
+ */
+
+import type { RewindFrame } from '../../../shared/types'
+import { ChunkFrameReader } from './chunkDecoder'
+
+/** Where a frame's pixels are. */
+export type FrameLocator =
+  | { kind: 'jpeg'; imagePath: string }
+  | { kind: 'chunk'; chunkPath: string; chunkOffset: number }
+  | { kind: 'missing' }
+
+/**
+ * Read a frame row's locator.
+ *
+ * A row carrying both is not a state the writer can produce (claiming a frame
+ * clears `image_path` in the same statement that sets `chunk_path`), but a
+ * corrupt or partially-migrated row could, so the chunk wins: it is the one the
+ * compactor verified before deleting anything.
+ */
+export function locateFrame(
+  frame: Pick<RewindFrame, 'imagePath' | 'chunkPath' | 'chunkOffset'>
+): FrameLocator {
+  const chunkPath = frame.chunkPath
+  const chunkOffset = frame.chunkOffset
+  if (typeof chunkPath === 'string' && chunkPath !== '' && typeof chunkOffset === 'number') {
+    return { kind: 'chunk', chunkPath, chunkOffset }
+  }
+  if (typeof frame.imagePath === 'string' && frame.imagePath !== '') {
+    return { kind: 'jpeg', imagePath: frame.imagePath }
+  }
+  return { kind: 'missing' }
+}
+
+/**
+ * Serves frame images to a view.
+ *
+ * One per view that shows frames. Object URLs it creates are owned by the
+ * caller, which must revoke them; `dispose` drops the decoder.
+ */
+export class FrameImageSource {
+  private reader: ChunkFrameReader | null = null
+
+  /**
+   * A `src` for this frame, or null when the row locates nothing.
+   *
+   * JPEG-backed frames come back as the data URL main has always returned.
+   * Chunk-backed frames are decoded here and come back as an object URL, which
+   * the caller revokes when it swaps images.
+   */
+  async srcFor(
+    frame: Pick<RewindFrame, 'imagePath' | 'chunkPath' | 'chunkOffset'>
+  ): Promise<{ src: string; revoke: boolean } | null> {
+    const locator = locateFrame(frame)
+    if (locator.kind === 'missing') return null
+    if (locator.kind === 'jpeg') {
+      const dataUrl = await window.omi.rewindFrameImage(locator.imagePath)
+      return { src: dataUrl, revoke: false }
+    }
+    if (!this.reader) this.reader = new ChunkFrameReader()
+    const blob = await this.reader.readFrame(locator.chunkPath, locator.chunkOffset, (path) =>
+      window.omi.rewindChunkBytes(path)
+    )
+    return { src: URL.createObjectURL(blob), revoke: true }
+  }
+
+  /** Drop the live decoder. The next chunk read reopens. */
+  dispose(): void {
+    this.reader?.retire()
+    this.reader = null
+  }
+}

--- a/desktop/windows/src/shared/types.ts
+++ b/desktop/windows/src/shared/types.ts
@@ -1005,6 +1005,14 @@ export type OmiBridgeApi = {
     session: { desktopApiBase: string; token: string } | null
   ) => Promise<void>
   rewindFrameImage: (imagePath: string) => Promise<string>
+  /** Raw bytes of one `.omichunk`, for the renderer to decode a frame out of. */
+  rewindChunkBytes: (chunkPath: string) => Promise<Uint8Array>
+  /** Run a compaction pass now. Returns what it wrote and what it skipped. */
+  rewindCompactNow: () => Promise<RewindCompactionResult>
+  /** The compactor asking this renderer to encode a run of frames. */
+  onRewindEncodeChunk: (cb: (request: RewindEncodeChunkRequest) => void) => () => void
+  /** This renderer's answer to that request. */
+  rewindChunkEncoded: (response: RewindEncodeChunkResponse) => void
   // --- Track 4 --- per-line OCR bounding boxes (normalized 0..1) for the
   // on-image search highlight overlay in the Rewind frame viewer.
   rewindFrameOcrLines: (frameId: number) => Promise<OcrLine[]>
@@ -2030,10 +2038,38 @@ export type RewindFrame = {
   windowTitle: string
   processName: string
   ocrText: string
+  /** Path to this frame's own JPEG, or `''` once it has been compacted. */
   imagePath: string
   width: number
   height: number
   indexed: number // 0 = not yet OCR'd, 1 = OCR done
+  /**
+   * Set once the frame has been compacted into a video chunk: the chunk's
+   * `<day>/<name>.omichunk` relative path and this frame's position inside it.
+   * Exactly one of `imagePath` / `chunkPath` locates a frame's pixels — see
+   * `main/rewind/chunks/ARCHITECTURE.md`.
+   */
+  chunkPath?: string | null
+  chunkOffset?: number | null
+}
+
+/** One run of frames the compactor wants turned into a chunk. */
+export type RewindEncodeChunkRequest = {
+  requestId: string
+  width: number
+  height: number
+  frames: { captureTsMs: number; jpeg: Uint8Array }[]
+}
+
+export type RewindEncodeChunkResponse =
+  | { requestId: string; ok: true; bytes: Uint8Array }
+  | { requestId: string; ok: false; error: string }
+
+export type RewindCompactionResult = {
+  chunksWritten: number
+  framesCompacted: number
+  bytesReclaimed: number
+  skipped: { chunk: string; reason: string }[]
 }
 
 export type RewindSearchGroup = {


### PR DESCRIPTION
Windows Rewind stores one JPEG per captured frame. Capture runs at one frame per second and retention defaults to 14 days, so the folder grows without any bound the user can see. This packs older frames into inter-frame-compressed video chunks, which is what macOS has done since the start.

## The measurement

Taken on this machine's own capture path at the shipped `standard` quality tier (1280x720, JPEG quality 0.7), over a real 60-second run of ordinary desktop work:

| Storage | Per frame | Per 60s chunk |
|---|---|---|
| JPEG (what ships today) | 115.8 KB | 6.95 MB |
| H.264 chunk @ 400 kbps | **2.26 KB** | **136 KB** |
| VP9 chunk @ 400 kbps | 3.35 KB | 201 KB |

51x, with all 60 frames decoding back at 37 to 41 dB PSNR against their sources. The saving is that large because consecutive frames of a screen are nearly identical, which is exactly the redundancy a JPEG-per-frame store cannot use and an inter-frame codec exists for. Scaled to the shipped defaults that is roughly 25 GB against roughly 0.5 GB for a fortnight of active use.

## Compaction, not live encoding

This is the deliberate divergence and everything else follows from it.

macOS encodes live: `VideoChunkEncoder.addFrame` takes each frame as it is captured and appends it to the chunk being written. Windows compacts after the fact. Capture keeps writing JPEGs exactly as it always has, and a background pass every 30 minutes packs runs older than 30 minutes.

Live encoding puts the codec in the capture path, and a bug there costs frames that no longer exist anywhere. Compacting instead means capture is untouched, a failed compaction leaves the JPEGs where they were, turning it off changes nothing about how frames are stored, and the backlog already on disk gets compacted too.

It also removes most of the machinery macOS needs. Because macOS encodes live, its rows necessarily exist while the chunk is still being written, so it carries a sidecar journal of abandoned writers, a quarantine table, and a generation/reservation ownership model to stop a stale finaliser clearing a newer writer's state. Here nothing references a chunk until it is finished, so none of that is load-bearing. The tombstone table is kept, because a chunk can still be found corrupt at read time long after it was written.

## The ordering that makes it safe

```
write chunk  ->  read it back and verify  ->  claim frame  ->  delete its JPEG
```

Every prefix is a safe place to crash.

| Crash after | State | Who cleans up |
|---|---|---|
| write | an unreferenced chunk file | the chunk sweep, after its grace period |
| verify | same | same |
| a claim | claimed frames read from a chunk proven to hold them; unclaimed frames still have their JPEGs | nothing to clean, the chunk holds a superset |
| a claim, before the delete | an orphaned JPEG | the existing orphan sweep |

Verify re-reads from disk rather than checking the buffer just written, so it also catches a write that never landed or landed short, and it checks the capture timestamp at every offset. That last check is the one that matters: a chunk with the right frame count but a shifted order would make every read return a neighbouring frame, silently.

## Rules worth knowing

**Only OCR'd frames are compacted.** The OCR backlog sweep reads `image_path` for `indexed = 0` frames and, when the file is missing, marks the frame indexed with empty text rather than failing (`ocrService.ts`). Compacting an un-OCR'd frame would therefore not error, it would quietly cost that frame its searchable text forever. This is the reason the compactor cannot simply take the oldest frames.

**Runs shorter than 8 frames are left alone.** Measured, a 5-frame run reached only 2.4x against a 60-frame run's 51x, because the opening key frame is most of a short chunk.

**Presentation timestamps come from the frame index, not the capture clock.** macOS derives them from a live capture rate and documents what that cost: a mid-chunk rate change made a later frame's timestamp fall below an already-appended one, which `AVAssetWriter` rejects as non-monotonic, dropping frames and sometimes the whole chunk. An index is monotonic by construction, and the real capture time travels per record in the container.

**The read cursor is one-way.** A chunk has no random access, so reopening per request makes a scrub quadratic. macOS measured 728 ms to walk an 18-frame chunk reopening each time against 59 ms keeping the reader alive, 12.3x and pixel-identical. The decision of when the open decoder can be reused is a pure state machine; the decoding that executes it needs a codec and lives in the renderer.

**A chunk is self-describing.** `rebuildIndex.ts` exists because Windows can re-create `rewind_frames` rows from `<day>/<ts>.jpg` after a database wipe. Compaction would have quietly taken that away from every frame it packed, leaving intact pixels that nothing references and that the sweep would then delete, so each record carries the timestamp its filename used to.

## Why a custom container

`.omichunk` rather than MP4. AVFoundation is a muxer-first API, so macOS gets a container whether it wants one or not. WebCodecs is codec-first, emitting bare `EncodedVideoChunk`s and accepting them back, so an MP4 here would mean writing a muxer and a demuxer to put bytes into a box structure and immediately take them out again. Frame N is record N, which is the same number stored in `chunk_offset`, and parsing is defensive: a truncated file raises rather than returning the frames it managed to read, because the compactor treats "reads back exactly" as the precondition for deleting anything.

## What running the real codec found

Three defects that reasoning did not, and all three would have shipped broken:

- `createImageBitmap` taken as a bare property reference throws "Illegal invocation". It is a method on the global object and loses its receiver.
- The container used Node's `Buffer`, which does not exist in a renderer.
- Flushing the decoder between reads breaks the cursor on the very next step, because WebCodecs requires a key frame after a flush. The tape now decodes incrementally and only flushes at the end of a chunk.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,414 passed, 18 skipped, 552 files. 179 of those are this feature; the branch point was 5,235.
- `npx tsc --noEmit` on `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint .` - 0 errors.
- `npx electron-vite build` - clean.
- `check_lifecycle_headers.py`, `check_brand_ui.py`, `check_arch_guardrails.py` - pass.
- `node --test e2e/rewind-chunks.spec.mjs` - passes against a real H.264 encoder.

The E2E is the only place the central claim can be made honestly, so it drives the production encoder and reader inside a real Electron renderer rather than a copy of them: 60 frames in, 60 out, 11,687 KB of JPEGs into a 1,813 KB chunk, worst mean per-channel pixel difference 1.69 of 255. Its frames are deliberately adversarial, dense high-entropy text with a full line changing every frame, which is why it measures 6.4x where real capture output measured 51x.

## Mutation audit

67 regressions seeded, 62 caught. Three findings are worth reporting rather than burying.

**One test could not fail.** It sized its fixtures from the very constant it was asserting, so lowering the minimum chunk length from 8 to 1 shrank the fixtures with it and the assertion still passed. It pins the literal now.

**Three guards were masking each other.** The compaction candidate query had two clauses that both excluded the same row, so either alone looked sufficient. The offset ordering was asserted with offsets that happened to ascend with rowid, so SQLite returned the right answer with the `ORDER BY` deleted. A chunk-listing extension filter was already subsumed by the path validator two lines below it. The first two now have cases that separate them; the third is deleted, because a guard that cannot be shown to matter is a guard that will drift.

**Four corruption cases in the container had no coverage at all** - a zero frame count, an empty declared geometry, an out-of-range header length, and the header scan's own frame ceiling. All four do now.

Five mutations still escape, and all five are defence in depth whose effect is genuinely unobservable today: the path containment check and the whitespace check, both behind a regex that already rejects what they catch; the atomic write's rename, which only shows up if the process dies mid-write; the day-directory filter, behind the same path validator; and the candidate query's id tiebreak, which SQLite happens to satisfy anyway. Each is documented where it sits with why it is kept, rather than covered by a test that would only be asserting the mutation.

## What is not here

Live encoding, and with it macOS' aspect-ratio debounce, frame-rate freeze, buffer-overflow emergency reset and writer-not-ready retry ladder, all of which exist to keep a live encoder healthy in the capture path. The reservation and generation ownership model, for the reason above. macOS' 3000px downscale cap, which would never bind because Windows already caps captured frames by quality tier at 2560x1440.

OCR cannot read a chunk-backed frame, which only matters after a database wipe: rebuilt chunk rows come back with their pixels but without their text, because the text lived only in the wiped database and was never written into a chunk. Teaching OCR to decode chunks needs a renderer and is its own change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

