### PR TITLE
fix(backend): bound the memory list page's suppressed-row walk in seconds, not only rows (#11803)

### DIFF
--- a/backend/tests/unit/test_universal_memory_list_cursor.py
+++ b/backend/tests/unit/test_universal_memory_list_cursor.py
@@ -429,6 +429,50 @@ def test_fully_suppressed_historical_set_stops_at_the_scan_row_budget(service_mo
     assert scanned < total
 
 
+def test_scan_budget_stops_on_the_wall_clock_deadline_before_the_row_budget(service_mod, monkeypatch):
+    """Prod 2026-08-18T08:09Z+: first pages still 504'd after the row budget shipped.
+
+    4000 skipped rows is ~80 sequential Firestore round trips, so a slow account
+    burned the whole 30s edge budget inside the bound and left the offset-read
+    fallback no time to answer. The walk must stop on elapsed seconds too, well
+    before the row budget is spent.
+    """
+    from fastapi import HTTPException
+    from models.product_memory import MemoryItemStatus
+
+    monkeypatch.setattr(service_mod, "MEMORY_LIST_SCAN_DEADLINE_SECONDS", 0.0)
+    service = service_mod.MemoryService(db_client=_Db())
+    total = 400
+    historical = [_dated_historical(service_mod, f"h-{index:05d}", day=9000 - index) for index in range(total)]
+    statuses = {f"h-{index:05d}": MemoryItemStatus.tombstoned for index in range(total)}
+    _, updated_mock, _ = _install_streams(service, service_mod, canonical=[], historical=historical, statuses=statuses)
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.read_page("uid-test", limit=8, cursor=None)
+
+    assert exc_info.value.status_code == 503
+    # Same detail the route's first-page fallback already keys on.
+    assert exc_info.value.detail == service_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL
+    # Time stopped the walk, not rows: far fewer rows were scanned than the row budget allows.
+    scanned = sum(call.kwargs["limit"] for call in updated_mock.call_args_list)
+    assert scanned < service_mod.MEMORY_LIST_SCAN_ROW_BUDGET
+
+
+def test_scan_budget_charges_within_the_deadline_do_not_raise(service_mod):
+    """The deadline is elapsed-time, not per-charge: charges before it are free."""
+    from fastapi import HTTPException
+
+    ticks = iter([100.0, 101.0, 105.9, 106.0])
+    budget = service_mod._ScanRowBudget(deadline_seconds=6.0, clock=lambda: next(ticks))
+
+    budget.charge()
+    budget.charge()
+
+    with pytest.raises(HTTPException) as exc_info:
+        budget.charge()
+    assert exc_info.value.detail == service_mod.MEMORY_LIST_SCAN_BUDGET_DETAIL
+
+
 def test_suppressed_prefix_under_the_budget_still_serves_the_page(service_mod, monkeypatch):
     """The budget bounds pathological accounts only — ordinary skips still page."""
     from models.product_memory import MemoryItemStatus

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -1,6 +1,7 @@
 """Memory routing seam — surfaces route reads/writes/search through MemoryService (WS-L)."""
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterable, Iterator, List, NoReturn, Optional, Tuple, cast
@@ -849,20 +850,37 @@ class HistoricalMemoryAdapter:
 # actually started serving. Bound the skipped work per request so a page either
 # lands or fails fast into the route's offset-read fallback.
 MEMORY_LIST_SCAN_ROW_BUDGET = 4000
+# The row budget alone does not bound the wall clock: 4000 skipped rows is ~80
+# sequential Firestore round trips, which at prod latency still lands near the
+# 30s edge timeout — and the offset-read fallback the budget exists to reach
+# then has no time left to answer. First pages kept 504ing after the row budget
+# shipped (~40/h on 2026-08-18T08:09Z+, offset=0 only) for exactly that reason.
+# Bound the skipped walk in seconds too, leaving the bulk of the request budget
+# for the fallback read.
+MEMORY_LIST_SCAN_DEADLINE_SECONDS = 6.0
 MEMORY_LIST_SCAN_BUDGET_DETAIL = "Memory scan budget exceeded"
 
 
 class _ScanRowBudget:
-    """Bounds the rows one ``read_page`` call may skip without emitting."""
+    """Bounds the rows and the seconds one ``read_page`` call may skip without emitting."""
 
-    def __init__(self, limit: Optional[int] = None) -> None:
-        # Read the module constant at construction, not as a default argument,
-        # so the bound stays tunable in one place.
+    def __init__(
+        self,
+        limit: Optional[int] = None,
+        *,
+        deadline_seconds: Optional[float] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        # Read the module constants at construction, not as default arguments,
+        # so the bounds stay tunable in one place.
         self._remaining = max(1, int(MEMORY_LIST_SCAN_ROW_BUDGET if limit is None else limit))
+        self._clock = clock
+        seconds = MEMORY_LIST_SCAN_DEADLINE_SECONDS if deadline_seconds is None else deadline_seconds
+        self._deadline = clock() + max(0.0, float(seconds))
 
     def charge(self) -> None:
         self._remaining -= 1
-        if self._remaining < 0:
+        if self._remaining < 0 or self._clock() >= self._deadline:
             raise HTTPException(status_code=503, detail=MEMORY_LIST_SCAN_BUDGET_DETAIL)
 
 


### PR DESCRIPTION
## Bug

`GET /v3/memories` still 504s at the 30s edge timeout after PR #11800's scan row budget reached prod. I dispatched the prod deploy of `922b30db1c` this morning (`backend-922b30d-32113104414-1` took 100% traffic at ~08:09Z); the 504 rate fell from ~110/h to ~40/h but did not go to zero — still **first pages only** (`offset=0`, limit 8/100/500/5000), while successful first pages run at p90 5–11s with maxima of 26–28s.

```
('8',    'off0', 504) n=4 p50 30.01 max 30.36
('100',  'off0', 504) n=3 p50 30.00
('5000', 'off0', 504) n=3 p50 30.00
('8',    'off0', 200) n=185 p50 0.72 p90 10.84 max 26.59
```

## Root cause

`MEMORY_LIST_SCAN_ROW_BUDGET = 4000` bounds *rows*, not *seconds*. 4000 skipped rows is ~80 sequential Firestore round trips, so a slow account can spend most of the 30s request budget inside the bound — and the offset-read fallback the budget exists to reach then has no time left to answer. The request 504s anyway, which is exactly the failure class the bound was meant to close.

## Fix

Give the shared per-request `_ScanRowBudget` a wall-clock deadline (6s) alongside the row bound. Exhausting either raises the same `Memory scan budget exceeded` 503 the route's first-page fallback already keys on, so the page is served from the offset read — which does not walk suppressed rows — with the bulk of the request budget still unspent. The clock is injectable so the deadline is asserted without sleeping.

## Tested

- `backend/test.sh` over all 85 `*memor*` test files (`BACKEND_UNIT_TEST_FILE_LIST`) — green, no failures.
- The two new tests fail on clean `origin/main` with the source hunk stashed (`TypeError: _ScanRowBudget.__init__() got an unexpected keyword argument 'deadline_seconds'`; the deadline test otherwise scans past the row budget) and pass with it.
- `make preflight` — green with the line-count exception below.
- Post-merge: I will deploy prod and confirm the `/v3/memories` 504 rate goes to zero on the new revision.

## Product invariants

- **INV-MEM-1**, **INV-MEM-3** — path-glob match on `backend/utils/memory/memory_service.py`. The diff changes no tier vocabulary, no collection layout, no exposure policy and no ordering: it only bounds how long one page may walk rows it must not emit before falling back to the read path that already serves the same page.

Failure-Class: FC-bounded-read-exceeds-request-budget

Line-Count-Exception: backend/utils/memory/memory_service.py | 2540 -> 2558 | one wall-clock bound plus its incident comment inside the existing scan-budget class; splitting the file is not in scope for a live-504 fix

Fixes #11803

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

