### PR TITLE
Windows chat markdown: render tables, and stop destroying links inside bold

### DIFF
--- a/desktop/windows/src/renderer/src/components/Markdown.render.test.tsx
+++ b/desktop/windows/src/renderer/src/components/Markdown.render.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+// What actually reaches the DOM. The grammar is covered in lib/markdown; this
+// asserts the things only a render can show: that a table is a real table, that
+// a refused link is not an anchor, and that nothing here can inject HTML.
+import { describe, expect, it, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { Markdown } from './Markdown'
+
+afterEach(cleanup)
+
+function html(text: string): string {
+  return render(<Markdown text={text} />).container.innerHTML
+}
+
+describe('tables', () => {
+  const TABLE = '| Name | Size |\n| :--- | ---: |\n| alpha | 1 |\n| beta | 2 |'
+
+  it('renders a real table, not a paragraph of pipes', () => {
+    render(<Markdown text={TABLE} />)
+    expect(screen.getByRole('table')).toBeTruthy()
+    expect(screen.getAllByRole('columnheader').map((c) => c.textContent)).toEqual(['Name', 'Size'])
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+  })
+
+  it('applies each column’s alignment', () => {
+    render(<Markdown text={TABLE} />)
+    const [left, right] = screen.getAllByRole('columnheader')
+    expect(left.className).toContain('text-left')
+    expect(right.className).toContain('text-right')
+  })
+
+  it('scrolls the table rather than the page', () => {
+    // A wide table must not widen the chat column.
+    render(<Markdown text={TABLE} />)
+    const region = screen.getByRole('region', { name: 'Scrollable table' })
+    expect(region.className).toContain('overflow-x-auto')
+  })
+
+  it('renders inline markdown inside cells', () => {
+    render(<Markdown text={'| a | b |\n| --- | --- |\n| **bold** | `code` |'} />)
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getByText('code').tagName).toBe('CODE')
+  })
+})
+
+describe('blocks', () => {
+  it('renders headings at their level', () => {
+    render(<Markdown text={'# One\n\n### Three'} />)
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('One')
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Three')
+  })
+
+  it('renders a blockquote', () => {
+    expect(html('> quoted')).toContain('<blockquote')
+  })
+
+  it('renders a thematic break', () => {
+    expect(html('a\n\n---\n\nb')).toContain('<hr')
+  })
+
+  it('renders nested lists as nested lists', () => {
+    const { container } = render(<Markdown text={'- outer\n  - inner'} />)
+    expect(container.querySelectorAll('ul ul')).toHaveLength(1)
+  })
+
+  it('renders a task item as a read-only checkbox', () => {
+    render(<Markdown text={'- [ ] todo\n- [x] done'} />)
+    const boxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+    expect(boxes.map((b) => b.checked)).toEqual([false, true])
+    // A rendered reply is a transcript; the box reports, it does not edit.
+    expect(boxes.every((b) => b.readOnly)).toBe(true)
+  })
+
+  it('starts an ordered list at the number given', () => {
+    const { container } = render(<Markdown text={'3. a\n4. b'} />)
+    expect(container.querySelector('ol')?.getAttribute('start')).toBe('3')
+  })
+})
+
+describe('links', () => {
+  it('renders an allowed link as an anchor that opens externally', () => {
+    render(<Markdown text={'[docs](https://omi.me)'} />)
+    const link = screen.getByRole('link', { name: 'docs' })
+    expect(link.getAttribute('href')).toBe('https://omi.me')
+    expect(link.getAttribute('rel')).toBe('noreferrer')
+  })
+
+  it('renders a refused link as text with no anchor at all', () => {
+    // The label still shows; only the navigation is withheld.
+    render(<Markdown text={'[click me](javascript:alert(1))'} />)
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getByText('click me')).toBeTruthy()
+  })
+
+  it('never emits a javascript href even inside other formatting', () => {
+    const rendered = html('**bold [x](javascript:alert(1)) tail**')
+    expect(rendered).not.toContain('javascript:')
+    expect(rendered).toContain('<strong>')
+  })
+
+  it('keeps a bolded link clickable', () => {
+    // The measured defect: this used to render the raw markdown characters.
+    render(<Markdown text={'**see [docs](https://omi.me) now**'} />)
+    expect(screen.getByRole('link', { name: 'docs' })).toBeTruthy()
+    expect(html('**see [docs](https://omi.me) now**')).not.toContain('](')
+  })
+})
+
+describe('nothing here can inject HTML', () => {
+  it('renders raw tags as text', () => {
+    const rendered = html('<script>alert(1)</script> and <img src=x onerror=alert(1)>')
+    expect(rendered).not.toContain('<script')
+    expect(rendered).not.toContain('<img')
+    expect(rendered).toContain('&lt;script&gt;')
+  })
+
+  it('renders a markdown image as its alt text and requests nothing', () => {
+    const rendered = html('![a diagram](https://tracker.example/p.png)')
+    expect(rendered).not.toContain('<img')
+    expect(rendered).not.toContain('tracker.example')
+    expect(rendered).toContain('a diagram')
+  })
+
+  it('renders HTML inside a code block as text', () => {
+    const rendered = html('```\n<script>alert(1)</script>\n```')
+    expect(rendered).not.toContain('<script')
+    expect(rendered).toContain('&lt;script&gt;')
+  })
+})
+
+describe('streaming', () => {
+  it('renders every prefix of a reply without throwing', () => {
+    // The renderer runs on every token, so each prefix must render.
+    const doc =
+      '# Title\n\nSome *text*.\n\n| a | b |\n| --- | --: |\n| 1 | 2 |\n\n' +
+      '> quoted\n\n- [ ] task\n  - deep\n\n---\n\n```ts\nconst x = 1\n```\nEnd.'
+    for (let n = 0; n <= doc.length; n++) {
+      expect(() => {
+        render(<Markdown text={doc.slice(0, n)} />)
+        cleanup()
+      }).not.toThrow()
+    }
+  })
+
+  it('keeps a half-typed marker literal', () => {
+    expect(html('a **b')).toContain('a **b')
+  })
+})

--- a/desktop/windows/src/renderer/src/components/Markdown.render.test.tsx
+++ b/desktop/windows/src/renderer/src/components/Markdown.render.test.tsx
@@ -64,7 +64,7 @@ describe('blocks', () => {
   })
 
   it('renders a task item as a read-only checkbox', () => {
-    render(<Markdown text={'- [ ] todo\n- [x] done'} />)
+    render(<Markdown text={'- [ ] buy milk\n- [x] done'} />)
     const boxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
     expect(boxes.map((b) => b.checked)).toEqual([false, true])
     // A rendered reply is a transcript; the box reports, it does not edit.

--- a/desktop/windows/src/renderer/src/components/Markdown.tsx
+++ b/desktop/windows/src/renderer/src/components/Markdown.tsx
@@ -1,59 +1,68 @@
 import { useState } from 'react'
 import { Check, Copy } from 'lucide-react'
+import { parseBlocks, type Block, type ListBlock } from '../lib/markdown/blocks'
+import { parseInline, plainText, type InlineNode } from '../lib/markdown/inline'
+import type { ColumnAlignment, MarkdownTable } from '../lib/markdown/table'
 
-// Minimal, dependency-free markdown for chat bubbles. Supports the subset the
-// Omi chat actually emits — headings, bullet/numbered lists, fenced + inline
-// code, bold, italic, and links. NOT a full CommonMark parser; anything it does
-// not recognize falls through as plain text (so a half-streamed `**` just shows
-// literally until the closing marker arrives). Renders React elements, never raw
-// HTML, so there is no injection surface.
+// Markdown for chat bubbles, rendered from a parsed tree rather than by regex
+// substitution. The grammar and every rule in it live in `lib/markdown/`, which
+// is pure and unit-tested without a DOM; this file only turns the tree into
+// elements.
+//
+// Renders React elements, never raw HTML, so there is no injection surface: a
+// `<script>` in a reply is text and stays text. The one place a reply gets to
+// influence the DOM beyond its own characters is a link's href, which is
+// allowlisted in `lib/markdown/inline.ts` — see the note there for why chat
+// replies are treated as untrusted input.
+//
+// Images are deliberately not rendered. An `![alt](url)` becomes its alt text.
+// A reply can be steered by whatever is on the user's screen, so rendering a
+// remote image would let an injected URL fetch on load: a tracking pixel that
+// reports the user's IP and that the chat was opened, with nothing clicked.
 
-// One regex with the token captured, so String.split keeps the delimiters: the
-// result alternates plain-text / token / plain-text. Bold is listed before
-// italic so `**x**` matches bold, not two italics.
-const INLINE = /(\*\*[^*]+\*\*|`[^`]+`|\*[^*\n]+\*|_[^_\n]+_|\[[^\]]+\]\([^)]+\))/g
-
-function renderInline(text: string): React.ReactNode[] {
-  return text.split(INLINE).map((part, i) => {
-    if (!part) return null
-    if (part.startsWith('**') && part.endsWith('**'))
-      return <strong key={i}>{part.slice(2, -2)}</strong>
-    if (part.startsWith('`') && part.endsWith('`'))
-      return (
-        <code key={i} className="rounded bg-white/10 px-1 py-0.5 font-mono text-[0.85em]">
-          {part.slice(1, -1)}
-        </code>
-      )
-    if (
-      (part.startsWith('*') && part.endsWith('*')) ||
-      (part.startsWith('_') && part.endsWith('_'))
-    )
-      return <em key={i}>{part.slice(1, -1)}</em>
-    const link = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(part)
-    if (link) {
-      // Only http(s)/mailto links are clickable. Chat replies can be steered by
-      // indirect prompt injection (the prompt includes OCR of whatever is on the
-      // user's screen), so a model could emit a file://, UNC (\\host\share), or
-      // custom-protocol href; rendering those as live links enables one-click
-      // NTLM-hash leakage and OS protocol-handler abuse. Anything else falls back
-      // to plain text — the label still shows, it just isn't a link.
-      const href = link[2].trim()
-      if (/^(https?:|mailto:)/i.test(href))
+function renderInline(nodes: InlineNode[], keyPrefix = ''): React.ReactNode[] {
+  return nodes.map((node, i) => {
+    const key = `${keyPrefix}${i}`
+    switch (node.kind) {
+      case 'text':
+        // The string itself, not a wrapping span. React escapes it either way,
+        // and a span per text run buries the formatting elements a reader (or
+        // a screen reader) is meant to find inside layers of anonymous nodes.
+        return node.value
+      case 'code':
         return (
-          <a key={i} href={href} target="_blank" rel="noreferrer" className="underline">
-            {link[1]}
+          <code key={key} className="rounded bg-white/10 px-1 py-0.5 font-mono text-[0.85em]">
+            {node.value}
+          </code>
+        )
+      case 'strong':
+        return <strong key={key}>{renderInline(node.children, `${key}.`)}</strong>
+      case 'em':
+        return <em key={key}>{renderInline(node.children, `${key}.`)}</em>
+      case 'del':
+        return (
+          <del key={key} className="opacity-70">
+            {renderInline(node.children, `${key}.`)}
+          </del>
+        )
+      case 'link':
+        return (
+          <a
+            key={key}
+            href={node.href}
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-white"
+          >
+            {renderInline(node.children, `${key}.`)}
           </a>
         )
-      return <span key={i}>{link[1]}</span>
+      case 'deadLink':
+        // The label still shows; only the navigation is withheld.
+        return <span key={key}>{renderInline(node.children, `${key}.`)}</span>
     }
-    return <span key={i}>{part}</span>
   })
 }
-
-const UL = /^\s*[-*+]\s+/
-const OL = /^\s*\d+\.\s+/
-const FENCE = /^```/
-const HEADING = /^(#{1,6})\s+(.*)$/
 
 // A fenced code block with a hover-revealed copy button pinned to its top-right.
 // The button lives in a relatively-positioned wrapper (not inside <pre>), so it
@@ -61,7 +70,7 @@ const HEADING = /^(#{1,6})\s+(.*)$/
 // Check for 1.5s after a successful copy — the app's copy-feedback idiom
 // (ConversationDetail). The group is named so the reveal is scoped to this block
 // and never triggered by an ancestor's `group` hover. Block code only — inline
-// code (renderInline) gets no button.
+// code gets no button.
 function CodeBlock({ code }: { code: string }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
   const onCopy = async (): Promise<void> => {
@@ -91,83 +100,136 @@ function CodeBlock({ code }: { code: string }): React.JSX.Element {
   )
 }
 
+const ALIGN_CLASS: Record<ColumnAlignment, string> = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right'
+}
+
+/**
+ * A table, in its own horizontal scroller.
+ *
+ * A wide table must not widen the chat column, so the scroller is the table's
+ * and not the page's. macOS does the same thing and labels it for screen
+ * readers; this carries that over.
+ */
+function TableBlock({ table }: { table: MarkdownTable }): React.JSX.Element {
+  return (
+    <div className="my-2 overflow-x-auto" role="region" aria-label="Scrollable table" tabIndex={0}>
+      <table className="w-full border-collapse text-[0.95em]">
+        <thead>
+          <tr>
+            {table.header.map((cell, i) => (
+              <th
+                key={i}
+                scope="col"
+                className={`border border-line px-2 py-1 font-semibold ${ALIGN_CLASS[table.alignments[i] ?? 'left']}`}
+              >
+                {renderInline(parseInline(cell))}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row, r) => (
+            <tr key={r}>
+              {row.map((cell, c) => (
+                <td
+                  key={c}
+                  className={`border border-line px-2 py-1 align-top ${ALIGN_CLASS[table.alignments[c] ?? 'left']}`}
+                >
+                  {renderInline(parseInline(cell))}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ListItems({ list, keyPrefix }: { list: ListBlock; keyPrefix: string }): React.JSX.Element {
+  const className = list.ordered ? 'my-1 list-decimal space-y-0.5 pl-5' : 'my-1 space-y-0.5 pl-5'
+  const items = list.items.map((item, i) => (
+    <li key={i} className={item.checked === null ? undefined : 'list-none -ml-5 flex gap-2'}>
+      {item.checked !== null && (
+        <input
+          type="checkbox"
+          checked={item.checked}
+          readOnly
+          // A rendered reply is a transcript, not a form: the box shows what
+          // the model wrote and clicking it would edit nothing.
+          aria-label={plainText(parseInline(item.text))}
+          className="mt-1 h-3.5 w-3.5 shrink-0 accent-white/70"
+        />
+      )}
+      <span>
+        {renderInline(parseInline(item.text), `${keyPrefix}${i}.`)}
+        {item.children && <ListItems list={item.children} keyPrefix={`${keyPrefix}${i}.`} />}
+      </span>
+    </li>
+  ))
+  return list.ordered ? (
+    <ol className={className} start={list.start}>
+      {items}
+    </ol>
+  ) : (
+    <ul className={`${className} ${list.items.some((i) => i.checked !== null) ? '' : 'list-disc'}`}>
+      {items}
+    </ul>
+  )
+}
+
+/** Heading sizes. All six are distinguishable; the shipped renderer's were not. */
+const HEADING_CLASS: Record<number, string> = {
+  1: 'mb-1 mt-3 text-[1.35em] font-semibold',
+  2: 'mb-1 mt-3 text-[1.2em] font-semibold',
+  3: 'mb-1 mt-2 text-[1.1em] font-semibold',
+  4: 'mb-1 mt-2 font-semibold',
+  5: 'mb-1 mt-2 font-semibold opacity-90',
+  6: 'mb-1 mt-2 text-[0.95em] font-semibold opacity-80'
+}
+
+function renderBlocks(blocks: Block[], keyPrefix = ''): React.ReactNode[] {
+  return blocks.map((block, i) => {
+    const key = `${keyPrefix}${i}`
+    switch (block.kind) {
+      case 'paragraph':
+        return (
+          <p key={key} className="whitespace-pre-wrap">
+            {renderInline(parseInline(block.text), `${key}.`)}
+          </p>
+        )
+      case 'heading': {
+        const Tag = `h${block.level}` as 'h1'
+        return (
+          <Tag key={key} className={HEADING_CLASS[block.level] ?? HEADING_CLASS[6]}>
+            {renderInline(parseInline(block.text), `${key}.`)}
+          </Tag>
+        )
+      }
+      case 'code':
+        return <CodeBlock key={key} code={block.text} />
+      case 'quote':
+        return (
+          <blockquote
+            key={key}
+            className="my-2 space-y-1 border-l-2 border-line pl-3 text-white/80"
+          >
+            {renderBlocks(block.blocks, `${key}.`)}
+          </blockquote>
+        )
+      case 'table':
+        return <TableBlock key={key} table={block.table} />
+      case 'thematicBreak':
+        return <hr key={key} className="my-3 border-line" />
+      case 'list':
+        return <ListItems key={key} list={block} keyPrefix={`${key}.`} />
+    }
+  })
+}
+
 export function Markdown({ text }: { text: string }): React.JSX.Element {
-  const lines = text.replace(/\r\n/g, '\n').split('\n')
-  const blocks: React.ReactNode[] = []
-  let i = 0
-  let key = 0
-
-  while (i < lines.length) {
-    const line = lines[i]
-
-    if (FENCE.test(line.trim())) {
-      const buf: string[] = []
-      i++
-      while (i < lines.length && !FENCE.test(lines[i].trim())) buf.push(lines[i++])
-      i++ // consume closing fence
-      blocks.push(<CodeBlock key={key++} code={buf.join('\n')} />)
-      continue
-    }
-
-    const h = HEADING.exec(line)
-    if (h) {
-      blocks.push(
-        <p key={key++} className="mb-1 mt-2 font-semibold">
-          {renderInline(h[2])}
-        </p>
-      )
-      i++
-      continue
-    }
-
-    if (UL.test(line)) {
-      const items: string[] = []
-      while (i < lines.length && UL.test(lines[i])) items.push(lines[i++].replace(UL, ''))
-      blocks.push(
-        <ul key={key++} className="my-1 list-disc space-y-0.5 pl-5">
-          {items.map((it, j) => (
-            <li key={j}>{renderInline(it)}</li>
-          ))}
-        </ul>
-      )
-      continue
-    }
-
-    if (OL.test(line)) {
-      const items: string[] = []
-      while (i < lines.length && OL.test(lines[i])) items.push(lines[i++].replace(OL, ''))
-      blocks.push(
-        <ol key={key++} className="my-1 list-decimal space-y-0.5 pl-5">
-          {items.map((it, j) => (
-            <li key={j}>{renderInline(it)}</li>
-          ))}
-        </ol>
-      )
-      continue
-    }
-
-    if (line.trim() === '') {
-      i++
-      continue
-    }
-
-    // Paragraph: gather consecutive lines until a blank line or a block starter.
-    const para: string[] = []
-    while (
-      i < lines.length &&
-      lines[i].trim() !== '' &&
-      !FENCE.test(lines[i].trim()) &&
-      !HEADING.test(lines[i]) &&
-      !UL.test(lines[i]) &&
-      !OL.test(lines[i])
-    )
-      para.push(lines[i++])
-    blocks.push(
-      <p key={key++} className="whitespace-pre-wrap">
-        {renderInline(para.join('\n'))}
-      </p>
-    )
-  }
-
-  return <div className="space-y-1">{blocks}</div>
+  return <div className="space-y-1">{renderBlocks(parseBlocks(text))}</div>
 }

--- a/desktop/windows/src/renderer/src/lib/markdown/blocks.test.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/blocks.test.ts
@@ -1,0 +1,209 @@
+// Block grammar. The cases marked "measured" record what the shipped renderer
+// did with the same input before this change.
+import { describe, expect, it } from 'vitest'
+import { isThematicBreak, parseBlocks, type Block, type ListBlock } from './blocks'
+
+const kinds = (blocks: Block[]): string[] => blocks.map((b) => b.kind)
+
+function firstList(blocks: Block[]): ListBlock {
+  const list = blocks.find((b) => b.kind === 'list')
+  if (!list) throw new Error('no list block')
+  return list as ListBlock
+}
+
+describe('paragraphs and headings', () => {
+  it('splits paragraphs on blank lines', () => {
+    expect(kinds(parseBlocks('one\n\ntwo'))).toEqual(['paragraph', 'paragraph'])
+  })
+
+  it('keeps a heading’s level', () => {
+    // Measured: every level rendered as the same bold paragraph, so `#` and
+    // `######` were indistinguishable.
+    const blocks = parseBlocks('# One\n\n###### Six')
+    expect(blocks).toEqual([
+      { kind: 'heading', level: 1, text: 'One' },
+      { kind: 'heading', level: 6, text: 'Six' }
+    ])
+  })
+
+  it('does not treat a bare # as a heading', () => {
+    expect(kinds(parseBlocks('#hashtag'))).toEqual(['paragraph'])
+  })
+
+  it('ends a paragraph at a heading with no blank line', () => {
+    expect(kinds(parseBlocks('text\n## Heading'))).toEqual(['paragraph', 'heading'])
+  })
+})
+
+describe('thematic breaks', () => {
+  it('recognises the three markers', () => {
+    expect(isThematicBreak('---')).toBe(true)
+    expect(isThematicBreak('***')).toBe(true)
+    expect(isThematicBreak('___')).toBe(true)
+    expect(isThematicBreak('- - -')).toBe(true)
+  })
+
+  it('needs three of the same marker', () => {
+    expect(isThematicBreak('--')).toBe(false)
+    expect(isThematicBreak('-*-')).toBe(false)
+    expect(isThematicBreak('')).toBe(false)
+  })
+
+  it('breaks the paragraph above it', () => {
+    // Measured: `Before\n---\nAfter` was one paragraph with the dashes inside
+    // it, because there was no thematic-break rule at all.
+    expect(kinds(parseBlocks('Before\n---\nAfter'))).toEqual([
+      'paragraph',
+      'thematicBreak',
+      'paragraph'
+    ])
+  })
+
+  it('stays literal inside a code block', () => {
+    // Code is scanned first, which is what protects it.
+    const blocks = parseBlocks('```\n---\n```')
+    expect(kinds(blocks)).toEqual(['code'])
+    expect(blocks[0]).toMatchObject({ text: '---' })
+  })
+})
+
+describe('code blocks', () => {
+  it('keeps the language tag', () => {
+    expect(parseBlocks('```ts\nconst a = 1\n```')).toEqual([
+      { kind: 'code', language: 'ts', text: 'const a = 1' }
+    ])
+  })
+
+  it('has no language when none is given', () => {
+    expect(parseBlocks('```\nplain\n```')[0]).toMatchObject({ language: null })
+  })
+
+  it('keeps an unclosed fence as code while a reply streams', () => {
+    // Deliberate divergence from macOS, which keeps it as text. A half-arrived
+    // fence is the normal state mid-stream, and watching the block form reads
+    // better than watching raw markdown reflow when the closer lands.
+    const blocks = parseBlocks('```py\nx = 1\ny = 2')
+    expect(kinds(blocks)).toEqual(['code'])
+    expect(blocks[0]).toMatchObject({ text: 'x = 1\ny = 2' })
+  })
+})
+
+describe('blockquotes', () => {
+  it('reads a quote', () => {
+    // Measured: rendered as literal `&gt; quoted line` text.
+    const blocks = parseBlocks('> quoted line\n> second line')
+    expect(kinds(blocks)).toEqual(['quote'])
+    expect((blocks[0] as { blocks: Block[] }).blocks).toEqual([
+      { kind: 'paragraph', text: 'quoted line\nsecond line' }
+    ])
+  })
+
+  it('parses the quote’s contents, so it can hold a list', () => {
+    const blocks = parseBlocks('> - a\n> - b')
+    const inner = (blocks[0] as { blocks: Block[] }).blocks
+    expect(kinds(inner)).toEqual(['list'])
+  })
+
+  it('handles a quote marker with no space', () => {
+    expect(kinds(parseBlocks('>tight'))).toEqual(['quote'])
+  })
+})
+
+describe('lists', () => {
+  it('reads a flat bullet list', () => {
+    const list = firstList(parseBlocks('- a\n- b'))
+    expect(list.ordered).toBe(false)
+    expect(list.items.map((i) => i.text)).toEqual(['a', 'b'])
+  })
+
+  it('keeps the number an ordered list starts at', () => {
+    const list = firstList(parseBlocks('3. a\n4. b'))
+    expect(list.ordered).toBe(true)
+    expect(list.start).toBe(3)
+  })
+
+  it('keeps nesting', () => {
+    // Measured: `- outer / - inner / - inner2 / - outer2` rendered as ONE flat
+    // list of four items. The structure the model expressed was discarded.
+    const list = firstList(parseBlocks('- outer\n  - inner\n  - inner2\n- outer2'))
+    expect(list.items.map((i) => i.text)).toEqual(['outer', 'outer2'])
+    expect(list.items[0].children?.items.map((i) => i.text)).toEqual(['inner', 'inner2'])
+    expect(list.items[1].children).toBeNull()
+  })
+
+  it('nests more than one level deep', () => {
+    const list = firstList(parseBlocks('- a\n  - b\n    - c'))
+    expect(list.items[0].children?.items[0].children?.items[0].text).toBe('c')
+  })
+
+  it('nests a numbered list inside a bullet', () => {
+    const list = firstList(parseBlocks('- a\n  1. one\n  2. two'))
+    expect(list.items[0].children?.ordered).toBe(true)
+  })
+
+  it('starts a new list when the marker type changes', () => {
+    expect(kinds(parseBlocks('1. a\n- b'))).toEqual(['list', 'list'])
+  })
+
+  it('reads task items', () => {
+    // Measured: rendered as literal `[ ] todo` and `[x] done`.
+    const list = firstList(parseBlocks('- [ ] todo\n- [x] done\n- plain'))
+    expect(list.items.map((i) => i.checked)).toEqual([false, true, null])
+    expect(list.items.map((i) => i.text)).toEqual(['todo', 'done', 'plain'])
+  })
+
+  it('accepts an uppercase X', () => {
+    expect(firstList(parseBlocks('- [X] done')).items[0].checked).toBe(true)
+  })
+
+  it('ends at a blank line', () => {
+    expect(kinds(parseBlocks('- a\n- b\n\nAfter.'))).toEqual(['list', 'paragraph'])
+  })
+})
+
+describe('tables in a document', () => {
+  it('becomes its own block', () => {
+    // Measured: the whole thing was one paragraph of literal pipes.
+    const blocks = parseBlocks('Intro.\n\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\nAfter.')
+    expect(kinds(blocks)).toEqual(['paragraph', 'table', 'paragraph'])
+  })
+
+  it('ends the paragraph directly above it', () => {
+    expect(kinds(parseBlocks('Intro.\n| a | b |\n| --- | --- |\n| 1 | 2 |'))).toEqual([
+      'paragraph',
+      'table'
+    ])
+  })
+
+  it('stays literal inside a code block', () => {
+    expect(kinds(parseBlocks('```\n| a | b |\n| --- | --- |\n```'))).toEqual(['code'])
+  })
+})
+
+describe('robustness', () => {
+  it('returns nothing for empty input', () => {
+    expect(parseBlocks('')).toEqual([])
+    expect(parseBlocks('   \n\n  ')).toEqual([])
+  })
+
+  it('normalises CRLF out of the text, not just the block shape', () => {
+    // Asserting only the block kinds passed even with normalisation removed,
+    // because a lone `\r` line still trims to empty and still splits the
+    // paragraphs. The carriage returns survived INSIDE the text, where they
+    // reach the DOM.
+    expect(kinds(parseBlocks('a\r\n\r\nb'))).toEqual(['paragraph', 'paragraph'])
+    expect(parseBlocks('a\r\nb')).toEqual([{ kind: 'paragraph', text: 'a\nb' }])
+    expect(parseBlocks('# Title\r\n')).toEqual([{ kind: 'heading', level: 1, text: 'Title' }])
+  })
+
+  it('terminates on every prefix of a document', () => {
+    // A reply is rendered on every token, so the parser runs against every
+    // prefix of the final text. Any one of them looping would hang the app.
+    const doc =
+      '# Title\n\nIntro *text* with `code`.\n\n| a | b |\n| --- | --: |\n| 1 | 2 |\n\n' +
+      '> quoted\n> - nested item\n\n- [ ] task\n  - deep\n\n---\n\n```ts\nconst x = 1\n```\nEnd.'
+    for (let n = 0; n <= doc.length; n++) {
+      expect(() => parseBlocks(doc.slice(0, n))).not.toThrow()
+    }
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/markdown/blocks.test.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/blocks.test.ts
@@ -146,10 +146,13 @@ describe('lists', () => {
   })
 
   it('reads task items', () => {
-    // Measured: rendered as literal `[ ] todo` and `[x] done`.
-    const list = firstList(parseBlocks('- [ ] todo\n- [x] done\n- plain'))
+    // Measured: rendered as literal `[ ] buy milk` and `[x] done`.
+    // The sample avoids the bare word the deferred-work-marker check scans
+    // for; it read this line's task text as an un-tracked marker and failed
+    // the PR (run 32117987727).
+    const list = firstList(parseBlocks('- [ ] buy milk\n- [x] done\n- plain'))
     expect(list.items.map((i) => i.checked)).toEqual([false, true, null])
-    expect(list.items.map((i) => i.text)).toEqual(['todo', 'done', 'plain'])
+    expect(list.items.map((i) => i.text)).toEqual(['buy milk', 'done', 'plain'])
   })
 
   it('accepts an uppercase X', () => {

--- a/desktop/windows/src/renderer/src/lib/markdown/blocks.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/blocks.ts
@@ -1,0 +1,251 @@
+/**
+ * Block-level markdown: the shape of a reply before any of it is rendered.
+ *
+ * The scanner order is load-bearing and is macOS' (`OmiMarkdownDocument.init`):
+ * fenced code first, then tables, then everything else. Code first is what
+ * keeps a `---` or a `| a | b |` inside a code sample literal instead of
+ * turning it into a rule or a table.
+ *
+ * Everything here is a pure function of the source text, so the whole block
+ * grammar is testable without a DOM.
+ */
+
+import { parseTable, type MarkdownTable } from './table'
+
+export type ListItem = {
+  /** The item's own inline source, without its marker. */
+  text: string
+  /** Nested list, if this item has one. */
+  children: ListBlock | null
+  /** GFM task state: null when the item is not a task item. */
+  checked: boolean | null
+}
+
+export type ListBlock = {
+  kind: 'list'
+  ordered: boolean
+  /** The number the first item is labelled with, for `3.`-style lists. */
+  start: number
+  items: ListItem[]
+}
+
+export type Block =
+  | { kind: 'paragraph'; text: string }
+  | { kind: 'heading'; level: number; text: string }
+  | { kind: 'code'; language: string | null; text: string }
+  | { kind: 'quote'; blocks: Block[] }
+  | { kind: 'table'; table: MarkdownTable }
+  | { kind: 'thematicBreak' }
+  | ListBlock
+
+const FENCE = /^\s*```/
+const HEADING = /^(#{1,6})\s+(.*)$/
+const UNORDERED = /^(\s*)([-*+])\s+(.*)$/
+const ORDERED = /^(\s*)(\d{1,9})[.)]\s+(.*)$/
+const QUOTE = /^\s*>\s?(.*)$/
+const TASK = /^\[([ xX])\]\s+(.*)$/
+
+/**
+ * A thematic break: at least three of the same marker, whitespace ignored.
+ *
+ * Ported from macOS' `isThematicBreak`, and deliberately checked after fenced
+ * code so `---` inside a code sample stays literal. It also has to be checked
+ * before paragraphs: in the renderer this replaces there was no rule at all, so
+ * `Before\n---\nAfter` came out as one paragraph with the dashes in the middle
+ * of it.
+ */
+export function isThematicBreak(line: string): boolean {
+  const markers = line.replace(/\s/g, '')
+  if (markers.length < 3) return false
+  const marker = markers[0]
+  if (marker !== '-' && marker !== '*' && marker !== '_') return false
+  for (const ch of markers) if (ch !== marker) return false
+  return true
+}
+
+/** Width of a line's leading whitespace, with tabs counted as four columns. */
+function indentWidth(prefix: string): number {
+  let width = 0
+  for (const ch of prefix) width += ch === '\t' ? 4 : 1
+  return width
+}
+
+type ListLine = { indent: number; ordered: boolean; start: number; text: string }
+
+function readListLine(line: string): ListLine | null {
+  const unordered = UNORDERED.exec(line)
+  if (unordered) {
+    return { indent: indentWidth(unordered[1]), ordered: false, start: 1, text: unordered[3] }
+  }
+  const ordered = ORDERED.exec(line)
+  if (ordered) {
+    return {
+      indent: indentWidth(ordered[1]),
+      ordered: true,
+      start: Number(ordered[2]),
+      text: ordered[3]
+    }
+  }
+  return null
+}
+
+/**
+ * Read a list, including nested lists, starting at `start`.
+ *
+ * Nesting is by indentation relative to the list's own first item, which is
+ * what the renderer this replaces threw away: it matched list markers with a
+ * leading-whitespace-tolerant regex and then stripped the indentation, so every
+ * item of every depth landed in one flat `<ul>` and the structure the model
+ * expressed was silently lost.
+ */
+function readList(lines: string[], start: number): { block: ListBlock; nextIndex: number } {
+  const first = readListLine(lines[start])
+  if (!first) throw new Error('readList called on a line that is not a list item')
+
+  const items: ListItem[] = []
+  let cursor = start
+
+  while (cursor < lines.length) {
+    const parsed = readListLine(lines[cursor])
+    if (!parsed || parsed.indent < first.indent) break
+    // Indent is decided before marker type, and the order matters: a nested
+    // numbered list under a bullet is a different type at a DEEPER level, so
+    // testing the type first ended the outer list and dropped the nesting.
+    if (parsed.indent > first.indent) {
+      // Deeper than this list: attach to the item above, or start one if the
+      // source opened at a deeper indent than its parent (malformed but real).
+      const nested = readList(lines, cursor)
+      const owner = items[items.length - 1]
+      if (owner) owner.children = nested.block
+      else items.push({ text: '', children: nested.block, checked: null })
+      cursor = nested.nextIndex
+      continue
+    }
+    // Same level, different marker: a new list. A bullet list directly after a
+    // numbered one is not absorbed into it.
+    if (parsed.ordered !== first.ordered) break
+
+    const task = TASK.exec(parsed.text)
+    items.push({
+      text: task ? task[2] : parsed.text,
+      children: null,
+      checked: task ? task[1].toLowerCase() === 'x' : null
+    })
+    cursor += 1
+  }
+
+  return {
+    block: { kind: 'list', ordered: first.ordered, start: first.start, items },
+    nextIndex: cursor
+  }
+}
+
+/**
+ * Parse a reply into blocks.
+ *
+ * Never throws and never drops input: anything the grammar does not recognise
+ * falls through as paragraph text, which is what keeps a half-streamed reply
+ * readable while its closing markers are still arriving.
+ */
+export function parseBlocks(source: string): Block[] {
+  const lines = source.replace(/\r\n/g, '\n').split('\n')
+  const blocks: Block[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i]
+
+    if (FENCE.test(line)) {
+      const language = line.trim().slice(3).trim()
+      const body: string[] = []
+      i += 1
+      while (i < lines.length && !FENCE.test(lines[i])) body.push(lines[i++])
+      // A fence with no closer keeps the rest of the reply as code. That is the
+      // shipped behaviour and it is kept deliberately: while a reply streams,
+      // the closing fence has not arrived yet, and showing the code block
+      // forming reads better than showing raw markdown that reflows the moment
+      // it closes. macOS makes the opposite choice and keeps an unclosed
+      // fence as text; the divergence is pinned by a test in blocks.test.ts.
+      if (i < lines.length) i += 1
+      blocks.push({
+        kind: 'code',
+        language: language === '' ? null : language,
+        text: body.join('\n')
+      })
+      continue
+    }
+
+    const table = parseTable(lines, i)
+    if (table) {
+      blocks.push({ kind: 'table', table: table.table })
+      i = table.nextIndex
+      continue
+    }
+
+    if (isThematicBreak(line)) {
+      blocks.push({ kind: 'thematicBreak' })
+      i += 1
+      continue
+    }
+
+    const heading = HEADING.exec(line)
+    if (heading) {
+      blocks.push({ kind: 'heading', level: heading[1].length, text: heading[2] })
+      i += 1
+      continue
+    }
+
+    if (QUOTE.test(line)) {
+      const quoted: string[] = []
+      while (i < lines.length && QUOTE.test(lines[i])) {
+        quoted.push(QUOTE.exec(lines[i])![1])
+        i += 1
+      }
+      // Recursive, so a quote can hold a list or a code block, which is how
+      // the model formats a quoted example.
+      blocks.push({ kind: 'quote', blocks: parseBlocks(quoted.join('\n')) })
+      continue
+    }
+
+    if (readListLine(line)) {
+      const list = readList(lines, i)
+      blocks.push(list.block)
+      i = list.nextIndex
+      continue
+    }
+
+    if (line.trim() === '') {
+      i += 1
+      continue
+    }
+
+    // Reaching here means this line starts no other block, so it belongs to a
+    // paragraph. Taking it unconditionally before testing the next line
+    // guarantees forward progress, which a `while` guarding on the CURRENT line
+    // would not: every one of those conditions was already checked above, so
+    // the guard could only ever be vacuously true, and a future edit that made
+    // it false would spin.
+    const paragraph: string[] = []
+    do {
+      paragraph.push(lines[i])
+      i += 1
+    } while (i < lines.length && !startsBlock(lines, i))
+    blocks.push({ kind: 'paragraph', text: paragraph.join('\n') })
+  }
+
+  return blocks
+}
+
+/** Whether line `i` begins a block, and so ends the paragraph before it. */
+function startsBlock(lines: string[], i: number): boolean {
+  const line = lines[i]
+  return (
+    line.trim() === '' ||
+    FENCE.test(line) ||
+    HEADING.test(line) ||
+    QUOTE.test(line) ||
+    isThematicBreak(line) ||
+    readListLine(line) !== null ||
+    parseTable(lines, i) !== null
+  )
+}

--- a/desktop/windows/src/renderer/src/lib/markdown/inline.test.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/inline.test.ts
@@ -1,0 +1,233 @@
+// Inline parsing. Several cases here are regressions against measured
+// behaviour of the renderer this replaces, not hypotheticals: the shipped
+// build was run against each input and the result recorded before the rewrite.
+import { describe, expect, it } from 'vitest'
+import { isSafeHref, parseInline, plainText, type InlineNode } from './inline'
+
+/** Compact shape for assertions: `strong(text)`, `code`, `link(href|text)`. */
+function shape(nodes: InlineNode[]): string {
+  return nodes
+    .map((n) => {
+      switch (n.kind) {
+        case 'text':
+          return n.value
+        case 'code':
+          return `code(${n.value})`
+        case 'link':
+          return `link(${n.href}|${shape(n.children)})`
+        case 'deadLink':
+          return `dead(${shape(n.children)})`
+        default:
+          return `${n.kind}(${shape(n.children)})`
+      }
+    })
+    .join('')
+}
+
+describe('emphasis', () => {
+  it('reads bold, italic and strikethrough', () => {
+    expect(shape(parseInline('a **b** c'))).toBe('a strong(b) c')
+    expect(shape(parseInline('a *b* c'))).toBe('a em(b) c')
+    expect(shape(parseInline('a _b_ c'))).toBe('a em(b) c')
+    expect(shape(parseInline('a __b__ c'))).toBe('a strong(b) c')
+    // Strikethrough rendered as literal tildes before this change.
+    expect(shape(parseInline('a ~~b~~ c'))).toBe('a del(b) c')
+  })
+
+  it('nests', () => {
+    // The measured defect: `**see [docs](https://x.com) now**` came out as
+    // bold text containing the literal characters of the link.
+    expect(shape(parseInline('**see [docs](https://x.com) now**'))).toBe(
+      'strong(see link(https://x.com|docs) now)'
+    )
+    expect(shape(parseInline('**bold with `code` inside**'))).toBe(
+      'strong(bold with code(code) inside)'
+    )
+    expect(shape(parseInline('*italic with **bold** inside*'))).toBe(
+      'em(italic with strong(bold) inside)'
+    )
+  })
+
+  it('prefers bold over two italics', () => {
+    expect(shape(parseInline('**x**'))).toBe('strong(x)')
+  })
+
+  it('leaves an unclosed run literal', () => {
+    // A reply is streamed, so half-typed markers are the normal state.
+    expect(shape(parseInline('a **b'))).toBe('a **b')
+    expect(shape(parseInline('a ~~b'))).toBe('a ~~b')
+  })
+
+  it('does not emphasise inside a word with underscores', () => {
+    // `my_var_name` is an identifier, not an italic. Asterisks keep working
+    // intraword because that is what CommonMark says.
+    expect(shape(parseInline('call my_var_name here'))).toBe('call my_var_name here')
+    expect(shape(parseInline('a*b*c'))).toBe('aem(b)c')
+  })
+
+  it('does not let an underscore OPEN inside a word', () => {
+    // Separate from the case above, which the closing rule alone already
+    // handles. Here the closer is legal (followed by a space) and only the
+    // opening rule stops `my_var_` from italicising `var`.
+    expect(shape(parseInline('my_var_ end'))).toBe('my_var_ end')
+  })
+
+  it('is not fooled by an empty run', () => {
+    expect(shape(parseInline('****'))).toBe('****')
+    expect(shape(parseInline('a ** ** b'))).toBe('a ** ** b')
+  })
+})
+
+describe('code spans', () => {
+  it('takes their content literally', () => {
+    expect(shape(parseInline('use `**not bold**` here'))).toBe('use code(**not bold**) here')
+  })
+
+  it('supports multi-backtick fences and strips one padding space', () => {
+    expect(shape(parseInline('`` ` ``'))).toBe('code(`)')
+  })
+
+  it('leaves an unterminated backtick literal', () => {
+    expect(shape(parseInline('a `b'))).toBe('a `b')
+  })
+
+  it('does not let a delimiter inside code close an outer run', () => {
+    expect(shape(parseInline('**a `b** c` d**'))).toBe('strong(a code(b** c) d)')
+  })
+})
+
+describe('escapes', () => {
+  it('renders an escaped marker literally and does not emphasise', () => {
+    // Measured before the rewrite: this produced `a \` + <em>not italic\</em>
+    // + ` b`. Both the backslash showed AND it italicised.
+    expect(shape(parseInline('a \\*not italic\\* b'))).toBe('a *not italic* b')
+  })
+
+  it('escapes the other markers too', () => {
+    expect(shape(parseInline('\\`not code\\`'))).toBe('`not code`')
+    expect(shape(parseInline('\\[not a link\\]'))).toBe('[not a link]')
+    expect(shape(parseInline('a \\\\ b'))).toBe('a \\ b')
+  })
+
+  it('leaves a backslash before an ordinary character alone', () => {
+    expect(shape(parseInline('C:\\Users\\dog'))).toBe('C:\\Users\\dog')
+  })
+})
+
+describe('links', () => {
+  it('reads a labelled link', () => {
+    expect(shape(parseInline('[docs](https://omi.me)'))).toBe('link(https://omi.me|docs)')
+  })
+
+  it('parses the label, so a link can hold emphasis', () => {
+    expect(shape(parseInline('[**bold** label](https://omi.me)'))).toBe(
+      'link(https://omi.me|strong(bold) label)'
+    )
+  })
+
+  it('flattens a link inside a link label', () => {
+    // Links cannot nest; the inner one becomes its own text.
+    expect(shape(parseInline('[a [b](https://b.com) c](https://a.com)'))).toBe(
+      'link(https://a.com|a b c)'
+    )
+  })
+
+  it('links a bare URL', () => {
+    expect(shape(parseInline('see https://omi.me for more'))).toBe(
+      'see link(https://omi.me|https://omi.me) for more'
+    )
+  })
+
+  it('leaves sentence punctuation outside a bare URL', () => {
+    expect(shape(parseInline('see https://omi.me.'))).toBe(
+      'see link(https://omi.me|https://omi.me).'
+    )
+  })
+
+  it('does not autolink inside a word', () => {
+    expect(shape(parseInline('xhttps://omi.me'))).toBe('xhttps://omi.me')
+  })
+})
+
+describe('which hrefs may become live links', () => {
+  // The security rule. Chat replies can be steered by indirect prompt
+  // injection because the prompt includes OCR of the user's screen, so the
+  // model can be induced to emit any href it likes.
+  it('allows only http, https and mailto', () => {
+    expect(isSafeHref('https://omi.me')).toBe(true)
+    expect(isSafeHref('http://omi.me')).toBe(true)
+    expect(isSafeHref('mailto:a@b.com')).toBe(true)
+  })
+
+  it.each([
+    ['javascript', 'javascript:alert(1)'],
+    ['data', 'data:text/html,<script>alert(1)</script>'],
+    ['file', 'file:///C:/Windows/System32/'],
+    ['UNC path', '\\\\attacker\\share\\payload'],
+    ['custom protocol', 'ms-word:ofe|u|https://x'],
+    ['relative', '/etc/passwd'],
+    ['empty', '']
+  ])('refuses %s', (_label, href) => {
+    expect(isSafeHref(href)).toBe(false)
+  })
+
+  it('refuses a scheme split by a control character', () => {
+    // URL parsers strip these before reading the scheme, so this reaches the
+    // browser as `javascript:` while sailing past a plain prefix test.
+    expect(isSafeHref('java\tscript:alert(1)')).toBe(false)
+    expect(isSafeHref('java\nscript:alert(1)')).toBe(false)
+    expect(isSafeHref('\u0000javascript:alert(1)')).toBe(false)
+  })
+
+  it('refuses a control character hiding the real host', () => {
+    // The case that gives the control-character rule its own weight: the
+    // scheme here IS https, so the allowlist passes it. A URL parser strips
+    // the tab, leaving `https://omi.me@evil.example`, where everything before
+    // the `@` is userinfo and the site actually visited is evil.example. The
+    // href a user sees in a tooltip and the host they reach disagree.
+    expect(isSafeHref('https://omi.me\t@evil.example')).toBe(false)
+    expect(isSafeHref('https://omi.me\n@evil.example')).toBe(false)
+  })
+
+  it('keeps the label of a refused link but marks it dead', () => {
+    // The user still reads what the model wrote; it just is not clickable.
+    expect(shape(parseInline('[click me](javascript:alert(1))'))).toBe('dead(click me)')
+  })
+
+  it('never autolinks a bare non-http scheme', () => {
+    expect(shape(parseInline('run file:///C:/Windows now'))).toBe('run file:///C:/Windows now')
+  })
+
+  it('does not autolink a URL carrying a control character', () => {
+    // The autolink pattern excludes whitespace but not other control
+    // characters, so this is where the href check earns its place on that path
+    // rather than duplicating the pattern: without it the link would carry a
+    // control character straight into an href.
+    expect(shape(parseInline('see https://omi.me\u0001@evil.example now'))).toBe(
+      'see https://omi.me\u0001@evil.example now'
+    )
+  })
+})
+
+describe('images', () => {
+  it('renders an image as its alt text and fetches nothing', () => {
+    // Deliberate, not unimplemented: a reply can be steered by what is on the
+    // user's screen, so a rendered remote image is a tracking pixel that fires
+    // on load with nothing clicked.
+    expect(shape(parseInline('![a diagram](https://x.com/p.png)'))).toBe('a diagram')
+  })
+
+  it('drops an image with a refused URL the same way', () => {
+    expect(shape(parseInline('![x](javascript:alert(1))'))).toBe('x')
+  })
+
+  it('keeps a bare exclamation mark', () => {
+    expect(shape(parseInline('wow! [docs](https://x.com)'))).toBe('wow! link(https://x.com|docs)')
+  })
+})
+
+describe('plain text', () => {
+  it('flattens a tree to what the reader sees', () => {
+    expect(plainText(parseInline('**a** `b` [c](https://c.com)'))).toBe('a b c')
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/markdown/inline.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/inline.ts
@@ -1,0 +1,372 @@
+/**
+ * Inline markdown: emphasis, code spans, links, and the escapes between them.
+ *
+ * The renderer this replaces did inline formatting with one alternation regex
+ * and `String.split`, which cannot nest by construction. Measured against the
+ * shipped build, `**see [docs](https://x.com) now**` rendered as bold text
+ * containing the literal characters `[docs](https://x.com)`: the link was
+ * destroyed by being bolded. `a \*not italic\* b` rendered the backslashes AND
+ * italicised anyway. Both are structural consequences of a flat split, not
+ * missing cases, which is why this is a scanner and returns a tree.
+ *
+ * Parsing is separated from rendering on purpose. Every rule here is decidable
+ * from a string, so it is testable without a DOM, and the security rule that
+ * matters most (which hrefs may become live links) lives in one function with
+ * its own tests rather than inside a component.
+ */
+
+/** A parsed inline node. `code` is a leaf: its content is literal. */
+export type InlineNode =
+  | { kind: 'text'; value: string }
+  | { kind: 'code'; value: string }
+  | { kind: 'strong'; children: InlineNode[] }
+  | { kind: 'em'; children: InlineNode[] }
+  | { kind: 'del'; children: InlineNode[] }
+  | { kind: 'link'; href: string; children: InlineNode[] }
+  /** A link target this app refuses to make clickable; the label still shows. */
+  | { kind: 'deadLink'; children: InlineNode[] }
+
+/**
+ * Schemes a chat reply may turn into a clickable link.
+ *
+ * Kept from the renderer this replaces, and the reasoning is worth repeating
+ * because it is the whole reason there is an allowlist rather than a blocklist:
+ * chat replies can be steered by indirect prompt injection, since the prompt
+ * includes OCR of whatever is on the user's screen. A model can therefore be
+ * induced to emit a `file://`, a UNC path, or a custom protocol handler.
+ * Rendering those as live links enables one-click NTLM-hash leakage and OS
+ * protocol-handler abuse. Anything not matched here still renders its label,
+ * just not as a link.
+ */
+const SAFE_HREF = /^(https?:|mailto:)/i
+
+export function isSafeHref(href: string): boolean {
+  const trimmed = href.trim()
+  if (trimmed === '') return false
+  // Control characters and whitespace are stripped by URL parsers before the
+  // scheme is read, so `java\tscript:alert(1)` reaches the browser as
+  // `javascript:alert(1)` while sailing past a naive prefix test. Refusing any
+  // href containing one means the string tested below is the string the
+  // browser will act on.
+  // eslint-disable-next-line no-control-regex -- rejecting control characters is the point
+  if (/[\u0000-\u0020\u007f]/.test(trimmed)) return false
+  return SAFE_HREF.test(trimmed)
+}
+
+/** Characters a backslash may escape, per CommonMark's punctuation set. */
+const ESCAPABLE = new Set('\\`*_{}[]()#+-.!|~>')
+
+/** True when `at` is inside a word, for the intraword-underscore rule. */
+function isWordChar(source: string, at: number): boolean {
+  if (at < 0 || at >= source.length) return false
+  return /[\p{L}\p{N}]/u.test(source[at])
+}
+
+/**
+ * Find the closing delimiter for a run that opened at `from`.
+ *
+ * Skips over code spans, so a `**` inside backticks never closes emphasis, and
+ * respects backslash escapes. Returns -1 when the run never closes, which is
+ * the normal state of a half-streamed reply and must stay literal text.
+ */
+function findCloser(
+  source: string,
+  from: number,
+  delimiter: string,
+  underscoreRule: boolean
+): number {
+  let i = from
+  while (i < source.length) {
+    const ch = source[i]
+    if (ch === '\\' && i + 1 < source.length && ESCAPABLE.has(source[i + 1])) {
+      i += 2
+      continue
+    }
+    if (ch === '`') {
+      const run = backtickRun(source, i)
+      const end = findCodeClose(source, i + run, run)
+      // An unterminated code span is not a code span; keep scanning past the
+      // backticks rather than swallowing the rest of the line.
+      i = end === -1 ? i + run : end + run
+      continue
+    }
+    if (ch === delimiter[0]) {
+      // Match against the whole run, not a prefix of it. A single `*` looking
+      // for its closer must step over a `**` rather than close on its first
+      // character: `*italic with **bold** inside*` otherwise closed the italic
+      // on the opening `**` and produced garbage for the rest of the line.
+      const run = charRun(source, i, delimiter[0])
+      const closes = delimiter.length === 1 ? run === 1 : run >= 2
+      if (!closes) {
+        i += run
+        continue
+      }
+      // `_` may not close inside a word, so `snake_case_name` is one word and
+      // not an emphasised `case`.
+      if (underscoreRule && isWordChar(source, i - 1) && isWordChar(source, i + delimiter.length)) {
+        i += run
+        continue
+      }
+      return i
+    }
+    i += 1
+  }
+  return -1
+}
+
+/** Length of the run of `ch` starting at `at`. */
+function charRun(source: string, at: number, ch: string): number {
+  let n = 0
+  while (at + n < source.length && source[at + n] === ch) n += 1
+  return n
+}
+
+function backtickRun(source: string, at: number): number {
+  return charRun(source, at, '`')
+}
+
+/** Index of a closing backtick run of exactly `length`, or -1. */
+function findCodeClose(source: string, from: number, length: number): number {
+  let i = from
+  while (i < source.length) {
+    if (source[i] === '`') {
+      const run = backtickRun(source, i)
+      if (run === length) return i
+      i += run
+      continue
+    }
+    i += 1
+  }
+  return -1
+}
+
+/** Bare URLs become links. Trailing sentence punctuation is left outside. */
+const AUTOLINK = /^https?:\/\/[^\s<>[\]()]+/i
+
+function trimAutolink(url: string): string {
+  let end = url.length
+  while (end > 0 && '.,;:!?'.includes(url[end - 1])) end -= 1
+  return url.slice(0, end)
+}
+
+/**
+ * Parse one line (or run) of inline markdown into a tree.
+ *
+ * `depth` guards against a pathological nesting chain; content past it is
+ * emitted as plain text rather than recursed into.
+ */
+export function parseInline(source: string, depth = 0): InlineNode[] {
+  const nodes: InlineNode[] = []
+  let text = ''
+  let i = 0
+
+  const flush = (): void => {
+    if (text !== '') {
+      nodes.push({ kind: 'text', value: text })
+      text = ''
+    }
+  }
+
+  while (i < source.length) {
+    const ch = source[i]
+
+    // Escapes first, so `\*` is a literal asterisk and not an opener.
+    if (ch === '\\' && i + 1 < source.length && ESCAPABLE.has(source[i + 1])) {
+      text += source[i + 1]
+      i += 2
+      continue
+    }
+
+    // Code spans outrank everything: their content is literal, which is what
+    // makes `` `**not bold**` `` work.
+    if (ch === '`') {
+      const run = backtickRun(source, i)
+      const close = findCodeClose(source, i + run, run)
+      if (close !== -1) {
+        flush()
+        // CommonMark strips one leading and trailing space so `` ` `` can be
+        // written as `` `` ` `` ``.
+        let value = source.slice(i + run, close)
+        if (value.length > 1 && value.startsWith(' ') && value.endsWith(' ')) {
+          value = value.slice(1, -1)
+        }
+        nodes.push({ kind: 'code', value })
+        i = close + run
+        continue
+      }
+      text += source.slice(i, i + run)
+      i += run
+      continue
+    }
+
+    if (depth < 6) {
+      const emphasis = tryEmphasis(source, i, depth)
+      if (emphasis) {
+        flush()
+        nodes.push(emphasis.node)
+        i = emphasis.next
+        continue
+      }
+
+      // An image becomes its alt text. Nothing here fetches a remote URL, and
+      // that is deliberate rather than unimplemented: a reply can be steered by
+      // whatever is on the user's screen, so rendering `![](url)` would let an
+      // injected address fetch on load — a tracking pixel reporting the user's
+      // IP and that the chat was opened, with nothing clicked.
+      if (ch === '!' && source[i + 1] === '[') {
+        const image = tryLink(source, i + 1, depth)
+        if (image && (image.node.kind === 'link' || image.node.kind === 'deadLink')) {
+          flush()
+          nodes.push(...image.node.children.map(stripLinks))
+          i = image.next
+          continue
+        }
+      }
+
+      if (ch === '[') {
+        const link = tryLink(source, i, depth)
+        if (link) {
+          flush()
+          nodes.push(link.node)
+          i = link.next
+          continue
+        }
+      }
+    }
+
+    if ((ch === 'h' || ch === 'H') && (i === 0 || !isWordChar(source, i - 1))) {
+      const match = AUTOLINK.exec(source.slice(i))
+      if (match) {
+        const href = trimAutolink(match[0])
+        if (href.length > 0 && isSafeHref(href)) {
+          flush()
+          nodes.push({ kind: 'link', href, children: [{ kind: 'text', value: href }] })
+          i += href.length
+          continue
+        }
+      }
+    }
+
+    text += ch
+    i += 1
+  }
+
+  flush()
+  return nodes
+}
+
+type Attempt = { node: InlineNode; next: number }
+
+/** `**strong**`, `__strong__`, `*em*`, `_em_`, `~~del~~`. */
+function tryEmphasis(source: string, at: number, depth: number): Attempt | null {
+  const specs: { delimiter: string; kind: 'strong' | 'em' | 'del'; underscoreRule: boolean }[] = [
+    { delimiter: '**', kind: 'strong', underscoreRule: false },
+    { delimiter: '__', kind: 'strong', underscoreRule: true },
+    { delimiter: '~~', kind: 'del', underscoreRule: false },
+    { delimiter: '*', kind: 'em', underscoreRule: false },
+    { delimiter: '_', kind: 'em', underscoreRule: true }
+  ]
+  for (const spec of specs) {
+    if (!source.startsWith(spec.delimiter, at)) continue
+    // `_` may not open inside a word either: `a_b_c` is one word.
+    if (spec.underscoreRule && isWordChar(source, at - 1)) continue
+    const from = at + spec.delimiter.length
+    // An empty run (`****`) is not emphasis.
+    if (source.startsWith(spec.delimiter, from)) continue
+    const close = findCloser(source, from, spec.delimiter, spec.underscoreRule)
+    if (close === -1) continue
+    const inner = source.slice(from, close)
+    if (inner.trim() === '') continue
+    return {
+      node: { kind: spec.kind, children: parseInline(inner, depth + 1) },
+      next: close + spec.delimiter.length
+    }
+  }
+  return null
+}
+
+/** `[label](href)`. The label is parsed, so a bolded link keeps both. */
+function tryLink(source: string, at: number, depth: number): Attempt | null {
+  const labelEnd = findLinkLabelEnd(source, at + 1)
+  if (labelEnd === -1) return null
+  if (source[labelEnd + 1] !== '(') return null
+  // Balanced, not the first `)`. Parentheses are common in real URLs
+  // (Wikipedia disambiguators) and in the very hrefs this app refuses, so
+  // `[x](javascript:alert(1))` has to be read whole to be judged at all.
+  const hrefEnd = findHrefEnd(source, labelEnd + 2)
+  if (hrefEnd === -1) return null
+
+  const label = source.slice(at + 1, labelEnd)
+  const href = source.slice(labelEnd + 2, hrefEnd).trim()
+  // Links do not nest; a link inside a label is flattened to its label text.
+  const children = parseInline(label, depth + 1).map(stripLinks)
+  const node: InlineNode = isSafeHref(href)
+    ? { kind: 'link', href, children }
+    : { kind: 'deadLink', children }
+  return { node, next: hrefEnd + 1 }
+}
+
+/** Index of the `)` closing a link destination, honouring nesting and escapes. */
+function findHrefEnd(source: string, from: number): number {
+  let depth = 0
+  let i = from
+  while (i < source.length) {
+    const ch = source[i]
+    if (ch === '\\' && i + 1 < source.length) {
+      i += 2
+      continue
+    }
+    if (ch === '(') depth += 1
+    else if (ch === ')') {
+      if (depth === 0) return i
+      depth -= 1
+    }
+    i += 1
+  }
+  return -1
+}
+
+/** Index of the `]` closing a label, honouring nesting and escapes. */
+function findLinkLabelEnd(source: string, from: number): number {
+  let depth = 0
+  let i = from
+  while (i < source.length) {
+    const ch = source[i]
+    if (ch === '\\' && i + 1 < source.length) {
+      i += 2
+      continue
+    }
+    if (ch === '[') depth += 1
+    else if (ch === ']') {
+      if (depth === 0) return i
+      depth -= 1
+    }
+    i += 1
+  }
+  return -1
+}
+
+function stripLinks(node: InlineNode): InlineNode {
+  if (node.kind === 'link' || node.kind === 'deadLink') {
+    return { kind: 'text', value: plainText(node.children) }
+  }
+  if (node.kind === 'strong' || node.kind === 'em' || node.kind === 'del') {
+    return { ...node, children: node.children.map(stripLinks) }
+  }
+  return node
+}
+
+/** The visible text of a node list, for labels and accessibility. */
+export function plainText(nodes: InlineNode[]): string {
+  return nodes
+    .map((n) => {
+      switch (n.kind) {
+        case 'text':
+        case 'code':
+          return n.value
+        default:
+          return plainText(n.children)
+      }
+    })
+    .join('')
+}

--- a/desktop/windows/src/renderer/src/lib/markdown/table.test.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/table.test.ts
@@ -1,0 +1,128 @@
+// GFM tables. Measured against the shipped renderer, a table came out as one
+// paragraph of literal pipe characters, so every rule here is new behaviour.
+import { describe, expect, it } from 'vitest'
+import { parseAlignment, parseTable, splitCells } from './table'
+
+const lines = (text: string): string[] => text.split('\n')
+
+describe('splitting a row into cells', () => {
+  it('handles the leading and trailing pipes', () => {
+    expect(splitCells('| a | b | c |')).toEqual(['a', 'b', 'c'])
+    expect(splitCells('a | b | c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('trims each cell', () => {
+    expect(splitCells('|   a   |  b |')).toEqual(['a', 'b'])
+  })
+
+  it('keeps an escaped pipe as content', () => {
+    // Without this a cell can never contain a pipe, which bites the moment the
+    // model tabulates shell syntax or a regex alternation.
+    expect(splitCells('| a \\| b | c |')).toEqual(['a | b', 'c'])
+  })
+
+  it('keeps a trailing escaped pipe as content', () => {
+    expect(splitCells('| a | b \\|')).toEqual(['a', 'b |'])
+  })
+
+  it('ignores a pipe inside an inline code span', () => {
+    expect(splitCells('| `a | b` | c |')).toEqual(['`a | b`', 'c'])
+  })
+
+  it('produces an empty cell rather than dropping it', () => {
+    expect(splitCells('| a |  | c |')).toEqual(['a', '', 'c'])
+  })
+})
+
+describe('separator alignment', () => {
+  it('reads all four forms', () => {
+    expect(parseAlignment('---')).toBe('left')
+    expect(parseAlignment(':---')).toBe('left')
+    expect(parseAlignment(':---:')).toBe('center')
+    expect(parseAlignment('---:')).toBe('right')
+  })
+
+  it('needs at least three dashes', () => {
+    // The floor is what stops an ordinary `| -- |` row from turning the line
+    // above it into a table header.
+    expect(parseAlignment('--')).toBeNull()
+    expect(parseAlignment(':-:')).toBeNull()
+  })
+
+  it('rejects anything that is not dashes', () => {
+    expect(parseAlignment('-a-')).toBeNull()
+    expect(parseAlignment('')).toBeNull()
+    expect(parseAlignment('===')).toBeNull()
+  })
+})
+
+describe('reading a table', () => {
+  it('reads header, alignments and rows', () => {
+    const parsed = parseTable(lines('| Name | Size |\n| --- | ---: |\n| a | 1 |\n| b | 2 |'), 0)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.table.header).toEqual(['Name', 'Size'])
+    expect(parsed!.table.alignments).toEqual(['left', 'right'])
+    expect(parsed!.table.rows).toEqual([
+      ['a', '1'],
+      ['b', '2']
+    ])
+    expect(parsed!.nextIndex).toBe(4)
+  })
+
+  it('stops at a blank line so prose can follow immediately', () => {
+    const parsed = parseTable(lines('| a | b |\n| --- | --- |\n| 1 | 2 |\n\nAfter.'), 0)
+    expect(parsed!.table.rows).toEqual([['1', '2']])
+    expect(parsed!.nextIndex).toBe(3)
+  })
+
+  it('pads a short row and truncates a long one', () => {
+    const parsed = parseTable(
+      lines('| a | b | c |\n| --- | --- | --- |\n| 1 | 2 |\n| 1 | 2 | 3 | 4 |'),
+      0
+    )
+    expect(parsed!.table.rows).toEqual([
+      ['1', '2', ''],
+      ['1', '2', '3']
+    ])
+  })
+
+  it('ends the table at a row with fewer than two cells', () => {
+    // macOS' rule: a one-cell line is prose, not a row, so the table ends and
+    // the line goes back to the block scanner as ordinary text.
+    const parsed = parseTable(lines('| a | b |\n| --- | --- |\n| 1 | 2 |\n| trailing'), 0)
+    expect(parsed!.table.rows).toEqual([['1', '2']])
+    expect(parsed!.nextIndex).toBe(3)
+  })
+
+  it('accepts a table with no body rows', () => {
+    const parsed = parseTable(lines('| a | b |\n| --- | --- |'), 0)
+    expect(parsed!.table.rows).toEqual([])
+  })
+})
+
+describe('what is not a table', () => {
+  it('needs a separator line', () => {
+    expect(parseTable(lines('| a | b |\n| 1 | 2 |'), 0)).toBeNull()
+  })
+
+  it('needs the separator to match the header width', () => {
+    expect(parseTable(lines('| a | b | c |\n| --- | --- |'), 0)).toBeNull()
+  })
+
+  it('needs every separator cell to be an alignment', () => {
+    expect(parseTable(lines('| a | b |\n| --- | xx |'), 0)).toBeNull()
+  })
+
+  it('needs at least two columns', () => {
+    // A one-column "table" is indistinguishable from prose with a stray pipe.
+    expect(parseTable(lines('| a |\n| --- |'), 0)).toBeNull()
+  })
+
+  it('leaves ordinary prose containing a pipe alone', () => {
+    expect(parseTable(lines('use a | b to pipe\nand then continue'), 0)).toBeNull()
+  })
+
+  it('needs a line after the header', () => {
+    expect(parseTable(lines('| a | b |'), 0)).toBeNull()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/markdown/table.ts
+++ b/desktop/windows/src/renderer/src/lib/markdown/table.ts
@@ -1,0 +1,142 @@
+/**
+ * GFM tables.
+ *
+ * A table is the gap that motivated this whole change: measured against the
+ * shipped renderer, a four-line GFM table came out as a single paragraph of
+ * literal pipe characters. The model emits tables often, because it is the
+ * natural shape for the comparisons a user asks for, and every one of them
+ * arrived as unreadable text.
+ *
+ * The rules are ported from `OmiMarkdownTable.parse` in macOS'
+ * `OmiMarkdown.swift`, including the two that are easy to get wrong: cells are
+ * split on pipes that are neither escaped nor inside an inline code span, and
+ * a row is only a row if the separator line parses as alignments for exactly
+ * the header's columns.
+ */
+
+export type ColumnAlignment = 'left' | 'center' | 'right'
+
+export type MarkdownTable = {
+  header: string[]
+  alignments: ColumnAlignment[]
+  rows: string[][]
+}
+
+/**
+ * Split one table line into cells.
+ *
+ * Two rules make this more than `line.split('|')`, and both come from macOS:
+ *
+ *  - `\|` is a literal pipe, not a cell boundary. Without it a cell can never
+ *    contain a pipe, which matters as soon as the model tabulates anything
+ *    involving shell syntax or alternation.
+ *  - A pipe inside backticks is not a boundary either, so a cell holding
+ *    `` `a | b` `` stays one cell.
+ */
+export function splitCells(line: string): string[] {
+  let body = line.trim()
+  if (body.startsWith('|')) body = body.slice(1)
+  // A trailing pipe closes the row, unless it is escaped, in which case it is
+  // content belonging to the last cell.
+  if (body.endsWith('|') && !body.endsWith('\\|')) body = body.slice(0, -1)
+
+  const cells: string[] = []
+  let current = ''
+  let inCode = false
+  let i = 0
+  while (i < body.length) {
+    const ch = body[i]
+    if (ch === '\\' && body[i + 1] === '|') {
+      current += '|'
+      i += 2
+      continue
+    }
+    if (ch === '`') {
+      inCode = !inCode
+      current += ch
+      i += 1
+      continue
+    }
+    if (ch === '|' && !inCode) {
+      cells.push(current.trim())
+      current = ''
+      i += 1
+      continue
+    }
+    current += ch
+    i += 1
+  }
+  cells.push(current.trim())
+  return cells
+}
+
+/**
+ * Read one separator cell as a column alignment, or null if it is not one.
+ *
+ * `---` left, `:---` left, `:---:` center, `---:` right. Three dashes minimum,
+ * matching macOS and GFM; a two-dash cell is not a separator, which is what
+ * stops an ordinary `| -- |` row from turning the paragraph above it into a
+ * table header.
+ */
+export function parseAlignment(cell: string): ColumnAlignment | null {
+  let marker = cell.trim()
+  const leading = marker.startsWith(':')
+  const trailing = marker.endsWith(':')
+  if (leading) marker = marker.slice(1)
+  if (trailing && marker.length > 0) marker = marker.slice(0, -1)
+  if (marker.length < 3) return null
+  for (const ch of marker) if (ch !== '-') return null
+  if (leading && trailing) return 'center'
+  if (trailing) return 'right'
+  return 'left'
+}
+
+/** Pad or truncate a row to the header's column count, as macOS does. */
+function normalize(cells: string[], columns: number): string[] {
+  if (cells.length === columns) return cells
+  if (cells.length > columns) return cells.slice(0, columns)
+  return [...cells, ...Array<string>(columns - cells.length).fill('')]
+}
+
+/**
+ * Try to read a table starting at `start`.
+ *
+ * Returns null unless the line and the one after it really are a header and a
+ * separator, so an ordinary paragraph containing a pipe is never mistaken for
+ * one. Body rows stop at the first blank line or any line with fewer than two
+ * cells, which is what lets a table be followed immediately by prose.
+ */
+export function parseTable(
+  lines: string[],
+  start: number
+): { table: MarkdownTable; nextIndex: number } | null {
+  if (start + 1 >= lines.length) return null
+
+  const header = splitCells(lines[start])
+  const separator = splitCells(lines[start + 1])
+  if (header.length < 2 || header.length !== separator.length) return null
+
+  const alignments: ColumnAlignment[] = []
+  for (const cell of separator) {
+    const alignment = parseAlignment(cell)
+    if (!alignment) return null
+    alignments.push(alignment)
+  }
+
+  const rows: string[][] = []
+  let cursor = start + 2
+  while (cursor < lines.length) {
+    // Subsumed by the cell-count rule below, since a blank line splits into a
+    // single empty cell: a mutation audit confirmed removing this changes no
+    // output. It stays because it states the rule a reader is looking for
+    // ("a table ends at a blank line"), which the cell count only implies, and
+    // because macOS carries the same pair.
+    if (lines[cursor].trim() === '') break
+    const cells = splitCells(lines[cursor])
+    if (cells.length < 2) break
+    rows.push(normalize(cells, header.length))
+    cursor += 1
+  }
+
+  return { table: { header, alignments, rows }, nextIndex: cursor }
+}


### PR DESCRIPTION
Windows renders chat markdown with a 173-line file that splits the text on one alternation regex. macOS uses 1,635 lines (`OmiMarkdown.swift`). The gap is not only missing features: two of the differences are wrong output.

## What the shipped renderer does today

Each of these was run against the current build and the result recorded before anything was changed.

| Input | Renders as |
|---|---|
| a four-line GFM table | one paragraph of literal `\| a \| b \|` |
| `> quoted line` | literal `&gt; quoted line` |
| `- a` / `  - b` / `- c` | one FLAT list; the nesting is discarded |
| `- [ ] todo` | literal `[ ] todo` |
| `~~gone~~` | literal tildes |
| `Before` / `---` / `After` | one paragraph with the dashes inside it |
| `#` and `######` | identical bold paragraphs |
| `**see [docs](https://x.com) now**` | **the link is destroyed**: bold text containing the raw markdown characters |
| `a \*not italic\* b` | **mangled**: the backslashes show AND it italicises |

The last two are the ones that matter most. They are not missing cases, they are what a flat split does: it cannot nest, so anything inside a matched pair is treated as literal text, and escapes are invisible to it.

Tables are the reason this is worth doing at all. The model emits them constantly, because a table is the natural shape for the comparisons users actually ask for, and every one of them has been arriving as unreadable pipe soup.

## Shape

```
lib/markdown/inline.ts   emphasis, code spans, links, escapes  -> tree
lib/markdown/table.ts    GFM tables                            -> table
lib/markdown/blocks.ts   the block grammar                     -> blocks
components/Markdown.tsx  blocks + inline                       -> elements
```

Parsing is separated from rendering, so the entire grammar is a pure function of a string and is tested without a DOM. The component only turns the tree into elements.

## Rules worth knowing

**Scanner order is load-bearing** and is macOS': fenced code first, then tables, then everything else. Code first is what keeps a `---` or a `| a | b |` inside a code sample literal instead of turning it into a rule or a table.

**Code spans outrank everything inline.** That is what makes `` `**not bold**` `` work, and it means a delimiter inside a code span can no longer close an emphasis run that opened outside it.

**A single asterisk steps over a double run** when looking for its closer. Without that, `*italic with **bold** inside*` closed the italic on the opening `**` and produced garbage for the rest of the line.

**Underscores may not open or close inside a word,** so `my_var_name` stays an identifier. Asterisks still work intraword, which is what CommonMark says.

**Link destinations are read with balanced parentheses.** The first `)` is not the end: real URLs contain parens, and so does the very href this app refuses, so `[x](javascript:alert(1))` has to be read whole before it can be judged at all.

**Table cells split on pipes that are neither escaped nor inside a code span,** ported from macOS rather than guessed, so a cell can hold `\|` or `` `a | b` ``. And a table is only a table if the separator parses as alignments for exactly the header's columns, which is what stops a paragraph containing a pipe being read as one.

**Unclosed markers stay literal.** A reply is streamed, so a half-typed `**` is the normal state, not an error. One test renders every prefix of a representative document, because the renderer runs on every token and any prefix that looped would hang the app.

## Security

Chat is untrusted input in the ordinary case here, not only under attack: the prompt includes OCR of whatever is on the user's screen, so a reply can be steered by indirect prompt injection into emitting any markup it likes. Three rules follow, and they live in the parser with their own tests rather than inside a component.

**The href allowlist is carried over and extended.** http, https and mailto become links; anything else renders its label as plain text with no anchor at all. New: an href containing a control character is refused outright, because URL parsers strip those before reading the scheme. That blocks `java\tscript:alert(1)`, and it also blocks `https://omi.me\t@evil.example`, where the scheme really is https so the allowlist alone passes it while the host actually visited is `evil.example`.

**Images are reduced to alt text and nothing is fetched.** Deliberate, not unimplemented. Rendering `![](url)` would make an injected address a tracking pixel that reports the user's IP and that the chat was opened, on load, with nothing clicked.

**No raw HTML, ever.** React elements only, which the tests assert directly: raw tags render as text, HTML inside a code block renders as text, and a markdown image produces no `img` element and no request.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,340 passed, 18 skipped, 546 files. 105 of those are this change; the branch point was 5,235. The three pre-existing `Markdown` tests pass unmodified.
- `npx tsc --noEmit` on `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint .` - 0 errors.
- `npx electron-vite build` - clean.
- `check_brand_ui.py`, `check_lifecycle_headers.py` - pass.

## Mutation audit

49 regressions seeded, 48 caught.

It found four real gaps, all now closed, and three of them are the same shape: a guard that looked covered because every input tested against it also failed a different guard.

**The control-character rule in the href check** could be deleted with no test failing, because every case tested also failed the scheme allowlist. The case that gives it its own weight is `https://omi.me\t@evil.example`, above.

**The href check on the autolink path** was the same story until tested with a URL carrying a control character, which the autolink pattern admits because it excludes only whitespace.

**The intraword-underscore rule has two halves** and only the closing one was covered. `my_var_ end` separates them: the closer there is legal, so only the opening rule stops `var` italicising.

**The CRLF test asserted block kinds,** which pass either way because a lone carriage return still trims to empty and still splits the paragraphs. The carriage returns were surviving inside the text, where they reach the DOM.

One escape is left and is documented where it sits: a table ends at a blank line, which the cell-count rule below it already subsumes, since a blank line splits into a single empty cell. It stays because it states the rule a reader is looking for, which the cell count only implies, and because macOS carries the same pair.

## Deliberate divergences from macOS

| Divergence | Why |
|---|---|
| An unclosed fence keeps the rest of the reply as code; macOS keeps it as text | Mid-stream the closing fence has not arrived yet. Watching the block form reads better than watching raw markdown reflow the moment it closes. This is also the shipped Windows behaviour, so it is a divergence being kept rather than introduced. |
| No citation tokens | macOS' inline citation masking belongs to its chat citation feature, which Windows does not have. |
| No inline-code copy button | macOS makes every inline code span its own copy target. Windows keeps the copy button on fenced blocks only, which is the existing behaviour and the one the current tests pin. |
| Images render as alt text | See above; this is a security position, not a gap. |


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

