### PR TITLE
feat(desktop): halt voice playback on user speech barge-in

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -23,7 +23,7 @@ extension AppState {
         isSpeaking: FloatingBarVoicePlaybackService.shared.isSpeaking
       ) {
         log("Transcription [BARGE-IN]: User spoke mid-playback; interrupting voice output")
-        FloatingBarVoicePlaybackService.shared.stop()
+        FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
       }
 
       // Convert backend segment to local SpeakerSegment

--- a/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
@@ -14,6 +14,18 @@ extension AppState {
       // Extract speaker_id from backend (e.g. "SPEAKER_00" → 0)
       let speakerId = segment.speaker_id ?? 0
 
+      // Barge-in interruption: if the user speaks while voice playback is active,
+      // halt playback immediately so Omi never talks over the user.
+      if VoiceBargeInPolicy.shouldInterrupt(
+        isUser: segment.is_user,
+        speaker: speakerId,
+        text: segment.text,
+        isSpeaking: FloatingBarVoicePlaybackService.shared.isSpeaking
+      ) {
+        log("Transcription [BARGE-IN]: User spoke mid-playback; interrupting voice output")
+        FloatingBarVoicePlaybackService.shared.stop()
+      }
+
       // Convert backend segment to local SpeakerSegment
       let translations = (segment.translations ?? []).map {
         SegmentTranslation(lang: $0.lang, text: $0.text)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceBargeInPolicy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceBargeInPolicy.swift
@@ -5,7 +5,7 @@ import Foundation
 /// When the assistant is speaking (proactive advice, voice response, or TTS)
 /// and the user begins speaking, barge-in halts playback immediately so Omi
 /// never talks over the user.
-enum VoiceBargeInPolicy {
+enum VoiceBargeInPolicy: Sendable {
   /// Evaluates whether an incoming transcript segment warrants interrupting voice playback.
   ///
   /// - Parameters:

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceBargeInPolicy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/VoiceBargeInPolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Pure policy deciding when incoming ambient speech interrupts active voice output.
+///
+/// When the assistant is speaking (proactive advice, voice response, or TTS)
+/// and the user begins speaking, barge-in halts playback immediately so Omi
+/// never talks over the user.
+enum VoiceBargeInPolicy {
+  /// Evaluates whether an incoming transcript segment warrants interrupting voice playback.
+  ///
+  /// - Parameters:
+  ///   - isUser: Whether diarization flagged the segment as the user.
+  ///   - speaker: Speaker identifier (0 is the primary user).
+  ///   - text: Transcript utterance text.
+  ///   - isSpeaking: Whether voice playback/synthesis is currently active.
+  /// - Returns: True if playback should be halted immediately.
+  static func shouldInterrupt(
+    isUser: Bool,
+    speaker: Int,
+    text: String,
+    isSpeaking: Bool
+  ) -> Bool {
+    guard isSpeaking else { return false }
+    guard isUser || speaker == 0 else { return false }
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+    return true
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+JournalProjection.swift
@@ -227,6 +227,12 @@ extension ChatProvider {
     ) {
       let trimmed = sourceID.trimmingCharacters(in: .whitespacesAndNewlines)
       guard !trimmed.isEmpty, seen.insert("\(kind.rawValue):\(trimmed)").inserted else { return }
+      let formattedDate: String?
+      if let createdAt = createdAt {
+        formattedDate = formatter.string(from: createdAt)
+      } else {
+        formattedDate = nil
+      }
       result.append(
         ChatCitationReference(
           ordinal: ordinal,
@@ -234,7 +240,7 @@ extension ChatProvider {
           sourceID: trimmed,
           title: title,
           preview: preview,
-          createdAt: createdAt.map { formatter.string(from: $0) }))
+          createdAt: formattedDate))
       ordinal += 1
     }
     for memory in memories {

--- a/desktop/macos/Desktop/Tests/VoiceBargeInPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/VoiceBargeInPolicyTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class VoiceBargeInPolicyTests: XCTestCase {
+
+  func testUserSpeechInterruptsActivePlayback() {
+    let result = VoiceBargeInPolicy.shouldInterrupt(
+      isUser: true,
+      speaker: 0,
+      text: "Wait, stop that",
+      isSpeaking: true
+    )
+    XCTAssertTrue(result)
+  }
+
+  func testUserSpeechNoopWhenNotPlaying() {
+    let result = VoiceBargeInPolicy.shouldInterrupt(
+      isUser: true,
+      speaker: 0,
+      text: "Hello there",
+      isSpeaking: false
+    )
+    XCTAssertFalse(result)
+  }
+
+  func testOtherSpeakerSpeechDoesNotInterrupt() {
+    let result = VoiceBargeInPolicy.shouldInterrupt(
+      isUser: false,
+      speaker: 1,
+      text: "Sure, let's look at the next slide",
+      isSpeaking: true
+    )
+    XCTAssertFalse(result, "Other speakers on a call should not interrupt the user's assistant output")
+  }
+
+  func testEmptyOrWhitespaceSpeechDoesNotInterrupt() {
+    let emptyResult = VoiceBargeInPolicy.shouldInterrupt(
+      isUser: true,
+      speaker: 0,
+      text: "",
+      isSpeaking: true
+    )
+    XCTAssertFalse(emptyResult)
+
+    let whitespaceResult = VoiceBargeInPolicy.shouldInterrupt(
+      isUser: true,
+      speaker: 0,
+      text: "   \n\t  ",
+      isSpeaking: true
+    )
+    XCTAssertFalse(whitespaceResult)
+  }
+
+  func testSpeakerZeroTreatedAsUserEvenIfIsUserFlagFalse() {
+    let result = VoiceBargeInPolicy.shouldInterrupt(
+      isUser: false,
+      speaker: 0,
+      text: "Cancel that order",
+      isSpeaking: true
+    )
+    XCTAssertTrue(result, "Speaker 0 is the primary local user and must be allowed to interrupt")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260818-voice-barge-in-interrupt.json
+++ b/desktop/macos/changelog/unreleased/20260818-voice-barge-in-interrupt.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added voice barge-in interruption to halt playback immediately when the user begins speaking"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/Audio/PreferredMicrophoneReconnect.swift
   - desktop/macos/Desktop/Sources/AppState/SharedCaptureSilentMicRecoveryPolicy.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+ListenEvents.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/VoiceBargeInPolicy.swift
   - desktop/macos/Desktop/Sources/AppState/LocalTranscriptionDuplicatePolicy.swift
   - desktop/macos/Desktop/Sources/AppState/STTSessionState.swift
   - desktop/macos/Desktop/Sources/LocalTranscriptionService.swift


### PR DESCRIPTION
## What changed and why
Adds voice barge-in interruption during ambient listening. When the assistant is speaking (delivering proactive voice advice, answering queries, or synthesizing TTS) and the user begins speaking, playback is halted immediately so Omi never talks over the user.

## Product invariants affected
- INV-CHAT-1

## How it was verified
1. Built and executed unit tests:
   `swift test --filter VoiceBargeInPolicyTests` -> 5 passed in 0.006s
   - User speech interrupts active playback
   - User speech is a no-op when not playing
   - Other speaker turns on multi-party calls do not interrupt
   - Empty/whitespace utterances are ignored
   - Speaker 0 is treated as primary user
2. Added e2e flow coverage entry in `capture-lifecycle.yaml`
3. Added changelog fragment

## Tests
- `desktop/macos/Desktop/Tests/VoiceBargeInPolicyTests.swift` (5 unit tests)

## Failure class (fixes)
Failure-Class: none