### PR TITLE
Mutation-audit the Windows suite: close 24 proven holes, and one real Rewind defect

### DIFF
--- a/desktop/windows/src/main/rewind/captureDecision.test.ts
+++ b/desktop/windows/src/main/rewind/captureDecision.test.ts
@@ -19,10 +19,16 @@ describe('shouldCaptureFrame', () => {
     expect(shouldCaptureFrame(base)).toEqual({ capture: true })
   })
   it('skips when the screen is locked', () => {
-    expect(shouldCaptureFrame({ ...base, locked: true })).toEqual({ capture: false, reason: 'locked' })
+    expect(shouldCaptureFrame({ ...base, locked: true })).toEqual({
+      capture: false,
+      reason: 'locked'
+    })
   })
   it('skips when the user is idle past the threshold', () => {
-    expect(shouldCaptureFrame({ ...base, idleSeconds: 120 })).toEqual({ capture: false, reason: 'idle' })
+    expect(shouldCaptureFrame({ ...base, idleSeconds: 120 })).toEqual({
+      capture: false,
+      reason: 'idle'
+    })
   })
   it('skips when a previous frame is still processing', () => {
     expect(shouldCaptureFrame({ ...base, busy: true })).toEqual({ capture: false, reason: 'busy' })
@@ -52,18 +58,26 @@ describe('shouldCaptureFrame', () => {
     expect(shouldCaptureFrame({ ...base, excludedApps: ['', '  '] })).toEqual({ capture: true })
   })
   it('does not exclude an unrelated app', () => {
-    expect(
-      shouldCaptureFrame({ ...base, appName: 'Notepad', excludedApps: ['chrome'] })
-    ).toEqual({ capture: true })
+    expect(shouldCaptureFrame({ ...base, appName: 'Notepad', excludedApps: ['chrome'] })).toEqual({
+      capture: true
+    })
   })
   it('skips a login page by window title (sensitive)', () => {
     expect(
-      shouldCaptureFrame({ ...base, appName: 'Google Chrome', windowTitle: 'Sign in - Google Accounts' })
+      shouldCaptureFrame({
+        ...base,
+        appName: 'Google Chrome',
+        windowTitle: 'Sign in - Google Accounts'
+      })
     ).toEqual({ capture: false, reason: 'sensitive' })
   })
   it('skips an incognito window by title (sensitive)', () => {
     expect(
-      shouldCaptureFrame({ ...base, appName: 'Google Chrome', windowTitle: 'New Tab - Google Chrome (Incognito)' })
+      shouldCaptureFrame({
+        ...base,
+        appName: 'Google Chrome',
+        windowTitle: 'New Tab - Google Chrome (Incognito)'
+      })
     ).toEqual({ capture: false, reason: 'sensitive' })
   })
   it('skips a password page by title (sensitive)', () => {
@@ -110,8 +124,121 @@ describe('shouldCaptureFrame', () => {
     ).toEqual({ capture: true })
   })
   it('captures the first-ever frame even if the hash matches (nothing stored yet)', () => {
-    expect(
-      shouldCaptureFrame({ ...base, lastHash: base.hash, lastCapturedAtMs: null })
-    ).toEqual({ capture: true })
+    expect(shouldCaptureFrame({ ...base, lastHash: base.hash, lastCapturedAtMs: null })).toEqual({
+      capture: true
+    })
+  })
+})
+
+/** A hash differing from `base.hash` in exactly `bits` positions. */
+function hashDifferingBy(bits: number): string {
+  const chars = base.hash.split('')
+  for (let i = 0; i < bits; i++) chars[i] = chars[i] === '1' ? '0' : '1'
+  return chars.join('')
+}
+
+// Every case above sits comfortably PAST the boundary it exercises: idle at 120
+// against a threshold of 60, "very different" against identical, 29s and 31s
+// against a 30s window. None of them sits ON the boundary, so each of these
+// three comparisons could be flipped by one step and the suite stayed green. A
+// mutation audit confirmed all three.
+//
+// The boundary matters to a user in each case: whether a frame is recorded at
+// the instant they go idle, whether a screen that changed by a hair is stored
+// again, and whether a static screen still gets its periodic anchor.
+//
+// The distances and durations below are written as LITERALS rather than derived
+// from the constants they bracket. Deriving them looks tidier and cannot fail:
+// the first version of this block built its fixtures with
+// `hashDifferingBy(DUP_HAMMING_THRESHOLD)`, so zeroing that constant moved the
+// fixture with it and the assertion still passed. A boundary test has to state
+// the boundary.
+describe('shouldCaptureFrame boundaries', () => {
+  describe('the idle threshold', () => {
+    it('does not capture at exactly the threshold', () => {
+      // `>=`: the threshold second is already idle. One step to `>` and Rewind
+      // takes one more frame after the user has walked away.
+      expect(shouldCaptureFrame({ ...base, idleSeconds: 60, idleThresholdSeconds: 60 })).toEqual({
+        capture: false,
+        reason: 'idle'
+      })
+    })
+
+    it('captures one second before the threshold', () => {
+      expect(shouldCaptureFrame({ ...base, idleSeconds: 59, idleThresholdSeconds: 60 })).toEqual({
+        capture: true
+      })
+    })
+  })
+
+  describe('the duplicate-frame threshold', () => {
+    // macOS measured the scale this rides on and recorded it in
+    // `RewindOCRService.swift` (`dedupThreshold`): "spinner animation = 1,
+    // cursor shift = 4, real content change = 23". A distance of 4 is a cursor
+    // moving, which is the same screen; 5 is where Windows starts storing again.
+    it('treats a frame four bits away as the same screen', () => {
+      expect(shouldCaptureFrame({ ...base, lastHash: hashDifferingBy(4) })).toEqual({
+        capture: false,
+        reason: 'duplicate'
+      })
+    })
+
+    it('captures a frame five bits away', () => {
+      expect(shouldCaptureFrame({ ...base, lastHash: hashDifferingBy(5) })).toEqual({
+        capture: true
+      })
+    })
+
+    it('pins the threshold itself, which the cases above cannot', () => {
+      // Those two bracket the CURRENT value; only this notices it moving. Worth
+      // a line of its own because macOS uses 5 where Windows uses 4, so the two
+      // platforms disagree about a screen that changed by exactly five bits.
+      expect(DUP_HAMMING_THRESHOLD).toBe(4)
+    })
+
+    it('still captures a near-duplicate once the anchor window has passed', () => {
+      // The two rules compose: the dedup threshold only suppresses a frame
+      // while the anchor window is open.
+      expect(
+        shouldCaptureFrame({
+          ...base,
+          lastHash: hashDifferingBy(4),
+          nowMs: 1_000_000,
+          lastCapturedAtMs: 1_000_000 - 30_001
+        })
+      ).toEqual({ capture: true })
+    })
+  })
+
+  describe('the keyframe anchor window', () => {
+    it('suppresses a duplicate at exactly thirty seconds', () => {
+      // `<=`: at exactly 30s the last stored frame is still the anchor. macOS
+      // uses the same comparison against the same value
+      // (`RewindIndexer.swift:218`, `<= frameDedupeMaxInterval`).
+      expect(
+        shouldCaptureFrame({
+          ...base,
+          lastHash: base.hash,
+          nowMs: 1_000_000,
+          lastCapturedAtMs: 1_000_000 - 30_000
+        })
+      ).toEqual({ capture: false, reason: 'duplicate' })
+    })
+
+    it('anchors one millisecond past thirty seconds', () => {
+      expect(
+        shouldCaptureFrame({
+          ...base,
+          lastHash: base.hash,
+          nowMs: 1_000_000,
+          lastCapturedAtMs: 1_000_000 - 30_001
+        })
+      ).toEqual({ capture: true })
+    })
+
+    it('pins the window to the value macOS sets', () => {
+      // `frameDedupeMaxInterval: TimeInterval = 30.0`, RewindIndexer.swift:36.
+      expect(KEYFRAME_ANCHOR_MS).toBe(30_000)
+    })
   })
 })

--- a/desktop/windows/src/main/rewind/frameHash.test.ts
+++ b/desktop/windows/src/main/rewind/frameHash.test.ts
@@ -29,3 +29,146 @@ describe('hammingDistance', () => {
     expect(hammingDistance('001', '0011')).toBe(Number.POSITIVE_INFINITY)
   })
 })
+
+// Everything above builds its bitmaps from `px(v)`, which sets B, G and R to
+// the SAME value. That makes every fixture greyscale, and a greyscale fixture
+// cannot see which channels the luminance actually reads: swapping the red
+// channel for a second copy of blue leaves every assertion above green. A
+// mutation audit confirmed it.
+//
+// It matters because this hash is the only thing deciding whether two frames
+// are "the same screen" (`captureDecision.ts`). A hash blind to a channel means
+// a screen that changed only in that channel is treated as unchanged and never
+// stored, and the user simply finds nothing in Rewind for that stretch.
+const bgra = (b: number, g: number, r: number): number[] => [b, g, r, 255]
+
+function colourBitmap(pixels: [number, number, number][]): Buffer {
+  return Buffer.from(pixels.flatMap(([b, g, r]) => bgra(b, g, r)))
+}
+
+describe('averageHash reads every colour channel', () => {
+  it('distinguishes frames that differ only in red', () => {
+    const dimRed = colourBitmap([
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 60],
+      [0, 0, 60]
+    ])
+    const brightRed = colourBitmap([
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 255],
+      [0, 0, 255]
+    ])
+    // Both are "0011" by shape; what matters is that red reaches the average at
+    // all, so the two frames are not hashed as one flat field.
+    expect(averageHash(dimRed, 4)).toBe('0011')
+    expect(averageHash(brightRed, 4)).toBe('0011')
+  })
+
+  it('weighs red the same as blue and green', () => {
+    // Three pixels carrying the same total luminance in different channels must
+    // hash alike. If a channel were dropped or doubled they would not.
+    const viaBlue = colourBitmap([
+      [90, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ])
+    const viaGreen = colourBitmap([
+      [0, 90, 0],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ])
+    const viaRed = colourBitmap([
+      [0, 0, 90],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ])
+    expect(averageHash(viaGreen, 4)).toBe(averageHash(viaBlue, 4))
+    expect(averageHash(viaRed, 4)).toBe(averageHash(viaBlue, 4))
+  })
+
+  it('notices a red-only change between two frames', () => {
+    // The end-to-end version of the same property, stated the way the capture
+    // path consumes it: two different screens must not hash identically.
+    const before = colourBitmap([
+      [0, 0, 0],
+      [0, 0, 0],
+      [200, 0, 0],
+      [0, 0, 0]
+    ])
+    const after = colourBitmap([
+      [0, 0, 200],
+      [0, 0, 0],
+      [0, 0, 0],
+      [0, 0, 0]
+    ])
+    expect(averageHash(after, 4)).not.toBe(averageHash(before, 4))
+  })
+})
+
+describe('averageHash at the average', () => {
+  it('gives a pixel exactly at the average a 0 bit', () => {
+    // Strictly greater, not greater-or-equal. Flipping that comparison changes
+    // the hash of every flat region, which is most of a real screen.
+    expect(
+      averageHash(
+        colourBitmap([
+          [10, 10, 10],
+          [10, 10, 10]
+        ]),
+        2
+      )
+    ).toBe('00')
+  })
+
+  it('hashes a completely uniform frame to all zeros', () => {
+    // The degenerate case, worth stating because it is what a broken luminance
+    // calculation collapses every frame to, and because a hash of all zeros
+    // makes every frame a duplicate of every other.
+    expect(
+      averageHash(
+        colourBitmap([
+          [7, 7, 7],
+          [7, 7, 7],
+          [7, 7, 7],
+          [7, 7, 7]
+        ]),
+        4
+      )
+    ).toBe('0000')
+  })
+
+  it('does not collapse a varied frame to all zeros', () => {
+    // The guard that a uniform-frame assertion cannot give on its own.
+    expect(
+      averageHash(
+        colourBitmap([
+          [0, 0, 0],
+          [255, 255, 255]
+        ]),
+        2
+      )
+    ).toBe('01')
+  })
+})
+
+describe('hammingDistance edges', () => {
+  it('counts a distance of exactly the dedup threshold', () => {
+    // 4 is the value `captureDecision` treats as "same screen"; this is the
+    // arithmetic half of that boundary.
+    expect(hammingDistance('11110000', '00000000')).toBe(4)
+    expect(hammingDistance('11111000', '00000000')).toBe(5)
+  })
+
+  it('treats an empty pair as identical rather than as a mismatch', () => {
+    expect(hammingDistance('', '')).toBe(0)
+  })
+
+  it('is symmetric', () => {
+    expect(hammingDistance('1010', '0001')).toBe(hammingDistance('0001', '1010'))
+  })
+})

--- a/desktop/windows/src/main/rewind/orphanSelection.test.ts
+++ b/desktop/windows/src/main/rewind/orphanSelection.test.ts
@@ -153,3 +153,49 @@ describe('C1 regression — DST/TZ offset shift must not false-delete valid file
     ).toEqual([]) // fix: no false deletion
   })
 })
+
+// The grace window is the only thing standing between the sweep and a file the
+// capture path is still inserting a row for, and this function's output is fed
+// straight to `unlink`. Every case above sits a full second or more clear of
+// the boundary on one side or the other, so flipping the comparison by one step
+// changed nothing the suite could see; a mutation audit confirmed it.
+//
+// Ages are written as literals rather than derived from ORPHAN_GRACE_MS: a
+// fixture built from the constant moves with it, and then the assertion pins
+// nothing.
+describe('selectOrphanFiles at the grace boundary', () => {
+  const args = (f: SweepFile) => ({
+    files: [f],
+    dbImagePaths: new Set<string>(),
+    nowMs: NOW,
+    graceMs: 60_000
+  })
+
+  it('deletes an orphan aged exactly the grace window', () => {
+    // `>=`: at exactly the window the file is old enough to go.
+    const f = file(NOW - 60_000)
+    expect(selectOrphanFiles(args(f))).toEqual([f.fullPath])
+  })
+
+  it('keeps an orphan one millisecond younger than the window', () => {
+    const f = file(NOW - 59_999)
+    expect(selectOrphanFiles(args(f))).toEqual([])
+  })
+
+  it('pins the grace window itself, which the two cases above cannot', () => {
+    // Sixty seconds is the same order as the gap between writing a frame and
+    // inserting its row; shortening it is how the sweep starts racing capture.
+    expect(ORPHAN_GRACE_MS).toBe(60_000)
+  })
+
+  it('uses the NEWER of filename and mtime at the boundary too', () => {
+    // The conservative rule: an old name with a fresh mtime is young. Pinned at
+    // the boundary because that is where "whichever is newer" can silently
+    // become "whichever is older" without any other case noticing.
+    const oldNameFreshMtime = file(NOW - 10 * 60_000, NOW - 59_999)
+    expect(selectOrphanFiles(args(oldNameFreshMtime))).toEqual([])
+
+    const oldNameOldMtime = file(NOW - 10 * 60_000, NOW - 60_000)
+    expect(selectOrphanFiles(args(oldNameOldMtime))).toEqual([oldNameOldMtime.fullPath])
+  })
+})

--- a/desktop/windows/src/shared/rewindExclusions.test.ts
+++ b/desktop/windows/src/shared/rewindExclusions.test.ts
@@ -1,0 +1,245 @@
+// The built-in Rewind exclusions are a privacy list: password managers whose
+// windows must never be stored, and screen-recording tools that would otherwise
+// capture a recording of a recording. Nothing tested either list. It is reached
+// only indirectly, through `captureDecision`, and only three of the twelve
+// window-title markers were exercised there.
+//
+// A privacy list is exactly the kind of thing that decays without a contract:
+// entries get added over time, and the failure mode of a wrong one is silent in
+// both directions. An entry that stops matching means a password manager is
+// recorded, which is a breach. An entry that matches too much means an ordinary
+// app is never recorded, which the user experiences as Rewind quietly having
+// holes in it. Both are invisible without a test.
+//
+// These iterate the REAL exported arrays rather than a copy, so an entry added
+// later is covered the day it lands.
+import { describe, expect, it } from 'vitest'
+import { BUILT_IN_EXCLUDED_APPS, SENSITIVE_WINDOW_MARKERS } from './rewindExclusions'
+import { shouldCaptureFrame, type CaptureState } from '../main/rewind/captureDecision'
+
+/** A frame that would otherwise be captured, so any refusal is the rule firing. */
+const capturable: CaptureState = {
+  locked: false,
+  idleSeconds: 0,
+  idleThresholdSeconds: 60,
+  busy: false,
+  appName: 'SomeOrdinaryApp',
+  processName: 'someordinaryapp.exe',
+  windowTitle: 'Untitled document',
+  excludedApps: [...BUILT_IN_EXCLUDED_APPS],
+  hash: '1111000011110000',
+  lastHash: '0000111100001111',
+  nowMs: 1_000_000,
+  lastCapturedAtMs: 995_000
+}
+
+describe('the frame this file uses as its control', () => {
+  it('is captured, so every refusal below is a rule firing', () => {
+    expect(shouldCaptureFrame(capturable)).toEqual({ capture: true })
+  })
+})
+
+describe('built-in app exclusions', () => {
+  it('has not silently shrunk', () => {
+    // A count, so removing an entry is not invisible. The per-entry cases below
+    // all iterate the list, so they get shorter with it and stay green.
+    expect(BUILT_IN_EXCLUDED_APPS).toHaveLength(21)
+  })
+
+  it.each(BUILT_IN_EXCLUDED_APPS)('never captures %s', (app) => {
+    expect(shouldCaptureFrame({ ...capturable, appName: app })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+  })
+
+  const SINGLE_TOKEN = BUILT_IN_EXCLUDED_APPS.filter((a) => !a.includes(' '))
+  const MULTI_TOKEN = BUILT_IN_EXCLUDED_APPS.filter((a) => a.includes(' '))
+
+  it.each(SINGLE_TOKEN)('never captures %s by process name alone', (app) => {
+    // The app name and the process name are matched together as one string, so
+    // a single-token entry catches the app even when Windows reports only the
+    // executable.
+    expect(
+      shouldCaptureFrame({
+        ...capturable,
+        appName: 'Unknown',
+        processName: `${app.toLowerCase()}.exe`
+      })
+    ).toEqual({ capture: false, reason: 'excluded' })
+  })
+
+  it.each(MULTI_TOKEN)('%s is matched by app name only, never by process name', (app) => {
+    // Found by writing the case above and watching it fail. Four entries
+    // contain a space, and a Windows process name never does, so these four
+    // cannot match an executable: they rely entirely on the friendly app name
+    // being reported. That is fine while it is, and a silent gap if it is not,
+    // which is worth stating rather than leaving to be rediscovered.
+    expect(
+      shouldCaptureFrame({
+        ...capturable,
+        appName: 'Unknown',
+        processName: `${app.replace(/[^a-z0-9]/gi, '').toLowerCase()}.exe`
+      })
+    ).toEqual({ capture: true })
+
+    expect(shouldCaptureFrame({ ...capturable, appName: app })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+  })
+
+  it('has exactly four entries that depend on the app name', () => {
+    expect(MULTI_TOKEN).toEqual([
+      'Snipping Tool',
+      'Snip & Sketch',
+      'Proton Pass',
+      'Keeper Password'
+    ])
+  })
+
+  it('keeps every password manager in the list', () => {
+    // Named individually because losing one is a privacy breach, and because a
+    // list-driven test cannot notice a deletion.
+    const lowered = BUILT_IN_EXCLUDED_APPS.map((a) => a.toLowerCase())
+    for (const manager of [
+      '1password',
+      'bitwarden',
+      'keepass',
+      'lastpass',
+      'dashlane',
+      'nordpass',
+      'proton pass',
+      'keeper password',
+      'roboform',
+      'enpass'
+    ]) {
+      expect(lowered).toContain(manager)
+    }
+  })
+
+  it('matches case-insensitively, as the exclusion is documented to', () => {
+    expect(shouldCaptureFrame({ ...capturable, appName: '1PASSWORD' })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+    expect(shouldCaptureFrame({ ...capturable, appName: 'bitwarden' })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+  })
+
+  it('does not exclude an ordinary app', () => {
+    expect(shouldCaptureFrame({ ...capturable, appName: 'Notion' })).toEqual({ capture: true })
+    expect(shouldCaptureFrame({ ...capturable, appName: 'Visual Studio Code' })).toEqual({
+      capture: true
+    })
+    // The app list holds product names, not the bare word: an app merely called
+    // "Password Generator" is captured. The window-TITLE list is what covers a
+    // page about passwords, and it is tested separately below.
+    expect(shouldCaptureFrame({ ...capturable, appName: 'Password Generator' })).toEqual({
+      capture: true
+    })
+  })
+})
+
+// These are real apps that no one intended to exclude. They are excluded anyway,
+// because the built-in list is matched as a case-insensitive SUBSTRING against
+// the app and process name together, and two entries are short enough to
+// appear inside unrelated names.
+//
+// The one that matters is Obsidian: `OBS` is a substring of it, so Rewind never
+// records an Obsidian window. Omi ships an Obsidian export integration
+// (`main/memoryExport/obsidian.ts`), so this is a product the app expects its
+// users to have.
+//
+// These cases DOCUMENT the collisions rather than bless them. They are written
+// so that fixing the list turns them red, which is the point: whoever narrows
+// these entries should be told which behaviour they changed. Not fixed here
+// deliberately, because the two failure directions are not symmetric — an
+// over-exclusion means an app is not recorded, while a botched narrowing means
+// a password manager IS recorded, and only someone who knows the real process
+// names of OBS Studio and Loom on Windows can make that change safely.
+describe('known over-exclusions from substring matching', () => {
+  it.each([
+    ['Obsidian', 'OBS'],
+    ['Bloomberg Terminal', 'Loom'],
+    ['Observer', 'OBS'],
+    ['Jobs', 'OBS']
+  ])('%s is excluded because the list contains %s', (app) => {
+    expect(shouldCaptureFrame({ ...capturable, appName: app, processName: '' })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+  })
+
+  it('excludes the tools those entries were meant for', () => {
+    // The exclusions themselves are correct and must survive any narrowing.
+    expect(shouldCaptureFrame({ ...capturable, appName: 'OBS Studio' })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+    expect(shouldCaptureFrame({ ...capturable, appName: 'Loom' })).toEqual({
+      capture: false,
+      reason: 'excluded'
+    })
+  })
+})
+
+describe('sensitive window-title markers', () => {
+  it('has not silently shrunk', () => {
+    expect(SENSITIVE_WINDOW_MARKERS).toHaveLength(12)
+  })
+
+  it.each(SENSITIVE_WINDOW_MARKERS)('never captures a window titled around %s', (marker) => {
+    // The whole point of the title list: the app is an ordinary browser, so the
+    // app-name list cannot help and only the title can.
+    expect(
+      shouldCaptureFrame({
+        ...capturable,
+        appName: 'Chrome',
+        processName: 'chrome.exe',
+        windowTitle: `Acme Bank — ${marker} — Google Chrome`
+      })
+    ).toEqual({ capture: false, reason: 'sensitive' })
+  })
+
+  it('matches a marker case-insensitively', () => {
+    expect(shouldCaptureFrame({ ...capturable, windowTitle: 'ACME BANK LOGIN' })).toEqual({
+      capture: false,
+      reason: 'sensitive'
+    })
+  })
+
+  it('keeps the markers that cover the common auth screens', () => {
+    // Named individually for the same reason as the password managers: a
+    // list-driven test cannot notice a deletion.
+    for (const marker of ['password', 'login', 'sign in', '2fa', 'incognito', 'one-time code']) {
+      expect(SENSITIVE_WINDOW_MARKERS).toContain(marker)
+    }
+  })
+
+  it('captures an ordinary browser tab', () => {
+    expect(
+      shouldCaptureFrame({
+        ...capturable,
+        appName: 'Chrome',
+        processName: 'chrome.exe',
+        windowTitle: 'Quarterly report — Google Docs'
+      })
+    ).toEqual({ capture: true })
+  })
+
+  it('checks the title even when the app is not excluded', () => {
+    // Ordering: the exclusion list runs first, so a sensitive title in an
+    // ordinary app has to be caught by its own rule.
+    expect(
+      shouldCaptureFrame({
+        ...capturable,
+        appName: 'Firefox',
+        processName: 'firefox.exe',
+        windowTitle: 'Sign in to your account'
+      })
+    ).toEqual({ capture: false, reason: 'sensitive' })
+  })
+})

--- a/desktop/windows/src/shared/timelineGeometry.test.ts
+++ b/desktop/windows/src/shared/timelineGeometry.test.ts
@@ -10,7 +10,8 @@ import {
   gapSegments,
   frameIndexAtCursor,
   shouldRecenterTimeline,
-  REWIND_BREAK_THRESHOLD_MS
+  REWIND_BREAK_THRESHOLD_MS,
+  REWIND_LINEAR_MIN_PX
 } from './timelineGeometry'
 
 const H = 3_600_000
@@ -342,5 +343,45 @@ describe('shouldRecenterTimeline', () => {
   it('re-centers once the playhead drifts just past a quarter-viewport', () => {
     expect(shouldRecenterTimeline(1000, CW, 1201)).toBe(true)
     expect(shouldRecenterTimeline(1000, CW, 799)).toBe(true)
+  })
+})
+
+// The three cases below came out of a mutation audit against the 47 tests above.
+// Each survived them, and each is something a user would see.
+describe('timeline geometry gaps found by mutation', () => {
+  const HOUR = 3_600_000
+
+  it('gives a two-second activity block a clickable width', () => {
+    // Natural width here is (2000 / 3_600_000) * 100 = 0.056px. The floor is
+    // the only reason a short burst of activity between two long idle gaps is
+    // visible on the bar at all, let alone clickable. Nothing exercised it, so
+    // dropping the floor to zero left every test green while making the piece
+    // disappear.
+    const m = buildTimelineMapping([HOUR, HOUR + 2_000], 0, 2 * HOUR, {
+      pxPerHour: 100,
+      minWidth: 0
+    })
+    const linear = m.pieces.filter((p) => p.kind === 'linear')
+    expect(linear).toHaveLength(1)
+    expect(linear[0].xEnd - linear[0].xStart).toBe(REWIND_LINEAR_MIN_PX)
+    expect(REWIND_LINEAR_MIN_PX).toBe(3)
+  })
+
+  it('takes the finest interval that still fits the tick budget', () => {
+    // The cap is `span / interval <= maxTicks - 1`, an inclusive bound, because
+    // the tick count across a span is floor(span/interval) + 1. At exactly the
+    // bound the finer interval is still allowed; one step to `<` and the axis
+    // silently jumps to the next coarser interval everywhere.
+    const ticks = axisTicks(0, 4 * 60_000, 5)
+    expect(ticks).toHaveLength(5)
+    expect(ticks[1] - ticks[0]).toBe(60_000)
+  })
+
+  it('can select the six-hour interval', () => {
+    // A twenty-hour span with a five-tick budget is the only shape that picks
+    // it: three hours gives seven ticks, twelve gives two. Nothing reached this
+    // entry, so it could be removed from the table without a test noticing.
+    const ticks = axisTicks(0, 20 * HOUR, 5)
+    expect(ticks[1] - ticks[0]).toBe(6 * HOUR)
   })
 })


### PR DESCRIPTION
This adds no features and changes no production source. Every file it touches is a test.

`AGENTS.md` is explicit that coverage grows by ratchet and not by mandate, and that a suite people distrust is worse than a smaller suite. So rather than adding tests to raise a number, I ran a mutation audit against the existing Windows suite and only wrote cases where a specific regression provably shipped silently. Every case below cites the mutation it closes, and each mutation was re-run afterwards to confirm the case actually turns the suite red.

## How this was found

For a target module, find the test files that reach it transitively by import, seed a mutation, and run only those tests. A mutation that leaves them green is a proven hole: that exact regression ships today with no failure anywhere.

The mutations are generated rather than chosen, from two operators that almost always compile and almost always mean a real behaviour change: a comparison moved one step (`>=` to `>`, `<=` to `<`), and a numeric literal changed. Everything the generator flagged was then adjudicated by hand, because plenty of mutations are equivalent and prove nothing. The equivalent ones are called out below rather than quietly dropped.

## The pattern this kept finding

Almost every hole had the same shape: **the tests sit in the comfortable middle of a range and never on its edge.**

`captureDecision` has three comparisons that decide what of the user's screen is recorded. The existing cases test idle at 120 seconds against a threshold of 60, "very different" against identical, and 29 and 31 seconds against a 30 second window. All correct, all well clear of the boundary, and so all three comparisons could be moved a step with the suite staying green.

The boundaries are not academic. They are whether a frame is recorded at the instant the user walks away from the machine, whether a screen that changed by a hair is stored again, and whether a static screen still gets its periodic anchor in the timeline.

`orphanSelection` is the same shape with more at stake, because its return value is passed to `unlink`. The grace window is the only thing standing between the sweep and a file whose database row is still being written, and every existing case cleared it by a second or more.

## What else the audit turned up

**A frame hash that cannot see colour.** `frameHash` builds every fixture from a helper that sets blue, green and red to the same value. A greyscale fixture cannot see which channels the luminance reads, so swapping red for a second copy of blue left all four cases green. This hash is the only thing deciding whether two frames are "the same screen", so a hash blind to a channel means a screen that changed only in that channel is treated as unchanged and never stored. The user finds nothing in Rewind for that stretch and nothing anywhere says why.

**Three unreached rules in the timeline geometry, behind 47 tests.** `REWIND_LINEAR_MIN_PX` is the floor that gives a short burst of activity a clickable width: measured, a two second block between two idle gaps has a natural width of 0.056px, so without the floor it is invisible, and nothing noticed the floor going to zero. The tick-budget comparison is inclusive because the tick count across a span is `floor(span/interval) + 1`, and one step to exclusive silently coarsens every axis. And the six-hour tick interval was never selected by any test, so it could be deleted from the table without a failure; reaching it takes a twenty-hour span with a five-tick budget.

**A privacy list with no test at all.** `BUILT_IN_EXCLUDED_APPS` and `SENSITIVE_WINDOW_MARKERS` are the lists that stop Rewind storing password manager windows and login screens. Nothing tested either. They were reached only indirectly, and three of the twelve title markers were exercised.

## A real defect, found by writing that last one

The exclusion list is matched as a case-insensitive **substring** against the app and process name together, and two entries are short enough to appear inside unrelated names.

**`OBS` is a substring of Obsidian, so Rewind never records an Obsidian window.** Omi ships an Obsidian export integration (`main/memoryExport/obsidian.ts`), so this is a product the app expects its users to have. `Loom` is a substring of Bloomberg. Also caught: Observer, and any executable with "obs" in the name.

I have documented this rather than fixed it, deliberately. The two failure directions are not symmetric. An over-exclusion means an app is not recorded. A botched narrowing means a password manager IS recorded. Narrowing these entries safely needs the real process names of OBS Studio and Loom on Windows, which is a maintainer's call rather than something a test change should decide. The cases are written so that fixing the list turns them red, which tells whoever does it exactly which behaviour they changed.

A second, smaller finding from the same file: four entries contain a space, and a Windows process name never does, so `Snipping Tool`, `Snip & Sketch`, `Proton Pass` and `Keeper Password` cannot match an executable and depend entirely on the friendly app name being reported.

## The trap I walked into myself

The first version of the `captureDecision` boundary block could not fail. It built its fixtures with `hashDifferingBy(DUP_HAMMING_THRESHOLD)` and then asserted behaviour at that distance, so zeroing the constant moved the fixture with it and the assertion still passed. The audit caught it in a test written minutes earlier.

Every fixture here is now a literal rather than an expression over the constant it brackets. A boundary test has to state the boundary.

Two constants are pinned directly, and both cite a source outside this repo rather than the code under test. `KEYFRAME_ANCHOR_MS` matches macOS' `frameDedupeMaxInterval = 30.0` (`RewindIndexer.swift:36`, which also uses `<=` at line 218). The dedup threshold is pinned because macOS uses 5 where Windows uses 4, so the two platforms already disagree about a screen that changed by exactly five bits, and that disagreement should not move silently.

The exclusion tests also failed me twice before this was committed: I asserted twelve markers as fifteen, and asserted that an app called "Password Generator" was excluded when the app list holds product names and not the bare word. That is the argument for having them.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,330 passed, 18 skipped, 543 files.
- `npx tsc --noEmit` on `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint .` - 0 errors.
- No production source file is modified; `git diff --stat` is five test files.

**24 mutations seeded across the five modules, every one of them re-run after the cases were written. All 24 turn the suite red now. All 24 left it green before.**

| Module | Mutations | What they represent |
|---|---|---|
| `captureDecision.ts` | 5 | idle, dedup and anchor boundaries; both constants |
| `orphanSelection.ts` | 3 | grace boundary, grace window, newest-signal rule |
| `frameHash.ts` | 5 | each colour channel, the average comparison, the length guard |
| `timelineGeometry.ts` | 4 | the min-width floor, the tick budget, the six-hour interval |
| `rewindExclusions.ts` | 7 | a dropped password manager, a dropped marker, case-sensitivity, each check disabled |

## What is deliberately not here

Bulk coverage. I measured first: of 650 Windows source files over 40 lines, only 75 are never reached by any test, and most of those are Electron wiring or React pages where a unit test would assert the mock. This is a well-tested codebase, and adding cases to raise a number would be the noise `AGENTS.md` warns about.

Two escapes are recorded as equivalent mutations rather than papered over with a case that would only be asserting the mutation. In `xToTs`, changing `px <= pc.xEnd` to `<` changes nothing observable, because adjacent pieces share the timestamp at their common edge and both readings return the same value. In `retentionCutoff`, changing `retentionDays <= 0` to `< 0` is equivalent because the arithmetic on the other branch produces the same answer at zero.

The harness itself is not included. It is a developer tool with no blocking audience, and `AGENTS.md` is clear that a check nothing runs is a dead check. I am happy to contribute it wired into a CI lane as a separate change if that is wanted.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

