### PR TITLE
fix(backend): reissue a retired external evidence identity so a deleted memory can be re-added (#11812)

### DIFF
--- a/.github/failure-classes/FC-content-derived-identity-retired-by-deletion.json
+++ b/.github/failure-classes/FC-content-derived-identity-retired-by-deletion.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "FC-content-derived-identity-retired-by-deletion",
+  "violated_contract": "When a durable identity is derived from user content and its lifecycle state is monotonic, a later authorized submission of the same content must mint a fresh identity. Reusing the identity a deletion retired binds the new write to a tombstone that no retry can ever satisfy, so the user-facing operation fails permanently for that exact text.",
+  "canonical_prevention": "Resolve the derived identity against its stored lifecycle state on the write path and reissue it when the stored state is not active, keeping the retired identity retired; prove it with a write -> delete -> rewrite test through the production write path.",
+  "canonical_prevention_artifact": ["backend/utils/memory/canonical_memory_adapter.py"],
+  "evidence_prs": [],
+  "scope_hints": ["backend/utils/memory/**", "backend/database/memory_apply_store.py"],
+  "status": "open"
+}

--- a/.github/failure-classes/FC-content-derived-identity-retired-by-deletion.json
+++ b/.github/failure-classes/FC-content-derived-identity-retired-by-deletion.json
@@ -3,8 +3,15 @@
   "id": "FC-content-derived-identity-retired-by-deletion",
   "violated_contract": "When a durable identity is derived from user content and its lifecycle state is monotonic, a later authorized submission of the same content must mint a fresh identity. Reusing the identity a deletion retired binds the new write to a tombstone that no retry can ever satisfy, so the user-facing operation fails permanently for that exact text.",
   "canonical_prevention": "Resolve the derived identity against its stored lifecycle state on the write path and reissue it when the stored state is not active, keeping the retired identity retired; prove it with a write -> delete -> rewrite test through the production write path.",
-  "canonical_prevention_artifact": ["backend/utils/memory/canonical_memory_adapter.py"],
-  "evidence_prs": [],
-  "scope_hints": ["backend/utils/memory/**", "backend/database/memory_apply_store.py"],
+  "canonical_prevention_artifact": [
+    "backend/utils/memory/canonical_memory_adapter.py"
+  ],
+  "evidence_prs": [
+    11813
+  ],
+  "scope_hints": [
+    "backend/utils/memory/**",
+    "backend/database/memory_apply_store.py"
+  ],
   "status": "open"
 }

--- a/backend/tests/unit/test_ws_j_delete_privacy.py
+++ b/backend/tests/unit/test_ws_j_delete_privacy.py
@@ -62,7 +62,7 @@ def _install_heavy_import_stubs():
 
 
 ensure_utils_memory_packages_importable(str(BACKEND_DIR))
-from models.memories import MemoryCategory
+from models.memories import Memory, MemoryCategory, MemoryDB
 from models.memory_apply import MemoryControlState
 from models.memory_review import build_memory_review_conflict
 from models.product_memory import MemoryItem, MemoryItemStatus, MemoryTier, ProcessingState
@@ -81,8 +81,10 @@ from utils.memory.canonical_memory_adapter import (
     update_canonical_memory_product_fields,
     update_canonical_memory_visibility,
     write_canonical_extraction_memory,
+    write_canonical_external_memory,
 )
 from utils.memory.memory_system import MemorySystem, resolve_memory_system
+from utils.memory.required_promotion import required_processing_payload
 
 
 def _refresh_canonical_memory_adapter_runtime() -> None:
@@ -101,6 +103,7 @@ def _refresh_canonical_memory_adapter_runtime() -> None:
             "update_canonical_memory_product_fields": canonical_adapter.update_canonical_memory_product_fields,
             "update_canonical_memory_visibility": canonical_adapter.update_canonical_memory_visibility,
             "write_canonical_extraction_memory": canonical_adapter.write_canonical_extraction_memory,
+            "write_canonical_external_memory": canonical_adapter.write_canonical_external_memory,
         }
     )
 
@@ -839,6 +842,79 @@ def test_delete_canonical_memory_calls_kg_invalidation_hook(monkeypatch, canonic
     assert deleted_vectors == [(uid, memory_id)]
     tombstoned = canonical_db.docs[f"users/{uid}/memory_items/{memory_id}"]
     assert tombstoned["status"] == MemoryItemStatus.tombstoned.value
+
+
+def _external_memory_payload(uid: str, content: str) -> dict:
+    """The payload POST /v3/memories submits for a manually typed memory."""
+    memory_db = MemoryDB.from_memory(
+        Memory(content=content, category=MemoryCategory.manual),
+        uid,
+        None,
+        True,
+        source_type="manual",
+        source_signal="manual",
+        extractor_id="manual_memory_submission",
+    )
+    return required_processing_payload(memory_db.model_dump(mode="python"), source_surface="v3_manual")
+
+
+def _tombstoned_evidence_paths(db: "_FakeDb", uid: str) -> list[str]:
+    prefix = f"users/{uid}/memory_evidence/"
+    return [
+        path for path, data in db.docs.items() if path.startswith(prefix) and data.get("source_state") == "tombstoned"
+    ]
+
+
+def _stub_delete_side_effects(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.invalidate_kg_for_memory_retraction",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.delete_canonical_memory_vector",
+        lambda *args, **kwargs: None,
+    )
+
+
+def test_readding_a_deleted_manual_memory_lands_on_a_fresh_evidence_identity(monkeypatch, canonical_db):
+    uid = "uid-canonical-ws-j"
+    content = "I drink oat milk"
+    _stub_delete_side_effects(monkeypatch)
+
+    first_id = write_canonical_external_memory(uid, _external_memory_payload(uid, content), db_client=canonical_db)
+    delete_canonical_memory(uid, first_id, db_client=canonical_db)
+    retired_evidence = _tombstoned_evidence_paths(canonical_db, uid)
+    assert retired_evidence
+
+    write_canonical_external_memory(uid, _external_memory_payload(uid, content), db_client=canonical_db)
+
+    live = read_canonical_memories(uid, db_client=canonical_db, include_pending_processing=True)
+    assert content in [memory.content for memory in live]
+    # The deleted submission's evidence identity stays retired: the re-add is a
+    # new source artifact, not a resurrection of the deleted one.
+    assert all(canonical_db.docs[path]["source_state"] == "tombstoned" for path in retired_evidence)
+
+
+def test_conversation_sourced_evidence_is_never_reissued_after_delete(monkeypatch, canonical_db):
+    uid = "uid-canonical-ws-j"
+    conversation_id = "conv-deleted-source"
+    content = "Deleted conversation fact"
+    _stub_delete_side_effects(monkeypatch)
+
+    payload = _sample_memory_payload(uid=uid, conversation_id=conversation_id, content=content)
+    memory_id = write_canonical_extraction_memory(uid, payload, db_client=canonical_db)
+    delete_canonical_memory(uid, memory_id, db_client=canonical_db)
+
+    resubmitted = required_processing_payload(
+        _sample_memory_payload(uid=uid, conversation_id=conversation_id, content=content),
+        source_surface="v3_api",
+    )
+    with pytest.raises(RuntimeError, match="source_not_active"):
+        write_canonical_external_memory(uid, resubmitted, db_client=canonical_db)
 
 
 def test_delete_canonical_survivor_tombstones_active_alias_lineage(monkeypatch, canonical_db):

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -1061,6 +1061,7 @@ def _canonical_extraction_apply_write(
     data: Dict[str, Any],
     *,
     control: MemoryControlState,
+    evidence_items: Optional[List[MemoryEvidence]] = None,
 ) -> tuple[CanonicalApplyWrite, str]:
     content = (data.get("content") or "").strip()
     if not content:
@@ -1083,7 +1084,8 @@ def _canonical_extraction_apply_write(
         idempotency_identity,
     )
 
-    evidence_items = _evidence_items_from_payload(data)
+    if evidence_items is None:
+        evidence_items = _evidence_items_from_payload(data)
     raw_evidence = [
         cast(Payload, raw) for raw in cast(List[object], data.get("evidence") or []) if isinstance(raw, dict)
     ]
@@ -1154,11 +1156,22 @@ def _canonical_extraction_apply_write(
     )
 
 
-def write_canonical_extraction_memory(uid: str, data: Dict[str, Any], *, db_client: Any = None) -> str:
+def write_canonical_extraction_memory(
+    uid: str,
+    data: Dict[str, Any],
+    *,
+    db_client: Any = None,
+    evidence_items: Optional[List[MemoryEvidence]] = None,
+) -> str:
     """Persist one memory to memory_items + ledger (extraction or external/manual writes)."""
     client = db_client if db_client is not None else default_db_client
     control = _ensure_control_state(uid, db_client=client)
-    write, memory_id = _canonical_extraction_apply_write(uid, data, control=control)
+    write, memory_id = _canonical_extraction_apply_write(
+        uid,
+        data,
+        control=control,
+        evidence_items=evidence_items,
+    )
     for evidence in write.evidence:
         _persist_evidence(uid, evidence, db_client=client)
 
@@ -1199,9 +1212,67 @@ def write_canonical_extraction_memory(uid: str, data: Dict[str, Any], *, db_clie
     return committed_id
 
 
+_EXTERNAL_EVIDENCE_REISSUE_LIMIT = 25
+
+
+def _reissued_external_evidence(
+    uid: str,
+    evidence_items: List[MemoryEvidence],
+    *,
+    db_client: Any,
+) -> List[MemoryEvidence]:
+    """Mint a fresh evidence identity when an external submission reuses a retired one.
+
+    External evidence ids are derived from the submitted content, and evidence
+    source_state is monotonic per identity. Deleting a memory tombstones its
+    evidence, so re-adding the same text would otherwise reuse the tombstoned
+    identity and fail the apply source gate on every retry. The new submission is
+    a new source artifact and gets its own identity; the tombstone stays retired.
+    Conversation-sourced evidence keeps the retired identity: a deleted
+    conversation is a deleted source, not a fresh one.
+    """
+    collections = MemoryCollections(uid=uid)
+    reissued: List[MemoryEvidence] = []
+    for item in evidence_items:
+        if item.conversation_id or item.source_type == "conversation":
+            reissued.append(item)
+            continue
+        evidence_id = item.evidence_id
+        for attempt in range(1, _EXTERNAL_EVIDENCE_REISSUE_LIMIT + 1):
+            snapshot = db_client.document(f"{collections.memory_evidence}/{evidence_id}").get()
+            if not getattr(snapshot, "exists", False):
+                break
+            stored = _snapshot_payload(snapshot)
+            if SourceState(stored.get("source_state") or SourceState.active.value) == SourceState.active:
+                break
+            evidence_id = (
+                "ev_"
+                + deterministic_contract_id(
+                    "canonical-external-evidence-reissue",
+                    {"evidence_id": item.evidence_id, "attempt": attempt},
+                )[:32]
+            )
+        else:
+            raise RuntimeError("canonical external write exhausted evidence identity reissues")
+        reissued.append(
+            item if evidence_id == item.evidence_id else item.model_copy(update={"evidence_id": evidence_id})
+        )
+    return reissued
+
+
 def write_canonical_external_memory(uid: str, data: Dict[str, Any], *, db_client: Any = None) -> str:
     """Persist a manual/API/integration memory via the canonical apply path."""
-    return write_canonical_extraction_memory(uid, data, db_client=db_client)
+    client = db_client if db_client is not None else default_db_client
+    return write_canonical_extraction_memory(
+        uid,
+        data,
+        db_client=client,
+        evidence_items=_reissued_external_evidence(
+            uid,
+            _evidence_items_from_payload(data),
+            db_client=client,
+        ),
+    )
 
 
 def _read_replacement_control(uid: str, *, db_client: Any) -> MemoryControlState:


### PR DESCRIPTION
## Bug

`POST /v3/memories` returned **503 for every memory whose text the user had previously deleted** — permanently, for that exact text. Prod (`backend-7d99abc`): 42 tracebacks in a 1.5h sample and 54 in 24h, one user retrying a create that could never succeed.

```
File "/app/routers/memories.py", line 344, in create_memory
File "/app/utils/memory/canonical_memory_adapter.py", line 1178, in write_canonical_extraction_memory
RuntimeError: canonical write failed: ApplyStatus.source_not_active
  (cannot apply memory patch from deleted/purged source evidence)
```

## Root cause

External evidence identity is derived from the submitted content, but evidence `source_state` is monotonic per identity:

- `MemoryDB.from_memory` sets `memory_id = document_id_from_seed(content)` and `evidence_source_id = f"external:{memory_id}"`; `Evidence.from_source` hashes that into the `evidence_id`. Same text ⇒ same evidence identity, forever.
- Deleting the memory privacy-tombstones that evidence doc (`_privacy_tombstoned_evidence`) → `source_state=tombstoned, reason=deleted_by_user`. Confirmed in prod Firestore for the affected uid: many `memory_evidence` docs with `source_state=tombstoned`, `source_type=api`, `source_id=external:<uuid>`.
- Re-adding the same text recomputes the same id. `_persist_evidence` deliberately refuses to reactivate it — *"Source state is monotonic for one evidence identity. A later authorized extraction must use a fresh evidence_id"* — and the apply gate (`models/memory_apply.py:704`) then rejects the patch with `source_not_active`.

No caller ever minted that fresh id, so nothing could satisfy the retry. Each create is a distinct operation (`promotion.submitted_at` varies), so it was not even idempotency-skipped: every attempt burned a 503.

## Fix

On the **external** write path only, resolve evidence identity against its stored lifecycle state and mint a fresh id when the stored state is not active. The tombstone stays retired — the new submission is a new source artifact, not a resurrection.

Conversation-sourced evidence keeps the retired identity: a deleted conversation is a deleted source, not a fresh one. That branch has its own test.

## Tested

- New `test_readding_a_deleted_manual_memory_lands_on_a_fresh_evidence_identity` drives the production path — `write_canonical_external_memory` → `delete_canonical_memory` → `write_canonical_external_memory` — through the canonical apply store, and asserts the re-added memory is live again while the deleted submission's evidence stays tombstoned.
- The same test reproduces the exact production `RuntimeError` when only the production hunk is reverted (verified).
- New `test_conversation_sourced_evidence_is_never_reissued_after_delete` asserts the privacy fence still rejects a resubmission of conversation-sourced evidence.
- `tests/unit/test_ws_j_delete_privacy.py`: 36 passed. Changed-file selection (10 files, `select_backend_unit_tests.py --changed-files` → `test.sh`): green. `make preflight`: green.

## Product invariants

- **INV-MEM-1** (path-matched via `backend/utils/memory/**`) — unchanged: this fix touches evidence identity on the write path only. No tier vocabulary, collection, or default access policy changes; `backend/tests/unit/test_inv_mem_1_guard.py` passes in the changed-file selection.

Failure-Class: new

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 2491 -> 2562 | one identity-reissue helper inside the module that already owns canonical evidence identity and `_persist_evidence`'s monotonicity rule; splitting the adapter is not in scope for a live 503 fix

Fixes #11812

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

