### PR TITLE
fix(backend): route Modulate-primary live STT through the provider fallback chain

### DIFF
--- a/backend/routers/listen/receiver.py
+++ b/backend/routers/listen/receiver.py
@@ -48,6 +48,7 @@ from utils.stt.live_failure import (
 from utils.stt.streaming import (
     STTService,
     connect_stt_socket_with_fallback,
+    deepgram_fallback_model,
     make_stream_callback,
     modulate_is_configured_fallback,
     parakeet_is_configured_fallback,
@@ -223,7 +224,50 @@ class ListenReceiver:
                 self.host.stt_model = 'velma-2'
             return socket
         if self.host.stt_service == STTService.modulate:
-            return await process_audio_modulate(modulate_callback or callback, sample_rate, self.host.stt_language)
+            # Velma-2 accepts the upgrade and only then reports being over quota,
+            # so a Modulate primary needs the same chain its siblings use (#11752).
+            dg_fallback_model = deepgram_fallback_model(self.host.stt_language)
+
+            def connect_deepgram_fallback() -> Any:
+                return process_audio_dg(
+                    callback,
+                    self.host.stt_language,
+                    sample_rate,
+                    1,
+                    model=cast(str, dg_fallback_model),
+                    keywords=keywords,
+                    is_active=lambda: self.host.state.active,
+                )
+
+            def connect_parakeet_fallback() -> Any:
+                return process_audio_parakeet(
+                    callback,
+                    self.host.stt_language,
+                    sample_rate,
+                    1,
+                    model='parakeet',
+                    keywords=keywords,
+                    is_active=lambda: self.host.state.active,
+                )
+
+            socket, actual_service = await connect_stt_socket_with_fallback(
+                primary_service=STTService.modulate,
+                connect_primary=lambda: process_audio_modulate(
+                    modulate_callback or callback,
+                    sample_rate,
+                    self.host.stt_language,
+                ),
+                connect_deepgram=connect_deepgram_fallback if dg_fallback_model else None,
+                connect_parakeet=(
+                    connect_parakeet_fallback if parakeet_is_configured_fallback(self.host.stt_language) else None
+                ),
+            )
+            self.host.stt_service = actual_service
+            if actual_service == STTService.deepgram:
+                self.host.stt_model = cast(str, dg_fallback_model)
+            elif actual_service == STTService.parakeet:
+                self.host.stt_model = 'parakeet'
+            return socket
         if self.host.stt_service == STTService.deepgram:
 
             def connect_deepgram() -> Any:

--- a/backend/tests/unit/test_deepgram_connection_fallback.py
+++ b/backend/tests/unit/test_deepgram_connection_fallback.py
@@ -371,11 +371,6 @@ def test_parakeet_is_a_configured_fallback_only_when_the_deployment_can_serve_it
         assert streaming.parakeet_is_configured_fallback('en') is False
 
 
-@pytest.mark.anyio
-async def test_modulate_primary_is_still_rejected():
-    with pytest.raises(ValueError, match='modulate'):
-        await streaming.connect_stt_socket_with_fallback(
-            primary_service=STTService.modulate,
-            connect_primary=AsyncMock(),
-            connect_modulate=AsyncMock(),
-        )
+# A Modulate primary is no longer rejected by the helper — it walks the chain like
+# its siblings. That contract, including the "never falls back to itself" guard this
+# assertion used to provide, now lives in test_modulate_connection_fallback.py (#11752).

--- a/backend/tests/unit/test_modulate_connection_fallback.py
+++ b/backend/tests/unit/test_modulate_connection_fallback.py
@@ -1,0 +1,330 @@
+"""Regression (#11752): a Modulate-primary session must walk the configured fallbacks.
+
+``prod-omi-backend-listen`` ran ``STT_SERVICE_MODELS=modulate-velma-2,dg-nova-3,parakeet``
+and lost 100% of its live sessions for ~50 minutes: Modulate accepted every
+WebSocket upgrade and then answered ``Monthly usage limit reached.``. Deepgram and
+Parakeet were listed right behind it, but ``_create_stt_socket`` called
+``process_audio_modulate`` directly and returned, so a Modulate primary had no
+fallback at all while the Parakeet and Deepgram legs sat idle.
+
+Deepgram-primary (#11695) and Parakeet-primary sessions already route through
+``connect_stt_socket_with_fallback``. These tests pin the Modulate entry point to
+the same contract.
+"""
+
+import os
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from routers.listen import receiver as receiver_mod
+from routers.listen.receiver import ListenReceiver
+from utils.stt import provider_resilience, streaming
+from utils.stt.streaming import STTService
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+def _modulate_receiver():
+    """Duck-typed receiver exposing only what `_create_stt_socket` touches."""
+    host = SimpleNamespace(
+        state=SimpleNamespace(active=True),
+        stt_service=STTService.modulate,
+        stt_language='en',
+        stt_model='velma-2',
+        vocabulary=[],
+    )
+    return SimpleNamespace(host=host)
+
+
+@contextmanager
+def _serving_policy(models=('modulate-velma-2', 'dg-nova-3', 'parakeet')):
+    """Drive the real provider gates, not a stubbed answer about them.
+
+    The outage deployment listed Modulate first with Deepgram and Parakeet behind
+    it, so the fallback decision has to come from ``STT_SERVICE_MODELS`` itself.
+    """
+    with (
+        patch.object(streaming, 'stt_service_models', list(models)),
+        patch.object(streaming, '_deepgram_is_available', return_value=True),
+        patch.dict(os.environ, {'HOSTED_PARAKEET_API_URL': 'ws://parakeet.omi.me/v3/stream'}),
+    ):
+        yield
+
+
+class _RejectedSocket:
+    """Velma's over-quota shape: the upgrade succeeds, then the stream is refused."""
+
+    def __init__(self, reason: str = 'modulate error: Monthly usage limit reached.') -> None:
+        self.death_reason = reason
+        self.finished = False
+
+    @property
+    def is_connection_dead(self) -> bool:
+        return True
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+def _live_socket():
+    return SimpleNamespace(is_connection_dead=False, death_reason=None)
+
+
+# --- the receiver seam: what the outage actually exercised -------------------
+
+
+@pytest.mark.anyio
+async def test_a_modulate_connect_that_returns_no_socket_serves_from_deepgram():
+    receiver = _modulate_receiver()
+    dg_socket = _live_socket()
+
+    with (
+        _serving_policy(),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=None)) as modulate,
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=dg_socket)) as dg,
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    modulate.assert_awaited_once()
+    dg.assert_awaited_once()
+    assert socket is dg_socket
+    assert receiver.host.stt_service == STTService.deepgram
+    assert receiver.host.stt_model == 'nova-3'
+
+
+@pytest.mark.anyio
+async def test_an_over_quota_modulate_stream_moves_the_session_to_deepgram():
+    """The real #11752 shape: the upgrade succeeds, then Velma refuses the stream."""
+    receiver = _modulate_receiver()
+    rejected = _RejectedSocket()
+    dg_socket = _live_socket()
+
+    with (
+        _serving_policy(),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=rejected)),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=dg_socket)),
+        patch.object(streaming, 'record_fallback') as record,
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    assert socket is dg_socket
+    assert receiver.host.stt_service == STTService.deepgram
+    assert rejected.finished, 'the over-quota socket must be released, not leaked'
+    leg = record.call_args.kwargs
+    assert (leg['component'], leg['from_mode'], leg['to_mode'], leg['outcome']) == (
+        'stt_selection',
+        'modulate',
+        'deepgram',
+        'recovered',
+    )
+
+
+@pytest.mark.anyio
+async def test_a_healthy_modulate_session_still_serves_from_modulate():
+    receiver = _modulate_receiver()
+    modulate_socket = _live_socket()
+
+    with (
+        _serving_policy(),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=modulate_socket)),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock()) as dg,
+        patch.object(receiver_mod, 'process_audio_parakeet', new=AsyncMock()) as parakeet,
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    assert socket is modulate_socket
+    assert receiver.host.stt_service == STTService.modulate
+    assert receiver.host.stt_model == 'velma-2'
+    dg.assert_not_awaited()
+    parakeet.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_the_session_reaches_parakeet_when_both_vendors_are_in_billing_failure():
+    """Both #11752 vendors down at once: Modulate over quota, Deepgram at HTTP 402."""
+    receiver = _modulate_receiver()
+    parakeet_socket = _live_socket()
+
+    with (
+        _serving_policy(),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=_RejectedSocket())),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=None)),
+        patch.object(receiver_mod, 'process_audio_parakeet', new=AsyncMock(return_value=parakeet_socket)) as parakeet,
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket = await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    parakeet.assert_awaited_once()
+    assert socket is parakeet_socket
+    assert receiver.host.stt_service == STTService.parakeet
+    assert receiver.host.stt_model == 'parakeet'
+
+
+@pytest.mark.anyio
+async def test_deepgram_is_not_offered_a_session_the_deployment_never_listed_it_for():
+    """Modulate-only policy keeps failing closed rather than inventing a provider."""
+    receiver = _modulate_receiver()
+
+    with (
+        _serving_policy(models=('modulate-velma-2',)),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=None)),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock()) as dg,
+        patch.object(receiver_mod, 'process_audio_parakeet', new=AsyncMock()) as parakeet,
+        patch.object(streaming, 'record_fallback'),
+        pytest.raises(RuntimeError),
+    ):
+        await ListenReceiver._create_stt_socket(receiver, MagicMock(), 16000)
+
+    dg.assert_not_awaited()
+    parakeet.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_the_deepgram_leg_gets_the_plain_callback_not_the_modulate_one():
+    """Modulate segments arrive in Velma's shape; Deepgram must not be handed it."""
+    receiver = _modulate_receiver()
+    callback = MagicMock(name='callback')
+    modulate_callback = MagicMock(name='modulate_callback')
+
+    with (
+        _serving_policy(),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=None)) as modulate,
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=_live_socket())) as dg,
+        patch.object(streaming, 'record_fallback'),
+    ):
+        await ListenReceiver._create_stt_socket(receiver, callback, 16000, modulate_callback=modulate_callback)
+
+    assert modulate.await_args.args[0] is modulate_callback
+    assert dg.await_args.args[0] is callback
+
+
+# --- the helper seam: chain construction for a Modulate primary -------------
+
+
+@pytest.mark.anyio
+async def test_a_modulate_primary_never_falls_back_to_itself():
+    """Replaces the old `test_modulate_primary_is_still_rejected` guard.
+
+    The helper used to raise `ValueError` for a Modulate primary because its
+    candidate list hard-coded Modulate as the first fallback — a Modulate primary
+    would have retried the provider that just failed. The chain now excludes the
+    primary, so the rejection is no longer the thing keeping it correct.
+    """
+    connect_modulate = AsyncMock()
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        socket, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.modulate,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=connect_modulate,
+            connect_deepgram=AsyncMock(return_value=_live_socket()),
+        )
+
+    assert service == STTService.deepgram
+    assert socket is not None
+    connect_modulate.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_a_modulate_primary_walks_deepgram_then_parakeet_in_policy_order():
+    parakeet_socket = _live_socket()
+
+    with (
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback') as record,
+    ):
+        socket, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.modulate,
+            connect_primary=AsyncMock(return_value=_RejectedSocket()),
+            connect_modulate=AsyncMock(),
+            connect_deepgram=AsyncMock(return_value=None),
+            connect_parakeet=AsyncMock(return_value=parakeet_socket),
+        )
+
+    assert socket is parakeet_socket
+    assert service == STTService.parakeet
+    dg_leg, parakeet_leg = [call.kwargs for call in record.call_args_list]
+    assert (dg_leg['from_mode'], dg_leg['to_mode'], dg_leg['outcome']) == ('modulate', 'deepgram', 'exhausted')
+    assert (parakeet_leg['from_mode'], parakeet_leg['to_mode'], parakeet_leg['outcome']) == (
+        'deepgram',
+        'parakeet',
+        'recovered',
+    )
+
+
+@pytest.mark.anyio
+async def test_repeated_modulate_rejections_open_its_own_circuit():
+    """A quota-exhausted Modulate account stops costing every session a connect."""
+    circuit = MagicMock()
+    circuit.allow_request.return_value = True
+
+    with (
+        patch.object(streaming, '_modulate_circuit', circuit),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        _, service = await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.modulate,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(),
+            connect_deepgram=AsyncMock(return_value=_live_socket()),
+        )
+
+    assert service == STTService.deepgram
+    circuit.record_failure.assert_called_once_with()
+
+
+@pytest.mark.anyio
+async def test_the_modulate_circuit_stays_independent_of_the_other_providers():
+    deepgram_circuit = MagicMock()
+    deepgram_circuit.allow_request.return_value = True
+
+    with (
+        patch.object(streaming, '_deepgram_circuit', deepgram_circuit),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        await streaming.connect_stt_socket_with_fallback(
+            primary_service=STTService.modulate,
+            connect_primary=AsyncMock(return_value=None),
+            connect_modulate=AsyncMock(),
+            connect_deepgram=AsyncMock(return_value=_live_socket()),
+        )
+
+    deepgram_circuit.record_failure.assert_not_called()
+    deepgram_circuit.allow_request.assert_not_called()
+
+
+# --- the policy gate --------------------------------------------------------
+
+
+def test_deepgram_is_a_configured_fallback_only_when_the_policy_lists_it():
+    with patch.object(streaming, '_deepgram_is_available', return_value=True):
+        with patch.object(streaming, 'stt_service_models', ['modulate-velma-2', ' dg-nova-3', 'parakeet']):
+            assert streaming.deepgram_fallback_model('en') == 'nova-3'
+            # Nova-3 has no capability for an unknown code, so the session must not move.
+            assert streaming.deepgram_fallback_model('zz') is None
+        with patch.object(streaming, 'stt_service_models', ['modulate-velma-2', 'parakeet']):
+            assert streaming.deepgram_fallback_model('en') is None
+    # No reachable Deepgram credential means Deepgram cannot take the session over.
+    with (
+        patch.object(streaming, '_deepgram_is_available', return_value=False),
+        patch.object(streaming, 'stt_service_models', ['modulate-velma-2', 'dg-nova-3']),
+    ):
+        assert streaming.deepgram_fallback_model('en') is None

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -197,9 +197,12 @@ async def connect_stt_socket_with_fallback(
             reason = 'provider_5xx'
             circuit.record_failure()
 
-    # Ordered by STT_SERVICE_MODELS preference. A provider is never offered its
-    # own failure as a fallback, so the chain is derived from the primary rather
-    # than fixed: a Modulate primary walks Deepgram then Parakeet (#11752).
+    # A provider is never offered its own failure as a fallback, so the chain
+    # excludes the primary: a Modulate primary walks Deepgram then Parakeet
+    # (#11752). The relative order of the fallback legs is fixed here and is not
+    # parsed out of STT_SERVICE_MODELS; it matches the declared deployment
+    # config, and callers already gate each leg on whether the deployment can
+    # serve it. Reading the true order off the policy list is a separate change.
     ordered: List[Tuple[STTService, Optional[Callable[[], Awaitable[Optional[STTSocket]]]]]] = [
         (STTService.modulate, connect_modulate),
         (STTService.deepgram, connect_deepgram),

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -101,6 +101,23 @@ def _fallback_failure_reason(error: BaseException) -> str:
     return 'provider_5xx'
 
 
+# Deepgram and Parakeet refuse at connect time, so a returned socket is proof
+# enough. Velma-2 accepts the upgrade and only then answers "Monthly usage limit
+# reached.", so a Modulate socket is not evidence that the session is served.
+_POST_CONNECT_REJECTING_PRIMARIES: Final = frozenset({STTService.modulate})
+
+
+async def _primary_is_serving(primary_service: STTService, socket: STTSocket) -> bool:
+    """Return whether a connected primary is actually serving the session.
+
+    Only providers that reject after the upgrade pay the liveness grace, so live
+    session setup keeps its hot path for the providers that fail at connect.
+    """
+    if primary_service not in _POST_CONNECT_REJECTING_PRIMARIES:
+        return True
+    return await fallback_socket_is_serving(socket)
+
+
 async def _connect_serving_fallback(
     connect: Callable[[], Awaitable[Optional[STTSocket]]], service: STTService
 ) -> STTSocket:
@@ -143,11 +160,19 @@ async def connect_stt_socket_with_fallback(
     if circuit.allow_request():
         try:
             socket = await connect_primary()
-            if socket is not None:
+            if socket is None:
+                reason = 'config_incomplete'
+                circuit.record_failure()
+            elif await _primary_is_serving(primary_service, socket):
                 circuit.record_success()
                 return socket, primary_service
-            reason = 'config_incomplete'
-            circuit.record_failure()
+            else:
+                # The primary took the session and then refused it. Release the
+                # socket and walk the chain instead of serving a dead stream.
+                detail = getattr(socket, 'death_reason', None) or 'stream rejected'
+                close_rejected_socket(socket)
+                reason = _fallback_failure_reason(RuntimeError(detail))
+                circuit.record_failure()
         except ParakeetConnectionError as error:
             reason = error.reason
             if reason in EXPECTED_REJECTIONS:

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -340,6 +340,27 @@ def modulate_is_configured_fallback(language: Optional[str]) -> bool:
     )
 
 
+def deepgram_fallback_model(language: Optional[str]) -> Optional[str]:
+    """Return the Deepgram model that may take over a session whose primary failed.
+
+    Same contract as ``modulate_is_configured_fallback``, but it resolves a model
+    rather than answering yes/no: a Modulate primary resolved ``stt_model`` and
+    ``stt_language`` for Velma-2, so the caller has no Deepgram model to reuse and
+    cannot know which ``dg-*`` deployment the runtime actually lists. ``None``
+    means Deepgram must not be offered the session at all.
+    """
+    if not provider_is_enabled(deepgram_provider_for_runtime(is_dg_self_hosted), STTServingSurface.STREAMING):
+        return None
+    if not _deepgram_is_available():
+        return None
+    if language not in deepgram_nova3_multi_languages and language not in deepgram_nova3_languages:
+        return None
+    for model in (model.strip() for model in stt_service_models):
+        if model.startswith('dg-'):
+            return model.replace('dg-', '', 1)
+    return None
+
+
 def parakeet_is_configured_fallback(language: Optional[str]) -> bool:
     """Return whether Parakeet may take over a session whose earlier providers failed.
 

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -83,11 +83,19 @@ _deepgram_circuit = ProviderCircuitBreaker(
 )
 
 
+_modulate_circuit = ProviderCircuitBreaker(
+    failure_threshold=int(os.getenv('MODULATE_CIRCUIT_FAILURE_THRESHOLD', '3')),
+    cooldown_seconds=float(os.getenv('MODULATE_CIRCUIT_COOLDOWN_SECONDS', '30')),
+)
+
+
 def _circuit_for_primary(primary_service: STTService) -> ProviderCircuitBreaker:
     if primary_service == STTService.parakeet:
         return _parakeet_circuit
     if primary_service == STTService.deepgram:
         return _deepgram_circuit
+    if primary_service == STTService.modulate:
+        return _modulate_circuit
     raise ValueError(f'connection fallback is not defined for a {primary_service.value} primary')
 
 
@@ -149,6 +157,9 @@ async def connect_stt_socket_with_fallback(
     (#11695). The chain must not stop at Modulate either: with Deepgram at HTTP
     402 and Modulate answering 500/over quota, an English session died while a
     healthy Parakeet deployment sat idle behind them in the same list (#11752).
+    Modulate is a primary as well as a fallback: a deployment listing
+    ``modulate-velma-2,dg-nova-3,parakeet`` lost 100% of its sessions for ~50
+    minutes because a Modulate primary bypassed this helper entirely (#11752).
 
     The circuit is deliberately process-local and never owns capacity. The
     Parakeet service rejects excess streams at its GPU boundary; this helper

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -119,7 +119,8 @@ async def connect_stt_socket_with_fallback(
     *,
     primary_service: STTService,
     connect_primary: Callable[[], Awaitable[Optional[STTSocket]]],
-    connect_modulate: Callable[[], Awaitable[Optional[STTSocket]]],
+    connect_modulate: Optional[Callable[[], Awaitable[Optional[STTSocket]]]] = None,
+    connect_deepgram: Optional[Callable[[], Awaitable[Optional[STTSocket]]]] = None,
     connect_parakeet: Optional[Callable[[], Awaitable[Optional[STTSocket]]]] = None,
 ) -> Tuple[STTSocket, STTService]:
     """Connect the selected primary before audio starts, walking the configured fallbacks.
@@ -160,11 +161,17 @@ async def connect_stt_socket_with_fallback(
             reason = 'provider_5xx'
             circuit.record_failure()
 
-    candidates: List[Tuple[STTService, Callable[[], Awaitable[Optional[STTSocket]]]]] = [
-        (STTService.modulate, connect_modulate)
+    # Ordered by STT_SERVICE_MODELS preference. A provider is never offered its
+    # own failure as a fallback, so the chain is derived from the primary rather
+    # than fixed: a Modulate primary walks Deepgram then Parakeet (#11752).
+    ordered: List[Tuple[STTService, Optional[Callable[[], Awaitable[Optional[STTSocket]]]]]] = [
+        (STTService.modulate, connect_modulate),
+        (STTService.deepgram, connect_deepgram),
+        (STTService.parakeet, connect_parakeet),
     ]
-    if connect_parakeet is not None and primary_service != STTService.parakeet:
-        candidates.append((STTService.parakeet, connect_parakeet))
+    candidates: List[Tuple[STTService, Callable[[], Awaitable[Optional[STTSocket]]]]] = [
+        (service, connect) for service, connect in ordered if connect is not None and service != primary_service
+    ]
 
     from_mode = primary_service.value
     for service, connect in candidates:


### PR DESCRIPTION
# Fix Modulate-primary STT fallback

## Problem

Modulate-primary live STT sessions did not fail over to the configured backup providers.

In production, Modulate hit its monthly quota and **100% of live sessions failed for ~50 minutes**, even though Deepgram and Parakeet were configured as fallbacks.

There was also a second issue: Modulate can accept the WebSocket upgrade and report `Monthly usage limit reached` ~150ms later. The fallback helper treated the initial socket as a success, so fallback was never triggered.

## Fix

* Route Modulate-primary sessions through the shared STT fallback helper.
* Build the fallback chain from the failed primary so a provider is never retried as its own fallback.
* Validate primary socket liveness before accepting a post-connect provider.
* Record post-connect rejection as a provider failure and continue to the next provider.
* Keep provider/language serving-policy checks and existing fallback telemetry.

Result:

```text
Modulate primary
      ↓
healthy? ── yes → use Modulate
      │
      no
      ↓
   Deepgram
      ↓
   Parakeet
```

## Verification

Regression tests reproduced the production failure on the unmodified code:

* **10/11 tests failed before the fix**
* **11/11 passed after the fix**
* **40/40 passed** across the affected STT/fallback test suites
* `pyright`: 0 errors
* `black`: clean

## Tradeoff

Modulate-primary sessions now spend ~320ms validating the connection before adopting it, because Modulate's quota rejection arrives after the WebSocket upgrade.

This cost is limited to Modulate-primary sessions; Deepgram- and Parakeet-primary paths keep their existing fast path. The grace period is configurable via `STT_FALLBACK_LIVENESS_GRACE_SECONDS`.

## Known follow-ups

* Derive fallback ordering directly from `STT_SERVICE_MODELS` instead of the current fixed order.
* Tune the liveness grace period using measured provider rejection latency.
* Fix provider-error accounting for mid-session failures (`lifetime_done`) in a separate PR.

## Verification note

The full `backend/test.sh` suite is currently unstable on this machine and fails on the unmodified base commit as well. The affected STT/listen suites for this change are green.

Fixes #11752

Failure-Class: FC-recoverable-provider-failure-terminal

Line-Count-Exception: backend/utils/stt/streaming.py | 1616 -> 1683 | fallback chain, post-connect liveness proof and Modulate circuit; splitting a live-STT hot-path module is separate work

