### PR TITLE
fix(backend): stop the legacy memory offset read costing O(rounds x prefix) Firestore work (#11803)

### DIFF
--- a/backend/tests/unit/test_memory_offset_read_cost.py
+++ b/backend/tests/unit/test_memory_offset_read_cost.py
@@ -1,0 +1,189 @@
+"""The legacy offset read must not cost O(rounds x prefix) Firestore work.
+
+``MemoryService.read`` deepens an adaptive historical scan when the newest-first
+prefix is suppressed by canonical. Every round re-reads that prefix from the
+start, so a linear step plus an uncached status lookup made one page of a fully
+suppressed account cost 330 sequential Firestore round trips over 82,500
+documents — past the 30s edge timeout, which is how GET /v3/memories 504'd in
+prod on 2026-08-18 for both the offset>0 pages and the first page's fallback.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.unit.test_memory_service_parity import _load_memory_service, _sample_memory_dict
+
+# Scaled-down mirror of the prod window so the guard stays a fast unit test.
+TEST_COMPATIBILITY_WINDOW = 500
+TEST_PAGE_SIZE = 50
+
+
+class _Snapshot:
+    def __init__(self, payload=None, *, exists=True, reference=None):
+        self._payload = payload
+        self.exists = exists
+        self.reference = reference
+
+    def to_dict(self):
+        return self._payload
+
+
+class _Ref:
+    def __init__(self, db, path):
+        self.db = db
+        self.path = path
+
+    def get(self, **_kwargs):
+        payload = self.db.docs.get(self.path)
+        return _Snapshot(payload, exists=payload is not None)
+
+
+class _CountingDb:
+    """Counts batch-get round trips, the documents they read, and repeat reads."""
+
+    def __init__(self, docs=None):
+        self.docs = dict(docs or {})
+        self.get_all_calls = 0
+        self.get_all_docs = 0
+        self.read_paths = []
+
+    def document(self, path):
+        return _Ref(self, path)
+
+    def get_all(self, refs):
+        refs = list(refs)
+        self.get_all_calls += 1
+        self.get_all_docs += len(refs)
+        for ref in refs:
+            self.read_paths.append(ref.path)
+            payload = self.docs.get(ref.path)
+            yield _Snapshot(payload, exists=payload is not None, reference=ref)
+
+
+@pytest.fixture
+def service_mod(monkeypatch):
+    monkeypatch.setenv("MEMORY_MODE", "read")
+    module = _load_memory_service(monkeypatch)
+    monkeypatch.setattr(
+        module.HistoricalMemoryAdapter,
+        "MAX_COMPATIBILITY_WINDOW",
+        TEST_COMPATIBILITY_WINDOW,
+    )
+    monkeypatch.setattr(module.HistoricalMemoryAdapter, "MAX_PAGE_SIZE", TEST_PAGE_SIZE)
+    return module
+
+
+def _suppressed_account(service_mod, monkeypatch, uid, *, rows):
+    """An account whose entire historical prefix is suppressed by canonical."""
+    from database.memory_collections import MemoryCollections
+
+    collections = MemoryCollections(uid=uid)
+    docs = {}
+    payloads = []
+    for index in range(rows):
+        memory_id = f"hist-{index:05d}"
+        docs[f"{collections.memory_historical_overrides}/{memory_id}"] = {"status": "tombstoned"}
+        payload = _sample_memory_dict(memory_id)
+        payload["updated_at"] = f"2026-01-01T00:00:{index % 60:02d}+00:00"
+        payloads.append(payload)
+
+    db = _CountingDb(docs)
+    stats = {"calls": 0, "docs": 0}
+
+    def fake_get_memories(_uid, limit, offset, sort=None, **_kwargs):
+        del _uid, sort
+        page = payloads[offset : offset + limit]
+        stats["calls"] += 1
+        stats["docs"] += len(page)
+        return [dict(row) for row in page]
+
+    monkeypatch.setattr(service_mod.memories_db, "get_memories", fake_get_memories)
+    service = service_mod.MemoryService(db_client=db)
+    service._canonical.read = MagicMock(return_value=[])
+    return service, db, stats
+
+
+def test_fully_suppressed_offset_read_stays_within_a_bounded_scan_cost(service_mod, monkeypatch):
+    uid = "uid-cost"
+    service, db, stats = _suppressed_account(
+        service_mod,
+        monkeypatch,
+        uid,
+        rows=TEST_COMPATIBILITY_WINDOW,
+    )
+
+    assert service.read(uid, limit=TEST_PAGE_SIZE, offset=0) == []
+
+    # Linear growth walked the prefix 10 times (55 queries / 2,750 documents);
+    # geometric growth needs 5 rounds and never re-reads the whole window.
+    assert stats["calls"] <= 30
+    assert stats["docs"] <= 1500
+    # Canonical status is a stable read within one request, so a repeated
+    # prefix must not be re-queried: previously 30 batch gets / 3,000 documents.
+    assert db.get_all_calls <= 8
+    assert len(db.read_paths) == len(set(db.read_paths))
+
+
+def test_status_lookups_are_not_repeated_across_expansion_rounds(service_mod, monkeypatch):
+    uid = "uid-cache"
+    service, db, _ = _suppressed_account(
+        service_mod,
+        monkeypatch,
+        uid,
+        rows=TEST_COMPATIBILITY_WINDOW,
+    )
+    seen = []
+    original = service.canonical_statuses
+
+    def tracking_statuses(_uid, memory_ids):
+        seen.extend(memory_ids)
+        return original(_uid, memory_ids)
+
+    monkeypatch.setattr(service, "canonical_statuses", tracking_statuses)
+
+    service.read(uid, limit=TEST_PAGE_SIZE, offset=0)
+
+    assert seen, "the suppressed prefix must still be status-checked"
+    assert len(seen) == len(set(seen))
+
+
+def test_first_expansion_step_is_unchanged_for_a_lightly_suppressed_account(service_mod, monkeypatch):
+    """Geometric growth must not over-scan an account that needs one expansion."""
+    from datetime import datetime, timezone
+
+    from database.memory_collections import MemoryCollections
+
+    uid = "uid-light"
+    service = service_mod.MemoryService(db_client=_CountingDb())
+    records = []
+    for index in range(4):
+        memory_id = f"hist-{index}"
+        if index < 3:
+            path = f"{MemoryCollections(uid=uid).memory_historical_overrides}/{memory_id}"
+            service.db_client.docs[path] = {"status": "tombstoned"}
+        payload = _sample_memory_dict(memory_id)
+        memory = service_mod.MemoryDB.model_validate(payload).model_copy(
+            update={"updated_at": datetime(2026, 1, 20 - index, tzinfo=timezone.utc)}
+        )
+        records.append(
+            service_mod.HistoricalMemoryRecord(
+                memory=memory,
+                locator=service_mod.MemoryLocator(uid, "legacy", memory_id),
+            )
+        )
+    scan_limits = []
+
+    def fake_history_read(_uid, *, limit, offset, device_scope_request=None):
+        del _uid, offset, device_scope_request
+        scan_limits.append(limit)
+        return records[:limit]
+
+    service._canonical.read = MagicMock(return_value=[])
+    service.history.read = MagicMock(side_effect=fake_history_read)
+
+    page = service.read(uid, limit=1)
+
+    assert [memory.id for memory in page] == ["hist-3"]
+    # window == step == 1, so the first expansion is still current + step.
+    assert scan_limits[:2] == [1, 2]

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -4,7 +4,7 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Iterable, Iterator, List, NoReturn, Optional, Tuple, cast
+from typing import Any, Callable, Dict, Iterable, Iterator, List, NoReturn, Optional, Set, Tuple, cast
 
 from fastapi import HTTPException
 from pydantic import ValidationError
@@ -1514,6 +1514,20 @@ class MemoryService:
     def _sort_memories(cls, memories: List[MemoryDB]) -> None:
         memories.sort(key=cls._memory_sort_key)
 
+    @staticmethod
+    def _next_historical_scan_limit(current: int, *, step: int) -> int:
+        """Grow the adaptive historical scan at least geometrically.
+
+        Every expansion round re-reads the whole newest-first prefix from the
+        start, so a linear step makes one page cost O(rounds x prefix): a fully
+        suppressed account at window=500 stepped 500, 1000, ... 5000 and read
+        27,500 documents over 55 queries for a single page. Doubling keeps the
+        light case identical (the first expansion is still ``current + step``)
+        and bounds the heavy case to a logarithmic number of rescans.
+        """
+        grown = max(current + max(1, int(step)), current * 2)
+        return min(HistoricalMemoryAdapter.MAX_COMPATIBILITY_WINDOW, grown)
+
     def read(
         self,
         uid: str,
@@ -1548,6 +1562,14 @@ class MemoryService:
         identity_suppressed = 0
         state_suppressed = 0
         historical_kept = 0
+        # Each expansion round rescans the same newest-first prefix with a
+        # larger limit, so an uncached status lookup pays for every earlier
+        # round again: a fully suppressed account at window=500 issued 275
+        # batch gets over 55,000 documents for one page and took the request
+        # past the 30s edge timeout. Canonical status is a stable read within
+        # one request, so ask for each memory id exactly once.
+        statuses: Dict[str, MemoryItemStatus] = {}
+        status_ids_read: Set[str] = set()
         while True:
             historical = self.history.read(
                 uid,
@@ -1559,7 +1581,14 @@ class MemoryService:
             identity_suppressed = 0
             state_suppressed = 0
             historical_kept = 0
-            statuses = self.canonical_statuses(uid, [record.memory.id for record in historical])
+            unread_ids = [
+                record.memory.id
+                for record in historical
+                if record.memory.id and record.memory.id not in status_ids_read
+            ]
+            if unread_ids:
+                statuses.update(self.canonical_statuses(uid, unread_ids))
+                status_ids_read.update(unread_ids)
             for record in historical:
                 if record.memory.id in canonical_ids:
                     identity_suppressed += 1
@@ -1583,9 +1612,9 @@ class MemoryService:
 
             if len(merged) < window:
                 missing = window - len(merged)
-                historical_limit = min(
-                    HistoricalMemoryAdapter.MAX_COMPATIBILITY_WINDOW,
-                    historical_limit + max(missing, bounded_limit),
+                historical_limit = self._next_historical_scan_limit(
+                    historical_limit,
+                    step=max(missing, bounded_limit),
                 )
                 continue
 
@@ -1596,9 +1625,9 @@ class MemoryService:
             oldest_scanned = historical[-1].memory
             if self._memory_sort_key(oldest_scanned) >= self._memory_sort_key(cutoff):
                 break
-            historical_limit = min(
-                HistoricalMemoryAdapter.MAX_COMPATIBILITY_WINDOW,
-                historical_limit + max(bounded_limit, window),
+            historical_limit = self._next_historical_scan_limit(
+                historical_limit,
+                step=max(bounded_limit, window),
             )
 
         # Emit telemetry once for the final scan only — retries must not


### PR DESCRIPTION
## Bug

`GET /v3/memories` 504s at the 30s edge for accounts whose newest-first historical prefix is fully suppressed by canonical. Live in prod on 2026-08-18 at ~26/h across 18 client IPs — the Windows desktop app (`omi-windows/1.0.0 Electron`, `limit=5000&offset=0`), iOS (`Omi/12187 CFNetwork`), and API clients — hitting both the `offset>0` pages and the first page's documented scan-budget fallback. The user-visible result is a memory list that never loads.

This is the residual class left open on #11803 after PR #11805: "4x `limit=5000&offset=0` (a 5000-row page pays for rows it EMITS)".

## Root cause

`MemoryService.read` (the legacy offset path, and the first page's fallback target) deepens an adaptive historical scan when canonical suppression hides the rows a page needs. Two costs compound inside that loop:

1. **Every round re-reads the prefix from the start.** `HistoricalMemoryAdapter.read(limit=L, offset=0)` always pages Firestore from `db_offset=0`, and the loop stepped `L` linearly: 500, 1000, 1500, … 5000.
2. **Every round re-read the canonical status of the whole prefix.** `canonical_statuses` was called with every scanned row's id each round, so round *k* paid for rounds 1..*k-1* again.

One page therefore cost `O(rounds x prefix)`. Measured for the prod shape (window=500, 5000 suppressed rows):

| | queries | documents |
|---|---|---|
| `get_memories` | 55 | 27,500 |
| `get_all` (statuses) | 275 | 55,000 |
| **total** | **330 sequential round trips** | **82,500** |

330 sequential Firestore round trips is what takes the request past the 30s edge timeout. This is also a direct contributor to the standing "Firestore Document Reads exceeded 10k/s" alerts (#11282, #10950, #10817).

## Fix

Two surgical changes in the same loop, no contract change:

- **Read each memory id's canonical status once per request.** It is a stable read within one request, so a repeated prefix must not be re-queried. 275 batch gets → 50.
- **Grow the scan at least geometrically** (`_next_historical_scan_limit`). The first expansion is still `current + step`, so an account needing one expansion is completely unchanged; a heavily suppressed account now needs a logarithmic number of rescans instead of a linear one. 55 queries → 25.

| | before | after |
|---|---|---|
| round trips | 330 | **75** (4.4x) |
| documents | 82,500 | **22,500** (3.7x) |

## What I tested

- `backend/test.sh` over all 84 memory test files: **801 passed, exit 0**.
- New guards in `backend/tests/unit/test_memory_offset_read_cost.py` **fail on clean main** with the source hunks stashed — `assert 55 <= 30` (queries) and `assert 2750 == 500` (status reads for 500 unique ids, the 5.5x amplification) — and pass with the fix.
- `test_first_expansion_step_is_unchanged_for_a_lightly_suppressed_account` passes both with and without the fix, proving the geometric growth does not over-scan the light case.
- `make preflight` green.

Not verified live yet: prod backend deploy is `workflow_dispatch`-only behind two approval gates, so this lands on `main` first and is measured on the real route after deploy.

## Not fixed here

The historical prefix is still re-read from `db_offset=0` on each remaining expansion round (25 queries / 12,500 docs). Removing that needs an incremental historical page reader, which would reintroduce the offset-scan shape `read_scan_page` was deliberately retired to prevent. Left tracked on #11803.

Product invariants affected:

- INV-MEM-1
- INV-MEM-3

Line-Count-Exception: backend/utils/memory/memory_service.py | 2558 -> 2587 | adds a 12-line documented scan-growth helper and a status cache inside the existing read loop; splitting the file is a separate refactor with far wider blast radius than this 504 fix

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

