### PR TITLE
Test the bounds the app promises: delegation spend caps and the cold-start quota box

### DIFF
--- a/desktop/windows/src/main/agentKernel/kernel.test.ts
+++ b/desktop/windows/src/main/agentKernel/kernel.test.ts
@@ -22,6 +22,12 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { AgentRuntimeKernel } from './kernel'
 import { AdapterRegistry } from './adapterRegistry'
 import { SqliteAgentStore, type DatabaseFactory } from './store'
+import {
+  DEFAULT_DELEGATION_MAX_BUDGET_USD,
+  DEFAULT_DELEGATION_MAX_DEPTH,
+  HARD_DELEGATION_MAX_BUDGET_USD,
+  HARD_DELEGATION_MAX_DEPTH
+} from './kernelSupport'
 import type {
   AdapterAttemptContext,
   AdapterAttemptResult,
@@ -1240,6 +1246,54 @@ describe('AgentRuntimeKernel — delegateAgent', () => {
     await expect(
       kernel.delegateAgent(delegation(parentRunId, { maxBudgetUsd: 11 }))
     ).rejects.toThrow(/maxBudgetUsd must be greater than 0 and at most 10/)
+  })
+
+  // The two cases above reject 0 and 11, and 0 and 6, which leaves the end of
+  // each range untested — and the end is what the error message promises the
+  // caller: "at most 10", "between 1 and 5". Moving either comparison one step
+  // rejects the exact maximum the message advertises, and a mutation audit
+  // confirmed nothing here noticed.
+  it('allows a delegation at exactly the budget ceiling', async () => {
+    const { kernel } = newKernel(fakeAdapter())
+    const parentRunId = await parentRun(kernel)
+
+    await expect(
+      kernel.delegateAgent(
+        delegation(parentRunId, { maxBudgetUsd: HARD_DELEGATION_MAX_BUDGET_USD })
+      )
+    ).resolves.toBeTruthy()
+  })
+
+  it('allows a delegation at exactly the depth ceiling', async () => {
+    const { kernel } = newKernel(fakeAdapter())
+    const parentRunId = await parentRun(kernel)
+
+    await expect(
+      kernel.delegateAgent(delegation(parentRunId, { maxDepth: HARD_DELEGATION_MAX_DEPTH }))
+    ).resolves.toBeTruthy()
+  })
+
+  it('gives a delegation that names no budget the documented default', async () => {
+    // The default is the allowance a delegated agent gets when the caller says
+    // nothing, so it is the number that decides what an ordinary delegation may
+    // spend. Nothing read it: cutting it from 5 to 1 left the suite green,
+    // because every case above passes an explicit value.
+    const { kernel } = newKernel(fakeAdapter())
+    const parentRunId = await parentRun(kernel)
+
+    const created = await kernel.delegateAgent(delegation(parentRunId))
+    // The resolved bounds are recorded in the delegation's request payload,
+    // which is what a later audit of "what was this agent allowed to spend"
+    // reads. Asserting the literal as well as the constant so that moving the
+    // constant is a visible change and not a silently-tracking one.
+    const request = JSON.parse(created.delegation.requestJson) as {
+      maxBudgetUsd: number
+      maxDepth: number
+    }
+    expect(request.maxBudgetUsd).toBe(5)
+    expect(request.maxBudgetUsd).toBe(DEFAULT_DELEGATION_MAX_BUDGET_USD)
+    expect(request.maxDepth).toBe(3)
+    expect(request.maxDepth).toBe(DEFAULT_DELEGATION_MAX_DEPTH)
   })
 
   it('refuses to delegate from another owner’s run', async () => {

--- a/desktop/windows/src/renderer/src/lib/chatQuotaGate.test.ts
+++ b/desktop/windows/src/renderer/src/lib/chatQuotaGate.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import type { ChatUsageQuota } from './omiApi.generated'
-import { createChatQuotaGate, isLimitReached, limitMessage } from './chatQuotaGate'
+import {
+  createChatQuotaGate,
+  isLimitReached,
+  limitMessage,
+  COLD_START_SYNC_TIMEOUT_MS
+} from './chatQuotaGate'
 
 // The bar's pre-send chat-quota gate (port of macOS FloatingBarUsageLimiter).
 // The bug it closes: the bar's send path had NO gate, so a user over their
@@ -122,6 +127,46 @@ describe('createChatQuotaGate', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('uses the exported time box when the caller names none — the path production takes', async () => {
+    // Every case above passes an explicit 5_000, so none of them reads
+    // COLD_START_SYNC_TIMEOUT_MS. Production does the opposite: barSend.ts calls
+    // createChatQuotaGate() with no arguments and therefore runs entirely on the
+    // default. A mutation audit confirmed the gap — setting the constant to 0
+    // left this whole file green while defeating the cold-start gate in the
+    // shipped app, because the box would fire before the first sync could land
+    // and an over-cap user would get a free send.
+    vi.useFakeTimers()
+    try {
+      let land!: (q: ChatUsageQuota) => void
+      const fetchQuota = vi.fn(
+        () =>
+          new Promise<ChatUsageQuota>((resolve) => {
+            land = resolve
+          })
+      )
+      const gate = createChatQuotaGate(fetchQuota)
+
+      const verdict = gate.check()
+      // Just inside the box: the send is still waiting, so a verdict that lands
+      // here still gates.
+      await vi.advanceTimersByTimeAsync(COLD_START_SYNC_TIMEOUT_MS - 1)
+      land(quota({ allowed: false }))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(await verdict).toMatchObject({ blocked: true })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('pins the cold-start box, which the cases above cannot', () => {
+    // Five seconds is chosen against a real bound rather than picked: apiClient
+    // retries 429/503 with backoff over five tries up to 16s apart, so an
+    // unbounded await would hold a send — and a voice turn — for roughly 30s
+    // with no feedback. The box has to be short enough to stay under a user's
+    // patience and long enough for a healthy round trip.
+    expect(COLD_START_SYNC_TIMEOUT_MS).toBe(5_000)
   })
 
   it('fails OPEN when the quota fetch errors — the server stays the real enforcer', async () => {


### PR DESCRIPTION
## Product invariants affected

- INV-CHAT-1

`desktop/windows/src/main/agentKernel/**` is one of the INV-CHAT-1 path globs
(`docs/product/invariants/chat-continuity.md:150`), and `kernel.test.ts` sits
under it. The citation is path-based, not intent-based: nothing here changes
chat behaviour, and the invariant's guard test is untouched. I checked every
other invariant doc for a glob matching either changed file and INV-CHAT-1 is
the only match.

No production source changes. Two test files.

The app makes numeric promises to the user: how much a delegated agent may spend, and how long a send may wait before it gives up. This closes the cases where the number carrying that promise had nothing testing it. Each case cites the mutation it closes, and each mutation was re-run afterwards to confirm the case turns the suite red.

## Delegation spend and depth caps

`kernel.test.ts` already rejects `maxBudgetUsd` of 0 and 11, and `maxDepth` of 0 and 6. That covers past both ends of each range and never the end itself, which is the part the error message promises the caller:

```
Delegation maxBudgetUsd must be greater than 0 and at most 10
Delegation maxDepth must be between 1 and 5
```

Moving either comparison one step (`>` to `>=`) rejects the exact maximum those messages advertise. Neither mutation failed a test.

Separately, nothing read either DEFAULT. Every existing case passes an explicit value, so cutting `DEFAULT_DELEGATION_MAX_BUDGET_USD` from 5 to 1 left the suite green. That default is the number deciding what an ordinary delegation may spend when the caller names nothing, and it is recorded into the delegation's request payload, which is what a later audit of "what was this agent allowed to spend" reads.

Three cases now: the budget ceiling is inclusive, the depth ceiling is inclusive, and a delegation naming no bounds gets the documented defaults.

## The chat quota gate's cold-start time box

Every case in `chatQuotaGate.test.ts` passes an explicit `5_000`, so none of them reads `COLD_START_SYNC_TIMEOUT_MS`. Production does the opposite: `barSend.ts` calls `createChatQuotaGate()` with no arguments and runs entirely on the default.

So setting that constant to 0 left the whole file green while defeating the cold-start gate in the shipped app. The box would fire before the first sync could land, and a user already over their cap would get a free send, which is precisely what the neighbouring case ("cold start forces exactly ONE sync so an over-cap user gets no free send") exists to prevent.

The new case takes the default, holds a probe just inside the box, and proves the verdict still gates.

## Why the constants are pinned

Both are pinned with the reasoning that sets them rather than as bare numbers, so that changing one is a decision rather than an edit.

Five seconds is chosen against a real bound and the source says so: `apiClient` retries 429/503 with backoff over five tries up to 16s apart, so an unbounded await would hold a send, and a voice turn, for roughly 30s with no feedback.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,240 passed, 18 skipped, 542 files.
- `npx tsc --noEmit` on `tsconfig.web.json` and `tsconfig.node.json` - clean.
- `npx eslint .` - 0 errors.

**7 mutations seeded, each the regression its case was written for. All 7 turn the suite red now. All 7 left it green before.**

| Mutation | Was |
|---|---|
| `DEFAULT_DELEGATION_MAX_BUDGET_USD` 5 to 1 | green |
| `DEFAULT_DELEGATION_MAX_DEPTH` 3 to 1 | caught already |
| budget ceiling `>` to `>=` | green |
| depth ceiling `>` to `>=` | green |
| `COLD_START_SYNC_TIMEOUT_MS` to 0 | green |
| `COLD_START_SYNC_TIMEOUT_MS` to 1 | green |
| cold-start `withTimeout` removed entirely | green |

## How these were found

The same mutation harness as #11811, pointed at a different question: the app exports 42 timing and budget bounds, and 17 are never named by any test. That list is a starting point rather than a work item, because a constant no test names can still be covered behaviourally and pinning a literal for its own sake is the noise `AGENTS.md` warns about. These two are the ones where a mutation proved the bound was doing unwatched work and where the consequence lands on the user's money or the user's wait.

Worth recording what this run did NOT find, since the absence is also information. I chased three suspected gaps and measured all three as non-issues before writing anything:

- I suspected Windows 11's `graphicsCaptureProgrammatic` privacy toggle silently gates Rewind, making the onboarding comment ("Windows has NO OS consent prompt for desktop capture") stale. Setting both that consent and its `NonPackaged` desktop-app entry to `Deny` and re-running a real Electron capture left capture completely unaffected. The comment is correct.
- Same for the microphone consent: with `microphone\NonPackaged` set to `Deny`, `getUserMedia({audio:true})` still returned a live, unmuted track.
- Rewind playback transport, which an older parity audit lists as missing, already ships.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

## Product invariants affected

- INV-CHAT-1
