### PR TITLE
fix(backend): read the historical memory prefix in one query, not an offset walk (#11803)

### DIFF
--- a/backend/tests/unit/test_memory_offset_read_cost.py
+++ b/backend/tests/unit/test_memory_offset_read_cost.py
@@ -6,6 +6,12 @@ start, so a linear step plus an uncached status lookup made one page of a fully
 suppressed account cost 330 sequential Firestore round trips over 82,500
 documents — past the 30s edge timeout, which is how GET /v3/memories 504'd in
 prod on 2026-08-18 for both the offset>0 pages and the first page's fallback.
+
+The cost a page pays is what Firestore reads, not what it returns: the
+newest-first sort is index-less, so each historical query streams two candidate
+windows of ``limit + offset`` documents. Walking the prefix in offset pages
+re-reads everything it skips, which kept the page over the edge timeout after
+the round cost was fixed.
 """
 
 from unittest.mock import MagicMock
@@ -17,6 +23,10 @@ from tests.unit.test_memory_service_parity import _load_memory_service, _sample_
 # Scaled-down mirror of the prod window so the guard stays a fast unit test.
 TEST_COMPATIBILITY_WINDOW = 500
 TEST_PAGE_SIZE = 50
+# One geometric walk of the window reads it once per round (2,500 scanned here,
+# 25,000 at the prod window). Chunking the walk into MAX_PAGE_SIZE offset pages
+# read 10,500 (105,000 in prod).
+SCANNED_DOCUMENT_BUDGET = 3000
 
 
 class _Snapshot:
@@ -89,13 +99,20 @@ def _suppressed_account(service_mod, monkeypatch, uid, *, rows):
         payloads.append(payload)
 
     db = _CountingDb(docs)
-    stats = {"calls": 0, "docs": 0}
+    stats = {"calls": 0, "docs": 0, "scanned": 0}
 
     def fake_get_memories(_uid, limit, offset, sort=None, **_kwargs):
         del _uid, sort
         page = payloads[offset : offset + limit]
         stats["calls"] += 1
         stats["docs"] += len(page)
+        # Charge what Firestore actually reads. The newest-first sort has no
+        # index, so ``get_memories`` streams two candidate windows of
+        # ``limit + offset`` documents and orders them in Python: rows that an
+        # offset skips are still read and billed. Counting only returned rows
+        # hides an offset walk's quadratic cost, which is how the 105,000-read
+        # prod page passed this guard at 12,500.
+        stats["scanned"] += 2 * min(limit + offset, TEST_COMPATIBILITY_WINDOW)
         return [dict(row) for row in page]
 
     monkeypatch.setattr(service_mod.memories_db, "get_memories", fake_get_memories)
@@ -119,6 +136,9 @@ def test_fully_suppressed_offset_read_stays_within_a_bounded_scan_cost(service_m
     # geometric growth needs 5 rounds and never re-reads the whole window.
     assert stats["calls"] <= 30
     assert stats["docs"] <= 1500
+    # Each round must fetch its prefix in one query, not an offset walk that
+    # re-reads every row it skips.
+    assert stats["scanned"] <= SCANNED_DOCUMENT_BUDGET
     # Canonical status is a stable read within one request, so a repeated
     # prefix must not be re-queried: previously 30 batch gets / 3,000 documents.
     assert db.get_all_calls <= 8

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -546,6 +546,15 @@ class HistoricalMemoryAdapter:
             raise HTTPException(status_code=413, detail="Historical memory pagination window exceeded")
         # Over-fetch when adapt/device filters skip rows so a page of N valid
         # memories is not silently shortened by malformed documents.
+        # Ask for the whole prefix in one query: the newest-first sort has no
+        # index, so ``get_memories`` streams two candidate windows of
+        # ``limit + offset`` documents and orders them in Python. An offset walk
+        # therefore re-reads every row it skips — chunking cost 105,000 reads
+        # over 25 queries for one page of a suppressed 5,000-row account, which
+        # is what took GET /v3/memories past the 30s edge timeout on 2026-08-18.
+        # ``needed`` is bounded by MAX_COMPATIBILITY_WINDOW above and each chunk's
+        # candidate window had grown that large anyway, so this reads no more at
+        # once than the last chunked query already did.
         records: List[HistoricalMemoryRecord] = []
         db_offset = 0
         while len(records) < needed:
@@ -555,7 +564,6 @@ class HistoricalMemoryAdapter:
             fetch_size = min(
                 max(needed - len(records), bounded_limit),
                 remaining_window,
-                self.MAX_PAGE_SIZE,
             )
             try:
                 raw_rows = memories_db.get_memories(


### PR DESCRIPTION
## Bug

`GET /v3/memories` still 504s at the 30s edge on the **current prod image** (`backend-2976cc3`, which carries PR #11816): ~20/h between 2026-08-18 13:30Z and 14:20Z, across the Windows desktop app, iOS (`Omi/12187`) and Python API clients, on both `limit=5000&offset=0` (the first page's documented scan-budget fallback) and the `offset>0` pages. Continuation of #11803.

## Root cause

The remaining cost is what Firestore **reads**, not what the page returns.

`get_memories(sort="updated_or_created_desc")` has no index to order by — `updated_at` is absent from a material slice of the collection — so it streams two candidate windows of `limit + offset` documents and applies the final order in Python. Every row an offset skips is still read and billed.

`HistoricalMemoryAdapter.read` walked the prefix in `MAX_PAGE_SIZE` chunks with a growing `db_offset`, so each chunk rescanned everything the previous chunks had already scanned: **O(prefix² / page)** instead of O(prefix).

Measured on a fully suppressed 5,000-row account, one page:

| | queries | documents scanned |
|---|---|---|
| before | 25 | 105,000 |
| after | 5 | 25,000 |

## Fix

Ask for the whole prefix in one query. `needed` is already bounded by `MAX_COMPATIBILITY_WINDOW`, and each chunked query's candidate window had grown to that size anyway, so a single query reads no more at once than the last chunked query already did. `MAX_PAGE_SIZE` keeps its real job as the API page cap.

The guard added with #11816 counted only the rows a query *returned*, which is why a 105,000-read page passed it at 12,500. It now charges the scanned candidate windows, and fails on the chunked walk.

Also a direct contributor to the standing "Firestore Document Reads exceeded 10k/s" alerts (#11282, #10950, #10817).

## Tested

- `backend/test.sh` over the 84 memory test files: **856 passed, exit 0**.
- The updated cost guard **fails on the chunked walk** (10,500 > 3,000 scanned at test scale) and **passes with the fix** (2,500).
- **Page-content equivalence** checked against the pre-fix chunked walk over 25 scenarios — suppression density 0 / 33% / 100%, malformed rows forcing over-fetch continuation rounds, offsets 0 through the window edge — identical ids in every case.
- Not reproducible against the real prod account, so the prod claim is the measured read/round-trip reduction, not an observed sub-30s page. Watchdog re-checks the live 504 rate next hour.

Line-Count-Exception: backend/utils/memory/memory_service.py | 2587 -> 2595 | 8-line comment recording why the prefix must be fetched in one query, so the offset walk is not reintroduced

Product invariants affected: INV-MEM-1, INV-MEM-3 — behavior unchanged (page content proven identical across 25 scenarios); this is a read-cost fix only.
Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

