### PR TITLE
fix(backend): stop deleting the knowledge graph before the rebuild that replaces it

### DIFF
--- a/backend/routers/knowledge_graph.py
+++ b/backend/routers/knowledge_graph.py
@@ -248,6 +248,9 @@ def get_canonical_knowledge_graph(
 
 
 def _rebuild_graph_task(uid: str, user_name: str) -> None:
+    # The gate is re-checked here because it was last answered before the response
+    # was returned. Bailing out must leave the graph exactly as it was, so nothing
+    # upstream of `rebuild_knowledge_graph` may delete it.
     if _legacy_graph_mutation_decision(uid) is not LegacyGraphMutation.ALLOWED:
         return
     memories: MemoryPayloads = [
@@ -265,7 +268,10 @@ def rebuild_graph(
 ):
     _require_legacy_graph_mutation(uid)
     user_name = get_user_name(uid) or ""
-    kg_db.delete_knowledge_graph(uid)
+    # No eager delete here: `rebuild_knowledge_graph` clears the graph itself as its
+    # first step, so deleting before scheduling only widens the window where the user
+    # has no graph and nothing is rebuilding one — a task that never runs, or one that
+    # bails on the re-checked gate, would leave them with nothing.
     background_tasks.add_task(_rebuild_graph_task, uid, user_name)
     return RebuildResponse(status="rebuilding", nodes_count=0, edges_count=0)
 

--- a/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
@@ -124,8 +124,57 @@ def test_legacy_principal_can_rebuild(client, monkeypatch, deleted, fallbacks):
 
     assert response.status_code == 200
     assert response.json()["status"] == "rebuilding"
-    assert deleted == [UID]
+    # The route hands the delete to the rebuild itself; see the regression tests below.
+    assert deleted == []
     assert scheduled == [(UID, "Ada")]
+
+
+def test_rebuild_does_not_delete_the_graph_before_the_rebuild_runs(client, monkeypatch, deleted, fallbacks):
+    # The route used to delete the graph and only then schedule the rebuild, so any
+    # background task that never ran — process restart, pod eviction — left the user
+    # with no graph at all behind a 200 that said "rebuilding".
+    _legacy_principal(monkeypatch)
+
+    # Stands in for a task that is scheduled and then never executes.
+    monkeypatch.setattr(kg_router, "_rebuild_graph_task", lambda uid, user_name: None)
+
+    response = client.post("/v1/knowledge-graph/rebuild")
+
+    assert response.status_code == 200
+    assert deleted == []
+
+
+def test_a_regate_that_flips_after_the_response_leaves_the_graph_intact(client, monkeypatch, deleted, fallbacks):
+    # The task re-checks the gate after the response is returned. An account that
+    # becomes assertion-backed in that window no-ops the rebuild — which used to mean
+    # the legacy graph stayed deleted, with nothing left to own it.
+    _head(monkeypatch, _failed_head(Reason.MISSING_STATE_HEAD))
+    answers = iter([False, True])  # route says legacy, the task's re-check says assertion-backed
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: next(answers))
+
+    def _must_not_run(*_args: Any, **_kwargs: Any):  # pragma: no cover - asserts absence
+        raise AssertionError("legacy rebuild ran for an account that became assertion-backed")
+
+    monkeypatch.setattr(kg_router, "_run_rebuild_knowledge_graph", _must_not_run)
+
+    response = client.post("/v1/knowledge-graph/rebuild")
+
+    assert response.status_code == 200
+    assert deleted == []
+
+
+def test_the_legacy_rebuild_still_clears_the_graph_itself(monkeypatch):
+    # The route relies on this: dropping its eager delete is only safe while
+    # `rebuild_knowledge_graph` starts by clearing the old graph, so a rebuild
+    # cannot merge new extractions into stale nodes.
+    llm_kg = kg_router._knowledge_graph_llm_module()
+    calls: List[str] = []
+    monkeypatch.setattr(kg_db, "delete_knowledge_graph", lambda uid, **_kw: calls.append(uid))
+    monkeypatch.setattr(kg_db, "get_knowledge_graph", lambda uid, **_kw: {"nodes": [], "edges": []})
+
+    llm_kg.rebuild_knowledge_graph(UID, [], "Ada", db_client=object())
+
+    assert calls == [UID]
 
 
 def test_legacy_principal_can_delete(client, monkeypatch, deleted, fallbacks):


### PR DESCRIPTION
## What

`POST /v1/knowledge-graph/rebuild` no longer deletes the legacy knowledge graph before
scheduling the rebuild that replaces it. The delete now happens where the rebuild happens.

## Why

From #11796. The route did:

```python
_require_legacy_graph_mutation(uid)
user_name = get_user_name(uid) or ""
kg_db.delete_knowledge_graph(uid)          # committed before any rebuild work
background_tasks.add_task(_rebuild_graph_task, uid, user_name)
return RebuildResponse(status="rebuilding", ...)
```

Two ways a user ended up with no graph at all behind a 200 that said "rebuilding":

1. **The task never runs to completion** — process restart, pod eviction. The delete is
   already committed; nothing is rebuilding anything.
2. **The re-checked gate says no.** `_rebuild_graph_task` re-evaluates
   `_legacy_graph_mutation_decision` *after* the delete. An account that became
   assertion-backed in that window — or, since the mutation-gate hardening, one whose
   canonical head read times out and returns `UNVERIFIED` — hits the early return, so the
   task no-ops and the legacy graph stays deleted permanently.

The eager delete was also redundant: `rebuild_knowledge_graph`
(`backend/utils/llm/knowledge_graph.py:341`) clears the graph itself as its first step.
So the happy path is byte-identical, and both loss windows above close. Dropping the
duplicate owner is the point — the graph's delete transition now has exactly one owner,
the rebuild that immediately repopulates it.

Not addressed here (unchanged, pre-existing): a rebuild that dies *after* its own delete
still leaves the graph empty. Closing that needs the shadow-collection-and-swap the issue
describes, which is a much larger change than this one and does not belong in a fix that
can be verified hermetically.

## What I tested

```
$ pytest tests/unit/test_knowledge_graph_canonical_mutation_routes.py
20 passed in 2.20s
```

The three new/updated assertions are real regression coverage — against the unfixed route
they fail with `AssertionError: assert ['uid-arbitrary-account'] == []`:

- `test_rebuild_does_not_delete_the_graph_before_the_rebuild_runs` — a scheduled task that
  never executes leaves the graph intact.
- `test_a_regate_that_flips_after_the_response_leaves_the_graph_intact` — the account
  becomes assertion-backed between the route's gate check and the task's; the rebuild
  no-ops and the graph is still there.
- `test_the_legacy_rebuild_still_clears_the_graph_itself` — locks the invariant the route
  now relies on, by calling the real `rebuild_knowledge_graph`.
- `test_legacy_principal_can_rebuild` updated: the route itself no longer deletes.

Wider knowledge-graph lane, unchanged: `130 passed, 1 skipped` across
`test_knowledge_graph_canonical_mutation_routes.py`, `test_knowledge_graph_legacy_fallback.py`,
`test_kg_prompt_node_cap.py`, `test_kg_prune_memory_citations.py`,
`test_knowledge_graph_extract_helper.py`, `test_memory_graph_assertion_read.py`,
`test_rate_limiting.py`.

`make preflight`: 11 checks passed. `black --line-length 120 --skip-string-normalization`
reports both files unchanged.

Not exercised against live Firestore — the loss window is a process death between two
writes, which is not reproducible hermetically. The route path itself is exercised through
the real FastAPI app via `TestClient`, including the inline background task.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: FC-split-mutation-authority

The legacy graph's delete transition had two owners — the route and
`rebuild_knowledge_graph` — and only the second one is the authority that also repopulates
it. This converges the transition on that single owner.

fixes #11796

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

