### PR TITLE
fix(backend): name the serving provider on the live-STT ready event

### DIFF
--- a/backend/routers/listen/runtime.py
+++ b/backend/routers/listen/runtime.py
@@ -115,6 +115,7 @@ class ListenSessionRuntime:
         self.is_multi_channel = request.channels >= 2
         self.language = request.language
         self.stt_service: Any = None
+        self.stt_service_selected: Any = None
         self.stt_language = ''
         self.stt_model = ''
         self.vocabulary: List[str] = []
@@ -275,6 +276,10 @@ class ListenSessionRuntime:
             multi_lang_enabled=not single_language_mode,
             preferred_service=request.stt_service,
         )
+        # The provider the serving policy chose, captured before `_create_stt_socket`
+        # can walk the fallback chain. Only the *selected* value is safe to hold onto:
+        # the serving one has to be read at use time (#11306).
+        self.stt_service_selected = self.stt_service
         self.parity_capture = ListenParityCapture.from_environ(
             principal_id=request.uid,
             session_id=getattr(self, 'session_id', ''),
@@ -574,6 +579,32 @@ class ListenSessionRuntime:
                 self.task_supervisor.create_lifetime_task(session.audio_bytes_consume(), name='pusher_audio')
             )
 
+    def _ready_event(self) -> MessageServiceStatusEvent:
+        """Name the provider actually serving this session on the `ready` event (#11306).
+
+        The client clears its terminal-failure state on `ready`, so a bare event leaves a
+        fallback socket that is about to die indistinguishable from a healthy session on
+        the provider the user selected. `_create_stt_socket` can walk the fallback chain
+        (#11695, #11752), so the serving provider is only knowable once the socket exists
+        — resolving it any earlier is the attribution bug #11359 fixed on the
+        terminal-failure path, which is why this reads `_serving_provider()` here rather
+        than reusing a value from bootstrap.
+
+        Both fields are optional and dropped by `exclude_none=True`, so a client that does
+        not read them sees exactly the payload it sees today.
+        """
+        if self.use_custom_stt:
+            # Custom-STT clients produce their own transcripts; no backend provider serves.
+            return MessageServiceStatusEvent(status='ready')
+        serving = self.receiver._serving_provider()
+        selected = getattr(self.stt_service_selected, 'value', self.stt_service_selected)
+        fell_back = bool(serving) and bool(selected) and serving != selected
+        return MessageServiceStatusEvent(
+            status='ready',
+            provider=serving,
+            reason=f'fallback_from_{selected}' if fell_back else None,
+        )
+
     async def run(self) -> None:
         if not await self._admit() or not await self._bootstrap():
             return
@@ -628,7 +659,7 @@ class ListenSessionRuntime:
                         self.task_supervisor.create_finite_task(self.speakers.load_and_run(), name='speaker_id'),
                     ]
                 )
-            self.send_event(MessageServiceStatusEvent(status='ready'))
+            self.send_event(self._ready_event())
             result = await self.task_supervisor.supervise(receive_task=receive_task)
             logger.info('Listen supervisor exited reason=%s', result.reason)
             if result.reason in {'crash', 'lifetime_done'}:

--- a/backend/tests/unit/test_listen_ready_provider.py
+++ b/backend/tests/unit/test_listen_ready_provider.py
@@ -1,0 +1,284 @@
+"""Regression (#11306): the live-STT `ready` event must name the provider serving.
+
+The backend emitted a bare ``MessageServiceStatusEvent(status='ready')`` as soon as
+the provider socket opened. ``_create_stt_socket`` can walk the fallback chain
+(#11695, #11752), so "Listening" could equally mean the Parakeet session the user
+selected or a Modulate/Deepgram fallback socket that is about to die — the client
+clears its terminal-failure state on ``ready`` and cannot tell the two apart.
+
+These tests drive the real ``run()`` sequence with the vendor connect functions
+stubbed, so the fallback the event has to report is produced by the production
+chain rather than asserted about.
+"""
+
+import asyncio
+import os
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from routers.listen import receiver as receiver_mod
+from routers.listen.contracts import ListenRequest, ListenSessionState
+from routers.listen.receiver import ListenReceiver
+from routers.listen.runtime import ListenSessionRuntime
+from utils.stt import provider_resilience, streaming
+from utils.stt.streaming import STTService
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+
+@contextmanager
+def _serving_policy(models=('modulate-velma-2', 'dg-nova-3', 'parakeet')):
+    """Drive the real provider gates off ``STT_SERVICE_MODELS``, not a stubbed answer."""
+    with (
+        patch.object(streaming, 'stt_service_models', list(models)),
+        patch.object(streaming, '_deepgram_is_available', return_value=True),
+        patch.dict(os.environ, {'HOSTED_PARAKEET_API_URL': 'ws://parakeet.omi.me/v3/stream'}),
+    ):
+        yield
+
+
+class _RejectedSocket:
+    """Velma's over-quota shape: the upgrade succeeds, then the stream is refused."""
+
+    def __init__(self) -> None:
+        self.death_reason = 'modulate error: Monthly usage limit reached.'
+        self.finished = False
+
+    @property
+    def is_connection_dead(self) -> bool:
+        return True
+
+    def finish(self) -> None:
+        self.finished = True
+
+
+def _live_socket():
+    return SimpleNamespace(is_connection_dead=False, death_reason=None, finish=lambda: None)
+
+
+async def _idle():
+    return None
+
+
+def _runtime_for_ready(*, selected=STTService.modulate, custom_stt=False):
+    """A runtime wired with the real receiver, stubbed only outside the STT path."""
+    request = ListenRequest(
+        websocket=SimpleNamespace(),
+        uid='ready-user',
+        codec='pcm8',
+        sample_rate=16000,
+    )
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.request = request
+    runtime.state = ListenSessionState()
+    runtime.session_id = 'ready-session'
+    runtime.use_custom_stt = custom_stt
+    runtime.is_multi_channel = False
+    runtime.language = 'en'
+    runtime.stt_service = selected
+    runtime.stt_service_selected = selected
+    runtime.stt_language = 'en'
+    runtime.stt_model = 'velma-2'
+    runtime.vocabulary = []
+    runtime.client_device_context = SimpleNamespace(platform='ios')
+    runtime.limits = SimpleNamespace(bg_drain_timeout=5.0)
+    runtime.pusher_tasks = []
+
+    events = []
+    runtime.send_event = events.append
+
+    async def asend_event(event):
+        events.append(event)
+        return True
+
+    runtime.asend_event = asend_event
+    runtime.emitted_events = events
+
+    runtime._admit = AsyncMock(return_value=True)
+    runtime._bootstrap = AsyncMock(return_value=True)
+    runtime._start_pusher = AsyncMock()
+    runtime._teardown = AsyncMock()
+    runtime._heartbeat = _idle
+    runtime._record_usage_periodically = _idle
+
+    runtime.conversations = SimpleNamespace(
+        send_last_conversation=AsyncMock(),
+        prepare=AsyncMock(return_value=False),
+        lifecycle_loop=_idle,
+        process_pending=lambda *_args: _idle(),
+    )
+    runtime.transcripts = SimpleNamespace(process_loop=_idle)
+    runtime.speakers = SimpleNamespace(load_and_run=_idle)
+
+    def create_task(coro, *, name, **_kwargs):
+        return asyncio.ensure_future(coro)
+
+    async def supervise(*, receive_task):
+        await receive_task
+        return SimpleNamespace(reason='client_disconnect')
+
+    runtime.task_supervisor = SimpleNamespace(
+        start_session=lambda: None,
+        create_task=create_task,
+        create_lifetime_task=create_task,
+        create_finite_task=create_task,
+        supervise=supervise,
+        drain_monitored=AsyncMock(return_value=0),
+    )
+    runtime.spawn = lambda coro, *, name: asyncio.ensure_future(coro)
+
+    runtime.receiver = ListenReceiver(runtime, [], {})
+    runtime.receiver.receive_data = _idle
+    runtime.receiver._monitor_stt_death = _idle
+    return runtime
+
+
+def _ready_payload(runtime):
+    ready = [event for event in runtime.emitted_events if getattr(event, 'status', None) == 'ready']
+    assert len(ready) == 1, f'expected exactly one ready event, got {len(ready)}'
+    return ready[0].to_json()
+
+
+async def _run_session(runtime, *, modulate_socket, dg_socket=None):
+    with (
+        _serving_policy(),
+        patch.object(provider_resilience, 'STT_FALLBACK_LIVENESS_GRACE_SECONDS', 0.05),
+        patch.object(receiver_mod, 'is_gate_enabled', return_value=False),
+        patch.object(receiver_mod, 'process_audio_modulate', new=AsyncMock(return_value=modulate_socket)),
+        patch.object(receiver_mod, 'process_audio_dg', new=AsyncMock(return_value=dg_socket)),
+        patch.object(receiver_mod, 'process_audio_parakeet', new=AsyncMock(return_value=None)),
+        patch.object(streaming, 'record_fallback'),
+    ):
+        await runtime.run()
+
+
+@pytest.mark.anyio
+async def test_ready_names_the_fallback_provider_actually_serving():
+    """The #11306 shape: Modulate takes the session, refuses it, Deepgram serves.
+
+    ``ready`` must say ``deepgram`` — the provider on the other end of the socket
+    the client is about to stream into — not the ``modulate`` the policy selected.
+    """
+    runtime = _runtime_for_ready(selected=STTService.modulate)
+
+    await _run_session(runtime, modulate_socket=_RejectedSocket(), dg_socket=_live_socket())
+
+    assert runtime.stt_service == STTService.deepgram, 'the fallback chain did not move the session'
+    payload = _ready_payload(runtime)
+    assert payload['provider'] == 'deepgram'
+    assert payload['reason'] == 'fallback_from_modulate'
+
+
+@pytest.mark.anyio
+async def test_ready_on_a_healthy_selected_provider_carries_no_fallback_reason():
+    """A session served by the selected provider must not look like a fallback."""
+    runtime = _runtime_for_ready(selected=STTService.modulate)
+
+    await _run_session(runtime, modulate_socket=_live_socket())
+
+    payload = _ready_payload(runtime)
+    assert payload['provider'] == 'modulate'
+    assert 'reason' not in payload, 'a healthy session must not carry a fallback reason'
+
+
+@pytest.mark.anyio
+async def test_ready_claims_no_backend_provider_for_custom_stt_sessions():
+    """Custom-STT clients own transcript production; no backend provider serves them."""
+    runtime = _runtime_for_ready(selected=STTService.modulate, custom_stt=True)
+
+    await _run_session(runtime, modulate_socket=_live_socket())
+
+    payload = _ready_payload(runtime)
+    assert 'provider' not in payload
+    assert 'reason' not in payload
+
+
+@pytest.mark.anyio
+async def test_ready_stays_additive_for_clients_that_ignore_the_new_fields():
+    """``exclude_none=True`` keeps the legacy payload shape intact."""
+    runtime = _runtime_for_ready(selected=STTService.modulate)
+
+    await _run_session(runtime, modulate_socket=_live_socket())
+
+    payload = _ready_payload(runtime)
+    assert payload['type'] == 'service_status'
+    assert payload['status'] == 'ready'
+    assert 'status_text' not in payload
+    assert 'outcome' not in payload
+    assert 'retryable' not in payload
+
+
+def test_ready_provider_is_resolved_at_emission_time_not_at_selection():
+    """Pin the accessor contract #11359 established for the terminal-failure path.
+
+    A value read before ``_create_stt_socket`` returns attributes a fallback
+    session to the provider that never served it.
+    """
+    runtime = _runtime_for_ready(selected=STTService.parakeet)
+
+    assert runtime._ready_event().to_json()['provider'] == 'parakeet'
+
+    runtime.stt_service = STTService.modulate  # what _create_stt_socket does on fallback
+
+    payload = runtime._ready_event().to_json()
+    assert payload['provider'] == 'modulate'
+    assert payload['reason'] == 'fallback_from_parakeet'
+
+
+@pytest.mark.anyio
+async def test_bootstrap_records_the_selected_provider_for_fallback_comparison(monkeypatch):
+    """``_bootstrap`` must keep the selected provider so ``ready`` can spot a fallback."""
+    import routers.listen.runtime as runtime_module
+    from utils.listen_session_bootstrap import ListenConnectBase
+
+    runtime = object.__new__(ListenSessionRuntime)
+    runtime.request = ListenRequest(websocket=SimpleNamespace(), uid='select-user', stt_service='parakeet')
+    runtime.use_custom_stt = False
+    runtime.session_id = 'select-session'
+    runtime.language = 'en'
+
+    base = ListenConnectBase(
+        user_exists=True,
+        user_has_credits=True,
+        transcription_prefs={'single_language_mode': False, 'uses_custom_stt': False},
+        fair_use_init_stage=None,
+        fair_use_track_dg_usage=False,
+        fair_use_dg_budget_exhausted=False,
+    )
+
+    async def close(**_kwargs):
+        raise AssertionError('bootstrap must not close the socket in this test')
+
+    monkeypatch.setattr(runtime_module, 'load_listen_connect_base', lambda *_a, **_k: _resolved(base))
+    monkeypatch.setattr(
+        runtime_module,
+        'get_stt_service_for_language',
+        lambda *_a, **_k: (STTService.modulate, 'en', 'velma-2'),
+    )
+    monkeypatch.setattr(runtime_module, 'finalize_listen_connect_context', _stop_after_selection)
+
+    with pytest.raises(_SelectionRecorded):
+        await runtime._bootstrap()
+
+    assert runtime.stt_service_selected == STTService.modulate
+
+
+class _SelectionRecorded(Exception):
+    """Stop `_bootstrap` once provider selection is done; the rest needs live IO."""
+
+
+def _stop_after_selection(*_args, **_kwargs):
+    raise _SelectionRecorded
+
+
+def _resolved(value):
+    async def _coro():
+        return value
+
+    return _coro()

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -139,7 +139,7 @@ sequenceDiagram
     Backend-->>Client: {type: "conversation_session", conversation_id, recording_session_id, lifecycle_version, lifecycle_phase, lifecycle_sequence}
     Backend->>STT: Open STT WebSocket
     Backend->>Pusher: Open Pusher WebSocket
-    Backend-->>Client: {type: "service_status", status: "ready"}
+    Backend-->>Client: {type: "service_status", status: "ready", provider, reason?}
 
     Note over Backend: Start background tasks:<br/>conversation_lifecycle_manager (5s poll)<br/>speaker_identification_task<br/>stream_transcript_process
 
@@ -478,7 +478,7 @@ Staleness is fingerprint-driven: when late chunks change `audio_files` (pusher b
 
 | Event | Fields | When |
 |-------|--------|------|
-| `service_status` | `{type, status: "ready"}` | After WS connect, services initialized |
+| `service_status` | `{type, status: "ready", provider?, reason?}` | After WS connect, services initialized. `provider` names the STT provider actually serving (absent for custom-STT sessions); `reason` is `fallback_from_<selected>` only when the fallback chain moved the session off the selected provider |
 | `conversation_session` | `{type, conversation_id, recording_session_id?, status}` | Exact recording-to-conversation binding; identified clients require IDs to match |
 | `memory_processing_started` | `{type, recording_session_id?, memory: {id, ...}}` | Conversation sent to pusher for LLM; only emitted for the listen session's current conversation |
 | `memory_created` | `{type, recording_session_id?, memory: {id, structured: {title, overview, ...}}}` | LLM processing complete; only emitted for the listen session's current conversation |

--- a/docs/doc/developer/backend/transcription.mdx
+++ b/docs/doc/developer/backend/transcription.mdx
@@ -563,9 +563,17 @@ sequenceDiagram
     {
       "type": "service_status",
       "status": "ready",
-      "status_text": "Service Ready"
+      "provider": "deepgram",
+      "reason": "fallback_from_modulate"
     }
     ```
+
+    `provider` names the STT provider actually serving the session, resolved after the
+    fallback chain has settled — a session may be served by a provider other than the one
+    the serving policy selected. `reason` appears only in that case, as
+    `fallback_from_<selected>`, so a client can tell a fallback session from a healthy one.
+    Both fields are omitted when absent, and `provider` is omitted entirely for custom-STT
+    sessions, where the client produces its own transcripts.
   </Tab>
 
   <Tab title="Speaker Suggestion" icon="user-plus">


### PR DESCRIPTION
Closes the remaining backend slice of #11306.

## What was wrong

`ListenSessionRuntime.run` emitted a bare `ready` as soon as the provider socket opened:

```python
self.send_event(MessageServiceStatusEvent(status='ready'))
```

`_create_stt_socket` can walk the fallback chain (#11695, #11752), so by the time this
fires the session may be served by a provider other than the one the serving policy
selected. The client clears its terminal-failure state on `ready`, so "Listening" equally
described a healthy session and a fallback socket about to die, with nothing in the
payload to tell them apart.

`MessageServiceStatusEvent` already carries `provider` and `reason` — added as the
additive terminal-failure contract and unused on this path — and
`ListenReceiver._serving_provider()` already resolves the serving provider at use time.
This wires the two together.

@kodjima33 named this slice explicitly when merging the attribution half as #11359:

> Still open here: … surfacing the actual provider + fallback reason on the `ready` event
> so the client can tell a fallback session from a healthy Parakeet one.

## What changed

- `ready` now carries `provider`, read from `_serving_provider()` **at emission time**.
  Resolving it any earlier is precisely the attribution bug #11359 fixed on the
  terminal-failure path, so the accessor is called here rather than reusing a value held
  from bootstrap.
- `_bootstrap` records the policy-**selected** provider (`stt_service_selected`). That
  value is fixed at selection and is not a snapshot of the serving provider; it exists
  only so the emission can tell whether the chain moved the session.
- When serving ≠ selected, `reason` is `fallback_from_<selected>`. A healthy session
  carries no `reason` at all.
- Custom-STT sessions claim no backend provider — the client produces its own
  transcripts — so neither field is emitted.

Payload for a Modulate session that Velma refused and Deepgram took over:

```json
{"type": "service_status", "status": "ready", "provider": "deepgram", "reason": "fallback_from_modulate"}
```

## Scope

**Backend emission only.** Making the clients *act* on the new fields is a separate,
larger change across three platforms (Flutter app, iOS, desktop) and is deliberately not
included here. This PR only makes the information available to them.

The underlying vendor cause of a fallback (`quota` / `timeout` / `provider_5xx`) is
classified inside `connect_stt_socket_with_fallback` and already recorded through
`record_fallback`; it is not returned to the caller. Plumbing it onto the event would
change that shared helper's signature and its four call sites, so it is left out of this
slice. No new provider-changing or mode-changing branch is introduced here, so the
fallback-telemetry contract needs no new `record_fallback` call.

## Compatibility

Purely additive. `MessageServiceStatusEvent.to_json` uses `exclude_none=True`, so a client
that does not read the new fields sees exactly the payload it sees today — verified by
`test_ready_stays_additive_for_clients_that_ignore_the_new_fields`.

This is a WebSocket event and does not appear in the REST app-client contract
(`grep -c service_status docs/api-reference/app-client-openapi.json` → `0`). The gate was
run anyway:

```
$ python scripts/check_app_client_openapi_compatibility.py --base-ref upstream/main
App-client OpenAPI compatibility passed against merge-base 5712bfacef587c0fe47f48a35a2a14e934bc4cd5.
```

## Verification

### Red before green

The regression test was written first and run against unmodified code. It drives the real
`run()` sequence with a real `ListenReceiver`, stubbing only the vendor connect functions,
so the fallback it reports is produced by the production chain rather than asserted about.

```
$ python -m pytest tests/unit/test_listen_ready_provider.py -q      # before the fix
___________ test_ready_names_the_fallback_provider_actually_serving ____________
>       assert payload['provider'] == 'deepgram'
E       KeyError: 'provider'
_____ test_ready_on_a_healthy_selected_provider_carries_no_fallback_reason _____
>       assert payload['provider'] == 'modulate'
E       KeyError: 'provider'
______ test_ready_provider_is_resolved_at_emission_time_not_at_selection _______
>       assert runtime._ready_event().to_json()['provider'] == 'parakeet'
E       AttributeError: 'ListenSessionRuntime' object has no attribute '_ready_event'
_____ test_bootstrap_records_the_selected_provider_for_fallback_comparison _____
>       assert runtime.stt_service_selected == STTService.modulate
E       AttributeError: 'ListenSessionRuntime' object has no attribute 'stt_service_selected'
4 failed, 2 passed, 9 warnings in 2.72s
```

`KeyError: 'provider'` is the exact pre-fix shape: the field was `None` and `exclude_none=True`
stripped it from the payload entirely. The first failure only reaches its assertion after
`assert runtime.stt_service == STTService.deepgram` passes, which proves the fallback chain
really moved the session before `ready` was emitted.

After the fix:

```
$ python -m pytest tests/unit/test_listen_ready_provider.py -q
6 passed, 9 warnings in 1.94s
```

### Blast radius

The full GitHub Actions unit contract for this diff — `scripts/select_backend_unit_tests.py`
selected 148 files from the changed paths — run through `test.sh` with CI's file-isolation
and timing guards:

```
$ BACKEND_UNIT_TEST_FILE_LIST=<selected> BACKEND_FAST_UNIT_FAIL_SECONDS=1.0 \
  BACKEND_PYTEST_FILE_ISOLATION=1 bash test.sh
143 files, 2473 tests passed, exit 0
```

Type check and the isolation scanners:

```
$ bash scripts/typecheck.sh
0 errors, 3660 warnings, 0 informations

$ python scripts/check_module_stub_pollution.py
Checked 903 backend test file(s); 0 violation(s).

$ python scripts/scan_import_time_side_effects.py
Checked 800 backend production file(s); 0 violation(s).

$ black --line-length 120 --skip-string-normalization --check
2 files would be left unchanged.
```

### Not verified here

Four of the 148 selected files could not run on this machine, for reasons unrelated to
this diff:

- `test_verify_pusher_config_references.py` shells out to `helm`, which is not installed
  (`FileNotFoundError: [Errno 2] No such file or directory: 'helm'`). Excluded from the
  2473-test run above; CI has helm.
- `test-preflight.sh` reports one failure: Python 3.11.13 installed vs 3.11.15 pinned in
  `.python-version`. Patch-level, environmental.

**This was verified hermetically at the `process_audio_*` seam. It was not exercised
against live Deepgram, Modulate, or Parakeet**, and I have not run a real device session
against it. The provider values asserted are the ones the production fallback chain
assigns to `host.stt_service`; that those match what a live vendor socket serves is
existing behavior this PR does not change.

## Gates

- **Product invariants affected:** none (`scripts/pr-preflight --base upstream/main --suggest`).
- **Docs:** `docs/doc/developer/backend/transcription.mdx` and
  `listen_pusher_pipeline.mdx` both documented the `ready` payload and are updated.

Failure-Class: none

Rationale: this adds reporting fields to an existing event. It introduces no new
failure, recovery, or fallback branch — the fallback behavior it reports on landed in
#11695/#11752/#11814. #11359, the attribution half of this same issue on the same code
path, also declared `Failure-Class: none`. `scripts/failure-class prepare` inferred no
class from the diff.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

