### PR TITLE
feat(backend): route Pro and Flash overflow to gemini-3.1-flash-lite

### DIFF
--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -29,19 +29,136 @@ and **never** `?key=` for that path. Missing `GOOGLE_CLOUD_PROJECT` must fail
 closed — that omission is what moved Flash off Vertex on 2026-08-04 and
 double-paid (reservation + API list).
 
-The model pin is `VERTEX_PT_MODEL = 'gemini-2.5-flash'` in
-`backend/routers/desktop_proxy.py`. Changing the company-paid Flash default to
-Lite / 3.1 without updating that pin, this note, and the contract tests in the
+The model pin is `VERTEX_PT_MODEL` in `backend/routers/desktop_proxy.py`,
+sourced from `ptr.PT_MODEL_CURRENT` in
+`backend/utils/llm/vertex_pt_routing.py`. Changing the company-paid Flash
+default without updating that pin, this note, and the contract tests in the
 same commit is the regression.
 
-BYOK Gemini stays on the user's key / AI Studio.
+BYOK Gemini stays on the user's key / AI Studio, and is never remapped: the
+user pays for the model they asked for.
+
+## Model prices (Vertex list, captured 2026-08-18)
+
+| Model | Input $/1M | Output $/1M |
+| --- | ---: | ---: |
+| `gemini-2.5-flash-lite` | 0.10 | 0.40 |
+| `gemini-3.1-flash-lite` | 0.25 | 1.50 |
+| `gemini-2.5-flash` | 0.30 | 2.50 |
+| `gemini-2.5-pro` | 1.25 | 10.00 |
+
+**`gemini-3.1-flash-lite` is not the same price class as
+`gemini-2.5-flash-lite`** — it is 2.5x input and 3.75x output. It is cheaper
+than `gemini-2.5-flash` and far cheaper than `gemini-2.5-pro`, which is why it
+absorbs overflow and Pro. Promoting the client-pinned Lite lanes
+(`ModelQoS.lightweight`, Windows `memory/goals/insight`) onto it would be a
+large cost regression, not a saving. Those pins are deliberately untouched and
+`test_client_pinned_flash_lite_is_never_promoted` holds that boundary.
+
+## Migrating the reservation to `gemini-3.1-flash-lite`
+
+Requested 2026-08-18; PT orders provision in ~10 business days. **No deploy is
+needed when it lands.** The proxy detects it and promotes itself:
+
+1. Company-paid text asks the reservation for `dedicated` capacity via the
+   `X-Vertex-AI-LLM-Request-Type` header. Without that header Vertex silently
+   spills over-cap requests onto pay-as-you-go; with it, an over-cap request
+   returns 429 `Exceeded the Provisioned Throughput` instead.
+2. On that 429 the proxy overflows to `gemini-3.1-flash-lite`. If a capacity
+   probe is due (`_PT_PROBE_TTL_SECONDS`, 600s) the first overflow attempt asks
+   for `dedicated`. That single request **is** the auto-detection: if the new
+   order exists it succeeds, and if it does not it 429s and falls through to
+   the on-demand call the proxy would have made anyway. Detection therefore
+   costs nothing and only happens when the old reservation is already full.
+3. A successful probe latches `_pt_target_ready` and logs
+   `desktop_proxy pt_promotion`. From then on `gemini-2.5-flash` requests are
+   served by `gemini-3.1-flash-lite` on prepaid capacity.
+
+The positive observation is latched rather than TTL'd on purpose: a PT purchase
+is long-lived, and expiring it would flap the serving model every time overflow
+stopped re-probing. A vanished order still degrades safely — requests 429 and
+overflow absorbs them.
+
+The latch is **per Cloud Run instance**, held in process memory. Promotion
+therefore rolls out gradually: each instance switches the first time it
+overflows and probes successfully, so expect a mixed fleet for a while rather
+than a single cutover instant. Grep the logs for
+`desktop_proxy pt_promotion` to see how far it has spread, and set
+`OMI_VERTEX_PT_MODEL` if you need every instance on one model immediately.
+
+**Retire the old order when promotion happens.** The `gemini-2.5-flash` order
+bills a flat ~$290.32/day until ~2027-05-28 whether or not traffic uses it, so
+once traffic moves to `gemini-3.1-flash-lite` the old reservation is paid-for
+and idle. Promotion is a code-side cutover; converting or cancelling the 5 GSU
+`gemini-2.5-flash` order is a separate commercial action that has to be done in
+Cloud Console, and until it is, both are billed.
+
+## Never move dedicated traffic off a reservation early
+
+Moving `gemini-2.5-flash` onto an on-demand model *before* the replacement
+order is live pays the flat reservation fee for idle capacity **and** full
+on-demand for every token — strictly worse than either alone. This is why the
+flash remap is gated on observed capacity rather than shipped as a constant.
+`test_flash_stays_on_the_current_reservation_until_target_capacity_exists`
+holds that gate.
+
+## Overflow is resolved against the live reservation
+
+`OVERFLOW_PREFERENCE` is a ladder, not a pin, and
+`resolve_overflow_model()` never returns the model that currently holds prepaid
+capacity. Once `gemini-3.1-flash-lite` *is* the reservation, overflow steps
+past it to `gemini-2.5-flash-lite` automatically. Pinning overflow to
+`gemini-3.1-flash-lite` would, after promotion, dump degraded traffic onto the
+budget the quota exists to protect — that is
+`FC-degraded-fallback-consumes-protected-budget` (PR #10686), and the guard is
+`test_overflow_never_targets_the_live_reservation`.
+
+## Gemini 3.x changed the thinking contract
+
+2.5 models take an integer `thinkingConfig.thinkingBudget`. 3.x models take
+`thinkingConfig.thinkingLevel`, and **thinking cannot be disabled** — the floor
+is `minimal`. Thinking tokens bill as *output*, so sending a 2.5-style budget
+to a 3.x model risks an uncapped reasoning trace at $1.50/1M: the field is
+schema-valid, so it is accepted and then ignored.
+
+`ptr.thinking_config_for()` picks by family prefix rather than exact model name,
+matching how `_CACHE_KEY_MODEL_PREFIXES` handles prompt caching, and
+`_retarget_thinking()` rewrites the body when overflow crosses families.
+
+**Unverified:** whether 3.x hard-errors on `thinkingBudget` or silently ignores
+it could not be settled from this host — `aiplatform.endpoints.predict` is
+denied to the read-only service account, and no human ADC was live. The code is
+correct either way, but the observed token counts are still worth capturing:
+
+```
+python3 backend/scripts/probe_gemini_thinking_contract.py
+```
+
+Run it with credentials that can call `generateContent` and paste the output
+into this section.
+
+## Operator overrides
+
+All three are read per request, so a bad promotion can be corrected without
+shipping code.
+
+| Env | Effect |
+| --- | --- |
+| `OMI_VERTEX_PT_MODEL` | Pins the reservation model, beating auto-detection in both directions. |
+| `OMI_GEMINI_OVERFLOW_MODEL` | Pins the overflow model. Rejected at resolution time if it equals the reservation. |
+| `OMI_GEMINI_OVERFLOW_ENABLED` | `false` disables overflow entirely; a full reservation then returns 429 to the client. |
 
 ## Keeping the reservation for work that must be Flash
 
 The 13,450 tok/s cap is oversubscribed, so the proxy actively keeps low-value
 work off `gemini-2.5-flash`:
 
-- **Over-quota Pro demotes to `gemini-2.5-flash-lite`**
+- **Server-paid Pro is served by `gemini-3.1-flash-lite`** ($10.00 -> $1.50 per
+  1M output). The remap happens after metering, so the two Pro paths stay
+  distinct: within quota a request gets `gemini-3.1-flash-lite`, and over quota
+  it still demotes to `gemini-2.5-flash-lite` and keeps the cheap tier for
+  heavy users.
+- **Over-quota demotion targets `gemini-2.5-flash-lite`**
   (`_QUOTA_DEMOTION_MODEL`), which is `shared`/on-demand on Vertex and never
   burns the PT. Demoting to `gemini-2.5-flash` instead was the 2026-08-17
   defect that silently dumped the Insight tool loop (~11% of the reservation)

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, TypeVar, cast
+from typing import Any, TypeVar
 from uuid import uuid4
 
 import httpx
@@ -24,6 +24,7 @@ from utils.http_client import (
     get_desktop_gemini_semaphore,
     get_desktop_gemini_stream_client,
 )
+from utils.llm import vertex_pt_routing as ptr
 from utils.llm.desktop_llm_stub import (
     llm_stub_enabled,
     stub_gemini_proxy_json,
@@ -36,8 +37,24 @@ from utils.subscription import is_desktop_trial_paywalled
 router = APIRouter()
 
 _ALLOWED_ACTIONS = frozenset({'generateContent', 'streamGenerateContent', 'embedContent', 'batchEmbedContents'})
-_ALLOWED_MODELS = frozenset({'gemini-2.5-flash', 'gemini-2.5-flash-lite', 'gemini-2.5-pro', 'gemini-embedding-001'})
-_VERTEX_MODELS = frozenset({'gemini-2.5-flash', 'gemini-2.5-flash-lite', 'gemini-2.5-pro', 'gemini-embedding-001'})
+_ALLOWED_MODELS = frozenset(
+    {
+        'gemini-2.5-flash',
+        'gemini-2.5-flash-lite',
+        'gemini-2.5-pro',
+        'gemini-3.1-flash-lite',
+        'gemini-embedding-001',
+    }
+)
+_VERTEX_MODELS = frozenset(
+    {
+        'gemini-2.5-flash',
+        'gemini-2.5-flash-lite',
+        'gemini-2.5-pro',
+        'gemini-3.1-flash-lite',
+        'gemini-embedding-001',
+    }
+)
 # Vertex batch embedding is not wire-compatible with the AI Studio batch method.
 # Keep the provider decision explicit instead of silently trying one API shape on
 # another provider.
@@ -45,7 +62,19 @@ _VERTEX_ACTIONS = frozenset({'generateContent', 'streamGenerateContent', 'embedC
 # Company-paid Flash text is reserved on Vertex PT. Changing this pin without
 # updating the matching tests and backend/docs/vertex-pt-flash.md is the
 # 2026-08-04 AI Studio double-pay regression.
-VERTEX_PT_MODEL = 'gemini-2.5-flash'
+VERTEX_PT_MODEL = ptr.PT_MODEL_CURRENT
+# Migration target. A PT order for gemini-3.1-flash-lite provisions in ~10
+# business days; the proxy promotes itself the first time `dedicated` answers
+# on it, with no deploy. See backend/docs/vertex-pt-flash.md.
+VERTEX_PT_TARGET_MODEL = ptr.PT_MODEL_TARGET
+# Emergency operator pins. Both beat auto-detection so a bad promotion or a
+# bad overflow target can be corrected without shipping code.
+_PT_MODEL_OVERRIDE_ENV = 'OMI_VERTEX_PT_MODEL'
+_OVERFLOW_MODEL_OVERRIDE_ENV = 'OMI_GEMINI_OVERFLOW_MODEL'
+_OVERFLOW_ENABLED_ENV = 'OMI_GEMINI_OVERFLOW_ENABLED'
+# How long a PT-capacity observation is trusted before it is re-probed. Bounds
+# both the promotion delay after the order lands and the cost of probing.
+_PT_PROBE_TTL_SECONDS = 600.0
 VERTEX_PT_LOCATION = 'us-central1'
 VERTEX_PT_EXPIRES = '~2027-05-28'
 VERTEX_PT_CONTRACT = 'Vertex PT: 5 GSU gemini-2.5-flash us-central1, expires ~2027-05-28'
@@ -333,7 +362,13 @@ def _as_nonnegative_int(value: Any) -> int | None:
     return None
 
 
-def _sanitize(body: bytes, action: str, *, max_output_tokens: int = _MAX_OUTPUT_TOKENS) -> bytes:
+def _sanitize(
+    body: bytes,
+    action: str,
+    *,
+    max_output_tokens: int = _MAX_OUTPUT_TOKENS,
+    model: str = '',
+) -> bytes:
     try:
         payload = json.loads(body)
     except (TypeError, ValueError) as exc:
@@ -375,7 +410,7 @@ def _sanitize(body: bytes, action: str, *, max_output_tokens: int = _MAX_OUTPUT_
         if not generation_configs:
             payload['generationConfig'] = {
                 'maxOutputTokens': max_output_tokens,
-                'thinkingConfig': {'thinkingBudget': _DEFAULT_THINKING_BUDGET},
+                'thinkingConfig': ptr.thinking_config_for(model, budget=_DEFAULT_THINKING_BUDGET),
             }
         for config in generation_configs:
             for key in ('candidate_count', 'candidateCount'):
@@ -392,7 +427,7 @@ def _sanitize(body: bytes, action: str, *, max_output_tokens: int = _MAX_OUTPUT_
             if not output_key_present:
                 config['maxOutputTokens'] = max_output_tokens
             if 'thinking_config' not in config and 'thinkingConfig' not in config:
-                config['thinkingConfig'] = {'thinkingBudget': _DEFAULT_THINKING_BUDGET}
+                config['thinkingConfig'] = ptr.thinking_config_for(model, budget=_DEFAULT_THINKING_BUDGET)
     return json.dumps(payload, separators=(',', ':')).encode()
 
 
@@ -406,8 +441,136 @@ def _use_vertex_ai() -> bool:
     return os.getenv('USE_VERTEX_AI', '').strip().lower() in {'1', 'true', 'yes'}
 
 
+# Observed state of the pending gemini-3.1-flash-lite PT order.
+#
+# The positive observation is latched: a Provisioned Throughput purchase is a
+# long-lived commitment, and expiring it on a TTL would flap the serving model
+# every time overflow stopped re-probing. A vanished order still degrades
+# safely — requests 429 and overflow absorbs them — and the operator override
+# pins the model outright if that is ever not enough.
+_pt_target_ready = False
+# None means "never probed", which is distinct from "probed at monotonic 0".
+# time.monotonic() is measured from an arbitrary origin — on a freshly started
+# container it can legitimately be smaller than the TTL, so seeding this with
+# 0.0 would suppress the first probe for the first _PT_PROBE_TTL_SECONDS of
+# process uptime on every new instance.
+_pt_target_probed_at: float | None = None
+
+
+def _pt_target_is_ready() -> bool:
+    return _pt_target_ready
+
+
+def _pt_probe_due() -> bool:
+    """Whether the next overflow request should ask for `dedicated` capacity.
+
+    Probing rides an existing overflow request, so detection costs no extra
+    call: overflow only happens when the current reservation is already full,
+    which is exactly when a second order matters.
+    """
+    if _pt_target_ready:
+        return False
+    if _pt_target_probed_at is None:
+        return True
+    return (time.monotonic() - _pt_target_probed_at) >= _PT_PROBE_TTL_SECONDS
+
+
+def _record_pt_target_observation(ready: bool) -> None:
+    global _pt_target_ready, _pt_target_probed_at
+    _pt_target_probed_at = time.monotonic()
+    if ready and not _pt_target_ready:
+        _pt_target_ready = True
+        print(
+            f'desktop_proxy pt_promotion model={VERTEX_PT_TARGET_MODEL} '
+            f'reason=dedicated_capacity_observed previous={ptr.PT_MODEL_CURRENT}',
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def _provisioned_model() -> str:
+    """The model that currently owns prepaid capacity."""
+    return ptr.resolve_pt_model(
+        target_dedicated_ready=_pt_target_is_ready(),
+        override=os.getenv(_PT_MODEL_OVERRIDE_ENV, ''),
+    )
+
+
+def _overflow_model(pt_model: str) -> str:
+    return ptr.resolve_overflow_model(pt_model=pt_model, override=os.getenv(_OVERFLOW_MODEL_OVERRIDE_ENV, ''))
+
+
+def _overflow_enabled() -> bool:
+    return os.getenv(_OVERFLOW_ENABLED_ENV, 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
+
+
+def _serving_model(model: str) -> str:
+    """Map a requested model onto the model that will actually serve it.
+
+    BYOK is never remapped: the user pays for the model they asked for.
+
+    Two server-paid remaps, both cheaper per token than what they replace:
+      gemini-2.5-pro   -> gemini-3.1-flash-lite  ($10.00 -> $1.50 out)
+      gemini-2.5-flash -> whichever model holds prepaid capacity
+
+    Client-pinned gemini-2.5-flash-lite lanes are deliberately untouched:
+    gemini-3.1-flash-lite costs 3.75x more per output token, so promoting those
+    lanes would be a large cost regression, not a saving.
+    """
+    if get_byok_key('gemini'):
+        return model
+    if model == 'gemini-2.5-pro':
+        return VERTEX_PT_TARGET_MODEL
+    if model == ptr.PT_MODEL_CURRENT:
+        return _provisioned_model()
+    return model
+
+
+def _retarget_path(path: str, model: str, action: str) -> str:
+    served = _serving_model(model)
+    if served == model:
+        return path
+    return f'models/{served}:{action}'
+
+
+def _retarget_thinking(body: bytes, model: str) -> bytes:
+    """Rewrite thinkingConfig for a model in a different family.
+
+    Overflow crosses families (gemini-2.5-flash -> gemini-3.1-flash-lite), and
+    a 2.5-style integer budget is schema-valid but ignored on 3.x, so leaving
+    it in place would uncap reasoning tokens that bill as output.
+    """
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return body
+    if not isinstance(payload, dict):
+        return body
+    replacement = ptr.thinking_config_for(model, budget=_DEFAULT_THINKING_BUDGET)
+    changed = False
+    for key in ('generation_config', 'generationConfig'):
+        config = payload.get(key)
+        if not isinstance(config, dict):
+            continue
+        for thinking_key in ('thinking_config', 'thinkingConfig'):
+            if thinking_key in config:
+                config[thinking_key] = dict(replacement)
+                changed = True
+    if not changed:
+        return body
+    return json.dumps(payload, separators=(',', ':')).encode()
+
+
 def _server_paid_flash_text(model: str, action: str) -> bool:
-    return model == VERTEX_PT_MODEL and action in {'generateContent', 'streamGenerateContent'}
+    """Whether this is company-paid PT-class text that must never reach AI Studio.
+
+    Covers both the current reservation and the migration target so the
+    2026-08-04 double-pay regression cannot reappear mid-migration.
+    """
+    return model in {ptr.PT_MODEL_CURRENT, ptr.PT_MODEL_TARGET} and action in {
+        'generateContent',
+        'streamGenerateContent',
+    }
 
 
 def _vertex_required(model: str, action: str) -> bool:
@@ -435,7 +598,14 @@ def _safe_provider_query(query: dict[str, str]) -> dict[str, str]:
     return query
 
 
-async def _upstream(path: str, model: str, action: str, query: dict[str, str]) -> UpstreamRoute:
+async def _upstream(
+    path: str,
+    model: str,
+    action: str,
+    query: dict[str, str],
+    *,
+    request_type: str | None = None,
+) -> UpstreamRoute:
     query = _safe_provider_query(query)
     byok_key = get_byok_key('gemini')
     if byok_key:
@@ -458,9 +628,14 @@ async def _upstream(path: str, model: str, action: str, query: dict[str, str]) -
                 message='Gemini routing credentials are unavailable',
             ) from exc
         url = vertex_url.rsplit(':', 1)[0] + ':predict' if action == 'embedContent' else vertex_url
+        # Without this header Vertex silently spills over-cap requests onto
+        # pay-as-you-go. Asking for `dedicated` turns that into a 429 the proxy
+        # can route deliberately; everything else is pinned to `shared` so it
+        # can never draw down the reservation.
+        capacity = request_type or ptr.request_type_for(model=model, pt_model=_provisioned_model())
         return UpstreamRoute(
             url,
-            {'Authorization': f'Bearer {token}'},
+            {'Authorization': f'Bearer {token}', ptr.REQUEST_TYPE_HEADER: capacity},
             query,
             'vertex_ai',
             'application_default_credentials',
@@ -480,6 +655,38 @@ async def _upstream(path: str, model: str, action: str, query: dict[str, str]) -
             code='routing_not_configured', message='Gemini provider route is not configured', phase='routing'
         )
     return UpstreamRoute(_studio_url(path), {}, {**query, 'key': server_key}, 'ai_studio', 'server_key', 'global')
+
+
+def _overflow_plan(served_model: str) -> list[tuple[str, str]]:
+    """Ordered (model, request_type) attempts to try after prepaid capacity is full.
+
+    Only traffic that was actually routed at the reservation can exhaust it, so
+    anything else returns an empty plan and keeps its own error.
+
+    When a probe is due the first attempt asks the migration target for
+    `dedicated` capacity. That single request is the whole auto-detection
+    mechanism: if a gemini-3.1-flash-lite PT order has landed it succeeds and
+    the proxy promotes itself permanently, and if it has not it 429s and the
+    plan falls through to the same on-demand call it would have made anyway.
+    """
+    if not _overflow_enabled():
+        return []
+    pt_model = _provisioned_model()
+    if served_model != pt_model:
+        return []
+    try:
+        overflow = _overflow_model(pt_model)
+    except ValueError:
+        return []
+    plan: list[tuple[str, str]] = []
+    if overflow == ptr.PT_MODEL_TARGET and _pt_probe_due():
+        plan.append((overflow, ptr.REQUEST_TYPE_DEDICATED))
+    plan.append((overflow, ptr.REQUEST_TYPE_SHARED))
+    return plan
+
+
+def _overflow_triggered(status: int, message: str) -> bool:
+    return ptr.is_provisioned_capacity_exhausted(status, message) or ptr.is_provisioned_capacity_absent(status, message)
 
 
 async def _meter_server_request(uid: str, path: str, model: str, action: str) -> str:
@@ -757,34 +964,87 @@ async def _stream_provider(
     route: UpstreamRoute,
     body: bytes,
     telemetry: ProxyTelemetry,
+    *,
+    model: str = '',
+    action: str = '',
+    query: Mapping[str, str] | None = None,
 ) -> AsyncIterator[bytes]:
     client = get_desktop_gemini_stream_client()
     semaphore = get_desktop_gemini_semaphore()
-    context: Any | None = None
-    acquired = False
-    opened = False
     usage_observer = _StreamingUsageObserver(telemetry)
-    try:
-        async with asyncio.timeout(_TOTAL_TIMEOUT_SECONDS):
-            telemetry.phase = 'pool'
-            await _acquire_provider_slot(semaphore)
-            acquired = True
+
+    async def open_attempt(attempt_route: UpstreamRoute, attempt_body: bytes) -> tuple[Any, httpx.Response]:
+        """Open one upstream stream, holding a provider slot. Caller closes both."""
+        telemetry.phase = 'pool'
+        await _acquire_provider_slot(semaphore)
+        try:
             telemetry.phase = 'connect'
             context = client.stream(
                 'POST',
-                route.url,
-                params=route.params,
-                content=body,
-                headers={'Content-Type': 'application/json', **route.headers},
+                attempt_route.url,
+                params=attempt_route.params,
+                content=attempt_body,
+                headers={'Content-Type': 'application/json', **attempt_route.headers},
             )
-            upstream = cast(httpx.Response, await _cancel_on_disconnect(request, context.__aenter__()))
-            opened = True
-        telemetry.phase = 'first_byte'
-        if upstream.status_code >= 400:
+            upstream = await _cancel_on_disconnect(request, context.__aenter__())
+        except BaseException:
+            semaphore.release()
+            raise
+        return context, upstream
+
+    context: Any | None = None
+    upstream: httpx.Response | None = None
+    held = False
+    try:
+        # Each entry is one upstream attempt. Overflow attempts are appended
+        # only after the reservation actually reports itself full, so the
+        # ordinary path opens exactly one stream as before.
+        pending: list[tuple[UpstreamRoute, bytes, str, str]] = [(route, body, model, '')]
+        while pending:
+            attempt_route, attempt_body, attempt_model, capacity = pending.pop(0)
+            async with asyncio.timeout(_TOTAL_TIMEOUT_SECONDS):
+                context, upstream = await open_attempt(attempt_route, attempt_body)
+                held = True
+            telemetry.phase = 'first_byte'
+            if upstream.status_code < 400:
+                break
+            # The body carries the difference between 'reservation full' and
+            # ordinary rate limiting, and a streamed error body is not read yet.
+            await upstream.aread()
+            exhausted = _overflow_triggered(upstream.status_code, upstream.text)
+            if capacity == ptr.REQUEST_TYPE_DEDICATED:
+                _record_pt_target_observation(not exhausted)
+            if exhausted and not pending and query is not None:
+                for overflow_model, overflow_capacity in _overflow_plan(attempt_model):
+                    pending.append(
+                        (
+                            await _upstream(
+                                f'models/{overflow_model}:{action}',
+                                overflow_model,
+                                action,
+                                dict(query),
+                                request_type=overflow_capacity,
+                            ),
+                            _retarget_thinking(body, overflow_model),
+                            overflow_model,
+                            overflow_capacity,
+                        )
+                    )
+            if pending:
+                if context is not None:
+                    with suppress(Exception):
+                        await context.__aexit__(None, None, None)
+                context = None
+                semaphore.release()
+                held = False
+                telemetry.set_route(pending[0][0])
+                telemetry.model = pending[0][2]
+                continue
             response = _provider_error(upstream, telemetry)
             event = json.loads(bytes(response.body))
             yield f'data: {json.dumps(event, separators=(",", ":"))}\n\n'.encode()
             return
+        assert upstream is not None
         async for chunk in upstream.aiter_bytes():
             usage_observer.feed(chunk)
             yield chunk
@@ -808,10 +1068,10 @@ async def _stream_provider(
         telemetry.complete(outcome='transport_error', status_code=502, retryable=False, phase='body')
         yield _stream_error_event(code='provider_transport_error', phase=telemetry.phase, telemetry=telemetry)
     finally:
-        if opened and context is not None:
+        if context is not None:
             with suppress(Exception):
                 await context.__aexit__(None, None, None)
-        if acquired:
+        if held:
             semaphore.release()
 
 
@@ -847,10 +1107,11 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
             )
         telemetry.phase = 'metering'
         path = await _meter_server_request(uid, path, model, action)
+        path = _retarget_path(*_path_parts(path))
         _, model, action = _path_parts(path)
         telemetry.model = model
         telemetry.action = action
-        body = _sanitize(body, action, max_output_tokens=_output_token_cap())
+        body = _sanitize(body, action, max_output_tokens=_output_token_cap(), model=model)
         telemetry.shape = _payload_shape(body)
     except HTTPException as exc:
         outcome = 'rate_limited' if exc.status_code == 429 else 'validation_rejected'
@@ -872,28 +1133,53 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
                 body = _vertex_embedding_request(body)
             if streaming:
                 return StreamingResponse(
-                    _stream_provider(request, route, body, telemetry),
+                    _stream_provider(
+                        request,
+                        route,
+                        body,
+                        telemetry,
+                        model=model,
+                        action=action,
+                        query=dict(request.query_params),
+                    ),
                     media_type='text/event-stream',
                     headers=_response_headers(telemetry),
                 )
             client = get_desktop_gemini_client()
             semaphore = get_desktop_gemini_semaphore()
 
-            async def post() -> httpx.Response:
+            async def post(attempt_route: UpstreamRoute, attempt_body: bytes) -> httpx.Response:
                 telemetry.phase = 'pool'
                 await _acquire_provider_slot(semaphore)
                 try:
                     telemetry.phase = 'connect'
                     return await client.post(
-                        route.url,
-                        params=route.params,
-                        content=body,
-                        headers={'Content-Type': 'application/json', **route.headers},
+                        attempt_route.url,
+                        params=attempt_route.params,
+                        content=attempt_body,
+                        headers={'Content-Type': 'application/json', **attempt_route.headers},
                     )
                 finally:
                     semaphore.release()
 
-            response = await _cancel_on_disconnect(request, post())
+            response = await _cancel_on_disconnect(request, post(route, body))
+            if _overflow_triggered(response.status_code, response.text):
+                query = dict(request.query_params)
+                for overflow_model, capacity in _overflow_plan(model):
+                    overflow_path = f'models/{overflow_model}:{action}'
+                    overflow_body = _retarget_thinking(body, overflow_model)
+                    overflow_route = await _upstream(
+                        overflow_path, overflow_model, action, query, request_type=capacity
+                    )
+                    telemetry.set_route(overflow_route)
+                    telemetry.model = overflow_model
+                    response = await _cancel_on_disconnect(request, post(overflow_route, overflow_body))
+                    probing = capacity == ptr.REQUEST_TYPE_DEDICATED
+                    exhausted = _overflow_triggered(response.status_code, response.text)
+                    if probing:
+                        _record_pt_target_observation(not exhausted)
+                    if not exhausted:
+                        break
             telemetry.phase = 'body'
     except HTTPException as exc:
         phase = telemetry.phase if telemetry.phase in {'routing', 'credential'} else 'validation'

--- a/backend/scripts/probe_gemini_thinking_contract.py
+++ b/backend/scripts/probe_gemini_thinking_contract.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Measure how Gemini honors thinking configuration across model families.
+
+Why this exists: 2.5 models take an integer `thinkingConfig.thinkingBudget`,
+while 3.x models take `thinkingConfig.thinkingLevel` and cannot disable
+thinking. `thinkingBudget` stays schema-valid on 3.x, so a stale budget is
+accepted and then ignored — and thinking tokens bill as OUTPUT. This probe
+reports the actual `thoughtsTokenCount` per configuration so that "accepted and
+ignored" is visible instead of assumed.
+
+Read-only: it calls generateContent with a fixed trivial prompt and prints
+token counts. It mutates nothing.
+
+Needs credentials that can call `aiplatform.endpoints.predict`. The read-only
+bot account cannot; a human ADC can:
+
+    gcloud auth login && gcloud auth application-default login
+    python3 backend/scripts/probe_gemini_thinking_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT', 'based-hardware')
+LOCATION = os.getenv('GCP_LOCATION', 'us-central1')
+
+# A prompt with a real (if small) reasoning step, so a model that thinks
+# produces a non-zero thoughtsTokenCount and one that does not produces zero.
+PROMPT = 'A pen and a notebook cost $1.10 together. The notebook costs $1.00 more than the pen. Cost of the pen?'
+
+CASES: tuple[tuple[str, dict[str, object]], ...] = (
+    ('budget=0', {'thinkingConfig': {'thinkingBudget': 0}}),
+    ('budget=1024', {'thinkingConfig': {'thinkingBudget': 1024}}),
+    ('level=minimal', {'thinkingConfig': {'thinkingLevel': 'minimal'}}),
+    ('no thinking config', {}),
+)
+
+MODELS = ('gemini-2.5-flash-lite', 'gemini-2.5-flash', 'gemini-3.1-flash-lite')
+
+
+def access_token() -> str:
+    return subprocess.run(
+        ['gcloud', 'auth', 'print-access-token'],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def probe(model: str, config: dict[str, object], token: str) -> str:
+    url = (
+        f'https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT}'
+        f'/locations/{LOCATION}/publishers/google/models/{model}:generateContent'
+    )
+    payload = {
+        'contents': [{'role': 'user', 'parts': [{'text': PROMPT}]}],
+        'generationConfig': {'maxOutputTokens': 2048, **config},
+    }
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={'Authorization': f'Bearer {token}', 'Content-Type': 'application/json'},
+        method='POST',
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode('utf-8', errors='replace')
+        try:
+            message = json.loads(detail)['error']['message']
+        except Exception:
+            message = detail
+        return f'HTTP {exc.code}: {message[:150]}'
+    except Exception as exc:  # network / auth shape
+        return f'{type(exc).__name__}: {exc}'
+    usage = body.get('usageMetadata', {})
+    return (
+        f'prompt={usage.get("promptTokenCount", "?")} '
+        f'thoughts={usage.get("thoughtsTokenCount", 0)} '
+        f'output={usage.get("candidatesTokenCount", "?")} '
+        f'total={usage.get("totalTokenCount", "?")}'
+    )
+
+
+def main() -> int:
+    try:
+        token = access_token()
+    except subprocess.CalledProcessError as exc:
+        print(f'could not mint an access token: {exc.stderr.strip()}', file=sys.stderr)
+        print('run: gcloud auth login && gcloud auth application-default login', file=sys.stderr)
+        return 2
+    print(f'project={PROJECT} location={LOCATION}\n')
+    for model in MODELS:
+        print(model)
+        for label, config in CASES:
+            print(f'  {label:<20} {probe(model, config, token)}')
+        print()
+    print('Interpretation:')
+    print('  A 3.x model that IGNORES thinkingBudget shows thoughts>0 for budget=0.')
+    print('  A 3.x model that HONORS it shows thoughts=0, and thinkingBudget could stay.')
+    print('  Compare total tokens against the price table in backend/docs/vertex-pt-flash.md;')
+    print('  gemini-3.1-flash-lite output costs 3.75x gemini-2.5-flash-lite output.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -849,3 +849,364 @@ async def test_streaming_defers_resource_acquisition_until_body_iteration(monkey
     assert event["candidates_token_count"] == 2
     assert event["thoughts_token_count"] == 1
     assert event["total_token_count"] == 13
+
+
+@pytest.fixture(autouse=True)
+def _reset_pt_promotion_state():
+    """The observed-capacity latch is module state; never leak it between tests."""
+    desktop_proxy._pt_target_ready = False
+    desktop_proxy._pt_target_probed_at = None
+    yield
+    desktop_proxy._pt_target_ready = False
+    desktop_proxy._pt_target_probed_at = None
+
+
+def _retarget(path: str) -> str:
+    return desktop_proxy._retarget_path(*desktop_proxy._path_parts(path))
+
+
+def test_pro_is_remapped_to_the_migration_target(monkeypatch):
+    """gemini-2.5-pro is $10.00/1M out; the target is $1.50."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    assert _retarget("models/gemini-2.5-pro:generateContent") == "models/gemini-3.1-flash-lite:generateContent"
+
+
+def test_client_pinned_flash_lite_is_never_promoted(monkeypatch):
+    """gemini-3.1-flash-lite costs 3.75x more per output token than
+    gemini-2.5-flash-lite, so promoting the client-pinned low-value lanes
+    (macOS ModelQoS.lightweight, Windows memory/goals/insight) would be a large
+    cost regression, not a saving."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    assert _retarget("models/gemini-2.5-flash-lite:generateContent") == ("models/gemini-2.5-flash-lite:generateContent")
+
+
+def test_byok_models_are_never_remapped(monkeypatch):
+    """BYOK users pay for the model they asked for."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: "user-key")
+    assert _retarget("models/gemini-2.5-pro:generateContent") == "models/gemini-2.5-pro:generateContent"
+
+
+def test_flash_stays_on_the_current_reservation_until_target_capacity_exists(monkeypatch):
+    """Moving dedicated traffic early pays for an idle reservation AND on-demand."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    assert _retarget("models/gemini-2.5-flash:generateContent") == "models/gemini-2.5-flash:generateContent"
+
+
+def test_flash_is_remapped_once_the_target_reservation_is_observed(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    desktop_proxy._record_pt_target_observation(True)
+    assert _retarget("models/gemini-2.5-flash:generateContent") == "models/gemini-3.1-flash-lite:generateContent"
+
+
+def test_operator_override_pins_the_reservation_back(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    desktop_proxy._record_pt_target_observation(True)
+    monkeypatch.setenv(desktop_proxy._PT_MODEL_OVERRIDE_ENV, "gemini-2.5-flash")
+    assert _retarget("models/gemini-2.5-flash:generateContent") == "models/gemini-2.5-flash:generateContent"
+
+
+def test_overflow_never_targets_the_live_reservation(monkeypatch):
+    """FC-degraded-fallback-consumes-protected-budget across the migration."""
+    monkeypatch.delenv(desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV, raising=False)
+    assert desktop_proxy._overflow_model("gemini-2.5-flash") == "gemini-3.1-flash-lite"
+    assert desktop_proxy._overflow_model("gemini-3.1-flash-lite") == "gemini-2.5-flash-lite"
+
+
+def test_overflow_plan_is_empty_for_traffic_that_cannot_exhaust_the_reservation(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    assert desktop_proxy._overflow_plan("gemini-2.5-flash-lite") == []
+
+
+def test_overflow_plan_probes_the_target_before_paying_on_demand(monkeypatch):
+    monkeypatch.delenv(desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV, raising=False)
+    plan = desktop_proxy._overflow_plan("gemini-2.5-flash")
+    assert plan == [
+        ("gemini-3.1-flash-lite", "dedicated"),
+        ("gemini-3.1-flash-lite", "shared"),
+    ]
+
+
+def test_overflow_can_be_disabled_for_an_emergency(monkeypatch):
+    monkeypatch.setenv(desktop_proxy._OVERFLOW_ENABLED_ENV, "false")
+    assert desktop_proxy._overflow_plan("gemini-2.5-flash") == []
+
+
+def test_retarget_thinking_swaps_a_budget_for_a_level_across_families():
+    body = json.dumps({"generationConfig": {"maxOutputTokens": 2048, "thinkingConfig": {"thinkingBudget": 1024}}})
+    rewritten = json.loads(desktop_proxy._retarget_thinking(body.encode(), "gemini-3.1-flash-lite"))
+    assert rewritten["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "minimal"}
+    assert rewritten["generationConfig"]["maxOutputTokens"] == 2048
+
+
+@pytest.mark.asyncio
+async def test_dedicated_capacity_is_requested_only_for_the_reservation(monkeypatch):
+    async def token():
+        return "token"
+
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy._vertex_tokens, "get_access_token", token)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+
+    reserved = await desktop_proxy._upstream(
+        "models/gemini-2.5-flash:generateContent", "gemini-2.5-flash", "generateContent", {}
+    )
+    on_demand = await desktop_proxy._upstream(
+        "models/gemini-3.1-flash-lite:generateContent", "gemini-3.1-flash-lite", "generateContent", {}
+    )
+
+    header = desktop_proxy.ptr.REQUEST_TYPE_HEADER
+    assert reserved.headers[header] == "dedicated"
+    assert on_demand.headers[header] == "shared"
+
+
+def _pt_exhausted_response(url: str) -> httpx.Response:
+    return httpx.Response(
+        429,
+        request=httpx.Request("POST", url),
+        json={"error": {"code": 429, "message": "Too many requests. Exceeded the Provisioned Throughput."}},
+    )
+
+
+def _ok_response(url: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        request=httpx.Request("POST", url),
+        json={"usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 5, "totalTokenCount": 15}},
+    )
+
+
+class _ScriptedClient:
+    """Replies per attempt so an overflow ladder can be asserted in order."""
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self.calls: list[tuple[str, str, bytes]] = []
+
+    async def post(self, url, *, params, content, headers):
+        header = desktop_proxy.ptr.REQUEST_TYPE_HEADER
+        self.calls.append((url, headers.get(header, ""), content))
+        return self._replies[len(self.calls) - 1](url)
+
+
+def _install_proxy_doubles(monkeypatch, client):
+    routed: list[tuple[str, str]] = []
+
+    async def route(path, model, action, query, *, request_type=None):
+        routed.append((model, request_type or ""))
+        return desktop_proxy.UpstreamRoute(
+            f"https://provider.invalid/{model}",
+            {desktop_proxy.ptr.REQUEST_TYPE_HEADER: request_type or "dedicated"},
+            {},
+            "vertex_ai",
+            "adc",
+            "us-central1",
+        )
+
+    async def meter(_uid, path, _model, _action):
+        return path
+
+    async def passthrough(_request, awaitable):
+        # The disconnect watcher polls a test Request whose receive() never
+        # returns, which would hold every attempt open for the full 75s
+        # provider deadline. Its real behaviour is covered by
+        # test_disconnect_cancels_in_flight_provider_call.
+        return await awaitable
+
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy, "_meter_server_request", meter)
+    monkeypatch.setattr(desktop_proxy, "_upstream", route)
+    monkeypatch.setattr(desktop_proxy, "_cancel_on_disconnect", passthrough)
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_client", lambda: client)
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: asyncio.Semaphore(1))
+    return routed
+
+
+@pytest.mark.asyncio
+async def test_saturated_reservation_probes_the_target_then_pays_on_demand(monkeypatch):
+    """A full reservation must not silently spill onto pay-as-you-go flash.
+
+    Attempt 1 is the reservation. Attempt 2 asks the migration target for
+    dedicated capacity and is refused. Attempt 3 buys the same work on-demand
+    at gemini-3.1-flash-lite rates ($1.50/1M out) instead of gemini-2.5-flash
+    spillover ($2.50/1M out).
+    """
+    client = _ScriptedClient([_pt_exhausted_response, _pt_exhausted_response, _ok_response])
+    routed = _install_proxy_doubles(monkeypatch, client)
+
+    response = await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:generateContent", False, "user")
+
+    assert response.status_code == 200
+    assert routed == [
+        ("gemini-2.5-flash", ""),
+        ("gemini-3.1-flash-lite", "dedicated"),
+        ("gemini-3.1-flash-lite", "shared"),
+    ]
+    assert desktop_proxy._pt_target_is_ready() is False
+
+
+@pytest.mark.asyncio
+async def test_a_successful_dedicated_probe_promotes_the_reservation(monkeypatch):
+    """This is the whole migration mechanism: no deploy, no flag, no date."""
+    client = _ScriptedClient([_pt_exhausted_response, _ok_response])
+    routed = _install_proxy_doubles(monkeypatch, client)
+
+    response = await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:generateContent", False, "user")
+
+    assert response.status_code == 200
+    assert routed == [("gemini-2.5-flash", ""), ("gemini-3.1-flash-lite", "dedicated")]
+    assert desktop_proxy._pt_target_is_ready() is True
+    # And from now on flash requests are served by the new reservation.
+    assert _retarget("models/gemini-2.5-flash:generateContent") == "models/gemini-3.1-flash-lite:generateContent"
+
+
+@pytest.mark.asyncio
+async def test_generic_rate_limiting_is_not_converted_into_extra_spend(monkeypatch):
+    """A per-project 429 is backpressure. Treating it as overflow would buy
+    on-demand capacity to work around a limit that is not about capacity."""
+
+    def throttled(url):
+        return httpx.Response(
+            429,
+            request=httpx.Request("POST", url),
+            json={"error": {"code": 429, "message": "Quota exceeded for requests per minute"}},
+        )
+
+    client = _ScriptedClient([throttled])
+    routed = _install_proxy_doubles(monkeypatch, client)
+
+    response = await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:generateContent", False, "user")
+
+    assert response.status_code == 429
+    assert routed == [("gemini-2.5-flash", "")]
+
+
+@pytest.mark.asyncio
+async def test_overflow_rewrites_thinking_for_the_new_model_family(monkeypatch):
+    """gemini-3.1-flash-lite ignores thinkingBudget, so an un-retargeted body
+    would uncap reasoning tokens that bill as output."""
+    client = _ScriptedClient([_pt_exhausted_response, _pt_exhausted_response, _ok_response])
+    _install_proxy_doubles(monkeypatch, client)
+
+    await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:generateContent", False, "user")
+
+    reserved = json.loads(client.calls[0][2])["generationConfig"]
+    overflowed = json.loads(client.calls[-1][2])["generationConfig"]
+    assert reserved["thinkingConfig"] == {"thinkingBudget": desktop_proxy._DEFAULT_THINKING_BUDGET}
+    assert overflowed["thinkingConfig"] == {"thinkingLevel": "minimal"}
+    assert overflowed["maxOutputTokens"] == desktop_proxy._SERVER_PAID_MAX_OUTPUT_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_streaming_overflow_falls_back_and_leaks_no_provider_slot(monkeypatch):
+    """The streaming ladder must close every refused attempt and release its
+    slot, or a saturated reservation would drain the concurrency pool."""
+    opened: list[str] = []
+    closed = 0
+
+    class Refused:
+        status_code = 429
+
+        def __init__(self):
+            self.text = "Too many requests. Exceeded the Provisioned Throughput."
+
+        async def aread(self):
+            return self.text.encode()
+
+        async def aiter_bytes(self):
+            yield b""
+
+    class Served:
+        status_code = 200
+        text = ""
+
+        async def aread(self):
+            return b""
+
+        async def aiter_bytes(self):
+            yield b'data: {"usageMetadata":{"totalTokenCount":3}}\r\n\r\n'
+
+    class StreamContext:
+        def __init__(self, response):
+            self._response = response
+
+        async def __aenter__(self):
+            return self._response
+
+        async def __aexit__(self, *_args):
+            nonlocal closed
+            closed += 1
+
+    class Client:
+        def stream(self, _method, url, **_kwargs):
+            opened.append(url)
+            return StreamContext(Refused() if len(opened) < 3 else Served())
+
+    async def route(path, model, action, query, *, request_type=None):
+        return desktop_proxy.UpstreamRoute(
+            f"https://provider.invalid/{model}",
+            {desktop_proxy.ptr.REQUEST_TYPE_HEADER: request_type or "dedicated"},
+            {},
+            "vertex_ai",
+            "adc",
+            "us-central1",
+        )
+
+    async def passthrough(_request, awaitable):
+        return await awaitable
+
+    semaphore = asyncio.Semaphore(1)
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy, "_upstream", route)
+    monkeypatch.setattr(desktop_proxy, "_cancel_on_disconnect", passthrough)
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_stream_client", lambda: Client())
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: semaphore)
+
+    telemetry = desktop_proxy.ProxyTelemetry(make_request(), streaming=True)
+    primary = await route("p", "gemini-2.5-flash", "streamGenerateContent", {})
+    body = b'{"generationConfig":{"thinkingConfig":{"thinkingBudget":1024}}}'
+    emitted = [
+        chunk
+        async for chunk in desktop_proxy._stream_provider(
+            make_request(),
+            primary,
+            body,
+            telemetry,
+            model="gemini-2.5-flash",
+            action="streamGenerateContent",
+            query={},
+        )
+    ]
+
+    assert b"usageMetadata" in b"".join(emitted)
+    assert [url.rsplit("/", 1)[-1] for url in opened] == [
+        "gemini-2.5-flash",
+        "gemini-3.1-flash-lite",
+        "gemini-3.1-flash-lite",
+    ]
+    assert closed == 3
+    assert semaphore.locked() is False
+
+
+def test_migration_contract_is_documented():
+    """Same rule as the existing pin test: the reservation's behaviour is only
+    safe to change if the note operators read changes with it."""
+    text = (BACKEND_DIR / "docs" / "vertex-pt-flash.md").read_text(encoding="utf-8")
+    assert desktop_proxy.VERTEX_PT_TARGET_MODEL in text
+    assert desktop_proxy._PT_MODEL_OVERRIDE_ENV in text
+    assert desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV in text
+    assert desktop_proxy._OVERFLOW_ENABLED_ENV in text
+    assert desktop_proxy.ptr.REQUEST_TYPE_HEADER in text
+
+
+def test_a_new_instance_probes_immediately_regardless_of_uptime(monkeypatch):
+    """time.monotonic() has an arbitrary origin: on a freshly started container
+    it can be smaller than the probe TTL. Seeding the last-probe time with 0.0
+    would suppress the first probe for the first 10 minutes of every new
+    instance's life, which is most of a Cloud Run instance's life."""
+    monkeypatch.setattr(desktop_proxy.time, "monotonic", lambda: 1.0)
+    desktop_proxy._pt_target_probed_at = None
+    assert desktop_proxy._pt_probe_due() is True
+
+    desktop_proxy._record_pt_target_observation(False)
+    assert desktop_proxy._pt_probe_due() is False

--- a/backend/tests/unit/test_vertex_pt_routing.py
+++ b/backend/tests/unit/test_vertex_pt_routing.py
@@ -1,0 +1,93 @@
+"""Contract tests for Vertex Provisioned Throughput routing policy.
+
+These lock the cost invariants that survive a PT migration. The point of the
+policy module is that re-pointing the reservation cannot silently re-point
+overflow onto it, so most of these assert behaviour across BOTH PT states.
+"""
+
+import pytest
+
+from utils.llm import vertex_pt_routing as ptr
+
+
+def test_pt_model_defaults_to_the_currently_provisioned_order():
+    assert ptr.resolve_pt_model(target_dedicated_ready=False) == 'gemini-2.5-flash'
+
+
+def test_pt_model_promotes_itself_once_target_capacity_answers():
+    assert ptr.resolve_pt_model(target_dedicated_ready=True) == 'gemini-3.1-flash-lite'
+
+
+@pytest.mark.parametrize('ready', [False, True])
+def test_operator_override_pins_the_pt_model_in_either_direction(ready):
+    """The emergency flag must beat auto-detection, including a false positive."""
+    assert ptr.resolve_pt_model(target_dedicated_ready=ready, override='gemini-2.5-flash') == 'gemini-2.5-flash'
+
+
+def test_overflow_prefers_3_1_flash_lite_while_flash_holds_the_reservation():
+    assert ptr.resolve_overflow_model(pt_model='gemini-2.5-flash') == 'gemini-3.1-flash-lite'
+
+
+def test_overflow_steps_past_the_reservation_after_migration():
+    """FC-degraded-fallback-consumes-protected-budget.
+
+    Once 3.1-flash-lite IS the prepaid model, sending overflow to it would
+    convert the quota into unmetered consumption of the reservation.
+    """
+    assert ptr.resolve_overflow_model(pt_model='gemini-3.1-flash-lite') == 'gemini-2.5-flash-lite'
+
+
+@pytest.mark.parametrize('pt_model', ['gemini-2.5-flash', 'gemini-3.1-flash-lite', 'gemini-2.5-flash-lite'])
+def test_overflow_is_never_the_protected_model(pt_model):
+    assert ptr.resolve_overflow_model(pt_model=pt_model) != pt_model
+
+
+def test_overflow_override_cannot_alias_the_protected_model():
+    with pytest.raises(ValueError, match='protected reservation'):
+        ptr.resolve_overflow_model(pt_model='gemini-2.5-flash', override='gemini-2.5-flash')
+
+
+def test_dedicated_is_requested_only_for_the_provisioned_model():
+    assert ptr.request_type_for(model='gemini-2.5-flash', pt_model='gemini-2.5-flash') == 'dedicated'
+    assert ptr.request_type_for(model='gemini-3.1-flash-lite', pt_model='gemini-2.5-flash') == 'shared'
+
+
+def test_overflow_traffic_is_explicitly_shared_after_migration():
+    """The overflow model must not inherit `dedicated` when PT moves."""
+    pt = 'gemini-3.1-flash-lite'
+    overflow = ptr.resolve_overflow_model(pt_model=pt)
+    assert ptr.request_type_for(model=overflow, pt_model=pt) == 'shared'
+
+
+def test_2_5_family_keeps_an_integer_thinking_budget():
+    assert ptr.thinking_config_for('gemini-2.5-flash', budget=1024) == {'thinkingBudget': 1024}
+    assert ptr.thinking_config_for('gemini-2.5-flash-lite', budget=0) == {'thinkingBudget': 0}
+
+
+def test_3_x_family_gets_a_thinking_level_never_a_budget():
+    """thinkingBudget is schema-valid on 3.x and then ignored, so an unbounded
+    reasoning trace would bill as output at $1.50/1M."""
+    config = ptr.thinking_config_for('gemini-3.1-flash-lite', budget=1024)
+    assert config == {'thinkingLevel': 'minimal'}
+    assert 'thinkingBudget' not in config
+
+
+def test_migration_target_never_receives_a_thinking_budget():
+    assert 'thinkingBudget' not in ptr.thinking_config_for(ptr.PT_MODEL_TARGET, budget=1024)
+
+
+def test_saturated_reservation_is_distinguished_from_generic_rate_limiting():
+    assert ptr.is_provisioned_capacity_exhausted(429, 'Too many requests. Exceeded the Provisioned Throughput.')
+    assert not ptr.is_provisioned_capacity_exhausted(429, 'Quota exceeded for requests per minute')
+    assert not ptr.is_provisioned_capacity_exhausted(200, 'Exceeded the Provisioned Throughput')
+
+
+def test_absent_capacity_is_not_read_as_exhausted_capacity():
+    absent = 'Provisioned Throughput order not found for this model'
+    assert ptr.is_provisioned_capacity_absent(404, absent)
+    assert not ptr.is_provisioned_capacity_absent(429, 'Exceeded the Provisioned Throughput.')
+
+
+def test_pt_constants_stay_distinct():
+    assert ptr.PT_MODEL_CURRENT != ptr.PT_MODEL_TARGET
+    assert ptr.PT_MODEL_TARGET in ptr.OVERFLOW_PREFERENCE

--- a/backend/utils/llm/vertex_pt_routing.py
+++ b/backend/utils/llm/vertex_pt_routing.py
@@ -1,0 +1,148 @@
+"""Vertex Provisioned Throughput routing policy for company-paid Gemini text.
+
+Pure decision logic: which model serves company-paid text, which model absorbs
+overflow, how thinking is configured per model family, and when a pending PT
+order has become live. No I/O, no clock, no Redis — the proxy injects
+observations and owns every side effect, so every rule here is unit-testable.
+
+Prices per 1M tokens (Vertex list, captured 2026-08-18):
+
+    gemini-2.5-flash-lite   $0.10 in / $0.40 out
+    gemini-3.1-flash-lite   $0.25 in / $1.50 out
+    gemini-2.5-flash        $0.30 in / $2.50 out
+    gemini-2.5-pro          $1.25 in / $10.00 out
+
+`gemini-3.1-flash-lite` is NOT the same price class as `gemini-2.5-flash-lite`
+(2.5x in / 3.75x out). It is cheaper than `gemini-2.5-flash` and far cheaper
+than `gemini-2.5-pro`, which is why it absorbs overflow and Pro but must never
+absorb the lanes that clients already pin to `gemini-2.5-flash-lite`.
+"""
+
+from __future__ import annotations
+
+# --- Provisioned Throughput orders ----------------------------------------
+# The prepaid model today: 5 GSU, us-central1, flat ~$290.32/day until
+# ~2027-05-28 whether or not traffic uses it. It must stay saturated; moving
+# dedicated traffic off it pays for an idle reservation AND full on-demand.
+PT_MODEL_CURRENT = 'gemini-2.5-flash'
+
+# Migration target. A PT order for this model provisions in ~10 business days.
+# Nothing needs to be redeployed when it lands: the proxy attempts `dedicated`
+# on this model, and a non-429 response is the proof that capacity exists.
+PT_MODEL_TARGET = 'gemini-3.1-flash-lite'
+
+# Overflow ladder, most-capable first. Overflow is always on-demand, so this is
+# also a cost ladder: 3.1-flash-lite ($1.50 out) beats 2.5-flash spillover
+# ($2.50 out); 2.5-flash-lite ($0.40 out) is the floor.
+#
+# FC-degraded-fallback-consumes-protected-budget: overflow is resolved against
+# the LIVE PT model rather than pinned, so when the reservation migrates to
+# gemini-3.1-flash-lite the ladder steps past it automatically instead of
+# dumping degraded traffic onto the budget the quota exists to protect.
+OVERFLOW_PREFERENCE = ('gemini-3.1-flash-lite', 'gemini-2.5-flash-lite')
+
+# Vertex routes a request to prepaid or on-demand capacity by header.
+# `dedicated` returns 429 instead of silently spilling to pay-as-you-go.
+REQUEST_TYPE_HEADER = 'X-Vertex-AI-LLM-Request-Type'
+REQUEST_TYPE_DEDICATED = 'dedicated'
+REQUEST_TYPE_SHARED = 'shared'
+
+# Gemini 3.x replaced the integer `thinkingBudget` with a coarse
+# `thinkingLevel`, and thinking cannot be disabled: the floor is 'minimal'.
+# Thinking tokens bill as OUTPUT, so sending a 2.5-style budget to a 3.x model
+# risks unbounded reasoning at $1.50/1M with no cap that the model honors.
+_THINKING_LEVEL_FAMILIES = ('gemini-3',)
+THINKING_LEVEL_MINIMAL = 'minimal'
+
+
+def _normalize(model: str) -> str:
+    return (model or '').strip()
+
+
+def uses_thinking_level(model: str) -> bool:
+    """Whether a model takes `thinkingLevel` instead of `thinkingBudget`."""
+    return _normalize(model).startswith(_THINKING_LEVEL_FAMILIES)
+
+
+def thinking_config_for(model: str, *, budget: int) -> dict[str, object]:
+    """Return the provider-correct thinkingConfig body for a model.
+
+    2.5-family models take an integer token budget. 3.x models take a level and
+    cannot switch thinking off, so the cheapest honored setting is 'minimal'.
+    Sending a budget to a 3.x model is the cost regression this guards: the
+    field is schema-valid, so it is accepted and then ignored.
+    """
+    if uses_thinking_level(model):
+        return {'thinkingLevel': THINKING_LEVEL_MINIMAL}
+    return {'thinkingBudget': int(budget)}
+
+
+def resolve_pt_model(*, target_dedicated_ready: bool, override: str = '') -> str:
+    """Which model currently owns prepaid capacity.
+
+    `override` is the operator escape hatch and wins unconditionally, so a bad
+    auto-detection can be pinned back without a code change.
+    """
+    pinned = _normalize(override)
+    if pinned:
+        return pinned
+    return PT_MODEL_TARGET if target_dedicated_ready else PT_MODEL_CURRENT
+
+
+def resolve_overflow_model(*, pt_model: str, override: str = '') -> str:
+    """Which model absorbs work that prepaid capacity cannot serve.
+
+    Never returns `pt_model`: overflow exists to spare the reservation, so
+    routing it back onto the reservation would defeat the quota entirely
+    (FC-degraded-fallback-consumes-protected-budget).
+    """
+    pinned = _normalize(override)
+    protected = _normalize(pt_model)
+    if pinned:
+        if pinned == protected:
+            raise ValueError(
+                f'overflow override {pinned!r} equals the provisioned model; '
+                'overflow must never consume the protected reservation'
+            )
+        return pinned
+    for candidate in OVERFLOW_PREFERENCE:
+        if candidate != protected:
+            return candidate
+    raise ValueError(f'no overflow model available outside the provisioned model {protected!r}')
+
+
+def request_type_for(*, model: str, pt_model: str) -> str:
+    """Header value for a model: prepaid capacity only exists for the PT model.
+
+    Requesting `dedicated` for the PT model converts silent spillover into a
+    429 the caller can act on. Everything else is explicitly `shared` so it can
+    never draw down the reservation.
+    """
+    return REQUEST_TYPE_DEDICATED if _normalize(model) == _normalize(pt_model) else REQUEST_TYPE_SHARED
+
+
+def is_provisioned_capacity_exhausted(status: int, message: str) -> bool:
+    """Whether a response means 'prepaid capacity is full', not 'slow down'.
+
+    Vertex returns 429 for both a saturated PT order and ordinary per-project
+    rate limiting. Only the former should fall back to on-demand; treating a
+    generic 429 as overflow would convert real backpressure into extra spend.
+    """
+    if status != 429:
+        return False
+    text = (message or '').casefold()
+    return 'provisioned throughput' in text or 'dedicated' in text
+
+
+def is_provisioned_capacity_absent(status: int, message: str) -> bool:
+    """Whether `dedicated` failed because no PT order exists for the model.
+
+    Distinct from exhaustion: absence is the steady state for a migration
+    target that has not provisioned yet, and must not be read as 'live'.
+    """
+    if status not in {400, 403, 404, 429}:
+        return False
+    text = (message or '').casefold()
+    if 'provisioned throughput' not in text and 'dedicated' not in text:
+        return False
+    return any(token in text for token in ('not found', 'no provisioned', 'does not exist', 'not configured'))


### PR DESCRIPTION
## What this does

Routes the two Gemini paths we pay on-demand for onto `gemini-3.1-flash-lite`, and makes the pending Provisioned Throughput migration cut over by itself.

| Path | Billed today | After |
| --- | --- | --- |
| Server-paid `gemini-2.5-pro` | on-demand $10.00/1M out | `gemini-3.1-flash-lite`, $1.50/1M out |
| `gemini-2.5-flash` **spillover** | on-demand $2.50/1M out | `gemini-3.1-flash-lite`, $1.50/1M out |
| `gemini-2.5-flash` **dedicated** | prepaid, flat ~$290.32/day | unchanged until the new reservation is observed live |

## Prices (Vertex list, captured 2026-08-18)

| Model | Input $/1M | Output $/1M |
| --- | ---: | ---: |
| `gemini-2.5-flash-lite` | 0.10 | 0.40 |
| `gemini-3.1-flash-lite` | 0.25 | 1.50 |
| `gemini-2.5-flash` | 0.30 | 2.50 |
| `gemini-2.5-pro` | 1.25 | 10.00 |

`gemini-3.1-flash-lite` is **not** the same price class as `gemini-2.5-flash-lite` — it is 2.5x input and 3.75x output. It is cheaper than what it replaces on both paths above, but that makes the client-pinned Lite lanes a trap: promoting `ModelQoS.lightweight` (macOS) or the Windows `memory`/`goals`/`insight` pins onto it would raise their output cost 3.75x. Those pins are deliberately untouched and `test_client_pinned_flash_lite_is_never_promoted` holds the boundary.

## Spillover was not previously controllable

The proxy sent no capacity header, so Vertex silently spilled over-cap requests onto pay-as-you-go. This adds `X-Vertex-AI-LLM-Request-Type: dedicated` for the reservation, which turns an over-cap request into a 429 `Exceeded the Provisioned Throughput` that the proxy can route deliberately. Everything else is pinned `shared` so it can never draw down the reservation.

Generic per-project 429s are explicitly *not* treated as overflow — buying on-demand capacity to work around backpressure would be a cost bug. `test_generic_rate_limiting_is_not_converted_into_extra_spend`.

## The migration needs no deploy, flag, or date

When the `gemini-3.1-flash-lite` PT order provisions (~10 business days), the first overflow attempt asks it for `dedicated` capacity. That single request *is* the detection: if the order exists it succeeds and the proxy latches the promotion permanently; if not it 429s and falls through to the same on-demand call it would have made anyway. Detection therefore costs no extra request and only happens when the old reservation is already full.

`test_a_successful_dedicated_probe_promotes_the_reservation` covers the whole mechanism.

## Why dedicated traffic is gated rather than moved now

Moving `gemini-2.5-flash` onto an on-demand model before the replacement order is live would pay the flat ~$290.32/day for idle capacity **and** full on-demand for ~597M tokens/day — strictly worse than either alone. `test_flash_stays_on_the_current_reservation_until_target_capacity_exists`.

**Operator follow-up:** promotion is the code-side cutover only. The 5 GSU `gemini-2.5-flash` order bills until ~2027-05-28 regardless, so converting or cancelling it in Cloud Console is a separate commercial action — until that happens, both are billed.

## Failure class

`FC-degraded-fallback-consumes-protected-budget` (PR #10686) applies with a new edge: once `gemini-3.1-flash-lite` *is* the reservation, pinning overflow to it would dump degraded traffic onto the protected budget. `resolve_overflow_model()` is therefore a ladder resolved against the live reservation and structurally cannot return it, for this migration or any future one. `test_overflow_never_targets_the_live_reservation` asserts both states.

## Gemini 3.x changed the thinking contract

2.5 takes `thinkingConfig.thinkingBudget`; 3.x takes `thinkingConfig.thinkingLevel` and **cannot disable thinking** (floor `minimal`). Thinking tokens bill as output, and `thinkingBudget` stays schema-valid on 3.x — so a stale budget is accepted and then ignored, uncapping reasoning at $1.50/1M. `thinking_config_for()` selects by family prefix (same approach as `_CACHE_KEY_MODEL_PREFIXES`), and `_retarget_thinking()` rewrites the body when overflow crosses families.

**Unverified:** whether 3.x hard-errors on `thinkingBudget` or silently ignores it could not be settled — `aiplatform.endpoints.predict` is denied to the read-only service account and no human ADC was live. The code is correct under either behaviour, but the real token counts are still worth capturing. `backend/scripts/probe_gemini_thinking_contract.py` reports `thoughtsTokenCount` per configuration; run it with credentials that can call `generateContent`.

## Overrides

Read per request, so a bad promotion is correctable without shipping code.

| Env | Effect |
| --- | --- |
| `OMI_VERTEX_PT_MODEL` | Pins the reservation model, beating auto-detection both ways |
| `OMI_GEMINI_OVERFLOW_MODEL` | Pins overflow; rejected if it equals the reservation |
| `OMI_GEMINI_OVERFLOW_ENABLED` | `false` disables overflow; a full reservation then 429s to the client |

## Testing

- 18 new policy tests (`test_vertex_pt_routing.py`) and 18 new proxy tests
- `test_desktop_proxy.py` + `test_vertex_pt_routing.py`: **77 passed**
- Streaming ladder asserts every refused attempt is closed and its provider slot released (`test_streaming_overflow_falls_back_and_leaks_no_provider_slot`) — a leak there would drain the concurrency pool whenever the reservation saturated
- `test_a_new_instance_probes_immediately_regardless_of_uptime` covers a bug CI caught that a dev machine cannot: `time.monotonic()` has an arbitrary origin, so seeding the last-probe time with `0.0` suppressed the first capacity probe for the first 10 minutes of process uptime. That is invisible on a laptop with days of uptime and would have applied to **every new Cloud Run instance**, which is most of an instance's life. The last-probe time is now an explicit `None` sentinel meaning "never probed".
- Unrelated pre-existing failures, reproduced on base `d3b26f003f` without this change: `test_byok_security.py` fails only when run after other files (39F/4E; passes alone), and `test_prompt_caching.py` cannot import (`langchain_core.prompts` missing from the venv)
