### PR TITLE
fix(backend): stop the local fast-unit duration guard failing a moving set of tests

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -28,10 +28,15 @@ fi
 export ENCRYPTION_SECRET="omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv"
 export OPENAI_API_KEY="test-openai-key-not-real"
 export BACKEND_PYTEST_TIMING_SUMMARY="${BACKEND_PYTEST_TIMING_SUMMARY:-1}"
-# Direct focused runs and pre-push keep the strict default. The CI runner alone supplies
-# a 1.0-second ceiling so cross-machine CPU differences do not block unrelated PRs.
+# The warn value is the per-test CPU target; the fail value is the blocking budget and
+# must keep headroom above it. CPU time is less load-sensitive than wall-clock but not
+# immune: contention stall cycles are charged to the process, so identical work measured
+# ~2x higher with the machine saturated (0.03s -> 0.06s on an 8-core host). At the former
+# 0.12s budget -- only 1.2x the target -- a busy runner failed a shifting set of files
+# that all passed in isolation. CI already carries a 1.0-second ceiling for the same
+# reason; this is the local lane's equivalent headroom.
 export BACKEND_FAST_UNIT_WARN_SECONDS="${BACKEND_FAST_UNIT_WARN_SECONDS:-0.1}"
-export BACKEND_FAST_UNIT_FAIL_SECONDS="${BACKEND_FAST_UNIT_FAIL_SECONDS:-0.12}"
+export BACKEND_FAST_UNIT_FAIL_SECONDS="${BACKEND_FAST_UNIT_FAIL_SECONDS:-0.30}"
 
 # The file-isolated runner already parallelizes pytest processes. Letting each process
 # start a native BLAS/OpenMP pool oversubscribes the machine and makes process CPU time

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -42,10 +42,12 @@ use `bash test.sh` or a focused `pytest` invocation while iterating, and let CI 
 ### Per-test duration guard
 
 `BACKEND_FAST_UNIT_WARN_SECONDS=<seconds>` (default `0.1`) is the per-test CPU-time target.
-`BACKEND_FAST_UNIT_FAIL_SECONDS=<seconds>` (default `0.12` for direct local `test.sh` and pre-push use; `1.0` in
+`BACKEND_FAST_UNIT_FAIL_SECONDS=<seconds>` (default `0.30` for direct local `test.sh` and pre-push use; `1.0` in
 the CI runner) is the blocking budget. The guard measures
 **CPU time of the call phase only** (`time.process_time`), not wall-clock: wall-clock inflates unpredictably
-under parallel contention and makes a hard limit flake. Native numerical pools are capped as described above so
+under parallel contention and makes a hard limit flake. CPU time is the better signal but still inflates
+(~2x measured on a saturated host, since contention stall cycles are charged to the process), so the failure
+budget keeps headroom over the warning target instead of sitting just above it. Native numerical pools are capped as described above so
 aggregate process CPU remains comparable regardless of `BACKEND_PYTEST_WORKERS`. GitHub Actions keeps the same 100ms warning target but uses a higher
 failure threshold so near-target CPU-accounting differences do not block unrelated PRs. The slowest wall-clock
 times are still printed in the `Backend unit test durations` summary for visibility.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -103,10 +103,12 @@ def pytest_runtest_logreport(report):
 def pytest_runtest_call(item):
     """Measure per-test CPU time (call phase only) for the duration guard.
 
-    CPU time (``time.process_time``) is load-independent: a test that does X ms of work
-    reads ~X ms whether the machine is idle or running many sibling pytest processes, so a
-    hard limit is deterministic (unlike wall-clock ``report.duration``, which inflates under
-    parallel contention). Only the *call* phase is measured so that shared class/file setup
+    CPU time (``time.process_time``) is far less load-sensitive than wall-clock
+    ``report.duration``, but it is not load-independent: contention stall cycles are charged
+    to the process, so identical work reads ~2x higher CPU when the file-isolated runner
+    saturates the machine. The blocking budget therefore has to keep headroom over the warn
+    target (see ``test.sh``) rather than sit just above it. Only the *call* phase is measured
+    so that shared class/file setup
     (FastAPI app / TestClient construction, per-process module import) — which file-isolated
     runs charge once to the first test — is not misattributed as a per-test regression. The
     advisory timing summary still reports wall-clock for visibility.
@@ -179,10 +181,12 @@ def _enforce_fast_unit_duration_guard(session):
         session.exitstatus = 1
         return
 
-    # The guard measures per-test CPU time (``_test_item_cpu``), not wall-clock. CPU time is
-    # load-independent: a test that does X ms of work reads ~X ms whether the machine is idle or
-    # running many sibling pytest processes, whereas wall-clock ``report.duration`` inflates
-    # unpredictably under parallel contention and makes a hard limit flake. Sleep/wait-based
+    # The guard measures per-test CPU time (``_test_item_cpu``), not wall-clock, because
+    # wall-clock inflates unpredictably under parallel contention. CPU time is the better
+    # signal but not an immune one: it still inflated ~2x on a saturated host, so the budget
+    # relies on headroom rather than on the measurement being exact. A calibration probe
+    # cannot correct for this -- a cache-resident CPU loop does not inflate at all, so the
+    # inflation is memory-bound and workload-specific. Sleep/wait-based
     # slowness (real asyncio sleeps, network, stress) is excluded from the PR unit lane via
     # ``slow``/``integration`` markers, so CPU time is the right signal here. The advisory
     # timing summary in pytest_terminal_summary still reports wall-clock for visibility.

--- a/backend/tests/fast_unit_duration_allowlist.txt
+++ b/backend/tests/fast_unit_duration_allowlist.txt
@@ -35,6 +35,11 @@ tests/unit/test_backend_runtime_env_validator.py::test_repo_parakeet_admission_d
 # remaining hermetic; their CPU cost fluctuates narrowly around the unit guard threshold.
 tests/unit/test_backend_runtime_env_validator.py::test_repo_ilb_endpoints_use_http_scheme[prod]
 tests/unit/test_backend_runtime_env_validator.py::test_parakeet_admission_deploy_contract_rejects_missing_or_invalid_values[PARAKEET_STREAM_CAPACITY-0-PARAKEET_STREAM_CAPACITY must be an integer >= 1]
+# Same group: each renders the desktop-backend compose contract end to end. Measured 0.10-0.13s
+# CPU on an idle host, i.e. already above the 0.1s target before any contention.
+tests/unit/test_backend_runtime_env_validator.py::test_desktop_backend_compose_requires_vertex_pt_env[dev]
+tests/unit/test_backend_runtime_env_validator.py::test_desktop_backend_compose_requires_vertex_pt_env[prod]
+tests/unit/test_backend_runtime_env_validator.py::test_desktop_backend_vertex_pt_omission_fails_loud
 tests/unit/test_render_backend_runtime_env.py::test_selected_job_renders_only_shared_network_and_named_job_outputs
 tests/unit/test_render_backend_runtime_env.py::test_render_prod_gateway_callers_inject_verified_endpoint
 tests/unit/test_render_backend_runtime_env.py::test_render_prod_emits_memory_maintenance_job_cron_on

--- a/backend/tests/unit/test_fast_unit_duration_guard.py
+++ b/backend/tests/unit/test_fast_unit_duration_guard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from pathlib import Path
+import re
 import sys
 
 TESTS_DIR = Path(__file__).resolve().parents[1]
@@ -98,3 +99,56 @@ def test_fast_unit_duration_guard_rejects_fail_threshold_below_warn_threshold(mo
 
     assert session.exitstatus == 1
     assert any('configuration error' in message for message in reporter.messages)
+
+
+# The guard measures CPU time because wall-clock inflates under parallel load. CPU
+# time inflates too, just less: contention stall cycles are charged to the process,
+# so identical work reads higher CPU when the file-isolated runner saturates the
+# machine. Measured on an idle vs saturated 8-core host, one file's slowest test read
+# 0.03s CPU idle (3 of 3 runs) and 0.05-0.06s saturated -- about 2x. A calibration
+# probe cannot cancel this: a cache-resident CPU loop does not inflate at all
+# (0.49ms -> 0.46ms median), so the inflation is memory-bound and workload-specific.
+# The blocking budget must therefore keep headroom over the warn target, or a test
+# that meets the target fails whenever the machine happens to be busy.
+_MEASURED_CONTENTION_FACTOR = 2.0
+
+
+def _shipped_local_thresholds():
+    """Read the defaults ``test.sh`` ships so this tracks what developers actually run."""
+    runner = (TESTS_DIR.parent / 'test.sh').read_text()
+    warn = re.search(r'BACKEND_FAST_UNIT_WARN_SECONDS="\$\{BACKEND_FAST_UNIT_WARN_SECONDS:-([0-9.]+)\}"', runner)
+    fail = re.search(r'BACKEND_FAST_UNIT_FAIL_SECONDS="\$\{BACKEND_FAST_UNIT_FAIL_SECONDS:-([0-9.]+)\}"', runner)
+    assert warn is not None and fail is not None, 'test.sh no longer declares default fast-unit thresholds'
+    return float(warn.group(1)), float(fail.group(1))
+
+
+def test_shipped_local_budget_survives_contention_inflation(monkeypatch):
+    """Regression: the local lane failed a moving set of files under parallel load.
+
+    Two full ``test.sh`` runs on one machine disagreed on 15 files, in both
+    directions, and every one of them passed in isolation -- all 15 were duration
+    guard failures clustered just above the budget. A test that meets the CPU
+    target must not fail merely because the runner was busy.
+    """
+    warn_limit, fail_limit = _shipped_local_thresholds()
+    at_target_under_contention = warn_limit * _MEASURED_CONTENTION_FACTOR
+
+    reporter = _Reporter()
+    session = _Session(reporter)
+    monkeypatch.setenv('BACKEND_FAST_UNIT_WARN_SECONDS', str(warn_limit))
+    monkeypatch.setenv('BACKEND_FAST_UNIT_FAIL_SECONDS', str(fail_limit))
+    monkeypatch.setattr(backend_conftest, '_collected_unit_files', {'tests/unit/test_example.py'})
+    monkeypatch.setattr(
+        backend_conftest,
+        '_test_item_cpu',
+        defaultdict(float, {'tests/unit/test_example.py::test_at_target': at_target_under_contention}),
+    )
+    monkeypatch.setattr(backend_conftest, '_read_duration_allowlist', lambda: set())
+
+    backend_conftest._enforce_fast_unit_duration_guard(session)
+
+    assert session.exitstatus == 0, (
+        f'a test meeting the {warn_limit}s CPU target measures '
+        f'{at_target_under_contention:.2f}s under {_MEASURED_CONTENTION_FACTOR}x contention, '
+        f'which the shipped {fail_limit}s local budget fails'
+    )

--- a/backend/tests/unit/test_pusher_readiness_drain.py
+++ b/backend/tests/unit/test_pusher_readiness_drain.py
@@ -4,8 +4,8 @@ Strategy: the REAL ``pusher.main`` handler functions (``health_check``, ``ready`
 ``drain``) are imported once at module-scope fixture setup and awaited *directly*
 (not via TestClient). Driving the full pusher app through TestClient costs
 ~0.13-0.22s of CPU per request in its portal thread, which the repo's fast-unit
-duration guard (0.12s call-phase CPU) treats as integration-level work; calling
-the handlers directly exercises the real loopback/JSON/gauge logic in microseconds.
+duration guard treats as integration-level work; calling the handlers directly
+exercises the real loopback/JSON/gauge logic in microseconds.
 A structural test additionally verifies the real app wires the routes (paths +
 HTTP methods) and that ``shutdown_event`` calls ``begin_drain``.
 


### PR DESCRIPTION
## The local backend suite failed a moving set of tests

Running `backend/test.sh` locally failed a different set of files almost every
time, and every failing file passed when run on its own. That is the "a few tests
flake but it's hard to catch which ones" symptom — the set moves, so there is
nothing stable to chase.

**The tests are not flaky. The duration guard is.**

Two full `test.sh` runs on one machine, at two commits that differ only in an
unrelated STT file, disagreed on **15 files, in both directions** (10 failed only
in run A, 5 only in run B). All 15 were fast-unit duration guard failures, and all
15 passed in isolation.

## Root cause

The guard measures per-test CPU time and fails anything over
`BACKEND_FAST_UNIT_FAIL_SECONDS`. `conftest.py` justified CPU time over wall-clock
by asserting it is immune to load:

> CPU time (`time.process_time`) is load-independent: a test that does X ms of work
> reads ~X ms whether the machine is idle or running many sibling pytest processes,
> so a hard limit is deterministic

CPU time is the better signal, but it is **not** load-independent. Contention stall
cycles are charged to the process, so identical work measures higher when the
file-isolated runner saturates the machine. Same file, same test, 8-core host:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| idle | 0.03s | 0.03s | 0.03s |
| saturated | 0.05s | 0.06s | 0.06s |

**~2x inflation. The local budget was 0.12s against a 0.10s target — 1.2x
headroom.** So any test near the design target failed whenever the machine was
busy, and which ones crossed depended on scheduling. The measured failures cluster
exactly where that predicts: 56 of ~90 sit in 0.12–0.16s, just over the line.

CI never had this problem because its budget is 1.0s — **10x headroom** — added,
per `tests/README.md`, "so near-target CPU-accounting differences do not block
unrelated PRs". The reasoning was already right; it was just never applied to the
local lane. `main` is 21/21 green on this workflow.

## What I ruled out

Normalising the measurement with a calibration probe **does not work**, and it is
worth recording so the next person doesn't spend an afternoon on it. A
cache-resident CPU loop does not inflate under the same contention (0.49ms → 0.46ms
median), while real tests inflate 2x. The inflation is memory-bandwidth bound and
workload-specific, so there is no generic signal to divide by.

## The fix

1. **Local budget 0.12s → 0.30s** (3x the target, still well under CI's 1.0s).
2. **Three genuinely-slow tests allowlisted.** `test_desktop_backend_compose_requires_vertex_pt_env[dev|prod]`
   and `test_desktop_backend_vertex_pt_omission_fails_loud` measure 0.10–0.13s CPU
   *idle*, so they are above the 0.1s target on their own merits, not
   target-conforming tests being inflated. They were the last file still flapping.
   Raising the shared budget until it absorbed them would weaken the guard for
   everything else, which is what the allowlist exists to avoid — 48 node IDs from
   this same file are already listed, including a group whose comment describes
   exactly this cost.
3. **Docs corrected** where they asserted load-independence, plus a stale hardcoded
   `0.12s` dropped from a test docstring.
4. **A regression test** driving the real guard with the thresholds read from
   `test.sh`, so lowering the budget back toward the target fails immediately
   instead of resurfacing as unrelated flakes days later.

## Verification

Red first — the new test against the unmodified 0.12s default:

```
AssertionError: a test meeting the 0.1s CPU target measures 0.20s under
2.0x contention, which the shipped 0.12s local budget fails
```

Two consecutive full `test.sh` runs, before and after:

| | failing files | files differing between runs | duration-guard failures |
|---|---|---|---|
| before | 31 / 26 | **15** | 53 files |
| after | **2 / 2** | **0 — identical** | **0** |

The 2 remaining failures are identical in both runs and are not flakes:
`test_rendered_deployment_contract.py` and `test_verify_pusher_config_references.py`
fail with `AssertionError: helm must be installed for the rendered deployment
contract` on a host without `helm`. CI has it.

```
$ python -m pytest tests/unit/test_fast_unit_duration_guard.py \
    tests/unit/test_workflow_contracts.py tests/unit/test_backend_unit_ci_runner.py -q
30 passed
```

## Scope

- **CI thresholds are unchanged.** CI already had adequate headroom and is green;
  only the local lane is adjusted.
- **The 0.1s warn target is unchanged** — it is still the design target for a fast
  unit test, and still reported.
- **No allowlist pruning.** Now that the budget has headroom, some existing entries
  are likely redundant, but verifying ~278 of them is its own change.
- Measurements are from a single 8-core macOS host. The direction holds anywhere
  the runner saturates the machine, but the exact factor will vary by hardware.

Failure-Class: FC-gate-timeout-below-cold-cost


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

