### PR TITLE
fix(desktop): treat Discord, Slack huddles, and WhatsApp calls as meetings

### DIFF
--- a/desktop/macos/Desktop/Sources/ConferencingApps.swift
+++ b/desktop/macos/Desktop/Sources/ConferencingApps.swift
@@ -10,9 +10,15 @@ import Foundation
 ///  - `ProactiveAssistantsPlugin`, which throttles screen capture while a call app is frontmost.
 enum ConferencingApps {
 
-  /// Apps whose primary purpose is video/audio calls. Matched by app/owner name, which is
+  /// Apps that host audio/video calls. Matched by app/owner name, which is
   /// available from `NSRunningApplication` and `CGWindowList` **without** Screen Recording
   /// permission.
+  ///
+  /// Includes chat apps whose calls hold the microphone (Discord voice, Slack huddles,
+  /// WhatsApp calls) — same shape as Teams. Meeting gating still requires the app to be
+  /// *using the microphone* (`nativeCallBundleIDs` + `callAppIsUsingMicrophone()`), so an
+  /// idle Slack/Discord/WhatsApp window does not start capture; this owner-name list only
+  /// feeds the call-window/share-indicator screen paths.
   static let nativeCallApps: Set<String> = [
     "Microsoft Teams",
     "zoom.us",
@@ -21,6 +27,9 @@ enum ConferencingApps {
     "Cisco Webex Meetings",
     "GoTo Meeting",
     "GoToMeeting",
+    "Discord",
+    "Slack",
+    "WhatsApp",
   ]
 
   /// Browser app names. Browser-based calls are matched by window title.
@@ -44,6 +53,9 @@ enum ConferencingApps {
   /// Bundle IDs (lowercased) of native conferencing apps, used for mic-in-use ("in a call")
   /// detection. A native call app that is *running but idle* (open, not in a call) is NOT using
   /// the microphone, so it won't be treated as a meeting.
+  ///
+  /// Chat apps are listed because their calls (Discord voice, Slack huddles, WhatsApp calls)
+  /// open the microphone — the mic-in-use rule below is what keeps idle chat non-meetings.
   static let nativeCallBundleIDs: Set<String> = [
     "us.zoom.xos",  // Zoom
     "com.microsoft.teams",  // Microsoft Teams (classic)
@@ -54,6 +66,9 @@ enum ConferencingApps {
     "com.webex.meetingmanager",  // Webex (older)
     "com.logmein.gotomeeting",  // GoTo Meeting
     "com.logmein.goto",  // GoTo
+    "com.hnc.discord",  // Discord (com.hnc.Discord)
+    "com.tinyspeck.slackmacgap",  // Slack
+    "net.whatsapp.whatsapp",  // WhatsApp (net.whatsapp.WhatsApp)
   ]
 
   /// Whether a bundle ID belongs to a known native conferencing app (case-insensitive).

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -22,6 +22,16 @@ import XCTest
       XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "Webex", title: nil))
     }
 
+    func testChatAppCallMatchesOnOwnerName() {
+      // Discord voice, Slack huddles, and WhatsApp calls are meetings, same as Teams:
+      // the owner name alone marks the app's windows as call windows (no title /
+      // Screen Recording permission needed). Meeting gating stays mic-in-use based
+      // (`callAppIsUsingMicrophone`), so this does not make idle chat a meeting.
+      XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "Discord", title: nil))
+      XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "Slack", title: "#general | Acme"))
+      XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "WhatsApp", title: nil))
+    }
+
     func testBrowserRequiresCallKeywordInTitle() {
       XCTAssertTrue(
         ConferencingApps.isCallWindow(ownerName: "Google Chrome", title: "Google Meet — Standup"))
@@ -44,6 +54,21 @@ import XCTest
       XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.microsoft.teams2"))
       XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.apple.facetime"))
       // Omi itself (which is always using the mic while recording) must not count as a meeting.
+      XCTAssertFalse(ConferencingApps.isNativeCallApp(bundleID: "com.omi.omi-mtg-sysaudio"))
+      XCTAssertFalse(ConferencingApps.isNativeCallApp(bundleID: "com.google.Chrome"))
+    }
+
+    func testChatAppBundleIDsAreNativeCallApps() {
+      // Verified macOS bundle IDs (Homebrew cask quit targets for the current apps):
+      // Discord com.hnc.Discord, Slack com.tinyspeck.slackmacgap, WhatsApp
+      // net.whatsapp.WhatsApp. Their calls hold the mic, so mic-in-use detection
+      // fires while in a Discord voice channel, Slack huddle, or WhatsApp call.
+      XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.hnc.Discord"))
+      XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.hnc.discord"))  // case-insensitive
+      XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.tinyspeck.slackmacgap"))
+      XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "net.whatsapp.WhatsApp"))
+      // Omi itself and browsers are not native call apps (browser calls are matched
+      // separately by browserBundleIDPrefixes inside callAppIsUsingMicrophone).
       XCTAssertFalse(ConferencingApps.isNativeCallApp(bundleID: "com.omi.omi-mtg-sysaudio"))
       XCTAssertFalse(ConferencingApps.isNativeCallApp(bundleID: "com.google.Chrome"))
     }
@@ -95,6 +120,24 @@ import XCTest
       XCTAssertFalse(ConferencingApps.isShareIndicatorWindow(ownerName: "zoom.us", title: nil))
       XCTAssertFalse(ConferencingApps.isShareIndicatorWindow(ownerName: nil, title: "zoom share"))
       XCTAssertFalse(ConferencingApps.isShareIndicatorWindow(ownerName: "zoom.us", title: ""))
+    }
+
+    func testChatAppOrdinaryWindowsAreNotShareIndicators() {
+      // Ordinary Slack/Discord/WhatsApp chat windows are not presenting-toolbars;
+      // only the Zoom/Teams/browser share signatures may pause capture (#10143).
+      XCTAssertFalse(
+        ConferencingApps.isShareIndicatorWindow(
+          ownerName: "Slack", title: "#general | Acme Workspace"))
+      XCTAssertFalse(
+        ConferencingApps.isShareIndicatorWindow(
+          ownerName: "Discord", title: "#general | Discord"))
+      XCTAssertFalse(
+        ConferencingApps.isShareIndicatorWindow(
+          ownerName: "WhatsApp", title: "Chats"))
+      // Even a chat about sharing in one of these apps is not the toolbar itself.
+      XCTAssertFalse(
+        ConferencingApps.isShareIndicatorWindow(
+          ownerName: "Slack", title: "Screen sharing toolbar"))
     }
 
     func testBrowserBundleIDPrefixMatchingCatchesHelpers() {

--- a/desktop/macos/changelog/unreleased/20260818-only-meetings-discord-slack-whatsapp.json
+++ b/desktop/macos/changelog/unreleased/20260818-only-meetings-discord-slack-whatsapp.json
@@ -1,0 +1,3 @@
+{
+  "change": "Only Meetings mode now recognizes Discord, Slack huddle, and WhatsApp calls as meetings, so capture starts when you join those calls"
+}


### PR DESCRIPTION
# fix(desktop): Only Meetings catalog — Discord, Slack huddles, WhatsApp

## What

Desktop **Only Meetings** mode stayed idle during Discord voice, Slack huddle, and WhatsApp calls — `ConferencingApps` only catalogued Zoom / Teams / Meet / FaceTime / Webex / GoTo, so `MeetingDetector` never saw those calls as meetings (mic closed, empty / `word_count=0` sessions).

This adds the three chat apps to the shared catalog, **same shape as Teams**:

- `nativeCallApps` owner names: `Discord`, `Slack`, `WhatsApp` (call-window / screen paths — `ProactiveAssistantsPlugin` capture throttling).
- `nativeCallBundleIDs`: `com.hnc.discord` (Discord), `com.tinyspeck.slackmacgap` (Slack), `net.whatsapp.whatsapp` (WhatsApp) — stored lowercased per the set's contract. These are the current shipping macOS bundle IDs, verified via the Homebrew cask `uninstall.quit` targets for each app. The legacy Electron wrapper `net.whatsapp.WhatsAppDesktop` is **not** included (unverifiable / discontinued).

No new detector, no UI change, no settings change.

## Semantics unchanged

A native catalog hit still counts as a meeting **only while that process is using the microphone** (`callAppIsUsingMicrophone()` via CoreAudio, macOS 14.4+). Idle Slack/Discord/WhatsApp — app open, no call — does **not** start capture, exactly like Zoom/Teams today. Discord voice channels, Slack huddles, and WhatsApp calls hold the mic, which is the trigger.

Browser calls (Discord/Slack/WhatsApp web) were already covered generically: any browser process using the mic matches `browserBundleIDPrefixes` inside `callAppIsUsingMicrophone()`. I deliberately did **not** add browser title keywords (`discord.com`, `app.slack.com`, …): those feed `browserCallWindowPresent()`, which matches on title alone without mic evidence, so a chat tab showing the domain in its title would flag idle chat as a meeting.

## Known false-positive ceiling (same as Teams)

A Slack/Discord/WhatsApp voice note or call that holds the mic reads as a meeting. Not distinguishing these further.

## Tests

Extended `ConferencingAppsTests` in `desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift`:

- `testChatAppCallMatchesOnOwnerName` — Discord / Slack / WhatsApp windows are call windows on owner name alone.
- `testChatAppBundleIDsAreNativeCallApps` — the three added IDs match `isNativeCallApp` (case-insensitive); Omi / Chrome still do not.
- `testChatAppOrdinaryWindowsAreNotShareIndicators` — ordinary Slack/Discord/WhatsApp chat window titles are **not** share indicators (protects the #10143 presenting-window pause).

Command (from `desktop/macos`; the suite's file name matches no test class, so the filter names its classes):

```text
xcrun swift test --package-path Desktop --filter 'ConferencingAppsTests|MeetingDetectorTests|AudioRecordingModeSettingsTests|MeetingConversationBoundaryPolicyTests'
```

Result: **32 executed, 0 failures** — `ConferencingAppsTests` 10/10 (incl. the 3 new cases), `MeetingDetectorTests` 7/7, `AudioRecordingModeSettingsTests` 4/4, `MeetingConversationBoundaryPolicyTests` 11/11.

## Changelog

`desktop/macos/changelog/unreleased/20260818-only-meetings-discord-slack-whatsapp.json` — user-visible: Only Meetings now starts capture on Discord / Slack huddle / WhatsApp calls.

## Related (do not close)

- #10798 — closed; broader macOS 26.5 empty-capture + green Listening report. Not this catalog miss.
- #6768 — open FR for auto-detect/auto-start product expansion. Out of scope here.
- #6953 — system-audio vs conversation split. Out of scope.

## Out of scope

macOS 26.5 CoreAudio / silent-mic empty capture, Listening chrome, auto-start (#6768), pendant double-record (#3244), browser-only redesign, new telemetry/settings/dependencies.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

