### PR TITLE
fix(backend): address Gemini 3.x at its real endpoint, and give every model a fallback chain

### DIFF
--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -55,35 +55,115 @@ absorbs overflow and Pro. Promoting the client-pinned Lite lanes
 large cost regression, not a saving. Those pins are deliberately untouched and
 `test_client_pinned_flash_lite_is_never_promoted` holds that boundary.
 
-## Publisher models are enabled per project
+## Gemini 3.x is multi-region only; regional URLs 404
 
-**Listing the catalog does not prove availability.** `GET /publishers/google/models`
-(no project in the path) enumerates models that exist in Vertex. The
-project-scoped `projects/{p}/locations/{l}/publishers/google/models/{m}` path
-is what decides whether this project may call one.
+**This was the production defect in #11826.** `_vertex_url()` built one
+regional URL for every model:
 
-Measured 2026-08-18 on `based-hardware` / `us-central1` with credentials that
-can invoke inference:
+```
+https://{loc}-aiplatform.googleapis.com/v1/projects/{p}/locations/{loc}/publishers/google/models/{m}:{action}
+```
 
-| Model | Global catalog | Project endpoint |
+Gemini 3.x has no regional endpoint, so that URL can never work for it. Every
+3.x request 404d, which reads exactly like a project access gap and is not one.
+
+Measured 2026-08-18 on `based-hardware` with credentials that can invoke
+inference:
+
+| Endpoint | `gemini-3.1-flash-lite` |
+| --- | --- |
+| `aiplatform.googleapis.com` + `locations/us` | **200** ON_DEMAND |
+| `aiplatform.googleapis.com` + `locations/global` | **200** ON_DEMAND |
+| `aiplatform.googleapis.com` + `locations/us` + `dedicated` | **429** provisioned throughput |
+| `us-central1` / `us-east5` / `us-west1` / `europe-west4` / `asia-northeast1` | **404** |
+| `eu-aiplatform.googleapis.com` + `locations/eu` | **404** |
+
+The host is always plain `aiplatform.googleapis.com` — `us-aiplatform.googleapis.com`
+is not a valid host (400 `Invalid hostname`). Only the `locations/{loc}` path
+segment changes.
+
+The 429 to a `dedicated` request is the "no PT order for this model" answer,
+which is what we expect while we own no 3.1 order. It also proves the capacity
+header is honored on the multi-region endpoint, so the auto-detect probe below
+works there. Note the message reads lowercase `provisioned throughput` where
+the regional endpoint uses title case; the matcher casefolds, and must keep
+doing so.
+
+### Why `us` and not `global`
+
+`MULTI_REGION_LOCATION` is `us`, overridable with `OMI_VERTEX_GLOBAL_LOCATION`.
+Both `us` and `global` answer, but **`global` may serve a request from anywhere
+in the world**, while `us` is the US multi-region. This path carries users'
+personal conversations, transcripts and memories, and every other server-paid
+Gemini call in this service runs in `us-central1`. `us` preserves that
+residency posture; `global` silently widens it. That is a deliberate operator
+decision, not something a routing change should make on its own — do not
+"simplify" `us` into `global`.
+
+### The reservation model must stay regional
+
+`gemini-2.5-flash` **also** returns 200 on `locations/us` and
+`locations/global` (trafficType=ON_DEMAND). Routing it there anyway would
+bypass the 5 GSU **us-central1** Provisioned Throughput order and bill
+on-demand while the reservation kept charging ~$290/day — paying twice for the
+same tokens, which is the 2026-08-04 incident above.
+
+So the endpoint rule is **by model family, never by what happens to answer**:
+
+| Model | Host | Location |
 | --- | --- | --- |
-| `gemini-2.5-flash-lite` | listed | **200** |
-| `gemini-3.1-flash-lite` | listed | **404** |
-| `gemini-3.1-flash-lite-preview` | listed | **404** |
-| `gemini-3-flash-preview` | listed | **404** |
-| `gemini-3.5-flash-lite` | listed | **404** |
+| `gemini-3.*` | `aiplatform.googleapis.com` | `us` (`OMI_VERTEX_GLOBAL_LOCATION`) |
+| everything else | `{loc}-aiplatform.googleapis.com` | `GCP_LOCATION`, default `us-central1` |
 
-No Gemini 3.x model is callable by this project yet, on `v1` or `v1beta1`, in
-`us-central1` or `global`. **Access must be enabled before any 3.x routing or
-any 3.x Provisioned Throughput purchase can do anything** — you cannot buy PT
-for a model the project cannot call.
+`test_the_reservation_model_is_never_routed_off_its_region` holds that
+boundary. Location is resolved **per model**, never once per process: a
+fallback chain crosses families, so the reservation and the model absorbing its
+overflow legitimately sit on different endpoints.
 
-The proxy treats this as a first-class state rather than an error: a 404 from
-the target latches `_target_model_unavailable_at`, Pro falls back to
-`_QUOTA_DEMOTION_MODEL`, and the overflow ladder drops the dead rung so no
-request pays a round trip to fail. The latch is re-checked on the same TTL as
-capacity, so **enabling 3.x access later recovers the routing with no deploy**,
-exactly like the reservation promotion.
+**Unresolved:** whether a Provisioned Throughput order for a 3.x model is
+purchased as a multi-region order and how that would interact with the existing
+regional `gemini-2.5-flash` order. Nothing in the code assumes an answer.
+
+## Fallback chains and learned reachability
+
+Every model the proxy can route to declares its fallback chain as data, in
+`MODEL_FALLBACKS` in `backend/utils/llm/vertex_pt_routing.py`:
+
+| Model | Falls back to |
+| --- | --- |
+| `gemini-2.5-pro` | `gemini-3.1-flash-lite`, `gemini-2.5-flash-lite` |
+| `gemini-2.5-flash` | `gemini-3.1-flash-lite`, `gemini-2.5-flash-lite` |
+| `gemini-3.1-flash-lite` | `gemini-2.5-flash-lite` |
+| `gemini-2.5-flash-lite` | *(terminal)* |
+| `gemini-embedding-001` | *(terminal)* |
+
+Three invariants, each enforced by a test rather than by convention:
+
+- **Never onto the reservation.** The live PT model is filtered out of every
+  chain at resolution time, at both PT states
+  (FC-degraded-fallback-consumes-protected-budget). Degraded traffic must not
+  consume the budget the quota exists to protect.
+- **Never upward in price.** Each chain is non-increasing in output price
+  (`PRICE_PER_MTOK_OUT`), so a degraded request cannot cost more than the one
+  it replaces. This is also why `gemini-2.5-flash-lite` is terminal: it is the
+  floor of the ladder and the model the desktop clients pin directly.
+- **Never onto itself.** A chain never contains its own head, so a dead model
+  cannot retry itself.
+
+**Reachability is learned only from real `generateContent` attempts.** There is
+deliberately no startup probe. The metadata endpoint
+`GET .../publishers/google/models/{m}` is not an oracle — it 404s for
+`gemini-2.5-flash-lite`, which works fine — and burning one inference call per
+model per instance is unaffordable on Cloud Run, which churns instances
+constantly. When an attempt comes back "publisher model not found", the proxy
+latches that model for `_PT_PROBE_TTL_SECONDS` and skips it, then re-tries once
+the TTL lapses, so a routing fix or a serving change recovers with no deploy.
+BYOK responses never teach this table: they come from AI Studio on the user's
+own key, so one user must not be able to latch a model dead for the fleet.
+
+A generic 429 (`Quota exceeded for requests per minute`) is backpressure and
+never triggers a fallback. Only a PT-exhaustion 429 or a model-unavailable 404
+does.
 
 ## Thinking contract, measured
 
@@ -96,14 +176,28 @@ Run 2026-08-18 via `backend/scripts/probe_gemini_thinking_contract.py`:
 | `gemini-2.5-flash-lite` | `thinkingLevel: minimal` | **HTTP 400 — not supported** | |
 | `gemini-2.5-flash` | `thinkingBudget: 0` | 0 | 309 |
 | `gemini-2.5-flash` | no config | 516 | 213 |
+| `gemini-3.1-flash-lite` | `thinkingBudget: 0` | 0 | 64 |
+| `gemini-3.1-flash-lite` | `thinkingBudget: 1024` | 278 | 77 |
+| `gemini-3.1-flash-lite` | `thinkingLevel: minimal` | 0 | 75 |
+| `gemini-3.1-flash-lite` | `thinkingLevel: high` | 603 | 76 |
+| `gemini-3.1-flash-lite` | no config | 0 | 64 |
 
-Two things this settles. 2.5 models **honor** `thinkingBudget` (0 really is 0),
-and they **reject** `thinkingLevel` outright with a 400 — so the family split
-is required in both directions, not a precaution. It also shows why the proxy
-injects a budget at all: `gemini-2.5-flash` with no thinking config spent 516
-thinking tokens on a trivial prompt, all billed as output.
+The 3.x rows were measured on the multi-region endpoint once the routing fix
+made those models reachable.
 
-The 3.x half is still unmeasured because the project cannot call those models.
+**This table deleted a branch rather than justifying one.** `gemini-3.1-flash-lite`
+*honors* `thinkingBudget` — budget 0 really is 0 thoughts, budget 1024 spends
+278 — and 2.5 models *reject* `thinkingLevel` with HTTP 400
+(`thinking_level is not supported by this model`). So `thinkingBudget` is the
+one option both families accept and `thinkingLevel` is the one that works on
+neither universally. An earlier revision split on family from documentation
+rather than measurement and had the direction backwards. `ptr.thinking_config_for()`
+is now a single path, and a fallback that crosses families needs no body
+rewriting at all.
+
+It also shows why the proxy injects a budget: `gemini-2.5-flash` with no
+thinking config spent 516 thinking tokens on a trivial prompt, all billed as
+output.
 
 ## Migrating the reservation to `gemini-3.1-flash-lite`
 
@@ -163,33 +257,9 @@ budget the quota exists to protect — that is
 `FC-degraded-fallback-consumes-protected-budget` (PR #10686), and the guard is
 `test_overflow_never_targets_the_live_reservation`.
 
-## Gemini 3.x changed the thinking contract
-
-2.5 models take an integer `thinkingConfig.thinkingBudget`. 3.x models take
-`thinkingConfig.thinkingLevel`, and **thinking cannot be disabled** — the floor
-is `minimal`. Thinking tokens bill as *output*, so sending a 2.5-style budget
-to a 3.x model risks an uncapped reasoning trace at $1.50/1M: the field is
-schema-valid, so it is accepted and then ignored.
-
-`ptr.thinking_config_for()` picks by family prefix rather than exact model name,
-matching how `_CACHE_KEY_MODEL_PREFIXES` handles prompt caching, and
-`_retarget_thinking()` rewrites the body when overflow crosses families.
-
-**Unverified:** whether 3.x hard-errors on `thinkingBudget` or silently ignores
-it could not be settled from this host — `aiplatform.endpoints.predict` is
-denied to the read-only service account, and no human ADC was live. The code is
-correct either way, but the observed token counts are still worth capturing:
-
-```
-python3 backend/scripts/probe_gemini_thinking_contract.py
-```
-
-Run it with credentials that can call `generateContent` and paste the output
-into this section.
-
 ## Operator overrides
 
-All three are read per request, so a bad promotion can be corrected without
+All four are read per request, so a bad promotion can be corrected without
 shipping code.
 
 | Env | Effect |
@@ -197,6 +267,7 @@ shipping code.
 | `OMI_VERTEX_PT_MODEL` | Pins the reservation model, beating auto-detection in both directions. |
 | `OMI_GEMINI_OVERFLOW_MODEL` | Pins the overflow model. Rejected at resolution time if it equals the reservation. |
 | `OMI_GEMINI_OVERFLOW_ENABLED` | `false` disables overflow entirely; a full reservation then returns 429 to the client. |
+| `OMI_VERTEX_GLOBAL_LOCATION` | Multi-region for families with no regional endpoint. Default `us`. Setting `global` widens data residency worldwide — see above before flipping it. |
 
 ## Keeping the reservation for work that must be Flash
 

--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -55,6 +55,56 @@ absorbs overflow and Pro. Promoting the client-pinned Lite lanes
 large cost regression, not a saving. Those pins are deliberately untouched and
 `test_client_pinned_flash_lite_is_never_promoted` holds that boundary.
 
+## Publisher models are enabled per project
+
+**Listing the catalog does not prove availability.** `GET /publishers/google/models`
+(no project in the path) enumerates models that exist in Vertex. The
+project-scoped `projects/{p}/locations/{l}/publishers/google/models/{m}` path
+is what decides whether this project may call one.
+
+Measured 2026-08-18 on `based-hardware` / `us-central1` with credentials that
+can invoke inference:
+
+| Model | Global catalog | Project endpoint |
+| --- | --- | --- |
+| `gemini-2.5-flash-lite` | listed | **200** |
+| `gemini-3.1-flash-lite` | listed | **404** |
+| `gemini-3.1-flash-lite-preview` | listed | **404** |
+| `gemini-3-flash-preview` | listed | **404** |
+| `gemini-3.5-flash-lite` | listed | **404** |
+
+No Gemini 3.x model is callable by this project yet, on `v1` or `v1beta1`, in
+`us-central1` or `global`. **Access must be enabled before any 3.x routing or
+any 3.x Provisioned Throughput purchase can do anything** — you cannot buy PT
+for a model the project cannot call.
+
+The proxy treats this as a first-class state rather than an error: a 404 from
+the target latches `_target_model_unavailable_at`, Pro falls back to
+`_QUOTA_DEMOTION_MODEL`, and the overflow ladder drops the dead rung so no
+request pays a round trip to fail. The latch is re-checked on the same TTL as
+capacity, so **enabling 3.x access later recovers the routing with no deploy**,
+exactly like the reservation promotion.
+
+## Thinking contract, measured
+
+Run 2026-08-18 via `backend/scripts/probe_gemini_thinking_contract.py`:
+
+| Model | Config | thoughts | output |
+| --- | --- | ---: | ---: |
+| `gemini-2.5-flash-lite` | `thinkingBudget: 0` | 0 | 225 |
+| `gemini-2.5-flash-lite` | `thinkingBudget: 1024` | 863 | 300 |
+| `gemini-2.5-flash-lite` | `thinkingLevel: minimal` | **HTTP 400 — not supported** | |
+| `gemini-2.5-flash` | `thinkingBudget: 0` | 0 | 309 |
+| `gemini-2.5-flash` | no config | 516 | 213 |
+
+Two things this settles. 2.5 models **honor** `thinkingBudget` (0 really is 0),
+and they **reject** `thinkingLevel` outright with a 400 — so the family split
+is required in both directions, not a precaution. It also shows why the proxy
+injects a budget at all: `gemini-2.5-flash` with no thinking config spent 516
+thinking tokens on a trivial prompt, all billed as output.
+
+The 3.x half is still unmeasured because the project cannot call those models.
+
 ## Migrating the reservation to `gemini-3.1-flash-lite`
 
 Requested 2026-08-18; PT orders provision in ~10 business days. **No deploy is

--- a/backend/docs/vertex-pt-flash.md
+++ b/backend/docs/vertex-pt-flash.md
@@ -137,6 +137,17 @@ Every model the proxy can route to declares its fallback chain as data, in
 | `gemini-2.5-flash-lite` | *(terminal)* |
 | `gemini-embedding-001` | *(terminal)* |
 
+**Reading this table correctly:** it lists chains for every model a client may
+**request**, which is not the same as the set of models server-paid traffic is
+ever **served** by. `gemini-2.5-pro` appears here because it stays
+proxy-allowlisted and BYOK users pay for it on their own key — but no
+server-paid request is dispatched as Pro. `_serving_model()` remaps it to
+`gemini-3.1-flash-lite` before dispatch, and over the daily soft limit the
+metering path demotes it to `gemini-2.5-flash-lite` first. Pro's chain is what
+would happen if it were ever dispatched anyway, not a route in normal use.
+`test_server_paid_traffic_never_dispatches_gemini_2_5_pro` asserts that across
+both reservation states and both reachability states.
+
 Three invariants, each enforced by a test rather than by convention:
 
 - **Never onto the reservation.** The live PT model is filtered out of every

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -449,6 +449,12 @@ def _use_vertex_ai() -> bool:
 # safely — requests 429 and overflow absorbs them — and the operator override
 # pins the model outright if that is ever not enough.
 _pt_target_ready = False
+# Whether the migration target answers at all for this project. Publisher
+# models must be enabled per project: on 2026-08-18 every gemini-3.x model was
+# present in the global catalog and 404 on the project-scoped endpoint, so
+# "listed" is not "callable". This is re-checked on a TTL so access being
+# granted later promotes the proxy with no deploy, exactly like capacity.
+_target_model_unavailable_at: float | None = None
 # None means "never probed", which is distinct from "probed at monotonic 0".
 # time.monotonic() is measured from an arbitrary origin — on a freshly started
 # container it can legitimately be smaller than the TTL, so seeding this with
@@ -458,7 +464,32 @@ _pt_target_probed_at: float | None = None
 
 
 def _pt_target_is_ready() -> bool:
-    return _pt_target_ready
+    return _pt_target_ready and _target_model_believed_available()
+
+
+def _target_model_believed_available() -> bool:
+    if _target_model_unavailable_at is None:
+        return True
+    return (time.monotonic() - _target_model_unavailable_at) >= _PT_PROBE_TTL_SECONDS
+
+
+def _record_target_model_unavailable() -> None:
+    global _target_model_unavailable_at, _pt_target_ready
+    if _target_model_believed_available():
+        print(
+            f'desktop_proxy target_model_unavailable model={VERTEX_PT_TARGET_MODEL} '
+            f'reason=publisher_model_not_enabled_for_project',
+            file=sys.stderr,
+            flush=True,
+        )
+    _target_model_unavailable_at = time.monotonic()
+    # A model the project cannot call cannot be holding prepaid capacity.
+    _pt_target_ready = False
+
+
+def _record_target_model_available() -> None:
+    global _target_model_unavailable_at
+    _target_model_unavailable_at = None
 
 
 def _pt_probe_due() -> bool:
@@ -496,10 +527,6 @@ def _provisioned_model() -> str:
     )
 
 
-def _overflow_model(pt_model: str) -> str:
-    return ptr.resolve_overflow_model(pt_model=pt_model, override=os.getenv(_OVERFLOW_MODEL_OVERRIDE_ENV, ''))
-
-
 def _overflow_enabled() -> bool:
     return os.getenv(_OVERFLOW_ENABLED_ENV, 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
 
@@ -520,7 +547,11 @@ def _serving_model(model: str) -> str:
     if get_byok_key('gemini'):
         return model
     if model == 'gemini-2.5-pro':
-        return VERTEX_PT_TARGET_MODEL
+        if _target_model_believed_available():
+            return VERTEX_PT_TARGET_MODEL
+        # The target is not callable for this project; keep Pro on the model
+        # the quota path has always demoted to rather than failing the request.
+        return _QUOTA_DEMOTION_MODEL
     if model == ptr.PT_MODEL_CURRENT:
         return _provisioned_model()
     return model
@@ -675,14 +706,47 @@ def _overflow_plan(served_model: str) -> list[tuple[str, str]]:
     if served_model != pt_model:
         return []
     try:
-        overflow = _overflow_model(pt_model)
+        ladder = ptr.resolve_overflow_ladder(pt_model=pt_model, override=os.getenv(_OVERFLOW_MODEL_OVERRIDE_ENV, ''))
     except ValueError:
         return []
     plan: list[tuple[str, str]] = []
-    if overflow == ptr.PT_MODEL_TARGET and _pt_probe_due():
-        plan.append((overflow, ptr.REQUEST_TYPE_DEDICATED))
-    plan.append((overflow, ptr.REQUEST_TYPE_SHARED))
+    for rung in ladder:
+        if rung == ptr.PT_MODEL_TARGET:
+            if not _target_model_believed_available():
+                # Skip a rung the project cannot call at all; trying it would
+                # spend a round trip to fail on every single overflow request.
+                continue
+            if _pt_probe_due():
+                plan.append((rung, ptr.REQUEST_TYPE_DEDICATED))
+        plan.append((rung, ptr.REQUEST_TYPE_SHARED))
     return plan
+
+
+def _safe_rungs() -> list[tuple[str, str]]:
+    """On-demand models this project can actually call, best first."""
+    try:
+        ladder = ptr.resolve_overflow_ladder(
+            pt_model=_provisioned_model(), override=os.getenv(_OVERFLOW_MODEL_OVERRIDE_ENV, '')
+        )
+    except ValueError:
+        return []
+    return [(rung, ptr.REQUEST_TYPE_SHARED) for rung in ladder if rung != ptr.PT_MODEL_TARGET]
+
+
+def _recovery_plan(served_model: str, status: int, message: str) -> list[tuple[str, str]]:
+    """Attempts to make after a response this proxy can route around.
+
+    Two distinct recoverable conditions:
+      * the reservation is full          -> walk the overflow ladder
+      * the target model is not callable -> fall back to a model that is, and
+        latch the observation so later requests skip the dead rung entirely
+    """
+    if served_model == ptr.PT_MODEL_TARGET and ptr.is_model_unavailable(status, message):
+        _record_target_model_unavailable()
+        return _safe_rungs()
+    if _overflow_triggered(status, message):
+        return _overflow_plan(served_model)
+    return []
 
 
 def _overflow_triggered(status: int, message: str) -> bool:
@@ -1011,11 +1075,16 @@ async def _stream_provider(
             # The body carries the difference between 'reservation full' and
             # ordinary rate limiting, and a streamed error body is not read yet.
             await upstream.aread()
+            unavailable = ptr.is_model_unavailable(upstream.status_code, upstream.text)
             exhausted = _overflow_triggered(upstream.status_code, upstream.text)
-            if capacity == ptr.REQUEST_TYPE_DEDICATED:
+            if attempt_model == ptr.PT_MODEL_TARGET and not unavailable and upstream.status_code < 400:
+                _record_target_model_available()
+            if capacity == ptr.REQUEST_TYPE_DEDICATED and not unavailable:
                 _record_pt_target_observation(not exhausted)
-            if exhausted and not pending and query is not None:
-                for overflow_model, overflow_capacity in _overflow_plan(attempt_model):
+            if not pending and query is not None:
+                for overflow_model, overflow_capacity in _recovery_plan(
+                    attempt_model, upstream.status_code, upstream.text
+                ):
                     pending.append(
                         (
                             await _upstream(
@@ -1163,9 +1232,10 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
                     semaphore.release()
 
             response = await _cancel_on_disconnect(request, post(route, body))
-            if _overflow_triggered(response.status_code, response.text):
+            recovery = _recovery_plan(model, response.status_code, response.text)
+            if recovery:
                 query = dict(request.query_params)
-                for overflow_model, capacity in _overflow_plan(model):
+                for overflow_model, capacity in recovery:
                     overflow_path = f'models/{overflow_model}:{action}'
                     overflow_body = _retarget_thinking(body, overflow_model)
                     overflow_route = await _upstream(
@@ -1175,10 +1245,15 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
                     telemetry.model = overflow_model
                     response = await _cancel_on_disconnect(request, post(overflow_route, overflow_body))
                     probing = capacity == ptr.REQUEST_TYPE_DEDICATED
+                    unavailable = ptr.is_model_unavailable(response.status_code, response.text)
                     exhausted = _overflow_triggered(response.status_code, response.text)
-                    if probing:
+                    if unavailable and overflow_model == ptr.PT_MODEL_TARGET:
+                        _record_target_model_unavailable()
+                    elif overflow_model == ptr.PT_MODEL_TARGET and response.status_code < 400:
+                        _record_target_model_available()
+                    if probing and not unavailable:
                         _record_pt_target_observation(not exhausted)
-                    if not exhausted:
+                    if not exhausted and not unavailable:
                         break
             telemetry.phase = 'body'
     except HTTPException as exc:

--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -72,6 +72,9 @@ VERTEX_PT_TARGET_MODEL = ptr.PT_MODEL_TARGET
 _PT_MODEL_OVERRIDE_ENV = 'OMI_VERTEX_PT_MODEL'
 _OVERFLOW_MODEL_OVERRIDE_ENV = 'OMI_GEMINI_OVERFLOW_MODEL'
 _OVERFLOW_ENABLED_ENV = 'OMI_GEMINI_OVERFLOW_ENABLED'
+# Data-residency pin for the families that have no regional endpoint. `us`
+# keeps inference in the US multi-region; `global` would widen it worldwide.
+_MULTI_REGION_LOCATION_ENV = 'OMI_VERTEX_GLOBAL_LOCATION'
 # How long a PT-capacity observation is trusted before it is re-probed. Bounds
 # both the promotion delay after the order lands and the cost of probing.
 _PT_PROBE_TTL_SECONDS = 600.0
@@ -279,8 +282,11 @@ def _safe_revision(value: object) -> str:
 
 
 def _safe_region(value: object) -> str:
+    # Regional (`us-central1`) and multi-region (`us`, `eu`, `global`) labels
+    # are both legitimate now that 3.x traffic is addressed multi-region, so
+    # the bare form must survive telemetry instead of being logged as 'none'.
     text = str(value or '').strip().lower()
-    return text if text == 'global' or re.fullmatch(r'[a-z]+(?:-[a-z0-9]+)+', text) else 'none'
+    return text if re.fullmatch(r'[a-z]{2,16}(?:-[a-z0-9]{1,16}){0,2}', text) else 'none'
 
 
 def _status_class(status: int | None) -> str:
@@ -367,7 +373,6 @@ def _sanitize(
     action: str,
     *,
     max_output_tokens: int = _MAX_OUTPUT_TOKENS,
-    model: str = '',
 ) -> bytes:
     try:
         payload = json.loads(body)
@@ -410,7 +415,7 @@ def _sanitize(
         if not generation_configs:
             payload['generationConfig'] = {
                 'maxOutputTokens': max_output_tokens,
-                'thinkingConfig': ptr.thinking_config_for(model, budget=_DEFAULT_THINKING_BUDGET),
+                'thinkingConfig': ptr.thinking_config_for(budget=_DEFAULT_THINKING_BUDGET),
             }
         for config in generation_configs:
             for key in ('candidate_count', 'candidateCount'):
@@ -427,7 +432,7 @@ def _sanitize(
             if not output_key_present:
                 config['maxOutputTokens'] = max_output_tokens
             if 'thinking_config' not in config and 'thinkingConfig' not in config:
-                config['thinkingConfig'] = ptr.thinking_config_for(model, budget=_DEFAULT_THINKING_BUDGET)
+                config['thinkingConfig'] = ptr.thinking_config_for(budget=_DEFAULT_THINKING_BUDGET)
     return json.dumps(payload, separators=(',', ':')).encode()
 
 
@@ -449,47 +454,73 @@ def _use_vertex_ai() -> bool:
 # safely — requests 429 and overflow absorbs them — and the operator override
 # pins the model outright if that is ever not enough.
 _pt_target_ready = False
-# Whether the migration target answers at all for this project. Publisher
-# models must be enabled per project: on 2026-08-18 every gemini-3.x model was
-# present in the global catalog and 404 on the project-scoped endpoint, so
-# "listed" is not "callable". This is re-checked on a TTL so access being
-# granted later promotes the proxy with no deploy, exactly like capacity.
-_target_model_unavailable_at: float | None = None
-# None means "never probed", which is distinct from "probed at monotonic 0".
-# time.monotonic() is measured from an arbitrary origin — on a freshly started
-# container it can legitimately be smaller than the TTL, so seeding this with
-# 0.0 would suppress the first probe for the first _PT_PROBE_TTL_SECONDS of
-# process uptime on every new instance.
+# Learned reachability, per model. A model is entered here only when a real
+# `generateContent` attempt came back "no such publisher model", and the entry
+# expires on the same TTL as capacity so a routing fix or a serving change
+# recovers with no deploy.
+#
+# Reachability is deliberately NOT probed at startup. The metadata endpoint
+# `GET .../publishers/google/models/{m}` is not an oracle — it 404s for
+# `gemini-2.5-flash-lite`, which works — so the only honest signal is a real
+# inference attempt, and burning one per model per instance is unaffordable on
+# Cloud Run, which churns instances constantly. Traffic teaches this table.
+#
+# Absent key means "never observed unreachable", which is distinct from
+# "observed at monotonic 0". time.monotonic() is measured from an arbitrary
+# origin — on a freshly started container it can legitimately be smaller than
+# the TTL, so seeding an observation with 0.0 would mark a model dead for the
+# first _PT_PROBE_TTL_SECONDS of every new instance's life.
+_model_unavailable_at: dict[str, float] = {}
+# None means "never probed", same sentinel rule as above.
 _pt_target_probed_at: float | None = None
 
 
 def _pt_target_is_ready() -> bool:
-    return _pt_target_ready and _target_model_believed_available()
+    return _pt_target_ready and _model_believed_available(VERTEX_PT_TARGET_MODEL)
 
 
-def _target_model_believed_available() -> bool:
-    if _target_model_unavailable_at is None:
+def _model_believed_available(model: str) -> bool:
+    observed = _model_unavailable_at.get(model)
+    if observed is None:
         return True
-    return (time.monotonic() - _target_model_unavailable_at) >= _PT_PROBE_TTL_SECONDS
+    return (time.monotonic() - observed) >= _PT_PROBE_TTL_SECONDS
 
 
-def _record_target_model_unavailable() -> None:
-    global _target_model_unavailable_at, _pt_target_ready
-    if _target_model_believed_available():
+def _unreachable_models() -> frozenset[str]:
+    return frozenset(model for model in _model_unavailable_at if not _model_believed_available(model))
+
+
+def _learns_reachability() -> bool:
+    """Whether the current request may teach the reachability table.
+
+    BYOK traffic goes to AI Studio on the user's own key, so its answers say
+    nothing about what this project can reach on Vertex. One user's key must
+    never be able to latch a model dead for the whole fleet.
+    """
+    return not get_byok_key('gemini')
+
+
+def _record_model_unavailable(model: str) -> None:
+    global _pt_target_ready
+    if not _learns_reachability():
+        return
+    if _model_believed_available(model):
         print(
-            f'desktop_proxy target_model_unavailable model={VERTEX_PT_TARGET_MODEL} '
-            f'reason=publisher_model_not_enabled_for_project',
+            f'desktop_proxy model_unreachable model={model} '
+            f'location={_vertex_location(model)} reason=publisher_model_not_found_at_endpoint',
             file=sys.stderr,
             flush=True,
         )
-    _target_model_unavailable_at = time.monotonic()
-    # A model the project cannot call cannot be holding prepaid capacity.
-    _pt_target_ready = False
+    _model_unavailable_at[model] = time.monotonic()
+    if model == VERTEX_PT_TARGET_MODEL:
+        # A model that cannot be reached cannot be holding prepaid capacity.
+        _pt_target_ready = False
 
 
-def _record_target_model_available() -> None:
-    global _target_model_unavailable_at
-    _target_model_unavailable_at = None
+def _record_model_available(model: str) -> None:
+    if not _learns_reachability():
+        return
+    _model_unavailable_at.pop(model, None)
 
 
 def _pt_probe_due() -> bool:
@@ -531,6 +562,34 @@ def _overflow_enabled() -> bool:
     return os.getenv(_OVERFLOW_ENABLED_ENV, 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
 
 
+def _fallback_chain(model: str) -> tuple[str, ...]:
+    """Reachable models that may serve `model`'s traffic, best first."""
+    try:
+        return ptr.resolve_fallback_chain(
+            model=model,
+            pt_model=_provisioned_model(),
+            unreachable=_unreachable_models(),
+            override=os.getenv(_OVERFLOW_MODEL_OVERRIDE_ENV, ''),
+        )
+    except ValueError:
+        return ()
+
+
+def _first_reachable(model: str) -> str:
+    """`model`, or the best rung of its chain if traffic has proved it dead.
+
+    Falling back before dispatch is what keeps a known-unreachable model from
+    costing a wasted round trip on every single request.
+    """
+    if _model_believed_available(model):
+        return model
+    for candidate in _fallback_chain(model):
+        return candidate
+    # Nothing declared and reachable. Keep the request honest and let the
+    # provider answer rather than inventing a substitute.
+    return model
+
+
 def _serving_model(model: str) -> str:
     """Map a requested model onto the model that will actually serve it.
 
@@ -540,21 +599,24 @@ def _serving_model(model: str) -> str:
       gemini-2.5-pro   -> gemini-3.1-flash-lite  ($10.00 -> $1.50 out)
       gemini-2.5-flash -> whichever model holds prepaid capacity
 
+    Whatever comes out is then resolved against learned reachability, so a
+    model traffic has proved uncallable is stepped past using its declared
+    chain instead of failing the request.
+
     Client-pinned gemini-2.5-flash-lite lanes are deliberately untouched:
     gemini-3.1-flash-lite costs 3.75x more per output token, so promoting those
-    lanes would be a large cost regression, not a saving.
+    lanes would be a large cost regression, not a saving. Its chain is empty
+    for exactly that reason.
     """
     if get_byok_key('gemini'):
         return model
     if model == 'gemini-2.5-pro':
-        if _target_model_believed_available():
-            return VERTEX_PT_TARGET_MODEL
-        # The target is not callable for this project; keep Pro on the model
-        # the quota path has always demoted to rather than failing the request.
-        return _QUOTA_DEMOTION_MODEL
-    if model == ptr.PT_MODEL_CURRENT:
-        return _provisioned_model()
-    return model
+        intended = VERTEX_PT_TARGET_MODEL
+    elif model == ptr.PT_MODEL_CURRENT:
+        intended = _provisioned_model()
+    else:
+        intended = model
+    return _first_reachable(intended)
 
 
 def _retarget_path(path: str, model: str, action: str) -> str:
@@ -562,34 +624,6 @@ def _retarget_path(path: str, model: str, action: str) -> str:
     if served == model:
         return path
     return f'models/{served}:{action}'
-
-
-def _retarget_thinking(body: bytes, model: str) -> bytes:
-    """Rewrite thinkingConfig for a model in a different family.
-
-    Overflow crosses families (gemini-2.5-flash -> gemini-3.1-flash-lite), and
-    a 2.5-style integer budget is schema-valid but ignored on 3.x, so leaving
-    it in place would uncap reasoning tokens that bill as output.
-    """
-    try:
-        payload = json.loads(body)
-    except (TypeError, ValueError):
-        return body
-    if not isinstance(payload, dict):
-        return body
-    replacement = ptr.thinking_config_for(model, budget=_DEFAULT_THINKING_BUDGET)
-    changed = False
-    for key in ('generation_config', 'generationConfig'):
-        config = payload.get(key)
-        if not isinstance(config, dict):
-            continue
-        for thinking_key in ('thinking_config', 'thinkingConfig'):
-            if thinking_key in config:
-                config[thinking_key] = dict(replacement)
-                changed = True
-    if not changed:
-        return body
-    return json.dumps(payload, separators=(',', ':')).encode()
 
 
 def _server_paid_flash_text(model: str, action: str) -> bool:
@@ -610,12 +644,49 @@ def _vertex_required(model: str, action: str) -> bool:
     return _server_paid_flash_text(model, action) or _use_vertex_ai()
 
 
+def _regional_location() -> str:
+    return os.getenv('GCP_LOCATION', VERTEX_PT_LOCATION).strip() or VERTEX_PT_LOCATION
+
+
+def _multi_region_location() -> str:
+    """Multi-region for the model families that have no regional endpoint.
+
+    Defaults to `us`, not `global`: both answer, but `global` may serve from
+    anywhere in the world while every other server-paid call in this service
+    runs in `us-central1`. Widening the residency of users' conversations and
+    transcripts is an operator decision, so it is one env flip and not a
+    literal buried in a URL builder.
+    """
+    return os.getenv(_MULTI_REGION_LOCATION_ENV, ptr.MULTI_REGION_LOCATION).strip() or ptr.MULTI_REGION_LOCATION
+
+
+def _vertex_endpoint(model: str) -> tuple[str, str]:
+    """The (host, location) a model is actually addressed at.
+
+    Per model, never per process: `gemini-3.x` has no regional endpoint, so a
+    fallback chain that crosses families also crosses endpoints.
+    """
+    return ptr.vertex_endpoint(
+        model=model,
+        regional_location=_regional_location(),
+        multi_region_location=_multi_region_location(),
+    )
+
+
+def _vertex_location(model: str) -> str:
+    return _vertex_endpoint(model)[1]
+
+
 def _vertex_url(model: str, action: str) -> str | None:
     project = os.getenv('GOOGLE_CLOUD_PROJECT', '').strip()
     if model not in _VERTEX_MODELS or action not in _VERTEX_ACTIONS or not project:
         return None
-    location = os.getenv('GCP_LOCATION', VERTEX_PT_LOCATION).strip() or VERTEX_PT_LOCATION
-    return f'https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:{action}'
+    # Gemini 3.x has no regional endpoint: it needs the un-prefixed host plus a
+    # multi-region `locations/{loc}`. Building a regional URL for it is what
+    # made every 3.x request 404 in production on 2026-08-18 while the model
+    # itself was perfectly callable.
+    host, location = _vertex_endpoint(model)
+    return f'https://{host}/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:{action}'
 
 
 def _studio_url(path: str) -> str:
@@ -670,7 +741,7 @@ async def _upstream(
             query,
             'vertex_ai',
             'application_default_credentials',
-            os.getenv('GCP_LOCATION', VERTEX_PT_LOCATION).strip() or VERTEX_PT_LOCATION,
+            _vertex_location(model),
         )
     if _vertex_required(model, action):
         # Missing GOOGLE_CLOUD_PROJECT is the 2026-08-04 production bug: Flash
@@ -711,39 +782,34 @@ def _overflow_plan(served_model: str) -> list[tuple[str, str]]:
         return []
     plan: list[tuple[str, str]] = []
     for rung in ladder:
-        if rung == ptr.PT_MODEL_TARGET:
-            if not _target_model_believed_available():
-                # Skip a rung the project cannot call at all; trying it would
-                # spend a round trip to fail on every single overflow request.
-                continue
-            if _pt_probe_due():
-                plan.append((rung, ptr.REQUEST_TYPE_DEDICATED))
+        if not _model_believed_available(rung):
+            # Skip a rung traffic has proved unreachable; trying it would spend
+            # a round trip to fail on every single overflow request.
+            continue
+        if rung == ptr.PT_MODEL_TARGET and _pt_probe_due():
+            plan.append((rung, ptr.REQUEST_TYPE_DEDICATED))
         plan.append((rung, ptr.REQUEST_TYPE_SHARED))
     return plan
-
-
-def _safe_rungs() -> list[tuple[str, str]]:
-    """On-demand models this project can actually call, best first."""
-    try:
-        ladder = ptr.resolve_overflow_ladder(
-            pt_model=_provisioned_model(), override=os.getenv(_OVERFLOW_MODEL_OVERRIDE_ENV, '')
-        )
-    except ValueError:
-        return []
-    return [(rung, ptr.REQUEST_TYPE_SHARED) for rung in ladder if rung != ptr.PT_MODEL_TARGET]
 
 
 def _recovery_plan(served_model: str, status: int, message: str) -> list[tuple[str, str]]:
     """Attempts to make after a response this proxy can route around.
 
-    Two distinct recoverable conditions:
-      * the reservation is full          -> walk the overflow ladder
-      * the target model is not callable -> fall back to a model that is, and
-        latch the observation so later requests skip the dead rung entirely
+    Two distinct recoverable conditions, for ANY routable model rather than
+    just the migration target:
+      * the model is not reachable  -> latch the observation so later requests
+        skip it entirely, and walk its declared fallback chain
+      * the reservation is full     -> walk the overflow ladder
+
+    BYOK responses teach this proxy nothing: they come from a different
+    provider and a different project, so one user's key must never latch a
+    model dead for everyone.
     """
-    if served_model == ptr.PT_MODEL_TARGET and ptr.is_model_unavailable(status, message):
-        _record_target_model_unavailable()
-        return _safe_rungs()
+    if get_byok_key('gemini'):
+        return []
+    if ptr.is_model_unavailable(status, message):
+        _record_model_unavailable(served_model)
+        return [(rung, ptr.REQUEST_TYPE_SHARED) for rung in _fallback_chain(served_model)]
     if _overflow_triggered(status, message):
         return _overflow_plan(served_model)
     return []
@@ -1071,14 +1137,15 @@ async def _stream_provider(
                 held = True
             telemetry.phase = 'first_byte'
             if upstream.status_code < 400:
+                # Positive proof of reachability, which is the only kind this
+                # proxy trusts. Clears any stale latch on this model.
+                _record_model_available(attempt_model)
                 break
             # The body carries the difference between 'reservation full' and
             # ordinary rate limiting, and a streamed error body is not read yet.
             await upstream.aread()
             unavailable = ptr.is_model_unavailable(upstream.status_code, upstream.text)
             exhausted = _overflow_triggered(upstream.status_code, upstream.text)
-            if attempt_model == ptr.PT_MODEL_TARGET and not unavailable and upstream.status_code < 400:
-                _record_target_model_available()
             if capacity == ptr.REQUEST_TYPE_DEDICATED and not unavailable:
                 _record_pt_target_observation(not exhausted)
             if not pending and query is not None:
@@ -1094,7 +1161,7 @@ async def _stream_provider(
                                 dict(query),
                                 request_type=overflow_capacity,
                             ),
-                            _retarget_thinking(body, overflow_model),
+                            body,
                             overflow_model,
                             overflow_capacity,
                         )
@@ -1180,7 +1247,7 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
         _, model, action = _path_parts(path)
         telemetry.model = model
         telemetry.action = action
-        body = _sanitize(body, action, max_output_tokens=_output_token_cap(), model=model)
+        body = _sanitize(body, action, max_output_tokens=_output_token_cap())
         telemetry.shape = _payload_shape(body)
     except HTTPException as exc:
         outcome = 'rate_limited' if exc.status_code == 429 else 'validation_rejected'
@@ -1232,25 +1299,26 @@ async def _proxy(request: Request, path: str, streaming: bool, uid: str) -> Resp
                     semaphore.release()
 
             response = await _cancel_on_disconnect(request, post(route, body))
+            if response.status_code < 400:
+                _record_model_available(model)
             recovery = _recovery_plan(model, response.status_code, response.text)
             if recovery:
                 query = dict(request.query_params)
                 for overflow_model, capacity in recovery:
                     overflow_path = f'models/{overflow_model}:{action}'
-                    overflow_body = _retarget_thinking(body, overflow_model)
                     overflow_route = await _upstream(
                         overflow_path, overflow_model, action, query, request_type=capacity
                     )
                     telemetry.set_route(overflow_route)
                     telemetry.model = overflow_model
-                    response = await _cancel_on_disconnect(request, post(overflow_route, overflow_body))
+                    response = await _cancel_on_disconnect(request, post(overflow_route, body))
                     probing = capacity == ptr.REQUEST_TYPE_DEDICATED
                     unavailable = ptr.is_model_unavailable(response.status_code, response.text)
                     exhausted = _overflow_triggered(response.status_code, response.text)
-                    if unavailable and overflow_model == ptr.PT_MODEL_TARGET:
-                        _record_target_model_unavailable()
-                    elif overflow_model == ptr.PT_MODEL_TARGET and response.status_code < 400:
-                        _record_target_model_available()
+                    if unavailable:
+                        _record_model_unavailable(overflow_model)
+                    elif response.status_code < 400:
+                        _record_model_available(overflow_model)
                     if probing and not unavailable:
                         _record_pt_target_observation(not exhausted)
                     if not exhausted and not unavailable:

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -961,6 +961,7 @@ def test_an_unavailable_target_cannot_be_considered_a_live_reservation():
 def test_model_unavailability_is_distinguished_from_capacity_conditions():
     not_enabled = "Publisher model `projects/p/locations/l/publishers/google/models/m` was not found"
     assert desktop_proxy.ptr.is_model_unavailable(404, not_enabled)
+    assert not desktop_proxy.ptr.is_model_unavailable(404, "The requested resource was not found")
     assert not desktop_proxy.ptr.is_model_unavailable(429, "Exceeded the Provisioned Throughput.")
     assert not desktop_proxy._overflow_triggered(404, not_enabled)
 

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -856,9 +856,11 @@ def _reset_pt_promotion_state():
     """The observed-capacity latch is module state; never leak it between tests."""
     desktop_proxy._pt_target_ready = False
     desktop_proxy._pt_target_probed_at = None
+    desktop_proxy._target_model_unavailable_at = None
     yield
     desktop_proxy._pt_target_ready = False
     desktop_proxy._pt_target_probed_at = None
+    desktop_proxy._target_model_unavailable_at = None
 
 
 def _retarget(path: str) -> str:
@@ -908,8 +910,11 @@ def test_operator_override_pins_the_reservation_back(monkeypatch):
 def test_overflow_never_targets_the_live_reservation(monkeypatch):
     """FC-degraded-fallback-consumes-protected-budget across the migration."""
     monkeypatch.delenv(desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV, raising=False)
-    assert desktop_proxy._overflow_model("gemini-2.5-flash") == "gemini-3.1-flash-lite"
-    assert desktop_proxy._overflow_model("gemini-3.1-flash-lite") == "gemini-2.5-flash-lite"
+    ladder = desktop_proxy.ptr.resolve_overflow_ladder
+    assert ladder(pt_model="gemini-2.5-flash")[0] == "gemini-3.1-flash-lite"
+    assert ladder(pt_model="gemini-3.1-flash-lite")[0] == "gemini-2.5-flash-lite"
+    for pt in ("gemini-2.5-flash", "gemini-3.1-flash-lite", "gemini-2.5-flash-lite"):
+        assert pt not in ladder(pt_model=pt)
 
 
 def test_overflow_plan_is_empty_for_traffic_that_cannot_exhaust_the_reservation(monkeypatch):
@@ -923,7 +928,39 @@ def test_overflow_plan_probes_the_target_before_paying_on_demand(monkeypatch):
     assert plan == [
         ("gemini-3.1-flash-lite", "dedicated"),
         ("gemini-3.1-flash-lite", "shared"),
+        ("gemini-2.5-flash-lite", "shared"),
     ]
+
+
+def test_overflow_skips_a_target_the_project_cannot_call(monkeypatch):
+    """Publisher models are enabled per project. Keeping an unreachable rung in
+    the plan would spend a round trip to 404 on every overflow request."""
+    monkeypatch.delenv(desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV, raising=False)
+    desktop_proxy._record_target_model_unavailable()
+    assert desktop_proxy._overflow_plan("gemini-2.5-flash") == [("gemini-2.5-flash-lite", "shared")]
+
+
+def test_pro_falls_back_when_the_target_is_not_enabled_for_the_project(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    desktop_proxy._record_target_model_unavailable()
+    assert _retarget("models/gemini-2.5-pro:generateContent") == (
+        f"models/{desktop_proxy._QUOTA_DEMOTION_MODEL}:generateContent"
+    )
+
+
+def test_an_unavailable_target_cannot_be_considered_a_live_reservation():
+    """A model the project cannot call cannot be holding prepaid capacity."""
+    desktop_proxy._record_pt_target_observation(True)
+    assert desktop_proxy._pt_target_is_ready() is True
+    desktop_proxy._record_target_model_unavailable()
+    assert desktop_proxy._pt_target_is_ready() is False
+
+
+def test_model_unavailability_is_distinguished_from_capacity_conditions():
+    not_enabled = "Publisher model `projects/p/locations/l/publishers/google/models/m` was not found"
+    assert desktop_proxy.ptr.is_model_unavailable(404, not_enabled)
+    assert not desktop_proxy.ptr.is_model_unavailable(429, "Exceeded the Provisioned Throughput.")
+    assert not desktop_proxy._overflow_triggered(404, not_enabled)
 
 
 def test_overflow_can_be_disabled_for_an_emergency(monkeypatch):
@@ -1210,3 +1247,68 @@ def test_a_new_instance_probes_immediately_regardless_of_uptime(monkeypatch):
 
     desktop_proxy._record_pt_target_observation(False)
     assert desktop_proxy._pt_probe_due() is False
+
+
+def _model_not_found_response(url: str) -> httpx.Response:
+    model = url.rsplit("/", 1)[-1]
+    return httpx.Response(
+        404,
+        request=httpx.Request("POST", url),
+        json={
+            "error": {
+                "code": 404,
+                "message": (
+                    f"Publisher model `projects/based-hardware/locations/us-central1"
+                    f"/publishers/google/models/{model}` was not found or your project "
+                    f"does not have access to it."
+                ),
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_pro_recovers_when_the_target_model_is_not_enabled(monkeypatch):
+    """Observed in production 2026-08-18: every gemini-3.x model was listed in
+    the global publisher catalog and 404 on the project-scoped endpoint. A Pro
+    request remapped onto it must still be served, not fail."""
+    client = _ScriptedClient([_model_not_found_response, _ok_response])
+    routed = _install_proxy_doubles(monkeypatch, client)
+
+    response = await desktop_proxy._proxy(make_request(), "models/gemini-2.5-pro:generateContent", False, "user")
+
+    assert response.status_code == 200
+    assert routed == [
+        ("gemini-3.1-flash-lite", ""),
+        ("gemini-2.5-flash-lite", "shared"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_one_404_stops_the_whole_fleet_retrying_a_dead_model(monkeypatch):
+    """The latch is what keeps a project-wide access gap from costing a wasted
+    round trip on every single request."""
+    client = _ScriptedClient([_model_not_found_response, _ok_response, _ok_response])
+    routed = _install_proxy_doubles(monkeypatch, client)
+
+    await desktop_proxy._proxy(make_request(), "models/gemini-2.5-pro:generateContent", False, "user")
+    assert desktop_proxy._target_model_believed_available() is False
+
+    await desktop_proxy._proxy(make_request(), "models/gemini-2.5-pro:generateContent", False, "user")
+    # Second request goes straight to a model the project can call.
+    assert routed[-1] == ("gemini-2.5-flash-lite", "")
+
+
+@pytest.mark.asyncio
+async def test_access_granted_later_promotes_without_a_deploy(monkeypatch):
+    """Availability is re-checked on the same TTL as capacity, so enabling
+    gemini-3.x for the project recovers the routing on its own."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    clock = {"now": 1_000.0}
+    monkeypatch.setattr(desktop_proxy.time, "monotonic", lambda: clock["now"])
+
+    desktop_proxy._record_target_model_unavailable()
+    assert _retarget("models/gemini-2.5-pro:generateContent") != ("models/gemini-3.1-flash-lite:generateContent")
+
+    clock["now"] += desktop_proxy._PT_PROBE_TTL_SECONDS + 1
+    assert _retarget("models/gemini-2.5-pro:generateContent") == ("models/gemini-3.1-flash-lite:generateContent")

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -1601,3 +1601,38 @@ async def test_streaming_unreachable_model_falls_back_and_leaks_no_provider_slot
     assert closed == 2
     assert semaphore.locked() is False
     assert desktop_proxy._model_believed_available("gemini-3.1-flash-lite") is False
+
+
+@pytest.mark.parametrize("target_reachable", [True, False])
+@pytest.mark.parametrize("reservation_promoted", [True, False])
+def test_server_paid_traffic_never_dispatches_gemini_2_5_pro(monkeypatch, target_reachable, reservation_promoted):
+    """gemini-2.5-pro is $10.00/1M out — 6.7x gemini-3.1-flash-lite and 25x
+    gemini-2.5-flash-lite. No combination of reservation state and learned
+    reachability may leave a server-paid request actually being served by it.
+
+    MODEL_FALLBACKS still lists a chain for it because a client may still
+    *request* it (it stays proxy-allowlisted, and BYOK users pay for it
+    themselves), but no server-paid request reaches dispatch as Pro.
+    """
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    if reservation_promoted:
+        desktop_proxy._record_pt_target_observation(True)
+    if not target_reachable:
+        desktop_proxy._record_model_unavailable(desktop_proxy.VERTEX_PT_TARGET_MODEL)
+
+    served = _retarget("models/gemini-2.5-pro:generateContent")
+
+    assert "gemini-2.5-pro" not in served
+    expected = (
+        f"models/{desktop_proxy.VERTEX_PT_TARGET_MODEL}:generateContent"
+        if target_reachable
+        else f"models/{desktop_proxy._QUOTA_DEMOTION_MODEL}:generateContent"
+    )
+    assert served == expected
+
+
+def test_byok_pro_is_still_honoured_because_the_user_pays_for_it(monkeypatch):
+    """The guarantee above is about company-paid spend, not about banning the
+    model: a BYOK user asking for Pro gets Pro on their own key."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: "user-key")
+    assert _retarget("models/gemini-2.5-pro:generateContent") == ("models/gemini-2.5-pro:generateContent")

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -853,14 +853,16 @@ async def test_streaming_defers_resource_acquisition_until_body_iteration(monkey
 
 @pytest.fixture(autouse=True)
 def _reset_pt_promotion_state():
-    """The observed-capacity latch is module state; never leak it between tests."""
+    """Observed capacity and learned reachability are module state; never leak
+    them between tests. Reachability is a per-model table now, so clearing one
+    target field is no longer enough."""
     desktop_proxy._pt_target_ready = False
     desktop_proxy._pt_target_probed_at = None
-    desktop_proxy._target_model_unavailable_at = None
+    desktop_proxy._model_unavailable_at.clear()
     yield
     desktop_proxy._pt_target_ready = False
     desktop_proxy._pt_target_probed_at = None
-    desktop_proxy._target_model_unavailable_at = None
+    desktop_proxy._model_unavailable_at.clear()
 
 
 def _retarget(path: str) -> str:
@@ -932,27 +934,27 @@ def test_overflow_plan_probes_the_target_before_paying_on_demand(monkeypatch):
     ]
 
 
-def test_overflow_skips_a_target_the_project_cannot_call(monkeypatch):
-    """Publisher models are enabled per project. Keeping an unreachable rung in
-    the plan would spend a round trip to 404 on every overflow request."""
+def test_overflow_skips_a_rung_traffic_has_proved_unreachable(monkeypatch):
+    """Keeping an unreachable rung in the plan would spend a round trip to 404
+    on every overflow request."""
     monkeypatch.delenv(desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV, raising=False)
-    desktop_proxy._record_target_model_unavailable()
+    desktop_proxy._record_model_unavailable(desktop_proxy.VERTEX_PT_TARGET_MODEL)
     assert desktop_proxy._overflow_plan("gemini-2.5-flash") == [("gemini-2.5-flash-lite", "shared")]
 
 
-def test_pro_falls_back_when_the_target_is_not_enabled_for_the_project(monkeypatch):
+def test_pro_falls_back_when_the_target_is_unreachable(monkeypatch):
     monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
-    desktop_proxy._record_target_model_unavailable()
+    desktop_proxy._record_model_unavailable(desktop_proxy.VERTEX_PT_TARGET_MODEL)
     assert _retarget("models/gemini-2.5-pro:generateContent") == (
         f"models/{desktop_proxy._QUOTA_DEMOTION_MODEL}:generateContent"
     )
 
 
 def test_an_unavailable_target_cannot_be_considered_a_live_reservation():
-    """A model the project cannot call cannot be holding prepaid capacity."""
+    """A model that cannot be reached cannot be holding prepaid capacity."""
     desktop_proxy._record_pt_target_observation(True)
     assert desktop_proxy._pt_target_is_ready() is True
-    desktop_proxy._record_target_model_unavailable()
+    desktop_proxy._record_model_unavailable(desktop_proxy.VERTEX_PT_TARGET_MODEL)
     assert desktop_proxy._pt_target_is_ready() is False
 
 
@@ -968,11 +970,15 @@ def test_overflow_can_be_disabled_for_an_emergency(monkeypatch):
     assert desktop_proxy._overflow_plan("gemini-2.5-flash") == []
 
 
-def test_retarget_thinking_swaps_a_budget_for_a_level_across_families():
-    body = json.dumps({"generationConfig": {"maxOutputTokens": 2048, "thinkingConfig": {"thinkingBudget": 1024}}})
-    rewritten = json.loads(desktop_proxy._retarget_thinking(body.encode(), "gemini-3.1-flash-lite"))
-    assert rewritten["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "minimal"}
-    assert rewritten["generationConfig"]["maxOutputTokens"] == 2048
+def test_thinking_budget_is_sent_to_every_model_family():
+    """Measured 2026-08-18: gemini-3.1-flash-lite honors thinkingBudget
+    (0 -> thoughts 0, 1024 -> thoughts 278) and 2.5 models reject
+    thinkingLevel with HTTP 400. One body is therefore valid on both families,
+    so a fallback that crosses families rewrites nothing."""
+    body = desktop_proxy._sanitize(b'{"contents":[]}', "generateContent")
+    assert json.loads(body)["generationConfig"]["thinkingConfig"] == {
+        "thinkingBudget": desktop_proxy._DEFAULT_THINKING_BUDGET
+    }
 
 
 @pytest.mark.asyncio
@@ -1119,9 +1125,10 @@ async def test_generic_rate_limiting_is_not_converted_into_extra_spend(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_overflow_rewrites_thinking_for_the_new_model_family(monkeypatch):
-    """gemini-3.1-flash-lite ignores thinkingBudget, so an un-retargeted body
-    would uncap reasoning tokens that bill as output."""
+async def test_overflow_keeps_the_bounded_generation_config(monkeypatch):
+    """Overflow crosses model families, and the caps that bound paid output
+    must survive the crossing. thinkingBudget is honored by both families
+    (measured 2026-08-18), so the body is forwarded rather than rewritten."""
     client = _ScriptedClient([_pt_exhausted_response, _pt_exhausted_response, _ok_response])
     _install_proxy_doubles(monkeypatch, client)
 
@@ -1130,7 +1137,7 @@ async def test_overflow_rewrites_thinking_for_the_new_model_family(monkeypatch):
     reserved = json.loads(client.calls[0][2])["generationConfig"]
     overflowed = json.loads(client.calls[-1][2])["generationConfig"]
     assert reserved["thinkingConfig"] == {"thinkingBudget": desktop_proxy._DEFAULT_THINKING_BUDGET}
-    assert overflowed["thinkingConfig"] == {"thinkingLevel": "minimal"}
+    assert overflowed["thinkingConfig"] == {"thinkingBudget": desktop_proxy._DEFAULT_THINKING_BUDGET}
     assert overflowed["maxOutputTokens"] == desktop_proxy._SERVER_PAID_MAX_OUTPUT_TOKENS
 
 
@@ -1234,6 +1241,17 @@ def test_migration_contract_is_documented():
     assert desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV in text
     assert desktop_proxy._OVERFLOW_ENABLED_ENV in text
     assert desktop_proxy.ptr.REQUEST_TYPE_HEADER in text
+    # The generalized fallback table and the endpoint split are operator-facing
+    # behaviour: an operator reading only this note must be able to predict
+    # which model and which endpoint a degraded request lands on.
+    assert "MODEL_FALLBACKS" in text
+    assert desktop_proxy.ptr.MULTI_REGION_HOST in text
+    assert f"locations/{desktop_proxy.ptr.MULTI_REGION_LOCATION}" in text
+    assert desktop_proxy._MULTI_REGION_LOCATION_ENV in text
+    for model, chain in desktop_proxy.ptr.MODEL_FALLBACKS.items():
+        assert model in text, f"{model} has a declared fallback chain but is undocumented"
+        for rung in chain:
+            assert rung in text
 
 
 def test_a_new_instance_probes_immediately_regardless_of_uptime(monkeypatch):
@@ -1292,7 +1310,7 @@ async def test_one_404_stops_the_whole_fleet_retrying_a_dead_model(monkeypatch):
     routed = _install_proxy_doubles(monkeypatch, client)
 
     await desktop_proxy._proxy(make_request(), "models/gemini-2.5-pro:generateContent", False, "user")
-    assert desktop_proxy._target_model_believed_available() is False
+    assert desktop_proxy._model_believed_available(desktop_proxy.VERTEX_PT_TARGET_MODEL) is False
 
     await desktop_proxy._proxy(make_request(), "models/gemini-2.5-pro:generateContent", False, "user")
     # Second request goes straight to a model the project can call.
@@ -1307,8 +1325,278 @@ async def test_access_granted_later_promotes_without_a_deploy(monkeypatch):
     clock = {"now": 1_000.0}
     monkeypatch.setattr(desktop_proxy.time, "monotonic", lambda: clock["now"])
 
-    desktop_proxy._record_target_model_unavailable()
+    desktop_proxy._record_model_unavailable(desktop_proxy.VERTEX_PT_TARGET_MODEL)
     assert _retarget("models/gemini-2.5-pro:generateContent") != ("models/gemini-3.1-flash-lite:generateContent")
 
     clock["now"] += desktop_proxy._PT_PROBE_TTL_SECONDS + 1
     assert _retarget("models/gemini-2.5-pro:generateContent") == ("models/gemini-3.1-flash-lite:generateContent")
+
+
+# --- Endpoint selection ----------------------------------------------------
+
+
+def test_gemini_3_x_is_routed_to_the_us_multi_region_endpoint(monkeypatch):
+    """The production defect behind #11826.
+
+    Measured 2026-08-18 with credentials that can invoke inference:
+    gemini-3.1-flash-lite answers 200 on locations/us and 404s on us-central1,
+    us-east5, us-west1, europe-west4 and asia-northeast1. The proxy built a
+    regional URL for every model, so no 3.x request could ever succeed. It was
+    never a project access gap.
+    """
+    monkeypatch.delenv(desktop_proxy._MULTI_REGION_LOCATION_ENV, raising=False)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+    assert desktop_proxy._vertex_url("gemini-3.1-flash-lite", "generateContent") == (
+        "https://aiplatform.googleapis.com/v1/projects/based-hardware/locations/us"
+        "/publishers/google/models/gemini-3.1-flash-lite:generateContent"
+    )
+
+
+def test_the_multi_region_residency_pin_is_us_and_is_operator_flippable(monkeypatch):
+    """`global` may serve a request from anywhere in the world; `us` keeps
+    inference in the US multi-region, matching where every other server-paid
+    Gemini call in this service already runs. Users' conversations and
+    transcripts go through this path, so widening residency must be a
+    deliberate operator flip, never a side effect of a routing change."""
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    monkeypatch.delenv(desktop_proxy._MULTI_REGION_LOCATION_ENV, raising=False)
+    assert "/locations/us/" in str(desktop_proxy._vertex_url("gemini-3.1-flash-lite", "generateContent"))
+
+    monkeypatch.setenv(desktop_proxy._MULTI_REGION_LOCATION_ENV, "global")
+    assert "/locations/global/" in str(desktop_proxy._vertex_url("gemini-3.1-flash-lite", "generateContent"))
+
+
+def test_the_reservation_model_is_never_routed_off_its_region(monkeypatch):
+    """FC-degraded-fallback-consumes-protected-budget / the 2026-08-04 incident.
+
+    gemini-2.5-flash ALSO answers 200 on locations/us and locations/global
+    (trafficType=ON_DEMAND), so "route whatever answers multi-region to
+    multi-region" is a tempting simplification. It would bypass the 5 GSU
+    us-central1 Provisioned Throughput order and bill on-demand while the
+    reservation kept charging ~$290/day — paying twice for the same tokens,
+    which is precisely the 2026-08-04 double-pay regression recorded in
+    docs/vertex-pt-flash.md. The endpoint rule is by model family, never by
+    what happens to answer.
+    """
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+    monkeypatch.setenv(desktop_proxy._MULTI_REGION_LOCATION_ENV, "global")
+    url = desktop_proxy._vertex_url("gemini-2.5-flash", "generateContent")
+    assert url == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/based-hardware/locations/us-central1"
+        "/publishers/google/models/gemini-2.5-flash:generateContent"
+    )
+    assert "locations/global" not in url
+    assert "locations/us/" not in url
+    assert "//aiplatform.googleapis.com" not in url
+
+
+@pytest.mark.asyncio
+async def test_a_fallback_across_families_also_crosses_endpoints(monkeypatch):
+    """The reservation and the model that absorbs its overflow do not share a
+    location, so location must be resolved per model, not once per process."""
+
+    async def token():
+        return "token"
+
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy._vertex_tokens, "get_access_token", token)
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "based-hardware")
+    monkeypatch.setenv("GCP_LOCATION", "us-central1")
+
+    reserved = await desktop_proxy._upstream(
+        "models/gemini-2.5-flash:generateContent", "gemini-2.5-flash", "generateContent", {}
+    )
+    overflow = await desktop_proxy._upstream(
+        "models/gemini-3.1-flash-lite:generateContent", "gemini-3.1-flash-lite", "generateContent", {}
+    )
+    assert reserved.region == "us-central1"
+    assert overflow.region == "us"
+    # Multi-region labels must survive the telemetry sanitizer, not log as none.
+    assert desktop_proxy._safe_region(overflow.region) == "us"
+
+
+# --- Generalized fallback chains -------------------------------------------
+
+
+def test_every_routable_model_declares_a_fallback_chain():
+    """A model the proxy can route to but that has no declared chain would have
+    no defined behaviour when it stops answering."""
+    text_models = {m for m in desktop_proxy._ALLOWED_MODELS}
+    assert text_models <= set(desktop_proxy.ptr.MODEL_FALLBACKS)
+
+
+def test_reachability_is_learned_per_model_not_globally(monkeypatch):
+    """One dead model must not take the rest of the ladder down with it."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    desktop_proxy._record_model_unavailable("gemini-3.1-flash-lite")
+    assert desktop_proxy._model_believed_available("gemini-3.1-flash-lite") is False
+    assert desktop_proxy._model_believed_available("gemini-2.5-flash-lite") is True
+    assert desktop_proxy._model_believed_available("gemini-2.5-flash") is True
+
+
+def test_a_new_instance_believes_every_model_reachable_regardless_of_uptime(monkeypatch):
+    """Same arbitrary-origin trap as the probe timestamp: time.monotonic() on a
+    fresh container can be smaller than the TTL, so an observation seeded with
+    0.0 would mark every model dead for the first 10 minutes of the instance's
+    life. Absence of a key, not a zero, means 'never observed'."""
+    monkeypatch.setattr(desktop_proxy.time, "monotonic", lambda: 1.0)
+    desktop_proxy._model_unavailable_at.clear()
+    for model in desktop_proxy.ptr.MODEL_FALLBACKS:
+        assert desktop_proxy._model_believed_available(model) is True
+
+
+def test_a_success_clears_a_stale_unreachable_latch(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    desktop_proxy._record_model_unavailable("gemini-3.1-flash-lite")
+    assert desktop_proxy._model_believed_available("gemini-3.1-flash-lite") is False
+    desktop_proxy._record_model_available("gemini-3.1-flash-lite")
+    assert desktop_proxy._model_believed_available("gemini-3.1-flash-lite") is True
+
+
+def test_byok_traffic_never_teaches_the_reachability_table(monkeypatch):
+    """BYOK goes to AI Studio on the user's own key, so its answers say nothing
+    about what this project can reach on Vertex. One user's key must not be
+    able to latch a model dead for the whole fleet."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: "user-key")
+    desktop_proxy._record_model_unavailable("gemini-3.1-flash-lite")
+    assert desktop_proxy._model_unavailable_at == {}
+    assert desktop_proxy._recovery_plan("gemini-3.1-flash-lite", 404, "publisher model was not found") == []
+
+
+@pytest.mark.parametrize("pt_model", ["gemini-2.5-flash", "gemini-3.1-flash-lite"])
+def test_no_recovery_plan_ever_routes_onto_the_reservation(monkeypatch, pt_model):
+    """FC-degraded-fallback-consumes-protected-budget, through the proxy rather
+    than the policy module, at both PT states."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.delenv(desktop_proxy._OVERFLOW_MODEL_OVERRIDE_ENV, raising=False)
+    monkeypatch.setenv(desktop_proxy._PT_MODEL_OVERRIDE_ENV, pt_model)
+    not_found = "Publisher model was not found or your project does not have access to it."
+    exhausted = "Too many requests. Exceeded the provisioned throughput."
+    for model in sorted(desktop_proxy.ptr.MODEL_FALLBACKS):
+        desktop_proxy._model_unavailable_at.clear()
+        for status, message in ((404, not_found), (429, exhausted)):
+            plan = desktop_proxy._recovery_plan(model, status, message)
+            assert pt_model not in [rung for rung, _ in plan], (model, status, plan)
+
+
+def test_a_dead_model_is_never_offered_its_own_name_as_a_fallback(monkeypatch):
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    plan = desktop_proxy._recovery_plan("gemini-3.1-flash-lite", 404, "publisher model was not found")
+    assert "gemini-3.1-flash-lite" not in [rung for rung, _ in plan]
+
+
+def test_a_terminal_model_has_no_recovery_plan(monkeypatch):
+    """gemini-2.5-flash-lite is the floor of the ladder. Inventing a fallback
+    for it would promote the client-pinned lanes onto a costlier model."""
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    assert desktop_proxy._recovery_plan("gemini-2.5-flash-lite", 404, "publisher model was not found") == []
+
+
+@pytest.mark.asyncio
+async def test_a_404_on_any_model_falls_back_and_latches_it(monkeypatch):
+    """Generalized from the migration target to every routable model: the
+    second request must not repeat the round trip that already failed."""
+    client = _ScriptedClient([_model_not_found_response, _ok_response, _ok_response])
+    routed = _install_proxy_doubles(monkeypatch, client)
+    desktop_proxy._record_pt_target_observation(True)  # 3.1-flash-lite now holds PT
+
+    response = await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:generateContent", False, "user")
+
+    assert response.status_code == 200
+    # Flash is served by the promoted reservation, 404s, and steps to the floor.
+    assert routed == [("gemini-3.1-flash-lite", ""), ("gemini-2.5-flash-lite", "shared")]
+    assert desktop_proxy._model_believed_available("gemini-3.1-flash-lite") is False
+
+    # The second request never re-attempts the latched model: a model that
+    # cannot be reached cannot be holding prepaid capacity, so the reservation
+    # demotes back to gemini-2.5-flash and serves flash traffic directly.
+    await desktop_proxy._proxy(make_request(), "models/gemini-2.5-flash:generateContent", False, "user")
+    assert routed[-1] == ("gemini-2.5-flash", "")
+    assert "gemini-3.1-flash-lite" not in [model for model, _ in routed[2:]]
+
+
+@pytest.mark.asyncio
+async def test_streaming_unreachable_model_falls_back_and_leaks_no_provider_slot(monkeypatch):
+    """The 404 ladder gets the same lifecycle guarantee as the overflow ladder:
+    every refused attempt is closed and its provider slot released."""
+    opened: list[str] = []
+    closed = 0
+
+    class NotFound:
+        status_code = 404
+        text = "Publisher model `.../models/gemini-3.1-flash-lite` was not found or your project does not have access."
+
+        async def aread(self):
+            return self.text.encode()
+
+        async def aiter_bytes(self):
+            yield b""
+
+    class Served:
+        status_code = 200
+        text = ""
+
+        async def aread(self):
+            return b""
+
+        async def aiter_bytes(self):
+            yield b'data: {"usageMetadata":{"totalTokenCount":3}}\r\n\r\n'
+
+    class StreamContext:
+        def __init__(self, response):
+            self._response = response
+
+        async def __aenter__(self):
+            return self._response
+
+        async def __aexit__(self, *_args):
+            nonlocal closed
+            closed += 1
+
+    class Client:
+        def stream(self, _method, url, **_kwargs):
+            opened.append(url)
+            return StreamContext(NotFound() if len(opened) < 2 else Served())
+
+    async def route(path, model, action, query, *, request_type=None):
+        return desktop_proxy.UpstreamRoute(
+            f"https://provider.invalid/{model}",
+            {desktop_proxy.ptr.REQUEST_TYPE_HEADER: request_type or "shared"},
+            {},
+            "vertex_ai",
+            "adc",
+            "us-central1",
+        )
+
+    async def passthrough(_request, awaitable):
+        return await awaitable
+
+    semaphore = asyncio.Semaphore(1)
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy, "_upstream", route)
+    monkeypatch.setattr(desktop_proxy, "_cancel_on_disconnect", passthrough)
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_stream_client", lambda: Client())
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: semaphore)
+
+    telemetry = desktop_proxy.ProxyTelemetry(make_request(), streaming=True)
+    primary = await route("p", "gemini-3.1-flash-lite", "streamGenerateContent", {})
+    emitted = [
+        chunk
+        async for chunk in desktop_proxy._stream_provider(
+            make_request(),
+            primary,
+            b'{"generationConfig":{"thinkingConfig":{"thinkingBudget":1024}}}',
+            telemetry,
+            model="gemini-3.1-flash-lite",
+            action="streamGenerateContent",
+            query={},
+        )
+    ]
+
+    assert b"usageMetadata" in b"".join(emitted)
+    assert [url.rsplit("/", 1)[-1] for url in opened] == ["gemini-3.1-flash-lite", "gemini-2.5-flash-lite"]
+    assert closed == 2
+    assert semaphore.locked() is False
+    assert desktop_proxy._model_believed_available("gemini-3.1-flash-lite") is False

--- a/backend/tests/unit/test_vertex_pt_routing.py
+++ b/backend/tests/unit/test_vertex_pt_routing.py
@@ -59,21 +59,23 @@ def test_overflow_traffic_is_explicitly_shared_after_migration():
     assert ptr.request_type_for(model=overflow, pt_model=pt) == 'shared'
 
 
-def test_2_5_family_keeps_an_integer_thinking_budget():
-    assert ptr.thinking_config_for('gemini-2.5-flash', budget=1024) == {'thinkingBudget': 1024}
-    assert ptr.thinking_config_for('gemini-2.5-flash-lite', budget=0) == {'thinkingBudget': 0}
+def test_thinking_budget_is_the_one_option_both_families_accept():
+    """Measured 2026-08-18, not read from documentation.
+
+    gemini-3.1-flash-lite honors `thinkingBudget` on the global endpoint
+    (budget 0 -> thoughts 0; budget 1024 -> thoughts 278), and 2.5 models
+    reject `thinkingLevel` with HTTP 400 'thinking_level is not supported by
+    this model'. So `thinkingBudget` works on both families and `thinkingLevel`
+    works on neither universally: there is no family split to make.
+    """
+    assert ptr.thinking_config_for(budget=1024) == {'thinkingBudget': 1024}
+    assert ptr.thinking_config_for(budget=0) == {'thinkingBudget': 0}
 
 
-def test_3_x_family_gets_a_thinking_level_never_a_budget():
-    """thinkingBudget is schema-valid on 3.x and then ignored, so an unbounded
-    reasoning trace would bill as output at $1.50/1M."""
-    config = ptr.thinking_config_for('gemini-3.1-flash-lite', budget=1024)
-    assert config == {'thinkingLevel': 'minimal'}
-    assert 'thinkingBudget' not in config
-
-
-def test_migration_target_never_receives_a_thinking_budget():
-    assert 'thinkingBudget' not in ptr.thinking_config_for(ptr.PT_MODEL_TARGET, budget=1024)
+def test_no_model_is_ever_sent_a_thinking_level():
+    """A 2.5 model answers 400 to `thinkingLevel`, so emitting one anywhere
+    would break every request that crossed onto the 2.5 family."""
+    assert 'thinkingLevel' not in ptr.thinking_config_for(budget=1024)
 
 
 def test_saturated_reservation_is_distinguished_from_generic_rate_limiting():
@@ -91,3 +93,158 @@ def test_absent_capacity_is_not_read_as_exhausted_capacity():
 def test_pt_constants_stay_distinct():
     assert ptr.PT_MODEL_CURRENT != ptr.PT_MODEL_TARGET
     assert ptr.PT_MODEL_TARGET in ptr.OVERFLOW_PREFERENCE
+
+
+# --- Endpoint selection ----------------------------------------------------
+
+
+def test_gemini_3_x_is_addressed_on_the_us_multi_region_endpoint():
+    """Measured 2026-08-18: gemini-3.1-flash-lite answers 200 on locations/us
+    and locations/global, and 404s on us-central1, us-east5, us-west1,
+    europe-west4 and asia-northeast1. The 404 was an endpoint-shape error,
+    never an access gap.
+
+    `us` rather than `global` is a data-residency choice: `global` may serve a
+    request from anywhere in the world, while every other server-paid call in
+    this service runs in us-central1. The host is plain
+    `aiplatform.googleapis.com` — `us-aiplatform.googleapis.com` is not a valid
+    host (400 Invalid hostname).
+    """
+    assert ptr.vertex_endpoint(model='gemini-3.1-flash-lite', regional_location='us-central1') == (
+        'aiplatform.googleapis.com',
+        'us',
+    )
+
+
+def test_the_multi_region_default_is_us_and_stays_operator_overridable():
+    assert ptr.MULTI_REGION_LOCATION == 'us'
+    assert ptr.vertex_endpoint(
+        model='gemini-3.1-flash-lite', regional_location='us-central1', multi_region_location='global'
+    ) == ('aiplatform.googleapis.com', 'global')
+
+
+def test_the_reservation_model_stays_regional_even_though_global_would_answer():
+    """FC-degraded-fallback-consumes-protected-budget, and the 2026-08-04
+    double-pay incident.
+
+    gemini-2.5-flash ALSO answers on locations/us and locations/global
+    (measured: 200, trafficType=ON_DEMAND). Routing it there would bypass the
+    5 GSU us-central1 Provisioned Throughput order and bill on-demand while the
+    reservation kept charging ~$290/day — paying twice for the same tokens,
+    which is exactly what backend/docs/vertex-pt-flash.md records for
+    2026-08-04. The endpoint rule is therefore by model FAMILY, never
+    'multi-region for anything that answers multi-region'.
+    """
+    assert ptr.vertex_endpoint(model=ptr.PT_MODEL_CURRENT, regional_location='us-central1') == (
+        'us-central1-aiplatform.googleapis.com',
+        'us-central1',
+    )
+    assert ptr.uses_multi_region_endpoint(ptr.PT_MODEL_CURRENT) is False
+
+
+@pytest.mark.parametrize(
+    'model', ['gemini-2.5-flash', 'gemini-2.5-flash-lite', 'gemini-2.5-pro', 'gemini-embedding-001']
+)
+def test_every_non_3_x_model_keeps_the_regional_endpoint(model):
+    host, location = ptr.vertex_endpoint(model=model, regional_location='us-central1')
+    assert host == 'us-central1-aiplatform.googleapis.com'
+    assert location == 'us-central1'
+
+
+def test_location_is_resolved_per_model_not_once_per_process():
+    """A fallback chain crosses families, so the reservation and the model that
+    absorbs its overflow can legitimately live on different endpoints."""
+    reserved = ptr.vertex_endpoint(model='gemini-2.5-flash', regional_location='us-central1')
+    overflow = ptr.vertex_endpoint(model='gemini-3.1-flash-lite', regional_location='us-central1')
+    assert reserved != overflow
+
+
+# --- Fallback chains -------------------------------------------------------
+
+
+def test_every_declared_fallback_is_itself_a_declared_model():
+    """A chain that names an undeclared model has no chain of its own, so a
+    second failure on it would have nowhere to go."""
+    for model, chain in ptr.MODEL_FALLBACKS.items():
+        for rung in chain:
+            assert rung in ptr.MODEL_FALLBACKS, f'{model} falls back to undeclared {rung}'
+
+
+def test_no_chain_contains_its_own_head():
+    for model, chain in ptr.MODEL_FALLBACKS.items():
+        assert model not in chain
+
+
+def test_every_chain_is_non_increasing_in_output_price():
+    """A degraded request must never cost more than the request it replaces."""
+    for model, chain in ptr.MODEL_FALLBACKS.items():
+        prices = [ptr.PRICE_PER_MTOK_OUT[m] for m in (model, *chain) if m in ptr.PRICE_PER_MTOK_OUT]
+        assert prices == sorted(prices, reverse=True), f'{model} chain {chain} climbs in price'
+
+
+def test_the_cheapest_text_model_is_terminal():
+    """gemini-2.5-flash-lite is the floor of the ladder AND the model the
+    clients pin directly (macOS ModelQoS.lightweight, Windows
+    memory/goals/insight). Any chain here would promote those lanes onto a
+    costlier model."""
+    assert ptr.MODEL_FALLBACKS['gemini-2.5-flash-lite'] == ()
+    cheapest = min(ptr.PRICE_PER_MTOK_OUT, key=lambda m: ptr.PRICE_PER_MTOK_OUT[m])
+    assert cheapest == 'gemini-2.5-flash-lite'
+
+
+@pytest.mark.parametrize('pt_model', ['gemini-2.5-flash', 'gemini-3.1-flash-lite'])
+@pytest.mark.parametrize('model', sorted(ptr.MODEL_FALLBACKS))
+def test_no_fallback_chain_ever_routes_onto_the_reservation(model, pt_model):
+    """FC-degraded-fallback-consumes-protected-budget, at every PT state."""
+    assert pt_model not in ptr.resolve_fallback_chain(model=model, pt_model=pt_model)
+
+
+def test_chain_steps_past_the_reservation_after_migration():
+    before = ptr.resolve_fallback_chain(model='gemini-2.5-pro', pt_model='gemini-2.5-flash')
+    after = ptr.resolve_fallback_chain(model='gemini-2.5-pro', pt_model='gemini-3.1-flash-lite')
+    assert before == ('gemini-3.1-flash-lite', 'gemini-2.5-flash-lite')
+    assert after == ('gemini-2.5-flash-lite',)
+
+
+def test_unreachable_rungs_are_dropped_from_the_chain():
+    chain = ptr.resolve_fallback_chain(
+        model='gemini-2.5-pro',
+        pt_model='gemini-2.5-flash',
+        unreachable=('gemini-3.1-flash-lite',),
+    )
+    assert chain == ('gemini-2.5-flash-lite',)
+
+
+def test_a_terminal_model_has_nowhere_to_fall_back_to():
+    assert ptr.resolve_fallback_chain(model='gemini-2.5-flash-lite', pt_model='gemini-2.5-flash') == ()
+    assert ptr.resolve_fallback_chain(model='gemini-embedding-001', pt_model='gemini-2.5-flash') == ()
+
+
+def test_fallback_override_replaces_the_chain_but_not_the_protection():
+    assert ptr.resolve_fallback_chain(
+        model='gemini-2.5-flash', pt_model='gemini-2.5-flash', override='gemini-2.5-flash-lite'
+    ) == ('gemini-2.5-flash-lite',)
+    with pytest.raises(ValueError, match='protected reservation'):
+        ptr.resolve_fallback_chain(model='gemini-2.5-pro', pt_model='gemini-2.5-flash', override='gemini-2.5-flash')
+
+
+def test_override_can_never_point_a_model_at_itself():
+    """Otherwise a dead model would retry itself until the plan ran out."""
+    assert (
+        ptr.resolve_fallback_chain(
+            model='gemini-2.5-flash-lite', pt_model='gemini-2.5-flash', override='gemini-2.5-flash-lite'
+        )
+        == ()
+    )
+
+
+def test_overflow_ladder_and_the_reservation_chain_cannot_drift():
+    """Two tables describing the same degraded ladder; pin them together."""
+    assert ptr.MODEL_FALLBACKS[ptr.PT_MODEL_CURRENT] == ptr.OVERFLOW_PREFERENCE
+
+
+def test_exhaustion_matching_is_case_insensitive():
+    """The global endpoint answers with lowercase 'provisioned throughput'
+    where the regional one uses title case. Measured 2026-08-18."""
+    assert ptr.is_provisioned_capacity_exhausted(429, 'Too many requests. Exceeded the provisioned throughput.')
+    assert ptr.is_provisioned_capacity_exhausted(429, 'Too many requests. Exceeded the Provisioned Throughput.')

--- a/backend/utils/llm/vertex_pt_routing.py
+++ b/backend/utils/llm/vertex_pt_routing.py
@@ -1,9 +1,10 @@
 """Vertex Provisioned Throughput routing policy for company-paid Gemini text.
 
-Pure decision logic: which model serves company-paid text, which model absorbs
-overflow, how thinking is configured per model family, and when a pending PT
-order has become live. No I/O, no clock, no Redis — the proxy injects
-observations and owns every side effect, so every rule here is unit-testable.
+Pure decision logic: which model serves company-paid text, which endpoint a
+model is addressed at, which models may absorb its traffic when it cannot serve
+it, and when a pending PT order has become live. No I/O, no clock, no Redis —
+the proxy injects observations and owns every side effect, so every rule here
+is unit-testable without a network.
 
 Prices per 1M tokens (Vertex list, captured 2026-08-18):
 
@@ -19,6 +20,8 @@ absorb the lanes that clients already pin to `gemini-2.5-flash-lite`.
 """
 
 from __future__ import annotations
+
+from collections.abc import Iterable
 
 # --- Provisioned Throughput orders ----------------------------------------
 # The prepaid model today: 5 GSU, us-central1, flat ~$290.32/day until
@@ -41,39 +44,134 @@ PT_MODEL_TARGET = 'gemini-3.1-flash-lite'
 # dumping degraded traffic onto the budget the quota exists to protect.
 OVERFLOW_PREFERENCE = ('gemini-3.1-flash-lite', 'gemini-2.5-flash-lite')
 
+# --- Fallback chains -------------------------------------------------------
+# Output price per 1M tokens (Vertex list, captured 2026-08-18). Declared here
+# so the cost direction of every chain is checkable rather than asserted in
+# prose. Embedding has no output tokens and no substitute, so it is absent.
+PRICE_PER_MTOK_OUT: dict[str, float] = {
+    'gemini-2.5-flash-lite': 0.40,
+    'gemini-3.1-flash-lite': 1.50,
+    'gemini-2.5-flash': 2.50,
+    'gemini-2.5-pro': 10.00,
+}
+
+# Every model the proxy can route to declares, as data, the ordered models that
+# may serve its traffic when it cannot serve it itself. One reviewable table
+# beats per-model conditionals scattered through the proxy.
+#
+# Three invariants, all enforced by tests rather than convention:
+#   * every chain is non-increasing in output price, so a degraded request can
+#     never cost more than the request it replaces;
+#   * a chain never contains its own head, so a dead model cannot retry itself;
+#   * the model currently holding Provisioned Throughput is filtered out at
+#     resolution time (FC-degraded-fallback-consumes-protected-budget) —
+#     degraded traffic must not consume the reservation the quota protects.
+#
+# An empty chain means terminal: the model is the cheapest option in its lane
+# and there is nothing left to fall back to. `gemini-2.5-flash-lite` is the
+# floor of the text ladder and is also the model clients pin directly, so
+# giving it a chain would promote those lanes onto costlier models.
+MODEL_FALLBACKS: dict[str, tuple[str, ...]] = {
+    'gemini-2.5-pro': ('gemini-3.1-flash-lite', 'gemini-2.5-flash-lite'),
+    'gemini-2.5-flash': ('gemini-3.1-flash-lite', 'gemini-2.5-flash-lite'),
+    'gemini-3.1-flash-lite': ('gemini-2.5-flash-lite',),
+    'gemini-2.5-flash-lite': (),
+    'gemini-embedding-001': (),
+}
+
+# --- Where a model is served ----------------------------------------------
+# Vertex publishes most models on regional endpoints
+# (`{loc}-aiplatform.googleapis.com` + `locations/{loc}`). The Gemini 3.x
+# family is not served regionally at all: it needs the un-prefixed host plus a
+# multi-region `locations/{loc}` segment.
+#
+# Measured 2026-08-18 on `based-hardware` with credentials that can invoke
+# inference:
+#
+#     locations/us      gemini-3.1-flash-lite  -> 200 ON_DEMAND
+#     locations/global  gemini-3.1-flash-lite  -> 200 ON_DEMAND
+#     locations/us      + `dedicated` header   -> 429 provisioned throughput
+#     us-central1 / us-east5 / us-west1 / europe-west4 / asia-northeast1 -> 404
+#
+# So the 404 is an endpoint-shape error, not a project access gap — reading it
+# as "the project cannot call 3.x" sends you looking for an allowlist that does
+# not exist. The host is always plain `aiplatform.googleapis.com`;
+# `us-aiplatform.googleapis.com` is not a valid host (400 Invalid hostname),
+# only the `locations/{loc}` path segment changes.
+MULTI_REGION_ENDPOINT_FAMILIES = ('gemini-3',)
+MULTI_REGION_HOST = 'aiplatform.googleapis.com'
+# `us`, not `global`. Both answer, but `global` may serve a request from
+# anywhere in the world while `us` is the US multi-region. This product
+# processes users' personal conversations, transcripts and memories, and every
+# other server-paid Gemini call runs in `us-central1`, so `us` preserves the
+# existing data-residency posture. Widening it is a deliberate decision, not
+# something a routing change should make implicitly — which is why this is a
+# named default an operator can flip rather than a literal in a URL.
+MULTI_REGION_LOCATION = 'us'
+
 # Vertex routes a request to prepaid or on-demand capacity by header.
 # `dedicated` returns 429 instead of silently spilling to pay-as-you-go.
 REQUEST_TYPE_HEADER = 'X-Vertex-AI-LLM-Request-Type'
 REQUEST_TYPE_DEDICATED = 'dedicated'
 REQUEST_TYPE_SHARED = 'shared'
 
-# Gemini 3.x replaced the integer `thinkingBudget` with a coarse
-# `thinkingLevel`, and thinking cannot be disabled: the floor is 'minimal'.
-# Thinking tokens bill as OUTPUT, so sending a 2.5-style budget to a 3.x model
-# risks unbounded reasoning at $1.50/1M with no cap that the model honors.
-_THINKING_LEVEL_FAMILIES = ('gemini-3',)
-THINKING_LEVEL_MINIMAL = 'minimal'
-
 
 def _normalize(model: str) -> str:
     return (model or '').strip()
 
 
-def uses_thinking_level(model: str) -> bool:
-    """Whether a model takes `thinkingLevel` instead of `thinkingBudget`."""
-    return _normalize(model).startswith(_THINKING_LEVEL_FAMILIES)
+def uses_multi_region_endpoint(model: str) -> bool:
+    """Whether a model is served only on the multi-region Vertex endpoint.
 
-
-def thinking_config_for(model: str, *, budget: int) -> dict[str, object]:
-    """Return the provider-correct thinkingConfig body for a model.
-
-    2.5-family models take an integer token budget. 3.x models take a level and
-    cannot switch thinking off, so the cheapest honored setting is 'minimal'.
-    Sending a budget to a 3.x model is the cost regression this guards: the
-    field is schema-valid, so it is accepted and then ignored.
+    Decided by model FAMILY, never by what happens to answer. `gemini-2.5-flash`
+    also returns 200 on `locations/us` and `locations/global`, but sending it
+    there would bypass the regional Provisioned Throughput order and bill
+    on-demand while the reservation kept charging — the 2026-08-04 double-pay
+    incident. "Route whatever works multi-region to multi-region" is the
+    simplification that reintroduces it.
     """
-    if uses_thinking_level(model):
-        return {'thinkingLevel': THINKING_LEVEL_MINIMAL}
+    return _normalize(model).startswith(MULTI_REGION_ENDPOINT_FAMILIES)
+
+
+def vertex_endpoint(
+    *,
+    model: str,
+    regional_location: str,
+    multi_region_location: str = MULTI_REGION_LOCATION,
+) -> tuple[str, str]:
+    """Return the (host, location) pair a model must be addressed with.
+
+    Location is resolved PER MODEL, never once per process: a fallback chain
+    routinely crosses families, so the reservation model and the model that
+    absorbs its overflow can legitimately live on different endpoints. Building
+    one regional URL for everything is what made every Gemini 3.x request 404.
+    """
+    if uses_multi_region_endpoint(model):
+        return MULTI_REGION_HOST, _normalize(multi_region_location) or MULTI_REGION_LOCATION
+    location = _normalize(regional_location)
+    return f'{location}-aiplatform.googleapis.com', location
+
+
+def thinking_config_for(*, budget: int) -> dict[str, object]:
+    """Return the thinkingConfig body to send, for every model.
+
+    There is deliberately no per-family branch here. Measured 2026-08-18 on the
+    global endpoint, `gemini-3.1-flash-lite` HONORS `thinkingBudget`:
+
+        thinkingBudget: 0        -> thoughts=0    output=64
+        thinkingBudget: 1024     -> thoughts=278  output=77
+        thinkingLevel: 'minimal' -> thoughts=0    output=75
+        thinkingLevel: 'high'    -> thoughts=603  output=76
+        (no thinking config)     -> thoughts=0    output=64
+
+    while 2.5-family models reject `thinkingLevel` outright with HTTP 400
+    ('thinking_level is not supported by this model'). `thinkingBudget` is
+    therefore the one option both families accept, and `thinkingLevel` is the
+    one that works on neither universally. An earlier revision split on family
+    from documentation rather than measurement and had it backwards; the split
+    is gone rather than inverted, so a fallback chain that crosses families
+    needs no body rewriting at all.
+    """
     return {'thinkingBudget': int(budget)}
 
 
@@ -133,6 +231,45 @@ def resolve_overflow_ladder(*, pt_model: str, override: str = '') -> tuple[str, 
     return ladder
 
 
+def resolve_fallback_chain(
+    *,
+    model: str,
+    pt_model: str,
+    unreachable: Iterable[str] = (),
+    override: str = '',
+) -> tuple[str, ...]:
+    """Models that may serve `model`'s traffic when `model` itself cannot, best first.
+
+    Generalizes the overflow ladder to every routable model. Two filters apply
+    to the declared chain:
+
+      * `pt_model` is removed — a degraded request must never be answered out
+        of the prepaid reservation
+        (FC-degraded-fallback-consumes-protected-budget).
+      * `unreachable` is removed — models a real `generateContent` attempt has
+        already proved uncallable. Keeping such a rung would spend a round trip
+        to fail on every request.
+
+    `override` is the operator pin and replaces the whole chain, which is what
+    makes a bad table correctable without a deploy. It is still refused when it
+    aliases the reservation, and it can never point a model at itself.
+    """
+    protected = _normalize(pt_model)
+    head = _normalize(model)
+    dead = {_normalize(name) for name in unreachable}
+    pinned = _normalize(override)
+    if pinned:
+        if pinned == protected:
+            raise ValueError(
+                f'fallback override {pinned!r} equals the provisioned model; '
+                'fallback must never consume the protected reservation'
+            )
+        chain: tuple[str, ...] = (pinned,)
+    else:
+        chain = MODEL_FALLBACKS.get(head, ())
+    return tuple(rung for rung in chain if rung != protected and rung != head and rung not in dead)
+
+
 def request_type_for(*, model: str, pt_model: str) -> str:
     """Header value for a model: prepaid capacity only exists for the PT model.
 
@@ -157,18 +294,18 @@ def is_provisioned_capacity_exhausted(status: int, message: str) -> bool:
 
 
 def is_model_unavailable(status: int, message: str) -> bool:
-    """Whether a model cannot be called by this project at all.
+    """Whether a model is not reachable at the endpoint the request used.
 
     Distinct from both exhaustion and absent capacity: those mean "the model
     works but prepaid throughput did not serve this request". This means the
-    publisher model is not enabled for the project, so every request to it
-    fails no matter how it is routed.
+    publisher model does not exist at the host/location that was addressed, so
+    every identically-routed request to it fails.
 
-    Listing the global publisher catalog does NOT prove availability — the
-    catalog enumerates models that exist in Vertex, while the project-scoped
-    endpoint is what decides whether this project may call one. On
-    2026-08-18 every gemini-3.x model was in the catalog and 404 on the
-    project path, which is the case this predicate exists to survive.
+    The 2026-08-18 production case was exactly this: `gemini-3.1-flash-lite` is
+    served only on the global endpoint, so every regional URL returned 404
+    while the model itself was callable. `vertex_endpoint` is the fix; this
+    predicate is the safety net for the next model whose serving surface does
+    not match the URL the proxy builds.
     """
     if status != 404:
         return False

--- a/backend/utils/llm/vertex_pt_routing.py
+++ b/backend/utils/llm/vertex_pt_routing.py
@@ -310,7 +310,7 @@ def is_model_unavailable(status: int, message: str) -> bool:
     if status != 404:
         return False
     text = (message or '').casefold()
-    return 'publisher model' in text or 'was not found' in text
+    return 'publisher model' in text
 
 
 def is_provisioned_capacity_absent(status: int, message: str) -> bool:

--- a/backend/utils/llm/vertex_pt_routing.py
+++ b/backend/utils/llm/vertex_pt_routing.py
@@ -111,6 +111,28 @@ def resolve_overflow_model(*, pt_model: str, override: str = '') -> str:
     raise ValueError(f'no overflow model available outside the provisioned model {protected!r}')
 
 
+def resolve_overflow_ladder(*, pt_model: str, override: str = '') -> tuple[str, ...]:
+    """Every on-demand model that may absorb work, best first.
+
+    A ladder rather than a single model so a rung that cannot be called at all
+    falls through to one that can, instead of failing the request. Never
+    includes `pt_model` (FC-degraded-fallback-consumes-protected-budget).
+    """
+    protected = _normalize(pt_model)
+    pinned = _normalize(override)
+    if pinned:
+        if pinned == protected:
+            raise ValueError(
+                f'overflow override {pinned!r} equals the provisioned model; '
+                'overflow must never consume the protected reservation'
+            )
+        return (pinned,)
+    ladder = tuple(c for c in OVERFLOW_PREFERENCE if c != protected)
+    if not ladder:
+        raise ValueError(f'no overflow model available outside the provisioned model {protected!r}')
+    return ladder
+
+
 def request_type_for(*, model: str, pt_model: str) -> str:
     """Header value for a model: prepaid capacity only exists for the PT model.
 
@@ -132,6 +154,26 @@ def is_provisioned_capacity_exhausted(status: int, message: str) -> bool:
         return False
     text = (message or '').casefold()
     return 'provisioned throughput' in text or 'dedicated' in text
+
+
+def is_model_unavailable(status: int, message: str) -> bool:
+    """Whether a model cannot be called by this project at all.
+
+    Distinct from both exhaustion and absent capacity: those mean "the model
+    works but prepaid throughput did not serve this request". This means the
+    publisher model is not enabled for the project, so every request to it
+    fails no matter how it is routed.
+
+    Listing the global publisher catalog does NOT prove availability — the
+    catalog enumerates models that exist in Vertex, while the project-scoped
+    endpoint is what decides whether this project may call one. On
+    2026-08-18 every gemini-3.x model was in the catalog and 404 on the
+    project path, which is the case this predicate exists to survive.
+    """
+    if status != 404:
+        return False
+    text = (message or '').casefold()
+    return 'publisher model' in text or 'was not found' in text
 
 
 def is_provisioned_capacity_absent(status: int, message: str) -> bool:


### PR DESCRIPTION
## The defect

`gemini-3.1-flash-lite` returns **404** for `based-hardware`. #11823 routes server-paid Pro and Flash overflow onto it, so that routing could not work.

**The first diagnosis in this PR was wrong, and is corrected here.** The original claim was "no Gemini 3.x model is callable by this project". It is not an access gap:

> **Gemini 3.x has no regional endpoint.** It is served on plain `aiplatform.googleapis.com` with a multi-region `locations/{loc}` path segment. `_vertex_url()` built a regional URL for every model, and a regional URL can never work for a 3.x model.

Measured 2026-08-18 on `based-hardware` with credentials that can invoke inference:

| Endpoint | `gemini-3.1-flash-lite` |
| --- | --- |
| `aiplatform.googleapis.com` + `locations/us` | **200** ON_DEMAND |
| `aiplatform.googleapis.com` + `locations/global` | **200** ON_DEMAND |
| `aiplatform.googleapis.com` + `locations/us` + `dedicated` header | **429** provisioned throughput |
| `us-central1` / `us-east5` / `us-west1` / `europe-west4` / `asia-northeast1` | **404** |
| `eu-aiplatform.googleapis.com` + `locations/eu` | **404** |

The host is always plain `aiplatform.googleapis.com`; `us-aiplatform.googleapis.com` is not a valid host (400 `Invalid hostname`). Only the `locations/{loc}` segment changes.

The `dedicated` 429 is the "no PT order for this model" answer, expected while we own no 3.1 order. It also proves the capacity header is honored multi-region, so the existing auto-detect probe works there. Note it reads lowercase `provisioned throughput` where the regional endpoint uses title case — the matcher casefolds, and a regression test now pins that.

**How it got through:** availability was checked with `GET /publishers/google/models` — the *global* catalog, no project in the path. That enumerates models that exist in Vertex; it says nothing about whether the URL you are about to build will reach one. Only a real `generateContent` attempt answers that.

## Blast radius had it deployed

`bc7f7657c9` is merged but prod still serves `c5b0b5d14b`, so this never reached production traffic.

- **Server-paid Pro** — every request 404s. `is_model_unavailable` is not `_overflow_triggered`, so there was no retry: hard failure to the client.
- **Flash spillover at peak** — requests that previously spilled and *succeeded* would 429 on the reservation, fall to a 404 target, and fail. A working degraded path converted into an outage under exactly the load that triggers it.

## Failure class

Failure-Class: FC-platform-grant-record-as-live-capability

Same contract, new subsystem: a platform *record* was treated as proof the running process can exercise the capability it names. There it was `CGPreflightScreenCaptureAccess()` reading `true` while ScreenCaptureKit refused the same process; here it is the global publisher catalog listing a model while the request the proxy actually builds 404s. Correcting the root cause from "access gap" to "wrong endpoint" does not move the class — the defect is still that a catalog entry was accepted in place of an invocation. The class's canonical prevention prescribes the shape used here: resolve the capability from the refusal reported by the subsystem that actually performs the work, and latch that in memory rather than persisting it, because it is a fact about this process and this deployment rather than a durable truth.

## Fix 1 — address each model at its real endpoint

`ptr.vertex_endpoint()` resolves `(host, location)` **per model, by family**, in the pure policy module:

| Model | Host | Location |
| --- | --- | --- |
| `gemini-3.*` | `aiplatform.googleapis.com` | `us` (`OMI_VERTEX_GLOBAL_LOCATION`) |
| everything else | `{loc}-aiplatform.googleapis.com` | `GCP_LOCATION`, default `us-central1` |

**Why `us` and not `global`.** Both answer. `global` may serve a request from anywhere in the world; `us` is the US multi-region. This path carries users' personal conversations, transcripts and memories, and every other server-paid Gemini call in this service runs in `us-central1`, so `us` preserves the existing residency posture. Widening it is a deliberate operator decision, not a side effect of a routing change — hence a named default and an env flip rather than a literal in a URL builder.

**Why the rule is by family and not "whatever answers".** `gemini-2.5-flash` *also* returns 200 on `locations/us` and `locations/global`. Sending it there would bypass the 5 GSU **us-central1** Provisioned Throughput order and bill on-demand while the reservation kept charging ~$290/day — paying twice for the same tokens, which is the 2026-08-04 double-pay incident. `test_the_reservation_model_is_never_routed_off_its_region` exists specifically to stop that "simplification", and cites the incident in its docstring.

Location being per-model also means nothing assumes the reservation and the model absorbing its overflow share a location. **Unresolved and not encoded anywhere:** whether a PT order for a 3.x model is purchased multi-region, and how that interacts with the existing regional order.

## Fix 2 — every routable model gets a declared fallback chain

Generalized from the single migration target in the first revision of this PR. Now defense in depth rather than the headline fix: a model that 404s degrades instead of erroring, whatever the reason.

`MODEL_FALLBACKS` in the policy module is one reviewable data table:

| Model | Falls back to |
| --- | --- |
| `gemini-2.5-pro` | `gemini-3.1-flash-lite`, `gemini-2.5-flash-lite` |
| `gemini-2.5-flash` | `gemini-3.1-flash-lite`, `gemini-2.5-flash-lite` |
| `gemini-3.1-flash-lite` | `gemini-2.5-flash-lite` |
| `gemini-2.5-flash-lite` | *(terminal)* |
| `gemini-embedding-001` | *(terminal)* |

**`gemini-2.5-pro` is not a route in normal use.** It appears in the table because it stays proxy-allowlisted and BYOK users pay for it on their own key, but no server-paid request is dispatched as Pro: `_serving_model()` remaps it to `gemini-3.1-flash-lite` before dispatch, and over the daily soft limit the metering path demotes it to `gemini-2.5-flash-lite` first. `test_server_paid_traffic_never_dispatches_gemini_2_5_pro` asserts this across both reservation states and both reachability states — 4 parametrised cases — and a companion test asserts BYOK Pro is still honoured.

Three invariants, each enforced by a test rather than by convention:

- **Never onto the reservation.** The live PT model is filtered out of every chain at resolution time, asserted at both PT states across every model (FC-degraded-fallback-consumes-protected-budget).
- **Never upward in price.** Each chain is non-increasing in `PRICE_PER_MTOK_OUT`, so a degraded request cannot cost more than the one it replaces. This is also why `gemini-2.5-flash-lite` is terminal — it is the floor of the ladder *and* the model the desktop clients pin directly (`ModelQoS.lightweight`, Windows `memory`/`goals`/`insight`). `test_client_pinned_flash_lite_is_never_promoted` still holds.
- **Never onto itself.** A chain never contains its own head, so a dead model cannot retry itself.

## Fix 3 — reachability is learned, per model, from traffic only

- **No startup probe.** The metadata endpoint `GET .../publishers/google/models/{m}` is not an oracle: it 404s for `gemini-2.5-flash-lite`, which works fine. The only honest signal is a real `generateContent` attempt, and burning one per model per instance is unaffordable on Cloud Run, which churns instances constantly.
- **Per model**, so one dead model cannot take the ladder down with it.
- **Absence of an entry — never `0.0` — means "never observed".** `time.monotonic()` has an arbitrary origin, so a zero-seeded observation would mark every model dead for the first 10 minutes of each new instance's life. Regression test included, alongside the existing one for the probe timestamp.
- **BYOK never teaches the table.** BYOK goes to AI Studio on the user's own key, so its answers say nothing about what this project reaches on Vertex; one user's key must not latch a model dead for the fleet. (This also closes a narrower version of the same hole in the previous revision.)
- Entries expire on the capacity TTL, so a routing fix or a serving change recovers with no deploy.
- A generic 429 (`Quota exceeded for requests per minute`) is still backpressure and never triggers fallback. Only a PT-exhaustion 429 or a model-unavailable 404 does.

Both the streaming and non-streaming paths get all of this; `test_streaming_unreachable_model_falls_back_and_leaks_no_provider_slot` asserts every refused attempt is closed and its provider slot released, matching the existing overflow-ladder guarantee.

## The thinking contract: measured, and it deleted a branch

The 3.x half of the table was unmeasurable before, because those models were unreachable. With the endpoint fixed:

| Model | Config | thoughts | output |
| --- | --- | ---: | ---: |
| `gemini-2.5-flash-lite` | `thinkingBudget: 0` | 0 | 225 |
| `gemini-2.5-flash-lite` | `thinkingBudget: 1024` | 863 | 300 |
| `gemini-2.5-flash-lite` | `thinkingLevel: minimal` | **HTTP 400 — not supported** | |
| `gemini-2.5-flash` | no config | 516 | 213 |
| `gemini-3.1-flash-lite` | `thinkingBudget: 0` | 0 | 64 |
| `gemini-3.1-flash-lite` | `thinkingBudget: 1024` | 278 | 77 |
| `gemini-3.1-flash-lite` | `thinkingLevel: minimal` | 0 | 75 |
| `gemini-3.1-flash-lite` | `thinkingLevel: high` | 603 | 76 |
| `gemini-3.1-flash-lite` | no config | 0 | 64 |

**This reverses the earlier conclusion.** #11823 split `thinkingConfig` by family on the documented claim that 3.x ignores `thinkingBudget` and cannot disable thinking. Measured, `gemini-3.1-flash-lite` **honors** `thinkingBudget` — 0 really is 0 thoughts, 1024 spends 278 — while 2.5 models **reject** `thinkingLevel` with HTTP 400. So `thinkingBudget` is the one option both families accept and `thinkingLevel` is the one that works on neither universally.

The split is therefore **deleted rather than inverted**: `ptr.thinking_config_for()` is a single path and `_retarget_thinking()` is gone, so a fallback that crosses families rewrites nothing. Net removal of a branch and a body-rewriting function.

It still justifies injecting a budget at all: `gemini-2.5-flash` with no thinking config spent 516 thinking tokens on a trivial prompt, all billed as output.

## Testing

```
backend $ .venv/bin/python -m pytest tests/unit/test_desktop_proxy.py \
      tests/unit/test_vertex_pt_routing.py -q
128 passed

$ .venv/bin/python -m pyright backend/routers/desktop_proxy.py \
      backend/utils/llm/vertex_pt_routing.py
0 errors, 0 warnings, 0 informations
```

Behavioral coverage added for each claim above:

- `test_gemini_3_x_is_routed_to_the_us_multi_region_endpoint` — the actual production defect
- `test_the_reservation_model_is_never_routed_off_its_region` — the 2026-08-04 double-pay guard
- `test_the_multi_region_residency_pin_is_us_and_is_operator_flippable` — residency default and its escape hatch
- `test_a_fallback_across_families_also_crosses_endpoints` — per-model location, end to end through `_upstream`
- `test_no_fallback_chain_ever_routes_onto_the_reservation` / `test_no_recovery_plan_ever_routes_onto_the_reservation` — parametrized over every model at both PT states
- `test_every_chain_is_non_increasing_in_output_price`, `test_the_cheapest_text_model_is_terminal` — the cost invariants
- `test_reachability_is_learned_per_model_not_globally`, `test_byok_traffic_never_teaches_the_reachability_table`
- `test_a_new_instance_believes_every_model_reachable_regardless_of_uptime` — the `monotonic()` origin trap
- `test_a_404_on_any_model_falls_back_and_latches_it`, `test_streaming_unreachable_model_falls_back_and_leaks_no_provider_slot`
- `test_thinking_budget_is_the_one_option_both_families_accept` — cites the measurement above, per the rule that a test rewritten alongside its code must cite an external source

`backend/docs/vertex-pt-flash.md` carries the corrected endpoint finding, the residency reasoning, the fallback table, and the full measured thinking contract; `test_migration_contract_is_documented` now asserts every declared model and both endpoint constants appear there.

## Operator note

The earlier note here said enabling Gemini 3.x access for `based-hardware` was a prerequisite for any of this. **That was wrong — there is nothing to enable.** 3.x is reachable today at the multi-region endpoint, so the routing and the PT migration are unblocked. What remains genuinely open is whether a 3.x PT order is purchased multi-region and how it interacts with the existing regional `gemini-2.5-flash` order; no code here assumes an answer.

