### PR TITLE
fix(desktop): serve the legacy graph when this account has no canonical state

### DIFF
--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+KnowledgeGraph.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+KnowledgeGraph.swift
@@ -325,13 +325,20 @@ struct RebuildGraphResponse: Codable {
 
 // MARK: - Knowledge Graph API
 
+/// The backend's answer when this account has no canonical graph state at all.
+/// Production fences canonical intake, so `/v1/knowledge-graph/canonical` gives
+/// this to accounts whose graph only exists in the legacy store — a statement
+/// about the account, not a transient outage. Any other 503 stays an outage.
+private let canonicalGraphUnavailableDetail = "canonical_graph_unavailable"
+
 extension APIClient {
 
   /// Gets the complete canonical graph, exhausting the bounded page endpoint.
   ///
   /// The endpoint was added after the legacy graph route, so a 404/405 on the
-  /// canonical route is the only condition that selects the legacy request.
-  /// Every other error is returned to the caller.
+  /// canonical route selects the legacy request, as does a 503 that names this
+  /// account as having no canonical state. Every other error is returned to the
+  /// caller.
   func getKnowledgeGraphImpl(
     expectedOwnerId: String? = nil,
     authorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
@@ -348,12 +355,17 @@ extension APIClient {
       return try await getCanonicalKnowledgeGraph(
         expectedOwnerId: expectedOwnerId,
         authorizationSnapshot: pinnedAuthorization)
-    } catch APIError.httpError(statusCode: let statusCode, detail: _) where statusCode == 404 || statusCode == 405 {
+    } catch APIError.httpError(statusCode: let statusCode, detail: let detail)
+      where statusCode == 404 || statusCode == 405
+      || (statusCode == 503 && detail == canonicalGraphUnavailableDetail)
+    {
       DesktopDiagnosticsManager.shared.recordFallback(
         area: "memory_atlas",
         from: "canonical_paged_graph",
         to: "legacy_graph",
-        reason: "canonical_endpoint_unavailable_" + String(statusCode),
+        reason: statusCode == 503
+          ? "canonical_state_unavailable_503"
+          : "canonical_endpoint_unavailable_" + String(statusCode),
         outcome: .recovered
       )
       let legacy: KnowledgeGraphResponse = try await get(

--- a/desktop/macos/Desktop/Tests/KnowledgeGraphPaginationTests.swift
+++ b/desktop/macos/Desktop/Tests/KnowledgeGraphPaginationTests.swift
@@ -361,6 +361,46 @@ final class KnowledgeGraphPaginationTests: XCTestCase {
       ])
   }
 
+  func testCanonicalGraphUnavailable503FallsBackToLegacyGraph() async throws {
+    // Production fences canonical intake, so accounts with no canonical state
+    // get 503 `canonical_graph_unavailable` — their graph is in the legacy
+    // store, which `/v1/knowledge-graph` serves. Failing here left the atlas
+    // permanently empty for those accounts.
+    KnowledgeGraphURLStub.setResponses([
+      (503, Data(#"{"detail":"canonical_graph_unavailable"}"#.utf8)),
+      (200, pageData(nodes: [nodeData(id: "legacy-503")])),
+    ])
+    let client = await makeClient(urlProtocolClass: KnowledgeGraphURLStub.self)
+
+    let graph = try await client.getKnowledgeGraph()
+
+    XCTAssertEqual(graph.nodes.map(\.id), ["legacy-503"])
+    XCTAssertEqual(
+      KnowledgeGraphURLStub.requests().map { $0.url?.path },
+      [
+        "/v1/knowledge-graph/canonical",
+        "/v1/knowledge-graph",
+      ])
+  }
+
+  func testTransient503DoesNotFallBackToLegacyGraph() async throws {
+    // An outage is not a statement that this account has no canonical graph;
+    // hiding it behind the legacy store would publish a stale graph as current.
+    KnowledgeGraphURLStub.setResponses([
+      (503, Data(#"{"detail":"temporarily unavailable"}"#.utf8)),
+      (200, pageData(nodes: [nodeData(id: "must-not-be-used")])),
+    ])
+    let client = await makeClient(urlProtocolClass: KnowledgeGraphURLStub.self)
+
+    do {
+      _ = try await client.getKnowledgeGraph()
+      XCTFail("A transient 503 must not be hidden by the legacy fallback")
+    } catch APIError.httpError(let statusCode, _) {
+      XCTAssertEqual(statusCode, 503)
+    }
+    XCTAssertEqual(KnowledgeGraphURLStub.requests().count, 1)
+  }
+
   func testOwnerSwitchDiscardsAnInFlightCanonicalPage() async throws {
     try await transitionOwner(to: "graph-owner-a")
     let snapshot = try XCTUnwrap(

--- a/desktop/macos/changelog/unreleased/20260818-memory-atlas-legacy-graph.json
+++ b/desktop/macos/changelog/unreleased/20260818-memory-atlas-legacy-graph.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Memory Atlas failing to load for accounts whose knowledge graph still lives in the legacy store"
+}


### PR DESCRIPTION
## Bug

The desktop **Memory Atlas fails to load** for every account whose knowledge graph still lives in the legacy store. Live in prod right now on the current image (`c5b0b5d`): `GET /v1/knowledge-graph/canonical?limit=200` → **503 `canonical_graph_unavailable`**, ~11 per 90 min from macOS clients (`Omi/12187 CFNetwork/… Darwin/25`), in bursts of three — the page's retry loop giving up.

## Root cause

Production fences canonical intake (`MEMORY_MODE`), so `users/{uid}/memory_state/head` is never written and the canonical read is *permanently* unavailable for those accounts. The backend already handles that: `fbb005c15b` (#11623, 2026-08-15) made `GET /v1/knowledge-graph` serve the legacy graph instead of failing, and deliberately kept `/v1/knowledge-graph/canonical` answering 503 — "the caller asking for canonical specifically" (`backend/tests/unit/test_knowledge_graph_legacy_fallback.py::test_the_explicit_canonical_route_still_reports_unavailable`).

The desktop client never takes that path. `getKnowledgeGraphImpl` falls back to the legacy route **only on 404/405** ("endpoint not deployed", `b13562c123`). A 503 propagates, and `MemoryGraphViewModel` publishes an empty atlas. So the server-side fix landed on the one route the desktop app does not call.

## Fix

Treat `503 canonical_graph_unavailable` as the same "this account has no canonical store" signal as 404/405 and take the existing legacy path, with the existing `recordFallback` telemetry (`reason=canonical_state_unavailable_503`). Every **other** 503 still propagates — an outage is not a statement about the account, and hiding it would publish a stale graph as current.

## Tested

`./scripts/dev-feedback.py --once swift 'KnowledgeGraphPaginationTests'` — 11 tests executed. Both new tests pass. One pre-existing local-only failure (`testCatalogOnlyCanonicalAtlasIsRenderableAndActivationCached`) reproduces identically with this commit reverted — it comes from `MemoryAtlasOwnerIdentity` minting the synthetic `atlas-owner` anchor when the test host has a profile name, which CI does not; `Desktop Swift CI` is green on `main`.

Two regression tests through the real production seam (`URLProtocol` stub → real `URLSession` → real `OmiHTTPTransport` error mapping → `getKnowledgeGraph()`), with the exact wire body prod returns:
- `testCanonicalGraphUnavailable503FallsBackToLegacyGraph` — 503 `canonical_graph_unavailable` then legacy 200; asserts the graph renders and that both requests were made in order. **Fails on clean `main`** (control run with only this source hunk reverted: `caught error: "httpError(statusCode: 503, detail: Optional("canonical_graph_unavailable"))"`).
- `testTransient503DoesNotFallBackToLegacyGraph` — 503 `temporarily unavailable` still throws, exactly one request. Guards the invariant behind `testCanonicalAtlas503DoesNotPublishNonemptyLocalProjection`.

Failure-Class: FC-derived-state-gate-without-legacy-source-path

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

