### PR TITLE
fix(context-for-claude): stop the scheduled analytics flush cancelling itself

### DIFF
--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsSink.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsSink.swift
@@ -50,15 +50,21 @@ actor AnalyticsSink {
     private var flushTask: Task<Void, Never>?
     private let spoolURL: URL
     private let transport: AnalyticsTransport
+    /// Injected so a test can drive the *scheduled* path in milliseconds. The scheduled path is not
+    /// a faster version of the direct one — it is the only path production ever takes while the app
+    /// is running, and it was broken in 1.0.13 precisely because nothing exercised it.
+    private let flushInterval: TimeInterval
 
     /// `transport` and `spoolURL` are injected so tests drive the whole path — spool, batch, retry,
     /// drop — without a network and without touching the real support directory.
     init(
         spoolURL: URL = ContextPaths.supportDirectory.appendingPathComponent("analytics-spool.json"),
-        transport: AnalyticsTransport = URLSessionAnalyticsTransport()
+        transport: AnalyticsTransport = URLSessionAnalyticsTransport(),
+        flushInterval: TimeInterval = AnalyticsSink.flushInterval
     ) {
         self.spoolURL = spoolURL
         self.transport = transport
+        self.flushInterval = flushInterval
         self.spool = Self.loadSpool(from: spoolURL)
     }
 
@@ -84,7 +90,24 @@ actor AnalyticsSink {
     /// send and persist re-sends a batch, which PostHog tolerates; the opposite ordering would lose
     /// events silently, which it cannot.
     func flush() async {
+        // Cancels a *pending* timer, never the caller.
+        //
+        // **This is the bug that shipped in 1.0.13.** The scheduled task's body called this method,
+        // whose first line cancelled `flushTask` — itself. `URLSession.data(for:)` honours task
+        // cancellation, so the very next `await` threw, `send` reported the batch unsent, and the
+        // spool grew forever. The app talked to `api.omi.me` all day and delivered no analytics at
+        // all. Nothing caught it because every test called `flush()` directly, where `flushTask` is
+        // nil and the cancel is a no-op — the scheduled path, the only one production takes while
+        // running, had no coverage.
         flushTask?.cancel()
+        flushTask = nil
+        await drain()
+    }
+
+    /// Sends everything queued. Assumes any pending timer has already been dealt with by the caller,
+    /// which is what keeps the scheduled task from cancelling itself.
+    private func drain() async {
+        // Whoever is draining now owns the queue, so a later `enqueue` is free to schedule again.
         flushTask = nil
 
         while !spool.isEmpty {
@@ -106,9 +129,11 @@ actor AnalyticsSink {
     private func scheduleFlush() {
         guard flushTask == nil else { return }
         flushTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(Self.flushInterval * 1_000_000_000))
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(await self.flushInterval * 1_000_000_000))
             guard !Task.isCancelled else { return }
-            await self?.flush()
+            // `drain()`, not `flush()`: this *is* the scheduled task, and `flush()` would cancel it.
+            await self.drain()
         }
     }
 

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsSinkTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsSinkTests.swift
@@ -152,3 +152,63 @@ private actor RecordingTransport: AnalyticsTransport {
         return true
     }
 }
+
+/// The scheduled path — the only one production takes while the app is running.
+///
+/// Everything in `AnalyticsSinkTests` calls `flush()` directly, and that is exactly why 1.0.13
+/// shipped delivering nothing: with no timer pending, `flush()`'s `flushTask?.cancel()` is a no-op,
+/// so the direct path passed every test while the scheduled path cancelled itself on the first line
+/// and threw out of `URLSession`. A suite that only exercises the caller's convenience entry point is
+/// not testing the product.
+final class AnalyticsScheduledFlushTests: XCTestCase {
+
+    private var spoolURL: URL!
+
+    override func setUpWithError() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("sched-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        spoolURL = directory.appendingPathComponent("analytics-spool.json")
+    }
+
+    /// **The 1.0.13 regression.** Enqueue and then touch nothing: the timer alone must deliver.
+    func testTheScheduledFlushActuallyDelivers() async throws {
+        let transport = CancellationAwareTransport()
+        let sink = AnalyticsSink(spoolURL: spoolURL, transport: transport, flushInterval: 0.1)
+
+        await sink.enqueue(AnalyticsPayload(
+            event: .appLaunched,
+            distinctID: "cfc_0123456789abcdef",
+            timestamp: Date(timeIntervalSince1970: 1_760_000_000),
+            superProperties: AnalyticsPayload.superProperties(
+                version: "1.0.14", build: "1000014", macOSVersion: "test")))
+
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
+        let delivered = await transport.deliveredCount
+        let sawCancellation = await transport.sawCancelledTask
+        let stillSpooled = await sink.spooledCountForTesting
+
+        XCTAssertFalse(
+            sawCancellation,
+            "the scheduled task cancelled itself — URLSession would have thrown and the batch would never send")
+        XCTAssertEqual(delivered, 1, "the timer alone must deliver; nothing else runs in production")
+        XCTAssertEqual(stillSpooled, 0, "a delivered batch must leave the spool")
+    }
+}
+
+/// Reports whether the task calling it had already been cancelled — which is precisely what the
+/// real `URLSession.data(for:)` reacts to, and what made the shipped build silent.
+private actor CancellationAwareTransport: AnalyticsTransport {
+    private(set) var deliveredCount = 0
+    private(set) var sawCancelledTask = false
+
+    func send(_ batch: [AnalyticsPayload], token: String, to endpoint: URL) async -> Bool {
+        if Task.isCancelled {
+            sawCancelledTask = true
+            return false  // exactly what URLSession does when its task is cancelled
+        }
+        deliveredCount += batch.count
+        return true
+    }
+}


### PR DESCRIPTION
## What happened

1.0.13 shipped analytics that delivered nothing. The app ran on **11 distinct machines** for a full day, talked to `api.omi.me` continuously, and PostHog received **zero** `cfc_*` events — the only one in the project is a smoke test sent from a test process.

## Root cause

The scheduled flush cancelled the task that was running it.

```swift
flushTask = Task { ... await self.flush() }

func flush() async {
    flushTask?.cancel()      // ← cancels the task executing this very line
```

`URLSession.data(for:)` honours task cancellation, so the next `await` threw, `send` reported the batch unsent, `guard sent else { return }` left it queued, and every later `enqueue` re-entered the same self-cancelling path. The spool grew for the life of the process and nothing ever left the Mac.

The scheduled task now calls a private `drain()` that cancels nothing. `flush()` keeps cancel-then-drain for the one caller that needs it: termination, where a pending timer really must be stood down first.

## Why every existing test passed

All of them called `flush()` directly, and with no timer pending `flushTask?.cancel()` is a no-op. The direct path had full coverage — batching, retry, the 4xx drop rule, spool durability, overflow. The **scheduled** path, the only one production takes while the app is running, had none.

That asymmetry is the real defect, so the guard drives the timer rather than the convenience entry point: `flushInterval` is injectable, and `AnalyticsScheduledFlushTests.testTheScheduledFlushActuallyDelivers` enqueues one event, touches nothing else, and asserts the timer alone delivers it. Its transport double reports whether the task calling it was already cancelled — exactly what URLSession reacts to, and what made the shipped build silent.

## Verification

- The new test **fails against the shipped behaviour** on all three assertions (task cancelled, 0 delivered, event still spooled) and passes with the fix. I reintroduced the bug to confirm this rather than assume it.
- Full package suite: **1645 tests, 0 failures**.

Failure-Class: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

