### PR TITLE
fix(backend): stop listing GETs decrypting/overscanning past the 30s GET timeout

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -443,6 +443,46 @@ def get_action_item(uid: str, action_item_id: str) -> Optional[Dict[str, Any]]:
 # Hard safety caps for list reads. Unbounded streams + in-process sort caused prod GET
 # /v1/action-items to hit HTTP_GET_TIMEOUT (30s) → 504 on large accounts.
 _ACTION_ITEMS_LIST_HARD_MAX = 2000
+# Slack so a handful of soft-deleted rows in a Firestore prefix still fill the page.
+_ACTION_ITEMS_LIST_DELETED_SLACK = 32
+# Lean projection for GET /v1/action-items. Omit `provenance` (evidence arrays dominate
+# payload on large accounts; ActionItemResponse defaults it to []). Do not add
+# `order_by due_at` here: missing `due_at` is excluded from that index and would
+# drop undated tasks. Existing `action_items_completed_due` stays for due-range reads.
+_ACTION_ITEMS_LIST_SELECT_FIELDS = (
+    'description',
+    'status',
+    'completed',
+    'deleted',
+    'goal_id',
+    'workstream_id',
+    'owner',
+    'due_at',
+    'due_confidence',
+    'source',
+    'priority',
+    'sort_order',
+    'indent_level',
+    'recurrence_rule',
+    'recurrence_parent_id',
+    'created_at',
+    'updated_at',
+    'completed_at',
+    'superseded_by',
+    'conversation_id',
+    'is_locked',
+    'exported',
+    'export_date',
+    'export_platform',
+    'apple_reminder_id',
+)
+
+
+def _list_scan_budget(row_budget: int) -> int:
+    """Docs to pull for one page: the page itself plus deleted slack, never 2× the page."""
+    if row_budget <= 0:
+        return 0
+    return min(_ACTION_ITEMS_LIST_HARD_MAX, int(row_budget) + _ACTION_ITEMS_LIST_DELETED_SLACK)
 
 
 def _action_item_list_sort_key(item: Dict[str, Any]) -> tuple:
@@ -456,11 +496,17 @@ def _action_item_list_sort_key(item: Dict[str, Any]) -> tuple:
 
 
 def _stream_action_items_bounded(query: Any, *, max_docs: int) -> tuple[List[Dict[str, Any]], int]:
-    """Stream at most max_docs Firestore documents; skip soft-deleted rows."""
+    """Stream at most max_docs Firestore documents; skip soft-deleted rows.
+
+    Applies a field projection and a Firestore ``limit`` so the backend process
+    never downloads full documents past the page budget (Python ``break`` alone
+    still lets the client library buffer the rest of the stream).
+    """
     action_items: List[Dict[str, Any]] = []
     document_count = 0
     if max_docs <= 0:
         return action_items, 0
+    query = query.select(list(_ACTION_ITEMS_LIST_SELECT_FIELDS)).limit(max_docs)
     for doc in query.stream():
         document_count += 1
         data: Dict[str, Any] = _typed_doc(doc)
@@ -520,7 +566,11 @@ def get_action_items(
     Legacy documents with missing/null ``completed`` are harvested via a separate bounded
     unfiltered scan and treated as active after ``_prepare_action_item_for_read``.
     All paths are hard-capped so GET /v1/action-items cannot unbounded-scan under
-    HTTP_GET_TIMEOUT. Pagination is applied after the product sort.
+    HTTP_GET_TIMEOUT. Pagination is applied after the product sort. When
+    ``completed`` is set, the scan budget is the page plus deleted slack
+    (not 2× the page). Offset is a live-item slice after that sort so it stays
+    aligned with Windows ``offset += items.length`` — Firestore ``offset``
+    counts deleted documents and would skip/duplicate across pages.
     """
     offset = max(0, int(offset or 0))
     if limit is None or limit <= 0:
@@ -551,8 +601,7 @@ def get_action_items(
         q = _base_query()
         if completed_filter is not None:
             q = q.where(filter=FieldFilter('completed', '==', completed_filter))
-        scan = min(_ACTION_ITEMS_LIST_HARD_MAX, max(row_budget * 2, row_budget + 32))
-        items, docs = _stream_action_items_bounded(q, max_docs=scan)
+        items, docs = _stream_action_items_bounded(q, max_docs=_list_scan_budget(row_budget))
         total_docs += docs
         items.sort(key=_action_item_list_sort_key)
         return items[:row_budget]

--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -185,6 +185,124 @@ def _prepare_memory_for_read(memory_data: Optional[Dict[str, Any]], uid: str) ->
 # *****************************
 
 
+# Dual-window list order is ``updated_at`` with ``created_at`` fallback. The
+# released collection is missing ``updated_at`` on a material slice, so there is
+# no single index for that key. Stream two already-indexed windows, merge in
+# Python, then hydrate only the returned page. Content decrypt via
+# ``prepare_for_read`` must not run on the prefix an offset skips — that prefix
+# decrypt is what took GET /v3/memories past HTTP_GET_TIMEOUT on 2026-08-18.
+_MEMORY_LIST_INDEX_FIELDS = (
+    'updated_at',
+    'created_at',
+    'user_review',
+    'invalid_at',
+    'visibility',
+    'capture_device_ids',
+)
+_MEMORY_LIST_CANDIDATE_WINDOW_MAX = 5000
+
+
+def _memory_list_sort_key(memory: Dict[str, Any]) -> tuple[float, str]:
+    value = memory.get('updated_at') or memory.get('created_at')
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        except ValueError:
+            value = None
+    if not isinstance(value, datetime):
+        timestamp = float('-inf')
+    else:
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        timestamp = value.timestamp()
+    return (-timestamp, str(memory.get('id') or ''))
+
+
+def _stream_memory_list_index_window(memories_ref: Any, order_field: str, candidate_limit: int) -> List[Any]:
+    query = memories_ref.select(list(_MEMORY_LIST_INDEX_FIELDS)).order_by(
+        order_field, direction=firestore.Query.DESCENDING
+    )
+    return list(query.limit(candidate_limit).stream())
+
+
+def _merge_memory_list_index_docs(
+    candidate_docs: List[Any],
+    *,
+    include_invalidated: bool,
+) -> List[Dict[str, Any]]:
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for doc in candidate_docs:
+        payload = _typed_doc(doc)
+        doc_id = getattr(doc, 'id', None) or payload.get('id')
+        if not isinstance(doc_id, str) or not doc_id:
+            continue
+        payload.setdefault('id', doc_id)
+        by_id.setdefault(doc_id, payload)
+    return sorted(
+        (
+            memory
+            for memory in by_id.values()
+            if memory.get('user_review') is not False and (include_invalidated or memory.get('invalid_at') is None)
+        ),
+        key=_memory_list_sort_key,
+    )
+
+
+def list_memory_updated_or_created_index(
+    uid: str,
+    limit: int = 100,
+    offset: int = 0,
+    categories: List[str] = [],
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    include_invalidated: bool = False,
+    *,
+    firestore_client: Any = None,
+) -> List[Dict[str, Any]]:
+    """Newest-first historical index rows without content or decrypt.
+
+    Streams two candidate windows of ``min(limit+offset, 5000)`` metadata
+    documents (``updated_at`` DESC and ``created_at`` DESC), merges them, and
+    returns the requested slice. Callers hydrate only the page they will emit.
+    """
+    database = _get_db(firestore_client)
+    memories_ref = database.collection(users_collection).document(uid).collection(memories_collection)
+    if categories:
+        memories_ref = memories_ref.where(filter=FieldFilter('category', 'in', categories))
+    if start_date:
+        memories_ref = memories_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date:
+        memories_ref = memories_ref.where(filter=FieldFilter('created_at', '<=', end_date))
+    candidate_limit = max(1, min(int(limit) + max(int(offset), 0), _MEMORY_LIST_CANDIDATE_WINDOW_MAX))
+    candidate_docs = list(_stream_memory_list_index_window(memories_ref, 'updated_at', candidate_limit))
+    candidate_docs.extend(_stream_memory_list_index_window(memories_ref, 'created_at', candidate_limit))
+    memories = _merge_memory_list_index_docs(candidate_docs, include_invalidated=include_invalidated)
+    return memories[max(0, int(offset)) : max(0, int(offset)) + max(1, int(limit))]
+
+
+def _fetch_memory_docs_by_ids(
+    uid: str, memory_ids: List[str], *, firestore_client: Any = None
+) -> Dict[str, Dict[str, Any]]:
+    """Batch-get full historical docs. Does not decrypt — callers that need
+    plaintext go through ``prepare_for_read`` or ``_prepare_memory_for_read``."""
+    if not memory_ids:
+        return {}
+    database = _get_db(firestore_client)
+    memories_ref = database.collection(users_collection).document(uid).collection(memories_collection)
+    doc_refs = [memories_ref.document(memory_id) for memory_id in memory_ids]
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for doc in database.get_all(doc_refs):
+        if getattr(doc, 'exists', True) is False:
+            continue
+        payload = _typed_doc(doc)
+        doc_id = getattr(doc, 'id', None) or payload.get('id')
+        if not isinstance(doc_id, str) or not doc_id:
+            continue
+        payload.setdefault('id', doc_id)
+        by_id[doc_id] = payload
+    return by_id
+
+
 @prepare_for_read(decrypt_func=cast(_DecryptFunc, _prepare_memory_for_read))
 def get_memories(
     uid: str,
@@ -219,49 +337,25 @@ def get_memories(
         # Python. A row in the final top-N must occur in the corresponding top-N
         # source window (updated rows in updated order, legacy rows in created
         # order), so this remains bounded without dropping old data.
-        candidate_limit = max(1, min(limit + max(offset, 0), 5000))
-
-        def _ordered_query(order_fields: tuple[str, ...]) -> Any:
-            query = memories_ref
-            for field in order_fields:
-                query = query.order_by(field, direction=firestore.Query.DESCENDING)
-            return query.limit(candidate_limit).stream()
-
-        candidate_docs = list(_ordered_query(('updated_at',)))
-        candidate_docs.extend(_ordered_query(('created_at',)))
-        by_id: Dict[str, Dict[str, Any]] = {}
-        for doc in candidate_docs:
-            payload = _typed_doc(doc)
-            doc_id = getattr(doc, 'id', None) or payload.get('id')
-            if not isinstance(doc_id, str) or not doc_id:
-                continue
-            payload.setdefault('id', doc_id)
-            by_id.setdefault(doc_id, payload)
-
-        def _sort_key(memory: Dict[str, Any]) -> tuple[float, str]:
-            value = memory.get('updated_at') or memory.get('created_at')
-            if isinstance(value, str):
-                try:
-                    value = datetime.fromisoformat(value.replace('Z', '+00:00'))
-                except ValueError:
-                    value = None
-            if not isinstance(value, datetime):
-                timestamp = float('-inf')
-            else:
-                if value.tzinfo is None:
-                    value = value.replace(tzinfo=timezone.utc)
-                timestamp = value.timestamp()
-            return (-timestamp, str(memory.get('id') or ''))
-
-        memories = sorted(
-            (
-                memory
-                for memory in by_id.values()
-                if memory.get('user_review') is not False and (include_invalidated or memory.get('invalid_at') is None)
-            ),
-            key=_sort_key,
+        #
+        # The two windows are metadata-only. Full documents (and therefore
+        # ``prepare_for_read`` decrypt) are fetched only for the returned page,
+        # not for the offset prefix. Dual 5000-doc full-document streams plus
+        # prefix decrypt is what 504'd GET /v3/memories at HTTP_GET_TIMEOUT on
+        # 2026-08-18 after the first-page keyset scan fell back here.
+        page_index = list_memory_updated_or_created_index(
+            uid,
+            limit=limit,
+            offset=offset,
+            categories=categories,
+            start_date=start_date,
+            end_date=end_date,
+            include_invalidated=include_invalidated,
+            firestore_client=firestore_client,
         )
-        return memories[max(0, offset) : max(0, offset) + max(1, limit)]
+        page_ids = [str(row['id']) for row in page_index if isinstance(row.get('id'), str) and row.get('id')]
+        by_id = _fetch_memory_docs_by_ids(uid, page_ids, firestore_client=firestore_client)
+        return [by_id[memory_id] for memory_id in page_ids if memory_id in by_id]
 
     # Keep the default query on the existing indexed scoring order. Unrelated
     # legacy callers retain their released order and pagination semantics.
@@ -306,9 +400,11 @@ def _historical_scan_page(
 ) -> tuple[list[dict[str, Any]], list[HistoricalScanCursor], bool]:
     """Shared bounded keyset scan for one historical order field.
 
-    Returns decrypted payloads (snapshot.id as ``id`` authority), the raw scan
+    Returns payloads (snapshot.id as ``id`` authority), the raw scan
     cursors aligned 1:1 with those payloads, and whether the underlying query
-    is exhausted. Callers filter duplicates / visibility into None slots.
+    is exhausted. Callers filter duplicates / visibility into None slots and
+    decrypt only rows they may emit — decrypting the skipped prefix here is
+    what left first-page ``read_page`` with no time for the offset fallback.
     """
     database = _get_db(firestore_client)
     memories_ref = database.collection(users_collection).document(uid).collection(memories_collection)
@@ -339,10 +435,7 @@ def _historical_scan_page(
             order_time = _coerce_historical_scan_time(order_raw)
         else:
             order_time = datetime.fromtimestamp(0, tz=timezone.utc)
-        decrypted = _prepare_memory_for_read(payload, uid) or payload
-        decrypted = dict(decrypted)
-        decrypted['id'] = doc_id
-        payloads.append(decrypted)
+        payloads.append(payload)
         cursors.append((order_time, doc_id))
     exhausted = len(snapshots) < bounded_limit
     return payloads, cursors, exhausted

--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -180,6 +180,11 @@ def _prepare_memory_for_read(memory_data: Optional[Dict[str, Any]], uid: str) ->
     return memory_data
 
 
+def prepare_memory_for_read(memory_data: Optional[Dict[str, Any]], uid: str) -> Optional[Dict[str, Any]]:
+    """Decrypt one historical memory document for non-decorated readers."""
+    return _prepare_memory_for_read(memory_data, uid)
+
+
 # *****************************
 # ********** CRUD *************
 # *****************************

--- a/backend/tests/unit/test_action_item_canonical_contract.py
+++ b/backend/tests/unit/test_action_item_canonical_contract.py
@@ -226,6 +226,9 @@ def test_action_item_lists_hide_soft_retired_rows_before_pagination(monkeypatch)
     }
     query = MagicMock()
     query.order_by.return_value = query
+    query.select.return_value = query
+    query.limit.return_value = query
+    query.offset.return_value = query
     query.stream.return_value = [retired, active]
     collection = MagicMock()
     collection.where.return_value = query

--- a/backend/tests/unit/test_action_items_due_range_index_contract.py
+++ b/backend/tests/unit/test_action_items_due_range_index_contract.py
@@ -55,6 +55,9 @@ class _RecordingQuery:
         self._current.append(('order_by', field, direction))
         return self
 
+    def select(self, _fields):
+        return self
+
     def offset(self, _n):
         return self
 

--- a/backend/tests/unit/test_action_items_pagination_order.py
+++ b/backend/tests/unit/test_action_items_pagination_order.py
@@ -57,6 +57,9 @@ class _Query:
     def order_by(self, *a, **k):
         return self
 
+    def select(self, _fields):
+        return self
+
     def offset(self, n):
         self._offset = n
         return self

--- a/backend/tests/unit/test_bounded_firestore_list_reads.py
+++ b/backend/tests/unit/test_bounded_firestore_list_reads.py
@@ -54,17 +54,42 @@ class _FakeQuery:
         self._docs = docs
         self._filters = list(filters or [])
         self._limit = None
+        self._offset = 0
+        self._select: Optional[List[str]] = None
+
+    last_select: Optional[List[str]] = None
 
     def where(self, *args, **kwargs):
         filt = kwargs.get('filter') or (args[0] if args else None)
-        return _FakeQuery(self._docs, self._filters + [filt])
+        q = _FakeQuery(self._docs, self._filters + [filt])
+        q._limit = self._limit
+        q._offset = self._offset
+        q._select = self._select
+        return q
 
     def order_by(self, *args, **kwargs):
         return self
 
+    def select(self, fields):
+        q = _FakeQuery(self._docs, self._filters)
+        q._limit = self._limit
+        q._offset = self._offset
+        q._select = list(fields)
+        _FakeQuery.last_select = list(fields)
+        return q
+
+    def offset(self, n: int):
+        q = _FakeQuery(self._docs, self._filters)
+        q._limit = self._limit
+        q._offset = n
+        q._select = self._select
+        return q
+
     def limit(self, n: int):
         q = _FakeQuery(self._docs, self._filters)
         q._limit = n
+        q._offset = self._offset
+        q._select = self._select
         return q
 
     def stream(self):
@@ -78,6 +103,8 @@ class _FakeQuery:
                 docs = [d for d in docs if bool(d._data.get('completed')) is bool(value)]
             elif field == 'conversation_id' and op == '==':
                 docs = [d for d in docs if d._data.get('conversation_id') == value]
+        if self._offset:
+            docs = docs[self._offset :]
         if self._limit is not None:
             docs = docs[: self._limit]
         # yield copies so callers can mutate safely
@@ -183,6 +210,51 @@ def test_get_action_items_skips_deleted_in_active_bucket(ai_mod, monkeypatch):
     ids = [x['id'] for x in page]
     assert 'del1' not in ids
     assert ids[0] == 'a1'
+
+
+def test_completed_filter_scans_page_plus_slack_not_double(ai_mod, monkeypatch):
+    """Windows sends completed= + limit=500; the old 2× overscan pulled ~1000 full docs."""
+    ai, recorded, metrics = ai_mod
+    docs = [_FakeDoc(_item(f'c{i}', completed=True)) for i in range(2000)]
+    monkeypatch.setattr(ai, 'db', _FakeDB(docs))
+
+    page = ai.get_action_items('uid', completed=True, limit=500, offset=0)
+    assert len(page) == 500
+    assert recorded[0][1] == metrics.FirestoreReadMode.BOUNDED
+    assert recorded[0][2] <= 500 + ai._ACTION_ITEMS_LIST_DELETED_SLACK
+    assert recorded[0][2] < 1000
+
+
+def test_completed_offset_is_a_live_item_slice_not_a_firestore_offset(ai_mod, monkeypatch):
+    """Client offset counts returned rows. Firestore offset would also skip deleted docs.
+
+    High offset still reads offset+limit+slack (capped at HARD_MAX), not 2×.
+    """
+    ai, recorded, metrics = ai_mod
+    docs = [_FakeDoc(_item(f'c{i}', completed=True)) for i in range(2000)]
+    monkeypatch.setattr(ai, 'db', _FakeDB(docs))
+
+    page = ai.get_action_items('uid', completed=True, limit=500, offset=1500)
+    assert [x['id'] for x in page[:2]] == ['c1500', 'c1501']
+    assert len(page) == 500
+    assert recorded[0][1] == metrics.FirestoreReadMode.BOUNDED
+    assert recorded[0][2] <= ai._ACTION_ITEMS_LIST_HARD_MAX
+    assert recorded[0][2] < 2 * (1500 + 500)
+
+
+def test_list_projects_lean_fields_and_omits_provenance(ai_mod, monkeypatch):
+    ai, recorded, _metrics = ai_mod
+    _FakeQuery.last_select = None
+    docs = [_FakeDoc(_item('a1', completed=False))]
+    monkeypatch.setattr(ai, 'db', _FakeDB(docs))
+
+    ai.get_action_items('uid', completed=False, limit=10, offset=0)
+    assert _FakeQuery.last_select is not None
+    assert 'description' in _FakeQuery.last_select
+    assert 'completed' in _FakeQuery.last_select
+    assert 'deleted' in _FakeQuery.last_select
+    assert 'provenance' not in _FakeQuery.last_select
+    assert recorded[0][2] <= 10 + ai._ACTION_ITEMS_LIST_DELETED_SLACK
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_chat_memory_adapter.py
+++ b/backend/tests/unit/test_chat_memory_adapter.py
@@ -33,6 +33,8 @@ _CHAT_QUOTE_TEXT = 'User likes safe chat memory reads.'
 def _empty_historical_store(monkeypatch):
     """Canonical chat fixtures declare no historical rows unless a test opts in."""
     monkeypatch.setattr(memories_db, 'get_memories', lambda *args, **kwargs: [])
+    monkeypatch.setattr(memories_db, 'list_memory_updated_or_created_index', lambda *args, **kwargs: [])
+    monkeypatch.setattr(memories_db, 'get_memories_by_ids', lambda *args, **kwargs: [])
 
 
 def _memory_item(memory_id: str, *, tier=MemoryTier.short_term, now=None, captured_at=None, content=None, **overrides):

--- a/backend/tests/unit/test_developer_memory_adapter.py
+++ b/backend/tests/unit/test_developer_memory_adapter.py
@@ -31,6 +31,8 @@ def _empty_historical_store(monkeypatch):
     import utils.memory.memory_service as memory_service
 
     monkeypatch.setattr(memory_service.memories_db, 'get_memories', lambda *args, **kwargs: [])
+    monkeypatch.setattr(memory_service.memories_db, 'list_memory_updated_or_created_index', lambda *args, **kwargs: [])
+    monkeypatch.setattr(memory_service.memories_db, 'get_memories_by_ids', lambda *args, **kwargs: [])
 
 
 def _developer_source() -> str:

--- a/backend/tests/unit/test_firestore_query_contract.py
+++ b/backend/tests/unit/test_firestore_query_contract.py
@@ -502,6 +502,15 @@ class _StreamRecordingQuery:
     def order_by(self, field_path, direction):
         return _StreamRecordingQuery(self._recorder, self._filters, (*self._orders, (field_path, direction)))
 
+    def select(self, _fields):
+        return self
+
+    def offset(self, _n):
+        return self
+
+    def limit(self, _n):
+        return self
+
     def stream(self):
         self._recorder.append((self._filters, self._orders))
         return []

--- a/backend/tests/unit/test_memory_offset_read_cost.py
+++ b/backend/tests/unit/test_memory_offset_read_cost.py
@@ -25,8 +25,10 @@ TEST_COMPATIBILITY_WINDOW = 500
 TEST_PAGE_SIZE = 50
 # One geometric walk of the window reads it once per round (2,500 scanned here,
 # 25,000 at the prod window). Chunking the walk into MAX_PAGE_SIZE offset pages
-# read 10,500 (105,000 in prod).
+# read 10,500 (105,000 in prod). Metadata windows are still billed reads; the
+# 504 was decrypting that prefix. Hydrate only the emitted page.
 SCANNED_DOCUMENT_BUDGET = 3000
+HYDRATED_DOCUMENT_BUDGET = 0
 
 
 class _Snapshot:
@@ -99,23 +101,27 @@ def _suppressed_account(service_mod, monkeypatch, uid, *, rows):
         payloads.append(payload)
 
     db = _CountingDb(docs)
-    stats = {"calls": 0, "docs": 0, "scanned": 0}
+    stats = {"calls": 0, "docs": 0, "scanned": 0, "hydrated": 0}
 
-    def fake_get_memories(_uid, limit, offset, sort=None, **_kwargs):
-        del _uid, sort
+    def fake_index(_uid, limit, offset=0, **_kwargs):
+        del _uid
         page = payloads[offset : offset + limit]
         stats["calls"] += 1
         stats["docs"] += len(page)
         # Charge what Firestore actually reads. The newest-first sort has no
-        # index, so ``get_memories`` streams two candidate windows of
-        # ``limit + offset`` documents and orders them in Python: rows that an
-        # offset skips are still read and billed. Counting only returned rows
-        # hides an offset walk's quadratic cost, which is how the 105,000-read
-        # prod page passed this guard at 12,500.
+        # index, so the list index streams two candidate windows of
+        # ``limit + offset`` metadata documents and orders them in Python.
         stats["scanned"] += 2 * min(limit + offset, TEST_COMPATIBILITY_WINDOW)
         return [dict(row) for row in page]
 
-    monkeypatch.setattr(service_mod.memories_db, "get_memories", fake_get_memories)
+    def fake_by_ids(_uid, memory_ids, **_kwargs):
+        del _uid
+        stats["hydrated"] += len(memory_ids)
+        by_id = {row["id"]: dict(row) for row in payloads}
+        return [by_id[memory_id] for memory_id in memory_ids if memory_id in by_id]
+
+    monkeypatch.setattr(service_mod.memories_db, "list_memory_updated_or_created_index", fake_index)
+    monkeypatch.setattr(service_mod.memories_db, "get_memories_by_ids", fake_by_ids)
     service = service_mod.MemoryService(db_client=db)
     service._canonical.read = MagicMock(return_value=[])
     return service, db, stats
@@ -139,6 +145,8 @@ def test_fully_suppressed_offset_read_stays_within_a_bounded_scan_cost(service_m
     # Each round must fetch its prefix in one query, not an offset walk that
     # re-reads every row it skips.
     assert stats["scanned"] <= SCANNED_DOCUMENT_BUDGET
+    # Fully suppressed: the mixed page is empty, so no content decrypt.
+    assert stats["hydrated"] <= HYDRATED_DOCUMENT_BUDGET
     # Canonical status is a stable read within one request, so a repeated
     # prefix must not be re-queried: previously 30 batch gets / 3,000 documents.
     assert db.get_all_calls <= 8
@@ -194,7 +202,7 @@ def test_first_expansion_step_is_unchanged_for_a_lightly_suppressed_account(serv
         )
     scan_limits = []
 
-    def fake_history_read(_uid, *, limit, offset, device_scope_request=None):
+    def fake_history_read(_uid, *, limit, offset, device_scope_request=None, **_kwargs):
         del _uid, offset, device_scope_request
         scan_limits.append(limit)
         return records[:limit]
@@ -207,3 +215,195 @@ def test_first_expansion_step_is_unchanged_for_a_lightly_suppressed_account(serv
     assert [memory.id for memory in page] == ["hist-3"]
     # window == step == 1, so the first expansion is still current + step.
     assert scan_limits[:2] == [1, 2]
+
+
+def test_high_offset_read_hydrates_only_the_emitted_page(service_mod, monkeypatch):
+    """offset=2500/limit=100 in prod streamed 5200 full docs and decrypted 2600.
+
+    The mixed list still indexes ``limit+offset`` metadata rows so merge order
+    is preserved, but content decrypt is the returned page only.
+    Scaled: offset=250, limit=10, window=260.
+    """
+    uid = "uid-offset"
+    service, _db, stats = _suppressed_account(
+        service_mod,
+        monkeypatch,
+        uid,
+        rows=TEST_COMPATIBILITY_WINDOW,
+    )
+    # Visible historical: skip tombstone overrides so the page is hydrated.
+    service.db_client.docs.clear()
+    service.canonical_statuses = MagicMock(return_value={})
+
+    page = service.read(uid, limit=10, offset=250)
+
+    assert len(page) == 10
+    assert stats["scanned"] <= 2 * 260
+    assert stats["hydrated"] == 10
+    assert stats["hydrated"] < stats["scanned"]
+
+
+class _IndexDoc:
+    def __init__(self, doc_id, data, *, selected=None):
+        self.id = doc_id
+        self.exists = True
+        self._data = {k: v for k, v in data.items() if selected is None or k in selected}
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _DocRef:
+    def __init__(self, doc_id):
+        self.id = doc_id
+
+
+class _MemoriesCollection:
+    def __init__(self, db):
+        self.db = db
+
+    def select(self, fields):
+        self.db.select_fields.append(tuple(fields))
+        return _DualWindowQuery(self.db, selected=set(fields))
+
+    def order_by(self, field, **_kwargs):
+        return _DualWindowQuery(self.db, order_field=field)
+
+    def document(self, memory_id):
+        return _DocRef(memory_id)
+
+
+class _DualWindowQuery:
+    def __init__(self, db, *, selected=None, order_field=None, limit_n=None):
+        self.db = db
+        self.selected = selected
+        self.order_field = order_field
+        self.limit_n = limit_n
+
+    def select(self, fields):
+        self.db.select_fields.append(tuple(fields))
+        return _DualWindowQuery(self.db, selected=set(fields), order_field=self.order_field, limit_n=self.limit_n)
+
+    def order_by(self, field, **_kwargs):
+        return _DualWindowQuery(self.db, selected=self.selected, order_field=field, limit_n=self.limit_n)
+
+    def limit(self, n):
+        return _DualWindowQuery(self.db, selected=self.selected, order_field=self.order_field, limit_n=n)
+
+    def stream(self):
+        rows = list(self.db.rows)
+        if self.order_field:
+
+            def _key(row):
+                value = row.get(self.order_field) or row.get("created_at")
+                return value is not None, value
+
+            rows.sort(key=_key, reverse=True)
+        if self.limit_n is not None:
+            rows = rows[: self.limit_n]
+        self.db.streamed += len(rows)
+        for row in rows:
+            yield _IndexDoc(row["id"], row, selected=self.selected)
+
+
+class _DualWindowDb:
+    """Counts metadata streams vs full-document hydrates for get_memories."""
+
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.streamed = 0
+        self.hydrated = 0
+        self.select_fields = []
+
+    def collection(self, name):
+        assert name == "users"
+        return self
+
+    def document(self, _uid):
+        return self
+
+    def collection_memories(self):
+        return _MemoriesCollection(self)
+
+    def get_all(self, refs):
+        refs = list(refs)
+        self.hydrated += len(refs)
+        by_id = {row["id"]: row for row in self.rows}
+        for ref in refs:
+            payload = by_id.get(ref.id)
+            yield _IndexDoc(ref.id, payload or {}, selected=None)
+
+
+def test_get_memories_dual_window_hydrates_only_the_returned_page(service_mod, monkeypatch):
+    """Billed-read contract for the remaining 504 path.
+
+    Before: offset=0/limit=500 streamed and decrypted 1000 docs; offset=2500
+    limit=100 streamed 5200 full docs and decrypted 2600 (MemoryService asked
+    for the prefix). After: metadata windows of 2*(limit+offset), hydrate the
+    page only.
+    """
+    from datetime import datetime, timezone
+
+    memories_db = service_mod.memories_db
+    get_memories = service_mod._prod_get_memories
+    monkeypatch.setattr(
+        memories_db,
+        "list_memory_updated_or_created_index",
+        service_mod._prod_list_memory_updated_or_created_index,
+    )
+
+    def _rows(n):
+        rows = []
+        for index in range(n):
+            stamp = datetime(2026, 1, 1, tzinfo=timezone.utc).replace(minute=index % 60, second=index % 60)
+            rows.append(
+                {
+                    "id": f"m-{index:04d}",
+                    "uid": "uid-db",
+                    "content": f"secret-{index}",
+                    "created_at": stamp,
+                    "updated_at": stamp if index % 2 == 0 else None,
+                    "user_review": None,
+                    "invalid_at": None,
+                }
+            )
+        return rows
+
+    class _Client(_DualWindowDb):
+        def collection(self, name):
+            if name == "users":
+                return self
+            assert name == "memories"
+            return _MemoriesCollection(self)
+
+        def document(self, uid_or_id):
+            # users/{uid} then memories/{id}
+            return self
+
+    first = _Client(_rows(2000))
+    page = get_memories(
+        "uid-db",
+        500,
+        0,
+        sort="updated_or_created_desc",
+        firestore_client=first,
+    )
+    assert len(page) == 500
+    assert first.streamed == 1000  # two metadata windows of 500
+    assert first.hydrated == 500
+    assert first.select_fields
+    assert "visibility" in first.select_fields[0]
+    assert "capture_device_ids" in first.select_fields[0]
+    assert page[0]["content"].startswith("secret-")
+
+    high = _Client(_rows(4000))
+    page = get_memories(
+        "uid-db",
+        100,
+        2500,
+        sort="updated_or_created_desc",
+        firestore_client=high,
+    )
+    assert len(page) == 100
+    assert high.streamed == 5200  # two windows of min(100+2500, 5000)
+    assert high.hydrated == 100

--- a/backend/tests/unit/test_memory_service_parity.py
+++ b/backend/tests/unit/test_memory_service_parity.py
@@ -103,7 +103,16 @@ def _load_memory_service(monkeypatch):
 
         database.memories = memories_db_mod
         database.vector_db = vector_db_mod
+    service_mod._prod_get_memories = service_mod.memories_db.get_memories
+    service_mod._prod_list_memory_updated_or_created_index = (
+        service_mod.memories_db.list_memory_updated_or_created_index
+    )
     monkeypatch.setattr(service_mod.memories_db, "get_memories", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        service_mod.memories_db,
+        "list_memory_updated_or_created_index",
+        lambda *args, **kwargs: [],
+    )
     monkeypatch.setattr(service_mod.memories_db, "get_memories_by_ids", lambda *args, **kwargs: [])
     monkeypatch.setattr(service_mod.memories_db, "get_memory", lambda *args, **kwargs: None)
     monkeypatch.setattr(service_mod.memories_db, "get_memory_ids", lambda *args, **kwargs: [])

--- a/backend/tests/unit/test_memory_visibility_export_fixes.py
+++ b/backend/tests/unit/test_memory_visibility_export_fixes.py
@@ -69,15 +69,17 @@ def test_historical_read_compensates_for_skipped_malformed_rows(service_mod, mon
     bad = _sample_memory_dict("bad")
     bad["id"] = ""  # adapter skips identity-less rows
     # First page: two good + one skipped. Compensation must pull the third good.
-    pages = {
-        0: [good[0], bad, good[1]],
-        3: [good[2]],
-    }
+    all_rows = [good[0], bad, good[1], good[2]]
 
-    def get_memories(_uid, limit, offset, **_kwargs):
-        return list(pages.get(offset, []))[:limit]
+    def list_index(_uid, limit, offset=0, **_kwargs):
+        return list(all_rows[offset : offset + limit])
 
-    monkeypatch.setattr(service_mod.memories_db, "get_memories", get_memories)
+    def get_by_ids(_uid, memory_ids, **_kwargs):
+        by_id = {row["id"]: row for row in good}
+        return [by_id[memory_id] for memory_id in memory_ids if memory_id in by_id]
+
+    monkeypatch.setattr(service_mod.memories_db, "list_memory_updated_or_created_index", list_index)
+    monkeypatch.setattr(service_mod.memories_db, "get_memories_by_ids", get_by_ids)
     adapter = service_mod.HistoricalMemoryAdapter(db_client=object())
 
     page = adapter.read("uid-test", limit=3, offset=0)

--- a/backend/tests/unit/test_product_memory_read_service.py
+++ b/backend/tests/unit/test_product_memory_read_service.py
@@ -59,6 +59,8 @@ class _FirestoreFake:
 def _empty_historical_store(monkeypatch):
     """Canonical fixtures in this module intentionally have no legacy rows."""
     monkeypatch.setattr(memories_db, 'get_memories', lambda *args, **kwargs: [])
+    monkeypatch.setattr(memories_db, 'list_memory_updated_or_created_index', lambda *args, **kwargs: [])
+    monkeypatch.setattr(memories_db, 'get_memories_by_ids', lambda *args, **kwargs: [])
 
 
 def _evidence(source_id='conv1'):

--- a/backend/tests/unit/test_universal_memory_service.py
+++ b/backend/tests/unit/test_universal_memory_service.py
@@ -148,7 +148,6 @@ def test_memory_enabled_off_blocks_intake_like_mode_off(service_mod, monkeypatch
 
 def test_historical_adapter_uses_injected_firestore_client(service_mod, monkeypatch):
     db = _Db()
-    monkeypatch.setattr(service_mod.memories_db, "get_memories", lambda *args, **kwargs: [])
     service = service_mod.MemoryService(db_client=db)
     service._canonical.read = MagicMock(return_value=[])
     service.read("uid-test", limit=3)
@@ -161,7 +160,7 @@ def test_historical_adapter_uses_injected_firestore_client(service_mod, monkeypa
         calls.append((args, kwargs))
         return []
 
-    monkeypatch.setattr(service_mod.memories_db, "get_memories", capture)
+    monkeypatch.setattr(service_mod.memories_db, "list_memory_updated_or_created_index", capture)
     service.read("uid-test", limit=3)
     assert calls[-1][1]["firestore_client"] is db
 
@@ -376,6 +375,7 @@ def test_offset_merge_fetches_a_complete_bounded_prefix(service_mod):
         "limit": 510,
         "offset": 0,
         "device_scope_request": None,
+        "hydrate": False,
     }
 
 
@@ -436,7 +436,7 @@ def test_adaptive_merge_scan_surfaces_visible_rows_behind_suppressed_prefix(serv
     all_historical = suppressed + visible
     read_limits: list[int] = []
 
-    def fake_history_read(_uid, *, limit, offset, device_scope_request=None):
+    def fake_history_read(_uid, *, limit, offset, device_scope_request=None, **_kwargs):
         del _uid, offset, device_scope_request
         read_limits.append(limit)
         return all_historical[:limit]
@@ -492,7 +492,7 @@ def test_adaptive_merge_scan_does_not_double_count_suppression_across_retries(se
     )
     rows = suppressed + [visible]
 
-    def fake_history_read(_uid, *, limit, offset, device_scope_request=None):
+    def fake_history_read(_uid, *, limit, offset, device_scope_request=None, **_kwargs):
         del _uid, offset, device_scope_request
         return rows[:limit]
 
@@ -753,6 +753,46 @@ def test_device_scope_keeps_device_neutral_historical_rows(service_mod):
     request = service_mod.DeviceScopeRequest(device_scope="current", client_device_id="macos_abcd1234")
 
     assert [item.id for item in service.read("uid-test", device_scope_request=request)] == ["neutral"]
+
+
+def test_index_stub_respects_visibility_and_capture_device(service_mod):
+    adapter = service_mod.HistoricalMemoryAdapter()
+    created = "2026-01-01T00:00:00+00:00"
+    unknown = adapter._stub_from_index(
+        "uid-test",
+        {"id": "bad-vis", "created_at": created, "visibility": "secret"},
+    )
+    assert unknown is None
+
+    private = adapter._stub_from_index(
+        "uid-test",
+        {"id": "priv", "created_at": created, "visibility": "private"},
+    )
+    assert private is not None
+    assert private.memory.visibility == "private"
+
+    scoped = service_mod.DeviceScopeRequest(device_scope="current", client_device_id="device-a")
+    other_device = adapter._stub_from_index(
+        "uid-test",
+        {
+            "id": "other",
+            "created_at": created,
+            "capture_device_ids": ["device-b"],
+        },
+    )
+    assert other_device is not None
+    assert adapter.matches_device(other_device, scoped) is False
+
+    matching = adapter._stub_from_index(
+        "uid-test",
+        {
+            "id": "mine",
+            "created_at": created,
+            "capture_device_ids": ["device-a"],
+        },
+    )
+    assert matching is not None
+    assert adapter.matches_device(matching, scoped) is True
 
 
 def test_fetch_applies_device_scope_to_canonical_items(service_mod, monkeypatch):

--- a/backend/tests/unit/test_universal_memory_service.py
+++ b/backend/tests/unit/test_universal_memory_service.py
@@ -201,7 +201,7 @@ def test_mixed_read_does_not_hydrate_canonical_identity_from_historical_stub(ser
         assert [record.memory.id for record in records] == ["legacy"]
         return [_historical(service_mod, "legacy", content="legacy-full")]
 
-    monkeypatch.setattr(service.history, "_hydrate_records", hydrate_page_stubs)
+    monkeypatch.setattr(service.history, "hydrate_records", hydrate_page_stubs)
 
     result = service.read("uid-test", limit=10)
     assert {item.id for item in result} == {"same", "legacy"}

--- a/backend/tests/unit/test_universal_memory_service.py
+++ b/backend/tests/unit/test_universal_memory_service.py
@@ -179,6 +179,36 @@ def test_mixed_read_deduplicates_canonical_public_identity(service_mod, monkeypa
     assert next(item for item in result if item.id == "same").content == "canonical"
 
 
+def test_mixed_read_does_not_hydrate_canonical_identity_from_historical_stub(service_mod, monkeypatch):
+    """Index stubs share migrated ids. Hydrating the suppressed prefix would
+    replace the canonical row with the grandfathered document, or drop it."""
+    service = service_mod.MemoryService(db_client=_Db())
+    canonical = _memory(service_mod, "same", content="canonical")
+    service._canonical.read = MagicMock(return_value=[canonical])
+    colliding_stub = service_mod.HistoricalMemoryRecord(
+        memory=_memory(service_mod, "same", content=""),
+        locator=service_mod.MemoryLocator("uid-test", "legacy", "same"),
+        hydrated=False,
+    )
+    legacy_stub = service_mod.HistoricalMemoryRecord(
+        memory=_memory(service_mod, "legacy", content=""),
+        locator=service_mod.MemoryLocator("uid-test", "legacy", "legacy"),
+        hydrated=False,
+    )
+    service.history.read = MagicMock(return_value=[colliding_stub, legacy_stub])
+
+    def hydrate_page_stubs(_uid, records):
+        assert [record.memory.id for record in records] == ["legacy"]
+        return [_historical(service_mod, "legacy", content="legacy-full")]
+
+    monkeypatch.setattr(service.history, "_hydrate_records", hydrate_page_stubs)
+
+    result = service.read("uid-test", limit=10)
+    assert {item.id for item in result} == {"same", "legacy"}
+    assert next(item for item in result if item.id == "same").content == "canonical"
+    assert next(item for item in result if item.id == "legacy").content == "legacy-full"
+
+
 def test_canonical_read_preserves_lock_and_returns_only_a_preview(service_mod, monkeypatch):
     backend = service_mod.CanonicalMemoryBackend(db_client=_Db())
     secret = "LOCKED_SECRET_CONTENT_" * 10

--- a/backend/tests/unit/test_ws_c_backfill.py
+++ b/backend/tests/unit/test_ws_c_backfill.py
@@ -1538,10 +1538,19 @@ def test_historical_read_path_is_non_mutating_for_arbitrary_uid(_trusted_account
     _seed_legacy_memories_in_db(db, arbitrary_uid, arbitrary_rows)
     arbitrary_before = _legacy_memory_docs_snapshot(db, arbitrary_uid)
 
+    def _index_from_fake_db(uid, limit, offset=0, **kwargs):
+        return _get_memories_from_fake_db(db, uid, limit=limit, offset=offset)
+
+    def _ids_from_fake_db(uid, memory_ids, **kwargs):
+        wanted = set(memory_ids)
+        return [row for row in _get_memories_from_fake_db(db, uid, limit=10_000) if row.get("id") in wanted]
+
+    monkeypatch.setattr("utils.memory.memory_service.memories_db.get_memories", _index_from_fake_db)
     monkeypatch.setattr(
-        "utils.memory.memory_service.memories_db.get_memories",
-        lambda uid, limit, offset=0, **kwargs: _get_memories_from_fake_db(db, uid, limit=limit, offset=offset),
+        "utils.memory.memory_service.memories_db.list_memory_updated_or_created_index",
+        _index_from_fake_db,
     )
+    monkeypatch.setattr("utils.memory.memory_service.memories_db.get_memories_by_ids", _ids_from_fake_db)
     service = MemoryService(db_client=db)
     legacy_memories = service.read(arbitrary_uid, limit=10)
 

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -427,6 +427,9 @@ class HistoricalMemoryRecord:
     memory: MemoryDB
     locator: MemoryLocator
     lifecycle: str = "grandfathered_long_term"
+    # False when the row is an index stub (id + sort timestamps only). Merge
+    # and suppression use stubs; the mixed list hydrates only the emitted page.
+    hydrated: bool = True
 
 
 class HistoricalMemoryAdapter:
@@ -531,6 +534,85 @@ class HistoricalMemoryAdapter:
         )
         return not known_devices or request.client_device_id in known_devices
 
+    def _stub_from_index(self, uid: str, raw: Dict[str, Any]) -> Optional[HistoricalMemoryRecord]:
+        memory_id = raw.get("id")
+        if not isinstance(memory_id, str) or not memory_id.strip():
+            return None
+
+        def _as_datetime(value: Any) -> Optional[datetime]:
+            if isinstance(value, datetime):
+                return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+            if isinstance(value, str):
+                try:
+                    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+                except ValueError:
+                    return None
+                return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+            return None
+
+        created_at = _as_datetime(raw.get("created_at"))
+        updated_at = _as_datetime(raw.get("updated_at")) or created_at
+        if created_at is None and updated_at is None:
+            return None
+        created_value = created_at or updated_at
+        updated_value = updated_at or created_value
+        assert created_value is not None and updated_value is not None
+        visibility = raw.get("visibility")
+        if visibility is None or visibility == "":
+            # Missing visibility is the released legacy default, same as _adapt.
+            visibility = "public"
+        elif visibility not in {"private", "public", "shared"}:
+            return None
+        capture_ids = raw.get("capture_device_ids") or []
+        if not isinstance(capture_ids, list):
+            capture_ids = []
+        capture_ids = [device_id for device_id in capture_ids if isinstance(device_id, str) and device_id]
+        try:
+            memory = MemoryDB.model_validate(
+                {
+                    "id": memory_id,
+                    "uid": uid,
+                    "content": "",
+                    "category": "interesting",
+                    "created_at": created_value,
+                    "updated_at": updated_value,
+                    "visibility": visibility,
+                    "capture_device_ids": capture_ids,
+                }
+            )
+        except (ValidationError, TypeError, ValueError):
+            return None
+        memory = memory.model_copy(update={"memory_tier": MemoryTier.long_term})
+        return HistoricalMemoryRecord(
+            memory=memory,
+            locator=MemoryLocator(uid=uid, origin="legacy", physical_id=memory.id),
+            hydrated=False,
+        )
+
+    def _hydrate_records(self, uid: str, records: List[HistoricalMemoryRecord]) -> List[HistoricalMemoryRecord]:
+        memory_ids = [record.memory.id for record in records if not record.hydrated]
+        if not memory_ids:
+            return records
+        try:
+            raw_rows = memories_db.get_memories_by_ids(uid, memory_ids, **self._firestore_kwargs())
+        except Exception as exc:
+            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
+        adapted: Dict[str, HistoricalMemoryRecord] = {}
+        for raw in raw_rows:
+            record = self._adapt(uid, raw)
+            if record is None:
+                continue
+            adapted[record.memory.id] = record
+        hydrated: List[HistoricalMemoryRecord] = []
+        for record in records:
+            if record.hydrated:
+                hydrated.append(record)
+                continue
+            replacement = adapted.get(record.memory.id)
+            if replacement is not None:
+                hydrated.append(replacement)
+        return hydrated
+
     def read(
         self,
         uid: str,
@@ -538,62 +620,60 @@ class HistoricalMemoryAdapter:
         limit: int = 100,
         offset: int = 0,
         device_scope_request: Optional[DeviceScopeRequest] = None,
+        hydrate: bool = True,
     ) -> List[HistoricalMemoryRecord]:
         bounded_limit = max(1, min(int(limit or 100), self.MAX_COMPATIBILITY_WINDOW))
         bounded_offset = max(0, int(offset or 0))
         needed = bounded_offset + bounded_limit
         if needed > self.MAX_COMPATIBILITY_WINDOW:
             raise HTTPException(status_code=413, detail="Historical memory pagination window exceeded")
-        # Over-fetch when adapt/device filters skip rows so a page of N valid
-        # memories is not silently shortened by malformed documents.
-        # Ask for the whole prefix in one query: the newest-first sort has no
-        # index, so ``get_memories`` streams two candidate windows of
-        # ``limit + offset`` documents and orders them in Python. An offset walk
-        # therefore re-reads every row it skips — chunking cost 105,000 reads
-        # over 25 queries for one page of a suppressed 5,000-row account, which
-        # is what took GET /v3/memories past the 30s edge timeout on 2026-08-18.
-        # ``needed`` is bounded by MAX_COMPATIBILITY_WINDOW above and each chunk's
-        # candidate window had grown that large anyway, so this reads no more at
-        # once than the last chunked query already did.
+        # Index the whole prefix in one dual-window metadata query, then hydrate
+        # only the returned page. ``updated_or_created_desc`` has no single index,
+        # so the helper streams two candidate windows of ``limit + offset``
+        # documents. Hydrating that prefix (and decrypting it) is what took
+        # GET /v3/memories past the 30s edge timeout on 2026-08-18 once first
+        # pages fell back here. Mixed-list expansion needs prefix ids and
+        # timestamps, not content — pass hydrate=False for that caller.
+        # Grow the indexed prefix when adapt/device filters skip rows so a page
+        # of N valid memories is not silently shortened by malformed documents.
+        index_limit = needed
         records: List[HistoricalMemoryRecord] = []
-        db_offset = 0
-        while len(records) < needed:
-            remaining_window = self.MAX_COMPATIBILITY_WINDOW - db_offset
-            if remaining_window <= 0:
-                break
-            fetch_size = min(
-                max(needed - len(records), bounded_limit),
-                remaining_window,
-            )
-            try:
-                raw_rows = memories_db.get_memories(
+        try:
+            while True:
+                index_rows = memories_db.list_memory_updated_or_created_index(
                     uid,
-                    fetch_size,
-                    db_offset,
-                    sort="updated_or_created_desc",
+                    index_limit,
+                    0,
                     **self._firestore_kwargs(),
                 )
-            except Exception as exc:
-                raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
-            if not raw_rows:
-                break
-            for raw in raw_rows:
-                record = self._adapt(uid, raw)
-                if record is None or not self.matches_device(record, device_scope_request):
-                    continue
-                records.append(record)
-                if len(records) >= needed:
+                records = []
+                for raw in index_rows:
+                    record = self._stub_from_index(uid, raw)
+                    if record is None or not self.matches_device(record, device_scope_request):
+                        continue
+                    records.append(record)
+                    if len(records) >= needed:
+                        break
+                if len(records) >= needed or len(index_rows) < index_limit:
                     break
-            db_offset += len(raw_rows)
-            if len(raw_rows) < fetch_size:
-                break
+                if index_limit >= self.MAX_COMPATIBILITY_WINDOW:
+                    break
+                index_limit = min(
+                    self.MAX_COMPATIBILITY_WINDOW,
+                    max(index_limit + bounded_limit, index_limit * 2),
+                )
+        except Exception as exc:
+            raise HTTPException(status_code=503, detail="Historical memory unavailable") from exc
         records.sort(
             key=lambda record: (
                 -self._timestamp(record.memory).timestamp(),
                 record.memory.id,
             )
         )
-        return records[bounded_offset : bounded_offset + bounded_limit]
+        page = records[bounded_offset : bounded_offset + bounded_limit]
+        if not hydrate or not page:
+            return page
+        return self._hydrate_records(uid, page)
 
     def read_scan_page(
         self,
@@ -630,7 +710,10 @@ class HistoricalMemoryAdapter:
             if raw.get('user_review') is False or raw.get('invalid_at') is not None:
                 slots.append((None, scan_cursor))
                 continue
-            record = self._adapt(uid, raw, include_locked_content=include_locked_content)
+            decrypted = memories_db._prepare_memory_for_read(raw, uid) or raw
+            decrypted = dict(decrypted)
+            decrypted['id'] = raw.get('id')
+            record = self._adapt(uid, decrypted, include_locked_content=include_locked_content)
             if record is None or not self.matches_device(record, device_scope_request):
                 slots.append((None, scan_cursor))
             else:
@@ -867,6 +950,11 @@ MEMORY_LIST_SCAN_ROW_BUDGET = 4000
 # for the fallback read.
 MEMORY_LIST_SCAN_DEADLINE_SECONDS = 6.0
 MEMORY_LIST_SCAN_BUDGET_DETAIL = "Memory scan budget exceeded"
+# First-page 504s on 2026-08-18 still spent 17s+ inside ``read_page`` before
+# ``get_memories`` ran: ``max(page_limit, 50)`` fetched 500-doc chunks and
+# decrypted them before ``charge()`` could see the 6s deadline. Cap each
+# keyset fetch so the deadline is checked between small pages.
+MEMORY_LIST_SCAN_CHUNK_SIZE = 50
 
 
 class _ScanRowBudget:
@@ -886,10 +974,13 @@ class _ScanRowBudget:
         seconds = MEMORY_LIST_SCAN_DEADLINE_SECONDS if deadline_seconds is None else deadline_seconds
         self._deadline = clock() + max(0.0, float(seconds))
 
-    def charge(self) -> None:
-        self._remaining -= 1
+    def check(self) -> None:
         if self._remaining < 0 or self._clock() >= self._deadline:
             raise HTTPException(status_code=503, detail=MEMORY_LIST_SCAN_BUDGET_DETAIL)
+
+    def charge(self) -> None:
+        self._remaining -= 1
+        self.check()
 
 
 class _HistoricalRawStream:
@@ -928,6 +1019,7 @@ class _HistoricalRawStream:
     def _ensure_slots(self) -> None:
         if self._slot_index < len(self._slots) or self.exhausted:
             return
+        self._budget.check()
         start_after: Optional[Tuple[datetime, str]] = None
         if self.scan_keyset is not None:
             start_after = self._service.stream_keyset_to_scan_cursor(self.scan_keyset)
@@ -939,7 +1031,7 @@ class _HistoricalRawStream:
         try:
             raw_slots, stream_exhausted = reader(
                 self._uid,
-                limit=max(self._page_limit, 50),
+                limit=MEMORY_LIST_SCAN_CHUNK_SIZE,
                 start_after=start_after,
                 device_scope_request=self._device_scope_request,
             )
@@ -1162,13 +1254,14 @@ class _CanonicalCursorStream:
     def _ensure_slots(self) -> None:
         if self._slot_index < len(self._slots) or self.exhausted:
             return
+        self._budget.check()
         start_after: Optional[CanonicalScanCursor] = None
         if self.scan_keyset is not None:
             start_after = self._service.stream_keyset_to_scan_cursor(self.scan_keyset)
         try:
             raw_slots, stream_exhausted = read_canonical_scan_page(
                 self._uid,
-                limit=max(self._page_limit, 50),
+                limit=MEMORY_LIST_SCAN_CHUNK_SIZE,
                 start_after=start_after,
                 db_client=self._service.db_client,
                 device_scope_request=self._device_scope_request,
@@ -1584,6 +1677,7 @@ class MemoryService:
                 limit=historical_limit,
                 offset=0,
                 device_scope_request=device_scope_request,
+                hydrate=False,
             )
             merged = list(canonical)
             identity_suppressed = 0
@@ -1646,7 +1740,48 @@ class MemoryService:
             MEMORY_HISTORICAL_SUPPRESSION_TOTAL.labels(reason="canonical_identity").inc(identity_suppressed)
         if state_suppressed:
             MEMORY_HISTORICAL_SUPPRESSION_TOTAL.labels(reason="canonical_state").inc(state_suppressed)
-        return merged[bounded_offset : bounded_offset + bounded_limit]
+        page = merged[bounded_offset : bounded_offset + bounded_limit]
+        stub_ids = {record.memory.id for record in historical if not record.hydrated}
+        if stub_ids:
+            page = self._hydrate_merged_historical_stubs(uid, page, stub_ids)
+        return page
+
+    def _hydrate_merged_historical_stubs(
+        self,
+        uid: str,
+        page: List[MemoryDB],
+        stub_ids: Set[str],
+    ) -> List[MemoryDB]:
+        """Replace mixed-list historical stubs with decrypted documents.
+
+        Canonical rows on the page are already hydrated. Index stubs exist so
+        expansion can suppress and sort without decrypting the prefix.
+        """
+        page_stub_ids = [memory.id for memory in page if memory.id in stub_ids]
+        if not page_stub_ids:
+            return page
+        hydrated_records = self.history._hydrate_records(
+            uid,
+            [
+                HistoricalMemoryRecord(
+                    memory=memory,
+                    locator=MemoryLocator(uid=uid, origin="legacy", physical_id=memory.id),
+                    hydrated=False,
+                )
+                for memory in page
+                if memory.id in stub_ids
+            ],
+        )
+        by_id = {record.memory.id: record.memory for record in hydrated_records}
+        hydrated_page: List[MemoryDB] = []
+        for memory in page:
+            if memory.id not in stub_ids:
+                hydrated_page.append(memory)
+                continue
+            replacement = by_id.get(memory.id)
+            if replacement is not None:
+                hydrated_page.append(replacement)
+        return hydrated_page
 
     @classmethod
     def _datetime_to_us(cls, value: datetime) -> int:

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -1671,6 +1671,7 @@ class MemoryService:
         # one request, so ask for each memory id exactly once.
         statuses: Dict[str, MemoryItemStatus] = {}
         status_ids_read: Set[str] = set()
+        kept_stub_ids: Set[str] = set()
         while True:
             historical = self.history.read(
                 uid,
@@ -1683,6 +1684,7 @@ class MemoryService:
             identity_suppressed = 0
             state_suppressed = 0
             historical_kept = 0
+            kept_stub_ids = set()
             unread_ids = [
                 record.memory.id
                 for record in historical
@@ -1705,6 +1707,8 @@ class MemoryService:
                     continue
                 merged.append(record.memory)
                 historical_kept += 1
+                if not record.hydrated:
+                    kept_stub_ids.add(record.memory.id)
             self._sort_memories(merged)
 
             historical_exhausted = len(historical) < historical_limit
@@ -1741,9 +1745,8 @@ class MemoryService:
         if state_suppressed:
             MEMORY_HISTORICAL_SUPPRESSION_TOTAL.labels(reason="canonical_state").inc(state_suppressed)
         page = merged[bounded_offset : bounded_offset + bounded_limit]
-        stub_ids = {record.memory.id for record in historical if not record.hydrated}
-        if stub_ids:
-            page = self._hydrate_merged_historical_stubs(uid, page, stub_ids)
+        if kept_stub_ids:
+            page = self._hydrate_merged_historical_stubs(uid, page, kept_stub_ids)
         return page
 
     def _hydrate_merged_historical_stubs(
@@ -1754,8 +1757,10 @@ class MemoryService:
     ) -> List[MemoryDB]:
         """Replace mixed-list historical stubs with decrypted documents.
 
-        Canonical rows on the page are already hydrated. Index stubs exist so
-        expansion can suppress and sort without decrypting the prefix.
+        ``stub_ids`` must be ids that were actually appended from historical,
+        not the suppressed prefix. Migrated memories share ids across stores;
+        hydrating every historical stub id would replace (or drop) the
+        canonical row that already won identity suppression.
         """
         page_stub_ids = [memory.id for memory in page if memory.id in stub_ids]
         if not page_stub_ids:

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -589,7 +589,7 @@ class HistoricalMemoryAdapter:
             hydrated=False,
         )
 
-    def _hydrate_records(self, uid: str, records: List[HistoricalMemoryRecord]) -> List[HistoricalMemoryRecord]:
+    def hydrate_records(self, uid: str, records: List[HistoricalMemoryRecord]) -> List[HistoricalMemoryRecord]:
         memory_ids = [record.memory.id for record in records if not record.hydrated]
         if not memory_ids:
             return records
@@ -673,7 +673,7 @@ class HistoricalMemoryAdapter:
         page = records[bounded_offset : bounded_offset + bounded_limit]
         if not hydrate or not page:
             return page
-        return self._hydrate_records(uid, page)
+        return self.hydrate_records(uid, page)
 
     def read_scan_page(
         self,
@@ -710,7 +710,7 @@ class HistoricalMemoryAdapter:
             if raw.get('user_review') is False or raw.get('invalid_at') is not None:
                 slots.append((None, scan_cursor))
                 continue
-            decrypted = memories_db._prepare_memory_for_read(raw, uid) or raw
+            decrypted = memories_db.prepare_memory_for_read(raw, uid) or raw
             decrypted = dict(decrypted)
             decrypted['id'] = raw.get('id')
             record = self._adapt(uid, decrypted, include_locked_content=include_locked_content)
@@ -1765,7 +1765,7 @@ class MemoryService:
         page_stub_ids = [memory.id for memory in page if memory.id in stub_ids]
         if not page_stub_ids:
             return page
-        hydrated_records = self.history._hydrate_records(
+        hydrated_records = self.history.hydrate_records(
             uid,
             [
                 HistoricalMemoryRecord(

--- a/desktop/windows/src/main/tasks/taskSyncEngine.test.ts
+++ b/desktop/windows/src/main/tasks/taskSyncEngine.test.ts
@@ -721,6 +721,8 @@ describe('one-time full sync (versioned flag)', () => {
     const urls = listingCalls().map(urlOf)
     expect(urls.some((u) => u.includes('completed=true'))).toBe(true)
     expect(urls.some((u) => u.includes('completed=false'))).toBe(true)
+    expect(urls.every((u) => u.includes('limit=100'))).toBe(true)
+    expect(urls.some((u) => u.includes('limit=500'))).toBe(false)
     // …and the forced sweeps took their keep-set from the (uncapped) census.
     expect(censusCalls()).toHaveLength(2)
     expect(h.hardDeleteAbsentTasks).toHaveBeenCalledWith(['b1'])
@@ -1062,6 +1064,7 @@ describe('explicit reconcile (strong path, tasks:reconcile)', () => {
 
     // The strong path pages both full listings for content…
     expect(listingCalls().length).toBeGreaterThanOrEqual(2)
+    expect(listingCalls().map(urlOf).every((u) => u.includes('limit=100'))).toBe(true)
     // …censuses for the sweep keep-set (uncapped, unlike the 2000-doc listing
     // cap), and its reconciles are forced (run even at t0, where a throttled
     // call would have skipped).
@@ -1082,13 +1085,81 @@ describe('explicit reconcile (strong path, tasks:reconcile)', () => {
     await Promise.all([a, b])
     expect(listingCalls()).toHaveLength(2) // one run's worth (incomplete + completed)
   })
+
+  it('pages at 100 and advances offset by delivered items, not a stale 500 step', async () => {
+    h.appMeta.values = {}
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const method = init?.method ?? 'GET'
+      const u = String(url)
+      if (method === 'GET' && u.includes('/v1/action-items/ids')) {
+        return h.jsonResponse({
+          ids: u.includes('completed=true') ? [] : ['i0', 'i1']
+        })
+      }
+      if (method === 'GET' && u.includes('/v1/action-items?')) {
+        if (u.includes('completed=false') && u.includes('offset=0')) {
+          expect(u).toContain('limit=100')
+          return h.jsonResponse({
+            action_items: [backendItem({ id: 'i0' })],
+            has_more: true
+          })
+        }
+        if (u.includes('completed=false') && u.includes('offset=1')) {
+          return h.jsonResponse({
+            action_items: [backendItem({ id: 'i1' })],
+            has_more: false
+          })
+        }
+        if (u.includes('completed=false') && u.includes('offset=100')) {
+          throw new Error('offset advanced by PAGE_LIMIT instead of delivered length')
+        }
+        return h.jsonResponse({ action_items: [], has_more: false })
+      }
+      if (method === 'POST') return h.jsonResponse(backendItem({ id: 'srv-new' }))
+      if (method === 'PATCH') return h.jsonResponse(backendItem({ completed: true }))
+      if (method === 'DELETE') return h.jsonResponse({}, true, 204)
+      return h.jsonResponse({})
+    })
+    const { engine } = await freshEngine()
+    await engine.scheduleBackgroundSync()
+    const incompleteOffsets = listingCalls()
+      .map(urlOf)
+      .filter((u) => u.includes('completed=false'))
+    expect(incompleteOffsets.some((u) => u.includes('offset=1'))).toBe(true)
+    expect(incompleteOffsets.some((u) => u.includes('offset=100'))).toBe(false)
+  })
+
+  it('a listing abort during populate does not retry the same dual-bucket fetch at 30s', async () => {
+    h.appMeta.values = {}
+    const t0 = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(t0)
+    h.netFetch.mockImplementation(async (url: string, init?: { method?: string }) => {
+      const u = String(url)
+      if ((init?.method ?? 'GET') === 'GET' && u.includes('/v1/action-items?')) {
+        const err = new Error('aborted')
+        err.name = 'AbortError'
+        throw err
+      }
+      if ((init?.method ?? 'GET') === 'GET' && u.includes('/v1/action-items/ids')) {
+        return h.jsonResponse({ ids: [] })
+      }
+      return h.jsonResponse({ action_items: [], has_more: false })
+    })
+    const { engine } = await freshEngine()
+    await engine.scheduleBackgroundSync()
+    const listingsAfterFirst = listingCalls().length
+    expect(listingsAfterFirst).toBeGreaterThan(0)
+    nowSpy.mockReturnValue(t0 + 31_000)
+    await engine.scheduleBackgroundSync()
+    expect(listingCalls()).toHaveLength(listingsAfterFirst)
+  })
 })
 
 // The deterministic cost guard. The script mirrors what the renderer actually
 // does over 5 minutes of Tasks use (mount reads; every `tasks:changed` broadcast
 // re-reads from the Tasks page, the Hub stats hook, and the Quick Task widget;
 // then a toggle, a create, and a rename). Under origin/main EVERY one of these
-// reads kicked a paged `GET /v1/action-items?limit=500` hydrate — measured by
+// reads kicked a paged `GET /v1/action-items?limit=100` hydrate — measured by
 // running the identical flushed script against an origin/main worktree:
 // 22 listing requests / 500 listing documents / 25 requests total, vs 0 / 0 / 5
 // on this branch (see the PR body's before/after request log).

--- a/desktop/windows/src/main/tasks/taskSyncEngine.ts
+++ b/desktop/windows/src/main/tasks/taskSyncEngine.ts
@@ -32,7 +32,8 @@
 // steady state with no remote changes costs two census requests and ZERO
 // document transfers. Full paged listings are reserved for the one-time
 // per-account populate (versioned flag) and the explicit user reconcile
-// (`tasks:reconcile`), so the every-read `?limit=500` listing storm is gone.
+// the every-read `?limit=500` listing storm is gone. Remaining full listings
+// (populate / explicit reconcile) page at 100, not 500.
 //
 // FIX (ii) — embedding eviction via DEPENDENCY INJECTION (no hard import of the
 // embedding service): `setTaskDeletionListener` wires a callback that every
@@ -85,7 +86,7 @@ const REQUEST_TIMEOUT_MS = 15_000
 // many local reads / focus events ask for one. This single number is what kills
 // the every-read listing storm (billing RCA 2026-08: ~61-73 RPS of
 // `GET /v1/action-items?limit=500` from omi-windows). Mac's TasksStore uses the
-// same 5-minute reconcile bound.
+// same 5-minute reconcile bound. Populate/reconcile listings now page at 100.
 const SYNC_THROTTLE_MS = 5 * 60_000
 // A FAILED background sync retries at most this often (not the full 5-min window)
 // so an offline-then-online user isn't locked out of freshness, while a 429 storm
@@ -94,8 +95,10 @@ const SYNC_RETRY_MS = 30_000
 // Reconcile (hard-delete tasks absent from the backend) at most once per 5 min —
 // Mac's `lastReconcileAt` throttle. Prevents an every-keystroke reconcile sweep.
 const RECONCILE_THROTTLE_MS = 5 * 60_000
-// Page size for full listings (the backend caps `limit` at 500).
-const PAGE_LIMIT = 500
+// Page size for full listings. Match macOS TasksStore (pageSize = 100). The
+// backend accepts up to 500, but a 500-doc full-document page on a heavy
+// account exceeds the Windows 15s client timeout and the backend 30s GET timeout.
+const PAGE_LIMIT = 100
 // Hard ceiling on paging so a runaway `has_more` can never loop forever.
 const MAX_PAGES = 200
 // Per-id document lookups one background sync may issue (new / bucket-moved ids).
@@ -331,8 +334,11 @@ async function fetchPage(
 ): Promise<{ items: BackendActionItem[]; hasMore: boolean }> {
   const q = new URLSearchParams({ limit: String(PAGE_LIMIT), offset: String(offset) })
   if (completed !== undefined) q.set('completed', String(completed))
+  // Stamp BEFORE the round-trip: aborting at REQUEST_TIMEOUT_MS leaves the
+  // Cloud Run worker running until HTTP_GET_TIMEOUT (30s). Treating that as
+  // "already billed" prevents a 30s retry of the same dual-bucket populate.
+  roundServedBackendRead = true
   const res = await apiFetch('GET', `/v1/action-items?${q.toString()}`, undefined, external)
-  roundServedBackendRead = true // a response arrived — its reads are billed
   if (!res.ok) throw new HttpError(res.status)
   const json = (await res.json()) as { action_items?: BackendActionItem[]; has_more?: boolean }
   return {
@@ -359,7 +365,7 @@ async function fetchAll(
     const { items, hasMore } = await fetchPage(completed, offset, external)
     out.push(...items)
     if (!hasMore || items.length === 0) break
-    offset += PAGE_LIMIT
+    offset += items.length
   }
   return out
 }


### PR DESCRIPTION
## Summary

Prod GET listings 504 at exactly 30.0s (`HTTP_GET_TIMEOUT`). Cloud Run timeout is 3600s; empty 504s are `TimeoutMiddleware`. Two failure classes sharing that deadline, not one shared query.

- **`GET /v3/memories`:** dual-window `updated_or_created_desc` streamed two windows of `min(limit+offset, 5000)` **full docs** and decrypted the offset prefix. First-page keyset `read_page` used `max(page_limit, 50)` = 500-doc chunks and decrypted before the 6s scan budget could `charge()`, so fallback `get_memories` often started at t+17s.
- **`GET /v1/action-items`:** Windows `omi-windows/1.0.0` (Electron still emits 1.0.0) sent `limit=500` on both `completed=` buckets. The completed filter scanned **2×** the page as full documents. One saturated Cloud Run instance (`containerConcurrency=20`) then 504'd cheap GETs in the same minutes.

Do not raise `HTTP_GET_TIMEOUT`. Firestore `select()` still bills 1 read/doc — this drops CPU/payload, not billed reads.

### Memories

Index the two windows as metadata (`updated_at`/`created_at`/`user_review`/`invalid_at`/`visibility`/`capture_device_ids`), merge, then hydrate only the returned page. Mixed-list expansion uses the same stubs (`hydrate=False`) and decrypts **kept** historical page rows only — not suppressed ids that collided with canonical (migrated memories share ids). Index stubs keep real `visibility` (missing → public; unknown → skip) and `capture_device_ids`. Keyset fetches are 50-doc chunks with the 6s budget checked **before** each fetch.

### Action items + Windows

List reads `select()` lean fields (omit `provenance`), Firestore `limit(page + 32 deleted slack)` instead of 2× overscan, and apply offset as a **live-item slice after product sort** so it stays aligned with Windows `offset += items.length`. Do not use Firestore `.offset()` — that counts deleted documents and would skip/duplicate pages. Windows populate/reconcile pages at **100** (macOS TasksStore) and stamps `roundServedBackendRead` **before** the request so a 15s client abort does not retry a still-running 30s Cloud Run worker.

## Product invariants affected

- **INV-MEM-1** — path glob only (`backend/database/memories.py`, `backend/utils/memory/**`). Historical stubs still classify as `long_term`. Default access policy and the three product tiers are unchanged.
- **INV-MEM-3** — mixed-origin reads still go through `MemoryService`. Canonical failure still 503s; historical is a read-only input. Hydration of index stubs does not bypass canonical suppression or fail open onto a direct legacy reader.

## Failure class (fixes)

Failure-Class: FC-bounded-read-exceeds-request-budget

A request-scoped collection read must bound its aggregate document work low enough to finish within the request middleware budget; a large per-query `limit` is not a sufficient bound when several reads compose (two 5000-doc windows + prefix decrypt; 2× full-document overscan). Guard artifact: `backend/tests/unit/test_bounded_firestore_list_reads.py`.

Line-Count-Exception: backend/utils/memory/memory_service.py | 2595 -> 2735 | Page-only hydrate and 50-doc keyset chunks have to live on HistoricalMemoryAdapter; splitting that owner is a follow-up, not this timeout fix.

## Test plan

- [x] Backend focused units (142 passed): `test_memory_offset_read_cost.py`, `test_universal_memory_service.py`, `test_universal_memory_list_cursor.py`, `test_memories_pagination_clamp.py`, `test_memory_service_parity.py`, `test_memory_visibility_export_fixes.py`, `test_bounded_firestore_list_reads.py`, `test_action_items_pagination_order.py`, `test_action_items_due_range_index_contract.py`, `test_firestore_query_contract.py`, `test_action_item_lists_hide_soft_retired_rows_before_pagination`
- [x] Windows `taskSyncEngine.test.ts`: **50 passed** (pages at `limit=100`, offset advances by delivered length)
- [x] `make preflight` against this body (local lane, `origin/main`)
- [ ] CI backend unit selection for the touched paths
- [ ] After deploy: Cloud Logging for `/v3/memories` and `/v1/action-items` 504s over a comparable 3h window; Windows populate should not stampede `limit=500`

Not exercised here: live prod accounts, a real Windows populate against prod. Hermetic fixtures cover the dual-window hydrate bound, live-item offset vs Firestore offset, and the 100-item page step.

## Verification

```
cd backend && python -m pytest -q -m "not integration and not slow" \
  tests/unit/test_memory_offset_read_cost.py \
  tests/unit/test_universal_memory_service.py \
  tests/unit/test_bounded_firestore_list_reads.py \
  tests/unit/test_action_items_pagination_order.py
# 142 focused tests passed across the listing files above (full command in commit)

cd desktop/windows && npx vitest run src/main/tasks/taskSyncEngine.test.ts
# 50 passed
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

