### PR TITLE
fix(desktop): detect Telegram calls and gate meeting treatment at finalization

### DIFF
--- a/backend/database/conversation_finalization_jobs.py
+++ b/backend/database/conversation_finalization_jobs.py
@@ -731,6 +731,7 @@ def _mark_finalization_fanout_completed_txn(
     dispatch_generation: int,
     lease_epoch: int,
     now: datetime,
+    meeting_treatment_eligible: bool,
 ) -> bool:
     snapshot = job_ref.get(transaction=transaction)
     if not getattr(snapshot, 'exists', False):
@@ -745,6 +746,7 @@ def _mark_finalization_fanout_completed_txn(
         {
             'fanout_status': 'completed',
             'fanout_completed_at': now,
+            'meeting_treatment_eligible': meeting_treatment_eligible,
             'updated_at': now,
         },
     )
@@ -756,12 +758,20 @@ def mark_finalization_fanout_completed(
     dispatch_generation: int,
     lease_epoch: int,
     *,
+    meeting_treatment_eligible: bool,
     firestore_client: Any = None,
 ) -> bool:
     client = _client(firestore_client)
     transaction = client.transaction()
     transactional = firestore.transactional(_mark_finalization_fanout_completed_txn)
-    return transactional(transaction, _job_ref(client, job_id), dispatch_generation, lease_epoch, _now())
+    return transactional(
+        transaction,
+        _job_ref(client, job_id),
+        dispatch_generation,
+        lease_epoch,
+        _now(),
+        meeting_treatment_eligible,
+    )
 
 
 def _mark_finalization_retryable_txn(

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -348,6 +348,7 @@ class ConversationFinalizationStatusResponse(BaseModel):
     retryable: bool
     attempt_count: int
     task_retry_count: int
+    meeting_treatment_eligible: bool = False
 
 
 # MIGRATE: For backward compatibility with the old memories routes and app

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -56,6 +56,7 @@ from utils.notifications import send_action_item_data_message, sync_action_item_
 from utils.conversations.process_conversation import process_conversation
 from utils.conversations import lifecycle as lifecycle_service
 from utils.conversations.location import resolve_geolocation
+from utils.conversations.meeting_treatment import is_meeting_treatment_eligible
 from utils.executors import postprocess_executor
 from utils.request_validation import HistoryDays
 from utils.llm.memories import identify_category_for_memory
@@ -1084,6 +1085,7 @@ class ConversationResponse(BaseModel):
     id: str
     status: str
     discarded: bool
+    meeting_treatment_eligible: bool = False
 
 
 class UpdateConversationRequest(BaseModel):
@@ -1474,6 +1476,7 @@ def _conversation_response_from_data(conversation: dict) -> ConversationResponse
         id=conversation['id'],
         status=status,
         discarded=bool(conversation.get('discarded', False)),
+        meeting_treatment_eligible=is_meeting_treatment_eligible(conversation),
     )
 
 
@@ -1670,6 +1673,7 @@ def _create_conversation_from_segments(
         id=conversation.id,
         status=conversation.status.value if conversation.status else 'completed',
         discarded=conversation.discarded,
+        meeting_treatment_eligible=is_meeting_treatment_eligible(conversation),
     )
 
 

--- a/backend/tests/unit/test_chat_first_proactive_engine.py
+++ b/backend/tests/unit/test_chat_first_proactive_engine.py
@@ -1,6 +1,6 @@
 """Failure-isolated, content-free proactive-judgment contracts."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -15,6 +15,12 @@ from models.chat_first import (
     QuestionOption,
 )
 from utils.task_intelligence.chat_first_eligibility import ChatFirstEligibility
+from utils.conversations.meeting_treatment import (
+    MIN_MEETING_DURATION_SECONDS,
+    MIN_TRANSCRIBED_SPEECH_SECONDS,
+    deduplicated_transcribed_speech_seconds,
+    is_meeting_treatment_eligible,
+)
 
 NOW = datetime(2026, 7, 15, 12, tzinfo=timezone.utc)
 SUBJECT = ChatFirstSubject(kind='goal', id='goal-1')
@@ -223,6 +229,9 @@ def test_desktop_meeting_adapter_uses_stored_role_and_skips_non_meeting_or_rotat
         'source': 'desktop',
         'status': 'completed',
         'discarded': False,
+        'started_at': NOW,
+        'finished_at': NOW + timedelta(seconds=MIN_MEETING_DURATION_SECONDS),
+        'transcript_segments': [{'text': 'A substantive exchange', 'start': 0, 'end': MIN_TRANSCRIBED_SPEECH_SECONDS}],
         'structured': {'title': 'Ambient capture'},
         'external_data': {'conversation_role': 'ambient'},
     }
@@ -252,6 +261,35 @@ def test_desktop_meeting_adapter_uses_stored_role_and_skips_non_meeting_or_rotat
     }
     engine.persist_desktop_meeting_arrival('user-1', rotation)
     persist.assert_not_called()
+
+
+def test_meeting_treatment_requires_five_minutes_and_deduplicated_speech():
+    eligible = {
+        'source': 'desktop',
+        'discarded': False,
+        'started_at': NOW,
+        'finished_at': NOW + timedelta(seconds=MIN_MEETING_DURATION_SECONDS),
+        'external_data': {'conversation_role': 'meeting'},
+        'transcript_segments': [
+            {'text': 'first exchange', 'start': 0, 'end': 35},
+            {'text': 'second exchange', 'start': 35, 'end': MIN_TRANSCRIBED_SPEECH_SECONDS},
+        ],
+    }
+    assert is_meeting_treatment_eligible(eligible) is True
+
+    short_call = {**eligible, 'finished_at': NOW + timedelta(seconds=MIN_MEETING_DURATION_SECONDS - 1)}
+    assert is_meeting_treatment_eligible(short_call) is False
+
+    duplicate_streams = {
+        **eligible,
+        'finished_at': NOW + timedelta(minutes=20),
+        'transcript_segments': [
+            {'text': 'remote stream from mic', 'start': 0, 'end': 45},
+            {'text': 'same remote stream from system audio', 'start': 0, 'end': 45},
+        ],
+    }
+    assert deduplicated_transcribed_speech_seconds(duplicate_streams['transcript_segments']) == 45
+    assert is_meeting_treatment_eligible(duplicate_streams) is False
 
 
 def test_proactive_failure_logs_redact_authenticated_uid(monkeypatch, caplog):

--- a/backend/tests/unit/test_conversation_finalization_jobs.py
+++ b/backend/tests/unit/test_conversation_finalization_jobs.py
@@ -493,7 +493,8 @@ def test_finalization_completion_requires_durable_fanout_completion():
     ref.data = ref.data | fanout.updates[0][1]
 
     completed_fanout = _Transaction()
-    assert jobs._mark_finalization_fanout_completed_txn(completed_fanout, ref, 1, 4, now) is True
+    assert jobs._mark_finalization_fanout_completed_txn(completed_fanout, ref, 1, 4, now, True) is True
+    assert completed_fanout.updates[0][1]['meeting_treatment_eligible'] is True
     ref.data = ref.data | completed_fanout.updates[0][1]
 
     completed = _Transaction()

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -696,6 +696,7 @@ def test_finalization_status_endpoint_exposes_retryable_durable_state():
         'retryable': True,
         'attempt_count': 2,
         'task_retry_count': 1,
+        'meeting_treatment_eligible': False,
     }
     with (
         patch.object(conv.conversations_db, 'get_conversation', return_value={'id': 'conv-1'}),

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -173,6 +173,25 @@ def _request(**overrides):
     return developer.CreateConversationFromTranscriptRequest.model_validate(data)
 
 
+def _eligible_meeting_request(**overrides):
+    data = {
+        'transcript_segments': [
+            {
+                'text': 'substantive meeting discussion',
+                'speaker': 'SPEAKER_00',
+                'is_user': True,
+                'start': 0.0,
+                'end': 60.0,
+            }
+        ],
+        'started_at': NOW,
+        'finished_at': NOW + timedelta(minutes=5),
+        'conversation_role': 'meeting',
+    }
+    data.update(overrides)
+    return _request(**data)
+
+
 def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
     captured = {}
 
@@ -200,7 +219,7 @@ def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
 
     arrival = MagicMock()
     monkeypatch.setattr(proactive_engine, 'persist_capture_arrival_intent', arrival)
-    response = developer._create_conversation_from_segments('uid1', _request(conversation_role='meeting'))
+    response = developer._create_conversation_from_segments('uid1', _eligible_meeting_request())
 
     assert response.id == 'random-process-id'
     assert isinstance(captured['conversation'], CreateConversation)
@@ -281,10 +300,11 @@ def test_completed_desktop_meeting_persists_exact_conversation_arrival(monkeypat
     monkeypatch.setattr(proactive_engine, 'persist_capture_arrival_intent', arrival)
 
     response = developer._create_conversation_from_segments(
-        'uid1', _request(client_session_id='meeting-session-1', conversation_role='meeting')
+        'uid1', _eligible_meeting_request(client_session_id='meeting-session-1')
     )
 
     assert response.id == expected_id
+    assert response.meeting_treatment_eligible is True
     arrival.assert_called_once_with(
         'uid1', conversation_id=expected_id, summary='Design review', is_desktop_meeting=True
     )
@@ -342,6 +362,9 @@ def test_completed_desktop_meeting_retry_repairs_missing_arrival(monkeypatch):
                 'source': 'desktop',
                 'status': 'completed',
                 'discarded': False,
+                'started_at': NOW,
+                'finished_at': NOW + timedelta(minutes=5),
+                'transcript_segments': [{'text': 'substantive meeting discussion', 'start': 0.0, 'end': 60.0}],
                 'structured': {'title': 'Design review'},
                 'external_data': {'conversation_role': 'meeting'},
             }
@@ -353,14 +376,44 @@ def test_completed_desktop_meeting_retry_repairs_missing_arrival(monkeypatch):
     monkeypatch.setattr(proactive_engine, 'persist_capture_arrival_intent', arrival)
 
     response = developer._create_conversation_from_segments(
-        'uid1', _request(client_session_id='meeting-session-1', conversation_role='meeting')
+        'uid1', _eligible_meeting_request(client_session_id='meeting-session-1')
     )
 
     assert response.id == expected_id
+    assert response.meeting_treatment_eligible is True
     process.assert_not_called()
     arrival.assert_called_once_with(
         'uid1', conversation_id=expected_id, summary='Design review', is_desktop_meeting=True
     )
+
+
+def test_short_desktop_meeting_stays_ordinary_conversation(monkeypatch):
+    monkeypatch.setattr(conversations_db, 'get_conversation', MagicMock())
+    monkeypatch.setattr(developer.lifecycle_service, 'create_processing_conversation', MagicMock())
+
+    def _process(_uid, _language, conversation):
+        return Conversation(
+            id='short-meeting',
+            created_at=NOW,
+            started_at=conversation.started_at,
+            finished_at=conversation.finished_at,
+            source=conversation.source,
+            language=conversation.language,
+            structured={'title': 'Short call'},
+            transcript_segments=conversation.transcript_segments,
+            external_data=conversation.external_data,
+            status=ConversationStatus.completed,
+        )
+
+    monkeypatch.setattr(developer, 'process_conversation', _process)
+    arrival = MagicMock()
+    monkeypatch.setattr(proactive_engine, 'persist_capture_arrival_intent', arrival)
+
+    response = developer._create_conversation_from_segments('uid1', _request(conversation_role='meeting'))
+
+    assert response.status == 'completed'
+    assert response.meeting_treatment_eligible is False
+    arrival.assert_not_called()
 
 
 def test_completed_ambient_retry_cannot_reclassify_conversation_as_meeting(monkeypatch):

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import runpy
 from types import SimpleNamespace
@@ -315,10 +316,12 @@ def test_finalization_status_exposes_retry_and_terminal_state(monkeypatch):
         'retryable': True,
         'attempt_count': 2,
         'task_retry_count': 0,
+        'meeting_treatment_eligible': False,
     }
 
     job['status'] = 'dead_letter'
     job['task_retry_count'] = 3
+    job['meeting_treatment_eligible'] = True
     assert lifecycle_service.get_finalization_status('uid-1', 'conversation-1') == {
         'job_id': 'job-1',
         'status': 'dead_letter',
@@ -326,6 +329,7 @@ def test_finalization_status_exposes_retry_and_terminal_state(monkeypatch):
         'retryable': False,
         'attempt_count': 2,
         'task_retry_count': 3,
+        'meeting_treatment_eligible': True,
     }
 
 
@@ -1054,6 +1058,9 @@ async def test_completed_conversation_replays_only_the_durable_fanout_boundary(
         source=SimpleNamespace(value=source),
         external_data=external_data,
         discarded=discarded,
+        started_at=datetime(2026, 8, 18, 12, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 8, 18, 12, tzinfo=timezone.utc) + timedelta(minutes=10),
+        transcript_segments=[SimpleNamespace(text='substantive exchange', start=0, end=60)],
         structured=SimpleNamespace(title='Captured title', overview='Captured overview'),
     )
     integrations = AsyncMock(return_value=[])
@@ -1097,7 +1104,12 @@ async def test_completed_conversation_replays_only_the_durable_fanout_boundary(
     else:
         extracted.assert_called_once_with('uid-1', conversation)
     assert disposition == ConversationFinalizationDisposition.completed
-    completed.assert_called_once_with('job-1', 2, 3)
+    completed.assert_called_once_with(
+        'job-1',
+        2,
+        3,
+        meeting_treatment_eligible=(source == 'desktop' and expected_intent_kwargs is not None),
+    )
     if expected_intent_kwargs is None:
         capture_arrival.assert_not_called()
     else:
@@ -1440,7 +1452,7 @@ async def test_finalizer_runs_derived_effects_only_after_winning_claim(monkeypat
     assert disposition == ConversationFinalizationDisposition.completed
     derived_runner.assert_called_once()
     integrations.assert_awaited_once()
-    complete.assert_called_once_with('job-1', 2, 3)
+    complete.assert_called_once_with('job-1', 2, 3, meeting_treatment_eligible=False)
 
 
 @pytest.mark.anyio
@@ -1520,7 +1532,7 @@ async def test_finalizer_completes_when_an_app_permanently_rejects_the_delivery(
     )
 
     assert disposition == ConversationFinalizationDisposition.completed
-    complete.assert_called_once_with('job-1', 2, 3)
+    complete.assert_called_once_with('job-1', 2, 3, meeting_treatment_eligible=False)
     safe_target.assert_called_once_with('https://app.test/hook?uid=uid-1')
     webhook_client.post.assert_awaited_once_with(
         pinned_url,

--- a/backend/tests/unit/test_meeting_treatment.py
+++ b/backend/tests/unit/test_meeting_treatment.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+
+from utils.conversations.meeting_treatment import (
+    MIN_MEETING_DURATION_SECONDS,
+    MIN_TRANSCRIBED_SPEECH_SECONDS,
+    deduplicated_transcribed_speech_seconds,
+    is_meeting_treatment_eligible,
+)
+
+NOW = datetime(2026, 8, 18, 12, tzinfo=timezone.utc)
+
+
+def _meeting(*, duration_seconds: int, segments: list[dict]) -> dict:
+    return {
+        'source': 'desktop',
+        'discarded': False,
+        'started_at': NOW,
+        'finished_at': NOW + timedelta(seconds=duration_seconds),
+        'external_data': {'conversation_role': 'meeting'},
+        'transcript_segments': segments,
+    }
+
+
+def test_call_under_five_minutes_is_ineligible():
+    conversation = _meeting(
+        duration_seconds=MIN_MEETING_DURATION_SECONDS - 1,
+        segments=[{'text': 'continuous discussion', 'start': 0, 'end': MIN_TRANSCRIBED_SPEECH_SECONDS}],
+    )
+
+    assert is_meeting_treatment_eligible(conversation) is False
+
+
+def test_call_over_five_minutes_with_enough_speech_is_eligible():
+    conversation = _meeting(
+        duration_seconds=MIN_MEETING_DURATION_SECONDS + 60,
+        segments=[
+            {'text': 'first exchange', 'start': 0, 'end': 35},
+            {'text': 'second exchange', 'start': 45, 'end': 70},
+        ],
+    )
+
+    assert is_meeting_treatment_eligible(conversation) is True
+
+
+def test_long_mostly_silent_call_is_ineligible():
+    conversation = _meeting(
+        duration_seconds=20 * 60,
+        segments=[
+            {
+                'text': 'brief accidental transcription',
+                'start': 300,
+                'end': 300 + MIN_TRANSCRIBED_SPEECH_SECONDS - 1,
+            }
+        ],
+    )
+
+    assert is_meeting_treatment_eligible(conversation) is False
+
+
+def test_overlapping_duplicate_stream_segments_are_counted_once():
+    segments = [
+        {'text': 'remote party through microphone', 'start': 0, 'end': 45},
+        {'text': 'remote party through system audio', 'start': 0, 'end': 45},
+        {'text': 'partially overlapping continuation', 'start': 35, 'end': 60},
+    ]
+
+    assert deduplicated_transcribed_speech_seconds(segments) == 60
+    assert is_meeting_treatment_eligible(_meeting(duration_seconds=10 * 60, segments=segments)) is True

--- a/backend/utils/conversations/ARCHITECTURE.md
+++ b/backend/utils/conversations/ARCHITECTURE.md
@@ -15,6 +15,9 @@ and background processing.
   A caller must have already acquired a finalization-job lease before invoking
   it; it loads the conversation, performs enrichment through the postprocess
   bulkhead, and runs external integrations.
+- `meeting_treatment.py` owns the post-capture meeting policy. It uses durable
+  conversation timestamps plus the union of transcribed-speech intervals, so
+  dual microphone/system-audio transcripts cannot double-count speech.
 - Route- or worker-specific ownership, retries, queues, and leases belong
   outside this package: `database/conversation_finalization_jobs.py`,
   `services/conversation_finalization.py`, and their callers own those states.

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -16,6 +16,7 @@ from models.geolocation import Geolocation
 from utils.app_integrations import trigger_external_integrations
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.location import async_resolve_geolocation
+from utils.conversations.meeting_treatment import is_meeting_treatment_eligible
 from utils.conversations.process_conversation import extract_memories, process_conversation
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, postprocess_executor, run_blocking
@@ -169,18 +170,12 @@ async def finalize_persisted_conversation(
         # where a completed projection existed without a notes-ready intent.
         source = getattr(conversation, 'source', None)
         source_value = getattr(source, 'value', source)
-        external_data = getattr(conversation, 'external_data', None) or {}
-        is_desktop_meeting = (
-            source_value == 'desktop'
-            and external_data.get('conversation_role') == 'meeting'
-            and external_data.get('conversation_finalization_reason') != 'max_duration_rotation'
-            and not getattr(conversation, 'discarded', False)
-        )
-        if (source_value == 'omi' and not getattr(conversation, 'discarded', False)) or is_desktop_meeting:
+        meeting_treatment_eligible = is_meeting_treatment_eligible(conversation)
+        if (source_value == 'omi' and not getattr(conversation, 'discarded', False)) or meeting_treatment_eligible:
             try:
                 structured = getattr(conversation, 'structured', None)
                 summary = getattr(structured, 'title', '') or getattr(structured, 'overview', '') or ''
-                if is_desktop_meeting:
+                if meeting_treatment_eligible:
                     persist_capture_arrival_intent(
                         uid,
                         conversation_id=conversation_id,
@@ -201,6 +196,7 @@ async def finalize_persisted_conversation(
             finalization_job_id,
             dispatch_generation,
             lease_epoch,
+            meeting_treatment_eligible=meeting_treatment_eligible,
         )
         if not fanout_completed:
             raise ConversationFinalizationError('fanout_completion_conflict')

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -644,9 +644,20 @@ def claim_finalization_fanout(
     return jobs_db.claim_finalization_fanout(job_id, dispatch_generation, lease_epoch)
 
 
-def complete_finalization_fanout(job_id: str, dispatch_generation: int, lease_epoch: int) -> bool:
+def complete_finalization_fanout(
+    job_id: str,
+    dispatch_generation: int,
+    lease_epoch: int,
+    *,
+    meeting_treatment_eligible: bool,
+) -> bool:
     """Persist completion only after the idempotency-keyed fanout succeeds."""
-    return jobs_db.mark_finalization_fanout_completed(job_id, dispatch_generation, lease_epoch)
+    return jobs_db.mark_finalization_fanout_completed(
+        job_id,
+        dispatch_generation,
+        lease_epoch,
+        meeting_treatment_eligible=meeting_treatment_eligible,
+    )
 
 
 def complete_fenced_finalization(job_id: str, dispatch_generation: int, lease_epoch: int) -> bool:
@@ -748,4 +759,5 @@ def get_finalization_status(uid: str, conversation_id: str) -> dict[str, Any] | 
         'retryable': status == 'queued',
         'attempt_count': int(job.get('attempt_count') or 0),
         'task_retry_count': int(job.get('task_retry_count') or 0),
+        'meeting_treatment_eligible': bool(job.get('meeting_treatment_eligible', False)),
     }

--- a/backend/utils/conversations/meeting_treatment.py
+++ b/backend/utils/conversations/meeting_treatment.py
@@ -1,0 +1,89 @@
+"""Authoritative meeting-treatment policy for finalized conversations."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from typing import Any
+
+MIN_MEETING_DURATION_SECONDS = 5 * 60
+MIN_TRANSCRIBED_SPEECH_SECONDS = 60
+
+
+def _value(item: Any, name: str, default: Any = None) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(name, default)
+    return getattr(item, name, default)
+
+
+def deduplicated_transcribed_speech_seconds(segments: Iterable[Any]) -> float:
+    """Return the union of non-empty transcript intervals.
+
+    Desktop can transcribe the remote party through both the microphone and the
+    system-audio tap. Those streams frequently emit twins at the same start
+    time, so summing segment durations would count the same speech twice.
+    Taking the interval union also handles partially overlapping twins.
+    """
+
+    intervals: list[tuple[float, float]] = []
+    for segment in segments:
+        text = _value(segment, 'text', '')
+        if not isinstance(text, str) or not text.strip():
+            continue
+        try:
+            start = float(_value(segment, 'start'))
+            end = float(_value(segment, 'end'))
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(start) or not math.isfinite(end):
+            continue
+        start = max(0.0, start)
+        if end <= start:
+            continue
+        intervals.append((start, end))
+
+    if not intervals:
+        return 0.0
+
+    intervals.sort()
+    total = 0.0
+    current_start, current_end = intervals[0]
+    for start, end in intervals[1:]:
+        if start <= current_end:
+            current_end = max(current_end, end)
+            continue
+        total += current_end - current_start
+        current_start, current_end = start, end
+    return total + current_end - current_start
+
+
+def is_meeting_treatment_eligible(conversation: Any) -> bool:
+    """Whether a finalized desktop meeting merits meeting-specific treatment."""
+
+    source = _value(conversation, 'source')
+    source_value = getattr(source, 'value', source)
+    external_data = _value(conversation, 'external_data') or {}
+    if not isinstance(external_data, Mapping):
+        return False
+    if (
+        source_value != 'desktop'
+        or external_data.get('conversation_role') != 'meeting'
+        or external_data.get('conversation_finalization_reason') == 'max_duration_rotation'
+        or bool(_value(conversation, 'discarded', False))
+    ):
+        return False
+
+    started_at = _value(conversation, 'started_at')
+    finished_at = _value(conversation, 'finished_at')
+    if not isinstance(started_at, datetime) or not isinstance(finished_at, datetime):
+        return False
+    try:
+        duration_seconds = (finished_at - started_at).total_seconds()
+    except TypeError:
+        return False
+    if duration_seconds < MIN_MEETING_DURATION_SECONDS:
+        return False
+
+    segments = _value(conversation, 'transcript_segments', []) or []
+    return deduplicated_transcribed_speech_seconds(segments) >= MIN_TRANSCRIBED_SPEECH_SECONDS

--- a/backend/utils/task_intelligence/proactive_engine.py
+++ b/backend/utils/task_intelligence/proactive_engine.py
@@ -16,6 +16,7 @@ from models.chat_first import (
     QuestionCardSpec,
     QuestionOption,
 )
+from utils.conversations.meeting_treatment import is_meeting_treatment_eligible
 from utils.log_sanitizer import sanitize_pii
 from utils.metrics import CHAT_FIRST_PROACTIVE_TOTAL
 from utils.task_intelligence.chat_first_eligibility import ChatFirstEligibility, resolve_chat_first_eligibility
@@ -338,17 +339,9 @@ def persist_capture_arrival_intent(
 def persist_desktop_meeting_arrival(uid: str, conversation) -> None:
     """Repair-safe adapter from a completed desktop conversation to its exact Chat receipt."""
 
-    source = conversation.get('source') if isinstance(conversation, dict) else conversation.source
     status = conversation.get('status') if isinstance(conversation, dict) else conversation.status
-    discarded = conversation.get('discarded', False) if isinstance(conversation, dict) else conversation.discarded
-    external_data = conversation.get('external_data') if isinstance(conversation, dict) else conversation.external_data
-    source = getattr(source, 'value', source)
     status = getattr(status, 'value', status)
-    if (external_data or {}).get('conversation_role') != 'meeting':
-        return
-    if (external_data or {}).get('conversation_finalization_reason') == 'max_duration_rotation':
-        return
-    if source != 'desktop' or discarded or status != 'completed':
+    if status != 'completed' or not is_meeting_treatment_eligible(conversation):
         return
     conversation_id = conversation['id'] if isinstance(conversation, dict) else conversation.id
     structured = (conversation.get('structured') if isinstance(conversation, dict) else conversation.structured) or {}

--- a/desktop/macos/Desktop/Sources/ConferencingApps.swift
+++ b/desktop/macos/Desktop/Sources/ConferencingApps.swift
@@ -10,6 +10,13 @@ import Foundation
 ///  - `ProactiveAssistantsPlugin`, which throttles screen capture while a call app is frontmost.
 enum ConferencingApps {
 
+  /// Shipping and legacy Telegram bundle IDs shared by meeting detection and proactive capture.
+  /// Keep both because existing installations may still report the legacy identifier.
+  static let telegramBundleIDs: Set<String> = [
+    "com.tdesktop.telegram",
+    "ru.keepcoder.telegram",
+  ]
+
   /// Apps whose primary purpose is video/audio calls. Matched by app/owner name, which is
   /// available from `NSRunningApplication` and `CGWindowList` **without** Screen Recording
   /// permission.
@@ -44,7 +51,7 @@ enum ConferencingApps {
   /// Bundle IDs (lowercased) of native conferencing apps, used for mic-in-use ("in a call")
   /// detection. A native call app that is *running but idle* (open, not in a call) is NOT using
   /// the microphone, so it won't be treated as a meeting.
-  static let nativeCallBundleIDs: Set<String> = [
+  static let nativeCallBundleIDs: Set<String> = Set([
     "us.zoom.xos",  // Zoom
     "com.microsoft.teams",  // Microsoft Teams (classic)
     "com.microsoft.teams2",  // Microsoft Teams (new)
@@ -54,7 +61,7 @@ enum ConferencingApps {
     "com.webex.meetingmanager",  // Webex (older)
     "com.logmein.gotomeeting",  // GoTo Meeting
     "com.logmein.goto",  // GoTo
-  ]
+  ]).union(telegramBundleIDs)
 
   /// Whether a bundle ID belongs to a known native conferencing app (case-insensitive).
   static func isNativeCallApp(bundleID: String) -> Bool {

--- a/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
+++ b/desktop/macos/Desktop/Sources/ConversationFinalizationService.swift
@@ -84,10 +84,15 @@ actor ConversationFinalizationService {
       guard let latestSession = try await TranscriptionStorage.shared.getSession(id: sessionId) else {
         throw TranscriptionStorageError.sessionNotFound
       }
-      guard try await resolveExhaustedCloudReconciliation(session: latestSession, sessionId: sessionId) else {
+      let outcome = try await resolveExhaustedCloudReconciliation(session: latestSession, sessionId: sessionId)
+      guard outcome.handled else {
         throw TranscriptionStorageError.invalidState("Exhausted cloud session has no local fallback")
       }
-      await postMeetingCompletionIfReady(session: latestSession, reason: .retry)
+      await postMeetingCompletionIfReady(
+        session: latestSession,
+        reason: .retry,
+        meetingTreatmentEligible: outcome.meetingTreatmentEligible
+      )
     } catch {
       await markRetryableFailure(sessionId: sessionId, error: error)
     }
@@ -110,21 +115,29 @@ actor ConversationFinalizationService {
       guard try await TranscriptionStorage.shared.markSessionUploading(id: sessionId) else {
         return
       }
+      let meetingTreatmentEligible: Bool?
       switch strategy {
       case .localSegments:
-        try await uploadLocalSegments(sessionId: sessionId)
+        meetingTreatmentEligible = try await uploadLocalSegments(sessionId: sessionId)
       case .cloudReconcile:
         guard let latestSession = try await TranscriptionStorage.shared.getSession(id: sessionId) else {
           throw TranscriptionStorageError.sessionNotFound
         }
-        try await finalizeCloudSession(session: latestSession, allowForceProcess: allowCloudForceProcess)
+        meetingTreatmentEligible = try await finalizeCloudSession(
+          session: latestSession,
+          allowForceProcess: allowCloudForceProcess
+        )
       }
       // Meeting provenance is persisted on the recording session, while the
       // finalization reason only describes why this particular attempt ended.
       // A max-duration split must not announce a meeting fragment as ready;
       // explicit stop and detector-end completions may wake Chat after the
       // backend/local reconciliation has reached completed.
-      await postMeetingCompletionIfReady(session: session, reason: reason)
+      await postMeetingCompletionIfReady(
+        session: session,
+        reason: reason,
+        meetingTreatmentEligible: meetingTreatmentEligible
+      )
     } catch {
       await markRetryableFailure(sessionId: sessionId, error: error)
     }
@@ -137,14 +150,14 @@ actor ConversationFinalizationService {
     return session.source == ConversationSource.desktop.rawValue ? .localSegments : .cloudReconcile
   }
 
-  private func uploadLocalSegments(sessionId: Int64, allowBackendIdOverride: Bool = false) async throws {
+  private func uploadLocalSegments(sessionId: Int64, allowBackendIdOverride: Bool = false) async throws -> Bool {
     guard let bundle = try await TranscriptionStorage.shared.getSessionWithSegments(id: sessionId) else {
       throw TranscriptionStorageError.sessionNotFound
     }
     guard !bundle.segments.isEmpty else {
       log("ConversationFinalization: Deleting empty local session \(sessionId)")
       try await TranscriptionStorage.shared.deleteSession(id: sessionId)
-      return
+      return false
     }
 
     var merged: [APIClient.UploadSegment] = []
@@ -209,7 +222,7 @@ actor ConversationFinalizationService {
         latest.status == .completed,
         latest.backendSynced
       {
-        return
+        return response.meetingTreatmentEligible
       }
       throw TranscriptionStorageError.invalidState(
         "from-segments returned \(response.id) but local completion was rejected"
@@ -217,6 +230,7 @@ actor ConversationFinalizationService {
     }
     await hydrateUploadedLocalConversation(id: response.id)
     log("ConversationFinalization: Uploaded local session \(sessionId) -> backend conversation \(response.id)")
+    return response.meetingTreatmentEligible
   }
 
   private func hydrateUploadedLocalConversation(id conversationId: String) async {
@@ -270,8 +284,8 @@ actor ConversationFinalizationService {
   private func finalizeCloudSession(
     session: TranscriptionSessionRecord,
     allowForceProcess: Bool
-  ) async throws {
-    guard let sessionId = session.id else { return }
+  ) async throws -> Bool? {
+    guard let sessionId = session.id else { return nil }
 
     if let backendId = session.backendId, !backendId.isEmpty {
       if let clientConversationId = session.clientConversationId,
@@ -287,7 +301,7 @@ actor ConversationFinalizationService {
           allowForceProcess: allowForceProcess,
           allowBackendIdOverride: true
         ) {
-          return
+          return nil
         }
         throw TranscriptionStorageError.invalidState(
           "Bound backend conversation conflicts with client recording identity")
@@ -311,7 +325,7 @@ actor ConversationFinalizationService {
           conversationStatus: status
         )
         log("ConversationFinalization: Finalized cloud session \(sessionId) by backend id \(conversation.id)")
-        return
+        return nil
       }
       throw TranscriptionStorageError.invalidState("Bound backend conversation is not completed")
     }
@@ -322,7 +336,7 @@ actor ConversationFinalizationService {
         sessionId: sessionId,
         allowForceProcess: true
       ) {
-        return
+        return nil
       }
     }
 
@@ -339,7 +353,7 @@ actor ConversationFinalizationService {
           conversationStatus: status
         )
         log("ConversationFinalization: Force-processed unbound cloud session \(sessionId) -> \(conversation.id)")
-        return
+        return nil
       }
     }
 
@@ -360,7 +374,7 @@ actor ConversationFinalizationService {
     }
     for match in timestampMatches {
       if try await completeTimestampMatchedConversation(match, sessionId: sessionId) {
-        return
+        return nil
       }
     }
 
@@ -371,11 +385,12 @@ actor ConversationFinalizationService {
           sessionId: sessionId,
           allowForceProcess: true
         ) {
-          return
+          return nil
         }
       }
-      if try await resolveExhaustedCloudReconciliation(session: session, sessionId: sessionId) {
-        return
+      let outcome = try await resolveExhaustedCloudReconciliation(session: session, sessionId: sessionId)
+      if outcome.handled {
+        return outcome.meetingTreatmentEligible
       }
     }
 
@@ -416,27 +431,35 @@ actor ConversationFinalizationService {
   func resolveExhaustedCloudReconciliation(
     session: TranscriptionSessionRecord,
     sessionId: Int64
-  ) async throws -> Bool {
+  ) async throws -> ExhaustedCloudReconciliationOutcome {
     let segmentCount = try await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
     switch Self.cloudReconciliationExhaustionAction(session: session, segmentCount: segmentCount) {
     case .keepRetrying:
-      return false
+      return ExhaustedCloudReconciliationOutcome(handled: false, meetingTreatmentEligible: nil)
     case .uploadLocalSegments:
       log(
         "ConversationFinalization: Cloud reconciliation exhausted for session \(sessionId); uploading \(segmentCount) saved local segments"
       )
-      try await uploadLocalSegments(
+      let meetingTreatmentEligible = try await uploadLocalSegments(
         sessionId: sessionId,
         allowBackendIdOverride: session.backendId?.isEmpty == false
       )
-      return true
+      return ExhaustedCloudReconciliationOutcome(
+        handled: true,
+        meetingTreatmentEligible: meetingTreatmentEligible
+      )
     case .discardEmptyDesktopSession:
       log("ConversationFinalization: Deleting empty unreconciled desktop session \(sessionId)")
       try await TranscriptionStorage.shared.deleteSession(id: sessionId)
-      return true
+      return ExhaustedCloudReconciliationOutcome(handled: true, meetingTreatmentEligible: false)
     case .reportFailure:
-      return false
+      return ExhaustedCloudReconciliationOutcome(handled: false, meetingTreatmentEligible: nil)
     }
+  }
+
+  struct ExhaustedCloudReconciliationOutcome: Equatable {
+    let handled: Bool
+    let meetingTreatmentEligible: Bool?
   }
 
   enum CloudReconciliationExhaustionAction: Equatable {
@@ -514,11 +537,15 @@ actor ConversationFinalizationService {
         // recorded audio/transcript we still hold locally (#9083). Try to finalize from saved local
         // segments first so the recording is not lost.
         if let session,
-          let recovered = try? await resolveExhaustedCloudReconciliation(session: session, sessionId: sessionId),
-          recovered
+          let outcome = try? await resolveExhaustedCloudReconciliation(session: session, sessionId: sessionId),
+          outcome.handled
         {
           log("ConversationFinalization: Recovered exhausted session \(sessionId) from local data after finalize error")
-          await postMeetingCompletionIfReady(session: session, reason: .retry)
+          await postMeetingCompletionIfReady(
+            session: session,
+            reason: .retry,
+            meetingTreatmentEligible: outcome.meetingTreatmentEligible
+          )
           return
         }
         let segmentCount = try? await TranscriptionStorage.shared.getSegmentCount(sessionId: sessionId)
@@ -567,9 +594,14 @@ actor ConversationFinalizationService {
       || effectiveReason == .crashRecovery
   }
 
+  static func shouldWakeMeetingCompletion(finalizationStatus: ConversationFinalizationStatusResponse) -> Bool {
+    finalizationStatus.status == "completed" && finalizationStatus.meetingTreatmentEligible == true
+  }
+
   private func postMeetingCompletionIfReady(
     session: TranscriptionSessionRecord,
-    reason: TranscriptionFinalizationReason
+    reason: TranscriptionFinalizationReason,
+    meetingTreatmentEligible: Bool?
   ) async {
     guard Self.shouldNotifyMeetingCompletion(session: session, reason: reason), let sessionId = session.id else {
       return
@@ -579,6 +611,11 @@ actor ConversationFinalizationService {
         completed.status == .completed, completed.backendSynced, completed.backendId?.isEmpty == false
       else { return }
       guard let conversationID = completed.backendId else { return }
+      if let meetingTreatmentEligible {
+        guard meetingTreatmentEligible else { return }
+        scheduleMeetingCompletionNotification(conversationID: conversationID)
+        return
+      }
       guard
         await waitForFinalizationProjectionIfNeeded(
           conversationID: conversationID,
@@ -592,9 +629,11 @@ actor ConversationFinalizationService {
   }
 
   /// Cloud finalization marks the conversation completed before its durable
-  /// worker finishes fanout. Do not wake Chat during that gap: the first
+  /// worker finishes fanout. Do not wake Chat during that gap, and require the
+  /// backend's duration/speech policy result before notifying: the first
   /// materialization would consume its debounce window while no meeting intent
-  /// exists. Legacy/no-job conversations keep the historical behavior.
+  /// exists. A missing legacy job has no authoritative eligibility result and
+  /// therefore fails closed.
   private func waitForFinalizationProjectionIfNeeded(
     conversationID: String,
     strategy: TranscriptionFinalizationStrategy
@@ -612,14 +651,16 @@ actor ConversationFinalizationService {
       do {
         let status = try await apiClient.getConversationFinalizationStatus(id: conversationID)
         if status.status == "completed" {
-          return true
+          return Self.shouldWakeMeetingCompletion(finalizationStatus: status)
         }
         if status.status == "dead_letter" {
           log("ConversationFinalization: Skipping meeting wake for dead-letter conversation \(conversationID)")
           return false
         }
       } catch APIError.httpError(statusCode: 404, detail: _) {
-        return true
+        // Old inline finalization has no authoritative treatment result. Fail
+        // closed so a short meeting cannot bypass the backend policy.
+        return false
       } catch {
         // Transient status-read failures should not make a completed meeting
         // permanently silent; continue through the bounded retry window.
@@ -647,14 +688,14 @@ actor ConversationFinalizationService {
         guard !Task.isCancelled else { return }
         do {
           let status = try await self?.apiClient.getConversationFinalizationStatus(id: conversationID)
-          if status?.status == "completed" {
-            await self?.scheduleMeetingCompletionNotification(conversationID: conversationID)
+          if let status, status.status == "completed" {
+            if Self.shouldWakeMeetingCompletion(finalizationStatus: status) {
+              await self?.scheduleMeetingCompletionNotification(conversationID: conversationID)
+            }
             return
           }
           if status?.status == "dead_letter" { return }
         } catch APIError.httpError(statusCode: 404, detail: _) {
-          // Legacy inline finalization has no projection; wake Chat normally.
-          await self?.scheduleMeetingCompletionNotification(conversationID: conversationID)
           return
         } catch {
           continue

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ProactiveAssistantOrchestrationPolicy.swift
@@ -573,16 +573,15 @@ enum PreviewSimilarityThresholdPolicy {
     "IntelliJ IDEA", "PyCharm", "WebStorm", "GoLand", "CLion", "DataGrip",
   ]
 
-  private static let chatBundleIDs: Set<String> = [
+  private static let chatBundleIDs: Set<String> = Set([
     "com.tinyspeck.slackmacgap",
     "com.hnc.discord",
-    "ru.keepcoder.telegram",
     "net.whatsapp.whatsapp",
     "com.apple.mobilesms",
     "com.microsoft.teams2",
     "com.microsoft.teams",
     "com.apple.facetime",
-  ]
+  ]).union(ConferencingApps.telegramBundleIDs)
   private static let chatAppNames: Set<String> = [
     "Slack", "Discord", "Telegram", "WhatsApp", "Messages",
     "Microsoft Teams", "FaceTime",

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+ConversationModels.swift
@@ -51,6 +51,7 @@ struct ConversationFinalizationStatusResponse: Decodable, Equatable {
   let retryable: Bool
   let attemptCount: Int
   let taskRetryCount: Int
+  let meetingTreatmentEligible: Bool?
 
   enum CodingKeys: String, CodingKey {
     case jobID = "job_id"
@@ -59,6 +60,7 @@ struct ConversationFinalizationStatusResponse: Decodable, Equatable {
     case retryable
     case attemptCount = "attempt_count"
     case taskRetryCount = "task_retry_count"
+    case meetingTreatmentEligible = "meeting_treatment_eligible"
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Memories.swift
@@ -471,11 +471,13 @@ extension APIClient {
     let id: String
     let status: String
     let discarded: Bool
+    let meetingTreatmentEligible: Bool
 
     enum CodingKeys: String, CodingKey {
       case id
       case status
       case discarded
+      case meetingTreatmentEligible = "meeting_treatment_eligible"
     }
 
     init(from decoder: Decoder) throws {
@@ -483,6 +485,7 @@ extension APIClient {
       id = try container.decode(String.self, forKey: .id)
       status = try container.decodeIfPresent(String.self, forKey: .status) ?? ConversationStatus.processing.rawValue
       discarded = try container.decodeIfPresent(Bool.self, forKey: .discarded) ?? false
+      meetingTreatmentEligible = try container.decodeIfPresent(Bool.self, forKey: .meetingTreatmentEligible) ?? false
     }
   }
 

--- a/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientConversationCountTests.swift
@@ -71,6 +71,7 @@ final class APIClientConversationCountTests: XCTestCase {
     XCTAssertEqual(response.id, "conversation-1")
     XCTAssertEqual(response.status, "processing")
     XCTAssertFalse(response.discarded)
+    XCTAssertFalse(response.meetingTreatmentEligible)
   }
 
   func testConversationCountEndpointIncludesVisibleFilters() throws {

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -43,6 +43,8 @@ import XCTest
       XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "US.Zoom.XOS"))
       XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.microsoft.teams2"))
       XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.apple.facetime"))
+      XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "com.tdesktop.Telegram"))
+      XCTAssertTrue(ConferencingApps.isNativeCallApp(bundleID: "ru.keepcoder.telegram"))
       // Omi itself (which is always using the mic while recording) must not count as a meeting.
       XCTAssertFalse(ConferencingApps.isNativeCallApp(bundleID: "com.omi.omi-mtg-sysaudio"))
       XCTAssertFalse(ConferencingApps.isNativeCallApp(bundleID: "com.google.Chrome"))

--- a/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveAssistantOrchestrationPolicyTests.swift
@@ -579,6 +579,10 @@ final class ProactiveAssistantOrchestrationPolicyTests: XCTestCase {
       0.92)
     XCTAssertEqual(
       PreviewSimilarityThresholdPolicy.threshold(
+        bundleID: "com.tdesktop.Telegram", appName: "Telegram"),
+      0.92)
+    XCTAssertEqual(
+      PreviewSimilarityThresholdPolicy.threshold(
         bundleID: "com.apple.Safari", appName: "Safari"),
       0.90)
     XCTAssertEqual(

--- a/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
+++ b/desktop/macos/Desktop/Tests/TranscriptionFinalizationStateMachineTests.swift
@@ -379,6 +379,31 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
         session: continuedMeeting,
         reason: .finishAndContinue
       ))
+
+    XCTAssertTrue(
+      ConversationFinalizationService.shouldWakeMeetingCompletion(
+        finalizationStatus: ConversationFinalizationStatusResponse(
+          jobID: "job-eligible",
+          status: "completed",
+          terminal: true,
+          retryable: false,
+          attemptCount: 1,
+          taskRetryCount: 0,
+          meetingTreatmentEligible: true
+        )
+      ))
+    XCTAssertFalse(
+      ConversationFinalizationService.shouldWakeMeetingCompletion(
+        finalizationStatus: ConversationFinalizationStatusResponse(
+          jobID: "job-short-call",
+          status: "completed",
+          terminal: true,
+          retryable: false,
+          attemptCount: 1,
+          taskRetryCount: 0,
+          meetingTreatmentEligible: false
+        )
+      ))
   }
 
   func testSessionsNeedingFinalizationIncludesRetryableWorkOnly() async throws {
@@ -642,7 +667,7 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
           .utf8
       ),
       Data(
-        #"{"job_id":"job-1","status":"completed","terminal":true,"retryable":false,"attempt_count":1,"task_retry_count":0}"#
+        #"{"job_id":"job-1","status":"completed","terminal":true,"retryable":false,"attempt_count":1,"task_retry_count":0,"meeting_treatment_eligible":true}"#
           .utf8
       ),
     ])
@@ -903,12 +928,12 @@ final class TranscriptionFinalizationStateMachineTests: XCTestCase {
     let storedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
     let session = try XCTUnwrap(storedSession)
 
-    let handled = try await ConversationFinalizationService.shared.resolveExhaustedCloudReconciliation(
+    let outcome = try await ConversationFinalizationService.shared.resolveExhaustedCloudReconciliation(
       session: session,
       sessionId: sessionId
     )
 
-    XCTAssertTrue(handled)
+    XCTAssertTrue(outcome.handled)
     let deletedSession = try await TranscriptionStorage.shared.getSession(id: sessionId)
     XCTAssertNil(deletedSession)
   }

--- a/desktop/macos/changelog/unreleased/20260818-telegram-meeting-detection.json
+++ b/desktop/macos/changelog/unreleased/20260818-telegram-meeting-detection.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Telegram calls being missed by meeting detection and prevented short or mostly silent calls from being announced as completed meetings"
+}

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1158,12 +1158,14 @@ export interface ConversationAudioUrlInfo {
 export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
+  meeting_treatment_eligible?: boolean;
   status: string;
 }
 
 export interface ConversationFinalizationStatusResponse {
   attempt_count: number;
   job_id: string;
+  meeting_treatment_eligible?: boolean;
   retryable: boolean;
   status: string;
   task_retry_count: number;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -7284,6 +7284,11 @@
             "title": "Id",
             "type": "string"
           },
+          "meeting_treatment_eligible": {
+            "default": false,
+            "title": "Meeting Treatment Eligible",
+            "type": "boolean"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -7307,6 +7312,11 @@
           "job_id": {
             "title": "Job Id",
             "type": "string"
+          },
+          "meeting_treatment_eligible": {
+            "default": false,
+            "title": "Meeting Treatment Eligible",
+            "type": "boolean"
           },
           "retryable": {
             "title": "Retryable",

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -160,6 +160,11 @@
             "title": "Id",
             "type": "string"
           },
+          "meeting_treatment_eligible": {
+            "default": false,
+            "title": "Meeting Treatment Eligible",
+            "type": "boolean"
+          },
           "status": {
             "title": "Status",
             "type": "string"

--- a/docs/doc/developer/backend/listen_pusher_pipeline.mdx
+++ b/docs/doc/developer/backend/listen_pusher_pipeline.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Listen + Pusher Pipeline"
 icon: "tower-broadcast"
-description: "Sequence diagrams for the /v4/listen WebSocket and Pusher processing pipeline"
+description: "Sequence diagrams and finalization policy for the /v4/listen WebSocket and Pusher pipeline"
 ---
 
 # Listen + Pusher Pipeline — Sequence Diagrams
 
-> Last updated: 2026-07-26 (bounded Pusher delivery, validated frames, and durable finalization ownership)
+> Last updated: 2026-08-18 (meeting-treatment eligibility and deduplicated speech duration)
 >
 > These diagrams document the real behavior observed during E2E testing with
 > live services (backend, pusher, STT providers, embedding API). Update when the
@@ -61,9 +61,20 @@ resource before it creates or resumes a conversation. A client-generated
 clients receive a server-generated UUID. The optional
 `conversation_role=meeting` marker is supplied by desktop after a
 machine-observed call-start boundary; omitted or invalid values remain
-`ambient`. That bounded marker is persisted with the conversation so the
-post-finalization Chat receipt can distinguish meeting notes from ordinary
-always-on ambient chunks without inspecting transcript text.
+`ambient`. That bounded marker is durable session provenance committed at
+OPEN; finalization does not rewrite it based on how long the session lasted.
+
+Meeting treatment is a separate finalization decision. A desktop meeting that
+was neither discarded nor created by a maximum-duration rotation is eligible
+only when its durable `started_at` and `finished_at` span at least five minutes
+and its non-empty transcript covers at least 60 seconds of speech. Speech time
+is the union of valid segment intervals, so overlapping microphone and system-
+audio transcriptions of the same remote speech count once. The backend uses the
+result to gate the meeting Chat receipt and exposes it on the durable
+finalization status; desktop completion notifications require the same value.
+The synchronous desktop upload route applies and returns the same decision.
+Short or mostly silent calls still finalize as ordinary conversations, with
+their original role and provenance unchanged.
 
 The resource atomically binds the recording to exactly one conversation, so
 reconnects return the original canonical mapping rather than falling back to a

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1158,12 +1158,14 @@ export interface ConversationAudioUrlInfo {
 export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
+  meeting_treatment_eligible?: boolean;
   status: string;
 }
 
 export interface ConversationFinalizationStatusResponse {
   attempt_count: number;
   job_id: string;
+  meeting_treatment_eligible?: boolean;
   retryable: boolean;
   status: string;
   task_retry_count: number;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1158,12 +1158,14 @@ export interface ConversationAudioUrlInfo {
 export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
+  meeting_treatment_eligible?: boolean;
   status: string;
 }
 
 export interface ConversationFinalizationStatusResponse {
   attempt_count: number;
   job_id: string;
+  meeting_treatment_eligible?: boolean;
   retryable: boolean;
   status: string;
   task_retry_count: number;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1158,12 +1158,14 @@ export interface ConversationAudioUrlInfo {
 export interface ConversationCreateResponse {
   discarded: boolean;
   id: string;
+  meeting_treatment_eligible?: boolean;
   status: string;
 }
 
 export interface ConversationFinalizationStatusResponse {
   attempt_count: number;
   job_id: string;
+  meeting_treatment_eligible?: boolean;
   retryable: boolean;
   status: string;
   task_retry_count: number;


### PR DESCRIPTION
## What and why

- Add Telegram Desktop's shipping bundle ID (`com.tdesktop.Telegram`, normalized to lowercase) and legacy `ru.keepcoder.telegram` ID to native call detection. The proactive chat-app policy consumes the same Telegram ID set so the catalogs cannot drift independently.
- Keep `conversation_role` as OPEN-time session provenance. Introduce a separate backend-owned `meeting_treatment_eligible` finalization result, persist it with the durable finalization job, and expose it through both the finalization-status and synchronous from-segments responses.
- Gate the meeting Chat arrival and desktop completion notification on that finalization result. Short or mostly silent calls still finalize as ordinary conversations without rewriting their role or provenance.
- Count actual speech as the union of non-empty transcript intervals, preventing simultaneous microphone and system-audio transcript twins from roughly doubling the speech measure.

Meeting treatment requires at least five minutes of wall-clock duration and at least 60 seconds of deduplicated transcribed speech. Five minutes filters quick calls that should remain ordinary conversations. The smaller speech floor still admits listening-heavy meetings and natural pauses while rejecting long hold/silence captures with only a brief accidental transcription. Interval union makes the floor independent of whether one or both desktop audio streams transcribed the same remote speech.

## Line-count exception

Line-Count-Exception: backend/routers/developer.py | 2111 -> 2115 | propagates the new meeting_treatment_eligible field through the existing conversation response model and its two projection sites; splitting this router is unrelated to this fix and would make the change unreviewable.

## Failure class

Failure-Class: none

No registered failure class matches this macOS native-process catalog omission or the separate finalization-time treatment boundary. `FC-meeting-trigger-title-identity-drift` is a Windows browser-title/event identity contract. The production `isNativeCallApp` regression and shared Telegram ID set guard the catalog boundary; backend behavioral tests guard duration, deduplicated speech, finalization persistence, Chat arrival, and response projection.

## Verification

- `PYTHON=/Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python bash test-preflight.sh` (from `backend/`) — 17 passed, 9 optional warnings, 0 failed.
- `PYTHON=/Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python BACKEND_PYTEST_WORKERS=6 BACKEND_UNIT_TEST_FILE_LIST=../.backend-meeting-test-files.txt bash test.sh` (from `backend/`; the temporary selector listed the six changed/new backend test files and was then deleted) — 195 passed, including the four dedicated meeting-treatment policy tests.
- `PYTHON=/Users/dazheng/workspace/omi/upstream-keep-clean/backend/.venv/bin/python BACKEND_PYTEST_WORKERS=10 bash test.sh` (from `backend/`) — all 856 backend unit-test files were selected and the runner progressed through nearly the entire suite, but one remaining file produced no output for several minutes and the file-isolated runner has no per-file timeout. The run was interrupted and did not produce a terminal pass/fail summary; full-suite status is therefore unverified.
- `./scripts/run-swift-ci.sh --test` (from `desktop/macos/`) — could not start because the pinned `/Applications/Xcode_16.4.app` toolchain is unavailable in this environment.
- `CLANG_MODULE_CACHE_PATH=/Volumes/scratch/tmp/meeting-detect-swift-cache/clang SWIFTPM_MODULECACHE_OVERRIDE=/Volumes/scratch/tmp/meeting-detect-swift-cache/clang xcrun swift test --jobs 1 -Xswiftc -j1 --disable-index-store --disable-sandbox --skip-update --disable-build-manifest-caching --manifest-cache none --cache-path /Volumes/scratch/tmp/meeting-detect-swift-cache/swiftpm-cache --config-path /Volumes/scratch/tmp/meeting-detect-swift-cache/swiftpm-config --security-path /Volumes/scratch/tmp/meeting-detect-swift-cache/swiftpm-security --scratch-path /private/tmp/meeting-swift-build --package-path desktop/macos/Desktop --filter 'ConferencingAppsTests|TranscriptionFinalizationStateMachineTests|ProactiveAssistantOrchestrationPolicyTests|APIClientConversationCountTests'` — SwiftPM reached the debug build and then failed with opaque `error: fatalError`; tests did not execute.
- `CLANG_MODULE_CACHE_PATH=/Volumes/scratch/tmp/meeting-detect-swift-cache/harness-clang SWIFTPM_MODULECACHE_OVERRIDE=/Volumes/scratch/tmp/meeting-detect-swift-cache/harness-clang xcrun swiftc -module-cache-path /Volumes/scratch/tmp/meeting-detect-swift-cache/harness-clang desktop/macos/Desktop/Sources/ConferencingApps.swift .meeting-detect-catalog-harness.swift -o /private/tmp/meeting-detect-catalog-harness && /private/tmp/meeting-detect-catalog-harness` — directly compiled the production classifier; both Telegram IDs classified as native call apps and Omi did not. Printed `Telegram catalog classification passed`; the temporary source was deleted.
- `python3 scripts/check_desktop_test_quality.py` (from `desktop/macos/`) — passed with no new source-reading tests, trapping dictionary initializers, or wall-clock waits.
- `scripts/swift-format-wrapper.sh lint <nine changed Swift files>` (from `desktop/macos/`) — passed.
- `make preflight` — all 11 manifest checks passed. Because the changes were still uncommitted, the preflight runner reported `files=0`; rerun after the commit so diff-scoped selection is meaningful.
- `git diff --check` — passed.

## Verification limits

- A real Telegram call and named desktop bundle were not exercised because the pinned desktop toolchain is unavailable and SwiftPM cannot complete whole-module emission with the available toolchain.
- The full backend suite did not reach a terminal summary; the changed-area component run is green, but the remaining backend files are not claimed as verified.

## Follow-ups

- Add Tier-2 detection for unknown CoreAudio processes only after a telemetry-only phase builds an observed allowlist from real process topologies. `isRunningOutput` means an active output stream, not audible speech; games, DAWs, and media apps can satisfy it, while split-process Electron/browser calls can fail a same-process input+output rule.
- Design idle-based conversation rotation through the existing serialized meeting-boundary path. It must never become a second rotation authority: a failed meeting rotation can call `stopTranscription()`, so an independent idle race could stop always-on capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

