### PR TITLE
fix(backend): a deleted folder must not 500 the move that leaves it

### DIFF
--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -1,12 +1,16 @@
+import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, cast
 
+from google.api_core.exceptions import NotFound
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
 from database.document_ids import system_folder_doc_id
+
+logger = logging.getLogger(__name__)
 
 # System folders that are created for new users
 SYSTEM_FOLDERS: List[Dict[str, Any]] = [
@@ -199,25 +203,29 @@ def delete_folder(uid: str, folder_id: str, move_to_folder_id: Optional[str] = N
         if default_folder:
             target_folder_id = str(default_folder['id'])
 
-    # Move all conversations from this folder to the target folder
-    if target_folder_id:
-        conversations_ref = user_ref.collection('conversations')
-        conversations = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id)).stream()
+    # Repoint every conversation off this folder. target_folder_id is None for
+    # users with no default folder (accounts created after the 'Other' system
+    # folder was removed) — they get unfiled, not left pointing at the document
+    # deleted below. A stale pointer used to survive here and 500 every later
+    # move of that conversation.
+    conversations_ref = user_ref.collection('conversations')
+    conversations = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id)).stream()
 
-        batch = db.batch()
-        count = 0
-        for conv_doc in conversations:
-            batch.update(conv_doc.reference, {'folder_id': target_folder_id})
-            count += 1
-            if count >= 450:
-                batch.commit()
-                batch = db.batch()
-                count = 0
-
-        if count > 0:
+    batch = db.batch()
+    count = 0
+    for conv_doc in conversations:
+        batch.update(conv_doc.reference, {'folder_id': target_folder_id})
+        count += 1
+        if count >= 450:
             batch.commit()
+            batch = db.batch()
+            count = 0
 
-        # Update target folder count
+    if count > 0:
+        batch.commit()
+
+    # Update target folder count
+    if target_folder_id:
         update_folder_conversation_count(uid, target_folder_id)
 
     # Delete the folder
@@ -396,7 +404,15 @@ def update_folder_conversation_count(uid: str, folder_id: str) -> int:
     count = int(result[0][0].value or 0)
 
     folder_ref = user_ref.collection('folders').document(folder_id)
-    folder_ref.update({'conversation_count': count})
+    try:
+        folder_ref.update({'conversation_count': count})
+    except NotFound:
+        # conversation_count is derived state on a document the folders
+        # collection owns. A refresh for a folder that no longer exists has
+        # nothing to write — it must not fail the move that triggered it.
+        # Callers reach here only via a conversation still pointing at a
+        # deleted folder, which delete_folder no longer leaves behind.
+        logger.warning(f"folder {folder_id} no longer exists; skipping conversation_count refresh")
 
     return count
 

--- a/backend/tests/unit/test_folder_move_deleted_folder.py
+++ b/backend/tests/unit/test_folder_move_deleted_folder.py
@@ -1,0 +1,200 @@
+"""PATCH /v1/conversations/{id}/folder must survive a conversation whose old folder was deleted.
+
+Prod signature (2026-08-18, image c5b0b5d): three 500s on that route, all from
+database/folders.py:update_folder_conversation_count ->
+`google.api_core.exceptions.NotFound: 404 No document to update: .../folders/852e33fd-...`.
+
+Two defects made that reachable:
+
+1. delete_folder repointed its conversations only `if target_folder_id` — and
+   target_folder_id is None for every account created after the 'Other' system
+   folder was removed (no folder carries is_default; see
+   test_conversation_folder_assignment). Those conversations kept the deleted
+   folder's id.
+2. The next move of such a conversation wrote the new folder_id, then refreshed
+   the *old* folder's count. The router validates only the target folder, so the
+   refresh hit a tombstone and raised. The move had already committed, so the
+   user saw a permanent 500 on a write that actually succeeded, and every retry
+   500'd the same way.
+
+The fake below models the one server behavior that matters here: `update()` on a
+missing document raises NotFound.
+"""
+
+from unittest.mock import patch
+
+from google.api_core.exceptions import NotFound
+
+import database.folders as folders
+
+
+class _FakeSnapshot:
+    def __init__(self, doc_id, data, reference=None):
+        self.id = doc_id
+        self._data = data
+        self.exists = data is not None
+        self.reference = reference
+
+    def to_dict(self):
+        return dict(self._data) if self._data is not None else None
+
+
+class _FakeDocRef:
+    def __init__(self, store, doc_id):
+        self._store = store
+        self.id = doc_id
+
+    def get(self):
+        return _FakeSnapshot(self.id, self._store.get(self.id), reference=self)
+
+    def update(self, values):
+        if self.id not in self._store:
+            raise NotFound(f"404 No document to update: {self.id}")
+        self._store[self.id].update(values)
+
+    def delete(self):
+        self._store.pop(self.id, None)
+
+
+class _FakeAggregate:
+    def __init__(self, total):
+        self._total = total
+
+    def get(self):
+        return [[type('AggregationResult', (), {'value': self._total})()]]
+
+
+class _FakeQuery:
+    def __init__(self, store, predicates):
+        self._store = store
+        self._predicates = predicates
+
+    def where(self, filter=None):
+        return _FakeQuery(self._store, self._predicates + [(filter.field_path, filter.value)])
+
+    def order_by(self, _field, direction=None):
+        return self
+
+    def offset(self, _n):
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def _matching(self):
+        return [
+            (doc_id, data)
+            for doc_id, data in self._store.items()
+            if all(data.get(field) == value for field, value in self._predicates)
+        ]
+
+    def stream(self):
+        for doc_id, data in self._matching():
+            yield _FakeSnapshot(doc_id, data, reference=_FakeDocRef(self._store, doc_id))
+
+    def count(self):
+        return _FakeAggregate(len(self._matching()))
+
+
+class _FakeCollection(_FakeQuery):
+    def __init__(self, store):
+        super().__init__(store, [])
+
+    def document(self, doc_id):
+        return _FakeDocRef(self._store, doc_id)
+
+
+class _FakeUserRef:
+    def __init__(self, collections):
+        self._collections = collections
+
+    def collection(self, name):
+        return _FakeCollection(self._collections.setdefault(name, {}))
+
+
+class _FakeUsersCollection:
+    def __init__(self, collections):
+        self._collections = collections
+
+    def document(self, _uid):
+        return _FakeUserRef(self._collections)
+
+
+class _FakeBatch:
+    def __init__(self):
+        self._writes = []
+
+    def update(self, reference, values):
+        self._writes.append((reference, values))
+
+    def commit(self):
+        for reference, values in self._writes:
+            reference.update(values)
+        self._writes = []
+
+
+class _FakeDb:
+    def __init__(self, conversations, folders_store):
+        self._collections = {'conversations': conversations, 'folders': folders_store}
+
+    def collection(self, _name):
+        return _FakeUsersCollection(self._collections)
+
+    def batch(self):
+        return _FakeBatch()
+
+    def get_all(self, references):
+        return [reference.get() for reference in references]
+
+
+def test_move_off_a_deleted_folder_does_not_500():
+    conversations = {'conv-1': {'folder_id': 'deleted-folder', 'discarded': False}}
+    folders_store = {'work': {'conversation_count': 0}}
+
+    with patch.object(folders, 'db', _FakeDb(conversations, folders_store)):
+        # Pre-fix this raised NotFound from the old folder's count refresh.
+        assert folders.move_conversation_to_folder('u1', 'conv-1', 'work') is True
+
+    assert conversations['conv-1']['folder_id'] == 'work'
+    assert conversations['conv-1']['folder_user_set'] is True
+    assert folders_store['work']['conversation_count'] == 1
+
+
+def test_bulk_move_off_a_deleted_folder_does_not_500():
+    conversations = {
+        'conv-1': {'folder_id': 'deleted-folder', 'discarded': False},
+        'conv-2': {'folder_id': 'deleted-folder', 'discarded': False},
+    }
+    folders_store = {'work': {'conversation_count': 0}}
+
+    with patch.object(folders, 'db', _FakeDb(conversations, folders_store)):
+        assert folders.bulk_move_conversations_to_folder('u1', ['conv-1', 'conv-2'], 'work') == 2
+
+    assert folders_store['work']['conversation_count'] == 2
+
+
+def test_delete_folder_without_a_default_target_unfiles_instead_of_orphaning():
+    conversations = {'conv-1': {'folder_id': 'doomed', 'discarded': False}}
+    # No folder carries is_default — the post-'Other' account shape.
+    folders_store = {'doomed': {'conversation_count': 1, 'order': 0}}
+
+    with patch.object(folders, 'db', _FakeDb(conversations, folders_store)):
+        assert folders.delete_folder('u1', 'doomed') is True
+
+    assert 'doomed' not in folders_store
+    # Pre-fix this stayed 'doomed' and poisoned every later move.
+    assert conversations['conv-1']['folder_id'] is None
+
+
+def test_delete_folder_still_moves_conversations_to_the_default_folder():
+    conversations = {'conv-1': {'folder_id': 'doomed', 'discarded': False}}
+    folders_store = {
+        'doomed': {'conversation_count': 1, 'order': 0},
+        'other': {'is_default': True, 'conversation_count': 0, 'order': 1},
+    }
+
+    with patch.object(folders, 'db', _FakeDb(conversations, folders_store)):
+        assert folders.delete_folder('u1', 'doomed') is True
+
+    assert conversations['conv-1']['folder_id'] == 'other'
+    assert folders_store['other']['conversation_count'] == 1


### PR DESCRIPTION
## Summary

`PATCH /v1/conversations/{id}/folder` returns a **bare 500** whenever the conversation's *current* folder has been deleted — and the move it reports as failed has already committed. Every retry 500s identically, so the folder is unchangeable from the UI for that conversation forever.

Live signature (prod Cloud Run `backend`, image `c5b0b5d`, 2026-08-18 17:00–23:35Z): 3× `500 /v1/conversations/{id}/folder`, one trace, one folder id.

```
File "/app/routers/folders.py", line 165, in move_conversation_to_folder
File "/app/database/folders.py", line 331, in move_conversation_to_folder
File "/app/database/folders.py", line 399, in update_folder_conversation_count
google.api_core.exceptions.NotFound: 404 No document to update:
  .../users/{uid}/folders/852e33fd-0355-4d45-b67e-8f5ed6ecad1d
```

## Root cause — two defects chained

**1. `delete_folder` mints the stale pointer.** It repointed its conversations only `if target_folder_id`, and `target_folder_id` is `None` for every account created after the `Other` system folder was removed — no folder carries `is_default` for them (the same population `test_conversation_folder_assignment.py` already documents). For those users, deleting a folder left every conversation in it pointing at the document deleted three lines later.

**2. `move_conversation_to_folder` dereferences it terminally.** It writes the new `folder_id`, then refreshes the **old** folder's `conversation_count`. The router validates only the *target* folder (`routers/folders.py:160-163`), never the source, so the refresh hits a tombstone and `folder_ref.update()` raises. The conversation write had already committed at that point: the client reads 500 as "the move failed", retries an applied mutation, and the count never gets refreshed.

## Fix

- `delete_folder` repoints unconditionally — `target_folder_id=None` means **unfiled**, which is the correct terminal state and is already representable everywhere (`move_conversation_to_folder(folder_id: Optional[str])`, `validate_folder_assignment` returning `None`). No new stale pointers are minted.
- `update_folder_conversation_count` tolerates a missing folder doc. `conversation_count` is derived state on a document the folders collection owns; a refresh for a folder that no longer exists has nothing to write and must not fail the mutation that triggered it. This heals the pointers **already in prod**, which fix 1 alone cannot reach.

The guard sits inside the maintenance boundary, not at each call site, so all five callers are covered at once: single move, bulk move, `delete_folder`'s target refresh, and `process_conversation`'s assignment refresh.

`+34 / -18` in one source file, plus one new test file.

## Verification

**Real user-facing path.** `PATCH /v1/conversations/{id}/folder` driven through the actual FastAPI app + `routers/folders.py` + `database/folders.py`, with only the Firestore client faked, on a conversation whose folder was deleted:

| source | HTTP | stored `folder_id` | `work.conversation_count` |
|---|---|---|---|
| `origin/main` (b27420e01c) | **500** | `work` — the write had landed | `0` — never refreshed |
| this branch | **200** | `work` | `1` |

The control row reproduces the prod behaviour exactly, including the write landing before the 500.

**Regression tests** — `backend/tests/unit/test_folder_move_deleted_folder.py`, 4 tests through a Firestore double whose `update()` raises `NotFound` on a missing document (the one server behaviour that matters here):

- `test_move_off_a_deleted_folder_does_not_500`
- `test_bulk_move_off_a_deleted_folder_does_not_500`
- `test_delete_folder_without_a_default_target_unfiles_instead_of_orphaning`
- `test_delete_folder_still_moves_conversations_to_the_default_folder` (no-regression guard for the default-folder path)

Control run against unfixed `database/folders.py`: **3 fail, 1 passes** (the no-regression guard, correctly). With the fix: 4 pass.

`backend/test.sh` (full 857-file selection — `select_backend_unit_tests.py` maps `database/folders.py` to the full suite) and `black --line-length 120 --skip-string-normalization` clean.

## Failure class

`FC-post-commit-index-maintenance-terminal` — *"a raise from the index boundary turns a landed create/update/delete into a 5xx the client reads as 'the write failed', which drives retries of an applied mutation and shows the user an error for state that changed."* Second instance after #10871 (vector index). Same shape, different maintenance surface: a derived counter rather than a search index, and the same canonical prevention — contain the failure inside the maintenance boundary rather than at each call site. Precedent for the guard itself: `test_advice_update_missing_doc_guard.py`, where `ref.update()` raising `NotFound` on a concurrently-deleted doc was likewise turned into a non-500.

Failure-Class: FC-post-commit-index-maintenance-terminal

Product invariants affected: none.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

