### PR TITLE
Cut the Windows app's idle and focus-driven backend request volume

### DIFF
--- a/desktop/windows/src/main/assistants/goals/context.test.ts
+++ b/desktop/windows/src/main/assistants/goals/context.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   assembleGoalContext,
+  fetchActiveGoalCountWith,
   hasSufficientContext,
   type GoalContextFetchers,
   type GoalContextData,
@@ -56,6 +57,56 @@ describe('assembleGoalContext', () => {
       fetchers({ fetchGoals: async () => [{ title: 'X', targetValue: 10, currentValue: 2.5 }] })
     )
     expect(data.activeGoals).toEqual(['- X (2.5/10)'])
+  })
+})
+
+describe('fetchActiveGoalCountWith', () => {
+  // The auto-generation cap is now decided on this one read instead of the full
+  // five-read bundle. Two derivations of "how many goals are active" therefore exist,
+  // and if they drift the cap starts meaning different things depending on which path
+  // evaluated it. These cases hold them together.
+  const goals: RawGoal[] = [
+    { title: 'Read books', targetValue: 12, currentValue: 3 }, // active
+    { title: 'Ship v1', targetValue: 1, currentValue: 1 }, // complete (>=target)
+    { title: 'Run miles', targetValue: 100, currentValue: 100 }, // complete
+    { title: 'No target', targetValue: 0, currentValue: 0 } // target 0 → active
+  ]
+
+  it('agrees with assembleGoalContext on the same goals', async () => {
+    const f = fetchers({ fetchGoals: async () => goals })
+    const bundle = await assembleGoalContext(f)
+    await expect(fetchActiveGoalCountWith(f)).resolves.toBe(bundle.activeGoalCount)
+    await expect(fetchActiveGoalCountWith(f)).resolves.toBe(2)
+  })
+
+  it('reads goals and nothing else', async () => {
+    // The whole point is the four reads it does NOT make. `/v3/memories?limit=500` and
+    // `/v1/conversations?limit=100` are the expensive two.
+    const calls: string[] = []
+    const spying: GoalContextFetchers = {
+      fetchMemories: async () => {
+        calls.push('memories')
+        return []
+      },
+      fetchConversations: async () => {
+        calls.push('conversations')
+        return []
+      },
+      fetchTasks: async () => {
+        calls.push('tasks')
+        return []
+      },
+      fetchPersona: async () => {
+        calls.push('persona')
+        return null
+      },
+      fetchGoals: async () => {
+        calls.push('goals')
+        return goals
+      }
+    }
+    await fetchActiveGoalCountWith(spying)
+    expect(calls).toEqual(['goals'])
   })
 })
 

--- a/desktop/windows/src/main/assistants/goals/context.test.ts
+++ b/desktop/windows/src/main/assistants/goals/context.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   assembleGoalContext,
-  fetchActiveGoalCountWith,
+  activeGoalCount,
+  withPrefetchedGoals,
   hasSufficientContext,
   type GoalContextFetchers,
   type GoalContextData,
@@ -60,33 +61,54 @@ describe('assembleGoalContext', () => {
   })
 })
 
-describe('fetchActiveGoalCountWith', () => {
-  // The auto-generation cap is now decided on this one read instead of the full
-  // five-read bundle. Two derivations of "how many goals are active" therefore exist,
-  // and if they drift the cap starts meaning different things depending on which path
-  // evaluated it. These cases hold them together.
+describe('activeGoalCount', () => {
+  // The auto-generation cap is decided on this number, taken straight off the goal
+  // list rather than from the full five-read bundle. Two derivations of "how many
+  // goals are active" would let the cap mean different things depending on which path
+  // evaluated it, so `assembleGoalContext` and the gate share this one function.
   const goals: RawGoal[] = [
     { title: 'Read books', targetValue: 12, currentValue: 3 }, // active
     { title: 'Ship v1', targetValue: 1, currentValue: 1 }, // complete (>=target)
     { title: 'Run miles', targetValue: 100, currentValue: 100 }, // complete
-    { title: 'No target', targetValue: 0, currentValue: 0 } // target 0 → active
+    { title: 'No target', targetValue: 0, currentValue: 0 } // target 0 -> active
   ]
 
-  it('agrees with assembleGoalContext on the same goals', async () => {
-    const f = fetchers({ fetchGoals: async () => goals })
-    const bundle = await assembleGoalContext(f)
-    await expect(fetchActiveGoalCountWith(f)).resolves.toBe(bundle.activeGoalCount)
-    await expect(fetchActiveGoalCountWith(f)).resolves.toBe(2)
+  it('is the same number assembleGoalContext reports', async () => {
+    const bundle = await assembleGoalContext(fetchers({ fetchGoals: async () => goals }))
+    expect(activeGoalCount(goals)).toBe(bundle.activeGoalCount)
+    expect(activeGoalCount(goals)).toBe(2)
   })
 
-  it('reads goals and nothing else', async () => {
-    // The whole point is the four reads it does NOT make. `/v3/memories?limit=500` and
-    // `/v1/conversations?limit=100` are the expensive two.
+  it('counts an empty list as zero', () => {
+    expect(activeGoalCount([])).toBe(0)
+  })
+})
+
+describe('withPrefetchedGoals', () => {
+  const goals: RawGoal[] = [{ title: 'Read books', targetValue: 12, currentValue: 3 }]
+
+  it('serves goals from the prefetched list without asking for them again', async () => {
+    let goalFetches = 0
+    const wrapped = withPrefetchedGoals(
+      fetchers({
+        fetchGoals: async () => {
+          goalFetches += 1
+          return []
+        }
+      }),
+      goals
+    )
+    const data = await assembleGoalContext(wrapped)
+    expect(goalFetches).toBe(0)
+    expect(data.activeGoals).toEqual(['- Read books (3/12)'])
+  })
+
+  it('leaves the other four reads untouched', async () => {
     const calls: string[] = []
-    const spying: GoalContextFetchers = {
+    const base = fetchers({
       fetchMemories: async () => {
         calls.push('memories')
-        return []
+        return ['m']
       },
       fetchConversations: async () => {
         calls.push('conversations')
@@ -99,14 +121,26 @@ describe('fetchActiveGoalCountWith', () => {
       fetchPersona: async () => {
         calls.push('persona')
         return null
-      },
-      fetchGoals: async () => {
-        calls.push('goals')
-        return goals
       }
-    }
-    await fetchActiveGoalCountWith(spying)
-    expect(calls).toEqual(['goals'])
+    })
+    await assembleGoalContext(withPrefetchedGoals(base, goals))
+    expect(calls.sort()).toEqual(['conversations', 'memories', 'persona', 'tasks'])
+  })
+
+  it('falls back to the real fetcher when nothing was prefetched', async () => {
+    let goalFetches = 0
+    const wrapped = withPrefetchedGoals(
+      fetchers({
+        fetchGoals: async () => {
+          goalFetches += 1
+          return goals
+        }
+      }),
+      undefined
+    )
+    const data = await assembleGoalContext(wrapped)
+    expect(goalFetches).toBe(1)
+    expect(data.activeGoals).toEqual(['- Read books (3/12)'])
   })
 })
 

--- a/desktop/windows/src/main/assistants/goals/context.ts
+++ b/desktop/windows/src/main/assistants/goals/context.ts
@@ -219,6 +219,28 @@ export async function assembleGoalContext(f: GoalContextFetchers): Promise<GoalC
   }
 }
 
+/** The active-goal count on its own: ONE `GET /v1/goals/all` and none of the other
+ *  four reads. Derived exactly as `assembleGoalContext` derives `activeGoalCount`, so
+ *  the cap gate means the same thing whichever path evaluates it.
+ *
+ *  This exists so the auto-generation cap can be checked BEFORE the expensive context
+ *  build. A user sitting at the cap is the steady state, not the exception, and that
+ *  user used to re-pay all five reads — including 500 memories and 100 conversations —
+ *  on every 4-hourly tick, forever, because the bail does not stamp the day. */
+export async function fetchActiveGoalCountWith(
+  f: Pick<GoalContextFetchers, 'fetchGoals'>
+): Promise<number> {
+  const goals = await f.fetchGoals()
+  return goals.filter((g) => !isProgressComplete(g)).length
+}
+
+/** Production `fetchActiveGoalCountWith`. `null` = no session (nothing to decide on). */
+export async function fetchActiveGoalCount(): Promise<number | null> {
+  const session = getBackendSession()
+  if (!session) return null
+  return fetchActiveGoalCountWith(realFetchers(session))
+}
+
 /** Mac's insufficient-context guard (throws `insufficientContext` there): skip
  *  generation entirely unless there is at least one memory OR conversation OR
  *  task. Goal history alone is not enough to reason from. */

--- a/desktop/windows/src/main/assistants/goals/context.ts
+++ b/desktop/windows/src/main/assistants/goals/context.ts
@@ -219,26 +219,28 @@ export async function assembleGoalContext(f: GoalContextFetchers): Promise<GoalC
   }
 }
 
-/** The active-goal count on its own: ONE `GET /v1/goals/all` and none of the other
- *  four reads. Derived exactly as `assembleGoalContext` derives `activeGoalCount`, so
- *  the cap gate means the same thing whichever path evaluates it.
+/** How many of these goals are still active. The ONE definition of the cap gate's
+ *  number: `assembleGoalContext` reports it as `activeGoalCount`, and the auto-
+ *  generation gate reads it straight off the goal list, so the cap cannot come to mean
+ *  two different things depending on which path evaluated it. */
+export function activeGoalCount(goals: RawGoal[]): number {
+  return goals.filter((g) => !isProgressComplete(g)).length
+}
+
+/** Just the goal list: ONE `GET /v1/goals/all` and none of the other four reads.
+ *  `null` = no session (nothing to decide on).
  *
  *  This exists so the auto-generation cap can be checked BEFORE the expensive context
  *  build. A user sitting at the cap is the steady state, not the exception, and that
  *  user used to re-pay all five reads — including 500 memories and 100 conversations —
- *  on every 4-hourly tick, forever, because the bail does not stamp the day. */
-export async function fetchActiveGoalCountWith(
-  f: Pick<GoalContextFetchers, 'fetchGoals'>
-): Promise<number> {
-  const goals = await f.fetchGoals()
-  return goals.filter((g) => !isProgressComplete(g)).length
-}
-
-/** Production `fetchActiveGoalCountWith`. `null` = no session (nothing to decide on). */
-export async function fetchActiveGoalCount(): Promise<number | null> {
+ *  on every 4-hourly tick, forever, because the bail does not stamp the day.
+ *
+ *  Hand the result back to `fetchGoalContext` so a run that does proceed reuses it
+ *  instead of asking for the same list twice. */
+export async function fetchGoals(): Promise<RawGoal[] | null> {
   const session = getBackendSession()
   if (!session) return null
-  return fetchActiveGoalCountWith(realFetchers(session))
+  return realFetchers(session).fetchGoals()
 }
 
 /** Mac's insufficient-context guard (throws `insufficientContext` there): skip
@@ -250,8 +252,22 @@ export function hasSufficientContext(data: GoalContextData): boolean {
 
 /** Production entry: assemble the bundle for the current session, or null when
  *  there is no session (a soft no-op — nothing to fetch with). */
-export async function fetchGoalContext(): Promise<GoalContextData | null> {
+/** Serve `fetchGoals` from a list the caller already has, leaving the other four reads
+ *  alone. The cap gate fetches goals before deciding whether to build the context, so
+ *  without this a run that proceeds would ask for the same list a second time. Split
+ *  out from `fetchGoalContext` because that one needs a live session, and this is the
+ *  part worth testing. */
+export function withPrefetchedGoals(
+  f: GoalContextFetchers,
+  goals?: RawGoal[]
+): GoalContextFetchers {
+  return goals ? { ...f, fetchGoals: async () => goals } : f
+}
+
+export async function fetchGoalContext(
+  prefetchedGoals?: RawGoal[]
+): Promise<GoalContextData | null> {
   const session = getBackendSession()
   if (!session) return null
-  return assembleGoalContext(realFetchers(session))
+  return assembleGoalContext(withPrefetchedGoals(realFetchers(session), prefetchedGoals))
 }

--- a/desktop/windows/src/main/assistants/goals/schedule.test.ts
+++ b/desktop/windows/src/main/assistants/goals/schedule.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
   },
   session: null as unknown,
   fetchGoalContext: vi.fn(),
+  fetchActiveGoalCount: vi.fn(),
   removeStaleGoals: vi.fn(async () => ({ deleted: [] })),
   buildCandidateWith: vi.fn(),
   createCandidateWith: vi.fn(),
@@ -28,7 +29,10 @@ vi.mock('../../appSettings', () => ({
   setAppSettings: (patch: Record<string, unknown>) => Object.assign(h.settings, patch)
 }))
 vi.mock('../core/session', () => ({ getBackendSession: () => h.session }))
-vi.mock('./context', () => ({ fetchGoalContext: h.fetchGoalContext }))
+vi.mock('./context', () => ({
+  fetchGoalContext: h.fetchGoalContext,
+  fetchActiveGoalCount: h.fetchActiveGoalCount
+}))
 vi.mock('./generate', () => ({
   buildCandidateWith: h.buildCandidateWith,
   createCandidateWith: h.createCandidateWith,
@@ -116,15 +120,20 @@ describe('runGoalGenerationIfDue gates (auto path)', () => {
   it('cleans up but does not generate when 3+ goals are already active', async () => {
     h.settings.goalAutoGenerationEnabled = true
     h.session = { token: 't' }
-    h.fetchGoalContext.mockResolvedValue(ctx({ activeGoalCount: 3 }))
+    h.fetchActiveGoalCount.mockResolvedValue(3)
     await runGoalGenerationIfDue()
     expect(h.removeStaleGoals).toHaveBeenCalled()
     expect(h.buildCandidateWith).not.toHaveBeenCalled()
+    // The cap is the resting state for an engaged user and this bail never stamps the
+    // day, so it repeats every 4h forever. It must not pay for the full context build
+    // (5 reads, including 500 memories and 100 conversations) to learn nothing.
+    expect(h.fetchGoalContext).not.toHaveBeenCalled()
   })
 
   it('generates + creates when due and stamps the day on success', async () => {
     h.settings.goalAutoGenerationEnabled = true
     h.session = { token: 't' }
+    h.fetchActiveGoalCount.mockResolvedValue(1)
     h.fetchGoalContext.mockResolvedValue(ctx({ activeGoalCount: 1 }))
     h.buildCandidateWith.mockResolvedValue({ status: 'candidate', candidate })
     h.createCandidateWith.mockResolvedValue({ status: 'created', goalId: 'g1', title: 'G' })
@@ -137,6 +146,7 @@ describe('runGoalGenerationIfDue gates (auto path)', () => {
   it('does not create (nor stamp the day) when generation skips', async () => {
     h.settings.goalAutoGenerationEnabled = true
     h.session = { token: 't' }
+    h.fetchActiveGoalCount.mockResolvedValue(1)
     h.fetchGoalContext.mockResolvedValue(ctx({ activeGoalCount: 1 }))
     h.buildCandidateWith.mockResolvedValue({ status: 'skipped', reason: 'insufficient_context' })
     await runGoalGenerationIfDue()

--- a/desktop/windows/src/main/assistants/goals/schedule.test.ts
+++ b/desktop/windows/src/main/assistants/goals/schedule.test.ts
@@ -14,7 +14,8 @@ const h = vi.hoisted(() => ({
   },
   session: null as unknown,
   fetchGoalContext: vi.fn(),
-  fetchActiveGoalCount: vi.fn(),
+  fetchGoals: vi.fn(),
+  activeGoalCount: vi.fn(),
   removeStaleGoals: vi.fn(async () => ({ deleted: [] })),
   buildCandidateWith: vi.fn(),
   createCandidateWith: vi.fn(),
@@ -31,7 +32,8 @@ vi.mock('../../appSettings', () => ({
 vi.mock('../core/session', () => ({ getBackendSession: () => h.session }))
 vi.mock('./context', () => ({
   fetchGoalContext: h.fetchGoalContext,
-  fetchActiveGoalCount: h.fetchActiveGoalCount
+  fetchGoals: h.fetchGoals,
+  activeGoalCount: h.activeGoalCount
 }))
 vi.mock('./generate', () => ({
   buildCandidateWith: h.buildCandidateWith,
@@ -120,7 +122,8 @@ describe('runGoalGenerationIfDue gates (auto path)', () => {
   it('cleans up but does not generate when 3+ goals are already active', async () => {
     h.settings.goalAutoGenerationEnabled = true
     h.session = { token: 't' }
-    h.fetchActiveGoalCount.mockResolvedValue(3)
+    h.fetchGoals.mockResolvedValue([])
+    h.activeGoalCount.mockReturnValue(3)
     await runGoalGenerationIfDue()
     expect(h.removeStaleGoals).toHaveBeenCalled()
     expect(h.buildCandidateWith).not.toHaveBeenCalled()
@@ -133,7 +136,9 @@ describe('runGoalGenerationIfDue gates (auto path)', () => {
   it('generates + creates when due and stamps the day on success', async () => {
     h.settings.goalAutoGenerationEnabled = true
     h.session = { token: 't' }
-    h.fetchActiveGoalCount.mockResolvedValue(1)
+    const goals = [{ title: 'Read books', targetValue: 12, currentValue: 3 }]
+    h.fetchGoals.mockResolvedValue(goals)
+    h.activeGoalCount.mockReturnValue(1)
     h.fetchGoalContext.mockResolvedValue(ctx({ activeGoalCount: 1 }))
     h.buildCandidateWith.mockResolvedValue({ status: 'candidate', candidate })
     h.createCandidateWith.mockResolvedValue({ status: 'created', goalId: 'g1', title: 'G' })
@@ -141,12 +146,16 @@ describe('runGoalGenerationIfDue gates (auto path)', () => {
     expect(h.removeStaleGoals).toHaveBeenCalled()
     expect(h.createCandidateWith).toHaveBeenCalled()
     expect(h.settings.goalGenerationLastDate).toBe(localDateString())
+    // The cap gate already paid for the goal list, so a run that proceeds must hand it
+    // on rather than making the bundle ask for the same list a second time.
+    expect(h.fetchGoalContext).toHaveBeenCalledWith(goals)
   })
 
   it('does not create (nor stamp the day) when generation skips', async () => {
     h.settings.goalAutoGenerationEnabled = true
     h.session = { token: 't' }
-    h.fetchActiveGoalCount.mockResolvedValue(1)
+    h.fetchGoals.mockResolvedValue([])
+    h.activeGoalCount.mockReturnValue(1)
     h.fetchGoalContext.mockResolvedValue(ctx({ activeGoalCount: 1 }))
     h.buildCandidateWith.mockResolvedValue({ status: 'skipped', reason: 'insufficient_context' })
     await runGoalGenerationIfDue()

--- a/desktop/windows/src/main/assistants/goals/schedule.ts
+++ b/desktop/windows/src/main/assistants/goals/schedule.ts
@@ -14,7 +14,7 @@
 // generateNow cadence); create stamps the day so the auto timer won't also fire.
 import { getAppSettings, setAppSettings } from '../../appSettings'
 import { getBackendSession } from '../core/session'
-import { fetchGoalContext } from './context'
+import { fetchActiveGoalCount, fetchGoalContext } from './context'
 import {
   buildCandidateWith,
   createCandidateWith,
@@ -88,9 +88,17 @@ export async function runGoalGenerationIfDue(): Promise<void> {
       console.warn('[goals] cleanup failed:', e instanceof Error ? e.name : 'Error')
     )
 
+    // Cap check first, on one cheap read. Reaching the cap is the ordinary resting
+    // state for an engaged user, and this bail deliberately does NOT stamp the day
+    // (so finishing a goal at noon can still generate a replacement) — which means
+    // the tick repeats every 4 hours indefinitely. Behind the full context build that
+    // cost five reads a time; in front of it, one.
+    const activeGoalCount = await fetchActiveGoalCount()
+    if (activeGoalCount === null) return // session vanished mid-run
+    if (activeGoalCount >= MAX_ACTIVE_GOALS) return
+
     const context = await fetchGoalContext()
     if (!context) return // session vanished mid-run
-    if (context.activeGoalCount >= MAX_ACTIVE_GOALS) return
 
     // Generate reusing the already-fetched context (no double fetch), then create
     // directly — a background job has no preview surface.

--- a/desktop/windows/src/main/assistants/goals/schedule.ts
+++ b/desktop/windows/src/main/assistants/goals/schedule.ts
@@ -14,7 +14,7 @@
 // generateNow cadence); create stamps the day so the auto timer won't also fire.
 import { getAppSettings, setAppSettings } from '../../appSettings'
 import { getBackendSession } from '../core/session'
-import { fetchActiveGoalCount, fetchGoalContext } from './context'
+import { activeGoalCount, fetchGoalContext, fetchGoals } from './context'
 import {
   buildCandidateWith,
   createCandidateWith,
@@ -93,11 +93,13 @@ export async function runGoalGenerationIfDue(): Promise<void> {
     // (so finishing a goal at noon can still generate a replacement) — which means
     // the tick repeats every 4 hours indefinitely. Behind the full context build that
     // cost five reads a time; in front of it, one.
-    const activeGoalCount = await fetchActiveGoalCount()
-    if (activeGoalCount === null) return // session vanished mid-run
-    if (activeGoalCount >= MAX_ACTIVE_GOALS) return
+    const goals = await fetchGoals()
+    if (goals === null) return // session vanished mid-run
+    if (activeGoalCount(goals) >= MAX_ACTIVE_GOALS) return
 
-    const context = await fetchGoalContext()
+    // Hand the goals on so proceeding costs the same four remaining reads it always
+    // did, rather than asking for the same list twice.
+    const context = await fetchGoalContext(goals)
     if (!context) return // session vanished mid-run
 
     // Generate reusing the already-fetched context (no double fetch), then create

--- a/desktop/windows/src/main/assistants/tasks/create.ts
+++ b/desktop/windows/src/main/assistants/tasks/create.ts
@@ -421,6 +421,14 @@ export async function promoteIfNeeded(opts?: { bypassDebounce?: boolean }): Prom
   }
 }
 
+/** When the last SUCCESSFUL promote landed (0 = never this launch). Read by the
+ *  promotion safety net to tell "a tick that promoted something" from "a tick that
+ *  found nothing", which is what its backoff ladder keys on. Exposed as a getter
+ *  rather than the binding so the single-writer rule above still holds. */
+export function getLastPromotedAt(): number {
+  return lastPromotedAt
+}
+
 /** Reset the module-level promotion debounce/lock. Test-only seam so a suite can
  *  exercise the debounce deterministically without a shared-state carryover. */
 export function __resetPromotionStateForTests(): void {

--- a/desktop/windows/src/main/assistants/tasks/promotionService.test.ts
+++ b/desktop/windows/src/main/assistants/tasks/promotionService.test.ts
@@ -54,7 +54,11 @@ import {
   promoteIfNeeded,
   __resetPromotionStateForTests
 } from './create'
-import { startTaskPromotionService, __resetPromotionServiceForTests } from './promotionService'
+import {
+  startTaskPromotionService,
+  stopTaskPromotionService,
+  __resetPromotionServiceForTests
+} from './promotionService'
 
 // --- FIFO fake backend -------------------------------------------------------
 // `POST /v1/staged-tasks` pushes an id; `POST /v1/staged-tasks/promote` pops the
@@ -232,11 +236,14 @@ describe('T-B — startup promote', () => {
     expect(promotedBackendIds()).toEqual(['ai-st-pre'])
 
     // The poll stopped after firing: advancing 5 more minutes over an empty FIFO
-    // yields only the 60s safety ticks (all promoted:false), no poll re-fires.
+    // yields only safety ticks (all promoted:false), no poll re-fires. Each of those
+    // finds nothing and steps down the backoff ladder (60s, then 120s, then 300s), so
+    // the window buys 2 ticks. The guard here is the poll — 60 five-second poll
+    // attempts would show up as ~60 posts, not 2.
     const postsBefore = promotePostCount
     await vi.advanceTimersByTimeAsync(5 * 60_000)
     const ticks = promotePostCount - postsBefore
-    expect(ticks).toBe(5) // exactly 5 safety-timer ticks, not 60 poll attempts
+    expect(ticks).toBe(2)
     expect(promotedBackendIds()).toEqual(['ai-st-pre']) // nothing left to promote
   })
 
@@ -273,6 +280,88 @@ describe('T-C — safety-timer bypass semantics', () => {
   })
 })
 
+describe('T-D — safety-net backoff (idle request volume)', () => {
+  // The regression: a flat 60s timer POSTed /v1/staged-tasks/promote 1,440x/day per
+  // client, essentially all returning promoted:false, each costing the backend two
+  // full collection scans to answer "nothing".
+  it('steps 60s -> 2m -> 5m -> 10m and holds at 10m while nothing is stageable', async () => {
+    startTaskPromotionService()
+    await vi.advanceTimersByTimeAsync(0) // startup promote (empty FIFO, no post)
+    const at = (): number => promotePostCount
+
+    // Each tick lands exactly at the ladder delay, and NOT one millisecond earlier.
+    for (const delay of [60_000, 120_000, 300_000, 600_000]) {
+      const before = at()
+      await vi.advanceTimersByTimeAsync(delay - 1)
+      expect(at()).toBe(before) // still armed
+      await vi.advanceTimersByTimeAsync(1)
+      expect(at()).toBe(before + 1) // fired
+    }
+
+    // Ladder is capped, not unbounded: the next tick is 10m again, not 20m.
+    const before = at()
+    await vi.advanceTimersByTimeAsync(600_000 - 1)
+    expect(at()).toBe(before)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(at()).toBe(before + 1)
+
+    // An idle hour costs single digits, where the flat timer cost 60.
+    expect(at()).toBeLessThanOrEqual(8)
+  })
+
+  it('a promote resets to the 60s floor, so a backlog still drains one per minute', async () => {
+    startTaskPromotionService()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Walk down to the slow end of the ladder over an empty FIFO.
+    await vi.advanceTimersByTimeAsync(60_000 + 120_000 + 300_000)
+    const posts = promotePostCount
+
+    // Something is staged out of band and the next (10m) tick finds it.
+    stagedQueue.push('st-remote')
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(promotedBackendIds()).toEqual(['ai-st-remote'])
+    expect(promotePostCount).toBe(posts + 1)
+
+    // Reset proof: a second out-of-band row is picked up on the very next MINUTE,
+    // not 10 minutes later. Without the reset this assertion fails.
+    stagedQueue.push('st-remote-2')
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(promotedBackendIds()).toEqual(['ai-st-remote', 'ai-st-remote-2'])
+  })
+
+  it('a failing backend backs off instead of retrying at a flat 60s forever', async () => {
+    h.fetch.mockImplementation(async () => ({ ok: false, status: 500, json: async () => ({}) }))
+    startTaskPromotionService()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // One hour against a hard-failing promote endpoint.
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+    // Flat-60s behavior would be ~60 posts. The ladder caps the hour in single digits.
+    expect(promotePostCount).toBeLessThanOrEqual(8)
+  })
+
+  it('a signed-out stretch does not strand a returning user on the slow cadence', async () => {
+    // Walk the ladder to its slow end WHILE SIGNED IN first — a service that starts
+    // signed out is already at the floor, so it would prove nothing about the reset.
+    startTaskPromotionService()
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(60_000 + 120_000 + 300_000) // now on the 10m rung
+
+    h.session = null
+    const postsBefore = promotePostCount
+    await vi.advanceTimersByTimeAsync(30 * 60_000) // half an hour signed out
+    expect(promotePostCount).toBe(postsBefore) // signed out costs nothing
+
+    // Signed-out ticks prove nothing about the backlog, so they must return the net to
+    // the floor: a row staged while away is picked up a minute after sign-in, not ten.
+    h.session = { apiBase: 'https://api', desktopApiBase: 'https://d', token: 't' }
+    stagedQueue.push('st-after-signin')
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(promotedBackendIds()).toEqual(['ai-st-after-signin'])
+  })
+})
+
 describe('T-E — safety negatives', () => {
   it('a timer tick with no session makes zero network calls', async () => {
     h.session = null
@@ -302,6 +391,26 @@ describe('T-E — safety negatives', () => {
     // The racing promote's write was dropped by the epoch guard — only the startup
     // promote's write survives.
     expect(promotedBackendIds()).toEqual(['ai-st-race'])
+  })
+
+  it('a stop that lands mid-promote does not leave the timer re-armed', async () => {
+    // The tick re-arms from inside its own promise chain, so a stop while a promote is
+    // in flight must not be undone by that chain finishing afterwards.
+    const gate: { resolve: (v: unknown) => void } = { resolve: () => {} }
+    stagedQueue.push('st-inflight')
+    startTaskPromotionService()
+    await vi.advanceTimersByTimeAsync(0) // startup promote drains it
+    stagedQueue.push('st-next')
+    deferPromote = gate
+    await vi.advanceTimersByTimeAsync(60_000) // tick fires, POST pending
+
+    stopTaskPromotionService()
+    gate.resolve(undefined)
+    await vi.advanceTimersByTimeAsync(0)
+
+    const after = promotePostCount
+    await vi.advanceTimersByTimeAsync(60 * 60_000) // an hour with the service stopped
+    expect(promotePostCount).toBe(after)
   })
 
   it('starting twice runs a single safety interval (idempotent)', async () => {

--- a/desktop/windows/src/main/assistants/tasks/promotionService.ts
+++ b/desktop/windows/src/main/assistants/tasks/promotionService.ts
@@ -29,19 +29,72 @@
 // guard across the await), so a tick that fires with no session or across a
 // sign-out is already safe with no extra guards here.
 import { getBackendSession } from '../core/session'
-import { promoteIfNeeded } from './create'
+import { getLastPromotedAt, promoteIfNeeded } from './create'
 
 // Mac `TaskPromotionService` safety-net cadence (TPS.swift:43 — the code is 60s; the
 // stale "5-minute" doc comment loses to the code).
 const SAFETY_TIMER_MS = 60_000
+
+// Backoff ladder for the safety net, in ms. The net exists to discover staged rows
+// created OUT OF BAND (another device, a backend extraction) — every in-app path that
+// stages a task already promotes inline (create.ts:324) or on the task-complete /
+// task-delete events (taskSyncEngine.ts:807, :884), and none of those go through this
+// timer. So the timer's only job is discovery latency for a case that is rare and
+// idle-shaped, while a flat 60s made it the single loudest request source in the app:
+// a POST /v1/staged-tasks/promote every minute for the life of the process, ~1,440 a
+// day, essentially all returning `promoted:false`. Each one costs the backend two full
+// collection scans (staged_tasks + candidates) to answer "nothing".
+//
+// A tick that promotes something resets to the floor, so a backlog still drains one
+// per minute exactly as before. Only a tick that finds nothing (or errors — the flat
+// timer had NO backoff for a failing backend either) steps down the ladder. Worst-case
+// out-of-band discovery latency becomes 10 minutes, which is inside Mac's own
+// documented 5-minute intent and well inside the hours-to-days shape of the case.
+const SAFETY_BACKOFF_MS = [SAFETY_TIMER_MS, 120_000, 300_000, 600_000] as const
 // Session-wait cadence for the startup promote — mirrors register.ts:53–54 (the
 // renderer relays the session a few seconds after startup).
 const SESSION_POLL_MS = 5_000
 const SESSION_POLL_MAX_ATTEMPTS = 60 // ~5 min
 
 let started = false
-let safetyTimer: ReturnType<typeof setInterval> | null = null
+let safetyTimer: ReturnType<typeof setTimeout> | null = null
 let sessionPollTimer: ReturnType<typeof setInterval> | null = null
+// Index into SAFETY_BACKOFF_MS for the NEXT safety tick.
+let safetyStep = 0
+
+/** Arm the next safety tick at the current ladder delay. No-op once stopped: a tick
+ *  re-arms from inside its own promise chain, so a stop that lands while a promote is
+ *  in flight would otherwise resurrect the timer after `stopTaskPromotionService`
+ *  cleared it. `clearInterval` used to make that impossible for free. */
+function scheduleSafetyTick(): void {
+  if (!started) return
+  const delay = SAFETY_BACKOFF_MS[Math.min(safetyStep, SAFETY_BACKOFF_MS.length - 1)]
+  safetyTimer = setTimeout(() => {
+    void runSafetyTick()
+  }, delay)
+  safetyTimer.unref?.() // never hold the process open
+}
+
+/** One safety-net pass, then re-arm at the delay this pass earned. */
+async function runSafetyTick(): Promise<void> {
+  // Signed out costs nothing and proves nothing about the backlog, so it must not
+  // walk the ladder down — otherwise a long signed-out stretch would leave a
+  // just-signed-in user on the slowest cadence.
+  if (!getBackendSession()) {
+    safetyStep = 0
+    scheduleSafetyTick()
+    return
+  }
+  const before = getLastPromotedAt()
+  try {
+    await promoteIfNeeded({ bypassDebounce: true })
+  } finally {
+    // A promote landed → there may be more behind it, so return to the 60s floor and
+    // drain at the original rate. Nothing promoted (or the POST failed) → step down.
+    safetyStep = getLastPromotedAt() !== before ? 0 : safetyStep + 1
+    scheduleSafetyTick()
+  }
+}
 
 /**
  * Start the promotion safety net + the one-shot startup promote. Idempotent (a
@@ -55,12 +108,10 @@ export function startTaskPromotionService(): void {
   if (started) return
   started = true
 
-  // Trigger 2 — 60s safety-net timer. `bypassDebounce` beats the 30s inline
-  // debounce so a strand always drains one task per tick.
-  safetyTimer = setInterval(() => {
-    void promoteIfNeeded({ bypassDebounce: true })
-  }, SAFETY_TIMER_MS)
-  safetyTimer.unref?.() // never hold the process open
+  // Trigger 2 — safety-net timer, floor 60s. `bypassDebounce` beats the 30s inline
+  // debounce so a strand always drains one task per tick. Self-scheduling rather than
+  // setInterval so each tick can pick its own next delay off SAFETY_BACKOFF_MS.
+  scheduleSafetyTick()
 
   // Trigger 1 — startup promote. Fire immediately if signed in (Mac start()); else
   // poll for a session, fire once when it appears, and stop (register.ts pattern).
@@ -92,10 +143,11 @@ function stopSessionPoll(): void {
  *  is unref'd; there is nothing to clean up at quit). */
 export function stopTaskPromotionService(): void {
   if (safetyTimer) {
-    clearInterval(safetyTimer)
+    clearTimeout(safetyTimer)
     safetyTimer = null
   }
   stopSessionPoll()
+  safetyStep = 0
   started = false
 }
 

--- a/desktop/windows/src/renderer/src/components/chat/ChatAppPicker.tsx
+++ b/desktop/windows/src/renderer/src/components/chat/ChatAppPicker.tsx
@@ -141,17 +141,28 @@ function AssistantRow(props: {
   )
 }
 
-/** Gated container: reads the pref + fetches chat apps + wires selection into the
- *  shared chat engine. Renders nothing unless the pref is ON and there is at least
- *  one chat-capable app (Mac disables its picker when `chatApps.isEmpty`). */
+/** Gate wrapper: reads the pref and renders nothing when the picker is off — WITHOUT
+ *  mounting the component that fetches chat apps.
+ *
+ *  `chatAppPickerEnabled` is optional, so the picker is off for almost everyone, and
+ *  the fetch used to run above the gate: every ask-bar focus mounts the chat panel,
+ *  so each focus cycle issued a `GET /v1/apps` for a picker that then returned null.
+ *  This is the same split (and the same reason) as HubChatHeader's. */
 export function ChatAppPicker(): React.JSX.Element | null {
   const [enabled, setEnabled] = useState(() => getPreferences().chatAppPickerEnabled === true)
   useEffect(() => onPreferencesChange((p) => setEnabled(p.chatAppPickerEnabled === true)), [])
 
+  if (!enabled) return null
+  return <ChatAppPickerGated />
+}
+
+/** Fetches chat apps + wires selection into the shared chat engine. Renders nothing
+ *  when there is no chat-capable app (Mac disables its picker when `chatApps.isEmpty`). */
+function ChatAppPickerGated(): React.JSX.Element | null {
   const { chat } = useAppState()
   const { chatApps } = useChatApps()
 
-  if (!enabled || chatApps.length === 0) return null
+  if (chatApps.length === 0) return null
 
   return (
     <div className="mb-3 flex items-center">

--- a/desktop/windows/src/renderer/src/components/home/HomeGoalsChips.tsx
+++ b/desktop/windows/src/renderer/src/components/home/HomeGoalsChips.tsx
@@ -6,6 +6,7 @@ import { goalEmoji, DEFAULT_GOAL_EMOJI } from '../../lib/goalEmoji'
 import { isCompleted, progressColor, progressPct } from '../../lib/goalVisuals'
 import { cache as goalsCache, hydrateGoalsFromDisk, writeCache } from '../../lib/goalsCache'
 import { getCacheUid } from '../../lib/persistentCache'
+import { useThrottledWindowFocus } from '../../lib/focusRefetch'
 import type { GoalResponse as Goal } from '../../lib/omiApi.generated'
 import type { HubHomeWidgetsProps } from './hub/hubHomeWidgetsSlot'
 
@@ -119,13 +120,12 @@ export function HomeGoalsChips({ onShowAll, onOpenGoal }: HubHomeWidgetsProps): 
   }, [pathname, fetchGoals])
 
   // Refetch on window focus, so a goal added/completed in another window shows up.
-  useEffect(() => {
-    const onFocus = (): void => {
-      if (auth.currentUser) fetchGoals()
-    }
-    window.addEventListener('focus', onFocus)
-    return () => window.removeEventListener('focus', onFocus)
-  }, [fetchGoals])
+  // Throttled — the app blurs its own main window on every bar/orb interaction, so an
+  // unthrottled listener fired many times a minute during normal voice use. See
+  // lib/focusRefetch.ts.
+  useThrottledWindowFocus(() => {
+    if (auth.currentUser) fetchGoals()
+  })
 
   // Loading — a height-stable skeleton so the cluster never jumps when data lands.
   if (goals === null) {

--- a/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
+++ b/desktop/windows/src/renderer/src/components/settings/tabs/RewindTab.tsx
@@ -13,6 +13,7 @@ import {
   ScanText
 } from 'lucide-react'
 import { runScreenSynthesisOnce } from '../../../lib/screenSynthesis'
+import { runRetentionSweep } from '../../../lib/retentionSweep'
 import { BUILT_IN_EXCLUDED_APPS } from '../../../../../shared/rewindExclusions'
 import { SettingRow } from '../SettingRow'
 import { Toggle } from '../Toggle'
@@ -56,6 +57,11 @@ export function RewindTab(): React.JSX.Element {
   const changeRetention = (mode: 'off' | 'dry-run' | 'live'): void => {
     setRetention(mode)
     setPreferences({ retentionMode: mode })
+    // Preview is a one-shot the user just asked for, so run it here — the 30-minute
+    // background timer only runs 'live' passes now. Pressing Preview is what makes
+    // the "logs what it would delete" subtitle true, instead of it happening 48x a
+    // day whether or not anyone is looking.
+    if (mode === 'dry-run') void runRetentionSweep('manual')
   }
 
   useEffect(() => {

--- a/desktop/windows/src/renderer/src/lib/chatQuotaGate.test.ts
+++ b/desktop/windows/src/renderer/src/lib/chatQuotaGate.test.ts
@@ -179,3 +179,86 @@ describe('checkSync — synchronous PTT pre-capture veto', () => {
     expect(gate.checkSync()).toMatchObject({ blocked: true })
   })
 })
+
+describe('sync throttle — reveal/reply request volume', () => {
+  // The regression: `sync()` had only an in-flight dedupe, which does nothing for
+  // sequential calls. It runs on every bar reveal and after every chat reply, so a
+  // normal voice session issued one GET /v1/users/me/usage-quota per interaction.
+  const gate = (
+    fetchQuota: () => Promise<ChatUsageQuota>
+  ): ReturnType<typeof createChatQuotaGate> => createChatQuotaGate(fetchQuota, 5_000, 60_000)
+
+  it('fetches once across a burst of reveals', async () => {
+    const fetchQuota = vi.fn(async () => quota())
+    const g = gate(fetchQuota)
+    for (let i = 0; i < 8; i++) await g.sync()
+    expect(fetchQuota).toHaveBeenCalledTimes(1)
+  })
+
+  it('throttles on the shipped default when built with no interval argument', async () => {
+    // barSend.ts calls createChatQuotaGate() with no arguments, so production runs
+    // entirely on MIN_SYNC_INTERVAL_MS. Every other case here passes an explicit
+    // interval, which would leave the shipped constant unread by any test.
+    const fetchQuota = vi.fn(async () => quota())
+    const g = createChatQuotaGate(fetchQuota)
+    for (let i = 0; i < 8; i++) await g.sync()
+    expect(fetchQuota).toHaveBeenCalledTimes(1)
+  })
+
+  it('fetches again once the interval has elapsed', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    try {
+      const fetchQuota = vi.fn(async () => quota())
+      const g = gate(fetchQuota)
+      await g.sync()
+      expect(fetchQuota).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(59_999)
+      await g.sync()
+      expect(fetchQuota).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(1)
+      await g.sync()
+      expect(fetchQuota).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('never throttles the cold start, so an over-cap user still gets blocked', async () => {
+    // check() forces a sync when there is no snapshot. Throttling that would hand a
+    // free send to exactly the user the gate exists to stop.
+    const fetchQuota = vi.fn(async () => quota({ used: 30 }))
+    const g = gate(fetchQuota)
+    await expect(g.check()).resolves.toMatchObject({ blocked: true })
+    expect(fetchQuota).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps counting sends while the snapshot is held, so the cap still binds', async () => {
+    // The throttle is only safe because the optimistic delta covers the gap.
+    const fetchQuota = vi.fn(async () => quota({ used: 28 }))
+    const g = gate(fetchQuota)
+    await g.sync()
+    expect(g.isLimitReached()).toBe(false)
+
+    g.recordQuery()
+    await g.sync() // throttled — no fresh snapshot to reset the delta
+    g.recordQuery()
+    expect(fetchQuota).toHaveBeenCalledTimes(1)
+    expect(g.isLimitReached()).toBe(true)
+  })
+
+  it('backs off a failing probe instead of retrying it on every reveal', async () => {
+    const fetchQuota = vi.fn(async () => {
+      throw new Error('boom')
+    })
+    const g = gate(fetchQuota)
+    await g.sync()
+    await g.sync()
+    await g.sync()
+    // A failure leaves no snapshot, so the cold-start exemption would let every
+    // reveal re-probe a backend that is already failing. The attempt stamp stops it.
+    expect(fetchQuota).toHaveBeenCalledTimes(1)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/chatQuotaGate.ts
+++ b/desktop/windows/src/renderer/src/lib/chatQuotaGate.ts
@@ -35,6 +35,20 @@ import { fetchChatQuota } from './billing'
 /** Longest a cold-start send may wait on the first quota sync before failing open. */
 export const COLD_START_SYNC_TIMEOUT_MS = 5_000
 
+/** Floor between two network refreshes of the same snapshot.
+ *
+ *  `sync()` is called on every floating-bar reveal (BarApp's onShow) and after every
+ *  completed chat reply (UsageLimitTriggerHost) — both driven by the primary voice
+ *  interaction, so they fire many times a minute in ordinary use. Its only guard was
+ *  an in-flight dedupe, which does nothing for calls that are merely sequential, so
+ *  N taps meant N `GET /v1/users/me/usage-quota`.
+ *
+ *  A month-to-date counter does not move meaningfully inside a minute, and the gate
+ *  already tracks sends between refreshes with `recordQuery()`'s optimistic delta, so
+ *  the verdict stays correct across the gap. A cold start (no snapshot at all) is
+ *  never throttled — that path is load-bearing for blocking an over-cap user. */
+export const MIN_SYNC_INTERVAL_MS = 60_000
+
 /** Resolve when `p` settles or the bound elapses, whichever comes first. */
 function withTimeout(p: Promise<void>, ms: number): Promise<void> {
   return new Promise<void>((resolve) => {
@@ -93,20 +107,38 @@ export function isLimitReached(quota: ChatUsageQuota | null, optimisticDelta: nu
 
 export function createChatQuotaGate(
   fetchQuota: () => Promise<ChatUsageQuota> = fetchChatQuota,
-  coldStartTimeoutMs: number = COLD_START_SYNC_TIMEOUT_MS
+  coldStartTimeoutMs: number = COLD_START_SYNC_TIMEOUT_MS,
+  minSyncIntervalMs: number = MIN_SYNC_INTERVAL_MS
 ): ChatQuotaGate {
   let quota: ChatUsageQuota | null = null
   let optimisticDelta = 0
   // Dedupe concurrent syncs (a reveal-refresh racing a cold-start send fetch).
   let inFlight: Promise<void> | null = null
+  // When the last refresh was ATTEMPTED (0 = never). Attempt, not success, so a
+  // failing backend backs off too instead of being re-probed on every reveal.
+  let lastSyncAt = 0
 
   const applyQuota = (next: ChatUsageQuota): void => {
     quota = next
     optimisticDelta = 0
+    // A snapshot handed in from elsewhere (e.g. a send response) is just as fresh as
+    // one we fetched, so it restarts the interval rather than being ignored by it.
+    lastSyncAt = Date.now()
   }
 
   const sync = (): Promise<void> => {
     if (inFlight) return inFlight
+    // One probe per interval, counted from the last ATTEMPT. The first probe of a
+    // session is never throttled (lastSyncAt is 0), so check()'s cold start still gets
+    // the fetch it needs to keep an already-over-cap user from getting a free send.
+    //
+    // Failures are throttled too, deliberately. `fetchChatQuota` goes through
+    // apiClient, which already retries 429/503 five times with capped backoff, so a
+    // rejection here means the endpoint is genuinely down — and re-probing it on every
+    // bar reveal is the same waste this floor exists to remove. The gate is fail-open
+    // on a missing snapshot by design, so the cost of waiting is bounded and known.
+    if (Date.now() - lastSyncAt < minSyncIntervalMs) return Promise.resolve()
+    lastSyncAt = Date.now()
     inFlight = fetchQuota()
       .then(applyQuota)
       .catch(() => {

--- a/desktop/windows/src/renderer/src/lib/focusRefetch.test.tsx
+++ b/desktop/windows/src/renderer/src/lib/focusRefetch.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+// The window-focus refetch throttle. Three always-mounted surfaces (Memories, Apps,
+// Home goal chips) revalidate on focus, and the app blurs its own main window every
+// time the bar/orb/capture window takes focus — so before the throttle, ordinary voice
+// use re-issued six-plus backend requests per interaction, including a full
+// `/v3/memories` page-through for a page that was not even on screen.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { FOCUS_REFETCH_MIN_INTERVAL_MS, useThrottledWindowFocus } from './focusRefetch'
+
+const focus = (): void => {
+  window.dispatchEvent(new Event('focus'))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // A realistic wall clock. The hook uses 0 as its "never run" sentinel, so a 1970
+  // clock would make a genuine run indistinguishable from never having run.
+  vi.setSystemTime(1_700_000_000_000)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useThrottledWindowFocus', () => {
+  it('collapses a burst of focus events into a single run', () => {
+    const handler = vi.fn()
+    renderHook(() => useThrottledWindowFocus(handler))
+
+    // Alt-tabbing between the main window and the floating bar, five times, fast.
+    for (let i = 0; i < 5; i++) {
+      focus()
+      vi.advanceTimersByTime(200)
+    }
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs again once the interval has genuinely elapsed', () => {
+    const handler = vi.fn()
+    renderHook(() => useThrottledWindowFocus(handler))
+
+    focus()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    // One millisecond short: still throttled. This is the assertion that fails if the
+    // comparison is flipped or the interval is dropped to zero.
+    vi.advanceTimersByTime(FOCUS_REFETCH_MIN_INTERVAL_MS - 1)
+    focus()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(1)
+    focus()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('always runs the first focus of a session', () => {
+    // Revalidating on focus is the behavior these surfaces promise (a goal completed
+    // in another window shows up when you come back). The throttle only drops the
+    // repeats — deferring the first one would be a behavior change, not a cost fix.
+    // Memories.focusRefresh and Apps.focusRefresh assert this from the page side.
+    const handler = vi.fn()
+    renderHook(() => useThrottledWindowFocus(handler))
+    focus()
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors a caller-supplied interval', () => {
+    const handler = vi.fn()
+    renderHook(() => useThrottledWindowFocus(handler, 5_000))
+
+    focus()
+    focus()
+    expect(handler).toHaveBeenCalledTimes(1) // second one throttled
+
+    vi.advanceTimersByTime(5_000)
+    focus()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-renders resubscribe the listener without disturbing the throttle window', () => {
+    // Call sites pass a NEW closure every render (they close over loading/refresh), so
+    // the effect really does tear down and re-add the listener constantly. Wrapping
+    // the spy in a fresh arrow here reproduces that; passing the spy directly would
+    // keep the dep stable and never exercise a resubscribe at all.
+    const handler = vi.fn()
+    const { rerender } = renderHook(({ fn }) => useThrottledWindowFocus(() => fn()), {
+      initialProps: { fn: handler }
+    })
+
+    focus()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    // A re-render mid-window must not REOPEN the window.
+    vi.advanceTimersByTime(1_000)
+    rerender({ fn: handler })
+    focus()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    // ...and must not EXTEND it either. A surface that re-renders faster than the
+    // interval would otherwise stop revalidating on focus entirely.
+    for (let i = 0; i < 6; i++) {
+      vi.advanceTimersByTime(10_000)
+      rerender({ fn: handler })
+    }
+    focus()
+    expect(handler).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops listening once unmounted', () => {
+    const handler = vi.fn()
+    const { unmount } = renderHook(() => useThrottledWindowFocus(handler))
+    unmount()
+    focus()
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/focusRefetch.ts
+++ b/desktop/windows/src/renderer/src/lib/focusRefetch.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+
+// Window-focus revalidation, throttled.
+//
+// Three always-mounted surfaces refetch on window focus: the Memories page (a full
+// `/v3/memories` page-through), the Apps page (three requests), and the Home goals
+// chips (one). `components/layout/MainViews.tsx` mounts every panel 1.8s after launch
+// and never unmounts them, so all three listeners are live no matter which tab the
+// user is on — one focus event costs six-plus backend requests for surfaces that are
+// not on screen.
+//
+// The trigger is not rare. It is any alt-tab back into the main window, and the app
+// blurs its own main window every time the floating bar, the orb, or the capture
+// window takes focus — so ordinary voice use pays this repeatedly per minute.
+//
+// Revalidating on focus is still the right behavior; doing it on EVERY focus is not.
+// A minimum interval keeps the freshness guarantee (a user coming back to a surface
+// after real time away gets fresh data) and drops the burst (flicking between windows
+// costs nothing after the first).
+export const FOCUS_REFETCH_MIN_INTERVAL_MS = 60_000
+
+/**
+ * Run `handler` on window focus, at most once per `minIntervalMs`.
+ *
+ * The FIRST focus of a session always runs: these surfaces revalidate on focus so a
+ * change made in another window shows up, and deferring that would be a visible
+ * behavior change rather than a cost fix. Only the repeats are dropped, which is where
+ * the waste actually is.
+ *
+ * Call sites pass a fresh closure each render (they all close over `loading`/`refresh`),
+ * so the listener is re-subscribed on re-render exactly as it was before. The throttle
+ * clock lives in a ref, so re-subscribing does not reopen the window.
+ */
+export function useThrottledWindowFocus(
+  handler: () => void,
+  minIntervalMs: number = FOCUS_REFETCH_MIN_INTERVAL_MS
+): void {
+  // When the handler last ran (0 = never, so the first focus is never throttled).
+  const lastRunAtRef = useRef(0)
+
+  useEffect(() => {
+    const onFocus = (): void => {
+      const now = Date.now()
+      if (now - lastRunAtRef.current < minIntervalMs) return
+      lastRunAtRef.current = now
+      handler()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [handler, minIntervalMs])
+}

--- a/desktop/windows/src/renderer/src/lib/retentionSweep.test.ts
+++ b/desktop/windows/src/renderer/src/lib/retentionSweep.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+// The retention sweep's REQUEST-VOLUME contract. `retentionMode` is optional and
+// falls back to 'dry-run', and a dry-run pass ends at a console.log — so before the
+// trigger split, every default install ran a full `/v3/memories` page-through plus a
+// 200-conversation fetch every 30 minutes, forever, and threw all of it away. These
+// cases pin who is allowed to spend a request: the background timer only in 'live',
+// the user's Preview button in 'dry-run'.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  get: vi.fn(),
+  del: vi.fn(),
+  fetchAllMemories: vi.fn(),
+  deleteMemoriesPaced: vi.fn(),
+  getPreferences: vi.fn(),
+  invalidateConversationsCache: vi.fn()
+}))
+
+vi.mock('./apiClient', () => ({ omiApi: { get: h.get, delete: h.del } }))
+vi.mock('./memoriesBulk', () => ({
+  fetchAllMemories: h.fetchAllMemories,
+  deleteMemoriesPaced: h.deleteMemoriesPaced
+}))
+vi.mock('./preferences', () => ({ getPreferences: h.getPreferences }))
+vi.mock('./pageCache', () => ({ invalidateConversationsCache: h.invalidateConversationsCache }))
+
+import { maybeStartRetentionSweep, runRetentionSweep } from './retentionSweep'
+
+const listLocalConversations = vi.fn()
+
+/** Every backend call the sweep can make, from either of its two fetch paths. */
+const backendCalls = (): number => h.get.mock.calls.length + h.fetchAllMemories.mock.calls.length
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  listLocalConversations.mockResolvedValue([])
+  ;(globalThis as unknown as { window: Record<string, unknown> }).window.omi = {
+    listLocalConversations,
+    deleteLocalConversation: vi.fn(async () => {})
+  }
+  h.get.mockResolvedValue({ data: [] })
+  h.fetchAllMemories.mockResolvedValue([])
+  h.deleteMemoriesPaced.mockResolvedValue({ deleted: 0, failed: 0 })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('scheduled passes', () => {
+  it('spends nothing on a default install, where retentionMode is unset', async () => {
+    // The exact production default: the key is absent from preferences entirely.
+    h.getPreferences.mockReturnValue({})
+    await runRetentionSweep('scheduled')
+    expect(backendCalls()).toBe(0)
+  })
+
+  it('spends nothing when the user has explicitly chosen Preview', async () => {
+    h.getPreferences.mockReturnValue({ retentionMode: 'dry-run' })
+    await runRetentionSweep('scheduled')
+    expect(backendCalls()).toBe(0)
+  })
+
+  it('spends nothing when retention is off', async () => {
+    h.getPreferences.mockReturnValue({ retentionMode: 'off' })
+    await runRetentionSweep('scheduled')
+    expect(backendCalls()).toBe(0)
+  })
+
+  it('still runs in live mode, which is the mode that deletes something', async () => {
+    h.getPreferences.mockReturnValue({ retentionMode: 'live' })
+    await runRetentionSweep('scheduled')
+    expect(h.fetchAllMemories).toHaveBeenCalledTimes(1)
+    expect(h.get).toHaveBeenCalledWith('/v1/conversations', expect.anything())
+  })
+})
+
+describe('manual passes', () => {
+  it('runs the Preview the user just asked for', async () => {
+    // Pressing Preview in Settings is the trigger that makes the mode's advertised
+    // "logs what it would delete" true, so this path must still do the work.
+    h.getPreferences.mockReturnValue({ retentionMode: 'dry-run' })
+    await runRetentionSweep('manual')
+    expect(h.fetchAllMemories).toHaveBeenCalledTimes(1)
+    expect(h.get).toHaveBeenCalledWith('/v1/conversations', expect.anything())
+  })
+
+  it('still respects off — the one mode that means do nothing', async () => {
+    h.getPreferences.mockReturnValue({ retentionMode: 'off' })
+    await runRetentionSweep('manual')
+    expect(backendCalls()).toBe(0)
+  })
+})
+
+// Kept last on purpose: `started` is a module-level latch with no reset seam, so
+// maybeStartRetentionSweep can only be exercised once per module instance.
+describe('the scheduler wiring', () => {
+  it('costs a default install nothing for the first two hours of uptime', async () => {
+    // The guard above only helps if the scheduler keeps passing 'scheduled'. This is
+    // the end-to-end version of that: launch the real timers on a default install and
+    // let four sweep windows go by.
+    vi.useFakeTimers()
+    try {
+      h.getPreferences.mockReturnValue({})
+      maybeStartRetentionSweep()
+      await vi.advanceTimersByTimeAsync(8_000) // the deferred startup pass
+      expect(backendCalls()).toBe(0)
+      await vi.advanceTimersByTimeAsync(2 * 60 * 60 * 1000) // 4 x 30-minute windows
+      expect(backendCalls()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/retentionSweep.ts
+++ b/desktop/windows/src/renderer/src/lib/retentionSweep.ts
@@ -63,10 +63,21 @@ async function deleteConvosPaced(localIds: string[], cloudIds: string[]): Promis
 
 let running = false
 
+// Who asked for this pass. A 'scheduled' pass is the 30-minute background timer;
+// a 'manual' pass is the user pressing Preview in Settings and waiting for output.
+export type SweepTrigger = 'scheduled' | 'manual'
+
 // One sweep pass: identify junk, then log (dry-run) or delete (live).
-export async function runRetentionSweep(): Promise<void> {
+export async function runRetentionSweep(trigger: SweepTrigger = 'manual'): Promise<void> {
   const mode = getPreferences().retentionMode ?? 'dry-run'
   if (mode === 'off' || running) return
+  // A scheduled pass only earns its cost in 'live' mode, where it actually deletes
+  // something. In 'dry-run' the entire pass — a full `/v3/memories` page-through plus
+  // 200 conversations — ends at a console.log, and `retentionMode` is optional, so
+  // EVERY default install was paying that 48x/day to write a line into a DevTools
+  // console that is not open. Dry-run is a preview the user asks for (RewindTab's
+  // Preview button passes 'manual'), not a background job.
+  if (trigger === 'scheduled' && mode !== 'live') return
   running = true
   try {
     const [convos, memories] = await Promise.all([loadConvos(), fetchAllMemories()])
@@ -114,10 +125,12 @@ export async function runRetentionSweep(): Promise<void> {
 let started = false
 
 // Start the periodic sweep once per app session (deferred past startup, then every
-// 30 min). No-op when retentionMode is 'off' (re-checked each pass).
+// 30 min). Each pass re-reads the mode, so the timer stays armed across a settings
+// change and only does work while the user is in 'live' mode — no start/stop
+// lifecycle to keep in sync with the preference.
 export function maybeStartRetentionSweep(): void {
   if (started) return
   started = true
-  setTimeout(() => void runRetentionSweep(), 8000)
-  setInterval(() => void runRetentionSweep(), SWEEP_INTERVAL_MS)
+  setTimeout(() => void runRetentionSweep('scheduled'), 8000)
+  setInterval(() => void runRetentionSweep('scheduled'), SWEEP_INTERVAL_MS)
 }

--- a/desktop/windows/src/renderer/src/lib/voice/aboutUser.test.ts
+++ b/desktop/windows/src/renderer/src/lib/voice/aboutUser.test.ts
@@ -206,3 +206,73 @@ describe('getAboutUserCard / refreshAboutUserCard — cache', () => {
     currentUser!.displayName = 'Ada'
   })
 })
+
+describe('refreshAboutUserCard — rebuild floor', () => {
+  // The hub calls this on every warm, and it deliberately re-warms all session long
+  // (hubController's aliveFor>60 strike reset — Gemini idle-closes around every two
+  // minutes). Each rebuild is a `GET /v3/memories`, so an unthrottled refresh
+  // re-downloaded the card's memories hundreds of times a day to produce the same card.
+  it('reuses a fresh card instead of rebuilding on every warm', async () => {
+    get.mockResolvedValue({ data: [] })
+    refreshAboutUserCard()
+    await whenAboutUserCardSettled()
+    expect(get).toHaveBeenCalledTimes(1)
+
+    for (let i = 0; i < 10; i++) {
+      refreshAboutUserCard()
+      await whenAboutUserCardSettled()
+    }
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds once the card has aged past the floor', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    try {
+      get.mockResolvedValue({ data: [] })
+      refreshAboutUserCard()
+      await whenAboutUserCardSettled()
+      expect(get).toHaveBeenCalledTimes(1)
+
+      vi.setSystemTime(1_700_000_000_000 + 5 * 60_000 - 1)
+      refreshAboutUserCard()
+      await whenAboutUserCardSettled()
+      expect(get).toHaveBeenCalledTimes(1)
+
+      vi.setSystemTime(1_700_000_000_000 + 5 * 60_000)
+      refreshAboutUserCard()
+      await whenAboutUserCardSettled()
+      expect(get).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('never holds back an account switch', async () => {
+    // The floor must not outrank the uid check, or a returning user would be greeted
+    // with the other account's card for up to five minutes.
+    get.mockResolvedValue({ data: [] })
+    refreshAboutUserCard()
+    await whenAboutUserCardSettled()
+    expect(get).toHaveBeenCalledTimes(1)
+
+    currentUser!.uid = 'u2'
+    refreshAboutUserCard()
+    await whenAboutUserCardSettled()
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(getAboutUserCard()).toContain('<about_user>')
+    currentUser!.uid = 'u1'
+  })
+
+  it('rebuilds immediately after a reset', async () => {
+    get.mockResolvedValue({ data: [] })
+    refreshAboutUserCard()
+    await whenAboutUserCardSettled()
+    expect(get).toHaveBeenCalledTimes(1)
+
+    resetAboutUserCard()
+    refreshAboutUserCard()
+    await whenAboutUserCardSettled()
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+})

--- a/desktop/windows/src/renderer/src/lib/voice/aboutUser.ts
+++ b/desktop/windows/src/renderer/src/lib/voice/aboutUser.ts
@@ -111,6 +111,14 @@ let inFlightUid = ''
 // Bumped by resetAboutUserCard so an in-flight build from before the reset
 // (e.g. the previous account's) can never land in the cache afterwards.
 let generation = 0
+// When the cached card was built. The hub calls refreshAboutUserCard() on every warm,
+// and the hub deliberately re-warms for the life of the session (hubController's
+// aliveFor>60 strike reset, ~2 minutes apart against Gemini), so without a floor this
+// re-fetched the user's memories hundreds of times a day to rebuild a card that had
+// not changed. The dedupe above only covers builds that overlap in flight.
+let cachedAt = 0
+/** How long a built card is reused before a warm is allowed to rebuild it. */
+const CARD_TTL_MS = 5 * 60_000
 
 /** The cached card, or '' when nothing has been built for this user yet (in
  *  which case the caller simply omits the block — never a stale/other-user card
@@ -129,6 +137,10 @@ export function refreshAboutUserCard(): void {
   // Dedupe only against a build for the SAME account — an account switch must be
   // able to start its own build even while the previous one is still in flight.
   if (inFlight && inFlightUid === uid) return
+  // Still-fresh card for THIS account: nothing to do. Neither invalidation path can be
+  // held back by this — an account switch fails the uid check, and resetAboutUserCard
+  // nulls `cached`, which the guard requires.
+  if (cached && cached.uid === uid && Date.now() - cachedAt < CARD_TTL_MS) return
   const gen = generation
   inFlightUid = uid
   const build = buildAboutUserCard()
@@ -137,7 +149,10 @@ export function refreshAboutUserCard(): void {
       // ran against whatever token was current when they landed, so an account
       // switch mid-build would otherwise file the NEW user's name and memories
       // under the OLD uid — and serve them back if the old account returned.
-      if (gen === generation && (auth.currentUser?.uid ?? '') === uid) cached = { uid, card }
+      if (gen === generation && (auth.currentUser?.uid ?? '') === uid) {
+        cached = { uid, card }
+        cachedAt = Date.now()
+      }
     })
     .catch(() => {
       /* best-effort: keep whatever card we already had */

--- a/desktop/windows/src/renderer/src/pages/Apps.tsx
+++ b/desktop/windows/src/renderer/src/pages/Apps.tsx
@@ -36,6 +36,7 @@ import { worksExternally, setupUrl, isSetupCompleted, startSetupPolling } from '
 import { AppDetailSheet } from '../components/apps/AppDetailSheet'
 import { auth } from '../lib/firebase'
 import { getE2EUser } from '../lib/dev/e2eAuth'
+import { useThrottledWindowFocus } from '../lib/focusRefetch'
 
 // Cap rendered search results so a broad query (e.g. "a") can't mount the whole
 // catalog at once. Users refine rather than scroll hundreds of cards.
@@ -329,19 +330,18 @@ export function Apps(): React.JSX.Element {
   // failed revalidation — never a blank list. Mirrors the Memories page's focus
   // refresh. Skipped while an initial load or manual refresh is already in flight, and
   // during a sign-out transition (auth.currentUser null).
-  useEffect(() => {
-    const onFocus = (): void => {
-      // Resolve the signed-in user the same way the app's auth does (useAuth):
-      // getE2EUser() is null in normal use (flag-gated), so this is exactly
-      // auth.currentUser in production — but it also honors the fake-auth E2E user,
-      // so the focus-revalidation path is exercisable end to end. Skips during a
-      // sign-out transition (no user) and while a load/refresh is already in flight.
-      const signedIn = getE2EUser() ?? auth.currentUser
-      if (signedIn && !loading && !refreshing) void load()
-    }
-    window.addEventListener('focus', onFocus)
-    return () => window.removeEventListener('focus', onFocus)
-  }, [loading, refreshing, load])
+  // Throttled: `load()` is three requests and this listener is live even while the
+  // user is on another tab, so an unthrottled one billed all three per alt-tab. See
+  // lib/focusRefetch.ts.
+  useThrottledWindowFocus(() => {
+    // Resolve the signed-in user the same way the app's auth does (useAuth):
+    // getE2EUser() is null in normal use (flag-gated), so this is exactly
+    // auth.currentUser in production — but it also honors the fake-auth E2E user,
+    // so the focus-revalidation path is exercisable end to end. Skips during a
+    // sign-out transition (no user) and while a load/refresh is already in flight.
+    const signedIn = getE2EUser() ?? auth.currentUser
+    if (signedIn && !loading && !refreshing) void load()
+  })
 
   // Debounce search so the network/filter doesn't run on every keystroke.
   useEffect(() => {

--- a/desktop/windows/src/renderer/src/pages/Memories.tsx
+++ b/desktop/windows/src/renderer/src/pages/Memories.tsx
@@ -22,6 +22,7 @@ import { MemoryFilterBar } from '../components/memories/MemoryFilterBar'
 import { MemoryDetailSheet } from '../components/memories/MemoryDetailSheet'
 import { UndoDeleteToast } from '../components/memories/UndoDeleteToast'
 import { auth } from '../lib/firebase'
+import { useThrottledWindowFocus } from '../lib/focusRefetch'
 
 // Cap how many cards render at once so a multi-thousand list stays responsive;
 // filtering/selection still operate on the full (filtered) set, not just what's
@@ -148,13 +149,12 @@ export function Memories(): React.JSX.Element {
   // swaps the list in place with no spinner, so this isn't a jarring reload; the
   // loading guard skips a redundant fetch while the initial load is still in
   // flight, and auth.currentUser skips it during a sign-out transition.
-  useEffect(() => {
-    const onFocus = (): void => {
-      if (auth.currentUser && !loading) void refresh()
-    }
-    window.addEventListener('focus', onFocus)
-    return () => window.removeEventListener('focus', onFocus)
-  }, [loading, refresh])
+  // Throttled: this refresh is a full `/v3/memories` page-through and the listener is
+  // live even while the user is on another tab, so an unthrottled one made every
+  // alt-tab re-paginate the whole collection. See lib/focusRefetch.ts.
+  useThrottledWindowFocus(() => {
+    if (auth.currentUser && !loading) void refresh()
+  })
 
   // Compose (add memory).
   const [composing, setComposing] = useState(false)

--- a/desktop/windows/src/renderer/src/pages/Tasks.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.tsx
@@ -156,20 +156,28 @@ export function Tasks(): React.JSX.Element {
     }
   }, [])
 
-  // Cold load: local rows (instant) + the conversation title map. Both loaders do
-  // their setState after an await, so nest them in a callback rather than invoking
-  // them straight from the effect body (their state updates are deferred, not sync).
-  //
-  // The title map waits until this panel is actually on screen. MainViews mounts every
-  // panel 1.8s after launch and never unmounts them, so an unconditional call here
-  // fetched 200 conversations at every launch to label source links on a page the user
-  // may never open. `readTasks` stays unconditional — it is a local SQLite read.
+  // Cold load of the local rows. Both loaders do their setState after an await, so
+  // nest them in a callback rather than invoking them straight from the effect body
+  // (their state updates are deferred, not sync). Kept in its own effect, keyed only
+  // on `readTasks`, so it stays a once-per-mount read: folding the route into these
+  // deps would re-run it on every navigation in and out of the tab.
   useEffect(() => {
     void (async () => {
       await readTasks()
-      if (tasksPanelIsActive) await readConvs()
     })()
-  }, [readTasks, readConvs, tasksPanelIsActive])
+  }, [readTasks])
+
+  // The conversation title map waits until this panel is actually on screen. MainViews
+  // mounts every panel 1.8s after launch and never unmounts them, so an unconditional
+  // call fetched 200 conversations at every launch to label source links on a page the
+  // user may never open. `readConvs` short-circuits on the populated cache, so
+  // revisiting the tab costs nothing.
+  useEffect(() => {
+    if (!tasksPanelIsActive) return
+    void (async () => {
+      await readConvs()
+    })()
+  }, [readConvs, tasksPanelIsActive])
 
   // Local-first freshness: main fires `onTasksChanged` on every optimistic write
   // and whenever a background sync lands, so a single subscription replaces the old

--- a/desktop/windows/src/renderer/src/pages/Tasks.tsx
+++ b/desktop/windows/src/renderer/src/pages/Tasks.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { ListChecks, Check, RefreshCw, Plus, Trash2, Calendar, X, Loader2 } from 'lucide-react'
 import { omiApi } from '../lib/apiClient'
 import { fetchAllActionItems } from '../lib/actionItems'
@@ -29,6 +29,9 @@ function apiError(e: unknown): string {
     (e as Error).message
   )
 }
+
+/** Must stay in sync with the `tasks` entry in `routes/manifest.ts`. */
+const TASKS_PATH = '/tasks'
 
 // Best-effort conversation title/emoji map for the per-task source links. A failed
 // conversations call still leaves the map empty (tasks come from the local store).
@@ -97,6 +100,10 @@ function moveSelection(
 }
 
 export function Tasks(): React.JSX.Element {
+  const { pathname } = useLocation()
+  // This panel stays mounted while the user is on another tab, so "mounted" is not
+  // "on screen". Same signal the Conversations panel gates its fetches on.
+  const tasksPanelIsActive = pathname === TASKS_PATH
   const [items, setItems] = useState<ActionItemRecord[]>(cache.items ?? [])
   const [convs, setConvs] = useState<Record<string, ConvMeta>>(cache.convs)
   const [loading, setLoading] = useState(!cache.loaded)
@@ -136,6 +143,10 @@ export function Tasks(): React.JSX.Element {
   }, [])
 
   const readConvs = useCallback(async (): Promise<void> => {
+    // `cache.convs` was written on every load and never consulted, so this re-paid a
+    // 200-conversation fetch for a label map it already had. Once per session is what
+    // the old mount-only call effectively gave us, and this keeps that.
+    if (Object.keys(cache.convs).length > 0) return
     try {
       const map = await fetchConvMeta()
       cache.convs = map
@@ -148,12 +159,17 @@ export function Tasks(): React.JSX.Element {
   // Cold load: local rows (instant) + the conversation title map. Both loaders do
   // their setState after an await, so nest them in a callback rather than invoking
   // them straight from the effect body (their state updates are deferred, not sync).
+  //
+  // The title map waits until this panel is actually on screen. MainViews mounts every
+  // panel 1.8s after launch and never unmounts them, so an unconditional call here
+  // fetched 200 conversations at every launch to label source links on a page the user
+  // may never open. `readTasks` stays unconditional — it is a local SQLite read.
   useEffect(() => {
     void (async () => {
       await readTasks()
-      await readConvs()
+      if (tasksPanelIsActive) await readConvs()
     })()
-  }, [readTasks, readConvs])
+  }, [readTasks, readConvs, tasksPanelIsActive])
 
   // Local-first freshness: main fires `onTasksChanged` on every optimistic write
   // and whenever a background sync lands, so a single subscription replaces the old


### PR DESCRIPTION
A systematic sweep of what the Windows app asks the backend for when nobody is asking it to, following the billing RCA that `index.ts:997` already records. Seven changes, each with the mutation that proves its test can fail.

The single largest item is first, and it is worth reading on its own: a full memory page-through, every 30 minutes, on every default install, whose entire result is thrown away.

## What was found

I inventoried every recurring timer, every mount-time fetch, and every focus listener in `desktop/windows`, then traced each candidate to the endpoint it reaches and the work that endpoint does. Below is what is fixed here. Findings I did NOT act on are listed at the end, including three that turned out to be deliberate and one backend change that is worth more than anything in this PR but does not belong in it.

### 1. The retention sweep runs on a timer for every default install, and discards the result

`retentionMode` is optional, and the sweep falls back to `dry-run`. Only `off` returned early. So on default settings, every 30 minutes forever:

- `fetchAllMemories()` pages `/v3/memories` to exhaustion
- `GET /v1/conversations?limit=200`

and then, in dry-run, hands all of it to a `console.log` and returns. Every request was paid to write a line into a DevTools console that is not open, 48 times a day, for every user.

Scheduled passes now require `live`, the only mode that deletes anything. `dry-run` becomes what its own label already claims: pressing Preview in Settings runs one pass, so the plan is logged when the user asks for it.

This is the item where the backend cost is concentrated. Every page after the first takes the `offset>0` path in `memories.py`, which streams the whole `memory_items` collection and slices in Python.

### 2. The staged-task promote timer POSTs about 1,440 times a day to be told "nothing"

`promotionService` ran `POST /v1/staged-tasks/promote` on a flat 60s timer for the life of the process, with `bypassDebounce: true`, no local pre-check, and no backoff of any kind. Nearly every call returns `promoted:false`, and each one costs the backend two full collection scans to say so. A 500ing endpoint got the same flat 60s forever.

The net exists for staged rows created out of band. Every in-app path that stages a task already promotes inline or on the task-complete and task-delete events, none of which go through this timer, so its cadence is discovery latency for a rare case rather than responsiveness for a common one.

Ticks now walk 60s, 2m, 5m, 10m and hold. Any tick that actually promotes drops back to the 60s floor, so a backlog still drains one per minute exactly as before. Signed-out ticks make no request and do not walk the ladder.

### 3. Six-plus requests per window focus, for surfaces that are not on screen

`MainViews` mounts every panel 1.8s after launch and never unmounts them, so a `window` focus listener registered by any page is live app-wide regardless of the current tab. Three pages register one, none route-gated and none throttled: Memories (a full `/v3/memories` page-through), Apps (three requests), and the Home goal chips (one).

The trigger is not rare. The app blurs its own main window every time the floating bar, the orb, or the capture window takes focus, so ordinary voice use pays this repeatedly per minute.

Now throttled to once a minute per surface. The first focus always runs, so the behavior these surfaces promise is intact and the two existing page-side guards pass unchanged.

### 4. The chat quota is re-fetched on every bar reveal and every reply

`sync()` had an in-flight dedupe and nothing else, which does nothing for sequential calls. It runs from `BarApp`'s `onShow` and from `UsageLimitTriggerHost` after every completed reply, both driven by the primary voice interaction.

The per-reply probe doubles the request count of every chat turn: the "at most once per session" latch it relies on only sets when the quota is already exhausted, so for an under-cap user it never sets.

Refreshes are now floored at 60s. The gate already tracks sends between refreshes with `recordQuery()`'s optimistic delta, so the verdict stays correct across the gap, and the first probe of a session is never throttled because `check()` depends on it.

This endpoint is cheap per call, unlike the others here. It is in the PR for call volume, not read cost.

### 5. The about-user card is rebuilt on every hub warm

`refreshAboutUserCard()` deduped only against a build already in flight. The hub deliberately re-warms all session long, and those warms are minutes apart, so the dedupe never applied. Each rebuild is a `GET /v3/memories`, several hundred times a day on an idle machine, to produce a card that had not changed. Now reused for five minutes.

The warm loop itself is untouched. See the deliberate-behavior note below.

### 6. The goal cap is checked after the expensive read, not before

`runGoalGenerationIfDue` fetched five parallel reads including `/v3/memories?limit=500` and `/v1/conversations?limit=100`, and only then checked the three-active-goal cap. Sitting at the cap is the ordinary resting state, and that bail deliberately does not stamp the day, so the 4-hourly tick repeats indefinitely, re-paying all five reads each time.

The count now comes from one `/v1/goals/all` ahead of the bundle, and that list is handed on to the context build so a run that proceeds reuses it rather than asking for the same list twice. Bail costs one read, proceed costs the same five it always did. The file's header already described the intended order as "cheap ones first, then the heavy context fetch"; the code now matches it.

Default-off, so this is latent rather than live, but it is a real wedge for anyone who turns it on.

### 7. Two panels fetch for surfaces the user is not looking at

`ChatAppPicker` called `useChatApps()` above its own gate, issuing `GET /v1/apps` and then returning null because the pref is off for almost everyone. Split into gate plus inner, exactly as the sibling `HubChatHeader` already does for the same stated reason.

`Tasks` fetched `GET /v1/conversations?limit=200` on mount for source-link labels, at every launch, whether or not Tasks was ever opened, and wrote a cache it never read. Now waits for the panel to be the active route and short-circuits on the cache: one request on first open, none after, against one per launch before.

## Verification

Run in `desktop/windows`:

- `npx vitest run` - 5,267 passed, 18 skipped, 544 files.
- `npm run typecheck` - clean.
- `npx eslint .` - 0 errors. The 735 warnings are pre-existing prettier formatting in files this PR does not touch; the changed files add none.
- `npm run build` - builds clean, bytecode patch and verify both OK.

**29 mutations seeded across the seven changes. Every one turns the suite red now. Every one left it green before.** They are listed per-commit with what each represents.

Three of those rounds found something rather than confirming something:

- A focus-throttle case of mine could not fail: it re-rendered with the same handler reference, so the effect never resubscribed. Rewritten to pass a fresh closure, as the real call sites do.
- `MIN_SYNC_INTERVAL_MS` escaped, because every quota case passed an explicit interval while production `barSend.ts` constructs the gate with no arguments and runs entirely on the default. Added a case that does the same.
- Clearing the timestamp in `resetAboutUserCard` was unobservable, since nulling the card already defeats the guard. Dead line removed.

Self-review also caught a defect in change 2 before it shipped: a tick re-arms from inside its own promise chain, so a stop landing mid-promote resurrected the timer `stopTaskPromotionService` had just cleared, which `clearInterval` had made impossible for free. Guarded, with a case.

### Two defects of my own, fixed in a follow-up commit

Both found by re-reading this diff and asking what each change costs on the paths it did NOT target, rather than by a test failing:

- The goal cap check moved in front of the context build, but the bundle still fetched `/v1/goals/all` itself, so a run that generated asked for the same list twice: five reads became six. The bail path is the common one and got far cheaper, so the net was still a large win, but a PR about removing redundant requests should not add one.
- Gating the Tasks title fetch on the active route folded the route into the deps of the effect that reads local tasks, so `readTasks` re-ran on every navigation in and out of the tab instead of once per mount. Local SQLite over IPC, so no backend cost and no spinner, but unintended and not what the commit claimed.

The first fix needed a second round of mutation work: the schedule test proved the goal list was PASSED to the context build, but that build is mocked there, so nothing proved it was USED. `withPrefetchedGoals` exists to make that substitution testable without a live session.

### What is not verified

I did not exercise these against a live signed-in account. Signed out the app makes no backend requests at all, so a signed-out run cannot observe any of these paths, and I was not willing to generate real load on a real account to measure. Everything above is traced from the mount, route, and timer paths and covered by hermetic tests.

The two changes in commit 7 are the ones where that matters most, since neither has a test observing the request from the page side. The visible thing to confirm is that source-link titles still render on the first visit to Tasks.

## One existing test changed

`promotionService.test.ts` pinned the flat cadence ("5 minutes buys 5 ticks"). It now pins the ladder. The guard it was written for, that the session poll stops rather than running 60 five-second attempts, is unchanged and still asserted. The new expected values come from the ladder constants introduced in the same commit, and four separate mutations hold that ladder in place.

## Deliberate behavior I did not touch

Worth stating, since two of these look like bugs and are not:

- **The hub re-warms for the whole session.** `hubController` resets its strike budget on any socket that lived past the idle window, and the provider idle-closes at roughly two minutes, so an idle user's hub rebuilds indefinitely. The code documents this at length as the mechanism that keeps the next press on the warm lane. That is a latency-versus-cost product decision, not spam, so I left it and fixed only the memory fetch it was dragging along (change 5). If the tradeoff is worth revisiting, the lever is an idle release below the provider's close, and that is a product call.
- **The promote net is not gated on `taskEnabled`.** Deliberate Mac parity, so backlog staged before the toggle was turned off still drains. Unchanged.
- **The auto-generation bail does not stamp the day.** Deliberate, so finishing a goal at noon can still generate a replacement. Left alone; only its cost changed.

## Follow-ups, deliberately not in this PR

Each is real and located, and each is a different review surface:

- **`GET /v1/action-items/ids` is the biggest remaining item, and the fix is server-side.** `taskSyncEngine` runs an ID census every 5 minutes, two requests, and `database/action_items.py:111` streams the collection with no `.where()` and filters `completed` in Python, so each call reads every doc and the pair scans the collection twice. That is 24 full collection scans per idle hour per running client. Pushing `.where('completed','==',completed)` server-side roughly halves it immediately; a change token or `updated_since` would make a steady-state round nearly free. Worth more than anything in this PR, and it is a backend change with its own correctness questions around soft-deleted and `status` rows, so it should not ride along here. Also `get_visible_action_item_ids` never calls `record_firestore_read`, so this path is invisible in the read metrics.
- **`DELETE /v3/memories/{id}` costs a full canonical scan per id**, and Windows deletes serially in a loop. `DELETE /v3/memories/batch` exists and pays the scan once per batch. Windows already uses the batch POST but not the batch DELETE.
- **The launch burst.** Settings mounts all eleven tabs at once, so Plan and Usage issues four billing requests at every launch for a screen the user has not opened. Fixing it properly means teaching the hydration pass to warm the render without warming the data, which is a bigger structural change than anything here.
- **`preferences.retention.test.ts` cannot fail.** Its default assertion is `getPreferences().retentionMode ?? 'dry-run'`, which is the fallback the test itself supplies. Left in place because the correct fix is to assert against the production default, and that default is exactly what change 1 is about.

## Product invariants affected

- INV-CHAT-1

From `scripts/pr-preflight --suggest`, matched on the `chatQuotaGate` change. The gate's verdict is unchanged: the cold-start probe that blocks an over-cap user is explicitly exempt from the new floor, and the optimistic delta still counts sends between refreshes, both of which are asserted. Only the refresh cadence moved.

`scripts/pr-preflight` also reports no `fix:` commits, so no `Failure-Class` declaration is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


