### PR TITLE
fix(backend): import get_default_basic_subscription so plan-less users can read their subscription

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -87,6 +87,7 @@ from utils.apps import get_available_app_by_id
 from utils.subscription import (
     enforce_chat_quota,
     get_chat_quota_snapshot,
+    get_default_basic_subscription,
     get_paid_plan_definitions,
     get_plan_display_name,
     get_plan_limits,

--- a/backend/tests/routers/test_users.py
+++ b/backend/tests/routers/test_users.py
@@ -492,3 +492,33 @@ def test_marketplace_reviewer_subscription_endpoint_returns_unlimited_plan():
 
     assert response.subscription.plan == users_router.PlanType.unlimited
     assert response.subscription.limits.words_transcribed is None
+
+
+def test_subscription_endpoint_falls_back_to_basic_when_no_valid_subscription():
+    # `get_default_basic_subscription` was called at routers/users.py:1220 without being
+    # imported, so a user whose subscription is missing or expired got NameError -> 500
+    # instead of the basic plan the branch exists to return.
+    with patch.object(users_router.users_db, 'is_byok_active', MagicMock(return_value=False)), patch.object(
+        users_router, 'get_user_subscription', MagicMock(return_value=None)
+    ), patch.object(users_router, 'reconcile_basic_plan_with_stripe', MagicMock()), patch.object(
+        users_router, 'get_user_valid_subscription', MagicMock(return_value=None)
+    ), patch.object(
+        users_router, 'get_monthly_usage_for_subscription', MagicMock(return_value={})
+    ), patch.object(
+        users_router, 'get_paid_plan_definitions', MagicMock(return_value=[])
+    ), patch.object(
+        users_router, 'should_hide_subscription_ui', MagicMock(return_value=False)
+    ), patch.object(
+        users_router,
+        'get_phone_call_quota_snapshot',
+        MagicMock(return_value=MagicMock(to_client_dict=lambda: {'has_access': False, 'is_paid': False})),
+    ), patch.object(
+        users_router,
+        'get_chat_quota_snapshot',
+        MagicMock(return_value={'used': 0.0, 'limit': None, 'unit': 'questions', 'allowed': True, 'reset_at': None}),
+    ):
+        response = users_router.get_user_subscription_endpoint(
+            uid='uid-without-subscription', x_app_platform='ios', x_app_version='1.0.0'
+        )
+
+    assert response.subscription.plan == users_router.PlanType.basic


### PR DESCRIPTION
## Bug

`GET /v1/users/me/subscription` answers **500** for any user whose subscription lookup
returns nothing valid, so the plan / paywall screen fails to load for them.

Prod, image `c5b0b5d`, 2026-08-18T16:08:08Z and 16:08:09Z, Flutter client (`Dart/3.11`):

```
  File "/app/routers/users.py", line 1220, in get_user_subscription_endpoint
    subscription = get_default_basic_subscription()
NameError: name 'get_default_basic_subscription' is not defined
```

## Root cause

`routers/users.py` calls `get_default_basic_subscription()` in the branch that is supposed
to return the basic plan when `get_user_valid_subscription(uid)` finds none — but the name
was never added to the module's `from utils.subscription import (...)` block. The `from
database.users import *` above it does not re-export it either (`database/users.py` imports
it inside functions, not at module scope). So the fallback branch has always raised instead
of falling back.

Present since the branch landed in `daad3bfe3b`. This is the same failure class as the
`PlanLimits` import fixed in #11763 — same endpoint, the branches immediately above this one.

## Fix

Add `get_default_basic_subscription` to the existing `utils.subscription` import block —
one line, no behavior change beyond letting the intended fallback run. No new module edge:
`routers/users.py` already imports `utils.subscription` at module scope, so the
`database.users` ↔ `utils.subscription` cycle guarded by
`tests/unit/test_subscription_import_cycle.py` is untouched (both its cases still pass).

## Verification

- Regression test `test_subscription_endpoint_falls_back_to_basic_when_no_valid_subscription`
  drives the endpoint through that branch. On clean `main` it fails with the exact prod error
  (`NameError: name 'get_default_basic_subscription' is not defined`, `routers/users.py:1220`);
  with the fix it passes and the response carries `plan == basic`.
- **Real route over HTTP**, not just the function: the registered route mounted on a FastAPI
  app and called through `TestClient` with only the auth and datastore edges stubbed —
  `GET /v1/users/me/subscription` → **500 Internal Server Error** without the fix,
  **200** with `subscription.plan == "basic"` with it.
- `pytest tests/routers/test_users.py tests/unit/test_subscription_import_cycle.py
  tests/unit/test_stripe_webhook_behavioral.py tests/unit/test_users_missing_doc_guards.py`
  → 67 passed; the two `slow` import-cycle cases pass when selected explicitly.
- Fresh interpreter `import routers.users` succeeds and resolves the symbol to
  `utils.subscription`.
- `make preflight` (with the PR body): all selected manifest checks pass.

## Product invariants affected

none

Failure-Class: none

Line-Count-Exception: backend/routers/users.py | 2176 -> 2177 | one-line import that restores the file's existing default-basic fallback; splitting this router is out of scope for a 500 fix

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

