### PR TITLE
Arm candidates on a discrete transition, not on a condition that merely persists

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextWorkstreamReconciler.swift
@@ -1017,16 +1017,22 @@ actor ContextWorkstreamReconciler {
   /// uncommitted files": a candidate built on a minute-volatile count went
   /// stale before anything could show it. The message survives to delivery only
   /// if it is written for the moment of delivery, not the moment of writing.
+  /// Durability is actionability, not mere truth: a standing condition is
+  /// maximally still-true hours later, which is exactly why it is not worth
+  /// interrupting. Arming requires a discrete transition.
   static let candidateInstructions = """
     \(ScreenDerivedContent.untrustedPreamble)
     For each bucket below, write at most one short notification, or omit the bucket.
     Omitting most buckets is normal.
-    Ask first: do the facts record a commitment, a deadline, a blocker, a conflict,
-    or a change the user may not have seen? If not, omit the bucket.
+    Ask first: do the facts record a discrete transition the user may not have seen?
+    Something became blocked, a deadline moved or now approaches, a commitment was
+    made, a conflict appeared, or a state changed. A condition that merely persists
+    is not enough. If not, omit the bucket.
     Never write a notification that merely describes what was on the user's screen.
     The notification will be delivered hours later, when the user returns to this
-    context. Write only what will still be true and useful then. Do not build the
-    message around counts or figures that change minute to minute.
+    context. Write only what will still be actionable then: name the object the user
+    can act on. Do not build the message around counts or figures that change minute
+    to minute.
     List in fact_ids every supplied fact id the message relies on.
     Add a one-line trigger_note describing when it should fire.
     """

--- a/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextWorkstreamReconcilerTests.swift
@@ -350,6 +350,36 @@ final class ContextWorkstreamReconcilerTests: XCTestCase {
       "two different instruction blocks under one key would only evict each other")
   }
 
+  /// Arming selects for a discrete transition, not a standing condition. The
+  /// durability test is actionability at delivery, not mere truth; the
+  /// minute-volatile-count guard stays beside it.
+  func testCandidateInstructionsRequireADiscreteTransitionAndStayActionable() {
+    let instructions = ContextWorkstreamReconciler.candidateInstructions
+    // Clause assertions run against a whitespace-flattened copy: these sentences
+    // wrap across source lines, and rewrapping one must not silently pass or
+    // fail an assertion about whether the clause is still there.
+    let flattened = instructions.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    XCTAssertTrue(
+      instructions.hasPrefix(ScreenDerivedContent.untrustedPreamble),
+      "the safety preamble must stay above every quoted statement")
+    XCTAssertTrue(
+      flattened.contains("discrete transition"),
+      "arming must require a discrete transition, not a standing commitment or blocker")
+    XCTAssertTrue(
+      flattened.contains("merely persists is not enough"),
+      "a condition that merely persists must be an explicit omit")
+    XCTAssertTrue(
+      flattened.contains("still be actionable"),
+      "the delivery-time test is actionability, not whether the statement stays true")
+    XCTAssertFalse(
+      flattened.contains("still be true and useful"),
+      "the old truth-durability line selected for standing state")
+    XCTAssertTrue(
+      flattened.contains(
+        "Do not build the message around counts or figures that change minute to minute."),
+      "the minute-volatile-count staleness guard is load-bearing")
+  }
+
   func testInsertsSkipAGarbageCollectedBucketWithoutAbortingTheRestOfTheBatch() throws {
     let queue = try migratedQueue()
     try queue.write { db in

--- a/desktop/macos/changelog/unreleased/20260818-candidate-arming-requires-event.json
+++ b/desktop/macos/changelog/unreleased/20260818-candidate-arming-requires-event.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive notifications now wait for something that changed, like a new blocker or approaching deadline, instead of repeating a standing status"
+}


### PR DESCRIPTION
## What changed and why

The candidate-arming prompt selected for standing conditions. Two lines did it:

1. `Ask first: do the facts record a commitment, a deadline, a blocker, a conflict, or a change the user may not have seen?` — "blocker" and "commitment" had no requirement that anything *changed*. A sentence of the form "X is still blocked on Y" is a blocker; "Z is still pending" is a commitment. Both are standing conditions that would read equally true yesterday and tomorrow, and both satisfied this instruction.
2. `Write only what will still be true and useful then.` — a staleness guard against minute-volatile counts (load-bearing; a candidate built on a file count went stale before delivery). A standing condition is *maximally* durable, so the guard optimized straight into another failure.

Arming now requires a discrete transition (became blocked, deadline moved/approaches, commitment was made, conflict appeared, state changed). A condition that merely persists is not enough. The delivery-time test is actionability (name the object the user can act on), not mere truth. The minute-volatile-count warning is unchanged.

## Measurement

A prompt rewrite (`e0681c28dd`, 17:28 UTC 2026-08-16) fixed the delivery gate (3/69 approved → 7/10; Fisher exact two-sided p = 4.4e-06). That exposed this upstream defect:

- 3 of 7 new-prompt approvals were rated "should not have interrupted" (3 raters, unanimous). All three described a standing condition.
- Held-out set of 23 later-armed candidates, never used to form the hypothesis: **12 of 23 (52%) STANDING**, 21/23 unanimous across 3 raters.

## Falsifiable prediction

After this lands, re-classifying newly-armed candidates should show the STANDING share well below 52%. If it does not, the criterion is not what drives it and fact worthiness is the next place to look.

## Quality change, not a cost saving

The candidate ceiling already short-circuits before the gate's model call, so capped candidates cost zero tokens today. Arming volume is not a token driver. This is a quality change with no expected cost saving.

## Product invariants affected

none

## How it was verified

Did not launch or disturb any running Omi bundle; a dogfood measurement is in progress.

- `swift test --filter ContextWorkstreamReconciler` — 25 tests, 0 failures
- `swift test --filter ContextBucketPromptAssemblerTests` — 26 tests, 0 failures
- `swift test --filter ContextProactivityRetrievalHopTests` — 21 tests, 0 failures
- `swift test --filter ContextFactWritePolicyTests` — 11 tests, 0 failures
- `swift test --filter ContextBucketDirectorProbeTests` — 7 tests, 0 failures
- Repo pre-push preflight, no `--no-verify` and no `PRE_PUSH_SKIP_DESKTOP_CHANGELOG`

The new test initially failed: the rewrite rewrapped the minute-volatile-count guard
across a source line, so an exact-literal `contains` no longer matched even though the
guard was intact. The clause assertions now run against a whitespace-flattened copy of
the instructions, so rewrapping a sentence can neither silently pass nor silently fail
an assertion about whether that clause is still present.


## Tests

`testCandidateInstructionsRequireADiscreteTransitionAndStayActionable` asserts the load-bearing clauses: discrete-transition requirement, persist-is-not-enough omit, actionability (not truth) at delivery, and the minute-volatile-count staleness guard. Existing composition/preamble tests are unchanged.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


