### PR TITLE
feat(admin): true per-platform metrics (all/macOS/mobile) — mobile is instrumented, boards now mirror

### DIFF
--- a/.github/scripts/test_check_admin_deploy_scope.py
+++ b/.github/scripts/test_check_admin_deploy_scope.py
@@ -345,7 +345,9 @@ class OmiTvDashboardContractTests(unittest.TestCase):
 
     def test_activation_panels_use_firestore_activation_selectors(self) -> None:
         panels = {panel["title"]: panel for panel in self.dashboard()["panels"]}
-        rate = panels["Activation rate"]["targets"][0]
+        # The base (all-platform) board labels the Firestore-backed activation
+        # panels "(macOS)" because that route only covers macOS signups.
+        rate = panels["Activation rate (macOS)"]["targets"][0]
         self.assertEqual(rate["url"], "http://127.0.0.1:8899/api/omi/stats/activation?days=60")
         self.assertEqual([column["selector"] for column in rate["columns"]], ["rate"])
         self.assertNotIn("viral-metrics", rate["url"])

--- a/web/admin/app/api/omi/stats/dau-trends/route.ts
+++ b/web/admin/app/api/omi/stats/dau-trends/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyAdmin } from "@/lib/auth";
 import { posthogResults } from "@/lib/posthog";
+import { parsePlatformScope, scopeFilterAnd } from "@/lib/platform-scope";
 
 export const dynamic = "force-dynamic";
 
 // Module-level cache (30 min TTL)
-let cache: { data: { date: string; dau: number }[]; days: number; timestamp: number } | null = null;
+let cache: { data: { date: string; dau: number }[]; days: number; platform: string; timestamp: number } | null = null;
 const CACHE_TTL = 30 * 60 * 1000;
 
 export async function GET(request: NextRequest) {
@@ -26,20 +27,23 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const days = Math.min(parseInt(searchParams.get("days") || "60", 10), 90);
+    const platform = parsePlatformScope(searchParams.get("platform") ?? "macos");
 
-    if (cache && cache.days === days && Date.now() - cache.timestamp < CACHE_TTL) {
+    if (cache && cache.days === days && cache.platform === platform && Date.now() - cache.timestamp < CACHE_TTL) {
       return NextResponse.json({ data: cache.data, days });
     }
 
-    // Daily unique macOS users = distinct clients emitting ANY event (rename-proof;
-    // the old `App Became Active` lifecycle event was removed from the desktop app).
+    // Daily unique users = distinct clients emitting ANY event (rename-proof;
+    // the old `App Became Active` lifecycle event was removed from the desktop
+    // app). `platform` scopes to macos / mobile / all (default macos keeps the
+    // legacy meaning for existing callers).
     const hogql = `
       SELECT
         toDate(timestamp) as day,
         count(DISTINCT distinct_id) as users
       FROM events
-      WHERE properties.$os_name = 'macOS'
-        AND timestamp >= now() - interval ${days} day
+      WHERE timestamp >= now() - interval ${days} day
+        ${scopeFilterAnd(platform)}
       GROUP BY day
       ORDER BY day
     `;
@@ -74,7 +78,7 @@ export async function GET(request: NextRequest) {
       current.setDate(current.getDate() + 1);
     }
 
-    cache = { data, days, timestamp: Date.now() };
+    cache = { data, days, platform, timestamp: Date.now() };
     return NextResponse.json({ data, days });
   } catch (error: any) {
     console.error("DAU trends error:", error);

--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 import { posthogResults } from '@/lib/posthog';
+import { parsePlatformScope, scopeFilterAnd, type PlatformScope } from '@/lib/platform-scope';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 3600;
 
 // Run the k-factor proxy HogQL query through posthogResults (Firestore
 // query-cache + 429 backoff + stale fallback) and shape the panel payload.
 // Exported so the precompute cron can warm the underlying query cache.
-export async function computeKFactor(days: number) {
+export async function computeKFactor(days: number, platform: PlatformScope = 'macos') {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
   const host = (process.env.POSTHOG_HOST || 'https://us.posthog.com').replace(/\/$/, '');
@@ -29,7 +30,7 @@ export async function computeKFactor(days: number) {
           FROM events
           WHERE event IN ('Sign In Completed', 'Memory Share Button Clicked')
             AND timestamp >= now() - INTERVAL ${days} DAY
-            AND properties.$os = 'macOS'
+            ${scopeFilterAnd(platform, 'properties.$os')}
           GROUP BY event
         `;
 
@@ -80,9 +81,10 @@ export async function GET(request: NextRequest) {
 
   const searchParams = request.nextUrl.searchParams;
   const days = parseInt(searchParams.get('days') || '30', 10);
+  const platform = parsePlatformScope(searchParams.get('platform') ?? 'macos');
 
   try {
-    const payload = await computeKFactor(days);
+    const payload = await computeKFactor(days, platform);
     return NextResponse.json(payload);
   } catch (error) {
     // PostHog still failing (e.g. 429 with no cached fallback) — degrade

--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -42,7 +42,9 @@ export async function GET(request: NextRequest) {
     const eventFilter =
       platform === 'macos'
         ? `AND properties.$os = 'macOS' ${excludeOtherProducts}`
-        : excludeOtherProducts;
+        : platform === 'mobile'
+          ? `AND properties.$os IN ('iOS', 'Android', 'iPadOS') ${excludeOtherProducts}`
+          : excludeOtherProducts;
     const url = `${host}/api/projects/${projectId}/query/`;
 
     const cohortRows = await posthogQuery(

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -11,6 +11,7 @@ import {
   summarizeActivation,
   type DailyActivationPoint,
 } from "@/lib/growth-metrics";
+import { parsePlatformScope, scopeFilterAnd } from "@/lib/platform-scope";
 
 export const dynamic = "force-dynamic";
 
@@ -21,7 +22,7 @@ export const dynamic = "force-dynamic";
  */
 const MIN_ACTIVATION_TELEMETRY_VERSION = [0, 12, 167] as const;
 
-let cache: { data: any; days: number; timestamp: number } | null = null;
+let cache: { data: any; days: number; platform: string; timestamp: number } | null = null;
 const CACHE_TTL = 30 * 60 * 1000;
 
 async function hogql(apiKey: string, projectId: string, host: string, query: string) {
@@ -46,14 +47,23 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const days = Math.min(parseInt(searchParams.get("days") || "60", 10), 90);
+    // Default macos preserves the legacy meaning for existing callers.
+    const platform = parsePlatformScope(searchParams.get("platform") ?? "macos");
+    const os = scopeFilterAnd(platform);
+    // Mobile never emits `Sign In Completed`, so non-macOS signup cohorts
+    // anchor on the user's first-ever event instead.
+    const signupAnchor = platform === "macos" ? `AND event = 'Sign In Completed' ${os}` : os;
+    // The Firestore activation overlay is macOS-scoped by construction
+    // (conversation-within-7-days of a macOS signup) — never smear it over
+    // mobile or all-platform telemetry.
+    const activationOverlay = async () =>
+      platform === "macos"
+        ? (await getPayload<FirestoreActivationCompat>(activationCacheKey(days)))?.data ?? null
+        : null;
 
-    if (cache && cache.days === days && Date.now() - cache.timestamp < CACHE_TTL) {
+    if (cache && cache.days === days && cache.platform === platform && Date.now() - cache.timestamp < CACHE_TTL) {
       return NextResponse.json(
-        applyFirestoreActivationCompat(
-          cache.data,
-          (await getPayload<FirestoreActivationCompat>(activationCacheKey(days)))
-            ?.data ?? null,
-        ),
+        applyFirestoreActivationCompat(cache.data, await activationOverlay()),
       );
     }
 
@@ -67,6 +77,7 @@ export async function GET(request: NextRequest) {
       activationResults,
       wauResult,
       mauResult,
+      allTimeResult,
     ] = await Promise.all([
       // 1. New users per week (first-ever Sign In Completed)
       hogql(apiKey, projectId, host, `
@@ -76,8 +87,8 @@ export async function GET(request: NextRequest) {
         FROM (
           SELECT distinct_id, min(timestamp) as min_ts
           FROM events
-          WHERE event = 'Sign In Completed'
-            AND properties.$os_name = 'macOS'
+          WHERE 1 = 1
+            ${signupAnchor}
           GROUP BY distinct_id
         )
         WHERE min_ts >= now() - interval ${days} day
@@ -91,8 +102,8 @@ export async function GET(request: NextRequest) {
           toMonday(toDate(timestamp)) as week,
           count(DISTINCT distinct_id) as active_users
         FROM events
-        WHERE properties.$os_name = 'macOS'
-          AND timestamp >= now() - interval ${days} day
+        WHERE timestamp >= now() - interval ${days} day
+          ${os}
         GROUP BY week
         ORDER BY week
       `),
@@ -106,15 +117,15 @@ export async function GET(request: NextRequest) {
         FROM (
           SELECT distinct_id as did, toMonday(toDate(timestamp)) as week
           FROM events
-          WHERE properties.$os_name = 'macOS'
-            AND timestamp >= now() - interval ${days} day
+          WHERE timestamp >= now() - interval ${days} day
+            ${os}
           GROUP BY did, week
         ) curr
         INNER JOIN (
           SELECT distinct_id as did, toMonday(toDate(timestamp)) as week
           FROM events
-          WHERE properties.$os_name = 'macOS'
-            AND timestamp >= now() - interval ${days + 7} day
+          WHERE timestamp >= now() - interval ${days + 7} day
+            ${os}
           GROUP BY did, week
         ) prev ON curr.did = prev.did AND prev.week = curr.week - interval 7 day
         GROUP BY curr_week
@@ -127,8 +138,8 @@ export async function GET(request: NextRequest) {
           toDate(timestamp) as day,
           count(DISTINCT distinct_id) as dau
         FROM events
-        WHERE properties.$os_name = 'macOS'
-          AND timestamp >= now() - interval ${days} day
+        WHERE timestamp >= now() - interval ${days} day
+          ${os}
         GROUP BY day
         ORDER BY day
       `),
@@ -143,8 +154,8 @@ export async function GET(request: NextRequest) {
             distinct_id,
             count(DISTINCT toDate(timestamp)) as days_active
           FROM events
-          WHERE properties.$os_name = 'macOS'
-            AND timestamp >= now() - interval 30 day
+          WHERE timestamp >= now() - interval 30 day
+            ${os}
           GROUP BY distinct_id
         )
         GROUP BY days_active
@@ -192,15 +203,15 @@ export async function GET(request: NextRequest) {
                 splitByChar('.', coalesce(argMin(properties.$app_version, timestamp), '0'))
               ) >= [${MIN_ACTIVATION_TELEMETRY_VERSION.join(", ")}] as reports_activation
             FROM events
-            WHERE event = 'Sign In Completed'
-              AND properties.$os_name = 'macOS'
+            WHERE 1 = 1
+              ${signupAnchor}
             GROUP BY distinct_id
           ) signups
           LEFT JOIN (
             SELECT distinct_id as m_id, timestamp as m_ts
             FROM events
             WHERE event = 'Memory Created'
-              AND properties.$os_name = 'macOS'
+              ${os}
               AND timestamp >= now() - interval ${days + 7} day
           ) memories ON signups.s_id = memories.m_id
           WHERE signups.s_ts >= now() - interval ${days} day
@@ -214,16 +225,25 @@ export async function GET(request: NextRequest) {
       hogql(apiKey, projectId, host, `
         SELECT count(DISTINCT distinct_id)
         FROM events
-        WHERE properties.$os_name = 'macOS'
-          AND timestamp >= now() - interval 7 day
+        WHERE timestamp >= now() - interval 7 day
+          ${os}
       `),
 
       // 8. MAU (current month)
       hogql(apiKey, projectId, host, `
         SELECT count(DISTINCT distinct_id)
         FROM events
-        WHERE properties.$os_name = 'macOS'
-          AND timestamp >= now() - interval 30 day
+        WHERE timestamp >= now() - interval 30 day
+          ${os}
+      `),
+
+      // 9. All-time users on this platform (person-deduped, counted since
+      // each platform's PostHog instrumentation began)
+      hogql(apiKey, projectId, host, `
+        SELECT uniq(COALESCE(person_id, distinct_id))
+        FROM events
+        WHERE 1 = 1
+          ${os}
       `),
     ]);
 
@@ -273,6 +293,7 @@ export async function GET(request: NextRequest) {
     // Weekly stickiness: avg DAU / WAU for each week
     const wau = (wauResult as any[])[0]?.[0] ?? 0;
     const mau = (mauResult as any[])[0]?.[0] ?? 0;
+    const allTimeUsers = (allTimeResult as any[])[0]?.[0] ?? 0;
     const recentDau = dailyDau.slice(-7);
     const avgDau = recentDau.length > 0
       ? Math.round(recentDau.reduce((s, d) => s + d.dau, 0) / recentDau.length)
@@ -385,13 +406,13 @@ export async function GET(request: NextRequest) {
           mau,
           l5PlusPct,
           totalUsers: totalPowerUsers,
+          allTimeUsers,
         },
       },
-      (await getPayload<FirestoreActivationCompat>(activationCacheKey(days)))
-        ?.data ?? null,
+      await activationOverlay(),
     );
 
-    cache = { data: result, days, timestamp: Date.now() };
+    cache = { data: result, days, platform, timestamp: Date.now() };
     return NextResponse.json(result);
   } catch (error: any) {
     console.error("Viral metrics error:", error);

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -6,13 +6,19 @@ then:
   1. In place: pins timezone to America/New_York, routes daily/weekly/monthly
      date columns through the proxy's `_tzdates` rewrite (so each bucket
      renders on its labeled calendar day instead of shifting 8 pm earlier),
-     and adds the All / macOS / Mobile switcher links.
-  2. Writes dashboards/omi-tv-macos.json — macOS-only view: platform-native
-     panels kept, cross-platform panels re-pointed at the desktop series of
-     /api/omi/stats/profitability, unplittable panels dropped.
-  3. Writes dashboards/omi-tv-mobile.json — the honestly-available mobile
-     view (signups, revenue, cost, conversion from profitability; mobile
-     DAU/retention are not instrumented and say so).
+     pins `platform=all` on the PostHog-backed routes, and adds the
+     All / macOS / Mobile switcher links.
+  2. Writes dashboards/omi-tv-macos.json and dashboards/omi-tv-mobile.json —
+     the SAME board scoped per platform (`platform=macos` / `platform=mobile`
+     on viral-metrics, dau-trends, retention and k-factor; per-platform series
+     of /api/omi/stats/profitability for signups/revenue/cost/conversion).
+     The mobile board mirrors the macOS board panel-for-panel except the
+     desktop-only product surfaces (floating bar, desktop notifications,
+     desktop crash rate, macOS version pies), which have no mobile analog.
+
+Mobile IS instrumented in PostHog (iOS since 2025-03, Android since 2026-05)
+but does not emit `Sign In Completed`, so its signup/activation cohorts anchor
+on first-seen-any-event (handled inside viral-metrics).
 
 Idempotent: run after editing omi-tv.json, commit all three outputs.
 apply_omi_tv_dashboard.py publishes every dashboards/*.json to Grafana.
@@ -30,9 +36,23 @@ DASH_DIR = HERE / "dashboards"
 BASE_PATH = DASH_DIR / "omi-tv.json"
 
 PROFIT_PATH = "/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3"
+VIRAL_PATH = "/api/omi/stats/viral-metrics?days=60"
 PROXY = "http://127.0.0.1:8899"
 RFC3339 = "2006-01-02T15:04:05Z07:00"
 DAY_FORMATS = {"2006-01-02", "2006-01"}
+
+# Routes that accept ?platform=all|macos|mobile.
+PLATFORM_ROUTES = ("viral-metrics", "dau-trends", "retention/posthog", "k-factor/posthog")
+
+# Desktop-only product surfaces — the only panels absent from the mobile board.
+DESKTOP_ONLY_TITLES = {
+    "Floating bar sessions per user", "Floating bar queries",
+    "Floating bar notification CTR", "Daily notifications sent",
+    "Notifications sent — last 168 hours", "Weekly notification reach",
+    "Notifications enabled", "Crash-free rate (today)", "Crash-free rate",
+    "macOS: beta vs production (today)", "macOS: by version (today)",
+    "macOS active today",
+}
 
 LINKS = [
     {"title": title, "type": "link", "url": f"/grafana/d/{uid}/", "icon": "dashboard",
@@ -55,6 +75,41 @@ def add_query_param(url: str, key: str, value: str) -> str:
     return f"{url}{sep}{key}={value}"
 
 
+def set_url_param(url: str, key: str, value: str) -> str:
+    """Set/replace a query param, preserving the rest of the URL."""
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qsl(parsed.query)
+    params = [(k, v) for k, v in params if k != key] + [(key, value)]
+    return parsed._replace(query=urllib.parse.urlencode(params)).geturl()
+
+
+def set_platform(url: str, scope: str) -> str:
+    """Pin ?platform=<scope> on platform-aware routes, including routes
+    wrapped inside a /compare?path=… URL."""
+    if "/compare?" in url:
+        parsed = urllib.parse.urlparse(url)
+        params = dict(urllib.parse.parse_qsl(parsed.query))
+        inner = params.get("path", "")
+        if any(route in inner for route in PLATFORM_ROUTES):
+            params["path"] = set_url_param(inner, "platform", scope)
+            return f"{PROXY}{parsed.path}?" + urllib.parse.urlencode(params)
+        return url
+    if any(route in url for route in PLATFORM_ROUTES):
+        return set_url_param(url, "platform", scope)
+    return url
+
+
+def apply_platform(dash, scope: str) -> None:
+    for panel in dash.get("panels", []):
+        for target in panel.get("targets", []):
+            if "url" in target:
+                target["url"] = set_platform(target["url"], scope)
+    for var in dash.get("templating", {}).get("list", []):
+        q = var.get("query", {}).get("infinityQuery", {})
+        if "url" in q:
+            q["url"] = set_platform(q["url"], scope)
+
+
 def apply_tzdates(dash) -> None:
     for panel in dash.get("panels", []):
         for target in panel.get("targets", []):
@@ -65,13 +120,6 @@ def apply_tzdates(dash) -> None:
                     col["timestampFormat"] = RFC3339
             if fields:
                 target["url"] = add_query_param(target["url"], "_tzdates", ",".join(fields))
-
-
-def compare_url(path: str, root: str, fields: str, agg: str, window: int, label: str = "") -> str:
-    params = {"path": path, "root": root, "fields": fields, "agg": agg, "window": window}
-    if label:
-        params["label"] = label
-    return f"{PROXY}/compare?" + urllib.parse.urlencode(params)
 
 
 def set_compare(query_holder: dict, url_key: str, **overrides) -> None:
@@ -165,134 +213,118 @@ def finish(dash, uid: str, title: str) -> dict:
     return dash
 
 
-def build_macos(base) -> dict:
+def build_platform_board(base, scope: str) -> dict:
+    """One pipeline for both platform boards, so they stay mirrors of each
+    other: same panels, same layout, per-platform data. `scope` is "macos"
+    or "mobile"."""
+    profit_field = "desktop" if scope == "macos" else "mobile"
+    label = "macOS" if scope == "macos" else "Mobile"
+
     dash = copy.deepcopy(base)
+    apply_platform(dash, scope)
+
+    # Cross-platform business panels that have no per-platform breakdown.
     drop_panels(dash, {
         "Users → 1M goal", "ARR", "Active subscriptions", "Trialing",
         "Trials in pipeline", "Conversations", "MRR by product", "MRR over time",
         "New subscriptions / month", "Message ratings",
         "Infra cost by service — last 30 days",
     })
+    if scope == "mobile":
+        drop_panels(dash, DESKTOP_ONLY_TITLES)
 
     ticker = panel_by_title(dash, "Total users")
-    ticker["title"] = "macOS users"
+    ticker["title"] = f"{label} users (all-time)"
     ticker["gridPos"]["h"] = 6
-    set_stat_query(ticker, PROFIT_PATH, "summary", "totalUsersDesktop", "macOS users")
+    set_stat_query(
+        ticker, set_url_param(VIRAL_PATH, "platform", scope),
+        "summary", "allTimeUsers", f"{label} users",
+    )
 
     mrr = panel_by_title(dash, "MRR")
-    mrr["title"] = "MRR (macOS)"
-    set_stat_query(mrr, PROFIT_PATH, "summary", "mrrDesktop", "MRR")
+    mrr["title"] = f"MRR ({label})"
+    set_stat_query(mrr, PROFIT_PATH, "summary",
+                   "mrrDesktop" if scope == "macos" else "mrrMobile", "MRR")
 
     signups = panel_by_title(dash, "Signups — last 7 days")
-    signups["title"] = "macOS signups — last 7 days"
-    set_compare(signups["targets"][0], "url", path=PROFIT_PATH, root="users", fields="desktop")
+    signups["title"] = f"{label} signups — last 7 days"
+    set_compare(signups["targets"][0], "url",
+                path=PROFIT_PATH, root="users", fields=profit_field)
 
     daily = panel_by_title(dash, "Daily new users")
-    platform_series(daily, PROFIT_PATH, "users", "desktop", "New users")
-    retarget_var(dash, "d_daily", path=PROFIT_PATH, root="users", fields="desktop")
+    platform_series(daily, PROFIT_PATH, "users", profit_field, "New users")
+    retarget_var(dash, "d_daily", path=PROFIT_PATH, root="users", fields=profit_field)
 
     cumulative = panel_by_title(dash, "Cumulative users")
-    cumulative["title"] = "Cumulative users (macOS)  ·  ${d_cum}"
-    platform_series(cumulative, PROFIT_PATH, "cumulativeUsers", "desktop", "Total users")
-    retarget_var(dash, "d_cum", path=PROFIT_PATH, root="users", fields="desktop")
+    cumulative["title"] = f"Cumulative users ({label})  ·  ${{d_cum}}"
+    platform_series(cumulative, PROFIT_PATH, "cumulativeUsers", profit_field, "Total users")
+    retarget_var(dash, "d_cum", path=PROFIT_PATH, root="users", fields=profit_field)
 
+    series_label = "Desktop" if scope == "macos" else "Mobile"
     for title, new_title, series in [
-        ("New users / day by platform", "New users / day (desktop)  ·  ${d_pusers}", "Desktop"),
-        ("Revenue / day by platform (est.)", "Revenue / day (desktop, est.)  ·  ${d_prev}", "Desktop"),
-        ("Infra cost / day by platform", "Infra cost / day (desktop)  ·  ${d_cost}", "Desktop"),
-        ("Cost / user / day", "Cost / user / day (desktop)  ·  ${d_cpu}", "Desktop $/user"),
-        ("Free → paid conversion", "Free → paid conversion (desktop)  ·  ${d_conv}", "Desktop"),
+        ("New users / day by platform", f"New users / day ({profit_field})  ·  ${{d_pusers}}", series_label),
+        ("Revenue / day by platform (est.)", f"Revenue / day ({profit_field}, est.)  ·  ${{d_prev}}", series_label),
+        ("Infra cost / day by platform", f"Infra cost / day ({profit_field})  ·  ${{d_cost}}", series_label),
+        ("Cost / user / day", f"Cost / user / day ({profit_field})  ·  ${{d_cpu}}", f"{series_label} $/user"),
+        ("Free → paid conversion", f"Free → paid conversion ({profit_field})  ·  ${{d_conv}}", series_label),
     ]:
         panel = panel_by_title(dash, title)
         panel["title"] = new_title
         keep_series(panel, {series})
     for var in ["d_pusers", "d_prev", "d_cost", "d_cpu", "d_conv"]:
-        retarget_var(dash, var, fields="desktop")
+        retarget_var(dash, var, fields=profit_field)
+
+    if scope == "macos":
+        # Board context makes the (macOS) marker redundant.
+        panel_by_title(dash, "Activation rate (macOS)")["title"] = "Activation rate"
+        chart = panel_by_title(dash, "Activation (signup → activated, macOS)")
+        chart["title"] = "Activation (signup → activated)" + (
+            "  ·  " + chart["title"].split("  ·  ")[1] if "  ·  " in chart["title"] else "")
+    if scope == "mobile":
+        # The Firestore activation route is macOS-only (conversation within 7
+        # days of a macOS signup); mobile activation uses PostHog telemetry
+        # (first-seen → Memory Created within 7 days) via viral-metrics.
+        viral_mobile = set_url_param(VIRAL_PATH, "platform", "mobile")
+        rate = panel_by_title(dash, "Activation rate (macOS)")
+        rate["title"] = "Activation rate"
+        set_stat_query(rate, viral_mobile, "summary", "activationRate", "Activation")
+        chart = panel_by_title(dash, "Activation (signup → activated, macOS)")
+        chart["title"] = "Activation (signup → activated)  ·  ${d_act}"
+        target = chart["targets"][0]
+        target["url"] = add_query_param(f"{PROXY}{viral_mobile}", "_tzdates", "date")
+        target["root_selector"] = "activation"
+        target["columns"] = [
+            {"selector": "date", "text": "time", "type": "timestamp", "timestampFormat": RFC3339},
+            {"selector": "signups", "text": "Signups", "type": "number"},
+            {"selector": "activated", "text": "Activated", "type": "number"},
+            {"selector": "rate", "text": "Rate", "type": "number"},
+        ]
+        chart["description"] = ("First-seen mobile users creating a Memory within 7 days "
+                                "(PostHog telemetry; mobile does not emit Sign In Completed).")
 
     prune_vars_and_titles(dash)
     reflow(dash)
-    return finish(dash, "omi-tv-macos", "Omi TV — macOS")
-
-
-def build_mobile(base) -> dict:
-    dash = copy.deepcopy(base)
-
-    ticker = panel_by_title(dash, "Total users")
-    ticker["title"] = "Mobile users"
-    set_stat_query(ticker, PROFIT_PATH, "summary", "totalUsersMobile", "Mobile users")
-
-    mrr = panel_by_title(dash, "MRR")
-    mrr["title"] = "MRR (mobile)"
-    set_stat_query(mrr, PROFIT_PATH, "summary", "mrrMobile", "MRR")
-
-    signups = panel_by_title(dash, "Signups — last 7 days")
-    signups["title"] = "Mobile signups — last 7 days"
-    set_compare(signups["targets"][0], "url", path=PROFIT_PATH, root="users", fields="mobile")
-
-    cumulative = panel_by_title(dash, "Cumulative users")
-    cumulative["title"] = "Cumulative users (mobile)  ·  ${d_cum}"
-    platform_series(cumulative, PROFIT_PATH, "cumulativeUsers", "mobile", "Total users")
-    retarget_var(dash, "d_cum", path=PROFIT_PATH, root="users", fields="mobile")
-
-    daily = panel_by_title(dash, "Daily new users")
-    daily["title"] = "Daily new users  ·  ${d_daily}"
-    platform_series(daily, PROFIT_PATH, "users", "mobile", "New users")
-    retarget_var(dash, "d_daily", path=PROFIT_PATH, root="users", fields="mobile")
-
-    charts = []
-    for title, new_title, series in [
-        ("New users / day by platform", "New users / day (mobile)  ·  ${d_pusers}", "Mobile"),
-        ("Revenue / day by platform (est.)", "Revenue / day (mobile, est.)  ·  ${d_prev}", "Mobile"),
-        ("Infra cost / day by platform", "Infra cost / day (mobile)  ·  ${d_cost}", "Mobile"),
-        ("Cost / user / day", "Cost / user / day (mobile)  ·  ${d_cpu}", "Mobile $/user"),
-        ("Free → paid conversion", "Free → paid conversion (mobile)  ·  ${d_conv}", "Mobile"),
-    ]:
-        panel = panel_by_title(dash, title)
-        panel["title"] = new_title
-        keep_series(panel, {series})
-        charts.append(panel)
-    for var in ["d_pusers", "d_prev", "d_cost", "d_cpu", "d_conv"]:
-        retarget_var(dash, var, fields="mobile")
-
-    note = {
-        "id": 999,
-        "type": "text",
-        "title": "",
-        "transparent": True,
-        "gridPos": {"x": 0, "y": 0, "w": 24, "h": 3},
-        "options": {
-            "mode": "markdown",
-            "content": "**Mobile engagement (DAU/WAU, retention, activation) is not instrumented yet** — "
-                       "PostHog only covers desktop and mobile Mixpanel is dead. These panels come from "
-                       "Firebase signups split by platform token, Stripe MRR attribution, and infra cost shares.",
-        },
-        "targets": [],
-    }
-
-    keep = [ticker, mrr, signups, daily, charts[1], charts[2], charts[3], charts[4],
-            cumulative, note]
-    for stat_panel in (ticker, mrr, signups):
-        stat_panel["gridPos"].update({"w": 8, "h": 5})
-    dash["panels"] = keep
-    prune_vars_and_titles(dash)
-    reflow(dash)
-    return finish(dash, "omi-tv-mobile", "Omi TV — Mobile")
+    return finish(dash, f"omi-tv-{scope}", f"Omi TV — {label}")
 
 
 def main() -> None:
     base = json.loads(BASE_PATH.read_text(encoding="utf-8"))
     apply_tzdates(base)
+    apply_platform(base, "all")
+    # The two Firestore-backed activation panels are macOS-scoped by
+    # definition; their delta var compares macOS activation to stay coherent.
+    retarget_var(base, "d_act", path=set_url_param(VIRAL_PATH, "platform", "macos"))
     finish(base, "omi-tv", "Omi TV")
 
-    macos = build_macos(base)
-    mobile = build_mobile(base)
+    macos = build_platform_board(base, "macos")
+    mobile = build_platform_board(base, "mobile")
 
     BASE_PATH.write_text(json.dumps(base, indent=2) + "\n", encoding="utf-8")
     for dash, name in [(macos, "omi-tv-macos.json"), (mobile, "omi-tv-mobile.json")]:
         (DASH_DIR / name).write_text(json.dumps(dash, indent=2) + "\n", encoding="utf-8")
         print(f"wrote {name}: {len(dash['panels'])} panels, "
               f"{len(dash['templating']['list'])} vars")
-    print(f"updated omi-tv.json: {len(base['panels'])} panels (NYC tz + _tzdates + links)")
+    print(f"updated omi-tv.json: {len(base['panels'])} panels (NYC tz + _tzdates + platform=all + links)")
 
 
 if __name__ == "__main__":

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -57,7 +57,7 @@
         {
           "columns": [
             {
-              "selector": "totalUsersDesktop",
+              "selector": "allTimeUsers",
               "text": "macOS users",
               "type": "number"
             }
@@ -72,14 +72,14 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "macOS users",
+      "title": "macOS users (all-time)",
       "type": "stat"
     },
     {
@@ -184,7 +184,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -480,7 +480,7 @@
           }
         }
       ],
-      "title": "W4 retention (macOS)",
+      "title": "W4 retention",
       "type": "stat"
     },
     {
@@ -556,7 +556,7 @@
           "root_selector": "proxy",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -655,7 +655,7 @@
           "root_selector": "growthAccounting",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -839,7 +839,7 @@
           }
         }
       ],
-      "title": "Retention curve \u2014 macOS, 30d cohorts",
+      "title": "Retention curve \u2014 30d cohorts",
       "type": "barchart"
     },
     {
@@ -981,7 +981,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1055,7 +1055,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1129,7 +1129,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1205,7 +1205,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1280,7 +1280,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1356,7 +1356,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1438,7 +1438,7 @@
           }
         }
       ],
-      "title": "Retention D1 (macOS)",
+      "title": "Retention D1",
       "type": "stat"
     },
     {
@@ -1513,7 +1513,7 @@
           }
         }
       ],
-      "title": "Retention D7 (macOS)",
+      "title": "Retention D7",
       "type": "stat"
     },
     {
@@ -1858,7 +1858,7 @@
           "root_selector": "data",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/dau-trends?days=60&_tzdates=date",
+          "url": "http://127.0.0.1:8899/api/omi/stats/dau-trends?days=60&_tzdates=date&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -2018,7 +2018,7 @@
           "root_selector": "growthAccounting",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -2184,7 +2184,7 @@
           "root_selector": "stickinessTrend",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -2428,7 +2428,7 @@
           "root_selector": "powerUserCurve",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -4236,7 +4236,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -4347,7 +4347,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fdau-trends%3Fdays%3D60&root=data&fields=dau&agg=avg&window=30&label=avg+vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fdau-trends%3Fdays%3D60%26platform%3Dmacos&root=data&fields=dau&agg=avg&window=30&label=avg+vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -4384,7 +4384,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=growthAccounting&fields=newUsers&agg=sum&window=4&label=new+vs+prev+4w",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=newUsers&agg=sum&window=4&label=new+vs+prev+4w",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -4421,7 +4421,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=stickinessTrend&fields=dauWau&agg=avg&window=4&label=vs+prev+4w",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=stickinessTrend&fields=dauWau&agg=avg&window=4&label=vs+prev+4w",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -4458,7 +4458,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=activation&fields=rate&agg=avg&window=30&label=vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=activation&fields=rate&agg=avg&window=30&label=vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -35,8 +35,8 @@
       "gridPos": {
         "x": 0,
         "y": 0,
-        "w": 8,
-        "h": 5
+        "w": 4,
+        "h": 6
       },
       "id": 1,
       "options": {
@@ -57,7 +57,7 @@
         {
           "columns": [
             {
-              "selector": "totalUsersMobile",
+              "selector": "allTimeUsers",
               "text": "Mobile users",
               "type": "number"
             }
@@ -72,14 +72,14 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "Mobile users",
+      "title": "Mobile users (all-time)",
       "type": "stat"
     },
     {
@@ -87,33 +87,65 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
+      "description": "Weekly active users (last full week) and change vs the week before (new + resurrected \u2212 churned). Compounding \u22657% WoW is the 1M trajectory.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "#22c55e",
-            "mode": "fixed"
+            "mode": "thresholds"
           },
-          "decimals": 0,
+          "decimals": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "#22c55e",
+                "color": "#ef4444",
                 "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 0
+              },
+              {
+                "color": "#22c55e",
+                "value": 7
               }
             ]
           },
-          "unit": "currencyUSD"
+          "unit": "percent"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WAU"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "locale"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 4,
         "y": 0,
-        "w": 8,
-        "h": 5
+        "w": 4,
+        "h": 6
       },
-      "id": 11,
+      "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -126,14 +158,19 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "textMode": "value_and_name"
       },
       "targets": [
         {
           "columns": [
             {
-              "selector": "mrrMobile",
-              "text": "MRR",
+              "selector": "current",
+              "text": "WAU",
+              "type": "number"
+            },
+            {
+              "selector": "pct",
+              "text": "WoW %",
               "type": "number"
             }
           ],
@@ -144,17 +181,17 @@
           "format": "table",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "summary",
+          "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "MRR (mobile)",
+      "title": "Net WAU growth WoW",
       "type": "stat"
     },
     {
@@ -226,10 +263,10 @@
         ]
       },
       "gridPos": {
-        "x": 16,
+        "x": 8,
         "y": 0,
-        "w": 8,
-        "h": 5
+        "w": 4,
+        "h": 6
       },
       "id": 4,
       "options": {
@@ -285,6 +322,355 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
+      "description": "% of signups reaching the aha moment on day 1. Biggest controllable lever \u2014 first-5-minutes work.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#ef4444",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 10
+              },
+              {
+                "color": "#22c55e",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 4,
+        "h": 6
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "activationRate",
+              "text": "Activation",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Activation rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Day-28 retention of the last 30 daily cohorts. Curve must flatten \u226525% before pouring traffic in; \u226540% = strong.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#ef4444",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 25
+              },
+              {
+                "color": "#22c55e",
+                "value": 40
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 0,
+        "w": 4,
+        "h": 6
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "retention",
+              "text": "W4",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data[day=28]",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "W4 retention",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Sharers \u00f7 new users, last 30d (macOS). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#ef4444",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 10
+              },
+              {
+                "color": "#22c55e",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 0,
+        "w": 4,
+        "h": 6
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "shareRatePct",
+              "text": "Sharers / new users",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "proxy",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Share rate (K-factor proxy)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Last bucket is the current partial week.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "lineWidth": 3,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WAU"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 8,
+        "h": 8
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "active",
+              "text": "WAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "growthAccounting",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "90d",
+      "title": "WAU \u2014 weekly active users  \u00b7  ${d_wau}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -326,8 +712,8 @@
         ]
       },
       "gridPos": {
-        "x": 0,
-        "y": 5,
+        "x": 8,
+        "y": 6,
         "w": 8,
         "h": 8
       },
@@ -377,6 +763,1639 @@
       ],
       "timeFrom": "30d",
       "title": "Daily new users  \u00b7  ${d_daily}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "PMF check: the curve must flatten, not decay to zero.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#14b8a6",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "lineWidth": 0
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 6,
+        "w": 8,
+        "h": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "auto",
+        "showValue": "never",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "day",
+              "text": "Day",
+              "type": "string"
+            },
+            {
+              "selector": "retention",
+              "text": "Retention",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Retention curve \u2014 30d cohorts",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#22c55e",
+            "mode": "fixed"
+          },
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#22c55e",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "mrrMobile",
+              "text": "MRR",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "MRR (Mobile)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#3b82f6",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3b82f6",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 3,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "dau",
+              "text": "DAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "DAU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#3b82f6",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3b82f6",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "wau",
+              "text": "WAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "WAU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#3b82f6",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3b82f6",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 9,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "mau",
+              "text": "MAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "MAU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "(new + resurrected) / churned, weekly",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#f59e0b",
+            "mode": "fixed"
+          },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#f59e0b",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "quickRatio",
+              "text": "Quick ratio",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Quick ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#f59e0b",
+            "mode": "fixed"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#f59e0b",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 15,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "dauMau",
+              "text": "DAU/MAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "DAU / MAU",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Share of MAU active 5+ days in the last 30",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#f59e0b",
+            "mode": "fixed"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#f59e0b",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "l5PlusPct",
+              "text": "L5+",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "summary",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "L5+ users",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#14b8a6",
+            "mode": "fixed"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#14b8a6",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 21,
+        "y": 14,
+        "w": 3,
+        "h": 4
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "retention",
+              "text": "D1",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data[day=1]",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Retention D1",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#14b8a6",
+            "mode": "fixed"
+          },
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#14b8a6",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 18,
+        "w": 3,
+        "h": 4
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "retention",
+              "text": "D7",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data[day=7]",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Retention D7",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total users"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 3,
+        "y": 18,
+        "w": 8,
+        "h": 8
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "mobile",
+              "text": "Total users",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "cumulativeUsers",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "Cumulative users (Mobile)  \u00b7  ${d_cum}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DAU"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 11,
+        "y": 18,
+        "w": 8,
+        "h": 8
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "dau",
+              "text": "DAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "data",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/dau-trends?days=60&_tzdates=date&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "DAU  \u00b7  ${d_dau}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Churned is negative; quick ratio = (new + resurrected) / churned.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "New"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Resurrected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#14b8a6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Retained"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Churned"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#ef4444",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 26,
+        "w": 8,
+        "h": 8
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "newUsers",
+              "text": "New",
+              "type": "number"
+            },
+            {
+              "selector": "resurrected",
+              "text": "Resurrected",
+              "type": "number"
+            },
+            {
+              "selector": "retained",
+              "text": "Retained",
+              "type": "number"
+            },
+            {
+              "selector": "churned",
+              "text": "Churned",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "growthAccounting",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "90d",
+      "title": "Growth accounting (weekly)  \u00b7  ${d_ga}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Avg DAU"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "WAU"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0ea5e9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DAU/WAU"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f59e0b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 26,
+        "w": 8,
+        "h": 8
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "avgDau",
+              "text": "Avg DAU",
+              "type": "number"
+            },
+            {
+              "selector": "wau",
+              "text": "WAU",
+              "type": "number"
+            },
+            {
+              "selector": "dauWau",
+              "text": "DAU/WAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "stickinessTrend",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "90d",
+      "title": "Stickiness (weekly)  \u00b7  ${d_stick}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Signups"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Activated"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f59e0b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 26,
+        "w": 8,
+        "h": 8
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "signups",
+              "text": "Signups",
+              "type": "number"
+            },
+            {
+              "selector": "activated",
+              "text": "Activated",
+              "type": "number"
+            },
+            {
+              "selector": "rate",
+              "text": "Rate",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "activation",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile&_tzdates=date",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "60d",
+      "title": "Activation (signup \u2192 activated)  \u00b7  ${d_act}",
+      "type": "timeseries",
+      "description": "First-seen mobile users creating a Memory within 7 days (PostHog telemetry; mobile does not emit Sign In Completed)."
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Days active in the last 30, as % of MAU",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#3b82f6",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "lineWidth": 0
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 34,
+        "w": 8,
+        "h": 8
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "auto",
+        "showValue": "never",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "daysActive",
+              "text": "Days active",
+              "type": "string"
+            },
+            {
+              "selector": "pct",
+              "text": "% of MAU",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "powerUserCurve",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Power user curve",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Desktop"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Mobile"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 34,
+        "w": 8,
+        "h": 8
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "mobile",
+              "text": "Mobile",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "users",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "New users / day (mobile)  \u00b7  ${d_pusers}",
       "type": "timeseries"
     },
     {
@@ -440,8 +2459,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 5,
+        "x": 16,
+        "y": 34,
         "w": 8,
         "h": 8
       },
@@ -554,8 +2573,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 5,
+        "x": 0,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -668,8 +2687,8 @@
         ]
       },
       "gridPos": {
-        "x": 0,
-        "y": 13,
+        "x": 8,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -782,8 +2801,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 13,
+        "x": 16,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -834,122 +2853,6 @@
       "timeFrom": "30d",
       "title": "Free \u2192 paid conversion (mobile)  \u00b7  ${d_conv}",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "opacity",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Total users"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#22c55e",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 16,
-        "y": 13,
-        "w": 8,
-        "h": 8
-      },
-      "id": 29,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "date",
-              "text": "time",
-              "type": "timestamp",
-              "timestampFormat": "2006-01-02T15:04:05Z07:00"
-            },
-            {
-              "selector": "mobile",
-              "text": "Total users",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "cumulativeUsers",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "30d",
-      "title": "Cumulative users (mobile)  \u00b7  ${d_cum}",
-      "type": "timeseries"
-    },
-    {
-      "id": 999,
-      "type": "text",
-      "title": "",
-      "transparent": true,
-      "gridPos": {
-        "x": 0,
-        "y": 21,
-        "w": 24,
-        "h": 3
-      },
-      "options": {
-        "mode": "markdown",
-        "content": "**Mobile engagement (DAU/WAU, retention, activation) is not instrumented yet** \u2014 PostHog only covers desktop and mobile Mixpanel is dead. These panels come from Firebase signups split by platform token, Stripe MRR attribution, and infra cost shares."
-      },
-      "targets": []
     }
   ],
   "refresh": "5m",
@@ -960,6 +2863,43 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_wau",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
       {
         "current": {},
         "datasource": {
@@ -1022,6 +2962,191 @@
             "source": "url",
             "type": "json",
             "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=mobile&agg=sum&window=30&label=vs+prev+30d",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_dau",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fdau-trends%3Fdays%3D60%26platform%3Dmobile&root=data&fields=dau&agg=avg&window=30&label=avg+vs+prev+30d",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_ga",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=newUsers&agg=sum&window=4&label=new+vs+prev+4w",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_stick",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=stickinessTrend&fields=dauWau&agg=avg&window=4&label=vs+prev+4w",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_act",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=activation&fields=rate&agg=avg&window=30&label=vs+prev+30d",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_pusers",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=mobile&agg=sum&window=15&label=vs+prev+15d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -267,7 +267,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -480,7 +480,7 @@
           }
         }
       ],
-      "title": "Activation rate",
+      "title": "Activation rate (macOS)",
       "type": "stat"
     },
     {
@@ -556,14 +556,14 @@
           "root_selector": "data[day=28]",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "W4 retention (macOS)",
+      "title": "W4 retention",
       "type": "stat"
     },
     {
@@ -639,7 +639,7 @@
           "root_selector": "proxy",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30",
+          "url": "http://127.0.0.1:8899/api/omi/stats/k-factor/posthog?days=30&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -738,7 +738,7 @@
           "root_selector": "growthAccounting",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -915,14 +915,14 @@
           "root_selector": "data",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "Retention curve \u2014 macOS, 30d cohorts",
+      "title": "Retention curve \u2014 30d cohorts",
       "type": "barchart"
     },
     {
@@ -1287,7 +1287,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1361,7 +1361,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1435,7 +1435,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1585,7 +1585,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1660,7 +1660,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1736,7 +1736,7 @@
           "root_selector": "summary",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1811,14 +1811,14 @@
           "root_selector": "data[day=1]",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "Retention D1 (macOS)",
+      "title": "Retention D1",
       "type": "stat"
     },
     {
@@ -1886,14 +1886,14 @@
           "root_selector": "data[day=7]",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=macos",
+          "url": "http://127.0.0.1:8899/api/omi/stats/retention/posthog?days=30&intervals=30&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
           }
         }
       ],
-      "title": "Retention D7 (macOS)",
+      "title": "Retention D7",
       "type": "stat"
     },
     {
@@ -2530,7 +2530,7 @@
           "root_selector": "data",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/dau-trends?days=60&_tzdates=date",
+          "url": "http://127.0.0.1:8899/api/omi/stats/dau-trends?days=60&_tzdates=date&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -2690,7 +2690,7 @@
           "root_selector": "growthAccounting",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -2856,7 +2856,7 @@
           "root_selector": "stickinessTrend",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&_tzdates=week&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -3030,7 +3030,7 @@
         }
       ],
       "timeFrom": "60d",
-      "title": "Activation (signup \u2192 activated)  \u00b7  ${d_act}",
+      "title": "Activation (signup \u2192 activated, macOS)  \u00b7  ${d_act}",
       "type": "timeseries"
     },
     {
@@ -3266,7 +3266,7 @@
           "root_selector": "powerUserCurve",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=all",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -5310,7 +5310,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -5495,7 +5495,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fdau-trends%3Fdays%3D60&root=data&fields=dau&agg=avg&window=30&label=avg+vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fdau-trends%3Fdays%3D60%26platform%3Dall&root=data&fields=dau&agg=avg&window=30&label=avg+vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -5532,7 +5532,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=growthAccounting&fields=newUsers&agg=sum&window=4&label=new+vs+prev+4w",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=newUsers&agg=sum&window=4&label=new+vs+prev+4w",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -5569,7 +5569,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=stickinessTrend&fields=dauWau&agg=avg&window=4&label=vs+prev+4w",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=stickinessTrend&fields=dauWau&agg=avg&window=4&label=vs+prev+4w",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -5606,7 +5606,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60&root=activation&fields=rate&agg=avg&window=30&label=vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=activation&fields=rate&agg=avg&window=30&label=vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -2,18 +2,23 @@
 """Behavioral coverage for build_dashboards.py — the platform boards and the
 NYC-time/latest-day display contract.
 
-The regression this guards: daily buckets arrive as bare date strings
-("2026-08-18"); parsed as UTC midnight they render at 8 pm the previous day
-in America/New_York, so the latest day silently disappears from every daily
-chart. The builder must (a) pin every board to America/New_York and (b) route
-every daily/weekly/monthly timestamp column through the proxy's `_tzdates`
-rewrite with an RFC3339 parse format.
+Regressions guarded here:
+  - Daily buckets arrive as bare date strings; parsed as UTC midnight they
+    render 8 pm the previous NYC day and the latest day disappears. Every
+    day-grain column must go through `_tzdates` + RFC3339.
+  - The platform boards must actually be platform-scoped: every PostHog-backed
+    query (including ones nested in /compare URLs) pins platform=macos /
+    platform=mobile / platform=all per board. Unscoped viral-metrics silently
+    reports macOS numbers as all-platform (the "same DAU on every board" bug).
+  - The mobile board mirrors the macOS board panel-for-panel except the
+    desktop-only product surfaces.
 """
 
 from __future__ import annotations
 
 import copy
 import json
+import re
 import sys
 import unittest
 import urllib.parse
@@ -25,6 +30,7 @@ sys.path.insert(0, str(HERE))
 import build_dashboards  # noqa: E402
 
 BOARDS = ["omi-tv", "omi-tv-macos", "omi-tv-mobile"]
+BOARD_SCOPE = {"omi-tv": "all", "omi-tv-macos": "macos", "omi-tv-mobile": "mobile"}
 RFC3339 = "2006-01-02T15:04:05Z07:00"
 BARE_DAY_FORMATS = {"2006-01-02", "2006-01"}
 
@@ -41,15 +47,40 @@ def timestamp_columns(dash):
                     yield panel, target, col
 
 
+def all_urls(dash):
+    for panel in dash.get("panels", []):
+        for target in panel.get("targets", []):
+            if "url" in target:
+                yield panel.get("title", "?"), target["url"]
+    for var in dash.get("templating", {}).get("list", []):
+        q = var.get("query", {}).get("infinityQuery", {})
+        if "url" in q:
+            yield f"var:{var['name']}", q["url"]
+
+
+def platform_of(url: str) -> str | None:
+    """The effective platform param of a URL (unwrapping /compare paths)."""
+    parsed = urllib.parse.urlparse(url)
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    if "/compare" in parsed.path and "path" in params:
+        inner = urllib.parse.urlparse(params["path"])
+        params = dict(urllib.parse.parse_qsl(inner.query))
+        url = params.get("path", "") or inner.path
+        return params.get("platform")
+    return params.get("platform")
+
+
+def touches_platform_route(url: str) -> bool:
+    haystack = urllib.parse.unquote(url)
+    return any(route in haystack for route in build_dashboards.PLATFORM_ROUTES)
+
+
 class NycTimeContractTests(unittest.TestCase):
     def test_every_board_is_pinned_to_new_york(self) -> None:
         for uid in BOARDS:
             self.assertEqual(load(uid)["timezone"], "America/New_York", uid)
 
     def test_no_bare_date_columns_survive(self) -> None:
-        """Bare date formats parse as UTC midnight and shift the latest day
-        off the chart in NYC time — every day-grain column must go through
-        _tzdates and parse as RFC3339."""
         for uid in BOARDS:
             for panel, target, col in timestamp_columns(load(uid)):
                 fmt = col.get("timestampFormat")
@@ -63,8 +94,6 @@ class NycTimeContractTests(unittest.TestCase):
                                   "not routed through _tzdates")
 
     def test_hourly_columns_stay_utc_parsed(self) -> None:
-        """Hourly buckets are genuine UTC instants; they must NOT be rewritten
-        (the dashboard timezone converts them to NYC wall-clock at render)."""
         hourly = [
             (panel, target, col)
             for panel, target, col in timestamp_columns(load("omi-tv"))
@@ -75,7 +104,20 @@ class NycTimeContractTests(unittest.TestCase):
             self.assertNotIn("_tzdates", target["url"])
 
 
-class PlatformBoardTests(unittest.TestCase):
+class PlatformScopeTests(unittest.TestCase):
+    def test_every_posthog_query_pins_its_board_platform(self) -> None:
+        """The 'same DAU on every board' bug: an unscoped viral-metrics /
+        dau-trends / retention / k-factor URL reports macOS-only numbers
+        wherever it appears."""
+        for uid, scope in BOARD_SCOPE.items():
+            exceptions = {"var:d_act"} if uid == "omi-tv" else set()
+            for where, url in all_urls(load(uid)):
+                if not touches_platform_route(url):
+                    continue
+                expected = "macos" if where in exceptions else scope
+                self.assertEqual(platform_of(url), expected,
+                                 f"{uid} / {where}: expected platform={expected} in {url}")
+
     def test_switcher_links_on_every_board(self) -> None:
         for uid in BOARDS:
             urls = [link["url"] for link in load(uid)["links"]]
@@ -85,40 +127,40 @@ class PlatformBoardTests(unittest.TestCase):
                 uid,
             )
 
-    def test_macos_board_has_no_mobile_series(self) -> None:
-        dash = load("omi-tv-macos")
-        for panel in dash["panels"]:
-            for target in panel.get("targets", []):
-                for col in target.get("columns", []):
-                    self.assertNotIn("mobile", col.get("selector", "").lower(),
-                                     f"macOS board leaks mobile series in {panel['title']}")
-        titles = " ".join(p["title"] for p in dash["panels"])
-        self.assertIn("macOS users", titles)
-        self.assertNotIn("by platform", titles)
 
-    def test_mobile_board_is_honest(self) -> None:
-        """Mobile engagement isn't instrumented — the board must only carry
-        profitability-derived series plus the instrumentation note."""
-        dash = load("omi-tv-mobile")
-        titles = [p["title"] for p in dash["panels"]]
-        joined = " ".join(titles)
-        for absent in ["Retention", "Floating bar", "WAU", "notification", "Crash"]:
-            self.assertNotIn(absent, joined, f"mobile board should not claim {absent}")
-        note = next(p for p in dash["panels"] if p["type"] == "text")
-        self.assertIn("not instrumented", note["options"]["content"])
-        for panel in dash["panels"]:
-            for target in panel.get("targets", []):
-                for col in target.get("columns", []):
-                    self.assertNotIn("desktop", col.get("selector", "").lower(),
-                                     f"mobile board leaks desktop series in {panel['title']}")
+class MirrorTests(unittest.TestCase):
+    @staticmethod
+    def normalized_titles(dash) -> set[str]:
+        return {
+            re.sub(r"desktop|mobile|macOS|Mobile", "×", build_dashboards.base_title(p))
+            for p in dash["panels"]
+        }
 
-    def test_platform_delta_variables_follow_their_board(self) -> None:
-        for uid, field in [("omi-tv-macos", "desktop"), ("omi-tv-mobile", "mobile")]:
-            for var in load(uid)["templating"]["list"]:
-                url = var["query"]["infinityQuery"]["url"]
-                params = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
-                if "profitability" in params.get("path", [""])[0]:
-                    self.assertEqual(params["fields"], [field], f"{uid}: {var['name']}")
+    def test_mobile_mirrors_macos_except_desktop_features(self) -> None:
+        macos, mobile = load("omi-tv-macos"), load("omi-tv-mobile")
+        desktop_only = {
+            re.sub(r"desktop|mobile|macOS|Mobile", "×", t)
+            for t in build_dashboards.DESKTOP_ONLY_TITLES
+        }
+        self.assertEqual(self.normalized_titles(macos) - desktop_only,
+                         self.normalized_titles(mobile))
+        self.assertEqual(len(mobile["panels"]),
+                         len(macos["panels"]) - len(build_dashboards.DESKTOP_ONLY_TITLES))
+
+    def test_boards_do_not_leak_the_other_platforms_series(self) -> None:
+        for uid, foreign in [("omi-tv-macos", "mobile"), ("omi-tv-mobile", "desktop")]:
+            for panel in load(uid)["panels"]:
+                for target in panel.get("targets", []):
+                    for col in target.get("columns", []):
+                        self.assertNotIn(foreign, col.get("selector", "").lower(),
+                                         f"{uid} leaks {foreign} series in {panel['title']}")
+
+    def test_platform_tickers_use_alltime_users(self) -> None:
+        for uid, label in [("omi-tv-macos", "macOS"), ("omi-tv-mobile", "Mobile")]:
+            ticker = build_dashboards.panel_by_title(load(uid), f"{label} users (all-time)")
+            target = ticker["targets"][0]
+            self.assertIn("viral-metrics", target["url"])
+            self.assertEqual(target["columns"][0]["selector"], "allTimeUsers")
 
 
 class ApplyScopeTests(unittest.TestCase):
@@ -145,15 +187,20 @@ class ApplyScopeTests(unittest.TestCase):
 
 class BuilderIdempotencyTests(unittest.TestCase):
     def test_rebuild_is_idempotent(self) -> None:
-        """Running the builder against its own output changes nothing —
-        guards against _tzdates double-append and title suffix drift."""
         base = load("omi-tv")
         rebuilt = copy.deepcopy(base)
         build_dashboards.apply_tzdates(rebuilt)
+        build_dashboards.apply_platform(rebuilt, "all")
+        build_dashboards.retarget_var(
+            rebuilt, "d_act",
+            path=build_dashboards.set_url_param(build_dashboards.VIRAL_PATH, "platform", "macos"),
+        )
         build_dashboards.finish(rebuilt, "omi-tv", "Omi TV")
         self.assertEqual(base, rebuilt)
-        self.assertEqual(build_dashboards.build_macos(rebuilt), load("omi-tv-macos"))
-        self.assertEqual(build_dashboards.build_mobile(rebuilt), load("omi-tv-mobile"))
+        self.assertEqual(build_dashboards.build_platform_board(rebuilt, "macos"),
+                         load("omi-tv-macos"))
+        self.assertEqual(build_dashboards.build_platform_board(rebuilt, "mobile"),
+                         load("omi-tv-mobile"))
 
 
 if __name__ == "__main__":

--- a/web/admin/lib/platform-scope.ts
+++ b/web/admin/lib/platform-scope.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared platform scoping for the PostHog-backed stats routes.
+ *
+ * Scopes:
+ *   - "macos"  — desktop events (`$os_name = 'macOS'`).
+ *   - "mobile" — the mobile apps (iOS / Android / iPadOS). Mobile has sent
+ *     PostHog events since 2025-03 (iOS) / 2026-05 (Android) — it is fully
+ *     instrumented for usage metrics, but does NOT emit `Sign In Completed`,
+ *     so signup cohorts for non-macOS scopes anchor on first-seen-any-event.
+ *   - "all"    — every Omi platform. No OS constraint (keeps Windows and any
+ *     events missing `$os_name`), but excludes the `cfc_*` events of Context
+ *     for Claude, a second product reporting into this PostHog project whose
+ *     events carry no `$os` and would otherwise be counted as Omi users.
+ */
+
+export type PlatformScope = "all" | "macos" | "mobile";
+
+export const MOBILE_OS_NAMES = ["iOS", "Android", "iPadOS"] as const;
+
+export function parsePlatformScope(raw: string | null): PlatformScope {
+  return raw === "macos" || raw === "mobile" ? raw : "all";
+}
+
+/**
+ * SQL fragment (starting with `AND …`, or empty) restricting an events query
+ * to the scope. `osColumn` exists because older routes filter on
+ * `properties.$os` while newer ones use `properties.$os_name` — the values
+ * are identical for macOS/iOS/Android/iPadOS.
+ */
+export function scopeFilterAnd(
+  scope: PlatformScope,
+  osColumn = "properties.$os_name",
+): string {
+  if (scope === "macos") return `AND ${osColumn} = 'macOS'`;
+  if (scope === "mobile") {
+    return `AND ${osColumn} IN (${MOBILE_OS_NAMES.map((os) => `'${os}'`).join(", ")})`;
+  }
+  return "AND NOT startsWith(event, 'cfc_')";
+}


### PR DESCRIPTION
## Summary

Fixes three reported metric defects on the Grafana boards:

1. **"All platforms" numbers were macOS-only.** Mobile IS instrumented in PostHog (iOS since 2025-03, Android since 2026-05) but every stats route hardcoded `$os_name = 'macOS'`, so the All board showed DAU 884 when the true all-platform DAU is ~3,000. `viral-metrics`, `dau-trends`, `retention/posthog` and `k-factor/posthog` now take `platform=all|macos|mobile` (shared `lib/platform-scope.ts`; `all` excludes the `cfc_*` second product; non-macOS signup cohorts anchor on first-seen-any-event because mobile never emits `Sign In Completed`; the Firestore activation overlay stays macOS-scoped).
2. **macOS ticker undercounted (5,124).** New `summary.allTimeUsers` reports the real platform total: **13,880** macOS / **28,718** mobile (person-deduped PostHog actors).
3. **Mobile board mirrors macOS panel-for-panel** — same 41-panel structure minus the 12 desktop-only surfaces (floating bar, desktop notifications, crash rate, macOS version pies), all engagement metrics (WAU/DAU/MAU, growth accounting, stickiness, retention curve, activation, power users) now real per-platform data.

## Verification

- Route outputs cross-checked against independent direct PostHog HogQL queries: Aug 18 DAU all 3,050 / macOS 1,068 / mobile 2,196 — exact match; mobile MAU 10,396 exact; all-time 13,880 / 28,718 exact; mobile retention D1 39.76% / D7 30.48% / W4 17.37%.
- Exercised all three boards in local Grafana against the local Next dev server end-to-end (proxy upstream override): All board DAU 2.73K/WAU 6.57K/MAU 13.8K; macOS 13,880 ticker / DAU 847; Mobile 28,718 / DAU 2.05K / W4 17.5% — screenshots taken of each painted board.
- `web/admin/grafana/test_build_dashboards.py` 11/11 (new mirror + platform-pinning guards); `.github/scripts/test_check_admin_deploy_scope.py` 16/16; `npx tsc --noEmit` clean.

## Product invariants affected

none

## Failure class

No `fix:` commits; no declaration required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

