### PR TITLE
fix(deploy): publish backend release provenance from the deployed artifact

### DIFF
--- a/.github/actions/deploy-backend-stack/action.yml
+++ b/.github/actions/deploy-backend-stack/action.yml
@@ -467,7 +467,9 @@ runs:
           ${{ inputs.deploy_profile == 'auto-dev' && format('--tag={0}', inputs.candidate_tag) || '' }}
           --remove-env-vars=MEMORY_ENABLED_USERS,MEMORY_CANONICAL_PROMOTION_CRON_ENABLED,MEMORY_CANONICAL_PROMOTION_CRON_INTERVAL_HOURS,MEMORY_CANONICAL_PROMOTION_FAST_TRACK_ENABLED
           ${{ steps.runtime-env.outputs.cloud_run_flags }}
-        env_vars: ${{ steps.runtime-env.outputs.backend_env_vars }}
+        env_vars: |-
+          ${{ steps.runtime-env.outputs.backend_env_vars }}
+          OMI_BACKEND_RELEASE_SHA=${{ inputs.admitted_sha }}
         secrets: ${{ steps.runtime-env.outputs.backend_secrets }}
 
     - name: Capture ${{ inputs.service }} revision
@@ -475,6 +477,31 @@ runs:
       shell: bash
       run: |
         echo "revision=backend-${{ steps.image-tag.outputs.revision_suffix }}" >> "$GITHUB_OUTPUT"
+
+    # deploy-cloudrun stamps a `commit-sha` label from GITHUB_SHA -- the ref the
+    # workflow was TRIGGERED on, not the release_sha this job checked out and
+    # built. For any pinned deploy (release_sha != main HEAD) that label names a
+    # commit that was never deployed, and it is the marker an operator reaches
+    # for first. On 2026-08-19 it sent an incident responder chasing five
+    # commits that were not in production. The label cannot be corrected here,
+    # so the fix is to publish a marker that is true by construction and then
+    # prove it: read the value back off the revision that was actually created.
+    - name: Verify ${{ inputs.service }} release provenance
+      shell: bash
+      run: |
+        set -euo pipefail
+        expected='${{ inputs.admitted_sha }}'
+        revision='${{ steps.capture-backend-revision.outputs.revision }}'
+        actual="$(gcloud run revisions describe "$revision" \
+          --region='${{ inputs.region }}' --project='${{ inputs.project_id }}' --format=json \
+          | jq -r '[.spec.containers[0].env[]? | select(.name == "OMI_BACKEND_RELEASE_SHA") | .value] | first // ""')"
+        if [[ "$actual" != "$expected" ]]; then
+          echo "ERROR: ${{ inputs.service }} revision $revision reports release sha '$actual'," >&2
+          echo "       but this deploy admitted '$expected'. Refusing to report success:" >&2
+          echo "       an untrue provenance marker is worse than none." >&2
+          exit 1
+        fi
+        echo "$revision publishes OMI_BACKEND_RELEASE_SHA=$actual"
 
     - name: Deploy sync-backfill worker
       id: sync-backfill

--- a/.github/failure-classes/FC-provenance-marker-from-trigger-not-artifact.json
+++ b/.github/failure-classes/FC-provenance-marker-from-trigger-not-artifact.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-provenance-marker-from-trigger-not-artifact",
+  "violated_contract": "A deployment's published provenance marker must be derived from the artifact that was actually built and deployed, never from the workflow's trigger context. google-github-actions/deploy-cloudrun stamps a `commit-sha` label from GITHUB_SHA -- the ref the run was triggered on -- while a pinned deploy checks out and builds `release_sha`. The two differ on exactly the deploys that were deliberate, so the label names a commit that was never deployed at the moment operators most need the truth. This is worse than publishing nothing: `commit-sha` is the first marker an operator reads when answering 'what is running in production', and a marker that is confidently wrong converts verification into false belief. On 2026-08-19 it cost an incident responder two reversals -- first concluding production carried five commits it did not, then re-attributing a latency improvement to a fix that was not deployed -- while the truthful signals (revision-name suffix and image tag, both derived from the checked-out SHA) sat unread beside it.",
+  "canonical_prevention": "Publish a marker whose value is the admitted release SHA the job actually checked out, and prove it in the same job: read the value back off the revision that was created and fail the deploy on mismatch, so an untrue marker stops the release instead of outliving it. Never let a third-party action's trigger-derived default stand as the provenance of record, and when a service already exposes a correct marker, propagate that pattern rather than adding a second disagreeing one.",
+  "canonical_prevention_artifact": [
+    ".github/actions/deploy-backend-stack/action.yml"
+  ],
+  "evidence_prs": [
+    11841
+  ],
+  "scope_hints": [
+    ".github/actions/deploy-backend-stack/action.yml",
+    ".github/workflows/gcp_backend.yml",
+    ".github/workflows/desktop_backend_prod.yml"
+  ],
+  "status": "open"
+}


### PR DESCRIPTION
## The defect

`google-github-actions/deploy-cloudrun` stamps a `commit-sha` label from `GITHUB_SHA` — the ref the workflow run was **triggered** on. A pinned deploy checks out and builds `release_sha`. Those differ on exactly the deploys that were deliberate, so the label names a commit that was never deployed.

Measured on the 2026-08-19 production deploy of `backend`, dispatched with `release_sha=2ebef0dc12`:

| Marker | Value | Derived from | Truthful |
| --- | --- | --- | --- |
| revision name `backend-2ebef0d-…` | `2ebef0dc12` | `git rev-parse --short=7 HEAD` after checkout | yes |
| image tag `gcr.io/…/backend:2ebef0d` | `2ebef0dc12` | same short SHA | yes |
| **`commit-sha` label** | **`b27420e01c`** | **`GITHUB_SHA`** | **no** |

`b27420e01c` was `main` HEAD when the run was dispatched. It was never built and never deployed.

## Why this is worse than publishing nothing

`commit-sha` is the first marker an operator reads to answer *"what is running in production"*. During the 2026-08-19 incident it produced two reversals in one session: first the conclusion that production carried five commits it did not, then a latency improvement re-attributed to `#11830` — a fix that was not actually deployed. The truthful signals (revision-name suffix, image tag) sat unread beside it, because nobody reaches for an image digest when a field literally named `commit-sha` is present.

`desktop-backend` was unaffected: it already publishes `OMI_DESKTOP_BACKEND_RELEASE_SHA` from its admitted source SHA, and reading that env var resolved the same incident in one query.

## The fix

Propagate the pattern that already works, and prove it:

1. **`OMI_BACKEND_RELEASE_SHA`** is published on the `backend` Cloud Run service from `inputs.admitted_sha` — the `release_sha` that `verify_backend_release_admission.py` validated as an ancestor of `main` and that the job checked out. True by construction.
2. **A post-deploy readback** describes the revision that was actually created, extracts the marker, and fails the deploy on mismatch. An untrue provenance marker now stops the release rather than outliving it.

The misleading `commit-sha` label cannot be suppressed from inside the action, so this adds a marker that is correct rather than trying to correct one that is structurally wrong. The failure-class definition records that asymmetry so the next person does not read the label and re-derive the same wrong answer.

## Scope

`backend` only, matching the service the incident touched. `backend-sync`, `backend-sync-backfill` and `backend-integration` deploy through the same action and have the same gap — deliberately left for a follow-up rather than widening a production deploy path in one change. A per-service serving-SHA drift view is the natural next step, and it is only meaningful once the markers it reads are trustworthy.

## Verification

- `jq` extraction expression validated against a live revision: returns `b27420e01cd7a48cecc7f75107895feb45dafcc9` from `desktop-backend-b27420e01cd7-32203390739-1`
- YAML parses; the readback is a single piped line, so it cannot break the block scalar the way an inline heredoc did
- `make preflight` green

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

