### PR TITLE
feat(admin): full mobile/macOS panel parity, single user population per board

### DIFF
--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -78,6 +78,7 @@ export async function GET(request: NextRequest) {
       wauResult,
       mauResult,
       allTimeResult,
+      userGrowthResult,
     ] = await Promise.all([
       // 1. New users per week (first-ever Sign In Completed)
       hogql(apiKey, projectId, host, `
@@ -245,6 +246,23 @@ export async function GET(request: NextRequest) {
         WHERE 1 = 1
           ${os}
       `),
+
+      // 10. Daily new users by first-seen date, same person-deduped
+      // population as query 9 — its running sum must end at allTimeUsers so
+      // the cumulative chart and the all-time ticker agree by construction.
+      hogql(apiKey, projectId, host, `
+        SELECT first_day, count(*) as new_users
+        FROM (
+          SELECT COALESCE(person_id, distinct_id) as actor,
+                 toDate(min(timestamp)) as first_day
+          FROM events
+          WHERE 1 = 1
+            ${os}
+          GROUP BY actor
+        )
+        GROUP BY first_day
+        ORDER BY first_day
+      `),
     ]);
 
     // ── Process Growth Accounting ──
@@ -294,6 +312,14 @@ export async function GET(request: NextRequest) {
     const wau = (wauResult as any[])[0]?.[0] ?? 0;
     const mau = (mauResult as any[])[0]?.[0] ?? 0;
     const allTimeUsers = (allTimeResult as any[])[0]?.[0] ?? 0;
+
+    // ── User growth (first-seen daily + cumulative) ──
+    const userGrowth: { date: string; users: number; cumulative: number }[] = [];
+    let cumulative = 0;
+    for (const [day, users] of userGrowthResult as any[]) {
+      cumulative += users;
+      userGrowth.push({ date: day, users, cumulative });
+    }
     const recentDau = dailyDau.slice(-7);
     const avgDau = recentDau.length > 0
       ? Math.round(recentDau.reduce((s, d) => s + d.dau, 0) / recentDau.length)
@@ -385,6 +411,7 @@ export async function GET(request: NextRequest) {
 
     const result = applyFirestoreActivationCompat(
       {
+        userGrowth,
         growthAccounting,
         stickinessTrend,
         dailyDau,

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -44,7 +44,9 @@ DAY_FORMATS = {"2006-01-02", "2006-01"}
 # Routes that accept ?platform=all|macos|mobile.
 PLATFORM_ROUTES = ("viral-metrics", "dau-trends", "retention/posthog", "k-factor/posthog")
 
-# Desktop-only product surfaces — the only panels absent from the mobile board.
+# Desktop-only product surfaces — kept on the mobile board as explicit
+# "not available on mobile" placeholders so both platform boards stay
+# panel-for-panel identical without mislabeling desktop data as mobile.
 DESKTOP_ONLY_TITLES = {
     "Floating bar sessions per user", "Floating bar queries",
     "Floating bar notification CTR", "Daily notifications sent",
@@ -203,6 +205,41 @@ def drop_panels(dash, titles: set[str]) -> None:
     dash["panels"] = [p for p in dash["panels"] if base_title(p) not in titles]
 
 
+def placeholder_panels(dash, titles: set[str]) -> None:
+    """Replace panels in place with same-size 'not available' text panels."""
+    for i, panel in enumerate(dash["panels"]):
+        if base_title(panel) not in titles:
+            continue
+        dash["panels"][i] = {
+            "id": panel["id"],
+            "type": "text",
+            "title": base_title(panel),
+            "gridPos": panel["gridPos"],
+            "transparent": True,
+            "options": {
+                "mode": "markdown",
+                "content": "**Desktop-only surface — no mobile equivalent.**\n\n"
+                           "This feature exists only in the macOS app; see the "
+                           "[macOS board](/grafana/d/omi-tv-macos/).",
+            },
+            "targets": [],
+        }
+
+
+def user_growth_series(panel, scope: str, field: str, series_name: str) -> None:
+    """Point a chart at viral-metrics userGrowth — the same person-deduped
+    population as the all-time ticker, so counts agree across the board."""
+    viral = set_url_param(VIRAL_PATH, "platform", scope)
+    target = panel["targets"][0]
+    target["url"] = add_query_param(f"{PROXY}{viral}", "_tzdates", "date")
+    target["root_selector"] = "userGrowth"
+    target["columns"] = [
+        {"selector": "date", "text": "time", "type": "timestamp", "timestampFormat": RFC3339},
+        {"selector": field, "text": series_name, "type": "number"},
+    ]
+    panel["timeFrom"] = "30d"
+
+
 def finish(dash, uid: str, title: str) -> dict:
     dash["uid"] = uid
     dash["title"] = title
@@ -231,7 +268,7 @@ def build_platform_board(base, scope: str) -> dict:
         "Infra cost by service — last 30 days",
     })
     if scope == "mobile":
-        drop_panels(dash, DESKTOP_ONLY_TITLES)
+        placeholder_panels(dash, DESKTOP_ONLY_TITLES)
 
     ticker = panel_by_title(dash, "Total users")
     ticker["title"] = f"{label} users (all-time)"
@@ -246,19 +283,23 @@ def build_platform_board(base, scope: str) -> dict:
     set_stat_query(mrr, PROFIT_PATH, "summary",
                    "mrrDesktop" if scope == "macos" else "mrrMobile", "MRR")
 
+    # Signups / daily-new / cumulative all use viral-metrics userGrowth —
+    # the same person-deduped PostHog population as the all-time ticker, so
+    # the cumulative chart ends exactly at the ticker value.
+    viral_scoped = set_url_param(VIRAL_PATH, "platform", scope)
     signups = panel_by_title(dash, "Signups — last 7 days")
     signups["title"] = f"{label} signups — last 7 days"
     set_compare(signups["targets"][0], "url",
-                path=PROFIT_PATH, root="users", fields=profit_field)
+                path=viral_scoped, root="userGrowth", fields="users")
 
     daily = panel_by_title(dash, "Daily new users")
-    platform_series(daily, PROFIT_PATH, "users", profit_field, "New users")
-    retarget_var(dash, "d_daily", path=PROFIT_PATH, root="users", fields=profit_field)
+    user_growth_series(daily, scope, "users", "New users")
+    retarget_var(dash, "d_daily", path=viral_scoped, root="userGrowth", fields="users")
 
     cumulative = panel_by_title(dash, "Cumulative users")
     cumulative["title"] = f"Cumulative users ({label})  ·  ${{d_cum}}"
-    platform_series(cumulative, PROFIT_PATH, "cumulativeUsers", profit_field, "Total users")
-    retarget_var(dash, "d_cum", path=PROFIT_PATH, root="users", fields=profit_field)
+    user_growth_series(cumulative, scope, "cumulative", "Total users")
+    retarget_var(dash, "d_cum", path=viral_scoped, root="userGrowth", fields="users")
 
     series_label = "Desktop" if scope == "macos" else "Mobile"
     for title, new_title, series in [

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -307,7 +307,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=desktop&agg=sum&window=7",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=userGrowth&fields=users&agg=sum&window=7",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -739,7 +739,7 @@
               "timestampFormat": "2006-01-02T15:04:05Z07:00"
             },
             {
-              "selector": "desktop",
+              "selector": "users",
               "text": "New users",
               "type": "number"
             }
@@ -751,10 +751,10 @@
           "format": "timeseries",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "users",
+          "root_selector": "userGrowth",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos&_tzdates=date",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1744,7 +1744,7 @@
               "timestampFormat": "2006-01-02T15:04:05Z07:00"
             },
             {
-              "selector": "desktop",
+              "selector": "cumulative",
               "text": "Total users",
               "type": "number"
             }
@@ -1756,10 +1756,10 @@
           "format": "timeseries",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "cumulativeUsers",
+          "root_selector": "userGrowth",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=macos&_tzdates=date",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -4273,7 +4273,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=desktop&agg=sum&window=30&label=vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=userGrowth&fields=users&agg=sum&window=30&label=vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -4310,7 +4310,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=desktop&agg=sum&window=30&label=vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=userGrowth&fields=users&agg=sum&window=30&label=vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -307,7 +307,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=mobile&agg=sum&window=7",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=userGrowth&fields=users&agg=sum&window=7",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -739,7 +739,7 @@
               "timestampFormat": "2006-01-02T15:04:05Z07:00"
             },
             {
-              "selector": "mobile",
+              "selector": "users",
               "text": "New users",
               "type": "number"
             }
@@ -751,10 +751,10 @@
           "format": "timeseries",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "users",
+          "root_selector": "userGrowth",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile&_tzdates=date",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1517,6 +1517,40 @@
       "type": "stat"
     },
     {
+      "id": 24,
+      "type": "text",
+      "title": "Crash-free rate (today)",
+      "gridPos": {
+        "x": 3,
+        "y": 18,
+        "w": 3,
+        "h": 4
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 25,
+      "type": "text",
+      "title": "macOS active today",
+      "gridPos": {
+        "x": 6,
+        "y": 18,
+        "w": 3,
+        "h": 4
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
@@ -1562,7 +1596,7 @@
         ]
       },
       "gridPos": {
-        "x": 3,
+        "x": 9,
         "y": 18,
         "w": 8,
         "h": 8
@@ -1589,7 +1623,7 @@
               "timestampFormat": "2006-01-02T15:04:05Z07:00"
             },
             {
-              "selector": "mobile",
+              "selector": "cumulative",
               "text": "Total users",
               "type": "number"
             }
@@ -1601,10 +1635,10 @@
           "format": "timeseries",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "cumulativeUsers",
+          "root_selector": "userGrowth",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/profitability?days=30&desktop_cost=1.2&mobile_cost=0.3&_tzdates=date",
+          "url": "http://127.0.0.1:8899/api/omi/stats/viral-metrics?days=60&platform=mobile&_tzdates=date",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -1661,8 +1695,8 @@
         ]
       },
       "gridPos": {
-        "x": 11,
-        "y": 18,
+        "x": 0,
+        "y": 26,
         "w": 8,
         "h": 8
       },
@@ -1806,7 +1840,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 26,
         "w": 8,
         "h": 8
@@ -1977,7 +2011,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 26,
         "w": 8,
         "h": 8
@@ -2143,8 +2177,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 26,
+        "x": 0,
+        "y": 34,
         "w": 8,
         "h": 8
       },
@@ -2229,7 +2263,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 34,
         "w": 8,
         "h": 8
@@ -2283,6 +2317,142 @@
       ],
       "title": "Power user curve",
       "type": "barchart"
+    },
+    {
+      "id": 36,
+      "type": "text",
+      "title": "Floating bar sessions per user",
+      "gridPos": {
+        "x": 16,
+        "y": 34,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 37,
+      "type": "text",
+      "title": "Floating bar queries",
+      "gridPos": {
+        "x": 0,
+        "y": 42,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 38,
+      "type": "text",
+      "title": "Floating bar notification CTR",
+      "gridPos": {
+        "x": 8,
+        "y": 42,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 39,
+      "type": "text",
+      "title": "Daily notifications sent",
+      "gridPos": {
+        "x": 16,
+        "y": 42,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 40,
+      "type": "text",
+      "title": "Weekly notification reach",
+      "gridPos": {
+        "x": 0,
+        "y": 50,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 41,
+      "type": "text",
+      "title": "Crash-free rate",
+      "gridPos": {
+        "x": 8,
+        "y": 50,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 43,
+      "type": "text",
+      "title": "macOS: beta vs production (today)",
+      "gridPos": {
+        "x": 16,
+        "y": 50,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 44,
+      "type": "text",
+      "title": "macOS: by version (today)",
+      "gridPos": {
+        "x": 0,
+        "y": 58,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
     },
     {
       "datasource": {
@@ -2346,7 +2516,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 34,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -2460,7 +2630,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 34,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -2574,7 +2744,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 42,
+        "y": 66,
         "w": 8,
         "h": 8
       },
@@ -2688,7 +2858,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 42,
+        "y": 66,
         "w": 8,
         "h": 8
       },
@@ -2802,7 +2972,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 42,
+        "y": 66,
         "w": 8,
         "h": 8
       },
@@ -2853,6 +3023,40 @@
       "timeFrom": "30d",
       "title": "Free \u2192 paid conversion (mobile)  \u00b7  ${d_conv}",
       "type": "timeseries"
+    },
+    {
+      "id": 50,
+      "type": "text",
+      "title": "Notifications enabled",
+      "gridPos": {
+        "x": 0,
+        "y": 74,
+        "w": 8,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
+    },
+    {
+      "id": 51,
+      "type": "text",
+      "title": "Notifications sent \u2014 last 168 hours",
+      "gridPos": {
+        "x": 0,
+        "y": 82,
+        "w": 24,
+        "h": 8
+      },
+      "transparent": true,
+      "options": {
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+      },
+      "targets": []
     }
   ],
   "refresh": "5m",
@@ -2924,7 +3128,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=mobile&agg=sum&window=30&label=vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=userGrowth&fields=users&agg=sum&window=30&label=vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"
@@ -2961,7 +3165,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=users&fields=mobile&agg=sum&window=30&label=vs+prev+30d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=userGrowth&fields=users&agg=sum&window=30&label=vs+prev+30d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -136,16 +136,34 @@ class MirrorTests(unittest.TestCase):
             for p in dash["panels"]
         }
 
-    def test_mobile_mirrors_macos_except_desktop_features(self) -> None:
+    def test_mobile_mirrors_macos_panel_for_panel(self) -> None:
         macos, mobile = load("omi-tv-macos"), load("omi-tv-mobile")
-        desktop_only = {
-            re.sub(r"desktop|mobile|macOS|Mobile", "×", t)
-            for t in build_dashboards.DESKTOP_ONLY_TITLES
-        }
-        self.assertEqual(self.normalized_titles(macos) - desktop_only,
-                         self.normalized_titles(mobile))
-        self.assertEqual(len(mobile["panels"]),
-                         len(macos["panels"]) - len(build_dashboards.DESKTOP_ONLY_TITLES))
+        self.assertEqual(len(mobile["panels"]), len(macos["panels"]))
+        self.assertEqual(self.normalized_titles(macos), self.normalized_titles(mobile))
+        for m_panel, mob_panel in zip(macos["panels"], mobile["panels"]):
+            self.assertEqual(m_panel["gridPos"], mob_panel["gridPos"],
+                             f"layout diverges at {m_panel['title']}")
+
+    def test_desktop_only_surfaces_are_explicit_placeholders_on_mobile(self) -> None:
+        mobile = load("omi-tv-mobile")
+        for title in build_dashboards.DESKTOP_ONLY_TITLES:
+            panel = build_dashboards.panel_by_title(mobile, title)
+            self.assertEqual(panel["type"], "text", title)
+            self.assertIn("Desktop-only", panel["options"]["content"], title)
+            self.assertIn("/grafana/d/omi-tv-macos/", panel["options"]["content"], title)
+
+    def test_platform_growth_charts_share_the_ticker_population(self) -> None:
+        """The cumulative chart must end at the all-time ticker value: both
+        read viral-metrics (userGrowth / allTimeUsers), same person-dedup."""
+        for uid in ["omi-tv-macos", "omi-tv-mobile"]:
+            dash = load(uid)
+            for title in ["Daily new users", "Cumulative users"]:
+                panel = next(p for p in dash["panels"]
+                             if build_dashboards.base_title(p).startswith(title.split(" (")[0])
+                             and p["type"] == "timeseries")
+                target = panel["targets"][0]
+                self.assertIn("viral-metrics", target["url"], f"{uid}/{title}")
+                self.assertEqual(target["root_selector"], "userGrowth", f"{uid}/{title}")
 
     def test_boards_do_not_leak_the_other_platforms_series(self) -> None:
         for uid, foreign in [("omi-tv-macos", "mobile"), ("omi-tv-mobile", "desktop")]:

--- a/web/admin/lib/__tests__/platform-scope.test.ts
+++ b/web/admin/lib/__tests__/platform-scope.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MOBILE_OS_NAMES,
+  parsePlatformScope,
+  scopeFilterAnd,
+} from "@/lib/platform-scope";
+
+describe("parsePlatformScope", () => {
+  it("accepts the two platform scopes and defaults everything else to all", () => {
+    expect(parsePlatformScope("macos")).toBe("macos");
+    expect(parsePlatformScope("mobile")).toBe("mobile");
+    expect(parsePlatformScope("all")).toBe("all");
+    expect(parsePlatformScope(null)).toBe("all");
+    expect(parsePlatformScope("windows")).toBe("all");
+  });
+});
+
+describe("scopeFilterAnd", () => {
+  it("produces three distinct filters — the same-DAU-on-every-board bug", () => {
+    const fragments = new Set(
+      (["all", "macos", "mobile"] as const).map((scope) => scopeFilterAnd(scope)),
+    );
+    expect(fragments.size).toBe(3);
+  });
+
+  it("scopes macos to the desktop os only", () => {
+    const sql = scopeFilterAnd("macos");
+    expect(sql).toContain("'macOS'");
+    for (const os of MOBILE_OS_NAMES) expect(sql).not.toContain(`'${os}'`);
+  });
+
+  it("scopes mobile to the mobile os list and excludes macOS", () => {
+    const sql = scopeFilterAnd("mobile");
+    for (const os of MOBILE_OS_NAMES) expect(sql).toContain(`'${os}'`);
+    expect(sql).not.toContain("'macOS'");
+  });
+
+  it("keeps the other product out of the all scope", () => {
+    expect(scopeFilterAnd("all")).toContain("cfc_");
+  });
+
+  it("supports the legacy $os column used by retention and k-factor", () => {
+    expect(scopeFilterAnd("macos", "properties.$os")).toBe(
+      "AND properties.$os = 'macOS'",
+    );
+  });
+});
+
+describe("viral-metrics platform scoping (query capture)", () => {
+  it("generates disjoint HogQL per platform and anchors non-macOS cohorts on first-seen", async () => {
+    vi.resetModules();
+    const captured: string[] = [];
+    vi.doMock("@/lib/posthog", () => ({
+      posthogResults: vi.fn(async (_h: string, _p: string, _k: string, query: string) => {
+        captured.push(query);
+        return [];
+      }),
+    }));
+    vi.doMock("@/lib/auth", () => ({ verifyAdmin: vi.fn(async () => ({ uid: "test" })) }));
+    vi.doMock("@/lib/payload-cache", () => ({
+      getPayload: vi.fn(async () => null),
+      setPayload: vi.fn(),
+    }));
+    process.env.POSTHOG_PERSONAL_API_KEY = "phx_test";
+    process.env.POSTHOG_PROJECT_ID = "1";
+
+    const { GET } = await import("@/app/api/omi/stats/viral-metrics/route");
+    const { NextRequest } = await import("next/server");
+
+    const queriesFor = async (platform: string) => {
+      captured.length = 0;
+      const response = await GET(
+        new NextRequest(`http://localhost/api/omi/stats/viral-metrics?days=60&platform=${platform}`),
+      );
+      expect(response.status).toBe(200);
+      return captured.join("\n---\n");
+    };
+
+    const macos = await queriesFor("macos");
+    expect(macos).toContain("= 'macOS'");
+    expect(macos).toContain("Sign In Completed");
+
+    const mobile = await queriesFor("mobile");
+    expect(mobile).toContain("'iOS'");
+    expect(mobile).not.toContain("= 'macOS'");
+    // Mobile never emits Sign In Completed — cohorts anchor on first-seen.
+    expect(mobile).not.toContain("Sign In Completed");
+
+    const all = await queriesFor("all");
+    expect(all).toContain("cfc_");
+    expect(all).not.toContain("= 'macOS'");
+    expect(all).not.toContain("'iOS'");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #11840 addressing review findings:

- **Panel parity**: the mobile board now mirrors macOS panel-for-panel (41 == 41, identical titles and grid positions). The 12 desktop-only surfaces (floating bar, desktop notifications, crash rate, macOS version pies) render as explicit *'Desktop-only surface — no mobile equivalent'* placeholders linking to the macOS board, instead of being dropped — full structural parity without mislabeling desktop data as mobile.
- **One user population per board**: `viral-metrics` gains `userGrowth` (first-seen daily + cumulative, person-deduped with the same scope filter as `allTimeUsers`). Platform boards' signups / daily-new / cumulative panels read it, so the cumulative chart ends exactly at the all-time ticker (13,881 == 13,881, verified live) instead of mixing fcm-token counts (5.1K) with PostHog actors (13.9K).
- **Route filter coverage**: new vitest `lib/__tests__/platform-scope.test.ts` — the three scope filters are distinct, and a query-capture test through viral-metrics GET proves macos/mobile/all generate disjoint HogQL with mobile cohorts anchored on first-seen.

## Verification

- Local Grafana against local Next dev: macOS ticker 13,881 with cumulative chart ending 13.8K; mobile board 28,727 all-time / DAU 2.08K / MAU 10.4K with visible placeholders; composite screenshot of all three boards captured.
- `npx vitest run lib/__tests__/platform-scope.test.ts` 7/7; `web/admin/grafana/test_build_dashboards.py` 13/13; `.github/scripts/test_check_admin_deploy_scope.py` 16/16; `npx tsc --noEmit` clean.

## Product invariants affected

none

## Failure class

No `fix:` commits; no declaration required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

