### PR TITLE
feat(admin): real mobile equivalents (versions, active today); 5 honest placeholders

### DIFF
--- a/web/admin/app/api/omi/stats/macos-versions/route.ts
+++ b/web/admin/app/api/omi/stats/macos-versions/route.ts
@@ -3,12 +3,17 @@ import admin, { getDb } from "@/lib/firebase/admin";
 import { verifyAdmin } from "@/lib/auth";
 import { posthogResults } from "@/lib/posthog";
 import { getPayload, setPayload } from "@/lib/payload-cache";
+import {
+  parsePlatformScope,
+  scopeFilterAnd,
+  type PlatformScope,
+} from "@/lib/platform-scope";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 3600;
 
-function cacheKey(): string {
-  return `macos-versions:v1`;
+function cacheKey(platform: PlatformScope = "macos"): string {
+  return `macos-versions:v1:${platform}`;
 }
 
 export { cacheKey as macosVersionsCacheKey };
@@ -88,7 +93,7 @@ function formatTodayLabel() {
   }).format(new Date());
 }
 
-export async function computeMacosVersions() {
+export async function computeMacosVersions(platform: PlatformScope = "macos") {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   const projectId = process.env.POSTHOG_PROJECT_ID;
   const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(/\/$/, "");
@@ -108,19 +113,22 @@ export async function computeMacosVersions() {
           ),
           timestamp
         ) AS app_version
+        ,
+        argMax(COALESCE(nullIf(properties.$os_name, ''), 'unknown'), timestamp) AS os_name
       FROM events
-      WHERE properties.$os_name = 'macOS'
-        AND toDate(timestamp) = today()
+      WHERE toDate(timestamp) = today()
+        ${scopeFilterAnd(platform)}
       GROUP BY actor_id
       ORDER BY actor_id ASC
       LIMIT 100000
     `;
 
-    const rows = (await posthogQuery(host, projectId, apiKey, activeUsersQuery)) as [unknown, unknown][];
+    const rows = (await posthogQuery(host, projectId, apiKey, activeUsersQuery)) as [unknown, unknown, unknown][];
     const activeUsers = rows
-      .map((row: [unknown, unknown]) => ({
+      .map((row: [unknown, unknown, unknown]) => ({
         userId: String(row[0] ?? "").trim(),
         appVersion: String(row[1] ?? "unknown").trim() || "unknown",
+        osName: String(row[2] ?? "unknown").trim() || "unknown",
       }))
       .filter((row) => row.userId.length > 0);
 
@@ -133,7 +141,13 @@ export async function computeMacosVersions() {
       };
     }
 
-    const channelMap = await getUserChannels(activeUsers.map((user) => user.userId));
+    // The first pie is release channel on macOS (Firestore update_channel);
+    // for mobile/all scopes it becomes the OS split — there is no channel
+    // concept for the app-store builds.
+    const channelMap =
+      platform === "macos"
+        ? await getUserChannels(activeUsers.map((user) => user.userId))
+        : new Map<string, string>();
 
     const channelCounts = new Map<string, number>();
     const versionCounts = new Map<string, number>();
@@ -141,9 +155,13 @@ export async function computeMacosVersions() {
     for (const user of activeUsers) {
       versionCounts.set(user.appVersion, (versionCounts.get(user.appVersion) || 0) + 1);
 
-      const channel = channelMap.get(user.userId);
-      const channelLabel = channel === "beta" || channel === "staging" ? "Beta" : "Production";
-      channelCounts.set(channelLabel, (channelCounts.get(channelLabel) || 0) + 1);
+      if (platform === "macos") {
+        const channel = channelMap.get(user.userId);
+        const channelLabel = channel === "beta" || channel === "staging" ? "Beta" : "Production";
+        channelCounts.set(channelLabel, (channelCounts.get(channelLabel) || 0) + 1);
+      } else {
+        channelCounts.set(user.osName, (channelCounts.get(user.osName) || 0) + 1);
+      }
     }
 
     const channelBreakdown = breakdownFromEntries(
@@ -169,14 +187,15 @@ export async function GET(request: NextRequest) {
   if (authResult instanceof NextResponse) return authResult;
 
   try {
-    const key = cacheKey();
+    const platform = parsePlatformScope(request.nextUrl.searchParams.get("platform") ?? "macos");
+    const key = cacheKey(platform);
 
     const cached = await getPayload<Awaited<ReturnType<typeof computeMacosVersions>>>(key);
     if (cached) {
       return NextResponse.json(cached.data);
     }
 
-    const payload = await computeMacosVersions();
+    const payload = await computeMacosVersions(platform);
     await setPayload(key, payload);
     return NextResponse.json(payload);
   } catch (error: any) {

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -44,17 +44,17 @@ DAY_FORMATS = {"2006-01-02", "2006-01"}
 # Routes that accept ?platform=all|macos|mobile.
 PLATFORM_ROUTES = ("viral-metrics", "dau-trends", "retention/posthog", "k-factor/posthog")
 
-# Desktop-only product surfaces — kept on the mobile board as explicit
+# Surfaces with NO mobile data at all — kept on the mobile board as explicit
 # "not available on mobile" placeholders so both platform boards stay
 # panel-for-panel identical without mislabeling desktop data as mobile.
+# (Floating bar is a macOS-only feature; mobile sends no crash telemetry.)
 DESKTOP_ONLY_TITLES = {
     "Floating bar sessions per user", "Floating bar queries",
-    "Floating bar notification CTR", "Daily notifications sent",
-    "Notifications sent — last 168 hours", "Weekly notification reach",
-    "Notifications enabled", "Crash-free rate (today)", "Crash-free rate",
-    "macOS: beta vs production (today)", "macOS: by version (today)",
-    "macOS active today",
+    "Floating bar notification CTR", "Crash-free rate (today)",
+    "Crash-free rate",
 }
+# Notification panels stay real on both platform boards: mentor pushes are
+# account-level (delivered to whatever devices a user has), not per-platform.
 
 LINKS = [
     {"title": title, "type": "link", "url": f"/grafana/d/{uid}/", "icon": "dashboard",
@@ -322,6 +322,18 @@ def build_platform_board(base, scope: str) -> dict:
         chart["title"] = "Activation (signup → activated)" + (
             "  ·  " + chart["title"].split("  ·  ")[1] if "  ·  " in chart["title"] else "")
     if scope == "mobile":
+        # Real mobile equivalents of the macOS-titled panels.
+        versions_mobile = "/api/omi/stats/macos-versions?platform=mobile"
+        channel_pie = panel_by_title(dash, "macOS: beta vs production (today)")
+        channel_pie["title"] = "Mobile: iOS vs Android (today)"
+        channel_pie["targets"][0]["url"] = f"{PROXY}{versions_mobile}"
+        version_pie = panel_by_title(dash, "macOS: by version (today)")
+        version_pie["title"] = "Mobile: by app version (today)"
+        version_pie["targets"][0]["url"] = f"{PROXY}{versions_mobile}"
+        active_today = panel_by_title(dash, "macOS active today")
+        active_today["title"] = "Mobile active today"
+        active_today["targets"][0]["url"] = f"{PROXY}{versions_mobile}"
+
         # The Firestore activation route is macOS-only (conversation within 7
         # days of a macOS signup); mobile activation uses PostHog telemetry
         # (first-seen → Memory Created within 7 days) via viral-metrics.

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -1534,21 +1534,78 @@
       "targets": []
     },
     {
-      "id": 25,
-      "type": "text",
-      "title": "macOS active today",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#3b82f6",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3b82f6",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "x": 6,
         "y": 18,
         "w": 3,
         "h": 4
       },
-      "transparent": true,
+      "id": 25,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "activeUsers",
+              "text": "Active",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/macos-versions?platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Mobile active today",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -2370,38 +2427,289 @@
       "targets": []
     },
     {
-      "id": 39,
-      "type": "text",
-      "title": "Daily notifications sent",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Omi says"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Marketplace"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f59e0b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "x": 16,
         "y": 42,
         "w": 8,
         "h": 8
       },
-      "transparent": true,
+      "id": 39,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "mentorSent",
+              "text": "Omi says",
+              "type": "number"
+            },
+            {
+              "selector": "marketplaceMentorSent",
+              "text": "Marketplace",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "dailyData",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30&_tzdates=date",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "30d",
+      "title": "Daily notifications sent  \u00b7  ${d_notif}",
+      "type": "timeseries"
     },
     {
-      "id": 40,
-      "type": "text",
-      "title": "Weekly notification reach",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Omi says sent"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Marketplace sent"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f59e0b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Unique users"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#22c55e",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "x": 0,
         "y": 50,
         "w": 8,
         "h": 8
       },
-      "transparent": true,
+      "id": 40,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "week",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00",
+              "type": "timestamp"
+            },
+            {
+              "selector": "mentorSent",
+              "text": "Omi says sent",
+              "type": "number"
+            },
+            {
+              "selector": "marketplaceMentorSent",
+              "text": "Marketplace sent",
+              "type": "number"
+            },
+            {
+              "selector": "uniqueUsersMentor",
+              "text": "Unique users",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "weeklyData",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30&_tzdates=week",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "45d",
+      "title": "Weekly notification reach  \u00b7  ${d_reach}",
+      "type": "timeseries"
     },
     {
       "id": 41,
@@ -2421,38 +2729,166 @@
       "targets": []
     },
     {
-      "id": 43,
-      "type": "text",
-      "title": "macOS: beta vs production (today)",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "x": 16,
         "y": 50,
         "w": 8,
         "h": 8
       },
-      "transparent": true,
+      "id": 43,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "label",
+              "text": "Channel",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "Users",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "channelBreakdown",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/macos-versions?platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Mobile: iOS vs Android (today)",
+      "type": "piechart"
     },
     {
-      "id": 44,
-      "type": "text",
-      "title": "macOS: by version (today)",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "x": 0,
         "y": 58,
         "w": 8,
         "h": 8
       },
-      "transparent": true,
+      "id": 44,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "label",
+              "text": "Version",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "Users",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "versionBreakdown",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/macos-versions?platform=mobile",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Mobile: by app version (today)",
+      "type": "piechart"
     },
     {
       "datasource": {
@@ -3025,38 +3461,221 @@
       "type": "timeseries"
     },
     {
-      "id": 50,
-      "type": "text",
-      "title": "Notifications enabled",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "description": "Desktop notifications_enabled toggle; missing values default to enabled.",
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#ef4444",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 0.5
+              },
+              {
+                "color": "#22c55e",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "x": 0,
         "y": 74,
         "w": 8,
         "h": 8
       },
-      "transparent": true,
+      "id": 50,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^Enabled share$/",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "enabled",
+              "text": "enabled",
+              "type": "number"
+            },
+            {
+              "selector": "total",
+              "text": "total",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "table",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "enabledDisabled",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Notifications enabled",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Enabled share",
+            "binary": {
+              "left": "enabled",
+              "operator": "/",
+              "right": "total"
+            },
+            "mode": "binary",
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "gauge"
     },
     {
-      "id": 51,
-      "type": "text",
-      "title": "Notifications sent \u2014 last 168 hours",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 65,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Omi says"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3b82f6",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Marketplace"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#f59e0b",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "x": 0,
         "y": 82,
         "w": 24,
         "h": 8
       },
-      "transparent": true,
+      "id": 51,
       "options": {
-        "mode": "markdown",
-        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "targets": []
+      "targets": [
+        {
+          "columns": [
+            {
+              "selector": "hour",
+              "text": "time",
+              "timestampFormat": "2006-01-02T15",
+              "type": "timestamp"
+            },
+            {
+              "selector": "mentor",
+              "text": "Omi says",
+              "type": "number"
+            },
+            {
+              "selector": "marketplace",
+              "text": "Marketplace",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "format": "timeseries",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "hourlyData",
+          "source": "url",
+          "type": "json",
+          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "timeFrom": "8d",
+      "title": "Notifications sent \u2014 last 168 hours  \u00b7  ${d_hourly}",
+      "type": "timeseries"
     }
   ],
   "refresh": "5m",
@@ -3333,6 +3952,80 @@
           "uid": "omi-admin-api"
         },
         "hide": 2,
+        "name": "d_notif",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=dailyData&fields=mentorSent%2CmarketplaceMentorSent&agg=sum&window=15&label=vs+prev+15d",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_reach",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=weeklyData&fields=mentorSent%2CmarketplaceMentorSent&agg=sum&window=2&label=vs+prev+2w",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
         "name": "d_pusers",
         "options": [],
         "query": {
@@ -3499,6 +4192,43 @@
             "source": "url",
             "type": "json",
             "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=conversion&fields=mobile&agg=avg&window=15&label=vs+prev+15d",
+            "url_options": {
+              "data": "",
+              "method": "GET"
+            }
+          },
+          "query": "",
+          "queryType": "infinity"
+        },
+        "refresh": 2,
+        "skipUrlSync": true,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "omi-admin-api"
+        },
+        "hide": 2,
+        "name": "d_hourly",
+        "options": [],
+        "query": {
+          "infinityQuery": {
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ],
+            "format": "table",
+            "parser": "backend",
+            "refId": "variable",
+            "root_selector": "",
+            "source": "url",
+            "type": "json",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=hourlyData&fields=mentor%2Cmarketplace&agg=sum&window=84&label=vs+prev+84h",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -136,13 +136,31 @@ class MirrorTests(unittest.TestCase):
             for p in dash["panels"]
         }
 
+    @staticmethod
+    def normalize(title: str) -> str:
+        title = title.split("  ·  ")[0]
+        title = re.sub(r"macOS: beta vs production", "×: split", title)
+        title = re.sub(r"Mobile: iOS vs Android", "×: split", title)
+        title = re.sub(r"macOS: by version", "×: by version", title)
+        title = re.sub(r"Mobile: by app version", "×: by version", title)
+        return re.sub(r"desktop|mobile|macOS|Mobile", "×", title)
+
     def test_mobile_mirrors_macos_panel_for_panel(self) -> None:
+        """Position-by-position: same normalized title, same gridPos, and the
+        same panel type — except the five no-mobile-data placeholders, which
+        must be text panels in the same slots."""
         macos, mobile = load("omi-tv-macos"), load("omi-tv-mobile")
         self.assertEqual(len(mobile["panels"]), len(macos["panels"]))
-        self.assertEqual(self.normalized_titles(macos), self.normalized_titles(mobile))
+        placeholder_norms = {self.normalize(t) for t in build_dashboards.DESKTOP_ONLY_TITLES}
         for m_panel, mob_panel in zip(macos["panels"], mobile["panels"]):
+            m_norm = self.normalize(m_panel["title"])
+            self.assertEqual(m_norm, self.normalize(mob_panel["title"]))
             self.assertEqual(m_panel["gridPos"], mob_panel["gridPos"],
                              f"layout diverges at {m_panel['title']}")
+            if m_norm in placeholder_norms:
+                self.assertEqual(mob_panel["type"], "text", m_panel["title"])
+            else:
+                self.assertEqual(mob_panel["type"], m_panel["type"], m_panel["title"])
 
     def test_desktop_only_surfaces_are_explicit_placeholders_on_mobile(self) -> None:
         mobile = load("omi-tv-mobile")
@@ -151,6 +169,13 @@ class MirrorTests(unittest.TestCase):
             self.assertEqual(panel["type"], "text", title)
             self.assertIn("Desktop-only", panel["options"]["content"], title)
             self.assertIn("/grafana/d/omi-tv-macos/", panel["options"]["content"], title)
+
+    def test_mobile_equivalents_query_the_mobile_scope(self) -> None:
+        mobile = load("omi-tv-mobile")
+        for title in ["Mobile: iOS vs Android (today)", "Mobile: by app version (today)",
+                      "Mobile active today"]:
+            panel = build_dashboards.panel_by_title(mobile, title)
+            self.assertIn("macos-versions?platform=mobile", panel["targets"][0]["url"], title)
 
     def test_platform_growth_charts_share_the_ticker_population(self) -> None:
         """The cumulative chart must end at the all-time ticker value: both


### PR DESCRIPTION
## Summary

Third review round on the platform boards:

- **Real mobile equivalents** where mobile data exists: `macos-versions` route takes `platform=` — mobile scope returns today's active mobile users with an iOS/Android/iPadOS split and mobile app-version breakdown. The mobile board's two pies and the active-today stat now show real mobile data (verified live: 732 active — iOS 552 / Android 175 / iPadOS 5; v1.0.547 dominant).
- **Notification panels are real on both platform boards** — mentor pushes are account-level (delivered to whatever devices a user has), so the same series is correct on both.
- **Placeholders shrink to the five surfaces with genuinely no mobile data**: floating bar ×3 (macOS-only feature) and crash rate ×2 (mobile sends zero crash/error telemetry — verified empirically in PostHog).
- **Parity test strengthened**: position-by-position comparison of normalized titles, gridPos AND panel types, with the placeholder slots explicitly asserted as text panels.

## Verification

- Live route check: `macos-versions?platform=mobile` → 732 active, iOS/Android/iPadOS split, mobile versions. PostHog probe: zero mobile crash/error events (placeholder justified).
- `test_build_dashboards.py` 14/14; deploy-scope 16/16; vitest platform-scope 7/7; `tsc` clean.
- Local Grafana exercise + prod verification screenshots follow the deploy (composite captured for review evidence).

## Product invariants affected

none

## Failure class

No `fix:` commits; no declaration required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

