### PR TITLE
fix(chat): name what a proactive notification is about, and make structured cards real chat history

### DIFF
--- a/app/lib/backend/schema/gen/messages_wire.g.dart
+++ b/app/lib/backend/schema/gen/messages_wire.g.dart
@@ -191,6 +191,7 @@ class GeneratedMessage {
   final Map<String, dynamic>? chartData;
   final String? chatSessionId;
   final String? clientMessageId;
+  final List<Map<String, dynamic>>? contentBlocks;
   final DateTime createdAt;
   final String? dataProtectionLevel;
   final List<GeneratedFileChat> files;
@@ -219,6 +220,7 @@ class GeneratedMessage {
     this.chartData,
     this.chatSessionId,
     this.clientMessageId,
+    this.contentBlocks,
     required this.createdAt,
     this.dataProtectionLevel,
     this.files = const [],
@@ -249,6 +251,7 @@ class GeneratedMessage {
       chartData: _readFieldValue<Map<String, dynamic>>(_readField(json, const ["chart_data"]), "chart_data", _readMap, requiredField: false, nullable: true),
       chatSessionId: _readFieldValue<String>(_readField(json, const ["chat_session_id"]), "chat_session_id", _readString, requiredField: false, nullable: true),
       clientMessageId: _readFieldValue<String>(_readField(json, const ["client_message_id"]), "client_message_id", _readString, requiredField: false, nullable: true),
+      contentBlocks: _readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["content_blocks"]), "content_blocks", _readMapList, requiredField: false, nullable: true),
       createdAt: _required(_readFieldValue<DateTime>(_readField(json, const ["created_at"]), "created_at", _readDateTime, requiredField: true, nullable: false), "created_at"),
       dataProtectionLevel: _readFieldValue<String>(_readField(json, const ["data_protection_level"]), "data_protection_level", _readString, requiredField: false, nullable: true),
       files: _required(_readFieldValue<List<GeneratedFileChat>>(_readField(json, const ["files"]), "files", (value) => _readObjectList(value, GeneratedFileChat.fromJson), requiredField: false, nullable: false, defaultValue: const []), "files"),
@@ -280,6 +283,7 @@ class GeneratedMessage {
       'chart_data': chartData,
       'chat_session_id': chatSessionId,
       'client_message_id': clientMessageId,
+      'content_blocks': contentBlocks,
       'created_at': createdAt.toUtc().toIso8601String(),
       'data_protection_level': dataProtectionLevel,
       'files': files.map((value) => value.toJson()).toList(),
@@ -312,6 +316,7 @@ class GeneratedResponseMessage {
   final Map<String, dynamic>? chartData;
   final String? chatSessionId;
   final String? clientMessageId;
+  final List<Map<String, dynamic>>? contentBlocks;
   final DateTime createdAt;
   final String? dataProtectionLevel;
   final List<GeneratedFileChat> files;
@@ -341,6 +346,7 @@ class GeneratedResponseMessage {
     this.chartData,
     this.chatSessionId,
     this.clientMessageId,
+    this.contentBlocks,
     required this.createdAt,
     this.dataProtectionLevel,
     this.files = const [],
@@ -372,6 +378,7 @@ class GeneratedResponseMessage {
       chartData: _readFieldValue<Map<String, dynamic>>(_readField(json, const ["chart_data"]), "chart_data", _readMap, requiredField: false, nullable: true),
       chatSessionId: _readFieldValue<String>(_readField(json, const ["chat_session_id"]), "chat_session_id", _readString, requiredField: false, nullable: true),
       clientMessageId: _readFieldValue<String>(_readField(json, const ["client_message_id"]), "client_message_id", _readString, requiredField: false, nullable: true),
+      contentBlocks: _readFieldValue<List<Map<String, dynamic>>>(_readField(json, const ["content_blocks"]), "content_blocks", _readMapList, requiredField: false, nullable: true),
       createdAt: _required(_readFieldValue<DateTime>(_readField(json, const ["created_at"]), "created_at", _readDateTime, requiredField: true, nullable: false), "created_at"),
       dataProtectionLevel: _readFieldValue<String>(_readField(json, const ["data_protection_level"]), "data_protection_level", _readString, requiredField: false, nullable: true),
       files: _required(_readFieldValue<List<GeneratedFileChat>>(_readField(json, const ["files"]), "files", (value) => _readObjectList(value, GeneratedFileChat.fromJson), requiredField: false, nullable: false, defaultValue: const []), "files"),
@@ -404,6 +411,7 @@ class GeneratedResponseMessage {
       'chart_data': chartData,
       'chat_session_id': chatSessionId,
       'client_message_id': clientMessageId,
+      'content_blocks': contentBlocks,
       'created_at': createdAt.toUtc().toIso8601String(),
       'data_protection_level': dataProtectionLevel,
       'files': files.map((value) => value.toJson()).toList(),

--- a/app/lib/backend/schema/message.dart
+++ b/app/lib/backend/schema/message.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:collection/collection.dart';
 import 'package:omi/backend/schema/gen/messages_wire.g.dart' as wire;
 import 'package:uuid/uuid.dart';
@@ -242,6 +244,7 @@ class ServerMessage {
   List<String> thinkings = [];
   ChartData? chartData;
   Map<String, dynamic>? rawChartData;
+  List<Map<String, dynamic>> contentBlocks;
 
   ServerMessage(
     this.id,
@@ -258,6 +261,7 @@ class ServerMessage {
     this.rating,
     this.chartData,
     this.rawChartData,
+    this.contentBlocks = const [],
   });
 
   static ServerMessage fromJson(Map<String, dynamic> json) {
@@ -267,13 +271,21 @@ class ServerMessage {
   static ServerMessage fromGeneratedWireJson(Map<String, dynamic> json) {
     final generated = wire.GeneratedMessage.fromJson(json);
     final fromIntegration = (json['from_integration'] as bool?) ?? generated.fromExternalIntegration;
-    return ServerMessage.fromGenerated(generated, fromIntegration: fromIntegration);
+    return ServerMessage.fromGenerated(
+      generated,
+      fromIntegration: fromIntegration,
+      contentBlocks: _decodeContentBlocks(json['content_blocks'], generated.metadata),
+    );
   }
 
   static ServerMessage fromResponseJson(Map<String, dynamic> json) {
     final generated = wire.GeneratedResponseMessage.fromJson(json);
     final fromIntegration = (json['from_integration'] as bool?) ?? generated.fromExternalIntegration;
-    return ServerMessage.fromGeneratedResponse(generated, fromIntegration: fromIntegration);
+    return ServerMessage.fromGeneratedResponse(
+      generated,
+      fromIntegration: fromIntegration,
+      contentBlocks: _decodeContentBlocks(json['content_blocks'], generated.metadata),
+    );
   }
 
   factory ServerMessage.fromGenerated(
@@ -281,13 +293,14 @@ class ServerMessage {
     bool? fromIntegration,
     bool askForNps = true,
     ChartData? chartData,
+    List<Map<String, dynamic>> contentBlocks = const [],
   }) {
     final rawChartData = generated.chartData;
     final parsedChartData = chartData ?? ChartData.tryFromJson(rawChartData);
     return ServerMessage(
       generated.id,
       generated.createdAt,
-      generated.text,
+      _textWithStructuredFallback(generated.text, contentBlocks),
       MessageSender.values.firstWhere((e) => e.toString().split('.').last == generated.sender),
       MessageType.valuesFromString(generated.type),
       generated.pluginId ?? generated.appId,
@@ -299,6 +312,7 @@ class ServerMessage {
       rating: generated.rating,
       chartData: parsedChartData,
       rawChartData: rawChartData,
+      contentBlocks: contentBlocks,
     );
   }
 
@@ -306,13 +320,14 @@ class ServerMessage {
     wire.GeneratedResponseMessage generated, {
     bool? fromIntegration,
     ChartData? chartData,
+    List<Map<String, dynamic>> contentBlocks = const [],
   }) {
     final rawChartData = generated.chartData;
     final parsedChartData = chartData ?? ChartData.tryFromJson(rawChartData);
     return ServerMessage(
       generated.id,
       generated.createdAt,
-      generated.text,
+      _textWithStructuredFallback(generated.text, contentBlocks),
       MessageSender.values.firstWhere((e) => e.toString().split('.').last == generated.sender),
       MessageType.valuesFromString(generated.type),
       generated.pluginId ?? generated.appId,
@@ -324,6 +339,7 @@ class ServerMessage {
       rating: generated.rating,
       chartData: parsedChartData,
       rawChartData: rawChartData,
+      contentBlocks: contentBlocks,
     );
   }
 
@@ -346,7 +362,81 @@ class ServerMessage {
       'ask_for_nps': askForNps,
       'rating': rating,
       'chart_data': chartJson,
+      'content_blocks': contentBlocks,
     };
+  }
+
+  static List<Map<String, dynamic>> _decodeContentBlocks(dynamic firstClass, String? metadata) {
+    final direct = _mapList(firstClass);
+    if (direct.isNotEmpty || firstClass is List) return direct;
+    if (metadata == null || metadata.isEmpty) return const [];
+    try {
+      final decoded = jsonDecode(metadata);
+      return decoded is Map<String, dynamic> ? _mapList(decoded['content_blocks']) : const [];
+    } on FormatException {
+      return const [];
+    }
+  }
+
+  static List<Map<String, dynamic>> _mapList(dynamic value) {
+    if (value is! List) return const [];
+    return value.whereType<Map>().map((item) => Map<String, dynamic>.from(item)).toList(growable: false);
+  }
+
+  static String _textWithStructuredFallback(String text, List<Map<String, dynamic>> blocks) {
+    if (text.trim().isNotEmpty || blocks.isEmpty) return text;
+    final fallbacks = blocks.map(_blockFallbackText).where((value) => value.isNotEmpty).toList(growable: false);
+    return fallbacks.join('\n');
+  }
+
+  static String _blockFallbackText(Map<String, dynamic> block) {
+    String value(String camel, [String? snake]) =>
+        ((block[camel] ?? (snake == null ? null : block[snake])) as String? ?? '').trim();
+    String labelled(String label, Iterable<String> details) {
+      final unique = details.where((detail) => detail.isNotEmpty).toSet().toList(growable: false);
+      return unique.isEmpty ? label : '$label - ${unique.join(' - ')}';
+    }
+
+    switch (block['type']) {
+      case 'text':
+        return value('text').isEmpty ? 'Message' : value('text');
+      case 'toolCall':
+      case 'tool_call':
+        return labelled('Tool', [value('name'), value('output'), value('inputSummary', 'input_summary')]);
+      case 'thinking':
+        return labelled('Thinking', [value('text')]);
+      case 'discoveryCard':
+      case 'discovery_card':
+        return labelled('Discovery', [value('title'), value('summary')]);
+      case 'questionCard':
+      case 'question_card':
+        return value('text').isEmpty ? 'Question' : value('text');
+      case 'taskCard':
+      case 'task_card':
+        return 'Task';
+      case 'goalLink':
+      case 'goal_link':
+        return labelled('Goal', [value('summary')]);
+      case 'captureLink':
+      case 'capture_link':
+        return labelled('Capture', [value('summary')]);
+      case 'conversationLink':
+      case 'conversation_link':
+        return labelled('Meeting notes ready', [value('summary')]);
+      case 'memoryLink':
+      case 'memory_link':
+        return labelled('Memory', [value('summary')]);
+      case 'citation':
+        return labelled('Source', [value('title'), value('preview')]);
+      case 'agentSpawn':
+      case 'agent_spawn':
+        return labelled('Agent started', [value('title'), value('objective')]);
+      case 'agentCompletion':
+      case 'agent_completion':
+        return labelled('Agent completed', [value('title'), value('output')]);
+      default:
+        return labelled('Chat item', [value('title'), value('summary'), value('text')]);
+    }
   }
 
   bool areFilesOfSameType() {

--- a/app/test/unit/server_message_content_blocks_test.dart
+++ b/app/test/unit/server_message_content_blocks_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:omi/backend/schema/message.dart';
+
+void main() {
+  Map<String, dynamic> messageJson({required String text, Object? contentBlocks, String? metadata}) {
+    return {
+      'id': 'message-1',
+      'created_at': '2026-08-18T12:00:00Z',
+      'text': text,
+      'sender': 'ai',
+      'type': 'text',
+      if (contentBlocks != null) 'content_blocks': contentBlocks,
+      if (metadata != null) 'metadata': metadata,
+    };
+  }
+
+  test('uses first-class conversation block fallback instead of a blank bubble', () {
+    final message = ServerMessage.fromJson(
+      messageJson(
+        text: '',
+        contentBlocks: [
+          {'type': 'conversationLink', 'conversationId': 'conversation-1', 'summary': 'Founders explore AI memory'},
+        ],
+      ),
+    );
+
+    expect(message.text, 'Meeting notes ready - Founders explore AI memory');
+    expect(message.contentBlocks.single['conversationId'], 'conversation-1');
+  });
+
+  test('keeps legacy metadata blocks readable during wire migration', () {
+    final message = ServerMessage.fromJson(
+      messageJson(
+        text: '',
+        metadata:
+            '{"content_blocks":[{"type":"conversationLink","conversationId":"conversation-legacy","summary":"Legacy weekly planning"}]}',
+      ),
+    );
+
+    expect(message.text, 'Meeting notes ready - Legacy weekly planning');
+    expect(message.contentBlocks.single['conversationId'], 'conversation-legacy');
+  });
+
+  test('preserves canonical backend fallback text when the client knows the block', () {
+    final message = ServerMessage.fromJson(
+      messageJson(
+        text: 'Meeting notes ready - Canonical title',
+        contentBlocks: [
+          {'type': 'conversationLink', 'summary': 'Different local rendering'},
+        ],
+      ),
+    );
+
+    expect(message.text, 'Meeting notes ready - Canonical title');
+  });
+}

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -1104,7 +1104,7 @@ def _apply_existing_message_revision(
             )
             existing['_revision_updated'] = False
             return existing
-        patch = {
+        patch: Dict[str, Any] = {
             'text': text,
             'metadata': metadata,
             'client_message_payload_hash': payload_hash,
@@ -1208,7 +1208,7 @@ def _message_idempotency_payload_hash(
     content_blocks: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """Return a stable digest of the caller-controlled immutable payload."""
-    payload = {
+    payload: Dict[str, Any] = {
         'app_id': app_id,
         'message_source': message_source,
         'metadata': metadata,

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -926,6 +926,7 @@ def save_message(
     app_id: Optional[str] = None,
     session_id: Optional[str] = None,
     metadata: Optional[str] = None,
+    content_blocks: Optional[List[Dict[str, Any]]] = None,
     client_message_id: Optional[str] = None,
     message_source: str = 'desktop_chat',
     journal_revision: Optional[int] = None,
@@ -944,6 +945,7 @@ def save_message(
         app_id=app_id,
         session_id=requested_session_id,
         metadata=metadata,
+        content_blocks=content_blocks,
         message_source=message_source,
     )
 
@@ -958,6 +960,7 @@ def save_message(
                 app_id=app_id,
                 session_id=requested_session_id,
                 metadata=metadata,
+                content_blocks=content_blocks,
                 message_source=message_source,
                 payload_hash=idempotency_payload_hash,
                 journal_revision=journal_revision,
@@ -986,6 +989,8 @@ def save_message(
         'metadata': metadata,
         'message_source': message_source,
     }
+    if content_blocks is not None:
+        doc['content_blocks'] = content_blocks
     if client_message_id:
         doc['client_message_id'] = client_message_id
         doc['client_message_payload_hash'] = idempotency_payload_hash
@@ -1003,6 +1008,7 @@ def save_message(
                 app_id=app_id,
                 session_id=requested_session_id,
                 metadata=metadata,
+                content_blocks=content_blocks,
                 message_source=message_source,
                 payload_hash=idempotency_payload_hash,
                 journal_revision=journal_revision,
@@ -1044,6 +1050,7 @@ def _apply_existing_message_revision(
     app_id: Optional[str],
     session_id: Optional[str],
     metadata: Optional[str],
+    content_blocks: Optional[List[Dict[str, Any]]],
     message_source: str,
     payload_hash: str,
     journal_revision: Optional[int],
@@ -1073,6 +1080,7 @@ def _apply_existing_message_revision(
                 app_id=app_id,
                 session_id=session_id,
                 metadata=metadata,
+                content_blocks=content_blocks,
                 message_source=message_source,
                 payload_hash=payload_hash,
             )
@@ -1090,6 +1098,7 @@ def _apply_existing_message_revision(
                 app_id=app_id,
                 session_id=session_id,
                 metadata=metadata,
+                content_blocks=content_blocks,
                 message_source=message_source,
                 payload_hash=payload_hash,
             )
@@ -1101,6 +1110,8 @@ def _apply_existing_message_revision(
             'client_message_payload_hash': payload_hash,
             'journal_revision': journal_revision,
         }
+        if content_blocks is not None:
+            patch['content_blocks'] = content_blocks
         write_transaction.update(message_ref, patch)
         existing.update(patch)
         existing['_revision_updated'] = True
@@ -1156,6 +1167,7 @@ def _assert_idempotent_message_payload(
     metadata: Optional[str],
     message_source: str,
     payload_hash: str,
+    content_blocks: Optional[List[Dict[str, Any]]] = None,
 ) -> None:
     """Reject an idempotency-key collision without exposing message content."""
     existing_payload_hash = existing.get('client_message_payload_hash')
@@ -1169,6 +1181,8 @@ def _assert_idempotent_message_payload(
     # reconstructed from the stored row. New writes always use the exact hash.
     mismatched = existing.get('text') != text or existing.get('sender') != sender
     mismatched = mismatched or existing.get('metadata') != metadata
+    if content_blocks is not None:
+        mismatched = mismatched or existing.get('content_blocks') != content_blocks
     mismatched = mismatched or existing.get('message_source', 'desktop_chat') != message_source
     existing_app_ids = [existing[field] for field in ('app_id', 'plugin_id') if field in existing] or [None]
     mismatched = mismatched or any(existing_app_id != app_id for existing_app_id in existing_app_ids)
@@ -1191,6 +1205,7 @@ def _message_idempotency_payload_hash(
     session_id: Optional[str],
     metadata: Optional[str],
     message_source: str,
+    content_blocks: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """Return a stable digest of the caller-controlled immutable payload."""
     payload = {
@@ -1201,6 +1216,8 @@ def _message_idempotency_payload_hash(
         'session_id': session_id,
         'text': text,
     }
+    if content_blocks is not None:
+        payload['content_blocks'] = content_blocks
     canonical = json.dumps(payload, ensure_ascii=False, separators=(',', ':'), sort_keys=True)
     return f'sha256:{hashlib.sha256(canonical.encode("utf-8")).hexdigest()}'
 

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from enum import Enum
 from typing import Any, List, Literal, Optional, Union
@@ -89,6 +90,13 @@ class Message(BaseModel):
     # message response remains readable by older clients while a new client can
     # reconcile the canonical turn identity and structured payload exactly.
     metadata: Optional[str] = None
+    content_blocks: List[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            'Structured chat content blocks. New rows store these directly; '
+            'legacy rows are projected from metadata.content_blocks.'
+        ),
+    )
     client_message_id: Optional[str] = None
     message_source: Optional[str] = None
     journal_revision: Optional[int] = None
@@ -105,6 +113,16 @@ class Message(BaseModel):
                 data['plugin_id'] = app_id_val
             elif plugin_id_val is not None:
                 data['app_id'] = plugin_id_val
+
+            if 'content_blocks' not in data:
+                metadata = data.get('metadata')
+                if isinstance(metadata, str):
+                    try:
+                        legacy_blocks = json.loads(metadata).get('content_blocks')
+                    except (AttributeError, TypeError, ValueError):
+                        legacy_blocks = None
+                    if isinstance(legacy_blocks, list):
+                        data['content_blocks'] = legacy_blocks
         return data
 
     @classmethod

--- a/backend/models/chat_first.py
+++ b/backend/models/chat_first.py
@@ -76,10 +76,16 @@ class CaptureLinkSpec(_StrictModel):
     summary: str = Field(min_length=1, max_length=200)
 
 
+class ConversationLinkActionItemSpec(_StrictModel):
+    description: str = Field(min_length=1, max_length=300)
+    task_id: StableId | None = None
+
+
 class ConversationLinkSpec(_StrictModel):
     type: Literal['conversationLink']
     conversation_id: StableId
     summary: str = Field(min_length=1, max_length=200)
+    recommended_action_items: list[ConversationLinkActionItemSpec] = Field(default_factory=list, max_length=8)
 
 
 class MemoryLinkSpec(_StrictModel):

--- a/backend/routers/chat_first.py
+++ b/backend/routers/chat_first.py
@@ -302,7 +302,12 @@ def _materialize_prompts(
     *,
     exclude_block_types: set[str] | frozenset[str] | None = None,
 ) -> MaterializePromptsResponse:
-    """Fetch ready intents and accept kernel receipts; never writes a Chat row."""
+    """Fetch ready intents and accept kernel receipts; never writes a Chat row.
+
+    Materialization acknowledgements retire an intent account-wide after one
+    client consumes it. Canonical server-side Chat-row creation is separate
+    follow-up work; until then the consuming client's kernel sync is the writer.
+    """
 
     _require_materialization_capability(
         uid,

--- a/backend/routers/chat_sessions.py
+++ b/backend/routers/chat_sessions.py
@@ -60,6 +60,10 @@ class SaveMessageRequest(BaseModel):
     app_id: str | None = Field(None, max_length=200)
     session_id: str | None = Field(None, max_length=200)
     metadata: str | None = None
+    content_blocks: list[dict[str, Any]] | None = Field(
+        None,
+        description='First-class structured chat content; message text remains the required fallback.',
+    )
     client_message_id: str | None = Field(None, pattern=r'^[A-Za-z0-9_-]{1,128}$')
     message_source: str = Field('desktop_chat', pattern=r'^(desktop_chat|realtime_voice)$')
     journal_revision: int | None = Field(None, ge=1, le=9_007_199_254_740_991)
@@ -172,6 +176,7 @@ def save_message(
             app_id=request.app_id,
             session_id=request.session_id,
             metadata=request.metadata,
+            content_blocks=request.content_blocks,
             client_message_id=request.client_message_id,
             message_source=request.message_source,
             journal_revision=request.journal_revision,

--- a/backend/tests/unit/test_chat_first_blocks.py
+++ b/backend/tests/unit/test_chat_first_blocks.py
@@ -55,6 +55,10 @@ def test_materialization_v1_suppresses_conversation_links_while_v2_returns_them(
                     'type': 'conversationLink',
                     'conversation_id': 'conversation-1',
                     'summary': 'Meeting notes ready',
+                    'recommended_action_items': [
+                        {'description': 'Send the deck', 'task_id': 'task-1'},
+                        {'description': 'Book the follow-up'},
+                    ],
                 }
             ],
             'created_at': '2026-08-13T00:00:00Z',
@@ -197,13 +201,27 @@ def test_chat_first_validate_admits_completed_desktop_conversation_link(monkeypa
     response = _client().post(
         '/v1/chat-first/blocks/validate',
         json=_request(
-            blocks=[{'type': 'conversationLink', 'conversation_id': 'desktop-1', 'summary': 'Meeting notes ready'}]
+            blocks=[
+                {
+                    'type': 'conversationLink',
+                    'conversation_id': 'desktop-1',
+                    'summary': 'Meeting notes ready',
+                    'recommended_action_items': [
+                        {'description': 'Send the deck', 'task_id': 'task-1'},
+                        {'description': 'Book the follow-up'},
+                    ],
+                }
+            ]
         ),
     )
 
     assert response.status_code == 200
     assert response.json()['accepted'] is True
     assert response.json()['blocks'][0]['conversation_id'] == 'desktop-1'
+    assert response.json()['blocks'][0]['recommended_action_items'] == [
+        {'description': 'Send the deck', 'task_id': 'task-1'},
+        {'description': 'Book the follow-up'},
+    ]
 
 
 def test_chat_first_validate_rejects_ambient_desktop_conversation_link(monkeypatch):

--- a/backend/tests/unit/test_chat_first_proactive_engine.py
+++ b/backend/tests/unit/test_chat_first_proactive_engine.py
@@ -207,6 +207,7 @@ def test_desktop_meeting_arrival_persists_exact_conversation_link(monkeypatch):
         'type': 'conversationLink',
         'conversation_id': 'conversation-1',
         'summary': 'Weekly planning',
+        'recommended_action_items': [],
     }
 
     engine.persist_capture_arrival_intent(
@@ -219,6 +220,24 @@ def test_desktop_meeting_arrival_persists_exact_conversation_link(monkeypatch):
     )
 
     assert created[1]['blocks'][0].summary == 'Your meeting notes are ready.'
+
+
+def test_meeting_recommendations_keep_bounded_open_user_commitments():
+    structured = {
+        'action_items': [
+            {'description': ' Send the deck ', 'capture_owner': 'user', 'target_task_id': 'task-1'},
+            {'description': 'Someone else reviews it', 'capture_owner': 'other'},
+            {'description': 'Already sent', 'capture_owner': 'user', 'completed': True},
+            {'description': 'Book the follow-up', 'capture_owner': 'user'},
+        ]
+    }
+
+    recommendations = engine.recommended_meeting_action_items(structured)
+
+    assert [item.model_dump() for item in recommendations] == [
+        {'description': 'Send the deck', 'task_id': 'task-1'},
+        {'description': 'Book the follow-up', 'task_id': None},
+    ]
 
 
 def test_desktop_meeting_adapter_uses_stored_role_and_skips_non_meeting_or_rotation(monkeypatch):
@@ -247,7 +266,11 @@ def test_desktop_meeting_adapter_uses_stored_role_and_skips_non_meeting_or_rotat
 
     engine.persist_desktop_meeting_arrival('user-1', meeting)
     persist.assert_called_once_with(
-        'user-1', conversation_id='meeting-1', summary='Design review', is_desktop_meeting=True
+        'user-1',
+        conversation_id='meeting-1',
+        summary='Design review',
+        is_desktop_meeting=True,
+        recommended_action_items=[],
     )
 
     persist.reset_mock()

--- a/backend/tests/unit/test_desktop_message_quota_router.py
+++ b/backend/tests/unit/test_desktop_message_quota_router.py
@@ -110,6 +110,7 @@ def test_desktop_human_message_records_quota_once_after_persistence_acceptance()
             app_id=None,
             session_id=None,
             metadata=None,
+            content_blocks=None,
             client_message_id='client-msg-1',
             message_source='desktop_chat',
             journal_revision=None,
@@ -161,6 +162,7 @@ def test_desktop_reconcile_response_preserves_canonical_identity_and_artifacts()
         assert payload['messages'][0]['client_message_id'] == 'turn-canonical'
         assert payload['messages'][0]['session_id'] == 'session-1'
         assert payload['messages'][0]['metadata'] == metadata
+        assert payload['messages'][0]['content_blocks'] == [{'type': 'agent_spawn'}]
         module.chat_db.get_messages_reconcile_page.assert_called_once_with(
             'test-uid',
             app_id=None,
@@ -168,6 +170,37 @@ def test_desktop_reconcile_response_preserves_canonical_identity_and_artifacts()
             limit=100,
             cursor_message_id=None,
         )
+    finally:
+        _cleanup(saved)
+
+
+def test_desktop_message_forwards_first_class_content_blocks():
+    client, module, saved = _make_client()
+    blocks = [{'type': 'conversationLink', 'summary': 'Weekly planning'}]
+    try:
+        response = client.post(
+            '/v2/desktop/messages',
+            json={
+                'text': 'Meeting notes ready - Weekly planning',
+                'sender': 'ai',
+                'content_blocks': blocks,
+            },
+        )
+
+        assert response.status_code == 200
+        module.chat_db.save_message.assert_called_once_with(
+            'test-uid',
+            text='Meeting notes ready - Weekly planning',
+            sender='ai',
+            app_id=None,
+            session_id=None,
+            metadata=None,
+            content_blocks=blocks,
+            client_message_id=None,
+            message_source='desktop_chat',
+            journal_revision=None,
+        )
+        module.llm_usage_db.record_chat_quota_question.assert_not_called()
     finally:
         _cleanup(saved)
 
@@ -205,6 +238,7 @@ def test_desktop_duplicate_human_message_retries_idempotent_quota_record():
             app_id=None,
             session_id=None,
             metadata=None,
+            content_blocks=None,
             client_message_id='client-msg-1',
             message_source='desktop_chat',
             journal_revision=None,
@@ -268,6 +302,7 @@ def test_desktop_message_forwards_bounded_journal_revision():
             app_id=None,
             session_id='session-1',
             metadata=None,
+            content_blocks=None,
             client_message_id='turn-1',
             message_source='desktop_chat',
             journal_revision=12,
@@ -337,6 +372,7 @@ def test_realtime_voice_human_message_does_not_record_desktop_message_quota():
             app_id=None,
             session_id=None,
             metadata=None,
+            content_blocks=None,
             client_message_id='voice-msg-1',
             message_source='realtime_voice',
             journal_revision=None,

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -1037,6 +1037,10 @@ class TestSaveMessageSessionBehavior:
                 sender='ai',
                 session_id='session-1',
                 metadata=enriched_metadata,
+                content_blocks=[
+                    {'type': 'agentSpawn', 'id': 'spawn-1'},
+                    {'type': 'agentCompletion', 'id': 'completion-1'},
+                ],
                 client_message_id='turn-1',
                 journal_revision=11,
             )
@@ -1047,6 +1051,10 @@ class TestSaveMessageSessionBehavior:
         patched_db.transaction.return_value.update.assert_called_once()
         update = patched_db.transaction.return_value.update.call_args.args[1]
         assert update['metadata'] == enriched_metadata
+        assert update['content_blocks'] == [
+            {'type': 'agentSpawn', 'id': 'spawn-1'},
+            {'type': 'agentCompletion', 'id': 'completion-1'},
+        ]
         assert update['journal_revision'] == 11
 
     def test_equal_journal_revision_with_different_payload_fails_closed(self):

--- a/backend/tests/unit/test_developer_from_segments_idempotency.py
+++ b/backend/tests/unit/test_developer_from_segments_idempotency.py
@@ -227,7 +227,11 @@ def test_no_client_session_id_preserves_create_conversation_path(monkeypatch):
     conversations_db.get_conversation.assert_not_called()
     claim.assert_not_called()
     arrival.assert_called_once_with(
-        'uid1', conversation_id='random-process-id', summary='Design review', is_desktop_meeting=True
+        'uid1',
+        conversation_id='random-process-id',
+        summary='Design review',
+        is_desktop_meeting=True,
+        recommended_action_items=[],
     )
 
 
@@ -306,7 +310,11 @@ def test_completed_desktop_meeting_persists_exact_conversation_arrival(monkeypat
     assert response.id == expected_id
     assert response.meeting_treatment_eligible is True
     arrival.assert_called_once_with(
-        'uid1', conversation_id=expected_id, summary='Design review', is_desktop_meeting=True
+        'uid1',
+        conversation_id=expected_id,
+        summary='Design review',
+        is_desktop_meeting=True,
+        recommended_action_items=[],
     )
 
 
@@ -383,7 +391,11 @@ def test_completed_desktop_meeting_retry_repairs_missing_arrival(monkeypatch):
     assert response.meeting_treatment_eligible is True
     process.assert_not_called()
     arrival.assert_called_once_with(
-        'uid1', conversation_id=expected_id, summary='Design review', is_desktop_meeting=True
+        'uid1',
+        conversation_id=expected_id,
+        summary='Design review',
+        is_desktop_meeting=True,
+        recommended_action_items=[],
     )
 
 

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -1033,7 +1033,12 @@ async def test_finalizer_never_logs_a_provider_exception_body(monkeypatch, caplo
             'desktop',
             {'conversation_role': 'meeting'},
             False,
-            {'conversation_id': 'conversation-1', 'summary': 'Captured title', 'is_desktop_meeting': True},
+            {
+                'conversation_id': 'conversation-1',
+                'summary': 'Captured title',
+                'is_desktop_meeting': True,
+                'recommended_action_items': [],
+            },
         ),
         ('desktop', {'conversation_role': 'ambient'}, False, None),
         (

--- a/backend/tests/unit/test_message_deserialize_safe.py
+++ b/backend/tests/unit/test_message_deserialize_safe.py
@@ -35,3 +35,22 @@ def test_tolerates_missing_callback():
 
 def test_empty():
     assert Message.deserialize_many_safe([]) == []
+
+
+def test_projects_legacy_metadata_blocks_to_first_class_wire_field():
+    record = _valid('legacy-rich-card')
+    record['metadata'] = '{"content_blocks":[{"type":"conversationLink","summary":"Weekly planning"}]}'
+
+    message = Message(**record)
+
+    assert message.content_blocks == [{'type': 'conversationLink', 'summary': 'Weekly planning'}]
+
+
+def test_first_class_blocks_override_legacy_metadata_shape():
+    record = _valid('first-class-rich-card')
+    record['content_blocks'] = [{'type': 'conversationLink', 'summary': 'Current'}]
+    record['metadata'] = '{"content_blocks":[{"type":"conversationLink","summary":"Legacy"}]}'
+
+    message = Message(**record)
+
+    assert message.content_blocks == [{'type': 'conversationLink', 'summary': 'Current'}]

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -21,7 +21,7 @@ from utils.conversations.process_conversation import extract_memories, process_c
 from utils.conversations import lifecycle as lifecycle_service
 from utils.executors import db_executor, postprocess_executor, run_blocking
 from utils.log_sanitizer import sanitize_pii
-from utils.task_intelligence.proactive_engine import persist_capture_arrival_intent
+from utils.task_intelligence.proactive_engine import persist_capture_arrival_intent, recommended_meeting_action_items
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +181,7 @@ async def finalize_persisted_conversation(
                         conversation_id=conversation_id,
                         summary=summary,
                         is_desktop_meeting=True,
+                        recommended_action_items=recommended_meeting_action_items(structured),
                     )
                 else:
                     persist_capture_arrival_intent(uid, conversation_id=conversation_id, summary=summary)

--- a/backend/utils/task_intelligence/proactive_engine.py
+++ b/backend/utils/task_intelligence/proactive_engine.py
@@ -9,6 +9,7 @@ import database.chat_first_intents as intent_db
 from models.chat_first import (
     CaptureLinkSpec,
     ConversationLinkSpec,
+    ConversationLinkActionItemSpec,
     ChatFirstBlockSpec,
     ChatFirstSubject,
     ColdStartSequence,
@@ -278,6 +279,37 @@ def run_goal_changed_wake(uid: str, *, goal_id: str, mutation_key: object) -> Pr
     )
 
 
+def recommended_meeting_action_items(structured: object) -> list[ConversationLinkActionItemSpec]:
+    """Project the user's open meeting commitments into the durable Chat receipt."""
+
+    action_items = (
+        structured.get('action_items', []) if isinstance(structured, dict) else getattr(structured, 'action_items', [])
+    )
+    recommendations: list[ConversationLinkActionItemSpec] = []
+    for item in action_items or []:
+        if isinstance(item, dict):
+            value = item
+        elif hasattr(item, '__dict__'):
+            value = vars(item)
+        else:
+            continue
+        if value.get('capture_owner') != 'user' or value.get('completed', False) or value.get('deleted', False):
+            continue
+        description = str(value.get('description') or '').strip()
+        if not description:
+            continue
+        task_id = value.get('target_task_id')
+        recommendations.append(
+            ConversationLinkActionItemSpec(
+                description=description[:300],
+                task_id=task_id if isinstance(task_id, str) and task_id else None,
+            )
+        )
+        if len(recommendations) == 8:
+            break
+    return recommendations
+
+
 def persist_capture_arrival_intent(
     uid: str,
     *,
@@ -287,6 +319,7 @@ def persist_capture_arrival_intent(
     now: datetime | None = None,
     eligibility_resolver: Callable[[str], ChatFirstEligibility] = resolve_chat_first_eligibility,
     is_desktop_meeting: bool = False,
+    recommended_action_items: list[ConversationLinkActionItemSpec] | None = None,
 ) -> ProactiveIntent | None:
     """Persist the deterministic capture receipt without calling an LLM.
 
@@ -311,7 +344,10 @@ def persist_capture_arrival_intent(
         block: ChatFirstBlockSpec
         if is_desktop_meeting:
             block = ConversationLinkSpec(
-                type='conversationLink', conversation_id=conversation_id, summary=bounded_summary
+                type='conversationLink',
+                conversation_id=conversation_id,
+                summary=bounded_summary,
+                recommended_action_items=recommended_action_items or [],
             )
         else:
             block = CaptureLinkSpec(type='captureLink', conversation_id=conversation_id, summary=bounded_summary)
@@ -352,6 +388,7 @@ def persist_desktop_meeting_arrival(uid: str, conversation) -> None:
         conversation_id=conversation_id,
         summary=title or overview or '',
         is_desktop_meeting=True,
+        recommended_action_items=recommended_meeting_action_items(structured),
     )
 
 

--- a/desktop/macos/Desktop/Sources/Chat/APIClient+KernelJournal.swift
+++ b/desktop/macos/Desktop/Sources/Chat/APIClient+KernelJournal.swift
@@ -9,6 +9,7 @@ extension APIClient {
     sender: String,
     appId: String? = nil,
     sessionId: String? = nil,
+    contentBlocksJSON: String? = nil,
     metadata: String? = nil,
     clientMessageId: String? = nil,
     messageSource: String = "desktop_chat",
@@ -20,16 +21,22 @@ extension APIClient {
       let sender: String
       let app_id: String?
       let session_id: String?
+      let content_blocks: [OmiAnyCodable]?
       let metadata: String?
       let client_message_id: String?
       let message_source: String
       let journal_revision: Int?
+    }
+    let contentBlocks = contentBlocksJSON.flatMap { json -> [OmiAnyCodable]? in
+      guard let data = json.data(using: .utf8) else { return nil }
+      return try? JSONDecoder().decode([OmiAnyCodable].self, from: data)
     }
     let body = SaveRequest(
       text: text,
       sender: sender,
       app_id: appId,
       session_id: sessionId,
+      content_blocks: contentBlocks,
       metadata: metadata,
       client_message_id: clientMessageId,
       message_source: messageSource,
@@ -114,7 +121,7 @@ struct SaveMessageResponse: Codable {
   }
 }
 
-struct ChatMessageDB: Codable, Identifiable {
+struct ChatMessageDB: Decodable, Identifiable {
   let id: String
   let text: String
   let createdAt: Date
@@ -124,10 +131,12 @@ struct ChatMessageDB: Codable, Identifiable {
   let rating: Int?
   let reported: Bool
   let metadata: String?
+  let contentBlocksJSON: String?
   let clientMessageId: String?
 
   enum CodingKeys: String, CodingKey {
     case id, text, sender, rating, reported, metadata
+    case contentBlocks = "content_blocks"
     case clientMessageId = "client_message_id"
     case createdAt = "created_at"
     case appId = "app_id"
@@ -145,11 +154,18 @@ struct ChatMessageDB: Codable, Identifiable {
     rating = try container.decodeIfPresent(Int.self, forKey: .rating)
     reported = try container.decodeIfPresent(Bool.self, forKey: .reported) ?? false
     metadata = try container.decodeIfPresent(String.self, forKey: .metadata)
+    if let blocks = try container.decodeIfPresent([OmiAnyCodable].self, forKey: .contentBlocks) {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = [.sortedKeys]
+      contentBlocksJSON = try String(decoding: encoder.encode(blocks), as: UTF8.self)
+    } else {
+      contentBlocksJSON = nil
+    }
     clientMessageId = try container.decodeIfPresent(String.self, forKey: .clientMessageId)
   }
 }
 
-struct DesktopMessageReconcilePage: Codable {
+struct DesktopMessageReconcilePage: Decodable {
   let messages: [ChatMessageDB]
   let nextCursor: String?
   let hasMore: Bool

--- a/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContentBlockCodec.swift
@@ -124,7 +124,19 @@ enum ChatContentBlockCodec {
         guard let conversationId = dict["conversationId"] as? String, let summary = dict["summary"] as? String else {
           continue
         }
-        blocks.append(.conversationLink(id: id, conversationId: conversationId, summary: summary))
+        let recommendedActionItems = (dict["recommendedActionItems"] as? [[String: Any]] ?? []).compactMap {
+          item -> ConversationLinkActionItem? in
+          guard let description = item["description"] as? String,
+            !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          else { return nil }
+          return ConversationLinkActionItem(description: description, taskID: item["taskId"] as? String)
+        }
+        blocks.append(
+          .conversationLink(
+            id: id,
+            conversationId: conversationId,
+            summary: summary,
+            recommendedActionItems: recommendedActionItems))
       case "memoryLink":
         guard let memoryId = dict["memoryId"] as? String, let summary = dict["summary"] as? String else { continue }
         blocks.append(.memoryLink(id: id, memoryId: memoryId, summary: summary))
@@ -302,8 +314,18 @@ enum ChatContentBlockCodec {
       var dict: [String: Any] = ["type": "captureLink", "id": id, "conversationId": conversationId, "summary": summary]
       if let momentTimestampMs { dict["momentTimestampMs"] = momentTimestampMs }
       return dict
-    case .conversationLink(let id, let conversationId, let summary):
-      return ["type": "conversationLink", "id": id, "conversationId": conversationId, "summary": summary]
+    case .conversationLink(let id, let conversationId, let summary, let recommendedActionItems):
+      var dict: [String: Any] = [
+        "type": "conversationLink", "id": id, "conversationId": conversationId, "summary": summary,
+      ]
+      if !recommendedActionItems.isEmpty {
+        dict["recommendedActionItems"] = recommendedActionItems.map { item in
+          var encoded: [String: Any] = ["description": item.description]
+          if let taskID = item.taskID { encoded["taskId"] = taskID }
+          return encoded
+        }
+      }
+      return dict
     case .memoryLink(let id, let memoryId, let summary):
       return ["type": "memoryLink", "id": id, "memoryId": memoryId, "summary": summary]
     case .citation(let id, let reference):

--- a/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
@@ -7,6 +7,7 @@ enum ProactiveNotificationKind: String, Equatable {
   case task
   case memory
   case goal
+  case meetingNotes = "meeting_notes"
   case resurface
 
   static func from(decisionType: String) -> Self {
@@ -26,6 +27,7 @@ enum ProactiveNotificationKind: String, Equatable {
     case "task": return .task
     case "memory-extraction": return .memory
     case "goals": return .goal
+    case "meeting-notes": return .meetingNotes
     default: return .general
     }
   }

--- a/desktop/macos/Desktop/Sources/Chat/ChatFirstBlockValidation.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatFirstBlockValidation.swift
@@ -95,7 +95,16 @@ enum ChatFirstBlockWire {
       guard let conversationID = block["conversationId"] as? String, let summary = block["summary"] as? String else {
         return nil
       }
-      return ["type": type, "conversation_id": conversationID, "summary": summary]
+      var result: [String: Any] = ["type": type, "conversation_id": conversationID, "summary": summary]
+      if let actionItems = block["recommendedActionItems"] as? [[String: Any]] {
+        result["recommended_action_items"] = actionItems.compactMap { item -> [String: Any]? in
+          guard let description = item["description"] as? String else { return nil }
+          var converted: [String: Any] = ["description": description]
+          if let taskID = item["taskId"] as? String { converted["task_id"] = taskID }
+          return converted
+        }
+      }
+      return result
     case "memoryLink":
       guard let memoryID = block["memoryId"] as? String, let summary = block["summary"] as? String else { return nil }
       return ["type": type, "memory_id": memoryID, "summary": summary]
@@ -154,7 +163,16 @@ enum ChatFirstBlockWire {
       guard let conversationID = block["conversation_id"] as? String, let summary = block["summary"] as? String else {
         return nil
       }
-      return ["type": type, "id": id, "conversationId": conversationID, "summary": summary]
+      var result: [String: Any] = ["type": type, "id": id, "conversationId": conversationID, "summary": summary]
+      if let actionItems = block["recommended_action_items"] as? [[String: Any]] {
+        result["recommendedActionItems"] = actionItems.compactMap { item -> [String: Any]? in
+          guard let description = item["description"] as? String else { return nil }
+          var converted: [String: Any] = ["description": description]
+          if let taskID = item["task_id"] as? String { converted["taskId"] = taskID }
+          return converted
+        }
+      }
+      return result
     case "memoryLink":
       guard let memoryID = block["memory_id"] as? String, let summary = block["summary"] as? String else { return nil }
       return ["type": type, "id": id, "memoryId": memoryID, "summary": summary]

--- a/desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
+++ b/desktop/macos/Desktop/Sources/Chat/KernelJournalBackendSyncDriver.swift
@@ -108,6 +108,7 @@ actor KernelJournalBackendSyncDriver {
     let sender: String
     let appId: String?
     let sessionId: String?
+    let contentBlocksJSON: String?
     let metadata: String?
     let messageSource: String
 
@@ -150,6 +151,14 @@ actor KernelJournalBackendSyncDriver {
       self.sender = sender
       self.appId = payload["appId"] as? String
       self.sessionId = payload["sessionId"] as? String
+      if payload["contentBlocks"] == nil || payload["contentBlocks"] is NSNull {
+        contentBlocksJSON = nil
+      } else {
+        guard let blocks = payload["contentBlocks"] as? [[String: Any]],
+          JSONSerialization.isValidJSONObject(blocks)
+        else { return nil }
+        contentBlocksJSON = KernelJournalBackendSyncDriver.jsonArrayString(blocks)
+      }
       self.metadata = payload["metadata"] as? String
       self.messageSource = messageSource
     }
@@ -388,6 +397,7 @@ actor KernelJournalBackendSyncDriver {
         sender: request.sender,
         appId: request.appId,
         sessionId: request.sessionId,
+        contentBlocksJSON: request.contentBlocksJSON,
         metadata: request.metadata,
         clientMessageId: request.turnId,
         messageSource: request.messageSource,
@@ -497,7 +507,7 @@ actor KernelJournalBackendSyncDriver {
       canonicalTurnId: row.clientMessageId.flatMap { $0.isEmpty ? nil : $0 },
       role: row.sender == "ai" || row.sender == "assistant" ? "assistant" : "user",
       content: row.text,
-      contentBlocksJSON: metadata.contentBlocksJSON,
+      contentBlocksJSON: row.contentBlocksJSON ?? metadata.contentBlocksJSON,
       resourcesJSON: metadata.resourcesJSON,
       metadataJSON: row.metadata ?? "{}",
       createdAtMs: Int(row.createdAt.timeIntervalSince1970 * 1_000)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -114,7 +114,7 @@ struct AIResponseView: View {
         return ["chatFirstGoal", id].joined(separator: "\u{1E}")
       case .captureLink(let id, _, _, _):
         return ["chatFirstCapture", id].joined(separator: "\u{1E}")
-      case .conversationLink(let id, _, _):
+      case .conversationLink(let id, _, _, _):
         return ["chatFirstConversation", id].joined(separator: "\u{1E}")
       case .memoryLink(let id, _, _):
         return ["chatFirstMemory", id].joined(separator: "\u{1E}")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -849,7 +849,7 @@ extension ChatContentBlock {
     case .taskCard(let id, _): return "t:\(id)"
     case .goalLink(let id, _, _): return "g:\(id)"
     case .captureLink(let id, _, _, _): return "c:\(id)"
-    case .conversationLink(let id, _, _): return "v:\(id)"
+    case .conversationLink(let id, _, _, _): return "v:\(id)"
     case .memoryLink(let id, _, _): return "m:\(id)"
     case .citation(let id, let reference): return "r:\(id):\(reference.ordinal)"
     case .agentSpawn(let id, let pillId, _, _, _, _, _): return "s:\(id):\(pillId?.uuidString ?? "")"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4206,8 +4206,9 @@ class FloatingControlBarManager {
     // Notifications become chat-visible only after canonical journal
     // admission. The notification card itself remains an independent
     // presentation surface while this async write is pending.
-    let bodyText = notification.message.trimmingCharacters(in: .whitespacesAndNewlines)
-    let messageText = bodyText.isEmpty ? notification.title : bodyText
+    let messageText = Self.notificationJournalText(
+      title: notification.title,
+      body: notification.message)
     let continuityKey = ChatContinuityInvariants.proactiveNotificationContinuityKey(
       id: notification.id,
       kind: notification.kind)
@@ -4246,6 +4247,14 @@ class FloatingControlBarManager {
       )
       self.mostRecentNotificationKey = key
     }
+  }
+
+  nonisolated static func notificationJournalText(title: String, body: String) -> String {
+    let headline = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    if headline.isEmpty { return detail }
+    if detail.isEmpty || detail == headline { return headline }
+    return "\(headline)\n\(detail)"
   }
 
   func mainChatSurfaceReference() -> AgentSurfaceReference {

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/Blocks/ChatFirstContentBlockViews.swift
@@ -452,6 +452,7 @@ struct CaptureLinkView: View {
 struct ConversationLinkView: View {
   let conversationID: String
   let summary: String
+  let recommendedActionItems: [ConversationLinkActionItem]
   let navigation: ChatFirstShellNavigation
 
   @State private var isOpening = false
@@ -473,6 +474,11 @@ struct ConversationLinkView: View {
           isOpening: isOpening,
           accessibilityID: "chat-first-conversation-\(conversationID)-open",
           action: { openConversation() },
+          recommendedActionItems: recommendedActionItems,
+          recommendedActionItemAction: { item in
+            guard let taskID = item.taskID else { return }
+            navigation.open(focus: .task(id: taskID))
+          },
           secondaryActionTitle: "Copy share link",
           secondaryActionSystemImage: "link",
           isSecondaryBusy: isCopyingLink,
@@ -608,6 +614,8 @@ private struct ChatFirstLinkBlockView: View {
   let isOpening: Bool
   let accessibilityID: String
   let action: () -> Void
+  var recommendedActionItems: [ConversationLinkActionItem] = []
+  var recommendedActionItemAction: ((ConversationLinkActionItem) -> Void)? = nil
   // Optional secondary chip rendered beside the primary destination chip
   // (e.g. "Copy share link" beside "Open conversation"). The transient
   // status renders on its own caption line under the chips so a long
@@ -632,6 +640,18 @@ private struct ChatFirstLinkBlockView: View {
         .scaledFont(size: OmiType.body, weight: .medium)
         .foregroundStyle(Ink.primary)
         .fixedSize(horizontal: false, vertical: true)
+
+      if !recommendedActionItems.isEmpty {
+        VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+          Text("Recommended next steps")
+            .scaledFont(size: OmiType.micro, weight: .semibold)
+            .foregroundStyle(Ink.secondary)
+
+          ForEach(recommendedActionItems.indices, id: \.self) { index in
+            recommendedActionItemRow(recommendedActionItems[index])
+          }
+        }
+      }
 
       HStack(spacing: OmiSpacing.sm) {
         Button(action: action) {
@@ -694,6 +714,41 @@ private struct ChatFirstLinkBlockView: View {
       RoundedRectangle(cornerRadius: PageGlass.rowRadius, style: .continuous)
         .stroke(Ink.glassEdge, lineWidth: 1)
     )
+  }
+
+  @ViewBuilder
+  private func recommendedActionItemRow(_ item: ConversationLinkActionItem) -> some View {
+    if item.taskID != nil, let recommendedActionItemAction {
+      Button {
+        recommendedActionItemAction(item)
+      } label: {
+        recommendedActionItemLabel(item, showsOpenIndicator: true)
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Open task: \(item.description)")
+    } else {
+      recommendedActionItemLabel(item, showsOpenIndicator: false)
+    }
+  }
+
+  private func recommendedActionItemLabel(
+    _ item: ConversationLinkActionItem,
+    showsOpenIndicator: Bool
+  ) -> some View {
+    HStack(alignment: .firstTextBaseline, spacing: OmiSpacing.xs) {
+      Image(systemName: "circle")
+        .scaledFont(size: OmiType.micro, weight: .medium)
+        .foregroundStyle(Ink.secondary)
+      Text(item.description)
+        .scaledFont(size: OmiType.caption, weight: .medium)
+        .foregroundStyle(Ink.primary)
+        .fixedSize(horizontal: false, vertical: true)
+      if showsOpenIndicator {
+        Image(systemName: "chevron.right")
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+          .foregroundStyle(Ink.secondary)
+      }
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift
@@ -495,12 +495,13 @@ struct ChatBubble: View {
           navigation: chatFirstRichBlockContext.navigation
         )
       )
-    case .conversationLink(_, let conversationID, let summary):
+    case .conversationLink(_, let conversationID, let summary, let recommendedActionItems):
       guard let chatFirstRichBlockContext else { return AnyView(EmptyView()) }
       return AnyView(
         ConversationLinkView(
           conversationID: conversationID,
           summary: summary,
+          recommendedActionItems: recommendedActionItems,
           navigation: chatFirstRichBlockContext.navigation
         )
       )
@@ -1147,7 +1148,12 @@ enum ContentBlockGroup: Identifiable {
   case taskCard(id: String, taskID: String)
   case goalLink(id: String, goalID: String, summary: String)
   case captureLink(id: String, conversationID: String, momentTimestampMs: Int?, summary: String)
-  case conversationLink(id: String, conversationID: String, summary: String)
+  case conversationLink(
+    id: String,
+    conversationID: String,
+    summary: String,
+    recommendedActionItems: [ConversationLinkActionItem]
+  )
   case memoryLink(id: String, memoryID: String, summary: String)
   case agentSpawn(
     id: String,
@@ -1180,7 +1186,7 @@ enum ContentBlockGroup: Identifiable {
     case .taskCard(let id, _): return id
     case .goalLink(let id, _, _): return id
     case .captureLink(let id, _, _, _): return id
-    case .conversationLink(let id, _, _): return id
+    case .conversationLink(let id, _, _, _): return id
     case .memoryLink(let id, _, _): return id
     case .agentSpawn(let id, _, _, _, _, _, _): return id
     case .agentCompletion(let id, _, _, _, _, _, _, _): return id
@@ -1240,10 +1246,15 @@ enum ContentBlockGroup: Identifiable {
             summary: summary
           )
         )
-      case .conversationLink(let id, let conversationID, let summary):
+      case .conversationLink(let id, let conversationID, let summary, let recommendedActionItems):
         flushToolCalls()
         guard richBlockRenderingEnabled else { continue }
-        groups.append(.conversationLink(id: id, conversationID: conversationID, summary: summary))
+        groups.append(
+          .conversationLink(
+            id: id,
+            conversationID: conversationID,
+            summary: summary,
+            recommendedActionItems: recommendedActionItems))
       case .memoryLink(let id, let memoryID, let summary):
         flushToolCalls()
         guard richBlockRenderingEnabled else { continue }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -255,6 +255,8 @@ struct ProactiveNotificationBadge: Equatable {
       (label, systemImage) = ("Memory", "brain.head.profile")
     case .goal:
       (label, systemImage) = ("Goal", "target")
+    case .meetingNotes:
+      (label, systemImage) = ("Meeting notes", "text.document")
     case .resurface:
       (label, systemImage) = ("Resurfaced", "clock.arrow.circlepath")
     case .general:

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -370,8 +370,51 @@ enum ContextProactivityPromptBuilder {
   /// simultaneously; every semantic rule from that version is preserved here,
   /// split so each can be applied independently.
   ///
+  /// The "Then say what it is about" block is the naming rule. A delivered
+  /// notification read "Insight / PR blocked, needs review", which tells the user
+  /// nothing about *which* pull request; the prompt above decides whether to speak
+  /// and which decision type to use, and never said what the spoken text must
+  /// contain, so that answer was fully compliant.
+  ///
+  /// Measured against the production reasoning model (gpt-5.6-luna,
+  /// reasoning_effort low) on the `referent-*` cases of the context-bucket
+  /// benchmark, 12 replicates per case. Scored on whether the user-visible text
+  /// contains one of the case's declared `referentTokens`:
+  ///
+  ///                        title        message      silence
+  ///   baseline             34/58 (59%)  58/58        26/84 (31%)
+  ///   schema text only     60/61 (98%)  57/61 (93%)  23/84 (27%)
+  ///   prose wording        61/61        61/61        23/84 (27%)
+  ///   this wording         67/67        67/67        17/84 (20%)
+  ///
+  /// The failure was in the title, not the body: the body already named the thing
+  /// 58/58 times, and the title only 34/58. Two wordings were tried. A one-
+  /// paragraph prose version reached 61/61 on both fields; this bulleted version
+  /// — the ordered-procedure shape the rest of this prompt already uses — matched
+  /// it and spoke more, and is kept for consistency with its neighbours.
+  ///
+  /// It does not buy the gain with silence. Silence *fell* (31% → 20%), the
+  /// benchmark's expected polarity improved (134/228 → 162/228 runs) and no
+  /// forbidden output term appeared in any of the 912 replayed runs. The
+  /// `referent-visible-on-screen` guard — the same blocked pull request, with the
+  /// review thread on screen — stayed silent 12/12 under every wording, so the
+  /// "already visible" rule is intact. On `referent-no-identifier`, whose context
+  /// supplies no handle at all, the rule invented none in 8/8 spoken runs; it
+  /// falls back to "the pull request you opened".
+  ///
+  /// Ceiling, for whoever tunes this next: wording cannot name what it was never
+  /// given. Across 69 spoken baseline runs the model named the referent whenever
+  /// one was anywhere in the prompt — including when it appeared only in an old
+  /// frozen-segment line among four distractor facts. The residual vague messages
+  /// all come from contexts carrying no identifier. `bucket_facts.identifiers` is
+  /// where extraction already stores the handles it was told to copy, and
+  /// `ContextBucketStore.snapshot` does not put that column into the fact lines
+  /// the director reads. That is the next lever, and it is a store change, not a
+  /// prompt change.
+  ///
   /// This text is the prompt-cache prefix: nothing volatile may be interpolated
-  /// into it, and it must stay byte-identical across calls for one bucket.
+  /// into it, and it must stay byte-identical across calls for one bucket. The
+  /// naming rule is static, so it invalidates the cached prefix exactly once.
   static func directorStablePrompt(snapshot: ContextBucketSnapshot, allowLookup: Bool = false) -> String {
     let stableBucket = String(data: ContextBucketPromptAssembler.assemble(snapshot), encoding: .utf8) ?? ""
     let lookup = allowLookup ? "\n" + directorLookupInstruction : ""
@@ -407,6 +450,17 @@ enum ContextProactivityPromptBuilder {
       - A commitment is required only for task_candidate. Insight, suggest, and resurface
         never require one: new, useful, grounded information the user has not seen is
         enough. Do not stay silent just because nobody made a commitment.
+      Then say what it is about:
+      - Name the specific thing in both the title and the message. The user reads them away
+        from the screen that produced them.
+      - Take the identifier from the supplied context: the pull-request number and repository,
+        the sender and the subject of the thread, the title of the document, the file and
+        branch, the name and time of the meeting, the person who asked.
+      - "PR blocked", "respond to the email", "document needs review" identify nothing. A
+        message the user cannot connect to one specific thing is not worth an interruption.
+      - Write identifiers exactly as the context spells them. Never invent one.
+      - The title is not a category. Never answer "Insight", "Suggestion", or "Task".
+      - A missing identifier is not a reason for silence. Speak with what the context supplies.
       Use only supplied bucket-entry refs.
       Timestamps supplied below are already in the user's local time zone. When a message
       mentions a date or time, use that local form as written; never convert to or mention UTC.\(lookup)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextProactivityEngine.swift
@@ -1097,11 +1097,39 @@ actor ContextProactivityEngine {
 
   static var schema: [String: Any] { schema(allowLookup: false) }
 
+  /// `title` and `message` are the only two fields the user ever reads, and they
+  /// were the only two declared as bare strings. A delivered notification read
+  /// "Insight / PR blocked, needs review" — the decision type answered back as a
+  /// title, and a body naming no pull request — which nothing in the schema or
+  /// the prompt forbade.
+  ///
+  /// These descriptions were measured together with the prompt's naming rule
+  /// (see `ContextProactivityPromptBuilder.directorStablePrompt`). Alone they
+  /// took title naming from 34/58 to 60/61 spoken runs but cost body naming
+  /// (58/58 → 57/61): the model moved the identifier into the title instead of
+  /// carrying it in both. The prompt rule is what holds both at 67/67, so the two
+  /// halves ship together and neither should be removed on its own.
   static func schema(allowLookup: Bool) -> [String: Any] {
     var properties: [String: Any] = [
       "decision": ["type": "string", "enum": ["suggest", "insight", "task_candidate", "resurface", "silence"]],
-      "title": ["type": "string"],
-      "message": ["type": "string"],
+      "title": [
+        "type": "string",
+        "description":
+          "The specific thing this is about, as the supplied context names it: the pull request "
+          + "number and repository, the sender and subject of the thread, the title of the "
+          + "document, the file and branch, the name and time of the meeting. Never a category "
+          + "word such as \"Insight\", \"Suggestion\", or \"Task\". Empty only when the decision "
+          + "is silence.",
+      ],
+      "message": [
+        "type": "string",
+        "description":
+          "What the user should know or do, written so it still makes sense away from the screen "
+          + "that produced it. Name the same specific thing the title names, then say what "
+          + "changed or what to do about it. A message that identifies only a category -- \"PR "
+          + "blocked\", \"respond to the email\", \"document needs review\" -- is useless. Empty "
+          + "only when the decision is silence.",
+      ],
       "reasoning": ["type": "string"],
       "bucket_entry_refs": ["type": "array", "items": ["type": "string"]],
       "fact_ids": ["type": "array", "items": ["type": "string"]],

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingActionItemBannerService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingActionItemBannerService.swift
@@ -84,15 +84,16 @@ final class MeetingActionItemBannerService {
         // Same owner-provenance and delivery gates as the other proactive
         // banners: master Notifications toggle, frequency throttle, and the
         // floating-bar preview policy all remain authoritative inside
-        // `sendNotification`. `deliverSystemBanner: true` because this banner's
-        // whole purpose is to reach a user who is away from the app.
+        // `sendNotification`. This is intentionally system-banner-only: the
+        // durable Chat surface is the conversation-link card, so presenting
+        // this recommendation must not journal a second Chat row.
         guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
         NotificationService.shared.sendNotification(
           ownerID: snapshot.ownerID,
           title: title,
           message: body,
           assistantId: MeetingActionItemBannerPolicy.assistantID,
-          deliverSystemBanner: true,
+          deliveryMode: .systemBannerOnly,
           authorizationSnapshot: snapshot
         )
       }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -26,6 +26,18 @@ enum NotificationSound {
 
 }
 
+/// Named delivery intent for notifications that must not become Chat rows.
+/// The default preserves the existing floating-bar presentation and journaling
+/// path; system-banner-only callers still pass every owner, toggle, and
+/// frequency gate in `NotificationService` before reaching UserNotifications.
+enum NotificationDeliveryMode: Equatable {
+  case standard
+  case systemBannerOnly
+
+  var presentsInFloatingBar: Bool { self == .standard }
+  var requiresSystemBanner: Bool { self == .systemBannerOnly }
+}
+
 @MainActor
 class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   static let shared = NotificationService(registerWithSystemNotificationCenter: true)
@@ -363,6 +375,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     insightDeliveryID: UUID? = nil,
     screenshotData: Data? = nil,
     deliverSystemBanner: Bool = false,
+    deliveryMode: NotificationDeliveryMode = .standard,
     respectFrequency: Bool = true,
     authorizationSnapshot suppliedAuthorizationSnapshot: RuntimeOwnerAuthorizationSnapshot? = nil
   ) {
@@ -467,10 +480,12 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
     let previewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
     let floatingBarEnabled = FloatingControlBarManager.shared.isEnabled
-    let floatingBarPreviewEnabled = FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
-      previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
-      deliverSystemBanner: deliverSystemBanner
-    )
+    let floatingBarPreviewEnabled =
+      deliveryMode.presentsInFloatingBar
+      && FloatingBarNotificationPreviewPolicy.shouldShowInBarPreview(
+        previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
+        deliverSystemBanner: deliverSystemBanner
+      )
 
     var floatingBarMayDeliver = false
     var floatingBarQueued = false
@@ -518,7 +533,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     // doc above). When the user explicitly muted in-bar previews (bar still enabled),
     // fall back to the system banner so the notification is never fully silenced.
     let shouldDeliverSystemBanner =
-      FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
+      deliveryMode.requiresSystemBanner
+      || FloatingBarNotificationPreviewPolicy.shouldDeliverSystemBannerAfterFloatingBar(
         previewsEnabled: previewsEnabled, floatingBarEnabled: floatingBarEnabled,
         deliverSystemBanner: deliverSystemBanner,
         floatingBarAccepted: floatingBarMayDeliver || floatingBarQueued

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -315,6 +315,11 @@ enum AgentTimelineOpenFeedback {
   }
 }
 
+struct ConversationLinkActionItem: Equatable {
+  let description: String
+  let taskID: String?
+}
+
 enum ChatContentBlock: Identifiable {
   case text(id: String, text: String)
   case toolCall(
@@ -337,7 +342,12 @@ enum ChatContentBlock: Identifiable {
   case taskCard(id: String, taskId: String)
   case goalLink(id: String, goalId: String, summary: String)
   case captureLink(id: String, conversationId: String, momentTimestampMs: Int?, summary: String)
-  case conversationLink(id: String, conversationId: String, summary: String)
+  case conversationLink(
+    id: String,
+    conversationId: String,
+    summary: String,
+    recommendedActionItems: [ConversationLinkActionItem]
+  )
   case memoryLink(id: String, memoryId: String, summary: String)
   /// Answer-level provenance. Unlike a rich link card, this is rendered at the matching inline
   /// numeric marker and is otherwise invisible in the transcript.
@@ -372,7 +382,7 @@ enum ChatContentBlock: Identifiable {
     case .taskCard(let id, _): return id
     case .goalLink(let id, _, _): return id
     case .captureLink(let id, _, _, _): return id
-    case .conversationLink(let id, _, _): return id
+    case .conversationLink(let id, _, _, _): return id
     case .memoryLink(let id, _, _): return id
     case .citation(let id, _): return id
     case .agentSpawn(let id, _, _, _, _, _, _): return id
@@ -824,7 +834,7 @@ extension ChatContentBlock {
     case .taskCard:
       return nil
     case .goalLink(_, _, let summary), .captureLink(_, _, _, let summary),
-      .conversationLink(_, _, let summary), .memoryLink(_, _, let summary):
+      .conversationLink(_, _, let summary, _), .memoryLink(_, _, let summary):
       let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
       return trimmed.isEmpty ? nil : trimmed
     case .citation:

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -899,7 +899,9 @@ extension ChatMessage {
   /// Convert a backend message to a local ChatMessage
   init(from db: ChatMessageDB) {
     let resources = ChatResource.decodeResourcesFromMessageMetadata(db.metadata)
-    let contentBlocks = ChatContentBlockCodec.decodeFromMessageMetadata(db.metadata)
+    let contentBlocks =
+      db.contentBlocksJSON.flatMap(ChatContentBlockCodec.decode)
+      ?? ChatContentBlockCodec.decodeFromMessageMetadata(db.metadata)
     self.init(
       id: db.id,
       text: db.text,
@@ -3200,7 +3202,9 @@ class ChatProvider: ObservableObject {
       )
       for entry in importPlan {
         let row = entry.row
-        let blocks = ChatContentBlockCodec.decodeFromMessageMetadata(row.metadata)
+        let blocks =
+          row.contentBlocksJSON.flatMap(ChatContentBlockCodec.decode)
+          ?? ChatContentBlockCodec.decodeFromMessageMetadata(row.metadata)
         let resources = ChatResource.decodeResourcesFromMessageMetadata(row.metadata)
         let accepted = await kernelTurnProjection.importRemoteTurn(
           surface: surface,

--- a/desktop/macos/Desktop/Tests/ChatFirstRichBlockTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstRichBlockTests.swift
@@ -76,15 +76,27 @@ final class ChatFirstRichBlockTests: XCTestCase {
             ["type": "taskCard", "taskId": "task-1"],
             ["type": "goalLink", "goalId": "goal-1", "summary": "Ship the plan"],
             ["type": "memoryLink", "memoryId": "memory-1", "summary": "Remember the launch constraint"],
+            [
+              "type": "conversationLink",
+              "conversationId": "conversation-1",
+              "summary": "Meeting notes",
+              "recommendedActionItems": [
+                ["description": "Send the deck", "taskId": "task-2"],
+                ["description": "Book the follow-up"],
+              ],
+            ],
           ]
         ]
       )
     )
 
-    XCTAssertEqual(converted.count, 3)
+    XCTAssertEqual(converted.count, 4)
     XCTAssertEqual(converted[0]["task_id"] as? String, "task-1")
     XCTAssertEqual(converted[1]["goal_id"] as? String, "goal-1")
     XCTAssertEqual(converted[2]["memory_id"] as? String, "memory-1")
+    let actionItems = try XCTUnwrap(converted[3]["recommended_action_items"] as? [[String: Any]])
+    XCTAssertEqual(actionItems.map { $0["description"] as? String }, ["Send the deck", "Book the follow-up"])
+    XCTAssertEqual(actionItems.first?["task_id"] as? String, "task-2")
   }
 
   func testCodecRoundTripsEveryChatFirstBlock() throws {
@@ -115,7 +127,11 @@ final class ChatFirstRichBlockTests: XCTestCase {
       .conversationLink(
         id: "conversation-link",
         conversationId: "conversation-1",
-        summary: "Meeting notes"
+        summary: "Meeting notes",
+        recommendedActionItems: [
+          ConversationLinkActionItem(description: "Send the deck", taskID: "task-2"),
+          ConversationLinkActionItem(description: "Book the follow-up", taskID: nil),
+        ]
       ),
       .memoryLink(id: "memory-link", memoryId: "memory-1", summary: "Launch constraint"),
     ]
@@ -153,17 +169,44 @@ final class ChatFirstRichBlockTests: XCTestCase {
     XCTAssertEqual(timestamp, 42_000)
     XCTAssertEqual(captureSummary, "Planning conversation")
 
-    guard case .conversationLink(_, let conversationID, let conversationSummary) = restored[4] else {
+    guard
+      case .conversationLink(
+        _, let conversationID, let conversationSummary, let recommendedActionItems) = restored[4]
+    else {
       return XCTFail("conversation link should survive persisted replay")
     }
     XCTAssertEqual(conversationID, "conversation-1")
     XCTAssertEqual(conversationSummary, "Meeting notes")
+    XCTAssertEqual(
+      recommendedActionItems,
+      [
+        ConversationLinkActionItem(description: "Send the deck", taskID: "task-2"),
+        ConversationLinkActionItem(description: "Book the follow-up", taskID: nil),
+      ])
 
     guard case .memoryLink(_, let memoryID, let memorySummary) = restored[5] else {
       return XCTFail("memory link should survive persisted replay")
     }
     XCTAssertEqual(memoryID, "memory-1")
     XCTAssertEqual(memorySummary, "Launch constraint")
+  }
+
+  func testLegacyConversationLinkWithoutRecommendedItemsDegradesToTheExistingCard() {
+    let restored = ChatContentBlockCodec.decode([
+      [
+        "type": "conversationLink",
+        "id": "conversation-link",
+        "conversationId": "conversation-1",
+        "summary": "Meeting notes",
+      ]
+    ])
+
+    guard let first = restored.first,
+      case .conversationLink(_, _, _, let recommendedActionItems) = first
+    else {
+      return XCTFail("legacy conversation link should still decode")
+    }
+    XCTAssertTrue(recommendedActionItems.isEmpty)
   }
 
   func testQuestionSelectionReceiptRoundTripsAndRetiresTheOptions() throws {

--- a/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextBucketPromptAssemblerTests.swift
@@ -37,6 +37,17 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
     "- A commitment is required only for task_candidate. Insight, suggest, and resurface",
     "  never require one: new, useful, grounded information the user has not seen is",
     "  enough. Do not stay silent just because nobody made a commitment.",
+    "Then say what it is about:",
+    "- Name the specific thing in both the title and the message. The user reads them away",
+    "  from the screen that produced them.",
+    "- Take the identifier from the supplied context: the pull-request number and repository,",
+    "  the sender and the subject of the thread, the title of the document, the file and",
+    "  branch, the name and time of the meeting, the person who asked.",
+    "- \"PR blocked\", \"respond to the email\", \"document needs review\" identify nothing. A",
+    "  message the user cannot connect to one specific thing is not worth an interruption.",
+    "- Write identifiers exactly as the context spells them. Never invent one.",
+    "- The title is not a category. Never answer \"Insight\", \"Suggestion\", or \"Task\".",
+    "- A missing identifier is not a reason for silence. Speak with what the context supplies.",
     "Use only supplied bucket-entry refs.",
     "Timestamps supplied below are already in the user's local time zone. When a message",
     "mentions a date or time, use that local form as written; never convert to or mention UTC.",
@@ -491,6 +502,63 @@ final class ContextBucketPromptAssemblerTests: XCTestCase {
         "statement", "identifiers", "evidence_text", "evidence_refs", "confidence",
         "notify_worthiness",
       ])
+  }
+
+  /// The two fields the user actually reads were declared as bare strings, which
+  /// is how "Insight / PR blocked, needs review" got delivered. Their descriptions
+  /// are the schema half of the naming rule and are load-bearing: see the measured
+  /// numbers on `ContextProactivityPromptBuilder.directorStablePrompt`.
+  func testDirectorSchemaTellsTitleAndMessageToNameTheirReferent() throws {
+    let properties = try XCTUnwrap(ContextProactivityEngine.schema["properties"] as? [String: Any])
+    for field in ["title", "message"] {
+      let property = try XCTUnwrap(properties[field] as? [String: Any])
+      let description = try XCTUnwrap(
+        property["description"] as? String,
+        "\(field) reaches the user; it must not be an undescribed string")
+      XCTAssertFalse(description.isEmpty)
+      XCTAssertTrue(
+        description.contains("specific thing"),
+        "\(field) must be told to name the thing it is about, not its category")
+    }
+    // The fields that never reach the user stay undescribed: the description text
+    // rides the request on every call, so it is only bought where it changes what
+    // the user reads.
+    for field in ["decision", "reasoning", "bucket_entry_refs", "fact_ids"] {
+      let property = try XCTUnwrap(properties[field] as? [String: Any])
+      XCTAssertNil(property["description"], "\(field) is not user-visible")
+    }
+  }
+
+  /// The rule must ride the cached prefix, not the per-call suffix. Putting it
+  /// below the breakpoint would rewrite the uncached half on every call for no
+  /// benefit, and putting anything volatile beside it would break the prefix.
+  func testNamingRuleRidesTheCachedPrefixAndNotTheVolatileSuffix() throws {
+    let snapshot = ContextBucketSnapshot(
+      bucketID: "bucket-naming",
+      versionID: 9,
+      version: 4,
+      header: "ignored",
+      frozenRankedSegment: Data("- entry:naming-1 Pull request #4821 in nimbus-labs/ingest-suite.\n".utf8),
+      tail: ["entry:naming-2 A reviewer requested changes."],
+      validatedFacts: ["fact:naming-1 A pull request the user opened is blocked."],
+      notifyWorthiness: 0.9,
+      visitCount: 3)
+    let stable = ContextProactivityPromptBuilder.directorStablePrompt(snapshot: snapshot)
+    let volatilePrompt = ContextProactivityPromptBuilder.directorVolatilePrompt(
+      tasks: [],
+      frame: CapturedFrame(
+        jpegData: Data(), appName: "SyntheticBrowser",
+        windowTitle: "nimbus-labs/ingest-suite - Pull requests", frameNumber: 0,
+        captureTime: Date(timeIntervalSince1970: 1_786_000_000)),
+      visitCount: 3,
+      timeZone: TimeZone(identifier: "UTC") ?? .current)
+    let rule = "- The title is not a category. Never answer \"Insight\", \"Suggestion\", or \"Task\"."
+    XCTAssertTrue(stable.contains(rule))
+    XCTAssertFalse(volatilePrompt.contains(rule))
+    // Above the bucket, so a new bucket version cannot move the rule's bytes.
+    let rulePosition = try XCTUnwrap(stable.range(of: rule)).lowerBound
+    let bucketPosition = try XCTUnwrap(stable.range(of: "== BUCKET HEADER ==")).lowerBound
+    XCTAssertLessThan(rulePosition, bucketPosition)
   }
 
   func testCanonicalIdentifierSetKeyIsNormalizationOnlyAndKeepsDistinctSetsSeparate() {

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -340,6 +340,19 @@ final class ChatRowPresentationTests: XCTestCase {
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "task"), .task)
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "memory-extraction"), .memory)
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "goals"), .goal)
+    XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "meeting-notes"), .meetingNotes)
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Meeting notes")
+  }
+
+  func testNotificationJournalTextPreservesTheHeadlineAndBody() {
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Insight",
+        body: "PR blocked, needs review"),
+      "Insight\nPR blocked, needs review")
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(title: "Meeting notes ready", body: ""),
+      "Meeting notes ready")
   }
 
   func testAnOrdinaryReplyAndAUserTurnAreNotPushes() {

--- a/desktop/macos/Desktop/Tests/KernelJournalBackendReconcileTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelJournalBackendReconcileTests.swift
@@ -41,7 +41,7 @@ final class KernelJournalBackendReconcileTests: XCTestCase {
     XCTAssertNil(KernelJournalBackendSyncDriver.ReconcileRequest(payload: missingSession))
   }
 
-  func testReconcilePageDecodesCanonicalIdentityAndStructuredMetadata() throws {
+  func testReconcilePageDecodesCanonicalIdentityAndLegacyStructuredMetadata() throws {
     let data = Data(
       #"{"messages":[{"id":"turn-canonical","text":"I started an agent.","created_at":0,"sender":"ai","app_id":null,"session_id":"session-1","rating":null,"reported":false,"metadata":"{\"content_blocks\":[{\"type\":\"agent_spawn\"},{\"type\":\"agent_completion\",\"runId\":\"run-1\"}],\"resources\":[{\"id\":\"artifact-1\",\"type\":\"file\",\"name\":\"result.txt\"}]}","client_message_id":"turn-canonical","journal_revision":12}],"next_cursor":"turn-canonical","has_more":true}"#
         .utf8)
@@ -60,6 +60,20 @@ final class KernelJournalBackendReconcileTests: XCTestCase {
     XCTAssertTrue(rollbackProjection.contentBlocksJSON.contains("agent_completion"))
     XCTAssertTrue(rollbackProjection.resourcesJSON.contains("artifact-1"))
     XCTAssertEqual(rollbackProjection.canonicalTurnId, "turn-canonical")
+  }
+
+  func testReconcilePrefersFirstClassContentBlocksOverLegacyMetadata() throws {
+    let data = Data(
+      #"{"messages":[{"id":"turn-rich","text":"Meeting notes ready - Weekly planning","created_at":0,"sender":"ai","reported":false,"content_blocks":[{"type":"conversationLink","summary":"Weekly planning"}],"metadata":"{\"content_blocks\":[{\"type\":\"memoryLink\",\"summary\":\"Legacy\"}]}"}],"next_cursor":null,"has_more":false}"#
+        .utf8
+    )
+    let page = try JSONDecoder().decode(DesktopMessageReconcilePage.self, from: data)
+
+    XCTAssertTrue(page.messages[0].contentBlocksJSON?.contains("conversationLink") == true)
+    let projection = KernelJournalBackendSyncDriver.reconcileProjection(page.messages[0])
+    XCTAssertTrue(projection.contentBlocksJSON.contains("conversationLink"))
+    XCTAssertFalse(projection.contentBlocksJSON.contains("memoryLink"))
+    XCTAssertEqual(projection.content, "Meeting notes ready - Weekly planning")
   }
 
   func testReconcileRejectsOwnerChangeBeforeHTTP() async throws {

--- a/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
+++ b/desktop/macos/Desktop/Tests/KernelTurnRecordedProjectionTests.swift
@@ -1251,11 +1251,15 @@ import XCTest
         "journalRevision": 11,
         "text": "hello",
         "sender": "human",
+        "contentBlocks": [["type": "taskCard", "id": "task-1", "taskId": "task-1"]],
         "messageSource": "desktop_chat",
       ]
       XCTAssertEqual(KernelJournalBackendSyncDriver.Request(payload: valid)?.turnId, "turn-1")
       XCTAssertEqual(KernelJournalBackendSyncDriver.Request(payload: valid)?.ownerId, "owner-1")
       XCTAssertEqual(KernelJournalBackendSyncDriver.Request(payload: valid)?.journalRevision, 11)
+      XCTAssertTrue(
+        KernelJournalBackendSyncDriver.Request(payload: valid)?.contentBlocksJSON?.contains(
+          "taskCard") == true)
 
       var invalid = valid
       invalid["clientMessageId"] = "another-id"
@@ -1271,6 +1275,10 @@ import XCTest
 
       invalid = valid
       invalid["journalRevision"] = 0
+      XCTAssertNil(KernelJournalBackendSyncDriver.Request(payload: invalid))
+
+      invalid = valid
+      invalid["contentBlocks"] = "not-an-array"
       XCTAssertNil(KernelJournalBackendSyncDriver.Request(payload: invalid))
 
     }

--- a/desktop/macos/Desktop/Tests/MeetingActionItemBannerServiceTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingActionItemBannerServiceTests.swift
@@ -180,6 +180,13 @@ final class MeetingActionItemBannerServiceTests: XCTestCase {
     )
   }
 
+  func testSystemBannerOnlyDeliveryNeverPresentsOrJournalsThroughTheFloatingBar() {
+    XCTAssertFalse(NotificationDeliveryMode.systemBannerOnly.presentsInFloatingBar)
+    XCTAssertTrue(NotificationDeliveryMode.systemBannerOnly.requiresSystemBanner)
+    XCTAssertTrue(NotificationDeliveryMode.standard.presentsInFloatingBar)
+    XCTAssertFalse(NotificationDeliveryMode.standard.requiresSystemBanner)
+  }
+
   // MARK: - Fixtures
 
   private static func item(

--- a/desktop/macos/agent/src/runtime/backend-turn-projection.ts
+++ b/desktop/macos/agent/src/runtime/backend-turn-projection.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import type { ConversationTurn } from "./types.js";
+import { structuredTurnFallbackText } from "./content-block-fallback.js";
+import type { ConversationContentBlock, ConversationTurn } from "./types.js";
 
 const MAX_JOURNAL_REVISION = 2_147_483_647;
 
@@ -11,15 +12,16 @@ export interface BackendTurnPayload {
   sender: "human" | "ai";
   appId: string | null;
   sessionId: string | null;
+  contentBlocks: ConversationContentBlock[];
   metadata: string | null;
   messageSource: "desktop_chat" | "realtime_voice";
 }
 
 export function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
   const metadata = parseObjectJson(turn.metadataJson);
+  const { content_blocks: _legacyContentBlocks, ...messageMetadata } = metadata;
   const backendMetadata = {
-    ...metadata,
-    ...(turn.contentBlocks.length > 0 ? { content_blocks: turn.contentBlocks } : {}),
+    ...messageMetadata,
     ...(turn.resources.length > 0 ? { resources: turn.resources } : {}),
   };
   const projectedText = turn.content.trim()
@@ -27,7 +29,7 @@ export function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
     : turn.role === "assistant"
       && turn.status === "completed"
       && (turn.contentBlocks.length > 0 || turn.resources.length > 0)
-      ? "Done."
+      ? structuredTurnFallbackText(turn.contentBlocks, turn.resources)
       : "";
   return {
     turnId: turn.turnId,
@@ -37,6 +39,7 @@ export function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
     sender: turn.role === "user" ? "human" : "ai",
     appId: typeof metadata.appId === "string" ? metadata.appId : null,
     sessionId: typeof metadata.sessionId === "string" ? metadata.sessionId : null,
+    contentBlocks: turn.contentBlocks,
     metadata: Object.keys(backendMetadata).length === 0 ? null : stableJson(backendMetadata),
     messageSource: turn.origin === "realtime_voice" ? "realtime_voice" : "desktop_chat",
   };

--- a/desktop/macos/agent/src/runtime/content-block-fallback.ts
+++ b/desktop/macos/agent/src/runtime/content-block-fallback.ts
@@ -1,0 +1,67 @@
+import type { ConversationContentBlock, ConversationResource } from "./types.js";
+
+const MAX_BACKEND_MESSAGE_TEXT_LENGTH = 100_000;
+
+/**
+ * Human-readable degradation contract for every structured chat block.
+ *
+ * Keeping this switch exhaustive makes a new block type a compile error until
+ * its unaware-client representation is defined. The rich desktop renderer
+ * still consumes the structured block; this text is the canonical fallback
+ * carried by the ordinary message field for every other client.
+ */
+export function contentBlockFallbackText(block: ConversationContentBlock): string {
+  switch (block.type) {
+    case "text":
+      return nonEmptyText(block.text, "Message");
+    case "toolCall":
+      return labelledText("Tool", block.name, block.output ?? block.inputSummary);
+    case "thinking":
+      return labelledText("Thinking", block.text);
+    case "discoveryCard":
+      return labelledText("Discovery", block.title, block.summary);
+    case "questionCard":
+      return nonEmptyText(block.text, "Question");
+    case "taskCard":
+      return "Task";
+    case "goalLink":
+      return labelledText("Goal", block.summary);
+    case "captureLink":
+      return labelledText("Capture", block.summary);
+    case "conversationLink":
+      return labelledText("Meeting notes ready", block.summary);
+    case "memoryLink":
+      return labelledText("Memory", block.summary);
+    case "citation":
+      return labelledText("Source", block.title, block.preview);
+    case "agentSpawn":
+      return labelledText("Agent started", block.title, block.objective);
+    case "agentCompletion":
+      return labelledText("Agent completed", block.title, block.output);
+    default: {
+      const exhaustive: never = block;
+      return exhaustive;
+    }
+  }
+}
+
+export function structuredTurnFallbackText(
+  blocks: readonly ConversationContentBlock[],
+  resources: readonly ConversationResource[],
+): string {
+  const lines = blocks.map(contentBlockFallbackText);
+  lines.push(...resources.map((resource) => labelledText("Attachment", resource.title)));
+  return lines.join("\n").slice(0, MAX_BACKEND_MESSAGE_TEXT_LENGTH).trim();
+}
+
+function labelledText(label: string, ...parts: Array<string | undefined>): string {
+  const detail = parts
+    .map((part) => part?.trim() ?? "")
+    .filter((part, index, values) => part.length > 0 && values.indexOf(part) === index)
+    .join(" - ");
+  return detail ? `${label} - ${detail}` : label;
+}
+
+function nonEmptyText(value: string, fallback: string): string {
+  return value.trim() || fallback;
+}

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { structuredTurnFallbackText } from "./content-block-fallback.js";
 import { conversationTurnFromRow } from "./conversation-turns.js";
 import { generateAgentId } from "./sqlite-store.js";
 import type {
@@ -284,6 +285,7 @@ export interface BackendTurnPayload {
   sender: "human" | "ai";
   appId: string | null;
   sessionId: string | null;
+  contentBlocks: ConversationContentBlock[];
   metadata: string | null;
   messageSource: "desktop_chat" | "realtime_voice";
 }
@@ -4120,8 +4122,7 @@ function journalTurnPayloadHash(value: Record<string, unknown>): string {
 
 function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
   const metadata = parseObjectJson(turn.metadataJson) as Record<string, unknown>;
-  const isChatFirstMaterialization = typeof metadata.chatFirstIntentId === "string"
-    && metadata.chatFirstIntentId.length > 0;
+  const { content_blocks: _legacyContentBlocks, ...messageMetadata } = metadata;
   // Rewind evidence is a device-local journal resource. The backend receives
   // enough metadata to preserve the card, but never the user's absolute local
   // filesystem path. Same-device reconciliation keeps the authoritative local
@@ -4134,18 +4135,15 @@ function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
     return pathless;
   });
   const backendMetadata = {
-    ...metadata,
-    ...(turn.contentBlocks.length > 0 ? { content_blocks: turn.contentBlocks } : {}),
+    ...messageMetadata,
     ...(backendResources.length > 0 ? { resources: backendResources } : {}),
   };
   const projectedText = turn.content.trim()
     ? turn.content
-    : isChatFirstMaterialization
-      ? ""
     : turn.role === "assistant"
       && turn.status === "completed"
       && (turn.contentBlocks.length > 0 || turn.resources.length > 0)
-      ? "Done."
+      ? structuredTurnFallbackText(turn.contentBlocks, backendResources)
       : "";
   return {
     turnId: turn.turnId,
@@ -4155,6 +4153,7 @@ function backendTurnPayload(turn: ConversationTurn): BackendTurnPayload {
     sender: turn.role === "user" ? "human" : "ai",
     appId: typeof metadata.appId === "string" ? metadata.appId : null,
     sessionId: typeof metadata.sessionId === "string" ? metadata.sessionId : null,
+    contentBlocks: turn.contentBlocks,
     metadata: Object.keys(backendMetadata).length === 0 ? null : stableJson(backendMetadata),
     messageSource: turn.origin === "realtime_voice" ? "realtime_voice" : "desktop_chat",
   };
@@ -4170,18 +4169,6 @@ function boundedJournalRevision(revision: number): number {
 function backendTombstoneCode(turn: ConversationTurn): string | null {
   const payload = backendTurnPayload(turn);
   if (payload.text.trim()) return null;
-  const metadata = parseObjectJson(turn.metadataJson) as Record<string, unknown>;
-  if (
-    turn.role === "assistant"
-    && turn.status === "completed"
-    && typeof metadata.chatFirstIntentId === "string"
-    && metadata.chatFirstIntentId.length > 0
-    && turn.contentBlocks.length > 0
-  ) {
-    // The canonical structured blocks are the content. This must still use
-    // the normal reconciliation outbox, just without fabricating "Done.".
-    return null;
-  }
   if (turn.status === "failed") return "empty_failed_turn_cancelled";
   if (turn.status === "completed") return "empty_completed_turn_cancelled";
   return null;

--- a/desktop/macos/agent/src/runtime/conversation-journal.ts
+++ b/desktop/macos/agent/src/runtime/conversation-journal.ts
@@ -3725,13 +3725,30 @@ function chatFirstIntentBlocks(
           summary: nonEmptyString(block.summary, "chat-first capture summary"),
         };
       }
-      case "conversationLink":
+      case "conversationLink": {
+        const recommendedActionItems = block.recommended_action_items === undefined
+          ? []
+          : arrayValue(block.recommended_action_items, "chat-first recommended action items").map((rawItem) => {
+            const item = recordValue(rawItem, "chat-first recommended action item");
+            const taskId = item.task_id === undefined || item.task_id === null
+              ? undefined
+              : nonEmptyString(item.task_id, "chat-first recommended action item task ID");
+            return {
+              description: nonEmptyString(
+                item.description,
+                "chat-first recommended action item description",
+              ),
+              ...(taskId === undefined ? {} : { taskId }),
+            };
+          });
         return {
           type,
           id,
           conversationId: nonEmptyString(block.conversation_id, "chat-first conversation ID"),
           summary: nonEmptyString(block.summary, "chat-first conversation summary"),
+          recommendedActionItems,
         };
+      }
       default:
         throw new Error("Chat-first intent block type is invalid");
     }
@@ -3887,7 +3904,18 @@ function boundedOutboxError(errorCode?: string): string {
 
 function validateContentBlocks(blocks: readonly ConversationContentBlock[]): ConversationContentBlock[] {
   const ids = new Set<string>();
-  return blocks.map((block) => {
+  return blocks.map((rawBlock) => {
+    // Persisted cards from before action-item recommendations omit this key.
+    // Normalize that legacy shape here while keeping it required for every new
+    // TypeScript producer through ConversationContentBlock.
+    const block: ConversationContentBlock = rawBlock.type === "conversationLink"
+      ? {
+          ...rawBlock,
+          recommendedActionItems: Array.isArray(rawBlock.recommendedActionItems)
+            ? rawBlock.recommendedActionItems
+            : [],
+        }
+      : rawBlock;
     const id = nonEmpty(block.id, "content block id");
     nonEmpty(block.type, "content block type");
     if (ids.has(id)) throw new Error(`Duplicate content block ID ${id}`);
@@ -3943,6 +3971,15 @@ function validateContentBlocks(blocks: readonly ConversationContentBlock[]): Con
       nonEmpty(block.conversationId, "conversation ID");
       if (block.summary.length === 0 || block.summary.length > 200) {
         throw new Error("Conversation summary is out of bounds");
+      }
+      if (block.recommendedActionItems.length > 8) {
+        throw new Error("Conversation recommended action item count is out of bounds");
+      }
+      for (const item of block.recommendedActionItems) {
+        if (item.description.length === 0 || item.description.length > 300) {
+          throw new Error("Conversation recommended action item description is out of bounds");
+        }
+        if (item.taskId !== undefined) nonEmpty(item.taskId, "recommended action item task ID");
       }
     }
     return structuredClone(block);

--- a/desktop/macos/agent/src/runtime/types.ts
+++ b/desktop/macos/agent/src/runtime/types.ts
@@ -123,7 +123,13 @@ export type ConversationContentBlock =
   | { type: "taskCard"; id: string; taskId: string }
   | { type: "goalLink"; id: string; goalId: string; summary: string }
   | { type: "captureLink"; id: string; conversationId: string; momentTimestampMs?: number; summary: string }
-  | { type: "conversationLink"; id: string; conversationId: string; summary: string }
+  | {
+      type: "conversationLink";
+      id: string;
+      conversationId: string;
+      summary: string;
+      recommendedActionItems: Array<{ description: string; taskId?: string }>;
+    }
   | { type: "memoryLink"; id: string; memoryId: string; summary: string }
   | {
       type: "citation";

--- a/desktop/macos/agent/tests/content-block-fallback.test.ts
+++ b/desktop/macos/agent/tests/content-block-fallback.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { contentBlockFallbackText } from "../src/runtime/content-block-fallback.js";
+import type { ConversationContentBlock } from "../src/runtime/types.js";
+
+describe("structured chat fallback text", () => {
+  it("derives the meeting headline from the conversation block", () => {
+    expect(contentBlockFallbackText({
+      type: "conversationLink",
+      id: "meeting-1",
+      conversationId: "conversation-1",
+      summary: "Founders explore AI memory",
+      recommendedActionItems: [],
+    })).toBe("Meeting notes ready - Founders explore AI memory");
+  });
+
+  it("keeps every content-block variant non-empty for unaware clients", () => {
+    const blocks: ConversationContentBlock[] = [
+      { type: "text", id: "1", text: "" },
+      { type: "toolCall", id: "2", name: "search", status: "completed" },
+      { type: "thinking", id: "3", text: "" },
+      { type: "discoveryCard", id: "4", title: "Result", summary: "Summary", fullText: "Full" },
+      {
+        type: "questionCard", id: "5", questionId: "question-1", text: "Choose?",
+        subject: { kind: "goal", id: "goal-1" },
+        options: [{ optionId: "yes", label: "Yes", preparedAnswer: "Yes" }],
+      },
+      { type: "taskCard", id: "6", taskId: "task-1" },
+      { type: "goalLink", id: "7", goalId: "goal-1", summary: "Ship it" },
+      { type: "captureLink", id: "8", conversationId: "capture-1", summary: "Capture" },
+      {
+        type: "conversationLink", id: "9", conversationId: "meeting-1", summary: "Meeting",
+        recommendedActionItems: [],
+      },
+      { type: "memoryLink", id: "10", memoryId: "memory-1", summary: "Preference" },
+      { type: "citation", id: "11", ordinal: 1, kind: "web", sourceId: "source-1" },
+      {
+        type: "agentSpawn", id: "12", sessionId: "session-1", runId: "run-1",
+        title: "Research", objective: "Find evidence",
+      },
+      {
+        type: "agentCompletion", id: "13", title: "Research", promptSnippet: "Find",
+        output: "Found evidence", status: "succeeded",
+      },
+    ];
+
+    expect(blocks.map(contentBlockFallbackText).every((text) => text.trim().length > 0)).toBe(true);
+  });
+});

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -154,6 +154,29 @@ describe("kernel conversation journal", () => {
       duplicate: false,
       receipt: { intentId: "intent-meeting" },
     });
+    const [delivery] = drainBackendTurnOutbox(fixture.store, {
+      ownerId: fixture.ownerId,
+      nowMs: 100,
+    });
+    expect(delivery.payload).toMatchObject({
+      text: "Meeting notes ready - Weekly planning",
+      contentBlocks: [{
+        type: "conversationLink",
+        conversationId: "conversation-1",
+      }],
+    });
+    expect(delivery.payload.metadata).not.toContain("content_blocks");
+    failBackendTurnOutbox(fixture.store, {
+      ownerId: fixture.ownerId,
+      turnId: delivery.turnId,
+      deliveryGeneration: delivery.deliveryGeneration,
+      attemptCount: delivery.attemptCount,
+      conversationGeneration: delivery.conversationGeneration,
+      payloadHash: delivery.payloadHash,
+      errorCode: "test_retry",
+      retryAtMs: 101,
+      nowMs: 100,
+    });
     const duplicate = materializeChatFirstIntent(fixture.store, {
       ownerId: fixture.ownerId,
       conversationId: fixture.conversationId,
@@ -212,8 +235,9 @@ describe("kernel conversation journal", () => {
     ]);
     const deliveries = drainBackendTurnOutbox(fixture.store, { ownerId: fixture.ownerId, nowMs: 103 });
     expect(deliveries).toHaveLength(2);
-    expect(deliveries.map((delivery) => delivery.payload.text)).toEqual(["", ""]);
-    expect(deliveries.every((delivery) => delivery.payload.metadata?.includes("content_blocks"))).toBe(true);
+    expect(deliveries.map((delivery) => delivery.payload.text)).toEqual(["Task", "Continue?"]);
+    expect(deliveries.every((delivery) => delivery.payload.contentBlocks.length === 1)).toBe(true);
+    expect(deliveries.every((delivery) => !delivery.payload.metadata?.includes("content_blocks"))).toBe(true);
 
     fixture.store.close();
   });
@@ -3808,9 +3832,9 @@ describe("kernel conversation journal", () => {
     const [delivery] = drainBackendTurnOutbox(fixture.store, { nowMs: 92 });
     expect(delivery).toMatchObject({
       turnId: "turn-structured",
-      payload: { text: "Done.", sender: "ai" },
+      payload: { text: "Thinking - finished", sender: "ai", contentBlocks: [block] },
     });
-    expect(JSON.parse(delivery.payload.metadata!)).toMatchObject({ content_blocks: [block] });
+    expect(delivery.payload.metadata).toBeNull();
     expect(delivery.payloadHash).toMatch(/^sha256:[a-f0-9]{64}$/);
     fixture.store.close();
   });

--- a/desktop/macos/agent/tests/conversation-journal.test.ts
+++ b/desktop/macos/agent/tests/conversation-journal.test.ts
@@ -130,6 +130,10 @@ describe("kernel conversation journal", () => {
         type: "conversationLink",
         conversation_id: "conversation-1",
         summary: "Weekly planning",
+        recommended_action_items: [
+          { description: "Send the deck", task_id: "task-1" },
+          { description: "Book the follow-up" },
+        ],
       }],
       nowMs: 100,
     });
@@ -139,6 +143,10 @@ describe("kernel conversation journal", () => {
       id: expect.any(String),
       conversationId: "conversation-1",
       summary: "Weekly planning",
+      recommendedActionItems: [
+        { description: "Send the deck", taskId: "task-1" },
+        { description: "Book the follow-up" },
+      ],
     }]);
     expect(result.turn?.conversationId).toBe(fixture.conversationId);
     expect(result).toMatchObject({
@@ -157,6 +165,10 @@ describe("kernel conversation journal", () => {
         type: "conversationLink",
         conversation_id: "conversation-1",
         summary: "Weekly planning",
+        recommended_action_items: [
+          { description: "Send the deck", task_id: "task-1" },
+          { description: "Book the follow-up" },
+        ],
       }],
       nowMs: 101,
     });

--- a/desktop/macos/changelog/unreleased/20260818-proactive-notification-names-its-referent.json
+++ b/desktop/macos/changelog/unreleased/20260818-proactive-notification-names-its-referent.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive notifications now name what they are about — the pull request, the email thread and sender, the document, the file, the meeting — instead of arriving as an unidentifiable \"PR blocked, needs review\""
+}

--- a/desktop/macos/e2e/fixtures/context-bucket-proactivity-benchmark.json
+++ b/desktop/macos/e2e/fixtures/context-bucket-proactivity-benchmark.json
@@ -1339,6 +1339,542 @@
       "expectedMaxAge": 0,
       "forbidden": ["resurface_completed_commitment", "create_followup_without_source", "notify_from_completion_receipt"],
       "rootCauseLabel": "commitment_already_completed"
+    },
+    {
+      "id": "referent-pull-request",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-pr-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-pr-001",
+          "workstreamId": "workstream-ingest",
+          "displayLabel": "Synthetic pull request review",
+          "version": 4,
+          "notifyWorthiness": 0.86,
+          "entries": [
+            {
+              "id": "entry-referent-pr-001",
+              "reference": "entry:referent:pr-001",
+              "appName": "SyntheticBrowser",
+              "contextKey": "web:pull-request-4821",
+              "narrative": "The user opened pull request #4821, \"Add a retry budget to the ingest lane\", in the nimbus-labs/ingest-suite repository and has been iterating on it across visits.",
+              "evidenceRefs": ["evidence:referent:pr-open"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-pr-002",
+              "reference": "entry:referent:pr-002",
+              "appName": "SyntheticBrowser",
+              "contextKey": "web:pull-request-4821",
+              "narrative": "Review activity arrived on that pull request after the user moved on to the repository's pull-request list.",
+              "evidenceRefs": ["evidence:referent:pr-blocked"],
+              "facts": [
+                {
+                  "id": "fact-referent-pr-blocked",
+                  "statement": "A pull request the user opened is blocked: a reviewer requested changes and one required check is failing.",
+                  "validityState": "validated",
+                  "confidence": 0.95,
+                  "notifyWorthiness": 0.86,
+                  "expiresAt": "2026-08-13T23:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-pr-001",
+            "capturedAt": "2026-08-13T16:20:00Z",
+            "appName": "SyntheticBrowser",
+            "windowTitle": "nimbus-labs/ingest-suite - Pull requests",
+            "contextKey": "web:ingest-suite-pull-requests",
+            "textSummary": "A list of open pull requests; no individual review thread is open."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "notify",
+      "expectedEvidenceRefs": ["evidence:referent:pr-blocked"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-pr-001",
+        "workstreamId": "workstream-ingest"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["#4821", "4821", "nimbus-labs/ingest-suite", "ingest-suite", "retry budget", "retry-budget"],
+      "forbidden": ["notify_without_validated_fact", "speak_without_naming_the_referent", "invent_an_identifier"],
+      "rootCauseLabel": "blocked_pull_request_named_only_in_narrative"
+    },
+    {
+      "id": "referent-email-thread",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-mail-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-mail-001",
+          "workstreamId": "workstream-renewals",
+          "displayLabel": "Synthetic renewal email thread",
+          "version": 4,
+          "notifyWorthiness": 0.84,
+          "entries": [
+            {
+              "id": "entry-referent-mail-001",
+              "reference": "entry:referent:mail-001",
+              "appName": "SyntheticMail",
+              "contextKey": "mail:thread-renewal-q3",
+              "narrative": "The user has been reading an email thread titled \"Q3 renewal terms\" from Marcus Chen about seat counts for the coming quarter.",
+              "evidenceRefs": ["evidence:referent:mail-thread"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-mail-002",
+              "reference": "entry:referent:mail-002",
+              "appName": "SyntheticMail",
+              "contextKey": "mail:inbox",
+              "narrative": "The user returned to the inbox without answering that thread's newest message.",
+              "evidenceRefs": ["evidence:referent:mail-unanswered"],
+              "facts": [
+                {
+                  "id": "fact-referent-mail-unanswered",
+                  "statement": "An email thread is waiting on a reply from the user, and the sender asked for the answer before Friday.",
+                  "validityState": "validated",
+                  "confidence": 0.93,
+                  "notifyWorthiness": 0.84,
+                  "expiresAt": "2026-08-14T23:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-mail-001",
+            "capturedAt": "2026-08-13T16:25:00Z",
+            "appName": "SyntheticMail",
+            "windowTitle": "Inbox - SyntheticMail",
+            "contextKey": "mail:inbox",
+            "textSummary": "A message list; no thread is open in the reading pane."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "notify",
+      "expectedEvidenceRefs": ["evidence:referent:mail-unanswered"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-mail-001",
+        "workstreamId": "workstream-renewals"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["Q3 renewal", "Marcus", "seat count", "seat-count"],
+      "forbidden": ["notify_without_validated_fact", "speak_without_naming_the_referent", "invent_a_sender"],
+      "rootCauseLabel": "unanswered_thread_named_only_in_narrative"
+    },
+    {
+      "id": "referent-document-comment",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-doc-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-doc-001",
+          "workstreamId": "workstream-pricing",
+          "displayLabel": "Synthetic pricing document",
+          "version": 4,
+          "notifyWorthiness": 0.81,
+          "entries": [
+            {
+              "id": "entry-referent-doc-001",
+              "reference": "entry:referent:doc-001",
+              "appName": "SyntheticDocs",
+              "contextKey": "doc:nimbus-pricing-one-pager",
+              "narrative": "The user has been editing the \"Nimbus pricing one-pager\", most recently the migration-discount table.",
+              "evidenceRefs": ["evidence:referent:doc-edit"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-doc-002",
+              "reference": "entry:referent:doc-002",
+              "appName": "SyntheticDocs",
+              "contextKey": "doc:workspace-recent",
+              "narrative": "Dana Whitfield left a comment on that document asking which tier the migration discount applies to, and it is still unresolved.",
+              "evidenceRefs": ["evidence:referent:doc-comment"],
+              "facts": [
+                {
+                  "id": "fact-referent-doc-comment",
+                  "statement": "A shared document has an unresolved comment addressed to the user, asking a question the user has not answered.",
+                  "validityState": "validated",
+                  "confidence": 0.91,
+                  "notifyWorthiness": 0.81,
+                  "expiresAt": "2026-08-14T20:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-doc-001",
+            "capturedAt": "2026-08-13T16:30:00Z",
+            "appName": "SyntheticDocs",
+            "windowTitle": "Nimbus workspace - Recent",
+            "contextKey": "doc:workspace-recent",
+            "textSummary": "A list of recently opened documents; none is open for editing."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "notify",
+      "expectedEvidenceRefs": ["evidence:referent:doc-comment"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-doc-001",
+        "workstreamId": "workstream-pricing"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["Nimbus pricing one-pager", "Nimbus pricing", "Dana", "migration discount", "migration-discount"],
+      "forbidden": ["notify_without_validated_fact", "speak_without_naming_the_referent", "invent_a_commenter"],
+      "rootCauseLabel": "unresolved_comment_named_only_in_narrative"
+    },
+    {
+      "id": "referent-person-request",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-chat-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-chat-001",
+          "workstreamId": "workstream-audit",
+          "displayLabel": "Synthetic direct message request",
+          "version": 4,
+          "notifyWorthiness": 0.88,
+          "entries": [
+            {
+              "id": "entry-referent-chat-001",
+              "reference": "entry:referent:chat-001",
+              "appName": "SyntheticChat",
+              "contextKey": "chat:dm-audit-vendor-list",
+              "narrative": "Aisha Okonkwo sent the user a direct message asking for the approved vendor list for the Halden audit before the 15:00 review.",
+              "evidenceRefs": ["evidence:referent:chat-dm"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-chat-002",
+              "reference": "entry:referent:chat-002",
+              "appName": "SyntheticChat",
+              "contextKey": "chat:channel-eng-general",
+              "narrative": "The user switched to a team channel without answering that direct message.",
+              "evidenceRefs": ["evidence:referent:chat-unanswered"],
+              "facts": [
+                {
+                  "id": "fact-referent-chat-unanswered",
+                  "statement": "Someone asked the user by direct message to send a document before a stated time, and that time has now passed.",
+                  "validityState": "validated",
+                  "confidence": 0.94,
+                  "notifyWorthiness": 0.88,
+                  "expiresAt": "2026-08-13T22:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-chat-001",
+            "capturedAt": "2026-08-13T16:35:00Z",
+            "appName": "SyntheticChat",
+            "windowTitle": "SyntheticChat - #eng-general",
+            "contextKey": "chat:channel-eng-general",
+            "textSummary": "A busy team channel; the direct-message thread is not open."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "notify",
+      "expectedEvidenceRefs": ["evidence:referent:chat-unanswered"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-chat-001",
+        "workstreamId": "workstream-audit"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["Aisha", "vendor list", "Halden"],
+      "forbidden": ["notify_without_validated_fact", "speak_without_naming_the_referent", "invent_a_requester"],
+      "rootCauseLabel": "person_request_named_only_in_narrative"
+    },
+    {
+      "id": "referent-meeting-conflict",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-cal-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-cal-001",
+          "workstreamId": "workstream-ingest",
+          "displayLabel": "Synthetic calendar conflict",
+          "version": 4,
+          "notifyWorthiness": 0.83,
+          "entries": [
+            {
+              "id": "entry-referent-cal-001",
+              "reference": "entry:referent:cal-001",
+              "appName": "SyntheticCalendar",
+              "contextKey": "cal:week-2026-08-10",
+              "narrative": "The user's week holds a \"Nimbus kickoff\" on Thursday at 15:00 and an \"Ingest retry design review\" with Tomas Iglesias at the same hour.",
+              "evidenceRefs": ["evidence:referent:cal-week"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-cal-002",
+              "reference": "entry:referent:cal-002",
+              "appName": "SyntheticCalendar",
+              "contextKey": "cal:day-2026-08-12",
+              "narrative": "The user moved to Wednesday's day view, where neither of those blocks is drawn.",
+              "evidenceRefs": ["evidence:referent:cal-overlap"],
+              "facts": [
+                {
+                  "id": "fact-referent-cal-overlap",
+                  "statement": "Two scheduled meetings later this week start at the same time and the user is expected at both.",
+                  "validityState": "validated",
+                  "confidence": 0.92,
+                  "notifyWorthiness": 0.83,
+                  "expiresAt": "2026-08-14T12:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-cal-001",
+            "capturedAt": "2026-08-13T16:40:00Z",
+            "appName": "SyntheticCalendar",
+            "windowTitle": "Day view - Wednesday, Aug 12",
+            "contextKey": "cal:day-2026-08-12",
+            "textSummary": "A single day's schedule; later days are not shown."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "notify",
+      "expectedEvidenceRefs": ["evidence:referent:cal-overlap"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-cal-001",
+        "workstreamId": "workstream-ingest"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["Nimbus kickoff", "Ingest retry design review", "Tomas", "Thursday"],
+      "forbidden": ["notify_without_validated_fact", "speak_without_naming_the_referent", "invent_an_attendee"],
+      "rootCauseLabel": "calendar_conflict_named_only_in_narrative"
+    },
+    {
+      "id": "referent-file-build-failure",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-build-001",
+          "subjectKind": "task",
+          "subjectId": "task-referent-build-001",
+          "workstreamId": "workstream-ingest",
+          "displayLabel": "Synthetic build failure",
+          "version": 4,
+          "notifyWorthiness": 0.85,
+          "entries": [
+            {
+              "id": "entry-referent-build-001",
+              "reference": "entry:referent:build-001",
+              "appName": "SyntheticTerminal",
+              "contextKey": "shell:ingest-suite-tests",
+              "narrative": "The user has been running the ingest-suite tests on branch feat/ingest-retry, which exercise decode_frame in packages/ingest/parser.rs.",
+              "evidenceRefs": ["evidence:referent:build-branch"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-build-002",
+              "reference": "entry:referent:build-002",
+              "appName": "SyntheticTerminal",
+              "contextKey": "shell:ingest-suite-editor",
+              "narrative": "The most recent run of those tests panicked in that function, and the user moved back to editing without rerunning them.",
+              "evidenceRefs": ["evidence:referent:build-panic"],
+              "facts": [
+                {
+                  "id": "fact-referent-build-panic",
+                  "statement": "The test run for the user's tracked branch fails reproducibly with a panic, and the failure is unaddressed.",
+                  "validityState": "validated",
+                  "confidence": 0.93,
+                  "notifyWorthiness": 0.85,
+                  "expiresAt": "2026-08-13T23:30:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-build-001",
+            "capturedAt": "2026-08-13T16:45:00Z",
+            "appName": "SyntheticTerminal",
+            "windowTitle": "ingest-suite - editor",
+            "contextKey": "shell:ingest-suite-editor",
+            "textSummary": "A source editor; no test output is visible."
+          }
+        ],
+        "tasks": [
+          {
+            "id": "task-referent-build-001",
+            "description": "Land the ingest retry budget",
+            "status": "open",
+            "dueAt": "2026-08-13T18:00:00Z",
+            "subjectId": "task-referent-build-001"
+          }
+        ]
+      },
+      "expectedAction": "notify",
+      "expectedEvidenceRefs": ["evidence:referent:build-panic"],
+      "expectedSubject": {
+        "kind": "task",
+        "id": "task-referent-build-001",
+        "workstreamId": "workstream-ingest"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["feat/ingest-retry", "ingest-retry", "parser.rs", "packages/ingest", "decode_frame"],
+      "forbidden": ["notify_without_validated_fact", "speak_without_naming_the_referent", "invent_a_fix"],
+      "rootCauseLabel": "build_failure_named_only_in_narrative"
+    },
+    {
+      "id": "referent-visible-on-screen",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-visible-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-visible-001",
+          "workstreamId": "workstream-ingest",
+          "displayLabel": "Synthetic pull request already open",
+          "version": 4,
+          "notifyWorthiness": 0.86,
+          "entries": [
+            {
+              "id": "entry-referent-visible-001",
+              "reference": "entry:referent:visible-001",
+              "appName": "SyntheticBrowser",
+              "contextKey": "web:pull-request-4821",
+              "narrative": "The user opened pull request #4821, \"Add a retry budget to the ingest lane\", in the nimbus-labs/ingest-suite repository.",
+              "evidenceRefs": ["evidence:referent:visible-open"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-visible-002",
+              "reference": "entry:referent:visible-002",
+              "appName": "SyntheticBrowser",
+              "contextKey": "web:pull-request-4821",
+              "narrative": "The user is reading the review thread on that pull request right now.",
+              "evidenceRefs": ["evidence:referent:visible-blocked"],
+              "facts": [
+                {
+                  "id": "fact-referent-visible-blocked",
+                  "statement": "A pull request the user opened is blocked: a reviewer requested changes and one required check is failing.",
+                  "validityState": "validated",
+                  "confidence": 0.95,
+                  "notifyWorthiness": 0.86,
+                  "expiresAt": "2026-08-13T23:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-visible-001",
+            "capturedAt": "2026-08-13T16:50:00Z",
+            "appName": "SyntheticBrowser",
+            "windowTitle": "Add a retry budget to the ingest lane by dazheng - Pull Request #4821 - nimbus-labs/ingest-suite",
+            "contextKey": "web:pull-request-4821",
+            "textSummary": "The review thread and the failing check are both on screen."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "silence",
+      "expectedEvidenceRefs": ["evidence:referent:visible-blocked"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-visible-001",
+        "workstreamId": "workstream-ingest"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": ["#4821", "4821", "nimbus-labs/ingest-suite", "ingest-suite", "retry budget"],
+      "forbidden": ["notify_about_what_is_already_on_screen", "speak_without_naming_the_referent"],
+      "rootCauseLabel": "referent_is_on_screen_so_silence_is_correct"
+    },
+    {
+      "id": "referent-no-identifier",
+      "category": "referent_identifiability",
+      "synthetic": {
+        "bucket": {
+          "id": "bucket-referent-none-001",
+          "subjectKind": "context",
+          "subjectId": "context-referent-none-001",
+          "workstreamId": "workstream-ingest",
+          "displayLabel": "Synthetic context with no handle",
+          "version": 4,
+          "notifyWorthiness": 0.84,
+          "entries": [
+            {
+              "id": "entry-referent-none-001",
+              "reference": "entry:referent:none-001",
+              "appName": "SyntheticBrowser",
+              "contextKey": "web:pull-request-unnamed",
+              "narrative": "The user has been iterating on a pull request across several visits.",
+              "evidenceRefs": ["evidence:referent:none-open"],
+              "facts": []
+            },
+            {
+              "id": "entry-referent-none-002",
+              "reference": "entry:referent:none-002",
+              "appName": "SyntheticBrowser",
+              "contextKey": "web:pull-requests",
+              "narrative": "Review activity arrived on it after the user moved on.",
+              "evidenceRefs": ["evidence:referent:none-blocked"],
+              "facts": [
+                {
+                  "id": "fact-referent-none-blocked",
+                  "statement": "A pull request the user opened is blocked: a reviewer requested changes and one required check is failing.",
+                  "validityState": "validated",
+                  "confidence": 0.95,
+                  "notifyWorthiness": 0.84,
+                  "expiresAt": "2026-08-13T23:00:00Z"
+                }
+              ]
+            }
+          ]
+        },
+        "frames": [
+          {
+            "id": "frame-referent-none-001",
+            "capturedAt": "2026-08-13T16:55:00Z",
+            "appName": "SyntheticBrowser",
+            "windowTitle": "Pull requests",
+            "contextKey": "web:pull-requests",
+            "textSummary": "A list of open pull requests with no repository or number legible."
+          }
+        ],
+        "tasks": []
+      },
+      "expectedAction": "either",
+      "expectedEvidenceRefs": ["evidence:referent:none-blocked"],
+      "expectedSubject": {
+        "kind": "context",
+        "id": "context-referent-none-001",
+        "workstreamId": "workstream-ingest"
+      },
+      "expectedMaxAge": 21600,
+      "referentTokens": [],
+      "forbidden": ["invent_an_identifier", "notify_without_validated_fact"],
+      "rootCauseLabel": "no_identifier_exists_so_none_may_be_invented"
     }
   ]
 }

--- a/desktop/macos/scripts/context-bucket-benchmark.py
+++ b/desktop/macos/scripts/context-bucket-benchmark.py
@@ -4,6 +4,13 @@
 This is an offline contract gate. It does not call a model or read local user
 data; it proves every director-owned fixture maps to the DEBUG probe ABI and
 keeps lifecycle-only cases explicitly separated.
+
+`--invoke` additionally replays the deck through the DEBUG probe on a running
+named QA bundle. There it scores referent identifiability: a case may declare
+`referentTokens`, the identifying strings its own synthetic context supplies,
+and a spoken decision whose title and message contain none of them fails as
+`unnamed_referent`. `reasoning` is excluded on purpose -- the user never sees
+it, so it cannot be what makes a notification identifiable.
 """
 
 from __future__ import annotations
@@ -35,7 +42,21 @@ DIRECTOR_CASES = {
     "privacy-sensitive-frame-not-evidence",
     "commitment-explicit-due-date",
     "commitment-ambiguous-mention",
+    "referent-pull-request",
+    "referent-email-thread",
+    "referent-document-comment",
+    "referent-person-request",
+    "referent-meeting-conflict",
+    "referent-file-build-failure",
+    "referent-visible-on-screen",
+    "referent-no-identifier",
 }
+
+# Cases whose point is that a spoken message must name the thing it is about.
+# Each declares `referentTokens`: the identifying strings its own synthetic
+# context supplies. A notification that contains none of them is unusable —
+# the user cannot tell which pull request, which thread, which document.
+REFERENT_CASES = {case for case in DIRECTOR_CASES if case.startswith("referent-")}
 
 STABLE_PROACTIVE_ERROR = re.compile(r"\bproactive_(?:http_error status=\d{3}|invalid_response|owner_changed)\b")
 DIRECTOR_DECISIONS = {"suggest", "insight", "task_candidate", "resurface", "silence"}
@@ -125,6 +146,16 @@ def validate(deck: dict) -> tuple[int, int]:
             decision not in DIRECTOR_DECISIONS for decision in allowed_decisions
         ):
             raise ValueError(f"{case['id']}: allowedDecisions must use director decision values")
+        referent_tokens = case.get("referentTokens", [])
+        if not isinstance(referent_tokens, list) or any(
+            not isinstance(token, str) or not token.strip() for token in referent_tokens
+        ):
+            raise ValueError(f"{case['id']}: referentTokens must be non-empty strings")
+        # `referent-no-identifier` is the deliberate exception: its whole point is
+        # that its context supplies no handle, so nothing may be named and nothing
+        # may be invented.
+        if case["id"] in REFERENT_CASES and not referent_tokens and case["id"] != "referent-no-identifier":
+            raise ValueError(f"{case['id']}: referent cases must declare referentTokens")
         if case["id"] in DIRECTOR_CASES:
             params = map_case(case)
             required = {
@@ -184,6 +215,12 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
     forbidden_terms_matched = [
         term for term in forbidden_output_terms if term.casefold() in response_text
     ]
+    # The user-visible surface is title + message; `reasoning` never reaches the
+    # user, so it cannot supply the identifying context.
+    visible_text = "\n".join(str(detail.get(field) or "") for field in ("title", "message")).casefold()
+    referent_tokens = case.get("referentTokens", [])
+    referent_hits = [token for token in referent_tokens if token.casefold() in visible_text]
+    referent_named = bool(referent_hits) if referent_tokens else None
     polarity_matched = expected == "either" or expected == polarity
     allowed_decisions = case.get("allowedDecisions", [])
     decision_matched = not allowed_decisions or decision in allowed_decisions
@@ -194,16 +231,26 @@ def invoke_case(case: dict, port: int, include_text: bool = False) -> dict:
         failure_reasons.append("decision")
     if forbidden_terms_matched:
         failure_reasons.append("forbidden_output")
+    referent_required = decision != "silence" and bool(referent_tokens)
+    if referent_required and not referent_hits:
+        failure_reasons.append("unnamed_referent")
     result = {
         "id": case["id"],
         "expectedAction": expected,
         "decision": decision,
         "polarity": polarity,
-        "matched": polarity_matched and decision_matched and not forbidden_terms_matched,
+        "matched": (
+            polarity_matched
+            and decision_matched
+            and not forbidden_terms_matched
+            and not (referent_required and not referent_hits)
+        ),
         "polarity_matched": polarity_matched,
         "decision_matched": decision_matched,
         "forbidden_output_matched": bool(forbidden_terms_matched),
         "forbidden_terms_matched": forbidden_terms_matched,
+        "referent_named": referent_named,
+        "referent_hits": referent_hits,
         "failure_reasons": failure_reasons,
         "model": detail.get("model"),
         "latency_ms": detail.get("latency_ms"),

--- a/desktop/macos/tests/test-context-bucket-benchmark.sh
+++ b/desktop/macos/tests/test-context-bucket-benchmark.sh
@@ -91,6 +91,46 @@ assert detailed["decision_matched"] is True
 assert detailed["forbidden_output_matched"] is False
 assert detailed["forbidden_terms_matched"] == []
 assert detailed["failure_reasons"] == []
+assert detailed["referent_named"] is None
+assert detailed["referent_hits"] == []
+
+# A case that declares referentTokens fails when the user-visible text names none
+# of them, and `reasoning` -- which the user never sees -- cannot rescue it.
+named_case = {**case, "referentTokens": ["Synthetic title"]}
+unnamed_case = {**case, "referentTokens": ["#4821", "nimbus-labs/ingest-suite"]}
+reasoning_only_case = {**case, "referentTokens": ["Synthetic reasoning"]}
+with patch.object(benchmark.request, "urlopen", return_value=Response()):
+    named = benchmark.invoke_case(named_case, 47910)
+    unnamed = benchmark.invoke_case(unnamed_case, 47910)
+    reasoning_only = benchmark.invoke_case(reasoning_only_case, 47910)
+assert named["referent_named"] is True
+assert named["referent_hits"] == ["Synthetic title"]
+assert named["failure_reasons"] == []
+assert named["matched"] is True
+assert unnamed["referent_named"] is False
+assert unnamed["failure_reasons"] == ["unnamed_referent"]
+assert unnamed["matched"] is False
+assert reasoning_only["referent_named"] is False
+assert reasoning_only["failure_reasons"] == ["unnamed_referent"]
+
+# Silence carries no user-visible text, so the criterion does not apply to it.
+envelope["result"]["detail"]["decision"] = "silence"
+silent_case = {**unnamed_case, "expectedAction": "silence", "allowedDecisions": ["silence"]}
+with patch.object(benchmark.request, "urlopen", return_value=Response()):
+    silent = benchmark.invoke_case(silent_case, 47910)
+assert silent["failure_reasons"] == []
+assert silent["matched"] is True
+envelope["result"]["detail"]["decision"] = "suggest"
+
+referent_ids = {c["id"] for c in fixture["cases"] if c["id"].startswith("referent-")}
+assert referent_ids <= benchmark.DIRECTOR_CASES
+assert benchmark.REFERENT_CASES == referent_ids
+for referent_case in (c for c in fixture["cases"] if c["id"] in referent_ids):
+    # The one deliberate exception is the control whose context supplies no handle.
+    if referent_case["id"] == "referent-no-identifier":
+        assert referent_case["referentTokens"] == []
+        continue
+    assert referent_case["referentTokens"], referent_case["id"]
 
 leaking_case = {**case, "forbiddenOutputTerms": ["synthetic MESSAGE"]}
 with patch.object(benchmark.request, "urlopen", return_value=Response()):

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1172,8 +1172,14 @@ export interface ConversationFinalizationStatusResponse {
   terminal: boolean;
 }
 
+export interface ConversationLinkActionItemSpec {
+  description: string;
+  task_id?: string | null;
+}
+
 export interface ConversationLinkSpec {
   conversation_id: string;
+  recommended_action_items?: Array<ConversationLinkActionItemSpec>;
   summary: string;
   type: "conversationLink";
 }
@@ -2497,6 +2503,7 @@ export interface Message {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -2925,6 +2932,7 @@ export interface ResponseMessage {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -4251,6 +4259,7 @@ export interface OmiApiSchemas {
   "ConversationAudioUrlInfo": ConversationAudioUrlInfo;
   "ConversationCreateResponse": ConversationCreateResponse;
   "ConversationFinalizationStatusResponse": ConversationFinalizationStatusResponse;
+  "ConversationLinkActionItemSpec": ConversationLinkActionItemSpec;
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -7346,6 +7346,36 @@
         "title": "ConversationFinalizationStatusResponse",
         "type": "object"
       },
+      "ConversationLinkActionItemSpec": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "maxLength": 300,
+            "minLength": 1,
+            "title": "Description",
+            "type": "string"
+          },
+          "task_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "title": "ConversationLinkActionItemSpec",
+        "type": "object"
+      },
       "ConversationLinkSpec": {
         "additionalProperties": false,
         "properties": {
@@ -7355,6 +7385,14 @@
             "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$",
             "title": "Conversation Id",
             "type": "string"
+          },
+          "recommended_action_items": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationLinkActionItemSpec"
+            },
+            "maxItems": 8,
+            "title": "Recommended Action Items",
+            "type": "array"
           },
           "summary": {
             "maxLength": 200,
@@ -15305,6 +15343,15 @@
             ],
             "title": "Client Message Id"
           },
+          "content_blocks": {
+            "description": "Structured chat content blocks. New rows store these directly; legacy rows are projected from metadata.content_blocks.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Content Blocks",
+            "type": "array"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -17768,6 +17815,15 @@
               }
             ],
             "title": "Client Message Id"
+          },
+          "content_blocks": {
+            "description": "Structured chat content blocks. New rows store these directly; legacy rows are projected from metadata.content_blocks.",
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Content Blocks",
+            "type": "array"
           },
           "created_at": {
             "format": "date-time",

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1172,8 +1172,14 @@ export interface ConversationFinalizationStatusResponse {
   terminal: boolean;
 }
 
+export interface ConversationLinkActionItemSpec {
+  description: string;
+  task_id?: string | null;
+}
+
 export interface ConversationLinkSpec {
   conversation_id: string;
+  recommended_action_items?: Array<ConversationLinkActionItemSpec>;
   summary: string;
   type: "conversationLink";
 }
@@ -2497,6 +2503,7 @@ export interface Message {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -2925,6 +2932,7 @@ export interface ResponseMessage {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -4251,6 +4259,7 @@ export interface OmiApiSchemas {
   "ConversationAudioUrlInfo": ConversationAudioUrlInfo;
   "ConversationCreateResponse": ConversationCreateResponse;
   "ConversationFinalizationStatusResponse": ConversationFinalizationStatusResponse;
+  "ConversationLinkActionItemSpec": ConversationLinkActionItemSpec;
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1172,8 +1172,14 @@ export interface ConversationFinalizationStatusResponse {
   terminal: boolean;
 }
 
+export interface ConversationLinkActionItemSpec {
+  description: string;
+  task_id?: string | null;
+}
+
 export interface ConversationLinkSpec {
   conversation_id: string;
+  recommended_action_items?: Array<ConversationLinkActionItemSpec>;
   summary: string;
   type: "conversationLink";
 }
@@ -2497,6 +2503,7 @@ export interface Message {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -2925,6 +2932,7 @@ export interface ResponseMessage {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -4251,6 +4259,7 @@ export interface OmiApiSchemas {
   "ConversationAudioUrlInfo": ConversationAudioUrlInfo;
   "ConversationCreateResponse": ConversationCreateResponse;
   "ConversationFinalizationStatusResponse": ConversationFinalizationStatusResponse;
+  "ConversationLinkActionItemSpec": ConversationLinkActionItemSpec;
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1172,8 +1172,14 @@ export interface ConversationFinalizationStatusResponse {
   terminal: boolean;
 }
 
+export interface ConversationLinkActionItemSpec {
+  description: string;
+  task_id?: string | null;
+}
+
 export interface ConversationLinkSpec {
   conversation_id: string;
+  recommended_action_items?: Array<ConversationLinkActionItemSpec>;
   summary: string;
   type: "conversationLink";
 }
@@ -2497,6 +2503,7 @@ export interface Message {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -2925,6 +2932,7 @@ export interface ResponseMessage {
   chart_data?: ChartData | Record<string, unknown> | null;
   chat_session_id?: string | null;
   client_message_id?: string | null;
+  content_blocks?: Array<Record<string, unknown>>;
   created_at: string;
   data_protection_level?: string | null;
   files?: Array<FileChat>;
@@ -4251,6 +4259,7 @@ export interface OmiApiSchemas {
   "ConversationAudioUrlInfo": ConversationAudioUrlInfo;
   "ConversationCreateResponse": ConversationCreateResponse;
   "ConversationFinalizationStatusResponse": ConversationFinalizationStatusResponse;
+  "ConversationLinkActionItemSpec": ConversationLinkActionItemSpec;
   "ConversationLinkSpec": ConversationLinkSpec;
   "ConversationMutationResponse": ConversationMutationResponse;
   "ConversationPhoto": ConversationPhoto;


### PR DESCRIPTION
## Summary

Three defects reported from a real chat transcript, each traced to a distinct root cause.

**1. A proactive notification that named nothing.** A delivered card read `Insight / PR blocked, needs review` — the user cannot tell which pull request. The director prompt decides *whether* to speak and *which* decision type, and never said what the spoken text must contain; the structured-output schema declared `title` and `message`, the only two fields a user reads, as bare strings with no description. Adds a generic naming rule spanning referent kinds (pull request, email thread, document, file, meeting, person), measured against the production reasoning model.

**2. A redundant, unactionable meeting notification.** One `.desktopMeetingConversationDidComplete` signal fanned out to two unaware presenters: the durable `conversationLink` card, and a banner that also became a chat row reading `<title>: <first item> and 2 more` — no items attached, no action, and mislabeled `Notification` because `meeting-notes` was not a known presentation kind. The Context Director's own prompt already forbids this exact claim for every other lane ("the conversation-finalization lane owns that claim"). The banner is now system-banner-only, and its recommendations are folded into the card that already opens the conversation.

**3. Structured chat cards were not real, synced chat history.** The meeting-notes card appeared on the Mac that captured the meeting and was absent on the user's other Mac. Two carve-outs collided: the kernel deliberately projected `text: ""` for chat-first materialization turns (to avoid a `"Done."` filler), while `SaveMessageRequest.text` requires `min_length=1` — so the row 422'd on every attempt and was permanently undeliverable. Compounding it, `content_blocks` lived inside an opaque `metadata` string with no Flutter support at all, so any card that did sync rendered as a blank bubble on mobile.

## Measurement (issue 1)

Against `gpt-5.6-luna` at `reasoning_effort=low` — the model and effort `desktop_proactive_reasoning` routes to — on new `referent-*` benchmark cases, 12 replicates per case, scoring whether user-visible text carries one of the case's declared `referentTokens`:

| condition | title | message | silence (referent cases) |
|---|---|---|---|
| baseline | 34/58 | 58/58 | 26/84 |
| schema descriptions only | 60/61 | 57/61 | 23/84 |
| prose rule + schema | 61/61 | 61/61 | 23/84 |
| **shipped (bulleted) + schema** | **67/67** | **67/67** | **17/84** |

The failure was in the title, not the body. Schema descriptions alone *regressed* body naming — the model moved the identifier into the title rather than carrying both — so the two halves ship together and a comment says neither should be removed alone. No silence regression: silence fell, expected polarity across the deck improved 134/228 → 162/228 runs, and the `referent-visible-on-screen` guard stayed silent 12/12 under every condition.

Caveat: the production prompt and schema bytes were driven through the repo's bench provider rather than the Omi backend, and that proxy drops `response_format`, so strict structured output was not exercised; the schema was supplied in-band, byte-identical across conditions.

## Product invariants

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1

## Failure class

Failure-Class: none

## Line-count exceptions

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5231 -> 5240 | The notification journaling owner needs a narrow title-preserving projection and moving that private persistence helper would broaden this fix.

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubble.swift | 2071 -> 2082 | The existing bubble decoder remains the compatibility boundary for first-class and legacy structured blocks.

Line-Count-Exception: desktop/macos/Desktop/Sources/Providers/ChatProvider.swift | 6844 -> 6858 | The existing sync/import owner must decode both wire shapes so persisted legacy rows continue rendering.

## Testing

- TypeScript: agent build + 65 focused tests (including a chat-first materialization turn now projecting `Meeting notes ready - Weekly planning` instead of `""`).
- Backend: 130 tests across the desktop message/migration/deserialization suites; broader run 248.
- Swift: focused suites plus the agent logic harness (545 Swift / 109 runtime / 109 extension).
- Flutter: structured-message degradation test.
- `make preflight`: all 36 checks pass.

Not covered: an authenticated two-Mac live sync run. Verification is build, unit, contract and hermetic-harness based.

## Follow-ups (deliberately not in this PR)

1. **Server-side canonical materialization.** `_materialize_prompts` still "never writes a Chat row"; the intent is retired account-wide on acknowledgement, so it reaches exactly one client, ever. Moving canonical meeting-card creation into the conversation-finalization lane is the real fix for cross-client durability and is an architecture change deserving its own PR. Noted in `backend/routers/chat_first.py`.
2. **Carry identifiers into the director prompt.** Wording cannot name what it was never given. Across 69 spoken baseline runs the model named the referent whenever one appeared anywhere in the prompt; the residual vague messages come from contexts carrying no identifier at all. `bucket_facts.identifiers` already stores the handles extraction is told to copy, and `ContextBucketStore.snapshot` leaves that column out of the fact lines the director reads. That is a store change, not a prompt change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

