### PR TITLE
fix(backend): surface a rate-limited BYOK key from connector synthesis as 429, not 502

### DIFF
--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -18,6 +18,7 @@ import database.users as users_db
 import database.redis_db as redis_db
 from utils.other import endpoints as auth
 from utils.log_sanitizer import sanitize
+from utils.llm.gateway_error_contract import BYOK_RATE_LIMIT_ERROR_DETAIL, is_byok_rate_limit_gateway_error
 from utils.subscription import is_trial_paywalled
 from utils.executors import run_blocking, db_executor, llm_executor
 from utils.integrations_registry import oauth_authorization_query, resolve_integration_provider
@@ -257,15 +258,21 @@ async def synthesize_connector_data(
 
     if await run_blocking(db_executor, is_trial_paywalled, uid, 'desktop'):
         raise HTTPException(status_code=402, detail='trial_expired')
-    synthesis = await run_blocking(
-        llm_executor,
-        lambda: connector_synthesis.synthesize_connector_items(
-            uid,
-            body.source,
-            body.items,
-            existing_memories=body.existing_memories,
-        ),
-    )
+    try:
+        synthesis = await run_blocking(
+            llm_executor,
+            lambda: connector_synthesis.synthesize_connector_items(
+                uid,
+                body.source,
+                body.items,
+                existing_memories=body.existing_memories,
+            ),
+        )
+    except Exception as e:
+        if not is_byok_rate_limit_gateway_error(e):
+            raise
+        logger.warning('Connector synthesis halted because the configured BYOK provider is rate limited')
+        raise HTTPException(status_code=429, detail=BYOK_RATE_LIMIT_ERROR_DETAIL) from None
     if synthesis is None:
         raise HTTPException(status_code=502, detail="connector_synthesis_failed")
     return ConnectorSynthesisResponse(

--- a/backend/tests/unit/test_connector_synthesis_helper.py
+++ b/backend/tests/unit/test_connector_synthesis_helper.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from contextlib import contextmanager
 from types import SimpleNamespace
 
+import httpx
+import openai
 import pytest
 
 from utils.llm import connector_synthesis
@@ -74,4 +76,44 @@ def test_calendar_synthesis_parses_and_dedupes(monkeypatch):
 
 def test_unparseable_response_returns_none(monkeypatch):
     _patch(monkeypatch, 'not json at all')
+    assert connector_synthesis.synthesize_connector_items('uid', 'gmail', ['From: a | Subject: b | c']) is None
+
+
+def byok_rate_limit_error() -> openai.RateLimitError:
+    """The gateway 429 envelope production raises when the user's own provider key throttles."""
+    return openai.RateLimitError(
+        'Error code: 429',
+        response=httpx.Response(429, request=httpx.Request('POST', 'http://gateway.test/v1/chat/completions')),
+        body={
+            'error': {
+                'message': 'provider request failed: byok_rate_limit',
+                'type': 'rate_limit_error',
+                'param': 'provider',
+                'code': 'credential_failure',
+                'failure_class': 'byok_rate_limit',
+            }
+        },
+    )
+
+
+def patch_llm_raising(monkeypatch, error: BaseException):
+    class FailingLLM:
+        def invoke(self, messages):
+            raise error
+
+    monkeypatch.setattr(connector_synthesis, 'get_llm', lambda feature: FailingLLM())
+    monkeypatch.setattr(connector_synthesis, 'track_usage', _fake_track_usage)
+    monkeypatch.setattr(connector_synthesis, 'current_date_for_uid', lambda uid: '2026-08-09')
+
+
+def test_byok_rate_limit_propagates_instead_of_collapsing_to_none(monkeypatch):
+    patch_llm_raising(monkeypatch, byok_rate_limit_error())
+
+    with pytest.raises(openai.RateLimitError):
+        connector_synthesis.synthesize_connector_items('uid', 'gmail', ['From: a | Subject: b | c'])
+
+
+def test_untyped_provider_failure_still_returns_none(monkeypatch):
+    patch_llm_raising(monkeypatch, RuntimeError('provider exploded'))
+
     assert connector_synthesis.synthesize_connector_items('uid', 'gmail', ['From: a | Subject: b | c']) is None

--- a/backend/tests/unit/test_connector_synthesis_route.py
+++ b/backend/tests/unit/test_connector_synthesis_route.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
 
 from routers import integrations as integrations_router
+from tests.unit.test_connector_synthesis_helper import byok_rate_limit_error, patch_llm_raising
 from utils.llm.connector_synthesis import ConnectorSynthesis, SynthesizedTask
 
 UID = 'uid-connector-synthesis'
+
+
+def _http_client() -> TestClient:
+    """Drive the real route: mounted router, only the auth edge overridden."""
+    app = FastAPI()
+    app.include_router(integrations_router.router)
+    app.dependency_overrides[integrations_router.auth.get_current_user_uid] = lambda: UID
+    return TestClient(app)
 
 
 @pytest.fixture(autouse=True)
@@ -65,6 +75,38 @@ async def test_synthesize_connector_data_fails_closed_when_synthesis_returns_non
             uid=UID,
         )
     assert exc.value.status_code == 502
+
+
+def test_synthesize_connector_data_surfaces_byok_rate_limit_as_429(monkeypatch):
+    """A rate-limited BYOK key is a typed, retryable class — not a generic 502.
+
+    Only the provider client is stubbed: the request runs through the real route, the
+    real ``synthesize_connector_items`` and the real executor hop, which is where the
+    production 502 was manufactured.
+    """
+    patch_llm_raising(monkeypatch, byok_rate_limit_error())
+
+    response = _http_client().post('/v1/connectors/synthesize', json={'source': 'gmail', 'items': ['From: a']})
+
+    assert response.status_code == 429
+    detail = response.json()['detail']
+    assert detail['code'] == 'byok_rate_limit'
+    assert (
+        detail['message'] == 'The configured provider account is rate limited. Please retry later or check its limits.'
+    )
+    # The provider error body never reaches the client.
+    assert 'gateway.test' not in response.text
+
+
+def test_synthesize_connector_data_keeps_502_for_untyped_failures(monkeypatch):
+    import utils.llm.connector_synthesis as connector_synthesis
+
+    monkeypatch.setattr(connector_synthesis, 'synthesize_connector_items', lambda *a, **k: None)
+
+    response = _http_client().post('/v1/connectors/synthesize', json={'source': 'notes', 'items': ['Bought a piano']})
+
+    assert response.status_code == 502
+    assert response.json()['detail'] == 'connector_synthesis_failed'
 
 
 async def test_synthesize_connector_data_blocks_a_trial_expired_account(monkeypatch):

--- a/backend/utils/llm/connector_synthesis.py
+++ b/backend/utils/llm/connector_synthesis.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 from utils.llm.temporal import current_date_for_uid
 from utils.llm.usage_tracker import Features, track_usage
 from .clients import get_llm
+from .gateway_error_contract import is_byok_rate_limit_gateway_error
 import logging
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,8 @@ def synthesize_connector_items(
 
     Returns an empty synthesis when there is nothing to work with, and ``None`` when the
     model call or parse fails so callers can surface a real error instead of silence.
+    The gateway's typed BYOK rate-limit failure propagates instead, so the HTTP boundary
+    can return the shared 429 contract rather than a generic failure.
     """
     guidance = _SOURCE_GUIDANCE.get(source)
     if guidance is None:
@@ -133,7 +136,11 @@ def synthesize_connector_items(
         except Exception as e:
             logger.error("Error parsing connector synthesis: source=%s error=%s", source, type(e).__name__)
             return None
-    except Exception:
+    except Exception as e:
+        if is_byok_rate_limit_gateway_error(e):
+            # The caller is the HTTP boundary and owns the shared 429 contract for this
+            # class; collapsing it into ``None`` here would surface it as a generic 502.
+            raise
         logger.exception("Error synthesizing connector items for uid=%s source=%s", uid, source)
         return None
 


### PR DESCRIPTION
## Bug

`POST /v1/connectors/synthesize` returns `502 connector_synthesis_failed` when the user's own (BYOK) provider key is rate limited. The macOS desktop calendar / Gmail / Notes importers surface that as an opaque backend failure, so a retryable, user-fixable condition looks like an Omi outage.

Live evidence (prod, image `c5b0b5d`): 5× 502 on `POST /v1/connectors/synthesize` from the Omi macOS client, 2026-08-17 → 2026-08-19. Each is immediately preceded by

```
File "/app/utils/llm/connector_synthesis.py", line 130, in synthesize_connector_items
    response = get_llm('memories').invoke(...)
openai.RateLimitError: Error code: 429 - {'error': {'message': 'provider request failed: byok_rate_limit',
  'type': 'rate_limit_error', 'param': 'provider', 'code': 'credential_failure',
  'failure_class': 'byok_rate_limit'}}
```

## Root cause

`synthesize_connector_items` wraps the whole model call in `except Exception → return None`, and the route maps `None` to 502. The gateway's typed BYOK rate-limit failure was swallowed with everything else, so the class is unrecoverable from the client response — even though `utils/llm/gateway_error_contract.py` already exists for exactly this class and every other composition boundary (conversation processing, `POST /v1/conversations/from-segments`) answers it with the shared `429 {code: byok_rate_limit}`.

## Fix

- `utils/llm/connector_synthesis.py` — re-raise **only** the typed class, via the existing `is_byok_rate_limit_gateway_error` contract. Every other failure keeps returning `None`.
- `routers/integrations.py` — catch it at the HTTP boundary and return the shared `429` detail (`BYOK_RATE_LIMIT_ERROR_DETAIL`). All other failures keep the existing `502 connector_synthesis_failed`. The provider error body is never forwarded to the client.

No new guard surface is added: the reusable one (`gateway_error_contract`) already existed and this PR routes the third boundary through it.

## What I tested

- `tests/unit/test_connector_synthesis_route.py::test_synthesize_connector_data_surfaces_byok_rate_limit_as_429` drives the **real path** — router mounted on a FastAPI app, real `synthesize_connector_items`, real `run_blocking` executor hop, only the provider client stubbed with the exact production `openai.RateLimitError` envelope. It returns **502 on clean main** (reproducing the production symptom) and **429 with the fix**.
- `test_synthesize_connector_data_keeps_502_for_untyped_failures` pins the unchanged generic path.
- `tests/unit/test_connector_synthesis_helper.py`: the typed class propagates; an untyped provider failure still returns `None`.
- Full backend selection for these changed files (`backend/test.sh`, 857 files — `routers/integrations.py` has no test-selection contract, so it selects everything): 852 files pass. The 5 failing files (`test_action_item_vector_best_effort`, `test_desktop_proactivity`, `test_modulate_stt`, `test_streaming_deepgram_backoff`, `test_sync_cloud_tasks`) fail **identically on a clean `origin/main` worktree** — 4 are import/STT-routing failures unrelated to this diff, and `test_action_item_vector_best_effort` is the local fast-unit CPU-time guard (`0.31s > 0.30s`, 4 tests passing, exit 1) on both branches.
- `make preflight`: 24/24 checks pass.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: FC-typed-failure-collapsed-to-generic

Second instance, first on the backend HTTP boundary (evidence PR #11487 was the desktop proactive-lane client). Same violated contract: a caller that already has a typed failure collapsed it into a generic bucket, making the true cause unrecoverable downstream.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

