### PR TITLE
fix(backend): push the completed filter server-side in the visible action-item ID scan, and meter it

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -119,17 +119,35 @@ def get_visible_action_item_ids(
     The account-wide ID census intentionally includes every document for reconciliation
     and account deletion. UI Select All needs a narrower contract: exclude soft-deleted
     rows and include only rows that the explicit ``completed`` list filter can render.
+
+    The ``completed`` filter is pushed server-side via ``FieldFilter`` so Firestore only
+    streams (and bills) documents in the requested bucket, instead of the whole collection.
+    Firestore equality does not match documents where the field is absent and does not
+    conflate 1/0 with booleans, so this is equivalent to the old Python identity check
+    (``completed_value is completed``) for every doc the query now returns.
+
+    ``deleted`` is deliberately NOT pushed into the query as
+    ``.where('deleted', '==', False)``: Firestore equality filters never match documents
+    where the field is absent, and most rows have no ``deleted`` field at all (it is only
+    set on soft-deleted rows). A server-side filter on it would silently drop every
+    undeleted row. Keep this check in Python instead.
     """
     client = firestore_client or get_firestore_client()
     coll = client.collection('users').document(uid).collection(action_items_collection)
+    query = coll.select(['completed', 'deleted']).where(filter=FieldFilter('completed', '==', completed))
     visible_ids: List[str] = []
-    for doc in coll.select(['completed', 'status', 'deleted']).stream():
+    doc_count = 0
+    for doc in query.stream():
+        doc_count += 1
         data = _typed_doc(doc)
         if data.get('deleted'):
             continue
-        completed_value = data.get('completed')
-        if completed_value is completed:
-            visible_ids.append(doc.id)
+        visible_ids.append(doc.id)
+    record_firestore_read(
+        FirestoreReadFamily.ACTION_ITEMS_VISIBLE_IDS,
+        FirestoreReadMode.UNBOUNDED,
+        doc_count,
+    )
     return visible_ids
 
 

--- a/backend/database/firestore_read_metrics.py
+++ b/backend/database/firestore_read_metrics.py
@@ -11,6 +11,7 @@ from prometheus_client import Counter, Histogram
 
 class FirestoreReadFamily(StrEnum):
     ACTION_ITEMS_LIST = 'action_items_list'
+    ACTION_ITEMS_VISIBLE_IDS = 'action_items_visible_ids'
     LISTEN_MONTHLY_USAGE = 'listen_monthly_usage'
     ALL_TIME_USAGE = 'all_time_usage'
     CHAT_QUOTA_MONTHLY_USAGE = 'chat_quota_monthly_usage'

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -417,9 +417,11 @@ def list_action_item_ids(
     Without ``completed``: returns every ID with no field reads — the cheapest
     way for a client to know which tasks it has without paging the full list.
 
-    With ``completed``: returns only non-deleted IDs in the requested bucket,
-    which requires a three-field projection (``completed``, ``status``,
-    ``deleted``) streamed across the collection.
+    With ``completed``: returns only non-deleted IDs in the requested bucket. The
+    ``completed`` bucket is filtered server-side; only documents in that bucket are
+    streamed (a two-field ``completed``, ``deleted`` projection), and the ``deleted``
+    exclusion is still applied in Python since Firestore equality filters would drop
+    undeleted rows that have no ``deleted`` field.
 
     Declared before /v1/action-items/{action_item_id} so the static path is not
     captured as an action item id.

--- a/backend/tests/unit/test_action_item_ids_endpoint.py
+++ b/backend/tests/unit/test_action_item_ids_endpoint.py
@@ -17,6 +17,7 @@ os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7
 
 from routers import action_items as ai_mod  # noqa: E402
 from database import action_items as action_items_db  # noqa: E402
+from database.firestore_read_metrics import FIRESTORE_READ_OPERATIONS  # noqa: E402
 
 
 class _Doc:
@@ -29,16 +30,41 @@ class _Doc:
 
 
 class _Query:
+    """Fake Firestore query that mimics real equality-filter semantics.
+
+    A ``.where(filter=FieldFilter(field, '==', value))`` only matches documents where
+    ``field`` is present AND equal to ``value`` — a missing field never matches, and this
+    fake enforces that so a test can tell server-side filtering apart from the old
+    Python-side filtering it replaces.
+    """
+
     def __init__(self, docs):
         self.docs = docs
         self.projected_fields = None
+        self.applied_filters = []
 
     def select(self, fields):
         self.projected_fields = fields
         return self
 
+    def where(self, filter):
+        self.applied_filters.append((filter.field_path, filter.op_string, filter.value))
+        return self
+
     def stream(self):
-        return self.docs
+        filtered = self.docs
+        for field_path, op_string, value in self.applied_filters:
+            assert op_string == '==', f'fake only supports == filters, got {op_string}'
+            # Real Firestore equality does not conflate int 1/0 with bool True/False, so
+            # match on type as well as value, not just Python's `1 == True`.
+            filtered = [
+                doc
+                for doc in filtered
+                if field_path in doc._data
+                and type(doc._data[field_path]) is type(value)
+                and doc._data[field_path] == value
+            ]
+        return filtered
 
 
 class _CollectionPath:
@@ -113,7 +139,10 @@ def test_visible_action_item_ids_matches_explicit_bucket_and_excludes_deleted():
     ids = action_items_db.get_visible_action_item_ids('user-9', completed=False, firestore_client=client)
 
     assert ids == ['active']
-    assert client.query.projected_fields == ['completed', 'status', 'deleted']
+    # `status` is never read in the function body, so it is dropped from the projection.
+    assert client.query.projected_fields == ['completed', 'deleted']
+    # The completion bucket is filtered server-side, not in Python.
+    assert client.query.applied_filters == [('completed', '==', False)]
 
 
 def test_visible_action_item_ids_excludes_legacy_null_completion_rows():
@@ -127,6 +156,42 @@ def test_visible_action_item_ids_excludes_legacy_null_completion_rows():
     ids = action_items_db.get_visible_action_item_ids('user-9', completed=True, firestore_client=client)
 
     assert ids == []
+
+
+def test_visible_action_item_ids_includes_docs_with_absent_deleted_field():
+    """The common case: most rows never had `deleted` set at all. A server-side
+    `.where('deleted', '==', False)` would silently drop these, since Firestore equality
+    filters never match a missing field. This must stay a Python-side check."""
+    client = _Firestore(
+        [
+            _Doc('never-deleted', {'completed': False}),
+            _Doc('explicitly-not-deleted', {'completed': False, 'deleted': False}),
+            _Doc('soft-deleted', {'completed': False, 'deleted': True}),
+        ]
+    )
+
+    ids = action_items_db.get_visible_action_item_ids('user-9', completed=False, firestore_client=client)
+
+    assert sorted(ids) == ['explicitly-not-deleted', 'never-deleted']
+    # No `deleted` filter was pushed to Firestore.
+    assert client.query.applied_filters == [('completed', '==', False)]
+
+
+def test_visible_action_item_ids_records_firestore_read():
+    client = _Firestore(
+        [
+            _Doc('active-1', {'completed': False}),
+            _Doc('active-2', {'completed': False, 'deleted': True}),
+            _Doc('done', {'completed': True}),  # excluded server-side by the `completed` filter
+        ]
+    )
+
+    before = FIRESTORE_READ_OPERATIONS.labels(family='action_items_visible_ids', mode='unbounded')._value.get()
+
+    action_items_db.get_visible_action_item_ids('user-9', completed=False, firestore_client=client)
+
+    after = FIRESTORE_READ_OPERATIONS.labels(family='action_items_visible_ids', mode='unbounded')._value.get()
+    assert after == before + 1
 
 
 def test_batch_delete_rejects_locked_items_before_any_delete(monkeypatch):

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -25763,7 +25763,7 @@
     },
     "/v1/action-items/ids": {
       "get": {
-        "description": "Return the user's action-item IDs (lightweight reconciliation).\n\nWithout ``completed``: returns every ID with no field reads — the cheapest\nway for a client to know which tasks it has without paging the full list.\n\nWith ``completed``: returns only non-deleted IDs in the requested bucket,\nwhich requires a three-field projection (``completed``, ``status``,\n``deleted``) streamed across the collection.\n\nDeclared before /v1/action-items/{action_item_id} so the static path is not\ncaptured as an action item id.",
+        "description": "Return the user's action-item IDs (lightweight reconciliation).\n\nWithout ``completed``: returns every ID with no field reads — the cheapest\nway for a client to know which tasks it has without paging the full list.\n\nWith ``completed``: returns only non-deleted IDs in the requested bucket. The\n``completed`` bucket is filtered server-side; only documents in that bucket are\nstreamed (a two-field ``completed``, ``deleted`` projection), and the ``deleted``\nexclusion is still applied in Python since Firestore equality filters would drop\nundeleted rows that have no ``deleted`` field.\n\nDeclared before /v1/action-items/{action_item_id} so the static path is not\ncaptured as an action item id.",
         "operationId": "list_action_item_ids_v1_action_items_ids_get",
         "parameters": [
           {


### PR DESCRIPTION
## What

`get_visible_action_item_ids()` (`backend/database/action_items.py`) backs
`GET /v1/action-items/ids?completed=...` and used to stream the entire
per-user `action_items` collection with a bare projection query, filtering
`completed` in Python. A projection query still bills one document read per
document scanned, so every call cost one read per action item the user has
ever created, regardless of how many were actually in the requested bucket.
The function also never called `record_firestore_read`, so this scan was
invisible in `backend/database/firestore_read_metrics.py`, unlike every
other reviewed read path in the module.

This PR:

1. Pushes the `completed` filter server-side with
   `.where(filter=FieldFilter('completed', '==', completed))`, so Firestore
   only streams (and bills) documents in the requested bucket instead of the
   whole collection.
2. Adds a `record_firestore_read` call with a new
   `FirestoreReadFamily.ACTION_ITEMS_VISIBLE_IDS` family, so this path is
   finally counted.
3. Drops `status` from the field projection — it is fetched but never read
   in the function body.

## What this does NOT change: the `deleted` semantics

The trap in this change is `deleted`. It is tempting to also push
`.where('deleted', '==', False)` server-side. **Don't** — Firestore equality
filters never match a document where the field is absent, and most action
items have no `deleted` field at all (it is only ever set on soft-deleted
rows). A server-side `deleted` filter would silently drop every ordinary,
undeleted row from every bucket. The `if data.get('deleted'): continue`
check stays in Python, and the diff adds a comment on the function saying
why.

## Does the `completed` semantics shift?

Current code matched with `completed_value is completed` — Python identity
against a bool, so a doc with `completed` absent/`None` or any non-bool
value (e.g. a stray `1`/`0`) never matched either bucket, since `is`
requires the exact `True`/`False` singleton, not just equality. Firestore's
`== True` / `== False` also never matches a missing field, and Firestore
equality does not coerce an int `1`/`0` into a bool match either. So the
server-side filter returns exactly the same document set the old Python
identity check selected, and that check is now redundant and was removed.
The new unit test
`test_visible_action_item_ids_matches_explicit_bucket_and_excludes_deleted`
still exercises the same legacy-row fixtures (`completed: None`,
status-only rows) to pin this.

## Value — please read this section literally

**This is a correctness and instrumentation fix, not a measured cost win.**
PR #11835's follow-up notes attributed a large share of the Windows app's
backend request volume to this function, estimating "24 full collection
scans per idle hour per running client." Production log sampling on
2026-08-19 found that attribution is wrong: there is effectively zero
traffic to `GET /v1/action-items/ids`. The ~60k req/hr Windows volume goes
to `GET /v1/action-items` (the listing endpoint), a different code path
already addressed by #11830. This PR does not claim to reduce measured
load.

The reason to land it anyway: the scan this function runs is unbounded per
call and, until this PR, completely unmetered. It is a latent cliff — cost
grows linearly with each user's lifetime action-item count — that we
currently cannot see coming because nothing records it. Fixing the query
shape and adding the metric closes both problems at once, independent of
today's traffic level.

## Testing

`backend/tests/unit/test_action_item_ids_endpoint.py` already covered
`get_visible_action_item_ids`; extended rather than duplicated:

- Updated the fake Firestore query fixture (`_Query`) to implement real
  equality-filter semantics for `.where()` — a filter only matches a
  document where the field is present and matches by both value and type
  (so a stray `int` 1/0 is never treated as `True`/`False`), same as real
  Firestore. This lets the tests actually distinguish server-side filtering
  from the old Python-side filtering it replaces.
- `test_visible_action_item_ids_matches_explicit_bucket_and_excludes_deleted`:
  now also asserts the projection is `['completed', 'deleted']` (not
  `status`) and that the `completed` filter was pushed to Firestore.
- `test_visible_action_item_ids_excludes_legacy_null_completion_rows`:
  unchanged behavior, kept as a regression pin.
- New `test_visible_action_item_ids_includes_docs_with_absent_deleted_field`:
  the trap case — rows with no `deleted` field, and rows with an explicit
  `deleted: False`, must both still come back; only `deleted: True` is
  excluded, and no `deleted` filter reaches Firestore.
- New `test_visible_action_item_ids_records_firestore_read`: asserts the
  `omi_firestore_read_operations_total{family="action_items_visible_ids",
  mode="unbounded"}` counter increments by exactly one per call.

Ran locally via `backend/test.sh` with a scoped file list
(`BACKEND_UNIT_TEST_FILE_LIST`) covering the touched test file plus the
neighboring action-item pagination and Firestore-read-cache suites — all
pass.

### Mutation testing

Four mutations against `database/action_items.py`, each turned red by an
existing or new test, then reverted:

| Mutation | Caught by |
| --- | --- |
| Remove the `.where(filter=FieldFilter('completed', ...))` push-down (revert to scanning the whole collection) | `test_visible_action_item_ids_matches_explicit_bucket_and_excludes_deleted`, `test_visible_action_item_ids_excludes_legacy_null_completion_rows`, `test_visible_action_item_ids_includes_docs_with_absent_deleted_field` |
| Add the forbidden `.where('deleted', '==', False)` server-side filter | `test_visible_action_item_ids_matches_explicit_bucket_and_excludes_deleted`, `test_visible_action_item_ids_includes_docs_with_absent_deleted_field` |
| Remove the Python `if data.get('deleted'): continue` guard | `test_visible_action_item_ids_matches_explicit_bucket_and_excludes_deleted`, `test_visible_action_item_ids_includes_docs_with_absent_deleted_field` |
| Remove the `record_firestore_read(...)` call | `test_visible_action_item_ids_records_firestore_read` |

## Product invariants affected

None — `scripts/pr-preflight --suggest` reports no locked invariant paths
touched by this diff.

## Failure class

`scripts/pr-preflight --suggest` confirms this is a `fix:` commit
requiring a declaration. I checked `.github/failure-classes/` for a
genuine match: the closest candidates —
`FC-bounded-read-exceeds-request-budget` (about per-query limits composing
against a request-scoped middleware budget, not applicable here — there's
no request budget in play, just an unbounded per-user scan),
`FC-unbounded-user-collection-in-prompt` (about rendering a full collection
into a provider/LLM prompt, not a Firestore billing concern), and
`FC-unthrottled-read-revalidation` (about a *client's* revalidation cadence
lacking a throttle; that class already exists and its
`canonical_prevention_artifact` targets `desktop/windows` — this PR is the
backend-side query fix, not the client cadence fix, and doesn't produce a
new reusable guard surface) — none genuinely describe this specific
defect (a per-user Firestore scan filtering in Python instead of pushing
an equality predicate server-side, paired with a missing metering call).
Declaring `new` isn't warranted either: this is a narrow, already-tested
query and instrumentation fix, not a recurring class worth a permanent
registry entry on its own evidence.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

