### PR TITLE
fix(deploy): make environment-gate binding total across dispatch workflows

### DIFF
--- a/.github/failure-classes/FC-environment-gate-bound-before-validation.json
+++ b/.github/failure-classes/FC-environment-gate-bound-before-validation.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "FC-environment-gate-bound-before-validation",
+  "violated_contract": "A workflow_dispatch job's approval gate comes from the GitHub environment it binds to, not from any in-job validation step that runs afterward. Interpolating a raw, under-constrained dispatch input directly into a job's `environment:` key lets a near-miss string (e.g. `production` instead of `prod`) bind an unprotected, incidentally-named environment and skip required-reviewer approval entirely -- the later validation step only stops the deploy, it never restores the gate that was already bypassed.",
+  "canonical_prevention": "Constrain every environment-selecting workflow_dispatch input to `type: choice` with that workflow's exact valid option set (GitHub validates choice inputs on dispatch, including via the API), and never interpolate the raw input into a job's `environment:` key -- map it through a total conditional expression (`input == known-value && known-value || fallback`) so only known, protected environments can ever bind, regardless of a future input change, an API caller, or a re-added free-text field.",
+  "evidence_prs": [11850],
+  "scope_hints": [
+    ".github/workflows/gcp_*.yml",
+    ".github/workflows/sync_ledger_fence_cutover.yml"
+  ],
+  "status": "open"
+}

--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -7,6 +7,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       release_sha:
         description: 'Exact main SHA with a successful Release Eligibility proof (deploy mode only)'
         required: false
@@ -137,7 +141,7 @@ jobs:
     if: >-
       github.ref == 'refs/heads/main' &&
       github.event.inputs.mode == 'repair-traffic-only'
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -191,7 +195,7 @@ jobs:
     if: >-
       github.ref == 'refs/heads/main' &&
       github.event.inputs.mode == 'deploy'
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       actions: 'read'
       contents: 'read'
@@ -365,7 +369,7 @@ jobs:
       needs.validate-production-boundary.result == 'success' &&
       needs.firestore_readiness.result == 'success' &&
       (needs.record_break_glass.result == 'success' || needs.record_break_glass.result == 'skipped')
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -14,6 +14,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -89,7 +93,7 @@ jobs:
   helm-upgrade:
     # On manual dispatch use the chosen environment; on auto push only deploy
     # to dev (prod still requires an explicit workflow_dispatch for safety).
-    environment: ${{ github.event.inputs.environment || 'development' }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -11,6 +11,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -57,7 +61,7 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       actions: 'read'
       contents: 'read'

--- a/.github/workflows/gcp_diarizer.yml
+++ b/.github/workflows/gcp_diarizer.yml
@@ -11,6 +11,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -31,7 +35,7 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_llm_gateway.yml
+++ b/.github/workflows/gcp_llm_gateway.yml
@@ -7,6 +7,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -50,7 +54,7 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       actions: 'read'
       contents: 'read'

--- a/.github/workflows/gcp_memory_maintenance_job.yml
+++ b/.github/workflows/gcp_memory_maintenance_job.yml
@@ -7,7 +7,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
-        type: string
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -30,7 +33,7 @@ concurrency:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
 

--- a/.github/workflows/gcp_models.yml
+++ b/.github/workflows/gcp_models.yml
@@ -13,6 +13,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -34,7 +38,7 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_nllb_translation.yml
+++ b/.github/workflows/gcp_nllb_translation.yml
@@ -7,6 +7,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -28,7 +32,7 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_notifications_job.yml
+++ b/.github/workflows/gcp_notifications_job.yml
@@ -11,7 +11,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
-        type: string
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -33,7 +36,7 @@ concurrency:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_parakeet.yml
+++ b/.github/workflows/gcp_parakeet.yml
@@ -7,6 +7,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -27,7 +31,7 @@ env:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/gcp_plugins.yml
+++ b/.github/workflows/gcp_plugins.yml
@@ -9,6 +9,10 @@ on:
         description: 'Select the environment to deploy to'
         required: true
         default: 'development'
+        type: choice
+        options:
+          - development
+          - prod
       branch:
         description: 'Branch to deploy from'
         required: true
@@ -29,7 +33,7 @@ concurrency:
 
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/sync_ledger_fence_cutover.yml
+++ b/.github/workflows/sync_ledger_fence_cutover.yml
@@ -38,7 +38,7 @@ env:
 
 jobs:
   stage:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       actions: read
       contents: read
@@ -130,7 +130,7 @@ jobs:
     needs: stage
     # This second protected environment gate gives the operator a pause to set
     # SYNC_LEDGER_FENCE_MODE=active only after the standby barrier is complete.
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## The gap

A `workflow_dispatch` job's approval gate comes from the GitHub *environment* it binds to (`environment: <name>`), not from any in-job validation step. Twelve deploy workflows took a free-text (or under-constrained) `environment` dispatch input and interpolated it directly into that binding:

```yaml
environment: ${{ github.event.inputs.environment }}
```

Only `prod` carries `required_reviewers` (`Git-on-my-level`, `mdmohsin7`, `kodjima33`) in this repo today. But environments named `production`, `prodd`, `prdo`, `pro`, `pod`, `main`, and `false` also exist in repo settings **with no protection rules at all**. Dispatching with `environment: production` bound every job in `gcp_backend.yml` to one of those unprotected environments and skipped the approval gate completely — the in-job check at line ~115 that rejects anything except `development`/`prod` only runs *after* the binding, so it stops the deploy but never restores the gate. **This was hit live today**: a deploy was briefed with `production` instead of `prod`.

## The fix

Two layers, applied to all twelve affected workflows:

1. **Constrain the input.** `environment` is now `type: choice` with `options:` listing exactly that workflow's valid environments. GitHub validates choice inputs at dispatch time, including via the API, so an arbitrary string is no longer dispatchable at all.
2. **Make the binding total.** No job's `environment:` key interpolates the raw input anymore. Each now maps through a total expression, e.g. `environment: ${{ github.event.inputs.environment == 'prod' && 'prod' || 'development' }}`, so only a known, protected environment can ever bind — even if a future change reintroduces a free-text field, or the workflow is dispatched through the API instead of the UI.

No deploy behavior, job structure, step order, or other input changed. The only behavioral difference: a previously-dispatchable invalid environment string (`production`, `prodd`, `main`, ...) now fails at dispatch time instead of after the environment gate has already been bound and skipped.

## Files changed

Every workflow in scope uses the same `development` / `prod` set — confirmed by reading each workflow's own in-job validation step (`Invalid environment: ... Must be 'development' or 'prod'`) and, for the two files without that check, its Cloud Run env resolution.

| File | Valid environment set (derived from) |
|---|---|
| `.github/workflows/gcp_backend.yml` | `development`, `prod` — explicit in-job check at 3 job bindings |
| `.github/workflows/gcp_backend_pusher.yml` | `development`, `prod` — explicit in-job check |
| `.github/workflows/gcp_backend_listen_helm.yml` | `development`, `prod` — explicit in-job check; also fixes the push-trigger default fallback (`|| 'development'`) into the same total mapping |
| `.github/workflows/gcp_llm_gateway.yml` | `development`, `prod` — explicit in-job check |
| `.github/workflows/gcp_models.yml` | `development`, `prod` — explicit in-job check |
| `.github/workflows/gcp_diarizer.yml` | `development`, `prod` — explicit in-job check |
| `.github/workflows/gcp_parakeet.yml` | `development`, `prod` — explicit in-job check |
| `.github/workflows/gcp_plugins.yml` | `development`, `prod` — explicit in-job check (`INPUT_ENV`) |
| `.github/workflows/gcp_nllb_translation.yml` | `development`, `prod` — explicit in-job check |
| `.github/workflows/gcp_memory_maintenance_job.yml` | `development`, `prod` — explicit in-job check (`INPUT_ENV`); input was already `type: string`, now `type: choice` |
| `.github/workflows/gcp_notifications_job.yml` | `development`, `prod` — explicit in-job check (`INPUT_ENV`); input was already `type: string`, now `type: choice` |
| `.github/workflows/sync_ledger_fence_cutover.yml` | `development`, `prod` — input was already `type: choice` with these two options; this PR adds the missing Layer 2 total-binding mapping to both of its job-level gates (`stage`, `activate`) for defense in depth |

No file was deferred — all twelve validated cleanly against `development`/`prod` from their own existing checks.

Only job-level `environment:` gate bindings were changed. Step-level `with: environment:` inputs passed to notification/summary actions (e.g. `./.github/actions/deployment-notifier`) were left untouched: they're already gated behind `if: ... == 'prod'`, aren't security-relevant, and changing them risked altering unrelated behavior outside this fix's scope.

## What this does NOT fix

The stray unprotected environments (`production`, `prodd`, `prdo`, `pro`, `pod`, `main`, `false`) still exist in repo settings. Deleting them, or adding protection rules to them, is a GitHub repo-settings change and out of scope for a source-only PR — recommended as an immediate follow-up, ideally before this merges, since Layer 1 (choice input) already closes the practical exploit path but the stray environments remain latent footguns for any future workflow that binds `environment:` from a raw variable.

## Verify

- `actionlint` on every changed file: no new findings versus the pre-change baseline (same pre-existing shellcheck `info`-level notes in unrelated `run:` blocks).
- `python3 -c "import yaml,sys; yaml.safe_load(open(f))"` on every changed file: all parse.
- Read the full diff: confirmed no remaining job-level `environment:` binding in any changed file interpolates the raw `github.event.inputs.environment` value directly.
- `scripts/pr-preflight --suggest` run and honored (failure-class declaration below; no product invariants affected).

## Failure-Class

Failure-Class: new

No existing class in `.github/failure-classes/` matched a workflow-dispatch approval gate binding before its own validation runs. Added `.github/failure-classes/FC-environment-gate-bound-before-validation.json` with `evidence_prs` pointing at this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

