### PR TITLE
fix(backend): serve app search from the shared public-app cache, not a per-request full scan

### DIFF
--- a/backend/database/apps.py
+++ b/backend/database/apps.py
@@ -6,11 +6,16 @@ from google.cloud.firestore import ArrayUnion, ArrayRemove
 
 from ulid import ULID
 
-from models.app import UsageHistoryType
+from models.app import App, UsageHistoryType
+from .redis_db import get_generic_cache, set_generic_cache
 from ._client import db
 import logging
 
 logger = logging.getLogger(__name__)
+
+# Shared with utils.apps (list + invalidation). Keep every reader and the invalidation path on this
+# one constant: a second literal is how a cache ends up populated but never cleared.
+PUBLIC_APPROVED_APPS_CACHE_KEY = 'get_public_approved_apps_data'
 
 # BaseCompositeFilter expects Operator enum but accepts 'AND' string at runtime.
 # Typed as Any to satisfy pyright without importing StructuredQuery (which fails
@@ -69,6 +74,20 @@ def get_public_approved_apps_db() -> List[Dict[str, Any]]:
     return [_typed_doc(doc) for doc in public_apps]
 
 
+def get_public_approved_apps_cached_db() -> List[Dict[str, Any]]:
+    """The approved+public app set, read through the marketplace's shared 10-minute Redis cache.
+
+    Same key, TTL, reduction and invalidation as `utils.apps.get_approved_available_apps`, so a
+    reader here can never serve a staler view than the list the user just came from.
+    """
+    cached = get_generic_cache(PUBLIC_APPROVED_APPS_CACHE_KEY)
+    if cached:
+        return cast(List[Dict[str, Any]], cached)
+    reduced = [App.reduce_dict(app) for app in get_public_approved_apps_db()]
+    set_generic_cache(PUBLIC_APPROVED_APPS_CACHE_KEY, reduced, 60 * 10)  # 10 minutes cached
+    return reduced
+
+
 def get_popular_apps_db() -> List[Dict[str, Any]]:
     filters = [FieldFilter('approved', '==', True), FieldFilter('is_popular', '==', True)]
     popular_apps = db.collection(apps_collection).where(filter=BaseCompositeFilter(_AND_OP, filters)).stream()
@@ -107,6 +126,10 @@ def search_apps_db(
         List of app dictionaries matching the filters
     """
     filters: List[FieldFilter] = []
+    # Whether the primary read is the whole approved+public app set. That set is 3k+ documents and
+    # streaming it per request is what made `?q=` search a p50-13s / p90-30s endpoint in prod; the
+    # marketplace list path already serves the same documents from Redis, so read through it here too.
+    reads_public_set = False
 
     # 1. Apply most restrictive filter first
     if my_apps:
@@ -120,16 +143,14 @@ def search_apps_db(
         if len(enabled_app_ids) > 30:
             # Firestore 'in' limited to 30 items
             # Query public approved apps first, then add user's own apps
-            filters.append(FieldFilter('approved', '==', True))
-            filters.append(FieldFilter('private', '==', False))
+            reads_public_set = True
         else:
             # Query by specific IDs
             filters.append(FieldFilter('id', 'in', enabled_app_ids))
 
     else:
         # Default: Public approved apps
-        filters.append(FieldFilter('approved', '==', True))
-        filters.append(FieldFilter('private', '==', False))
+        reads_public_set = True
 
     # 2. Add category filter
     if category and not my_apps:  # Don't add if already filtering by my_apps
@@ -141,7 +162,15 @@ def search_apps_db(
 
     # Execute query with all filters
     apps: List[Dict[str, Any]] = []
-    if filters:
+    if reads_public_set:
+        apps = get_public_approved_apps_cached_db()
+        # category/capability were server-side filters on the Firestore read this replaces; my_apps is
+        # False on this branch, so both are unconditional here.
+        if category:
+            apps = [app for app in apps if app.get('category') == category]
+        if capability:
+            apps = [app for app in apps if capability in (app.get('capabilities') or [])]
+    elif filters:
         query = db.collection(apps_collection).where(filter=BaseCompositeFilter(_AND_OP, filters))
         apps = [_typed_doc(doc) for doc in query.stream()]
 

--- a/backend/tests/unit/test_app_visibility_missing_doc_guard.py
+++ b/backend/tests/unit/test_app_visibility_missing_doc_guard.py
@@ -49,8 +49,9 @@ for _p in ["google", "google.cloud", "google.cloud.firestore_v1", "database", "m
 _mod("google.cloud.firestore_v1.base_query", BaseCompositeFilter=MagicMock(), FieldFilter=MagicMock())
 _mod("google.cloud.firestore", ArrayUnion=MagicMock(), ArrayRemove=MagicMock())
 _mod("ulid", ULID=lambda: "01HZZTESTULID")
-_mod("models.app", UsageHistoryType=MagicMock())
+_mod("models.app", App=MagicMock(), UsageHistoryType=MagicMock())
 _mod("database._client", db=MagicMock())
+_mod("database.redis_db", get_generic_cache=MagicMock(), set_generic_cache=MagicMock())
 
 
 def _load():

--- a/backend/tests/unit/test_apps_search_reads_cached_public_set.py
+++ b/backend/tests/unit/test_apps_search_reads_cached_public_set.py
@@ -1,0 +1,203 @@
+"""GET /v2/apps/search must read the approved+public app set through the shared Redis cache.
+
+Prod signature (api.omi.me load-balancer logs, 2026-08-18/19, image c5b0b5d): `?q=<term>` searches
+ran p50 13.4s / p90 30.0s and 24 of 29 requests exceeded 5s, most terminating as 504 at the 30s
+edge — app search was effectively unusable in the mobile Apps tab. `installed_apps=true` requests
+served by the same branch (>30 enabled apps) carried the same tail; the `id in [...]` fast path
+sat at p50 0.15s.
+
+Root cause: `search_apps_db` streamed `approved==True AND private==False` from Firestore on every
+request. That is 3,247 documents / ~25MB in prod. The marketplace list path
+(`utils.apps.get_approved_available_apps`) already serves exactly those documents from a 10-minute
+Redis cache under `get_public_approved_apps_data`; search was the one reader that bypassed it.
+
+These tests drive the real route over HTTP with only the Firestore client and the Redis cache
+helpers stubbed, so the router, `search_apps_db` and the cache read all execute.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
+
+import pytest  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from database import apps as apps_db  # noqa: E402
+from routers import apps as apps_mod  # noqa: E402
+
+UID = 'uid-apps-search'
+
+
+def _app_doc(app_id: str, name: str, **overrides):
+    doc = {
+        'id': app_id,
+        'name': name,
+        'category': 'productivity',
+        'author': 'Someone',
+        'description': f'{name} description',
+        'image': 'http://img',
+        'capabilities': ['chat'],
+        'approved': True,
+        'private': False,
+        'uid': 'author-uid',
+        # Excluded by App.reduce_dict — present on the Firestore document, absent from the cache.
+        'chat_prompt': 'x' * 128,
+        'memory_prompt': 'y' * 128,
+    }
+    doc.update(overrides)
+    return doc
+
+
+class _FakeDoc:
+    def __init__(self, data):
+        self._data = data
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _FakeQuery:
+    def __init__(self, collection, docs):
+        self._collection = collection
+        self._docs = docs
+
+    def stream(self):
+        self._collection.streams += 1
+        return [_FakeDoc(d) for d in self._docs]
+
+
+class _FakeCollection:
+    """Streams every seeded document; the point of the assertions is *whether* it is streamed."""
+
+    def __init__(self, docs):
+        self.docs = docs
+        self.streams = 0
+
+    def where(self, filter=None):  # noqa: A002 - matches the firestore kwarg
+        return _FakeQuery(self, self.docs)
+
+
+class _FakeFirestore:
+    def __init__(self, docs):
+        self.collection_obj = _FakeCollection(docs)
+
+    def collection(self, _name):
+        return self.collection_obj
+
+
+@pytest.fixture
+def env(monkeypatch):
+    """Real router + real search_apps_db; only Firestore and the Redis cache are stubbed."""
+    docs = [_app_doc('a1', 'Todoist'), _app_doc('a2', 'Grok'), _app_doc('a3', 'Calendar Sync')]
+    firestore = _FakeFirestore(docs)
+    cache: dict[str, object] = {}
+
+    monkeypatch.setattr(apps_db, 'db', firestore)
+    # raising=False so the control run against the pre-fix source still executes and fails on the
+    # behavioural assertion (a Firestore stream per request) rather than erroring at setup.
+    monkeypatch.setattr(apps_db, 'get_generic_cache', lambda key: cache.get(key), raising=False)
+    monkeypatch.setattr(
+        apps_db, 'set_generic_cache', lambda key, data, ttl=None: cache.__setitem__(key, data), raising=False
+    )
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda uid: set())
+    monkeypatch.setattr(apps_mod, 'get_apps_installs_count', lambda ids: {})
+    monkeypatch.setattr(apps_mod, 'get_apps_reviews', lambda ids: {})
+
+    app = FastAPI()
+    app.include_router(apps_mod.router)
+    app.dependency_overrides[apps_mod.auth.get_current_user_uid] = lambda: UID
+
+    class Env:
+        client = TestClient(app)
+
+    Env.firestore = firestore
+    Env.cache = cache
+    Env.docs = docs
+    return Env
+
+
+def test_search_populates_the_shared_cache_on_a_cold_read(env):
+    response = env.client.get('/v2/apps/search', params={'q': 'todoist', 'limit': 100})
+
+    assert response.status_code == 200
+    assert [a['id'] for a in response.json()['data']] == ['a1']
+    assert env.firestore.collection_obj.streams == 1
+
+    cached = env.cache['get_public_approved_apps_data']
+    assert [a['id'] for a in cached] == ['a1', 'a2', 'a3']
+    # Cached as reduced records, matching the marketplace list path.
+    assert 'chat_prompt' not in cached[0]
+    assert 'description' in cached[0]
+
+
+def test_warm_cache_serves_search_without_streaming_the_collection(env):
+    assert env.client.get('/v2/apps/search', params={'q': 'grok', 'limit': 100}).status_code == 200
+    env.firestore.collection_obj.streams = 0
+
+    response = env.client.get('/v2/apps/search', params={'q': 'grok', 'limit': 100})
+
+    assert response.status_code == 200
+    assert [a['id'] for a in response.json()['data']] == ['a2']
+    # The regression: this is the read that cost 13s+ per request in prod.
+    assert env.firestore.collection_obj.streams == 0
+
+
+def test_default_browse_and_filters_are_served_from_the_cache(env):
+    env.client.get('/v2/apps/search', params={'limit': 100})
+    env.firestore.collection_obj.streams = 0
+
+    browse = env.client.get('/v2/apps/search', params={'limit': 100})
+    assert [a['id'] for a in browse.json()['data']] == ['a3', 'a2', 'a1']  # name_asc default
+
+    matching = env.client.get('/v2/apps/search', params={'category': 'productivity', 'limit': 100})
+    assert [a['id'] for a in matching.json()['data']] == ['a3', 'a2', 'a1']
+    other = env.client.get('/v2/apps/search', params={'category': 'entertainment', 'limit': 100})
+    assert other.json()['data'] == []
+
+    has_cap = env.client.get('/v2/apps/search', params={'capability': 'chat', 'limit': 100})
+    assert len(has_cap.json()['data']) == 3
+    no_cap = env.client.get('/v2/apps/search', params={'capability': 'persona', 'limit': 100})
+    assert no_cap.json()['data'] == []
+
+    assert env.firestore.collection_obj.streams == 0
+
+
+def test_my_apps_still_reads_firestore(env):
+    """Private/unapproved records are not in the public cache — that branch must keep querying."""
+    env.client.get('/v2/apps/search', params={'limit': 100})  # warm the cache
+    env.firestore.collection_obj.streams = 0
+
+    response = env.client.get('/v2/apps/search', params={'my_apps': 'true', 'limit': 100})
+
+    assert response.status_code == 200
+    assert env.firestore.collection_obj.streams == 1
+
+
+def test_installed_apps_under_the_in_limit_still_reads_firestore(env, monkeypatch):
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda uid: {'a1'})
+    env.client.get('/v2/apps/search', params={'limit': 100})  # warm the cache
+    env.firestore.collection_obj.streams = 0
+
+    response = env.client.get('/v2/apps/search', params={'installed_apps': 'true', 'limit': 100})
+
+    assert response.status_code == 200
+    assert env.firestore.collection_obj.streams == 1
+
+
+def test_installed_apps_over_the_in_limit_uses_the_cache_for_the_public_set(env, monkeypatch):
+    """>30 enabled ids: the public set comes from the cache, the user's own apps still from Firestore."""
+    enabled = {'a1', 'a2'} | {f'x{i}' for i in range(30)}
+    monkeypatch.setattr(apps_mod, 'get_enabled_apps', lambda uid: enabled)
+    env.client.get('/v2/apps/search', params={'limit': 100})  # warm the cache
+    env.firestore.collection_obj.streams = 0
+
+    response = env.client.get('/v2/apps/search', params={'installed_apps': 'true', 'limit': 100})
+
+    assert response.status_code == 200
+    assert sorted(a['id'] for a in response.json()['data']) == ['a1', 'a2']
+    # Exactly one stream: the uid-scoped query for the user's own private/unapproved apps.
+    assert env.firestore.collection_obj.streams == 1

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from database.cache import get_memory_cache, get_pubsub_manager
 from database.redis_db import delete_generic_cache
 from database.apps import (
+    PUBLIC_APPROVED_APPS_CACHE_KEY,
     get_private_apps_db,
     get_public_unapproved_apps_db,
     get_public_approved_apps_db,
@@ -318,7 +319,7 @@ def get_popular_apps() -> List[App]:
 
 
 def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
-    cache_key = 'get_public_approved_apps_data'
+    cache_key = PUBLIC_APPROVED_APPS_CACHE_KEY
     memory_cache = get_memory_cache()
 
     # Cache tester flag per user (30s TTL) to avoid Firestore lookup every 1s (#5439 sub-task 3)
@@ -472,14 +473,14 @@ def invalidate_approved_apps_cache() -> None:
     pubsub_manager = get_pubsub_manager()
 
     # Invalidate both cache key variants (with and without reviews)
-    cache_keys = ['get_public_approved_apps_data:reviews=0', 'get_public_approved_apps_data:reviews=1']
+    cache_keys = [f'{PUBLIC_APPROVED_APPS_CACHE_KEY}:reviews={n}' for n in (0, 1)]
 
     # Clear local memory cache
     for key in cache_keys:
         memory_cache.delete(key)
 
     # Clear Redis cache
-    delete_generic_cache('get_public_approved_apps_data')
+    delete_generic_cache(PUBLIC_APPROVED_APPS_CACHE_KEY)
 
     # Notify all other instances to clear their memory cache
     pubsub_manager.publish_invalidation(cache_keys)
@@ -487,8 +488,8 @@ def invalidate_approved_apps_cache() -> None:
 
 def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
     # Use separate cache keys for with/without reviews
-    cache_key = f'get_public_approved_apps_data:reviews={int(include_reviews)}'
-    redis_cache_key = 'get_public_approved_apps_data'
+    cache_key = f'{PUBLIC_APPROVED_APPS_CACHE_KEY}:reviews={int(include_reviews)}'
+    redis_cache_key = PUBLIC_APPROVED_APPS_CACHE_KEY
     memory_cache = get_memory_cache()
 
     def fetch_and_process() -> List[App]:


### PR DESCRIPTION
## Bug

`GET /v2/apps/search` — the Apps tab search box — times out in prod. Load-balancer logs for `api.omi.me`, 2026-08-18T12Z → 2026-08-19T05Z on image `c5b0b5d`, broken down by query shape:

| query shape | n | p50 | p90 | >5s |
|---|---|---|---|---|
| `q=<term>&limit=100` | 29 | **13.44s** | **30.05s** | 24 |
| `installed_apps=true&limit=100` | 802 | 0.15s | 0.40s | 43 |
| `my_apps=true&limit=100` | 12 | 0.13s | 0.36s | 0 |

32 requests terminated as HTTP 504 at the 30s edge in that window (Dart/3.11 mobile and the web app). The 504s are spread evenly across the 17 hours and do not co-occur with the `/v3/memories` 504 spikes — this is its own defect, not shared instance starvation.

## Root cause

`search_apps_db` streamed `approved == True AND private == False` from Firestore on **every** request. Measured against prod Firestore right now: **3,247 documents, ~25MB of JSON**.

The split above is the proof: the only slow shapes are the ones that issue that read. `?q=` always does. `installed_apps=true` does only when the user has more than 30 enabled apps (Firestore's `in` limit forces the fallback) — which is precisely its 43-request tail; the `id in [...]` fast path sits at p50 0.15s. `my_apps=true` never does and never times out.

`utils.apps.get_approved_available_apps` — the marketplace list the user came from — already serves those same documents from a 10-minute Redis cache under `get_public_approved_apps_data`. Search was the one reader that bypassed it.

## Fix

`search_apps_db` reads that shared key for both public-set branches, via a new `get_public_approved_apps_cached_db()` that uses the same key, TTL and `App.reduce_dict` reduction as the list path, so search can never serve a staler or differently-shaped view than the marketplace. `category` / `capability` move to Python filters (they were server-side filters on the read being replaced; `my_apps` is False on this branch, so they apply unconditionally).

Unchanged and still querying Firestore: `my_apps=true`, the `id in [...]` installed-apps fast path, and the uid-scoped second read that adds a user's own private/unapproved enabled apps. Those records are not in the public cache.

The cache key becomes one shared constant (`database.apps.PUBLIC_APPROVED_APPS_CACHE_KEY`) used by the reader, the writer and `invalidate_apps_cache`, so no reader can drift off the invalidation path.

## What I tested

`backend/tests/unit/test_apps_search_reads_cached_public_set.py` (new, 6 tests) drives the **real route over HTTP** — `routers.apps.router` mounted on a FastAPI app, real `search_apps_db`, only the Firestore client and the two Redis cache helpers stubbed:

- cold read streams the collection exactly once and populates the shared key with reduced records (`chat_prompt` absent, `description` present)
- warm cache serves `?q=` with **zero** Firestore streams — the read that cost 13s+ in prod
- default browse plus `category` and `capability` filters all served from the cache, matching and non-matching values both asserted
- `my_apps=true` still streams Firestore
- `installed_apps` with ≤30 enabled ids still streams Firestore
- `installed_apps` with >30 enabled ids takes the public set from the cache and streams **once** for the user's own apps

**Control run** against the pre-fix source (source files stashed, test file kept, cache helpers patched with `raising=False` so it executes rather than erroring at collection): **4 failed, 2 passed** — the four cache assertions fail with a Firestore stream per request, and the two "still reads Firestore" tests pass, confirming those branches are genuinely untouched.

**Real prod data.** Pulled the live 3,247-document set and drove the same route against it: warm `?q=todoist` / `grok` / `calendar` all answer in **0.02s with 0 Firestore streams**; the cold read populates a 10.8MB reduced payload (down from 25MB raw). And the mechanism behind the tail, timing the real Firestore query against prod:

```
sequential full-set stream:  5.69s, 2.31s, 2.64s
4 concurrent streams:        per-request p50 9.27s  (wall 9.31s)
8 concurrent streams:        per-request p50 8.33s  (wall 8.45s)
```

Concurrent readers of the same 25MB streaming read degrade each other roughly linearly — which is how a query that costs ~2.5s alone reaches a 13.4s median and a 30s p90 under real traffic. (Absolute numbers are inflated by WAN from a laptop; the shape is the point, and in-region the payload transfer is the same 25MB.)

**Suites.** `backend/test.sh` over the 36 app/marketplace/persona test files: all pass, exit 0. Full `backend/test.sh` (857 files): the only failures are `test_action_item_vector_best_effort`, `test_desktop_proactivity`, `test_modulate_stt`, `test_streaming_deepgram_backoff`, `test_sync_cloud_tasks` — the identical pre-existing set documented on the previous run against clean `origin/main` (four STT/import failures plus the fast-unit CPU-time guard). One further file, `test_app_visibility_missing_doc_guard.py`, did break: it hand-stubs the exact leaves `database/apps.py` imports, so the two new imports had to be added to its stub inventory. That is included and it passes.

## Not addressed

Cold-cache reads still stream the full set once per 10 minutes per Redis key (shared across all instances and users). Bounding the catalog read itself — a served index or a real search backend for 3k+ apps — is the durable fix and is out of scope here.

Line-Count-Exception: backend/utils/apps.py | 1652 -> 1653 | one import line, so the cache key the reader, writer and invalidation all use is a single shared constant instead of five literals

Failure-Class: FC-bounded-read-exceeds-request-budget

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

