### PR TITLE
fix(desktop): replay Gemini requests dropped by a transport failure

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -441,10 +441,37 @@ actor GeminiClient {
   /// Replay only outcomes whose typed backend contract says they are safe.
   static func shouldAutoRetry(_ error: Error) -> Bool {
     if let geminiError = error as? GeminiClientError {
-      return geminiError.shouldAutoRetry
+      if geminiError.shouldAutoRetry { return true }
+      if case .networkError(let underlying) = geminiError {
+        return isReplayableTransportError(underlying)
+      }
+      return false
     }
-    // Raw URLSession errors are ambiguous after dispatch and must not be replayed.
-    return false
+    return isReplayableTransportError(error)
+  }
+
+  /// Transport failures that are safe to replay for this client.
+  ///
+  /// Replaying a dispatched request is only unsafe when the request may have had an
+  /// effect. Every call this client makes is a `generateContent` inference: it reads a
+  /// prompt and an image and returns text, with no server-side state change, so a duplicate
+  /// costs one extra inference and nothing else.
+  ///
+  /// `NSURLErrorNetworkConnectionLost` (-1005) is the dominant failure here and is a stale
+  /// pooled-connection race, not a real network outage: URLSession reuses a keep-alive
+  /// socket the server has already closed, and the request dies immediately. Measured on a
+  /// live desktop session, 12 of 13 suggestion evaluations failed this way while ordinary
+  /// requests to the same host succeeded in ~0.4s — every one of them was discarded without
+  /// a second attempt.
+  static func isReplayableTransportError(_ error: Error) -> Bool {
+    let code = (error as? URLError)?.code ?? URLError.Code(rawValue: (error as NSError).code)
+    switch code {
+    case .networkConnectionLost, .timedOut, .cannotConnectToHost, .notConnectedToInternet,
+      .dnsLookupFailed, .cannotFindHost:
+      return true
+    default:
+      return false
+    }
   }
 
   /// Closed Gemini model tier for fallback telemetry (no free model ID strings).

--- a/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
+++ b/desktop/macos/Desktop/Tests/AIBackendErrorNormalizationTests.swift
@@ -94,7 +94,40 @@ final class AIBackendErrorNormalizationTests: XCTestCase {
     XCTAssertTrue(GeminiClient.shouldAutoRetry(authorized))
     XCTAssertFalse(GeminiClient.shouldAutoRetry(denied))
     XCTAssertFalse(GeminiClient.shouldAutoRetry(absent))
-    XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.networkConnectionLost)))
-    XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.timedOut)))
+  }
+
+  /// A *response* still needs the backend's `X-Omi-Retryable` authorization to be replayed
+  /// — that contract is unchanged and asserted above. A transport failure produces no
+  /// response, so there is no authority to consult, and the previous policy discarded it
+  /// after a single attempt.
+  ///
+  /// That excluded the one error class most worth retrying.
+  /// `NSURLErrorNetworkConnectionLost` (-1005) is a stale pooled-connection race, not an
+  /// outage: URLSession reuses a keep-alive socket the server has already closed and the
+  /// request dies in milliseconds. Measured on a live desktop session, 12 of 13 suggestion
+  /// evaluations failed this way — 4-7s apart, with plain requests to the same host
+  /// returning 200 in ~0.4s throughout — and every one was dropped without a second try.
+  ///
+  /// Replay is safe here because every call this client makes is a `generateContent`
+  /// inference: prompt plus image in, text out, no server-side state change. A duplicate
+  /// costs one extra inference and nothing else.
+  func testTransportFailuresAreReplayedWithoutBackendAuthorization() {
+    for code in [
+      URLError.Code.networkConnectionLost, .timedOut, .cannotConnectToHost,
+      .notConnectedToInternet, .dnsLookupFailed, .cannotFindHost,
+    ] {
+      XCTAssertTrue(
+        GeminiClient.shouldAutoRetry(URLError(code)),
+        "expected transport failure \(code.rawValue) to be replayable")
+    }
+  }
+
+  /// The widened replay must stay bounded to transport failures. A cancelled request is the
+  /// user or a superseding evaluation withdrawing the work, and replaying it would resurrect
+  /// work nobody is waiting for.
+  func testNonTransportURLErrorsAreStillNotReplayed() {
+    XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.cancelled)))
+    XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.badURL)))
+    XCTAssertFalse(GeminiClient.shouldAutoRetry(URLError(.userAuthenticationRequired)))
   }
 }

--- a/desktop/macos/changelog/unreleased/20260819-gemini-transport-retry.json
+++ b/desktop/macos/changelog/unreleased/20260819-gemini-transport-retry.json
@@ -1,0 +1,3 @@
+{
+  "change": "Live suggestions no longer disappear when a network hiccup drops the request — the attempt is retried instead of discarded"
+}


### PR DESCRIPTION
## Summary

`GeminiClient.shouldAutoRetry` excluded every transport failure, so the existing 3-attempt retry loop only ever fired for a typed `apiError` the backend had authorized with `X-Omi-Retryable`. A dropped connection was discarded on the first attempt.

That excluded the one error class most worth retrying. `NSURLErrorNetworkConnectionLost` (-1005) is a stale pooled-connection race, not an outage: URLSession reuses a keep-alive socket the server has already closed and the request dies in milliseconds.

## Evidence

Measured on a live desktop session while dwelling on an ordinary work screen:

```
Suggestion: delivering [95%] "..."           1
Suggestion: evaluation failed (network)     12
curl to the same host, 5 probes             200 in ~0.4s each
```

Twelve of thirteen suggestion evaluations were lost, 4–7s apart, while plain requests to the same host succeeded in ~0.4s throughout. Each failure had already spent a screenshot downscale, a grounding pass and an upload, and returned nothing — with no user-visible signal that anything had gone wrong. The feature simply appears not to work.

## What changed

- `shouldAutoRetry` now replays a bounded set of transport failures: `networkConnectionLost`, `timedOut`, `cannotConnectToHost`, `notConnectedToInternet`, `dnsLookupFailed`, `cannotFindHost`.
- `.cancelled` stays excluded — that is the user or a superseding evaluation withdrawing the work, and replaying it would resurrect work nobody is waiting for.

**The response contract is unchanged.** A *response* still requires the backend's `X-Omi-Retryable` authorization to be replayed, and that assertion is kept as-is. A transport failure produces no response, so there is no authority to consult; the previous policy read "no authorization" as "must not retry".

Replay is safe here because every call this client makes is a `generateContent` inference — prompt plus image in, text out, no server-side state change. A duplicate costs one extra inference and nothing else.

## Verification

- `swift build` → clean
- `swift test --filter AIBackendErrorNormalizationTests` → 9 passed

Two assertions in `testGeminiRetryRequiresTypedBackendAuthorization` encoded the previous policy and were rewritten. Per the testing rules I am citing the external source rather than restating the implementation: the measurement above, plus Apple's documented guidance that -1005 is transient and should be retried. The backend-authorization assertions from that test are preserved unchanged in place.

## Honest gaps

- **Not measured end-to-end.** The retry should raise the hit rate, but I have not yet re-run a full session to quantify it. The underlying -1005 frequency on this network is itself unexplained and may warrant connection-reuse settings on the URLSession rather than retries alone — retries treat the symptom.
- **This widens replay for every `GeminiClient` caller** — memory extraction, task prioritization, task dedup, insight, live notes, suggestions. Safe while they are all inference reads; a future non-idempotent caller would need its own guard. Flagging explicitly because the previous policy was deliberate and I am relaxing it.
- No on-device/pendant verification; desktop only.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- Checked the registry: the nearest class, FC-permanent-write-rejection-retried-forever, is the
inverse of this defect (replaying a rejection that can never succeed, vs never replaying one that
would). No existing class fits, and this is a single instance rather than a recurring pattern, so
minting a new class would be paperwork without a reusable guard surface. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

