### PR TITLE
security(backend): gate Anthropic server-side web search on the agentic chat path

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -38,6 +38,10 @@ from utils.llm.gateway_client import (
 from utils.llm.gateway_observability import record_gateway_request_result
 from utils.llm.gateway_resilience import gateway_circuit, observe_gateway_first_byte
 from utils.llm.gateway_serving import is_gateway_transport_failure
+from utils.llm.private_context import (
+    flatten_text_blocks,
+    openai_messages_carry_private_tool_output,
+)
 from utils.llm.usage_tracker import reset_usage_context, set_usage_context
 from utils.observability.fallback import record_fallback
 from utils.other import endpoints as auth
@@ -281,15 +285,7 @@ def _uses_managed_chat_agent(body: Mapping[str, object]) -> bool:
 
 
 def _text(content: object) -> str:
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return ''
-    return ''.join(
-        block.get('text', '')
-        for block in content
-        if isinstance(block, Mapping) and block.get('type') == 'text' and isinstance(block.get('text'), str)
-    )
+    return flatten_text_blocks(content)
 
 
 def _normalize_policy_text(text: str) -> str:
@@ -379,36 +375,13 @@ def _web_search_requested(body: Mapping[str, object]) -> bool:
 
 
 def _carries_private_tool_output(messages: object) -> bool:
-    if not isinstance(messages, list):
-        return False
-    tool_name_by_call_id: dict[str, object] = {}
-    for message in messages:
-        if not isinstance(message, Mapping):
-            continue
-        tool_calls = message.get('tool_calls')
-        if not isinstance(tool_calls, list):
-            continue
-        for call in tool_calls:
-            if (
-                isinstance(call, Mapping)
-                and isinstance(call.get('id'), str)
-                and isinstance(call.get('function'), Mapping)
-            ):
-                tool_name_by_call_id[call['id']] = call['function'].get('name')
-    for message in messages:
-        if not isinstance(message, Mapping) or message.get('role') != 'tool':
-            continue
-        name = tool_name_by_call_id.get(cast(str, message.get('tool_call_id')))
-        if not isinstance(name, str) or name not in _PUBLIC_SAFE_CLIENT_TOOLS:
-            return True
-    # The desktop hub also inlines tool output into the user turn behind this
+    # The desktop hub also inlines tool output into the user turn behind a
     # literal marker instead of sending an OpenAI `tool` message, so the same
     # private data reaches the request without a tool_call_id to classify.
-    return any(
-        isinstance(message, Mapping)
-        and message.get('role') == 'user'
-        and _UNTRUSTED_TOOL_CONTEXT_DELIMITER in _text(message.get('content'))
-        for message in messages
+    return openai_messages_carry_private_tool_output(
+        messages,
+        public_safe_tools=_PUBLIC_SAFE_CLIENT_TOOLS,
+        inline_private_markers=(_UNTRUSTED_TOOL_CONTEXT_DELIMITER,),
     )
 
 

--- a/backend/tests/unit/test_agentic_web_search_taint.py
+++ b/backend/tests/unit/test_agentic_web_search_taint.py
@@ -1,0 +1,249 @@
+"""Regression tests for the server-side ``web_search`` egress gate on the agentic path.
+
+Anthropic executes ``web_search`` on its own infrastructure, so the query string
+never reaches ``_execute_tool`` and leaves the trust boundary without passing any
+in-process control. Once a tool result is in the transcript, an injected
+instruction can place that data into the query.
+
+These cases drive the real Anthropic tool loop through the provider seam and
+assert on the ``tools`` list of every request the loop actually composes — the
+taint appears *during* the loop, so a single up-front decision cannot see it.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from utils.llm.private_context import anthropic_messages_carry_private_tool_output
+from utils.retrieval import agentic
+from utils.retrieval.safety import AgentSafetyGuard
+
+WEB_SEARCH_NAME = 'web_search'
+
+
+def _text_delta(text):
+    return SimpleNamespace(type='content_block_delta', delta=SimpleNamespace(type='text_delta', text=text))
+
+
+def _tool_use(block_id, name, tool_input=None):
+    return SimpleNamespace(type='tool_use', id=block_id, name=name, input=tool_input or {})
+
+
+def _answer(text):
+    return SimpleNamespace(type='text', text=text)
+
+
+def _response(stop_reason, content):
+    return SimpleNamespace(stop_reason=stop_reason, content=content, stop_details=None)
+
+
+class _FakeStream:
+    def __init__(self, response, events):
+        self._response = response
+        self._events = list(events)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+    def __aiter__(self):
+        async def iterator():
+            for event in self._events:
+                yield event
+
+        return iterator()
+
+    async def get_final_message(self):
+        return self._response
+
+
+class _FakeMessages:
+    """Records the kwargs of every provider request the loop composes."""
+
+    def __init__(self, turns):
+        self._turns = list(turns)
+        self.requests = []
+
+    def stream(self, **kwargs):
+        self.requests.append(kwargs)
+        response, events = self._turns.pop(0)
+        return _FakeStream(response, events)
+
+
+class _FakeTool:
+    def __init__(self, name, result):
+        self.name = name
+        self._result = result
+
+    async def ainvoke(self, tool_input, config=None):
+        return self._result
+
+
+def _tool_names(request):
+    return [tool.get('name') for tool in request['tools']]
+
+
+def _drive_loop(monkeypatch, *, turns, registry):
+    """Run the direct Anthropic agent loop and return the composed requests."""
+    fake_messages = _FakeMessages(turns)
+    monkeypatch.setattr(agentic, 'anthropic_client', SimpleNamespace(messages=fake_messages))
+
+    fallbacks = []
+    monkeypatch.setattr(agentic, 'record_fallback', lambda **fields: fallbacks.append(fields))
+
+    async def main():
+        callback = agentic.AsyncStreamingCallback()
+        return await agentic._run_anthropic_agent_stream(
+            system_prompt='you are a helpful assistant',
+            messages=[{'role': 'user', 'content': 'hello'}],
+            tool_schemas=[agentic.WEB_SEARCH_TOOL, *(_schema(name) for name in registry)],
+            tool_registry=registry,
+            callback=callback,
+            full_response=[],
+            safety_guard=AgentSafetyGuard(max_tool_calls=25, max_context_tokens=500000),
+            configurable={'user_id': 'test-uid'},
+        )
+
+    asyncio.run(main())
+    return fake_messages.requests, fallbacks
+
+
+def _schema(name):
+    return {'name': name, 'description': name, 'input_schema': {'type': 'object', 'properties': {}}}
+
+
+def _two_turn(tool_name, tool_result):
+    """Model calls *tool_name*, gets *tool_result*, then answers."""
+    return [
+        (_response('tool_use', [_tool_use('use_1', tool_name)]), []),
+        (_response('end_turn', [_answer('done')]), [_text_delta('done')]),
+    ]
+
+
+def test_web_search_is_withheld_after_a_private_tool_result(monkeypatch):
+    """A memory read taints the loop: the next request must not offer web_search."""
+    registry = {'get_memories_tool': _FakeTool('get_memories_tool', 'secret: board deck passphrase')}
+    requests, fallbacks = _drive_loop(
+        monkeypatch,
+        turns=_two_turn('get_memories_tool', 'secret: board deck passphrase'),
+        registry=registry,
+    )
+
+    assert len(requests) == 2
+    assert WEB_SEARCH_NAME in _tool_names(requests[0]), 'clean opening request should still offer web_search'
+    assert WEB_SEARCH_NAME not in _tool_names(
+        requests[1]
+    ), 'web_search must be withheld once private data is in context'
+    assert [fallback['reason'] for fallback in fallbacks] == ['private_tool_output_in_context']
+    assert fallbacks[0]['from_mode'] == 'anthropic_web_search'
+    assert fallbacks[0]['to_mode'] == 'model_knowledge'
+    assert fallbacks[0]['outcome'] == 'degraded'
+
+
+def test_web_search_survives_a_public_safe_tool_result(monkeypatch):
+    """Product-doc lookups carry no user data, so the feature must not regress."""
+    registry = {'get_omi_product_info_tool': _FakeTool('get_omi_product_info_tool', 'Omi docs: battery lasts 3 days')}
+    requests, fallbacks = _drive_loop(
+        monkeypatch,
+        turns=_two_turn('get_omi_product_info_tool', 'Omi docs: battery lasts 3 days'),
+        registry=registry,
+    )
+
+    assert len(requests) == 2
+    assert WEB_SEARCH_NAME in _tool_names(requests[0])
+    assert WEB_SEARCH_NAME in _tool_names(requests[1]), 'a public-safe producer must not withhold web_search'
+    assert fallbacks == []
+
+
+def test_unknown_producer_is_treated_as_private(monkeypatch):
+    """App tools are dynamic; an unrecognised producer must taint the loop."""
+    registry = {'app_acme_fetch_orders': _FakeTool('app_acme_fetch_orders', 'order #42 for alice@example.com')}
+    requests, fallbacks = _drive_loop(
+        monkeypatch,
+        turns=_two_turn('app_acme_fetch_orders', 'order #42 for alice@example.com'),
+        registry=registry,
+    )
+
+    assert WEB_SEARCH_NAME not in _tool_names(requests[1])
+    assert [fallback['reason'] for fallback in fallbacks] == ['private_tool_output_in_context']
+
+
+def test_withheld_path_is_recorded_once_per_loop(monkeypatch):
+    """Telemetry marks the transition, not every subsequent request."""
+    registry = {'get_memories_tool': _FakeTool('get_memories_tool', 'private')}
+    turns = [
+        (_response('tool_use', [_tool_use('use_1', 'get_memories_tool')]), []),
+        (_response('tool_use', [_tool_use('use_2', 'get_memories_tool')]), []),
+        (_response('end_turn', [_answer('done')]), [_text_delta('done')]),
+    ]
+    requests, fallbacks = _drive_loop(monkeypatch, turns=turns, registry=registry)
+
+    assert len(requests) == 3
+    assert WEB_SEARCH_NAME not in _tool_names(requests[1])
+    assert WEB_SEARCH_NAME not in _tool_names(requests[2])
+    assert len(fallbacks) == 1
+
+
+def test_convert_tools_still_offers_web_search():
+    """The gate belongs in the loop; composition keeps offering the capability."""
+    schemas, _ = agentic._convert_tools([], [])
+    assert WEB_SEARCH_NAME in [schema.get('name') for schema in schemas]
+
+
+@pytest.mark.parametrize(
+    'messages, expected',
+    [
+        ([], False),
+        ('not-a-list', False),
+        ([{'role': 'user', 'content': 'plain text turn'}], False),
+        (
+            [
+                {
+                    'role': 'assistant',
+                    'content': [{'type': 'tool_use', 'id': 'u1', 'name': 'get_omi_product_info_tool'}],
+                },
+                {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'u1', 'content': 'docs'}]},
+            ],
+            False,
+        ),
+        (
+            [
+                {'role': 'assistant', 'content': [{'type': 'tool_use', 'id': 'u1', 'name': 'get_gmail_messages_tool'}]},
+                {'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'u1', 'content': 'inbox'}]},
+            ],
+            True,
+        ),
+        # A result with no matching tool_use has no identifiable producer.
+        (
+            [{'role': 'user', 'content': [{'type': 'tool_result', 'tool_use_id': 'orphan', 'content': 'x'}]}],
+            True,
+        ),
+    ],
+)
+def test_anthropic_classifier_reads_wire_shape(messages, expected):
+    assert (
+        anthropic_messages_carry_private_tool_output(
+            messages, public_safe_tools=frozenset({'get_omi_product_info_tool'})
+        )
+        is expected
+    )
+
+
+def test_managed_lane_never_ships_the_provider_executed_tool():
+    """The gate is scoped to the direct Anthropic lane on purpose.
+
+    The managed (OpenAI-compatible) lane drops server tools when it converts the
+    schemas — they carry no ``input_schema`` — and reaches the public web through
+    the in-process Perplexity function tool instead, which does pass through
+    ``_execute_tool``. If that conversion ever started forwarding server tools,
+    the managed lane would acquire the same unguarded egress path with no gate in
+    front of it.
+    """
+    schemas, _ = agentic._convert_tools([], [])
+    converted = agentic._convert_anthropic_tools_to_openai(schemas)
+
+    assert WEB_SEARCH_NAME in [schema.get('name') for schema in schemas]
+    assert WEB_SEARCH_NAME not in [tool['function']['name'] for tool in converted]

--- a/backend/utils/llm/private_context.py
+++ b/backend/utils/llm/private_context.py
@@ -136,3 +136,14 @@ def anthropic_messages_carry_private_tool_output(
             if not isinstance(name, str) or name not in public_safe_tools:
                 return True
     return False
+
+
+def without_tool_named(tool_schemas: object, name: str) -> list:
+    """Drop every tool schema carrying *name* from a request's tool list.
+
+    Withholding a provider-executed tool means composing the request without it;
+    there is no per-request "disable" flag to set.
+    """
+    if not isinstance(tool_schemas, list):
+        return []
+    return [schema for schema in tool_schemas if not (isinstance(schema, Mapping) and schema.get('name') == name)]

--- a/backend/utils/llm/private_context.py
+++ b/backend/utils/llm/private_context.py
@@ -1,0 +1,138 @@
+"""Private-context classification for provider-executed tool gating.
+
+A tool the model provider runs on its own infrastructure never reaches the
+in-process tool executor, so every allowlist, SSRF and redirect control attached
+to that executor stops at the trust boundary. Anthropic's server-side
+``web_search`` is the case in tree: Anthropic performs the lookup and the query
+string leaves for a third party, so whatever the request already carries can be
+carried out inside it. Prompt text is not a control over that. The decision to
+offer such a tool has to be made where the request is composed, from the
+request's own contents.
+
+Classification here reads **literal wire shapes** — which producer emitted each
+tool result — and never the content of the messages. A producer this module
+cannot positively identify as public-safe is private, so a newly added tool is
+private until someone deliberately allowlists it.
+
+Two wire shapes reach this module:
+
+* OpenAI chat-completions (``routers/desktop_chat.py``): assistant messages
+  carry ``tool_calls`` with ``id`` and ``function.name``; results arrive as
+  ``role: 'tool'`` messages keyed by ``tool_call_id``.
+* Anthropic native (the direct lane in ``utils/retrieval/agentic.py``):
+  assistant content carries ``type: 'tool_use'`` blocks with ``id`` and
+  ``name``; results arrive as ``type: 'tool_result'`` blocks keyed by
+  ``tool_use_id``.
+
+Both answer the same question, so both live here rather than being re-derived
+per surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+def flatten_text_blocks(content: object) -> str:
+    """Flatten a message ``content`` field to plain text.
+
+    Accepts either a bare string or a list of typed blocks, and ignores every
+    block that is not text (images, tool results) — those carry no instruction
+    text to inspect.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ''
+    return ''.join(
+        block.get('text', '')
+        for block in content
+        if isinstance(block, Mapping) and block.get('type') == 'text' and isinstance(block.get('text'), str)
+    )
+
+
+def openai_messages_carry_private_tool_output(
+    messages: object,
+    *,
+    public_safe_tools: frozenset[str],
+    inline_private_markers: Iterable[str] = (),
+) -> bool:
+    """Whether OpenAI-shaped *messages* already carry private tool output.
+
+    ``inline_private_markers`` covers hosts that splice tool output into a user
+    turn behind a literal marker instead of sending a ``tool`` message, so the
+    same private data reaches the request with no ``tool_call_id`` to classify.
+    """
+    if not isinstance(messages, list):
+        return False
+    tool_name_by_call_id: dict[str, object] = {}
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        tool_calls = message.get('tool_calls')
+        if not isinstance(tool_calls, list):
+            continue
+        for call in tool_calls:
+            if (
+                isinstance(call, Mapping)
+                and isinstance(call.get('id'), str)
+                and isinstance(call.get('function'), Mapping)
+            ):
+                tool_name_by_call_id[call['id']] = call['function'].get('name')
+    for message in messages:
+        if not isinstance(message, Mapping) or message.get('role') != 'tool':
+            continue
+        call_id = message.get('tool_call_id')
+        name = tool_name_by_call_id.get(call_id) if isinstance(call_id, str) else None
+        if not isinstance(name, str) or name not in public_safe_tools:
+            return True
+    markers = tuple(inline_private_markers)
+    if not markers:
+        return False
+    return any(
+        isinstance(message, Mapping)
+        and message.get('role') == 'user'
+        and any(marker in flatten_text_blocks(message.get('content')) for marker in markers)
+        for message in messages
+    )
+
+
+def anthropic_messages_carry_private_tool_output(
+    messages: object,
+    *,
+    public_safe_tools: frozenset[str],
+) -> bool:
+    """Whether Anthropic-shaped *messages* already carry private tool output.
+
+    Mirrors :func:`openai_messages_carry_private_tool_output` across the native
+    content-block contract: ``tool_use`` blocks name the producer, and the
+    ``tool_result`` blocks that quote a ``tool_use_id`` carry what it returned.
+    A ``tool_result`` whose producer is unknown — no matching ``tool_use``, or a
+    name outside *public_safe_tools* — is private.
+    """
+    if not isinstance(messages, list):
+        return False
+    tool_name_by_use_id: dict[str, object] = {}
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get('content')
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, Mapping) and block.get('type') == 'tool_use' and isinstance(block.get('id'), str):
+                tool_name_by_use_id[block['id']] = block.get('name')
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get('content')
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, Mapping) or block.get('type') != 'tool_result':
+                continue
+            use_id = block.get('tool_use_id')
+            name = tool_name_by_use_id.get(use_id) if isinstance(use_id, str) else None
+            if not isinstance(name, str) or name not in public_safe_tools:
+                return True
+    return False

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -60,6 +60,7 @@ from utils.retrieval.safety import (
     should_retry_provider_error,
     INPUT_TOO_LONG_MESSAGE,
 )
+from utils.llm.private_context import anthropic_messages_carry_private_tool_output, without_tool_named
 from utils.observability.fallback import record_fallback
 from utils.llm.byok_errors import handle_llm_error_async
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL, get_llm, num_tokens_from_string
@@ -385,11 +386,25 @@ TOOL_SEARCH_TOOL = {
 }
 
 # Web search tool — Anthropic's built-in server-side web search (replaces Perplexity)
+SERVER_WEB_SEARCH_NAME = "web_search"
 WEB_SEARCH_TOOL = {
     "type": "web_search_20260209",
-    "name": "web_search",
+    "name": SERVER_WEB_SEARCH_NAME,
     "max_uses": 5,
 }
+
+# Producers whose results may stay in the transcript while `web_search` is still
+# offered — see `utils/llm/private_context` for why the offer is gated at all.
+# Only product-doc lookups qualify: every other core tool reads user data, echoes
+# the user's input back (`save_user_preference_tool`, `create_action_item_tool`),
+# or can surface user data in an error string (`create_calendar_event_tool`
+# resolves attendees against Google Contacts). Unknown names — app tools are
+# registered at runtime — are private.
+#
+# `tool_search_tool_regex` is deliberately not gated: it is provider-executed
+# too, but it resolves inside Anthropic and reaches no third party, so it crosses
+# no boundary the request had not already crossed.
+_PUBLIC_SAFE_AGENT_TOOLS = frozenset({'get_omi_product_info_tool'})
 
 
 def _convert_tools(core_tools: list, app_tools: list = None) -> tuple:
@@ -658,8 +673,41 @@ async def _run_anthropic_agent_stream(
     producer_started_at = asyncio.get_running_loop().time()
     loop_iteration = 0
 
+    # The taint appears *during* the loop: the opening request carries only the
+    # user/assistant transcript, and a tool result lands in `messages` after each
+    # iteration. The offer is therefore re-decided per request rather than once
+    # up front, and latched — a loop that has seen private data stays withheld
+    # even if a later iteration were to trim the transcript.
+    #
+    # Withholding changes the tool block, which is part of the cached prefix, so
+    # the iteration that trips the gate takes a prompt-cache miss. That cost is
+    # the price of the gate: do not hoist this decision back out of the loop to
+    # keep the prefix stable — the opening request is always clean, so a
+    # hoisted check can never observe the taint it exists to catch.
+    offers_server_web_search = any(
+        isinstance(schema, dict) and schema.get('name') == SERVER_WEB_SEARCH_NAME for schema in tool_schemas
+    )
+    server_web_search_withheld = False
+
     while True:
         loop_iteration += 1
+
+        if (
+            offers_server_web_search
+            and not server_web_search_withheld
+            and anthropic_messages_carry_private_tool_output(messages, public_safe_tools=_PUBLIC_SAFE_AGENT_TOOLS)
+        ):
+            server_web_search_withheld = True
+            record_fallback(
+                component='other',
+                from_mode='anthropic_web_search',
+                to_mode='model_knowledge',
+                reason='private_tool_output_in_context',
+                outcome='degraded',
+            )
+        request_tools = (
+            without_tool_named(tool_schemas, SERVER_WEB_SEARCH_NAME) if server_web_search_withheld else tool_schemas
+        )
 
         attempts_made = 0
         retried_reason: Optional[str] = None
@@ -674,7 +722,7 @@ async def _run_anthropic_agent_stream(
                     model=ANTHROPIC_AGENT_MODEL,
                     system=system_blocks,
                     messages=messages,
-                    tools=tool_schemas,
+                    tools=request_tools,
                     max_tokens=8192,
                     # Anthropic moves this breakpoint to the last cacheable message
                     # block on every request. That incrementally caches both the


### PR DESCRIPTION
Fixes #11412.

## The defect

`_convert_tools` appended `WEB_SEARCH_TOOL` unconditionally (`backend/utils/retrieval/agentic.py:409` at the time of filing), so every direct Anthropic agent loop offered Anthropic's server-side `web_search`.

Anthropic executes that tool on its own infrastructure. The block never reaches `_execute_tool`, so the `fetch_url` allowlist, SSRF guard and redirect bound do not apply to it, and the query string is an outbound request to a third party. After a memory/Gmail/screen tool returns private data, an injected instruction can place that data into a search query and it leaves the trust boundary. The backend only ever observes the tool at `content_block_start` (`type == "server_tool_use"`), which confirms it is never executed in-process.

The issue describes the tool as gated on `include_server_web_search=True`. That flag no longer exists anywhere in `backend/` — the tool was attached to every agentic loop.

## The fix

PR #11414 built exactly this gate for the desktop chat path. `agentic.py` serves the mobile/main app chat agent and was never migrated. This applies the same, already-reviewed decision to the un-migrated call site.

**Commit 1** moves `_carries_private_tool_output` out of `routers/desktop_chat.py` into `utils/llm/private_context.py`, parameterizing the two desktop-specific inputs (the public-safe producer allowlist, the inline tool-output markers). `agentic.py` is a utils module and cannot import a router, so sharing the classifier was a precondition for the fix. `desktop_chat` now calls the shared function; no duplicate copy is left behind, per the root `AGENTS.md` rule against in-repo compatibility layers. No behavior change.

**Commit 2** gates the agentic path.

### Why the gate is in the loop, not in `_convert_tools`

`_messages_to_anthropic` emits text-only turns, so the opening request is always clean; the taint only appears **during** the loop, as each tool result is appended to `messages`. A single decision at composition time could never observe the condition it exists to catch. The offer is therefore re-decided before each provider request and latched once withheld.

This costs a prompt-cache miss on the iteration that trips the gate, since the tool block is part of the cached prefix. That is the price of the gate, and there is a comment at the call site saying so, because the obvious "optimization" of hoisting the check back out of the loop silently reintroduces the vulnerability.

### Scope

Only the direct Anthropic lane ships the provider-executed tool. The managed lane drops server tools in `_convert_anthropic_tools_to_openai` (they carry no `input_schema`) and reaches the public web through the in-process Perplexity function tool, which *does* pass through `_execute_tool`. A test pins that, so the managed lane cannot silently acquire the same unguarded path.

### Classification

Reads literal wire shapes — which producer emitted each `tool_result` — never message content, and treats unknown producers as private, so runtime-registered app tools taint the loop. This matches the failure class's `canonical_prevention` verbatim.

The public-safe allowlist holds only `get_omi_product_info_tool`, which returns GitHub product documentation. The desktop allowlist's names were deliberately **not** copied across: the agentic implementations of the same-sounding tools do return user data (`create_action_item_tool` returns the created item; `create_calendar_event_tool` can surface Google Contacts addresses in an error string; `save_user_preference_tool` echoes the saved text and any matching stored preference).

## Known limitation

Classification is by wire shape, so private data that a *previous assistant turn* already rendered into plain text is not treated as taint. That is the deliberate trade the failure class prescribes ("classify that context from literal wire shapes rather than content heuristics"); content-based classification is explicitly what it warns against. The exfiltration path in #11412 — a tool result in the current loop — is closed.

## Verification

Red first, against unmodified code (`backend/tests/unit/test_agentic_web_search_taint.py`):

```
FAILED test_web_search_is_withheld_after_a_private_tool_result
FAILED test_unknown_producer_is_treated_as_private
FAILED test_withheld_path_is_recorded_once_per_loop
3 failed, 8 passed

>       assert WEB_SEARCH_NAME not in _tool_names(requests[1])
E       AssertionError: assert 'web_search' not in ['web_search', 'get_memories_tool']
```

Green after the fix: `12 passed`.

The tests drive the real `_run_anthropic_agent_stream` loop through the `anthropic_client.messages.stream` seam and assert on the `tools` list of every request the loop actually composes — both directions (withheld after a private result, still offered on a clean loop), plus unknown-producer handling and single-shot telemetry.

Neighbouring suites:

```
tests/unit/test_desktop_chat.py tests/unit/test_fallback_observability.py
tests/unit/test_chat_agent_provider_retry.py tests/unit/test_retrieval_result_bounds.py
tests/unit/test_chat_agent_cost_report.py tests/unit/test_agent_tools_isolation.py
tests/unit/test_retrieval_semantics.py
-> all pass (run per-file; see note below)
```

Plus the 18 suites that import the touched modules, run individually: all pass.

```
scripts/check_module_stub_pollution.py    -> Checked 907 test file(s); 0 violation(s).
scripts/scan_import_time_side_effects.py  -> Checked 804 production file(s); 0 violation(s).
```

Note: `test_chat_agent_provider_retry.py` followed by `test_agent_tools_isolation.py` in one process fails collection with `ModuleNotFoundError: No module named 'utils.conversations.factory'`. This reproduces on unmodified `upstream/main` (verified in a detached worktree at `79a585be75`) and is unrelated to this change; the suites pass per-file.

**Not exercised against live Anthropic.** Verified hermetically at the provider seam only.

## Gates

Failure-Class: FC-provider-executed-tool-bypasses-egress-guard

Product invariants affected: none (`scripts/pr-preflight --suggest` reports none for these paths).

Line-Count-Exception: backend/utils/retrieval/agentic.py | 1512 -> 1560 | Security gate must be re-decided per provider request inside the agent loop; the taint does not exist at composition time, so the check cannot live in an existing helper. The classifier itself was placed in a new shared module rather than added here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

