### PR TITLE
fix(backend): test-prompt returns 500 when the summary provider times out

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -59,7 +59,7 @@ from utils.conversations.search import (
     parse_exact_conversation_reference,
     search_conversations,
 )
-from utils.llm.conversation_processing import generate_summary_with_prompt
+from utils.llm.conversation_processing import SummaryProviderError, generate_summary_with_prompt
 from utils.speaker_identification import extract_speaker_samples
 from utils.other import endpoints as auth
 from utils.other.storage import get_conversation_recording_if_exists
@@ -1456,7 +1456,18 @@ def test_prompt(
         raise HTTPException(status_code=400, detail="Conversation has no text content to summarize.")
 
     # Pass language code from conversation to match app behavior
-    summary = generate_summary_with_prompt(full_transcript, request.prompt, language_code=conversation.language or 'en')
+    try:
+        summary = generate_summary_with_prompt(
+            full_transcript, request.prompt, language_code=conversation.language or 'en'
+        )
+    except SummaryProviderError as exc:
+        # The provider failed on its own account, so this is an upstream failure and not a fault
+        # of the request: report it as one instead of as a 500 the client cannot act on.
+        logger.warning("test-prompt summary failed upstream: conversation_id=%s", conversation_id)
+        raise HTTPException(
+            status_code=504 if exc.timed_out else 502,
+            detail='summary_provider_timeout' if exc.timed_out else 'summary_provider_unavailable',
+        ) from exc
 
     return {"summary": summary}
 

--- a/backend/tests/unit/test_conversation_test_prompt_provider_failure.py
+++ b/backend/tests/unit/test_conversation_test_prompt_provider_failure.py
@@ -1,0 +1,197 @@
+"""POST /v1/conversations/{id}/test-prompt reports an upstream provider failure as one.
+
+Live prod signature (backend image 79a585b, api.omi.me, 2026-08-19):
+
+    File "/app/routers/conversations.py", line 1459, in test_prompt
+      summary = generate_summary_with_prompt(...)
+    File "/app/utils/llm/conversation_processing.py", line 1509, in generate_summary_with_prompt
+      response = get_llm('daily_summary', cache_key='omi-daily-summary').invoke(full_prompt)
+    openai.APITimeoutError: Request timed out.
+
+One user retried the same conversation three times; every attempt died at the 15s gateway
+first-byte deadline (15.19s / 15.45s / 15.34s of request latency) and returned HTTP 500. Two
+things were wrong: a foreground request inherited a deadline sized for background feature calls,
+and the resulting transport failure escaped unclassified, so a slow provider was indistinguishable
+from a bug in this route.
+
+Both halves are covered here: the classification at the provider call, and the status code the
+client actually receives, driven over HTTP against the real router.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from types import SimpleNamespace  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+import httpx  # noqa: E402
+import openai  # noqa: E402
+import pytest  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+import routers.conversations as conv  # noqa: E402
+import utils.llm.conversation_processing as processing  # noqa: E402
+from utils.llm.gateway_resilience import DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS  # noqa: E402
+from utils.other import endpoints as endpoints_module  # noqa: E402
+
+CONVERSATION_ID = "277d188e-9563-4fd1-bf1b-8a6bbcbe4b94"
+_REQUEST = httpx.Request("POST", "https://gateway.invalid/v1/chat/completions")
+
+
+def _upstream_5xx():
+    return openai.InternalServerError(
+        "upstream exploded",
+        response=httpx.Response(status_code=503, request=_REQUEST),
+        body=None,
+    )
+
+
+# --- classification at the provider call -------------------------------------------------
+
+
+@pytest.fixture
+def failing_llm(monkeypatch):
+    """Replace the provider client, leaving the real generate_summary_with_prompt in place."""
+
+    llm = MagicMock()
+    get_llm = MagicMock(return_value=llm)
+    monkeypatch.setattr(processing, "get_llm", get_llm)
+    return SimpleNamespace(llm=llm, get_llm=get_llm)
+
+
+def test_summary_asks_for_a_foreground_deadline(failing_llm):
+    """The 15s gateway first-byte deadline is what timed these requests out; ask for more."""
+    failing_llm.llm.invoke.return_value = SimpleNamespace(content="a summary")
+
+    assert processing.generate_summary_with_prompt("transcript", "summarize") == "a summary"
+
+    request_timeout = failing_llm.get_llm.call_args.kwargs["request_timeout"]
+    assert request_timeout == processing.SUMMARY_WITH_PROMPT_TIMEOUT_SECONDS
+    assert request_timeout > DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS
+
+
+def test_provider_timeout_becomes_a_typed_summary_failure(failing_llm):
+    failing_llm.llm.invoke.side_effect = openai.APITimeoutError(request=_REQUEST)
+
+    with pytest.raises(processing.SummaryProviderError) as raised:
+        processing.generate_summary_with_prompt("transcript", "summarize")
+
+    assert raised.value.timed_out is True
+
+
+def test_provider_5xx_becomes_a_typed_summary_failure(failing_llm):
+    failing_llm.llm.invoke.side_effect = _upstream_5xx()
+
+    with pytest.raises(processing.SummaryProviderError) as raised:
+        processing.generate_summary_with_prompt("transcript", "summarize")
+
+    assert raised.value.timed_out is False
+
+
+def test_non_provider_error_is_not_reclassified(failing_llm):
+    """A bug in this code path must keep its own exception instead of posing as an outage."""
+    failing_llm.llm.invoke.side_effect = ValueError("not a provider failure")
+
+    with pytest.raises(ValueError):
+        processing.generate_summary_with_prompt("transcript", "summarize")
+
+
+# --- what the client receives ------------------------------------------------------------
+
+
+def _conversation(text: str = "hello there"):
+    segments = [SimpleNamespace(text=text)] if text else []
+    return SimpleNamespace(transcript_segments=segments, language="en")
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Rate limiting is a Redis round trip that this route's error handling has nothing to do with.
+    monkeypatch.setattr(endpoints_module, "_enforce_rate_limit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(conv, "_get_valid_conversation_by_id", lambda uid, conversation_id: {"id": conversation_id})
+    monkeypatch.setattr(conv, "deserialize_conversation", lambda data: _conversation())
+
+    app = FastAPI()
+    app.include_router(conv.router)
+    app.dependency_overrides[conv.auth.get_current_user_uid] = lambda: "test-uid"
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _post(client, prompt="summarize this"):
+    return client.post(f"/v1/conversations/{CONVERSATION_ID}/test-prompt", json={"prompt": prompt})
+
+
+def _raise(exc):
+    def _raiser(*args, **kwargs):
+        raise exc
+
+    return _raiser
+
+
+def test_timed_out_provider_answers_504(client, monkeypatch):
+    monkeypatch.setattr(
+        conv,
+        "generate_summary_with_prompt",
+        _raise(conv.SummaryProviderError("provider timed out", timed_out=True)),
+    )
+
+    response = _post(client)
+
+    assert response.status_code == 504
+    assert response.json()["detail"] == "summary_provider_timeout"
+
+
+def test_unavailable_provider_answers_502(client, monkeypatch):
+    monkeypatch.setattr(
+        conv,
+        "generate_summary_with_prompt",
+        _raise(conv.SummaryProviderError("provider 5xx", timed_out=False)),
+    )
+
+    response = _post(client)
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "summary_provider_unavailable"
+
+
+def test_provider_timeout_answers_504_through_both_layers(client, monkeypatch):
+    """The prod signature end to end: only the provider client is replaced, nothing in between.
+
+    Against unmodified source this is the failure that shipped — HTTP 500.
+    """
+    llm = MagicMock()
+    llm.invoke.side_effect = openai.APITimeoutError(request=_REQUEST)
+    monkeypatch.setattr(processing, "get_llm", MagicMock(return_value=llm))
+
+    response = _post(client)
+
+    assert response.status_code == 504
+    assert response.json()["detail"] == "summary_provider_timeout"
+
+
+def test_unexpected_error_still_surfaces_as_500(client, monkeypatch):
+    monkeypatch.setattr(conv, "generate_summary_with_prompt", _raise(ValueError("route bug")))
+
+    response = _post(client)
+
+    assert response.status_code == 500
+
+
+def test_successful_summary_is_returned(client, monkeypatch):
+    monkeypatch.setattr(conv, "generate_summary_with_prompt", lambda *args, **kwargs: "a summary")
+
+    response = _post(client)
+
+    assert response.status_code == 200
+    assert response.json()["summary"] == "a summary"
+
+
+def test_conversation_without_text_still_rejected_as_bad_request(client, monkeypatch):
+    monkeypatch.setattr(conv, "deserialize_conversation", lambda data: _conversation(text=""))
+
+    response = _post(client)
+
+    assert response.status_code == 400

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1496,6 +1496,26 @@ def select_best_app_for_conversation(conversation: Conversation, apps: List[App]
         return None
 
 
+# POST /v1/conversations/{id}/test-prompt runs this inline while the user waits, so it must not
+# inherit the shared gateway transport deadline (15s to first response byte), which is sized for
+# background feature calls. A whole-transcript summary regularly needs longer than that: in prod on
+# 2026-08-19 the same conversation failed three times at 15.2s / 15.3s / 15.4s. The route's own
+# budget is the 120s default of TimeoutMiddleware, so a foreground attempt fits with headroom.
+SUMMARY_WITH_PROMPT_TIMEOUT_SECONDS = 60.0
+
+
+class SummaryProviderError(Exception):
+    """The summary provider failed on its own account, so no summary exists to return.
+
+    Classified here, at the call that owns the provider, so the caller only has to decide how to
+    report it. ``timed_out`` separates a deadline from an upstream 5xx.
+    """
+
+    def __init__(self, message: str, *, timed_out: bool) -> None:
+        super().__init__(message)
+        self.timed_out = timed_out
+
+
 def generate_summary_with_prompt(conversation_text: str, prompt: str, language_code: str = 'en') -> str:
     # Build prompt matching the app processing format (without forced "be concise" constraint)
     full_prompt = f"""
@@ -1506,5 +1526,19 @@ def generate_summary_with_prompt(conversation_text: str, prompt: str, language_c
     The conversation is:
     {conversation_text}
     """
-    response = get_llm('daily_summary', cache_key='omi-daily-summary').invoke(full_prompt)
+    llm = get_llm('daily_summary', cache_key='omi-daily-summary', request_timeout=SUMMARY_WITH_PROMPT_TIMEOUT_SECONDS)
+    try:
+        response = llm.invoke(full_prompt)
+    except Exception as exc:
+        # The shared provider-error classifier lives in the chat-retrieval package; this module is
+        # on the import path of most of the backend, so keep that package off it and pay for the
+        # import only on the failure branch.
+        from utils.retrieval.safety import is_transient_provider_error, provider_fallback_reason
+
+        if not is_transient_provider_error(exc):
+            raise
+        raise SummaryProviderError(
+            f'summary provider failed: {type(exc).__name__}',
+            timed_out=provider_fallback_reason(exc) == 'timeout',
+        ) from exc
     return _content_str(response)


### PR DESCRIPTION
## Bug

`POST /v1/conversations/{conversation_id}/test-prompt` (the app's **Test Prompt** sheet in conversation detail) returns **HTTP 500** whenever the summarization model needs more than 15 seconds.

Live prod signature, backend image `79a585b`, `api.omi.me`, 2026-08-19:

```
File "/app/routers/conversations.py", line 1459, in test_prompt
  summary = generate_summary_with_prompt(...)
File "/app/utils/llm/conversation_processing.py", line 1509, in generate_summary_with_prompt
  response = get_llm('daily_summary', cache_key='omi-daily-summary').invoke(full_prompt)
openai.APITimeoutError: Request timed out.
```

One user retried the same conversation three times inside 20 minutes (09:51:01Z, 10:09:52Z, 10:10:07Z); every attempt failed at the same place, with request latencies of 15.34s / 15.45s / 15.19s. `app/lib/backend/http/api/conversations.dart` maps any non-200 to `''` and `test_prompts.dart` renders `''` as nothing at all, so the user saw the spinner stop and an empty sheet, three times.

## Root cause

Two contracts failed at the same call.

1. **A foreground request inherited a background deadline.** `generate_summary_with_prompt` took the shared gateway client, whose transport timeout is `DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS = 15.0` — sized for background feature calls. A whole-transcript summary regularly needs longer, so long conversations fail deterministically. Nothing else in the chain wanted a 15s cap: the route's own budget is the 120s `TimeoutMiddleware` default and the Flutter client waits 300s on POST.
2. **The resulting transport failure escaped unclassified.** `openai.APITimeoutError` propagated out of the handler, so a slow upstream was reported as a fault of this request, indistinguishable from a real bug in the route.

## Fix

- `generate_summary_with_prompt` asks for an explicit foreground deadline (`SUMMARY_WITH_PROMPT_TIMEOUT_SECONDS = 60.0`) through the `request_timeout` parameter `get_llm` already supports.
- It also classifies a provider failure where that failure happens, with the existing `utils.retrieval.safety` helpers (the named guard artifact of `FC-recoverable-provider-failure-terminal`), and raises a typed `SummaryProviderError` carrying `timed_out`. Anything that is not a transport-class provider failure keeps its own exception.
- The route maps that one type onto the wire: **504 `summary_provider_timeout`** or **502 `summary_provider_unavailable`**. A non-provider error still surfaces as a 500, so a real bug here stays visible.

No retry is added: a timeout on a long transcript would simply repeat, and a second 60s attempt would push the request against the route budget.

## What I tested

- `backend/tests/unit/test_conversation_test_prompt_provider_failure.py` (new, **10 tests, all pass**), in two halves:
  - classification at the provider call — timeout → `timed_out=True`, upstream 5xx → `timed_out=False`, `ValueError` → propagates unchanged, and the deadline handed to `get_llm` is the foreground constant and strictly greater than the gateway first-byte default;
  - what the client receives, driven **over HTTP** against the real `routers.conversations` — 504, 502, still-500 for a route bug, 200 on success, still-400 for an empty transcript, plus an end-to-end case where only the provider client is replaced and the real classification runs.
- **Control run against `origin/main` source:** 6 of the 10 fail, the end-to-end one with exactly the prod signature — `assert 500 == 504`.
- `backend/test.sh` over the 45 unit files that touch `routers.conversations`, `utils.llm.conversation_processing`, or the provider-error classifier — **exit 0**. That set includes the two static call-site checkers (`test_omi_qos_tiers.py`, `test_process_conversation_usage_context.py`) that scan this file for `get_llm('daily_summary'`, which is why the call stays on one line. The full 861-file selection is left to CI, which is the suite's authority.
- `scripts/pr-preflight --pr-body-file` / `make preflight`.

Not verified: that a real >15s provider call now completes, which needs live provider latency. The deadline is asserted through the value handed to `get_llm`.

Failure-Class: FC-recoverable-provider-failure-terminal

Line-Count-Exception: backend/routers/conversations.py | 1527 -> 1538 | 11 lines: mapping the typed provider failure onto a status code belongs in the handler that owns the request
Line-Count-Exception: backend/utils/llm/conversation_processing.py | 1510 -> 1544 | 34 lines: the foreground deadline, the typed error and the classification belong with the provider call they bound

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

