### PR TITLE
fix(backend): stop syncing audio into conversations deleted mid-session

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -738,7 +738,13 @@ def iter_all_conversations(uid: str, batch_size: int = 400, include_discarded: b
         offset += batch_size
 
 
-def update_conversation(uid: str, conversation_id: str, update_data: dict):
+def update_conversation(uid: str, conversation_id: str, update_data: dict) -> bool:
+    """Apply ``update_data`` to a conversation.
+
+    Returns False when the conversation no longer exists, so callers that keep
+    producing work for it (e.g. the pusher's private-cloud audio sync) can stop
+    instead of writing into a deleted owner.
+    """
     lifecycle_fields = _LIFECYCLE_FIELDS.intersection(update_data)
     if lifecycle_fields:
         raise ValueError(
@@ -748,11 +754,12 @@ def update_conversation(uid: str, conversation_id: str, update_data: dict):
     doc_ref = db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
     doc_snapshot = doc_ref.get()
     if not doc_snapshot.exists:
-        return
+        return False
 
     doc_level = doc_snapshot.to_dict().get('data_protection_level', 'standard')
     prepared_data = _prepare_conversation_for_write(update_data, uid, doc_level)
     doc_ref.update(prepared_data)
+    return True
 
 
 def try_claim_conversation_memory_analytics(uid: str, conversation_id: str, firestore_client: Any = None) -> bool:

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -52,6 +52,7 @@ from utils.metrics import (
     PUSHER_PRIVATE_CLOUD_UPLOAD_DROPS,
 )
 from utils.readiness import ReadinessGate
+from utils.observability.fallback import record_fallback
 from utils.observability.journeys import JourneyAttempt
 from utils.speaker_identification import extract_speaker_samples
 import logging
@@ -185,8 +186,16 @@ async def _websocket_util_trigger(
         # Pending batches keyed by conversation_id
         pending: Dict[str, Dict[str, Any]] = {}
 
+        # Conversations deleted underneath us (e.g. discarded as empty at rollover).
+        # Their chunks can never be referenced, played or cleaned up again, so we
+        # stop uploading rather than leaving more orphans in the bucket (#11742).
+        deleted_conversations: set[str] = set()
+
         def _add_to_batch(chunk_info: PrivateCloudChunk) -> None:
             conv_id = chunk_info['conversation_id']
+            if conv_id in deleted_conversations:
+                audio_budget.release(len(chunk_info['data']))
+                return
             if conv_id not in pending:
                 bound_private_pending(pending, audio_budget)
                 pending[conv_id] = {
@@ -226,29 +235,41 @@ async def _websocket_util_trigger(
                     )
                     if audio_files:
                         files_payload = [af.model_dump() for af in audio_files]
-                        await run_blocking(
+                        applied = await run_blocking(
                             storage_executor,
                             conversations_db.update_conversation,
                             uid,
                             conv_id,
                             {'audio_files': files_payload},
                         )
-                        # Rebuild the conversation playback artifact if a stamped one
-                        # went stale. No stamp (the live-conversation common case) → no-op.
-                        if is_audio_merge_dispatch_enabled():
-                            stamp = await run_blocking(
-                                storage_executor, conversations_db.get_conversation_audio_stamp, uid, conv_id
-                            )
-                            if stamp:
-                                await run_blocking(
-                                    storage_executor,
-                                    maybe_invalidate_conversation_playback,
-                                    uid,
-                                    conv_id,
-                                    {'conversation_audio': stamp},
-                                    files_payload,
-                                    'pusher_flush',
+                        if applied:
+                            # Rebuild the conversation playback artifact if a stamped one
+                            # went stale. No stamp (the live-conversation common case) → no-op.
+                            if is_audio_merge_dispatch_enabled():
+                                stamp = await run_blocking(
+                                    storage_executor, conversations_db.get_conversation_audio_stamp, uid, conv_id
                                 )
+                                if stamp:
+                                    await run_blocking(
+                                        storage_executor,
+                                        maybe_invalidate_conversation_playback,
+                                        uid,
+                                        conv_id,
+                                        {'conversation_audio': stamp},
+                                        files_payload,
+                                        'pusher_flush',
+                                    )
+                        else:
+                            deleted_conversations.add(conv_id)
+                            logger.info(f"Conversation gone, stopped private cloud sync {uid} {conv_id}")
+                            record_fallback(
+                                component='pusher',
+                                from_mode='private_cloud_sync',
+                                to_mode='drop',
+                                reason='policy',
+                                outcome='exhausted',
+                                log=logger,
+                            )
                 except Exception as e:
                     logger.error(f"Error updating audio files: {e} {uid} {conv_id}")
                 audio_budget.release(len(chunk_data))

--- a/backend/tests/unit/test_conversation_lifecycle_contract.py
+++ b/backend/tests/unit/test_conversation_lifecycle_contract.py
@@ -152,6 +152,14 @@ def test_generic_lifecycle_field_write_fails_closed(lifecycle_store):
     assert lifecycle_store.conversation('uid', 'conversation')['status'] == ConversationStatus.completed.value
 
 
+def test_update_conversation_reports_a_deleted_owner(lifecycle_store):
+    """Callers that keep producing work for a conversation must be able to see it is gone (#11742)."""
+    lifecycle_store.put_conversation('uid', 'conversation', status=ConversationStatus.completed.value, discarded=False)
+
+    assert conversations_db.update_conversation('uid', 'conversation', {'language': 'en'}) is True
+    assert conversations_db.update_conversation('uid', 'missing', {'language': 'en'}) is False
+
+
 def test_concurrent_finalizers_have_one_service_admission(lifecycle_store):
     lifecycle_store.put_conversation(
         'uid', 'conversation', status=ConversationStatus.in_progress.value, discarded=False

--- a/backend/tests/unit/test_pusher_deleted_conversation_sync.py
+++ b/backend/tests/unit/test_pusher_deleted_conversation_sync.py
@@ -1,0 +1,136 @@
+"""Regression test for #11742: the pusher kept syncing audio into deleted conversations.
+
+Every listen generation discarded as "empty" deletes the Firestore conversation while the
+pusher session keeps running. The session's remaining private-cloud batches were still
+uploaded to ``chunks/{uid}/{conversation_id}/``, where nothing can ever reference, play or
+delete them — 41% of sampled chunk prefixes in prod belonged to conversations that no
+longer exist. Once ``update_conversation`` reports the owner is gone, the session must stop
+uploading for that conversation.
+"""
+
+import asyncio
+import struct
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.websockets import WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+import routers.pusher as pusher
+import utils.pusher_protocol as pusher_protocol
+
+UID = 'uid'
+CONVERSATION_ID = 'conversation'
+SAMPLE_RATE = 8000
+
+CONVERSATION_FRAME = struct.pack('<I', 103) + CONVERSATION_ID.encode()
+AUDIO_FRAME = struct.pack('<I', 101) + struct.pack('d', 1.0) + b'\x00' * 64
+
+
+class _AudioFile:
+    def model_dump(self) -> dict:
+        return {'path': 'audio.wav'}
+
+
+class SequencedWebSocket:
+    """Sends a second audio chunk only after the first flush has been handled.
+
+    The pusher's private-cloud worker is a separate task, so without this handshake the
+    two chunks would coalesce into a single batch and the test could not observe whether
+    the second one is still uploaded.
+    """
+
+    def __init__(self, first_flush_handled: asyncio.Event):
+        self.frames = deque([CONVERSATION_FRAME, AUDIO_FRAME])
+        self.first_flush_handled = first_flush_handled
+        self.second_chunk_sent = False
+        self.client_state = WebSocketState.CONNECTED
+        self.close_code = None
+
+    async def accept(self):
+        return None
+
+    async def close(self, code=1000, reason=None):
+        self.close_code = code
+        self.client_state = WebSocketState.DISCONNECTED
+
+    async def receive_bytes(self):
+        if self.frames:
+            return self.frames.popleft()
+        if not self.second_chunk_sent:
+            await self.first_flush_handled.wait()
+            self.second_chunk_sent = True
+            return AUDIO_FRAME
+        raise WebSocketDisconnect(1000)
+
+
+@pytest.fixture
+def private_cloud_session(monkeypatch):
+    """Drive a private-cloud sync session where each audio frame flushes immediately."""
+    monkeypatch.setattr(pusher, 'get_audio_bytes_webhook_seconds', lambda uid: None)
+    monkeypatch.setattr(pusher, 'is_audio_bytes_app_enabled', lambda uid: False)
+    monkeypatch.setattr(pusher, 'is_audio_merge_dispatch_enabled', lambda: False)
+    monkeypatch.setattr(pusher.users_db, 'get_user_private_cloud_sync_enabled', lambda uid: True)
+    monkeypatch.setattr(pusher.users_db, 'get_data_protection_level', lambda uid: 'standard')
+    monkeypatch.setattr(pusher, 'PUSHER_ACTIVE_WS_CONNECTIONS', MagicMock())
+    monkeypatch.setattr(pusher, 'PUSHER_PRIVATE_CLOUD_UPLOAD_DROPS', MagicMock())
+    monkeypatch.setattr(pusher_protocol, 'PUSHER_QUEUE_DROPS', MagicMock())
+    monkeypatch.setattr(pusher_protocol, 'PUSHER_QUEUE_DROPPED_BYTES', MagicMock())
+    # Flush every queued chunk on the next worker tick instead of after 60s of audio.
+    monkeypatch.setattr(pusher, 'PRIVATE_CLOUD_CHUNK_DURATION', 0.0)
+    monkeypatch.setattr(pusher, 'PRIVATE_CLOUD_BATCH_MAX_AGE', 0.0)
+    monkeypatch.setattr(pusher, 'PRIVATE_CLOUD_SYNC_PROCESS_INTERVAL', 0.01)
+
+    first_flush_handled = asyncio.Event()
+    uploaded: list[str] = []
+    fallbacks: list[dict] = []
+
+    def upload(chunks, uid, conversation_id, protection_level):
+        uploaded.append(conversation_id)
+
+    monkeypatch.setattr(pusher, 'upload_audio_chunks_batch', upload)
+    monkeypatch.setattr(
+        pusher.conversations_db, 'create_audio_files_from_chunks', lambda uid, conversation_id: [_AudioFile()]
+    )
+    monkeypatch.setattr(pusher, 'record_fallback', lambda **kwargs: fallbacks.append(kwargs))
+
+    def run(conversation_exists: bool):
+        def update_conversation(uid, conversation_id, update_data):
+            first_flush_handled.set()
+            return conversation_exists
+
+        monkeypatch.setattr(pusher.conversations_db, 'update_conversation', update_conversation)
+        return SequencedWebSocket(first_flush_handled)
+
+    return {'run': run, 'uploaded': uploaded, 'fallbacks': fallbacks}
+
+
+@pytest.mark.asyncio
+async def test_deleted_conversation_stops_further_audio_uploads(private_cloud_session):
+    websocket = private_cloud_session['run'](conversation_exists=False)
+
+    await pusher._websocket_util_trigger(websocket, UID, SAMPLE_RATE)
+
+    # The first batch races the delete and is unavoidable; the second must not be uploaded.
+    assert private_cloud_session['uploaded'] == [CONVERSATION_ID]
+    assert private_cloud_session['fallbacks'] == [
+        {
+            'component': 'pusher',
+            'from_mode': 'private_cloud_sync',
+            'to_mode': 'drop',
+            'reason': 'policy',
+            'outcome': 'exhausted',
+            'log': pusher.logger,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_conversation_keeps_syncing_audio(private_cloud_session):
+    websocket = private_cloud_session['run'](conversation_exists=True)
+
+    await pusher._websocket_util_trigger(websocket, UID, SAMPLE_RATE)
+
+    assert private_cloud_session['uploaded'] == [CONVERSATION_ID, CONVERSATION_ID]
+    assert private_cloud_session['fallbacks'] == []


### PR DESCRIPTION
## What

When a conversation is deleted while its pusher session is still live, the session now stops uploading private-cloud audio for it instead of writing more chunks into a bucket prefix nothing owns.

- `database/conversations.py` — `update_conversation` already returned early when the document was gone, but returned `None` either way, so no caller could tell a landed write from a dropped one. It now returns a `bool`.
- `routers/pusher.py` — the private-cloud worker treats a missing owner as terminal for that conversation: it stops uploading further batches for it, releases their byte budget, and calls `record_fallback` (`docs/agents/fallback-telemetry.md`) instead of failing silently.

## Why

From #11742, measured in prod on 2026-08-17:

- Every listen generation discarded as "empty" deletes the Firestore conversation while the pusher session keeps running. `prod-omi-pusher` logs the tail of that race — `Error updating audio files: 404 No document to update: .../conversations/<conv>` — at 34/hour across 34 distinct conversations.
- 17 of 41 sampled conversation prefixes under `gs://omi-private-cloud-sync/chunks/` (41%, 76.5 MB in a 15-uid sample) belong to conversations that no longer exist. The bucket lifecycle policy only covers `merged/` and `playback/`, so `chunks/` orphans are permanent.
- The session batches audio roughly every 60s, so before this change a single deleted conversation kept minting a fresh orphan for the rest of the session — the delete was never the last write.

## What this does not do

The issue stays open. Reclaiming the existing orphan backlog, and adding `delete_conversation_audio_files` to `delete_empty_recording_conversation`, are user-audio deletions — an explicit sign-off category in `AGENTS.md`, and not something the hermetic suite can exercise against a live GCS bucket. This PR is the prevention half only: it stops new orphans accumulating after the delete point.

## Tested

- `backend/tests/unit/test_pusher_deleted_conversation_sync.py` (new) drives the real `routers.pusher._websocket_util_trigger` over a fake websocket, with the storage/Firestore boundary faked and an explicit event handshake so the two audio chunks cannot coalesce into one batch:
  - **RED on the parent commit** — `assert ['conversation', 'conversation'] == ['conversation']`, i.e. the deleted conversation received a second upload (the orphan).
  - **GREEN here** — one upload, and the `record_fallback` contract fields are asserted.
  - Control test in the same file: when the conversation still exists, both chunks upload and no fallback fires — so the guard is specific to the deleted case, not a blanket stop.
- `test_conversation_lifecycle_contract.py` gains the `update_conversation` return contract (`True` for a live conversation, `False` for a missing one) against the file's existing fake Firestore.
- `backend/scripts/typecheck.sh` — 0 errors.
- `make preflight` — 11 checks pass.
- Backend unit selection for the changed files — pass.

Not reproduced against prod: the Firestore-delete-races-a-live-GCS-bucket path cannot be exercised hermetically, so the evidence above is the real handler driven over faked storage, not a live session.

Failure-Class: none

No existing class covers a storage boundary that silently reports a write to a deleted owner as success, and one instance is not enough to mint a class: the nearest, `FC-denial-rendered-as-empty-success`, is scoped to refused *reads* returning an empty collection.

Line-Count-Exception: backend/database/conversations.py | 1728 -> 1735 | +1 line for the `return True` and a 6-line contract docstring on an existing function; no new symbol, and splitting the file is unrelated to this fix.

Refs #11742

Auto-generated from issue feedback by the mini issues-improver — tested and merged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

