### PR TITLE
fix(backend): let desktop clients replay a Gemini provider outage

### DIFF
--- a/backend/routers/desktop_proxy.py
+++ b/backend/routers/desktop_proxy.py
@@ -116,6 +116,9 @@ _TOTAL_TIMEOUT_SECONDS = 75.0
 _CREDENTIAL_TIMEOUT_SECONDS = 5.0
 _POOL_WAIT_SECONDS = 5.0
 _DISCONNECT_POLL_SECONDS = 0.1
+# Both desktop clients already back off on their own (macOS 1s/2s, Windows
+# 400/800ms, two retries each), so this only floors how soon a replay may start.
+_PROVIDER_UNAVAILABLE_RETRY_AFTER_SECONDS = 1
 
 _REQUEST_ID_PATTERN = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._:-]{7,63}$')
 _REVISION_PATTERN = re.compile(r'^[A-Za-z0-9][A-Za-z0-9._-]{0,126}$')
@@ -1008,6 +1011,20 @@ def _provider_error(response: httpx.Response, telemetry: ProxyTelemetry) -> Resp
             'Gemini provider timed out before returning a terminal response',
             False,
             None,
+        )
+    elif status in {502, 503}:
+        # An upstream availability fault is a capacity signal, not a verdict on
+        # the request: nothing was delivered, so re-issuing is safe. This proxy
+        # delegates the re-issue to the caller, and both desktop clients gate on
+        # what it reports here — macOS on `X-Omi-Retryable`, Windows on seeing
+        # 503 itself. Collapsing it into a non-retryable 502 revoked that
+        # authorization on both, so one provider blip failed the user's call.
+        code, proxy_status, message, retryable, retry_after = (
+            'provider_unavailable',
+            503,
+            'Gemini provider is temporarily unavailable',
+            True,
+            _PROVIDER_UNAVAILABLE_RETRY_AFTER_SECONDS,
         )
     elif status >= 500:
         code, proxy_status, message, retryable, retry_after = (

--- a/backend/tests/unit/test_desktop_proxy.py
+++ b/backend/tests/unit/test_desktop_proxy.py
@@ -477,6 +477,80 @@ def test_provider_timeout_has_typed_non_retryable_terminal_response(monkeypatch)
     assert "private prompt" not in output.getvalue()
 
 
+@pytest.mark.parametrize("upstream_status", [502, 503])
+def test_provider_availability_fault_authorizes_client_replay(monkeypatch, upstream_status):
+    """An upstream 502/503 delivered nothing, so the caller may re-issue it.
+
+    Both desktop clients read this decision off the wire: macOS gates
+    `shouldAutoRetry` on `X-Omi-Retryable`, and the Windows Gemini and rewind
+    embedding clients retry only on a 429 or a 503 status. Reporting a
+    non-retryable 502 revoked replay on both at once.
+    """
+    output = io.StringIO()
+    monkeypatch.setattr(desktop_proxy.sys, "stdout", output)
+    telemetry = desktop_proxy.ProxyTelemetry(make_request(), streaming=False)
+    response = httpx.Response(upstream_status, request=httpx.Request("POST", "https://provider.invalid"))
+
+    result = desktop_proxy._provider_error(response, telemetry)
+
+    assert result.status_code == 503
+    assert result.headers["x-omi-error-class"] == "provider_unavailable"
+    assert result.headers["x-omi-retryable"] == "true"
+    assert result.headers["retry-after"] == str(desktop_proxy._PROVIDER_UNAVAILABLE_RETRY_AFTER_SECONDS)
+    event = json.loads(output.getvalue())
+    assert event["outcome"] == "provider_unavailable"
+    assert event["upstream_status"] == upstream_status
+    assert event["retryable"] is True
+
+
+def test_provider_internal_error_stays_terminal(monkeypatch):
+    """500 is not an availability signal — it can be a verdict on the request,
+    so it keeps the terminal 502 rather than inviting a replay of the same body."""
+    monkeypatch.setattr(desktop_proxy.sys, "stdout", io.StringIO())
+    telemetry = desktop_proxy.ProxyTelemetry(make_request(), streaming=False)
+    response = httpx.Response(500, request=httpx.Request("POST", "https://provider.invalid"))
+
+    result = desktop_proxy._provider_error(response, telemetry)
+
+    assert result.status_code == 502
+    assert result.headers["x-omi-retryable"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_proxy_reports_upstream_unavailable_as_retryable(monkeypatch):
+    """The whole non-stream route, from dispatch to the headers the client sees."""
+
+    class UnavailableClient:
+        async def post(self, *args, **kwargs):
+            return httpx.Response(
+                503,
+                json={"error": {"code": 503, "message": "The service is currently unavailable."}},
+                request=httpx.Request("POST", "https://provider.invalid"),
+            )
+
+    async def meter(_uid, path, _model, _action):
+        return path
+
+    async def route(path, _model, _action, _query, **_kwargs):
+        return desktop_proxy.UpstreamRoute("https://provider.invalid", {}, {}, "ai_studio", "server_key", "global")
+
+    monkeypatch.setattr(desktop_proxy.sys, "stdout", io.StringIO())
+    monkeypatch.setattr(desktop_proxy, "get_byok_key", lambda _: None)
+    monkeypatch.setattr(desktop_proxy, "_meter_server_request", meter)
+    monkeypatch.setattr(desktop_proxy, "_upstream", route)
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_client", lambda: UnavailableClient())
+    monkeypatch.setattr(desktop_proxy, "get_desktop_gemini_semaphore", lambda: asyncio.Semaphore(1))
+
+    response = await desktop_proxy._proxy(
+        make_request(), "models/gemini-embedding-001:batchEmbedContents", False, "user"
+    )
+
+    assert response.status_code == 503
+    assert response.headers["x-omi-retryable"] == "true"
+    assert response.headers["x-omi-error-class"] == "provider_unavailable"
+    assert "currently unavailable" not in response.body.decode()
+
+
 @pytest.mark.asyncio
 async def test_proxy_dispatches_once_and_classifies_read_timeout(monkeypatch):
     calls = 0


### PR DESCRIPTION
## Bug

`GET`/`POST` through the desktop Gemini proxy fails the user's call outright whenever Google's endpoint returns a transient availability error.

Prod evidence — `desktop-backend`, 2026-08-16 → 2026-08-19, `jsonPayload.event="desktop_gemini_proxy_terminal"`, `outcome="provider_unavailable"`: **186 terminal events, every one at `attempt: 1`**.

| upstream | n | top model / action |
|---|---|---|
| 503 | 82 | `gemini-embedding-001:batchEmbedContents` (80) |
| 502 | 19 | `gemini-2.5-flash:generateContent` (vertex_ai) |
| 500 | 15 | `gemini-2.5-flash:generateContent` |

Steady across the window (8 in the last hour sampled). The 80 `batchEmbedContents` failures are the Rewind index path — each one is screen text that never gets embedded.

## Root cause

`_provider_error` in `backend/routers/desktop_proxy.py` mapped **every** upstream `>= 500` to a single terminal shape: proxy status `502`, `X-Omi-Retryable: false`, no `Retry-After`.

An upstream 502/503 delivered nothing, so the request is safe to re-issue — and this proxy deliberately delegates the re-issue to the caller rather than retrying in-band. Both desktop clients read that decision off the wire, and the collapsed 502 revoked replay on both at once:

- **macOS** — `GeminiClient.httpError` parses `X-Omi-Retryable` into `apiError(_, retryable:)`, and `shouldAutoRetry` returns `retryable == true`. `false` ⇒ the retry loop rethrows on the first attempt (`GeminiClient.swift:254`, `:423`, `:623`).
- **Windows** — `renderer/src/lib/geminiClient.ts:62` and `main/rewind/embeddingClient.ts:70` retry on `res.status === 429 || res.status === 503` only. A `502` takes the `throw` branch immediately.

So the proxy converted a Google capacity blip into a hard user-visible failure, on both platforms, with the clients' own bounded retry (2 attempts, 1s/2s on macOS, 400/800ms on Windows) never firing.

## Fix

`_provider_error` now classifies upstream `502`/`503` as what they are — an availability fault, not a verdict on the request:

- proxy status `503` (so the Windows clients' existing `429 || 503` branch fires)
- `X-Omi-Retryable: true` (so macOS `shouldAutoRetry` fires)
- `Retry-After: 1` — a floor only; both clients already back off on their own

Upstream **500 keeps the terminal 502**. `INTERNAL` can be a verdict on the request body (oversized context), not a capacity signal, so it does not invite a replay of the same bytes.

No in-band retry is added: the proxy's replay-authorization contract is the existing seam, and `_provider_error` is shared by the streaming and non-streaming paths, so this is one change for both.

## What I tested

`backend/.venv/bin/python -m pytest backend/tests/unit/test_desktop_proxy.py`

Three new tests, one of them driving the **whole non-stream route** (`_proxy` → real `_provider_error` → the headers a client actually receives) with only the httpx client, metering and routing stubbed:

- `test_provider_availability_fault_authorizes_client_replay[502|503]`
- `test_proxy_reports_upstream_unavailable_as_retryable` — real route, asserts the upstream body is not echoed
- `test_provider_internal_error_stays_terminal` — pins the 500 boundary

**Control on clean `origin/main`** (`git stash` of the router change only): all three fail with `assert 502 == 503`. With the fix: pass.

- `test_desktop_proxy.py` — **91 passed** (163s)
- `test_desktop_core.py`, `test_desktop_backend_cors.py`, `test_desktop_rest_inventory.py`, `test_desktop_surface_parity.py`, `test_desktop_llm_stub.py` — **38 passed**

Failure-Class: FC-recoverable-provider-failure-terminal

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

