### PR TITLE
fix(desktop): stop Gemini requests reusing a dead pooled connection

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -439,6 +439,30 @@ actor GeminiClient {
   }
 
   /// Replay only outcomes whose typed backend contract says they are safe.
+  /// Issues one proxy request on a connection pool that does not outlive it.
+  ///
+  /// `URLSession.shared` pools keep-alive connections across every request the app makes.
+  /// When the server has already closed a pooled socket, the next caller is handed that
+  /// dead socket and fails instantly with `NSURLErrorNetworkConnectionLost` (-1005); a
+  /// retry draws from the same pool and reproduces the failure, which is why three
+  /// attempts could fail identically within seconds.
+  ///
+  /// Measured on a live desktop session: 5 of 5 suggestion evaluations failed this way,
+  /// while `curl` to the same endpoint with an 800 KB body returned in ~1.9s over both
+  /// IPv4 and IPv6 — the difference being that curl dials a fresh connection each time.
+  ///
+  /// An ephemeral per-request session costs one TLS handshake per evaluation. These are
+  /// dwell-gated and capped by a daily budget, so that is a trade worth making to remove
+  /// an entire class of stale-pool failure rather than manage it.
+  static func send(_ request: URLRequest) async throws -> (Data, URLResponse) {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = 60
+    configuration.timeoutIntervalForResource = 300
+    let session = URLSession(configuration: configuration)
+    defer { session.finishTasksAndInvalidate() }
+    return try await session.data(for: request)
+  }
+
   static func shouldAutoRetry(_ error: Error) -> Bool {
     if let geminiError = error as? GeminiClientError {
       if geminiError.shouldAutoRetry { return true }
@@ -599,7 +623,7 @@ actor GeminiClient {
         urlRequest.timeoutInterval = 300
         urlRequest.httpBody = requestBody
 
-        let (data, urlResponse) = try await URLSession.shared.data(for: urlRequest)
+        let (data, urlResponse) = try await Self.send(urlRequest)
         try checkHTTPStatus(urlResponse, data: data)
 
         let response = try JSONDecoder().decode(GeminiResponse.self, from: data)
@@ -675,7 +699,7 @@ actor GeminiClient {
         urlRequest.timeoutInterval = timeout
         urlRequest.httpBody = try JSONEncoder().encode(request)
 
-        let (data, urlResponse) = try await URLSession.shared.data(for: urlRequest)
+        let (data, urlResponse) = try await Self.send(urlRequest)
         try checkHTTPStatus(urlResponse, data: data)
 
         let response = try JSONDecoder().decode(GeminiResponse.self, from: data)
@@ -748,7 +772,7 @@ actor GeminiClient {
         urlRequest.timeoutInterval = 300
         urlRequest.httpBody = try JSONEncoder().encode(request)
 
-        let (data, urlResponse) = try await URLSession.shared.data(for: urlRequest)
+        let (data, urlResponse) = try await Self.send(urlRequest)
         try checkHTTPStatus(urlResponse, data: data)
 
         let response = try JSONDecoder().decode(GeminiResponse.self, from: data)
@@ -1054,7 +1078,7 @@ extension GeminiClient {
           urlRequest.timeoutInterval = 300
           urlRequest.httpBody = requestBody
 
-          let (data, urlResponse) = try await URLSession.shared.data(for: urlRequest)
+          let (data, urlResponse) = try await Self.send(urlRequest)
           try checkHTTPStatus(urlResponse, data: data)
 
           let response = try JSONDecoder().decode(GeminiToolResponse.self, from: data)

--- a/desktop/macos/changelog/unreleased/20260819-gemini-per-request-session.json
+++ b/desktop/macos/changelog/unreleased/20260819-gemini-per-request-session.json
@@ -1,0 +1,3 @@
+{
+  "change": "Live suggestions and other AI features no longer fail silently when a pooled network connection goes stale"
+}


### PR DESCRIPTION
## Summary

Follow-up to #11854. That PR stopped the client discarding a dropped request; this one stops the request being made on a connection that is already dead.

`GeminiClient` issued every proxy request on `URLSession.shared`, whose connection pool is shared with every other request the app makes. When the server has already closed a pooled socket, the next caller is handed that dead socket and fails instantly with `NSURLErrorNetworkConnectionLost` (-1005). A retry draws from the same pool and reproduces the failure — which is why three attempts could fail identically within seconds, and why the retry added in #11854 was necessary but not sufficient on its own.

## Evidence

Measured on a live desktop session, before and after, driving the real evaluation path via `omi-ctl action probe_suggestion_nudge`:

```
before   evaluation_failed (-1005)   5 / 5
after    reached delivery            5 / 5
```

In the same post-change session the log shows six -1005 failures still occurring **in-process** — every one of them from `ScreenActivitySync` and `OCREmbeddingService`, which remain on `URLSession.shared`. Zero came from Gemini, and the retry path was never entered:

```
-1005 at socket level:  6     (other subsystems, still on the shared pool)
retries needed:         0
evaluation failures:    0
```

That is an A/B result inside a single running process: the subsystem moved off the shared pool succeeds, the ones still on it do not.

`curl` to the same endpoint with an 800 KB body returned in ~1.9s over **both** IPv4 and IPv6 throughout, which is what ruled out bandwidth, MTU and IPv6 reachability — curl dials a fresh connection each time.

## What changed

All four `URLSession.shared.data(for:)` call sites now route through one `send(_:)` helper that builds an ephemeral session per request and invalidates it with `finishTasksAndInvalidate()`.

An ephemeral per-request session costs one TLS handshake per evaluation. These are dwell-gated and capped by a daily budget, so that is a trade worth making to remove a class of stale-pool failure rather than manage it.

## Verification

- `swift build` → clean
- `swift test --filter AIBackendErrorNormalizationTests` → 9 passed
- 5× `probe_suggestion_nudge` on a live session → 0 transport failures (was 5/5)

## Honest gaps

- This does not explain **why** the server closes pooled connections so aggressively for this host; it removes the client's exposure rather than diagnosing the peer.
- `ScreenActivitySync` and `OCREmbeddingService` still use `URLSession.shared` and still fail this way. I left them out to keep the diff to the subsystem I could measure end to end, but the same fix likely applies.
- No unit test asserts the per-request session directly — the behaviour is a connection-pool property, not something the existing seams expose. The evidence here is the live measurement above rather than a test.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- Checked the registry: no existing class covers a client reusing a pooled connection the
peer has closed. This is a single instance rather than a recurring pattern, so minting a new
class would be paperwork without a reusable guard surface. -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

