### PR TITLE
fix(context-for-claude): stop reporting a Claude Desktop that cannot answer as connected

### DIFF
--- a/desktop/context-for-claude/Sources/ContextApp/Integration/ClaudeConnection.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Integration/ClaudeConnection.swift
@@ -1,0 +1,88 @@
+import AppKit
+import ContextCore
+import Darwin
+import Foundation
+
+/// The Claude connection **as the user experiences it**: what is registered on disk, and whether the
+/// Claude Desktop running right now can actually reach us.
+///
+/// ## Why the disk answer alone is a lie
+///
+/// `ClaudeRegistrar.status()` reads two config files. That is the whole of what every user-facing
+/// surface knew, so both of them said `Connected to Claude Code and Claude Desktop` whenever the
+/// entry was on disk — including for the three days this Mac spent with a Claude Desktop whose
+/// server had failed to spawn at every launch. The config was perfect. The connector was dead. The
+/// app said "Connected", the menu bar said "Connected", and the only place the truth existed was a
+/// line in `~/Library/Logs/Claude/mcp-server-context-for-claude.log` that nothing points a user at.
+///
+/// `ClaudeServerLiveness` has been able to answer this since it was written — it looks for a live
+/// server descending from a running Claude Desktop — but it was reachable only from the tutorial,
+/// which runs once. This type is what puts that evidence in front of the two surfaces a user
+/// actually consults, so a registration that Claude has not picked up can no longer read as success.
+///
+/// ## What it does not do
+///
+/// It does not quit anybody's Claude. `ClaudeHandoff` may offer that, with consent, because it is
+/// about to hand Claude a question and the answer would be wrong without it; a status line has no
+/// such errand and no right to take a conversation away to tidy up its own wording. So the remedy
+/// here is a sentence, and the press stays the user's.
+struct ClaudeConnection: Equatable {
+    /// Registered on disk, pointing at this build's binary.
+    let claudeCode: Bool
+    let claudeDesktop: Bool
+
+    /// Registered for Claude Desktop, and Claude Desktop is demonstrably not serving us.
+    ///
+    /// **Only ever true on evidence.** `.unknown` — Claude Desktop is not running, or the process
+    /// list could not be read — leaves this false, because a surface that nags on absence of
+    /// evidence would tell users to restart an app that is working, or one that is not even open.
+    let desktopNeedsRestart: Bool
+
+    /// The sentence naming the remedy, or nil when there is nothing to remedy. Shared so the menu
+    /// bar and the settings pane cannot drift into describing the same state two different ways.
+    var restartNotice: String? {
+        desktopNeedsRestart ? "Quit and reopen Claude Desktop to finish connecting it." : nil
+    }
+
+    /// Whether Claude can reach this Mac through Claude Desktop *now*, as opposed to after a restart.
+    /// This, not `claudeDesktop`, is what a summary line may call connected.
+    var desktopIsReachable: Bool { claudeDesktop && !desktopNeedsRestart }
+
+    /// Pure, so the whole decision is testable without a Claude on the machine.
+    init(claudeCode: Bool, claudeDesktop: Bool, liveness: ClaudeServerLiveness.State) {
+        self.claudeCode = claudeCode
+        self.claudeDesktop = claudeDesktop
+        self.desktopNeedsRestart = claudeDesktop && liveness == .notServingClaudeDesktop
+    }
+
+    /// Reads both config files and the process list. Off the main actor at every call site: the
+    /// config half JSON-decodes `~/.claude.json`, and the liveness half sweeps every PID on the Mac.
+    static func current() -> ClaudeConnection {
+        let registration = ClaudeRegistrar.status()
+        return ClaudeConnection(
+            claudeCode: registration.claudeCode,
+            claudeDesktop: registration.claudeDesktop,
+            liveness: ClaudeServerLiveness.state(claudeDesktopPIDs: ClaudeDesktopProcesses.pids))
+    }
+}
+
+// MARK: - The running Claude Desktops
+
+/// Claude Desktop, as processes.
+///
+/// Separate from `ClaudeRegistrar` because that file is deliberately free of AppKit — its comment on
+/// `ClaudeServerLiveness.state` says so, and the PIDs are a parameter for exactly that reason. This
+/// is the one place that reads them, so the three callers that used to build the same
+/// `runningApplications(withBundleIdentifier:)` call by hand now share it and cannot disagree about
+/// which bundle identifier Claude Desktop has.
+enum ClaudeDesktopProcesses {
+    static let bundleIdentifier = "com.anthropic.claudefordesktop"
+
+    /// Empty when Claude Desktop is not running, which `ClaudeServerLiveness` reads as `.unknown`
+    /// rather than as an absence — there is nothing for a server to be serving.
+    static var pids: Set<pid_t> {
+        Set(
+            NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+                .map(\.processIdentifier))
+    }
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Integration/ClaudeRegistrar.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Integration/ClaudeRegistrar.swift
@@ -477,9 +477,10 @@ enum ClaudeServerLiveness {
     /// fails outright on a buffer below it.
     private static let executablePathCapacity = 4 * 1_024
 
-    /// How far up a process tree to look for Claude. The real chain is two hops
-    /// (`context-for-claude-mcp` → `Claude.app/Contents/Helpers/disclaimer` → `Claude`); the bound is
-    /// what stops a cyclic or corrupted parent chain from spinning this loop forever.
+    /// How far up a process tree to look for Claude. The chains are short — two hops to Claude
+    /// Desktop (`context-for-claude-mcp` → `Claude.app/Contents/Helpers/disclaimer` → `Claude`), one
+    /// to a Claude Code that is running inside it; the bound is what stops a cyclic or corrupted
+    /// parent chain from spinning this loop forever.
     private static let maximumAncestorHops = 8
 
     /// - Parameter claudeDesktopPIDs: the running Claude Desktop processes, passed in rather than
@@ -495,12 +496,92 @@ enum ClaudeServerLiveness {
         guard !servers.isEmpty else { return .notServingClaudeDesktop }
 
         // Attribution matters because Claude Code spawns this same binary, and one of *its* servers
-        // must never be read as proof that Claude Desktop has one. A chain that cannot be resolved
-        // counts as Claude's, because the cost of being wrong is asymmetric: the only thing this
-        // state gates is an offer to quit somebody's Claude, and guessing "not Claude's" would take
-        // an open conversation on the strength of a parent lookup that failed.
-        let servesClaude = servers.contains { descends($0, from: claudeDesktopPIDs) ?? true }
+        // must never be read as proof that Claude Desktop has one.
+        let servesClaude = servers.contains { server in
+            switch owner(
+                of: server,
+                claudeDesktopPIDs: claudeDesktopPIDs,
+                parent: parentPID(of:),
+                executablePath: executablePath(of:))
+            {
+            // A chain that cannot be resolved counts as Claude's, because the cost of being wrong is
+            // asymmetric in both directions this state is read: it gates an offer to quit somebody's
+            // Claude, and it gates a status line that would otherwise nag. Guessing "not Claude's"
+            // on a parent lookup that failed would do both on no evidence at all.
+            case .claudeDesktop, .unknown: return true
+            case .claudeCode, .none: return false
+            }
+        }
         return servesClaude ? .servingClaudeDesktop : .notServingClaudeDesktop
+    }
+
+    /// Who a server belongs to, decided by the **nearest** owner above it rather than by whether
+    /// Claude Desktop appears anywhere on the chain.
+    ///
+    /// **The distinction is the whole of it, because Claude Code now runs inside Claude Desktop.**
+    /// A Claude Code session opened in the desktop app has this ancestry, read off this Mac:
+    ///
+    /// ```
+    /// context-for-claude-mcp
+    ///   → …/Application Support/Claude/claude-code/2.1.229/claude.app/Contents/MacOS/claude
+    ///     → /Applications/Claude.app/Contents/Helpers/disclaimer
+    ///       → /Applications/Claude.app/Contents/MacOS/Claude     ← a Claude Desktop PID
+    /// ```
+    ///
+    /// A walk that only asks "is a Claude Desktop PID an ancestor" answers yes for every one of
+    /// those, so on any Mac where the user has a Claude Code session open in the desktop app, one of
+    /// *Claude Code's* servers is read as proof that Claude Desktop has one. Measured on the Mac
+    /// whose Claude Desktop connector had been failing to spawn for three days: every disk check
+    /// said connected, and this probe — the one thing that could have contradicted them — agreed,
+    /// because fifteen Claude Code servers were descendants of the same process.
+    ///
+    /// So the first owner met wins. A `claude-code` process between the server and Claude Desktop
+    /// means the server is Claude Code's, and Claude Desktop's own spawn is not on this chain at all.
+    ///
+    /// Pure, with the process table passed in as two lookups, because the tree it has to reason about
+    /// cannot be built inside a test — the real one needs a running Claude Desktop, a running Claude
+    /// Code inside it, and a server under each.
+    enum Owner: Equatable {
+        /// A Claude Code process sits between the server and anything else.
+        case claudeCode
+        /// A running Claude Desktop was reached first.
+        case claudeDesktop
+        /// The walk finished at launchd having met neither.
+        case none
+        /// The walk ran out of parents it could read. Not an answer, and never acted on.
+        case unknown
+    }
+
+    /// Claude Code's own install directory, which every copy of it the desktop app runs sits inside:
+    /// `~/Library/Application Support/Claude/claude-code/<version>/claude.app/…`.
+    ///
+    /// A path marker rather than an executable name because both binaries are called some case of
+    /// "claude", and a case-insensitive name test would classify Claude Desktop itself as Claude
+    /// Code. A Claude Code installed elsewhere — a CLI on `PATH`, say — is not matched and does not
+    /// need to be: it is not a descendant of Claude Desktop, so it was never a false positive here.
+    static let claudeCodePathMarker = "/claude-code/"
+
+    static func owner(
+        of pid: pid_t,
+        claudeDesktopPIDs: Set<pid_t>,
+        parent: (pid_t) -> pid_t?,
+        executablePath: (pid_t) -> String?
+    ) -> Owner {
+        var current = pid
+        for _ in 0..<maximumAncestorHops {
+            guard let ancestor = parent(current) else { return .unknown }
+            // **The line the old walk did not have.** Without it the loop below is the shipped
+            // behaviour — "is a Claude Desktop PID anywhere above this server" — and every Claude
+            // Code session inside the desktop app answers yes. Order between the two tests is
+            // immaterial (no process is both); presence of this one is the whole fix.
+            if executablePath(ancestor)?.contains(claudeCodePathMarker) == true { return .claudeCode }
+            if claudeDesktopPIDs.contains(ancestor) { return .claudeDesktop }
+            // launchd (1) and the kernel (0) top every tree: the walk finished, and neither owner
+            // was anywhere on it.
+            if ancestor <= 1 { return .none }
+            current = ancestor
+        }
+        return .unknown
     }
 
     /// Every live process whose executable is exactly `binary`, or nil when the process list could
@@ -528,21 +609,6 @@ enum ClaudeServerLiveness {
         // answers nothing — which is not the path we are looking for either way.
         guard proc_pidpath(pid, &buffer, UInt32(executablePathCapacity)) > 0 else { return nil }
         return String(cString: buffer)
-    }
-
-    /// Walks up from `pid` looking for one of `ancestors`. Nil means the walk ran out of parents it
-    /// could read before reaching an answer — "I could not tell", which is not "no".
-    private static func descends(_ pid: pid_t, from ancestors: Set<pid_t>) -> Bool? {
-        var current = pid
-        for _ in 0..<maximumAncestorHops {
-            guard let parent = parentPID(of: current) else { return nil }
-            if ancestors.contains(parent) { return true }
-            // launchd (1) and the kernel (0) top every tree: the walk finished, and Claude was not
-            // anywhere on it.
-            if parent <= 1 { return false }
-            current = parent
-        }
-        return nil
     }
 
     private static func parentPID(of pid: pid_t) -> pid_t? {

--- a/desktop/context-for-claude/Sources/ContextApp/MenuBar/MenuBarPresentation.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/MenuBar/MenuBarPresentation.swift
@@ -201,16 +201,28 @@ struct ClaudeConnectorLine: Equatable {
     /// rather than a second control, which is what stops a second press starting a second write.
     var action: String?
 
-    init(claudeCode: Bool, claudeDesktop: Bool, note: String?, isConnecting: Bool) {
-        switch (claudeCode, claudeDesktop) {
+    init(connection: ClaudeConnection, note: String?, isConnecting: Bool) {
+        // **`desktopIsReachable`, not `claudeDesktop`.** The line reports what Claude can do, and a
+        // Claude Desktop that has not read the registration yet cannot do anything — saying
+        // "Connected to Claude Desktop" over a connector that fails to answer is the exact claim
+        // `ClaudeConnection` exists to stop this surface making.
+        switch (connection.claudeCode, connection.desktopIsReachable) {
         case (true, true): summary = "Connected to Claude Code and Claude Desktop"
         case (true, false): summary = "Connected to Claude Code"
         case (false, true): summary = "Connected to Claude Desktop"
         case (false, false): summary = "Not connected to Claude"
         }
-        isConnected = claudeCode || claudeDesktop
-        self.note = note
-        action = isConnected ? nil : (isConnecting ? "Connecting…" : "Connect")
+        isConnected = connection.claudeCode || connection.desktopIsReachable
+        // The remedy takes the note slot only when there is no fresher one: a sentence describing
+        // the write the user just asked for is about the press they just made, and outranks a
+        // standing condition they can act on whenever they like.
+        self.note = note ?? connection.restartNotice
+        // **Offered only when nothing is registered at all.** `Connect` writes the config files, so
+        // in the needs-restart state it would rewrite two files that are already correct and change
+        // nothing the user can see — a control that answers a real complaint with a no-op is worse
+        // than no control. The sentence in `note` names what actually works.
+        let hasNothingRegistered = !connection.claudeCode && !connection.claudeDesktop
+        action = hasNothingRegistered ? (isConnecting ? "Connecting…" : "Connect") : nil
     }
 }
 

--- a/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusView.swift
@@ -42,7 +42,10 @@ struct StatusView: View {
     @ObservedObject private var auth = OmiAuth.shared
     @ObservedObject private var uploads = ConversationUploader.shared
 
-    @State private var claude: (claudeCode: Bool, claudeDesktop: Bool) = (false, false)
+    /// What is registered on disk *and* whether the running Claude Desktop is serving us. The
+    /// default is the honest one for "not probed yet": nothing connected, nothing to restart.
+    @State private var claude = ClaudeConnection(
+        claudeCode: false, claudeDesktop: false, liveness: .unknown)
     @State private var claudeNote: String?
     /// True while the two config files are being rewritten. A second press cannot start a second
     /// write, which is the same rule the account line's round trip follows.
@@ -512,11 +515,7 @@ struct StatusView: View {
     /// The Claude line as a value, for the reason `account` is one: this view keeps no judgement of
     /// its own about a state it cannot be driven through in a test.
     private var connector: ClaudeConnectorLine {
-        ClaudeConnectorLine(
-            claudeCode: claude.claudeCode,
-            claudeDesktop: claude.claudeDesktop,
-            note: claudeNote,
-            isConnecting: isConnecting)
+        ClaudeConnectorLine(connection: claude, note: claudeNote, isConnecting: isConnecting)
     }
 
     /// Same shape as `refresh()`, and for the same reason: `register()` reads, decodes and rewrites
@@ -528,7 +527,16 @@ struct StatusView: View {
         claudeNote = nil
         Task {
             let result = await Task.detached(priority: .userInitiated) { ClaudeRegistrar.register() }.value
-            claude = (result.claudeCode, result.claudeDesktop)
+            // Re-probed rather than built from `result`: registering writes the config, and Claude
+            // Desktop reads it at *its* launch, so the press that "connects" routinely leaves a
+            // Claude that still cannot answer. That is the state the user most needs to be told
+            // about, and it exists from the instant the write lands.
+            claude = await Task.detached(priority: .userInitiated) {
+                ClaudeConnection(
+                    claudeCode: result.claudeCode,
+                    claudeDesktop: result.claudeDesktop,
+                    liveness: ClaudeServerLiveness.state(claudeDesktopPIDs: ClaudeDesktopProcesses.pids))
+            }.value
             claudeNote = result.message
             isConnecting = false
         }
@@ -651,7 +659,7 @@ struct StatusView: View {
         readAskLedger()
         claudeNote = nil
         Task {
-            claude = await Task.detached(priority: .userInitiated) { ClaudeRegistrar.status() }.value
+            claude = await Task.detached(priority: .userInitiated) { ClaudeConnection.current() }.value
         }
     }
 }

--- a/desktop/context-for-claude/Sources/ContextApp/Settings/SettingsAgentsPane.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Settings/SettingsAgentsPane.swift
@@ -29,7 +29,7 @@ struct SettingsAgentsPane: View {
     /// Claude Desktop's config **synchronously in `View.init`** — and SwiftUI re-inits a view body's
     /// struct freely, so two file reads rode along with every unrelated state change on this pane.
     /// It is a disk probe like the other two here, so it belongs where they are.
-    @State private var registration: (claudeCode: Bool, claudeDesktop: Bool)?
+    @State private var registration: ClaudeConnection?
     @State private var registrationMessage: String?
     /// Bumped by each attempt so the expiry below restarts rather than clearing a newer message.
     @State private var registrationMessageAttempt = 0
@@ -96,6 +96,12 @@ struct SettingsAgentsPane: View {
                             title: "Claude Connection",
                             isOn: Binding(
                                 get: {
+                                    // Registration, not reachability: the switch's job is whether
+                                    // this app has written itself into Claude's config, and a
+                                    // Claude Desktop that has not restarted yet has not undone
+                                    // that. Flipping the switch off under the user because their
+                                    // Claude is stale would offer disconnecting as the cure for
+                                    // needing a restart.
                                     registration?.claudeCode == true || registration?.claudeDesktop == true
                                 },
                                 set: { setRegistered($0) }))
@@ -131,7 +137,7 @@ struct SettingsAgentsPane: View {
             // because they are the only ones that open and decode a file.
             targetDetail = ClaudeRouter.targetSubtitle(surface: ClaudeHandoff.surface)
             registration = await Task.detached(priority: .userInitiated) {
-                ClaudeRegistrar.status()
+                ClaudeConnection.current()
             }.value
         }
         // The result of the last connect/disconnect, expired rather than pinned. `.task(id:)`
@@ -160,15 +166,29 @@ struct SettingsAgentsPane: View {
     }
 
     private var connectionSubtitle: String {
-        guard let registration else { return "Checking whether Claude is connected…" }
-        // Explicit `return`: the guard above makes this a multi-statement body, and a switch
-        // expression only returns implicitly when it is the single expression in the getter.
-        return switch (registration.claudeCode, registration.claudeDesktop) {
+        Self.connectionSubtitle(registration)
+    }
+
+    /// The row's subtitle, as a function of the probe's answer.
+    ///
+    /// `static` and not a computed property on the view, for the reason `ClaudeConnectorLine` is a
+    /// value: this sentence is the one place the pane makes a claim about somebody else's process,
+    /// and it shipped making a false one — `Connected to Claude Code and Claude Desktop.` over a
+    /// Claude Desktop whose server had failed to spawn at every launch for three days. A claim that
+    /// wrong has to be reachable from a test, and a `private var` on a `View` is not.
+    static func connectionSubtitle(_ connection: ClaudeConnection?) -> String {
+        guard let connection else { return "Checking whether Claude is connected…" }
+        // `desktopIsReachable`, so a registration Claude Desktop has not picked up is never
+        // reported as a working connection. The remedy is appended rather than replacing the
+        // sentence: what is connected and what is pending are both facts the user needs.
+        let connected = switch (connection.claudeCode, connection.desktopIsReachable) {
         case (true, true): "Connected to Claude Code and Claude Desktop."
         case (true, false): "Connected to Claude Code."
         case (false, true): "Connected to Claude Desktop."
         case (false, false): "Not connected. Claude cannot read anything captured here yet."
         }
+        guard let notice = connection.restartNotice else { return connected }
+        return "\(connected) \(notice)"
     }
 
     /// Connect or disconnect, off the main actor, in the same shape as the probe in `.task` above.
@@ -204,7 +224,7 @@ struct SettingsAgentsPane: View {
             // Re-read rather than trusting `result`: the registrar reports what it *did*, and the row
             // states what is *on disk*. A write that half-succeeded must show the disk's answer.
             registration = await Task.detached(priority: .userInitiated) {
-                ClaudeRegistrar.status()
+                ClaudeConnection.current()
             }.value
             isRegistering = false
         }

--- a/desktop/context-for-claude/Sources/ContextApp/Tutorial/TutorialEnvironment.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Tutorial/TutorialEnvironment.swift
@@ -551,11 +551,7 @@ enum ClaudeHandoff {
                     }
                 },
                 serverIsLoaded: {
-                    ClaudeServerLiveness.state(
-                        claudeDesktopPIDs: Set(
-                            NSRunningApplication.runningApplications(
-                                withBundleIdentifier: ClaudeRelaunch.bundleIdentifier
-                            ).map(\.processIdentifier)))
+                    ClaudeServerLiveness.state(claudeDesktopPIDs: ClaudeDesktopProcesses.pids)
                 })
         }
     }
@@ -774,7 +770,10 @@ enum ClaudeHandoff {
 /// opened Claude and a card telling them to type something.
 @MainActor
 enum ClaudeRelaunch {
-    static let bundleIdentifier = "com.anthropic.claudefordesktop"
+    /// Claude Desktop's bundle identifier lives on `ClaudeDesktopProcesses` now: the liveness probe
+    /// and the status surfaces need the same string, and two copies of it is one copy too many for a
+    /// constant that decides whether we can see Claude at all.
+    static var bundleIdentifier: String { ClaudeDesktopProcesses.bundleIdentifier }
 
     static var isInstalled: Bool {
         NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil

--- a/desktop/context-for-claude/Tests/ContextAppTests/ClaudeConnectionTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ClaudeConnectionTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+
+@testable import ContextApp
+
+/// **The claim this app made for three days while it was false.**
+///
+/// A pre-release developer build wrote its own build directory into Claude Desktop's
+/// `claude_desktop_config.json`. The directory was deleted; the entry stayed. Every launch from
+/// 2026-08-16 to 2026-08-19, Claude Desktop tried to spawn a binary that was not there and logged
+/// `Failed to spawn process: No such file or directory`, and for all three days the menu bar and the
+/// Agents pane both read **Connected to Claude Code and Claude Desktop** — because the only question
+/// either of them asked was whether an entry existed in a file.
+///
+/// `ClaudeServerLiveness` could already answer the question that matters, and had been able to since
+/// it was written. It was reachable only from the tutorial, which runs once. So the tests here are
+/// about the wiring, not about the probe: given the probe's answer, no surface may report a
+/// connection Claude cannot use, and every surface must name the one thing that fixes it.
+///
+/// The probe itself is deliberately not exercised live. It walks the real process table for a real
+/// Claude Desktop, so a test that asserted on its output would pass or fail on whether the machine
+/// running the suite happened to have Claude open — which is why `ClaudeConnection`'s init takes the
+/// state as a parameter and every case below is arranged, not observed.
+final class ClaudeConnectionTests: XCTestCase {
+
+    // MARK: - The fact
+
+    /// A restart is claimed **only on evidence**, and `.notServingClaudeDesktop` is the only state
+    /// that is evidence. `.unknown` means Claude Desktop is not running or the process list could
+    /// not be read, and telling a user to restart an app on that basis would send them to quit
+    /// something that is working — or something that is not even open.
+    func testOnlyDemonstrableAbsenceAsksForARestart() {
+        XCTAssertTrue(
+            ClaudeConnection(claudeCode: true, claudeDesktop: true, liveness: .notServingClaudeDesktop)
+                .desktopNeedsRestart)
+        XCTAssertFalse(
+            ClaudeConnection(claudeCode: true, claudeDesktop: true, liveness: .servingClaudeDesktop)
+                .desktopNeedsRestart)
+        XCTAssertFalse(
+            ClaudeConnection(claudeCode: true, claudeDesktop: true, liveness: .unknown)
+                .desktopNeedsRestart)
+    }
+
+    /// Nothing registered for Claude Desktop means there is nothing for a restart to pick up. The
+    /// remedy for that state is connecting, and offering a restart instead would send the user to
+    /// quit an app that was never going to gain an entry by relaunching.
+    func testAnUnregisteredDesktopIsNeverAskedToRestart() {
+        for liveness: ClaudeServerLiveness.State in [
+            .notServingClaudeDesktop, .servingClaudeDesktop, .unknown,
+        ] {
+            XCTAssertFalse(
+                ClaudeConnection(claudeCode: true, claudeDesktop: false, liveness: liveness)
+                    .desktopNeedsRestart,
+                "an unregistered Claude Desktop was asked to restart on \(liveness)")
+        }
+    }
+
+    /// `desktopIsReachable` is the fact the summaries are allowed to call connected: registered
+    /// *and* actually serving. It is what separates "Claude can read this Mac" from "a file on this
+    /// Mac says it can".
+    func testReachabilityIsRegistrationAndLivenessTogether() {
+        XCTAssertTrue(
+            ClaudeConnection(claudeCode: false, claudeDesktop: true, liveness: .servingClaudeDesktop)
+                .desktopIsReachable)
+        XCTAssertFalse(
+            ClaudeConnection(claudeCode: false, claudeDesktop: true, liveness: .notServingClaudeDesktop)
+                .desktopIsReachable)
+        XCTAssertFalse(
+            ClaudeConnection(claudeCode: false, claudeDesktop: false, liveness: .servingClaudeDesktop)
+                .desktopIsReachable)
+    }
+
+    // MARK: - The menu bar
+
+    /// **The regression, at the surface that displayed it.** Registered, not serving: the line may
+    /// not name Claude Desktop as connected, and it has to say what to do instead.
+    func testTheMenuBarLineDoesNotCallADeadDesktopConnected() {
+        let line = ClaudeConnectorLine(
+            connection: ClaudeConnection(
+                claudeCode: true, claudeDesktop: true, liveness: .notServingClaudeDesktop),
+            note: nil,
+            isConnecting: false)
+
+        XCTAssertEqual(line.summary, "Connected to Claude Code")
+        XCTAssertFalse(
+            line.summary.contains("Claude Desktop"),
+            "the line still reports a Claude Desktop that cannot answer as connected")
+        XCTAssertEqual(line.note, "Quit and reopen Claude Desktop to finish connecting it.")
+    }
+
+    /// The state that is *only* a stale Claude Desktop still reads as unsettled, so it draws in the
+    /// contrast `StatusView` reserves for a line with something to do about it.
+    func testADesktopOnlyConnectionThatCannotAnswerIsNotReportedAsConnected() {
+        let line = ClaudeConnectorLine(
+            connection: ClaudeConnection(
+                claudeCode: false, claudeDesktop: true, liveness: .notServingClaudeDesktop),
+            note: nil,
+            isConnecting: false)
+
+        XCTAssertEqual(line.summary, "Not connected to Claude")
+        XCTAssertFalse(line.isConnected)
+    }
+
+    /// **No button that cannot help.** `Connect` rewrites the two config files, which in this state
+    /// are already correct — pressing it would change nothing the user can see and leave them with
+    /// the same dead connector. The registration is on disk, so the press is withheld and the note
+    /// carries the remedy.
+    func testTheConnectPressIsNotOfferedWhenItWouldRewriteACorrectConfig() {
+        let stale = ClaudeConnectorLine(
+            connection: ClaudeConnection(
+                claudeCode: false, claudeDesktop: true, liveness: .notServingClaudeDesktop),
+            note: nil,
+            isConnecting: false)
+        XCTAssertNil(stale.action, "offered a press that rewrites a config that is already correct")
+
+        // …and it is still offered when nothing is registered, which is the state it is for.
+        let nothing = ClaudeConnectorLine(
+            connection: ClaudeConnection(claudeCode: false, claudeDesktop: false, liveness: .unknown),
+            note: nil,
+            isConnecting: false)
+        XCTAssertEqual(nothing.action, "Connect")
+    }
+
+    /// The note slot is shared, and the sentence about the press the user just made is the fresher
+    /// fact. A standing condition they can act on at any time must not push it out.
+    func testAFreshRegistrationMessageOutranksTheStandingRemedy() {
+        let line = ClaudeConnectorLine(
+            connection: ClaudeConnection(
+                claudeCode: true, claudeDesktop: true, liveness: .notServingClaudeDesktop),
+            note: "Connected to Claude Code and Claude Desktop.",
+            isConnecting: false)
+
+        XCTAssertEqual(line.note, "Connected to Claude Code and Claude Desktop.")
+    }
+
+    /// Every state that is *not* the new one is byte-for-byte what it was before liveness existed.
+    /// The point of the change is one new state, not new wording for the four that were right.
+    func testTheSettledStatesAreUnchanged() {
+        let expected: [(Bool, Bool, String)] = [
+            (true, true, "Connected to Claude Code and Claude Desktop"),
+            (true, false, "Connected to Claude Code"),
+            (false, true, "Connected to Claude Desktop"),
+            (false, false, "Not connected to Claude"),
+        ]
+        for (code, desktop, summary) in expected {
+            for liveness: ClaudeServerLiveness.State in [.unknown, .servingClaudeDesktop] {
+                let line = ClaudeConnectorLine(
+                    connection: ClaudeConnection(
+                        claudeCode: code, claudeDesktop: desktop, liveness: liveness),
+                    note: nil,
+                    isConnecting: false)
+                XCTAssertEqual(line.summary, summary, "code=\(code) desktop=\(desktop) live=\(liveness)")
+                XCTAssertNil(line.note, "a settled state grew a note")
+            }
+        }
+    }
+
+    // MARK: - The settings pane
+
+    /// The same regression at the other surface. The pane says what is connected *and* what is
+    /// pending, because both are facts the user needs — one of them to know it worked, the other to
+    /// know it has not finished.
+    func testTheSettingsSubtitleReportsThePendingRestart() {
+        let subtitle = SettingsAgentsPane.connectionSubtitle(
+            ClaudeConnection(claudeCode: true, claudeDesktop: true, liveness: .notServingClaudeDesktop))
+
+        XCTAssertEqual(
+            subtitle,
+            "Connected to Claude Code. Quit and reopen Claude Desktop to finish connecting it.")
+    }
+
+    /// A working connection gains no nagging sentence, and the probe having said nothing yet is
+    /// still reported as not knowing rather than as a failure.
+    func testTheSettingsSubtitleStaysQuietWhenThereIsNothingToFix() {
+        XCTAssertEqual(
+            SettingsAgentsPane.connectionSubtitle(
+                ClaudeConnection(
+                    claudeCode: true, claudeDesktop: true, liveness: .servingClaudeDesktop)),
+            "Connected to Claude Code and Claude Desktop.")
+        XCTAssertEqual(
+            SettingsAgentsPane.connectionSubtitle(nil), "Checking whether Claude is connected…")
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/ClaudeServerLivenessTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/ClaudeServerLivenessTests.swift
@@ -1,0 +1,115 @@
+import Darwin
+import XCTest
+
+@testable import ContextApp
+
+/// **Who a running server belongs to.**
+///
+/// `ClaudeServerLiveness` exists to contradict the config files when they claim a connection Claude
+/// cannot use. It can only do that if it attributes servers correctly, and the version that shipped
+/// did not: it asked whether a Claude Desktop PID appeared *anywhere* above a server, and Claude
+/// Code now runs inside Claude Desktop, so every Claude Code session in the desktop app put one.
+///
+/// The tree below is not invented. It is the ancestry read off the Mac whose Claude Desktop
+/// connector had been failing to spawn since 2026-08-16 — where the old walk answered
+/// `servingClaudeDesktop` on the strength of fifteen Claude Code servers, which is the one answer
+/// that would have kept the status surfaces lying after they were wired to this probe.
+///
+/// Everything here drives the two process-table reads as closures. The real tree needs a running
+/// Claude Desktop with a running Claude Code inside it and a server under each, which no test may
+/// arrange and none should wait for.
+final class ClaudeServerLivenessTests: XCTestCase {
+
+    /// PIDs and paths from `ps` on 2026-08-19, unchanged.
+    private enum Real {
+        static let server: pid_t = 5160
+        static let claudeCode: pid_t = 5065
+        static let disclaimer: pid_t = 5064
+        static let claudeDesktop: pid_t = 1233
+        static let launchd: pid_t = 1
+
+        static let parents: [pid_t: pid_t] = [
+            server: claudeCode, claudeCode: disclaimer, disclaimer: claudeDesktop,
+            claudeDesktop: launchd,
+        ]
+        static let paths: [pid_t: String] = [
+            server: "/Applications/Context for Claude.app/Contents/MacOS/context-for-claude-mcp",
+            claudeCode:
+                "/Users/architlal/Library/Application Support/Claude/claude-code/2.1.229/claude.app/Contents/MacOS/claude",
+            disclaimer: "/Applications/Claude.app/Contents/Helpers/disclaimer",
+            claudeDesktop: "/Applications/Claude.app/Contents/MacOS/Claude",
+            launchd: "/sbin/launchd",
+        ]
+    }
+
+    private func owner(
+        of pid: pid_t,
+        desktops: Set<pid_t>,
+        parents: [pid_t: pid_t] = Real.parents,
+        paths: [pid_t: String] = Real.paths
+    ) -> ClaudeServerLiveness.Owner {
+        ClaudeServerLiveness.owner(
+            of: pid,
+            claudeDesktopPIDs: desktops,
+            parent: { parents[$0] },
+            executablePath: { paths[$0] })
+    }
+
+    /// **The regression.** Claude Code's server, on a chain that reaches Claude Desktop three hops
+    /// up, belongs to Claude Code.
+    func testAClaudeCodeServerInsideTheDesktopAppIsNotTheDesktopApps() {
+        XCTAssertEqual(owner(of: Real.server, desktops: [Real.claudeDesktop]), .claudeCode)
+    }
+
+    /// Claude Desktop's own server — spawned by the app rather than through Claude Code — is still
+    /// attributed to it. The fix must not silence the probe altogether.
+    func testAServerSpawnedByClaudeDesktopIsStillItsOwn() {
+        let server: pid_t = 900
+        XCTAssertEqual(
+            owner(
+                of: server,
+                desktops: [Real.claudeDesktop],
+                parents: [server: Real.disclaimer, Real.disclaimer: Real.claudeDesktop],
+                paths: [Real.disclaimer: "/Applications/Claude.app/Contents/Helpers/disclaimer"]),
+            .claudeDesktop)
+    }
+
+    /// A server under a Claude Code that Claude Desktop never launched — a terminal CLI — reaches
+    /// launchd having met nobody. It was never a false positive, and it does not become a false
+    /// negative either.
+    func testAServerUnderNoClaudeAtAllIsAttributedToNeither() {
+        let server: pid_t = 700
+        let shell: pid_t = 600
+        XCTAssertEqual(
+            owner(
+                of: server,
+                desktops: [Real.claudeDesktop],
+                parents: [server: shell, shell: Real.launchd],
+                paths: [shell: "/bin/zsh", Real.launchd: "/sbin/launchd"]),
+            .none)
+    }
+
+    /// An unreadable parent is "I could not tell", which is neither owner and is never acted on.
+    func testAnUnreadableChainIsUnknownRatherThanAnAnswer() {
+        XCTAssertEqual(
+            owner(of: Real.server, desktops: [Real.claudeDesktop], parents: [:], paths: [:]),
+            .unknown)
+    }
+
+    /// A cycle in the parent chain — corrupted, or a PID reused mid-walk — terminates instead of
+    /// spinning, and terminates as "could not tell" rather than as an answer.
+    func testACyclicChainTerminates() {
+        let a: pid_t = 10
+        let b: pid_t = 11
+        XCTAssertEqual(
+            owner(
+                of: a, desktops: [Real.claudeDesktop], parents: [a: b, b: a], paths: [:]),
+            .unknown)
+    }
+
+    /// With no Claude Desktop running there is nothing for a server to be serving, so the question
+    /// is moot rather than answered — and a moot question must never read as a fault.
+    func testNoRunningClaudeDesktopIsUnknownNotAbsence() {
+        XCTAssertEqual(ClaudeServerLiveness.state(claudeDesktopPIDs: []), .unknown)
+    }
+}

--- a/desktop/context-for-claude/Tests/ContextAppTests/StatusPopoverLayoutTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/StatusPopoverLayoutTests.swift
@@ -65,6 +65,7 @@ final class StatusPopoverLayoutTests: XCTestCase {
     private func block(
         claudeCode: Bool = false,
         claudeDesktop: Bool = false,
+        liveness: ClaudeServerLiveness.State = .unknown,
         connectorNote: String? = nil,
         signedIn: Bool = false,
         email: String? = nil,
@@ -72,8 +73,8 @@ final class StatusPopoverLayoutTests: XCTestCase {
         uploadFailed: Bool = false
     ) -> [String] {
         let connector = ClaudeConnectorLine(
-            claudeCode: claudeCode,
-            claudeDesktop: claudeDesktop,
+            connection: ClaudeConnection(
+                claudeCode: claudeCode, claudeDesktop: claudeDesktop, liveness: liveness),
             note: connectorNote,
             isConnecting: false)
         let account = AccountPresentation(
@@ -117,21 +118,30 @@ final class StatusPopoverLayoutTests: XCTestCase {
         ]
         let emails = ["a@b.co", "david.d.zhang.a.very.long.address@some-long-domain.example.com"]
 
+        // Liveness is in the sweep because `.notServingClaudeDesktop` adds a *fourth* line to the
+        // block — the restart notice — in the state that also carries the longest summary. That is
+        // the tallest the connection half can get, and it is the one the panel has to be sized by.
+        let livenesses: [ClaudeServerLiveness.State] = [
+            .unknown, .servingClaudeDesktop, .notServingClaudeDesktop,
+        ]
+
         for claudeCode in [false, true] {
             for claudeDesktop in [false, true] {
+                for liveness in livenesses {
                 for signedIn in [false, true] {
                     for note in notes {
                         for email in emails {
                             let lines = block(
                                 claudeCode: claudeCode,
                                 claudeDesktop: claudeDesktop,
+                                liveness: liveness,
                                 signedIn: signedIn,
                                 email: email,
                                 uploadNote: note,
                                 uploadFailed: note != nil)
                             let state =
-                                "code=\(claudeCode) desktop=\(claudeDesktop) signedIn=\(signedIn) "
-                                + "note=\(note ?? "nil")"
+                                "code=\(claudeCode) desktop=\(claudeDesktop) live=\(liveness) "
+                                + "signedIn=\(signedIn) note=\(note ?? "nil")"
 
                             XCTAssertGreaterThanOrEqual(lines.count, 2, state)
                             for line in lines {
@@ -143,6 +153,7 @@ final class StatusPopoverLayoutTests: XCTestCase {
                         }
                     }
                 }
+                }
             }
         }
     }
@@ -153,7 +164,9 @@ final class StatusPopoverLayoutTests: XCTestCase {
     /// lost, whatever its row height is.
     func testTheSentenceNamingBothSurfacesNeedsMoreThanOneRow() {
         let both = ClaudeConnectorLine(
-            claudeCode: true, claudeDesktop: true, note: nil, isConnecting: false)
+            connection: ClaudeConnection(claudeCode: true, claudeDesktop: true, liveness: .unknown),
+            note: nil,
+            isConnecting: false)
 
         XCTAssertGreaterThan(
             Self.height(of: both.summary), InkPermissionRow.menuRowHeight,
@@ -161,8 +174,16 @@ final class StatusPopoverLayoutTests: XCTestCase {
 
         // …and it is the tall one, so it is the state the panel has to be sized by.
         for shorter in [
-            ClaudeConnectorLine(claudeCode: true, claudeDesktop: false, note: nil, isConnecting: false),
-            ClaudeConnectorLine(claudeCode: false, claudeDesktop: false, note: nil, isConnecting: false),
+            ClaudeConnectorLine(
+                connection: ClaudeConnection(
+                    claudeCode: true, claudeDesktop: false, liveness: .unknown),
+                note: nil,
+                isConnecting: false),
+            ClaudeConnectorLine(
+                connection: ClaudeConnection(
+                    claudeCode: false, claudeDesktop: false, liveness: .unknown),
+                note: nil,
+                isConnecting: false),
         ] {
             XCTAssertGreaterThan(Self.height(of: both.summary), Self.height(of: shorter.summary))
         }

--- a/desktop/context-for-claude/changelog/unreleased/20260819-claude-desktop-reachability.json
+++ b/desktop/context-for-claude/changelog/unreleased/20260819-claude-desktop-reachability.json
@@ -1,0 +1,3 @@
+{
+  "change": "The connection status now tells you the truth about Claude Desktop. It used to read \"Connected\" whenever the config file had an entry, even when Claude Desktop had no working server — so a connector that had been dead for days still looked fine. It now checks for a live server and, when Claude Desktop has not picked the registration up yet, says to quit and reopen it"
+}


### PR DESCRIPTION
## What was wrong

Context for Claude told users it was connected to Claude Desktop by reading a config file. On this Mac that claim was false for three days and nothing anywhere said so.

A pre-1.0.11 developer build had written its own build directory into `claude_desktop_config.json`. The directory was deleted; the entry stayed. From 2026-08-16 to 2026-08-19 Claude Desktop tried to spawn a binary that was not there at every launch:

```
2026-08-16T17:51:54 [context-for-claude] Using MCP server command:
  /Users/…/omi-worktrees/ctx-release/desktop/context-for-claude/build/Context for Claude.app/…
Failed to spawn process: No such file or directory
```

For all three days the menu bar and the Agents pane both read **Connected to Claude Code and Claude Desktop**, because the only question either asked was whether an entry existed in a file. `ClaudeRegistrar.status()` reads two config files, and that was the whole of what the user-facing surfaces knew.

`ClaudeServerLiveness` has been able to answer the real question — is a server of ours alive inside the running Claude Desktop — since it was written. It was reachable only from `ClaudeHandoff`, which the tutorial runs once.

## Two commits

**1. Attribute a server to its nearest Claude, not to any Claude above it.**

The probe walked up looking for a Claude Desktop PID *anywhere* in a server's ancestry. Claude Code now runs inside Claude Desktop, so every Claude Code session in the desktop app puts one there:

```
context-for-claude-mcp
  → ~/Library/Application Support/Claude/claude-code/2.1.229/…/claude
    → /Applications/Claude.app/Contents/Helpers/disclaimer
      → /Applications/Claude.app/Contents/MacOS/Claude    ← a Claude Desktop PID
```

Its own comment says one of Claude Code's servers must never be read as proof that Claude Desktop has one; the walk defeated it. On the Mac above, the probe answered `servingClaudeDesktop` on the strength of fifteen Claude Code servers while Claude Desktop had none — so wiring the surfaces to it without this fix would have left them lying on exactly the setup that had the bug.

The first owner met now wins. `unknown` and `none` keep their existing meanings, so the tutorial's "never quit an app on a lookup that failed" doctrine is untouched.

**2. Wire liveness into the two surfaces that report the connection.**

`ClaudeConnection` joins registration (disk) to reachability (process table). A registration Claude Desktop has not picked up is no longer called connected, and both surfaces name the only thing that fixes it.

| state | before | after |
|---|---|---|
| registered, server live | Connected to Claude Code and Claude Desktop | unchanged |
| registered, no server | Connected to Claude Code and Claude Desktop | Connected to Claude Code. Quit and reopen Claude Desktop to finish connecting it. |
| Claude Desktop not running / unreadable | Connected … | unchanged — `.unknown` is never nagged on |

The `Connect` press is withheld in the needs-restart state: it rewrites two files that are already correct and would change nothing the user can see. The app still does not quit anybody's Claude — `ClaudeHandoff` may offer that with consent because it is about to hand Claude a question; a status line has no such errand. The remedy is a sentence.

`ClaudeDesktopProcesses` becomes the one place the running Claude Desktops are read, so `ClaudeRegistrar` stays free of AppKit and the three call sites that built the same `runningApplications()` query cannot disagree about the bundle identifier.

## Verification

- `swift test` in `desktop/context-for-claude`: **1655 tests, 9 skipped, 0 failures**.
- **Live, on a Mac in exactly the broken state** (registered for both surfaces, Claude Desktop running since Aug 14 with no server of its own), driving the shipping value types off the real config files and the real process table:
  ```
  connection = (claudeCode: true, claudeDesktop: true, desktopNeedsRestart: true)
  menu bar   = "Connected to Claude Code"
             + "Quit and reopen Claude Desktop to finish connecting it."
  settings   = "Connected to Claude Code. Quit and reopen Claude Desktop to finish connecting it."
  ```
  With the pre-fix behaviour restored, the same probe prints `Connected to Claude Code and Claude Desktop.` over the dead connector.
- **Mutation checks**, both run:
  - reverting `desktopIsReachable` to plain registration fails 6 of the 10 new `ClaudeConnectionTests`;
  - restoring the shipped ancestry walk fails `testAClaudeCodeServerInsideTheDesktopAppIsNotTheDesktopApps` with `("claudeDesktop") is not equal to ("claudeCode")`.
- **Ran the real app.** Built the bundle, launched it, and opened the menu-bar popover. It draws:

  > **Connected to Claude Code**
  > Quit and reopen Claude Desktop to finish connecting it.

  with the note on its own line, no `Connect` button, and no overlap in the connection block. The dev build registered under `context-for-claude-dev` and left the release's entry untouched, so #11712's split still holds with this change on top of it.
- `StatusPopoverLayoutTests` now sweeps liveness, because `notServingClaudeDesktop` adds a fourth line to the popover's connection block in the state that also carries the longest summary — the tallest the block can get, and the one the panel must be sized by.

Note for reviewers: `desktop/context-for-claude` has no Swift lane in CI, so the suite above was run locally and is not re-run by any check on this PR.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: FC-platform-grant-record-as-live-capability

Second instance in this app, same structure as the first (#10783): a persisted record was treated as proof of a live capability whose rights are actually bound at another process's start. There it was a TCC grant read back as `true` while ScreenCaptureKit refused the same process; here it is an `mcpServers` entry read back as connected while Claude Desktop, which reads that file only at its own launch, has no server. The class's canonical prevention already prescribes the shape used here — model the capability as granted / denied / granted-but-stale, resolve it from the platform record *and* from what the subsystem that does the work reports, and surface relaunch as the remedy rather than retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

