### PR TITLE
fix(chat): correct the referent ceiling note, and make the materialization drop rate readable

### DIFF
--- a/backend/pyrightconfig.json
+++ b/backend/pyrightconfig.json
@@ -18,6 +18,7 @@
         "scripts/backfill_mcp_key_full_access.py",
         "scripts/backfill_user_signup_platform.py",
         "scripts/chat/stream_test.py",
+        "scripts/chat_first_materialization_drop_rate.py",
         "scripts/check_module_stub_pollution.py",
         "scripts/check_workflow_contracts.py",
         "scripts/cutover_evidence_readiness.py",

--- a/backend/scripts/chat_first_materialization_drop_rate.py
+++ b/backend/scripts/chat_first_materialization_drop_rate.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Report how often a Chat-first proactive intent is never materialised.
+
+Read-only. Performs no writes and creates no Firestore index.
+
+Why this exists
+---------------
+``POST v2/chat/materialize-prompts`` hands a ready intent to whichever client is
+foregrounded, and the *client's* kernel is the sole writer of the visible Chat
+row; the server never writes one (see ``_materialize_prompts``). An intent is
+retired account-wide the moment one client acknowledges it. Since #11844 a
+client that receives an intent can persist the row and every other client sees
+it, so cards no longer diverge *between* devices. The remaining failure mode is
+narrower and account-wide: **no client ever materialised the intent at all**, so
+the card exists nowhere.
+
+That is what this script counts, and it is the number that decides whether
+canonical server-side materialisation is worth building. If the drop rate is
+negligible, that work buys very little. If cards are genuinely going missing,
+this is the baseline to design against.
+
+Why not the Prometheus counter
+------------------------------
+``CHAT_FIRST_PROACTIVE_TOTAL`` does label ``event='fetch'`` and
+``event='kernel_receipt'``, which looks like the obvious source. It is not
+readable in production: it is an in-process ``prometheus_client`` counter behind
+a bearer-gated ``/metrics``, the API backend runs on Cloud Run with no scrape
+annotation, and no dashboard or alert consumes it. Intent state, by contrast, is
+durable in Firestore and survives instance churn -- so this reads the state.
+
+What counts as a drop
+---------------------
+``delivered_at`` and ``materialization_receipt_id`` are written together, only on
+acknowledgement (``acknowledge_materialization``), so "delivered but unreceipted"
+is not a reachable state and is not what to look for. The signal is an intent
+still sitting in ``ready`` or ``pending_kernel_receipt`` well past the age by
+which a live client would have consumed it:
+
+    dropped    delivery_state != 'delivered' and created_at older than --stale-after-hours
+    in flight  delivery_state != 'delivered' and created_at newer than that
+    delivered  delivery_state == 'delivered'
+
+Drop rate is ``dropped / (dropped + delivered)``. Intents still in flight are
+excluded from the denominator: their outcome is not yet decided.
+
+Usage:
+    python scripts/chat_first_materialization_drop_rate.py --uid <uid>
+    python scripts/chat_first_materialization_drop_rate.py --limit 5000
+    python scripts/chat_first_materialization_drop_rate.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, cast
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from database._client import db  # noqa: E402
+
+INTENTS_COLLECTION = 'chat_first_proactive_intents'
+DELIVERED = 'delivered'
+DEFAULT_STALE_AFTER_HOURS = 48
+
+
+def _documents(uid: str | None, limit: int | None) -> Iterator[Dict[str, Any]]:
+    """Stream intent documents.
+
+    A ``--uid`` run reads that user's subcollection directly. The account-wide
+    run uses an unfiltered ``collection_group`` scan: age and delivery state are
+    bucketed in Python precisely so this needs no composite index and no entry
+    in ``firestore_index_registry``. Bound it with ``--limit`` on large projects.
+    """
+
+    if uid:
+        query: Any = db.collection('users').document(uid).collection(INTENTS_COLLECTION)
+    else:
+        query = db.collection_group(INTENTS_COLLECTION)
+    if limit is not None:
+        query = query.limit(limit)
+    for snapshot in query.stream():
+        raw: object = snapshot.to_dict()
+        if isinstance(raw, dict):
+            yield cast(Dict[str, Any], raw)
+
+
+def _created_at(document: Dict[str, Any]) -> datetime | None:
+    value = document.get('created_at')
+    if not isinstance(value, datetime):
+        return None
+    return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+
+
+def _block_types(document: Dict[str, Any]) -> List[str]:
+    blocks = document.get('blocks')
+    if not isinstance(blocks, list):
+        return []
+    types: List[str] = []
+    for block in cast(List[Any], blocks):
+        if isinstance(block, dict):
+            block_type = cast(Dict[str, Any], block).get('type')
+            if isinstance(block_type, str):
+                types.append(block_type)
+    return types
+
+
+def summarize(
+    documents: Iterable[Dict[str, Any]],
+    *,
+    scope: str,
+    stale_after_hours: int,
+    now: datetime,
+) -> Dict[str, Any]:
+    """Bucket intent documents into delivered / dropped / in-flight.
+
+    Kept free of Firestore so the classification is unit-testable on its own.
+    """
+
+    cutoff = now - timedelta(hours=stale_after_hours)
+    delivered = 0
+    in_flight = 0
+    undated = 0
+    dropped_by_source: collections.Counter[str] = collections.Counter()
+    dropped_by_block: collections.Counter[str] = collections.Counter()
+    delivered_by_source: collections.Counter[str] = collections.Counter()
+
+    for document in documents:
+        source = str(document.get('source') or 'unknown')
+        if document.get('delivery_state') == DELIVERED:
+            delivered += 1
+            delivered_by_source[source] += 1
+            continue
+        created_at = _created_at(document)
+        if created_at is None:
+            # Never silently fold a malformed record into either outcome.
+            undated += 1
+            continue
+        if created_at > cutoff:
+            in_flight += 1
+            continue
+        dropped_by_source[source] += 1
+        for block_type in set(_block_types(document)):
+            dropped_by_block[block_type] += 1
+
+    dropped = sum(dropped_by_source.values())
+    decided = dropped + delivered
+    return {
+        'scope': scope,
+        'stale_after_hours': stale_after_hours,
+        'delivered': delivered,
+        'dropped': dropped,
+        'in_flight': in_flight,
+        'undated': undated,
+        'decided': decided,
+        'drop_rate': (dropped / decided) if decided else None,
+        'dropped_by_source': dict(dropped_by_source.most_common()),
+        'delivered_by_source': dict(delivered_by_source.most_common()),
+        'dropped_by_block_type': dict(dropped_by_block.most_common()),
+    }
+
+
+def collect(uid: str | None, limit: int | None, stale_after_hours: int, now: datetime) -> Dict[str, Any]:
+    return summarize(
+        _documents(uid, limit),
+        scope=uid or 'all_accounts',
+        stale_after_hours=stale_after_hours,
+        now=now,
+    )
+
+
+def render(report: Dict[str, Any]) -> str:
+    rate = report['drop_rate']
+    lines = [
+        f"scope                {report['scope']}",
+        f"stale after          {report['stale_after_hours']}h",
+        f"delivered            {report['delivered']}",
+        f"dropped              {report['dropped']}",
+        f"still in flight      {report['in_flight']} (excluded from the rate)",
+        f"drop rate            {'n/a (no decided intents)' if rate is None else f'{rate:.2%}'}",
+    ]
+    if report['undated']:
+        lines.append(f"undated records      {report['undated']} (no created_at; not counted either way)")
+    for label, key in (('dropped by source', 'dropped_by_source'), ('dropped by block type', 'dropped_by_block_type')):
+        if report[key]:
+            lines.append(f"{label}:")
+            lines.extend(f"  {name:<24} {count}" for name, count in cast(Dict[str, int], report[key]).items())
+    return '\n'.join(lines)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--uid', help='Scope to one account. Omit to scan every account.')
+    parser.add_argument('--limit', type=int, help='Maximum intent documents to read.')
+    parser.add_argument(
+        '--stale-after-hours',
+        type=int,
+        default=DEFAULT_STALE_AFTER_HOURS,
+        help=f'Age past which an unacknowledged intent counts as dropped (default {DEFAULT_STALE_AFTER_HOURS}).',
+    )
+    parser.add_argument('--json', action='store_true', help='Emit the report as JSON.')
+    parser.add_argument(
+        '--fail-over-rate',
+        type=float,
+        help='Exit 1 when the drop rate exceeds this fraction, for use as a scheduled check.',
+    )
+    args = parser.parse_args(argv)
+
+    report = collect(args.uid, args.limit, args.stale_after_hours, datetime.now(timezone.utc))
+    print(json.dumps(report, indent=2) if args.json else render(report))
+
+    rate = report['drop_rate']
+    if args.fail_over_rate is not None and rate is not None and rate > args.fail_over_rate:
+        print(f'drop rate {rate:.2%} exceeds {args.fail_over_rate:.2%}', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/tests/unit/test_chat_first_materialization_drop_rate.py
+++ b/backend/tests/unit/test_chat_first_materialization_drop_rate.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+NOW = datetime(2026, 8, 19, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def report():
+    """Load the script under test without leaving it in ``sys.modules``.
+
+    Same isolation rule as the other script tests: ``scripts/check_module_stub_pollution.py``
+    bans leaking the registration into later tests, so it is scoped to the fixture.
+    """
+    spec = importlib.util.spec_from_file_location(
+        'chat_first_materialization_drop_rate',
+        BACKEND_ROOT / 'scripts' / 'chat_first_materialization_drop_rate.py',
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def _intent(**overrides: Any) -> dict[str, Any]:
+    document: dict[str, Any] = {
+        'source': 'capture_arrival',
+        'delivery_state': 'ready',
+        'created_at': NOW - timedelta(hours=72),
+        'blocks': [{'type': 'conversationLink'}],
+    }
+    document.update(overrides)
+    return document
+
+
+def _summarize(report: Any, documents: list[dict[str, Any]], stale_after_hours: int = 48) -> dict[str, Any]:
+    return report.summarize(documents, scope='test', stale_after_hours=stale_after_hours, now=NOW)
+
+
+def test_unacknowledged_and_old_counts_as_dropped(report: Any):
+    summary = _summarize(report, [_intent()])
+    assert summary['dropped'] == 1
+    assert summary['delivered'] == 0
+    assert summary['drop_rate'] == 1.0
+    assert summary['dropped_by_block_type'] == {'conversationLink': 1}
+
+
+def test_acknowledged_intent_counts_as_delivered(report: Any):
+    summary = _summarize(
+        report,
+        [_intent(delivery_state='delivered', delivered_at=NOW, materialization_receipt_id='r-1')],
+    )
+    assert summary['delivered'] == 1
+    assert summary['dropped'] == 0
+    assert summary['drop_rate'] == 0.0
+
+
+def test_recent_unacknowledged_intent_is_in_flight_not_dropped(report: Any):
+    """An intent younger than the threshold has no decided outcome yet.
+
+    Counting it as a drop would report ~100% on any healthy account, because
+    every intent starts life unacknowledged.
+    """
+    summary = _summarize(report, [_intent(created_at=NOW - timedelta(hours=1))])
+    assert summary['in_flight'] == 1
+    assert summary['dropped'] == 0
+    assert summary['decided'] == 0
+    assert summary['drop_rate'] is None
+
+
+def test_pending_kernel_receipt_is_not_treated_as_delivered(report: Any):
+    """``pending_kernel_receipt`` is a cold-start waiting state, not an acknowledgement."""
+    summary = _summarize(report, [_intent(delivery_state='pending_kernel_receipt', source='cold_start_sparse')])
+    assert summary['dropped'] == 1
+    assert summary['dropped_by_source'] == {'cold_start_sparse': 1}
+
+
+def test_missing_created_at_is_isolated_rather_than_guessed(report: Any):
+    summary = _summarize(report, [_intent(created_at=None)])
+    assert summary['undated'] == 1
+    assert summary['dropped'] == 0
+    assert summary['in_flight'] == 0
+
+
+def test_naive_created_at_is_read_as_utc(report: Any):
+    summary = _summarize(report, [_intent(created_at=datetime(2026, 8, 16, 12, 0))])
+    assert summary['dropped'] == 1
+
+
+def test_rate_excludes_in_flight_from_the_denominator(report: Any):
+    documents = [
+        _intent(),
+        _intent(delivery_state='delivered'),
+        _intent(delivery_state='delivered'),
+        _intent(created_at=NOW - timedelta(minutes=5)),
+    ]
+    summary = _summarize(report, documents)
+    assert (summary['dropped'], summary['delivered'], summary['in_flight']) == (1, 2, 1)
+    assert summary['decided'] == 3
+    assert summary['drop_rate'] == pytest.approx(1 / 3)
+
+
+def test_repeated_block_type_in_one_intent_counts_once(report: Any):
+    summary = _summarize(
+        report,
+        [_intent(blocks=[{'type': 'conversationLink'}, {'type': 'conversationLink'}, {'type': 'text'}])],
+    )
+    assert summary['dropped_by_block_type'] == {'conversationLink': 1, 'text': 1}

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketRollup.swift
@@ -406,11 +406,23 @@ enum ContextProactivityPromptBuilder {
   /// given. Across 69 spoken baseline runs the model named the referent whenever
   /// one was anywhere in the prompt — including when it appeared only in an old
   /// frozen-segment line among four distractor facts. The residual vague messages
-  /// all come from contexts carrying no identifier. `bucket_facts.identifiers` is
-  /// where extraction already stores the handles it was told to copy, and
-  /// `ContextBucketStore.snapshot` does not put that column into the fact lines
-  /// the director reads. That is the next lever, and it is a store change, not a
-  /// prompt change.
+  /// all come from contexts carrying no identifier.
+  ///
+  /// Surfacing `bucket_facts.identifiersJson` is not that lever, though it reads
+  /// like one, and an earlier version of this comment sent readers there.
+  /// `ContextBucketStore.snapshot` does omit the column from the fact lines the
+  /// director reads — but the same line carries `evidenceText` verbatim, and
+  /// `BucketFactValidator.acceptedIdentifiers` above keeps an identifier only when
+  /// that already-truncated `evidenceText` contains it. Every stored handle is
+  /// therefore a substring of a string the director is already reading, so the
+  /// column can add nothing the prompt does not already have. That holds by
+  /// construction rather than by sampling: `ContextBucketStore.writeExtraction` is
+  /// the only writer of the column, and it derives both values from one string.
+  ///
+  /// The lever is upstream, in extraction. The model leaves `identifiers` empty
+  /// while writing the same handle into the statement (0/39 on real work screens,
+  /// recorded above), and it cannot copy a handle the capture never contained.
+  /// Both are extraction-prompt and capture problems, not store problems.
   ///
   /// This text is the prompt-cache prefix: nothing volatile may be interpolated
   /// into it, and it must stay byte-identical across calls for one bucket. The

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Core/ContextBucketStore.swift
@@ -849,6 +849,11 @@ actor ContextBucketStore {
         """,
       arguments: [bucketID]
     ).reversed()
+    // `identifiersJson` is deliberately absent, and adding it would be a no-op:
+    // `BucketFactValidator.acceptedIdentifiers` only stores an identifier that the
+    // row's own (already truncated) `evidenceText` contains, and `evidenceText` is
+    // emitted verbatim right here. See the `Ceiling` note on
+    // `ContextBucketRollup.directorStablePrompt`.
     let facts = try String.fetchAll(
       db,
       sql: """

--- a/desktop/macos/changelog/unreleased/20260819-director-referent-ceiling-note.json
+++ b/desktop/macos/changelog/unreleased/20260819-director-referent-ceiling-note.json
@@ -1,0 +1,4 @@
+{
+  "kind": "none",
+  "reason": "Comment-only correction to the director referent ceiling note; no behaviour and no prompt bytes change."
+}


### PR DESCRIPTION
Two small follow-ups to #11844. No behaviour changes: the desktop half is comment-only, and the backend half adds a read-only ops script that nothing calls.

## 1. The referent "Ceiling" note pointed at a dead end

#11844 left a note on `directorStablePrompt` telling whoever tunes it next that carrying `bucket_facts.identifiersJson` into `ContextBucketStore.snapshot` was the next lever, and that it was "a store change, not a prompt change."

The premise is true and the conclusion is wrong. The snapshot does omit the column — but the same fact line emits `evidenceText` verbatim:

```sql
SELECT 'fact:' || id || ' ' || statement ||
  ' [evidence: ' || evidenceText || '; refs: ' || evidenceRefsJson || ']'
```

and `BucketFactValidator.acceptedIdentifiers` keeps an identifier only when the evidence contains it:

```swift
&& lowercasedEvidence.contains(identifier.lowercased())
```

`ContextBucketStore.writeExtraction` truncates evidence to 1,000 characters *first*, derives the identifiers from that truncated string, and stores both. It is the only writer of the column. So every stored handle is, by construction, a case-insensitive substring of a string the director is already reading, and surfacing the column separately can add nothing. Anyone acting on the old note would have spent the work to move a value that was already in the prompt.

The note now says that, and points at the real lever instead — extraction leaving `identifiers` empty while writing the same handle into the statement (0/39 on real work screens, already measured and recorded in the same file). A matching note sits at the snapshot SQL, which is where someone would look first.

The 912-run measurement and every conclusion #11844 drew from it are unaffected; only the forward-looking "next lever" sentence was wrong. No prompt bytes change, so the cached prefix is untouched.

## 2. A way to actually read the materialization drop rate

#11844 deliberately left canonical server-side materialization as follow-up work, to be decided by production data that only started existing at that merge. The intended instrument was `CHAT_FIRST_PROACTIVE_TOTAL`, which already labels `event='fetch'` and `event='kernel_receipt'`.

That instrument is not readable in production. It is an in-process `prometheus_client` counter behind a bearer-gated `/metrics`; the API backend runs on Cloud Run with no scrape annotation; and no dashboard or alert consumes it. The counters that *are* observable in this repo (`pusher_queue_drops_total`, `backend_listen_active_ws_connections`) belong to the GKE services, which carry `prometheus.io/scrape: "true"`. Waiting two weeks and then querying it would have produced nothing.

`backend/scripts/chat_first_materialization_drop_rate.py` reads durable intent state instead, which survives instance churn.

Two details that are easy to get wrong, both covered by tests:

- **"Delivered but unreceipted" is not a reachable state.** `acknowledge_materialization` writes `delivered_at` and `materialization_receipt_id` together, so looking for one without the other finds nothing. A drop is an intent still sitting in `ready` or `pending_kernel_receipt` past `--stale-after-hours`.
- **In-flight intents are excluded from the denominator.** Every intent starts life unacknowledged, so counting young ones as drops reports ~100% on a perfectly healthy account.

It needs no Firestore index and adds no entry to `firestore_index_registry`: age and delivery state are bucketed in Python, so the account-wide pass is an unfiltered collection-group scan. Read-only, no writes on any path.

```bash
python scripts/chat_first_materialization_drop_rate.py --uid <uid>
```

It also breaks drops down by block type, so `conversationLink` — the meeting-notes card from #11844 — can be read off directly.

## Testing

- `make preflight` — 32/32 pass
- Bounded pre-push gate — pass, including the desktop Swift build, black, the OpenAPI contract, and Flutter generated-artifact freshness
- `backend/scripts/typecheck.sh` — 0 errors; the new script is added to `pyrightconfig.json` and is clean under `strict`
- 8 new unit tests, all passing, covering the two classification traps above plus naive-datetime and malformed-record handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

