### PR TITLE
fix(backend): frame-align truncated PCM chunks so audio merge cannot lose the playback artifact

### DIFF
--- a/backend/tests/unit/test_sync_playback_frame_alignment.py
+++ b/backend/tests/unit/test_sync_playback_frame_alignment.py
@@ -1,0 +1,99 @@
+"""Regression tests: a PCM16 chunk truncated mid-sample must not lose the artifact.
+
+Prod signature (2026-08-17..19, backend-sync): ``POST /v2/audio-merge-jobs/run``
+returned 500 four times for the same conv/file with
+``data length must be a multiple of '(sample_width * channels)'`` — pydub
+rejecting an odd-length buffer. The error is deterministic, so every retry
+failed identically and the job then marked playback permanently unavailable.
+"""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydub import AudioSegment
+
+from utils.other import storage as storage_mod
+from utils.sync import playback as playback_mod
+
+
+class _FakeNotFound(Exception):
+    """storage_mod.NotFound is patched to this so the mocked blob can 404."""
+
+    pass
+
+
+def _blob_factory(ext_data_map):
+    def factory(path):
+        blob = MagicMock()
+        for ext, data in ext_data_map.items():
+            if path.endswith(f'.{ext}'):
+                blob.download_as_bytes.return_value = data
+                return blob
+        blob.download_as_bytes.side_effect = _FakeNotFound('not found')
+        return blob
+
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage_client(monkeypatch):
+    monkeypatch.setattr(storage_mod, "storage_client", MagicMock())
+
+
+def test_pydub_rejects_odd_length_pcm_control():
+    """Control for the prod error: the encode step really does fail on odd input."""
+    with pytest.raises(ValueError, match="multiple of"):
+        AudioSegment(data=b'\x00' * 641, sample_width=2, frame_rate=16000, channels=1)
+
+
+@patch.object(storage_mod, 'NotFound', _FakeNotFound)
+def test_truncated_chunk_is_frame_aligned():
+    """A chunk stored with a half sample is trimmed to whole PCM16 frames."""
+    bucket = MagicMock()
+    bucket.blob.side_effect = _blob_factory({'bin': b'\x11\x22' * 320 + b'\x33'})
+    storage_mod.storage_client.bucket.return_value = bucket
+
+    merged = storage_mod.download_audio_chunks_and_merge('uid', 'conv', [1000.0], fill_gaps=False)
+
+    assert len(merged) % 2 == 0
+    assert merged == b'\x11\x22' * 320
+
+
+@patch.object(storage_mod, 'NotFound', _FakeNotFound)
+def test_truncated_chunk_does_not_byte_shift_later_chunks():
+    """The trailing half sample must not push every later chunk off the frame grid."""
+    bucket = MagicMock()
+
+    def factory(path):
+        blob = MagicMock()
+        if path.endswith('1000.000.bin'):
+            blob.download_as_bytes.return_value = b'\x11\x22' * 320 + b'\x33'
+        elif path.endswith('1000.020.bin'):
+            blob.download_as_bytes.return_value = b'\x44\x55' * 320
+        else:
+            blob.download_as_bytes.side_effect = _FakeNotFound('not found')
+        return blob
+
+    bucket.blob.side_effect = factory
+    storage_mod.storage_client.bucket.return_value = bucket
+
+    merged = storage_mod.download_audio_chunks_and_merge('uid', 'conv', [1000.0, 1000.02], fill_gaps=False)
+
+    assert len(merged) % 2 == 0
+    # Second chunk still starts on an even offset, so its samples decode as stored.
+    assert merged.endswith(b'\x44\x55' * 320)
+    assert merged.index(b'\x44\x55' * 320) % 2 == 0
+
+
+@patch.object(storage_mod, 'NotFound', _FakeNotFound)
+def test_build_playback_artifact_survives_truncated_chunk():
+    """The real merge-job path builds an MP3 instead of raising the retried ValueError."""
+    bucket = MagicMock()
+    bucket.blob.side_effect = _blob_factory({'bin': b'\x00\x01' * 16000 + b'\x02'})
+    storage_mod.storage_client.bucket.return_value = bucket
+
+    mp3_data = playback_mod.build_playback_artifact('uid', 'conv', [1000.0])
+
+    assert mp3_data
+    assert AudioSegment.from_file(io.BytesIO(mp3_data), format='mp3').frame_rate > 0

--- a/backend/tests/unit/test_sync_playback_frame_alignment.py
+++ b/backend/tests/unit/test_sync_playback_frame_alignment.py
@@ -7,7 +7,6 @@ rejecting an odd-length buffer. The error is deterministic, so every retry
 failed identically and the job then marked playback permanently unavailable.
 """
 
-import io
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -88,12 +87,25 @@ def test_truncated_chunk_does_not_byte_shift_later_chunks():
 
 @patch.object(storage_mod, 'NotFound', _FakeNotFound)
 def test_build_playback_artifact_survives_truncated_chunk():
-    """The real merge-job path builds an MP3 instead of raising the retried ValueError."""
+    """The real merge-job path completes instead of raising the retried ValueError.
+
+    Only the MP3 encode is stubbed — pydub shells out to ffmpeg, which the unit
+    runner does not carry. The call that actually raised in production, the
+    AudioSegment construction over the merged buffer, still runs for real.
+    """
     bucket = MagicMock()
     bucket.blob.side_effect = _blob_factory({'bin': b'\x00\x01' * 16000 + b'\x02'})
     storage_mod.storage_client.bucket.return_value = bucket
 
-    mp3_data = playback_mod.build_playback_artifact('uid', 'conv', [1000.0])
+    encoded_lengths = []
 
-    assert mp3_data
-    assert AudioSegment.from_file(io.BytesIO(mp3_data), format='mp3').frame_rate > 0
+    def fake_export(self, out_f, **kwargs):
+        encoded_lengths.append(len(self.raw_data))
+        out_f.write(b'mp3-stub')
+        return out_f
+
+    with patch.object(AudioSegment, 'export', fake_export):
+        mp3_data = playback_mod.build_playback_artifact('uid', 'conv', [1000.0])
+
+    assert mp3_data == b'mp3-stub'
+    assert encoded_lengths == [32000]

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -27,6 +27,7 @@ from google.cloud.exceptions import NotFound
 from database.redis_db import cache_signed_url, get_cached_signed_url
 from utils import encryption
 from utils.cloud_tasks import enqueue_audio_merge_job, is_audio_merge_dispatch_enabled
+from utils.observability.fallback import record_fallback
 from utils.other.deferred_delete import DeferredDeleter
 from database import users as users_db
 import logging
@@ -771,6 +772,36 @@ def delete_conversation_audio_files(uid: str, conversation_id: str) -> None:
         blob.delete()
 
 
+# PCM16 mono: one sample is 2 bytes. A chunk whose byte count is not a multiple
+# of this is truncated mid-sample.
+_PCM16_FRAME_BYTES = 2
+
+
+def _align_pcm16_frames(pcm_data: bytes, source: str) -> bytes:
+    """Drop a trailing partial PCM16 sample so decoded chunks stay frame-aligned.
+
+    A chunk stored truncated mid-sample (interrupted upload) makes every later
+    chunk in the merge byte-misaligned and leaves the merged buffer an odd byte
+    count, which pydub rejects with a deterministic ValueError. The audio-merge
+    Cloud Task retried that unretryable error to exhaustion and then marked
+    playback permanently unavailable, losing the artifact for the conversation.
+    Trimming the partial sample costs 1/32000s and keeps the merge buildable.
+    """
+    remainder = len(pcm_data) % _PCM16_FRAME_BYTES
+    if not remainder:
+        return pcm_data
+    record_fallback(
+        component='audio_merge',
+        from_mode='pcm16_frames',
+        to_mode='pcm16_frames_truncated',
+        reason='malformed_doc',
+        outcome='recovered',
+        log=logger,
+    )
+    logger.warning(f'audio chunk not PCM16 frame-aligned, trimming {remainder} trailing byte(s): {source}')
+    return pcm_data[:-remainder]
+
+
 def download_audio_chunks_and_merge(
     uid: str,
     conversation_id: str,
@@ -853,7 +884,7 @@ def download_audio_chunks_and_merge(
             else:
                 pcm_data = raw_data
 
-            return pcm_data
+            return _align_pcm16_frames(pcm_data, path)
         except Exception as e:
             logger.warning(f"Failed to decode/decrypt {path}: {e}")
             return None
@@ -888,7 +919,7 @@ def download_audio_chunks_and_merge(
                 else:
                     pcm_data = raw_data
 
-                return (timestamp, pcm_data)
+                return (timestamp, _align_pcm16_frames(pcm_data, chunk_path))
             except Exception as e:
                 logger.warning(
                     f"Failed to decode/decrypt {ext} chunk at {formatted_timestamp}: {e}, trying next format"


### PR DESCRIPTION
## Bug

`POST /v2/audio-merge-jobs/run` (backend-sync) returns HTTP 500 four times in a row for the same conversation/file, always with:

```
audio_merge: attempt N failed conv=<id> file=<id>, will retry:
data length must be a multiple of '(sample_width * channels)'
```

Prod evidence, `based-hardware` / `backend-sync`, 2026-08-17 → 2026-08-19 — five distinct conv/file pairs across several users, each burning attempts 1–4:

| when (UTC) | conv | file |
|---|---|---|
| 08-19 16:06–16:10 | 48da1f77 | cadcc420 |
| 08-19 14:12–14:16 | 48da1f77 | 5aec953d |
| 08-19 11:53–11:57 | dad498c7 | b0c2a55c |
| 08-18 18:37–18:41 | dad498c7 | 5b4b2810 |
| 08-17 16:50–16:54 | b4f92d72 | e95e7c08 + 3ecb4f7d |

## Root cause

`download_audio_chunks_and_merge` concatenates each decoded chunk into the merged PCM16 buffer verbatim. A chunk stored truncated mid-sample — an odd byte count from an interrupted upload — has two consequences:

1. every later chunk in the merge lands on an odd byte offset, so its samples decode byte-swapped;
2. the merged buffer's length is odd, and `AudioSegment(data=..., sample_width=2, ...)` in `sync_playback.build_playback_artifact` raises `ValueError: data length must be a multiple of '(sample_width * channels)'`.

That ValueError is **deterministic** — no retry of the same bytes can ever satisfy it — but the Cloud Tasks handler in `routers/sync.py` treats every exception as retryable. So it spends all four attempts on it and then calls `mark_playback_unavailable(..., 'merge_failed')`. Because the consumed named task leaves a tombstone that blocks re-enqueue, the conversation's playback artifact is lost until the 30-day lifecycle grants a retry.

## Fix

Normalize at the shared read boundary rather than adding a call-site exception. `_align_pcm16_frames` drops the trailing partial sample (1/32000 s) from each decoded chunk in `download_audio_chunks_and_merge`, so chunk durations stay integral, later chunks stay on the frame grid, and the merge stays buildable. It is a no-op (identity return) for the aligned case. The fail-open branch calls the shared `record_fallback(component='audio_merge', from='pcm16_frames', to='pcm16_frames_truncated', reason='malformed_doc', outcome='recovered')` per `docs/agents/fallback-telemetry.md`.

## What I tested

- **New regression test** `backend/tests/unit/test_sync_playback_frame_alignment.py` (4 tests) drives the real `build_playback_artifact` merge path with a mocked bucket serving a chunk truncated mid-sample, plus the byte-shift case (a truncated chunk followed by a good one) and a control asserting pydub really does reject odd-length input.
- **Guard value proven:** with the two call sites reverted to the pre-fix `return pcm_data`, 3 of the 4 fail with the exact production message `ValueError: data length must be a multiple of '(sample_width * channels)'`; with the fix, `4 passed`.
- **Real encoder proven locally:** with ffmpeg present, the aligned 32000-byte buffer exports a 6741-byte MP3. The committed test stubs only pydub's `export` because the CI unit runner has no ffmpeg (that is what turned the first push red); the `AudioSegment` construction that actually raised in prod still runs for real, and the test asserts the buffer reaching it is 32000 bytes, not 32001.
- **Boundary control:** `_align_pcm16_frames(b'\x00\x01'*16000 + b'\x02')` → 32000 bytes → `AudioSegment.export(format='mp3', bitrate='48k')` → 6741-byte MP3, telemetry line `omi_fallback_event component=audio_merge ... outcome=recovered` emitted once. The same 32001-byte buffer raises the prod ValueError.
- **Regression sweep:** the 41 `storage`/`sync`/`playback`/`merge`/`audio` unit files run file-by-file the way `test.sh` invokes them — all green (`test_sync_v2` 168 passed, `test_storage_opus_encoding` 36 passed, `test_audio_merge_tasks` 18 passed, …) except `test_sync_cloud_tasks.py`, whose 9 failures reproduce identically on clean `origin/main` with this diff stashed (local `fakeredis` env gap, not this change).

Line-Count-Exception: backend/utils/other/storage.py | 1587 -> 1618 | +31 lines is the frame-alignment helper and its docstring at the shared chunk-read boundary; splitting this 1.6k-line module is out of scope for a data-loss hotfix.

Failure-Class: FC-malformed-doc-read

🤖 automated by hourly watchdog — tested and merged
