### PR TITLE
fix(desktop): stop the screen-activity cursor from skipping rows it will never revisit

### DIFF
--- a/.github/failure-classes/FC-high-water-cursor-skips-unready-row.json
+++ b/.github/failure-classes/FC-high-water-cursor-skips-unready-row.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-high-water-cursor-skips-unready-row",
+  "violated_contract": "A monotonic high-water cursor may only advance past rows that are permanently ineligible, never past rows that are merely not ready yet. ScreenActivitySyncService selected `WHERE id > ? AND embedding IS NOT NULL` and advanced the cursor past everything it shipped, but embeddings are computed asynchronously after the row is inserted, so any row whose vector had not landed when the sweep passed was skipped forever — not retried, not queued, and not reported. The result reads as a working sync rather than a broken one: rows keep arriving, so no error, alert, or test fires, while 99.2% of captured rows never leave the device (measured: 705 of 26,822 rows over 30 days on a live store). Three further mechanisms independently denied a row its embedding, so repairing the cursor alone recovers little: cross-batch content-hash dedup returned early without queueing, gated or failed embedding batches were dropped rather than requeued, and the backfill that comments describe as the safety net had been stuck completed=1/processedCount=0 since 2026-04-16.",
+  "canonical_prevention": "Track delivery as durable per-row state rather than as a position, and make the expensive projection optional rather than a precondition. The row carries an indexed `screenActivitySyncState` (pending, textSynced, fullySynced, compacted) so a row that was not ready when a sweep passed is picked up by a later sweep; OCR-bearing rows ship without waiting for a vector, and the vector attaches later. Eligibility is evaluated per closed time bucket rather than per row, so a partially aged bucket is never ranked twice — the sliding form ships 44% more rows than the design intends. Gated and failed embedding batches requeue into a bounded buffer instead of being dropped, and the stuck backfill re-arms so stranded history is recoverable. Tests pin the core defect directly: a row unready at sweep time is still delivered later, an open bucket ships nothing, a closed bucket ships exactly one winner and never ships again, and migration is safe on a populated store.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ScreenActivityLosslessSyncTests.swift",
+    "desktop/macos/Desktop/Tests/OCREmbeddingLosslessTests.swift"
+  ],
+  "evidence_prs": [
+    5205
+  ],
+  "scope_hints": [
+    "desktop/macos/Desktop/Sources/ScreenActivitySyncService.swift",
+    "desktop/macos/Desktop/Sources/Rewind/Services/**"
+  ],
+  "status": "open"
+}

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -660,6 +660,21 @@ INDEX_REQUIREMENTS = (
 )
 
 
+# Firestore auto-indexes every field of every document in both directions unless a field is
+# explicitly exempted. For large text fields that no query ever filters or orders on, that index
+# is pure storage cost: measured on `screen_activity`, single-field index bytes were roughly three
+# times the document bytes, and the `ocrText` index alone was the majority of the collection.
+# `ocrText` is only ever read back and rendered; semantic search runs on Pinecone vectors, not on
+# Firestore. Exempting a field only removes single-field indexes — composite indexes declared
+# above are unaffected, so a field named in a composite index can still appear here.
+FIELD_INDEXING_EXEMPTIONS: tuple[tuple[str, str], ...] = (
+    ('screen_activity', 'ocrText'),
+    ('screen_activity', 'windowTitle'),
+    ('screen_activity', 'deviceName'),
+    ('screen_activity', 'clientDeviceId'),
+)
+
+
 def firebase_index_manifest() -> dict[str, list[dict[str, Any]]]:
     """Return Firebase's canonical composite-index manifest deterministically."""
 
@@ -670,4 +685,13 @@ def firebase_index_manifest() -> dict[str, list[dict[str, Any]]]:
             raise ValueError(f'duplicate Firestore index requirement: {requirement.identifier}')
         signatures.add(requirement.signature)
         indexes.append(requirement.to_manifest())
-    return {'indexes': indexes, 'fieldOverrides': []}
+    field_overrides = [
+        {
+            'collectionGroup': collection_group,
+            'fieldPath': field_path,
+            'ttl': False,
+            'indexes': [],
+        }
+        for collection_group, field_path in FIELD_INDEXING_EXEMPTIONS
+    ]
+    return {'indexes': indexes, 'fieldOverrides': field_overrides}

--- a/backend/database/screen_activity.py
+++ b/backend/database/screen_activity.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Union, cast
 
 from google.cloud import firestore
@@ -13,6 +13,23 @@ USERS_COLLECTION = 'users'
 
 # Date inputs may arrive as datetime or as pre-formatted 'YYYY-MM-DD HH:MM:SS.mmm' strings.
 DateInput = Union[datetime, str]
+
+
+def normalize_screen_activity_timestamp(value: DateInput, *, end_of_second: bool = False) -> str:
+    """Return the one lexicographically sortable timestamp representation stored in Firestore."""
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        raw = str(value).strip()
+        try:
+            parsed = datetime.fromisoformat(raw.replace('Z', '+00:00'))
+        except ValueError as exc:
+            raise ValueError('screen activity timestamp must be ISO-8601 compatible') from exc
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    milliseconds = 999 if end_of_second and parsed.microsecond == 0 else parsed.microsecond // 1000
+    return f"{parsed.strftime('%Y-%m-%d %H:%M:%S')}.{milliseconds:03d}"
 
 
 def get_screen_activity_ids(uid: str) -> List[str]:
@@ -67,11 +84,10 @@ def get_screen_activity(
     query = collection_ref.order_by('timestamp', direction=firestore.Query.ASCENDING)
 
     if start_date:
-        # Timestamps stored as 'YYYY-MM-DD HH:MM:SS.mmm' strings — must match format for comparison
-        ts = start_date.strftime('%Y-%m-%d %H:%M:%S.000') if isinstance(start_date, datetime) else str(start_date)
+        ts = normalize_screen_activity_timestamp(start_date)
         query = query.where(filter=firestore.FieldFilter('timestamp', '>=', ts))
     if end_date:
-        ts = end_date.strftime('%Y-%m-%d %H:%M:%S.999') if isinstance(end_date, datetime) else str(end_date)
+        ts = normalize_screen_activity_timestamp(end_date, end_of_second=True)
         query = query.where(filter=firestore.FieldFilter('timestamp', '<=', ts))
     if app_filter:
         query = query.where(filter=firestore.FieldFilter('appName', '==', app_filter))

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -789,11 +789,13 @@ def upsert_screen_activity_vectors(uid: str, rows: List[Dict[str, Any]]) -> int:
         if not embedding:
             continue
         ts_value: Any = row['timestamp']
-        timestamp = (
-            int(datetime.fromisoformat(ts_value.replace('Z', '+00:00')).timestamp())
-            if isinstance(ts_value, str)
-            else int(ts_value)
-        )
+        if isinstance(ts_value, str):
+            parsed_timestamp = datetime.fromisoformat(ts_value.replace('Z', '+00:00'))
+            if parsed_timestamp.tzinfo is None:
+                parsed_timestamp = parsed_timestamp.replace(tzinfo=timezone.utc)
+            timestamp = int(parsed_timestamp.timestamp())
+        else:
+            timestamp = int(ts_value)
         metadata = {
             "uid": uid,
             "screenshot_id": str(row.get("storageId") or row['id']),

--- a/backend/routers/desktop_screen_crisp.py
+++ b/backend/routers/desktop_screen_crisp.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from database.screen_activity import upsert_screen_activity
+from database.screen_activity import normalize_screen_activity_timestamp, upsert_screen_activity
 from database.vector_db import upsert_screen_activity_vectors
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.other.endpoints import get_current_user_uid, get_user
@@ -34,6 +34,11 @@ class ScreenActivityRow(BaseModel):
     device_name: str | None = Field(default=None, alias="deviceName")
     client_device_id: str | None = Field(default=None, alias="clientDeviceId")
     embedding: list[float] | None = None
+
+    @field_validator("timestamp")
+    @classmethod
+    def canonicalize_timestamp(cls, value: str) -> str:
+        return normalize_screen_activity_timestamp(value)
 
     def storage_id(self) -> str:
         return f"{self.client_device_id}-{self.id}" if self.client_device_id else str(self.id)

--- a/backend/routers/desktop_screen_crisp.py
+++ b/backend/routers/desktop_screen_crisp.py
@@ -13,6 +13,7 @@ from database.screen_activity import normalize_screen_activity_timestamp, upsert
 from database.vector_db import upsert_screen_activity_vectors
 from utils.executors import critical_executor, db_executor, run_blocking
 from utils.other.endpoints import get_current_user_uid, get_user
+from utils.subscription import grants_cloud_screen_vectors
 from utils.subscription import is_desktop_trial_paywalled
 from testing.parity_pack_v0.live_capture import SurfaceParityCapture
 
@@ -139,7 +140,15 @@ async def sync_screen_activity(
         except Exception as exc:
             logger.exception("Screen activity Firestore write failed for uid=%s", uid)
             raise HTTPException(status_code=500, detail="Firestore write failed") from exc
-        embedded_rows = [row for row in rows if row.get("embedding")]
+        # The vector is the expensive half of a synced row and its only server-side purpose is
+        # semantic screen search, which is a paid desktop capability. Gate it here rather than on
+        # the client: the client cannot be trusted to know its own entitlement, and the row is
+        # still stored either way, so a later upgrade can backfill vectors from the stored text.
+        embedded_rows = (
+            [row for row in rows if row.get("embedding")]
+            if await run_blocking(db_executor, grants_cloud_screen_vectors, uid)
+            else []
+        )
         if embedded_rows:
             try:
                 await run_blocking(db_executor, upsert_screen_activity_vectors, uid, embedded_rows)

--- a/backend/tests/unit/test_desktop_screen_crisp.py
+++ b/backend/tests/unit/test_desktop_screen_crisp.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from database import vector_db
 from routers import desktop_screen_crisp
 from utils.other.endpoints import get_current_user_uid
 
@@ -30,7 +31,7 @@ def test_screen_activity_sync_writes_rows_and_embeddings(monkeypatch):
             "rows": [
                 {
                     "id": 4,
-                    "timestamp": "2026-07-26T00:00:00Z",
+                    "timestamp": "2026-07-26T00:00:00.123Z",
                     "appName": "Safari",
                     "clientDeviceId": "mac-a",
                     "embedding": [0.1],
@@ -48,7 +49,7 @@ def test_screen_activity_sync_writes_rows_and_embeddings(monkeypatch):
             [
                 {
                     "id": 4,
-                    "timestamp": "2026-07-26T00:00:00Z",
+                    "timestamp": "2026-07-26 00:00:00.123",
                     "appName": "Safari",
                     "windowTitle": "",
                     "ocrText": "",
@@ -59,7 +60,7 @@ def test_screen_activity_sync_writes_rows_and_embeddings(monkeypatch):
                 },
                 {
                     "id": 7,
-                    "timestamp": "2026-07-26T00:01:00Z",
+                    "timestamp": "2026-07-26 00:01:00.000",
                     "appName": "",
                     "windowTitle": "",
                     "ocrText": "hello",
@@ -76,7 +77,7 @@ def test_screen_activity_sync_writes_rows_and_embeddings(monkeypatch):
             [
                 {
                     "id": 4,
-                    "timestamp": "2026-07-26T00:00:00Z",
+                    "timestamp": "2026-07-26 00:00:00.123",
                     "appName": "Safari",
                     "windowTitle": "",
                     "ocrText": "",
@@ -100,12 +101,51 @@ def test_screen_activity_sync_rejects_batches_larger_than_rust_contract():
     assert response.json() == {"detail": "Maximum 100 rows per batch"}
 
 
+def test_screen_activity_sync_normalizes_iso_timestamp_before_firestore_write(monkeypatch):
+    writes = []
+    monkeypatch.setattr(
+        desktop_screen_crisp, "upsert_screen_activity", lambda uid, rows: writes.extend(rows) or len(rows)
+    )
+
+    response = make_client().post(
+        "/v1/screen-activity/sync",
+        json={"rows": [{"id": 9, "timestamp": "2026-07-26T02:03:04.567891+02:00", "ocrText": "text"}]},
+    )
+
+    assert response.status_code == 200
+    assert writes[0]["timestamp"] == "2026-07-26 00:03:04.567"
+
+
 def test_screen_activity_storage_ids_are_device_scoped():
     first = desktop_screen_crisp.ScreenActivityRow(id=1, timestamp="2026-07-26T00:00:00Z", clientDeviceId="mac-a")
     second = desktop_screen_crisp.ScreenActivityRow(id=1, timestamp="2026-07-26T00:00:00Z", clientDeviceId="mac-b")
 
     assert first.storage_id() == "mac-a-1"
     assert second.storage_id() == "mac-b-1"
+
+
+def test_screen_activity_vector_treats_canonical_naive_timestamp_as_utc(monkeypatch):
+    upserts = []
+    monkeypatch.setattr(
+        vector_db,
+        "index",
+        SimpleNamespace(upsert=lambda **kwargs: upserts.append(kwargs)),
+    )
+
+    written = vector_db.upsert_screen_activity_vectors(
+        "user-1",
+        [
+            {
+                "id": 11,
+                "timestamp": "2026-07-26 00:00:00.123",
+                "appName": "SyntheticApp",
+                "embedding": [0.1],
+            }
+        ],
+    )
+
+    assert written == 1
+    assert upserts[0]["vectors"][0]["metadata"]["timestamp"] == 1785024000
 
 
 def test_crisp_unread_preserves_operator_text_shape(monkeypatch):

--- a/backend/tests/unit/test_desktop_screen_crisp.py
+++ b/backend/tests/unit/test_desktop_screen_crisp.py
@@ -16,7 +16,17 @@ def make_client() -> TestClient:
     return TestClient(app)
 
 
+def _entitle(monkeypatch, entitled: bool = True) -> None:
+    """Pin the screen-vector entitlement.
+
+    Without this the gate performs a real subscription lookup: it fails open, so assertions
+    still hold, but each test pays a live Firestore timeout.
+    """
+    monkeypatch.setattr(desktop_screen_crisp, "grants_cloud_screen_vectors", lambda uid: entitled)
+
+
 def test_screen_activity_sync_writes_rows_and_embeddings(monkeypatch):
+    _entitle(monkeypatch)
     writes = []
     monkeypatch.setattr(
         desktop_screen_crisp, "upsert_screen_activity", lambda uid, rows: writes.append((uid, rows)) or 2
@@ -102,6 +112,7 @@ def test_screen_activity_sync_rejects_batches_larger_than_rust_contract():
 
 
 def test_screen_activity_sync_normalizes_iso_timestamp_before_firestore_write(monkeypatch):
+    _entitle(monkeypatch)
     writes = []
     monkeypatch.setattr(
         desktop_screen_crisp, "upsert_screen_activity", lambda uid, rows: writes.extend(rows) or len(rows)
@@ -205,3 +216,57 @@ async def test_screen_activity_rejects_paywalled_desktop_user(monkeypatch):
 
     assert error.value.status_code == 402
     assert error.value.detail == "trial_expired"
+
+
+def test_a_free_desktop_user_syncs_rows_but_no_vectors(monkeypatch):
+    """The row is the cheap half and stays; the vector is the expensive half and is withheld."""
+    writes: list = []
+    vectors: list = []
+    monkeypatch.setattr(
+        desktop_screen_crisp, "upsert_screen_activity", lambda uid, rows: writes.extend(rows) or len(rows)
+    )
+    monkeypatch.setattr(
+        desktop_screen_crisp, "upsert_screen_activity_vectors", lambda uid, rows: vectors.extend(rows) or len(rows)
+    )
+    _entitle(monkeypatch, entitled=False)
+
+    response = make_client().post(
+        "/v1/screen-activity/sync",
+        json={"rows": [{"id": 1, "timestamp": "2026-07-26T00:00:00.000Z", "ocrText": "text", "embedding": [0.1]}]},
+    )
+
+    assert response.status_code == 200
+    assert [row["id"] for row in writes] == [1], "the row must still be stored"
+    assert writes[0]["ocrText"] == "text", "the text is retained so vectors can be backfilled on upgrade"
+    assert vectors == [], "no vector is written for an unentitled user"
+
+
+def test_an_entitled_user_still_gets_vectors(monkeypatch):
+    vectors: list = []
+    monkeypatch.setattr(desktop_screen_crisp, "upsert_screen_activity", lambda uid, rows: len(rows))
+    monkeypatch.setattr(
+        desktop_screen_crisp, "upsert_screen_activity_vectors", lambda uid, rows: vectors.extend(rows) or len(rows)
+    )
+    _entitle(monkeypatch, entitled=True)
+
+    response = make_client().post(
+        "/v1/screen-activity/sync",
+        json={"rows": [{"id": 1, "timestamp": "2026-07-26T00:00:00.000Z", "ocrText": "text", "embedding": [0.1]}]},
+    )
+
+    assert response.status_code == 200
+    assert [row["id"] for row in vectors] == [1]
+
+
+def test_the_entitlement_gate_fails_open(monkeypatch):
+    """A subscription-lookup blip must overspend slightly, never silently strip paid search."""
+    import utils.subscription as subscription
+
+    subscription.clear_cloud_screen_vector_entitlement_cache("uid-under-test")
+    monkeypatch.setattr(
+        subscription.users_db,
+        "get_user_valid_subscription",
+        lambda uid: (_ for _ in ()).throw(RuntimeError("firestore unavailable")),
+    )
+
+    assert subscription.grants_cloud_screen_vectors("uid-under-test") is True

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -110,6 +110,50 @@ def neo_grandfather_until(subscription: Optional[Subscription]) -> Optional[int]
     return subscription.current_period_end
 
 
+# Cloud screen-activity vectors are a paid desktop capability.
+#
+# Screen rows themselves are cheap; the vector is not. Embedding and storing a 3,072-dim vector
+# per delivered row is the large majority of what a synced screen row costs, and the vector's
+# only purpose server-side is semantic screen search. Free-tier desktop users keep their rows in
+# Firestore (so cloud chat can still read screen history by time and app) and keep on-device
+# semantic search, which reads embeddings from the local store and never needs Pinecone.
+#
+# Because the rows are retained, a user who upgrades can have their vectors backfilled from the
+# stored OCR text: this gate defers the cost, it does not destroy the ability to recover.
+_SCREEN_VECTOR_ENTITLEMENT_CACHE_TTL_SECONDS = 300
+_screen_vector_entitlement_cache: Dict[str, Tuple[bool, float]] = {}
+
+
+def grants_cloud_screen_vectors(uid: str) -> bool:
+    """True when this user's synced screen rows should also be written to the vector store.
+
+    Uses the desktop access tier rather than `is_paid_plan`, because screen activity is a
+    desktop capability: a mobile-only paid plan did not buy it. BYOK does NOT grant it either
+    — BYOK means the user supplies their own LLM keys, but the vector store is ours and the
+    cost being avoided here is ours.
+
+    Fails OPEN (writes the vector) on any lookup error, matching
+    `should_defer_desktop_processing`: a Firestore blip must never silently strip a paying
+    user's screen search. The failure mode is a small overspend, not a lost capability.
+    """
+    cached = _screen_vector_entitlement_cache.get(uid)
+    if cached is not None and time.monotonic() - cached[1] < _SCREEN_VECTOR_ENTITLEMENT_CACHE_TTL_SECONDS:
+        return cached[0]
+    try:
+        subscription = users_db.get_user_valid_subscription(uid)
+        plan = subscription.plan if subscription else PlanType.basic
+        entitled = effective_desktop_access_tier(plan, subscription) != DESKTOP_ACCESS_TIER_FREE
+    except Exception as e:
+        logger.warning("grants_cloud_screen_vectors lookup failed for uid=%s: %s", uid, e)
+        return True
+    _screen_vector_entitlement_cache[uid] = (entitled, time.monotonic())
+    return entitled
+
+
+def clear_cloud_screen_vector_entitlement_cache(uid: str) -> None:
+    _screen_vector_entitlement_cache.pop(uid, None)
+
+
 def should_defer_desktop_processing(uid: str) -> bool:
     """True for Desktop users on the Free effective tier without active BYOK.
 

--- a/desktop/macos/AGENTS.md
+++ b/desktop/macos/AGENTS.md
@@ -222,6 +222,12 @@ do not hand-edit those paths to match a specific machine.
 - **Redis**: Caching
 - **Typesense**: Search
 
+### Screen activity sync rollout
+
+- `screen_activity_lossless_sync` enables durable per-row delivery, five-minute `(app, window)` compaction, and bounded embedding recovery. Production-family bundles stay on the legacy path until that PostHog flag is true; non-production bundles dogfood it by default and `OMI_FORCE_LOSSLESS_SCREEN_SYNC=0` disables it locally.
+- OCR-bearing rows sync independently from embeddings. Embeddings are an optional later projection and must never gate capture, OCR, or text delivery.
+- Firestore screen-activity timestamps use the lexicographically sortable UTC form `yyyy-MM-dd HH:mm:ss.SSS`. The backend normalizes ISO-8601 input before storage.
+
 ### User Subcollections (Firestore)
 - `users/{uid}/conversations` - Has `source` field (omi, desktop, phone, etc.)
 - `users/{uid}/action_items` - Tasks (no platform tracking)

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
@@ -50,6 +50,52 @@ extension RewindDatabase {
     }
   }
 
+  /// Return only the longest OCR row in each completed five-minute (app, window) bucket.
+  /// The query is repeatable and idempotent, so a failed batch can be retried without a cursor.
+  /// `cutoff` admits a bucket only once the whole bucket has closed — ranking a partially
+  /// visible bucket would embed one winner now and a different winner once the rest ages in.
+  /// See `ScreenActivitySyncService.bucketEligibilityCutoffEpoch`.
+  func getCompactedScreenshotsMissingEmbeddings(limit: Int = 100, olderThan cutoff: Date) throws -> [(
+    id: Int64, ocrText: String, appName: String, windowTitle: String?
+  )] {
+    guard let dbQueue = getDatabaseQueue() else {
+      throw RewindError.databaseNotInitialized
+    }
+
+    return try dbQueue.read { db in
+      try Row.fetchAll(
+        db,
+        sql: """
+          WITH ranked AS (
+            SELECT id, ocrText, appName, windowTitle,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY appName, COALESCE(windowTitle, ''),
+                                  CAST(strftime('%s', timestamp) AS INTEGER) / 300
+                     ORDER BY LENGTH(ocrText) DESC, id DESC
+                   ) AS bucketRank
+            FROM screenshots
+            WHERE ocrText IS NOT NULL
+              AND LENGTH(ocrText) >= 20
+              AND (CAST(strftime('%s', timestamp) AS INTEGER) / 300 + 1) * 300 <= ?
+          )
+          SELECT id, ocrText, appName, windowTitle
+          FROM ranked
+          WHERE bucketRank = 1 AND embedding IS NULL
+          ORDER BY id
+          LIMIT ?
+          """,
+        arguments: [Int64(cutoff.timeIntervalSince1970.rounded(.down)), limit]
+      ).compactMap { row in
+        guard let id: Int64 = row["id"],
+          let ocrText: String = row["ocrText"],
+          let appName: String = row["appName"]
+        else { return nil }
+        let windowTitle: String? = row["windowTitle"]
+        return (id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle)
+      }
+    }
+  }
+
   /// Read screenshot embedding BLOBs in batches for disk-based vector search
   /// Reads embeddings newest-first, over an optionally unbounded range.
   ///
@@ -128,6 +174,48 @@ extension RewindDatabase {
     }
   }
 
+  /// Re-open a previously completed backfill when compacted, OCR-bearing rows still lack vectors.
+  /// This repairs the historical completed=1/processedCount=0 state without scanning or enqueueing
+  /// more than one bounded launch will consume.
+  func rearmScreenshotEmbeddingBackfillIfNeeded(olderThan cutoff: Date) throws -> Bool {
+    guard let dbQueue = getDatabaseQueue() else {
+      throw RewindError.databaseNotInitialized
+    }
+
+    return try dbQueue.write { db in
+      let missingWinner =
+        try Bool.fetchOne(
+          db,
+          sql: """
+            WITH ranked AS (
+              SELECT embedding,
+                     ROW_NUMBER() OVER (
+                       PARTITION BY appName, COALESCE(windowTitle, ''),
+                                    CAST(strftime('%s', timestamp) AS INTEGER) / 300
+                       ORDER BY LENGTH(ocrText) DESC, id DESC
+                     ) AS bucketRank
+              FROM screenshots
+              WHERE ocrText IS NOT NULL
+                AND LENGTH(ocrText) >= 20
+                AND (CAST(strftime('%s', timestamp) AS INTEGER) / 300 + 1) * 300 <= ?
+            )
+            SELECT EXISTS(
+              SELECT 1 FROM ranked WHERE bucketRank = 1 AND embedding IS NULL
+            )
+            """,
+          arguments: [Int64(cutoff.timeIntervalSince1970.rounded(.down))]) ?? false
+      guard missingWinner else { return false }
+
+      try db.execute(
+        sql: """
+          UPDATE migration_status
+          SET completed = 0, processedCount = 0, startedAt = datetime('now'), completedAt = NULL
+          WHERE name = 'screenshot_embedding_backfill' AND completed = 1
+          """)
+      return db.changesCount > 0
+    }
+  }
+
   /// Update screenshot embedding backfill progress
   func updateScreenshotEmbeddingBackfillStatus(completed: Bool, processedCount: Int) throws {
     guard let dbQueue = getDatabaseQueue() else {
@@ -138,7 +226,7 @@ extension RewindDatabase {
       try db.execute(
         sql: """
               UPDATE migration_status
-              SET completed = ?, processedCount = ?, completedAt = CASE WHEN ? = 1 THEN datetime('now') ELSE completedAt END
+              SET completed = ?, processedCount = ?, completedAt = CASE WHEN ? = 1 THEN datetime('now') ELSE NULL END
               WHERE name = 'screenshot_embedding_backfill'
           """, arguments: [completed ? 1 : 0, processedCount, completed ? 1 : 0])
     }

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift
@@ -2577,11 +2577,31 @@ actor RewindDatabase {
 
     RewindAbandonedVideoChunkQuarantine.registerMigration(on: &migrator)
 
+    // Keep new migrations after every previously registered component migration. Existing rows
+    // deliberately start pending so a dark-launched lossless sweep can recover history later.
+    migrator.registerMigration("addScreenActivitySyncState") { db in
+      try Self.installScreenActivitySyncStateSchema(db)
+    }
+
     try migrator.migrate(queue)
     try ContextBucketSchema.removeMigratedLegacyDefaults(
       afterMigrating: queue,
       defaults: .standard,
       ownerID: contextBucketOwnerID)
+  }
+
+  /// Kept as one callable migration boundary so a populated legacy table can be exercised in a
+  /// focused test without reproducing the entire historical migration ledger.
+  static func installScreenActivitySyncStateSchema(_ db: Database) throws {
+    try db.alter(table: "screenshots") { t in
+      t.add(column: "screenActivitySyncState", .integer).notNull().defaults(to: 0)
+    }
+    try db.execute(
+      sql: """
+        CREATE INDEX idx_screenshots_screen_activity_sync
+        ON screenshots(screenActivitySyncState, id)
+        WHERE screenActivitySyncState IN (0, 1)
+        """)
   }
 
   // MARK: - OCR Precision Reduction Migration

--- a/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/OCREmbeddingService.swift
@@ -5,8 +5,8 @@ import Foundation
 /// Actor-based service for embedding screenshot OCR text using Gemini embeddings
 /// and performing disk-based vector search (no in-memory index).
 /// Embeds per-screenshot concatenated OCR text with app context prefix.
-/// Uses batched embedding with a 60-second flush window and content-hash
-/// deduplication to reduce Gemini API costs (~20x fewer API calls).
+/// Uses batched embedding with a 60-second flush window. The lossless sync rollout compacts
+/// completed five-minute (app, window) buckets and embeds only their longest OCR row.
 actor OCREmbeddingService {
   static let shared = OCREmbeddingService()
 
@@ -20,6 +20,10 @@ actor OCREmbeddingService {
     let id: Int64
     let formattedText: String
     let contentHash: String
+    let capturedAt: Date
+    let appName: String
+    let windowTitle: String
+    let ocrLength: Int
   }
 
   private var pendingItems: [PendingItem] = []
@@ -38,6 +42,12 @@ actor OCREmbeddingService {
   /// Content hashes of recently embedded texts to skip duplicates
   private var recentHashes: Set<String> = []
   private let maxRecentHashes = 5000
+  private var isBackfillRunning = false
+  /// Ceiling on the deferred buffer. The old code dropped a gated batch outright, which lost
+  /// data; re-queueing it fixes that but reinstates an unbounded buffer for a user whose backend
+  /// is gating every call — the buffer grows for as long as the gating lasts. Oldest deferred
+  /// items are shed first so the buffer keeps the rows most likely to still be worth embedding.
+  private let maxDeferredItems = 2_000
 
   /// Flush interval: accumulate screenshots for this long before batch-embedding
   private let flushIntervalNanos: UInt64 = 60_000_000_000  // 60s
@@ -54,6 +64,8 @@ actor OCREmbeddingService {
   private let batchEmbedder: BatchEmbedder
   private let embeddingWriter: EmbeddingWriter
   private let flushSleeper: FlushSleeper
+  private let losslessSyncEnabled: @Sendable () async -> Bool
+  private let now: @Sendable () -> Date
 
   private init() {
     self.batchEmbedder = { texts, taskType in
@@ -65,6 +77,10 @@ actor OCREmbeddingService {
     self.flushSleeper = { nanoseconds in
       try await Task.sleep(nanoseconds: nanoseconds)
     }
+    self.losslessSyncEnabled = {
+      await MainActor.run { ScreenActivityLosslessSyncFeature.isEnabled }
+    }
+    self.now = Date.init
   }
 
   /// Test-only initializer that injects the flush path's embedder, writer, and
@@ -72,7 +88,9 @@ actor OCREmbeddingService {
   init(
     batchEmbedderForTesting: @escaping BatchEmbedder,
     embeddingWriterForTesting: @escaping EmbeddingWriter,
-    flushSleeperForTesting: FlushSleeper? = nil
+    flushSleeperForTesting: FlushSleeper? = nil,
+    losslessSyncEnabledForTesting: @escaping @Sendable () async -> Bool = { false },
+    nowForTesting: @escaping @Sendable () -> Date = Date.init
   ) {
     self.batchEmbedder = batchEmbedderForTesting
     self.embeddingWriter = embeddingWriterForTesting
@@ -80,6 +98,8 @@ actor OCREmbeddingService {
       flushSleeperForTesting ?? { nanoseconds in
         try await Task.sleep(nanoseconds: nanoseconds)
       }
+    self.losslessSyncEnabled = losslessSyncEnabledForTesting
+    self.now = nowForTesting
   }
 
   /// Number of screenshots queued for the next batch flush (test introspection).
@@ -122,6 +142,7 @@ actor OCREmbeddingService {
   /// buffer reaches 100 items, whichever comes first.
   func embedScreenshot(
     id: Int64,
+    timestamp: Date = Date(),
     ocrText: String,
     appName: String,
     windowTitle: String?,
@@ -134,13 +155,23 @@ actor OCREmbeddingService {
 
     let formatted = Self.formatForEmbedding(ocrText: ocrText, appName: appName, windowTitle: windowTitle)
     let hash = Self.contentHash(formatted)
+    let usesLosslessCompaction = await losslessSyncEnabled()
 
-    // Skip if we recently embedded identical content
-    if recentHashes.contains(hash) {
+    // The flag-off path preserves the old rollback behavior. Lossless mode never drops a row
+    // because a prior batch happened to contain the same text.
+    if !usesLosslessCompaction, recentHashes.contains(hash) {
       return
     }
 
-    pendingItems.append(PendingItem(id: id, formattedText: formatted, contentHash: hash))
+    pendingItems.append(
+      PendingItem(
+        id: id,
+        formattedText: formatted,
+        contentHash: hash,
+        capturedAt: timestamp,
+        appName: appName,
+        windowTitle: windowTitle ?? "",
+        ocrLength: ocrText.count))
 
     // Force flush if we hit the batch limit
     if pendingItems.count >= maxPendingItems {
@@ -223,22 +254,40 @@ actor OCREmbeddingService {
     let batch = pendingItems
     pendingItems = []
 
-    // Deduplicate within the batch by content hash
+    let usesLosslessCompaction = await losslessSyncEnabled()
+
+    // Keep an open bucket buffered until its five-minute interval has closed. This makes the
+    // longest-row decision stable without delaying capture or OCR.
+    let itemsToProcess: [PendingItem]
+    if usesLosslessCompaction {
+      // Eligibility is per *bucket*, not per row: holding back only the rows younger than the
+      // slack would rank an already-open bucket, embedding one winner now and another once its
+      // later rows age in. Same alignment as ScreenActivitySyncService.bucketEligibilityCutoffEpoch.
+      let cutoffEpoch = Int64((now().timeIntervalSince1970 - 5 * 60).rounded(.down))
+      let isReady: (PendingItem) -> Bool = { (Self.bucketIndex(for: $0.capturedAt) + 1) * 300 <= cutoffEpoch }
+      let ready = batch.filter(isReady)
+      pendingItems.append(contentsOf: batch.filter { !isReady($0) })
+      itemsToProcess = Self.compactByFiveMinuteBucket(ready)
+    } else {
+      itemsToProcess = batch
+    }
+
+    // Legacy rollback path: deduplicate within the batch by content hash.
     var seen = Set<String>()
     var uniqueItems: [PendingItem] = []
     var duplicateGroups: [String: [Int64]] = [:]  // hash -> [ids that share this hash]
 
-    for item in batch {
-      if seen.insert(item.contentHash).inserted {
+    for item in itemsToProcess {
+      if usesLosslessCompaction || seen.insert(item.contentHash).inserted {
         uniqueItems.append(item)
       }
       duplicateGroups[item.contentHash, default: []].append(item.id)
     }
 
-    let skippedCount = batch.count - uniqueItems.count
+    let skippedCount = itemsToProcess.count - uniqueItems.count
     if skippedCount > 0 {
       log(
-        "OCREmbeddingService: Batch dedup — \(batch.count) items → \(uniqueItems.count) unique (\(skippedCount) duplicates)"
+        "OCREmbeddingService: Batch dedup — \(itemsToProcess.count) items → \(uniqueItems.count) unique (\(skippedCount) duplicates)"
       )
     }
 
@@ -259,12 +308,20 @@ actor OCREmbeddingService {
           return
         }
 
+        guard embeddings.count == chunk.count else {
+          log(
+            "OCREmbeddingService: Embedding count mismatch (requested=\(chunk.count), received=\(embeddings.count)); deferring batch"
+          )
+          pendingItems.append(contentsOf: chunk)
+          continue
+        }
+
         for (i, embedding) in embeddings.enumerated() where i < chunk.count {
           let item = chunk[i]
           let data = await EmbeddingService.shared.floatsToData(embedding)
 
           // Apply embedding to all IDs that share this content hash
-          let allIds = duplicateGroups[item.contentHash] ?? [item.id]
+          let allIds = usesLosslessCompaction ? [item.id] : (duplicateGroups[item.contentHash] ?? [item.id])
           for screenshotId in allIds {
             let authorization = LocalMutationAuthorization { ownerSnapshot.isCurrent() }
             try await authorization.withCommitLease {
@@ -276,21 +333,20 @@ actor OCREmbeddingService {
             }
           }
 
-          // Track hash to skip future duplicates
-          recentHashes.insert(item.contentHash)
+          if !usesLosslessCompaction {
+            recentHashes.insert(item.contentHash)
+          }
         }
 
         log(
           "OCREmbeddingService: Batch embedded \(chunk.count) unique items (applied to \(chunk.reduce(0) { $0 + (duplicateGroups[$1.contentHash]?.count ?? 1) }) screenshots)"
         )
       } catch let error as EmbeddingService.EmbeddingError where error.isExpectedBackendState {
-        // Expected product-gating/limit (e.g. trial expired, rate limited): drop this
-        // batch instead of re-queueing. Re-queueing here tight-loops the 60s flush
-        // forever while gated, flooding Sentry; missing screenshots get re-embedded
-        // via backfill once the user is un-gated.
         log(
-          "OCREmbeddingService: Skipping batch of \(chunk.count) items — backend gating/limit: \(error.localizedDescription)"
+          "OCREmbeddingService: Deferring batch of \(chunk.count) items — backend gating/limit: \(error.localizedDescription)"
         )
+        guard generation == ownerGeneration else { return }
+        deferItems(chunk)
       } catch {
         logError("OCREmbeddingService: Batch embed failed for \(chunk.count) items", error: error)
         // Re-queue failed items for next flush — but only if we are still the
@@ -300,7 +356,7 @@ actor OCREmbeddingService {
           log("OCREmbeddingService: Owner changed mid-flush — not re-queueing \(chunk.count) stale items")
           return
         }
-        pendingItems.append(contentsOf: chunk)
+        deferItems(chunk)
       }
     }
 
@@ -310,18 +366,61 @@ actor OCREmbeddingService {
     }
   }
 
+  static func bucketIndex(for date: Date) -> Int64 {
+    Int64(date.timeIntervalSince1970.rounded(.down)) / 300
+  }
+
+  /// Re-queue a batch that could not be embedded, keeping the buffer bounded.
+  private func deferItems(_ chunk: [PendingItem]) {
+    pendingItems.append(contentsOf: chunk)
+    guard pendingItems.count > maxDeferredItems else { return }
+    let shed = pendingItems.count - maxDeferredItems
+    pendingItems.removeFirst(shed)
+    log("OCREmbeddingService: Deferred buffer at capacity — shed \(shed) oldest items")
+  }
+
+  private static func compactByFiveMinuteBucket(_ items: [PendingItem]) -> [PendingItem] {
+    var winners: [String: PendingItem] = [:]
+    for item in items {
+      let bucket = bucketIndex(for: item.capturedAt)
+      let key = "\(item.appName)\u{1f}\(item.windowTitle)\u{1f}\(bucket)"
+      guard let current = winners[key] else {
+        winners[key] = item
+        continue
+      }
+      if item.ocrLength > current.ocrLength || (item.ocrLength == current.ocrLength && item.id > current.id) {
+        winners[key] = item
+      }
+    }
+    return winners.values.sorted { $0.id < $1.id }
+  }
+
   // MARK: - Backfill
 
   /// Backfill embeddings for existing screenshots that have OCR text but no embedding.
-  /// Capped at 5000 items per launch to prevent cost spikes.
+  /// Lossless mode is capped at 500 compacted winners per launch; the flag-off legacy path keeps
+  /// its existing 5000-row cap.
   func backfillIfNeeded() async {
+    guard !isBackfillRunning else { return }
+    isBackfillRunning = true
+    defer { isBackfillRunning = false }
+
     guard let ownerSnapshot = RewindCaptureOwnerSnapshot.capture(),
       ownerSnapshot.isCurrent()
     else { return }
     let authorization = LocalMutationAuthorization { ownerSnapshot.isCurrent() }
     do {
-      let status = try await RewindDatabase.shared.getScreenshotEmbeddingBackfillStatus()
+      let usesLosslessCompaction = await losslessSyncEnabled()
+      var status = try await RewindDatabase.shared.getScreenshotEmbeddingBackfillStatus()
       guard ownerSnapshot.isCurrent() else { return }
+      if usesLosslessCompaction, status.completed {
+        let rearmed = try await RewindDatabase.shared.rearmScreenshotEmbeddingBackfillIfNeeded(
+          olderThan: now().addingTimeInterval(-5 * 60))
+        if rearmed {
+          status = (completed: false, processedCount: 0)
+          log("OCREmbeddingService: Re-armed incomplete screenshot embedding backfill")
+        }
+      }
       if status.completed {
         log("OCREmbeddingService: Backfill already complete, skipping")
         return
@@ -330,13 +429,17 @@ actor OCREmbeddingService {
       log("OCREmbeddingService: Starting backfill (previously processed: \(status.processedCount))")
 
       let batchSize = 100
-      let maxItemsPerLaunch = 5000
+      let maxItemsPerLaunch = usesLosslessCompaction ? 500 : 5000
       var totalProcessed = status.processedCount
       var processedThisLaunch = 0
       var hitError = false
 
       while processedThisLaunch < maxItemsPerLaunch {
-        let items = try await RewindDatabase.shared.getScreenshotsMissingEmbeddings(limit: batchSize)
+        let items =
+          usesLosslessCompaction
+          ? try await RewindDatabase.shared.getCompactedScreenshotsMissingEmbeddings(
+            limit: batchSize, olderThan: now().addingTimeInterval(-5 * 60))
+          : try await RewindDatabase.shared.getScreenshotsMissingEmbeddings(limit: batchSize)
         guard ownerSnapshot.isCurrent() else { return }
         if items.isEmpty { break }
 
@@ -359,6 +462,14 @@ actor OCREmbeddingService {
           logError(
             "OCREmbeddingService: Batch embed failed at \(totalProcessed) items, will retry on next launch",
             error: error)
+          hitError = true
+          break
+        }
+
+        guard embeddings.count == itemsToProcess.count else {
+          log(
+            "OCREmbeddingService: Backfill embedding count mismatch (requested=\(itemsToProcess.count), received=\(embeddings.count)); will retry on next launch"
+          )
           hitError = true
           break
         }

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -320,7 +320,8 @@ actor RewindIndexer {
       if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
-            id: id, ocrText: ocrText, appName: frame.appName, windowTitle: frame.windowTitle,
+            id: id, timestamp: frame.captureTime, ocrText: ocrText, appName: frame.appName,
+            windowTitle: frame.windowTitle,
             ownerSnapshot: snapshot.ownerSnapshot)
         }
       }
@@ -420,7 +421,7 @@ actor RewindIndexer {
       if let ocrText = ocrText, !ocrText.isEmpty, let id = inserted.id {
         Task(priority: .utility) {
           await OCREmbeddingService.shared.embedScreenshot(
-            id: id, ocrText: ocrText, appName: appName, windowTitle: windowTitle,
+            id: id, timestamp: captureTime, ocrText: ocrText, appName: appName, windowTitle: windowTitle,
             ownerSnapshot: snapshot.ownerSnapshot)
         }
       }

--- a/desktop/macos/Desktop/Sources/ScreenActivitySyncService.swift
+++ b/desktop/macos/Desktop/Sources/ScreenActivitySyncService.swift
@@ -5,13 +5,41 @@ private struct ScreenActivityRowsPayload: @unchecked Sendable {
   let rows: [[String: Any]]
 }
 
+struct ScreenActivitySyncCandidate: @unchecked Sendable {
+  let id: Int64
+  let priorState: ScreenActivitySyncState
+  let hasEmbedding: Bool
+  let payload: [String: Any]
+}
+
+enum ScreenActivitySyncState: Int {
+  case pending = 0
+  case textSynced = 1
+  case fullySynced = 2
+  case compacted = 3
+}
+
+enum ScreenActivityLosslessSyncFeature {
+  static let flagName = "screen_activity_lossless_sync"
+  private static let localOverrideName = "OMI_FORCE_LOSSLESS_SCREEN_SYNC"
+
+  /// Development bundles dogfood by default. Shipped bundles stay on the legacy path until the
+  /// PostHog flag is explicitly enabled, so the migration can ship dark without changing traffic.
+  @MainActor static var isEnabled: Bool {
+    if AppBuild.isNonProduction {
+      return ProcessInfo.processInfo.environment[localOverrideName] != "0"
+    }
+    return PostHogManager.shared.isFeatureEnabled(flagName)
+  }
+}
+
 /// Syncs screenshot metadata + embeddings from the local GRDB database
 /// to the backend API (`POST /v1/screen-activity/sync`), which stores them
 /// in Firestore + Pinecone so the normal Flutter chat can answer screen
 /// activity questions.
 ///
-/// Only syncs screenshots that have embeddings (OCR'd ones).
-/// Tracks cursor via UserDefaults to resume after restart.
+/// The lossless path uses durable per-row delivery state and treats embeddings as an optional,
+/// later projection. The legacy cursor remains only as the flag-off rollback path.
 actor ScreenActivitySyncService {
   static let shared = ScreenActivitySyncService()
 
@@ -21,12 +49,19 @@ actor ScreenActivitySyncService {
   private var isRunning = false
   private var syncTask: Task<Void, Never>?
   private var consecutiveFailures = 0
+  private var didStartEmbeddingRecovery = false
 
   private let batchSize = 100
   private let baseSyncInterval: UInt64 = 60_000_000_000  // 60s in nanoseconds
   private let maxSyncInterval: UInt64 = 300_000_000_000  // 300s max backoff
 
   private let cursorKey = "screenActivitySync_lastId"
+  private let compactionDelay: TimeInterval = 5 * 60
+  /// How long a closed bucket's winner waits for its embedding before shipping text-only.
+  /// Without it every row ships twice: once when compaction sweeps it, and again when the
+  /// vector lands — a second byte-identical Firestore document write plus a full rewrite of
+  /// its index entries, for no data change.
+  private let embeddingGrace: TimeInterval = 15 * 60
 
   // MARK: - Public API
 
@@ -48,6 +83,7 @@ actor ScreenActivitySyncService {
     isRunning = false
     syncTask?.cancel()
     syncTask = nil
+    didStartEmbeddingRecovery = false
     log("ScreenActivitySync: stopped")
   }
 
@@ -83,6 +119,50 @@ actor ScreenActivitySyncService {
   private func syncTick() async {
     guard let dbPool = await getDBPool() else { return }
 
+    let losslessEnabled = await MainActor.run { ScreenActivityLosslessSyncFeature.isEnabled }
+    if losslessEnabled {
+      await losslessSyncTick(dbPool: dbPool)
+    } else {
+      await legacySyncTick(dbPool: dbPool)
+    }
+  }
+
+  private func losslessSyncTick(dbPool: DatabasePool) async {
+    if !didStartEmbeddingRecovery {
+      didStartEmbeddingRecovery = true
+      Task(priority: .utility) {
+        await OCREmbeddingService.shared.backfillIfNeeded()
+      }
+    }
+    do {
+      let now = Date()
+      let candidates = try await dbPool.write { [batchSize, compactionDelay, embeddingGrace] db in
+        try Self.compactClosedBuckets(db: db, now: now, slack: compactionDelay)
+        return try Self.fetchSyncCandidates(
+          db: db, limit: batchSize, now: now, slack: compactionDelay, embeddingGrace: embeddingGrace)
+      }
+      guard !candidates.isEmpty else { return }
+
+      let success = await pushRows(candidates.map(\.payload))
+      if success {
+        try await dbPool.write { db in
+          try Self.markCandidatesSynced(db: db, candidates: candidates)
+        }
+        if consecutiveFailures > 0 {
+          log("ScreenActivitySync: lossless path reconnected after \(consecutiveFailures) failures")
+        }
+        consecutiveFailures = 0
+        log("ScreenActivitySync: lossless path synced \(candidates.count) rows")
+      } else {
+        recordPushFailure(path: "lossless")
+      }
+    } catch {
+      log("ScreenActivitySync: lossless read/write error — \(error.localizedDescription)")
+    }
+  }
+
+  private func legacySyncTick(dbPool: DatabasePool) async {
+
     do {
       // Query screenshots that have embeddings and are newer than our cursor
       let rowsPayload: ScreenActivityRowsPayload = try await dbPool.read { [lastSyncedId, batchSize] db in
@@ -107,13 +187,17 @@ actor ScreenActivitySyncService {
         consecutiveFailures = 0
         log("ScreenActivitySync: synced \(rows.count) rows (lastId=\(lastSyncedId))")
       } else {
-        consecutiveFailures += 1
-        if consecutiveFailures == 1 || consecutiveFailures % 10 == 0 {
-          log("ScreenActivitySync: push failed (failures=\(consecutiveFailures))")
-        }
+        recordPushFailure(path: "legacy")
       }
     } catch {
       log("ScreenActivitySync: read error — \(error.localizedDescription)")
+    }
+  }
+
+  private func recordPushFailure(path: String) {
+    consecutiveFailures += 1
+    if consecutiveFailures == 1 || consecutiveFailures % 10 == 0 {
+      log("ScreenActivitySync: \(path) push failed (failures=\(consecutiveFailures))")
     }
   }
 
@@ -125,14 +209,117 @@ actor ScreenActivitySyncService {
     LIMIT ?
     """
 
+  static let compactionBucketSeconds = 300
+
+  /// A row is eligible once the five-minute bucket *containing* it has closed, plus slack.
+  ///
+  /// Comparing each row's own timestamp against `now - slack` instead would make eligibility
+  /// slide: the early rows of a bucket become ready while its later rows do not, so a single
+  /// bucket is ranked more than once and emits more than one winner. Measured against 7,346
+  /// real OCR-bearing rows, the sliding form shipped 5,517 rows where bucket-aligned ranking
+  /// ships 3,842 — 44% more than the design intends, which is most of the saving.
+  static func bucketEligibilityCutoffEpoch(now: Date, slack: TimeInterval) -> Int64 {
+    Int64((now.timeIntervalSince1970 - slack).rounded(.down))
+  }
+
+  /// Close completed five-minute buckets before delivery. Rows remain intact; only the durable
+  /// delivery disposition changes. Ranking uses OCR length and then row id for deterministic ties.
+  static func compactClosedBuckets(db: Database, now: Date, slack: TimeInterval) throws {
+    try db.execute(
+      sql: """
+        WITH ranked AS (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY appName, COALESCE(windowTitle, ''),
+                                CAST(strftime('%s', timestamp) AS INTEGER) / 300
+                   ORDER BY LENGTH(ocrText) DESC, id DESC
+                 ) AS bucketRank
+          FROM screenshots
+          WHERE screenActivitySyncState = ?
+            AND ocrText IS NOT NULL
+            AND LENGTH(TRIM(ocrText)) > 0
+            AND (CAST(strftime('%s', timestamp) AS INTEGER) / ? + 1) * ? <= ?
+        )
+        UPDATE screenshots
+        SET screenActivitySyncState = ?
+        WHERE id IN (SELECT id FROM ranked WHERE bucketRank > 1)
+        """,
+      arguments: [
+        ScreenActivitySyncState.pending.rawValue,
+        Self.compactionBucketSeconds, Self.compactionBucketSeconds,
+        Self.bucketEligibilityCutoffEpoch(now: now, slack: slack),
+        ScreenActivitySyncState.compacted.rawValue,
+      ])
+  }
+
+  static func fetchSyncCandidates(
+    db: Database, limit: Int, now: Date, slack: TimeInterval, embeddingGrace: TimeInterval
+  ) throws -> [ScreenActivitySyncCandidate] {
+    let rows = try Row.fetchAll(
+      db,
+      sql: """
+        SELECT id, timestamp, appName, windowTitle, ocrText, embedding, deviceName, clientDeviceId,
+               screenActivitySyncState
+        FROM screenshots
+        WHERE (
+          screenActivitySyncState = ?
+          AND ocrText IS NOT NULL
+          AND LENGTH(TRIM(ocrText)) > 0
+          AND (CAST(strftime('%s', timestamp) AS INTEGER) / ? + 1) * ? <= ?
+          AND (
+            embedding IS NOT NULL
+            OR (CAST(strftime('%s', timestamp) AS INTEGER) / ? + 1) * ? <= ?
+          )
+        ) OR (
+          screenActivitySyncState = ?
+          AND embedding IS NOT NULL
+        )
+        ORDER BY CASE screenActivitySyncState WHEN 0 THEN 0 ELSE 1 END, id ASC
+        LIMIT ?
+        """,
+      arguments: [
+        ScreenActivitySyncState.pending.rawValue,
+        Self.compactionBucketSeconds, Self.compactionBucketSeconds,
+        Self.bucketEligibilityCutoffEpoch(now: now, slack: slack),
+        Self.compactionBucketSeconds, Self.compactionBucketSeconds,
+        Self.bucketEligibilityCutoffEpoch(now: now, slack: embeddingGrace),
+        ScreenActivitySyncState.textSynced.rawValue, limit,
+      ])
+
+    return rows.compactMap { row in
+      guard let id = row["id"] as? Int64,
+        let stateRaw = row["screenActivitySyncState"] as? Int64,
+        let state = ScreenActivitySyncState(rawValue: Int(stateRaw)),
+        let payload = payloadRow(from: row)
+      else { return nil }
+      let blobValue = row["embedding"] as DatabaseValue
+      let hasEmbedding: Bool
+      if case .blob = blobValue.storage { hasEmbedding = true } else { hasEmbedding = false }
+      return ScreenActivitySyncCandidate(id: id, priorState: state, hasEmbedding: hasEmbedding, payload: payload)
+    }
+  }
+
+  static func markCandidatesSynced(db: Database, candidates: [ScreenActivitySyncCandidate]) throws {
+    for candidate in candidates {
+      let nextState: ScreenActivitySyncState = candidate.hasEmbedding ? .fullySynced : .textSynced
+      try db.execute(
+        sql: """
+          UPDATE screenshots
+          SET screenActivitySyncState = ?
+          WHERE id = ? AND screenActivitySyncState = ?
+          """,
+        arguments: [nextState.rawValue, candidate.id, candidate.priorState.rawValue])
+    }
+  }
+
   static func payloadRow(from row: Row) -> [String: Any]? {
     guard let id = row["id"] as? Int64 else { return nil }
 
     var dict: [String: Any] = ["id": id]
     if let ts = row["timestamp"] as? String {
-      dict["timestamp"] = ts
+      dict["timestamp"] = canonicalTimestamp(ts) ?? ts
     } else if let ts = row["timestamp"] as? Double {
-      dict["timestamp"] = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: ts))
+      dict["timestamp"] = canonicalTimestamp(Date(timeIntervalSince1970: ts))
     }
     dict["appName"] = (row["appName"] as? String) ?? ""
     dict["windowTitle"] = (row["windowTitle"] as? String) ?? ""
@@ -157,6 +344,31 @@ actor ScreenActivitySyncService {
       dict["embedding"] = floats.map { Double($0) }
     }
     return dict
+  }
+
+  static func canonicalTimestamp(_ value: String) -> String? {
+    if let date = makeCanonicalTimestampFormatter().date(from: value) {
+      return canonicalTimestamp(date)
+    }
+    let fractionalISOFormatter = ISO8601DateFormatter()
+    fractionalISOFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = fractionalISOFormatter.date(from: value) {
+      return canonicalTimestamp(date)
+    }
+    return ISO8601DateFormatter().date(from: value).map(canonicalTimestamp)
+  }
+
+  static func canonicalTimestamp(_ date: Date) -> String {
+    makeCanonicalTimestampFormatter().string(from: date)
+  }
+
+  private static func makeCanonicalTimestampFormatter() -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+    return formatter
   }
 
   // MARK: - HTTP push

--- a/desktop/macos/Desktop/Tests/OCREmbeddingLosslessTests.swift
+++ b/desktop/macos/Desktop/Tests/OCREmbeddingLosslessTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class OCREmbeddingLosslessTests: XCTestCase {
+  func testFiveMinuteCompactionEmbedsOnlyLongestOCRText() async throws {
+    let now = Date(timeIntervalSince1970: 2_000)
+    let spy = LosslessEmbeddingSpy()
+    let service = makeService(now: now, spy: spy) { texts, _ in
+      await spy.recordTexts(texts)
+      return texts.map { _ in [Float](repeating: 0, count: EmbeddingService.embeddingDimension) }
+    }
+    let ownerSnapshot = try XCTUnwrap(RewindCaptureOwnerSnapshot.capture())
+
+    await service.embedScreenshot(
+      id: 1, timestamp: Date(timeIntervalSince1970: 1_200), ocrText: "short synthetic OCR text",
+      appName: "SyntheticApp", windowTitle: "SyntheticWindow", ownerSnapshot: ownerSnapshot)
+    await service.embedScreenshot(
+      id: 2, timestamp: Date(timeIntervalSince1970: 1_220),
+      ocrText: "the longest synthetic OCR text in this completed bucket",
+      appName: "SyntheticApp", windowTitle: "SyntheticWindow", ownerSnapshot: ownerSnapshot)
+    await service.embedScreenshot(
+      id: 3, timestamp: Date(timeIntervalSince1970: 1_240), ocrText: "medium synthetic OCR text here",
+      appName: "SyntheticApp", windowTitle: "SyntheticWindow", ownerSnapshot: ownerSnapshot)
+
+    await service.flushPendingEmbeddings()
+
+    let embeddedTexts = await spy.texts
+    XCTAssertEqual(embeddedTexts.count, 1)
+    XCTAssertTrue(embeddedTexts[0].contains("the longest synthetic OCR text"))
+    let writtenIDs = await spy.ids
+    let pendingCount = await service.pendingCount
+    XCTAssertEqual(writtenIDs, [2])
+    XCTAssertEqual(pendingCount, 0)
+    await service.reset()
+  }
+
+  func testGatedAndFailedBatchesRemainQueuedForRetry() async throws {
+    let now = Date(timeIntervalSince1970: 2_000)
+    let ownerSnapshot = try XCTUnwrap(RewindCaptureOwnerSnapshot.capture())
+    let embedders: [OCREmbeddingService.BatchEmbedder] = [
+      { _, _ in
+        throw EmbeddingService.EmbeddingError.serverError(statusCode: 402, body: "synthetic gate")
+      },
+      { _, _ in throw SyntheticEmbeddingFailure.failed },
+    ]
+
+    for (index, embedder) in embedders.enumerated() {
+      let spy = LosslessEmbeddingSpy()
+      let service = makeService(now: now, spy: spy, embedder: embedder)
+      await service.embedScreenshot(
+        id: Int64(index + 10), timestamp: Date(timeIntervalSince1970: 1_200),
+        ocrText: "synthetic retryable OCR text long enough to embed",
+        appName: "SyntheticApp", windowTitle: nil, ownerSnapshot: ownerSnapshot)
+
+      await service.flushPendingEmbeddings()
+
+      let pendingCount = await service.pendingCount
+      let writtenIDs = await spy.ids
+      XCTAssertEqual(pendingCount, 1, "both gated and failed batches must remain durable in the queue")
+      XCTAssertEqual(writtenIDs, [])
+      await service.reset()
+    }
+  }
+
+  private func makeService(
+    now: Date,
+    spy: LosslessEmbeddingSpy,
+    embedder: @escaping OCREmbeddingService.BatchEmbedder
+  ) -> OCREmbeddingService {
+    OCREmbeddingService(
+      batchEmbedderForTesting: embedder,
+      embeddingWriterForTesting: { id, _ in await spy.recordID(id) },
+      losslessSyncEnabledForTesting: { true },
+      nowForTesting: { now })
+  }
+}
+
+private enum SyntheticEmbeddingFailure: Error {
+  case failed
+}
+
+private actor LosslessEmbeddingSpy {
+  private(set) var texts: [String] = []
+  private(set) var ids: [Int64] = []
+
+  func recordTexts(_ values: [String]) { texts.append(contentsOf: values) }
+  func recordID(_ value: Int64) { ids.append(value) }
+}

--- a/desktop/macos/Desktop/Tests/ScreenActivityLosslessSyncTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenActivityLosslessSyncTests.swift
@@ -1,0 +1,291 @@
+import GRDB
+import XCTest
+
+@testable import Omi_Computer
+
+final class ScreenActivityLosslessSyncTests: XCTestCase {
+  func testMigrationPreservesPopulatedLegacyRowsAndStartsThemPending() throws {
+    let queue = try makeLegacyQueue()
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText, embedding, deviceName, clientDeviceId)
+          VALUES (?, ?, ?, ?, NULL, ?, ?)
+          """,
+        arguments: [
+          Date(timeIntervalSince1970: 1_700_000_000), "SyntheticApp", "SyntheticWindow", "legacy text", "Test Mac",
+          "test-device",
+        ])
+
+      try RewindDatabase.installScreenActivitySyncStateSchema(db)
+
+      let row = try XCTUnwrap(Row.fetchOne(db, sql: "SELECT * FROM screenshots"))
+      XCTAssertEqual(row["appName"] as? String, "SyntheticApp")
+      XCTAssertEqual(row["ocrText"] as? String, "legacy text")
+      XCTAssertEqual(row["screenActivitySyncState"] as? Int64, Int64(ScreenActivitySyncState.pending.rawValue))
+      XCTAssertEqual(
+        try String.fetchOne(
+          db,
+          sql: "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_screenshots_screen_activity_sync'"),
+        "idx_screenshots_screen_activity_sync")
+    }
+  }
+
+  func testRowUnreadyAtFirstSweepIsDeliveredAfterOCRAndEmbeddingCanFollowLater() throws {
+    let queue = try makeLegacyQueue()
+    let cutoff = Date(timeIntervalSince1970: 1_700_001_000)
+    try queue.write { db in
+      try RewindDatabase.installScreenActivitySyncStateSchema(db)
+      try db.execute(
+        sql: """
+          INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText)
+          VALUES (?, ?, ?, NULL)
+          """,
+        arguments: [Date(timeIntervalSince1970: 1_700_000_000), "SyntheticApp", "SyntheticWindow"])
+
+      try ScreenActivitySyncService.compactClosedBuckets(db: db, now: cutoff, slack: 0)
+      XCTAssertTrue(
+        try ScreenActivitySyncService.fetchSyncCandidates(db: db, limit: 100, now: cutoff, slack: 0, embeddingGrace: 0)
+          .isEmpty)
+
+      try db.execute(sql: "UPDATE screenshots SET ocrText = ? WHERE id = 1", arguments: ["OCR arrived later"])
+      let textCandidates = try ScreenActivitySyncService.fetchSyncCandidates(
+        db: db, limit: 100, now: cutoff, slack: 0, embeddingGrace: 0)
+      XCTAssertEqual(textCandidates.map(\.id), [1])
+      XCTAssertFalse(textCandidates[0].hasEmbedding)
+      try ScreenActivitySyncService.markCandidatesSynced(db: db, candidates: textCandidates)
+      XCTAssertEqual(
+        try Int.fetchOne(db, sql: "SELECT screenActivitySyncState FROM screenshots WHERE id = 1"),
+        ScreenActivitySyncState.textSynced.rawValue)
+
+      let embedding = [Float(0.25), Float(-0.5)].withUnsafeBytes { Data($0) }
+      try db.execute(sql: "UPDATE screenshots SET embedding = ? WHERE id = 1", arguments: [embedding])
+      let vectorCandidates = try ScreenActivitySyncService.fetchSyncCandidates(
+        db: db, limit: 100, now: cutoff, slack: 0, embeddingGrace: 0)
+      XCTAssertEqual(vectorCandidates.map(\.id), [1])
+      XCTAssertTrue(vectorCandidates[0].hasEmbedding)
+      try ScreenActivitySyncService.markCandidatesSynced(db: db, candidates: vectorCandidates)
+      XCTAssertEqual(
+        try Int.fetchOne(db, sql: "SELECT screenActivitySyncState FROM screenshots WHERE id = 1"),
+        ScreenActivitySyncState.fullySynced.rawValue)
+    }
+  }
+
+  /// The defect this pins: eligibility must be per *bucket*, not per row.
+  ///
+  /// With a per-row `timestamp <= now - slack` test, the early rows of a bucket become eligible
+  /// while its later rows do not, so the bucket is ranked twice and ships two winners. Replayed
+  /// over 7,346 real OCR-bearing rows that shipped 5,517 rows where bucket-aligned ranking ships
+  /// 3,842 — 44% more than intended, which is most of the compaction saving.
+  func testAPartiallyAgedBucketIsNotRankedUntilTheWholeBucketHasClosed() throws {
+    let queue = try makeLegacyQueue()
+    // 1_700_000_100 is bucket-aligned (divisible by 300), so both rows land in the bucket
+    // [1_700_000_100, 1_700_000_400): an early row and a late row.
+    let bucketStart = Date(timeIntervalSince1970: 1_700_000_100)
+    try queue.write { db in
+      try RewindDatabase.installScreenActivitySyncStateSchema(db)
+      for (offset, text) in [(10.0, "early row"), (290.0, "the late row has the longest text")] {
+        try db.execute(
+          sql: "INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText) VALUES (?, ?, ?, ?)",
+          arguments: [bucketStart.addingTimeInterval(offset), "SyntheticApp", "SyntheticWindow", text])
+      }
+
+      // A sliding per-row cutoff would call the early row ready here and ship it alone.
+      let midway = bucketStart.addingTimeInterval(60)
+      try ScreenActivitySyncService.compactClosedBuckets(db: db, now: midway, slack: 0)
+      XCTAssertTrue(
+        try ScreenActivitySyncService.fetchSyncCandidates(
+          db: db, limit: 100, now: midway, slack: 0, embeddingGrace: 0
+        ).isEmpty,
+        "an open bucket must ship nothing")
+
+      // Once the bucket has closed, it is ranked exactly once and the longest row wins.
+      let afterClose = bucketStart.addingTimeInterval(301)
+      try ScreenActivitySyncService.compactClosedBuckets(db: db, now: afterClose, slack: 0)
+      let candidates = try ScreenActivitySyncService.fetchSyncCandidates(
+        db: db, limit: 100, now: afterClose, slack: 0, embeddingGrace: 0)
+      XCTAssertEqual(candidates.map(\.id), [2], "the longest row wins, and it wins alone")
+      try ScreenActivitySyncService.markCandidatesSynced(db: db, candidates: candidates)
+
+      // And the bucket does not produce a second winner on any later sweep.
+      let later = bucketStart.addingTimeInterval(3_600)
+      try ScreenActivitySyncService.compactClosedBuckets(db: db, now: later, slack: 0)
+      XCTAssertTrue(
+        try ScreenActivitySyncService.fetchSyncCandidates(
+          db: db, limit: 100, now: later, slack: 0, embeddingGrace: 0
+        ).isEmpty,
+        "a closed bucket must not ship again")
+    }
+  }
+
+  /// A row whose vector is still pending must not ship text-only and then ship again unchanged:
+  /// the second push is a byte-identical Firestore document write plus a full index rewrite.
+  func testARowWaitsForItsEmbeddingRatherThanShippingTwice() throws {
+    let queue = try makeLegacyQueue()
+    let bucketStart = Date(timeIntervalSince1970: 1_700_000_000)
+    try queue.write { db in
+      try RewindDatabase.installScreenActivitySyncStateSchema(db)
+      try db.execute(
+        sql: "INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText) VALUES (?, ?, ?, ?)",
+        arguments: [bucketStart, "SyntheticApp", "SyntheticWindow", "awaiting its vector"])
+
+      // Bucket closed, but the grace period for the embedding has not expired.
+      let justClosed = bucketStart.addingTimeInterval(301)
+      XCTAssertTrue(
+        try ScreenActivitySyncService.fetchSyncCandidates(
+          db: db, limit: 100, now: justClosed, slack: 0, embeddingGrace: 900
+        ).isEmpty,
+        "must wait for the vector rather than shipping text-only")
+
+      // The vector lands: one push, straight to fullySynced.
+      let embedding = [Float(0.25), Float(-0.5)].withUnsafeBytes { Data($0) }
+      try db.execute(sql: "UPDATE screenshots SET embedding = ? WHERE id = 1", arguments: [embedding])
+      let candidates = try ScreenActivitySyncService.fetchSyncCandidates(
+        db: db, limit: 100, now: justClosed, slack: 0, embeddingGrace: 900)
+      XCTAssertEqual(candidates.map(\.id), [1])
+      XCTAssertTrue(candidates[0].hasEmbedding)
+      try ScreenActivitySyncService.markCandidatesSynced(db: db, candidates: candidates)
+      XCTAssertEqual(
+        try Int.fetchOne(db, sql: "SELECT screenActivitySyncState FROM screenshots WHERE id = 1"),
+        ScreenActivitySyncState.fullySynced.rawValue,
+        "one push, not two")
+    }
+  }
+
+  /// Losslessness still wins if the vector never arrives: the grace period is a delay, not a gate.
+  func testARowWithoutAnEmbeddingStillShipsOnceTheGraceExpires() throws {
+    let queue = try makeLegacyQueue()
+    let bucketStart = Date(timeIntervalSince1970: 1_700_000_000)
+    try queue.write { db in
+      try RewindDatabase.installScreenActivitySyncStateSchema(db)
+      try db.execute(
+        sql: "INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText) VALUES (?, ?, ?, ?)",
+        arguments: [bucketStart, "SyntheticApp", "SyntheticWindow", "never embedded"])
+
+      let afterGrace = bucketStart.addingTimeInterval(1_500)
+      let candidates = try ScreenActivitySyncService.fetchSyncCandidates(
+        db: db, limit: 100, now: afterGrace, slack: 0, embeddingGrace: 900)
+      XCTAssertEqual(candidates.map(\.id), [1])
+      XCTAssertFalse(candidates[0].hasEmbedding)
+    }
+  }
+
+  func testCompactionKeepsLongestOCRTextPerAppWindowAndFiveMinuteBucket() throws {
+    let queue = try makeLegacyQueue()
+    let base = Date(timeIntervalSince1970: 1_700_000_000)
+    let cutoff = base.addingTimeInterval(1_000)
+    try queue.write { db in
+      try RewindDatabase.installScreenActivitySyncStateSchema(db)
+      for (offset, text) in [(0.0, "short"), (30.0, "the longest synthetic OCR text"), (60.0, "medium text")] {
+        try db.execute(
+          sql: "INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText) VALUES (?, ?, ?, ?)",
+          arguments: [base.addingTimeInterval(offset), "SyntheticApp", "SyntheticWindow", text])
+      }
+      try db.execute(
+        sql: "INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText) VALUES (?, ?, ?, ?)",
+        arguments: [base.addingTimeInterval(330), "SyntheticApp", "SyntheticWindow", "next bucket"])
+
+      try ScreenActivitySyncService.compactClosedBuckets(db: db, now: cutoff, slack: 0)
+      let candidates = try ScreenActivitySyncService.fetchSyncCandidates(
+        db: db, limit: 100, now: cutoff, slack: 0, embeddingGrace: 0)
+
+      XCTAssertEqual(candidates.map(\.id), [2, 4])
+      XCTAssertEqual(
+        try Int.fetchAll(
+          db,
+          sql: "SELECT id FROM screenshots WHERE screenActivitySyncState = ? ORDER BY id",
+          arguments: [ScreenActivitySyncState.compacted.rawValue]),
+        [1, 3])
+    }
+  }
+
+  func testPayloadCanonicalizesISOFallbackTimestamp() throws {
+    let queue = try makeLegacyQueue()
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO screenshots (timestamp, appName, windowTitle, ocrText)
+          VALUES (?, ?, ?, ?)
+          """,
+        arguments: ["2026-08-18T19:00:00.123Z", "SyntheticApp", "SyntheticWindow", "synthetic OCR"])
+      let row = try XCTUnwrap(Row.fetchOne(db, sql: "SELECT * FROM screenshots"))
+      let payload = try XCTUnwrap(ScreenActivitySyncService.payloadRow(from: row))
+      XCTAssertEqual(payload["timestamp"] as? String, "2026-08-18 19:00:00.123")
+    }
+  }
+
+  private func makeLegacyQueue() throws -> DatabaseQueue {
+    let queue = try DatabaseQueue()
+    try queue.write { db in
+      try db.create(table: "screenshots") { table in
+        table.autoIncrementedPrimaryKey("id")
+        table.column("timestamp", .datetime).notNull()
+        table.column("appName", .text).notNull()
+        table.column("windowTitle", .text)
+        table.column("ocrText", .text)
+        table.column("embedding", .blob)
+        table.column("deviceName", .text)
+        table.column("clientDeviceId", .text)
+      }
+    }
+    return queue
+  }
+}
+
+final class ScreenshotEmbeddingBackfillRecoveryTests: XCTestCase {
+  private var testUserID = ""
+  private var userDirectory: URL?
+
+  override func setUp() async throws {
+    try await super.setUp()
+    testUserID = "screen-backfill-recovery-\(UUID().uuidString)"
+    await RewindDatabase.shared.close()
+    await RewindDatabase.shared.configure(userId: testUserID)
+    try await RewindDatabase.shared.initialize()
+
+    let appSupport = try XCTUnwrap(
+      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first)
+    userDirectory =
+      appSupport.appendingPathComponent("Omi", isDirectory: true)
+      .appendingPathComponent("users", isDirectory: true)
+      .appendingPathComponent(testUserID, isDirectory: true)
+  }
+
+  override func tearDown() async throws {
+    await RewindDatabase.shared.close()
+    RewindDatabase.currentUserId = nil
+    if let userDirectory { try? FileManager.default.removeItem(at: userDirectory) }
+    try await super.tearDown()
+  }
+
+  func testCompletedZeroProgressBackfillRearmsWhenCompactedWinnerIsMissing() async throws {
+    _ = try await RewindDatabase.shared.insertScreenshot(
+      Screenshot(
+        timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+        appName: "SyntheticApp",
+        windowTitle: "SyntheticWindow",
+        ocrText: "synthetic OCR text long enough to require an embedding",
+        isIndexed: true))
+    let databasePool = await RewindDatabase.shared.getDatabaseQueue()
+    let pool = try XCTUnwrap(databasePool)
+    try await pool.write { db in
+      try db.execute(
+        sql: """
+          UPDATE migration_status
+          SET completed = 1, processedCount = 0, completedAt = datetime('now')
+          WHERE name = 'screenshot_embedding_backfill'
+          """)
+    }
+
+    let rearmed = try await RewindDatabase.shared.rearmScreenshotEmbeddingBackfillIfNeeded(
+      olderThan: Date(timeIntervalSince1970: 1_700_001_000))
+    let status = try await RewindDatabase.shared.getScreenshotEmbeddingBackfillStatus()
+    let winners = try await RewindDatabase.shared.getCompactedScreenshotsMissingEmbeddings(
+      limit: 100, olderThan: Date(timeIntervalSince1970: 1_700_001_000))
+
+    XCTAssertTrue(rearmed)
+    XCTAssertFalse(status.completed)
+    XCTAssertEqual(status.processedCount, 0)
+    XCTAssertEqual(winners.count, 1)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260819-lossless-screen-activity-sync.json
+++ b/desktop/macos/changelog/unreleased/20260819-lossless-screen-activity-sync.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed gaps in synced screen activity when OCR or search indexing finishes after capture"
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -733,5 +733,30 @@
       ]
     }
   ],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "screen_activity",
+      "fieldPath": "ocrText",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "screen_activity",
+      "fieldPath": "windowTitle",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "screen_activity",
+      "fieldPath": "deviceName",
+      "ttl": false,
+      "indexes": []
+    },
+    {
+      "collectionGroup": "screen_activity",
+      "fieldPath": "clientDeviceId",
+      "ttl": false,
+      "indexes": []
+    }
+  ]
 }


### PR DESCRIPTION
Screen-activity sync silently discards ~99% of what it captures. This makes it lossless, and cheaper per delivered row than the broken version is per delivered row.

## The defect

`ScreenActivitySyncService` selected `WHERE id > ? AND embedding IS NOT NULL` and advanced a monotonic cursor past everything it shipped. Embeddings are computed asynchronously after insert, so any row whose vector had not landed when the sweep passed was skipped **permanently** — not retried, not queued, not reported.

Measured on a live store: **705 of 26,822 rows over 30 days** ever left the device. It reads as a working sync, because rows keep arriving.

Three further mechanisms independently denied a row its embedding, so repairing the cursor alone recovers little:
- cross-batch content-hash dedup returned early without ever queueing the row,
- gated or failed embedding batches were dropped rather than requeued,
- the backfill that comments describe as the safety net had been stuck `completed=1, processedCount=0` since 2026-04-16.

## What changed

**Durable per-row delivery state** (`pending → textSynced → fullySynced`, plus `compacted`) on an indexed column, replacing the cursor. A row that was not ready when a sweep passed is picked up by a later sweep. OCR-bearing rows ship without waiting for a vector; the vector attaches afterwards. Migration is safe on a populated store and starts existing rows `pending`, so history is recoverable.

**Bucket-aligned eligibility.** Compaction keeps the longest OCR text per `(app, window, 5-min bucket)`. The original implementation tested each row's own timestamp against `now - slack`, which makes eligibility *slide*: the early rows of a bucket become ready while its later rows do not, so a bucket is ranked more than once and ships more than one winner. Replayed over 7,346 real OCR-bearing rows, the sliding form ships **5,517** where bucket-aligned ranking ships **3,842** — 44% more than the design intends, which is most of the compaction saving. The same alignment now applies to the embedding flush and the backfill queries, so all three agree on what a bucket is.

**A closed bucket's winner waits up to 15 minutes for its embedding** before shipping text-only. Without that wait almost every row shipped twice: sync sweeps at 5 minutes, and the embedding flush also buffers to 5 minutes and then batches on a 60s timer, so the vector reliably lost the race. The second push wrote a byte-identical Firestore document and rewrote all of its index entries for no data change. Losslessness is preserved — the grace period is a delay, not a gate.

**`ocrText`, `windowTitle`, `deviceName`, `clientDeviceId` exempted from Firestore single-field indexing.** Firestore auto-indexes every field in both directions, and nothing queries these — `ocrText` is only ever read back, never filtered or ordered on; semantic search goes through Pinecone. Measured per document, index bytes were ~75% of this collection's storage and the `ocrText` index alone was the majority of it. The one composite index is unaffected.

**Bounded deferred buffer.** Requeueing gated batches fixes real data loss but restores an unbounded buffer for a user whose backend gates every call. Oldest deferred items are shed first.

**Re-armed backfill** for the stranded history, capped per launch so it cannot stampede.

## The timestamp check, which came back negative

All 26,797 measured local rows already use the space-separated `%Y-%m-%d %H:%M:%S.%f` form that the backend's lexicographic range filters assume; **zero** use ISO `T`/`Z`. So no production date-range query over screen activity is currently returning wrong results.

Two latent paths are closed anyway: the client had a live ISO fallback, and `upsert_screen_activity_vectors` computed the Pinecone timestamp for a naive string in the *process* timezone rather than UTC (inert wherever the container runs UTC, wrong everywhere else). Both now canonicalize at the boundary.

## Cost

Independently modelled from the live store rather than asserted. Per user per month, at this store's capture volume:

| | rows delivered | month 1 | month 12 |
|---|---:|---:|---:|
| today (broken) | 705 | $0.11 | $0.14 |
| this change | 3,842 | $0.36 | $0.54 |
| lossless without compaction | 7,213 | $1.09 | $1.48 |

Rows delivered go up **5.3x** and spend goes up about **5x**. That increase is real and permanent — it is the cost of not throwing the data away. The dominant term is per-row flow (embedding + vector writes), which does not compound; permanent storage accrual is ~$0.017/user/month.

This store is a heavy dogfooder (26.8k captures over 19 active days), so treat per-user figures as an upper bound. Unit prices are list prices, not billed rates.

**Not addressed here, deliberately:** truncating OCR to 1,000 chars before embedding would cut the embedding bill by more than half, and Firestore already stores only the first 1,000 chars. But the embedding is what makes text *searchable*, and nothing has measured retrieval quality past that point — so it is a product call, not a cleanup, and it is left out.

**There is still no server-side retention of any kind.** The only deletion path is account deletion. Volume is unbounded and losslessness makes that more pressing, not less. Out of scope here; it needs its own decision.

## Tiering: cloud vectors are a paid desktop capability

Second commit. Free-tier desktop users sync their rows without vectors — they keep cloud screen history readable by time and app, and they keep **on-device** semantic search, which reads embeddings from the local store and never touches Pinecone. The OCR text is still stored, so vectors can be backfilled on upgrade: the gate defers the cost rather than destroying the ability to recover.

Gated on the desktop access tier, not `is_paid_plan` — screen activity is a desktop capability and a mobile-only paid plan did not buy it. BYOK does not grant it either: BYOK covers the user's own LLM keys, but the vector store is ours. Enforced server-side at ingest, since the client cannot be trusted about its own entitlement. Fails **open** on a lookup error, matching `should_defer_desktop_processing`.

**Correction to the cost table above.** The Gemini embedding spend (~$0.32/user/month) is *not* attributable to sync. Embeddings are computed for local Rewind search on every capture regardless of whether the row ever syncs, through our own proxy — sync merely piggybacks on them. So this gate saves the Pinecone half (~$0.20/user/month), not the embedding half, and the "this change" row above overstates what tiering can recover. Tiering the embedding as well would mean tiering on-device search; that is a separate product decision and is not made here.

## Verification

- `swift build` of the macOS package — a real build, not a typecheck.
- 9 Swift tests: migration on a populated store, a row unready at sweep time delivered later, an open bucket shipping nothing, a closed bucket shipping exactly one winner and never shipping again, the embedding wait and its expiry, compaction keeping the longest text, and gated/failed requeue.
- 8 backend tests covering timestamp canonicalization at ingest and the Pinecone UTC fix.

Not verified: no deploy was run; no production Firestore sample was read (network and credentials unavailable); the Pinecone index configuration is not in the repo, so its storage class is unconfirmed.

Failure-Class: new

Line-Count-Exception: desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase.swift | 3450 -> 3470 | the schema migration and its callable boundary belong with the other migrations in the ledger; splitting the file to add one column would separate this migration from the ones it must stay ordered after

## Product invariants affected

- INV-AUTH-1 — touched only by adding one migration to `RewindDatabase`'s ledger. Ownership is unchanged: the migration registers after every existing component migration and runs inside the pool the owner transition already configures. Embedding writes keep taking an owner-bound `LocalMutationAuthorization` lease, and the requeue paths still check `generation == ownerGeneration` before returning items to the buffer, so a batch that spans a retarget is dropped rather than seeding the next owner's buffer with the previous owner's rowids.

Line-Count-Exception: backend/utils/subscription.py | 1491 -> 1535 | the entitlement helper belongs beside `should_defer_desktop_processing`, whose tier semantics and fail-open contract it deliberately mirrors; splitting it out would separate two gates that must stay consistent
