### PR TITLE
fix(backend): stop one out-of-vocabulary extractor enum from failing a whole conversation

### DIFF
--- a/.github/failure-classes/FC-out-of-vocabulary-model-token-discards-extraction.json
+++ b/.github/failure-classes/FC-out-of-vocabulary-model-token-discards-extraction.json
@@ -8,7 +8,7 @@
     "backend/tests/unit/test_extracted_action_item_vocabulary.py"
   ],
   "evidence_prs": [
-    11870
+    11871
   ],
   "scope_hints": [
     "backend/models/**",

--- a/.github/failure-classes/FC-out-of-vocabulary-model-token-discards-extraction.json
+++ b/.github/failure-classes/FC-out-of-vocabulary-model-token-discards-extraction.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-out-of-vocabulary-model-token-discards-extraction",
+  "violated_contract": "A closed vocabulary a language model was asked to answer in is a preference, not a guarantee, so one out-of-vocabulary token must never discard the whole payload it appeared in. A provider completion is parsed as a batch: when a strict enum on one field of one list element raises, the parser fails the entire response, and every well-formed field the model produced -- the title, the overview, the other list elements -- is lost with it. The user then sees a server error for content that was almost entirely usable.",
+  "canonical_prevention": "Normalize provider-supplied enum fields on the parsed model before validation, not at the call site, so every parser target that embeds the model inherits the guard. Accept a recognized value in any casing or padding; map an unusable value to the field's own declared default, which is what an absent field already means; and where a wrong-but-meaningful answer has an obvious home in the schema, route it there instead of dropping it. Keep the strictness where it is load-bearing -- required fields and fields whose absence changes behavior still fail. The regression test replays a real provider completion through the production parser seam.",
+  "canonical_prevention_artifact": [
+    "backend/models/structured_extraction.py",
+    "backend/tests/unit/test_extracted_action_item_vocabulary.py"
+  ],
+  "evidence_prs": [
+    11870
+  ],
+  "scope_hints": [
+    "backend/models/**",
+    "backend/utils/llm/**"
+  ],
+  "status": "open"
+}

--- a/backend/models/structured_extraction.py
+++ b/backend/models/structured_extraction.py
@@ -1,10 +1,25 @@
 from datetime import datetime
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from models.conversation_enums import CategoryEnum
 from models.structured import ActionItem, Event, Section, Structured
+
+CAPTURE_OWNERS: Tuple[str, ...] = ('user', 'other', 'unknown')
+
+# The extractor is asked for a fixed vocabulary on these fields, but it answers outside of it often
+# enough to matter: on 2026-08-19 it returned a speaker's name for capture_owner on three items of
+# one conversation, pydantic raised literal_error, and the whole StructuredExtraction failed to
+# parse — so conversation processing returned HTTP 500 and the user got no summary at all. One
+# out-of-vocabulary token must never cost the conversation; an unusable value is worth exactly as
+# much as the field being absent, which is what these Optionals already model.
+_OPTIONAL_LITERAL_VOCABULARIES: Dict[str, Tuple[str, ...]] = {
+    'capture_kind': ('explicit_command', 'clear_commitment', 'direct_request', 'inferred_next_step'),
+    'capture_owner': CAPTURE_OWNERS,
+    'due_certainty': ('confirmed', 'tentative'),
+    'candidate_action': ('create', 'update', 'complete'),
+}
 
 
 class ExtractedActionItem(BaseModel):
@@ -29,6 +44,31 @@ class ExtractedActionItem(BaseModel):
         default_factory=list,
         description='Transcript segment IDs that directly support this action item',
     )
+
+    @model_validator(mode='before')
+    @classmethod
+    def drop_out_of_vocabulary_literals(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        coerced = dict(data)
+        for field, vocabulary in _OPTIONAL_LITERAL_VOCABULARIES.items():
+            value = coerced.get(field)
+            if value is None or value in vocabulary:
+                continue
+            normalized = value.strip().lower() if isinstance(value, str) else None
+            if normalized in vocabulary:
+                coerced[field] = normalized
+                continue
+            # A name where an owner class belongs still says the owner is somebody other than the
+            # user, and owner_name is where that name is meant to live.
+            if field == 'capture_owner' and normalized:
+                coerced[field] = 'other'
+                if not coerced.get('owner_name'):
+                    coerced['owner_name'] = value.strip()
+                continue
+            coerced[field] = None
+        return coerced
 
     def to_action_item(self) -> ActionItem:
         return ActionItem(

--- a/backend/tests/unit/test_extracted_action_item_vocabulary.py
+++ b/backend/tests/unit/test_extracted_action_item_vocabulary.py
@@ -1,0 +1,110 @@
+"""The extractor's out-of-vocabulary literals must not abort a whole conversation extraction.
+
+Prod, 2026-08-19: the structure model returned a speaker's name ("Archit") for `capture_owner` on
+three action items of one conversation. Pydantic raised literal_error for each, PydanticOutputParser
+turned that into OutputParserException, and `_get_structured` mapped it to HTTP 500 — the user's
+conversation never got a summary because of an enum token. The completion below is that prod
+payload, trimmed to the three offending items plus one good one.
+"""
+
+import json
+
+import pytest
+from langchain_core.output_parsers import PydanticOutputParser
+
+from models.structured_extraction import ActionItemsExtraction, ExtractedActionItem, StructuredExtraction
+
+PROD_COMPLETION = json.dumps(
+    {
+        "title": "Archit Defines Omi's Agent Context Strategy",
+        "overview": "Archit and the team discuss Omi's hardware, Mac app, and strategic direction.",
+        "emoji": "🧠",
+        "category": "technology",
+        "action_items": [
+            {
+                "description": "Collect a couple of weeks of performance data for the launch.",
+                "due_at": None,
+                "capture_kind": "clear_commitment",
+                "capture_confidence": 0.9,
+                "ownership_confidence": 0.9,
+                "capture_owner": "Archit",
+                "concrete_deliverable": True,
+                "candidate_action": "complete",
+                "target_task_id": None,
+                "source_segment_ids": [],
+            },
+            {
+                "description": "Download and personally test the Omi macOS app.",
+                "capture_kind": "direct_request",
+                "capture_owner": "user",
+                "candidate_action": "complete",
+                "source_segment_ids": [],
+            },
+            {
+                "description": "Submit the collaboration form discussed during the evaluation.",
+                "capture_kind": "clear_commitment",
+                "capture_owner": "Archit",
+                "candidate_action": "complete",
+                "source_segment_ids": [],
+            },
+            {
+                "description": "Give feedback on the Omi product after trying the device.",
+                "capture_kind": "clear_commitment",
+                "capture_owner": "Archit",
+                "candidate_action": "complete",
+                "source_segment_ids": [],
+            },
+        ],
+        "events": [],
+    }
+)
+
+
+def test_prod_completion_with_named_capture_owner_parses():
+    """The exact prod payload, through the exact production parser seam."""
+    extraction = PydanticOutputParser(pydantic_object=StructuredExtraction).parse(PROD_COMPLETION)
+
+    assert extraction.title == "Archit Defines Omi's Agent Context Strategy"
+    assert [item.capture_owner for item in extraction.action_items] == ['other', 'user', 'other', 'other']
+    assert len(extraction.to_structured().action_items) == 4
+
+
+def test_named_capture_owner_is_kept_as_owner_name():
+    item = ExtractedActionItem.model_validate({'description': 'Send the address', 'capture_owner': 'Archit'})
+
+    assert item.capture_owner == 'other'
+    assert item.owner_name == 'Archit'
+    assert item.to_action_item().owner_name == 'Archit'
+
+
+def test_named_capture_owner_does_not_overwrite_an_explicit_owner_name():
+    item = ExtractedActionItem.model_validate(
+        {'description': 'Send the address', 'capture_owner': 'Archit', 'owner_name': 'Archit Sharma'}
+    )
+
+    assert item.capture_owner == 'other'
+    assert item.owner_name == 'Archit Sharma'
+
+
+@pytest.mark.parametrize('value', ['User', ' other ', 'UNKNOWN'])
+def test_vocabulary_values_survive_casing_and_padding(value):
+    item = ExtractedActionItem.model_validate({'description': 'Ship it', 'capture_owner': value})
+
+    assert item.capture_owner == value.strip().lower()
+
+
+@pytest.mark.parametrize('field', ['capture_kind', 'due_certainty', 'candidate_action'])
+def test_unusable_optional_literal_is_dropped_rather_than_failing_the_item(field):
+    item = ExtractedActionItem.model_validate({'description': 'Ship it', field: 'something_the_model_invented'})
+
+    assert getattr(item, field) is None
+    assert item.description == 'Ship it'
+
+
+def test_action_items_extraction_survives_the_same_payload():
+    """The action-item-only parser shares the model, so it shares the guard."""
+    completion = json.dumps({'action_items': [{'description': 'Send the deck', 'capture_owner': 'Archit'}]})
+
+    extraction = PydanticOutputParser(pydantic_object=ActionItemsExtraction).parse(completion)
+
+    assert extraction.to_action_items()[0].capture_owner == 'other'


### PR DESCRIPTION
## Bug

`POST /v1/conversations/{id}/…` conversation structuring returns HTTP 500 and the user's conversation never gets a note, because the extractor answered one enum field outside its vocabulary.

Prod signature, `api.omi.me`, 2026-08-19T17:00Z, backend image `79a585b`:

```
File "/app/utils/conversations/process_conversation.py", line 295, in _get_structured
    structured = get_transcript_structure(
File "/app/utils/llm/conversation_processing.py", line 1178, in get_transcript_structure
    response = _coerce_structured(chain.invoke(legacy_prompt_values))
langchain_core.exceptions.OutputParserException: Failed to parse StructuredExtraction from
completion {...}. Got: 3 validation errors for StructuredExtraction
```

The completion is well formed JSON with a title, an overview, an emoji, a category and six action items. Three of the six carry `"capture_owner": "Archit"` — the speaker's name.

## Root cause

`ExtractedActionItem.capture_owner` is `Optional[Literal['user', 'other', 'unknown']]`. Every name-valued item raises `literal_error`, `PydanticOutputParser` converts the batch into `OutputParserException`, and `_get_structured`'s `except Exception` maps it through `conversation_processing_http_exception` to a generic HTTP 500. Three tokens discard an entire conversation's note, summary and action items.

The prompt invites the mistake: the notes-v2 task instructions say *"Set owner_name to the actual name when known"* and never state the `capture_owner` vocabulary at all (only the separate `extract_action_items` prompt does). The name-in-the-wrong-field answer is the model doing roughly what it was asked.

Replayed against `origin/main`, the exact prod completion reproduces exactly 3 errors:

```
action_items.0.capture_owner
  Input should be 'user', 'other' or 'unknown' [type=literal_error, input_value='Archit', ...]
action_items.4.capture_owner ...
action_items.5.capture_owner ...
```

## Fix

`ExtractedActionItem` normalizes its optional literal fields in a `mode='before'` model validator, mirroring the `set_category_default_on_error` guard that already exists on `category` in the same file:

- a recognized value in different casing or with padding is accepted (`'User'` → `'user'`);
- an unusable value falls back to the field's own declared default of `None`, which is exactly what an absent field already means (`capture_kind`, `due_certainty`, `candidate_action`);
- a name where an owner class belongs becomes `'other'` — a named third party is precisely `other` — and the name is carried into `owner_name`, the field the schema already has for it. An explicit `owner_name` is never overwritten.

The guard is on the model, not at a call site, so both parser targets that embed it are covered: `StructuredExtraction` (conversation structure, notes v2, reprocess) and `ActionItemsExtraction` (action-item extraction).

## Tested

`backend/tests/unit/test_extracted_action_item_vocabulary.py` — 10 tests, all pass on this branch, **all 10 fail against `origin/main`**.

```
$ ./test.sh (scoped) tests/unit/test_extracted_action_item_vocabulary.py
10 passed in 0.44s

$ git stash push models/structured_extraction.py && pytest …
10 failed in 0.51s
```

The first test drives the real prod completion through the production seam — `PydanticOutputParser(pydantic_object=StructuredExtraction).parse(...)`, the same construction as `conversation_processing.py:1128` — and asserts the resulting owners are `['other', 'user', 'other', 'other']`. Separately, that payload was run through the real `_coerce_structured` and now yields a `Structured` with `[('other', 'Archit'), ('user', None), …]` instead of raising.

Related suites re-run green (73 + 8 files, all passing): `test_conversation_notes_v2`, `test_backend_candidate_capture`, `test_chat_first_proactive_engine`, `test_llm_gateway_chat_extraction_pilot`, `test_action_item_date_validation`, `test_action_items_date_coercion`, `test_conversation_model_split`, `test_task_transcript_provenance`, `test_llm_gateway_openai_compatible`, `test_byok_llm_logging`, `test_omi_qos_tiers`, `test_daily_summary_zero_coordinate_locations`.

## Product invariants

none — `scripts/pr-preflight --suggest` reports no invariant path globs matched.

Failure-Class: new

This PR adds the definition `.github/failure-classes/FC-out-of-vocabulary-model-token-discards-extraction.json` in its own commit. The violated contract: *a single out-of-vocabulary token in a model-generated payload must not discard the whole extraction the payload carries.* The nearest registered class, `FC-malformed-doc-read`, covers a malformed **persisted document** turning a read into a 500; this source is a provider completion, where out-of-vocabulary answers are expected rather than exceptional. Per AGENTS.md, registry lifecycle transitions land in their own PR, so this declares `new` rather than adding a definition here.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

