### PR TITLE
fix(admin): unified first-seen platform cohorts; account-level panels off platform boards

### DIFF
--- a/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/k-factor/posthog/route.ts
@@ -22,37 +22,37 @@ export async function computeKFactor(days: number, platform: PlatformScope = 'ma
     };
   }
 
-  const query = `
+  const shareQuery = `
           SELECT
-            event,
             uniq(COALESCE(person_id, distinct_id)) AS unique_users,
             count() AS total_events
           FROM events
-          WHERE event IN ('Sign In Completed', 'Memory Share Button Clicked')
+          WHERE event = 'Memory Share Button Clicked'
             AND timestamp >= now() - INTERVAL ${days} DAY
-            ${scopeFilterAnd(platform, 'properties.$os')}
-          GROUP BY event
+            ${scopeFilterAnd(platform, 'properties.$os_name')}
+        `;
+  // First-seen on this platform inside the window — mobile never emits
+  // `Sign In Completed`, and every acquisition metric uses this definition.
+  const newUserQuery = `
+          SELECT count(*)
+          FROM (
+            SELECT COALESCE(person_id, distinct_id) AS actor, min(timestamp) AS first_ts
+            FROM events
+            WHERE 1 = 1
+              ${scopeFilterAnd(platform, 'properties.$os_name')}
+            GROUP BY actor
+          )
+          WHERE first_ts >= now() - INTERVAL ${days} DAY
         `;
 
-  const rows = (await posthogResults(host, projectId, apiKey, query)) as any[];
+  const [shareRows, newUserRows] = await Promise.all([
+    posthogResults(host, projectId, apiKey, shareQuery) as Promise<any[]>,
+    posthogResults(host, projectId, apiKey, newUserQuery) as Promise<any[]>,
+  ]);
 
-  let newUsers = 0;
-  let sharers = 0;
-  let shareEvents = 0;
-
-  for (const row of rows) {
-    const eventName = row[0];
-    const uniqueUsers = Number(row[1] ?? 0);
-    const totalEvents = Number(row[2] ?? 0);
-
-    if (eventName === 'Sign In Completed') {
-      newUsers = uniqueUsers;
-    }
-    if (eventName === 'Memory Share Button Clicked') {
-      sharers = uniqueUsers;
-      shareEvents = totalEvents;
-    }
-  }
+  const newUsers = Number(newUserRows?.[0]?.[0] ?? 0);
+  const sharers = Number(shareRows?.[0]?.[0] ?? 0);
+  const shareEvents = Number(shareRows?.[0]?.[1] ?? 0);
 
   const shareRatePct = newUsers > 0 ? (sharers / newUsers) * 100 : 0;
   const sharesPerSharer = sharers > 0 ? shareEvents / sharers : 0;

--- a/web/admin/app/api/omi/stats/retention/posthog/route.ts
+++ b/web/admin/app/api/omi/stats/retention/posthog/route.ts
@@ -41,9 +41,9 @@ export async function GET(request: NextRequest) {
     const excludeOtherProducts = `AND NOT startsWith(event, 'cfc_')`;
     const eventFilter =
       platform === 'macos'
-        ? `AND properties.$os = 'macOS' ${excludeOtherProducts}`
+        ? `AND properties.$os_name = 'macOS' ${excludeOtherProducts}`
         : platform === 'mobile'
-          ? `AND properties.$os IN ('iOS', 'Android', 'iPadOS') ${excludeOtherProducts}`
+          ? `AND properties.$os_name IN ('iOS', 'Android', 'iPadOS') ${excludeOtherProducts}`
           : excludeOtherProducts;
     const url = `${host}/api/projects/${projectId}/query/`;
 

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -50,9 +50,11 @@ export async function GET(request: NextRequest) {
     // Default macos preserves the legacy meaning for existing callers.
     const platform = parsePlatformScope(searchParams.get("platform") ?? "macos");
     const os = scopeFilterAnd(platform);
-    // Mobile never emits `Sign In Completed`, so non-macOS signup cohorts
-    // anchor on the user's first-ever event instead.
-    const signupAnchor = platform === "macos" ? `AND event = 'Sign In Completed' ${os}` : os;
+    // Mobile never emits `Sign In Completed`, so non-macOS activation cohorts
+    // anchor on the user's first-ever event instead. Acquisition series
+    // (weekly/daily new, cumulative, ticker) all use first-seen so every
+    // panel agrees on one "new user" definition per platform.
+    const activationAnchor = platform === "macos" ? `AND event = 'Sign In Completed' ${os}` : os;
     // The Firestore activation overlay is macOS-scoped by construction
     // (conversation-within-7-days of a macOS signup) — never smear it over
     // mobile or all-platform telemetry.
@@ -80,17 +82,18 @@ export async function GET(request: NextRequest) {
       allTimeResult,
       userGrowthResult,
     ] = await Promise.all([
-      // 1. New users per week (first-ever Sign In Completed)
+      // 1. New users per week — first-seen on this platform, the same
+      // person-deduped population as the daily userGrowth series.
       hogql(apiKey, projectId, host, `
         SELECT
           toMonday(toDate(toString(min_ts))) as week,
           count(*) as new_users
         FROM (
-          SELECT distinct_id, min(timestamp) as min_ts
+          SELECT COALESCE(person_id, distinct_id) as actor, min(timestamp) as min_ts
           FROM events
           WHERE 1 = 1
-            ${signupAnchor}
-          GROUP BY distinct_id
+            ${os}
+          GROUP BY actor
         )
         WHERE min_ts >= now() - interval ${days} day
         GROUP BY week
@@ -205,7 +208,7 @@ export async function GET(request: NextRequest) {
               ) >= [${MIN_ACTIVATION_TELEMETRY_VERSION.join(", ")}] as reports_activation
             FROM events
             WHERE 1 = 1
-              ${signupAnchor}
+              ${activationAnchor}
             GROUP BY distinct_id
           ) signups
           LEFT JOIN (

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -51,10 +51,8 @@ PLATFORM_ROUTES = ("viral-metrics", "dau-trends", "retention/posthog", "k-factor
 DESKTOP_ONLY_TITLES = {
     "Floating bar sessions per user", "Floating bar queries",
     "Floating bar notification CTR", "Crash-free rate (today)",
-    "Crash-free rate",
+    "Crash-free rate", "Notifications enabled",
 }
-# Notification panels stay real on both platform boards: mentor pushes are
-# account-level (delivered to whatever devices a user has), not per-platform.
 
 LINKS = [
     {"title": title, "type": "link", "url": f"/grafana/d/{uid}/", "icon": "dashboard",
@@ -261,10 +259,15 @@ def build_platform_board(base, scope: str) -> dict:
     apply_platform(dash, scope)
 
     # Cross-platform business panels that have no per-platform breakdown.
+    # Mentor "Omi says" pushes are account-level Firestore messages delivered
+    # to every device a user has, so notification volume cannot be split by
+    # platform either — those panels live on the All-platforms board only.
     drop_panels(dash, {
         "Users → 1M goal", "ARR", "Active subscriptions", "Trialing",
         "Trials in pipeline", "Conversations", "MRR by product", "MRR over time",
         "New subscriptions / month", "Message ratings",
+        "Daily notifications sent", "Notifications sent — last 168 hours",
+        "Weekly notification reach",
         "Infra cost by service — last 30 days",
     })
     if scope == "mobile":

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -2882,291 +2882,6 @@
           "custom": {
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 65,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Omi says"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#3b82f6",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Marketplace"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#f59e0b",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 16,
-        "y": 42,
-        "w": 8,
-        "h": 8
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "date",
-              "text": "time",
-              "timestampFormat": "2006-01-02T15:04:05Z07:00",
-              "type": "timestamp"
-            },
-            {
-              "selector": "mentorSent",
-              "text": "Omi says",
-              "type": "number"
-            },
-            {
-              "selector": "marketplaceMentorSent",
-              "text": "Marketplace",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "dailyData",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30&_tzdates=date",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "30d",
-      "title": "Daily notifications sent  \u00b7  ${d_notif}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 65,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Omi says sent"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#3b82f6",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Marketplace sent"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#f59e0b",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Unique users"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "short"
-              },
-              {
-                "id": "custom.stacking",
-                "value": {
-                  "group": "A",
-                  "mode": "none"
-                }
-              },
-              {
-                "id": "custom.drawStyle",
-                "value": "line"
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 2
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#22c55e",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 50,
-        "w": 8,
-        "h": 8
-      },
-      "id": 40,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "week",
-              "text": "time",
-              "timestampFormat": "2006-01-02T15:04:05Z07:00",
-              "type": "timestamp"
-            },
-            {
-              "selector": "mentorSent",
-              "text": "Omi says sent",
-              "type": "number"
-            },
-            {
-              "selector": "marketplaceMentorSent",
-              "text": "Marketplace sent",
-              "type": "number"
-            },
-            {
-              "selector": "uniqueUsersMentor",
-              "text": "Unique users",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "weeklyData",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30&_tzdates=week",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "45d",
-      "title": "Weekly notification reach  \u00b7  ${d_reach}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 12,
             "gradientMode": "opacity",
@@ -3201,8 +2916,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 50,
+        "x": 16,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -3269,7 +2984,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 16,
+        "x": 0,
         "y": 50,
         "w": 8,
         "h": 8
@@ -3350,8 +3065,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
-        "y": 58,
+        "x": 8,
+        "y": 50,
         "w": 8,
         "h": 8
       },
@@ -3477,8 +3192,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 58,
+        "x": 16,
+        "y": 50,
         "w": 8,
         "h": 8
       },
@@ -3591,7 +3306,7 @@
         ]
       },
       "gridPos": {
-        "x": 16,
+        "x": 0,
         "y": 58,
         "w": 8,
         "h": 8
@@ -3705,8 +3420,8 @@
         ]
       },
       "gridPos": {
-        "x": 0,
-        "y": 66,
+        "x": 8,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -3819,8 +3534,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 66,
+        "x": 16,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -3933,7 +3648,7 @@
         ]
       },
       "gridPos": {
-        "x": 16,
+        "x": 0,
         "y": 66,
         "w": 8,
         "h": 8
@@ -4018,8 +3733,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
-        "y": 74,
+        "x": 8,
+        "y": 66,
         "w": 8,
         "h": 8
       },
@@ -4083,125 +3798,6 @@
         }
       ],
       "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 65,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Omi says"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#3b82f6",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Marketplace"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#f59e0b",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 82,
-        "w": 24,
-        "h": 8
-      },
-      "id": 51,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "hour",
-              "text": "time",
-              "timestampFormat": "2006-01-02T15",
-              "type": "timestamp"
-            },
-            {
-              "selector": "mentor",
-              "text": "Omi says",
-              "type": "number"
-            },
-            {
-              "selector": "marketplace",
-              "text": "Marketplace",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "hourlyData",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "8d",
-      "title": "Notifications sent \u2014 last 168 hours  \u00b7  ${d_hourly}",
-      "type": "timeseries"
     }
   ],
   "refresh": "5m",
@@ -4589,80 +4185,6 @@
           "uid": "omi-admin-api"
         },
         "hide": 2,
-        "name": "d_notif",
-        "options": [],
-        "query": {
-          "infinityQuery": {
-            "columns": [
-              {
-                "selector": "value",
-                "text": "value",
-                "type": "string"
-              }
-            ],
-            "format": "table",
-            "parser": "backend",
-            "refId": "variable",
-            "root_selector": "",
-            "source": "url",
-            "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=dailyData&fields=mentorSent%2CmarketplaceMentorSent&agg=sum&window=15&label=vs+prev+15d",
-            "url_options": {
-              "data": "",
-              "method": "GET"
-            }
-          },
-          "query": "",
-          "queryType": "infinity"
-        },
-        "refresh": 2,
-        "skipUrlSync": true,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "yesoreyeram-infinity-datasource",
-          "uid": "omi-admin-api"
-        },
-        "hide": 2,
-        "name": "d_reach",
-        "options": [],
-        "query": {
-          "infinityQuery": {
-            "columns": [
-              {
-                "selector": "value",
-                "text": "value",
-                "type": "string"
-              }
-            ],
-            "format": "table",
-            "parser": "backend",
-            "refId": "variable",
-            "root_selector": "",
-            "source": "url",
-            "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=weeklyData&fields=mentorSent%2CmarketplaceMentorSent&agg=sum&window=2&label=vs+prev+2w",
-            "url_options": {
-              "data": "",
-              "method": "GET"
-            }
-          },
-          "query": "",
-          "queryType": "infinity"
-        },
-        "refresh": 2,
-        "skipUrlSync": true,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "yesoreyeram-infinity-datasource",
-          "uid": "omi-admin-api"
-        },
-        "hide": 2,
         "name": "d_crash",
         "options": [],
         "query": {
@@ -4866,43 +4388,6 @@
             "source": "url",
             "type": "json",
             "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=conversion&fields=desktop&agg=avg&window=15&label=vs+prev+15d",
-            "url_options": {
-              "data": "",
-              "method": "GET"
-            }
-          },
-          "query": "",
-          "queryType": "infinity"
-        },
-        "refresh": 2,
-        "skipUrlSync": true,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "yesoreyeram-infinity-datasource",
-          "uid": "omi-admin-api"
-        },
-        "hide": 2,
-        "name": "d_hourly",
-        "options": [],
-        "query": {
-          "infinityQuery": {
-            "columns": [
-              {
-                "selector": "value",
-                "text": "value",
-                "type": "string"
-              }
-            ],
-            "format": "table",
-            "parser": "backend",
-            "refId": "variable",
-            "root_selector": "",
-            "source": "url",
-            "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=hourlyData&fields=mentor%2Cmarketplace&agg=sum&window=84&label=vs+prev+84h",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -2427,297 +2427,12 @@
       "targets": []
     },
     {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 65,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Omi says"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#3b82f6",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Marketplace"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#f59e0b",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 16,
-        "y": 42,
-        "w": 8,
-        "h": 8
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "date",
-              "text": "time",
-              "timestampFormat": "2006-01-02T15:04:05Z07:00",
-              "type": "timestamp"
-            },
-            {
-              "selector": "mentorSent",
-              "text": "Omi says",
-              "type": "number"
-            },
-            {
-              "selector": "marketplaceMentorSent",
-              "text": "Marketplace",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "dailyData",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30&_tzdates=date",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "30d",
-      "title": "Daily notifications sent  \u00b7  ${d_notif}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 65,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Omi says sent"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#3b82f6",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Marketplace sent"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#f59e0b",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Unique users"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit",
-                "value": "short"
-              },
-              {
-                "id": "custom.stacking",
-                "value": {
-                  "group": "A",
-                  "mode": "none"
-                }
-              },
-              {
-                "id": "custom.drawStyle",
-                "value": "line"
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 2
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#22c55e",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 50,
-        "w": 8,
-        "h": 8
-      },
-      "id": 40,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "week",
-              "text": "time",
-              "timestampFormat": "2006-01-02T15:04:05Z07:00",
-              "type": "timestamp"
-            },
-            {
-              "selector": "mentorSent",
-              "text": "Omi says sent",
-              "type": "number"
-            },
-            {
-              "selector": "marketplaceMentorSent",
-              "text": "Marketplace sent",
-              "type": "number"
-            },
-            {
-              "selector": "uniqueUsersMentor",
-              "text": "Unique users",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "weeklyData",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30&_tzdates=week",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "45d",
-      "title": "Weekly notification reach  \u00b7  ${d_reach}",
-      "type": "timeseries"
-    },
-    {
       "id": 41,
       "type": "text",
       "title": "Crash-free rate",
       "gridPos": {
-        "x": 8,
-        "y": 50,
+        "x": 16,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -2743,7 +2458,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 16,
+        "x": 0,
         "y": 50,
         "w": 8,
         "h": 8
@@ -2824,8 +2539,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
-        "y": 58,
+        "x": 8,
+        "y": 50,
         "w": 8,
         "h": 8
       },
@@ -2951,8 +2666,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 58,
+        "x": 16,
+        "y": 50,
         "w": 8,
         "h": 8
       },
@@ -3065,7 +2780,7 @@
         ]
       },
       "gridPos": {
-        "x": 16,
+        "x": 0,
         "y": 58,
         "w": 8,
         "h": 8
@@ -3179,8 +2894,8 @@
         ]
       },
       "gridPos": {
-        "x": 0,
-        "y": 66,
+        "x": 8,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -3293,8 +3008,8 @@
         ]
       },
       "gridPos": {
-        "x": 8,
-        "y": 66,
+        "x": 16,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -3407,7 +3122,7 @@
         ]
       },
       "gridPos": {
-        "x": 16,
+        "x": 0,
         "y": 66,
         "w": 8,
         "h": 8
@@ -3461,221 +3176,21 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "description": "Desktop notifications_enabled toggle; missing values default to enabled.",
-      "fieldConfig": {
-        "defaults": {
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "#ef4444",
-                "value": null
-              },
-              {
-                "color": "#f59e0b",
-                "value": 0.5
-              },
-              {
-                "color": "#22c55e",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
+      "id": 50,
+      "type": "text",
+      "title": "Notifications enabled",
       "gridPos": {
-        "x": 0,
-        "y": 74,
+        "x": 8,
+        "y": 66,
         "w": 8,
         "h": 8
       },
-      "id": 50,
+      "transparent": true,
       "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^Enabled share$/",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "mode": "markdown",
+        "content": "**Desktop-only surface \u2014 no mobile equivalent.**\n\nThis feature exists only in the macOS app; see the [macOS board](/grafana/d/omi-tv-macos/)."
       },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "enabled",
-              "text": "enabled",
-              "type": "number"
-            },
-            {
-              "selector": "total",
-              "text": "total",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "table",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "enabledDisabled",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "title": "Notifications enabled",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Enabled share",
-            "binary": {
-              "left": "enabled",
-              "operator": "/",
-              "right": "total"
-            },
-            "mode": "binary",
-            "replaceFields": false
-          }
-        }
-      ],
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "omi-admin-api"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 65,
-            "gradientMode": "none",
-            "lineWidth": 2,
-            "pointSize": 4,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Omi says"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#3b82f6",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Marketplace"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "#f59e0b",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 82,
-        "w": 24,
-        "h": 8
-      },
-      "id": 51,
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "columns": [
-            {
-              "selector": "hour",
-              "text": "time",
-              "timestampFormat": "2006-01-02T15",
-              "type": "timestamp"
-            },
-            {
-              "selector": "mentor",
-              "text": "Omi says",
-              "type": "number"
-            },
-            {
-              "selector": "marketplace",
-              "text": "Marketplace",
-              "type": "number"
-            }
-          ],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "omi-admin-api"
-          },
-          "format": "timeseries",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "hourlyData",
-          "source": "url",
-          "type": "json",
-          "url": "http://127.0.0.1:8899/api/omi/stats/notifications?days=30",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "timeFrom": "8d",
-      "title": "Notifications sent \u2014 last 168 hours  \u00b7  ${d_hourly}",
-      "type": "timeseries"
+      "targets": []
     }
   ],
   "refresh": "5m",
@@ -3952,80 +3467,6 @@
           "uid": "omi-admin-api"
         },
         "hide": 2,
-        "name": "d_notif",
-        "options": [],
-        "query": {
-          "infinityQuery": {
-            "columns": [
-              {
-                "selector": "value",
-                "text": "value",
-                "type": "string"
-              }
-            ],
-            "format": "table",
-            "parser": "backend",
-            "refId": "variable",
-            "root_selector": "",
-            "source": "url",
-            "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=dailyData&fields=mentorSent%2CmarketplaceMentorSent&agg=sum&window=15&label=vs+prev+15d",
-            "url_options": {
-              "data": "",
-              "method": "GET"
-            }
-          },
-          "query": "",
-          "queryType": "infinity"
-        },
-        "refresh": 2,
-        "skipUrlSync": true,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "yesoreyeram-infinity-datasource",
-          "uid": "omi-admin-api"
-        },
-        "hide": 2,
-        "name": "d_reach",
-        "options": [],
-        "query": {
-          "infinityQuery": {
-            "columns": [
-              {
-                "selector": "value",
-                "text": "value",
-                "type": "string"
-              }
-            ],
-            "format": "table",
-            "parser": "backend",
-            "refId": "variable",
-            "root_selector": "",
-            "source": "url",
-            "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=weeklyData&fields=mentorSent%2CmarketplaceMentorSent&agg=sum&window=2&label=vs+prev+2w",
-            "url_options": {
-              "data": "",
-              "method": "GET"
-            }
-          },
-          "query": "",
-          "queryType": "infinity"
-        },
-        "refresh": 2,
-        "skipUrlSync": true,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "yesoreyeram-infinity-datasource",
-          "uid": "omi-admin-api"
-        },
-        "hide": 2,
         "name": "d_pusers",
         "options": [],
         "query": {
@@ -4192,43 +3633,6 @@
             "source": "url",
             "type": "json",
             "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=conversion&fields=mobile&agg=avg&window=15&label=vs+prev+15d",
-            "url_options": {
-              "data": "",
-              "method": "GET"
-            }
-          },
-          "query": "",
-          "queryType": "infinity"
-        },
-        "refresh": 2,
-        "skipUrlSync": true,
-        "type": "query"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "yesoreyeram-infinity-datasource",
-          "uid": "omi-admin-api"
-        },
-        "hide": 2,
-        "name": "d_hourly",
-        "options": [],
-        "query": {
-          "infinityQuery": {
-            "columns": [
-              {
-                "selector": "value",
-                "text": "value",
-                "type": "string"
-              }
-            ],
-            "format": "table",
-            "parser": "backend",
-            "refId": "variable",
-            "root_selector": "",
-            "source": "url",
-            "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fnotifications%3Fdays%3D30&root=hourlyData&fields=mentor%2Cmarketplace&agg=sum&window=84&label=vs+prev+84h",
             "url_options": {
               "data": "",
               "method": "GET"


### PR DESCRIPTION
## Summary
- One 'new user' definition per platform everywhere: first-seen-on-platform (weekly new, daily new, cumulative, all-time ticker, k-factor denominator agree by construction). `Sign In Completed` remains only as the macOS telemetry-activation anchor — mobile never emits it (k-factor mobile denominator was 0).
- k-factor + retention now filter `$os_name` like every other route (`$os` drifts: mobile 30d new users 4,067 vs 3,403).
- Mentor notification volume panels (Firestore account-level messages, delivered to all of a user's devices) cannot be platform-split → All board only; desktop notifications_enabled gauge is a placeholder on mobile. Platform boards stay 38/38 mirrors.

## Verification
Local next dev + proxy, cross-checked against direct PostHog HogQL: macOS userGrowth 28/23/29 (Aug 17–19) == direct first-seen exactly; weekly new 161/191/80 == direct exactly; k-factor newUsers mobile 4,067 == direct 4,067, macos 784 == 784; retention macos D1 58.98% cohort 3,408 vs mobile 39.71%/10,471 (filter differentiates). Builder tests 14/14, deploy-scope 16/16, tsc clean.

## Product invariants affected
none

## Failure class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

