### PR TITLE
feat(admin): UI-edited board layouts persist; hourly auto-refresh

### DIFF
--- a/.github/workflows/gcp_admin.yml
+++ b/.github/workflows/gcp_admin.yml
@@ -83,7 +83,20 @@ jobs:
           runtime_env_vars: OMI_LLM_GATEWAY_URL=${{ vars.OMI_LLM_GATEWAY_URL }}
           require_gateway_url: true
 
+      # The live boards are edited in the Grafana UI (drag/resize persists in
+      # its DB). Only overwrite them when this push actually changes the
+      # checked-in dashboard JSONs — an unconditional apply stomps UI edits on
+      # every unrelated admin deploy.
+      - name: Detect dashboard JSON changes
+        id: dashboards_diff
+        run: |
+          if git diff --name-only "${{ github.event.before || 'HEAD~1' }}" "${{ github.sha }}" -- 'web/admin/grafana/dashboards/*.json' | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Apply checked-in omi-tv dashboard
+        if: github.event_name == 'workflow_dispatch' || steps.dashboards_diff.outputs.changed == 'true'
         env:
           GRAFANA_URL: ${{ vars.GRAFANA_URL }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -252,6 +252,7 @@ def finish(dash, uid: str, title: str) -> dict:
     dash["title"] = title
     dash["links"] = LINKS
     dash["timezone"] = "America/New_York"
+    dash["refresh"] = "1h"  # Nik: auto-refresh at most hourly
     dash.pop("id", None)
     dash.pop("version", None)
     return dash

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -3702,7 +3702,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5m",
+  "refresh": "1h",
   "schemaVersion": 39,
   "tags": [
     "omi",

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -3176,7 +3176,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5m",
+  "refresh": "1h",
   "schemaVersion": 39,
   "tags": [
     "omi",

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -5278,7 +5278,7 @@
       "type": "table"
     }
   ],
-  "refresh": "5m",
+  "refresh": "1h",
   "schemaVersion": 39,
   "tags": [
     "omi",

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -80,6 +80,12 @@ class NycTimeContractTests(unittest.TestCase):
         for uid in BOARDS:
             self.assertEqual(load(uid)["timezone"], "America/New_York", uid)
 
+    def test_auto_refresh_is_hourly(self) -> None:
+        """Layout edits live in Grafana's DB; aggressive auto-refresh churns
+        panels and the boards must not refresh more than once an hour."""
+        for uid in BOARDS:
+            self.assertEqual(load(uid)["refresh"], "1h", uid)
+
     def test_no_bare_date_columns_survive(self) -> None:
         for uid in BOARDS:
             for panel, target, col in timestamp_columns(load(uid)):


### PR DESCRIPTION
## Summary
- Dragged/resized panels now persist: the CI dashboard apply is gated on actual changes to `web/admin/grafana/dashboards/*.json` (or manual dispatch) instead of running on every admin deploy, and the omi-grafana image no longer file-provisions boards (companion image change) — Grafana's DB is the layout master.
- All boards auto-refresh hourly (was 5m), with a builder test pinning it.

## Verification
Builder tests 16/16; deploy-scope contract + fixtures green. Live drag-persistence exercised on prod after the companion image deploy: dragged a panel as the anonymous editor, saved, reloaded past the old clobber cadence — layout persisted.

## Product invariants affected
none

## Failure class
No fix: commits.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

