### PR TITLE
fix(admin): platform boards chart exact-attribution revenue only

### DIFF
--- a/web/admin/app/api/omi/stats/profitability/route.ts
+++ b/web/admin/app/api/omi/stats/profitability/route.ts
@@ -605,22 +605,37 @@ export async function computeProfitability(opts: { days: number; desktopCost: nu
     let subIdx = 0;
     let cumulativeDesktop = 0;
     let cumulativeMobile = 0;
-    const revenue: DailyPoint[] = dateKeys.map((date) => {
-      const endOfDay = Date.parse(`${date}T23:59:59Z`) / 1000;
-      while (subIdx < sortedSubs.length && sortedSubs[subIdx].createdAt <= endOfDay) {
-        const s = sortedSubs[subIdx];
-        if (s.platform === "desktop") cumulativeDesktop += s.monthlyMrr;
-        else if (s.platform === "mobile") cumulativeMobile += s.monthlyMrr;
-        else {
-          cumulativeDesktop += s.monthlyMrr * desktopShare;
-          cumulativeMobile += s.monthlyMrr * mobileShare;
+    // Exact = only subscriptions attributed to the platform; unknown-platform
+    // revenue never enters these. The platform boards chart the exact series
+    // so "Revenue / day (desktop)" cannot include smeared unknown revenue;
+    // the All board keeps the proportional split so its stack ends at live MRR.
+    let cumulativeDesktopExact = 0;
+    let cumulativeMobileExact = 0;
+    const revenue: (DailyPoint & { desktopExact: number; mobileExact: number })[] =
+      dateKeys.map((date) => {
+        const endOfDay = Date.parse(`${date}T23:59:59Z`) / 1000;
+        while (subIdx < sortedSubs.length && sortedSubs[subIdx].createdAt <= endOfDay) {
+          const s = sortedSubs[subIdx];
+          if (s.platform === "desktop") {
+            cumulativeDesktop += s.monthlyMrr;
+            cumulativeDesktopExact += s.monthlyMrr;
+          } else if (s.platform === "mobile") {
+            cumulativeMobile += s.monthlyMrr;
+            cumulativeMobileExact += s.monthlyMrr;
+          } else {
+            cumulativeDesktop += s.monthlyMrr * desktopShare;
+            cumulativeMobile += s.monthlyMrr * mobileShare;
+          }
+          subIdx += 1;
         }
-        subIdx += 1;
-      }
-      const d = round2(cumulativeDesktop);
-      const m = round2(cumulativeMobile);
-      return { date, desktop: d, mobile: m, total: round2(d + m) };
-    });
+        const d = round2(cumulativeDesktop);
+        const m = round2(cumulativeMobile);
+        return {
+          date, desktop: d, mobile: m, total: round2(d + m),
+          desktopExact: round2(cumulativeDesktopExact),
+          mobileExact: round2(cumulativeMobileExact),
+        };
+      });
 
     // Prefer real cost from infra-costs endpoint (Firestore llm_usage buckets
     // + configurable monthly overhead). Fallback to active-users × per-user

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -326,6 +326,16 @@ def build_platform_board(base, scope: str) -> dict:
     for var in ["d_pusers", "d_prev", "d_cost", "d_cpu", "d_conv"]:
         retarget_var(dash, var, fields=profit_field)
 
+    # Revenue must be exact-attribution only: the plain desktop/mobile revenue
+    # series smears unknown-platform subscription MRR proportionally (fine for
+    # the All board's stack, wrong on a platform board).
+    exact_field = f"{profit_field}Exact"
+    revenue_panel = panel_by_title(dash, f"Revenue / day ({profit_field}, est.)")
+    for col in revenue_panel["targets"][0]["columns"]:
+        if col.get("type") != "timestamp":
+            col["selector"] = exact_field
+    retarget_var(dash, "d_prev", fields=exact_field)
+
     if scope == "macos":
         # Board context makes the (macOS) marker redundant.
         panel_by_title(dash, "Activation rate (macOS)")["title"] = "Activation rate"

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -3333,7 +3333,7 @@
               "type": "timestamp"
             },
             {
-              "selector": "desktop",
+              "selector": "desktopExact",
               "text": "Desktop",
               "type": "number"
             }
@@ -4178,7 +4178,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=revenue&fields=desktop&agg=sum&window=15&label=vs+prev+15d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=revenue&fields=desktopExact&agg=sum&window=15&label=vs+prev+15d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -2807,7 +2807,7 @@
               "type": "timestamp"
             },
             {
-              "selector": "mobile",
+              "selector": "mobileExact",
               "text": "Mobile",
               "type": "number"
             }
@@ -3504,7 +3504,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=revenue&fields=mobile&agg=sum&window=15&label=vs+prev+15d",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fprofitability%3Fdays%3D30%26desktop_cost%3D1.2%26mobile_cost%3D0.3&root=revenue&fields=mobileExact&agg=sum&window=15&label=vs+prev+15d",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -251,6 +251,24 @@ class AccountLevelLeakTests(unittest.TestCase):
                         "All board must keep the account-level panels")
 
 
+class ExactRevenueTests(unittest.TestCase):
+    def test_platform_revenue_never_includes_unknown_attribution(self) -> None:
+        """profitability's plain desktop/mobile revenue fields smear
+        unknown-platform subscription MRR proportionally; platform boards must
+        chart only the exact-attribution fields."""
+        for uid, field in [("omi-tv-macos", "desktopExact"), ("omi-tv-mobile", "mobileExact")]:
+            dash = load(uid)
+            panel = next(p for p in dash["panels"]
+                         if build_dashboards.base_title(p).startswith("Revenue / day"))
+            selectors = [c["selector"] for c in panel["targets"][0]["columns"]
+                         if c.get("type") != "timestamp"]
+            self.assertEqual(selectors, [field], uid)
+            var = next(v for v in dash["templating"]["list"] if v["name"] == "d_prev")
+            url = var["query"]["infinityQuery"]["url"]
+            params = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+            self.assertEqual(params["fields"], [field], uid)
+
+
 class BuilderIdempotencyTests(unittest.TestCase):
     def test_rebuild_is_idempotent(self) -> None:
         base = load("omi-tv")


### PR DESCRIPTION
## Summary
profitability's daily `revenue.desktop`/`revenue.mobile` intentionally smear unknown-platform subscription MRR proportionally (so the All board's stacked chart ends at live MRR). The macOS/mobile boards were charting those smeared series as platform revenue. Added `desktopExact`/`mobileExact` (attributed-only) fields; platform boards + their `d_prev` delta variables now use them. Regression test asserts platform revenue panels/vars select only the exact fields.

## Verification
Builder tests 17/17 (new ExactRevenueTests), deploy-scope 16/16, tsc clean. Local dev returns the new fields (zeros locally — no Stripe key; prod check after deploy: `revenue[-1].desktopExact == summary.mrrDesktop` by construction, vs smeared desktop ≈ +$158). Full macOS board re-captured on prod after deploy.

## Product invariants affected
none

## Failure class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

