### PR TITLE
fix(ci): dashboard-apply gate must fetch the before commit

### DIFF
--- a/.github/workflows/gcp_admin.yml
+++ b/.github/workflows/gcp_admin.yml
@@ -90,7 +90,17 @@ jobs:
       - name: Detect dashboard JSON changes
         id: dashboards_diff
         run: |
-          if git diff --name-only "${{ github.event.before || 'HEAD~1' }}" "${{ github.sha }}" -- 'web/admin/grafana/dashboards/*.json' | grep -q .; then
+          # The deploy job checks out at depth 1, so the push's `before` commit
+          # must be fetched or the diff fails — and a failed diff must NOT
+          # count as "changed" (an unconditional apply stomps UI-edited board
+          # layouts). Round-7 regression: silent grep-on-error skipped a real
+          # dashboard apply.
+          BEFORE="${{ github.event.before || 'HEAD~1' }}"
+          git fetch --no-tags --depth=1 origin "$BEFORE" 2>/dev/null || true
+          if ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "::warning::cannot resolve $BEFORE; dashboards not auto-applied — run workflow_dispatch if boards changed"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$BEFORE" "${{ github.sha }}" -- 'web/admin/grafana/dashboards/*.json' | grep -q .; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
The dashboard-apply gate added in #11877 silently failed on real board changes: the deploy job checks out at depth 1, `git diff before..sha` errored on the missing `before` commit, and `grep -q` on empty output reported `changed=false` — round-7's board changes (exact-attribution revenue) were never applied to Grafana. The gate now fetches the `before` commit explicitly and, if it still cannot resolve it, emits a workflow warning and skips (fail-closed, protecting UI-edited layouts) instead of mis-reporting.

## Verification
Round-7 boards applied manually and verified on prod (Revenue panel selector = desktopExact; revenue[-1].desktopExact == summary.mrrDesktop == 5,742.23). Admission contract check green. Gate logic exercised locally with resolvable and unresolvable BEFORE shas.

## Product invariants affected
none

## Failure class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

