### PR TITLE
fix(admin): share-rate tile description names its board's platform scope

### DIFF
--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -247,6 +247,18 @@ def user_growth_series(panel, scope: str, field: str, series_name: str) -> None:
     panel["timeFrom"] = "30d"
 
 
+def set_share_tile_description(dash, platform_label: str) -> None:
+    """The share-rate proxy is platform-scoped per board; keep its description
+    honest about which population the denominator counts."""
+    for panel in dash.get("panels", []):
+        if base_title(panel).startswith("Share rate"):
+            panel["description"] = (
+                f"Sharers ÷ new users, last 30d ({platform_label}). True K-factor needs "
+                "referral attribution — not instrumented yet, so this proxies the "
+                "share loop. 0% = no viral loop shipped."
+            )
+
+
 def finish(dash, uid: str, title: str) -> dict:
     dash["uid"] = uid
     dash["title"] = title
@@ -311,6 +323,8 @@ def build_platform_board(base, scope: str) -> dict:
     cumulative["title"] = f"Cumulative users ({label})  ·  ${{d_cum}}"
     user_growth_series(cumulative, scope, "cumulative", "Total users")
     retarget_var(dash, "d_cum", path=viral_scoped, root="userGrowth", fields="users")
+
+    set_share_tile_description(dash, label)
 
     series_label = "Desktop" if scope == "macos" else "Mobile"
     for title, new_title, series in [
@@ -384,6 +398,7 @@ def build_platform_board(base, scope: str) -> dict:
 def main() -> None:
     base = json.loads(BASE_PATH.read_text(encoding="utf-8"))
     apply_tzdates(base)
+    set_share_tile_description(base, "all platforms")
     apply_platform(base, "all")
     # The two Firestore-backed activation panels are macOS-scoped by
     # definition; their delta var compares macOS activation to stay coherent.

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -488,7 +488,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Sharers \u00f7 new users, last 30d (macOS). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
+      "description": "Sharers \u00f7 new users, last 30d (Mobile). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -571,7 +571,7 @@
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
       },
-      "description": "Sharers \u00f7 new users, last 30d (macOS). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
+      "description": "Sharers \u00f7 new users, last 30d (all platforms). True K-factor needs referral attribution \u2014 not instrumented yet, so this proxies the share loop. 0% = no viral loop shipped.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -251,6 +251,15 @@ class AccountLevelLeakTests(unittest.TestCase):
                         "All board must keep the account-level panels")
 
 
+class ShareTileDescriptionTests(unittest.TestCase):
+    def test_share_tile_description_names_its_board_scope(self) -> None:
+        for uid, label in [("omi-tv", "all platforms"), ("omi-tv-macos", "macOS"),
+                           ("omi-tv-mobile", "Mobile")]:
+            panel = next(p for p in load(uid)["panels"]
+                         if build_dashboards.base_title(p).startswith("Share rate"))
+            self.assertIn(f"last 30d ({label})", panel["description"], uid)
+
+
 class ExactRevenueTests(unittest.TestCase):
     def test_platform_revenue_never_includes_unknown_attribution(self) -> None:
         """profitability's plain desktop/mobile revenue fields smear


### PR DESCRIPTION
## Summary
The share-rate (K-factor proxy) tile description said "(macOS)" on all three boards — stale text from before platform scoping. The builder now writes the correct population label per board (all platforms / macOS / Mobile), with a regression test.

Companion (omi-tv-dashboard repo): proxy request-coalescing fixed so waiters consume the leader's outcome (success / stale fallback / error) instead of each becoming a new leader during upstream outages — one fetch per TTL window under failure, covered by threaded regression tests (3/3).

## Verification
Builder tests 18/18; boards regenerated. This merge also exercises the round-9 apply gate end-to-end (dashboards changed → CI apply must fire); verified in the workflow logs and on the live boards after deploy.

## Product invariants affected
none

## Failure class
Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

