### PR TITLE
fix(backend): stop a dead app webhook from dead-lettering the user's conversation

### DIFF
--- a/.github/failure-classes/FC-third-party-delivery-consumes-owner-retry-budget.json
+++ b/.github/failure-classes/FC-third-party-delivery-consumes-owner-retry-budget.json
@@ -1,0 +1,18 @@
+{
+ "schema_version": 1,
+ "id": "FC-third-party-delivery-consumes-owner-retry-budget",
+ "violated_contract": "A durable job's retry budget belongs to the user work it owns, not to a side effect delivered to a third party. A delivery the job cannot influence may keep that job retryable only while attempts remain: on the terminal attempt the job dead-letters regardless, so failing it one last time buys the delivery nothing and costs the owner its terminal state. An app webhook answering HTTP 530 for days dead-lettered every conversation of every user who installed it, because webhook health only auto-disables an endpoint after 72h.",
+ "canonical_prevention": "Tell the fanout whether the caller still has an attempt left (finalize_persisted_conversation(final_attempt=...) to trigger_external_integrations(last_delivery_attempt=...)) and drop the delivery on the terminal attempt with record_fallback(component='webhook', to_mode='dropped', outcome='exhausted') instead of raising ExternalIntegrationFanoutError. The owner's work reaches its terminal state; the abandoned delivery is visible in fallback telemetry rather than silent.",
+ "evidence_prs": [
+  11883
+ ],
+ "scope_hints": [
+  "backend/utils/app_integrations.py",
+  "backend/utils/conversations/finalizer.py",
+  "backend/routers/conversation_finalization.py"
+ ],
+ "canonical_prevention_artifact": [
+  "backend/tests/unit/test_listen_finalization_cloud_tasks.py"
+ ],
+ "status": "open"
+}

--- a/backend/routers/conversation_finalization.py
+++ b/backend/routers/conversation_finalization.py
@@ -152,6 +152,7 @@ async def run_listen_finalization_job(
                 dispatch_generation=dispatch_generation,
                 lease_epoch=claimed_lease_epoch,
                 force_process=bool(job.get('force_process')),
+                final_attempt=task_retry_count >= get_listen_finalization_tasks_max_attempts_for_worker() - 1,
             )
         except ConversationFinalizationError:
             terminal = await _retry_or_dead_letter(

--- a/backend/tests/unit/test_async_app_integrations.py
+++ b/backend/tests/unit/test_async_app_integrations.py
@@ -351,6 +351,43 @@ class TestDurableExternalIntegrationFanout:
         assert messages == []
         assert client.post.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_retryable_delivery_failure_is_dropped_on_the_last_attempt(self):
+        """A webhook stuck on 5xx must not dead-letter the user's conversation.
+
+        Webhook health only auto-disables an endpoint after 72h, and the
+        terminal attempt dead-letters the job whatever this delivery does, so
+        keeping it retryable only costs the conversation its fanout.
+        """
+        app = _make_app('app-1', 'https://app.test/hook')
+        app.triggers_on_conversation_creation.return_value = True
+        conversation = types.SimpleNamespace(id='conversation-1', discarded=False, is_locked=False, source=None)
+        response = MagicMock(status_code=530, text='origin unreachable')
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=response)
+
+        with patch.object(app_integrations, 'get_available_apps', return_value=[app]), patch.object(
+            app_integrations, 'get_webhook_client', return_value=client
+        ), patch.object(app_integrations, 'conversation_to_dict', return_value={}), patch.object(
+            app_integrations, 'record_fallback'
+        ) as fallback:
+            messages = await app_integrations.trigger_external_integrations(
+                'uid-1',
+                conversation,
+                idempotency_key='fanout-1',
+                require_delivery=True,
+                last_delivery_attempt=True,
+            )
+
+        assert messages == []
+        assert fallback.call_args.kwargs == {
+            'component': 'webhook',
+            'from_mode': 'durable_delivery',
+            'to_mode': 'dropped',
+            'reason': 'provider_5xx',
+            'outcome': 'exhausted',
+        }
+
 
 class TestSSRFConfigRejection:
     """A developer-configured webhook URL that resolves to a non-public

--- a/backend/tests/unit/test_listen_finalization_cloud_tasks.py
+++ b/backend/tests/unit/test_listen_finalization_cloud_tasks.py
@@ -612,7 +612,36 @@ async def test_worker_forwards_rest_force_processing_mode_from_the_durable_job(m
         dispatch_generation=1,
         lease_epoch=1,
         force_process=True,
+        final_attempt=False,
     )
+
+
+@pytest.mark.anyio
+async def test_worker_marks_the_terminal_attempt_so_delivery_cannot_strand_the_conversation(monkeypatch):
+    """The last attempt dead-letters regardless, so the finalizer may drop a failing webhook."""
+    monkeypatch.setattr(finalization_router, 'run_blocking', _inline_run_blocking)
+    monkeypatch.setattr(finalization_router, 'try_acquire_job_run_lock', lambda key: 'lock-token')
+    monkeypatch.setattr(finalization_router, 'release_job_run_lock', lambda key, token: None)
+    monkeypatch.setattr(
+        jobs_db, 'claim_finalization_job', lambda *args, **kwargs: {'status': 'claimed', 'lease_epoch': 1}
+    )
+    monkeypatch.setattr(
+        jobs_db,
+        'get_finalization_job',
+        lambda job_id: {'uid': 'uid-1', 'conversation_id': 'conversation-1', 'created_at': 'accepted-at'},
+    )
+    finalizer = AsyncMock()
+    monkeypatch.setattr(finalization_router, 'finalize_persisted_conversation', finalizer)
+    monkeypatch.setattr(jobs_db, 'mark_finalization_completed', MagicMock(return_value=True))
+    monkeypatch.setattr(finalization_router, 'record_capture_finalization_terminal', MagicMock())
+    monkeypatch.setattr(finalization_router, 'get_listen_finalization_tasks_max_attempts_for_worker', lambda: 3)
+
+    response = await finalization_router.run_listen_finalization_job(
+        _Request({'job_id': 'job-1', 'dispatch_generation': 1}), task_retry_count=2
+    )
+
+    assert response.status_code == 200
+    assert finalizer.await_args.kwargs['final_attempt'] is True
 
 
 @pytest.mark.anyio
@@ -797,6 +826,7 @@ async def test_pusher_claims_the_durable_job_before_finalizing(monkeypatch):
         finalization_job_id='job-1',
         dispatch_generation=3,
         lease_epoch=7,
+        final_attempt=False,
     )
     completed.assert_called_once_with('job-1', 3, 7)
     assert json.loads(websocket.sent[0][4:]) == {'conversation_id': 'conversation-1', 'success': True}
@@ -995,6 +1025,94 @@ async def test_pusher_tells_the_live_session_a_dead_lettered_job_is_terminal(mon
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(('final_attempt', 'expect_completion'), [(False, False), (True, True)])
+async def test_a_webhook_stuck_on_5xx_only_strands_the_conversation_while_retries_remain(
+    monkeypatch, final_attempt, expect_completion
+):
+    """Runs the real finalizer over the real fanout with an app endpoint answering 530.
+
+    A third-party endpoint that has been down for days (webhook health only
+    auto-disables after 72h) failed every attempt of the durable job, so the
+    conversation dead-lettered and its capture journey ended in `failure`. The
+    terminal attempt dead-letters whatever the delivery does, so it drops the
+    delivery and completes the conversation instead.
+    """
+
+    async def inline_run_blocking(_executor, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    conversation = SimpleNamespace(
+        id='conversation-1',
+        status=ConversationStatus.completed,
+        language='en',
+        source=SimpleNamespace(value='omi'),
+        external_data=None,
+        discarded=False,
+        is_locked=False,
+        started_at=datetime(2026, 8, 19, 12, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 8, 19, 12, tzinfo=timezone.utc) + timedelta(minutes=10),
+        transcript_segments=[SimpleNamespace(text='substantive exchange', start=0, end=60)],
+        structured=SimpleNamespace(title='Captured title', overview='Captured overview'),
+    )
+    app = SimpleNamespace(
+        id='app-1',
+        uid='owner-1',
+        enabled=True,
+        external_integration=SimpleNamespace(webhook_url='https://app.test/hook'),
+        triggers_on_conversation_creation=lambda: True,
+    )
+    response = MagicMock(status_code=530, text='origin unreachable')
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+
+    monkeypatch.setattr(persisted_finalizer, 'run_blocking', inline_run_blocking)
+    monkeypatch.setattr(app_integrations, 'run_blocking', inline_run_blocking)
+    monkeypatch.setattr(
+        persisted_finalizer.conversations_db,
+        'get_conversation',
+        lambda *args: {'id': 'conversation-1', 'status': ConversationStatus.completed.value, 'discarded': False},
+    )
+    monkeypatch.setattr(persisted_finalizer, 'deserialize_conversation', lambda value: conversation)
+    monkeypatch.setattr(persisted_finalizer, 'get_cached_user_geolocation', lambda uid: None)
+    monkeypatch.setattr(persisted_finalizer, 'extract_memories', MagicMock())
+    monkeypatch.setattr(persisted_finalizer, 'persist_capture_arrival_intent', MagicMock())
+    monkeypatch.setattr(
+        persisted_finalizer.lifecycle_service,
+        'claim_finalization_fanout',
+        lambda *args: {'status': 'claimed', 'fanout_key': 'conversation:conversation-1:finalization'},
+    )
+    completed = MagicMock(return_value=True)
+    monkeypatch.setattr(persisted_finalizer.lifecycle_service, 'complete_finalization_fanout', completed)
+    monkeypatch.setattr(app_integrations, 'get_available_apps', lambda uid: [app])
+    monkeypatch.setattr(app_integrations, 'is_app_webhook_disabled', lambda app_id: False)
+    monkeypatch.setattr(app_integrations, 'conversation_to_dict', lambda value: {})
+    monkeypatch.setattr(app_integrations, 'safe_request_target', lambda url: (url, {'headers': {}, 'extensions': {}}))
+    monkeypatch.setattr(app_integrations, 'get_webhook_circuit_breaker', lambda url: MagicMock())
+    monkeypatch.setattr(app_integrations, 'get_webhook_client', lambda: client)
+    monkeypatch.setattr(app_integrations, 'record_app_webhook_failure', MagicMock(return_value=0))
+    monkeypatch.setattr(app_integrations, '_handle_webhook_health_action', MagicMock())
+
+    async def finalize():
+        return await persisted_finalizer.finalize_persisted_conversation(
+            'uid-1',
+            'conversation-1',
+            finalization_job_id='job-1',
+            dispatch_generation=2,
+            lease_epoch=3,
+            final_attempt=final_attempt,
+        )
+
+    if expect_completion:
+        assert await finalize() == ConversationFinalizationDisposition.completed
+        completed.assert_called_once()
+    else:
+        with pytest.raises(ConversationFinalizationError):
+            await finalize()
+        completed.assert_not_called()
+    assert client.post.await_count == 1
+
+
+@pytest.mark.anyio
 async def test_finalizer_never_logs_a_provider_exception_body(monkeypatch, caplog):
     async def inline_run_blocking(_executor, func, *args, **kwargs):
         return func(*args, **kwargs)
@@ -1103,6 +1221,7 @@ async def test_completed_conversation_replays_only_the_durable_fanout_boundary(
         conversation,
         idempotency_key='conversation:conversation-1:finalization',
         require_delivery=True,
+        last_delivery_attempt=False,
     )
     if discarded:
         extracted.assert_not_called()

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -87,6 +87,26 @@ def _delivery_failure_is_retryable(status_code: int) -> bool:
     return status_code >= 500 or status_code in _RETRYABLE_DELIVERY_STATUSES
 
 
+def _drop_exhausted_delivery(app_id: str, reason: str) -> None:
+    """Give up on a delivery whose finalization job has no attempt left.
+
+    On the terminal attempt the job dead-letters no matter what this delivery
+    does, so keeping it retryable buys the webhook nothing and costs the user
+    the whole conversation: fanout never completes and the capture journey ends
+    in `failure`. An app endpoint answering 5xx for days (Cloudflare 530) took
+    every conversation of every user who installed it down with it, because
+    webhook health only auto-disables after 72h.
+    """
+    logger.info('durable webhook delivery dropped on final attempt app=%s reason=%s', app_id, reason)
+    record_fallback(
+        component='webhook',
+        from_mode='durable_delivery',
+        to_mode='dropped',
+        reason=reason,
+        outcome='exhausted',
+    )
+
+
 def _notify_app_owner(app_id: str, title: str, body: str):
     """Send a push notification to the app owner about webhook health."""
     try:
@@ -185,6 +205,7 @@ async def trigger_external_integrations(
     *,
     idempotency_key: str | None = None,
     require_delivery: bool = False,
+    last_delivery_attempt: bool = False,
 ) -> list:
     """ON CONVERSATION CREATED — uses asyncio.gather + httpx (Lane 1).
 
@@ -192,6 +213,10 @@ async def trigger_external_integrations(
     retry an interrupted external fanout without creating a second effect.
     They also require a delivery acknowledgement, preserving the existing
     best-effort behavior for non-finalization callers.
+
+    `last_delivery_attempt` marks the finalization job's terminal attempt: the
+    retry budget is spent, so a failed delivery is dropped with telemetry
+    instead of failing the conversation's fanout one final time.
     """
     if not conversation or conversation.discarded:
         return []
@@ -241,7 +266,10 @@ async def trigger_external_integrations(
         if not cb.allow_request():
             logger.info(f'trigger_external_integrations: circuit breaker open for {app.id}')
             if require_delivery:
-                failed_deliveries.append(app.id)
+                if last_delivery_attempt:
+                    _drop_exhausted_delivery(app.id, 'circuit_open')
+                else:
+                    failed_deliveries.append(app.id)
             return
 
         try:
@@ -270,7 +298,13 @@ async def trigger_external_integrations(
                 )
                 if require_delivery:
                     if _delivery_failure_is_retryable(response.status_code):
-                        failed_deliveries.append(app.id)
+                        if last_delivery_attempt:
+                            _drop_exhausted_delivery(
+                                app.id,
+                                'provider_429' if response.status_code == 429 else 'provider_5xx',
+                            )
+                        else:
+                            failed_deliveries.append(app.id)
                     else:
                         # The destination rejected this payload permanently (expired
                         # OAuth token, deleted target, malformed for that app). Every
@@ -321,7 +355,10 @@ async def trigger_external_integrations(
             await run_blocking(db_executor, _handle_webhook_health_action, app.id, action, error_str)
             logger.error('Plugin integration request failed app=%s error=%s', app.id, type(e).__name__)
             if require_delivery:
-                failed_deliveries.append(app.id)
+                if last_delivery_attempt:
+                    _drop_exhausted_delivery(app.id, 'timeout' if isinstance(e, TimeoutError) else 'other')
+                else:
+                    failed_deliveries.append(app.id)
             return
 
     await gather_safe(*[_single(app) for app in filtered_apps], label="trigger_integrations", max_concurrency=10)

--- a/backend/utils/conversations/finalizer.py
+++ b/backend/utils/conversations/finalizer.py
@@ -44,12 +44,17 @@ async def finalize_persisted_conversation(
     dispatch_generation: int,
     lease_epoch: int,
     force_process: bool = False,
+    final_attempt: bool = False,
 ) -> ConversationFinalizationDisposition:
     """Finalize persisted data once the caller has acquired the job lease.
 
     The pusher WebSocket request already installs request-scoped BYOK context
     before calling this helper.  Cloud Tasks never does, so it cannot silently
     substitute platform credentials for a BYOK job.
+
+    `final_attempt` says the job has no retry left, so a failed external
+    integration delivery is dropped rather than dead-lettering the whole
+    conversation for a third-party endpoint that is down.
     """
     conversation_data = await run_blocking(db_executor, conversations_db.get_conversation, uid, conversation_id)
     if not conversation_data:
@@ -163,6 +168,7 @@ async def finalize_persisted_conversation(
             conversation,
             idempotency_key=fanout['fanout_key'],
             require_delivery=True,
+            last_delivery_attempt=final_attempt,
         )
         # Publish the content-free capture-arrival intent before marking the
         # durable fanout projection completed. Desktop waits on that projection

--- a/backend/utils/pusher_finalization.py
+++ b/backend/utils/pusher_finalization.py
@@ -161,6 +161,7 @@ async def process_conversation_task(
             finalization_job_id=job_id,
             dispatch_generation=generation,
             lease_epoch=lease_epoch,
+            final_attempt=attempt_count >= get_listen_finalization_tasks_max_attempts(),
         )
 
         if disposition == ConversationFinalizationDisposition.fenced:


### PR DESCRIPTION
## Bug

A user's conversation finalization job treats **every** retryable external-integration delivery failure as a reason to retry the whole job. App `01KZX86TEG097S17H9TGJ3BVD9` has been answering **HTTP 530** (Cloudflare origin unreachable) — 25 deliveries in the 24h to 2026-08-19T21:00Z on `api.omi.me`. Each failure raised `ExternalIntegrationFanoutError`, so `POST /v1/conversation-finalization-jobs/run` returned 500 on all 5 Cloud Tasks attempts (they burn in ~2 minutes, since the endpoint fails instantly) and the job dead-lettered.

Dead-lettering means `complete_finalization_fanout` never runs and `record_capture_finalization_terminal('failure')` is recorded — the user's conversation never finalizes. **8 conversations across 2 users in 24h**, e.g.:

```
18:04:01Z INFO:httpx:HTTP Request: POST https://[2606:4700:3030::6815:5fa4]/omi/webhook?uid=vjobe... "HTTP/1.1 530 <none>"
18:04:05Z ERROR:utils.conversations.finalizer:persisted conversation finalization failed
          uid=vjobe6DiVWOU4tJzXmFdZNT1AO53 conversation=bda02dd1-f792-4d91-834b-476b6962bf61 failure=processing_failed
```

Memory extraction had already succeeded on that attempt ("Saving 6 canonical memories"); only the third-party delivery failed.

## Root cause

The durable job's retry budget belongs to the user's conversation, but a third-party endpoint gets to spend it. Webhook health (`record_app_webhook_failure`) only auto-disables such an endpoint after **72h**, so for up to three days every conversation of every user who installed that app is lost. `_delivery_failure_is_retryable` already encodes the right principle for permanent rejections (401/404 → drop, don't strand the conversation); it just never applied to an endpoint that returns 5xx forever.

## Fix

On the **terminal** attempt the job dead-letters whatever the delivery does, so keeping it retryable there buys the webhook nothing and costs the conversation its terminal state.

- `finalize_persisted_conversation(final_attempt=...)` — set from the Cloud Tasks retry count (`task_retry_count >= max_attempts - 1`) and from the pusher's claimed `attempt_count`.
- `trigger_external_integrations(last_delivery_attempt=...)` — on the last attempt a failed delivery is dropped via `record_fallback(component='webhook', from_mode='durable_delivery', to_mode='dropped', outcome='exhausted')` instead of raising.
- Behaviour while retries remain is unchanged; non-finalization callers are unaffected.

## Tested

- `tests/unit/test_listen_finalization_cloud_tasks.py` — 96 passed; `tests/unit/test_async_app_integrations.py` — 19 passed (repo runner runs each file in its own process).
- New regression test `test_a_webhook_stuck_on_5xx_only_strands_the_conversation_while_retries_remain` drives the **real** finalizer over the **real** fanout with a webhook returning 530: `final_attempt=False` still raises `ConversationFinalizationError` and never completes fanout; `final_attempt=True` completes the conversation with one delivery attempt made. Verified it **fails on the pre-fix code** (reverted the drop branch: 3 failed) and passes here.
- `make preflight` — all manifest checks pass.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

