### PR TITLE
docs(admin): grafana README matches the shipped platform boards

### DIFF
--- a/web/admin/grafana/README.md
+++ b/web/admin/grafana/README.md
@@ -1,13 +1,16 @@
 The `/dashboard` page embeds Grafana uid `omi-tv` (`/grafana/d/omi-tv/omi-tv`).
-The live board used to live only in Grafana's database. The checked-in copies
-are `dashboards/*.json` — three boards linked by the All / macOS / Mobile
-switcher at the top of each:
+The checked-in copies are `dashboards/*.json` — three boards linked by the
+All / macOS / Mobile switcher at the top of each:
 
 | uid | scope |
 |---|---|
 | `omi-tv` | all platforms combined (source of truth, edit this one) |
-| `omi-tv-macos` | macOS-native panels + desktop series from `profitability` |
-| `omi-tv-mobile` | the honestly-available mobile view (mobile DAU/retention are not instrumented; the board says so) |
+| `omi-tv-macos` | the same board scoped to macOS (`platform=macos` on the PostHog routes; desktop series of `profitability`) |
+| `omi-tv-mobile` | the same board scoped to iOS/Android/iPadOS (`platform=mobile`; mobile series of `profitability`). Mobile is fully instrumented in PostHog for usage metrics (iOS since 2025-03, Android since 2026-05) but emits no `Sign In Completed`, so its cohorts anchor on first-seen-any-event. Desktop-only surfaces (floating bar, crash telemetry, the desktop notifications toggle) are explicit placeholders. |
+
+Account-level metrics with no platform dimension (mentor "Omi says" volumes,
+the notifications-enabled gauge) live on the All board only — see
+`ACCOUNT_LEVEL_TITLES` in the builder.
 
 ## Build
 
@@ -18,30 +21,38 @@ python3 web/admin/grafana/build_dashboards.py
 ```
 
 which derives `omi-tv-macos.json` / `omi-tv-mobile.json` and re-applies the
-shared contract to all three: timezone pinned to `America/New_York`, switcher
-links, and every daily/weekly/monthly date column routed through the proxy's
-`_tzdates` rewrite (bare `YYYY-MM-DD` strings parse as UTC midnight, which
-renders as 8 pm the previous NYC day and hides the latest day). The builder is
-idempotent; commit all three outputs. `test_build_dashboards.py` (manifest
-check `grafana-dashboard-build`) enforces the contract.
+shared contract to all three: timezone pinned to `America/New_York`, hourly
+auto-refresh, switcher links, `platform=` pinned on every PostHog-backed
+query (viral-metrics, dau-trends, retention, k-factor — behavioral coverage
+in `web/admin/lib/__tests__/platform-scope-routes.test.ts`), exact-attribution
+revenue fields on the platform boards, and every daily/weekly/monthly date
+column routed through the proxy's `_tzdates` rewrite (bare `YYYY-MM-DD`
+strings parse as UTC midnight, which renders as 8 pm the previous NYC day and
+hides the latest day). The builder is idempotent; commit all three outputs.
+`test_build_dashboards.py` (manifest check `grafana-dashboard-build`) enforces
+the contract.
 
 ## Activation panels
 
-Those two panels read Firestore-backed activation, not PostHog `Memory Created`:
+Activation sources differ by board:
 
-| Panel | URL | Selector |
+| Board | Source | Definition |
 |---|---|---|
-| Activation rate | `/api/omi/stats/activation?days=60` | `rate` |
-| Activation (signup → activated) | `/api/omi/stats/activation?days=60` | `weeks[]` (`week`/`date`, `signups`, `activated`, `rate`) |
+| All, macOS | `/api/omi/stats/activation?days=60` (Firestore) | macOS signup activated iff a conversation exists in the first 7 days (`rate`, `weeks[]`) |
+| Mobile | `viral-metrics?platform=mobile` (PostHog telemetry) | first-seen mobile user with `Memory Created` within 7 days (`activation[]`, `summary.activationRate`) |
 
-macOS signup is activated iff a conversation exists in the first 7 days.
-PostHog coverage stays on viral-metrics as `summary.activationTelemetryCoverage`.
+PostHog coverage for the macOS telemetry path stays on viral-metrics as
+`summary.activationTelemetryCoverage`; the Firestore compat overlay applies
+only to the macOS scope.
 
 ## Apply
 
-`apply_omi_tv_dashboard.py` POSTs every `dashboards/*.json` (uids restricted
-to the three boards above) to the Grafana HTTP API. It no-ops when
-`GRAFANA_TOKEN` is unset — do not invent a write token.
+Grafana's database is the layout master — drag/resize edits made in the UI
+persist there. `apply_omi_tv_dashboard.py` overwrites the boards with the
+checked-in JSONs (uids restricted to the three above), so it runs only when a
+push actually changes `dashboards/*.json` (see the gated step in
+`gcp_admin.yml`) or on `workflow_dispatch`. It no-ops when `GRAFANA_TOKEN` is
+unset — do not invent a write token.
 
 ```bash
 export GRAFANA_URL="https://admin.omi.me/grafana"   # optional
@@ -49,7 +60,5 @@ export GRAFANA_TOKEN="..."                         # Grafana service-account tok
 python3 web/admin/grafana/apply_omi_tv_dashboard.py
 ```
 
-`gcp_admin.yml` runs the same script after a successful admin deploy. If the
-workflow secret `GRAFANA_TOKEN` is absent, apply is skipped and the Cloud Run
-ship still succeeds. Until the JSON is applied, `viral-metrics` overlays the
-Firestore activation cache onto `summary.activationRate` and `activation[]`.
+Note: large POSTs through the admin.omi.me rewrite get dropped — CI uses the
+repo variable `GRAFANA_URL` pointing at the direct Cloud Run URL.


### PR DESCRIPTION
## Summary
README caught up with the code: mobile is fully instrumented in PostHog (the old 'not instrumented' claim predates the platform work), activation sources are documented per board (Firestore for All/macOS, PostHog telemetry with first-seen cohorts for Mobile), and the apply section documents the UI-master layout model, the diff-gated CI apply, and the direct-URL requirement for large POSTs.

## Verification
Docs-only. Focused suites re-run green: builder 18/18, deploy-scope 16/16, vitest 131/131, tsc clean, eslint 0 errors.

## Product invariants affected
none

## Failure class
No fix: commits.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

