### PR TITLE
fix(desktop): project embedding into the compacted backfill CTE

### DIFF
--- a/.github/failure-classes/FC-cte-filter-on-unprojected-column.json
+++ b/.github/failure-classes/FC-cte-filter-on-unprojected-column.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-cte-filter-on-unprojected-column",
+  "violated_contract": "A raw SQL statement's outer query may only reference columns its CTE or subquery actually projects. SQLite resolves the reference when the statement is prepared, not when a row is scanned, so a filter on an unprojected column fails every single call regardless of whether any row would have matched. The result is a whole-feature outage that reads like a rare data-dependent edge case, and the throw surfaces far from the query in whatever caller wraps it.",
+  "canonical_prevention": "Execute every raw SQL string in a test against the real migrated schema. Preparation precedes the scan, so even a test that only exercises the empty case catches this — but only if the query is executed at all. A query reachable solely behind a rollout flag therefore needs a test that turns that flag on, otherwise the statement ships never having been prepared once.",
+  "canonical_prevention_artifact": [
+    "desktop/macos/Desktop/Tests/ScreenActivityLosslessSyncTests.swift"
+  ],
+  "evidence_prs": [
+    11865
+  ],
+  "scope_hints": [
+    "desktop/macos/**"
+  ],
+  "status": "open"
+}

--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
@@ -55,6 +55,16 @@ extension RewindDatabase {
   /// `cutoff` admits a bucket only once the whole bucket has closed — ranking a partially
   /// visible bucket would embed one winner now and a different winner once the rest ages in.
   /// See `ScreenActivitySyncService.bucketEligibilityCutoffEpoch`.
+  ///
+  /// `embedding` is projected into `ranked` even though the caller never reads it: the outer
+  /// filter runs against the CTE, not `screenshots`, so omitting it made SQLite reject the
+  /// statement at prepare time with `no such column: embedding` — on every call, for every
+  /// user, not just when a bucket had a winner. That threw out of `runBackfill`, so no
+  /// lossless-compaction account ever backfilled a screen vector. It read as a CI flake
+  /// because the desktop Swift phase only runs when a PR touches `desktop/`, so the
+  /// intervening green `main` runs had skipped the suite rather than passed it.
+  /// Ranking still happens before the filter, which is what keeps the query idempotent:
+  /// a bucket's winner is chosen among all its rows and drops out once it has an embedding.
   func getCompactedScreenshotsMissingEmbeddings(limit: Int = 100, olderThan cutoff: Date) throws -> [(
     id: Int64, ocrText: String, appName: String, windowTitle: String?
   )] {
@@ -67,7 +77,7 @@ extension RewindDatabase {
         db,
         sql: """
           WITH ranked AS (
-            SELECT id, ocrText, appName, windowTitle,
+            SELECT id, ocrText, appName, windowTitle, embedding,
                    ROW_NUMBER() OVER (
                      PARTITION BY appName, COALESCE(windowTitle, ''),
                                   CAST(strftime('%s', timestamp) AS INTEGER) / 300

--- a/desktop/macos/changelog/unreleased/20260819-compacted-screen-vector-backfill.json
+++ b/desktop/macos/changelog/unreleased/20260819-compacted-screen-vector-backfill.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed screen search vectors never backfilling for accounts on the new lossless screen history"
+}


### PR DESCRIPTION
## Summary

`getCompactedScreenshotsMissingEmbeddings` filtered its CTE on `embedding IS NULL`
while the CTE projected only `id, ocrText, appName, windowTitle, bucketRank`.
SQLite resolves column references at prepare time, so the statement failed with
`no such column: embedding` on **every call, for every user**, independent of data.

The throw propagates out of `OCREmbeddingService.runBackfill`, so no account on the
lossless-compaction path has ever backfilled a screen vector — paid-tier screen
search was silently inert for those users.

Failure-Class: new

## Evidence

Reproduced deterministically in isolation, red before and green after the change:

    xcrun swift test --package-path Desktop --filter 'ScreenshotEmbeddingBackfillRecoveryTests/'

The existing regression test already covered this. It read as a CI flake because the
desktop Swift phase only runs when a PR touches `desktop/`; the intervening green
`main` runs had **skipped** the suite, not passed it.

The defect reached `main` because #11865 merged at 18:40Z with both desktop Swift
checks red. `main` has no required status checks.

## Scope

Ranking still precedes the filter, so idempotency is unchanged: a bucket's winner is
chosen among all its rows and drops out once it has an embedding. The two sibling CTEs
(the `EXISTS` variant in this file, and `ScreenActivitySyncService`) were audited and
each already projects every column its outer query references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

