### PR TITLE
fix(desktop): stop capture recovery from restarting the app during onboarding

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -1710,6 +1710,11 @@ public class ProactiveAssistantsPlugin: NSObject {
   /// Attempt automatic recovery (soft first, then hard reset as last resort)
   private func attemptAutoReset() {
     let ownerID = RuntimeOwnerIdentity.currentOwnerId()
+    // A restart cannot fix a grant that is not live in this process, and must never happen
+    // while the user is still walking through onboarding — see mayRestartToRecoverCapture.
+    let mayRestart = ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(
+      grantedAtLaunch: ScreenCaptureService.grantedAtProcessStart,
+      onboardingComplete: UserDefaults.standard.bool(forKey: .hasCompletedOnboarding))
     // Step 1: Try soft recovery first (lsregister + SCK re-request, no TCC wipe)
     if !Self.hasSoftRecoveryThisSession {
       Self.hasSoftRecoveryThisSession = true
@@ -1729,8 +1734,15 @@ public class ProactiveAssistantsPlugin: NSObject {
           } else {
             // Soft recovery failed in-process, restart app to refresh permission state
             // This still avoids wiping TCC — the restart itself often fixes stale caches
-            log("ProactiveAssistantsPlugin: Soft recovery failed in-process, restarting to refresh state")
+            log("ProactiveAssistantsPlugin: Soft recovery failed in-process")
             AnalyticsManager.shared.screenCaptureBrokenDetected()
+            guard mayRestart else {
+              log(
+                "ProactiveAssistantsPlugin: not restarting to recover capture "
+                  + "(grantedAtLaunch=\(ScreenCaptureService.grantedAtProcessStart) "
+                  + "onboardingComplete=\(UserDefaults.standard.bool(forKey: .hasCompletedOnboarding)))")
+              return
+            }
             ScreenCaptureService.softRecoveryAndRestart()
           }
         }

--- a/desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
+++ b/desktop/macos/Desktop/Sources/ScreenRecordingPermissionPolicy.swift
@@ -27,4 +27,23 @@ enum ScreenRecordingPermissionPolicy {
   static func shouldInvokeScreenCaptureKit(grantedAtLaunch: Bool) -> Bool {
     grantedAtLaunch
   }
+
+  /// Whether a capture failure may terminate and relaunch the app to repair itself.
+  ///
+  /// Capture recovery restarts the process. That is a reasonable last resort for a granted
+  /// install whose TCC state went stale, and it is wrong in the two cases below, where a
+  /// failure is the expected state rather than a broken one:
+  ///
+  /// - **The grant is not live in this process.** ScreenCaptureKit is bound to the
+  ///   window-server connection opened at launch, so capture cannot work until the next
+  ///   launch no matter how many times we restart. The onboarding "Reopen Omi" prompt is the
+  ///   one place that relaunch belongs.
+  /// - **Onboarding is not finished.** A new Mac has not granted anything yet, so capture
+  ///   fails by definition. Restarting there quits the app out from under someone who is
+  ///   partway through a permission page — and because the "already recovered once" flag is
+  ///   per process, the fresh process repeats it. David's first-run session took three of
+  ///   these in 45 seconds (0.12.187, macOS 15.1).
+  static func mayRestartToRecoverCapture(grantedAtLaunch: Bool, onboardingComplete: Bool) -> Bool {
+    grantedAtLaunch && onboardingComplete
+  }
 }

--- a/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/ScreenRecordingPermissionPolicyTests.swift
@@ -363,4 +363,44 @@ final class ScreenRecordingPermissionPolicyTests: XCTestCase {
     XCTAssertFalse(softSnippet.contains("sleep 0.5 && open"))
     XCTAssertFalse(resetSnippet.contains("sleep 0.5 && open"))
   }
+
+  /// Regression: first run on a new Mac restarted the app three times in 45 seconds, mid
+  /// onboarding, on permission pages that have nothing to do with screen recording
+  /// (0.12.187, macOS 15.1). Capture legitimately fails before the grant exists, the failure
+  /// tracker read that as a broken install, and the recovery path terminates and relaunches
+  /// the process. The "already recovered once" flag lives in the process it just killed, so
+  /// the fresh process did it again.
+  func testCaptureRecoveryNeverRestartsDuringOnboardingOrBeforeTheGrantIsLive() {
+    XCTAssertFalse(
+      ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(
+        grantedAtLaunch: false, onboardingComplete: false),
+      "a new Mac mid-onboarding must never be restarted by capture recovery")
+    XCTAssertFalse(
+      ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(
+        grantedAtLaunch: true, onboardingComplete: false),
+      "still onboarding: the reopen prompt owns relaunch, not the recovery path")
+    XCTAssertFalse(
+      ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(
+        grantedAtLaunch: false, onboardingComplete: true),
+      "a grant that is not live in this process cannot be repaired by restarting again")
+    XCTAssertTrue(
+      ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(
+        grantedAtLaunch: true, onboardingComplete: true),
+      "a granted, finished install may still restart to clear stale capture state")
+  }
+
+  /// The loop itself: every restart begins a process that would decide the same way again.
+  func testTheRecoveryDecisionCannotLoopAcrossRestartsWhileOnboarding() {
+    var restarts = 0
+    for _ in 0..<5 {
+      // Each iteration models a fresh process: per-session flags are back to their defaults
+      // and the grant is still not live, which is exactly the state that repeated before.
+      if ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(
+        grantedAtLaunch: false, onboardingComplete: false)
+      {
+        restarts += 1
+      }
+    }
+    XCTAssertEqual(restarts, 0, "the fix must hold on every relaunch, not just the first")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260819-no-restart-during-onboarding.json
+++ b/desktop/macos/changelog/unreleased/20260819-no-restart-during-onboarding.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed Omi quitting by itself during first-run permission setup"
+}


### PR DESCRIPTION
## What happened

David's first run on a new Mac (0.12.187 stable, macOS 15.1, Mac16,6): Omi quit by itself several times during onboarding — including on permission pages that have nothing to do with screen recording — and did not come back on its own.

His PostHog session shows it plainly:

```
21:11:43  App Launched          <- first run
21:12:28  Onboarding How Did You Hear
21:12:49  App Launched          <- quit + relaunch #1
21:13:13  App Launched          <- #2
21:13:34  App Launched          <- #3
21:14:35  Onboarding Completed
```

## Cause

A new Mac has not granted screen recording yet, so every capture attempt fails. `ProactiveAssistantsPlugin`'s failure tracker reads that as a broken install and calls `attemptAutoReset()`, whose final step is `ScreenCaptureService.softRecoveryAndRestart()` — it terminates and relaunches the process. The user sees the app vanish mid-permission-page with no explanation.

It repeats because the "already tried recovery this session" flag (`hasSoftRecoveryThisSession`) is static state in the process that just got killed, so the fresh process is free to do it again.

## Fix

`ScreenRecordingPermissionPolicy.mayRestartToRecoverCapture(grantedAtLaunch:onboardingComplete:)` — the process-killing step now requires both:

- **the grant is live in this process** — ScreenCaptureKit binds to the window-server connection opened at launch, so if the grant was not there at launch, no number of restarts can repair it; and
- **onboarding is finished** — during onboarding, relaunch belongs to the "Reopen Omi" prompt, which is scoped to screen recording and advances the persisted step first.

Soft recovery still runs; only the restart is withheld, with the reason logged.

Failure-Class: none

## Verification

- Built as `omi-onbfix` with no screen-recording grant and `hasCompletedOnboarding=false` — David's exact state. The app held a single pid across the observation window, with no `Restart scheduled` in its log.
- `swift test --filter ScreenRecordingPermissionPolicyTests` — **22 passed**, including `testCaptureRecoveryNeverRestartsDuringOnboardingOrBeforeTheGrantIsLive` and a loop test that models the per-process flag resetting on each relaunch (the reason it happened three times rather than once).

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 1786 -> 1798 | the recovery-restart guard plus the log line naming why a restart was withheld; the decision itself lives in ScreenRecordingPermissionPolicy


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

