### PR TITLE
fix(context-for-claude): make the analytics tell the truth — the suite was reporting as production

### DIFF
--- a/.github/failure-classes/FC-identity-fallback-used-as-authorization-gate.json
+++ b/.github/failure-classes/FC-identity-fallback-used-as-authorization-gate.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-identity-fallback-used-as-authorization-gate",
+  "violated_contract": "A predicate that decides whether a process may act as the release must be derived from what that process actually reported about itself, never from an identity resolver whose contract is to supply a default for callers it does not recognise. Those resolvers exist so that unrelated processes still get a usable log subsystem, Keychain service or support directory, and defaulting an unknown principal INTO the shipping identity is the correct answer for all of those. Reusing the same answer as a gate inverts it: every foreign process is admitted as the release precisely because it could not be identified. Context for Claude derived `isDevelopmentBuild` from `ownIdentifier`, whose fallback hands the shipping bundle id to anything not running from a bundle of ours, so under `swift test` -- where Bundle.main is `com.apple.dt.xctest.tool` -- the suite was indistinguishable from the notarized app and POSTed to production PostHog from the real spool for as long as the suite had existed. It is silent by construction: the gate reports healthy, the events are well-formed, and the pollution is only visible by decoding a foreign bundle's version out of the payload.",
+  "canonical_prevention": "Keep the two questions separate and name them apart: an identity resolver answers 'which identity does this process own' and may default; a gate answers 'is this process the shipping app' over the raw reported identifier and treats unknown as no. Anything that phones home, spends quota, or writes shared production state asks the gate. Prove it from inside the process that was wrongly admitted -- a test asserting the suite itself is refused is the only seam that would have caught this -- and pair it with a pure table over the reported identifier covering nil, empty, a foreign id, and the dev-suffixed id.",
+  "canonical_prevention_artifact": [
+    "desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift",
+    "desktop/context-for-claude/Tests/ContextCoreTests/BuildIdentityTests.swift"
+  ],
+  "evidence_prs": [
+    11863
+  ],
+  "scope_hints": [
+    "desktop/context-for-claude/Sources/ContextCore/Paths.swift",
+    "desktop/context-for-claude/Sources/ContextApp/Support/Analytics/**"
+  ],
+  "status": "open"
+}

--- a/desktop/context-for-claude/Sources/ContextApp/Engine.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Engine.swift
@@ -1539,10 +1539,15 @@ private final class EngineStore: @unchecked Sendable {
                 personId: line.personId,
                 backendConversationId: line.backendConversationId,
                 backendSegmentId: line.backendSegmentId)
-            if segment.backendConversationId != nil, segment.backendSegmentId != nil {
-                try store.upsertCloudSegment(segment)
-            } else {
-                try store.insertSegment(segment)
+            // Wrapped rather than followed by an emit, so the report cannot outlive a throw. A
+            // cloud segment counts the same as a local one: it is this Mac's audio, transcribed a
+            // hop away. Once per install; every later write reports nothing.
+            try ContextAnalytics.recordFirstArtifact(.conversation) {
+                if segment.backendConversationId != nil, segment.backendSegmentId != nil {
+                    try store.upsertCloudSegment(segment)
+                } else {
+                    try store.insertSegment(segment)
+                }
             }
             // `max`, because a 10 s window from the other transcriber can land out of order and
             // must not drag the session's end backwards.
@@ -1554,7 +1559,7 @@ private final class EngineStore: @unchecked Sendable {
 
     private func insert(_ frame: Frame, into store: ContextStore) {
         do {
-            try store.insertFrame(frame)
+            try ContextAnalytics.recordFirstArtifact(.screen) { try store.insertFrame(frame) }
         } catch {
             ContextLog.error("Dropped a screen frame: \(error.localizedDescription)", "store")
         }

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
@@ -186,6 +186,16 @@ final class SearchBarWindow {
         // search beat — is being told a fact about the display, so it is announced after the display
         // has it and not before.
         SearchPanelWatch.report(.opened)
+        // **This branch and not the one above**, which is the difference between "the surface was
+        // opened" and "a key was pressed at a surface that was already up". Here rather than at the
+        // callers because there are five of them — the gesture, the bound shortcut, the menu bar,
+        // the timeline's "Search All" pill and the tutorial's own button — and a per-caller emit
+        // would have measured whichever ones somebody remembered.
+        //
+        // Not implied by `cfc_gesture_fired`: that counts the gesture, which also *closes* an open
+        // panel and fires from a Mac where the panel never appeared at all. This is the app's
+        // primary surface, and it was the only one in `Surface` with no emitter.
+        ContextAnalytics.record(.surfaceOpened(.search))
     }
 
     /// **Activating a result: open the timeline there, then get out of the way.**

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
@@ -77,6 +77,20 @@ enum AnalyticsEvent: Sendable {
     /// A local search ran. Length buckets only, never the query.
     case searchRan(resultCountBucket: CountBucket)
 
+    /// **The first thing this install ever durably stored**, and the only evidence that the app has
+    /// done its job for somebody rather than merely run.
+    ///
+    /// Nothing else in this schema distinguishes an install that captured all day from one that
+    /// captured nothing: `cfc_capture_state` says a source went live, which is a microphone being
+    /// switched on and says nothing about a row landing; `cfc_daily_active` carries capture minutes,
+    /// which the same install reports on its hundredth day as on its first. Activation is "did the
+    /// thing that makes this product a product ever happen here", and it needs the one moment it
+    /// first did.
+    ///
+    /// Once per install, and *not* once per artifact: this is the activation moment, and a per-write
+    /// event would be a capture pipeline reporting itself several times a second.
+    case firstArtifact(ArtifactKind)
+
     // MARK: - Health — "does it work for them"
 
     /// Sparkle's outcome. Update health is invisible without this and an app that silently stops
@@ -145,6 +159,23 @@ enum AnalyticsEvent: Sendable {
         case activity
         case settings
         case search
+    }
+
+    /// What the install first stored. **Two cases, because two things are stored**, and a case with
+    /// no emitter is the defect this file's `Surface` comment already names.
+    ///
+    /// A memory is conspicuously absent and that is a fact about the product, not an omission: this
+    /// app never stores one. `create_memory` writes to the Omi account, from
+    /// `context-for-claude-mcp` — a different process, spawned by Claude and killed without warning,
+    /// which cannot report anything (see `ToolCallLedger`, and `docs/analytics.md`). The local
+    /// `account_rows` cache is a copy of what the account already holds and is explicitly never an
+    /// authority, so first-storing a *downloaded* memory would fire this for an install that has
+    /// captured nothing at all — the exact question it exists to answer.
+    enum ArtifactKind: String, Sendable, CaseIterable {
+        /// A transcript segment — speech this Mac heard, now on disk.
+        case conversation
+        /// A screen frame.
+        case screen
     }
 
     enum UpdateOutcome: String, Sendable, CaseIterable {
@@ -230,6 +261,7 @@ enum AnalyticsEvent: Sendable {
         case .gestureFired: return "cfc_gesture_fired"
         case .surfaceOpened: return "cfc_surface_opened"
         case .searchRan: return "cfc_search_ran"
+        case .firstArtifact: return "cfc_first_artifact"
         case .updateOutcome: return "cfc_update_outcome"
         case .fallback: return "cfc_fallback"
         }
@@ -265,6 +297,9 @@ enum AnalyticsEvent: Sendable {
 
         case let .searchRan(bucket):
             return ["result_count": .string(bucket.rawValue)]
+
+        case let .firstArtifact(kind):
+            return ["kind": .string(kind.rawValue)]
 
         case let .updateOutcome(outcome):
             return ["outcome": .string(outcome.rawValue)]

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -203,6 +203,47 @@ enum ContextAnalytics {
         return .onboardingFinished(secondsElapsed: Int(max(0, now.timeIntervalSince1970 - started)))
     }
 
+    // MARK: - Activation
+
+    /// Performs one durable write and reports this install's first artifact **only if it landed**.
+    ///
+    /// The write is threaded through the report rather than sitting above a call to it, because
+    /// "after the write" is an ordering a call site can get wrong in silence: an emit a line too
+    /// early, or one that drifted into the `catch` a later refactor added, claims an install as
+    /// activated on the strength of an attempt. `EngineStore` catches and logs every failed insert,
+    /// so an install whose writes all fail is exactly the install this must not count — and here
+    /// there is nowhere to put the emit that a throw does not skip.
+    ///
+    /// Both call sites are on `EngineStore`'s serial writer queue, so the check-then-set inside
+    /// `firstArtifactEvent` cannot interleave with itself: a frame and a transcript line landing in
+    /// the same instant are still two turns of one queue. That is the only reason a plain
+    /// `UserDefaults` flag is enough here, where the defaults it sits beside are main-actor writes.
+    @discardableResult
+    static func recordFirstArtifact<Stored>(
+        _ kind: AnalyticsEvent.ArtifactKind,
+        in defaults: UserDefaults = .standard,
+        stored write: () throws -> Stored
+    ) rethrows -> Stored {
+        let stored = try write()
+        if let event = firstArtifactEvent(kind, in: defaults) { record(event) }
+        return stored
+    }
+
+    /// The decision, and it *spends* the flag: the second call answers nil however it arrives, in
+    /// this process or in any later one.
+    ///
+    /// Spent whether or not the event ends up leaving the Mac — `record` applies the three refusals
+    /// after this returns. That ordering is deliberate: it is what lets the rule be proved from a
+    /// suite that is itself refused, and the only cost is that a build which reports nothing burns
+    /// the flag in its own defaults domain, which is a domain no shipping install reads.
+    static func firstArtifactEvent(
+        _ kind: AnalyticsEvent.ArtifactKind, in defaults: UserDefaults = .standard
+    ) -> AnalyticsEvent? {
+        guard !defaults.bool(forKey: firstArtifactKey) else { return nil }
+        defaults.set(true, forKey: firstArtifactKey)
+        return .firstArtifact(kind)
+    }
+
     // MARK: - Fallbacks
 
     /// Mirrors a local `ContextTelemetry.recordFallback` into the remote series.
@@ -287,6 +328,9 @@ enum ContextAnalytics {
     static let onboardingStartedKey = "context.analytics.onboardingStartedAt"
     /// Whether the completion has already been reported. Once per install, never once per run.
     static let onboardingReportedKey = "context.analytics.onboardingFinishedReported"
+    /// Whether this install has already reported storing something. Never cleared — an install only
+    /// activates once, and a second `cfc_first_artifact` would be a second install in the numerator.
+    static let firstArtifactKey = "context.analytics.firstArtifact"
 
     @MainActor private static var rollupTimer: Timer?
 }

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -21,10 +21,12 @@ import Foundation
 ///    case is the one to design for — a machine whose config cannot be parsed may be under
 ///    exclusions we cannot express, and reporting from it would be reporting from a state where we
 ///    cannot honour what the user asked to hide.
-/// 2. **Development builds.** A locally built app reports nothing. This is not tidiness: the Cloud
-///    Run logs for the first three weeks of this app show a `Context for Claude/1` user agent from up
-///    to twenty machines a day — the team's own builds, indistinguishable in aggregate from users.
-///    Analytics that count their own authors answer a different question than the one being asked.
+/// 2. **Anything that is not the shipping app.** A locally built app reports nothing, and neither
+///    does the test runner. This is not tidiness: the Cloud Run logs for the first three weeks of this
+///    app show a `Context for Claude/1` user agent from up to twenty machines a day — the team's own
+///    builds, indistinguishable in aggregate from users. Analytics that count their own authors
+///    answer a different question than the one being asked. See `isEnabled` for the shape of that
+///    question, which is the half this shipped getting wrong.
 /// 3. **Nothing user-authored, ever.** Enforced by construction in `AnalyticsEvent` — there is no
 ///    API here that accepts a string from a call site.
 ///
@@ -59,7 +61,16 @@ enum ContextAnalytics {
         Task { await AnalyticsSink.shared.enqueue(payload) }
     }
 
-    /// False on development builds, which report nothing at all. See refusal 2 above.
+    /// True only in the shipping app. See refusal 2 above.
+    ///
+    /// **Asked as "is this the release?", not as "is this not a dev build?", and the difference is
+    /// the whole of a defect this shipped with.** `ContextPaths.isDevelopmentBuild` is derived from
+    /// `ownIdentifier`, which falls back to the shipping identifier for any process that is not one
+    /// of ours — correct for the log subsystem and the Keychain service, and exactly wrong here. The
+    /// process it let through is the test runner: `swift test` runs under `com.apple.dt.xctest.tool`,
+    /// so the suite counted as production and POSTed to PostHog from the real spool. Measured: 92
+    /// events under a single distinct id derived from the xctest defaults domain's install id, every
+    /// `cfc_gesture_fired` in the project and two thirds of `cfc_search_ran`.
     ///
     /// `CONTEXT_ANALYTICS_FORCE=1` overrides it for one purpose: proving end to end, from a local
     /// build, that events actually arrive in PostHog. There is no way to verify this pipeline without
@@ -69,7 +80,7 @@ enum ContextAnalytics {
     /// series: use a throwaway `CONTEXT_ANALYTICS_FORCE` session, not a day of ordinary work.
     static var isEnabled: Bool {
         if ProcessInfo.processInfo.environment["CONTEXT_ANALYTICS_FORCE"] == "1" { return true }
-        return !ContextPaths.isDevelopmentBuild
+        return ContextPaths.isShippingBundle
     }
 
     // MARK: - Lifecycle

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -150,21 +150,57 @@ enum ContextAnalytics {
     @MainActor
     static func recordOnboardingStep(index: Int, of total: Int) {
         guard isEnabled else { return }
-        if onboardingStartedAt == nil { onboardingStartedAt = Date() }
+        noteOnboardingStarted()
         record(.onboardingStep(index: index, of: total))
     }
 
-    /// Records that first run ended.
+    /// Records that first run ended, at most once per install.
+    @MainActor
+    static func recordOnboardingFinished() {
+        guard isEnabled, let event = onboardingFinishedEvent() else { return }
+        record(event)
+    }
+
+    /// Stamps when this install's first run began, if nothing has stamped it yet.
+    ///
+    /// **On disk rather than in a static, because onboarding is the one flow a successful step ends
+    /// the process from the middle of.** Screen Recording only applies to a process that already held
+    /// it when it connected to the window server, so the card's own "Restart to finish" — and macOS's
+    /// own "Quit & Reopen" — kill the app between the grant and the finish. The run that actually
+    /// reaches `.done` therefore often had no `go(to:)` of its own, and an in-memory start instant
+    /// left `recordOnboardingFinished` with nothing to measure from and nothing to send. Live
+    /// evidence: four of the five reporting installs have permissions granted and only one of them
+    /// ever sent `cfc_onboarding_finished`. `OnboardingResume` persists the card for exactly the same
+    /// reason; this is the same fact about the same relaunch.
+    static func noteOnboardingStarted(in defaults: UserDefaults = .standard, at now: Date = Date()) {
+        guard defaults.object(forKey: onboardingStartedKey) == nil else { return }
+        defaults.set(now.timeIntervalSince1970, forKey: onboardingStartedKey)
+    }
+
+    /// The completion this install still owes, or nil — and calling it *spends* the record, so a
+    /// second call reports nothing.
     ///
     /// The elapsed time is measured from the first *step transition*, not from app launch: onboarding
     /// opens behind a permission prompt and a sign-in browser hop, and counting the seconds a person
     /// spent in System Settings as time spent in our flow would make every install look slow for a
-    /// reason we did not cause.
-    @MainActor
-    static func recordOnboardingFinished() {
-        guard isEnabled, let started = onboardingStartedAt else { return }
-        onboardingStartedAt = nil
-        record(.onboardingFinished(secondsElapsed: Int(Date().timeIntervalSince(started))))
+    /// reason we did not cause. Across a relaunch it is still that instant, which is the honest
+    /// answer to "how long did setup cost this person" — including the minutes they spent in System
+    /// Settings between the two processes, because those minutes were setup.
+    ///
+    /// **The reported flag is what makes it once per install rather than once per run.** "Run setup
+    /// again" (`OnboardingReset`) deliberately puts a finished install back through the flow, and it
+    /// clears the three records that describe *where the user is*; this is not one of them. A second
+    /// `cfc_onboarding_finished` from the same install would be counted as a second install setting
+    /// itself up, which is the one thing this series is the denominator for.
+    static func onboardingFinishedEvent(
+        in defaults: UserDefaults = .standard, at now: Date = Date()
+    ) -> AnalyticsEvent? {
+        guard !defaults.bool(forKey: onboardingReportedKey),
+            let started = defaults.object(forKey: onboardingStartedKey) as? Double
+        else { return nil }
+        defaults.set(true, forKey: onboardingReportedKey)
+        defaults.removeObject(forKey: onboardingStartedKey)
+        return .onboardingFinished(secondsElapsed: Int(max(0, now.timeIntervalSince1970 - started)))
     }
 
     // MARK: - Fallbacks
@@ -184,8 +220,6 @@ enum ContextAnalytics {
     ) {
         record(.fallback(area: area, outcome: outcome, reason: reason))
     }
-
-    @MainActor private static var onboardingStartedAt: Date?
 
     // MARK: - The daily rollup
 
@@ -248,6 +282,11 @@ enum ContextAnalytics {
 
     private static let hasLaunchedKey = "context.analytics.hasLaunched"
     private static let lastRollupDayKey = "context.analytics.lastRollupDay"
+    /// When this install's first run reached its first step, as seconds since the epoch. Survives the
+    /// relaunch the Screen Recording grant forces; see `noteOnboardingStarted`.
+    static let onboardingStartedKey = "context.analytics.onboardingStartedAt"
+    /// Whether the completion has already been reported. Once per install, never once per run.
+    static let onboardingReportedKey = "context.analytics.onboardingFinishedReported"
 
     @MainActor private static var rollupTimer: Timer?
 }

--- a/desktop/context-for-claude/Sources/ContextCore/Paths.swift
+++ b/desktop/context-for-claude/Sources/ContextCore/Paths.swift
@@ -60,6 +60,34 @@ public enum ContextPaths {
         identifier != shippingBundleIdentifier
     }
 
+    /// **Whether this process is the shipping app itself** — asked of what `Bundle.main` actually
+    /// *reported*, not of the identity derived from it.
+    ///
+    /// The distinction looks pedantic and is not. `ownIdentifier` answers "which identity does this
+    /// process own", and its fallback to the shipping id is right for everything keyed on that: the
+    /// log subsystem, the Keychain service, the `tccutil` line. But it means a foreign process —
+    /// anything not running from a bundle of ours — resolves to the shipping identifier and therefore
+    /// looks, to `isDevelopmentBuild`, exactly like the notarized release.
+    ///
+    /// The process that is foreign in practice is the test runner. `swift test` runs under
+    /// `com.apple.dt.xctest.tool`, so `isDevelopmentBuild` was **false** inside the suite and
+    /// `ContextAnalytics.isEnabled` was **true**: the tests reported to production PostHog from the
+    /// real spool for as long as the suite has existed — measured, 92 events under one distinct id,
+    /// carrying the xctest tool's own `CFBundleShortVersionString` of `16.0`, and accounting for
+    /// every `cfc_gesture_fired` in the project and two thirds of `cfc_search_ran`.
+    ///
+    /// So anything that must run **only in the shipping app** asks this, and anything keyed on this
+    /// build's *identity* keeps asking `isDevelopmentBuild`. Unknown answers no: a process that
+    /// cannot prove it is the release is not the release.
+    public static func isShippingBundle(reportedBy reported: String?) -> Bool {
+        reported == shippingBundleIdentifier
+    }
+
+    /// The same question about the running process.
+    public static var isShippingBundle: Bool {
+        isShippingBundle(reportedBy: Bundle.main.bundleIdentifier)
+    }
+
     /// `~/Library/Application Support/ContextForClaude`
     public static var supportDirectory: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -289,6 +289,33 @@ final class AnalyticsFallbackBridgeTests: XCTestCase {
     }
 }
 
+/// **Refusal 2, asserted from inside the process it failed to refuse.**
+///
+/// This is not a table test about a hypothetical build. The test runner *is* the failure: `swift
+/// test` runs under `com.apple.dt.xctest.tool`, `ContextPaths.ownIdentifier` falls back to the
+/// shipping identifier for any process that is not ours, and `isEnabled` — asking
+/// `!isDevelopmentBuild` — therefore answered true here. Every run of this suite spooled events to
+/// the real `analytics-spool.json` and POSTed them to production PostHog: 92 of them by the time it
+/// was noticed, all of `cfc_gesture_fired` and two thirds of `cfc_search_ran`.
+///
+/// So the strongest available seam is the one below — `isEnabled` read in the process that must be
+/// refused, rather than a rule read anywhere else.
+final class AnalyticsBuildRefusalTests: XCTestCase {
+
+    func testTheTestProcessItselfIsRefused() throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["CONTEXT_ANALYTICS_FORCE"] == "1",
+            "the override is deliberately absolute, and a run under it is a run that means to send")
+
+        XCTAssertFalse(
+            ContextAnalytics.isEnabled,
+            """
+            This process reports \(Bundle.main.bundleIdentifier ?? "nil") and is not the shipping \
+            app, so nothing it does may reach production analytics.
+            """)
+    }
+}
+
 /// The day boundary the whole DAU series rests on.
 final class ContextAnalyticsDayTests: XCTestCase {
 

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -115,6 +115,7 @@ final class AnalyticsEventTests: XCTestCase {
         allowed += AnalyticsEvent.PermissionState.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.CaptureSource.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.Surface.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.ArtifactKind.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.UpdateOutcome.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.FallbackReason.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.CountBucket.allCases.map(\.rawValue)
@@ -170,7 +171,7 @@ final class AnalyticsEventTests: XCTestCase {
             .onboardingStep(index: 0, of: 1), .onboardingFinished(secondsElapsed: 0),
             .accountStateChanged(signedIn: false), .captureStateChanged(source: .screen, live: true),
             .gestureFired, .surfaceOpened(.settings), .searchRan(resultCountBucket: .zero),
-            .updateOutcome(.upToDate),
+            .firstArtifact(.conversation), .updateOutcome(.upToDate),
             .fallback(area: .capture, outcome: .degraded, reason: .offline),
         ]
         let names = representatives.map(\.name)
@@ -409,6 +410,78 @@ final class OnboardingCompletionReportTests: XCTestCase {
     }
 }
 
+/// **Activation: did this install ever store anything at all.**
+///
+/// Nothing in the schema answered that before `cfc_first_artifact`. `cfc_capture_state` reports a
+/// microphone being switched on, which is not a row landing; `cfc_daily_active` reports capture
+/// minutes, which look the same on an install's hundredth day as on its first. An install that
+/// captured all day and one that captured nothing were indistinguishable, and the product's
+/// activation metric cannot be computed from anything else here.
+///
+/// The flag is read and spent by `firstArtifactEvent`, which is what `recordFirstArtifact` reports
+/// through — so "did it report?" is asked below as "is the flag spent?". The suite is refused by
+/// `isEnabled`, as it must be, which is exactly why the decision is the seam rather than the sink.
+final class FirstArtifactTests: XCTestCase {
+
+    private struct WriteFailed: Error {}
+
+    /// The suite *name* comes back too: a relaunch, for this event, is nothing more than a second
+    /// `UserDefaults` object opened over the same persistent domain.
+    private func scratch() throws -> (String, UserDefaults, () -> Void) {
+        let suite = "com.omi.context-for-claude.FirstArtifactTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        return (suite, defaults, { UserDefaults.standard.removePersistentDomain(forName: suite) })
+    }
+
+    func testTheFirstStoredArtifactIsReportedWithWhatItWas() throws {
+        let (_, defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        let event = ContextAnalytics.firstArtifactEvent(.screen, in: defaults)
+        XCTAssertEqual(event?.name, "cfc_first_artifact")
+        XCTAssertEqual(event?.properties["kind"], .string("screen"))
+    }
+
+    /// Once per install, over the write path itself — and across the relaunch, which is a second
+    /// `UserDefaults` object over the same domain because that is all a relaunch is here.
+    func testAnInstallReportsItsFirstArtifactExactlyOnce() throws {
+        let (suite, defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        var writes = 0
+        ContextAnalytics.recordFirstArtifact(.conversation, in: defaults) { writes += 1 }
+        ContextAnalytics.recordFirstArtifact(.screen, in: defaults) { writes += 1 }
+        XCTAssertEqual(writes, 2, "the write itself always happens; only the report is once")
+
+        XCTAssertNil(
+            ContextAnalytics.firstArtifactEvent(.conversation, in: defaults),
+            "the first stored artifact spent the flag, so nothing after it may report")
+
+        // A day of capture later, in a process that has been restarted since.
+        let afterRelaunch = try XCTUnwrap(UserDefaults(suiteName: suite))
+        ContextAnalytics.recordFirstArtifact(.screen, in: afterRelaunch) { writes += 1 }
+        XCTAssertEqual(writes, 3)
+        XCTAssertNil(
+            ContextAnalytics.firstArtifactEvent(.screen, in: afterRelaunch),
+            "the flag is on disk, so the install stays activated exactly once across a relaunch")
+    }
+
+    /// **An attempt is not an artifact.** `EngineStore` catches and logs a failed insert, so an
+    /// install whose writes all fail would otherwise be counted as activated on the strength of
+    /// having tried — and the flag it spent could never be recovered.
+    func testAWriteThatFailedIsNotAnArtifact() throws {
+        let (_, defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        XCTAssertThrowsError(
+            try ContextAnalytics.recordFirstArtifact(.screen, in: defaults) { throw WriteFailed() })
+
+        XCTAssertNotNil(
+            ContextAnalytics.firstArtifactEvent(.screen, in: defaults),
+            "nothing was stored, so the install's first artifact is still ahead of it")
+    }
+}
+
 /// The day boundary the whole DAU series rests on.
 final class ContextAnalyticsDayTests: XCTestCase {
 
@@ -456,6 +529,7 @@ extension AnalyticsEvent {
              AnalyticsEvent.captureStateChanged(source: source, live: false)]
         }
         events += Surface.allCases.map { AnalyticsEvent.surfaceOpened($0) }
+        events += ArtifactKind.allCases.map { AnalyticsEvent.firstArtifact($0) }
         events += UpdateOutcome.allCases.map { AnalyticsEvent.updateOutcome($0) }
         events += FallbackReason.allCases.map {
             AnalyticsEvent.fallback(area: .capture, outcome: .degraded, reason: $0)
@@ -474,7 +548,7 @@ final class AnalyticsEventShapeTests: XCTestCase {
             "cfc_first_launch", "cfc_app_launched", "cfc_daily_active", "cfc_permission",
             "cfc_onboarding_step", "cfc_onboarding_finished", "cfc_account_state",
             "cfc_capture_state", "cfc_gesture_fired", "cfc_surface_opened", "cfc_search_ran",
-            "cfc_update_outcome", "cfc_fallback",
+            "cfc_first_artifact", "cfc_update_outcome", "cfc_fallback",
         ]
         XCTAssertEqual(
             covered, expected,

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -316,6 +316,99 @@ final class AnalyticsBuildRefusalTests: XCTestCase {
     }
 }
 
+/// **`cfc_onboarding_finished` has to survive the relaunch onboarding itself causes.**
+///
+/// Granting Screen Recording only takes effect in a new process, so the flow restarts the app from
+/// its own middle — the card's "Restart to finish", and macOS's "Quit & Reopen". The start instant
+/// used to be an in-memory static set only by `recordOnboardingStep`, so the process that actually
+/// reached `.done` frequently had no step transition of its own and `recordOnboardingFinished`
+/// returned having sent nothing. Live evidence: four of the five reporting installs have permissions
+/// granted and exactly one of them ever sent the event.
+///
+/// `recordOnboardingFinished` is `record(onboardingFinishedEvent())` and nothing else, so driving
+/// the decision over a scratch domain is driving the production rule — and it is the only way to
+/// drive it, because the suite is refused by `isEnabled`, as it must be.
+final class OnboardingCompletionReportTests: XCTestCase {
+
+    /// A scratch domain per test: the machine running the tests is the machine the app runs on, and
+    /// these are the very keys that decide whether a real install has already reported.
+    private func scratch() throws -> (UserDefaults, () -> Void) {
+        let suite = "com.omi.context-for-claude.OnboardingCompletionReportTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        return (defaults, { UserDefaults.standard.removePersistentDomain(forName: suite) })
+    }
+
+    private func seconds(_ event: AnalyticsEvent?) -> Int? {
+        guard case let .onboardingFinished(elapsed)? = event else { return nil }
+        return elapsed
+    }
+
+    /// The defect, driven: the first step happens in one process, the finish in another, and the
+    /// second process has nothing in memory from the first.
+    func testTheCompletionIsReportedByTheProcessThatComesBackFromTheGrant() throws {
+        let (defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        let started = Date(timeIntervalSince1970: 1_760_000_000)
+        ContextAnalytics.noteOnboardingStarted(in: defaults, at: started)
+
+        // — the Screen Recording grant ends the process here —
+
+        let event = ContextAnalytics.onboardingFinishedEvent(
+            in: defaults, at: started.addingTimeInterval(240))
+        XCTAssertEqual(event?.name, "cfc_onboarding_finished")
+        XCTAssertEqual(
+            seconds(event), 240,
+            "elapsed is measured from the first step, which was two processes ago and still counts")
+    }
+
+    /// Once per install, not once per run. The reported flag is deliberately not one of the three
+    /// records `OnboardingReset` spends, so "Run setup again" cannot add a second install-shaped
+    /// completion to the series.
+    func testNoSecondCompletionIsReportedHoweverManyTimesSetupIsRun() throws {
+        let (defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        let started = Date(timeIntervalSince1970: 1_760_000_000)
+        ContextAnalytics.noteOnboardingStarted(in: defaults, at: started)
+        XCTAssertNotNil(
+            ContextAnalytics.onboardingFinishedEvent(in: defaults, at: started.addingTimeInterval(90)))
+
+        // Settings → "Run setup again", walked all the way through a second time.
+        ContextAnalytics.noteOnboardingStarted(in: defaults, at: started.addingTimeInterval(3_600))
+        XCTAssertNil(
+            ContextAnalytics.onboardingFinishedEvent(in: defaults, at: started.addingTimeInterval(3_700)),
+            "a second completion from one install reads as a second install that set itself up")
+        // And a relaunch in the middle of *that* run reports nothing either.
+        XCTAssertNil(ContextAnalytics.onboardingFinishedEvent(in: defaults, at: started))
+    }
+
+    /// A finish with no recorded start is the one case that must stay silent: an elapsed time
+    /// measured from nothing would be a zero, and a floor of zero-second setups is worse than a gap.
+    func testARunThatNeverRecordedAStepReportsNothing() throws {
+        let (defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        XCTAssertNil(ContextAnalytics.onboardingFinishedEvent(in: defaults, at: Date()))
+    }
+
+    /// The stamp belongs to the run, so a later step must not move it — otherwise the elapsed time
+    /// shrinks to whatever the last card cost and the funnel's most useful number is a lie.
+    func testTheStartInstantIsTheFirstStepAndIsNotRestampedByLaterOnes() throws {
+        let (defaults, cleanup) = try scratch()
+        defer { cleanup() }
+
+        let started = Date(timeIntervalSince1970: 1_760_000_000)
+        ContextAnalytics.noteOnboardingStarted(in: defaults, at: started)
+        ContextAnalytics.noteOnboardingStarted(in: defaults, at: started.addingTimeInterval(120))
+
+        XCTAssertEqual(
+            seconds(ContextAnalytics.onboardingFinishedEvent(
+                in: defaults, at: started.addingTimeInterval(300))),
+            300)
+    }
+}
+
 /// The day boundary the whole DAU series rests on.
 final class ContextAnalyticsDayTests: XCTestCase {
 

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -482,6 +482,47 @@ final class FirstArtifactTests: XCTestCase {
     }
 }
 
+/// **A static tripwire, and labelled as one: it reads the app's source text rather than running it.**
+///
+/// The rule it guards is the one `AnalyticsEvent.Surface` states in prose — a case nobody emits
+/// produces a permanently empty series, which reads as "nobody opens it" rather than "nobody measured
+/// it", and the first of those looks like a finding. `.search` was exactly that: the app's primary
+/// surface, in the enum since the schema was written, with no emitter anywhere.
+///
+/// It is a tripwire because the behavioural version is not available here. The emit is inside
+/// `SearchBarWindow.present()`, and a test process has no display to put a panel on and cannot make
+/// one key — the reason `HotkeyToggleTests` drives the chord through injected closures instead. So
+/// this checks that an emitter *exists*, which is the whole of what went wrong, and claims nothing
+/// about it firing.
+final class SurfaceEmitterTripwireTests: XCTestCase {
+
+    func testEverySurfaceCaseIsEmittedSomewhereInTheApp() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // ContextAppTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // the package
+            .appendingPathComponent("Sources/ContextApp")
+
+        let files = try XCTUnwrap(
+            FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil),
+            "the app's sources have to be readable from the checkout for this tripwire to mean anything")
+        var text = ""
+        for case let url as URL in files where url.pathExtension == "swift" {
+            text += (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        }
+        XCTAssertFalse(text.isEmpty, "read no app source at all, so nothing below was checked")
+
+        for surface in AnalyticsEvent.Surface.allCases {
+            XCTAssertTrue(
+                text.contains(".surfaceOpened(.\(surface.rawValue))"),
+                """
+                No call site records \(surface.rawValue). Either give it one or take the case out — \
+                an empty series is read as an answer about users, not as a gap in the instrumentation.
+                """)
+        }
+    }
+}
+
 /// The day boundary the whole DAU series rests on.
 final class ContextAnalyticsDayTests: XCTestCase {
 

--- a/desktop/context-for-claude/Tests/ContextCoreTests/BuildIdentityTests.swift
+++ b/desktop/context-for-claude/Tests/ContextCoreTests/BuildIdentityTests.swift
@@ -47,7 +47,27 @@ final class BuildIdentityTests: XCTestCase {
             identifier — adopting a foreign one puts a stranger's string on the log subsystem and \
             on a Keychain service this app then owns forever.
             """)
+        // And the trap that follows from the line above: this process is *not* a development build
+        // by that rule, because the fallback made it look like the release. Anything that must run
+        // only in the shipping app therefore has to ask `isShippingBundle` instead — see
+        // `testOnlyTheShippingBundleItselfCountsAsShipping` below, and the analytics gate it fixed.
         XCTAssertFalse(ContextPaths.isDevelopmentBuild)
+    }
+
+    /// **The other question, and the one a foreign process answers differently.**
+    ///
+    /// `isDevelopmentBuild` is about the identity this process *owns*; this is about whether it is
+    /// the shipping app *itself*. They agree for both of our bundles and disagree for everything
+    /// else, which is the whole point: `ContextAnalytics.isEnabled` asked the first one and so
+    /// counted the XCTest runner as production for as long as the suite existed.
+    func testOnlyTheShippingBundleItselfCountsAsShipping() {
+        XCTAssertTrue(ContextPaths.isShippingBundle(reportedBy: shipping))
+
+        for reported in [nil, "", "com.apple.dt.xctest.tool", development] as [String?] {
+            XCTAssertFalse(
+                ContextPaths.isShippingBundle(reportedBy: reported),
+                "\(reported ?? "nil") is not the shipping app and must not be able to act as it")
+        }
     }
 
     func testOnlyOurOwnFamilyOfIdentifiersIsAdopted() {

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -97,10 +97,18 @@ Don't.
    config we cannot parse may carry exclusions we cannot express. The second case is the one that
    matters in practice: it means a machine with a corrupt config stops reporting rather than
    reporting from a state where it cannot honour the user's exclusions.
-2. **Development builds report nothing.** `ContextPaths.isDevelopmentBuild` gates the whole path. This
+2. **Only the shipping app reports.** `ContextPaths.isShippingBundle` gates the whole path. This
    is not tidiness: for this app's first three weeks the Cloud Run logs show a `Context for Claude/1`
    user agent from up to twenty machines a day — the team's own builds, indistinguishable in
    aggregate from users.
+
+   **The gate asks "is this the release?", not "is this not a dev build?"** — it used to ask the
+   second, via `ContextPaths.isDevelopmentBuild`, which is derived from an identifier that falls back
+   to the shipping one for any process that is not ours. `swift test` runs under
+   `com.apple.dt.xctest.tool` and so counted as production: the suite POSTed to this project from the
+   real spool for as long as it has existed, 92 events before it was noticed, which is all of
+   `cfc_gesture_fired` and two thirds of `cfc_search_ran`. Anything queried before 2026-08-19 carries
+   that noise.
 3. **Nothing user-authored, ever** — enforced by construction, not by review.
 
 ## MCP tool calls cross a process boundary

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -47,6 +47,16 @@ enum; `AnalyticsEventTests.testNoEventCarriesFreeFormText` fails if a free strin
 | `cfc_update_outcome` | update health — a fleet that stops updating looks like a fleet nobody uses |
 | `cfc_fallback` | fail-open paths, mirroring `ContextTelemetry.recordFallback` |
 
+### `cfc_onboarding_finished` is once per install, across a relaunch
+
+Granting Screen Recording only takes effect in a new process, so onboarding restarts the app from its
+own middle and the run that reaches the last card often had no step transition of its own. The start
+instant is therefore persisted (`context.analytics.onboardingStartedAt`) rather than held in memory,
+and the completion is spent against a second default
+(`context.analytics.onboardingFinishedReported`) so that Settings' "Run setup again" cannot add a
+second install-shaped completion. Before that, four of the five reporting installs had permissions
+granted and exactly one had ever sent the event, which made the setup funnel unreadable.
+
 ### `cfc_daily_active` is the spine
 
 One event per install per **local calendar day**, carrying the day's rollup:

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -44,8 +44,26 @@ enum; `AnalyticsEventTests.testNoEventCarriesFreeFormText` fails if a free strin
 | `cfc_gesture_fired` | ⌘ + ⌘ actually firing — inert without Accessibility |
 | `cfc_surface_opened` | which surfaces people open by hand |
 | `cfc_search_ran` | local search use, bucketed result counts only |
+| `cfc_first_artifact` | **activation** — the first time this install ever stored anything |
 | `cfc_update_outcome` | update health — a fleet that stops updating looks like a fleet nobody uses |
 | `cfc_fallback` | fail-open paths, mirroring `ContextTelemetry.recordFallback` |
+
+### `cfc_first_artifact` is the activation moment
+
+Once per install, the first time a write actually lands, carrying `kind` — `conversation` (a
+transcript segment) or `screen` (a frame). Emitted from `EngineStore`'s two write paths, threaded
+*through* the write so a failed insert cannot report one: an attempt is not an artifact, and
+`EngineStore` catches and logs every failed insert.
+
+Nothing else answers "did this install ever do the thing": `cfc_capture_state` reports a microphone
+being switched on, and `cfc_daily_active`'s capture minutes look the same on the hundredth day as on
+the first. An install that captured all day and one that captured nothing were indistinguishable.
+
+**There is no `memory` kind, and that is a fact about the product.** This app never stores a memory:
+`create_memory` writes to the Omi account from `context-for-claude-mcp`, a separate short-lived
+process that cannot report anything (see below), and the local `account_rows` table is a copy of what
+the account already holds — first-storing a *downloaded* memory would fire this for an install that
+has captured nothing at all.
 
 ### `cfc_onboarding_finished` is once per install, across a relaunch
 


### PR DESCRIPTION
## What was wrong

Context for Claude's analytics could not answer the question it exists to answer, for four separate reasons. All four were found by measuring the live data against the source, and all four are fixed here.

### 1. The test suite was reporting as production

`swift test` runs under `com.apple.dt.xctest.tool`. `ContextPaths.ownIdentifier` deliberately hands the shipping bundle id to any process not running from a bundle of ours — right for the log subsystem, the Keychain service and the support directory — so `isDevelopmentBuild` was **false inside the suite** and `ContextAnalytics.isEnabled` was **true**. The tests POSTed to production PostHog from the real spool for as long as the suite has existed.

Measured: **92 events under one distinct id**, carrying the xctest tool's own `CFBundleShortVersionString` of `16.0` — accounting for **every `cfc_gesture_fired` in the project** and **two thirds of `cfc_search_ran`**. The distinct id is the SHA of the xctest UserDefaults domain's install id, which is what makes the attribution certain rather than likely.

`isShippingBundle(reportedBy:)` now asks what the process actually reported, and unknown answers no. `isDevelopmentBuild` is untouched — its fallback is correct for everything else that uses it.

### 2. `cfc_onboarding_finished` could not fire for the run that finishes

It guarded on an in-memory start instant set only by `recordOnboardingStep`. Granting Screen Recording restarts the app from the middle of onboarding, so the process that reaches the end usually had no step transition of its own and sent nothing. Live evidence: four of five reporting installs have permissions granted; one ever reported finishing.

The start instant and a reported-once flag are now on disk, so completion is reported once per install across the relaunch it causes — and elapsed time still includes the minutes spent in System Settings, because those minutes were setup.

### 3. Nothing recorded that an install ever produced anything

There was no event for a conversation, a memory or a screen observation being stored, so an install that captured all day was indistinguishable from one that captured nothing. `cfc_first_artifact` now fires once per install, with `kind` of `conversation` or `screen`.

The write is threaded **through** the report (`recordFirstArtifact(_:stored:)` runs the closure and reports only if it returns) rather than an emit placed after it: `EngineStore` catches every failed insert, so "after the write" is an ordering a later refactor could silently break.

### 4. The `search` surface case had no emitter

`Surface.search` was unreachable — a permanently empty series. Wired at `SearchBarWindow.present()`'s fresh-mount branch, which covers all five ways the panel opens without a per-caller emit.

## One deliberate divergence

**`cfc_first_artifact` ships `conversation` and `screen`, not `memory`.** This app never durably stores a memory: `create_memory` writes to the Omi account from the short-lived MCP process, and the only memory-shaped local table is `account_rows`, whose contract is "a copy of what the account holds, never an authority". Firing on a downloaded memory would report activation for an install that captured nothing — the exact question the event exists to answer. A third case with no emitter would have been defect 4 again.

## Verification

- **`swift test`: 1671 tests, 9 skipped, 0 failures.** 1661 before; +10 are the ones added here.
- **Wire-level, pre-fix**, run with egress blocked so the measurement itself sent nothing (`sandbox-exec … (deny network*)`, confirmed with curl first): a 52-test filtered run left 7 `cfc_search_ran` events in the spool, stamped `"app_version":"16.0","app_build":"24507"`.
- **Wire-level, post-fix, against the real network**: spool deleted, full 1671-test suite run, spool **not recreated**. Re-verified independently after the agent's run.
- **PostHog is frozen**: newest xctest-runner event is still `2026-08-19T00:25:39Z`, count still 92, after repeated post-fix suite runs.
- Defects 2 and 3 are tested through their real decision functions over scratch `UserDefaults` domains, including a simulated relaunch. Defect 4 has no behavioural seam — a test process has no display and cannot make a window key — so its guard is a labelled static tripwire, verified to fail by deleting the emit.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: new

`FC-identity-fallback-used-as-authorization-gate` — an identity resolver that defaults unknown callers into the shipping identity was reused as the gate deciding who may report as the release, so every foreign process was admitted precisely because it could not be identified. The same fallback also backs the Keychain service and the log subsystem, where it is correct; the class is about the reuse, not the resolver. The guard is a test asserting that the suite itself is refused — the only seam that would have caught this, because the failing process is the test process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

