### PR TITLE
fix(backend): give every Deepgram client its own options object

### DIFF
--- a/.github/failure-classes/FC-per-request-credential-mutates-shared-client-config.json
+++ b/.github/failure-classes/FC-per-request-credential-mutates-shared-client-config.json
@@ -4,7 +4,7 @@
   "violated_contract": "A client built for one request's credential must not write that credential into state other requests' clients still read. An SDK config object handed to a constructor is such state whenever the constructor sets the key on it.",
   "canonical_prevention": "Construct the provider config per client rather than caching one at import, so a BYOK client and the account client never alias the same object.",
   "evidence_prs": [
-    11894
+    11895
   ],
   "scope_hints": [
     "backend/utils/stt/**",

--- a/.github/failure-classes/FC-per-request-credential-mutates-shared-client-config.json
+++ b/.github/failure-classes/FC-per-request-credential-mutates-shared-client-config.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "id": "FC-per-request-credential-mutates-shared-client-config",
+  "violated_contract": "A client built for one request's credential must not write that credential into state other requests' clients still read. An SDK config object handed to a constructor is such state whenever the constructor sets the key on it.",
+  "canonical_prevention": "Construct the provider config per client rather than caching one at import, so a BYOK client and the account client never alias the same object.",
+  "evidence_prs": [
+    11894
+  ],
+  "scope_hints": [
+    "backend/utils/stt/**",
+    "backend/utils/llm/**"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_parakeet_prerecorded.py
+++ b/backend/tests/unit/test_parakeet_prerecorded.py
@@ -153,6 +153,22 @@ class TestFactoryRouting:
         assert pr._deepgram_client_for_request() is client
         assert factory.call_args.args[0] == 'user-byok-key'
 
+    def test_byok_client_leaves_managed_credential_intact(self, monkeypatch):
+        """DeepgramClient.__init__ rewrites the options it is handed, so each
+        client needs its own — a shared object bills the managed client's
+        requests to whichever BYOK key was constructed last."""
+        monkeypatch.setattr(pr, '_deepgram_client', None)
+        monkeypatch.setattr(pr, 'get_byok_key', lambda _provider: None)
+        monkeypatch.setenv('DEEPGRAM_API_KEY', 'managed-key')
+
+        managed = pr._deepgram_client_for_request()
+        assert managed._config.api_key == 'managed-key'
+
+        monkeypatch.setattr(pr, 'get_byok_key', lambda _provider: 'user-byok-key')
+        assert pr._deepgram_client_for_request()._config.api_key == 'user-byok-key'
+
+        assert managed._config.api_key == 'managed-key'
+
 
 class TestTranscribeBytes:
     def test_missing_endpoint_raises_controlled_configuration_error(self, monkeypatch):

--- a/backend/tests/unit/test_streaming_deepgram_backoff.py
+++ b/backend/tests/unit/test_streaming_deepgram_backoff.py
@@ -334,6 +334,33 @@ def test_deepgram_options_never_enable_keepalive():
         assert opts.url == endpoint
 
 
+def test_byok_client_leaves_managed_credential_intact(monkeypatch):
+    """A BYOK request must not repoint the process-wide client at the user's key.
+
+    DeepgramClient.__init__ calls config.set_apikey(), so any options object
+    shared between the managed and BYOK clients carries whichever key was set
+    last. In prod that stranded a canary replica on a stale BYOK key: every
+    live session it served answered HTTP 401 for six hours.
+    """
+    import utils.stt.streaming as streaming
+
+    monkeypatch.setattr(streaming, 'is_dg_self_hosted', False)
+    monkeypatch.setenv('DEEPGRAM_API_KEY', 'managed-key')
+    monkeypatch.setattr(streaming, 'deepgram', None)
+    monkeypatch.setattr(streaming, '_managed_deepgram_ready', False)
+    monkeypatch.setattr(streaming, 'get_byok_key', lambda _provider: None)
+
+    managed = streaming._deepgram_client_for_request()
+    assert managed._config.api_key == 'managed-key'
+
+    monkeypatch.setattr(streaming, 'get_byok_key', lambda _provider: 'byok-key')
+    assert streaming._deepgram_client_for_request()._config.api_key == 'byok-key'
+
+    assert managed._config.api_key == 'managed-key'
+    monkeypatch.setattr(streaming, 'get_byok_key', lambda _provider: None)
+    assert streaming._deepgram_client_for_request()._config.api_key == 'managed-key'
+
+
 @pytest.mark.asyncio
 async def test_process_audio_dg_returns_safe_socket_no_gate():
     """process_audio_dg returns SafeDeepgramSocket when no VAD gate provided (#5870)."""

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -122,18 +122,18 @@ def get_prerecorded_service(language: Optional[str] = 'en') -> Tuple[str, Option
 
 # Lazily initialized because constructing the SDK client at import makes every
 # backend consumer credential-dependent, including schema export and unit discovery.
-_deepgram_options: Optional[DeepgramClientOptions] = None
 _deepgram_client: Optional[DeepgramClient] = None
 _deepgram_client_lock = RLock()
 
 
-def _get_deepgram_options() -> DeepgramClientOptions:
-    global _deepgram_options
-    if _deepgram_options is None:
-        with _deepgram_client_lock:
-            if _deepgram_options is None:
-                _deepgram_options = DeepgramClientOptions(options={"keepalive": "true"})
-    return _deepgram_options
+def _deepgram_options() -> DeepgramClientOptions:
+    """Build fresh options per client.
+
+    DeepgramClient.__init__ calls config.set_apikey(), so a cached options
+    object shared with a BYOK client rewrites the credential the managed
+    client still holds — every later request would bill that user's key.
+    """
+    return DeepgramClientOptions(options={"keepalive": "true"})
 
 
 def _get_deepgram_client() -> DeepgramClient:
@@ -144,7 +144,7 @@ def _get_deepgram_client() -> DeepgramClient:
                 api_key = os.getenv('DEEPGRAM_API_KEY')
                 if not api_key:
                     raise PrerecordedSTTConfigurationError(PrerecordedSTTService.DEEPGRAM, 'DEEPGRAM_API_KEY')
-                _deepgram_client = DeepgramClient(api_key, _get_deepgram_options())
+                _deepgram_client = DeepgramClient(api_key, _deepgram_options())
     return _deepgram_client
 
 
@@ -152,7 +152,7 @@ def _deepgram_client_for_request() -> DeepgramClient:
     """Route to BYOK Deepgram key when set; otherwise use the process-wide client."""
     byok = get_byok_key('deepgram')
     if byok:
-        return DeepgramClient(byok, _get_deepgram_options())
+        return DeepgramClient(byok, _deepgram_options())
     return _get_deepgram_client()
 
 

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -583,7 +583,10 @@ deepgram: Optional[DeepgramClient] = None
 
 
 def _deepgram_options(endpoint: str) -> DeepgramClientOptions:
-    """Build options pinned to an explicit endpoint, never the SDK default."""
+    """Build options per client, pinned to an endpoint, never the SDK default.
+
+    DeepgramClient.__init__ writes its key into what it is handed, so a shared
+    object strands the managed client on whichever BYOK key came last."""
     options = DeepgramClientOptions(options={"termination_exception_connect": "true"})
     options.url = endpoint
     return options
@@ -602,9 +605,6 @@ def _require_self_hosted_deepgram_endpoint(endpoint: str) -> str:
     return endpoint
 
 
-# Built once; also keys the per-request BYOK client below.
-deepgram_cloud_options = _deepgram_options(DEEPGRAM_CLOUD_ENDPOINT)
-
 _managed_deepgram_lock = threading.RLock()
 _managed_deepgram_ready = False
 
@@ -619,7 +619,7 @@ def _build_managed_deepgram_client() -> Optional[DeepgramClient]:
     if not api_key:
         return None
     logger.info('Using Deepgram hosted API')
-    return DeepgramClient(api_key, deepgram_cloud_options)
+    return DeepgramClient(api_key, _deepgram_options(DEEPGRAM_CLOUD_ENDPOINT))
 
 
 def _managed_deepgram_client() -> Optional[DeepgramClient]:
@@ -794,7 +794,7 @@ def _deepgram_client_for_request() -> DeepgramClient:
         return managed
     byok = get_byok_key('deepgram')
     if byok:
-        return DeepgramClient(byok, deepgram_cloud_options)
+        return DeepgramClient(byok, _deepgram_options(DEEPGRAM_CLOUD_ENDPOINT))
     if managed is None:
         raise RuntimeError('Deepgram is not configured; set DEEPGRAM_API_KEY or provide a BYOK key')
     return managed


### PR DESCRIPTION
## Bug

`prod-omi-backend-listen-dg-canary` replicas stopped transcribing. Pod `...-8584fd774f-xhvlr` last opened a Deepgram socket at `2026-08-19T17:09:41Z` and then answered **HTTP 401 on 100% of attempts for the next six hours** — 158 connects, 481 `start() returned False`, 161 sessions given up — while sibling replicas of the same deployment, same image `backend:6316415` and same `DEEPGRAM_API_KEY`, kept connecting fine. Every live session those replicas accepted got no transcription at all.

The env key is not the problem: it authenticates against `api.deepgram.com` from a laptop and from inside the failing pod (verified both, HTTP 200 / socket open).

## Root cause

`DeepgramClient.__init__` (deepgram-sdk v4.8.1) calls `config.set_apikey(api_key)` — it **writes the credential into the options object it is handed**:

```python
if api_key and api_key != "":
    config.set_apikey(api_key)
self._config = config
```

Both Deepgram paths handed every client the *same* module-level options object:

- `utils/stt/streaming.py` — `deepgram_cloud_options`, shared by `_build_managed_deepgram_client()` and the per-request BYOK client in `_deepgram_client_for_request()`
- `utils/stt/pre_recorded.py` — the cached `_get_deepgram_options()` singleton, shared the same way

So one BYOK request permanently repointed the process-wide managed client at that user's key. When that key was revoked or otherwise unusable, the replica answered 401 for every later session until restart. When it was valid, the failure was silent and worse: one user's Deepgram key billed for another user's audio.

## Fix

Build the options per client. `_deepgram_options()` is now called at each construction site instead of once at import.

## What I tested

- **Real path, live provider.** A script drives production `connect_to_deepgram()` against `api.deepgram.com`: managed connect → bogus-BYOK connect → managed connect.
  - parent commit: `True / False / False` — step 3 fails with the exact prod signature (`server rejected WebSocket connection: HTTP 401`)
  - this commit: `True / False / True` — the bogus BYOK key fails only its own request, as it should
- **Regression tests** (one per path) fail on the parent with `assert 'user-byok-key' == 'managed-key'` and pass here.
- `pytest tests/unit/test_streaming_deepgram_backoff.py tests/unit/test_parakeet_prerecorded.py` → 128 passed, 1 failed: `test_retired_configuration_uses_non_deepgram_defaults`, which fails identically on `origin/main` in this environment (env-dependent, pre-existing).
- `make preflight` green.

## Product invariants affected

none

Failure-Class: new

New class: a per-request credential written into a process-wide client object. Violated contract — *a client constructed for one request must not mutate state that other requests' clients still hold*. No existing definition covers it: `FC-shared-backoff-conflated-independent-budgets` is about a cooldown deadline keyed to the wrong identity, and `FC-loop-bound-resource-shared-process-wide` is about event-loop affinity. Definition added in this PR as `FC-per-request-credential-mutates-shared-client-config`; the guard surface is the two behavioral tests that construct a BYOK client and assert the managed client's credential is untouched.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

