### PR TITLE
fix(backend): back off conversation memory replacement under control CAS races

### DIFF
--- a/.github/failure-classes/FC-immediate-retry-loses-shared-cas.json
+++ b/.github/failure-classes/FC-immediate-retry-loses-shared-cas.json
@@ -1,0 +1,17 @@
+{
+ "schema_version": 1,
+ "id": "FC-immediate-retry-loses-shared-cas",
+ "violated_contract": "A conflict loop over a shared compare-and-swap must space its rounds. Retrying immediately re-reads the state the winning peer just advanced, so concurrent writers keep losing in lockstep and a bounded budget of immediate attempts is spent on ordinary contention rather than on a real failure — the caller fails closed even though every attempt was retryable.",
+ "canonical_prevention": "Give the loop a bounded backoff schedule and derive its attempt count from that schedule, so 'how many rounds' and 'how far apart' cannot drift apart. A caller that already owns an outer converging loop passes an explicit immediate schedule rather than the inner loop silently having none.",
+ "evidence_prs": [
+  11731
+ ],
+ "scope_hints": [
+  "backend/utils/memory/**",
+  "backend/database/memory_apply_store.py"
+ ],
+ "canonical_prevention_artifact": [
+  "backend/utils/memory/canonical_memory_adapter.py"
+ ],
+ "status": "open"
+}

--- a/backend/tests/unit/test_conversation_replacement_backoff.py
+++ b/backend/tests/unit/test_conversation_replacement_backoff.py
@@ -1,0 +1,181 @@
+"""Conversation memory extraction survives account-global control CAS races.
+
+``replace_conversation_sourced_memories`` is the write boundary every canonical
+memory path shares. Retraction wraps it in a converging loop (#11726), but
+extraction calls it straight from conversation processing
+(``process_conversation -> _extract_memories -> _extract_memories_canonical``),
+and that call is intentionally fail-closed: when it raises, the whole
+enrichment fails, so the user's conversation gets no memories *and* no summary.
+
+Prod (Cloud Run ``backend``, 2026-08-19) showed the replacement's three
+immediate attempts exhausting under sustained same-account contention —
+``ConversationSourceReplacementConflict: memory control changed during
+conversation replacement`` on four instances at once, bursting at 15:45Z,
+17:33Z and 22:55Z. An immediate retry re-reads the control the peer just
+advanced, so the writers keep losing in lockstep.
+
+These tests pin the backoff contract on the extraction entry:
+
+* conflicts that outlast the old immediate budget now converge and commit;
+* the retry budget stays bounded, and exhausting it still fails closed with the
+  account's control and items untouched (the #11627 fence must not regress);
+* callers that own an outer converging loop can still ask for immediate rounds.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.unit.memory_import_isolation import (
+    ensure_utils_memory_packages_importable,
+    install_database_client_stub,
+    install_ws_j_heavy_import_stubs,
+    restore_sys_modules,
+    snapshot_sys_modules,
+)
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _replacement_backoff_import_isolation():
+    saved = snapshot_sys_modules(["database._client", "firebase_admin", "utils.subscription", "database.users"])
+    install_database_client_stub()
+    install_ws_j_heavy_import_stubs()
+    yield
+    restore_sys_modules(saved)
+
+
+ensure_utils_memory_packages_importable(str(BACKEND_DIR))
+from database.memory_apply_store import ConversationSourceReplacementConflict  # noqa: E402
+from models.memory_apply import MemoryControlState  # noqa: E402
+from models.product_memory import MemoryItemStatus  # noqa: E402
+from utils.memory.canonical_memory_adapter import ConversationReplacementConflictError  # noqa: E402
+from tests.unit.fixtures.canonical_memory_fakes import (  # noqa: E402
+    _FakeDb,
+    _sample_memory_payload,
+    _trusted_account_generation,
+)
+
+UID = "uid-replacement-backoff"
+CONVERSATION_ID = "conv-extraction-under-storm"
+
+
+@pytest.fixture(autouse=True)
+def _reset_universal_memory_env(monkeypatch):
+    from tests.unit.universal_memory_test_helpers import reset_universal_memory_fixture
+
+    canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+    globals()["replace_conversation_sourced_memories"] = canonical_adapter.replace_conversation_sourced_memories
+    monkeypatch.setattr(
+        canonical_adapter,
+        "read_memory_v3_trusted_account_generation",
+        lambda **_: _trusted_account_generation(),
+    )
+    reset_universal_memory_fixture(monkeypatch)
+
+
+def _extraction_db() -> _FakeDb:
+    return _FakeDb(
+        {
+            f"users/{UID}/memory_state/apply_control": MemoryControlState(
+                uid=UID,
+                head_commit_id="head0",
+                account_generation=1,
+                source_generation=1,
+            ).model_dump(mode="json"),
+        }
+    )
+
+
+class _ConflictInjector:
+    """Raises the transaction fence's conflict for the first ``conflicts`` calls.
+
+    ``None`` conflicts on every call, standing in for a storm that never lets up.
+    """
+
+    def __init__(self, conflicts: int | None):
+        self.conflicts = conflicts
+        self.calls = 0
+        canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+        self._real = canonical_adapter.replace_conversation_source_firestore
+
+    def __call__(self, *args, **kwargs):
+        self.calls += 1
+        if self.conflicts is None or self.calls <= self.conflicts:
+            raise ConversationSourceReplacementConflict("memory control changed during conversation replacement")
+        return self._real(*args, **kwargs)
+
+
+def _record_backoff(monkeypatch) -> list[float]:
+    sleeps: list[float] = []
+    canonical_adapter = importlib.import_module("utils.memory.canonical_memory_adapter")
+    monkeypatch.setattr(canonical_adapter, "time", SimpleNamespace(sleep=sleeps.append))
+    return sleeps
+
+
+def _install_injector(monkeypatch, conflicts: int | None) -> _ConflictInjector:
+    injector = _ConflictInjector(conflicts=conflicts)
+    monkeypatch.setattr(
+        "utils.memory.canonical_memory_adapter.replace_conversation_source_firestore",
+        injector,
+    )
+    return injector
+
+
+def _extracted_items() -> list[dict]:
+    return [_sample_memory_payload(uid=UID, conversation_id=CONVERSATION_ID, content="User enjoys hiking")]
+
+
+def test_extraction_converges_past_the_immediate_retry_budget(monkeypatch):
+    db = _extraction_db()
+    items = _extracted_items()
+    sleeps = _record_backoff(monkeypatch)
+    injector = _install_injector(monkeypatch, conflicts=4)  # one more than the old budget allowed
+
+    result = replace_conversation_sourced_memories(UID, CONVERSATION_ID, items, db_client=db)
+
+    assert result["committed_memory_ids"] == [items[0]["id"]]
+    assert db.docs[f"users/{UID}/memory_items/{items[0]['id']}"]["status"] == MemoryItemStatus.active.value
+    assert db.docs[f"users/{UID}/memory_state/apply_control"]["source_generation"] == 2
+    assert injector.calls == 5  # 4 conflicted rounds, then the commit
+    assert sleeps == [0.05, 0.1, 0.25, 0.5]
+
+
+def test_extraction_retry_budget_stays_bounded_and_fails_closed(monkeypatch):
+    db = _extraction_db()
+    items = _extracted_items()
+    sleeps = _record_backoff(monkeypatch)
+    injector = _install_injector(monkeypatch, conflicts=None)
+
+    with pytest.raises(ConversationReplacementConflictError):
+        replace_conversation_sourced_memories(UID, CONVERSATION_ID, items, db_client=db)
+
+    assert injector.calls == 5  # one backoff entry per non-final round
+    assert sleeps == [0.05, 0.1, 0.25, 0.5]
+    # Nothing was committed — the caller keeps failing closed on the #11627 fence.
+    assert f"users/{UID}/memory_items/{items[0]['id']}" not in db.docs
+    assert db.docs[f"users/{UID}/memory_state/apply_control"]["source_generation"] == 1
+
+
+def test_caller_owning_an_outer_loop_keeps_immediate_rounds(monkeypatch):
+    db = _extraction_db()
+    items = _extracted_items()
+    sleeps = _record_backoff(monkeypatch)
+    injector = _install_injector(monkeypatch, conflicts=None)
+
+    with pytest.raises(ConversationReplacementConflictError):
+        replace_conversation_sourced_memories(
+            UID,
+            CONVERSATION_ID,
+            items,
+            db_client=db,
+            conflict_backoff_seconds=(0.0, 0.0),
+        )
+
+    assert injector.calls == 3
+    assert sleeps == []

--- a/backend/utils/memory/canonical_memory_adapter.py
+++ b/backend/utils/memory/canonical_memory_adapter.py
@@ -7,7 +7,7 @@ import hashlib
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, cast
 
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
@@ -103,6 +103,14 @@ UserMutationPatchBuilder = Callable[[MemoryItem, datetime], Tuple[Payload, Paylo
 # merge path — converges across those races instead of failing (#11726).
 _RETRACT_CONFLICT_ATTEMPTS = 5
 _RETRACT_CONFLICT_BACKOFF_SECONDS = (0.05, 0.1, 0.25, 0.5)
+# Extraction races the same control CAS but runs inside conversation processing,
+# which has no outer convergence loop: an immediate retry re-reads the control a
+# peer just advanced, so same-account writers keep losing in lockstep and the
+# whole enrichment fails. Back the replacement's own rounds off by default.
+_REPLACEMENT_CONFLICT_BACKOFF_SECONDS = (0.05, 0.1, 0.25, 0.5)
+# Retraction already wraps this call in the converging loop above; keeping its
+# inner rounds immediate stops the delete path's latency budget being multiplied.
+_IMMEDIATE_REPLACEMENT_RETRY_BACKOFF = (0.0, 0.0)
 _SETTLED_PROMOTION_FIELDS = frozenset(
     {
         "route",
@@ -1390,19 +1398,39 @@ def _conversation_replacement_digest(
     )
 
 
+def _backoff_before_replacement_retry(attempt: int, schedule: Sequence[float]) -> None:
+    """Pause between conversation-replacement conflict rounds.
+
+    A zero or missing entry keeps the round immediate, which is what callers
+    that own an outer converging loop pass.
+    """
+    if attempt >= len(schedule):
+        return
+    delay = schedule[attempt]
+    if delay > 0:
+        time.sleep(delay)
+
+
 def replace_conversation_sourced_memories(
     uid: str,
     conversation_id: str,
     items: List[Dict[str, Any]],
     *,
     db_client: Any = None,
+    conflict_backoff_seconds: Sequence[float] = _REPLACEMENT_CONFLICT_BACKOFF_SECONDS,
 ) -> Dict[str, Any]:
-    """Atomically replace one conversation's complete canonical memory set."""
+    """Atomically replace one conversation's complete canonical memory set.
+
+    Every same-account canonical write races the account-global control CAS, so
+    a conflicted round must re-plan against the control the peer left behind.
+    ``conflict_backoff_seconds`` bounds those rounds: one entry per retry, and
+    the number of attempts is ``len(...) + 1``.
+    """
     client = db_client if db_client is not None else default_db_client
     replacement_digest = _conversation_replacement_digest(uid, conversation_id, items)
     replacement_id = f"replace_{replacement_digest[:32]}"
     last_conflict: Optional[ConversationSourceReplacementConflict] = None
-    for _attempt in range(3):
+    for _attempt in range(len(conflict_backoff_seconds) + 1):
         observed_control = _read_replacement_control(uid, db_client=client)
         expected_source_items = [
             item
@@ -1438,6 +1466,7 @@ def replace_conversation_sourced_memories(
             last_conflict = ConversationSourceReplacementConflict(
                 "memory control changed during conversation source scan"
             )
+            _backoff_before_replacement_retry(_attempt, conflict_backoff_seconds)
             continue
         observed_control = confirmed_control
         next_generation = observed_control.source_generation + 1
@@ -1507,6 +1536,7 @@ def replace_conversation_sourced_memories(
             break
         except ConversationSourceReplacementConflict as exc:
             last_conflict = exc
+            _backoff_before_replacement_retry(_attempt, conflict_backoff_seconds)
     else:
         raise ConversationReplacementConflictError(
             "canonical conversation replacement conflicted repeatedly"
@@ -2317,6 +2347,7 @@ def retract_conversation_sourced_memories(uid: str, conversation_id: str, *, db_
                 conversation_id,
                 [],
                 db_client=client,
+                conflict_backoff_seconds=_IMMEDIATE_REPLACEMENT_RETRY_BACKOFF,
             )
         except ConversationReplacementConflictError as exc:
             last_conflict = exc


### PR DESCRIPTION
## Bug

Every same-account canonical memory write races the one account-global
`memory_state/apply_control` document. #11726 fixed that contention for
**retraction** (cascade delete + merge) with a converging, backed-off loop and
explicitly left **extraction** on its existing contract: three *immediate*
attempts inside `replace_conversation_sourced_memories`.

Extraction has no outer convergence loop. It is called straight from
conversation processing (`process_conversation` → `_extract_memories` →
`_extract_memories_canonical`) and is intentionally fail-closed, so when the
three attempts exhaust, `ConversationReplacementConflictError` propagates out
of `_emit_derived_effects` and the **whole enrichment fails**: the user's
conversation gets no memories and no summary, and the deferred-open path
re-arms and retries, feeding the storm.

### Prod evidence (read-only)

Cloud Run service `backend`, project `based-hardware`, 2026-08-19. 11 ×
`canonical conversation replacement conflicted repeatedly` raised from
`canonical_memory_adapter.replace_conversation_sourced_memories`, each caused
by `ConversationSourceReplacementConflict("memory control changed during
conversation replacement")` from the transaction fence in
`database/memory_apply_store.py`.

- 15:45:43–15:51Z, revision `backend-79a585b` — **four distinct instances**
  failing concurrently (`...9569c2b`, `...7981eb`, `...b603dbbf16`,
  `...a4b96`), i.e. genuine same-account contention, not one stuck worker.
- 17:33Z, same revision.
- 22:55Z on the **current** revision `backend-920fc55` — still live.

## Root cause

An immediate retry re-reads the control a peer just advanced, so a burst of
same-account writers keeps losing in lockstep. The budget is spent on ordinary
contention, not on a real failure.

## Fix

`replace_conversation_sourced_memories` now takes a bounded backoff schedule
(`0.05 → 0.5s`, five rounds) — the one the retraction path already proved in
prod. The attempt count is derived from the schedule so "how many rounds" and
"how far apart" cannot drift. Both conflict sites in the loop (the source-scan
control mismatch and the store fence) back off.

Exhaustion still raises the same typed `ConversationReplacementConflictError`
and nothing is committed on the way out — the #11627 never-orphan-live-memories
fence is unchanged.

Retraction keeps its inner rounds **immediate** (it passes the explicit
immediate schedule) so the cascade-delete latency budget is not multiplied by
its own outer converging loop. Its three existing convergence tests pass
untouched, which is the proof that path did not move.

## What I tested

- `backend/tests/unit/test_conversation_replacement_backoff.py` (3 new tests)
  drives the real production function through the real store boundary with the
  shared fake Firestore:
  - conflicts that outlast the old immediate budget now converge and **commit
    the memory item** (`source_generation` 1 → 2);
  - the budget stays bounded at 5 rounds with the `0.05/0.1/0.25/0.5` schedule
    and **fails closed** — `apply_control` left at `source_generation: 1`, no
    item written;
  - a caller passing an immediate schedule still gets 3 no-sleep rounds.
- All 3 **fail against `origin/main`** (2 on the un-backed-off budget, 1 on the
  absent parameter) and pass on this branch.
- `backend/tests/unit/test_cascade_retract_convergence.py`: 3 passed, file
  unmodified.
- 16-file memory/canonical selection: **273 passed**, 1 pre-existing ordering
  failure (`test_ws_c_backfill.py::test_stage_all_candidate_can_be_reviewed_processed_and_routed_by_l2`)
  reproduced identically on `origin/main` and passing when that file runs alone.
- `make preflight` (deterministic check manifest, CI lane).

## Product invariants affected

- INV-MEM-1

## Failure class

Second fix sharing this cause (#11731 was the first), so it is registered
rather than left as an instance fix, per root `AGENTS.md`.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged

Line-Count-Exception: backend/utils/memory/canonical_memory_adapter.py | 2562 -> 2593 | Surgical in-place fix to one existing conflict loop in this file (bounded backoff helper + schedule parameter + the prod-signature docstring). Splitting the canonical adapter is a separate, high-blast-radius refactor and is not appropriate inside a production incident fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

