### PR TITLE
fix(backend): give whole-transcript conversation structuring a foreground LLM deadline

### DIFF
--- a/.github/failure-classes/FC-foreground-call-inherits-background-deadline.json
+++ b/.github/failure-classes/FC-foreground-call-inherits-background-deadline.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-foreground-call-inherits-background-deadline",
+  "violated_contract": "A dependency call that a user-facing request cannot complete without must be bounded by a deadline sized for that request's own budget and that call's observed cost, not silently inherit the shared client deadline sized for cheap background work.",
+  "canonical_prevention": "Give each foreground call an explicit request timeout derived from its measured latency and the route's end-to-end budget, and hold it with a regression test that drives the real production function against a client which enforces the requested deadline against a provider slower than the shared default.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_conversation_structure_provider_timeout.py",
+    "backend/tests/unit/test_conversation_test_prompt_provider_failure.py"
+  ],
+  "evidence_prs": [11859],
+  "scope_hints": [
+    "backend/utils/llm/**",
+    "backend/utils/conversations/**"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_conversation_structure_provider_timeout.py
+++ b/backend/tests/unit/test_conversation_structure_provider_timeout.py
@@ -1,0 +1,143 @@
+"""Whole-transcript conversation structuring must not die on the background gateway deadline.
+
+Live prod signature (backend image 920fc55, api.omi.me, 2026-08-19/20):
+
+    File "/app/utils/conversations/process_conversation.py", line 473, in _get_structured
+      raise conversation_processing_http_exception(e) from e
+    fastapi.exceptions.HTTPException: 500: Error processing conversation, please try again later
+    [chained from]
+    File "/app/utils/llm/conversation_processing.py", line 1408, in get_reprocess_transcript_structure
+      chain.invoke(
+    openai.APITimeoutError: Request timed out.
+
+Every affected request ended at the 15s gateway first-byte deadline -- 15.42s / 15.53s / 15.55s /
+15.83s on POST /v1/conversations, POST /v1/conversations/from-segments and
+POST /v1/conversations/{id}/reprocess -- and the conversation was finalized with no title, summary
+or action items at all. Successful requests on those same routes already run to ~55s (p50 9.2s,
+p90 41.0s, p99 51.8s), so 15s to first byte is simply too short for the call that summarizes a
+whole transcript; it is sized for background feature calls.
+
+The seam here is the provider client: it enforces the deadline the production function asked for,
+exactly as httpx does, against a provider that needs longer than the background deadline to answer.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+from datetime import datetime, timezone  # noqa: E402
+
+import httpx  # noqa: E402
+import openai  # noqa: E402
+import pytest  # noqa: E402
+from langchain_core.messages import AIMessage  # noqa: E402
+from langchain_core.runnables import RunnableLambda  # noqa: E402
+
+import utils.llm.conversation_processing as processing  # noqa: E402
+from utils.llm.conversation_prompt_prefix import build_conversation_prompt_prefix  # noqa: E402
+from utils.llm.gateway_resilience import DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS  # noqa: E402
+
+# What the provider actually needs to answer a whole-transcript structuring prompt. Longer than the
+# background first-byte deadline, comfortably inside the route's 120s TimeoutMiddleware budget.
+PROVIDER_FIRST_BYTE_SECONDS = 25.0
+
+_REQUEST = httpx.Request("POST", "https://gateway.invalid/v1/chat/completions")
+_RESPONSE_JSON = (
+    '{"title": "Budget Review", "overview": "The team agreed on the Q2 budget.", '
+    '"emoji": "\\ud83e\\udde0", "category": "business", "sections": [], "action_items": [], "events": []}'
+)
+STARTED_AT = datetime(2026, 8, 19, 14, 0, tzinfo=timezone.utc)
+TRANSCRIPT = "Speaker 0: we should lock the Q2 budget today. Speaker 1: agreed, sending the sheet."
+
+
+@pytest.fixture
+def slow_provider(monkeypatch):
+    """Stand in for the provider client, enforcing whatever deadline the caller asked for.
+
+    Returns the list of request timeouts the production code requested, so a test can also state
+    which deadline was in play when the call succeeded or failed.
+    """
+
+    requested: list[float | None] = []
+
+    def _get_llm(feature, *args, request_timeout=None, **kwargs):
+        requested.append(request_timeout)
+        deadline = request_timeout if request_timeout is not None else DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS
+
+        def _invoke(_payload):
+            if deadline < PROVIDER_FIRST_BYTE_SECONDS:
+                raise openai.APITimeoutError(request=_REQUEST)
+            return AIMessage(content=_RESPONSE_JSON)
+
+        return RunnableLambda(_invoke)
+
+    monkeypatch.setattr(processing, "get_llm", _get_llm)
+    # The shadow comparison hands the same prompt to a second client on a background executor; it is
+    # not part of the deadline contract under test.
+    monkeypatch.setattr(processing, "_should_run_conversation_structure_shadow", lambda *a, **k: False)
+    return requested
+
+
+def _structure():
+    return processing.get_transcript_structure(
+        TRANSCRIPT,
+        STARTED_AT,
+        'en',
+        'UTC',
+        'test-uid',
+    )
+
+
+def _reprocess_structure():
+    return processing.get_reprocess_transcript_structure(TRANSCRIPT, STARTED_AT, 'en', 'UTC')
+
+
+def _conversation_notes():
+    prefix = build_conversation_prompt_prefix(
+        conversation_id='277d188e-9563-4fd1-bf1b-8a6bbcbe4b94',
+        transcript=TRANSCRIPT,
+        started_at=STARTED_AT,
+        timezone_name='UTC',
+        language_code='en',
+    )
+    return processing.get_conversation_notes(
+        prefix,
+        started_at=STARTED_AT,
+        language_code='en',
+        output_language_code=None,
+        tz='UTC',
+        task_intelligence_capture=False,
+    )
+
+
+STRUCTURING_CALLS = [
+    pytest.param(_structure, id='get_transcript_structure'),
+    pytest.param(_reprocess_structure, id='get_reprocess_transcript_structure'),
+    pytest.param(_conversation_notes, id='get_conversation_notes'),
+]
+
+
+@pytest.mark.parametrize('call', STRUCTURING_CALLS)
+def test_slow_provider_still_produces_a_summary(call, slow_provider):
+    """Against unmodified source this is the failure that shipped: APITimeoutError, no summary."""
+    structured = call()
+
+    assert structured.title == 'Budget Review'
+    assert structured.overview.startswith('The team agreed')
+    assert slow_provider[0] == processing.CONVERSATION_STRUCTURE_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize('call', STRUCTURING_CALLS)
+def test_background_deadline_is_what_lost_the_conversation(call, slow_provider, monkeypatch):
+    """Control: put the background deadline back and the exact prod exception returns."""
+    monkeypatch.setattr(
+        processing, 'CONVERSATION_STRUCTURE_TIMEOUT_SECONDS', DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS
+    )
+
+    with pytest.raises(openai.APITimeoutError):
+        call()
+
+
+def test_foreground_deadline_exceeds_the_background_one():
+    assert processing.CONVERSATION_STRUCTURE_TIMEOUT_SECONDS > DEFAULT_GATEWAY_FIRST_BYTE_TIMEOUT_SECONDS

--- a/backend/tests/unit/test_omi_qos_tiers.py
+++ b/backend/tests/unit/test_omi_qos_tiers.py
@@ -709,7 +709,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/conversation_processing.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         for key in [
             'conv_folder',
             'conv_discard',
@@ -727,7 +727,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/memories.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         for key in ['memories', 'learnings', 'memory_category', 'memory_conflict']:
             assert key in calls, f"Missing get_llm('{key}') in memories.py"
         assert calls.count('memories') == 3, "memories should appear exactly three times"
@@ -736,7 +736,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/knowledge_graph.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert calls.count('knowledge_graph') == 2, "knowledge_graph should appear exactly twice"
 
     def test_followup_key(self):
@@ -751,7 +751,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/chat.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'chat_responses' in calls
         assert 'chat_extraction' in calls
 
@@ -759,7 +759,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/persona.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'persona_clone' in calls
         assert calls.count('persona_clone') >= 4, "persona_clone should appear in multiple clone functions"
         # Dynamic persona_chat/persona_chat_premium routing via feature variable
@@ -769,7 +769,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/goals.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'goals' in calls, "Missing get_llm('goals') in goals.py"
         assert 'goals_advice' in calls, "Missing get_llm('goals_advice') in goals.py"
 
@@ -777,14 +777,14 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/notifications.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'notifications' in calls
 
     def test_app_generator_py_all_keys(self):
         import re
 
         source = self._read_source("utils/llm/app_generator.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'app_generator' in calls
         assert 'app_integration' in calls
         assert calls.count('app_integration') >= 2, "app_integration should appear in multiple functions"
@@ -793,7 +793,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/retrieval/graph.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'chat_graph' in calls
 
     def test_perplexity_tools_key(self):
@@ -819,7 +819,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/external_integrations.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'external_structure' in calls
         assert calls.count('external_structure') >= 2, "external_structure should appear at least twice"
         assert 'daily_summary_simple' in calls, "Missing get_llm('daily_summary_simple') in external_integrations.py"
@@ -829,7 +829,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/llm/proactive_notification.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'proactive_notification' in calls
         assert calls.count('proactive_notification') >= 4, "proactive_notification should appear in 4 functions"
 
@@ -837,7 +837,7 @@ class TestExpandedCallsiteCoverage:
         import re
 
         source = self._read_source("utils/wrapped/generate_2025.py")
-        calls = re.findall(r"get_llm\('(\w+)'", source)
+        calls = re.findall(r"get_llm\(\s*'(\w+)'", source)
         assert 'wrapped_analysis' in calls
 
     def test_onboarding_key(self):

--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -1010,7 +1010,7 @@ def test_llm_calls_use_omi_qos_tier_system():
 
     # get_transcript_structure should use the conv_structure QoS lane.
     struct_match = re.search(
-        r'def get_transcript_structure.*?get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
+        r'def get_transcript_structure.*?get_llm\(\s*[\'"](\w+)[\'"]\s*,\s*cache_key=',
         conv_proc_source,
         re.DOTALL,
     )
@@ -1021,7 +1021,7 @@ def test_llm_calls_use_omi_qos_tier_system():
 
     # get_app_result should use the conv_app_result QoS lane.
     app_match = re.search(
-        r'def get_app_result.*?get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
+        r'def get_app_result.*?get_llm\(\s*[\'"](\w+)[\'"]\s*,\s*cache_key=',
         conv_proc_source,
         re.DOTALL,
     )
@@ -1032,7 +1032,7 @@ def test_llm_calls_use_omi_qos_tier_system():
 
     # extract_action_items should use the conv_action_items QoS lane.
     action_match = re.search(
-        r'def extract_action_items.*?get_llm\([\'"](\w+)[\'"]\s*,\s*cache_key=',
+        r'def extract_action_items.*?get_llm\(\s*[\'"](\w+)[\'"]\s*,\s*cache_key=',
         conv_proc_source,
         re.DOTALL,
     )
@@ -1054,7 +1054,7 @@ def test_all_callsites_use_get_llm():
 
     # conversation_processing.py: 9 callsites
     conv_proc_source = (backend_dir / "utils" / "llm" / "conversation_processing.py").read_text(encoding="utf-8")
-    conv_proc_calls = re.findall(r"get_llm\('(\w+)'", conv_proc_source)
+    conv_proc_calls = re.findall(r"get_llm\(\s*'(\w+)'", conv_proc_source)
     assert 'conv_action_items' in conv_proc_calls, "Missing get_llm('conv_action_items') in conversation_processing.py"
     assert 'conv_app_result' in conv_proc_calls, "Missing get_llm('conv_app_result') in conversation_processing.py"
     assert 'conv_app_select' in conv_proc_calls, "Missing get_llm('conv_app_select') in conversation_processing.py"
@@ -1068,7 +1068,7 @@ def test_all_callsites_use_get_llm():
 
     # knowledge_graph.py: 2 callsites
     kg_source = (backend_dir / "utils" / "llm" / "knowledge_graph.py").read_text(encoding="utf-8")
-    kg_calls = re.findall(r"get_llm\('(\w+)'", kg_source)
+    kg_calls = re.findall(r"get_llm\(\s*'(\w+)'", kg_source)
     assert (
         kg_calls.count('knowledge_graph') == 2
     ), f"Expected 2 get_llm('knowledge_graph') calls, got {kg_calls.count('knowledge_graph')}"
@@ -1076,15 +1076,18 @@ def test_all_callsites_use_get_llm():
     # memories.py: 6 callsites (memories x3 incl. the memory-log extract SSOT, learnings x1,
     # memory_category x1, memory_conflict x1)
     mem_source = (backend_dir / "utils" / "llm" / "memories.py").read_text(encoding="utf-8")
-    mem_calls = re.findall(r"get_llm\('(\w+)'", mem_source)
+    mem_calls = re.findall(r"get_llm\(\s*'(\w+)'", mem_source)
     assert mem_calls.count('memories') == 3, f"Expected 3 get_llm('memories') calls, got {mem_calls.count('memories')}"
     assert 'learnings' in mem_calls, "Missing get_llm('learnings') in memories.py"
     assert 'memory_category' in mem_calls, "Missing get_llm('memory_category') in memories.py"
     assert 'memory_conflict' in mem_calls, "Missing get_llm('memory_conflict') in memories.py"
 
-    # Total: 10 + 2 + 6 = 18 callsites (notes v2 adds the merged note call).
+    # Total: 11 + 2 + 6 = 19 callsites (notes v2 adds the merged note call). This was 18 while the
+    # pattern above required the feature key on the same line as `get_llm(`: one already-wrapped
+    # conv_app_result callsite was invisible to it, so the count was calibrated against a scan that
+    # silently skipped wrapped calls.
     total = len(conv_proc_calls) + len(kg_calls) + len(mem_calls)
-    assert total == 18, f"Expected 18 total get_llm() callsites, got {total}"
+    assert total == 19, f"Expected 19 total get_llm() callsites, got {total}"
 
 
 def test_no_direct_llm_instance_usage_in_wired_files():

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -1085,6 +1085,16 @@ def render_sections_markdown(sections: List[Any]) -> str:
     return '\n\n'.join(rendered)
 
 
+# Whole-transcript structuring produces the title and summary a conversation cannot be finalized
+# without, so like the test-prompt summary above it must not inherit the shared gateway transport
+# deadline (15s to first response byte), which is sized for background feature calls. In prod on
+# 2026-08-19 every `Error processing conversation` 500 on /v1/conversations, /from-segments and
+# /reprocess ended at 15.2-15.8s of request latency chained from `openai.APITimeoutError`, leaving
+# the conversation with no summary; successful requests on those routes already run to ~55s, inside
+# the route's own 120s TimeoutMiddleware budget.
+CONVERSATION_STRUCTURE_TIMEOUT_SECONDS = 60.0
+
+
 def get_conversation_notes(
     prefix: ConversationPromptPrefix,
     *,
@@ -1188,7 +1198,12 @@ DATE CONTEXT
     messages = [*prefix.messages(cache_enabled=cache_enabled), SystemMessage(content=task_instructions)]
     cache_key = prefix.cache_key if cache_enabled else None
     cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if cache_enabled else None
-    model = get_llm('conv_structure', cache_key=cache_key, prompt_cache_options=cache_options)
+    model = get_llm(
+        'conv_structure',
+        cache_key=cache_key,
+        prompt_cache_options=cache_options,
+        request_timeout=CONVERSATION_STRUCTURE_TIMEOUT_SECONDS,
+    )
     response = extraction_parser.parse(_content_str(model.invoke(messages)))
     structured = response.to_structured()
 
@@ -1312,7 +1327,12 @@ def get_transcript_structure(
         else:
             cache_key = 'omi-transcript-structure'
         cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if explicit_cache_enabled else None
-        structure_llm = get_llm('conv_structure', cache_key=cache_key, prompt_cache_options=cache_options)
+        structure_llm = get_llm(
+            'conv_structure',
+            cache_key=cache_key,
+            prompt_cache_options=cache_options,
+            request_timeout=CONVERSATION_STRUCTURE_TIMEOUT_SECONDS,
+        )
         chain = prompt | structure_llm | parser
         response = _coerce_structured(chain.invoke(legacy_prompt_values))
     if _should_run_conversation_structure_shadow(uid, started_at, conversation_context):
@@ -1401,7 +1421,12 @@ def get_reprocess_transcript_structure(
     # requests back into implicit, billable cache writes.
     cache_key = None if gateway_mode_enabled else 'omi-transcript-structure'
     cache_options = GPT56_EXPLICIT_CACHE_OPTIONS if explicit_cache_enabled else None
-    structure_llm = get_llm('conv_structure', cache_key=cache_key, prompt_cache_options=cache_options)
+    structure_llm = get_llm(
+        'conv_structure',
+        cache_key=cache_key,
+        prompt_cache_options=cache_options,
+        request_timeout=CONVERSATION_STRUCTURE_TIMEOUT_SECONDS,
+    )
     chain = prompt | structure_llm | parser
 
     response = _coerce_structured(


### PR DESCRIPTION
## The bug

The call that turns a transcript into a title, summary and action items ran on the shared gateway client, whose transport deadline is **15s to the first response byte** — a budget sized for cheap background feature calls. A whole-transcript structuring prompt regularly needs longer, so the call died at the deadline and `openai.APITimeoutError` became `HTTPException: 500: Error processing conversation, please try again later` at `utils/conversations/process_conversation.py:473`.

```
File "/app/utils/llm/conversation_processing.py", line 1408, in get_reprocess_transcript_structure
  chain.invoke(
openai.APITimeoutError: Request timed out.
[became]
File "/app/utils/conversations/process_conversation.py", line 473, in _get_structured
  raise conversation_processing_http_exception(e) from e
fastapi.exceptions.HTTPException: 500: Error processing conversation, please try again later
```

Live prod evidence (Cloud Run `backend`, project `based-hardware`, image `920fc55`, 24h to 2026-08-20T02:30Z):

- 37 `Error processing conversation` failures, 41 `openai.APITimeoutError`.
- **Every** affected request ended at the deadline: 15.42s / 15.53s / 15.55s / 15.83s / 15.42s … on `POST /v1/conversations`, `POST /v1/conversations/from-segments` and `POST /v1/conversations/{id}/reprocess`.
- Each one is a conversation that was already durably written and then finalized with **no title, no summary and no action items**. On the deferred desktop path the enrichment re-arms and fails the same way on the next open.

15s was never the right bound for this call. Successful requests on the same routes already run far past it — of 300 sampled 200s: p50 9.2s, p90 41.0s, p99 51.8s, max 55.5s.

## The fix

All three structuring entry points — `get_transcript_structure`, the notes-v2 `get_conversation_notes`, and `get_reprocess_transcript_structure` — ask `get_llm` for an explicit **60s foreground deadline**. Same value and same reasoning as the test-prompt summary call directly above it (#11859, `SUMMARY_WITH_PROMPT_TIMEOUT_SECONDS`); the route's own budget is the 120s `TimeoutMiddleware` default, so a slow attempt still fits with headroom. A provider failure that is not a deadline propagates exactly as before.

The three source-scraping QoS callsite checks required the feature key on the same line as `get_llm(`, which a wrapped call breaks. They now tolerate the wrap (`get_llm\(\s*'(\w+)'`). That also revealed the guard was under-counting: one already-wrapped `conv_app_result` callsite had been invisible to it, so the total moves 18 → 19 with the count comment corrected.

## What I tested

`backend/tests/unit/test_conversation_structure_provider_timeout.py` — 7 tests, all pass. The seam is the provider client: it enforces whatever deadline the production function asked for, exactly as httpx does, against a provider that needs 25s to first byte. Each of the three real structuring functions runs unmodified.

- **Control against `origin/main` source** (production file reverted, test kept): all three `test_slow_provider_still_produces_a_summary` cases fail with `openai.APITimeoutError: Request timed out.` — the exact prod exception.
- In-test control: `test_background_deadline_is_what_lost_the_conversation` puts the 15s background deadline back and asserts the timeout returns, so the test cannot pass for the wrong reason.

Related existing suites, via the real runner (`BACKEND_UNIT_TEST_FILE_LIST=… ./test.sh`, timing guard on): `test_omi_qos_tiers.py` 95 passed, `test_process_conversation_usage_context.py` 34 passed, `test_prompt_cache_wire_payload.py` 5 passed, `test_conversation_test_prompt_provider_failure.py` 10 passed.

Not exercised against the live provider — that needs a real slow provider response in prod.

## Failure class

`FC-foreground-call-inherits-background-deadline` — **new**, registered by this PR. #11859 fixed the same cause one route over the day before; a second instance is the point at which the class and its guard artifact should exist rather than being folded into a broader provider-failure class.

Line-Count-Exception: backend/utils/llm/conversation_processing.py | 1706 -> 1731 | the file is already over the ratchet; this fix adds one module constant, its prod-evidence rationale, and the wrapping of three existing get_llm calls that now pass it

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

