### PR TITLE
fix(backend): a deleted chat session must not 500 the write it was linking

### DIFF
--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, List, Optional, cast
 
-from google.api_core.exceptions import AlreadyExists, Conflict, FailedPrecondition
+from google.api_core.exceptions import AlreadyExists, Conflict, FailedPrecondition, NotFound
 from google.cloud import firestore, firestore_v1
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -704,34 +704,51 @@ def delete_chat_session(uid: str, chat_session_id: str, cascade_messages: bool =
     return None
 
 
+def _update_chat_session_if_exists(uid: str, chat_session_id: str, values: Dict[str, Any], what: str) -> bool:
+    """Apply a derived-state update to a chat session, tolerating a deleted session.
+
+    The message/file id lists and the OpenAI ids are derived state the session
+    document owns. Every writer below runs after a multi-second LLM call, and
+    DELETE /v2/messages (clear chat) deletes the session it read at the start of
+    that same window — so a concurrent clear, or a client retrying the slow
+    request, leaves these writes pointing at a tombstone. Firestore's update()
+    then raises NotFound and the user's chat call 500s even though the work it
+    was reporting already succeeded. A session that no longer exists has nothing
+    to record.
+
+    Returns True when the update was applied.
+    """
+    session_ref = db.collection('users').document(uid).collection('chat_sessions').document(chat_session_id)
+    try:
+        session_ref.update(values)
+        return True
+    except NotFound:
+        logger.warning(f"chat session {chat_session_id} no longer exists; skipping {what}")
+        return False
+
+
 def add_message_to_chat_session(uid: str, chat_session_id: str, message_id: str) -> None:
-    user_ref = db.collection('users').document(uid)
-    session_ref = user_ref.collection('chat_sessions').document(chat_session_id)
-    session_ref.update({"message_ids": firestore.ArrayUnion([message_id])})
+    _update_chat_session_if_exists(
+        uid, chat_session_id, {"message_ids": firestore.ArrayUnion([message_id])}, "message link"
+    )
 
 
 def add_files_to_chat_session(uid: str, chat_session_id: str, file_ids: List[str]) -> None:
     if not file_ids:
         return
 
-    user_ref = db.collection('users').document(uid)
-    session_ref = user_ref.collection('chat_sessions').document(chat_session_id)
-    session_ref.update({"file_ids": firestore.ArrayUnion(file_ids)})
+    _update_chat_session_if_exists(uid, chat_session_id, {"file_ids": firestore.ArrayUnion(file_ids)}, "file link")
 
 
 def update_chat_session_openai_ids(uid: str, chat_session_id: str, thread_id: str, assistant_id: str) -> None:
     """Update OpenAI thread and assistant IDs for a chat session"""
-    user_ref = db.collection('users').document(uid)
-    session_ref = user_ref.collection('chat_sessions').document(chat_session_id)
-
     update_data: Dict[str, str] = {}
     if thread_id:
         update_data['openai_thread_id'] = thread_id
     if assistant_id:
         update_data['openai_assistant_id'] = assistant_id
 
-    if update_data:
-        session_ref.update(update_data)
+    if update_data and _update_chat_session_if_exists(uid, chat_session_id, update_data, "openai id link"):
         logger.info(f"Updated session {chat_session_id} with thread {thread_id} and assistant {assistant_id}")
 
 

--- a/backend/tests/unit/test_chat_session_link_deleted_session.py
+++ b/backend/tests/unit/test_chat_session_link_deleted_session.py
@@ -1,0 +1,140 @@
+"""Chat writes must survive a chat session deleted while they were in flight.
+
+Prod signature (2026-08-20T00:49:53Z, image 920fc55): DELETE /v2/messages returned
+500 after 31.5s from
+database/chat.py:add_message_to_chat_session ->
+`google.api_core.exceptions.NotFound: 404 No document to update:
+.../users/<uid>/chat_sessions/78489909-...`.
+
+The race is the endpoint's own latency. clear_chat_messages reads the session,
+deletes it, then calls initial_message_util, which acquires/creates a session and
+spends the whole LLM round trip (10-80s in prod on this route) generating the
+greeting before linking the new ai message back onto the session document. A second
+clear -- a double tap, or a client retrying a request that already looked hung --
+lands inside that window: it deletes the session the first call is still holding, so
+the first call's link write hits a tombstone. The user's clear then 500s even though
+the clear itself, and the message write it was reporting, both succeeded.
+
+The message/file/OpenAI-id lists are derived state the session document owns; a
+session that no longer exists has nothing to record. This mirrors the guard
+database/folders.py:update_folder_conversation_count already carries for the same
+failure class (see test_folder_move_deleted_folder).
+
+The fake below models the one server behavior that matters: update() on a missing
+document raises NotFound. test_fake_update_on_missing_session_raises is the control
+that keeps that true, so the other cases prove the guard rather than a lenient fake.
+"""
+
+import os
+
+import pytest
+from google.api_core.exceptions import NotFound
+from unittest.mock import patch
+
+os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
+os.environ.setdefault(
+    'ENCRYPTION_SECRET',
+    'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv',
+)
+
+import database.chat as chat_db
+
+UID = 'u1'
+SESSION_ID = '78489909-6ff7-41de-b292-0fedd332e1ba'
+
+
+class _FakeDocRef:
+    def __init__(self, store, doc_id):
+        self._store = store
+        self.id = doc_id
+
+    def update(self, values):
+        if self.id not in self._store:
+            raise NotFound(f"404 No document to update: {self.id}")
+        self._store[self.id].update(values)
+
+    def delete(self):
+        self._store.pop(self.id, None)
+
+
+class _FakeCollection:
+    def __init__(self, store):
+        self._store = store
+
+    def document(self, doc_id):
+        return _FakeDocRef(self._store, doc_id)
+
+
+class _FakeUserRef:
+    def __init__(self, store):
+        self._store = store
+
+    def collection(self, name):
+        assert name == 'chat_sessions'
+        return _FakeCollection(self._store)
+
+
+class _FakeDb:
+    def __init__(self, store):
+        self._store = store
+
+    def collection(self, name):
+        assert name == 'users'
+        return self
+
+    def document(self, _uid):
+        return _FakeUserRef(self._store)
+
+
+@pytest.fixture
+def live_session():
+    """A session store holding one session, patched in as database.chat's Firestore client."""
+    store = {SESSION_ID: {'id': SESSION_ID}}
+    with patch.object(chat_db, 'db', _FakeDb(store)):
+        yield store
+
+
+def _delete(store):
+    """The concurrent clear: the session is gone by the time the in-flight write lands."""
+    store.pop(SESSION_ID, None)
+
+
+def test_fake_update_on_missing_session_raises(live_session):
+    # Control: without the guard these writes propagate NotFound, which is the 500.
+    _delete(live_session)
+    with pytest.raises(NotFound):
+        _FakeDb(live_session).collection('users').document(UID).collection('chat_sessions').document(SESSION_ID).update(
+            {'message_ids': ['m1']}
+        )
+
+
+def test_add_message_links_message_onto_live_session(live_session):
+    chat_db.add_message_to_chat_session(UID, SESSION_ID, 'm1')
+    assert 'message_ids' in live_session[SESSION_ID]
+
+
+def test_add_message_to_deleted_session_does_not_raise(live_session):
+    _delete(live_session)
+    assert chat_db.add_message_to_chat_session(UID, SESSION_ID, 'm1') is None
+    assert SESSION_ID not in live_session
+
+
+def test_add_files_to_deleted_session_does_not_raise(live_session):
+    _delete(live_session)
+    assert chat_db.add_files_to_chat_session(UID, SESSION_ID, ['f1']) is None
+
+
+def test_add_files_still_links_onto_live_session(live_session):
+    chat_db.add_files_to_chat_session(UID, SESSION_ID, ['f1'])
+    assert 'file_ids' in live_session[SESSION_ID]
+
+
+def test_update_openai_ids_on_deleted_session_does_not_raise(live_session):
+    _delete(live_session)
+    assert chat_db.update_chat_session_openai_ids(UID, SESSION_ID, 'thread', 'assistant') is None
+
+
+def test_update_openai_ids_still_writes_to_live_session(live_session):
+    chat_db.update_chat_session_openai_ids(UID, SESSION_ID, 'thread', 'assistant')
+    assert live_session[SESSION_ID]['openai_thread_id'] == 'thread'
+    assert live_session[SESSION_ID]['openai_assistant_id'] == 'assistant'


### PR DESCRIPTION
## Bug

Prod (image `920fc55`, `2026-08-20T00:49:53Z`): `DELETE /v2/messages` returned **500 after 31.5s**, from

```
File "/app/routers/chat.py", line 665, in clear_chat_messages
    return initial_message_util(uid, compat_app_id)
File "/app/utils/chat.py", line 97, in initial_message_util
    chat_db.add_message_to_chat_session(uid, chat_session['id'], ai_message.id)
File "/app/database/chat.py", line 710, in add_message_to_chat_session
    session_ref.update({"message_ids": firestore.ArrayUnion([message_id])})
google.api_core.exceptions.NotFound: 404 No document to update:
    .../users/<uid>/chat_sessions/78489909-6ff7-41de-b292-0fedd332e1ba
```

Nine occurrences on `chat_sessions` since 2026-08-01; user-visible as a failed "clear chat".

## Root cause

The race is the endpoint's own latency. `clear_chat_messages` reads the session, deletes it, then
calls `initial_message_util`, which acquires/creates a session and spends the **whole LLM round
trip** generating the greeting before linking the new ai message back onto the session document.
That route measured 10–80s in prod. A second clear — a double tap, or a client retrying a request
that already looked hung — lands inside that window and deletes the session the first call is still
holding, so the first call's link write hits a tombstone.

Confirmed in the request log: the 500 started `00:49:21.99` (31.46s latency → error at `00:49:53.45`,
an exact match) and a second `DELETE /v2/messages` started `00:49:47`, inside it.

The clear itself, and the message write the link was reporting, had both already committed — so the
user got a 500 for work that succeeded, exactly the shape of #11833
(`update_folder_conversation_count`). The same window is open on the send-message path, where the
link write also trails a multi-second model call.

## Fix

`message_ids`, `file_ids` and the OpenAI thread/assistant ids are derived state the session document
owns; a session that no longer exists has nothing to record. The guard sits inside that maintenance
boundary (`_update_chat_session_if_exists`), so every caller of the three writers is covered at once
rather than each call site growing its own `try`. `update_chat_session_openai_ids` only logs its
success line when the write landed.

## What I tested

- **The exact prod path**: `utils.chat.initial_message_util` with the session deleted *during* the
  model call, real `database.chat`, only the Firestore client faked — returns the greeting with the
  fix, raises the identical `NotFound` without it.
- **7 new db-layer regression tests** (`tests/unit/test_chat_session_link_deleted_session.py`,
  0.03s). The three deleted-session cases fail on unfixed source with the prod exception; a control
  test keeps the fake's `update()` raising on a missing document, so the passes prove the guard and
  not a lenient fake.
- **57 chat/session/message unit files** run file-by-file the way `test.sh` invokes them: all green.
- `make preflight` green; `scripts/failure-class validate` OK.

Not exercised: a live `DELETE /v2/messages` against prod Firestore — reproducing it needs two
concurrent clears on a real account, so the router frame above `initial_message_util` (a direct
`return`) is covered by reasoning, not by execution.

Failure-Class: FC-post-commit-index-maintenance-terminal

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

