### PR TITLE
feat(desktop): make Home prove Omi's value

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
@@ -195,7 +195,7 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
   private var countSentence: String {
     guard let total else { return "Counting what you've captured…" }
     if mode == .answer {
-      return "Answered from \(QueryShellCount.number(total)) captured moments"
+      return "\(QueryShellCount.number(total)) captured moments ready as context"
     }
     return QueryShellCount.sentence(
       matching: matching, total: total, isFiltering: request.isFiltering, isSettled: corpusSettled)

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
@@ -193,10 +193,10 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
   }
 
   private var countSentence: String {
-    guard let total else { return "Counting what you've captured…" }
     if mode == .answer {
-      return "\(QueryShellCount.number(total)) captured moments ready as context"
+      return "Answers cite the context they use"
     }
+    guard let total else { return "Counting what you've captured…" }
     return QueryShellCount.sentence(
       matching: matching, total: total, isFiltering: request.isFiltering, isSettled: corpusSettled)
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
@@ -8,6 +8,9 @@ import SwiftUI
 struct QuerySearchBar: View {
   @Binding var text: String
   var accessibilityID: String = "query-search-field"
+  var focusClaim: Int = 0
+
+  @FocusState private var isFocused: Bool
 
   var body: some View {
     HStack(spacing: QueryShellLayout.heroRowSpacing) {
@@ -18,6 +21,7 @@ struct QuerySearchBar: View {
         .textFieldStyle(.plain)
         .scaledFont(size: QueryShellLayout.queryFontSize, weight: .regular)
         .foregroundStyle(Ink.primary)
+        .focused($isFocused)
         .accessibilityIdentifier(accessibilityID)
       if !text.isEmpty {
         Button {
@@ -34,5 +38,9 @@ struct QuerySearchBar: View {
     .padding(.horizontal, QueryShellLayout.barPaddingHorizontal)
     .frame(minHeight: QueryShellLayout.barMinHeight)
     .inkGlassPanel(cornerRadius: QueryShellLayout.panelCornerRadius, shadow: .ambient)
+    .onAppear {
+      if focusClaim > 0 { isFocused = true }
+    }
+    .onChange(of: focusClaim) { _, _ in isFocused = true }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -43,6 +43,7 @@ struct QueryShellHome: View {
   @ObservedObject var chatProvider: ChatProvider
   @ObservedObject var memoriesViewModel: MemoriesViewModel
   @ObservedObject private var tasksStore = TasksStore.shared
+  @ObservedObject private var homeSuggestionsStore = HomeSuggestionsStore.shared
   var taskChatCoordinator: TaskChatCoordinator? = nil
   /// The Chat-first shell keeps the existing modern Home presentation even when the reversible legacy
   /// preference is enabled. This is presentation-only; capability sampling and rich-block access
@@ -96,6 +97,10 @@ struct QueryShellHome: View {
   /// `.focused()` does not reach, and a flag already `true` could never re-claim a caret AppKit had
   /// since given away — which is precisely the case the `didBecomeActive` claim below exists for.
   @State private var caretClaims = 0
+  /// Home earns the word "Home" before it becomes a transcript: every visit begins with the compact
+  /// proof of what Omi knows and three real questions. Any send, automation handoff or explicit
+  /// continue swaps this for the established `QueryAnswerThread`; no transcript state is copied.
+  @State private var showsSecondBrainHome = true
 
   private var usesLegacyPresentation: Bool {
     useLegacyHomeDesign && !forceModernPresentation
@@ -169,6 +174,7 @@ struct QueryShellHome: View {
     // A typed character belongs in the field even when the field is not focused: this is a search
     // surface, and a search surface that swallows the first letter you type is broken.
     .onAppear {
+      if chatProvider.isSending { showsSecondBrainHome = false }
       claimCaret()
     }
     // **Coming back to Omi puts the caret back in the field.** This surface's whole job is to be typed
@@ -219,6 +225,7 @@ struct QueryShellHome: View {
     .onReceive(NotificationCenter.default.publisher(for: .homeStageOpenChat)) { _ in
       guard !usesLegacyPresentation else { return }
       searchText = HomeBridgeIntent.openChat.searchTextAfter(searchText)
+      showsSecondBrainHome = false
       claimCaret()
     }
     // `home_close_panel` collapses Home to its resting chat state — the same thing Escape does.
@@ -232,6 +239,7 @@ struct QueryShellHome: View {
     .onReceive(NotificationCenter.default.publisher(for: .homeStageAsk)) { note in
       guard !usesLegacyPresentation, let query = note.userInfo?["query"] as? String else { return }
       searchText = HomeBridgeIntent.ask.searchTextAfter(searchText)
+      showsSecondBrainHome = false
       chatProvider.draftText = query
       ask()
     }
@@ -247,7 +255,14 @@ struct QueryShellHome: View {
       searchText = ""
       return true
     }
-    .task { await loadScreenCount() }
+    .task {
+      async let screen: Void = loadScreenCount()
+      async let suggestions: Void = homeSuggestionsStore.refreshIfNeeded()
+      _ = await (screen, suggestions)
+    }
+    .onChange(of: chatProvider.isSending) { _, isSending in
+      if isSending { showsSecondBrainHome = false }
+    }
     // **No rule here reads an empty field as an instruction.** Emptying the bar used to eject you
     // from answer mode — so backspacing your last question to type a follow-up threw the conversation
     // off screen mid-edit, and the composer could never be cleared by the send either. `esc Results`
@@ -311,12 +326,21 @@ struct QueryShellHome: View {
         onOpenRewind: openRewind
       )
     case .answer:
-      QueryAnswerThread(
-        chatProvider: chatProvider,
-        onOpenCitation: openCitation,
-        onRetry: retry,
-        chatFirstRichBlockContext: chatFirstRichBlockContext
-      )
+      if showsSecondBrainHome {
+        SecondBrainHome(
+          snapshot: secondBrainSnapshot,
+          hasConversation: !chatProvider.messages.isEmpty,
+          onAsk: askFromSecondBrainHome,
+          onContinueConversation: revealConversation
+        )
+      } else {
+        QueryAnswerThread(
+          chatProvider: chatProvider,
+          onOpenCitation: openCitation,
+          onRetry: retry,
+          chatFirstRichBlockContext: chatFirstRichBlockContext
+        )
+      }
     }
   }
 
@@ -387,6 +411,7 @@ struct QueryShellHome: View {
   private func clearTranscript() {
     Task {
       await chatProvider.clearChat()
+      showsSecondBrainHome = true
     }
   }
 
@@ -418,6 +443,7 @@ struct QueryShellHome: View {
     let submission = QueryShellSubmission.resolve(text: chatProvider.draftText)
     if chatProvider.draftText != submission.text { chatProvider.draftText = submission.text }
     guard submission.mode != nil else { return }
+    showsSecondBrainHome = false
     claimCaret()
     guard let question = submission.question else { return }
     lastAskedQuestion = question
@@ -431,6 +457,18 @@ struct QueryShellHome: View {
       messageLength: question.count, hasSelectedAppContext: false, source: "query_shell")
     chatProvider.dismissOnboardingOpener()
     Task { await chatProvider.sendMessage(question) }
+  }
+
+  private func askFromSecondBrainHome(_ question: String) {
+    showsSecondBrainHome = false
+    PostOnboardingPromptSuggestions.consume()
+    lastAskedQuestion = question
+    send(question)
+  }
+
+  private func revealConversation() {
+    showsSecondBrainHome = false
+    claimCaret()
   }
 
   /// Re-sends the question that failed, not whatever the bar holds now — the send emptied it.
@@ -564,6 +602,17 @@ struct QueryShellHome: View {
     let conversations = appState.conversations.filter { $0.deleted != true }.count
     let tasks = tasksStore.tasks.filter { !$0.isRetired }.count
     return conversations + memoriesViewModel.memories.count + tasks + screenCount
+  }
+
+  private var secondBrainSnapshot: SecondBrainHomeSnapshot {
+    SecondBrainHomeSnapshot.compose(
+      conversations: appState.conversations.filter { $0.deleted != true }.count,
+      memories: memoriesViewModel.memories.count,
+      tasks: tasksStore.tasks.filter { !$0.isRetired }.count,
+      screenCount: screenCount,
+      personalizedPrompts: homeSuggestionsStore.personalizedQuestions,
+      onboardingPrompts: PostOnboardingPromptSuggestions.suggestions(),
+      opener: chatProvider.onboardingOpener)
   }
 
   private func loadScreenCount() async {

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -70,6 +70,10 @@ struct QueryShellHome: View {
   /// The always-visible search bar's text. Not the chat draft: the one chat composer lives inside
   /// the panel (INV-6) and keeps `chatProvider.composerDraft`; this field only narrows the spine.
   @State private var searchText = ""
+  /// Search is a compact command while Home is resting. It expands into the unchanged full search
+  /// field on demand, so the shared chat composer remains the only obvious text box on first paint.
+  @State private var isSearchExpanded = false
+  @State private var searchFocusClaims = 0
   // Home IS the conversation. The panel rests on the chat and shows search results only while the
   // search bar above it holds text — clearing the field (or esc) always lands back on the chat.
   // There is no stored mode, so no bridge action or stale state can strand the page on the list.
@@ -97,9 +101,9 @@ struct QueryShellHome: View {
   /// `.focused()` does not reach, and a flag already `true` could never re-claim a caret AppKit had
   /// since given away — which is precisely the case the `didBecomeActive` claim below exists for.
   @State private var caretClaims = 0
-  /// Home earns the word "Home" before it becomes a transcript: every visit begins with the compact
-  /// proof of what Omi knows and three real questions. Any send, automation handoff or explicit
-  /// continue swaps this for the established `QueryAnswerThread`; no transcript state is copied.
+  /// The overview is Home's activation and empty state. A returning user with a transcript goes
+  /// straight back to that transcript; onboarding may deliberately put its proof receipt in front
+  /// once, and any send or explicit continue returns to the established `QueryAnswerThread`.
   @State private var showsSecondBrainHome = true
 
   private var usesLegacyPresentation: Bool {
@@ -125,15 +129,19 @@ struct QueryShellHome: View {
   private var querySurface: some View {
     GeometryReader { proxy in
       let lane = QueryShellLayout.laneWidth(for: proxy.size.width)
-      // The search bar is always mounted above the panel, so the body's room subtracts it in both
-      // modes — `panelBodyHeight` only knows the hero reserve for `.results`.
+      let usesCompactSearch = HomeSearchPresentationPolicy.isCompact(
+        mode: mode, isExpanded: isSearchExpanded)
+      // Resting Home keeps its search command inside the answer panel's header. Only the expanded
+      // search field needs a separate glass object and the air between it and the panel.
+      let searchReserve =
+        usesCompactSearch
+        ? 0 : QueryShellLayout.barMinHeight + QueryShellLayout.panelGap
       let chrome = QueryShellLayout.panelChromeHeight(
         mode: mode,
         composerHeight: mode == .answer
           ? max(QueryShellLayout.panelComposerMinHeight, composerHeight) : 0)
       let room =
-        proxy.size.height - QueryShellLayout.surfaceTopInset - QueryShellLayout.barMinHeight
-        - QueryShellLayout.panelGap - chrome
+        proxy.size.height - QueryShellLayout.surfaceTopInset - searchReserve - chrome
       let bodyHeight = min(
         QueryShellLayout.maximumBodyHeight, max(QueryShellLayout.minimumBodyHeight, room))
       // **Only this column is woken by a keystroke.** The composer draft is not published on
@@ -141,10 +149,12 @@ struct QueryShellHome: View {
       // shell and the transcript while still giving the bar — and the list it filters — the live text.
       ChatDraftScope(draft: chatProvider.composerDraft) { draft in
         VStack(spacing: QueryShellLayout.panelGap) {
-          // **The search bar is always on screen.** It is pure search — typing narrows the spine
-          // below; clearing it returns the panel to the conversation. The chat composer is a
-          // different control and stays pinned inside the panel (INV-6: one chat composer).
-          QuerySearchBar(text: $searchText)
+          // Resting Home keeps search as a compact command so the chat composer is the only obvious
+          // field. Its command lives in the panel header; expanding it mounts the same pure-search
+          // bar used by results above the panel, and it never sends.
+          if !usesCompactSearch {
+            QuerySearchBar(text: $searchText, focusClaim: searchFocusClaims)
+          }
           QueryResultsPanel(
             request: requestBinding(),
             mode: mode,
@@ -171,8 +181,8 @@ struct QueryShellHome: View {
         .padding(.top, OmiSpacing.sm)
       }
     }
-    // A typed character belongs in the field even when the field is not focused: this is a search
-    // surface, and a search surface that swallows the first letter you type is broken.
+    // The shared chat composer receives the caret on Home. Search takes it only after the explicit
+    // Search history command (or ⌘K) expands that field.
     .onAppear {
       if chatProvider.isSending { showsSecondBrainHome = false }
       claimCaret()
@@ -185,6 +195,12 @@ struct QueryShellHome: View {
     // Harmless when the field already has it — the claim is a no-op once the caret is already there.
     .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
       claimCaret()
+    }
+    // Screen counts and the proof canvas are owner-bound. A completion from owner A must never
+    // publish into owner B's Home after the identity fence moves.
+    .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
+      screenCount = nil
+      Task { await loadScreenCount() }
     }
     // The two product flows the provider drives and nothing renders. Both were hosted only by the
     // deleted chat page, so since that deletion a browser tool with no extension token has killed
@@ -225,6 +241,7 @@ struct QueryShellHome: View {
     .onReceive(NotificationCenter.default.publisher(for: .homeStageOpenChat)) { _ in
       guard !usesLegacyPresentation else { return }
       searchText = HomeBridgeIntent.openChat.searchTextAfter(searchText)
+      isSearchExpanded = false
       showsSecondBrainHome = false
       claimCaret()
     }
@@ -239,6 +256,7 @@ struct QueryShellHome: View {
     .onReceive(NotificationCenter.default.publisher(for: .homeStageAsk)) { note in
       guard !usesLegacyPresentation, let query = note.userInfo?["query"] as? String else { return }
       searchText = HomeBridgeIntent.ask.searchTextAfter(searchText)
+      isSearchExpanded = false
       showsSecondBrainHome = false
       chatProvider.draftText = query
       ask()
@@ -251,8 +269,13 @@ struct QueryShellHome: View {
     // Escape while searching clears the search and lands back on the conversation; with an empty
     // field it falls through to the shell's own Escape (dismiss the window).
     .onEscapeKey(priority: .content) {
-      guard !searchText.isEmpty else { return false }
-      searchText = ""
+      if !searchText.isEmpty {
+        searchText = ""
+        return true
+      }
+      guard isSearchExpanded else { return false }
+      isSearchExpanded = false
+      claimCaret()
       return true
     }
     .task {
@@ -326,10 +349,11 @@ struct QueryShellHome: View {
         onOpenRewind: openRewind
       )
     case .answer:
-      if showsSecondBrainHome {
+      if shouldPresentSecondBrainHome {
         SecondBrainHome(
           snapshot: secondBrainSnapshot,
           hasConversation: !chatProvider.messages.isEmpty,
+          canUsePrompts: SecondBrainPromptPolicy.canUseSuggestion(draft: chatProvider.draftText),
           onAsk: askFromSecondBrainHome,
           onContinueConversation: revealConversation
         )
@@ -346,12 +370,40 @@ struct QueryShellHome: View {
 
   // MARK: - The panel's chat controls
 
+  private var compactSearchControl: some View {
+    Button(action: expandSearch) {
+      HStack(spacing: OmiSpacing.sm) {
+        Image(systemName: "magnifyingglass")
+          .accessibilityHidden(true)
+        Text("Search history")
+        Text("⌘K")
+          .foregroundStyle(Ink.secondary)
+      }
+      .inkStyle(InkType.statusLabel, color: Ink.primary)
+      .padding(.horizontal, OmiSpacing.md)
+      .frame(minHeight: 36)
+      .glassChip(isActive: false)
+    }
+    .buttonStyle(.plain)
+    .keyboardShortcut("k", modifiers: .command)
+    .help("Search everything Omi has captured")
+    .accessibilityIdentifier("query-search-expand")
+  }
+
+  private func expandSearch() {
+    isSearchExpanded = true
+    searchFocusClaims &+= 1
+  }
+
   /// The one slot the panel gives its host, filled differently per mode: on the list it is the way
   /// into the conversation, and in the conversation it is what you can do to it.
   @ViewBuilder
   private var headerAccessory: some View {
-    if mode == .answer, menu.isPresentable {
-      chatMenu
+    if mode == .answer {
+      compactSearchControl
+      if menu.isPresentable {
+        chatMenu
+      }
     }
   }
 
@@ -460,10 +512,13 @@ struct QueryShellHome: View {
   }
 
   private func askFromSecondBrainHome(_ question: String) {
-    showsSecondBrainHome = false
+    guard SecondBrainPromptPolicy.canUseSuggestion(draft: chatProvider.draftText) else {
+      claimCaret()
+      return
+    }
     PostOnboardingPromptSuggestions.consume()
-    lastAskedQuestion = question
-    send(question)
+    chatProvider.draftText = question
+    submit()
   }
 
   private func revealConversation() {
@@ -612,7 +667,49 @@ struct QueryShellHome: View {
       screenCount: screenCount,
       personalizedPrompts: homeSuggestionsStore.personalizedQuestions,
       onboardingPrompts: PostOnboardingPromptSuggestions.suggestions(),
-      opener: chatProvider.onboardingOpener)
+      opener: chatProvider.onboardingOpener,
+      contextEvidence: secondBrainContextEvidence)
+  }
+
+  private var shouldPresentSecondBrainHome: Bool {
+    SecondBrainHomePresentationPolicy.showsOverview(
+      requested: showsSecondBrainHome,
+      hasMessages: !chatProvider.messages.isEmpty,
+      hasOnboardingOpener: chatProvider.onboardingOpener != nil,
+      isSending: chatProvider.isSending)
+  }
+
+  /// A small, real window into what Omi can answer from. This is already-loaded account data: no
+  /// extra fetch, no invented example, and no second source of truth.
+  private var secondBrainContextEvidence: [SecondBrainHomeSnapshot.Evidence] {
+    var evidence: [SecondBrainHomeSnapshot.Evidence] = []
+
+    let recentConversation = appState.conversations
+      .filter { $0.deleted != true && !$0.discarded && !$0.title.isEmpty }
+      .max(by: { conversationDate($0) < conversationDate($1) })
+    if let conversation = recentConversation {
+      evidence.append(.init(kind: .conversation, text: conversation.title))
+    }
+
+    let recentTask = tasksStore.tasks
+      .filter { !$0.isRetired && !$0.completed && !$0.description.isEmpty }
+      .max(by: { ($0.updatedAt ?? $0.createdAt) < ($1.updatedAt ?? $1.createdAt) })
+    if let task = recentTask {
+      evidence.append(.init(kind: .task, text: task.description))
+    }
+
+    let recentMemory = memoriesViewModel.memories
+      .filter { !$0.content.isEmpty }
+      .max(by: { ($0.capturedAt ?? $0.updatedAt) < ($1.capturedAt ?? $1.updatedAt) })
+    if let memory = recentMemory {
+      evidence.append(.init(kind: .memory, text: memory.content))
+    }
+
+    return evidence
+  }
+
+  private func conversationDate(_ conversation: ServerConversation) -> Date {
+    conversation.finishedAt ?? conversation.startedAt ?? conversation.createdAt
   }
 
   private func loadScreenCount() async {
@@ -620,11 +717,13 @@ struct QueryShellHome: View {
     // ask that lands before it is open under-reports the archive by its entire size for the rest of
     // the session. That is what made the corner read "390 results · of 147 captured": 147 was the
     // conversations and memories alone, with the whole screen archive counted as nothing.
+    guard let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
     guard await SpineScreenIndex.poolWhenReady() != nil else {
-      screenCount = 0
       return
     }
-    screenCount = (try? await RewindDatabase.shared.getScreenshotCount()) ?? 0
+    let count = try? await RewindDatabase.shared.getScreenshotCount()
+    guard RuntimeOwnerIdentity.isAuthorizationCurrent(authorization) else { return }
+    screenCount = count
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/SecondBrainHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/SecondBrainHome.swift
@@ -1,0 +1,301 @@
+//
+//  SecondBrainHome.swift — the proof of value before the first question.
+//
+//  Home used to open directly on a transcript. That is useful after somebody already knows what to
+//  ask, but it makes the full app explain none of the reason Omi exists. This canvas shows the
+//  product loop with the person's real corpus: what they heard, what appeared on their screen and
+//  what Omi remembers flow into one personal answer. Its prompt rows call the host's one send path;
+//  it owns no provider, transcript, draft or route (INV-6).
+//
+//  Brand: one neutral ink ladder and the shared glass only (INV-UI-1).
+//
+
+import OmiTheme
+import SwiftUI
+
+/// The value canvas reduced to data and copy so new, returning and temporarily-unavailable context
+/// states can be verified without mounting a window.
+struct SecondBrainHomeSnapshot: Equatable {
+  struct Source: Equatable, Identifiable {
+    enum Kind: Equatable {
+      case conversations
+      case screen
+      case memories
+      case tasks
+    }
+
+    let kind: Kind
+    let title: String
+    let detail: String
+    let systemImage: String
+
+    var id: String { title }
+  }
+
+  let greeting: String?
+  let headline: String
+  let supportingCopy: String
+  let sources: [Source]
+  let prompts: [String]
+  let total: Int?
+
+  static func compose(
+    conversations: Int,
+    memories: Int,
+    tasks: Int,
+    screenCount: Int?,
+    personalizedPrompts: [String],
+    onboardingPrompts: [String],
+    opener: OnboardingOpenerContent?
+  ) -> SecondBrainHomeSnapshot {
+    let safeConversations = max(0, conversations)
+    let safeMemories = max(0, memories)
+    let safeTasks = max(0, tasks)
+    let safeScreenCount = screenCount.map { max(0, $0) }
+    let total = safeScreenCount.map { safeConversations + safeMemories + safeTasks + $0 }
+    let hasKnownContext = safeConversations + safeMemories + safeTasks + (safeScreenCount ?? 0) > 0
+
+    let prompts: [String]
+    let returningPrompts = HomeSuggestionComposer.compose(
+      personalized: personalizedPrompts,
+      onboarding: onboardingPrompts)
+    if let opener, !opener.starters.isEmpty {
+      prompts = uniquePrompts(opener.starters + returningPrompts)
+    } else {
+      prompts = returningPrompts
+    }
+
+    return SecondBrainHomeSnapshot(
+      greeting: opener?.greeting,
+      headline: hasKnownContext ? "Your life, ready to answer." : "Your second brain starts here.",
+      supportingCopy: opener?.subline
+        ?? "Omi connects what you heard, saw, and decided — then answers with your context, not the internet's.",
+      sources: [
+        Source(
+          kind: .conversations,
+          title: "Heard",
+          detail: count(safeConversations, singular: "conversation"),
+          systemImage: "waveform"),
+        Source(
+          kind: .screen,
+          title: "Seen",
+          detail: safeScreenCount.map { count($0, singular: "screen moment") } ?? "Counting moments…",
+          systemImage: "rectangle.on.rectangle"),
+        Source(
+          kind: .memories,
+          title: "Remembered",
+          detail: count(safeMemories, singular: "memory", plural: "memories"),
+          systemImage: "brain.head.profile"),
+        Source(
+          kind: .tasks,
+          title: "Decided",
+          detail: count(safeTasks, singular: "open task"),
+          systemImage: "checkmark.circle"),
+      ],
+      prompts: Array(prompts.prefix(3)),
+      total: total)
+  }
+
+  private static func count(_ value: Int, singular: String, plural: String? = nil) -> String {
+    "\(QueryShellCount.number(value)) \(value == 1 ? singular : (plural ?? singular + "s"))"
+  }
+
+  private static func uniquePrompts(_ candidates: [String]) -> [String] {
+    var seen = Set<String>()
+    return candidates.compactMap { candidate in
+      let prompt = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+      let key = prompt.lowercased()
+      guard !prompt.isEmpty, !seen.contains(key) else { return nil }
+      seen.insert(key)
+      return prompt
+    }
+  }
+}
+
+/// A landing state inside the established answer panel. Asking and continuing both replace this
+/// view with `QueryAnswerThread`; the shared composer remains mounted below it the entire time.
+struct SecondBrainHome: View {
+  let snapshot: SecondBrainHomeSnapshot
+  let hasConversation: Bool
+  let onAsk: (String) -> Void
+  let onContinueConversation: () -> Void
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: OmiSpacing.xxl) {
+        HStack(alignment: .top, spacing: OmiSpacing.page) {
+          promise
+            .frame(maxWidth: .infinity, alignment: .leading)
+          contextFlow
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        questions
+      }
+      .padding(.horizontal, OmiSpacing.md)
+      .padding(.top, OmiSpacing.lg)
+      .padding(.bottom, OmiSpacing.xxl)
+    }
+    .scrollIndicators(.hidden)
+    .accessibilityIdentifier("second-brain-home")
+  }
+
+  private var promise: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+      HStack(spacing: OmiSpacing.sm) {
+        SBLogo(size: 18)
+        Text(snapshot.greeting ?? "YOUR SECOND BRAIN")
+          .geistMono(size: OmiType.caption, weight: .medium, tracking: OmiType.caption * 0.08)
+          .foregroundStyle(Ink.secondary)
+          .lineLimit(1)
+      }
+
+      Text(snapshot.headline)
+        .inkStyle(InkType.introHero, color: Ink.primary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Text("The second brain you trust more than your first.")
+        .inkStyle(InkType.rowCopy, color: Ink.primary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      Text(snapshot.supportingCopy)
+        .inkStyle(InkType.statusLabel, color: Ink.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: 360, alignment: .leading)
+
+      if hasConversation {
+        Button(action: onContinueConversation) {
+          HStack(spacing: OmiSpacing.xs) {
+            Text("Continue last conversation")
+            Image(systemName: "arrow.right")
+          }
+        }
+        .buttonStyle(InkButtonStyle(kind: .secondary))
+        .accessibilityIdentifier("second-brain-continue")
+      }
+    }
+  }
+
+  /// A single diagram, rather than three feature cards: personal context converges on Omi, and one
+  /// grounded answer comes out. The relationship is the product value.
+  private var contextFlow: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.md) {
+      HStack {
+        Text("YOUR CONTEXT")
+          .geistMono(size: OmiType.caption, weight: .medium, tracking: OmiType.caption * 0.08)
+          .foregroundStyle(Ink.secondary)
+        Spacer(minLength: OmiSpacing.sm)
+        if let total = snapshot.total {
+          Text("\(QueryShellCount.number(total)) moments")
+            .inkStyle(InkType.statusLabel, color: Ink.secondary)
+            .monospacedDigit()
+        }
+      }
+
+      HStack(spacing: OmiSpacing.md) {
+        VStack(alignment: .leading, spacing: OmiSpacing.md) {
+          ForEach(snapshot.sources) { source in
+            SecondBrainSourceRow(source: source)
+          }
+        }
+
+        ZStack {
+          Rectangle()
+            .fill(Ink.separator)
+            .frame(width: 28, height: 1)
+          Circle()
+            .fill(Ink.surface)
+            .frame(width: 34, height: 34)
+            .overlay(Circle().strokeBorder(Ink.hairline, lineWidth: 1))
+            .overlay(SBLogo(size: 16))
+        }
+        .accessibilityHidden(true)
+
+        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+          Text("One personal answer")
+            .inkStyle(InkType.rowCopy, color: Ink.primary)
+          Text("with sources\nand a next step")
+            .inkStyle(InkType.statusLabel, color: Ink.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .padding(OmiSpacing.lg)
+      .glassCard(cornerRadius: PageGlass.cardRadius)
+    }
+  }
+
+  private var questions: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      Text("TRY YOUR SECOND BRAIN")
+        .geistMono(size: OmiType.caption, weight: .medium, tracking: OmiType.caption * 0.08)
+        .foregroundStyle(Ink.secondary)
+
+      HStack(spacing: OmiSpacing.sm) {
+        ForEach(Array(snapshot.prompts.enumerated()), id: \.element) { index, prompt in
+          SecondBrainPromptButton(prompt: prompt, index: index, isPrimary: index == 0) {
+            onAsk(prompt)
+          }
+        }
+      }
+    }
+  }
+}
+
+private struct SecondBrainSourceRow: View {
+  let source: SecondBrainHomeSnapshot.Source
+
+  var body: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      Image(systemName: source.systemImage)
+        .scaledFont(size: OmiType.body, weight: .medium)
+        .foregroundStyle(Ink.primary)
+        .frame(width: 20)
+      VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
+        Text(source.title)
+          .inkStyle(InkType.rowCopy, color: Ink.primary)
+        Text(source.detail)
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+          .monospacedDigit()
+          .lineLimit(1)
+      }
+    }
+  }
+}
+
+private struct SecondBrainPromptButton: View {
+  let prompt: String
+  let index: Int
+  let isPrimary: Bool
+  let action: () -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: OmiSpacing.sm) {
+        Text(prompt)
+          .inkStyle(InkType.statusLabel, color: isPrimary ? Ink.surface : Ink.primary)
+          .multilineTextAlignment(.leading)
+          .lineLimit(2)
+        Spacer(minLength: 0)
+        Image(systemName: "arrow.up.right")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundStyle(isPrimary ? Ink.surface : Ink.secondary)
+      }
+      .padding(.horizontal, OmiSpacing.md)
+      .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+      .background(
+        Capsule(style: .continuous)
+          .fill(isPrimary ? Ink.primary : (isHovering ? Ink.rowFillHover : Ink.rowFill))
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .strokeBorder(isPrimary ? Color.clear : Ink.hairline, lineWidth: 1)
+      )
+      .contentShape(Capsule(style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovering = $0 }
+    .accessibilityIdentifier("second-brain-prompt-\(index)")
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/SecondBrainHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/SecondBrainHome.swift
@@ -1,21 +1,55 @@
 //
-//  SecondBrainHome.swift — the proof of value before the first question.
+//  SecondBrainHome.swift — a useful first question, backed by the user's real context.
 //
-//  Home used to open directly on a transcript. That is useful after somebody already knows what to
-//  ask, but it makes the full app explain none of the reason Omi exists. This canvas shows the
-//  product loop with the person's real corpus: what they heard, what appeared on their screen and
-//  what Omi remembers flow into one personal answer. Its prompt rows call the host's one send path;
-//  it owns no provider, transcript, draft or route (INV-6).
+//  This is a landing state inside the established answer panel, not a second chat. Its one primary
+//  question, secondary suggestions, and Continue control all hand back to `QueryShellHome`, which
+//  owns the only provider, draft, transcript, and route (INV-6).
 //
-//  Brand: one neutral ink ladder and the shared glass only (INV-UI-1).
+//  The experience leads with proof rather than product architecture: a just-onboarded person sees
+//  the answer Omi produced from their screen; a returning person sees real recent context and a
+//  personalized question; a thin account sees readiness copy instead of a wall of zeroes.
 //
 
 import OmiTheme
 import SwiftUI
 
-/// The value canvas reduced to data and copy so new, returning and temporarily-unavailable context
+/// The overview is an activation/empty-state layer, never an interstitial over a conversation the
+/// user already started. The onboarding opener is the one exception because it is the explicit
+/// handoff from setup into Home.
+enum SecondBrainHomePresentationPolicy {
+  static func showsOverview(
+    requested: Bool,
+    hasMessages: Bool,
+    hasOnboardingOpener: Bool,
+    isSending: Bool
+  ) -> Bool {
+    guard requested, !isSending else { return false }
+    return hasOnboardingOpener || !hasMessages
+  }
+}
+
+/// Suggestions never replace words the user has already put in the shared composer.
+enum SecondBrainPromptPolicy {
+  static func canUseSuggestion(draft: String) -> Bool {
+    draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+}
+
+enum HomeSearchPresentationPolicy {
+  static func isCompact(mode: QueryShellMode, isExpanded: Bool) -> Bool {
+    mode == .answer && !isExpanded
+  }
+}
+
+/// The value experience reduced to data and copy so activation, returning, loading, and thin-context
 /// states can be verified without mounting a window.
 struct SecondBrainHomeSnapshot: Equatable {
+  enum Phase: Equatable {
+    case activation
+    case ready
+    case gathering
+  }
+
   struct Source: Equatable, Identifiable {
     enum Kind: Equatable {
       case conversations
@@ -32,11 +66,45 @@ struct SecondBrainHomeSnapshot: Equatable {
     var id: String { title }
   }
 
-  let greeting: String?
+  struct Evidence: Equatable, Identifiable {
+    enum Kind: Equatable {
+      case conversation
+      case memory
+      case task
+
+      var label: String {
+        switch self {
+        case .conversation: "Recent conversation"
+        case .memory: "Remembered"
+        case .task: "Open task"
+        }
+      }
+
+      var systemImage: String {
+        switch self {
+        case .conversation: "waveform"
+        case .memory: "brain.head.profile"
+        case .task: "checkmark.circle"
+        }
+      }
+    }
+
+    let kind: Kind
+    let text: String
+
+    var id: String { "\(kind.label)-\(text)" }
+  }
+
+  let phase: Phase
   let headline: String
   let supportingCopy: String
+  let promptLabel: String
+  let heroPrompt: String
+  let secondaryPrompts: [String]
   let sources: [Source]
-  let prompts: [String]
+  let sourceSummary: String
+  let evidence: [Evidence]
+  let proofReceipt: OnboardingProofReceipt?
   let total: Int?
 
   static func compose(
@@ -46,53 +114,133 @@ struct SecondBrainHomeSnapshot: Equatable {
     screenCount: Int?,
     personalizedPrompts: [String],
     onboardingPrompts: [String],
-    opener: OnboardingOpenerContent?
+    opener: OnboardingOpenerContent?,
+    contextEvidence: [Evidence] = []
   ) -> SecondBrainHomeSnapshot {
     let safeConversations = max(0, conversations)
     let safeMemories = max(0, memories)
     let safeTasks = max(0, tasks)
     let safeScreenCount = screenCount.map { max(0, $0) }
-    let total = safeScreenCount.map { safeConversations + safeMemories + safeTasks + $0 }
-    let hasKnownContext = safeConversations + safeMemories + safeTasks + (safeScreenCount ?? 0) > 0
+    let knownWithoutScreen = safeConversations + safeMemories + safeTasks
+    let total = safeScreenCount.map { knownWithoutScreen + $0 }
+    let hasKnownContext = knownWithoutScreen + (safeScreenCount ?? 0) > 0
 
-    let prompts: [String]
-    let returningPrompts = HomeSuggestionComposer.compose(
-      personalized: personalizedPrompts,
-      onboarding: onboardingPrompts)
-    if let opener, !opener.starters.isEmpty {
-      prompts = uniquePrompts(opener.starters + returningPrompts)
+    let cleanedPersonalized = HomeSuggestionComposer.sanitize(personalizedPrompts)
+    let returningFallbacks = HomeSuggestionComposer.compose(
+      personalized: [], onboarding: onboardingPrompts)
+    let rawPromptCandidates: [String]
+    if let opener, opener.proofReceipt != nil {
+      rawPromptCandidates =
+        ["What should I focus on based on what's on my screen?"] + opener.starters
+        + cleanedPersonalized + returningFallbacks
+    } else if let opener, !opener.starters.isEmpty {
+      rawPromptCandidates = opener.starters + cleanedPersonalized + returningFallbacks
+    } else if !cleanedPersonalized.isEmpty {
+      // Personal context earns the primary position. The universal question is a fallback, not the
+      // face of a product whose entire promise is that it knows this particular person.
+      rawPromptCandidates =
+        cleanedPersonalized + [HomeSuggestionComposer.universalFirstQuestion] + returningFallbacks
     } else {
-      prompts = returningPrompts
+      rawPromptCandidates = returningFallbacks
+    }
+    let promptCandidates = uniquePrompts(rawPromptCandidates).filter {
+      hasKnownContext || $0 != "What did I spend my time on this week?"
+    }
+
+    let heroPrompt = promptCandidates.first ?? HomeSuggestionComposer.universalFirstQuestion
+    let proofReceipt = opener?.proofReceipt
+    let phase: Phase = opener != nil ? .activation : (hasKnownContext ? .ready : .gathering)
+
+    let headline: String
+    let supportingCopy: String
+    let promptLabel: String
+    switch phase {
+    case .activation:
+      if proofReceipt != nil {
+        headline = "You asked. Omi answered."
+        supportingCopy = ""
+        promptLabel = "Keep going"
+      } else {
+        headline = "\(opener?.greeting ?? "You're ready")."
+        supportingCopy = opener?.subline ?? "Your context starts building as you talk and work."
+        promptLabel = "START WITH WHAT'S AHEAD"
+      }
+    case .ready:
+      headline = "What do you want to know?"
+      supportingCopy =
+        "Ask across your conversations, screen, memories, and tasks. When Omi uses your context, the answer links back to it."
+      promptLabel =
+        cleanedPersonalized.contains(heroPrompt)
+        ? "Suggested question" : "Ask across your day"
+    case .gathering:
+      headline = "Your second brain starts with one question."
+      supportingCopy =
+        "Ask about what is on your screen or what happened today. Omi builds useful context as you work."
+      promptLabel = "A good first question"
+    }
+
+    var sources: [Source] = []
+    if safeConversations > 0 {
+      sources.append(
+        Source(
+          kind: .conversations,
+          title: "Conversations",
+          detail: count(safeConversations, singular: "conversation"),
+          systemImage: "waveform"))
+    }
+    if let safeScreenCount, safeScreenCount > 0 {
+      sources.append(
+        Source(
+          kind: .screen,
+          title: "Screen",
+          detail: count(safeScreenCount, singular: "screen moment"),
+          systemImage: "rectangle.on.rectangle"))
+    } else if screenCount == nil {
+      sources.append(
+        Source(
+          kind: .screen,
+          title: "Screen",
+          detail: "Screen history isn't ready yet",
+          systemImage: "rectangle.on.rectangle"))
+    }
+    if safeMemories > 0 {
+      sources.append(
+        Source(
+          kind: .memories,
+          title: "Memories",
+          detail: count(safeMemories, singular: "memory", plural: "memories"),
+          systemImage: "brain.head.profile"))
+    }
+    if safeTasks > 0 {
+      sources.append(
+        Source(
+          kind: .tasks,
+          title: "Tasks",
+          detail: count(safeTasks, singular: "open task"),
+          systemImage: "checkmark.circle"))
+    }
+
+    let sourceSummary: String
+    let knownParts = sources.filter { $0.detail != "Screen history isn't ready yet" }.map(\.detail)
+    if !knownParts.isEmpty {
+      sourceSummary = "Ready to answer from \(naturalList(knownParts))."
+    } else if screenCount == nil {
+      sourceSummary = "Screen history isn't ready yet. Conversations, memories, and tasks join as they arrive."
+    } else {
+      sourceSummary = "Your context starts building from the conversations you have and the work on your screen."
     }
 
     return SecondBrainHomeSnapshot(
-      greeting: opener?.greeting,
-      headline: hasKnownContext ? "Your life, ready to answer." : "Your second brain starts here.",
-      supportingCopy: opener?.subline
-        ?? "Omi connects what you heard, saw, and decided — then answers with your context, not the internet's.",
-      sources: [
-        Source(
-          kind: .conversations,
-          title: "Heard",
-          detail: count(safeConversations, singular: "conversation"),
-          systemImage: "waveform"),
-        Source(
-          kind: .screen,
-          title: "Seen",
-          detail: safeScreenCount.map { count($0, singular: "screen moment") } ?? "Counting moments…",
-          systemImage: "rectangle.on.rectangle"),
-        Source(
-          kind: .memories,
-          title: "Remembered",
-          detail: count(safeMemories, singular: "memory", plural: "memories"),
-          systemImage: "brain.head.profile"),
-        Source(
-          kind: .tasks,
-          title: "Decided",
-          detail: count(safeTasks, singular: "open task"),
-          systemImage: "checkmark.circle"),
-      ],
-      prompts: Array(prompts.prefix(3)),
+      phase: phase,
+      headline: headline,
+      supportingCopy: supportingCopy,
+      promptLabel: promptLabel,
+      heroPrompt: heroPrompt,
+      secondaryPrompts: Array(promptCandidates.dropFirst().prefix(2)),
+      sources: sources,
+      sourceSummary: sourceSummary,
+      evidence: Array(cleanEvidence(contextEvidence).prefix(3)),
+      proofReceipt: proofReceipt,
       total: total)
   }
 
@@ -110,192 +258,368 @@ struct SecondBrainHomeSnapshot: Equatable {
       return prompt
     }
   }
+
+  private static func cleanEvidence(_ candidates: [Evidence]) -> [Evidence] {
+    var seen = Set<String>()
+    return candidates.compactMap { item in
+      let collapsed = item.text
+        .components(separatedBy: .whitespacesAndNewlines)
+        .filter { !$0.isEmpty }
+        .joined(separator: " ")
+      guard !collapsed.isEmpty else { return nil }
+      let key = collapsed.lowercased()
+      guard !seen.contains(key) else { return nil }
+      seen.insert(key)
+      let text = collapsed.count <= 96 ? collapsed : String(collapsed.prefix(95)) + "…"
+      return Evidence(kind: item.kind, text: text)
+    }
+  }
+
+  private static func naturalList(_ values: [String]) -> String {
+    switch values.count {
+    case 0: return ""
+    case 1: return values[0]
+    case 2: return "\(values[0]) and \(values[1])"
+    default: return values.dropLast().joined(separator: ", ") + ", and \(values.last ?? "")"
+    }
+  }
 }
 
-/// A landing state inside the established answer panel. Asking and continuing both replace this
-/// view with `QueryAnswerThread`; the shared composer remains mounted below it the entire time.
+/// A quiet daily doorway into the established answer thread. There is one obvious action, followed
+/// by evidence and two lower-weight alternatives; the shared composer remains mounted below it.
 struct SecondBrainHome: View {
   let snapshot: SecondBrainHomeSnapshot
   let hasConversation: Bool
+  let canUsePrompts: Bool
   let onAsk: (String) -> Void
   let onContinueConversation: () -> Void
 
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hasRevealed = false
+  /// Suggestions may refresh asynchronously. Freeze this presentation so a question cannot change
+  /// under the pointer; newly generated ideas appear the next time the overview is mounted.
+  @State private var frozenPrompts: [String]?
+
+  private var presentedPrompts: [String] {
+    frozenPrompts ?? [snapshot.heroPrompt] + snapshot.secondaryPrompts
+  }
+
   var body: some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: OmiSpacing.xxl) {
-        HStack(alignment: .top, spacing: OmiSpacing.page) {
-          promise
-            .frame(maxWidth: .infinity, alignment: .leading)
-          contextFlow
-            .frame(maxWidth: .infinity, alignment: .leading)
+      VStack(alignment: .leading, spacing: OmiSpacing.xl) {
+        identity
+        promise
+
+        if let proofReceipt = snapshot.proofReceipt {
+          proof(proofReceipt)
         }
 
-        questions
+        SecondBrainHeroQuestion(
+          label: snapshot.promptLabel,
+          prompt: presentedPrompts[0],
+          isEnabled: canUsePrompts,
+          action: { onAsk(presentedPrompts[0]) }
+        )
+
+        ViewThatFits(in: .horizontal) {
+          HStack(alignment: .top, spacing: OmiSpacing.page) {
+            context
+              .frame(minWidth: 360, maxWidth: .infinity, alignment: .leading)
+            moreQuestions
+              .frame(minWidth: 260, maxWidth: 320, alignment: .leading)
+          }
+          VStack(alignment: .leading, spacing: OmiSpacing.xl) {
+            context
+            moreQuestions
+          }
+        }
       }
-      .padding(.horizontal, OmiSpacing.md)
-      .padding(.top, OmiSpacing.lg)
+      .padding(.horizontal, OmiSpacing.lg)
+      .padding(.top, OmiSpacing.md)
       .padding(.bottom, OmiSpacing.xxl)
+      .opacity(hasRevealed ? 1 : 0)
+      .offset(y: hasRevealed || reduceMotion ? 0 : 7)
     }
     .scrollIndicators(.hidden)
     .accessibilityIdentifier("second-brain-home")
+    .onAppear {
+      if frozenPrompts == nil {
+        frozenPrompts = [snapshot.heroPrompt] + snapshot.secondaryPrompts
+      }
+      if reduceMotion {
+        hasRevealed = true
+      } else {
+        withAnimation(SBMotion.message) { hasRevealed = true }
+      }
+    }
   }
 
-  private var promise: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.md) {
-      HStack(spacing: OmiSpacing.sm) {
-        SBLogo(size: 18)
-        Text(snapshot.greeting ?? "YOUR SECOND BRAIN")
-          .geistMono(size: OmiType.caption, weight: .medium, tracking: OmiType.caption * 0.08)
-          .foregroundStyle(Ink.secondary)
-          .lineLimit(1)
-      }
-
-      Text(snapshot.headline)
-        .inkStyle(InkType.introHero, color: Ink.primary)
-        .fixedSize(horizontal: false, vertical: true)
-
-      Text("The second brain you trust more than your first.")
-        .inkStyle(InkType.rowCopy, color: Ink.primary)
-        .fixedSize(horizontal: false, vertical: true)
-
-      Text(snapshot.supportingCopy)
+  private var identity: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      SBLogo(size: 18)
+      Text("Omi")
         .inkStyle(InkType.statusLabel, color: Ink.secondary)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: 360, alignment: .leading)
-
+      Spacer(minLength: OmiSpacing.md)
       if hasConversation {
         Button(action: onContinueConversation) {
           HStack(spacing: OmiSpacing.xs) {
-            Text("Continue last conversation")
+            Text("Continue conversation")
             Image(systemName: "arrow.right")
           }
+          .inkStyle(InkType.statusLabel, color: Ink.primary)
         }
-        .buttonStyle(InkButtonStyle(kind: .secondary))
+        .buttonStyle(.plain)
         .accessibilityIdentifier("second-brain-continue")
       }
     }
   }
 
-  /// A single diagram, rather than three feature cards: personal context converges on Omi, and one
-  /// grounded answer comes out. The relationship is the product value.
-  private var contextFlow: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.md) {
-      HStack {
-        Text("YOUR CONTEXT")
-          .geistMono(size: OmiType.caption, weight: .medium, tracking: OmiType.caption * 0.08)
-          .foregroundStyle(Ink.secondary)
-        Spacer(minLength: OmiSpacing.sm)
-        if let total = snapshot.total {
-          Text("\(QueryShellCount.number(total)) moments")
-            .inkStyle(InkType.statusLabel, color: Ink.secondary)
-            .monospacedDigit()
+  private var promise: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      Text(snapshot.headline)
+        .inkStyle(InkType.introHero, color: Ink.primary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      if !snapshot.supportingCopy.isEmpty {
+        Text(snapshot.supportingCopy)
+          .inkStyle(InkType.rowCopy, color: Ink.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: 660, alignment: .leading)
+      }
+    }
+  }
+
+  private func proof(_ receipt: OnboardingProofReceipt) -> some View {
+    HStack(alignment: .top, spacing: OmiSpacing.md) {
+      Rectangle()
+        .fill(Ink.primary)
+        .frame(width: 2)
+        .accessibilityHidden(true)
+
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        Text("Your first Omi answer")
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+        Text(receipt.answerExcerpt)
+          .inkStyle(InkType.rowCopy, color: Ink.primary)
+          .fixedSize(horizontal: false, vertical: true)
+        Label(receipt.sourceLabel, systemImage: "rectangle.on.rectangle")
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+      }
+    }
+    .padding(.vertical, OmiSpacing.xs)
+    .accessibilityElement(children: .combine)
+    .accessibilityIdentifier("second-brain-proof")
+  }
+
+  @ViewBuilder
+  private var context: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+      Text(snapshot.evidence.isEmpty ? "What Omi can use" : "Recently available to Omi")
+        .inkStyle(InkType.statusLabel, color: Ink.secondary)
+
+      if !snapshot.evidence.isEmpty {
+        VStack(alignment: .leading, spacing: 0) {
+          ForEach(Array(snapshot.evidence.enumerated()), id: \.element.id) { index, item in
+            if index > 0 { Divider().overlay(Ink.separator) }
+            SecondBrainEvidenceRow(item: item)
+          }
+        }
+      } else if !snapshot.sources.isEmpty {
+        ViewThatFits(in: .horizontal) {
+          HStack(alignment: .top, spacing: OmiSpacing.lg) {
+            ForEach(snapshot.sources) { source in
+              SecondBrainSourceSummary(source: source)
+            }
+          }
+          VStack(alignment: .leading, spacing: OmiSpacing.sm) {
+            ForEach(snapshot.sources) { source in
+              SecondBrainSourceSummary(source: source)
+            }
+          }
         }
       }
 
-      HStack(spacing: OmiSpacing.md) {
-        VStack(alignment: .leading, spacing: OmiSpacing.md) {
-          ForEach(snapshot.sources) { source in
-            SecondBrainSourceRow(source: source)
-          }
+      if snapshot.sources.isEmpty {
+        Text(snapshot.sourceSummary)
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+      } else if !snapshot.evidence.isEmpty {
+        Label("Private context from your Omi account", systemImage: "lock")
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+      }
+    }
+    .accessibilityElement(children: .contain)
+  }
+
+  @ViewBuilder
+  private var moreQuestions: some View {
+    if presentedPrompts.count > 1 {
+      VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+        Text("More to ask")
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+
+        ForEach(Array(presentedPrompts.dropFirst().enumerated()), id: \.element) { index, prompt in
+          SecondBrainTextQuestion(
+            prompt: prompt,
+            index: index + 1,
+            isEnabled: canUsePrompts,
+            action: { onAsk(prompt) }
+          )
         }
 
-        ZStack {
-          Rectangle()
-            .fill(Ink.separator)
-            .frame(width: 28, height: 1)
-          Circle()
-            .fill(Ink.surface)
-            .frame(width: 34, height: 34)
-            .overlay(Circle().strokeBorder(Ink.hairline, lineWidth: 1))
-            .overlay(SBLogo(size: 16))
-        }
-        .accessibilityHidden(true)
-
-        VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
-          Text("One personal answer")
-            .inkStyle(InkType.rowCopy, color: Ink.primary)
-          Text("with sources\nand a next step")
+        if !canUsePrompts {
+          Text("Finish or clear your draft to use a suggestion.")
             .inkStyle(InkType.statusLabel, color: Ink.secondary)
             .fixedSize(horizontal: false, vertical: true)
         }
       }
-      .padding(OmiSpacing.lg)
-      .glassCard(cornerRadius: PageGlass.cardRadius)
-    }
-  }
-
-  private var questions: some View {
-    VStack(alignment: .leading, spacing: OmiSpacing.sm) {
-      Text("TRY YOUR SECOND BRAIN")
-        .geistMono(size: OmiType.caption, weight: .medium, tracking: OmiType.caption * 0.08)
-        .foregroundStyle(Ink.secondary)
-
-      HStack(spacing: OmiSpacing.sm) {
-        ForEach(Array(snapshot.prompts.enumerated()), id: \.element) { index, prompt in
-          SecondBrainPromptButton(prompt: prompt, index: index, isPrimary: index == 0) {
-            onAsk(prompt)
-          }
-        }
-      }
     }
   }
 }
 
-private struct SecondBrainSourceRow: View {
+private struct SecondBrainHeroQuestion: View {
+  let label: String
+  let prompt: String
+  let isEnabled: Bool
+  let action: () -> Void
+
+  @State private var isHovering = false
+  @FocusState private var isFocused: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.xs) {
+      Text(label)
+        .inkStyle(InkType.statusLabel, color: Ink.secondary)
+
+      Button(action: action) {
+        HStack(alignment: .center, spacing: OmiSpacing.lg) {
+          Text(prompt)
+            .scaledFont(size: OmiType.title, weight: .semibold)
+            .foregroundStyle(Ink.primary)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+          Spacer(minLength: OmiSpacing.md)
+          HStack(spacing: OmiSpacing.xs) {
+            Text("Ask")
+            Image(systemName: "arrow.right")
+          }
+          .inkStyle(InkType.statusLabel, color: Ink.surface)
+          .padding(.horizontal, OmiSpacing.md)
+          .frame(minHeight: 36)
+          .background(Capsule().fill(Ink.primary))
+          .accessibilityHidden(true)
+        }
+        .padding(.horizontal, OmiSpacing.sm)
+        .padding(.vertical, OmiSpacing.md)
+        .frame(maxWidth: .infinity, minHeight: 76, alignment: .leading)
+        .background(isHovering && isEnabled ? Ink.rowFillHover : Color.clear)
+        .overlay(alignment: .top) { Divider().overlay(Ink.separator) }
+        .overlay(alignment: .bottom) { Divider().overlay(Ink.separator) }
+        .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .disabled(!isEnabled)
+      .opacity(isEnabled ? 1 : 0.52)
+      .focused($isFocused)
+      .onHover { isHovering = $0 }
+      .overlay(
+        RoundedRectangle(cornerRadius: PageGlass.chipRadius, style: .continuous)
+          .strokeBorder(isFocused ? Ink.primary : Color.clear, lineWidth: 2)
+      )
+      .help(isEnabled ? "Ask Omi: \(prompt)" : "Finish or clear your draft first")
+      .accessibilityLabel("Ask Omi: \(prompt)")
+      .accessibilityIdentifier("second-brain-prompt-0")
+    }
+  }
+}
+
+private struct SecondBrainTextQuestion: View {
+  let prompt: String
+  let index: Int
+  let isEnabled: Bool
+  let action: () -> Void
+
+  @State private var isHovering = false
+  @FocusState private var isFocused: Bool
+
+  var body: some View {
+    Button(action: action) {
+      HStack(alignment: .firstTextBaseline, spacing: OmiSpacing.sm) {
+        Text(prompt)
+          .inkStyle(InkType.statusLabel, color: Ink.primary)
+          .multilineTextAlignment(.leading)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: OmiSpacing.sm)
+        Image(systemName: "arrow.right")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundStyle(Ink.secondary)
+          .accessibilityHidden(true)
+      }
+      .padding(.vertical, OmiSpacing.sm)
+      .padding(.horizontal, OmiSpacing.xs)
+      .background(
+        RoundedRectangle(cornerRadius: PageGlass.chipRadius, style: .continuous)
+          .fill(isHovering && isEnabled ? Ink.rowFillHover : Color.clear)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: PageGlass.chipRadius, style: .continuous)
+          .strokeBorder(isFocused ? Ink.primary : Color.clear, lineWidth: 2)
+      )
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .disabled(!isEnabled)
+    .opacity(isEnabled ? 1 : 0.45)
+    .focused($isFocused)
+    .onHover { isHovering = $0 }
+    .help(isEnabled ? "Ask Omi: \(prompt)" : "Finish or clear your draft first")
+    .accessibilityLabel("Ask Omi: \(prompt)")
+    .accessibilityIdentifier("second-brain-prompt-\(index)")
+  }
+}
+
+private struct SecondBrainEvidenceRow: View {
+  let item: SecondBrainHomeSnapshot.Evidence
+
+  var body: some View {
+    HStack(alignment: .top, spacing: OmiSpacing.md) {
+      Image(systemName: item.kind.systemImage)
+        .scaledFont(size: OmiType.body, weight: .medium)
+        .foregroundStyle(Ink.primary)
+        .frame(width: 20)
+        .accessibilityHidden(true)
+      VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
+        Text(item.kind.label)
+          .inkStyle(InkType.statusLabel, color: Ink.secondary)
+        Text(item.text)
+          .inkStyle(InkType.rowCopy, color: Ink.primary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .padding(.vertical, OmiSpacing.sm)
+    .accessibilityElement(children: .combine)
+  }
+}
+
+private struct SecondBrainSourceSummary: View {
   let source: SecondBrainHomeSnapshot.Source
 
   var body: some View {
-    HStack(spacing: OmiSpacing.sm) {
+    HStack(alignment: .top, spacing: OmiSpacing.sm) {
       Image(systemName: source.systemImage)
         .scaledFont(size: OmiType.body, weight: .medium)
         .foregroundStyle(Ink.primary)
         .frame(width: 20)
+        .accessibilityHidden(true)
       VStack(alignment: .leading, spacing: OmiSpacing.hairline) {
         Text(source.title)
-          .inkStyle(InkType.rowCopy, color: Ink.primary)
-        Text(source.detail)
           .inkStyle(InkType.statusLabel, color: Ink.secondary)
+        Text(source.detail)
+          .inkStyle(InkType.rowCopy, color: Ink.primary)
+          .fixedSize(horizontal: false, vertical: true)
           .monospacedDigit()
-          .lineLimit(1)
       }
     }
-  }
-}
-
-private struct SecondBrainPromptButton: View {
-  let prompt: String
-  let index: Int
-  let isPrimary: Bool
-  let action: () -> Void
-
-  @State private var isHovering = false
-
-  var body: some View {
-    Button(action: action) {
-      HStack(spacing: OmiSpacing.sm) {
-        Text(prompt)
-          .inkStyle(InkType.statusLabel, color: isPrimary ? Ink.surface : Ink.primary)
-          .multilineTextAlignment(.leading)
-          .lineLimit(2)
-        Spacer(minLength: 0)
-        Image(systemName: "arrow.up.right")
-          .scaledFont(size: OmiType.caption, weight: .semibold)
-          .foregroundStyle(isPrimary ? Ink.surface : Ink.secondary)
-      }
-      .padding(.horizontal, OmiSpacing.md)
-      .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
-      .background(
-        Capsule(style: .continuous)
-          .fill(isPrimary ? Ink.primary : (isHovering ? Ink.rowFillHover : Ink.rowFill))
-      )
-      .overlay(
-        Capsule(style: .continuous)
-          .strokeBorder(isPrimary ? Color.clear : Ink.hairline, lineWidth: 1)
-      )
-      .contentShape(Capsule(style: .continuous))
-    }
-    .buttonStyle(.plain)
-    .onHover { isHovering = $0 }
-    .accessibilityIdentifier("second-brain-prompt-\(index)")
+    .accessibilityElement(children: .combine)
   }
 }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/OnboardingOpenerComposer.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/OnboardingOpenerComposer.swift
@@ -7,6 +7,35 @@ struct OnboardingMeetingBrief: Equatable {
   let time: String
 }
 
+/// The bounded, in-memory receipt from the real answer Omi produced during onboarding.
+///
+/// It is deliberately not persisted: the answer can contain personal screen context. Home may use
+/// it for the immediate onboarding handoff, and it disappears when the opener is dismissed or the
+/// app relaunches.
+struct OnboardingProofReceipt: Equatable {
+  static let maxExcerptLength = 180
+
+  let answerExcerpt: String
+  let sourceLabel: String
+
+  static func setupAnswer(_ answer: String) -> OnboardingProofReceipt? {
+    let collapsed =
+      answer
+      .components(separatedBy: .whitespacesAndNewlines)
+      .filter { !$0.isEmpty }
+      .joined(separator: " ")
+    guard !collapsed.isEmpty else { return nil }
+
+    let excerpt: String
+    if collapsed.count <= maxExcerptLength {
+      excerpt = collapsed
+    } else {
+      excerpt = String(collapsed.prefix(maxExcerptLength - 1)).trimmingCharacters(in: .whitespaces) + "…"
+    }
+    return OnboardingProofReceipt(answerExcerpt: excerpt, sourceLabel: "Answered during your screen demo")
+  }
+}
+
 /// The personalized first beat shown in the Chat tab the instant onboarding
 /// finishes: a greeting addressed to the user by name + tappable starter
 /// questions that fire real Omi queries.
@@ -16,6 +45,19 @@ struct OnboardingOpenerContent: Equatable {
   /// Muted detail line under the headline: today's meetings + listening state.
   let subline: String
   let starters: [String]
+  let proofReceipt: OnboardingProofReceipt?
+
+  init(
+    greeting: String,
+    subline: String,
+    starters: [String],
+    proofReceipt: OnboardingProofReceipt? = nil
+  ) {
+    self.greeting = greeting
+    self.subline = subline
+    self.starters = starters
+    self.proofReceipt = proofReceipt
+  }
 }
 
 /// Pure, deterministic composer for the post-onboarding opener. Kept free of
@@ -41,12 +83,14 @@ enum OnboardingOpenerComposer {
     meetings: [OnboardingMeetingBrief],
     now: Date,
     baseStarters: [String],
+    proofReceipt: OnboardingProofReceipt? = nil,
     calendar: Calendar = .current
   ) -> OnboardingOpenerContent {
     OnboardingOpenerContent(
       greeting: greeting(name: name, now: now, calendar: calendar),
       subline: subline(mode: mode, meetings: meetings),
-      starters: starters(meetings: meetings, baseStarters: baseStarters)
+      starters: starters(meetings: meetings, baseStarters: baseStarters),
+      proofReceipt: proofReceipt
     )
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -3,6 +3,23 @@ import Combine
 import CoreGraphics
 import Foundation
 
+enum SBOnboardingScreenProofPolicy {
+  static func completedAnswer(
+    in messages: [ChatMessage],
+    activeClientTurnId: String?
+  ) -> String? {
+    guard let turnId = activeClientTurnId?.trimmingCharacters(in: .whitespacesAndNewlines),
+      !turnId.isEmpty,
+      let answer = messages.last(where: {
+        $0.clientTurnId == turnId && $0.sender == .ai && !$0.isStreaming
+      }),
+      answer.journalStatus != .failed
+    else { return nil }
+    let text = answer.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    return text.isEmpty ? nil : text
+  }
+}
+
 // MARK: - Permissions (one at a time)
 
 extension SBOnboardingModel {
@@ -795,26 +812,21 @@ extension SBOnboardingModel {
       bar.$showingAIResponse.filter { $0 }.map { _ in () },
       bar.$voiceProjection.dropFirst().filter { $0.isResponseActive }.map { _ in () }
     )
-    .compactMap { [weak self, weak bar] _ -> String? in
-      guard let self, let answer = bar?.aiResponseText(from: self.chatProvider), !answer.isEmpty else {
-        return nil
-      }
-      return answer
-    }
-    let responseTextUpdated = chatProvider.$messages
+    .map { _ -> String? in nil }
+    let completedAnswerUpdated = chatProvider.$messages
       .dropFirst()
-      .compactMap { [weak self, weak bar] _ -> String? in
-        guard let self, let answer = bar?.aiResponseText(from: self.chatProvider), !answer.isEmpty else {
-          return nil
-        }
-        return answer
+      .compactMap { [weak bar] messages in
+        SBOnboardingScreenProofPolicy.completedAnswer(
+          in: messages,
+          activeClientTurnId: bar?.chatViewport.activeClientTurnId)
       }
-    voiceCancellable = Publishers.Merge(responseBecameVisible, responseTextUpdated)
+      .map(Optional.some)
+    voiceCancellable = Publishers.Merge(responseBecameVisible, completedAnswerUpdated)
       .receive(on: DispatchQueue.main)
       .sink { [weak self] answer in
         guard let self else { return }
         self.screenDemoDone = true
-        self.voiceAnswer = answer
+        if let answer { self.voiceAnswer = answer }
       }
     screenDemoPTTReady = true
     FloatingControlBarManager.shared.showForOnboardingDemo()

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
@@ -743,6 +743,7 @@ extension SBOnboardingModel {
   /// the notch, which spins while Omi is thinking.
   func startScreenDemo() {
     screenDemoDone = false
+    voiceAnswer = nil
     screenDemoPTTReady = false
     screenDemoPTTUnavailable = false
     FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
@@ -790,12 +791,31 @@ extension SBOnboardingModel {
     // surface through `voiceProjection`; typed answers use `showingAIResponse`.
     // Drop the current voice projection so re-entering the demo cannot inherit a
     // stale response from a prior turn.
-    voiceCancellable = Publishers.Merge(
+    let responseBecameVisible = Publishers.Merge(
       bar.$showingAIResponse.filter { $0 }.map { _ in () },
       bar.$voiceProjection.dropFirst().filter { $0.isResponseActive }.map { _ in () }
     )
-    .receive(on: DispatchQueue.main)
-    .sink { [weak self] _ in self?.screenDemoDone = true }
+    .compactMap { [weak self, weak bar] _ -> String? in
+      guard let self, let answer = bar?.aiResponseText(from: self.chatProvider), !answer.isEmpty else {
+        return nil
+      }
+      return answer
+    }
+    let responseTextUpdated = chatProvider.$messages
+      .dropFirst()
+      .compactMap { [weak self, weak bar] _ -> String? in
+        guard let self, let answer = bar?.aiResponseText(from: self.chatProvider), !answer.isEmpty else {
+          return nil
+        }
+        return answer
+      }
+    voiceCancellable = Publishers.Merge(responseBecameVisible, responseTextUpdated)
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] answer in
+        guard let self else { return }
+        self.screenDemoDone = true
+        self.voiceAnswer = answer
+      }
     screenDemoPTTReady = true
     FloatingControlBarManager.shared.showForOnboardingDemo()
   }

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -284,7 +284,7 @@ final class SBOnboardingModel: ObservableObject {
     switch step {
     case .promise:
       return
-        "Hey, I'm Omi — the second brain you trust more than your first. I connect what happens on your computer with your real-life conversations, so every answer is personal. Three quick things:"
+        "Hey, I'm Omi — the second brain you trust more than your first. First I'll learn how you work. Then we'll connect what I can hear, see, and do — with every permission explained."
     case .name: return "What should I call you?"
     case .howHeard: return "Quick one. How did you hear about Omi?"
     case .language:
@@ -703,6 +703,9 @@ final class SBOnboardingModel: ObservableObject {
   /// `clearOnboardingChatFlag` is the only real difference between the two
   /// paths, and it is ordered exactly where each path had it.
   func finishOnboardingHandoff(clearOnboardingChatFlag: Bool) {
+    // `voiceAnswer` is sampled only while the screen-demo stage owns its isolated viewport. Do not
+    // reread the ambient floating bar here: a later answer may belong to a different turn.
+    let proofReceipt = voiceAnswer.flatMap(OnboardingProofReceipt.setupAnswer)
     teardownAll()
     // Fades rather than cuts: onboarding's last beat should not end on a click.
     OmiOnboardingCinematic.stopAmbientMusic()
@@ -716,7 +719,7 @@ final class SBOnboardingModel: ObservableObject {
     // the Chat tab's starter chips.
     savePostOnboardingGuidance()
     // Greet the user in the Home chat with the personalized opener + starters.
-    chatProvider.presentOnboardingOpener()
+    chatProvider.presentOnboardingOpener(proofReceipt: proofReceipt)
     ChatToolExecutor.onboardingAppState = nil
     OnboardingChatPersistence.clear()
     ChatDraftStore.shared.clear(.onboardingMain)

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -284,7 +284,7 @@ final class SBOnboardingModel: ObservableObject {
     switch step {
     case .promise:
       return
-        "Hey, I'm Omi, your second brain. I hear your conversations, remember everything, and handle the follow-ups. Three quick things:"
+        "Hey, I'm Omi — the second brain you trust more than your first. I connect what happens on your computer with your real-life conversations, so every answer is personal. Three quick things:"
     case .name: return "What should I call you?"
     case .howHeard: return "Quick one. How did you hear about Omi?"
     case .language:
@@ -328,7 +328,7 @@ final class SBOnboardingModel: ObservableObject {
       return "The more I can see, the more I can help. Connect anything you want me to know:"
     case .capture:
       return
-        "You're all set, \(name). One last thing: should I listen all the time, or only during your meetings?"
+        "Your second brain is ready, \(name). One last thing: should I listen all the time, or only during your meetings?"
     }
   }
 

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider+OnboardingOpener.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider+OnboardingOpener.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+extension ChatProvider {
+  /// Compose and present the personalized opener the instant Home appears after onboarding. Local
+  /// facts make the first paint immediate; a connected calendar may enrich it afterward.
+  func presentOnboardingOpener(proofReceipt: OnboardingProofReceipt? = nil) {
+    let name = Self.onboardingFirstName(AuthService.shared.givenName)
+    let mode: OnboardingOpenerComposer.ListeningMode =
+      AssistantSettings.shared.audioRecordingMode == .always ? .always : .meetingsOnly
+    let baseStarters = HomeSuggestionComposer.compose(
+      personalized: HomeSuggestionsStore.shared.personalizedQuestions,
+      onboarding: PostOnboardingPromptSuggestions.suggestions())
+
+    let presentedOpener = OnboardingOpenerComposer.compose(
+      name: name, mode: mode, meetings: [], now: Date(), baseStarters: baseStarters,
+      proofReceipt: proofReceipt)
+    onboardingOpener = presentedOpener
+    let authorization = RuntimeOwnerIdentity.captureAuthorizationSnapshot()
+
+    Task { [weak self] in
+      let meetings = await Self.todaysOnboardingMeetings()
+      guard !meetings.isEmpty else { return }
+      guard let self,
+        let authorization,
+        RuntimeOwnerIdentity.isAuthorizationCurrent(authorization),
+        self.onboardingOpener == presentedOpener
+      else { return }
+      self.onboardingOpener = OnboardingOpenerComposer.compose(
+        name: name, mode: mode, meetings: meetings, now: Date(), baseStarters: baseStarters,
+        proofReceipt: proofReceipt)
+    }
+  }
+
+  func dismissOnboardingOpener() {
+    onboardingOpener = nil
+  }
+
+  private static func onboardingFirstName(_ full: String) -> String {
+    let trimmed = full.trimmingCharacters(in: .whitespaces)
+    return trimmed.components(separatedBy: " ").first ?? trimmed
+  }
+
+  /// Today's remaining timed meetings, best-effort. Failure leaves the immediate local opener.
+  private static func todaysOnboardingMeetings() async -> [OnboardingMeetingBrief] {
+    guard
+      let events = try? await CalendarReaderService.shared.readEvents(
+        daysBack: 0, daysForward: 1, maxResults: 50)
+    else { return [] }
+
+    // Event offsets describe the user's day, so compare against a local—not UTC—date prefix.
+    let localDayFormatter = ISO8601DateFormatter()
+    localDayFormatter.timeZone = TimeZone.current
+    let todayPrefix = localDayFormatter.string(from: Date()).prefix(10)
+    let plain = ISO8601DateFormatter()
+    let fractional = ISO8601DateFormatter()
+    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    let timeFormatter = DateFormatter()
+    timeFormatter.locale = Locale.current
+    timeFormatter.setLocalizedDateFormatFromTemplate("jmm")
+    let cutoff = Date().addingTimeInterval(-30 * 60)
+
+    return
+      events
+      .filter { !$0.isAllDay && $0.startTime.prefix(10) == todayPrefix }
+      .compactMap { event -> (Date, OnboardingMeetingBrief)? in
+        guard let start = plain.date(from: event.startTime) ?? fractional.date(from: event.startTime),
+          start >= cutoff
+        else { return nil }
+        let title = event.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return nil }
+        return (start, OnboardingMeetingBrief(title: title, time: timeFormatter.string(from: start)))
+      }
+      .sorted { $0.0 < $1.0 }
+      .map(\.1)
+  }
+}

--- a/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/macos/Desktop/Sources/Providers/ChatProvider.swift
@@ -1695,6 +1695,9 @@ class ChatProvider: ObservableObject {
     currentError = nil
     errorMessage = nil
     lastFailedPrompt = nil
+    // The opener can contain the previous owner's name and an answer excerpt from onboarding.
+    // Clear it inside the same synchronous owner-transition fence as the transcript.
+    onboardingOpener = nil
     messages.removeAll()
     resetMessagesPagination()
     pendingAttachments.removeAll()
@@ -5529,86 +5532,6 @@ class ChatProvider: ObservableObject {
     releaseSendLock(sendGeneration: sendGen)
 
     return completedResponseText
-  }
-
-  // MARK: - Post-onboarding opener
-
-  /// Compose and present the personalized opener the instant the Chat tab
-  /// appears after onboarding. Composed synchronously from locally-known
-  /// facts (name, listening mode, cached suggestion chips) so it is instant
-  /// and never blank; today's calendar, if connected, enriches it a moment
-  /// later without ever blocking the first paint.
-  func presentOnboardingOpener() {
-    let name = Self.firstName(AuthService.shared.givenName)
-    let mode: OnboardingOpenerComposer.ListeningMode =
-      AssistantSettings.shared.audioRecordingMode == .always ? .always : .meetingsOnly
-    let baseStarters = HomeSuggestionComposer.compose(
-      personalized: HomeSuggestionsStore.shared.personalizedQuestions,
-      onboarding: PostOnboardingPromptSuggestions.suggestions())
-
-    onboardingOpener = OnboardingOpenerComposer.compose(
-      name: name, mode: mode, meetings: [], now: Date(), baseStarters: baseStarters)
-
-    // Enrich with today's real calendar when available — never blocks the
-    // instant opener above, and bails if the user has already started chatting.
-    Task { [weak self] in
-      let meetings = await Self.todaysMeetings()
-      guard !meetings.isEmpty else { return }
-      guard let self, self.onboardingOpener != nil else { return }
-      self.onboardingOpener = OnboardingOpenerComposer.compose(
-        name: name, mode: mode, meetings: meetings, now: Date(), baseStarters: baseStarters)
-    }
-  }
-
-  /// Hide the opener once the user sends their first message.
-  func dismissOnboardingOpener() {
-    onboardingOpener = nil
-  }
-
-  private static func firstName(_ full: String) -> String {
-    let trimmed = full.trimmingCharacters(in: .whitespaces)
-    return trimmed.components(separatedBy: " ").first ?? trimmed
-  }
-
-  /// Today's remaining timed meetings (soonest first), best-effort. Returns an
-  /// empty array when the calendar isn't connected or the read fails — the
-  /// opener simply stays in its name-only form.
-  private static func todaysMeetings() async -> [OnboardingMeetingBrief] {
-    guard
-      let events = try? await CalendarReaderService.shared.readEvents(
-        daysBack: 0, daysForward: 1, maxResults: 50)
-    else { return [] }
-
-    // Compute "today" in the user's local timezone. ISO8601DateFormatter defaults to
-    // UTC, but event start_time date strings carry the calendar's local offset, so a
-    // UTC prefix would drop today's meetings for any user behind/ahead of UTC near the
-    // day boundary.
-    let localDayFormatter = ISO8601DateFormatter()
-    localDayFormatter.timeZone = TimeZone.current
-    let todayPrefix = localDayFormatter.string(from: Date()).prefix(10)
-    let plain = ISO8601DateFormatter()
-    let fractional = ISO8601DateFormatter()
-    fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-    let timeFormatter = DateFormatter()
-    timeFormatter.locale = Locale.current
-    timeFormatter.setLocalizedDateFormatFromTemplate("jmm")
-
-    let cutoff = Date().addingTimeInterval(-30 * 60)  // include a meeting that just started
-
-    return
-      events
-      .filter { !$0.isAllDay && $0.startTime.prefix(10) == todayPrefix }
-      .compactMap { event -> (Date, OnboardingMeetingBrief)? in
-        guard let start = plain.date(from: event.startTime) ?? fractional.date(from: event.startTime),
-          start >= cutoff
-        else { return nil }
-        let title = event.summary.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !title.isEmpty else { return nil }
-        return (start, OnboardingMeetingBrief(title: title, time: timeFormatter.string(from: start)))
-      }
-      .sorted { $0.0 < $1.0 }
-      .map(\.1)
   }
 
   /// Sends the active main-chat composer and clears only the exact draft that

--- a/desktop/macos/Desktop/Tests/ChatTranscriptResetRevocationTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatTranscriptResetRevocationTests.swift
@@ -87,4 +87,21 @@ final class ChatTranscriptResetRevocationTests: XCTestCase {
     XCTAssertFalse(provider.isSending)
     XCTAssertFalse(provider.isStopping)
   }
+
+  func testOwnerChangeClearsThePreviousOwnersOnboardingProof() {
+    let provider = ChatProvider()
+    provider.onboardingOpener = OnboardingOpenerContent(
+      greeting: "Morning, Owner A",
+      subline: "Private setup context",
+      starters: ["What should I do today?"],
+      proofReceipt: OnboardingProofReceipt(
+        answerExcerpt: "Owner A's private screen answer",
+        sourceLabel: "Answered during your screen demo"))
+
+    NotificationCenter.default.post(name: .runtimeOwnerDidChange, object: nil)
+
+    XCTAssertNil(
+      provider.onboardingOpener,
+      "Owner change must clear the previous owner's name and proof excerpt synchronously")
+  }
 }

--- a/desktop/macos/Desktop/Tests/OnboardingOpenerComposerTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingOpenerComposerTests.swift
@@ -103,4 +103,39 @@ final class OnboardingOpenerComposerTests: XCTestCase {
     XCTAssertTrue(content.subline.hasPrefix("'Design sync' at 2:00 PM today"))
     XCTAssertEqual(content.starters, ["Prep me for 'Design sync'", "What should I do today?"])
   }
+
+  // MARK: screen proof
+
+  func testScreenProofUsesOnlyTheActiveCompletedTurn() {
+    let messages = [
+      ChatMessage(clientTurnId: "older", text: "Unrelated later answer", sender: .ai),
+      ChatMessage(clientTurnId: "demo", text: "  Focus the launch review.  ", sender: .ai),
+    ]
+
+    XCTAssertEqual(
+      SBOnboardingScreenProofPolicy.completedAnswer(in: messages, activeClientTurnId: "demo"),
+      "Focus the launch review.")
+  }
+
+  func testScreenProofRejectsStreamingAndFailedAnswers() {
+    let streaming = ChatMessage(
+      clientTurnId: "demo", text: "Partial", sender: .ai, isStreaming: true)
+    var failed = ChatMessage(clientTurnId: "demo", text: "Could not answer", sender: .ai)
+    failed.journalStatus = .failed
+
+    XCTAssertNil(
+      SBOnboardingScreenProofPolicy.completedAnswer(
+        in: [streaming], activeClientTurnId: "demo"))
+    XCTAssertNil(
+      SBOnboardingScreenProofPolicy.completedAnswer(in: [failed], activeClientTurnId: "demo"))
+  }
+
+  func testScreenProofRejectsMissingOrUnrelatedTurnIdentity() {
+    let answer = ChatMessage(clientTurnId: "other", text: "Not the demo", sender: .ai)
+
+    XCTAssertNil(
+      SBOnboardingScreenProofPolicy.completedAnswer(in: [answer], activeClientTurnId: nil))
+    XCTAssertNil(
+      SBOnboardingScreenProofPolicy.completedAnswer(in: [answer], activeClientTurnId: "demo"))
+  }
 }

--- a/desktop/macos/Desktop/Tests/SecondBrainHomeTests.swift
+++ b/desktop/macos/Desktop/Tests/SecondBrainHomeTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Omi_Computer
 
 final class SecondBrainHomeTests: XCTestCase {
-  func testReturningHomeMakesTheUsersRealContextTheProductProof() {
+  func testReturningHomeLeadsWithAQuestionFromTheUsersContext() {
     let snapshot = SecondBrainHomeSnapshot.compose(
       conversations: 12,
       memories: 34,
@@ -11,19 +11,25 @@ final class SecondBrainHomeTests: XCTestCase {
       screenCount: 1_200,
       personalizedPrompts: ["What did Priya need from me after our launch review?"],
       onboardingPrompts: [],
-      opener: nil)
+      opener: nil,
+      contextEvidence: [
+        .init(kind: .conversation, text: "Launch review with Priya"),
+        .init(kind: .task, text: "Send revised rollout plan"),
+      ])
 
-    XCTAssertEqual(snapshot.headline, "Your life, ready to answer.")
+    XCTAssertEqual(snapshot.phase, .ready)
+    XCTAssertEqual(snapshot.headline, "What do you want to know?")
     XCTAssertEqual(snapshot.total, 1_251)
-    XCTAssertEqual(snapshot.sources.map(\.title), ["Heard", "Seen", "Remembered", "Decided"])
+    XCTAssertEqual(snapshot.sources.map(\.title), ["Conversations", "Screen", "Memories", "Tasks"])
     XCTAssertEqual(
       snapshot.sources.map(\.detail),
       ["12 conversations", "1,200 screen moments", "34 memories", "5 open tasks"])
-    XCTAssertEqual(snapshot.prompts.first, HomeSuggestionComposer.universalFirstQuestion)
-    XCTAssertTrue(snapshot.prompts.contains("What did Priya need from me after our launch review?"))
+    XCTAssertEqual(snapshot.heroPrompt, "What did Priya need from me after our launch review?")
+    XCTAssertTrue(snapshot.secondaryPrompts.contains(HomeSuggestionComposer.universalFirstQuestion))
+    XCTAssertEqual(snapshot.evidence.map(\.text), ["Launch review with Priya", "Send revised rollout plan"])
   }
 
-  func testPostOnboardingHomeKeepsTheGreetingAndRealStarterQuestions() {
+  func testPostOnboardingHomeKeepsGreetingAndDoesNotRenderZeroProof() {
     let opener = OnboardingOpenerContent(
       greeting: "Morning, Sam",
       subline: "Two meetings today. I'll be listening.",
@@ -42,19 +48,54 @@ final class SecondBrainHomeTests: XCTestCase {
       onboardingPrompts: [],
       opener: opener)
 
-    XCTAssertEqual(snapshot.greeting, "Morning, Sam")
-    XCTAssertEqual(snapshot.headline, "Your second brain starts here.")
+    XCTAssertEqual(snapshot.phase, .activation)
+    XCTAssertEqual(snapshot.headline, "Morning, Sam.")
     XCTAssertEqual(snapshot.supportingCopy, opener.subline)
-    XCTAssertEqual(
-      snapshot.prompts,
-      [
-        "Prep me for product review",
-        "What should I do today?",
-        "What did I spend my time on this week?",
-      ])
+    XCTAssertEqual(snapshot.heroPrompt, "Prep me for product review")
+    XCTAssertEqual(snapshot.secondaryPrompts.first, "What should I do today?")
+    XCTAssertFalse(snapshot.secondaryPrompts.contains("What did I spend my time on this week?"))
+    XCTAssertTrue(snapshot.sources.isEmpty)
+    XCTAssertFalse(snapshot.sourceSummary.contains("0"))
   }
 
-  func testUnavailableScreenCountIsShownAsCountingRatherThanAFalseZero() {
+  func testOnboardingAnswerBecomesAnEphemeralProofReceipt() throws {
+    let receipt = try XCTUnwrap(
+      OnboardingProofReceipt.setupAnswer(
+        "  You are reviewing the launch plan.\nThe open issue is rollout ownership.  "))
+    let opener = OnboardingOpenerContent(
+      greeting: "Afternoon, Alex",
+      subline: "I'm set up and listening.",
+      starters: ["What should I do next?"],
+      proofReceipt: receipt)
+
+    let snapshot = SecondBrainHomeSnapshot.compose(
+      conversations: 0,
+      memories: 0,
+      tasks: 0,
+      screenCount: nil,
+      personalizedPrompts: [],
+      onboardingPrompts: [],
+      opener: opener)
+
+    XCTAssertEqual(snapshot.headline, "You asked. Omi answered.")
+    XCTAssertEqual(
+      snapshot.proofReceipt?.answerExcerpt,
+      "You are reviewing the launch plan. The open issue is rollout ownership.")
+    XCTAssertEqual(snapshot.proofReceipt?.sourceLabel, "Answered during your screen demo")
+    XCTAssertEqual(snapshot.heroPrompt, "What should I focus on based on what's on my screen?")
+  }
+
+  func testProofReceiptIsBoundedAndDoesNotPersistRawWhitespace() throws {
+    let raw = String(repeating: "personal context ", count: 30)
+    let receipt = try XCTUnwrap(OnboardingProofReceipt.setupAnswer("\n\(raw)\n"))
+
+    XCTAssertLessThanOrEqual(receipt.answerExcerpt.count, OnboardingProofReceipt.maxExcerptLength)
+    XCTAssertTrue(receipt.answerExcerpt.hasSuffix("…"))
+    XCTAssertFalse(receipt.answerExcerpt.contains("\n"))
+    XCTAssertNil(OnboardingProofReceipt.setupAnswer(" \n "))
+  }
+
+  func testUnavailableScreenCountIsAnHonestLoadingStateRatherThanAFalseZero() {
     let snapshot = SecondBrainHomeSnapshot.compose(
       conversations: 2,
       memories: 3,
@@ -65,10 +106,13 @@ final class SecondBrainHomeTests: XCTestCase {
       opener: nil)
 
     XCTAssertNil(snapshot.total)
-    XCTAssertEqual(snapshot.sources.first(where: { $0.kind == .screen })?.detail, "Counting moments…")
+    XCTAssertEqual(
+      snapshot.sources.first(where: { $0.kind == .screen })?.detail,
+      "Screen history isn't ready yet")
+    XCTAssertFalse(snapshot.sourceSummary.contains("0"))
   }
 
-  func testBadCountsCannotProduceNegativeProof() {
+  func testBadCountsCannotProduceNegativeOrZeroProof() {
     let snapshot = SecondBrainHomeSnapshot.compose(
       conversations: -4,
       memories: -3,
@@ -78,8 +122,59 @@ final class SecondBrainHomeTests: XCTestCase {
       onboardingPrompts: [],
       opener: nil)
 
+    XCTAssertEqual(snapshot.phase, .gathering)
     XCTAssertEqual(snapshot.total, 0)
-    XCTAssertEqual(snapshot.headline, "Your second brain starts here.")
-    XCTAssertFalse(snapshot.sources.map(\.detail).joined().contains("-"))
+    XCTAssertTrue(snapshot.sources.isEmpty)
+    XCTAssertFalse(snapshot.sourceSummary.contains("-"))
+    XCTAssertFalse(snapshot.sourceSummary.contains("0"))
+  }
+
+  func testEvidenceIsCollapsedDeduplicatedAndBounded() {
+    let long = String(repeating: "launch ", count: 30)
+    let snapshot = SecondBrainHomeSnapshot.compose(
+      conversations: 1,
+      memories: 1,
+      tasks: 1,
+      screenCount: 1,
+      personalizedPrompts: [],
+      onboardingPrompts: [],
+      opener: nil,
+      contextEvidence: [
+        .init(kind: .conversation, text: "  Launch\nreview  "),
+        .init(kind: .memory, text: "launch review"),
+        .init(kind: .task, text: long),
+        .init(kind: .task, text: "Fourth item is intentionally capped out"),
+      ])
+
+    XCTAssertEqual(snapshot.evidence.count, 3)
+    XCTAssertEqual(snapshot.evidence.first?.text, "Launch review")
+    XCTAssertLessThanOrEqual(snapshot.evidence[1].text.count, 96)
+    XCTAssertTrue(snapshot.evidence[1].text.hasSuffix("…"))
+  }
+
+  func testExistingTranscriptWinsOverOverviewUnlessOnboardingIsHandingOff() {
+    XCTAssertFalse(
+      SecondBrainHomePresentationPolicy.showsOverview(
+        requested: true, hasMessages: true, hasOnboardingOpener: false, isSending: false))
+    XCTAssertTrue(
+      SecondBrainHomePresentationPolicy.showsOverview(
+        requested: true, hasMessages: true, hasOnboardingOpener: true, isSending: false))
+    XCTAssertTrue(
+      SecondBrainHomePresentationPolicy.showsOverview(
+        requested: true, hasMessages: false, hasOnboardingOpener: false, isSending: false))
+    XCTAssertFalse(
+      SecondBrainHomePresentationPolicy.showsOverview(
+        requested: true, hasMessages: false, hasOnboardingOpener: true, isSending: true))
+  }
+
+  func testSuggestionNeverOverwritesAComposerDraft() {
+    XCTAssertTrue(SecondBrainPromptPolicy.canUseSuggestion(draft: "  "))
+    XCTAssertFalse(SecondBrainPromptPolicy.canUseSuggestion(draft: "my own question"))
+  }
+
+  func testSearchIsCompactOnlyOnTheRestingAnswerSurface() {
+    XCTAssertTrue(HomeSearchPresentationPolicy.isCompact(mode: .answer, isExpanded: false))
+    XCTAssertFalse(HomeSearchPresentationPolicy.isCompact(mode: .answer, isExpanded: true))
+    XCTAssertFalse(HomeSearchPresentationPolicy.isCompact(mode: .results, isExpanded: false))
   }
 }

--- a/desktop/macos/Desktop/Tests/SecondBrainHomeTests.swift
+++ b/desktop/macos/Desktop/Tests/SecondBrainHomeTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SecondBrainHomeTests: XCTestCase {
+  func testReturningHomeMakesTheUsersRealContextTheProductProof() {
+    let snapshot = SecondBrainHomeSnapshot.compose(
+      conversations: 12,
+      memories: 34,
+      tasks: 5,
+      screenCount: 1_200,
+      personalizedPrompts: ["What did Priya need from me after our launch review?"],
+      onboardingPrompts: [],
+      opener: nil)
+
+    XCTAssertEqual(snapshot.headline, "Your life, ready to answer.")
+    XCTAssertEqual(snapshot.total, 1_251)
+    XCTAssertEqual(snapshot.sources.map(\.title), ["Heard", "Seen", "Remembered", "Decided"])
+    XCTAssertEqual(
+      snapshot.sources.map(\.detail),
+      ["12 conversations", "1,200 screen moments", "34 memories", "5 open tasks"])
+    XCTAssertEqual(snapshot.prompts.first, HomeSuggestionComposer.universalFirstQuestion)
+    XCTAssertTrue(snapshot.prompts.contains("What did Priya need from me after our launch review?"))
+  }
+
+  func testPostOnboardingHomeKeepsTheGreetingAndRealStarterQuestions() {
+    let opener = OnboardingOpenerContent(
+      greeting: "Morning, Sam",
+      subline: "Two meetings today. I'll be listening.",
+      starters: [
+        "Prep me for product review",
+        "What should I do today?",
+        "Prep me for product review",
+      ])
+
+    let snapshot = SecondBrainHomeSnapshot.compose(
+      conversations: 0,
+      memories: 0,
+      tasks: 0,
+      screenCount: 0,
+      personalizedPrompts: [],
+      onboardingPrompts: [],
+      opener: opener)
+
+    XCTAssertEqual(snapshot.greeting, "Morning, Sam")
+    XCTAssertEqual(snapshot.headline, "Your second brain starts here.")
+    XCTAssertEqual(snapshot.supportingCopy, opener.subline)
+    XCTAssertEqual(
+      snapshot.prompts,
+      [
+        "Prep me for product review",
+        "What should I do today?",
+        "What did I spend my time on this week?",
+      ])
+  }
+
+  func testUnavailableScreenCountIsShownAsCountingRatherThanAFalseZero() {
+    let snapshot = SecondBrainHomeSnapshot.compose(
+      conversations: 2,
+      memories: 3,
+      tasks: 1,
+      screenCount: nil,
+      personalizedPrompts: [],
+      onboardingPrompts: [],
+      opener: nil)
+
+    XCTAssertNil(snapshot.total)
+    XCTAssertEqual(snapshot.sources.first(where: { $0.kind == .screen })?.detail, "Counting moments…")
+  }
+
+  func testBadCountsCannotProduceNegativeProof() {
+    let snapshot = SecondBrainHomeSnapshot.compose(
+      conversations: -4,
+      memories: -3,
+      tasks: -2,
+      screenCount: -1,
+      personalizedPrompts: [],
+      onboardingPrompts: [],
+      opener: nil)
+
+    XCTAssertEqual(snapshot.total, 0)
+    XCTAssertEqual(snapshot.headline, "Your second brain starts here.")
+    XCTAssertFalse(snapshot.sources.map(\.detail).joined().contains("-"))
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260819-second-brain-home.json
+++ b/desktop/macos/changelog/unreleased/20260819-second-brain-home.json
@@ -1,0 +1,3 @@
+{
+  "change": "Redesigned Home to show how your conversations, screen, memories, and tasks become personal answers before you ask"
+}

--- a/desktop/macos/changelog/unreleased/20260819-second-brain-home.json
+++ b/desktop/macos/changelog/unreleased/20260819-second-brain-home.json
@@ -1,3 +1,3 @@
 {
-  "change": "Redesigned Home to show how your conversations, screen, memories, and tasks become personal answers before you ask"
+  "change": "Redesigned Home around one personal question, real recent context, and the answer produced during onboarding"
 }

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -1,7 +1,7 @@
 version: 2
 name: home
 tier: manual
-description: Home tab — chat-first panel under the always-on search bar, plus its header controls and Capture/Listening status (v0.12.119+ redesign, replaces dashboard.yaml)
+description: Home tab — second-brain value canvas and the shared chat transcript under the always-on search bar, plus header controls and Capture/Listening status
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -9,6 +9,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+  - desktop/macos/Desktop/Sources/MainWindow/QueryShell/SecondBrainHome.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellModel.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryHeroBar.swift
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/QuerySearchBar.swift
@@ -26,12 +27,18 @@ preconditions:
 
 steps:
   - id: S1
-    name: Verify Home tab is active
-    do: "Verify the app opens on the conversation. The top bar shows Home, Memories, Tasks, Rewind and Apps pills. Below it, a search bar with the placeholder 'Search what you've seen and heard…' sits above the chat panel, whose own composer ('Ask a follow-up…') is pinned under the transcript. Typing in the search bar swaps the panel to live-narrowing results; clearing it returns to the chat."
+    name: Verify Home explains Omi before the first question
+    do: "Verify the app opens on the second-brain value canvas. It says either 'Your life, ready to answer.' or 'Your second brain starts here.', followed by 'The second brain you trust more than your first.' A single context diagram connects Heard, Seen, Remembered and Decided to 'One personal answer', using real counts or an honest counting state. Three starter questions are visible and the existing chat composer ('Ask a follow-up…') remains pinned below the canvas."
     expect:
       interactive_count: { min: 6 }
       text_visible:
-        - Chat
+        - The second brain you trust more than your first.
+
+  - id: S1b
+    name: Verify both new and returning paths use the same chat
+    do: "For a returning profile with transcript history, verify 'Continue last conversation' reveals the existing transcript without duplicating messages. Return to Home, activate a starter question, and verify the value canvas is replaced by that same transcript while the question sends through the existing composer. For a just-completed onboarding profile, verify the canvas uses the user's greeting and onboarding starter questions before the first send."
+    expect:
+      interactive_count: { min: 2 }
 
   - id: S2
     name: Verify the two inputs are distinct

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -27,22 +27,34 @@ preconditions:
 
 steps:
   - id: S1
-    name: Verify Home explains Omi before the first question
-    do: "Verify the app opens on the second-brain value canvas. It says either 'Your life, ready to answer.' or 'Your second brain starts here.', followed by 'The second brain you trust more than your first.' A single context diagram connects Heard, Seen, Remembered and Decided to 'One personal answer', using real counts or an honest counting state. Three starter questions are visible and the existing chat composer ('Ask a follow-up…') remains pinned below the canvas."
+    name: Verify Home proves Omi before the first question
+    do: "For a returning profile with no transcript, verify Home leads with one large question. When personalized suggestions exist, the most specific one is primary rather than the universal fallback. 'Recently available to Omi' shows real conversation, task, or memory text when available; the fallback names only non-zero sources or honestly says screen history is not ready. No zero metrics, repeated count sentence, or abstract data-flow diagram is visible. The existing chat composer remains pinned below the canvas."
     expect:
       interactive_count: { min: 6 }
       text_visible:
-        - The second brain you trust more than your first.
+        - Search history
 
   - id: S1b
     name: Verify both new and returning paths use the same chat
-    do: "For a returning profile with transcript history, verify 'Continue last conversation' reveals the existing transcript without duplicating messages. Return to Home, activate a starter question, and verify the value canvas is replaced by that same transcript while the question sends through the existing composer. For a just-completed onboarding profile, verify the canvas uses the user's greeting and onboarding starter questions before the first send."
+    do: "For a returning profile with transcript history, verify Home opens directly to the existing transcript without an overview interstitial. For a just-completed onboarding profile, verify Home uses the user's greeting and onboarding starter questions; when the screen demo produced an answer, verify a bounded excerpt appears under 'Your first Omi answer' with 'Answered during your screen demo'. Activate the primary question and verify it enters the shared composer/send path and the canvas is replaced by that same transcript without duplicated messages."
+    expect:
+      interactive_count: { min: 2 }
+
+  - id: S1c
+    name: Protect an in-progress question
+    do: "Type a draft in the shared chat composer while the value canvas is visible. Verify the suggested questions become unavailable and explain that the draft must be finished or cleared. Confirm activating a suggestion cannot replace the typed draft."
+    expect:
+      interactive_count: { min: 2 }
+
+  - id: S1d
+    name: Verify the value canvas at the minimum window and large text
+    do: "Resize the named test bundle to the supported minimum window. At the largest in-app font scale, verify the headline, primary question, source evidence, secondary questions, and composer remain reachable by scrolling, with no clipped text or horizontal overflow. Turn Reduce Motion on and revisit Home; the canvas appears without the entrance translation."
     expect:
       interactive_count: { min: 2 }
 
   - id: S2
     name: Verify the two inputs are distinct
-    do: "Verify the search bar above the panel is pure search (magnifying glass, no send control) and the chat composer inside the panel carries the conversation controls: text field, paperclip (Attach files), microphone, and the send disc."
+    do: "Verify resting Home shows the compact 'Search history ⌘K' affordance rather than a competing text box. Activate it and verify it expands into the pure search field (magnifying glass, no send control) and receives focus; press Escape to collapse it. The chat composer inside the panel remains the only send surface and carries the text field, paperclip (Attach files), microphone, and send disc."
     expect:
       interactive_count: { min: 4 }
 

--- a/desktop/macos/e2e/flows/onboarding-flow.yaml
+++ b/desktop/macos/e2e/flows/onboarding-flow.yaml
@@ -30,6 +30,7 @@ covers:
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel+Steps.swift
   - desktop/macos/Desktop/Sources/Onboarding/SecondBrain/OnboardingOpenerComposer.swift
+  - desktop/macos/Desktop/Sources/Providers/ChatProvider+OnboardingOpener.swift
   - desktop/macos/Desktop/Sources/MainWindow/OnboardingOpenerView.swift
   - desktop/macos/Desktop/Sources/Onboarding/Cinematic/OmiCinematicDirector.swift
   - desktop/macos/Desktop/Sources/Onboarding/Cinematic/OmiCinematicMark.swift


### PR DESCRIPTION
## Summary

- turn Home into a one-question doorway to Omi's real value instead of an architecture explainer
- carry the answer produced during onboarding into Home as an ephemeral proof receipt, then offer the most useful screen-aware follow-up
- give returning users a personalized primary question and a small, truthful view of recent conversations, memories, and tasks
- keep existing transcripts, the shared composer, every onboarding screen, and every dashboard destination intact
- collapse history search into a clear `Search history ⌘K` command so it no longer competes with the primary question

## Experience

### New users

Onboarding still uses the existing screen sequence, but the promise is now explicit: Omi connects what it can hear, see, and do, with every permission explained. During the screen demo, the answer produced in that isolated stage is captured in memory only. Home opens with **You asked. Omi answered.**, shows a bounded excerpt of that answer, and leads with **What should I focus on based on what's on my screen?**

If an answer was not produced, Home falls back honestly to the setup-aware greeting and questions already derived from onboarding. It never invents context or renders a wall of zero counts.

### Returning users

Home leads with one personalized question when Omi has one. Under it, users see up to three real recent context items already loaded by the app: a conversation, an open task, and a memory. Existing conversations reopen directly as conversations instead of being covered by the overview.

The resting surface has one obvious text input: the existing shared chat composer. History search stays available from the panel header or `⌘K`, and expands into the unchanged search experience only when requested.

## Trust and continuity

- answers state that citations appear when context is used; no source provenance is fabricated
- the onboarding proof receipt is bounded, whitespace-normalized, and never persisted
- screen counts and asynchronous calendar enrichment are owner-authorized before publication
- an account switch synchronously clears the prior owner's proof, opener, transcript, and draft state
- prompt refreshes freeze while the overview is mounted, and suggestions never overwrite a draft

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path desktop/macos/Desktop --skip-build --filter '<affected onboarding, query, permission, and Home suites>'` — **259 tests passed**
- post-extraction focused compile/test — **45 tests passed**
- completed-turn proof policy compile/test — **28 tests passed**
- `./desktop/macos/scripts/desktop-core-harness.sh --self-check --skip-backend-contracts` — **passed**; 72 flows and 159 registered actions linted
- `/Users/aadigupta/Documents/GitHub/omi/backend/.venv/bin/python -m pytest -q tests/unit/test_desktop_agent_vm.py tests/unit/test_desktop_chat.py tests/unit/test_desktop_core.py tests/unit/test_desktop_proxy.py tests/unit/test_desktop_realtime.py tests/unit/test_desktop_screen_crisp.py tests/unit/test_desktop_tts_updates.py` — **193 tests passed**
- built, ad-hoc signed, dependency-verified, and ran exactly one isolated `/Applications/omi-track0-value.app`
- visually exercised the real first-run promise and completed-onboarding Home at the 900×712 window size with a synthetic local account; production Omi bundles were untouched
- `make preflight` — passed with the PR body below supplying the required invariant citations

## Full-suite notes

The affected suites are green. A prior full Swift run exposed two unrelated failures already present outside this change: multi-monitor quiet-window geometry in `DesktopAutomationWindowPresentationTests` and an outdated SQLite fixture missing `embedding` in `ScreenshotEmbeddingBackfillRecoveryTests`. The official desktop runner's pytest handoff also has an existing trailing-continuation issue; the direct desktop backend selection above is green.

## Product invariants affected

- INV-AUTH-1
- INV-CHAT-1
- INV-UI-1

## Failure class

Not applicable; all commits are `feat:` changes.
