### PR TITLE
Fix desktop processing banner overlapping conversation details

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -7,8 +7,6 @@ enum ConversationDetailPane: Equatable {
   case transcript
 }
 
-/// Keeps deferred-processing feedback in the summary's layout flow so it
-/// reserves space instead of painting over metadata that is already available.
 struct ConversationDetailProcessingLayout<Banner: View, Content: View>: View {
   let isProcessing: Bool
   let banner: Banner
@@ -846,8 +844,8 @@ struct ConversationDetailView: View {
 
   // MARK: - Deferred Processing Loader
 
-  /// Displayed while a lazily-deferred conversation is enriched, ahead of any
-  /// details that are already available from the local cache.
+  /// Overlaid while a lazily-deferred conversation is enriched, preserving the
+  /// position of details that may already be available from the local cache.
   private var deferredProcessingSection: some View {
     HStack(spacing: OmiSpacing.md) {
       ProgressView()

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -7,6 +7,34 @@ enum ConversationDetailPane: Equatable {
   case transcript
 }
 
+/// Keeps deferred-processing feedback in the summary's layout flow so it
+/// reserves space instead of painting over metadata that is already available.
+struct ConversationDetailProcessingLayout<Banner: View, Content: View>: View {
+  let isProcessing: Bool
+  let banner: Banner
+  let content: Content
+
+  init(
+    isProcessing: Bool,
+    @ViewBuilder banner: () -> Banner,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.isProcessing = isProcessing
+    self.banner = banner()
+    self.content = content()
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: OmiSpacing.xxl) {
+      if isProcessing {
+        banner
+      }
+      content
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
 /// Full detail view for a single conversation
 struct ConversationDetailView: View {
   let conversation: ServerConversation
@@ -148,20 +176,16 @@ struct ConversationDetailView: View {
               .padding(.vertical, OmiSpacing.sm)
               .background(Ink.rowFillHover.opacity(0.4))
 
-              VStack(alignment: .leading, spacing: OmiSpacing.xxl) {
+              ConversationDetailProcessingLayout(isProcessing: isEnrichingDeferred) {
+                deferredProcessingSection
+                  .allowsHitTesting(false)
+              } content: {
                 summaryContent
               }
               .padding(OmiSpacing.xxl)
             }
             .glassCard(cornerRadius: OmiChrome.controlRadius)
             .clipShape(RoundedRectangle(cornerRadius: OmiChrome.controlRadius))
-            .overlay(alignment: .top) {
-              if isEnrichingDeferred {
-                deferredProcessingSection
-                  .padding(OmiSpacing.xxl)
-                  .allowsHitTesting(false)
-              }
-            }
             .padding(OmiSpacing.xxl)
           }
           .glassScrollFade()
@@ -822,8 +846,8 @@ struct ConversationDetailView: View {
 
   // MARK: - Deferred Processing Loader
 
-  /// Overlaid while a lazily-deferred conversation is enriched, preserving the
-  /// position of details that may already be available from the local cache.
+  /// Displayed while a lazily-deferred conversation is enriched, ahead of any
+  /// details that are already available from the local cache.
   private var deferredProcessingSection: some View {
     HStack(spacing: OmiSpacing.md) {
       ProgressView()

--- a/desktop/macos/Desktop/Tests/ConversationDetailAutomationStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDetailAutomationStateTests.swift
@@ -1,9 +1,33 @@
+import OmiTheme
+import SwiftUI
 import XCTest
 
 @testable import Omi_Computer
 
 @MainActor
 final class ConversationDetailAutomationStateTests: XCTestCase {
+  func testProcessingBannerReservesSpaceAboveConversationMetadata() {
+    let idle = ConversationDetailProcessingLayout(isProcessing: false) {
+      Color.red.frame(height: 32)
+    } content: {
+      Color.blue.frame(height: 20)
+    }
+    .frame(width: 200)
+
+    let processing = ConversationDetailProcessingLayout(isProcessing: true) {
+      Color.red.frame(height: 32)
+    } content: {
+      Color.blue.frame(height: 20)
+    }
+    .frame(width: 200)
+
+    let idleHeight = NSHostingView(rootView: idle).fittingSize.height
+    let processingHeight = NSHostingView(rootView: processing).fittingSize.height
+
+    XCTAssertEqual(idleHeight, 20, accuracy: 0.5)
+    XCTAssertEqual(processingHeight - idleHeight, 32 + OmiSpacing.xxl, accuracy: 0.5)
+  }
+
   func testTranscriptUsesAnExclusivePaneInsteadOfCompressingTheSummaryToolbar() {
     XCTAssertEqual(ConversationDetailView.visiblePane(transcriptOpen: false), .summary)
     XCTAssertEqual(ConversationDetailView.visiblePane(transcriptOpen: true), .transcript)

--- a/desktop/macos/changelog/unreleased/20260820-processing-banner-layout.json
+++ b/desktop/macos/changelog/unreleased/20260820-processing-banner-layout.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the conversation processing banner overlapping source and duration details"
+}


### PR DESCRIPTION
## Summary

- keep the deferred conversation-processing banner in the normal summary layout flow
- preserve a full spacing-token gap between processing feedback and conversation metadata
- add a behavioral layout regression test and a user-facing desktop changelog entry

## Problem

While a deferred conversation was being enriched, the **Processing conversation…** banner was attached as an overlay to the entire Conversation Details card. SwiftUI overlays do not participate in their parent’s size calculation, so the banner occupied the same vertical region as metadata that was already available from the local conversation record. The source and duration chips were consequently rendered underneath the banner.

This was reproduced in the macOS desktop app while verifying a separate conversation-deletion report.

## Root cause

`ConversationDetailView` rendered `summaryContent` in the card’s normal layout flow, then painted `deferredProcessingSection` over the card with `.overlay(alignment: .top)`. Both layers used the same outer spacing token, but the overlay reserved no height for itself and did not account for the card header.

## Fix

Introduce `ConversationDetailProcessingLayout`, a small production layout seam that places the conditional banner before the existing summary content in one `VStack`:

- the banner now contributes its intrinsic height
- `OmiSpacing.xxl` provides the existing 24-point section separation
- source, duration, and all later summary content remain in normal document flow
- no new spacing values, visual tokens, or interaction behavior are introduced

## Visual proof

### Before — processing banner overlaps metadata

![Processing banner overlapping conversation metadata](https://raw.githubusercontent.com/aryanorastar/omi/bfe99386aa3b2097e7fe7d95e80ee4d0093320ce/.pr-assets/11901-before-processing-banner-overlap.png)

### After — banner reserves space above metadata

![Fixed processing banner layout](https://raw.githubusercontent.com/aryanorastar/omi/bfe99386aa3b2097e7fe7d95e80ee4d0093320ce/.pr-assets/11901-fixed-processing-banner.png)

The patched state was physically verified in the named bundle `/Applications/omi-processing-layout.app`, including resizing the desktop window.

## Regression coverage

`testProcessingBannerReservesSpaceAboveConversationMetadata` renders the production layout seam in idle and processing states and verifies that enabling processing increases the measured height by the banner height plus `OmiSpacing.xxl`. This would fail if the banner were changed back to an overlay or another non-layout decoration.

## Verification

- `./scripts/dev-feedback.py --once swift 'ConversationDetailAutomationStateTests'` — 9 tests passed, 0 failures
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift Desktop/Tests/ConversationDetailAutomationStateTests.swift` — passed
- `python3 ../../.github/scripts/desktop-changelog.py validate` — passed
- `git diff --check` — passed
- named macOS bundle physical verification — passed
- `make preflight` — passed

## Scope and risk

The change is limited to conversation-detail presentation during deferred enrichment. Completed conversations and the underlying enrichment, persistence, transcript, deletion, and metadata behavior are unchanged. Risk is low and covered by the focused layout test plus physical verification.

Failure-Class: none

No product invariant citations are required for the changed paths.
