### PR TITLE
fix(desktop): expire leftover agent tool-output files after a week

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/AgentArtifactRetention.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentArtifactRetention.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Bounded retention for oversized agent control-tool dumps.
+///
+/// The Node runtime writes truncated tool results under
+/// `Application Support/Omi/Artifacts/<bundle>/tool-output` so a later
+/// `read_tool_output` can recover them. Those files were never expired, so
+/// existing installs accumulated months of JSON. User-facing run artifacts
+/// (owner/session/run/attempt copies) are outside this directory and stay.
+enum AgentArtifactRetention {
+  static let toolOutputDirectoryName = "tool-output"
+  static let toolOutputRetention: TimeInterval = 7 * 24 * 60 * 60
+
+  /// Pure retention decision: which files (by last-modified date) are stale
+  /// relative to `now`. Extracted so the sweep policy is testable without disk.
+  static func staleToolOutputURLs(
+    _ files: [(url: URL, modified: Date)],
+    now: Date,
+    retention: TimeInterval
+  ) -> [URL] {
+    files.filter { now.timeIntervalSince($0.modified) > retention }.map(\.url)
+  }
+
+  /// Delete expired `tool-output` files for this bundle's artifact root.
+  /// Existing users are cleaned on the next launch; new dumps expire after a week.
+  @discardableResult
+  static func pruneExpiredToolOutputs(
+    in artifactsDirectory: URL,
+    now: Date = Date(),
+    retention: TimeInterval = toolOutputRetention,
+    fileManager: FileManager = .default
+  ) -> Int {
+    let toolOutputRoot = artifactsDirectory.appendingPathComponent(
+      toolOutputDirectoryName, isDirectory: true)
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: toolOutputRoot.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else {
+      return 0
+    }
+
+    guard
+      let enumerator = fileManager.enumerator(
+        at: toolOutputRoot,
+        includingPropertiesForKeys: [
+          .isRegularFileKey, .isDirectoryKey, .isSymbolicLinkKey, .contentModificationDateKey,
+        ],
+        options: [.skipsPackageDescendants]
+      )
+    else {
+      return 0
+    }
+
+    var deleted = 0
+    var directories: [URL] = []
+    for case let url as URL in enumerator {
+      let values = try? url.resourceValues(forKeys: [
+        .isRegularFileKey, .isDirectoryKey, .isSymbolicLinkKey, .contentModificationDateKey,
+      ])
+      if values?.isSymbolicLink == true { continue }
+      if values?.isDirectory == true {
+        directories.append(url)
+        continue
+      }
+      guard values?.isRegularFile == true, let modified = values?.contentModificationDate else {
+        continue
+      }
+      guard now.timeIntervalSince(modified) > retention else { continue }
+      do {
+        try fileManager.removeItem(at: url)
+        deleted += 1
+      } catch {
+        continue
+      }
+    }
+
+    for directory in directories.sorted(by: { $0.path.count > $1.path.count }) {
+      if let contents = try? fileManager.contentsOfDirectory(atPath: directory.path), contents.isEmpty {
+        try? fileManager.removeItem(at: directory)
+      }
+    }
+    return deleted
+  }
+}

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -317,6 +317,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
     publishNamedBundleRuntimeManifest()
 
     runStartupSystemMaintenance()
+    pruneExpiredAgentToolOutputs()
 
     log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
     log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
@@ -760,6 +761,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
           executable: command.executable,
           arguments: command.arguments
         )
+      }
+    }
+  }
+
+  /// Expire leftover agent `tool-output` JSON so existing installs reclaim disk
+  /// on the next launch, without waiting for a chat that starts the Node runtime.
+  private func pruneExpiredAgentToolOutputs() {
+    let artifactsDirectory = URL(
+      fileURLWithPath: AgentRuntimeProcess.defaultArtifactsDirectory())
+    DispatchQueue.global(qos: .utility).async {
+      let deleted = AgentArtifactRetention.pruneExpiredToolOutputs(in: artifactsDirectory)
+      if deleted > 0 {
+        log("AppDelegate: pruned \(deleted) expired agent tool-output files")
       }
     }
   }

--- a/desktop/macos/Desktop/Tests/AgentArtifactRetentionTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentArtifactRetentionTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Regression coverage for agent `tool-output` JSON retention.
+///
+/// Oversized control-tool results were written under
+/// `~/Library/Application Support/Omi/Artifacts/.../tool-output` and never
+/// deleted, filling disks. The sweep removes files older than a week and
+/// leaves user-facing run artifacts alone.
+final class AgentArtifactRetentionTests: XCTestCase {
+  func testStaleFilesBeyondRetentionAreSelected() {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let dir = URL(fileURLWithPath: "/tmp/omi-tool-output")
+    let fresh = (url: dir.appendingPathComponent("fresh.json"), modified: now.addingTimeInterval(-60))
+    let stale = (
+      url: dir.appendingPathComponent("stale.json"),
+      modified: now.addingTimeInterval(-(AgentArtifactRetention.toolOutputRetention + 60))
+    )
+
+    let purge = AgentArtifactRetention.staleToolOutputURLs(
+      [fresh, stale], now: now, retention: AgentArtifactRetention.toolOutputRetention)
+
+    XCTAssertEqual(purge, [stale.url], "only files older than the retention window are swept")
+  }
+
+  func testExactlyAtRetentionBoundaryIsKept() {
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let dir = URL(fileURLWithPath: "/tmp/omi-tool-output")
+    let atBoundary = (
+      url: dir.appendingPathComponent("boundary.json"),
+      modified: now.addingTimeInterval(-AgentArtifactRetention.toolOutputRetention)
+    )
+    let purge = AgentArtifactRetention.staleToolOutputURLs(
+      [atBoundary], now: now, retention: AgentArtifactRetention.toolOutputRetention)
+    XCTAssertTrue(purge.isEmpty, "a file exactly at the boundary is not yet stale")
+  }
+
+  func testPruneDeletesExpiredToolOutputAndLeavesFreshAndUserArtifacts() throws {
+    let fileManager = FileManager.default
+    let root = fileManager.temporaryDirectory.appendingPathComponent(
+      "omi-artifact-retention-\(UUID().uuidString)", isDirectory: true)
+    defer { try? fileManager.removeItem(at: root) }
+
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let staleDate = now.addingTimeInterval(-(AgentArtifactRetention.toolOutputRetention + 60))
+    let freshDate = now.addingTimeInterval(-60)
+
+    let staleURL = root
+      .appendingPathComponent(AgentArtifactRetention.toolOutputDirectoryName, isDirectory: true)
+      .appendingPathComponent("owner", isDirectory: true)
+      .appendingPathComponent("session-old", isDirectory: true)
+      .appendingPathComponent("list_agent_sessions-stale.json")
+    let freshURL = root
+      .appendingPathComponent(AgentArtifactRetention.toolOutputDirectoryName, isDirectory: true)
+      .appendingPathComponent("owner", isDirectory: true)
+      .appendingPathComponent("session-new", isDirectory: true)
+      .appendingPathComponent("list_agent_sessions-fresh.json")
+    let deliveredURL = root
+      .appendingPathComponent("owner-1", isDirectory: true)
+      .appendingPathComponent("session-1", isDirectory: true)
+      .appendingPathComponent("run-1", isDirectory: true)
+      .appendingPathComponent("attempt-1", isDirectory: true)
+      .appendingPathComponent("answer.md")
+
+    try fileManager.createDirectory(at: staleURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: freshURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: deliveredURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data("{\"sessions\":[]}\n".utf8).write(to: staleURL)
+    try Data("{\"sessions\":[]}\n".utf8).write(to: freshURL)
+    try Data("# keep me\n".utf8).write(to: deliveredURL)
+    try fileManager.setAttributes([.modificationDate: staleDate], ofItemAtPath: staleURL.path)
+    try fileManager.setAttributes([.modificationDate: freshDate], ofItemAtPath: freshURL.path)
+    try fileManager.setAttributes([.modificationDate: staleDate], ofItemAtPath: deliveredURL.path)
+
+    let deleted = AgentArtifactRetention.pruneExpiredToolOutputs(
+      in: root, now: now, fileManager: fileManager)
+
+    XCTAssertEqual(deleted, 1)
+    XCTAssertFalse(fileManager.fileExists(atPath: staleURL.path))
+    XCTAssertFalse(
+      fileManager.fileExists(atPath: staleURL.deletingLastPathComponent().path),
+      "empty session directories under tool-output should be removed")
+    XCTAssertTrue(fileManager.fileExists(atPath: freshURL.path))
+    XCTAssertEqual(try String(contentsOf: deliveredURL, encoding: .utf8), "# keep me\n")
+  }
+}

--- a/desktop/macos/Desktop/Tests/AgentArtifactRetentionTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentArtifactRetentionTests.swift
@@ -46,17 +46,20 @@ final class AgentArtifactRetentionTests: XCTestCase {
     let staleDate = now.addingTimeInterval(-(AgentArtifactRetention.toolOutputRetention + 60))
     let freshDate = now.addingTimeInterval(-60)
 
-    let staleURL = root
+    let staleURL =
+      root
       .appendingPathComponent(AgentArtifactRetention.toolOutputDirectoryName, isDirectory: true)
       .appendingPathComponent("owner", isDirectory: true)
       .appendingPathComponent("session-old", isDirectory: true)
       .appendingPathComponent("list_agent_sessions-stale.json")
-    let freshURL = root
+    let freshURL =
+      root
       .appendingPathComponent(AgentArtifactRetention.toolOutputDirectoryName, isDirectory: true)
       .appendingPathComponent("owner", isDirectory: true)
       .appendingPathComponent("session-new", isDirectory: true)
       .appendingPathComponent("list_agent_sessions-fresh.json")
-    let deliveredURL = root
+    let deliveredURL =
+      root
       .appendingPathComponent("owner-1", isDirectory: true)
       .appendingPathComponent("session-1", isDirectory: true)
       .appendingPathComponent("run-1", isDirectory: true)

--- a/desktop/macos/agent/src/index.ts
+++ b/desktop/macos/agent/src/index.ts
@@ -1554,6 +1554,12 @@ async function main(): Promise<void> {
   registry.register("acp", () => acpAdapter, 1);
   const artifactStorage = new OmiArtifactStorage({ rootDir: agentArtifactsDir() });
   logErr(`Omi artifact root: ${artifactStorage.rootDir}`);
+  const prunedToolOutputs = artifactStorage.pruneExpiredToolOutputs();
+  if (prunedToolOutputs.deletedFiles > 0) {
+    logErr(
+      `Pruned ${prunedToolOutputs.deletedFiles} expired tool-output files (${prunedToolOutputs.freedBytes} bytes)`,
+    );
+  }
   const recoverRunInput = (adapterId: string) => {
     if (adapterId !== "acp") return {};
     return {

--- a/desktop/macos/agent/src/runtime/artifact-storage.ts
+++ b/desktop/macos/agent/src/runtime/artifact-storage.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -256,6 +256,10 @@ export class OmiArtifactStorage {
     );
   }
 
+  pruneExpiredToolOutputs(options: PruneToolOutputOptions = {}): ToolOutputPruneResult {
+    return pruneExpiredToolOutputs(this.rootDir, options);
+  }
+
   private writeManifest(directory: string, entry: Record<string, unknown>): void {
     const manifestPath = join(directory, "manifest.json");
     let entries: unknown[] = [];
@@ -272,6 +276,23 @@ export class OmiArtifactStorage {
   }
 }
 
+export const TOOL_OUTPUT_DIRECTORY_NAME = "tool-output";
+/** Oversized control-tool dumps are recoverable for a week, then deleted. */
+export const TOOL_OUTPUT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const TOOL_OUTPUT_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface PruneToolOutputOptions {
+  nowMs?: number;
+  retentionMs?: number;
+}
+
+export interface ToolOutputPruneResult {
+  deletedFiles: number;
+  freedBytes: number;
+}
+
+let lastToolOutputPruneAtMs = 0;
+
 export function defaultArtifactRoot(env: NodeJS.ProcessEnv = process.env): string {
   if (env.OMI_AGENT_ARTIFACTS_DIR) {
     return env.OMI_AGENT_ARTIFACTS_DIR;
@@ -283,6 +304,87 @@ export function defaultArtifactRoot(env: NodeJS.ProcessEnv = process.env): strin
   }
   const bundleId = env.__CFBundleIdentifier || "com.omi.computer-macos";
   return join(homedir(), "Library", "Application Support", "Omi", "Artifacts", bundleId);
+}
+
+/**
+ * Delete `tool-output` JSON dumps older than the retention window. User-facing
+ * run artifacts (owner/session/run/attempt copies) are left alone. Existing
+ * installs are cleaned on the next sweep; new dumps expire after a week.
+ */
+export function pruneExpiredToolOutputs(
+  rootDir: string,
+  options: PruneToolOutputOptions = {},
+): ToolOutputPruneResult {
+  const nowMs = options.nowMs ?? Date.now();
+  const retentionMs = options.retentionMs ?? TOOL_OUTPUT_RETENTION_MS;
+  const toolOutputRoot = join(resolve(rootDir), TOOL_OUTPUT_DIRECTORY_NAME);
+  const result = { deletedFiles: 0, freedBytes: 0 };
+  lastToolOutputPruneAtMs = nowMs;
+
+  if (!existsSync(toolOutputRoot)) return result;
+  try {
+    if (lstatSync(toolOutputRoot).isSymbolicLink()) return result;
+  } catch {
+    return result;
+  }
+
+  const cutoffMs = nowMs - retentionMs;
+  const directories: string[] = [];
+  const stack = [toolOutputRoot];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || !isInside(current, toolOutputRoot)) continue;
+    let entries;
+    try {
+      entries = readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    if (current !== toolOutputRoot) directories.push(current);
+    for (const entry of entries) {
+      const path = join(current, entry.name);
+      if (!isInside(path, toolOutputRoot) || entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        stack.push(path);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const stat = lstatSync(path);
+        if (stat.isSymbolicLink() || !stat.isFile() || stat.mtimeMs >= cutoffMs) continue;
+        const size = stat.size;
+        unlinkSync(path);
+        result.deletedFiles += 1;
+        result.freedBytes += size;
+      } catch {
+        // A file may disappear between listing and unlink. Keep sweeping.
+      }
+    }
+  }
+
+  for (const directory of directories.sort((left, right) => right.length - left.length)) {
+    try {
+      if (readdirSync(directory).length === 0) rmdirSync(directory);
+    } catch {
+      // Directory is not empty or already gone.
+    }
+  }
+  return result;
+}
+
+/** Persist paths call this so a long-lived runtime still expires old dumps. */
+export function maybePruneExpiredToolOutputs(
+  rootDir: string,
+  nowMs = Date.now(),
+): ToolOutputPruneResult {
+  if (lastToolOutputPruneAtMs > 0 && nowMs - lastToolOutputPruneAtMs < TOOL_OUTPUT_PRUNE_INTERVAL_MS) {
+    return { deletedFiles: 0, freedBytes: 0 };
+  }
+  try {
+    return pruneExpiredToolOutputs(rootDir, { nowMs });
+  } catch {
+    return { deletedFiles: 0, freedBytes: 0 };
+  }
 }
 
 function shouldKeepExternalLocation(artifact: AdapterArtifactReference): boolean {

--- a/desktop/macos/agent/src/runtime/control-tools.ts
+++ b/desktop/macos/agent/src/runtime/control-tools.ts
@@ -16,7 +16,7 @@ import type {
 } from "./types.js";
 import { AgentRuntimeKernel, type DesktopAwarenessSnapshot, type ExecuteAgentRunInput } from "./kernel.js";
 import { serializeArtifact } from "./artifact-serialization.js";
-import { defaultArtifactRoot } from "./artifact-storage.js";
+import { defaultArtifactRoot, maybePruneExpiredToolOutputs, TOOL_OUTPUT_DIRECTORY_NAME } from "./artifact-storage.js";
 import { assertToolResultEnvelope, makeToolResultEnvelope, type ToolResultEnvelope } from "./tool-result-envelope.js";
 import { agentControlCapabilityManifest, agentControlInputSchema } from "./control-tool-manifest.js";
 import type { McpServerBuildContext } from "./jsonl-transport.js";
@@ -2089,10 +2089,12 @@ function persistToolOutputArtifact(
   fullJson: string,
 ): string | null {
   try {
-    const directory = join(defaultArtifactRoot(), "tool-output", ownerId, sessionId);
+    const rootDir = defaultArtifactRoot();
+    const directory = join(rootDir, TOOL_OUTPUT_DIRECTORY_NAME, ownerId, sessionId);
     mkdirSync(directory, { recursive: true });
     const path = join(directory, `${toolName}-${randomUUID()}.json`);
     writeFileSync(path, `${fullJson}\n`, "utf8");
+    maybePruneExpiredToolOutputs(rootDir);
     const artifact = context.kernel.persistArtifact({
       sessionId,
       kind: "tool_output",

--- a/desktop/macos/agent/src/runtime/relay-tool-result.ts
+++ b/desktop/macos/agent/src/runtime/relay-tool-result.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { AgentRuntimeKernel } from "./kernel.js";
+import { maybePruneExpiredToolOutputs, TOOL_OUTPUT_DIRECTORY_NAME } from "./artifact-storage.js";
 import { assertToolResultEnvelope, makeToolResultEnvelope, type ToolResultEnvelope } from "./tool-result-envelope.js";
 
 /** One budget applies to every result put back on a model-facing stdio relay. */
@@ -192,10 +193,11 @@ function projectionFailure(
 function persistRelayToolOutput(input: FinalizeRelayToolResultInput, fullResult: string): string | null {
   if (!input.kernel) return null;
   try {
-    const directory = join(input.artifactRoot, "tool-output", input.identity.ownerId, input.identity.sessionId);
+    const directory = join(input.artifactRoot, TOOL_OUTPUT_DIRECTORY_NAME, input.identity.ownerId, input.identity.sessionId);
     mkdirSync(directory, { recursive: true });
     const path = join(directory, `relay-${randomUUID()}.json`);
     writeFileSync(path, `${fullResult}\n`, "utf8");
+    maybePruneExpiredToolOutputs(input.artifactRoot);
     const artifact = input.kernel.persistArtifact({
       sessionId: input.identity.sessionId,
       kind: "tool_output",

--- a/desktop/macos/agent/src/runtime/types.ts
+++ b/desktop/macos/agent/src/runtime/types.ts
@@ -624,8 +624,8 @@ export type NewDesktopAttentionOverride = Partial<DesktopAttentionOverride> &
 //   for local files; adapter:// or provider-specific schemes for native refs
 // - metadataJson carries adapter/provider ids and projection hints
 // - contentHash is preferably sha256:<hex>; sizeBytes is advisory metadata
-// - retention is currently local SQLite metadata only; blob retention/sync is
-//   deferred to the artifact storage layer.
+// - tool_output blobs under Artifacts/<bundle>/tool-output expire after 7 days
+//   via pruneExpiredToolOutputs. User-facing run artifacts are retained.
 export type NewAgentArtifact = Partial<AgentArtifact> &
   Pick<AgentArtifact, "sessionId" | "kind" | "role" | "uri">;
 

--- a/desktop/macos/agent/tests/artifact-storage.test.ts
+++ b/desktop/macos/agent/tests/artifact-storage.test.ts
@@ -1,10 +1,15 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { defaultArtifactRoot, OmiArtifactStorage } from "../src/runtime/artifact-storage.js";
+import {
+  defaultArtifactRoot,
+  OmiArtifactStorage,
+  TOOL_OUTPUT_DIRECTORY_NAME,
+  TOOL_OUTPUT_RETENTION_MS,
+} from "../src/runtime/artifact-storage.js";
 
 describe("OmiArtifactStorage", () => {
   it("imports emitted file artifacts into the managed artifact root", () => {
@@ -152,5 +157,48 @@ describe("OmiArtifactStorage", () => {
     } as NodeJS.ProcessEnv);
 
     expect(root).toBe("/Users/me/Library/Application Support/Omi/Artifacts/com.omi.omi-test");
+  });
+
+  it("deletes expired tool-output dumps and keeps fresh dumps plus user-facing run artifacts", () => {
+    const temp = mkdtempSync(join(tmpdir(), "omi-artifacts-"));
+    const root = join(temp, "Artifacts");
+    const storage = new OmiArtifactStorage({ rootDir: root });
+    const nowMs = 1_800_000_000_000;
+    const staleMs = (nowMs - TOOL_OUTPUT_RETENTION_MS - 60_000) / 1000;
+    const freshMs = (nowMs - 60_000) / 1000;
+    const boundaryMs = (nowMs - TOOL_OUTPUT_RETENTION_MS) / 1000;
+
+    const stalePath = join(root, TOOL_OUTPUT_DIRECTORY_NAME, "owner", "session-old", "list_agent_sessions-stale.json");
+    const freshPath = join(root, TOOL_OUTPUT_DIRECTORY_NAME, "owner", "session-new", "list_agent_sessions-fresh.json");
+    const boundaryPath = join(root, TOOL_OUTPUT_DIRECTORY_NAME, "owner", "session-boundary", "list_agent_sessions-boundary.json");
+    mkdirSync(join(stalePath, ".."), { recursive: true });
+    mkdirSync(join(freshPath, ".."), { recursive: true });
+    mkdirSync(join(boundaryPath, ".."), { recursive: true });
+    writeFileSync(stalePath, "{\"sessions\":[]}\n");
+    writeFileSync(freshPath, "{\"sessions\":[]}\n");
+    writeFileSync(boundaryPath, "{\"sessions\":[]}\n");
+    utimesSync(stalePath, staleMs, staleMs);
+    utimesSync(freshPath, freshMs, freshMs);
+    utimesSync(boundaryPath, boundaryMs, boundaryMs);
+
+    const scope = {
+      ownerId: "owner-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      attemptId: "attempt-1",
+    };
+    const deliveredPath = join(storage.prepareRunDirectory(scope), "answer.md");
+    writeFileSync(deliveredPath, "# keep me");
+    utimesSync(deliveredPath, staleMs, staleMs);
+
+    const pruned = storage.pruneExpiredToolOutputs({ nowMs });
+
+    expect(pruned.deletedFiles).toBe(1);
+    expect(pruned.freedBytes).toBeGreaterThan(0);
+    expect(existsSync(stalePath)).toBe(false);
+    expect(existsSync(join(root, TOOL_OUTPUT_DIRECTORY_NAME, "owner", "session-old"))).toBe(false);
+    expect(existsSync(freshPath)).toBe(true);
+    expect(existsSync(boundaryPath)).toBe(true);
+    expect(readFileSync(deliveredPath, "utf8")).toBe("# keep me");
   });
 });

--- a/desktop/macos/changelog/unreleased/20260820-agent-tool-output-retention.json
+++ b/desktop/macos/changelog/unreleased/20260820-agent-tool-output-retention.json
@@ -1,0 +1,3 @@
+{
+  "change": "Automatically deletes leftover agent tool-output files older than a week so they stop filling the Mac"
+}

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -28,6 +28,7 @@ covers:
   - desktop/macos/Desktop/Sources/StartupWarmupCoordinator.swift
   - desktop/macos/Desktop/Sources/Startup/StartupWarmupPolicy.swift
   - desktop/macos/Desktop/Sources/OmiApp.swift
+  - desktop/macos/Desktop/Sources/Chat/AgentArtifactRetention.swift
   - desktop/macos/Desktop/Sources/OmiSupport/DesktopDevRuntimeManifest.swift
   - desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
   - desktop/macos/Desktop/Sources/ViewModelContainer.swift


### PR DESCRIPTION
## Summary
- Oversized agent control-tool results (`list_agent_sessions`, `spawn_agent`, `get_agent_run`, …) were written as JSON under `~/Library/Application Support/Omi/Artifacts/<bundle>/tool-output` and never deleted. That is the folder filling users' disks (months-old JSON, hundreds of MB to gigabytes).
- Keep those dumps for **7 days**, then delete them. Existing installs are cleaned on the next app launch (and again when the agent runtime starts). New dumps expire on the same window. User-facing run artifacts outside `tool-output` are left alone.
- Long-lived sessions also sweep at most hourly after a persist, so a Mac that never restarts still expires week-old files.

## Test plan
- [x] `npx vitest run tests/artifact-storage.test.ts tests/control-tools.test.ts tests/relay-tool-result.test.ts` (101 passing)
- [x] `./scripts/dev-feedback.py --once swift 'AgentArtifactRetentionTests'` (3 passing)
- [ ] After merge/Beta: launch the updated app and confirm `~/Library/Application Support/Omi/Artifacts/com.omi.computer-macos/tool-output` drops files older than 7 days without touching chat history or delivered run artifacts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Product invariants affected

- INV-AGENT-*
- INV-AUTH-1
- INV-CHAT-1

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1606 -> 1620 | AppDelegate launch hook sweeps leftover tool-output so existing installs reclaim disk on next launch; retention policy itself lives in Chat/AgentArtifactRetention.swift
