### PR TITLE
fix: authorize OAuth MCP memory reads

### DIFF
--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -14,6 +14,12 @@ from google.cloud import firestore
 
 from database._client import db
 from database.account_deletion_policy import account_deletion_blocks_access, normalize_account_deletion_status
+from database.memory_app_key_grants import (
+    APP_KEY_MEMORY_GRANT_DOC_ID,
+    APP_KEY_MEMORY_GRANTS_COLLECTION,
+    MCP_CONSUMER,
+    build_app_key_scope_grant_contract_state,
+)
 
 PRODUCTION_MCP_RESOURCE_URL = "https://api.omi.me/v1/mcp/sse"
 # Omi Beta intentionally serves MCP data from dev while retaining the production
@@ -442,13 +448,63 @@ def _grant_write(
     return ref, existing, data
 
 
+def _oauth_memory_grant_ref(uid: str) -> Any:
+    return db.collection(f"users/{uid}/{APP_KEY_MEMORY_GRANTS_COLLECTION}").document(APP_KEY_MEMORY_GRANT_DOC_ID)
+
+
+def _oauth_memory_grant_contract(grant: Dict[str, Any]) -> Dict[str, Any]:
+    scopes = [scope for scope in grant.get("scopes") or [] if scope in {"memories.read", "memories.write"}]
+    return build_app_key_scope_grant_contract_state(
+        consumer=MCP_CONSUMER,
+        app_id=cast(str, grant["client_id"]),
+        key_id=cast(str, grant["id"]),
+        scopes=scopes,
+        default_read="memories.read" in scopes,
+        archive_read=False,
+        write="memories.write" in scopes,
+        enabled=True,
+    )
+
+
+def _ensure_oauth_memory_grant(grant: Dict[str, Any]) -> None:
+    """Backfill the app/key grant required by memory tools for active OAuth grants."""
+    expected = _oauth_memory_grant_contract(grant)
+    grant_ref = _oauth_memory_grant_ref(cast(str, grant["uid"]))
+    snapshot = grant_ref.get()
+    current: object = snapshot.to_dict() if getattr(snapshot, "exists", False) else {}
+    for field in (
+        "grants",
+        MCP_CONSUMER,
+        "apps",
+        grant["client_id"],
+        "keys",
+        grant["id"],
+    ):
+        current = current.get(field, {}) if isinstance(current, dict) else {}
+
+    expected_grant: object = expected
+    for field in (
+        "grants",
+        MCP_CONSUMER,
+        "apps",
+        grant["client_id"],
+        "keys",
+        grant["id"],
+    ):
+        expected_grant = expected_grant.get(field, {}) if isinstance(expected_grant, dict) else {}
+    if current != expected_grant:
+        grant_ref.set(expected, merge=True)
+
+
 def create_or_update_grant(uid: str, client_id: str, resource: str, scopes: List[str]) -> Dict[str, Any]:
     deterministic_grant_id = f"{uid}:{client_id}:{hash_secret(resource)[:16]}"
     now = _now()
     ref = db.collection("mcp_oauth_grants").document(deterministic_grant_id)
     ref, existing, data = _grant_write(uid, client_id, resource, scopes, ref=ref, doc=ref.get(), now=now)
     ref.set(data, merge=True)
-    return {**existing, **data}
+    grant = {**existing, **data}
+    _ensure_oauth_memory_grant(grant)
+    return grant
 
 
 def _authorization_code_write(
@@ -537,6 +593,7 @@ def create_grant_and_authorization_code_if_allowed(
             now=now,
         )
         transaction.set(current_grant_ref, grant_data, merge=True)
+        transaction.set(_oauth_memory_grant_ref(uid), _oauth_memory_grant_contract(grant_data), merge=True)
         transaction.set(code_ref, code_data)
         return {**existing, **grant_data}, raw_code
 
@@ -730,6 +787,7 @@ def validate_access_token(access_token: str, resource: str = MCP_RESOURCE_URL) -
     grant = get_active_grant(cast(str, data.get("grant_id")))
     if not grant:
         return None
+    _ensure_oauth_memory_grant(grant)
     db.collection("mcp_oauth_grants").document(data["grant_id"]).set({"last_used_at": _now()}, merge=True)
     return {
         "uid": data.get("uid"),

--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -466,12 +466,8 @@ def _oauth_memory_grant_contract(grant: Dict[str, Any]) -> Dict[str, Any]:
     )
 
 
-def _ensure_oauth_memory_grant(grant: Dict[str, Any]) -> None:
-    """Backfill the app/key grant required by memory tools for active OAuth grants."""
-    expected = _oauth_memory_grant_contract(grant)
-    grant_ref = _oauth_memory_grant_ref(cast(str, grant["uid"]))
-    snapshot = grant_ref.get()
-    current: object = snapshot.to_dict() if getattr(snapshot, "exists", False) else {}
+def _oauth_memory_grant_entry_is_absent(state: object, grant: Dict[str, Any]) -> bool:
+    current = state
     for field in (
         "grants",
         MCP_CONSUMER,
@@ -480,20 +476,36 @@ def _ensure_oauth_memory_grant(grant: Dict[str, Any]) -> None:
         "keys",
         grant["id"],
     ):
-        current = current.get(field, {}) if isinstance(current, dict) else {}
+        if not isinstance(current, dict):
+            return False
+        if field not in current:
+            return True
+        current = current[field]
+    return False
 
-    expected_grant: object = expected
-    for field in (
-        "grants",
-        MCP_CONSUMER,
-        "apps",
-        grant["client_id"],
-        "keys",
-        grant["id"],
-    ):
-        expected_grant = expected_grant.get(field, {}) if isinstance(expected_grant, dict) else {}
-    if current != expected_grant:
-        grant_ref.set(expected, merge=True)
+
+def _create_oauth_memory_grant_if_absent(
+    transaction: Any, grant_ref: Any, snapshot: Any, grant: Dict[str, Any]
+) -> bool:
+    if getattr(snapshot, "exists", False):
+        state: object = snapshot.to_dict()
+        if not _oauth_memory_grant_entry_is_absent(state, grant):
+            return False
+    transaction.set(grant_ref, _oauth_memory_grant_contract(grant), merge=True)
+    return True
+
+
+def _ensure_oauth_memory_grant(grant: Dict[str, Any]) -> bool:
+    """Create a missing OAuth memory grant without changing control-plane state."""
+    grant_ref = _oauth_memory_grant_ref(cast(str, grant["uid"]))
+    transaction = db.transaction()
+
+    @_typed_transactional
+    def _create(transaction: Any) -> bool:
+        snapshot = grant_ref.get(transaction=transaction)
+        return _create_oauth_memory_grant_if_absent(transaction, grant_ref, snapshot, grant)
+
+    return _create(transaction)
 
 
 def create_or_update_grant(uid: str, client_id: str, resource: str, scopes: List[str]) -> Dict[str, Any]:
@@ -582,6 +594,8 @@ def create_grant_and_authorization_code_if_allowed(
         current_grant_ref, existing, grant_data = _grant_write(
             uid, client_id, resource, scopes, ref=grant_ref, doc=grant_doc, now=now
         )
+        memory_grant_ref = _oauth_memory_grant_ref(uid)
+        memory_grant_doc = memory_grant_ref.get(transaction=transaction)
         code_data = _authorization_code_write(
             uid,
             current_grant_ref.id,
@@ -593,7 +607,7 @@ def create_grant_and_authorization_code_if_allowed(
             now=now,
         )
         transaction.set(current_grant_ref, grant_data, merge=True)
-        transaction.set(_oauth_memory_grant_ref(uid), _oauth_memory_grant_contract(grant_data), merge=True)
+        _create_oauth_memory_grant_if_absent(transaction, memory_grant_ref, memory_grant_doc, grant_data)
         transaction.set(code_ref, code_data)
         return {**existing, **grant_data}, raw_code
 
@@ -766,14 +780,90 @@ def _token_pair_response(access_token: str, refresh_token: str, scopes: List[str
 
 
 def get_active_grant(grant_id: str) -> Optional[Dict[str, Any]]:
+    if not grant_id.strip():
+        return None
     doc = db.collection("mcp_oauth_grants").document(grant_id).get()
     if not doc.exists:
         return None
     data: Dict[str, Any] = _typed_doc(doc)
     if data.get("revoked_at") or data.get("status") == "revoked":
         return None
-    data.setdefault("id", grant_id)
     return data
+
+
+def _valid_oauth_scopes(value: object) -> Optional[List[str]]:
+    if not isinstance(value, list) or not value:
+        return None
+    scopes = cast(List[Any], value)
+    if any(not isinstance(scope, str) or not scope or scope not in SUPPORTED_SCOPES for scope in scopes):
+        return None
+    if len(scopes) != len(set(scopes)):
+        return None
+    return cast(List[str], scopes)
+
+
+def _nonempty_string(data: Dict[str, Any], field: str) -> Optional[str]:
+    value = data.get(field)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _is_unexpired(value: object, now: datetime) -> bool:
+    if not isinstance(value, datetime):
+        return False
+    try:
+        return value > now
+    except (TypeError, ValueError):
+        return False
+
+
+def _validated_access_token_identity(
+    data: Dict[str, Any], grant: Dict[str, Any], resource: str, *, now: datetime
+) -> Optional[Dict[str, Any]]:
+    uid = _nonempty_string(data, "uid")
+    client_id = _nonempty_string(data, "client_id")
+    grant_id = _nonempty_string(data, "grant_id")
+    token_resource = _nonempty_string(data, "resource")
+    token_scopes = _valid_oauth_scopes(data.get("scopes"))
+    grant_uid = _nonempty_string(grant, "uid")
+    grant_client_id = _nonempty_string(grant, "client_id")
+    persisted_grant_id = _nonempty_string(grant, "id")
+    grant_resource = _nonempty_string(grant, "resource")
+    grant_scopes = _valid_oauth_scopes(grant.get("scopes"))
+    grant_expires_at = grant.get("expires_at")
+    if (
+        uid is None
+        or client_id is None
+        or grant_id is None
+        or token_resource is None
+        or token_scopes is None
+        or grant_uid is None
+        or grant_client_id is None
+        or persisted_grant_id is None
+        or grant_resource is None
+        or grant_scopes is None
+        or "revoked_at" not in data
+        or data.get("revoked_at") is not None
+        or not _is_unexpired(data.get("expires_at"), now)
+        or grant.get("status") != "active"
+        or "revoked_at" not in grant
+        or grant.get("revoked_at") is not None
+        or (grant_expires_at is not None and not _is_unexpired(grant_expires_at, now))
+        or token_resource != resource
+        or uid != grant_uid
+        or client_id != grant_client_id
+        or grant_id != persisted_grant_id
+        or token_resource != grant_resource
+        or not set(token_scopes).issubset(grant_scopes)
+    ):
+        return None
+    return {
+        "uid": uid,
+        "auth_type": "oauth",
+        "client_id": client_id,
+        "resource": token_resource,
+        "scopes": token_scopes,
+        "grant_id": grant_id,
+    }
 
 
 def validate_access_token(access_token: str, resource: str = MCP_RESOURCE_URL) -> Optional[Dict[str, Any]]:
@@ -781,22 +871,18 @@ def validate_access_token(access_token: str, resource: str = MCP_RESOURCE_URL) -
     if not doc.exists:
         return None
     data: Dict[str, Any] = _typed_doc(doc)
-    expires_at = data.get("expires_at")
-    if data.get("revoked_at") or data.get("resource") != resource or (expires_at and expires_at <= _now()):
+    grant_id = _nonempty_string(data, "grant_id")
+    if grant_id is None:
         return None
-    grant = get_active_grant(cast(str, data.get("grant_id")))
+    grant = get_active_grant(grant_id)
     if not grant:
         return None
+    identity = _validated_access_token_identity(data, grant, resource, now=_now())
+    if identity is None:
+        return None
     _ensure_oauth_memory_grant(grant)
-    db.collection("mcp_oauth_grants").document(data["grant_id"]).set({"last_used_at": _now()}, merge=True)
-    return {
-        "uid": data.get("uid"),
-        "auth_type": "oauth",
-        "client_id": data.get("client_id"),
-        "resource": data.get("resource"),
-        "scopes": data.get("scopes") or [],
-        "grant_id": data.get("grant_id"),
-    }
+    db.collection("mcp_oauth_grants").document(grant_id).set({"last_used_at": _now()}, merge=True)
+    return identity
 
 
 def rotate_refresh_token(

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -164,18 +164,17 @@ class MCPAuthContext:
     memory_context: Optional[ProductAuthorizationContext] = None
 
 
-def _mcp_memory_context_from_api_key_user_data(user_data: Dict[str, Any]) -> ProductAuthorizationContext:
+def _mcp_memory_context_from_auth_data(user_data: Dict[str, Any]) -> ProductAuthorizationContext:
     verified_auth = McpVerifiedAuth(
-        uid=user_data["user_id"],
-        app_id=user_data.get("app_id"),
-        key_id=user_data.get("key_id"),
+        uid=user_data.get("user_id") or user_data["uid"],
+        app_id=user_data.get("app_id") or user_data.get("client_id"),
+        key_id=user_data.get("key_id") or user_data.get("grant_id"),
         scopes=tuple(user_data.get("scopes") or ()),
     )
     return build_mcp_default_memory_read_context(verified_auth)
 
 
 def authenticate_api_key_auth_context(authorization: Optional[str]) -> Optional[ProductAuthorizationContext]:
-    """Validate an MCP API key and return its memory product auth context."""
     if not authorization:
         return None
 
@@ -193,7 +192,7 @@ def authenticate_api_key_auth_context(authorization: Optional[str]) -> Optional[
         return None
     enforce_account_deletion_http_access(user_data["user_id"])
     _enforce_mcp_cutover_access(user_data["user_id"])
-    return _mcp_memory_context_from_api_key_user_data(user_data)
+    return _mcp_memory_context_from_auth_data(user_data)
 
 
 def authenticate_mcp_request(authorization: Optional[str]) -> Optional[MCPAuthContext]:
@@ -219,7 +218,7 @@ def authenticate_mcp_request(authorization: Optional[str]) -> Optional[MCPAuthCo
             scopes=list(user_data.get("scopes") or MCP_LEGACY_API_KEY_SCOPES),
             app_id=user_data.get("app_id"),
             key_id=user_data.get("key_id"),
-            memory_context=_mcp_memory_context_from_api_key_user_data(user_data),
+            memory_context=_mcp_memory_context_from_auth_data(user_data),
         )
 
     oauth_context = mcp_oauth_db.validate_access_token(token, MCP_RESOURCE_URL)
@@ -234,6 +233,7 @@ def authenticate_mcp_request(authorization: Optional[str]) -> Optional[MCPAuthCo
         client_id=oauth_context.get("client_id"),
         resource=oauth_context.get("resource"),
         grant_id=oauth_context.get("grant_id"),
+        memory_context=_mcp_memory_context_from_auth_data(oauth_context),
     )
 
 

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -251,6 +251,50 @@ def test_sse_tools_list_filters_by_oauth_scopes():
     assert 'get_conversations' not in names
 
 
+def test_oauth_authentication_carries_memory_identity_into_advertised_memory_tools():
+    oauth_token_context = {
+        'uid': UID,
+        'scopes': ['memories.read'],
+        'client_id': 'omi-chatgpt-prod',
+        'resource': sse.MCP_RESOURCE_URL,
+        'grant_id': 'oauth-grant-1',
+    }
+    service = MagicMock()
+    service.read.return_value = []
+    service.search_mcp.return_value = []
+
+    with (
+        patch.object(sse.mcp_oauth_db, 'validate_access_token', return_value=oauth_token_context),
+        patch.object(sse, 'enforce_account_deletion_http_access'),
+        patch.object(sse, '_enforce_mcp_cutover_access'),
+        patch.object(
+            sse,
+            'authorize_memory_external_default_memory_read',
+            return_value=SimpleNamespace(allowed=True),
+        ),
+        patch.object(sse, 'MemoryService', return_value=service),
+    ):
+        auth_context = sse.authenticate_mcp_request('Bearer omi_oat_chatgpt')
+        assert auth_context is not None
+        get_response, _ = sse.handle_mcp_message(
+            auth_context,
+            {'id': 1, 'method': 'tools/call', 'params': {'name': 'get_memories', 'arguments': {}}},
+        )
+        search_response, _ = sse.handle_mcp_message(
+            auth_context,
+            {
+                'id': 2,
+                'method': 'tools/call',
+                'params': {'name': 'search_memories', 'arguments': {'query': 'coffee'}},
+            },
+        )
+
+    assert auth_context.memory_context.app_id == 'omi-chatgpt-prod'
+    assert auth_context.memory_context.key_id == 'oauth-grant-1'
+    assert 'error' not in get_response
+    assert 'error' not in search_response
+
+
 def test_sse_initialize_teaches_every_agent_to_retrieve_full_omi_context_safely():
     auth_context = sse.MCPAuthContext(uid=UID, auth_type='oauth', scopes=['memories.read'])
     response, session_id = sse.handle_mcp_message(auth_context, {'id': 1, 'method': 'initialize'})

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -262,16 +262,34 @@ def test_oauth_authentication_carries_memory_identity_into_advertised_memory_too
     service = MagicMock()
     service.read.return_value = []
     service.search_mcp.return_value = []
+    grant_state = {
+        'grants': {
+            'mcp': {
+                'apps': {
+                    'omi-chatgpt-prod': {
+                        'keys': {
+                            'oauth-grant-1': {
+                                'enabled': True,
+                                'scopes': ['memories.read'],
+                                'default_read': True,
+                                'archive_read': False,
+                                'write': False,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    snapshot = SimpleNamespace(exists=True, to_dict=lambda: grant_state)
+    fake_db = MagicMock()
+    fake_db.collection.return_value.document.return_value.get.return_value = snapshot
 
     with (
         patch.object(sse.mcp_oauth_db, 'validate_access_token', return_value=oauth_token_context),
         patch.object(sse, 'enforce_account_deletion_http_access'),
         patch.object(sse, '_enforce_mcp_cutover_access'),
-        patch.object(
-            sse,
-            'authorize_memory_external_default_memory_read',
-            return_value=SimpleNamespace(allowed=True),
-        ),
+        patch.object(sse, 'db', fake_db),
         patch.object(sse, 'MemoryService', return_value=service),
     ):
         auth_context = sse.authenticate_mcp_request('Bearer omi_oat_chatgpt')
@@ -293,6 +311,56 @@ def test_oauth_authentication_carries_memory_identity_into_advertised_memory_too
     assert auth_context.memory_context.key_id == 'oauth-grant-1'
     assert 'error' not in get_response
     assert 'error' not in search_response
+
+
+def test_oauth_memory_tool_execution_honors_a_disabled_persisted_grant():
+    oauth_token_context = {
+        'uid': UID,
+        'scopes': ['memories.read'],
+        'client_id': 'omi-chatgpt-prod',
+        'resource': sse.MCP_RESOURCE_URL,
+        'grant_id': 'oauth-disabled-grant',
+    }
+    grant_state = {
+        'grants': {
+            'mcp': {
+                'apps': {
+                    'omi-chatgpt-prod': {
+                        'keys': {
+                            'oauth-disabled-grant': {
+                                'enabled': False,
+                                'scopes': ['memories.read'],
+                                'default_read': True,
+                                'archive_read': False,
+                                'write': False,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    snapshot = SimpleNamespace(exists=True, to_dict=lambda: grant_state)
+    fake_db = MagicMock()
+    fake_db.collection.return_value.document.return_value.get.return_value = snapshot
+    service = MagicMock()
+
+    with (
+        patch.object(sse.mcp_oauth_db, 'validate_access_token', return_value=oauth_token_context),
+        patch.object(sse, 'enforce_account_deletion_http_access'),
+        patch.object(sse, '_enforce_mcp_cutover_access'),
+        patch.object(sse, 'db', fake_db),
+        patch.object(sse, 'MemoryService', return_value=service),
+    ):
+        auth_context = sse.authenticate_mcp_request('Bearer omi_oat_disabled')
+        assert auth_context is not None
+        response, _ = sse.handle_mcp_message(
+            auth_context,
+            {'id': 1, 'method': 'tools/call', 'params': {'name': 'get_memories', 'arguments': {}}},
+        )
+
+    assert response['error']['code'] == -32009
+    service.read.assert_not_called()
 
 
 def test_sse_initialize_teaches_every_agent_to_retrieve_full_omi_context_safely():

--- a/backend/tests/unit/test_mcp_memory_adapter.py
+++ b/backend/tests/unit/test_mcp_memory_adapter.py
@@ -157,6 +157,6 @@ def test_mcp_sse_transport_authenticates_full_api_key_context_without_inferred_s
     assert "mcp_api_key_db.get_api_key_auth_result(token)" in source
     assert 'record_api_key_repairs(key_kind="mcp", operation="auth"' in source
     assert "scopes=tuple(user_data.get(\"scopes\") or ())" in source
-    assert "memory_context=_mcp_memory_context_from_api_key_user_data(user_data)" in source
+    assert "memory_context=_mcp_memory_context_from_auth_data(user_data)" in source
     assert "auth_context = await run_blocking(db_executor, authenticate_mcp_request, authorization)" in source
     assert "user_id = auth_context.uid" in source

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
 
@@ -38,7 +39,7 @@ class _DocReference:
 
     def set(self, data, merge=False):
         if merge and self.id in self._collection._docs:
-            self._collection._docs[self.id].update(data)
+            _deep_merge(self._collection._docs[self.id], data)
         else:
             self._collection._docs[self.id] = dict(data)
 
@@ -59,6 +60,14 @@ class _Query:
         for doc_id, data in self._collection._docs.items():
             if data.get(self._field) == self._expected:
                 yield _DocSnapshot(_DocReference(self._collection, doc_id), data)
+
+
+def _deep_merge(target, source):
+    for key, value in source.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_merge(target[key], value)
+        else:
+            target[key] = value
 
 
 class _Collection:
@@ -224,12 +233,33 @@ def test_access_token_validation_backfills_memory_grant_for_existing_oauth_conse
     token_pair = mcp_oauth.issue_token_pair(grant, scopes=scopes)
 
     memory_grant_ref = mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants')
-    memory_grant_ref.delete()
+    memory_grant_ref.set(
+        {
+            'grants': {
+                'mcp': {
+                    'apps': {
+                        'other-client': {
+                            'keys': {
+                                'other-grant': {
+                                    'enabled': False,
+                                    'scopes': [],
+                                    'default_read': False,
+                                    'archive_read': False,
+                                    'write': False,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
 
     auth_context = mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL)
 
     assert auth_context['grant_id'] == grant['id']
-    repaired = memory_grant_ref.get().to_dict()['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']]
+    memory_grants = memory_grant_ref.get().to_dict()['grants']['mcp']['apps']
+    repaired = memory_grants['omi-chatgpt-prod']['keys'][grant['id']]
     assert repaired == {
         'enabled': True,
         'scopes': ['memories.read', 'memories.write'],
@@ -237,6 +267,206 @@ def test_access_token_validation_backfills_memory_grant_for_existing_oauth_conse
         'archive_read': False,
         'write': True,
     }
+    assert memory_grants['other-client']['keys']['other-grant']['enabled'] is False
+
+
+@pytest.mark.parametrize(
+    ('stored_entry', 'expected_reason'),
+    [
+        (
+            {
+                'enabled': False,
+                'scopes': ['memories.read'],
+                'default_read': True,
+                'archive_read': False,
+                'write': False,
+            },
+            'app_key_scope_grant_disabled',
+        ),
+        (
+            {
+                'enabled': True,
+                'scopes': [],
+                'default_read': False,
+                'archive_read': False,
+                'write': False,
+            },
+            'missing_persisted_scope_memories.read',
+        ),
+        ({'enabled': 'invalid'}, 'malformed_app_key_scope_grant'),
+    ],
+    ids=['disabled', 'narrowed', 'malformed'],
+)
+def test_access_token_backfill_never_overwrites_existing_memory_control_state(stored_entry, expected_reason):
+    uid = f"controlled-oauth-{expected_reason}"
+    grant = mcp_oauth.create_or_update_grant(uid, 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, ['memories.read'])
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=['memories.read'])
+    memory_grant_ref = mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants')
+    state = memory_grant_ref.get().to_dict()
+    state['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']] = stored_entry
+    memory_grant_ref.set(state)
+
+    auth_context = mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL)
+
+    assert auth_context is not None
+    persisted = memory_grant_ref.get().to_dict()
+    assert persisted['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']] == stored_entry
+    authorization = authorize_memory_external_default_memory_read(
+        build_mcp_default_memory_read_context(
+            McpVerifiedAuth(
+                uid=uid,
+                app_id='omi-chatgpt-prod',
+                key_id=grant['id'],
+                scopes=('memories.read',),
+            )
+        ),
+        db_client=mcp_oauth.db,
+    )
+    assert authorization.allowed is False
+    assert authorization.reason == expected_reason
+
+
+def test_access_token_backfill_does_not_repair_a_malformed_memory_control_parent():
+    uid = 'malformed-memory-control-parent'
+    grant = mcp_oauth.create_or_update_grant(uid, 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, ['memories.read'])
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=['memories.read'])
+    memory_grant_ref = mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants')
+    memory_grant_ref.set({'grants': 'malformed'})
+
+    assert mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL) is not None
+    assert memory_grant_ref.get().to_dict() == {'grants': 'malformed'}
+
+
+def test_reconsent_does_not_reenable_a_disabled_memory_control_grant():
+    uid = 'disabled-oauth-reconsent-user'
+    scopes = ['memories.read']
+    grant, _ = mcp_oauth.create_grant_and_authorization_code_if_allowed(
+        uid,
+        'omi-chatgpt-prod',
+        'https://chatgpt.com/connector_platform_oauth_redirect',
+        mcp_oauth.MCP_RESOURCE_URL,
+        scopes,
+        mcp_oauth.pkce_s256('r' * 64),
+    )
+    memory_grant_ref = mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants')
+    state = memory_grant_ref.get().to_dict()
+    stored_grant = state['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']]
+    stored_grant['enabled'] = False
+    memory_grant_ref.set(state)
+
+    renewed_grant, _ = mcp_oauth.create_grant_and_authorization_code_if_allowed(
+        uid,
+        'omi-chatgpt-prod',
+        'https://chatgpt.com/connector_platform_oauth_redirect',
+        mcp_oauth.MCP_RESOURCE_URL,
+        scopes,
+        mcp_oauth.pkce_s256('s' * 64),
+    )
+
+    assert renewed_grant['id'] == grant['id']
+    persisted = memory_grant_ref.get().to_dict()['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']]
+    assert persisted['enabled'] is False
+
+
+_MISSING = object()
+
+
+@pytest.mark.parametrize(
+    ('record', 'field', 'value'),
+    [
+        ('token', 'uid', _MISSING),
+        ('token', 'uid', ''),
+        ('token', 'client_id', _MISSING),
+        ('token', 'client_id', 7),
+        ('token', 'grant_id', _MISSING),
+        ('token', 'grant_id', ''),
+        ('token', 'resource', _MISSING),
+        ('token', 'resource', 'https://attacker.example/mcp'),
+        ('token', 'scopes', _MISSING),
+        ('token', 'scopes', 'memories.read'),
+        ('token', 'scopes', []),
+        ('token', 'scopes', ['memories.read', 'memories.read']),
+        ('token', 'scopes', ['memories.archive.read']),
+        ('token', 'expires_at', _MISSING),
+        ('token', 'expires_at', 'expired'),
+        ('token', 'revoked_at', 'revoked'),
+        ('grant', '__document__', _MISSING),
+        ('grant', 'uid', _MISSING),
+        ('grant', 'uid', 'other-user'),
+        ('grant', 'client_id', _MISSING),
+        ('grant', 'client_id', 'other-client'),
+        ('grant', 'id', _MISSING),
+        ('grant', 'id', 'other-grant'),
+        ('grant', 'resource', _MISSING),
+        ('grant', 'resource', 'https://other.example/mcp'),
+        ('grant', 'scopes', _MISSING),
+        ('grant', 'scopes', []),
+        ('grant', 'scopes', ['conversations.read']),
+        ('grant', 'status', 'revoked'),
+        ('grant', 'revoked_at', 'revoked'),
+        ('grant', 'expires_at', 'expired'),
+    ],
+)
+def test_access_token_validation_rejects_malformed_or_mismatched_token_grant_pairs(record, field, value):
+    uid = f'strict-token-{record}-{field}-{abs(hash(repr(value)))}'
+    grant = mcp_oauth.create_or_update_grant(uid, 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, ['memories.read'])
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=['memories.read'])
+    token_ref = mcp_oauth.db.collection('mcp_oauth_access_tokens').document(
+        mcp_oauth.hash_secret(token_pair['access_token'])
+    )
+    grant_ref = mcp_oauth.db.collection('mcp_oauth_grants').document(grant['id'])
+    target_ref = token_ref if record == 'token' else grant_ref
+
+    if field == '__document__':
+        target_ref.delete()
+    else:
+        target = target_ref.get().to_dict()
+        if value is _MISSING:
+            target.pop(field, None)
+        elif value == 'expired':
+            target[field] = mcp_oauth._now() - timedelta(seconds=1)
+        elif value == 'revoked':
+            target[field] = mcp_oauth._now()
+        else:
+            target[field] = value
+        target_ref.set(target)
+
+    assert mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL) is None
+    token_ref.delete()
+    grant_ref.delete()
+    mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants').delete()
+
+
+def test_oauth_memory_grant_never_carries_archive_capability():
+    uid = 'oauth-no-archive-user'
+    scopes = ['memories.read', 'memories.write']
+    grant = mcp_oauth.create_or_update_grant(uid, 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=scopes)
+
+    auth_context = mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL)
+    persisted = (
+        mcp_oauth.db.collection(f'users/{uid}/memory_control')
+        .document('app_key_memory_grants')
+        .get()
+        .to_dict()['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']]
+    )
+
+    assert auth_context is not None
+    assert auth_context['scopes'] == scopes
+    assert persisted['archive_read'] is False
+    authorization = authorize_memory_external_default_memory_read(
+        build_mcp_default_memory_read_context(
+            McpVerifiedAuth(
+                uid=uid,
+                app_id='omi-chatgpt-prod',
+                key_id=grant['id'],
+                scopes=tuple(auth_context['scopes']),
+            )
+        ),
+        db_client=mcp_oauth.db,
+    )
+    assert authorization.allowed is True
+    assert authorization.policy.archive_capability is False
 
 
 def test_consent_transaction_rejects_deletion_marker_without_oauth_writes():

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -6,6 +6,8 @@ from types import ModuleType
 import pytest
 
 from testing.import_isolation import load_module_fresh, stub_modules
+from utils.mcp_memories import McpVerifiedAuth, build_mcp_default_memory_read_context
+from utils.memory.product_authorization import authorize_memory_external_default_memory_read
 
 _BACKEND = Path(__file__).resolve().parents[2]
 
@@ -188,6 +190,53 @@ def test_consent_transaction_creates_grant_and_code_together():
     assert grant['uid'] == uid
     code_doc = mcp_oauth.db.collection('mcp_oauth_authorization_codes').document(mcp_oauth.hash_secret(code)).get()
     assert code_doc.to_dict()['grant_id'] == grant['id']
+
+    memory_grant_doc = (
+        mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants').get().to_dict()
+    )
+    memory_grant = memory_grant_doc['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']]
+    assert memory_grant == {
+        'enabled': True,
+        'scopes': ['memories.read'],
+        'default_read': True,
+        'archive_read': False,
+        'write': False,
+    }
+
+    authorization = authorize_memory_external_default_memory_read(
+        build_mcp_default_memory_read_context(
+            McpVerifiedAuth(
+                uid=uid,
+                app_id='omi-chatgpt-prod',
+                key_id=grant['id'],
+                scopes=tuple(scopes),
+            )
+        ),
+        db_client=mcp_oauth.db,
+    )
+    assert authorization.allowed is True
+
+
+def test_access_token_validation_backfills_memory_grant_for_existing_oauth_consent():
+    uid = 'existing-oauth-user'
+    scopes = ['memories.read', 'memories.write']
+    grant = mcp_oauth.create_or_update_grant(uid, 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, scopes)
+    token_pair = mcp_oauth.issue_token_pair(grant, scopes=scopes)
+
+    memory_grant_ref = mcp_oauth.db.collection(f'users/{uid}/memory_control').document('app_key_memory_grants')
+    memory_grant_ref.delete()
+
+    auth_context = mcp_oauth.validate_access_token(token_pair['access_token'], mcp_oauth.MCP_RESOURCE_URL)
+
+    assert auth_context['grant_id'] == grant['id']
+    repaired = memory_grant_ref.get().to_dict()['grants']['mcp']['apps']['omi-chatgpt-prod']['keys'][grant['id']]
+    assert repaired == {
+        'enabled': True,
+        'scopes': ['memories.read', 'memories.write'],
+        'default_read': True,
+        'archive_read': False,
+        'write': True,
+    }
 
 
 def test_consent_transaction_rejects_deletion_marker_without_oauth_writes():


### PR DESCRIPTION
## Summary

Fix ChatGPT and other OAuth MCP clients receiving JSON-RPC `-32009` from `get_memories` and `search_memories` even though the same connection can call `get_user_profile` and advertises the `memories.read` tools.

## User-visible failure

An OAuth access token preserved the authenticated UID, scopes, client ID, and grant ID, but the MCP transport did not project the client/grant pair into the product authorization context required by canonical memory reads. Tool discovery therefore advertised both memory tools from `memories.read`, while execution rejected them as missing app/key identity.

## Fix

- Treat the server-verified OAuth `client_id` and `grant_id` as the stable MCP app/key identity.
- Persist the matching server-owned memory grant in the same transaction as new OAuth consent and authorization-code creation.
- Lazily backfill that grant when an existing active OAuth token is validated, allowing already-connected ChatGPT clients to recover without reconnecting.
- Keep the canonical scope and persisted-grant checks fail-closed; this does not grant Archive access or infer scopes from tool metadata.

## Verification

- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/mcp-oauth-focused-tests.txt PYTHON=.venv/bin/python bash test.sh` — 91 passed.
- `PYRIGHT_PYTHON=.venv/bin/python bash scripts/typecheck.sh` — 0 errors.
- Full backend selector completed all MCP/OAuth tests successfully. Two unrelated speech-provider files fail on the current baseline because retired Deepgram configuration selects Deepgram instead of Modulate: `test_modulate_stt.py` and `test_streaming_deepgram_backoff.py`.
- Live ChatGPT connector verification: pending deployment.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

