### PR TITLE
fix(backend): one unusable extractor element must not 500 the whole conversation

### DIFF
--- a/backend/models/structured_extraction.py
+++ b/backend/models/structured_extraction.py
@@ -1,10 +1,13 @@
+import logging
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from models.conversation_enums import CategoryEnum
 from models.structured import ActionItem, Event, Section, Structured
+
+logger = logging.getLogger(__name__)
 
 CAPTURE_OWNERS: Tuple[str, ...] = ('user', 'other', 'unknown')
 
@@ -20,6 +23,60 @@ _OPTIONAL_LITERAL_VOCABULARIES: Dict[str, Tuple[str, ...]] = {
     'due_certainty': ('confirmed', 'tentative'),
     'candidate_action': ('create', 'update', 'complete'),
 }
+
+# The same principle applies one level up. Every list on the extraction is optional detail --
+# `default_factory=list` already says an empty one is a valid conversation -- but pydantic fails the
+# WHOLE model when a single element is unusable, so one malformed item costs the user their title,
+# summary and every other item. That is what shipped: on 2026-08-17/18 the extractor answered
+# `duration: 0` for an event, value_error propagated out of `_get_structured`, and the conversation
+# came back HTTP 500 with no summary at all; 30 more `Conversation processing failed: ValidationError`
+# 500s on POST /v1/dev/user/conversations followed on 2026-08-20. Drop the element the extractor made
+# unusable and keep the conversation, and log which field it was -- the prod signature carried no
+# traceback, so there was no way to tell one of these apart from the next.
+_DEFAULTED_SCALARS: Tuple[str, ...] = ('title', 'overview', 'emoji')
+
+
+def _usable_elements(values: Any, element_model: Type[BaseModel], field: str) -> Any:
+    if not isinstance(values, list):
+        return values
+
+    usable: List[Any] = []
+    for element in values:
+        if isinstance(element, element_model):
+            usable.append(element)
+            continue
+        try:
+            usable.append(element_model.model_validate(element))
+        except ValidationError as error:
+            # `include_input=False` is what keeps the extractor's text -- the user's own words --
+            # out of the log; location and error type are all that is needed to name the field.
+            logger.warning(
+                'Dropping unusable %s element from conversation extraction: %s',
+                field,
+                [
+                    f"{'.'.join(str(part) for part in item['loc'])}: {item['type']}"
+                    for item in error.errors(include_input=False)
+                ],
+            )
+    return usable
+
+
+def _keep_usable_content(data: Any, element_models: Dict[str, Type[BaseModel]]) -> Any:
+    if not isinstance(data, dict):
+        return data
+
+    coerced = dict(data)
+    for field in _DEFAULTED_SCALARS:
+        if coerced.get(field, '') is None:
+            del coerced[field]
+    for field, element_model in element_models.items():
+        if field not in coerced:
+            continue
+        if coerced[field] is None:
+            del coerced[field]
+            continue
+        coerced[field] = _usable_elements(coerced[field], element_model, field)
+    return coerced
 
 
 class ExtractedActionItem(BaseModel):
@@ -94,6 +151,11 @@ class ActionItemsExtraction(BaseModel):
         default_factory=list,
     )
 
+    @model_validator(mode='before')
+    @classmethod
+    def keep_usable_content(cls, data: Any) -> Any:
+        return _keep_usable_content(data, {'action_items': ExtractedActionItem})
+
     def to_action_items(self) -> List[ActionItem]:
         return [item.to_action_item() for item in self.action_items]
 
@@ -124,12 +186,29 @@ class ExtractedEvent(BaseModel):
     start: datetime = Field(description="The start date and time of the event")
     duration: int = Field(description="The duration of the event in minutes", default=30)
 
-    @field_validator('duration')
+    @model_validator(mode='before')
     @classmethod
-    def duration_must_be_positive(cls, v: int) -> int:
-        if v <= 0:
-            raise ValueError('duration must be a positive number of minutes')
-        return v
+    def default_unusable_duration(cls, data: Any) -> Any:
+        """Fall back to the documented default instead of rejecting the event.
+
+        A non-positive or unparseable duration still leaves a real event on the calendar; the field
+        already declares 30 minutes as its answer for "the extractor did not say", which is exactly
+        what a `0` means here.
+        """
+        if not isinstance(data, dict) or 'duration' not in data:
+            return data
+
+        try:
+            minutes = int(data['duration'])
+        except (TypeError, ValueError):
+            minutes = 0
+
+        coerced = dict(data)
+        if minutes > 0:
+            coerced['duration'] = minutes
+        else:
+            del coerced['duration']
+        return coerced
 
     def to_event(self) -> Event:
         return Event(
@@ -176,6 +255,14 @@ class StructuredExtraction(BaseModel):
         description="A list of events extracted from the conversation, that the user must have on his calendar.",
         default_factory=list,
     )
+
+    @model_validator(mode='before')
+    @classmethod
+    def keep_usable_content(cls, data: Any) -> Any:
+        return _keep_usable_content(
+            data,
+            {'sections': ExtractedSection, 'action_items': ExtractedActionItem, 'events': ExtractedEvent},
+        )
 
     @field_validator('category', mode='before')
     @classmethod

--- a/backend/tests/unit/test_structured_extraction_partial_content.py
+++ b/backend/tests/unit/test_structured_extraction_partial_content.py
@@ -1,0 +1,174 @@
+"""One unusable element from the extractor must not cost the user the whole conversation.
+
+Live prod signature (backend image 920fc55, api.omi.me):
+
+    ERROR:utils.llm.gateway_error_contract:Conversation processing failed: ValidationError
+    -> HTTP 500 {"detail": "Error processing conversation, please try again later"}
+
+30 of these on POST /v1/dev/user/conversations on 2026-08-20 alone (7-12s each, users retrying the
+same text twice ~14s apart and getting the same 500). The one instance prod did print a traceback
+for names the mechanism exactly:
+
+    Value error, duration must be a positive number of minutes [type=value_error, input_value=0]
+
+`ExtractedEvent.duration` had a validator that *raised* on `0`, so pydantic failed the entire
+`StructuredExtraction` -- title, overview, every action item and every other event -- and
+`_get_structured` mapped that to HTTP 500. The conversation was stored with no summary at all.
+
+Each list on the extraction is optional detail that already models its own absence
+(`default_factory=list`), so an unusable element is worth exactly as much as no element. Drop it,
+keep the conversation, and log which field it was: the prod 500s carried no traceback, which is why
+the other 30 could not be told apart from this one.
+"""
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv")
+os.environ.setdefault("OPENAI_API_KEY", "sk-test-not-real")
+
+import json  # noqa: E402
+from datetime import datetime  # noqa: E402
+from typing import Any  # noqa: E402
+
+import pytest  # noqa: E402
+from langchain_core.output_parsers import PydanticOutputParser  # noqa: E402
+from langchain_core.runnables import RunnableLambda  # noqa: E402
+from pydantic import BaseModel, ValidationError, field_validator  # noqa: E402
+
+import utils.llm.external_integrations as external_integrations  # noqa: E402
+from models.structured_extraction import (  # noqa: E402
+    ActionItemsExtraction,
+    ExtractedEvent,
+    StructuredExtraction,
+)
+
+# The payload shape prod answered with, trimmed to the offending event plus the content the user lost.
+PROD_PAYLOAD: dict[str, Any] = {
+    "title": "Kickoff With The Design Team",
+    "overview": "Agreed on the launch scope and who owns the landing page.",
+    "emoji": "🧠",
+    "category": "business",
+    "action_items": [{"description": "Send the landing page copy", "capture_owner": "user"}],
+    "events": [
+        {
+            "title": "Launch review",
+            "description": "Walk through the final scope",
+            "start": "2026-08-20T15:00:00+00:00",
+            "duration": 0,
+        }
+    ],
+}
+
+
+class _StructuredOutputLLM:
+    """The provider seam `summarize_experience_text` uses: a payload validated into the schema."""
+
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def with_structured_output(self, schema):
+        return RunnableLambda(lambda _prompt: schema.model_validate(self._payload))
+
+
+@pytest.fixture
+def provider_answers(monkeypatch):
+    def _install(payload: dict[str, Any]):
+        monkeypatch.setattr(external_integrations, 'get_llm', lambda *a, **k: _StructuredOutputLLM(payload))
+
+    return _install
+
+
+def test_prod_payload_still_produces_a_summary(provider_answers):
+    """The real production function for POST /v1/dev/user/conversations, on the payload that 500'd."""
+    provider_answers(PROD_PAYLOAD)
+
+    structured = external_integrations.summarize_experience_text('Kickoff notes.', 'other_text', tz='UTC')
+
+    assert structured.title == 'Kickoff With The Design Team'
+    assert structured.overview.startswith('Agreed on the launch scope')
+    assert [item.description for item in structured.action_items] == ['Send the landing page copy']
+    # The event survives too -- a zero duration says "unspecified", which is what the default means.
+    assert [(event.title, event.duration) for event in structured.events] == [('Launch review', 30)]
+
+
+def test_zero_duration_is_what_lost_the_conversation():
+    """Control: the pre-fix model, whose duration validator raised, on the same event."""
+
+    class PreFixExtractedEvent(BaseModel):
+        title: str
+        description: str = ''
+        start: datetime
+        duration: int = 30
+
+        @field_validator('duration')
+        @classmethod
+        def duration_must_be_positive(cls, v: int) -> int:
+            if v <= 0:
+                raise ValueError('duration must be a positive number of minutes')
+            return v
+
+    with pytest.raises(ValidationError, match='duration must be a positive number of minutes'):
+        PreFixExtractedEvent.model_validate(PROD_PAYLOAD['events'][0])
+
+    assert ExtractedEvent.model_validate(PROD_PAYLOAD['events'][0]).duration == 30
+
+
+@pytest.mark.parametrize(
+    'duration,expected',
+    [('45', 45), (45.0, 45), (-15, 30), (None, 30), ('a while', 30), (0, 30)],
+    ids=['numeric-string', 'float', 'negative', 'null', 'prose', 'zero'],
+)
+def test_duration_falls_back_to_the_documented_default(duration, expected):
+    event = ExtractedEvent.model_validate({'title': 'Sync', 'start': '2026-08-20T15:00:00+00:00', 'duration': duration})
+
+    assert event.duration == expected
+
+
+@pytest.mark.parametrize(
+    'field,unusable',
+    [
+        ('action_items', {'due_at': '2026-08-21T09:00:00+00:00'}),  # no description
+        ('events', {'title': 'Standup'}),  # no start
+        ('sections', {'heading': 'Decisions'}),  # no body_markdown
+    ],
+)
+def test_an_unusable_element_is_dropped_and_the_conversation_survives(field, unusable):
+    payload = dict(PROD_PAYLOAD)
+    payload[field] = [unusable, *PROD_PAYLOAD.get(field, [])]
+
+    extraction = PydanticOutputParser(pydantic_object=StructuredExtraction).parse(json.dumps(payload))
+
+    assert extraction.title == 'Kickoff With The Design Team'
+    assert len(getattr(extraction, field)) == len(PROD_PAYLOAD.get(field, []))
+    assert extraction.to_structured().title == 'Kickoff With The Design Team'
+
+
+def test_explicit_nulls_fall_back_to_defaults_instead_of_failing():
+    extraction = StructuredExtraction.model_validate(
+        {'title': 'Kickoff', 'overview': None, 'emoji': None, 'events': None, 'action_items': None}
+    )
+
+    assert extraction.title == 'Kickoff'
+    assert extraction.overview == ''
+    assert extraction.emoji == '🧠'
+    assert extraction.events == []
+    assert extraction.action_items == []
+
+
+def test_action_items_extraction_shares_the_guard():
+    """`extract_action_items` parses through the action-item-only model, on the main conversation path."""
+    completion = json.dumps({'action_items': [{'due_at': None}, {'description': 'Send the deck'}]})
+
+    extraction = PydanticOutputParser(pydantic_object=ActionItemsExtraction).parse(completion)
+
+    assert [item.description for item in extraction.to_action_items()] == ['Send the deck']
+
+
+def test_dropping_an_element_names_the_field_without_leaking_the_payload(caplog):
+    with caplog.at_level('WARNING', logger='models.structured_extraction'):
+        StructuredExtraction.model_validate(
+            {'title': 'Kickoff', 'action_items': [{'description': 'Call Dana about the invoice'}, {}]}
+        )
+
+    assert 'Dropping unusable action_items element' in caplog.text
+    assert 'Call Dana' not in caplog.text


### PR DESCRIPTION
## The bug

Prod, `api.omi.me`, backend image `920fc55`:

```
ERROR:utils.llm.gateway_error_contract:Conversation processing failed: ValidationError
-> HTTP 500 {"detail": "Error processing conversation, please try again later"}
```

**30 of these on `POST /v1/dev/user/conversations` on 2026-08-20 alone** (7-12s each), plus more on `POST /v1/conversations`. Users retry the same text ~14s later and get the same 500, so the conversation is simply lost. The one occurrence prod did print a traceback for names the mechanism exactly:

```
Value error, duration must be a positive number of minutes [type=value_error, input_value=0, input_type=int]
```

## Root cause

`ExtractedEvent.duration` carried a validator that **raised** on a non-positive value. Pydantic validates a list element as part of its parent, so one `duration: 0` on one event failed the entire `StructuredExtraction` — title, overview, every action item, every other event — and `_get_structured` mapped that to HTTP 500. The user got no summary at all because of one integer.

This is the same contract as #11871 (`FC-out-of-vocabulary-model-token-discards-extraction`), one level up: that PR normalized enum *fields*; the parser still fails the whole payload when a whole *element* is unusable.

## The fix

Each list on the extraction is optional detail that already models its own absence (`default_factory=list`), so an unusable element is worth exactly as much as no element:

- `StructuredExtraction` / `ActionItemsExtraction` validate `sections` / `action_items` / `events` element-by-element and drop the ones that fail, instead of failing the model.
- A non-positive or unparseable `duration` falls back to the field's own documented 30-minute default rather than being rejected — a zero duration means "unspecified", and the event itself is real, so it survives.
- An explicit `null` on a defaulted scalar (`title`, `overview`, `emoji`) or on a list falls back to the default instead of raising.
- Dropping an element logs the field plus the pydantic error `loc`/`type` with `include_input=False`. The prod 500s carried **no traceback at all**, which is why the other 30 could not be told apart from this one; the next occurrence is diagnosable.

Strictness stays where it is load-bearing: a required field on an element still fails *that element*.

## What I tested

- `backend/tests/unit/test_structured_extraction_partial_content.py` (14 tests) drives the real `summarize_experience_text` — the production function behind `POST /v1/dev/user/conversations` — on the prod payload shape, and the `PydanticOutputParser(StructuredExtraction)` seam the transcript paths use.
- **Pre-fix control:** reverting only `models/structured_extraction.py` and re-running the same file reproduces the exact prod failure (`ValidationError` out of `summarize_experience_text`). With the fix it returns a full summary with the event kept at 30 minutes.
- 17 related unit test files, **346 tests**, run file-by-file the way `test.sh` invokes them: all green — including `test_extracted_action_item_vocabulary.py` (the #11871 guard) and `test_action_item_date_validation.py` (sandboxed importer; the guard deliberately avoids a `models/` -> `utils/` import so it keeps passing).

Product invariants affected: none.

Failure-Class: FC-out-of-vocabulary-model-token-discards-extraction

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

