### PR TITLE
fix(backend): restore app icon generation on the current images API

### DIFF
--- a/.github/failure-classes/FC-pinned-vendor-request-contract-retired.json
+++ b/.github/failure-classes/FC-pinned-vendor-request-contract-retired.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-pinned-vendor-request-contract-retired",
+  "violated_contract": "A hardcoded vendor model name and its optional request parameters are a contract the vendor retires on its own schedule. A caller that pins them and is exercised only by the live provider call turns that retirement into a 100% outage of its feature, visible solely as a provider 400 in production logs.",
+  "canonical_prevention": "Pin the caller to a model/size/quality tuple the repository already declares in-tree (the gateway cost rate card), keep parameters the provider no longer accepts out of the client signature so they cannot be passed at all, and assert the outgoing request shape in a unit test.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_llm_gateway_client_config.py"
+  ],
+  "evidence_prs": [
+    11907
+  ],
+  "scope_hints": [
+    "backend/utils/llm/**",
+    "llm_gateway/config/cost_rate_cards.yaml"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_llm_gateway_client_config.py
+++ b/backend/tests/unit/test_llm_gateway_client_config.py
@@ -412,7 +412,13 @@ async def test_app_icon_generation_always_uses_gateway(monkeypatch):
     monkeypatch.setattr(app_generator, 'generate_image_via_gateway', gateway)
 
     assert await app_generator.generate_app_icon('Name', 'Description', 'other') == b'icon'
-    assert captured['model'] == 'dall-e-3'
+    # The images API rejects `response_format` (400 unknown_parameter) and no longer serves
+    # dall-e-3 (400 invalid_value), which made every app-icon generation a 500. Ask for a model
+    # and size/quality pair the gateway rate card prices, and let it return base64 by default.
+    assert captured['model'] == 'gpt-image-1'
+    assert captured['quality'] == 'medium'
+    assert captured['size'] == '1024x1024'
+    assert 'response_format' not in captured
 
 
 @pytest.mark.asyncio

--- a/backend/utils/llm/app_generator.py
+++ b/backend/utils/llm/app_generator.py
@@ -178,15 +178,18 @@ Design requirements:
     - Vibrant but not overwhelming colors
     - Style: Similar to modern iOS/Android app icons"""
 
+    # gpt-image-1 with an explicit size/quality pair the gateway rate card prices
+    # (openai.gpt-image-1.medium.1024x1024). The retired dall-e-3 `standard` quality and the
+    # `response_format` parameter are both rejected by the images API now, and it always
+    # returns base64 image data.
     response = await run_blocking(
         llm_executor,
         generate_image_via_gateway,
-        model="dall-e-3",
+        model="gpt-image-1",
         prompt=icon_prompt,
         size="1024x1024",
-        quality="standard",
+        quality="medium",
         n=1,
-        response_format="b64_json",
     )
 
     # Get the base64 image data and decode it

--- a/backend/utils/llm/gateway_client.py
+++ b/backend/utils/llm/gateway_client.py
@@ -518,7 +518,6 @@ def generate_image_via_gateway(
     size: str,
     quality: str,
     n: int,
-    response_format: str,
     timeout_seconds: float = 120.0,
 ) -> Mapping[str, object]:
     """Call the gateway-owned image generation surface."""
@@ -533,7 +532,6 @@ def generate_image_via_gateway(
                 'size': size,
                 'quality': quality,
                 'n': n,
-                'response_format': response_format,
             },
         )
         response.raise_for_status()


### PR DESCRIPTION
## Bug

`POST /v1/app/generate-icon` fails for **every** request in prod — app-icon generation in the app builder is 100% broken, with no successes at all. 12 × HTTP 500 in the 24h to 2026-08-20T08:00Z on `api.omi.me` (revision `backend-920fc55`), e.g. 05:40:37Z, 05:42:30Z, 05:43:23Z; every one paired with:

```
ERROR:routers.apps:Error generating icon: Client error '400 Bad Request' for url 'http://172.16.160.108/v1/images/generations'
```

The user sees `Failed to generate icon` and retrying never works.

## Root cause

`utils/llm/app_generator.generate_app_icon` pins a request contract the provider has retired twice over. The gateway (`llm_gateway/routers/openai_compatible.py`) forwards the body to `api.openai.com/v1/images/generations` unmodified and returns the provider status, so the 400 is the provider's:

1. `response_format: "b64_json"` → `400 unknown_parameter: Unknown parameter: 'response_format'`
2. even without it, `model: "dall-e-3"` → `400 invalid_value: The model 'dall-e-3' does not exist`

The gateway's own cost rate card (`llm_gateway/config/cost_rate_cards.yaml`) only prices `gpt-image-1` — the caller was never migrated with it, and `raise_for_status()` drops the provider's error body, so the log line above was the only signal.

## Fix

- ask for `gpt-image-1` at `1024x1024` / `quality=medium`, the tuple the rate card already prices (`openai.gpt-image-1.medium.1024x1024`, same $0.042/image as the old dall-e-3 `standard` call)
- drop `response_format` from `generate_image_via_gateway` entirely (no other caller) — the images API always returns base64 now, which is exactly what `generate_app_icon` decodes
- the existing gateway test now asserts the outgoing model/size/quality and that `response_format` is not sent

19 changed lines across 3 files; no gateway, workflow, auth or release changes.

## Verified

Against the live provider with the prod key (the expected values below are measured, not assumed):

| request | result |
|---|---|
| old body (`dall-e-3` + `response_format`) | `400 unknown_parameter` on `response_format` |
| `dall-e-3`, no `response_format` | `400 invalid_value` — model does not exist |
| new body (`gpt-image-1`, `medium`, `1024x1024`) | `200`, `data[0].b64_json` → PNG |

End-to-end through the real code path — `generate_app_icon` → `llm_gateway` `/v1/images/generations` (served locally from this branch) → OpenAI — returned a **1,098,468-byte 1024×1024 PNG**, decoded and opened successfully.

Backend tests (`backend/test.sh`, py3.11): `tests/unit/test_llm_gateway_client_config.py`, `tests/unit/test_llm_gateway_openai_compatible.py`, `tests/unit/test_llm_gateway_accounting.py` — **80 passed**.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

