### PR TITLE
refactor(backend): extract the agentic web_search taint gate

### DIFF
--- a/backend/tests/unit/test_agentic_web_search_taint.py
+++ b/backend/tests/unit/test_agentic_web_search_taint.py
@@ -17,6 +17,7 @@ import pytest
 
 from utils.llm.private_context import anthropic_messages_carry_private_tool_output
 from utils.retrieval import agentic
+from utils.retrieval import web_search_gate
 from utils.retrieval.safety import AgentSafetyGuard
 
 WEB_SEARCH_NAME = 'web_search'
@@ -92,7 +93,12 @@ def _drive_loop(monkeypatch, *, turns, registry):
     monkeypatch.setattr(agentic, 'anthropic_client', SimpleNamespace(messages=fake_messages))
 
     fallbacks = []
-    monkeypatch.setattr(agentic, 'record_fallback', lambda **fields: fallbacks.append(fields))
+
+    def _capture_fallback(**fields):
+        fallbacks.append(fields)
+
+    monkeypatch.setattr(agentic, 'record_fallback', _capture_fallback)
+    monkeypatch.setattr(web_search_gate, 'record_fallback', _capture_fallback)
 
     async def main():
         callback = agentic.AsyncStreamingCallback()

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -247,6 +247,13 @@ _load_module_from_file("utils.retrieval.safety", BACKEND_DIR / "utils" / "retrie
 # Real (import-light) fallback telemetry: agentic.py imports record_fallback from it.
 _load_module_from_file("utils.observability.fallback", BACKEND_DIR / "utils" / "observability" / "fallback.py")
 
+# Real (import-light) web_search gate. agentic.py now imports WEB_SEARCH_TOOL and
+# request_tools_after_private_taint from this sibling. utils.retrieval is stubbed
+# with an empty __path__, so the module must be loaded from file like safety.
+_load_module_from_file(
+    "utils.retrieval.web_search_gate", BACKEND_DIR / "utils" / "retrieval" / "web_search_gate.py"
+)
+
 # Stub firebase_admin (used by endpoints.py and auth)
 firebase_mod = _stub_module("firebase_admin")
 firebase_mod.auth = MagicMock()

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -250,9 +250,7 @@ _load_module_from_file("utils.observability.fallback", BACKEND_DIR / "utils" / "
 # Real (import-light) web_search gate. agentic.py now imports WEB_SEARCH_TOOL and
 # request_tools_after_private_taint from this sibling. utils.retrieval is stubbed
 # with an empty __path__, so the module must be loaded from file like safety.
-_load_module_from_file(
-    "utils.retrieval.web_search_gate", BACKEND_DIR / "utils" / "retrieval" / "web_search_gate.py"
-)
+_load_module_from_file("utils.retrieval.web_search_gate", BACKEND_DIR / "utils" / "retrieval" / "web_search_gate.py")
 
 # Stub firebase_admin (used by endpoints.py and auth)
 firebase_mod = _stub_module("firebase_admin")

--- a/backend/utils/retrieval/ARCHITECTURE.md
+++ b/backend/utils/retrieval/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Flow
 
-`graph.py` selects the chat path and streams the response. `agentic.py` owns the stable core-tool registry, tool schema conversion, and agentic execution. `rag.py`, `hybrid.py`, and `safety.py` provide retrieval, ranking, and response-safety boundaries.
+`graph.py` selects the chat path and streams the response. `agentic.py` owns the stable core-tool registry, tool schema conversion, and agentic execution. `web_search_gate.py` re-decides the Anthropic server-side web_search offer on each agent-loop request once private tool output is in the transcript. `rag.py`, `hybrid.py`, and `safety.py` provide retrieval, ranking, and response-safety boundaries.
 
 ## Tool boundaries
 

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -60,7 +60,7 @@ from utils.retrieval.safety import (
     should_retry_provider_error,
     INPUT_TOO_LONG_MESSAGE,
 )
-from utils.llm.private_context import anthropic_messages_carry_private_tool_output, without_tool_named
+from utils.retrieval.web_search_gate import SERVER_WEB_SEARCH_NAME, WEB_SEARCH_TOOL, request_tools_after_private_taint
 from utils.observability.fallback import record_fallback
 from utils.llm.byok_errors import handle_llm_error_async
 from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL, get_llm, num_tokens_from_string
@@ -385,27 +385,6 @@ TOOL_SEARCH_TOOL = {
     "name": "tool_search_tool_regex",
 }
 
-# Web search tool — Anthropic's built-in server-side web search (replaces Perplexity)
-SERVER_WEB_SEARCH_NAME = "web_search"
-WEB_SEARCH_TOOL = {
-    "type": "web_search_20260209",
-    "name": SERVER_WEB_SEARCH_NAME,
-    "max_uses": 5,
-}
-
-# Producers whose results may stay in the transcript while `web_search` is still
-# offered — see `utils/llm/private_context` for why the offer is gated at all.
-# Only product-doc lookups qualify: every other core tool reads user data, echoes
-# the user's input back (`save_user_preference_tool`, `create_action_item_tool`),
-# or can surface user data in an error string (`create_calendar_event_tool`
-# resolves attendees against Google Contacts). Unknown names — app tools are
-# registered at runtime — are private.
-#
-# `tool_search_tool_regex` is deliberately not gated: it is provider-executed
-# too, but it resolves inside Anthropic and reaches no third party, so it crosses
-# no boundary the request had not already crossed.
-_PUBLIC_SAFE_AGENT_TOOLS = frozenset({'get_omi_product_info_tool'})
-
 
 def _convert_tools(core_tools: list, app_tools: list = None) -> tuple:
     """Convert all tools and build name->object registry.
@@ -673,40 +652,15 @@ async def _run_anthropic_agent_stream(
     producer_started_at = asyncio.get_running_loop().time()
     loop_iteration = 0
 
-    # The taint appears *during* the loop: the opening request carries only the
-    # user/assistant transcript, and a tool result lands in `messages` after each
-    # iteration. The offer is therefore re-decided per request rather than once
-    # up front, and latched — a loop that has seen private data stays withheld
-    # even if a later iteration were to trim the transcript.
-    #
-    # Withholding changes the tool block, which is part of the cached prefix, so
-    # the iteration that trips the gate takes a prompt-cache miss. That cost is
-    # the price of the gate: do not hoist this decision back out of the loop to
-    # keep the prefix stable — the opening request is always clean, so a
-    # hoisted check can never observe the taint it exists to catch.
-    offers_server_web_search = any(
-        isinstance(schema, dict) and schema.get('name') == SERVER_WEB_SEARCH_NAME for schema in tool_schemas
-    )
+    # Re-decide the server-side web_search offer inside the loop. The taint
+    # only appears after tool results are appended; see web_search_gate.py.
     server_web_search_withheld = False
 
     while True:
         loop_iteration += 1
 
-        if (
-            offers_server_web_search
-            and not server_web_search_withheld
-            and anthropic_messages_carry_private_tool_output(messages, public_safe_tools=_PUBLIC_SAFE_AGENT_TOOLS)
-        ):
-            server_web_search_withheld = True
-            record_fallback(
-                component='other',
-                from_mode='anthropic_web_search',
-                to_mode='model_knowledge',
-                reason='private_tool_output_in_context',
-                outcome='degraded',
-            )
-        request_tools = (
-            without_tool_named(tool_schemas, SERVER_WEB_SEARCH_NAME) if server_web_search_withheld else tool_schemas
+        request_tools, server_web_search_withheld = request_tools_after_private_taint(
+            tool_schemas, messages, withheld=server_web_search_withheld
         )
 
         attempts_made = 0

--- a/backend/utils/retrieval/web_search_gate.py
+++ b/backend/utils/retrieval/web_search_gate.py
@@ -43,9 +43,7 @@ def request_tools_after_private_taint(
 ) -> tuple[list, bool]:
     """Return the tool list for this provider request and the latched withhold flag."""
     schemas = tool_schemas if isinstance(tool_schemas, list) else []
-    offers = any(
-        isinstance(schema, Mapping) and schema.get("name") == SERVER_WEB_SEARCH_NAME for schema in schemas
-    )
+    offers = any(isinstance(schema, Mapping) and schema.get("name") == SERVER_WEB_SEARCH_NAME for schema in schemas)
     if (
         offers
         and not withheld

--- a/backend/utils/retrieval/web_search_gate.py
+++ b/backend/utils/retrieval/web_search_gate.py
@@ -1,0 +1,63 @@
+"""Per-request gate for Anthropic server-side web_search on the agentic path.
+
+Anthropic executes ``web_search`` on its own infrastructure, so the query never
+reaches the in-process tool executor and leaves the trust boundary without any
+SSRF or allowlist control. After a private tool result is in the transcript, an
+injected instruction can place that data into the query.
+
+The opening request is always clean: ``_messages_to_anthropic`` emits text-only
+turns, and taint only appears *during* the loop as tool results are appended.
+The offer is therefore re-decided before each provider request and latched once
+withheld. Do not hoist the check out of the loop to keep the prompt-cache prefix
+stable — a hoisted check can never observe the taint it exists to catch.
+
+``tool_search_tool_regex`` is deliberately not gated: it is provider-executed
+too, but it resolves inside Anthropic and reaches no third party.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from utils.llm.private_context import anthropic_messages_carry_private_tool_output, without_tool_named
+from utils.observability.fallback import record_fallback
+
+SERVER_WEB_SEARCH_NAME = "web_search"
+WEB_SEARCH_TOOL = {
+    "type": "web_search_20260209",
+    "name": SERVER_WEB_SEARCH_NAME,
+    "max_uses": 5,
+}
+
+# Only product-doc lookups stay public-safe. Every other core tool reads user
+# data, echoes the user's input back, or can surface user data in an error
+# string. Unknown names — app tools are registered at runtime — are private.
+PUBLIC_SAFE_AGENT_TOOLS = frozenset({"get_omi_product_info_tool"})
+
+
+def request_tools_after_private_taint(
+    tool_schemas: object,
+    messages: object,
+    *,
+    withheld: bool,
+) -> tuple[list, bool]:
+    """Return the tool list for this provider request and the latched withhold flag."""
+    schemas = tool_schemas if isinstance(tool_schemas, list) else []
+    offers = any(
+        isinstance(schema, Mapping) and schema.get("name") == SERVER_WEB_SEARCH_NAME for schema in schemas
+    )
+    if (
+        offers
+        and not withheld
+        and anthropic_messages_carry_private_tool_output(messages, public_safe_tools=PUBLIC_SAFE_AGENT_TOOLS)
+    ):
+        withheld = True
+        record_fallback(
+            component="other",
+            from_mode="anthropic_web_search",
+            to_mode="model_knowledge",
+            reason="private_tool_output_in_context",
+            outcome="degraded",
+        )
+    request_tools = without_tool_named(schemas, SERVER_WEB_SEARCH_NAME) if withheld else schemas
+    return request_tools, withheld


### PR DESCRIPTION
## Summary

- Follow-up to #11857. That merge grew `backend/utils/retrieval/agentic.py` from 1512 to 1560 lines. PR-time Hygiene passed because the PR body declared `Line-Count-Exception`, but the squash commit on main was title-only, so main-push Hygiene failed `product-file-line-count-ratchet`.
- Move the per-request web_search withhold (allowlist, latch, `record_fallback`, `without_tool_named`) into `backend/utils/retrieval/web_search_gate.py` and call it from inside the agent loop. `agentic.py` shrinks 1560 → 1514. Behavior is unchanged: the offer is still re-decided per provider request and latched once withheld.
- This is the split the ratchet asked for. It does not rewrite the already-red #11857 merge commit; it makes the next main HEAD able to go green.

## Product invariants affected

none (`scripts/pr-preflight --suggest` paths for this change are not locked)

## Test plan

- [ ] Repo Checks / Hygiene re-runs on this PR and is green (line-count ratchet must see a shrink, not growth)
- [ ] `backend/tests/unit/test_agentic_web_search_taint.py` still covers both directions (withheld after private result, still offered on a clean loop)
- [ ] Neighbouring suites that import `agentic.WEB_SEARCH_TOOL` still resolve (re-exported from the new module)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2f93133701f871a1f64c680b046353a158d34a9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->