### PR TITLE
fix(ci): load the merged PR body for main-push Hygiene citations

### DIFF
--- a/.github/scripts/pr_metadata.py
+++ b/.github/scripts/pr_metadata.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -138,16 +139,92 @@ def load_from_gh(root: Path) -> PullRequestMetadata:
     return _parse_metadata(payload, "gh current PR")
 
 
+# GitHub squash-merge subjects end with `(#1234)`. A merge commit starts with
+# `Merge pull request #1234`. Either form is enough to recover the PR that
+# already passed Hygiene with INV-* / Failure-Class citations in its body.
+_SUBJECT_PR_RE = re.compile(r"\(#(\d+)\)")
+_MERGE_PR_RE = re.compile(r"^Merge pull request #(\d+)\b")
+
+
+def extract_merged_pr_number(commit_body: str) -> int | None:
+    """Return the merged PR number from a squash/merge commit subject, if any."""
+    first_line = commit_body.splitlines()[0].strip() if commit_body else ""
+    merge = _MERGE_PR_RE.match(first_line)
+    if merge:
+        return int(merge.group(1))
+    matches = list(_SUBJECT_PR_RE.finditer(first_line))
+    if not matches:
+        return None
+    return int(matches[-1].group(1))
+
+
+def resolve_main_push_body(
+    commit_body: str,
+    *,
+    repository: str,
+    token: str,
+    loader: Callable[..., PullRequestMetadata] = load_from_api,
+) -> str:
+    """Commit message plus the merged PR body when HEAD is a squash/merge.
+
+    #10965 passed only `git log -1` through --pr-body-file, assuming GitHub
+    folds the PR description into the squash message. This repo's squash
+    default is the commit list, so INV-* citations that made PR Hygiene
+    green (see #11835) vanish on the main push. Append the live PR body
+    when the subject carries (#NNNN). API failures keep the commit
+    message — fail-closed for direct pushes, no new flake on API outage
+    when the commit already cites the IDs.
+    """
+    number = extract_merged_pr_number(commit_body)
+    if number is None or not repository or not token:
+        return commit_body
+    try:
+        metadata = loader(repository, number, token)
+    except RuntimeError as exc:
+        print(f"WARN: could not load merged PR #{number} body: {exc}", file=sys.stderr)
+        return commit_body
+    pr_body = (metadata.body or "").strip()
+    if not pr_body or pr_body in commit_body:
+        return commit_body
+    return commit_body.rstrip() + "\n\n" + metadata.body
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repository", required=True, help="GitHub repository as owner/name")
-    parser.add_argument("--pr-number", required=True, type=int)
+    parser.add_argument("--pr-number", type=int, help="PR number when loading a live PR body")
+    parser.add_argument(
+        "--from-commit-body-file",
+        type=Path,
+        help="Main-push commit message; resolve (#NNNN) and append that PR body",
+    )
     parser.add_argument("--output", required=True, type=Path, help="File to receive the current PR body")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
+    if args.from_commit_body_file is not None:
+        try:
+            commit_body = args.from_commit_body_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"FAIL: could not read commit body: {exc}", file=sys.stderr)
+            return 1
+        body = resolve_main_push_body(
+            commit_body,
+            repository=args.repository,
+            token=os.getenv("GITHUB_TOKEN", ""),
+        )
+        args.output.write_text(body, encoding="utf-8")
+        number = extract_merged_pr_number(commit_body)
+        if number is not None and body != commit_body:
+            print(f"Loaded merged PR #{number} body and appended it to the commit message.")
+        else:
+            print("Using commit message as the main-push PR body.")
+        return 0
+    if args.pr_number is None:
+        print("FAIL: --pr-number or --from-commit-body-file is required", file=sys.stderr)
+        return 2
     try:
         metadata = load_from_api(args.repository, args.pr_number, os.getenv("GITHUB_TOKEN", ""))
     except RuntimeError as exc:

--- a/.github/scripts/test_check_product_invariants.py
+++ b/.github/scripts/test_check_product_invariants.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from check_product_invariants import (
     format_suggest_block,
     matched_invariants,
+    missing_invariant_hits,
     parse_invariant,
     path_matches,
     pr_body_cites_id,
@@ -252,6 +253,51 @@ class FailClosedTests(unittest.TestCase):
             result = load_locked_invariants(Path(tmp))
             self.assertEqual(len(result), 1)
             self.assertEqual(result[0]["id"], "INV-CHAT-1")
+
+
+class SquashCommitBodyTests(unittest.TestCase):
+    """#11835: squash commit list is not a substitute for the PR body."""
+
+    def test_about_user_voice_paths_require_inv_chat_1(self) -> None:
+        root = Path(__file__).resolve().parents[1].parent
+        invariants = load_locked_invariants(root)
+        hits = matched_invariants(
+            [
+                "desktop/windows/src/renderer/src/lib/voice/aboutUser.ts",
+                "desktop/windows/src/renderer/src/lib/voice/aboutUser.test.ts",
+            ],
+            invariants,
+        )
+        ids = {hit["id"] for hit in hits}
+        self.assertIn("INV-CHAT-1", ids)
+
+    def test_squash_commit_list_without_citation_fails(self) -> None:
+        root = Path(__file__).resolve().parents[1].parent
+        invariants = load_locked_invariants(root)
+        hits = matched_invariants(
+            ["desktop/windows/src/renderer/src/lib/voice/aboutUser.ts"],
+            invariants,
+        )
+        squash_body = (
+            "Cut the Windows app's idle and focus-driven backend request volume (#11835)\n\n"
+            "* Stop rebuilding the about-user card on every voice hub warm\n"
+        )
+        missing = missing_invariant_hits(hits, squash_body)
+        self.assertTrue(any(hit["id"] == "INV-CHAT-1" for hit in missing))
+
+    def test_appended_pr_body_citation_passes(self) -> None:
+        root = Path(__file__).resolve().parents[1].parent
+        invariants = load_locked_invariants(root)
+        hits = matched_invariants(
+            ["desktop/windows/src/renderer/src/lib/voice/aboutUser.ts"],
+            invariants,
+        )
+        combined = (
+            "Cut the Windows app's idle and focus-driven backend request volume (#11835)\n\n"
+            "* Stop rebuilding the about-user card\n\n"
+            "## Product invariants affected\n\n- INV-CHAT-1\n"
+        )
+        self.assertEqual(missing_invariant_hits(hits, combined), [])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_preflight.py
+++ b/.github/scripts/test_pr_preflight.py
@@ -18,7 +18,13 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import preflight_runner
-from pr_metadata import TransientPRMetadataError, load_from_api, load_from_event_file
+from pr_metadata import (
+    TransientPRMetadataError,
+    extract_merged_pr_number,
+    load_from_api,
+    load_from_event_file,
+    resolve_main_push_body,
+)
 from pr_preflight import changed_files, format_failure_class_suggest, resolve_pr_metadata, run_git, select_checks
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -105,6 +111,61 @@ class MetadataTests(unittest.TestCase):
         with self.assertRaisesRegex(TransientPRMetadataError, "request failed"):
             load_from_api("BasedHardware/omi", 9847, "test-token", opener=opener, sleeper=lambda _: None)
         self.assertEqual(calls["count"], 3)
+
+    def test_extract_merged_pr_number_from_squash_and_merge_subjects(self) -> None:
+        self.assertEqual(
+            extract_merged_pr_number(
+                "Cut the Windows app's idle request volume (#11835)\n\n* Run the retention sweep\n"
+            ),
+            11835,
+        )
+        self.assertEqual(extract_merged_pr_number('Merge pull request #10965 from aryanorastar/fix'), 10965)
+        self.assertEqual(extract_merged_pr_number('Revert "foo (#12)" (#99)'), 99)
+        self.assertIsNone(extract_merged_pr_number("security(backend): gate Anthropic web search"))
+        self.assertIsNone(extract_merged_pr_number(""))
+
+    def test_main_push_body_appends_live_pr_body_for_squash_head(self) -> None:
+        """#11835: squash commit list omitted INV-CHAT-1; the PR body had it."""
+        commit = (
+            "Cut the Windows app's idle and focus-driven backend request volume (#11835)\n\n"
+            "* Stop rebuilding the about-user card on every voice hub warm\n"
+        )
+        metadata = type("M", (), {"body": "## Product invariants affected\n\n- INV-CHAT-1\n", "number": 11835})()
+        combined = resolve_main_push_body(
+            commit,
+            repository="BasedHardware/omi",
+            token="test-token",
+            loader=lambda *args, **kwargs: metadata,
+        )
+        self.assertIn("INV-CHAT-1", combined)
+        self.assertTrue(combined.startswith(commit.rstrip()))
+
+    def test_main_push_body_keeps_commit_message_without_pr_number_or_token(self) -> None:
+        commit = "direct push that forgot INV-CHAT-1\n"
+        self.assertEqual(
+            resolve_main_push_body(commit, repository="BasedHardware/omi", token=""),
+            commit,
+        )
+        self.assertEqual(
+            resolve_main_push_body(commit, repository="BasedHardware/omi", token="tok"),
+            commit,
+        )
+
+    def test_main_push_body_falls_back_when_api_fails(self) -> None:
+        commit = "Cut the Windows app's idle volume (#11835)\n"
+
+        def loader(*args: object, **kwargs: object):
+            raise RuntimeError("GitHub API returned HTTP 502 while reading PR #11835")
+
+        self.assertEqual(
+            resolve_main_push_body(
+                commit,
+                repository="BasedHardware/omi",
+                token="test-token",
+                loader=loader,
+            ),
+            commit,
+        )
 
     def test_event_payload_loader_uses_top_level_pr_number(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test_run_checks.py
+++ b/.github/scripts/test_run_checks.py
@@ -198,12 +198,14 @@ class ManifestContractTests(unittest.TestCase):
     def test_ci_lane_is_reachable_from_repo_checks(self) -> None:
         workflow = (WORKFLOWS_DIR / "repo-checks.yml").read_text(encoding="utf-8")
         self.assertRegex(workflow, r"run_checks\.py\s+--lane\s+ci")
-        # #9744: main pushes must pass the merge-commit body through
-        # --pr-body-file (not --skip-pr-body-checks), so product-invariants can
-        # see the citations GitHub folds into the merge commit message. This
-        # assertion is the wiring regression guard for that path.
+        # #9744: main pushes must pass a body through --pr-body-file (not
+        # --skip-pr-body-checks). #11835: the body must be the squash commit
+        # message PLUS the live merged PR body, because this repo squashes
+        # with the commit list rather than the PR description.
         self.assertNotIn("--skip-pr-body-checks", workflow)
         self.assertRegex(workflow, r"git log -1 --format=%B HEAD")
+        self.assertRegex(workflow, r"pr_metadata\.py")
+        self.assertRegex(workflow, r"--from-commit-body-file")
         self.assertRegex(workflow, r"--pr-body-file")
         manifest = load_manifest(MANIFEST_PATH)
         self.assertTrue(any("ci" in check.lanes for check in manifest.checks))

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -146,15 +146,21 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           PR_BODY_FILE: /tmp/main-push-commit-body.txt
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          # On main pushes there is no PR body. GitHub folds the PR description
-          # into the merge commit message (fetch-depth: 0 gives us the full
-          # commit), so pass that through --pr-body-file instead of skipping the
-          # body-requiring checks. Without this, product-invariants cannot see
-          # the citations the merge commit carries and every main-push Hygiene
-          # run reports them as missing (see #9744). Fail-closed is preserved:
-          # a direct push whose message omits required invariant IDs still fails.
-          git log -1 --format=%B HEAD > "$PR_BODY_FILE"
+          # On main pushes there is no PR event payload. #10965 / #9744 pass
+          # the merge-commit body through --pr-body-file so product-invariants
+          # and failure-class-protocol still run. That is necessary but not
+          # sufficient here: this repo squashes with the commit list, not the
+          # PR description, so INV-* citations that already made PR Hygiene
+          # green disappear on the main push (see #11835). Recover the live
+          # (#NNNN) PR body and append it. Fail-closed is preserved: a direct
+          # push with no PR number still uses only the commit message.
+          git log -1 --format=%B HEAD > /tmp/main-push-commit-message.txt
+          python3 .github/scripts/pr_metadata.py \
+            --repository "${{ github.repository }}" \
+            --from-commit-body-file /tmp/main-push-commit-message.txt \
+            --output "$PR_BODY_FILE"
           python3 .github/scripts/run_checks.py --lane ci \
             --base "${{ needs.changes.outputs.diff_base }}" \
             --pr-body-file "$PR_BODY_FILE"


### PR DESCRIPTION
## What changed and why

Main-branch **Hygiene** is red on `d7485f4` (`#11835`) because `product-invariants` looks at the squash commit message, not the PR body.

`#11835` already named `INV-CHAT-1` in the PR body (it touches `desktop/windows/src/renderer/src/lib/voice/**`). The squash used the commit list, so that citation disappeared and the main-push run failed:

```
FAIL: PR touches locked product invariant paths but does not name the invariant ID(s).
  Missing: INV-CHAT-1
    - desktop/windows/src/renderer/src/lib/voice/aboutUser.test.ts
    - desktop/windows/src/renderer/src/lib/voice/aboutUser.ts
```

`#10965` / `#9744` correctly stopped skipping body-requiring checks on main, but assumed GitHub folds the PR description into the squash message. This repo does not.

On main pushes, resolve `(#NNNN)` / `Merge pull request #N` from `HEAD` and append the live PR body to the commit message before `run_checks.py`. Direct pushes with no PR number still use only the commit message (fail-closed). API failures fall back to the commit message rather than inventing a new flake.

## Product invariants affected

none

CI workflow + test wiring only. This restores enforcement of INV-* citations that already existed on the merged PR.

## Failure class (fixes)

Failure-Class: none

## How it was verified

- `python3 .github/scripts/test_pr_preflight.py MetadataTests` — 12 passed, including the `#11835` squash-vs-PR-body cases
- `python3 .github/scripts/test_check_product_invariants.py` — 21 passed, including the about-user path / squash-body regression
- `python3 .github/scripts/test_run_checks.py ManifestContractTests.test_ci_lane_is_reachable_from_repo_checks` — wiring guard now requires `--from-commit-body-file`

Do not merge over red Hygiene. After this PR's Hygiene is green, merging it is what turns main Hygiene green for the `#11835` head (the next main-push run will fetch `#11835`'s body only if this lands first; this PR itself does not touch locked invariant paths).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 63d6ede9cf75174bf20192d0e95438680b31030f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->