### PR TITLE
docs(backend): keep and justify 30-minute geolocation cache TTL

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -353,7 +353,10 @@ def cache_user_geolocation(uid: str, geolocation: Dict[str, Any]) -> None:
     # optional fields already default to ``None`` when absent.
     present_fields = {key: value for key, value in geolocation.items() if value is not None}
     r.set(f'users:{uid}:geolocation', _serialize_cache_value(present_fields))
-    r.expire(f'users:{uid}:geolocation', 60 * 30)  # FIXME: too much?
+    # 30m: conversation/tool place tagging does not need second-level freshness;
+    # clients re-upload on significant moves and at recording start. Keeps the
+    # last-known coords available without inventing a tighter freshness policy.
+    r.expire(f'users:{uid}:geolocation', 60 * 30)
 
 
 def get_cached_user_geolocation(uid: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Reviewed the `users:{uid}:geolocation` Redis TTL (`60 * 30`) in `backend/database/redis_db.py`. **Kept 30 minutes** and replaced the unresolved `FIXME: too much?` with a brief justification.

**Decision:** Keep 30 minutes. This cache holds last-known GPS coords for conversation place tagging and chat-tool context — approximate place, not second-level freshness. Clients already re-upload on significant moves (~4 decimal places) and at recording start (`ConversationLocationCapture`). Docs already state the 30-minute server-side cache (`docs/doc/developer/apps/ChatTools.mdx`). Reverse-geocode cost is controlled separately by the `geocode:` Redis cache (48h, ~100m). Shortening would drop location availability sooner without a product requirement for tighter freshness; lengthening would invent a policy without evidence of mis-tagging.

## Product invariants affected

none

## How it was verified

- Traced write path: `PATCH /v1/users/geolocation` → `cache_user_geolocation`
- Traced read paths: conversation processing/finalization, agentic chat tools
- Confirmed client refresh: significant-move uploads + recording-start capture
- Confirmed docs already document 30m server-side cache
- Diff is comment-only; TTL value unchanged (`60 * 30`)

## Tests

No test change — behavior unchanged (comment/docs clarification only). Existing geolocation serialization tests in `backend/tests/unit/test_redis_db_cache_serialization.py` still cover the cache write path.

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cacc968-92de-4dae-ac8c-84b4aa188674?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cacc968-92de-4dae-ac8c-84b4aa188674&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

