### PR TITLE
chore(backend): drop unused imports from chat router

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -27,8 +27,7 @@ from multipart.multipart import shutil
 from pydantic import BaseModel
 
 import database.chat as chat_db
-from utils.chat_session_target import resolve_chat_session, resolve_chat_target
-import database.conversations as conversations_db
+from utils.chat_session_target import resolve_chat_target
 import database.llm_usage as llm_usage_db
 from database.apps import record_app_usage
 from models.app import App, UsageHistoryType


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Re-verified `backend/routers/chat.py` on current `main` with Ruff F401. Two imports were still unused and are removed:

- `resolve_chat_session` — leftover from the session-resolution extract; the router only calls `resolve_chat_target`
- `database.conversations as conversations_db` — previously removed, then reintroduced by a merge; still unused

No behavior change.

## Product invariants affected

none

## How it was verified

```bash
uvx ruff@0.16.3 check backend/routers/chat.py --select F401
# before: F401 for resolve_chat_session and database.conversations
# after:  All checks passed!

uvx ruff@0.16.3 check backend/routers/chat.py --select F401,F811
# All checks passed!

black --line-length 120 --skip-string-normalization --check backend/routers/chat.py
# 1 file would be left unchanged

pyflakes backend/routers/chat.py
# (no output)
```

Pre-push bounded gate passed. Did not exercise chat HTTP endpoints: import-only cleanup with no runtime path change.

## Tests

No test change. This is dead-import removal only; Ruff F401 / pyflakes are the regression surface for unused imports.

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-833d3f71-7c9c-40ab-8993-f45e00a7f2ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-833d3f71-7c9c-40ab-8993-f45e00a7f2ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

