### PR TITLE
fix(chat): resolve sender display names from app_id

### DIFF
--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,9 +1,11 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
+
+from database.apps import get_app_by_id_db
 
 
 class MessageSender(str, Enum):
@@ -140,6 +142,26 @@ class Message(BaseModel):
         return parsed
 
     @staticmethod
+    def _resolve_sender_name(
+        message: 'Message',
+        *,
+        use_plugin_name_if_available: bool,
+        app_name_by_id: Dict[str, Optional[str]],
+    ) -> str:
+        if message.sender == 'human':
+            return 'User'
+        if use_plugin_name_if_available and message.app_id and message.app_id.strip():
+            app_id = message.app_id.strip()
+            if app_id not in app_name_by_id:
+                app = get_app_by_id_db(app_id)
+                name = app.get('name') if app else None
+                app_name_by_id[app_id] = name.strip() if isinstance(name, str) and name.strip() else None
+            resolved_name = app_name_by_id[app_id]
+            if resolved_name:
+                return resolved_name
+        return message.sender.upper()
+
+    @staticmethod
     def get_messages_as_string(
         messages: List['Message'],
         use_user_name_if_available: bool = False,
@@ -147,19 +169,16 @@ class Message(BaseModel):
         include_file_info: bool = False,
     ) -> str:
         sorted_messages = sorted(messages, key=lambda m: m.created_at)
-
-        def get_sender_name(message: Message) -> str:
-            if message.sender == 'human':
-                return 'User'
-            if use_plugin_name_if_available and message.app_id and message.app_id.strip():
-                return message.app_id
-            return message.sender.upper()
+        app_name_by_id: Dict[str, Optional[str]] = {}
 
         formatted_messages = []
         for message in sorted_messages:
-            msg_text = (
-                f"({message.created_at.strftime('%d %b %Y at %H:%M UTC')}) {get_sender_name(message)}: {message.text}"
+            sender_name = Message._resolve_sender_name(
+                message,
+                use_plugin_name_if_available=use_plugin_name_if_available,
+                app_name_by_id=app_name_by_id,
             )
+            msg_text = f"({message.created_at.strftime('%d %b %Y at %H:%M UTC')}) {sender_name}: {message.text}"
 
             # Add file info if requested and files exist
             if include_file_info and message.files_id and len(message.files_id) > 0:
@@ -178,13 +197,7 @@ class Message(BaseModel):
         include_file_info: bool = False,
     ) -> str:
         sorted_messages = sorted(messages, key=lambda m: m.created_at)
-
-        def get_sender_name(message: Message) -> str:
-            if message.sender == 'human':
-                return 'User'
-            if use_plugin_name_if_available and message.app_id and message.app_id.strip():
-                return message.app_id
-            return message.sender.upper()
+        app_name_by_id: Dict[str, Optional[str]] = {}
 
         formatted_messages = []
         for message in sorted_messages:
@@ -209,7 +222,7 @@ class Message(BaseModel):
 
             msg = f"""<message>
 <created_at>{message.created_at.strftime('%d %b %Y at %H:%M UTC')}</created_at>
-<sender>{get_sender_name(message)}</sender>
+<sender>{Message._resolve_sender_name(message, use_plugin_name_if_available=use_plugin_name_if_available, app_name_by_id=app_name_by_id)}</sender>
 <content>{message.text}</content>
 {file_section}
 </message>"""

--- a/backend/tests/unit/test_message_formatting.py
+++ b/backend/tests/unit/test_message_formatting.py
@@ -1,61 +1,57 @@
 from datetime import datetime, timezone
+from unittest.mock import patch
+
 from models.chat import Message, MessageSender, MessageType
 
 
-def test_get_messages_as_string_sender_app_id():
-    m = Message(
+def _ai_message(*, app_id='some-app-id', text='hello'):
+    return Message(
         id='m1',
-        text='hello',
+        text=text,
         created_at=datetime.now(timezone.utc),
         sender=MessageSender.ai,
         type=MessageType.text,
-        app_id='some-app-id',
+        app_id=app_id,
     )
-    result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
-    assert "some-app-id" in result
 
 
-def test_get_messages_as_xml_sender_app_id():
-    m = Message(
-        id='m1',
-        text='hello',
-        created_at=datetime.now(timezone.utc),
-        sender=MessageSender.ai,
-        type=MessageType.text,
-        app_id='some-app-id',
-    )
-    result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
-    assert "<sender>some-app-id</sender>" in result
+def test_get_messages_as_string_sender_uses_app_display_name():
+    m = _ai_message()
+    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
+        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+
+    assert 'Friendly Bot: hello' in result
+    assert 'some-app-id' not in result
+    lookup.assert_called_once_with('some-app-id')
+
+
+def test_get_messages_as_xml_sender_uses_app_display_name():
+    m = _ai_message()
+    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
+        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+
+    assert '<sender>Friendly Bot</sender>' in result
+    lookup.assert_called_once_with('some-app-id')
 
 
 def test_get_messages_as_string_defaults_to_ai_sender_for_app_id():
-    m = Message(
-        id='m1',
-        text='hello',
-        created_at=datetime.now(timezone.utc),
-        sender=MessageSender.ai,
-        type=MessageType.text,
-        app_id='some-app-id',
-    )
+    m = _ai_message()
 
-    result = Message.get_messages_as_string([m])
+    with patch('models.chat.get_app_by_id_db') as lookup:
+        result = Message.get_messages_as_string([m])
 
-    assert "AI: hello" in result
+    assert 'AI: hello' in result
+    lookup.assert_not_called()
 
 
 def test_get_messages_as_xml_defaults_to_ai_sender_for_app_id():
-    m = Message(
-        id='m1',
-        text='hello',
-        created_at=datetime.now(timezone.utc),
-        sender=MessageSender.ai,
-        type=MessageType.text,
-        app_id='some-app-id',
-    )
+    m = _ai_message()
 
-    result = Message.get_messages_as_xml([m])
+    with patch('models.chat.get_app_by_id_db') as lookup:
+        result = Message.get_messages_as_xml([m])
 
-    assert "<sender>AI</sender>" in result
+    assert '<sender>AI</sender>' in result
+    lookup.assert_not_called()
 
 
 def _blank_app_id_variants():
@@ -64,31 +60,66 @@ def _blank_app_id_variants():
 
 def test_get_messages_as_string_blank_app_id_falls_back_to_ai_sender():
     for app_id in _blank_app_id_variants():
-        m = Message(
-            id='m1',
-            text='hello',
-            created_at=datetime.now(timezone.utc),
-            sender=MessageSender.ai,
-            type=MessageType.text,
-            app_id=app_id,
-        )
+        m = _ai_message(app_id=app_id)
 
-        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+        with patch('models.chat.get_app_by_id_db') as lookup:
+            result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
 
-        assert "AI: hello" in result, f"blank app_id={app_id!r} must not emit an empty sender"
+        assert 'AI: hello' in result, f'blank app_id={app_id!r} must not emit an empty sender'
+        lookup.assert_not_called()
 
 
 def test_get_messages_as_xml_blank_app_id_falls_back_to_ai_sender():
     for app_id in _blank_app_id_variants():
-        m = Message(
-            id='m1',
-            text='hello',
+        m = _ai_message(app_id=app_id)
+
+        with patch('models.chat.get_app_by_id_db') as lookup:
+            result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+
+        assert '<sender>AI</sender>' in result, f'blank app_id={app_id!r} must not emit an empty sender'
+        lookup.assert_not_called()
+
+
+def test_get_messages_as_string_missing_app_falls_back_to_ai_sender():
+    m = _ai_message()
+    with patch('models.chat.get_app_by_id_db', return_value=None) as lookup:
+        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+
+    assert 'AI: hello' in result
+    lookup.assert_called_once_with('some-app-id')
+
+
+def test_get_messages_as_xml_missing_app_falls_back_to_ai_sender():
+    m = _ai_message()
+    with patch('models.chat.get_app_by_id_db', return_value=None) as lookup:
+        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+
+    assert '<sender>AI</sender>' in result
+    lookup.assert_called_once_with('some-app-id')
+
+
+def test_get_messages_as_string_blank_app_name_falls_back_to_ai_sender():
+    m = _ai_message()
+    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': '  '}):
+        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+
+    assert 'AI: hello' in result
+
+
+def test_sender_name_lookup_is_cached_per_app_id():
+    messages = [
+        _ai_message(app_id='shared-app', text='one'),
+        Message(
+            id='m2',
+            text='two',
             created_at=datetime.now(timezone.utc),
             sender=MessageSender.ai,
             type=MessageType.text,
-            app_id=app_id,
-        )
+            app_id='shared-app',
+        ),
+    ]
+    with patch('models.chat.get_app_by_id_db', return_value={'id': 'shared-app', 'name': 'Shared'}) as lookup:
+        result = Message.get_messages_as_string(messages, use_plugin_name_if_available=True)
 
-        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
-
-        assert "<sender>AI</sender>" in result, f"blank app_id={app_id!r} must not emit an empty sender"
+    assert result.count('Shared:') == 2
+    lookup.assert_called_once_with('shared-app')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

When `use_plugin_name_if_available` is enabled, chat history formatters now resolve an app's display `name` from `app_id` via `database.apps.get_app_by_id_db` instead of emitting the raw `app_id` or always falling back to uppercase `AI`.

This restores the original "RESTORE ME" intent that looked up `plugin.name`, using the current apps document API (`plugins_data` by id), which is still valid.

## How the lookup works

1. Human senders stay labeled `User`.
2. For non-human messages with a non-blank `app_id`, `_resolve_sender_name` calls `get_app_by_id_db(app_id)`.
3. If the document exists and has a non-blank `name`, that display name is used as the sender label in both `get_messages_as_string` and `get_messages_as_xml`.
4. Lookups are cached per formatting call so repeated messages from the same app only hit the DB once.

## Fallback if the app is missing

If `app_id` is blank/whitespace, the app document is missing, or `name` is blank/whitespace, the formatter falls back to `message.sender.upper()` (typically `AI`). When the opt-in flag is false, labeling stays `AI` and no lookup runs.

## Product invariants affected

none

## How it was verified

Pending focused unit tests after PR open (`backend/test-preflight.sh` + `BACKEND_UNIT_TEST_FILE_LIST=tests/unit/test_message_formatting.py,tests/unit/test_chat_xml_preserve_spacing.py bash test.sh`).

## Tests

- Updated `backend/tests/unit/test_message_formatting.py` for display-name success, missing-app fallback, blank-name fallback, blank `app_id`, default opt-out, and per-`app_id` lookup caching.

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee907edc-2066-4ca8-ae08-567b80b8187c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee907edc-2066-4ca8-ae08-567b80b8187c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

