### PR TITLE
test(backend): cover DELETE /v1/knowledge-graph 200 and 500 DB paths

### DIFF
--- a/backend/tests/unit/test_knowledge_graph_delete_route.py
+++ b/backend/tests/unit/test_knowledge_graph_delete_route.py
@@ -1,0 +1,74 @@
+"""DELETE /v1/knowledge-graph DB-outcome paths with a mocked deletion call.
+
+Covers the delete handler in `routers/knowledge_graph.py`: a successful mocked
+`kg_db.delete_knowledge_graph` returns 200 with `status=deleted`, and a raised
+DB error surfaces as HTTP 500. The handler has no try/except around the delete,
+so Starlette turns the uncaught error into a 500.
+
+Canonical mutation gate cases (409/503) stay in
+`test_knowledge_graph_canonical_mutation_routes.py`.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from database import knowledge_graph as kg_db
+from routers import knowledge_graph as kg_router
+from utils.memory import canonical_graph as kg
+from utils.memory.v3.account_generation_source import (
+    V3AccountGenerationFailureReason as Reason,
+    V3TrustedAccountGenerationResult as TrustedHead,
+)
+from utils.other import endpoints as auth
+
+UID = "uid-delete-route"
+HEAD_PATH = f"users/{UID}/memory_state/head"
+
+
+def _legacy_principal(monkeypatch) -> None:
+    """No memory_state/head, no assertions — unlocks the legacy delete path."""
+    monkeypatch.setattr(kg, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(kg_router, "get_firestore_client", lambda: object())
+    monkeypatch.setattr(
+        kg,
+        "read_memory_v3_trusted_account_generation",
+        lambda **_kw: TrustedHead(uid=UID, source_path=HEAD_PATH, read_error_reason=Reason.MISSING_STATE_HEAD),
+    )
+    monkeypatch.setattr(kg_db, "has_stored_memory_graph_assertions", lambda uid, **_kw: False)
+
+
+def _delete_client(monkeypatch) -> TestClient:
+    monkeypatch.setattr(auth, "_enforce_rate_limit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(kg_router, "record_fallback", lambda **_kwargs: None)
+    app = FastAPI()
+    app.include_router(kg_router.router)
+    app.dependency_overrides[auth.get_current_user_uid] = lambda: UID
+    # Uncaught DB errors must become HTTP 500 rather than re-raising in the test client.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_delete_knowledge_graph_returns_200_when_db_delete_succeeds(monkeypatch):
+    _legacy_principal(monkeypatch)
+    deleted = []
+    monkeypatch.setattr(kg_db, "delete_knowledge_graph", lambda uid, **_kw: deleted.append(uid))
+
+    response = _delete_client(monkeypatch).delete("/v1/knowledge-graph")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "deleted"}
+    assert deleted == [UID]
+
+
+def test_delete_knowledge_graph_returns_500_when_db_delete_raises(monkeypatch):
+    _legacy_principal(monkeypatch)
+
+    def _boom(uid, **_kw):
+        raise RuntimeError("firestore unavailable")
+
+    monkeypatch.setattr(kg_db, "delete_knowledge_graph", _boom)
+
+    response = _delete_client(monkeypatch).delete("/v1/knowledge-graph")
+
+    assert response.status_code == 500


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Added `backend/tests/unit/test_knowledge_graph_delete_route.py` for `DELETE /v1/knowledge-graph` in `backend/routers/knowledge_graph.py`. The suite mocks `kg_db.delete_knowledge_graph` and asserts:

- **200** when the mocked delete succeeds (`status: deleted`)
- **500** when the mocked delete raises (`TestClient(..., raise_server_exceptions=False)`)

No production code changed.

## Assumptions

- A combined DB-outcome 200/500 pair for this delete handler did not already exist. The mutation-gate suite already covers a successful legacy delete (`test_legacy_principal_can_delete`); this file is the focused DB mock contract, including the previously missing 500 arm, with a matching 200 so the pair is self-contained.
- The handler has no try/except around `kg_db.delete_knowledge_graph`, so an uncaught DB error correctly surfaces as HTTP 500 via Starlette.
- Gate cases (409/503) remain owned by `test_knowledge_graph_canonical_mutation_routes.py` and are out of scope here.

## Product invariants affected

none

## How it was verified

```bash
BACKEND_UNIT_TEST_FILE_LIST=/tmp/kg-tests.txt bash test.sh
# tests/unit/test_knowledge_graph_delete_route.py
# tests/unit/test_knowledge_graph_canonical_mutation_routes.py
# → 2 passed + 20 passed
```

Pre-push bounded gate also passed.

## Tests

- `test_delete_knowledge_graph_returns_200_when_db_delete_succeeds`
- `test_delete_knowledge_graph_returns_500_when_db_delete_raises`

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93f46d1c-426b-42cf-a978-5f03bcef3ea6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93f46d1c-426b-42cf-a978-5f03bcef3ea6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

