### PR TITLE
fix(backend): keep memories user_review list filter in Python

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -207,6 +207,21 @@ _MEMORY_LIST_INDEX_FIELDS = (
 _MEMORY_LIST_CANDIDATE_WINDOW_MAX = 5000
 
 
+def _memory_passes_list_visibility(memory: Dict[str, Any], *, include_invalidated: bool) -> bool:
+    """Return whether a historical memory row should appear in list/read results.
+
+    Product rule: exclude user-rejected rows (``user_review is False``) and, unless
+    ``include_invalidated``, exclude superseded/retracted rows (``invalid_at`` set).
+
+    This cannot be expressed as a Firestore ``where`` without changing results for
+    legacy documents: inequality / ``not-in`` / ``!=`` exclude docs missing the
+    field, while ``== None`` only matches an explicit null — not a missing field.
+    Missing ``user_review`` and missing ``invalid_at`` both mean "still visible"
+    (see #4498). Closest safe query: omit those predicates and filter here.
+    """
+    return memory.get('user_review') is not False and (include_invalidated or memory.get('invalid_at') is None)
+
+
 def _memory_list_sort_key(memory: Dict[str, Any]) -> tuple[float, str]:
     value = memory.get('updated_at') or memory.get('created_at')
     if isinstance(value, str):
@@ -247,7 +262,7 @@ def _merge_memory_list_index_docs(
         (
             memory
             for memory in by_id.values()
-            if memory.get('user_review') is not False and (include_invalidated or memory.get('invalid_at') is None)
+            if _memory_passes_list_visibility(memory, include_invalidated=include_invalidated)
         ),
         key=_memory_list_sort_key,
     )
@@ -368,18 +383,18 @@ def get_memories(
         'created_at', direction=firestore.Query.DESCENDING
     )
 
+    # Closest safe Firestore query for this path: category / created_at bounds
+    # (applied above) plus scoring+created_at order, limit, and offset. Do not add
+    # ``user_review`` / ``invalid_at`` FieldFilters — see
+    # ``_memory_passes_list_visibility``. A server-side ``user_review != False``
+    # (or ``not-in [False]``) would also need a new composite index with scoring
+    # and still drop legacy docs missing the field (#4498).
     memories_ref = memories_ref.limit(limit).offset(offset)
 
-    # TODO: put user review to firestore query
     memories: List[Dict[str, Any]] = [_typed_doc(doc) for doc in memories_ref.stream()]
     logger.info(f"get_memories {len(memories)}")
-    # Exclude user-rejected memories, and (by default) superseded/retracted ones.
-    # invalid_at is filtered in Python: old docs lack the field (-> None -> active),
-    # which a Firestore `== None` filter would wrongly drop.
     result: List[Dict[str, Any]] = [
-        memory
-        for memory in memories
-        if memory.get('user_review') is not False and (include_invalidated or memory.get('invalid_at') is None)
+        memory for memory in memories if _memory_passes_list_visibility(memory, include_invalidated=include_invalidated)
     ]
     return result
 

--- a/backend/tests/unit/test_memories_user_review.py
+++ b/backend/tests/unit/test_memories_user_review.py
@@ -1,9 +1,105 @@
 """
 Tests for get_memories user_review filtering logic.
 Regression test for issue #4498: KeyError when user_review field missing.
+
+Also guards the decision to keep the filter in Python: Firestore cannot express
+``user_review is not False`` without dropping legacy docs that omit the field.
 """
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
 import pytest
+
+import database.memories as memories_db
+
+
+class _FakeDoc:
+    def __init__(self, data: Dict[str, Any]):
+        self.id = data['id']
+        self._data = dict(data)
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _RecordingQuery:
+    def __init__(self, db: "_FakeDB", docs: List[_FakeDoc], filters: Optional[List] = None):
+        self._db = db
+        self._docs = docs
+        self._filters = list(filters or [])
+        self._limit = None
+        self._offset = 0
+        self._db.last_query = self
+
+    @property
+    def recorded_filters(self) -> List[Any]:
+        return self._filters
+
+    def where(self, *args, **kwargs):
+        filt = kwargs.get('filter') or (args[0] if args else None)
+        q = _RecordingQuery(self._db, self._docs, self._filters + [filt])
+        q._limit = self._limit
+        q._offset = self._offset
+        return q
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def select(self, fields):
+        return self
+
+    def offset(self, n: int):
+        q = _RecordingQuery(self._db, self._docs, self._filters)
+        q._limit = self._limit
+        q._offset = n
+        return q
+
+    def limit(self, n: int):
+        q = _RecordingQuery(self._db, self._docs, self._filters)
+        q._limit = n
+        q._offset = self._offset
+        return q
+
+    def stream(self):
+        docs = self._docs
+        if self._offset:
+            docs = docs[self._offset :]
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        for doc in docs:
+            yield _FakeDoc({'id': doc.id, **doc._data})
+
+
+class _FakeDB:
+    def __init__(self, docs: List[_FakeDoc]):
+        self._docs = docs
+        self.last_query: Optional[_RecordingQuery] = None
+
+    def collection(self, _name: str):
+        return self
+
+    def document(self, _uid: str):
+        return SimpleNamespace(collection=self._user_collection)
+
+    def _user_collection(self, _name: str):
+        return _RecordingQuery(self, self._docs)
+
+
+def _memory_row(memory_id: str, **fields: Any) -> Dict[str, Any]:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    row = {
+        'id': memory_id,
+        'content': memory_id,
+        'category': 'interesting',
+        'created_at': now,
+        'updated_at': now,
+        'scoring': 1.0,
+    }
+    row.update(fields)
+    return row
 
 
 class TestUserReviewFilterLogic:
@@ -20,8 +116,12 @@ class TestUserReviewFilterLogic:
     """
 
     def filter_memories(self, memories: list) -> list:
-        """Replicate the filtering logic from get_memories()."""
-        return [memory for memory in memories if memory.get('user_review') is not False]
+        """Use the production list visibility helper."""
+        return [
+            memory
+            for memory in memories
+            if memories_db._memory_passes_list_visibility(memory, include_invalidated=False)
+        ]
 
     def test_memory_without_user_review_field_included(self):
         """Memory without user_review field should be included (not crash with KeyError)."""
@@ -65,6 +165,19 @@ class TestUserReviewFilterLogic:
         assert '3' in result_ids
         assert '4' not in result_ids
 
+    def test_invalid_at_excluded_unless_requested(self):
+        memories = [
+            {'id': 'active'},
+            {'id': 'gone', 'invalid_at': datetime(2026, 1, 2, tzinfo=timezone.utc)},
+        ]
+        assert [m['id'] for m in self.filter_memories(memories)] == ['active']
+        kept = [
+            memory
+            for memory in memories
+            if memories_db._memory_passes_list_visibility(memory, include_invalidated=True)
+        ]
+        assert [m['id'] for m in kept] == ['active', 'gone']
+
     def test_old_behavior_would_keyerror(self):
         """
         Verify that the old behavior (direct dict access) would raise KeyError.
@@ -75,3 +188,57 @@ class TestUserReviewFilterLogic:
         with pytest.raises(KeyError):
             # Old buggy code: memory['user_review']
             _ = [memory for memory in memories if memory['user_review'] is not False]
+
+
+def test_get_memories_scoring_path_filters_user_review_in_python_not_firestore():
+    """Scoring list omits a user_review FieldFilter; Python keeps missing-field rows.
+
+    A Firestore ``!= False`` / ``not-in [False]`` would exclude docs that omit
+    ``user_review``, changing GET /v3/memories results for legacy data (#4498).
+    """
+    docs = [
+        _FakeDoc(_memory_row('keep-missing')),
+        _FakeDoc(_memory_row('keep-none', user_review=None)),
+        _FakeDoc(_memory_row('keep-true', user_review=True)),
+        _FakeDoc(_memory_row('drop-false', user_review=False)),
+        _FakeDoc(
+            _memory_row(
+                'drop-invalid',
+                user_review=True,
+                invalid_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            )
+        ),
+    ]
+    fake_db = _FakeDB(docs)
+
+    with patch.object(memories_db, '_prepare_memory_for_read', side_effect=lambda data, _uid: data):
+        result = memories_db.get_memories(
+            'uid-review', limit=10, offset=0, sort='scoring_desc', firestore_client=fake_db
+        )
+
+    assert [row['id'] for row in result] == ['keep-missing', 'keep-none', 'keep-true']
+    assert fake_db.last_query is not None
+    filter_fields = [
+        getattr(filt, 'field_path', None) or getattr(filt, 'field', None)
+        for filt in fake_db.last_query.recorded_filters
+    ]
+    assert 'user_review' not in filter_fields
+    assert 'invalid_at' not in filter_fields
+
+
+def test_merge_memory_list_index_docs_applies_same_visibility_helper():
+    class _Doc:
+        def __init__(self, payload):
+            self.id = payload['id']
+            self._payload = payload
+
+        def to_dict(self):
+            return dict(self._payload)
+
+    docs = [
+        _Doc(_memory_row('a', user_review=False)),
+        _Doc(_memory_row('b')),
+        _Doc(_memory_row('c', user_review=True, invalid_at=datetime(2026, 1, 3, tzinfo=timezone.utc))),
+    ]
+    merged = memories_db._merge_memory_list_index_docs(docs, include_invalidated=False)
+    assert [row['id'] for row in merged] == ['b']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Investigated moving the `user_review` list filter in `backend/database/memories.py` into Firestore. Firestore cannot express `user_review is not False` without dropping legacy docs that omit the field (#4498): inequality / `not-in` / `!=` exclude missing fields, and `== None` only matches explicit null. Closest safe query remains category/date bounds + scoring order + limit/offset, with visibility applied in Python via a shared helper (same semantics as before).

## Product invariants affected

- INV-MEM-1

## How it was verified

```bash
cd backend && source .venv/bin/activate
python -m pytest tests/unit/test_memories_user_review.py tests/unit/test_bounded_firestore_list_reads.py tests/unit/test_memories_pagination_clamp.py tests/unit/test_firestore_di_seam.py -q
# 34 passed
```

External API results unchanged: still includes missing/`None`/`True` `user_review`, excludes `False`, and keeps default `invalid_at` exclusion.

## Tests

- Extended `tests/unit/test_memories_user_review.py` to exercise production `_memory_passes_list_visibility`
- Added scoring-path fake asserting no `user_review`/`invalid_at` FieldFilter while Python still filters correctly
- Added merge-index coverage for the same helper

## Failure class (fixes)

Failure-Class: none
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c832a620-b65d-44d3-b9e8-e18e2ae1a492?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c832a620-b65d-44d3-b9e8-e18e2ae1a492&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

