### PR TITLE
docs(backend): defer Person photo until product picks storage

### DIFF
--- a/backend/models/other.py
+++ b/backend/models/other.py
@@ -35,6 +35,10 @@ class CreatePerson(BaseModel):
     name: str = Field(min_length=2, max_length=40)
 
 
+# Person photo deferred pending product input on storage: no photo/avatar/image
+# field today; GCS people_profiles/ is speech-sample audio only; the app uses
+# local speaker icons; unlike app/persona logos there is no person-photo URL or
+# upload pattern to mirror. Do not invent an optional photo string yet.
 class Person(BaseModel):
     id: str
     name: str

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -614,7 +614,7 @@ def get_private_cloud_sync(uid: str = Depends(auth.get_current_user_uid)):
 # ****************************************
 
 
-# TODO: consider adding person photo.
+# Person photo deferred — see models.other.Person (no photo field / storage yet).
 @router.post('/v1/users/people', tags=['v1'], response_model=Person)
 def get_or_create_person(data: CreatePerson, uid: str = Depends(auth.get_current_user_uid)):
     """Create a new person or return existing one with same name (idempotent by name).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

**Decision: defer adding a Person photo field** (do not ship an optional URL or upload pipeline in this PR).

Investigation on current `main`:
- `models.other.Person` / `CreatePerson` have **no** `photo` / `avatar` / `image` field (only name, timestamps, speech-sample fields).
- The people CRUD routes already had `# TODO: consider adding person photo.`
- Nearby people storage (`GCS …/people_profiles/{person_id}/`) is **speech-sample audio only**, not images.
- The Flutter Person UI uses local speaker icons / `colorIdx`, not a remote photo.
- App/persona logos and Firebase Auth `photo_url` are different entities — not a Person photo contract to mirror.

Per the task guidance: without an existing person-photo storage pattern, inventing an optional URL or upload path is product input, not a safe engineering default. This PR only replaces the open TODO with an explicit deferral note on `Person` and a pointer in `routers/users.py`.

## Product invariants affected

none

## How it was verified

- Inspected `backend/models/other.py`, people CRUD in `backend/routers/users.py`, GCS helpers under `people_profiles/`, and `app/lib/backend/schema/person.dart`.
- Confirmed no Person photo/avatar/image field and no person-photo upload pattern.
- Pre-push gate passed (comment-only; OpenAPI unchanged because the note is a `#` comment, not a Pydantic docstring).

## Tests

No test change: documentation/comment only; schema and runtime behavior unchanged.

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7aed208-5f81-4fb1-8ba1-92d8848ddc31?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7aed208-5f81-4fb1-8ba1-92d8848ddc31&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

