### PR TITLE
harden(app): migrate authToken to flutter_secure_storage

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -111,7 +111,7 @@ PR CI runs `flutter test` and an analyzer ratchet (`app/scripts/analyze_ratchet.
 ### Token Lifecycle
 1. `getAuthHeader()` in `lib/backend/http/shared.dart` checks token expiry (5-minute buffer)
 2. If expired, calls `AuthService.instance.getIdToken()` for Firebase refresh
-3. Token stored in SharedPreferencesUtil with expiration timestamp
+3. Token stored via SharedPreferencesUtil in flutter_secure_storage (Keychain / EncryptedSharedPreferences); expiration timestamp stays in SharedPreferences. One-time migrateAuthTokenFromPrefs() runs at SharedPreferencesUtil.init() so existing sessions keep their token.
 4. 401 responses trigger automatic refresh + retry
 
 ### Auth Methods

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:io' show Platform;
 
 import 'package:collection/collection.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:omi/backend/schema/app.dart';
@@ -16,6 +19,17 @@ import 'package:omi/utils/logger.dart';
 class SharedPreferencesUtil {
   static final SharedPreferencesUtil _instance = SharedPreferencesUtil._internal();
   static SharedPreferences? _preferences;
+  static FlutterSecureStorage? _secureStorage;
+
+  /// In-memory cache so [authToken] stays a sync getter (call sites are sync).
+  static String _authTokenCache = '';
+
+  /// Used under `flutter test` when no [FlutterSecureStorage] is injected, so
+  /// production code never calls `@visibleForTesting` mock APIs.
+  static Map<String, String>? _testSecureFallback;
+
+  static const String _authTokenSecureKey = 'authToken';
+  static const String _authTokenMigratedPrefsKey = 'authTokenSecureMigrated';
 
   factory SharedPreferencesUtil() {
     return _instance;
@@ -26,8 +40,80 @@ class SharedPreferencesUtil {
   String get deviceIdHash => _preferences?.getString('deviceIdHash') ?? '';
   set deviceIdHash(String value) => _preferences?.setString('deviceIdHash', value);
 
-  static Future<void> init() async {
+  static Future<void> init({FlutterSecureStorage? secureStorage}) async {
     _preferences = await SharedPreferences.getInstance();
+    if (secureStorage != null) {
+      _secureStorage = secureStorage;
+      _testSecureFallback = null;
+    } else if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      // Hermetic unit tests have no secure-storage plugin channel.
+      _secureStorage = null;
+      _testSecureFallback = <String, String>{};
+    } else {
+      _secureStorage = const FlutterSecureStorage(
+        aOptions: AndroidOptions(encryptedSharedPreferences: true),
+      );
+      _testSecureFallback = null;
+    }
+    await migrateAuthTokenFromPrefs();
+    _authTokenCache = await _readSecureAuthToken() ?? '';
+  }
+
+  /// One-time move of `authToken` from SharedPreferences into secure storage.
+  ///
+  /// Called from [init] at startup. Idempotent: a prefs flag skips work after
+  /// the first successful pass. If secure storage already has a token, the
+  /// prefs copy is discarded so we never overwrite a newer secure value.
+  static Future<void> migrateAuthTokenFromPrefs() async {
+    final prefs = _preferences;
+    if (prefs == null || (_secureStorage == null && _testSecureFallback == null)) return;
+    if (prefs.getBool(_authTokenMigratedPrefsKey) == true) {
+      // Scrub any prefs residue written after migration (e.g. stale native/cache paths).
+      if (prefs.containsKey('authToken')) {
+        await prefs.remove('authToken');
+      }
+      return;
+    }
+
+    final legacyToken = prefs.getString('authToken');
+    try {
+      final existingSecure = await _readSecureAuthToken();
+      if ((existingSecure == null || existingSecure.isEmpty) && legacyToken != null && legacyToken.isNotEmpty) {
+        await _writeSecureAuthToken(legacyToken);
+      }
+      if (legacyToken != null) {
+        await prefs.remove('authToken');
+      }
+      await prefs.setBool(_authTokenMigratedPrefsKey, true);
+    } catch (e, stack) {
+      // Leave the prefs copy and migration flag unset so the next launch retries.
+      Logger.debug('authToken secure migration failed: $e');
+      Logger.debug('Stack: $stack');
+    }
+  }
+
+  static Future<String?> _readSecureAuthToken() async {
+    final fallback = _testSecureFallback;
+    if (fallback != null) return fallback[_authTokenSecureKey];
+    return _secureStorage?.read(key: _authTokenSecureKey);
+  }
+
+  static Future<void> _writeSecureAuthToken(String value) async {
+    final fallback = _testSecureFallback;
+    if (fallback != null) {
+      fallback[_authTokenSecureKey] = value;
+      return;
+    }
+    await _secureStorage?.write(key: _authTokenSecureKey, value: value);
+  }
+
+  static Future<void> _deleteSecureAuthToken() async {
+    final fallback = _testSecureFallback;
+    if (fallback != null) {
+      fallback.remove(_authTokenSecureKey);
+      return;
+    }
+    await _secureStorage?.delete(key: _authTokenSecureKey);
   }
 
   /// Picks up values written natively (the Dart cache doesn't see those otherwise).
@@ -677,9 +763,16 @@ class SharedPreferencesUtil {
 
   //--------------------------------- Auth ------------------------------------//
 
-  String get authToken => getString('authToken');
+  String get authToken => _authTokenCache;
 
-  set authToken(String value) => saveString('authToken', value);
+  set authToken(String value) {
+    _authTokenCache = value;
+    if (value.isEmpty) {
+      unawaited(_deleteSecureAuthToken());
+    } else {
+      unawaited(_writeSecureAuthToken(value));
+    }
+  }
 
   int get tokenExpirationTime => getInt('tokenExpirationTime');
 
@@ -835,5 +928,9 @@ class SharedPreferencesUtil {
 
   Future<bool> remove(String key) async => await _preferences?.remove(key) ?? false;
 
-  Future<bool> clear() async => await _preferences?.clear() ?? false;
+  Future<bool> clear() async {
+    _authTokenCache = '';
+    await _deleteSecureAuthToken();
+    return await _preferences?.clear() ?? false;
+  }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -760,6 +760,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_sound:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -78,6 +78,8 @@ dependencies:
   phone_numbers_parser: ^9.0.25
   share_plus: 11.0.0
   shared_preferences: 2.5.3
+  # Auth token only — Keychain (iOS/macOS) / EncryptedSharedPreferences (Android).
+  flutter_secure_storage: 9.2.4
   url_launcher: ^6.3.0
   wav: ^1.4.0
   path: ^1.9.0

--- a/app/test/unit/auth_token_secure_storage_migration_test.dart
+++ b/app/test/unit/auth_token_secure_storage_migration_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('migrateAuthTokenFromPrefs moves legacy prefs token into secure storage once', () async {
+    SharedPreferences.setMockInitialValues({
+      'authToken': 'legacy-session-token',
+      'tokenExpirationTime': 42,
+      'uid': 'user-1',
+    });
+    FlutterSecureStorage.setMockInitialValues({});
+
+    const secure = FlutterSecureStorage();
+    await SharedPreferencesUtil.init(secureStorage: secure);
+
+    expect(SharedPreferencesUtil().authToken, 'legacy-session-token');
+    expect(await secure.read(key: 'authToken'), 'legacy-session-token');
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey('authToken'), isFalse);
+    expect(prefs.getBool('authTokenSecureMigrated'), isTrue);
+    // Non-secret expiry stays in SharedPreferences.
+    expect(SharedPreferencesUtil().tokenExpirationTime, 42);
+    expect(SharedPreferencesUtil().uid, 'user-1');
+
+    // Second init must not wipe the secure token or re-read a prefs copy.
+    await prefs.setString('authToken', 'should-be-ignored');
+    await SharedPreferencesUtil.init(secureStorage: secure);
+    expect(SharedPreferencesUtil().authToken, 'legacy-session-token');
+    expect(await secure.read(key: 'authToken'), 'legacy-session-token');
+    expect(prefs.containsKey('authToken'), isFalse);
+  });
+
+  test('migrateAuthTokenFromPrefs does not overwrite an existing secure token', () async {
+    SharedPreferences.setMockInitialValues({'authToken': 'stale-prefs-token'});
+    FlutterSecureStorage.setMockInitialValues({'authToken': 'secure-token'});
+
+    const secure = FlutterSecureStorage();
+    await SharedPreferencesUtil.init(secureStorage: secure);
+
+    expect(SharedPreferencesUtil().authToken, 'secure-token');
+    expect(await secure.read(key: 'authToken'), 'secure-token');
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey('authToken'), isFalse);
+    expect(prefs.getBool('authTokenSecureMigrated'), isTrue);
+  });
+
+  test('authToken setter writes secure storage and clear removes it', () async {
+    SharedPreferences.setMockInitialValues({});
+    FlutterSecureStorage.setMockInitialValues({});
+    const secure = FlutterSecureStorage();
+    await SharedPreferencesUtil.init(secureStorage: secure);
+
+    SharedPreferencesUtil().authToken = 'fresh-token';
+    // Allow the fire-and-forget write to complete.
+    await Future<void>.delayed(Duration.zero);
+    expect(await secure.read(key: 'authToken'), 'fresh-token');
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey('authToken'), isFalse);
+
+    await SharedPreferencesUtil().clear();
+    expect(SharedPreferencesUtil().authToken, isEmpty);
+    expect(await secure.read(key: 'authToken'), isNull);
+  });
+
+  test('init under flutter_test migrates prefs token without a plugin channel', () async {
+    SharedPreferences.setMockInitialValues({'authToken': 'test-fallback-token'});
+    await SharedPreferencesUtil.init();
+
+    expect(SharedPreferencesUtil().authToken, 'test-fallback-token');
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey('authToken'), isFalse);
+    expect(prefs.getBool('authTokenSecureMigrated'), isTrue);
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Auth tokens were stored in plaintext SharedPreferences. This moves `authToken` into `flutter_secure_storage` (iOS/macOS Keychain, Android EncryptedSharedPreferences) with a one-time startup migration so existing logged-in sessions are not logged out. `flutter_secure_storage` was not previously used in the app; this adds the dependency rather than duplicating an existing token path.

## Migration path and assumptions

1. **Startup:** `SharedPreferencesUtil.init()` (already called from `main.dart`) runs `migrateAuthTokenFromPrefs()` once, then loads the token into an in-memory cache so existing sync getters/setters keep working.
2. **One-time:** Prefs flag `authTokenSecureMigrated` makes migration idempotent. After success, any leftover prefs `authToken` is scrubbed.
3. **Conflict rule:** If secure storage already has a token, the prefs copy is discarded (never overwrites secure with stale prefs).
4. **Failure:** If secure write fails, the prefs copy and migration flag are left alone so the next launch retries — users stay logged in.
5. **Scope:** Only `authToken` moves. `tokenExpirationTime` and other identity fields (`uid`, email, names) stay in SharedPreferences (non-secret / display cache).
6. **Clearing:** `authToken = ''`, `clearUserDisplayCache()`, and `clear()` all clear the in-memory cache and delete the secure entry.
7. **Tests:** Under `FLUTTER_TEST` without an injected store, an in-memory fallback is used so hermetic tests do not need the plugin channel. Migration tests inject a mocked `FlutterSecureStorage`.

## Product invariants affected

none

## How it was verified

- `flutter test test/unit/auth_token_secure_storage_migration_test.dart test/unit/auth_service_token_result_test.dart test/unit/clear_deleted_account_session_test.dart` — all passed
- `flutter analyze lib/backend/preferences.dart test/unit/auth_token_secure_storage_migration_test.dart` — no issues
- `app/scripts/analyze_ratchet.sh` — passed
- Bounded pre-push gate passed; full Flutter suite deferred to CI

Could not exercise a real device login → kill → relaunch path on this Linux cloud VM (no iOS/Android runtime here).

## Tests

- New: `app/test/unit/auth_token_secure_storage_migration_test.dart` — migrates legacy prefs token once; does not overwrite existing secure token; setter/clear round-trip; flutter_test fallback path
- Existing auth/clear-session tests still pass with the new storage seam

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54bac567-33ed-40e8-92f1-7b8edd98b350?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54bac567-33ed-40e8-92f1-7b8edd98b350&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

