### PR TITLE
refactor(backend): combine RAG embedding visualization helpers

### DIFF
--- a/backend/scripts/rag/current.py
+++ b/backend/scripts/rag/current.py
@@ -78,61 +78,6 @@ def get_markers(
     )
 
 
-def generate_topics_visualization(
-    topics: List[str], file_path: str = 'embedding_visualization_multi_topic.html'
-) -> None:
-    # context: Tuple = determine_requires_context(conversation)
-    # if not context or not context[0]:
-    #     print('No context is needed')
-    #     return
-    # topics = context[0]
-    # topics = ['Business', 'Entrepreneurship', 'Failures']
-    os.makedirs('visualizations/', exist_ok=True)
-    file_path = os.path.join('visualizations/', file_path)
-
-    data = get_data(topics)
-    all_embeddings = cast(Any, np.array([item[1] for item in data.values()]))
-
-    topic_embeddings = [openai_embeddings.embed_query(topic) for topic in topics]
-    all_embeddings = cast(Any, np.vstack([all_embeddings] + topic_embeddings))
-
-    umap_transform = cast(Any, umap.UMAP(n_components=2, random_state=0, transform_seed=0))
-    umap_embeddings = umap_transform.fit_transform(all_embeddings)
-
-    data_points = umap_embeddings[: -len(topics)]
-    topic_points = umap_embeddings[-len(topics) :]
-
-    fig: Any = make_subplots(rows=1, cols=1)
-
-    colors = ['blue', 'green', 'orange', 'purple', 'cyan', 'magenta']
-
-    # Add all vectors
-    fig.add_trace(get_markers(data, data_points, 'gray', 'All Vectors'))
-
-    # Add vectors for each topic
-    for i, topic in enumerate(topics):
-        color = colors[i % len(colors)]
-        topic_data = {mid: item for mid, item in data.items() if topic in item[2]}
-        topic_data_points = cast(
-            Any, np.array([data_points[list(data.keys()).index(mid)] for mid in topic_data.keys()])
-        )
-
-        fig.add_trace(get_markers(topic_data, topic_data_points, color, f'Top 5 - {topic}'))
-        fig.add_trace(get_query_marker(topic_points[i], topic))
-
-    fig.update_layout(
-        title='Embedding Visualization for Multiple Topics',
-        xaxis_title='UMAP Dimension 1',
-        yaxis_title='UMAP Dimension 2',
-        width=800,
-        height=600,
-        showlegend=True,
-        hovermode='closest',
-    )
-
-    generate_html_visualization(fig, file_name=file_path)
-
-
 def get_data2(topics: List[str], retrieved_memories: List[Conversation]) -> dict[str, List[Any]]:
     # print('get_data2', len(topics), topics)
     # print('retrieved_memories', len(retrieved_memories))
@@ -157,14 +102,24 @@ def get_data2(topics: List[str], retrieved_memories: List[Conversation]) -> dict
 
 
 def generate_visualization(
-    topics: List[str], memories: List[Conversation], file_path: str = 'embedding_visualization_multi_topic.html'
+    topics: List[str],
+    memories: List[Conversation] | None = None,
+    file_path: str = 'embedding_visualization_multi_topic.html',
 ) -> None:
-    # TODO: combine in single function
+    # context: Tuple = determine_requires_context(conversation)
+    # if not context or not context[0]:
+    #     print('No context is needed')
+    #     return
+    # topics = context[0]
+    # topics = ['Business', 'Entrepreneurship', 'Failures']
     print('topics', topics)
     os.makedirs('visualizations/', exist_ok=True)
     file_path = os.path.join('visualizations/', file_path)
 
-    data = get_data2(topics, memories)
+    if memories is not None:
+        data = get_data2(topics, memories)
+    else:
+        data = get_data(topics)
     # print('data', len(data))
     all_embeddings = cast(Any, np.array([item[1] for item in data.values()]))
 
@@ -209,4 +164,4 @@ def generate_visualization(
 
 
 if __name__ == '__main__':
-    generate_topics_visualization([])
+    generate_visualization([])

--- a/backend/tests/unit/test_rag_visualization.py
+++ b/backend/tests/unit/test_rag_visualization.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+
+RAG_CURRENT_PATH = str(Path(__file__).resolve().parents[2] / 'scripts' / 'rag' / 'current.py')
+
+
+def _load_visualization_module():
+    shared = AutoMockModule('_shared')
+    chat = AutoMockModule('models.chat')
+    conversation = AutoMockModule('models.conversation')
+    umap_module = ModuleType('umap')
+    plotly_module = ModuleType('plotly')
+    plotly_subplots = ModuleType('plotly.subplots')
+    plotly_subplots.make_subplots = MagicMock()
+    plotly_module.subplots = plotly_subplots
+    umap_module.UMAP = MagicMock()
+    with stub_modules(
+        {
+            '_shared': shared,
+            'models.chat': chat,
+            'models.conversation': conversation,
+            'umap': umap_module,
+            'plotly': plotly_module,
+            'plotly.subplots': plotly_subplots,
+        }
+    ):
+        return load_module_fresh('rag_current_visualization', RAG_CURRENT_PATH), umap_module
+
+
+def test_generate_visualization_uses_get_data_without_memories(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    module.get_data = MagicMock(
+        return_value={
+            'memory-1': ['First', [1.0, 0.0], ['topic']],
+            'memory-2': ['Second', [0.0, 1.0], []],
+        }
+    )
+    module.get_data2 = MagicMock()
+    module.openai_embeddings = SimpleNamespace(embed_query=lambda topic: [0.5, 0.5])
+    module.get_markers = MagicMock(return_value=object())
+    module.get_query_marker = MagicMock(return_value=object())
+    module.generate_html_visualization = MagicMock()
+    figure = MagicMock()
+    module.make_subplots = MagicMock(return_value=figure)
+    umap_instance = MagicMock()
+    umap_instance.fit_transform.return_value = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    umap_module.UMAP.return_value = umap_instance
+
+    module.generate_visualization(['topic'])
+
+    module.get_data.assert_called_once_with(['topic'])
+    module.get_data2.assert_not_called()
+    assert umap_module.UMAP.call_args.kwargs == {
+        'n_components': 2,
+        'random_state': 0,
+        'transform_seed': 0,
+    }
+    assert module.generate_html_visualization.called
+
+
+def test_generate_visualization_uses_get_data2_with_memories(monkeypatch, tmp_path):
+    module, umap_module = _load_visualization_module()
+    monkeypatch.chdir(tmp_path)
+    memories = [SimpleNamespace(id='memory-1')]
+    module.get_data = MagicMock()
+    module.get_data2 = MagicMock(
+        return_value={
+            'memory-1': ['First', [1.0, 0.0], ['topic']],
+            'memory-2': ['Second', [0.0, 1.0], []],
+        }
+    )
+    module.openai_embeddings = SimpleNamespace(embed_query=lambda topic: [0.5, 0.5])
+    module.get_markers = MagicMock(return_value=object())
+    module.get_query_marker = MagicMock(return_value=object())
+    module.generate_html_visualization = MagicMock()
+    figure = MagicMock()
+    module.make_subplots = MagicMock(return_value=figure)
+    umap_instance = MagicMock()
+    umap_instance.fit_transform.return_value = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+    umap_module.UMAP.return_value = umap_instance
+
+    module.generate_visualization(['topic'], memories)
+
+    module.get_data2.assert_called_once_with(['topic'], memories)
+    module.get_data.assert_not_called()
+    assert module.generate_html_visualization.called


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Combined the duplicate embedding visualization entrypoints in `backend/scripts/rag/current.py`:

- **`generate_topics_visualization`** → folded into **`generate_visualization`**
- Shared UMAP + Plotly HTML pipeline is now one function
- Data source still differs only by caller intent: `get_data(topics)` when `memories` is omitted; `get_data2(topics, memories)` when retrieved memories are passed (Streamlit app path)

Plot construction (UMAP kwargs, marker traces, layout, HTML write) is unchanged so visualization output stays the same for the previous call paths. `__main__` now calls `generate_visualization([])`.

## Product invariants affected

none

## How it was verified

```bash
echo 'tests/unit/test_rag_visualization.py' > /tmp/omi-rag-viz-tests.txt
BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-rag-viz-tests.txt bash backend/test.sh
```

Result: 2 passed.

Pre-push bounded gate also passed (`black --check` clean on the two touched files).

Could not exercise the live Streamlit/Pinecone visualization path in this environment (needs live embeddings/index credentials).

## Tests

Added `backend/tests/unit/test_rag_visualization.py` sanity check covering both combined branches (`get_data` vs `get_data2`) and asserting UMAP is still constructed with `n_components=2, random_state=0, transform_seed=0`.

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d155a3cb-a8c0-473e-9557-735961eb4717?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d155a3cb-a8c0-473e-9557-735961eb4717&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

