### PR TITLE
feat(backend): lock, chunk, and validate audio-bytes developer webhooks

### DIFF
--- a/backend/tests/unit/test_async_webhooks.py
+++ b/backend/tests/unit/test_async_webhooks.py
@@ -5,6 +5,7 @@ use httpx.AsyncClient instead of blocking requests.post.
 """
 
 import ast
+import asyncio
 import os
 import re
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -174,6 +175,79 @@ class TestSendAudioBytesDeveloperWebhook:
         ):
             await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00'))
             mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_webhook_url_skips(self):
+        mock_client = AsyncMock()
+
+        with patch("utils.webhooks.get_user_webhook_db", return_value="ftp://evil.example/audio,5"), patch(
+            "utils.webhooks.get_webhook_client", return_value=mock_client
+        ):
+            await send_audio_bytes_developer_webhook("uid-1", 8000, bytearray(b'\x00' * 100))
+            mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_sample_rate_skips(self):
+        mock_client = AsyncMock()
+
+        with patch("utils.webhooks.get_webhook_client", return_value=mock_client):
+            await send_audio_bytes_developer_webhook("uid-1", 12, bytearray(b'\x00' * 100))
+            mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_large_payload_is_sent_in_one_second_chunks(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        sample_rate = 8000
+        chunk_size = sample_rate * 2  # 1s of PCM16 mono
+        payload = bytearray(b'\x11' * (chunk_size + 100))
+
+        with patch("utils.webhooks.get_webhook_client", return_value=mock_client):
+            await send_audio_bytes_developer_webhook("uid-1", sample_rate, payload)
+
+        assert mock_client.post.call_count == 2
+        first = mock_client.post.call_args_list[0].kwargs["content"]
+        second = mock_client.post.call_args_list[1].kwargs["content"]
+        assert len(first) == chunk_size
+        assert len(second) == 100
+        assert first + second == bytes(payload)
+
+    @pytest.mark.asyncio
+    async def test_per_uid_lock_serializes_overlapping_sends(self):
+        release_first = asyncio.Event()
+        first_started = asyncio.Event()
+        call_order: list[str] = []
+
+        async def slow_then_fast_post(url, **kwargs):
+            call_order.append("enter")
+            if not first_started.is_set():
+                first_started.set()
+                await release_first.wait()
+            call_order.append("exit")
+            response = MagicMock()
+            response.status_code = 200
+            return response
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=slow_then_fast_post)
+
+        with patch("utils.webhooks.get_webhook_client", return_value=mock_client), patch(
+            "utils.webhooks._get_dev_webhook_retry_delays", return_value=()
+        ):
+            first = asyncio.create_task(send_audio_bytes_developer_webhook("uid-lock", 8000, bytearray(b'\x01')))
+            await first_started.wait()
+            second = asyncio.create_task(send_audio_bytes_developer_webhook("uid-lock", 8000, bytearray(b'\x02')))
+            await asyncio.sleep(0)
+            assert call_order == ["enter"]
+            release_first.set()
+            await asyncio.gather(first, second)
+
+        assert call_order == ["enter", "exit", "enter", "exit"]
+        assert mock_client.post.call_count == 2
 
 
 class TestConversationAndSummaryWebhooksStructural:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -1,9 +1,10 @@
 import asyncio
 import json
 import os
+import re
 import uuid
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Iterable, List, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from database.redis_db import (
@@ -27,6 +28,66 @@ import logging
 logger = logging.getLogger(__name__)
 
 _DEV_WEBHOOK_RETRY_DELAYS = (1.0, 5.0, 30.0)
+
+_AUDIO_BYTES_WEBHOOK_CHUNK_SECONDS = 1
+_AUDIO_BYTES_WEBHOOK_MIN_SAMPLE_RATE = 1000
+_AUDIO_BYTES_WEBHOOK_MAX_SAMPLE_RATE = 192000
+_HTTP_WEBHOOK_URL_RE = re.compile(
+    r'^https?://'
+    r'(?:'
+    r'(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,}|'
+    r'localhost|'
+    r'\d{1,3}(?:\.\d{1,3}){3}'
+    r')'
+    r'(?::\d{1,5})?'
+    r'(?:/[^\s]*)?$',
+    re.IGNORECASE,
+)
+_UID_RE = re.compile(r'^[A-Za-z0-9_-]{1,128}$')
+_SAMPLE_RATE_RE = re.compile(r'^[1-9]\d{2,5}$')
+
+_audio_bytes_send_locks: dict[str, asyncio.Lock] = {}
+_audio_bytes_send_locks_guard = asyncio.Lock()
+
+
+async def _get_audio_bytes_send_lock(uid: str) -> asyncio.Lock:
+    async with _audio_bytes_send_locks_guard:
+        lock = _audio_bytes_send_locks.get(uid)
+        if lock is None:
+            lock = asyncio.Lock()
+            _audio_bytes_send_locks[uid] = lock
+        return lock
+
+
+def _is_valid_audio_bytes_webhook_url(url: str) -> bool:
+    if not url:
+        return False
+    candidate = url.strip()
+    if not _HTTP_WEBHOOK_URL_RE.fullmatch(candidate):
+        return False
+    parts = urlsplit(candidate)
+    return parts.scheme in ('http', 'https') and bool(parts.netloc)
+
+
+def _is_valid_audio_bytes_payload_fields(uid: str, sample_rate: int) -> bool:
+    if not isinstance(uid, str) or not _UID_RE.fullmatch(uid):
+        return False
+    if not isinstance(sample_rate, int) or isinstance(sample_rate, bool):
+        return False
+    if not _SAMPLE_RATE_RE.fullmatch(str(sample_rate)):
+        return False
+    return _AUDIO_BYTES_WEBHOOK_MIN_SAMPLE_RATE <= sample_rate <= _AUDIO_BYTES_WEBHOOK_MAX_SAMPLE_RATE
+
+
+def _audio_bytes_chunk_size(sample_rate: int) -> int:
+    return max(sample_rate, 1) * 2 * _AUDIO_BYTES_WEBHOOK_CHUNK_SECONDS
+
+
+def _iter_audio_bytes_chunks(data: bytearray | bytes, sample_rate: int) -> Iterable[bytes]:
+    chunk_size = _audio_bytes_chunk_size(sample_rate)
+    raw = memoryview(data)
+    for start in range(0, len(raw), chunk_size):
+        yield bytes(raw[start : start + chunk_size])
 
 
 def _get_dev_webhook_retry_delays() -> tuple[float, ...]:
@@ -311,41 +372,56 @@ def get_audio_bytes_webhook_seconds(uid: str):
 
 async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: bytearray):
     logger.info(f"send_audio_bytes_developer_webhook {uid}")
-    # TODO: add a lock, send shorter segments, validate regex.
+    if not data:
+        return
+    if not _is_valid_audio_bytes_payload_fields(uid, sample_rate):
+        logger.warning(
+            f'send_audio_bytes_developer_webhook: invalid payload fields uid={uid!r} sample_rate={sample_rate!r}'
+        )
+        return
+
     toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.audio_bytes)
-    if toggled:
-        webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
-        if not webhook_url:
-            return
-        webhook_url = webhook_url_from_setting(WebhookType.audio_bytes, webhook_url)
-        if not webhook_url:
-            return
-        webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
-        cb = get_webhook_circuit_breaker(webhook_url)
-        if not cb.allow_request():
-            logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
-            return
+    if not toggled:
+        return
+
+    webhook_setting = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.audio_bytes)
+    if not webhook_setting:
+        return
+    webhook_url = webhook_url_from_setting(WebhookType.audio_bytes, webhook_setting)
+    if not _is_valid_audio_bytes_webhook_url(webhook_url):
+        logger.warning(f'send_audio_bytes_developer_webhook: invalid webhook url for uid={uid}')
+        return
+
+    webhook_url = _append_query_params(webhook_url, {'sample_rate': sample_rate, 'uid': uid})
+    cb = get_webhook_circuit_breaker(webhook_url)
+    if not cb.allow_request():
+        logger.info(f'send_audio_bytes_developer_webhook: circuit breaker open for {webhook_url[:80]}')
+        return
+
+    lock = await _get_audio_bytes_send_lock(uid)
+    async with lock:
         try:
-            response = await _post_dev_webhook(
-                'send_audio_bytes_developer_webhook',
-                webhook_url,
-                content=bytes(data),
-                headers={'Content-Type': 'application/octet-stream'},
-            )
-            if response.status_code >= 200 and response.status_code < 300:
-                cb.record_success()
-                await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.audio_bytes)
-            else:
-                cb.record_failure()
-                should_disable = await run_blocking(
-                    db_executor,
-                    record_dev_webhook_failure,
-                    uid,
-                    WebhookType.audio_bytes,
-                    response.status_code,
-                    f'HTTP {response.status_code}',
+            for chunk in _iter_audio_bytes_chunks(data, sample_rate):
+                response = await _post_dev_webhook(
+                    'send_audio_bytes_developer_webhook',
+                    webhook_url,
+                    content=chunk,
+                    headers={'Content-Type': 'application/octet-stream'},
                 )
-                await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+                if not (200 <= response.status_code < 300):
+                    cb.record_failure()
+                    should_disable = await run_blocking(
+                        db_executor,
+                        record_dev_webhook_failure,
+                        uid,
+                        WebhookType.audio_bytes,
+                        response.status_code,
+                        f'HTTP {response.status_code}',
+                    )
+                    await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
+                    return
+            cb.record_success()
+            await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.audio_bytes)
         except Exception as e:
             cb.record_failure()
             should_disable = await run_blocking(
@@ -353,8 +429,6 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             )
             await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
             logger.error(f"Error sending audio bytes to developer webhook: {e}")
-    else:
-        return
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Fills the longstanding `TODO` on `send_audio_bytes_developer_webhook`: overlapping per-uid sends are serialized, large PCM payloads are split into shorter POSTs, and webhook URL / payload fields are regex-validated before delivery.

Related: narrower alternative to the still-open expansive #11353 (Redis lock + pusher/http_client changes). This PR stays scoped to `utils/webhooks.py` + unit tests.

## Lock scope

- **What:** in-process `asyncio.Lock` keyed by `uid`
- **Held for:** the full multi-chunk delivery for that uid (all sequential POSTs)
- **Not covered:** cross-pod overlap (no Redis). Same-process concurrent calls from the audio-bytes queue are the race this TODO targeted.

## Chunk size

- **1 second of PCM16 mono:** `sample_rate * 2` bytes per POST
- Oversized buffers (e.g. user interval 5–30s) are split and sent in order under the lock; audio is not truncated/dropped
- Empty payloads return early

## Validation rules

Before any HTTP call:

| Field | Rule |
|---|---|
| webhook URL | `http`/`https` only; host required (hostname, `localhost`, or IPv4); regex + `urlsplit` netloc check; applied to the URL after stripping the `,seconds` suffix |
| `uid` | `^[A-Za-z0-9_-]{1,128}$` |
| `sample_rate` | integer matching `^[1-9]\d{2,5}$` and in `[1000, 192000]` |

Invalid fields log a warning and skip delivery (no auto-disable).

## Assumptions

- Payload is PCM16 mono (matches docs / pusher path: `sample_rate * seconds * 2`)
- In-process serialization is enough for this delivery path; multi-replica Redis locking can land separately if needed
- Receivers that already handle multiple POSTs per interval continue to work; each chunk is a complete `application/octet-stream` body with the same query params

## Product invariants affected

none

## How it was verified

```bash
bash test-preflight.sh
BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-webhook-tests.txt bash test.sh
# files: tests/unit/test_async_webhooks.py tests/unit/test_webhook_auto_disable.py
# → 105 passed (29 in test_async_webhooks including new lock/chunk/validation cases)
```

Did not exercise a live listen/pusher session in this Cloud VM (no device audio path); hermetic unit coverage covers lock serialization, chunk boundaries, and invalid URL/sample_rate skips.

## Tests

- `test_invalid_webhook_url_skips`
- `test_invalid_sample_rate_skips`
- `test_large_payload_is_sent_in_one_second_chunks`
- `test_per_uid_lock_serializes_overlapping_sends`

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dccf8e30-f354-4c03-aa3c-d65a13375fe9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dccf8e30-f354-4c03-aa3c-d65a13375fe9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

