### PR TITLE
feat(backend): add Conversation.imported for Limitless ZIP imports

### DIFF
--- a/app/lib/backend/schema/gen/conversation_wire.g.dart
+++ b/app/lib/backend/schema/gen/conversation_wire.g.dart
@@ -584,6 +584,7 @@ class GeneratedConversation {
   final String? folderId;
   final GeneratedGeolocation? geolocation;
   final String id;
+  final bool imported;
   final bool isLocked;
   final String? language;
   final double? meetingDedupSpeechS;
@@ -625,6 +626,7 @@ class GeneratedConversation {
     this.folderId,
     this.geolocation,
     required this.id,
+    this.imported = false,
     this.isLocked = false,
     this.language,
     this.meetingDedupSpeechS,
@@ -668,6 +670,7 @@ class GeneratedConversation {
       folderId: _readFieldValue<String>(_readField(json, const ["folder_id"]), "folder_id", _readString, requiredField: false, nullable: true),
       geolocation: _readFieldValue<GeneratedGeolocation>(_readField(json, const ["geolocation"]), "geolocation", (value) => _readObject(value, GeneratedGeolocation.fromJson), requiredField: false, nullable: true),
       id: _required(_readFieldValue<String>(_readField(json, const ["id"]), "id", _readString, requiredField: true, nullable: false), "id"),
+      imported: _required(_readFieldValue<bool>(_readField(json, const ["imported"]), "imported", _readBool, requiredField: false, nullable: false, defaultValue: false), "imported"),
       isLocked: _required(_readFieldValue<bool>(_readField(json, const ["is_locked"]), "is_locked", _readBool, requiredField: false, nullable: false, defaultValue: false), "is_locked"),
       language: _readFieldValue<String>(_readField(json, const ["language"]), "language", _readString, requiredField: false, nullable: true),
       meetingDedupSpeechS: _readFieldValue<double>(_readField(json, const ["meeting_dedup_speech_s"]), "meeting_dedup_speech_s", _readDouble, requiredField: false, nullable: true),
@@ -712,6 +715,7 @@ class GeneratedConversation {
       'folder_id': folderId,
       'geolocation': geolocation?.toJson(),
       'id': id,
+      'imported': imported,
       'is_locked': isLocked,
       'language': language,
       'meeting_dedup_speech_s': meetingDedupSpeechS,

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -195,6 +195,9 @@ class Conversation(BaseModel):
     app_id: Optional[str] = None
 
     discarded: bool = False
+    # True for conversations created via an external data import (e.g. Limitless ZIP).
+    # Distinct from source=limitless, which also covers pendant/sync uploads of Limitless audio.
+    imported: bool = False
     visibility: ConversationVisibility = ConversationVisibility.private
     starred: bool = False
 

--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -237,10 +237,9 @@ def delete_limitless_conversations(
     Returns:
         Number of deleted conversations
     """
-    # TODO: This deletes all the other conversations as well (which were created in omi using the pendant)
-    # TODO: Add a flag to the conversation to indicate that it was imported
-    # deleted_count = conversations_db.delete_conversations_by_source(uid, 'limitless')
-
-    # return {'deleted_count': deleted_count, 'message': f'Successfully deleted {deleted_count} Limitless conversations'}
+    # Selective delete is not implemented here yet. Conversations created by the
+    # Limitless ZIP import path are stamped with imported=True (see Conversation
+    # and persist_imported_conversation). Do not delete by source=limitless alone —
+    # that also matches pendant/sync uploads.
 
     return {'deleted_count': 0, 'message': 'Successfully deleted 0 Limitless conversations'}

--- a/backend/tests/routers/test_imports.py
+++ b/backend/tests/routers/test_imports.py
@@ -104,3 +104,14 @@ class TestDeleteImportJob:
             with pytest.raises(HTTPException) as ei:
                 imports_mod.delete_import_job("j1", uid=UID)
         assert ei.value.status_code == 403
+
+
+class TestDeleteLimitlessConversationsStub:
+    """Selective delete stays stubbed until callers filter on imported=True."""
+
+    def test_delete_limitless_conversations_still_stubbed(self):
+        result = imports_mod.delete_limitless_conversations(uid=UID)
+        assert result == {
+            "deleted_count": 0,
+            "message": "Successfully deleted 0 Limitless conversations",
+        }

--- a/backend/tests/unit/test_conversation_lifecycle_contract.py
+++ b/backend/tests/unit/test_conversation_lifecycle_contract.py
@@ -305,7 +305,9 @@ def test_import_persists_through_the_lifecycle_owner(lifecycle_store):
 
     assert created is True
     assert list(lifecycle_store.documents) == [('users', 'uid', 'conversations', 'imported')]
-    assert lifecycle_store.conversation('uid', 'imported')['status'] == ConversationStatus.completed
+    stored = lifecycle_store.conversation('uid', 'imported')
+    assert stored['status'] == ConversationStatus.completed
+    assert stored['imported'] is True
     assert (
         lifecycle_service.persist_imported_conversation(
             'uid',
@@ -320,6 +322,24 @@ def test_import_persists_through_the_lifecycle_owner(lifecycle_store):
         is False
     )
     assert lifecycle_store.conversation('uid', 'imported')['title'] == 'imported title'
+    assert lifecycle_store.conversation('uid', 'imported')['imported'] is True
+
+
+def test_persist_imported_conversation_forces_imported_true(lifecycle_store):
+    created = lifecycle_service.persist_imported_conversation(
+        'uid',
+        {
+            'id': 'forced-imported',
+            'status': ConversationStatus.completed,
+            'discarded': False,
+            'imported': False,
+            'title': 'should be stamped',
+            'data_protection_level': 'standard',
+        },
+    )
+
+    assert created is True
+    assert lifecycle_store.conversation('uid', 'forced-imported')['imported'] is True
 
 
 def test_merge_rejects_processing_conversations():

--- a/backend/tests/unit/test_conversation_model_split.py
+++ b/backend/tests/unit/test_conversation_model_split.py
@@ -566,6 +566,66 @@ class TestAsDictCleanedDates:
         assert isinstance(d['finished_at'], str)
 
 
+class TestImportedFlag:
+    """imported marks ZIP/external imports; default False for normal captures."""
+
+    def test_defaults_to_false(self):
+        from models.conversation import Conversation
+        from models.conversation_enums import ConversationSource
+        from models.structured import Structured
+
+        now = datetime.now(timezone.utc)
+        conv = Conversation(
+            id="imported-default",
+            created_at=now,
+            started_at=now,
+            finished_at=now,
+            source=ConversationSource.limitless,
+            structured=Structured(title="Pendant sync"),
+        )
+        assert conv.imported is False
+
+    def test_limitless_import_sets_true_and_serializes(self):
+        from models.conversation import Conversation
+        from models.conversation_enums import ConversationSource
+        from models.structured import Structured
+
+        now = datetime.now(timezone.utc)
+        conv = Conversation(
+            id="imported-true",
+            created_at=now,
+            started_at=now,
+            finished_at=now,
+            source=ConversationSource.limitless,
+            structured=Structured(title="ZIP import"),
+            imported=True,
+        )
+        assert conv.imported is True
+        dumped = conv.model_dump()
+        cleaned = conv.as_dict_cleaned_dates()
+        assert dumped['imported'] is True
+        assert cleaned['imported'] is True
+
+    def test_missing_firestore_field_defaults_false(self):
+        from models.conversation import Conversation
+        from models.conversation_enums import ConversationSource
+        from models.structured import Structured
+
+        now = datetime.now(timezone.utc)
+        # Construct from a dict that omits the field (legacy docs).
+        from_legacy = Conversation.model_validate(
+            {
+                'id': 'legacy-no-imported',
+                'created_at': now,
+                'started_at': now,
+                'finished_at': now,
+                'source': ConversationSource.omi,
+                'structured': Structured(title='Legacy'),
+            }
+        )
+        assert from_legacy.imported is False
+
+
 class TestConversationSummaryWithTranscript:
     """ConversationSummary.from_conversation with real data."""
 

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -141,6 +141,9 @@ def persist_imported_conversation(uid: str, conversation_data: dict[str, Any]) -
     already existed. Re-imports must not overwrite user edits (first import wins).
     """
     _require_status(conversation_data, ConversationStatus.completed)
+    # Stamp imported so selective delete can distinguish ZIP imports from source=limitless
+    # pendant/sync uploads that share the same ConversationSource.
+    conversation_data['imported'] = True
     return conversations_db.create_conversation_if_absent_with_lifecycle(uid, conversation_data)
 
 

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -380,6 +380,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         apps_results=apps_results,
                         status=ConversationStatus.completed,
                         discarded=False,
+                        imported=True,
                     )
 
                     # Create-if-absent so re-importing the same export skips lifelogs already

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -1373,6 +1373,7 @@ public enum OmiAPI {
     public let folderId: String?
     public let geolocation: Geolocation?
     public let id: String
+    public let imported: Bool?
     public let isLocked: Bool?
     public let language: String?
     public let meetingDedupSpeechS: Double?
@@ -1414,6 +1415,7 @@ public enum OmiAPI {
       case folderId = "folder_id"
       case geolocation
       case id
+      case imported
       case isLocked = "is_locked"
       case language
       case meetingDedupSpeechS = "meeting_dedup_speech_s"
@@ -1457,6 +1459,7 @@ public enum OmiAPI {
       folderId = try c.decodeIfPresent(String.self, forKey: .folderId)
       geolocation = try c.decodeIfPresent(Geolocation.self, forKey: .geolocation)
       id = try c.decode(String.self, forKey: .id)
+      imported = try c.decodeIfPresent(Bool.self, forKey: .imported)
       isLocked = try c.decodeIfPresent(Bool.self, forKey: .isLocked)
       language = try c.decodeIfPresent(String.self, forKey: .language)
       meetingDedupSpeechS = try c.decodeIfPresent(Double.self, forKey: .meetingDedupSpeechS)
@@ -1481,7 +1484,7 @@ public enum OmiAPI {
       visibility = try c.decodeIfPresent(ConversationVisibility.self, forKey: .visibility)
     }
 
-    public init(appId: String? = nil, appsResults: [AppResult]? = nil, audioFiles: [AudioFile]? = nil, calendarEvent: CalendarEventLink? = nil, callId: String? = nil, clientDeviceId: String? = nil, clientPlatform: String? = nil, conversationAudio: ConversationAudio? = nil, createdAt: String, dataProtectionLevel: String? = nil, deferred: Bool? = nil, discarded: Bool? = nil, externalData: [String: OmiAnyCodable]? = nil, finishedAt: String? = nil, folderId: String? = nil, geolocation: Geolocation? = nil, id: String, isLocked: Bool? = nil, language: String? = nil, meetingDedupSpeechS: Double? = nil, meetingDurationS: Double? = nil, meetingTreatmentEligible: Bool? = nil, meetingTreatmentReason: String? = nil, photos: [ConversationPhoto]? = nil, pluginsResults: [PluginResult]? = nil, privateCloudSyncEnabled: Bool? = nil, processingConversationId: String? = nil, processingMemoryId: String? = nil, source: ConversationSource? = nil, starred: Bool? = nil, startedAt: String? = nil, status: ConversationStatus? = nil, structured: Structured, suggestedSummarizationApps: [String]? = nil, transcriptSegments: [TranscriptSegment]? = nil, transcriptSegmentsCompressed: Bool? = nil, updatedAt: String? = nil, usesCustomStt: Bool? = nil, visibility: ConversationVisibility? = nil) {
+    public init(appId: String? = nil, appsResults: [AppResult]? = nil, audioFiles: [AudioFile]? = nil, calendarEvent: CalendarEventLink? = nil, callId: String? = nil, clientDeviceId: String? = nil, clientPlatform: String? = nil, conversationAudio: ConversationAudio? = nil, createdAt: String, dataProtectionLevel: String? = nil, deferred: Bool? = nil, discarded: Bool? = nil, externalData: [String: OmiAnyCodable]? = nil, finishedAt: String? = nil, folderId: String? = nil, geolocation: Geolocation? = nil, id: String, imported: Bool? = nil, isLocked: Bool? = nil, language: String? = nil, meetingDedupSpeechS: Double? = nil, meetingDurationS: Double? = nil, meetingTreatmentEligible: Bool? = nil, meetingTreatmentReason: String? = nil, photos: [ConversationPhoto]? = nil, pluginsResults: [PluginResult]? = nil, privateCloudSyncEnabled: Bool? = nil, processingConversationId: String? = nil, processingMemoryId: String? = nil, source: ConversationSource? = nil, starred: Bool? = nil, startedAt: String? = nil, status: ConversationStatus? = nil, structured: Structured, suggestedSummarizationApps: [String]? = nil, transcriptSegments: [TranscriptSegment]? = nil, transcriptSegmentsCompressed: Bool? = nil, updatedAt: String? = nil, usesCustomStt: Bool? = nil, visibility: ConversationVisibility? = nil) {
       self.appId = appId
       self.appsResults = appsResults
       self.audioFiles = audioFiles
@@ -1499,6 +1502,7 @@ public enum OmiAPI {
       self.folderId = folderId
       self.geolocation = geolocation
       self.id = id
+      self.imported = imported
       self.isLocked = isLocked
       self.language = language
       self.meetingDedupSpeechS = meetingDedupSpeechS

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -1082,6 +1082,7 @@ export interface Conversation {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;
@@ -3163,6 +3164,7 @@ export interface SharedConversationResponse {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -6884,6 +6884,11 @@
             "title": "Id",
             "type": "string"
           },
+          "imported": {
+            "default": false,
+            "title": "Imported",
+            "type": "boolean"
+          },
           "is_locked": {
             "default": false,
             "title": "Is Locked",
@@ -19210,6 +19215,11 @@
           "id": {
             "title": "Id",
             "type": "string"
+          },
+          "imported": {
+            "default": false,
+            "title": "Imported",
+            "type": "boolean"
           },
           "is_locked": {
             "default": false,

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -1082,6 +1082,7 @@ export interface Conversation {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;
@@ -3163,6 +3164,7 @@ export interface SharedConversationResponse {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -1082,6 +1082,7 @@ export interface Conversation {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;
@@ -3163,6 +3164,7 @@ export interface SharedConversationResponse {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -1082,6 +1082,7 @@ export interface Conversation {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;
@@ -3163,6 +3164,7 @@ export interface SharedConversationResponse {
   folder_id?: string | null;
   geolocation?: Geolocation | null;
   id: string;
+  imported?: boolean;
   is_locked?: boolean;
   language?: string | null;
   meeting_dedup_speech_s?: number | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Adds `Conversation.imported: bool = False` so Limitless **ZIP-imported** conversations can be identified without treating all `source=limitless` rows the same. Pendant/sync uploads also use `source=limitless`; deleting by source alone would wipe those too (see #3684 / the stubbed `DELETE /v1/import/limitless/conversations` TODO).

This PR only stamps the flag and leaves selective delete unimplemented.

Rebased onto current `origin/main` after Limitless import idempotency landed (#11928) and the Codex follow-up (#11929). Conflicts were resolved to keep `imported=True` on the current create-if-absent import path (`persist_imported_conversation` still force-stamps, then `create_conversation_if_absent_with_lifecycle`). The Limitless ZIP constructor still passes `imported=True`. First-import-wins tests from main are preserved alongside the imported-flag tests.

- Model: `imported` defaults to `false`; legacy docs without the field still deserialize as `false`.
- Limitless ZIP create path sets `imported=True`.
- `persist_imported_conversation` always stamps `imported=True` so the lifecycle owner owns the marker.
- `DELETE /v1/import/limitless/conversations` remains a no-op stub; comments now point at `imported` instead of delete-by-source.
- Regenerated app-client OpenAPI + Dart/TS/Swift clients for the additive response field.

## Assumptions

- Only the Limitless ZIP import path should set `imported=True` for now (not pendant/sync limitless audio).
- `persist_imported_conversation` is import-only today; forcing the stamp there is intentional for future importers.
- Already-imported conversations in Firestore are not backfilled; they remain `imported=false` until a later migration/re-import.
- Selective delete (query/filter on `imported=True`) is intentionally out of scope.

## Product invariants affected

none

## How it was verified

Rebased `cursor/conversation-imported-flag-d764` onto `origin/main` (`4d7516ac`) and force-pushed the original branch. GitHub reports `mergeable: MERGEABLE` (no longer `dirty`). `git merge-tree --write-tree origin/main HEAD` succeeded.

```bash
cd backend && source .venv/bin/activate
BACKEND_UNIT_TEST_FILE_LIST=/tmp/backend-unit-tests.txt bash test.sh
# files: test_conversation_model_split.py, test_conversation_lifecycle_contract.py,
#        test_limitless_import_idempotency.py, test_import_job_status_detail_enum.py,
#        test_import_jobs_malformed.py, tests/routers/test_imports.py
# Result: all passed (including TestImportedFlag, force-stamp, first-import-wins, delete stub)

python scripts/check_app_client_openapi_compatibility.py --base-ref origin/main
# Result: passed (additive response field)

bash scripts/openapi_runner.sh scripts/export_openapi.py --surface app-client --check ../docs/api-reference/app-client-openapi.json
# Result: up to date
```

Could not exercise a live Limitless ZIP import end-to-end in this Linux cloud VM (no real Limitless export fixture / full serve path for that worker). Unit coverage covers model default/serialization, lifecycle stamp on create-if-absent, Limitless ZIP constructor `imported=True`, idempotent re-import, and the delete stub remaining a no-op.

## Tests

- `TestImportedFlag` — default false, explicit true serializes, legacy omit → false
- `test_persist_imported_conversation_forces_imported_true` — lifecycle forces the stamp even when input is `False`
- `test_import_persists_through_the_lifecycle_owner` — stamps `imported=True` and still first-import-wins
- `TestDeleteLimitlessConversationsStub` — selective delete still stubbed
- `test_limitless_import_idempotency.py` — current ZIP import path still first-import-wins after the stamp

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e86c5afe-a7b1-49e4-bc94-27acf264d764?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e86c5afe-a7b1-49e4-bc94-27acf264d764&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

