### PR TITLE
feat(chat): paginate GET /v2/messages with limit/offset

### DIFF
--- a/app/lib/backend/http/api/messages.dart
+++ b/app/lib/backend/http/api/messages.dart
@@ -8,11 +8,16 @@ import 'package:omi/env/env.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/string_utils.dart';
 
-Future<List<ServerMessage>> getMessagesServer({String? appId, bool dropdownSelected = false}) async {
+Future<List<ServerMessage>> getMessagesServer({
+  String? appId,
+  bool dropdownSelected = false,
+  int limit = 100,
+  int offset = 0,
+}) async {
   if (appId == 'no_selected') appId = null;
-  // TODO: Add pagination
   var response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v2/messages?app_id=${appId ?? ''}&dropdown_selected=$dropdownSelected',
+    url:
+        '${Env.apiBaseUrl}v2/messages?app_id=${appId ?? ''}&dropdown_selected=$dropdownSelected&limit=$limit&offset=$offset',
     headers: {},
     method: 'GET',
     body: '',

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -753,11 +753,9 @@ def get_messages(
             logger.info(f"  - Message {m.get('id')}: rating={m.get('rating')}")
 
     if not messages:
-        if offset > 0:
-            return []
         # The greeting belongs to the session that was read, not to whatever
         # session `acquire_chat_session` would pick for the app.
-        return [initial_message_util(uid, compat_app_id, chat_session_id=chat_session_id)]
+        return [] if offset > 0 else [initial_message_util(uid, compat_app_id, chat_session_id=chat_session_id)]
     return messages
 
 

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -15,6 +15,7 @@ from fastapi import (
     Depends,
     Header,
     HTTPException,
+    Query,
     Request,
     UploadFile,
     File,
@@ -722,6 +723,8 @@ def get_messages(
     plugin_id: Optional[str] = None,
     app_id: Optional[str] = None,
     chat_session_id: Optional[str] = None,
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
     uid: str = Depends(auth.get_current_user_uid),
 ):
     compat_app_id = app_id or plugin_id
@@ -733,7 +736,12 @@ def get_messages(
     chat_session_id = target.session_id
 
     messages = chat_db.get_messages(
-        uid, limit=100, include_conversations=True, app_id=compat_app_id, chat_session_id=chat_session_id
+        uid,
+        limit=limit,
+        offset=offset,
+        include_conversations=True,
+        app_id=compat_app_id,
+        chat_session_id=chat_session_id,
     )
     logger.info(f'get_messages {len(messages)} {compat_app_id}')
 
@@ -745,6 +753,8 @@ def get_messages(
             logger.info(f"  - Message {m.get('id')}: rating={m.get('rating')}")
 
     if not messages:
+        if offset > 0:
+            return []
         # The greeting belongs to the session that was read, not to whatever
         # session `acquire_chat_session` would pick for the app.
         return [initial_message_util(uid, compat_app_id, chat_session_id=chat_session_id)]

--- a/backend/tests/unit/test_chat_messages_pagination.py
+++ b/backend/tests/unit/test_chat_messages_pagination.py
@@ -1,0 +1,126 @@
+"""GET /v2/messages pagination (limit/offset).
+
+The DB layer already accepted limit/offset; the HTTP route hard-coded limit=100
+and omitted offset. This pins the query params through to chat_db and ensures
+empty later pages do not synthesize a greeting.
+"""
+
+from datetime import datetime, timezone
+
+import routers.chat as chat_router
+
+
+def test_get_messages_forwards_limit_and_offset(monkeypatch):
+    recorded = {}
+
+    monkeypatch.setattr(
+        chat_router,
+        'resolve_chat_target',
+        lambda uid, app_id, chat_session_id: type(
+            'Target',
+            (),
+            {'app_id': app_id, 'session_id': chat_session_id},
+        )(),
+    )
+
+    def _get_messages(uid, limit=20, offset=0, include_conversations=False, app_id=None, chat_session_id=None):
+        recorded.update(
+            {
+                'uid': uid,
+                'limit': limit,
+                'offset': offset,
+                'include_conversations': include_conversations,
+                'app_id': app_id,
+                'chat_session_id': chat_session_id,
+            }
+        )
+        return [{'id': 'm1', 'created_at': datetime(2026, 8, 20, tzinfo=timezone.utc)}]
+
+    monkeypatch.setattr(chat_router.chat_db, 'get_messages', _get_messages)
+
+    result = chat_router.get_messages(
+        plugin_id=None,
+        app_id='app-1',
+        chat_session_id=None,
+        limit=25,
+        offset=50,
+        uid='uid-1',
+    )
+
+    assert result == [{'id': 'm1', 'created_at': datetime(2026, 8, 20, tzinfo=timezone.utc)}]
+    assert recorded == {
+        'uid': 'uid-1',
+        'limit': 25,
+        'offset': 50,
+        'include_conversations': True,
+        'app_id': 'app-1',
+        'chat_session_id': None,
+    }
+
+
+def test_get_messages_empty_later_page_does_not_create_greeting(monkeypatch):
+    greeted = []
+
+    monkeypatch.setattr(
+        chat_router,
+        'resolve_chat_target',
+        lambda uid, app_id, chat_session_id: type(
+            'Target',
+            (),
+            {'app_id': app_id, 'session_id': chat_session_id},
+        )(),
+    )
+    monkeypatch.setattr(
+        chat_router.chat_db,
+        'get_messages',
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        chat_router,
+        'initial_message_util',
+        lambda *args, **kwargs: greeted.append(True) or {'id': 'greeting'},
+    )
+
+    assert (
+        chat_router.get_messages(
+            plugin_id=None,
+            app_id=None,
+            chat_session_id=None,
+            limit=100,
+            offset=100,
+            uid='uid-1',
+        )
+        == []
+    )
+    assert greeted == []
+
+
+def test_get_messages_empty_first_page_still_creates_greeting(monkeypatch):
+    monkeypatch.setattr(
+        chat_router,
+        'resolve_chat_target',
+        lambda uid, app_id, chat_session_id: type(
+            'Target',
+            (),
+            {'app_id': app_id, 'session_id': chat_session_id},
+        )(),
+    )
+    monkeypatch.setattr(
+        chat_router.chat_db,
+        'get_messages',
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        chat_router,
+        'initial_message_util',
+        lambda uid, app_id=None, chat_session_id=None: {'id': 'greeting', 'app_id': app_id},
+    )
+
+    assert chat_router.get_messages(
+        plugin_id=None,
+        app_id='app-1',
+        chat_session_id=None,
+        limit=100,
+        offset=0,
+        uid='uid-1',
+    ) == [{'id': 'greeting', 'app_id': 'app-1'}]

--- a/backend/tests/unit/test_chat_session_app_identity.py
+++ b/backend/tests/unit/test_chat_session_app_identity.py
@@ -104,7 +104,7 @@ def test_reading_an_empty_named_session_greets_that_session(monkeypatch, session
     monkeypatch.setattr(
         chat_router.chat_db,
         'get_messages',
-        lambda uid, limit=100, include_conversations=False, app_id=None, chat_session_id=None: [],
+        lambda uid, limit=100, offset=0, include_conversations=False, app_id=None, chat_session_id=None: [],
     )
 
     def _initial(uid, app_id=None, chat_session_id=None):
@@ -114,7 +114,7 @@ def test_reading_an_empty_named_session_greets_that_session(monkeypatch, session
 
     monkeypatch.setattr(chat_router, 'initial_message_util', _initial)
 
-    chat_router.get_messages(plugin_id=None, app_id=None, chat_session_id='sess-app', uid='uid-1')
+    chat_router.get_messages(plugin_id=None, app_id=None, chat_session_id='sess-app', limit=100, offset=0, uid='uid-1')
 
     # Without the session id the greeting is written into the *current* session.
     assert recorded['chat_session_id'] == 'sess-app'
@@ -124,16 +124,23 @@ def test_reading_an_empty_named_session_greets_that_session(monkeypatch, session
 def test_reading_a_named_session_scopes_history_to_its_app(monkeypatch, sessions):
     recorded = {}
 
-    def _get_messages(uid, limit=100, include_conversations=False, app_id=None, chat_session_id=None):
+    def _get_messages(uid, limit=100, offset=0, include_conversations=False, app_id=None, chat_session_id=None):
         recorded['app_id'] = app_id
         recorded['chat_session_id'] = chat_session_id
+        recorded['limit'] = limit
+        recorded['offset'] = offset
         return [{'id': 'm1'}]
 
     monkeypatch.setattr(chat_router.chat_db, 'get_messages', _get_messages)
 
-    chat_router.get_messages(plugin_id=None, app_id=None, chat_session_id='sess-app', uid='uid-1')
+    chat_router.get_messages(plugin_id=None, app_id=None, chat_session_id='sess-app', limit=100, offset=0, uid='uid-1')
 
-    assert recorded == {'app_id': 'app-9', 'chat_session_id': 'sess-app'}
+    assert recorded == {
+        'app_id': 'app-9',
+        'chat_session_id': 'sess-app',
+        'limit': 100,
+        'offset': 0,
+    }
 
 
 def test_over_quota_turn_in_a_named_session_carries_session_and_app(monkeypatch, sessions):

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -14171,7 +14171,7 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  public static func getMessagesV2MessagesGet(client: OmiApiClient, pluginId: String? = nil, appId: String? = nil, chatSessionId: String? = nil, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> [OmiAnyCodable] {
+  public static func getMessagesV2MessagesGet(client: OmiApiClient, pluginId: String? = nil, appId: String? = nil, chatSessionId: String? = nil, limit: Int? = nil, offset: Int? = nil, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> [OmiAnyCodable] {
     let _path = "/v2/messages"
     guard var components = URLComponents(string: client.baseURL + _path) else {
       throw OmiApiError.invalidURL
@@ -14185,6 +14185,12 @@ public enum OmiAPI {
     }
     if let chatSessionId {
       queryItems.append(URLQueryItem(name: "chat_session_id", value: String(chatSessionId)))
+    }
+    if let limit {
+      queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+    }
+    if let offset {
+      queryItems.append(URLQueryItem(name: "offset", value: String(offset)))
     }
     if !queryItems.isEmpty { components.queryItems = queryItems }
     guard let url = components.url else { throw OmiApiError.invalidURL }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -16040,7 +16040,7 @@ export async function create_initial_message_v2_initial_message_post(query: { ap
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
+export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null, limit?: number, offset?: number }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/messages`;
   const _params = query ? Object.entries(query)

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -57611,6 +57611,29 @@
             }
           },
           {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
             "in": "header",
             "name": "authorization",
             "required": false,

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -16040,7 +16040,7 @@ export async function create_initial_message_v2_initial_message_post(query: { ap
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
+export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null, limit?: number, offset?: number }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/messages`;
   const _params = query ? Object.entries(query)

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -16040,7 +16040,7 @@ export async function create_initial_message_v2_initial_message_post(query: { ap
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
+export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null, limit?: number, offset?: number }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/messages`;
   const _params = query ? Object.entries(query)

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -16040,7 +16040,7 @@ export async function create_initial_message_v2_initial_message_post(query: { ap
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
+export async function get_messages_v2_messages_get(query: { plugin_id?: string | null, app_id?: string | null, chat_session_id?: string | null, limit?: number, offset?: number }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<Array<Message>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v2/messages`;
   const _params = query ? Object.entries(query)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

`GET /v2/messages` hard-coded `limit=100` with no `offset`, while `chat_db.get_messages` and desktop `/v2/desktop/messages` already supported limit/offset. This wires optional `limit`/`offset` on the mobile route and Flutter `getMessagesServer`, matching existing Flutter list APIs and desktop chat.

## Pagination shape chosen and why

**limit/offset** (not cursor-based).

- Backend DB and desktop `/v2/desktop/messages` already use `limit`/`offset`.
- Flutter HTTP clients (`conversations`, `memories`, `action_items`, `apps`) consistently use `limit`/`offset` query params.
- Cursor pagination exists only on desktop reconcile (`/v2/desktop/messages/reconcile`); mobile history load is a simple page list, so offset matches the existing client style without a new response envelope.
- Defaults `limit=100`, `offset=0` preserve prior behavior for callers that omit the params. Empty later pages return `[]` and do not synthesize a greeting.

## Product invariants affected

none

## How it was verified

Rebased onto current `origin/main` (`4d7516ac`). `chat.py` is 1853 lines after the unused-import drop on main plus this 8-line pagination wire-up.

```bash
cd backend && source .venv/bin/activate
python -m pytest tests/unit/test_chat_messages_pagination.py \
  tests/unit/test_chat_session_app_identity.py \
  tests/unit/test_flutter_rest_inventory.py -q --tb=short
# 12 passed

bash web/app/test.sh
# typecheck + 5 moonshine smoke + 305 vitest passed

scripts/pr-preflight --base origin/main --pr-body-file /tmp/pr-body-11921.md
# product-file-line-count-ratchet PASS (1845 -> 1853)
# desktop-changelog-entry PASS (generated Swift is exempt)
```

App-client OpenAPI compatibility passed against merge-base `4d7516ac`. Flutter SDK and Desktop Swift compile are not available on this Linux cloud VM (`PRE_PUSH_SKIP_DART_FORMAT=1`, `PRE_PUSH_SKIP_DESKTOP_SWIFT=1`). The only Swift change is generated OpenAPI bindings under `Desktop/Sources/Generated/`, which are changelog-exempt. Prior Desktop Swift red on this PR was `AgentRuntimeProcessTests.testContextAdmissionGateCancelledWaiterDoesNotStealTurn` (admission-gate cancel race on the previous head), not this generated-client diff.

## Tests

- `backend/tests/unit/test_chat_messages_pagination.py` — core path forwards limit/offset; empty later page skips greeting; empty first page still greets.
- Updated `test_chat_session_app_identity.py` mocks for the new kwargs.

## Failure class (fixes)

Failure-Class: none

Line-Count-Exception: backend/routers/chat.py | 1845 -> 1853 | Additive limit/offset query params on get_messages; file already over the freeze threshold and a split is out of scope for this pagination wire-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b88914c6-1b26-40f4-9f8e-390a4a3a06c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b88914c6-1b26-40f4-9f8e-390a4a3a06c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

