### PR TITLE
docs(backend): orphaned postprocess short-audio is a historical app bug

### DIFF
--- a/backend/tests/unit/test_postprocess_audio_duration.py
+++ b/backend/tests/unit/test_postprocess_audio_duration.py
@@ -1,11 +1,32 @@
 import importlib
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 from models.conversation_enums import PostProcessingStatus
-from utils.conversations.postprocess_conversation import _minimum_audio_duration
+from utils.conversations.postprocess_conversation import _minimum_audio_duration, _transcript_span_seconds
 
 postprocess_module = importlib.import_module('utils.conversations.postprocess_conversation')
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+ROUTERS_DIR = BACKEND_DIR / 'routers'
+
+
+def _router_imports_of_postprocess_conversation() -> list[str]:
+    """Cheap text scan: full AST over routers exceeds the fast-unit CPU budget."""
+    offenders: list[str] = []
+    needle = 'postprocess_conversation'
+    for path in sorted(ROUTERS_DIR.rglob('*.py')):
+        text = path.read_text(encoding='utf-8')
+        if needle not in text:
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            stripped = line.lstrip()
+            if needle not in stripped:
+                continue
+            if stripped.startswith('import ') or stripped.startswith('from '):
+                offenders.append(f'{path.relative_to(BACKEND_DIR)}:{lineno} {stripped}')
+    return offenders
 
 
 def test_transcript_based_minimum_duration_never_drops_below_ten_seconds():
@@ -18,6 +39,16 @@ def test_transcript_based_minimum_duration_allows_the_transcript_padding_window(
     segments = [SimpleNamespace(start=0.0, end=25.0)]
 
     assert _minimum_audio_duration(segments) == 15.0
+
+
+def test_transcript_span_uses_timestamp_extrema_not_list_order():
+    segments = [
+        SimpleNamespace(start=40.0, end=50.0),
+        SimpleNamespace(start=0.0, end=10.0),
+    ]
+
+    assert _transcript_span_seconds(segments) == 50.0
+    assert _minimum_audio_duration(segments) == 40.0
 
 
 def test_postprocess_conversation_cancels_audio_shorter_than_transcript_window():
@@ -44,7 +75,12 @@ def test_postprocess_conversation_cancels_audio_shorter_than_transcript_window()
         )
 
     assert result == (500, 'Audio duration is too short, seems wrong.')
-    status.assert_called_once_with('user-1', 'conversation-1', PostProcessingStatus.canceled)
+    status.assert_called_once_with(
+        'user-1',
+        'conversation-1',
+        PostProcessingStatus.canceled,
+        fail_reason='Audio duration is too short, seems wrong (audio_s=14.00 min_required_s=15.00).',
+    )
 
 
 def test_postprocess_conversation_marks_allowed_audio_in_progress_before_processing():
@@ -77,3 +113,13 @@ def test_postprocess_conversation_marks_allowed_audio_in_progress_before_process
         call('user-1', 'conversation-1', PostProcessingStatus.in_progress),
         call('user-1', 'conversation-1', PostProcessingStatus.failed, fail_reason='stop'),
     ]
+
+
+def test_no_router_imports_orphaned_postprocess_conversation_util():
+    """Reachability ratchet: Jules #11345 tightened a util with no live caller.
+
+    If a router re-imports this module, restore a client contract that does not
+    strip quiet-timer seconds from the WAV before upload, then update this test.
+    """
+    offenders = _router_imports_of_postprocess_conversation()
+    assert not offenders, 'orphaned postprocess_conversation util imported by routers:\n' + '\n'.join(offenders)

--- a/backend/utils/conversations/ARCHITECTURE.md
+++ b/backend/utils/conversations/ARCHITECTURE.md
@@ -21,6 +21,12 @@ and background processing.
 - `meeting_receipt.py` is the sole writer of the final meeting verdict. It
   records reason and measured inputs on the finalization job, projects the
   verdict to the conversation, and attaches the deterministic Chat intent.
+- `postprocess_conversation.py` is an **orphaned** WAV retranscription util.
+  The historical Flutter upload (`memoryPostProcessing`) and
+  `POST /v1/memories/{id}/post-processing` router were removed; no current
+  router imports it. Short-audio cancels were caused by the old client
+  stripping `quietSecondsForMemoryCreation` (120s) from the WAV before upload,
+  not by backend truncation. Do not rewire without fixing that client contract.
 - Route- or worker-specific ownership, retries, queues, and leases belong
   outside this package: `database/conversation_finalization_jobs.py`,
   `services/conversation_finalization.py`, and their callers own those states.

--- a/backend/utils/conversations/postprocess_conversation.py
+++ b/backend/utils/conversations/postprocess_conversation.py
@@ -1,3 +1,14 @@
+"""Orphaned WAV retranscription pipeline (client upload path removed).
+
+Historically reached via ``POST /v1/memories/{id}/post-processing`` and a Flutter
+``memoryPostProcessing`` upload. That router was commented out (2024-09) and
+deleted (2025-05); no ``backend/routers`` caller remains. Short uploads were an
+app-side buffer bug (``createWavFile(removeLastNSeconds=120)`` on quiet-timer
+memory creation), not backend truncation — see module ARCHITECTURE.md.
+
+Keep the transcript-relative duration guard if this util is ever rewired.
+"""
+
 import asyncio
 import os
 import time
@@ -23,12 +34,24 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_MINIMUM_AUDIO_FLOOR_SECONDS = 10.0
+_TRANSCRIPT_DURATION_PADDING_SECONDS = 10.0
+
+
+def _transcript_span_seconds(transcript_segments: List[TranscriptSegment]) -> float:
+    """Wall-clock span covered by segment timestamps (extrema, not list order)."""
+    if not transcript_segments:
+        return 0.0
+    starts = [segment.start for segment in transcript_segments]
+    ends = [segment.end for segment in transcript_segments]
+    return max(ends) - min(starts)
+
 
 def _minimum_audio_duration(transcript_segments: List[TranscriptSegment]) -> float:
     if not transcript_segments:
-        return 10.0
-    transcript_duration = transcript_segments[-1].end - transcript_segments[0].start
-    return max(10.0, transcript_duration - 10.0)
+        return _MINIMUM_AUDIO_FLOOR_SECONDS
+    transcript_duration = _transcript_span_seconds(transcript_segments)
+    return max(_MINIMUM_AUDIO_FLOOR_SECONDS, transcript_duration - _TRANSCRIPT_DURATION_PADDING_SECONDS)
 
 
 # TODO: this pipeline vs groq+pyannote diarization 3.1, probably the latter is better.
@@ -55,11 +78,22 @@ def postprocess_conversation(
         return 400, "Conversation can't be post-processed again"
 
     aseg = AudioSegment.from_wav(file_path)
+    min_required = _minimum_audio_duration(conversation.transcript_segments)
 
-    if aseg.duration_seconds < _minimum_audio_duration(conversation.transcript_segments):
-        # TODO: fix app, sometimes audio uploaded is wrong, is too short.
-        logger.info('postprocess_conversation: Audio duration is too short, seems wrong.')
-        conversations_db.set_postprocessing_status(uid, conversation.id, PostProcessingStatus.canceled)
+    if aseg.duration_seconds < min_required:
+        # Historical root cause: mobile CaptureProvider built the upload with
+        # createWavFile(removeLastNSeconds=quietSecondsForMemoryCreation=120), so
+        # quiet-timer creations uploaded a truncated WAV while transcript segments
+        # still spanned the full session. Client + router for this path are gone;
+        # keep rejecting short files if the util is ever rewired.
+        fail_reason = (
+            f'Audio duration is too short, seems wrong '
+            f'(audio_s={aseg.duration_seconds:.2f} min_required_s={min_required:.2f}).'
+        )
+        logger.info('postprocess_conversation: %s', fail_reason)
+        conversations_db.set_postprocessing_status(
+            uid, conversation.id, PostProcessingStatus.canceled, fail_reason=fail_reason
+        )
         return 500, "Audio duration is too short, seems wrong."
 
     conversations_db.set_postprocessing_status(uid, conversation.id, PostProcessingStatus.in_progress)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Investigated the Jules short-audio item around `postprocess_conversation` duration validation. **Root cause is historical mobile upload construction, not live backend truncation** — and the upload path is already gone.

Jules #11345 correctly tightened `_minimum_audio_duration` against transcript span, but that util has **no live router caller** today. This PR documents that finding and keeps the smallest safe defensive guards if the util is ever rewired.

### Finding

| Fact | Evidence |
|---|---|
| Short uploads were an **app buffer bug** | Historical `CaptureProvider` built the postprocess WAV with `createWavFile(removeLastNSeconds: quietSecondsForMemoryCreation)` where `quietSecondsForMemoryCreation = 120`, so quiet-timer creations stripped up to two minutes while transcript segments still spanned the full session (`9750b3e7b4`) |
| Client upload removed | Flutter `memoryPostProcessing` path cleaned in `2010336aa5` / commented in `7570c9d5f0` |
| Backend route removed | `POST /v1/memories/{id}/post-processing` commented `714090afb3`, deleted `b8d2c4a52d` |
| No current caller | Repo-wide: only tests / workflow_contracts / pyrightconfig reference `postprocess_conversation`; no `backend/routers` import |

### Decision

Do **not** chase a blind further backend validation change or a mobile fix for a deleted client path. Keep a small defensive guard on the orphaned util and a reachability ratchet so rewiring cannot silently revive the bug.

### Code changes

- Document orphaned status + historical root cause in the util docstring and `ARCHITECTURE.md`
- Use transcript timestamp **extrema** (not list order) for the duration span
- Persist `fail_reason` with measured `audio_s` / `min_required_s` on cancel
- Add a fast router-import ratchet test

## Product invariants affected

none

## How it was verified

```bash
cd backend
PYTHON=.venv/bin/python bash test-preflight.sh
: > /tmp/omi-backend-unit-failures.txt
echo tests/unit/test_postprocess_audio_duration.py >> /tmp/omi-backend-unit-failures.txt
BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh
# 6 passed
```

Could not exercise a real user-facing upload path: none remains on current main.

## Tests

- Extended `backend/tests/unit/test_postprocess_audio_duration.py`: extrema span, cancel `fail_reason`, router import ratchet.

## Failure class (fixes)

Failure-Class: none

## New guards (only when adding a check or ratchet)

Router import ratchet for `postprocess_conversation`: would have caught Jules #11345 changing an unreachable util without noticing the path was dead. Kept local (not a shared primitive) because it asserts one orphaned symbol's reachability, not a general import hierarchy rule (`test_utils_import_boundary` already covers utils→routers).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12d98dcd-c4bb-4b8e-a4e7-f9a4c277acd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12d98dcd-c4bb-4b8e-a4e7-f9a4c277acd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

