### PR TITLE
fix(backend): build the rebuilt knowledge graph before deleting the old one (#11923)

### DIFF
--- a/.github/failure-classes/FC-destructive-replace-precedes-derivation.json
+++ b/.github/failure-classes/FC-destructive-replace-precedes-derivation.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-destructive-replace-precedes-derivation",
+  "violated_contract": "A replace-in-place rebuild may destroy the state it is replacing only once the replacement is fully derived. The delete belongs with the writes that land the new state, never ahead of the work that produces it: if the derivation is slow (per-item provider calls) and its driver is not durable (an in-process background task with no retry), then any redeploy, restart, eviction or driver error inside that window leaves the owner with a partial state and no copy of what it replaced. A derivation loop that reads its own intermediate writes back out of the durable store is what forces the destructive ordering, and using the store as scratch space is the defect, not the sequencing.",
+  "canonical_prevention": "Derive the replacement outside the durable store — staged in the driver's own memory, or into a shadow generation — and delete plus write in one late phase, so an interruption before the swap is a no-op on stored state. Where the loop previously re-read the store for its own intermediate state, move that state into the driver and mirror the store's identity and merge rules there so the swap stays behaviour-preserving. Prove it with a regression test that drives the production function and asserts both that the delete is ordered after the last derivation step and that an interrupted run leaves the prior state untouched.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_knowledge_graph_rebuild_ordering.py"
+  ],
+  "evidence_prs": [
+    11924
+  ],
+  "scope_hints": [
+    "backend/utils/llm/knowledge_graph.py",
+    "backend/database/knowledge_graph.py"
+  ],
+  "status": "open"
+}

--- a/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
+++ b/backend/tests/unit/test_knowledge_graph_canonical_mutation_routes.py
@@ -165,8 +165,9 @@ def test_a_regate_that_flips_after_the_response_leaves_the_graph_intact(client, 
 
 def test_the_legacy_rebuild_still_clears_the_graph_itself(monkeypatch):
     # The route relies on this: dropping its eager delete is only safe while
-    # `rebuild_knowledge_graph` starts by clearing the old graph, so a rebuild
-    # cannot merge new extractions into stale nodes.
+    # `rebuild_knowledge_graph` clears the old graph itself, so a rebuild cannot
+    # merge new extractions into stale nodes. The clear now runs at the end of the
+    # rebuild rather than the start (#11923), but it still runs.
     llm_kg = kg_router._knowledge_graph_llm_module()
     calls: List[str] = []
     monkeypatch.setattr(kg_db, "delete_knowledge_graph", lambda uid, **_kw: calls.append(uid))

--- a/backend/tests/unit/test_knowledge_graph_rebuild_ordering.py
+++ b/backend/tests/unit/test_knowledge_graph_rebuild_ordering.py
@@ -16,7 +16,7 @@ both observed through the same seam production writes through.
 from __future__ import annotations
 
 import json
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import nullcontext
 from typing import Any, Dict, List, Optional
 
@@ -79,6 +79,21 @@ class _FakeKgStore:
     def get_knowledge_graph(self, uid: str, *, db_client: Any = None) -> Dict[str, Any]:
         self.calls.append('get_knowledge_graph')
         return {'nodes': list(self.nodes.values()), 'edges': list(self.edges.values())}
+
+
+class _InlineExecutor:
+    """Runs each memory inline, in submission order.
+
+    A worker thread left running past the end of a test calls `kg.get_llm` again
+    after the next test has repatched it, so its extraction lands in that test's
+    recorder — order-dependent, and only on a loaded runner. Nothing here needs
+    real concurrency, so nothing here starts a thread.
+    """
+
+    def submit(self, fn: Any, *args: Any, **kwargs: Any) -> "Future[Any]":
+        future: Future[Any] = Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
 
 
 def _response(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> Any:
@@ -146,18 +161,17 @@ def test_rebuild_interrupted_before_the_swap_leaves_the_old_graph_intact(rebuild
 
     monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
 
-    class _DyingExecutor:
+    class _DyingExecutor(_InlineExecutor):
         """Stands in for the serving process going away: submission stops working."""
 
         def __init__(self) -> None:
-            self._inner = ThreadPoolExecutor(max_workers=1)
             self._submitted = 0
 
-        def submit(self, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        def submit(self, fn: Any, *args: Any, **kwargs: Any) -> "Future[Any]":
             self._submitted += 1
             if self._submitted > 1:
                 raise RuntimeError('cannot schedule new futures after shutdown')
-            return self._inner.submit(fn, *args, **kwargs)
+            return super().submit(fn, *args, **kwargs)
 
     monkeypatch.setattr(kg, 'llm_executor', _DyingExecutor())
 
@@ -198,7 +212,7 @@ def test_rebuilt_graph_still_merges_entities_across_memories(rebuild_harness):
     monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
 
     # Serial so m2 observes m1's staged nodes, matching the ordering this asserts.
-    monkeypatch.setattr(kg, 'llm_executor', ThreadPoolExecutor(max_workers=1))
+    monkeypatch.setattr(kg, 'llm_executor', _InlineExecutor())
 
     graph = kg.rebuild_knowledge_graph(
         'uid-1',
@@ -242,7 +256,7 @@ def test_edges_follow_the_ids_their_nodes_actually_landed_on(rebuild_harness):
         return scripted['m1' if 'Neo woke up.' in prompt else 'm2']
 
     monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
-    monkeypatch.setattr(kg, 'llm_executor', ThreadPoolExecutor(max_workers=1))
+    monkeypatch.setattr(kg, 'llm_executor', _InlineExecutor())
 
     graph = kg.rebuild_knowledge_graph(
         'uid-1',

--- a/backend/tests/unit/test_knowledge_graph_rebuild_ordering.py
+++ b/backend/tests/unit/test_knowledge_graph_rebuild_ordering.py
@@ -1,0 +1,256 @@
+"""A legacy graph rebuild must not destroy the stored graph before the new one exists.
+
+`rebuild_knowledge_graph` used to delete the account's graph as its first statement and
+then upsert row by row as each memory's LLM round-trip returned — up to 500 memories at
+concurrency 4. `_rebuild_graph_task` drives it from FastAPI `BackgroundTasks`, in the
+serving process, with no retry: a deploy, restart or eviction inside that multi-minute
+window left the account with whatever partial subset had been written and no copy of the
+graph it replaced.
+
+These run the production function against an in-memory stand-in for
+`database.knowledge_graph` that mirrors the merge semantics of the real
+`upsert_knowledge_node` / `upsert_knowledge_edge`, so ordering and the rebuilt graph are
+both observed through the same seam production writes through.
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from utils.llm import knowledge_graph as kg
+
+
+class _FakeKgStore:
+    """Mirrors the merge/identity rules of `database.knowledge_graph`."""
+
+    def __init__(self, nodes: Optional[List[Dict[str, Any]]] = None) -> None:
+        self.nodes: Dict[str, Dict[str, Any]] = {node['id']: dict(node) for node in (nodes or [])}
+        self.edges: Dict[str, Dict[str, Any]] = {}
+        self.calls: List[str] = []
+
+    def get_knowledge_nodes(self, uid: str, *, db_client: Any = None, **_: Any) -> List[Dict[str, Any]]:
+        self.calls.append('get_knowledge_nodes')
+        return [dict(node) for node in self.nodes.values()]
+
+    def delete_knowledge_graph(self, uid: str, *, db_client: Any = None) -> None:
+        self.calls.append('delete_knowledge_graph')
+        self.nodes.clear()
+        self.edges.clear()
+
+    def _find_by_label_or_alias(self, label: str) -> Optional[str]:
+        wanted = label.lower()
+        for node in self.nodes.values():
+            if node.get('label', '').lower() == wanted:
+                return node['id']
+        for node in self.nodes.values():
+            if wanted in {alias.lower() for alias in node.get('aliases', [])}:
+                return node['id']
+        return None
+
+    def upsert_knowledge_node(self, uid: str, node_data: Dict[str, Any], *, db_client: Any = None) -> Dict[str, Any]:
+        self.calls.append('upsert_knowledge_node')
+        node_id = node_data['id']
+        if node_id not in self.nodes:
+            # The real upsert re-resolves a node it cannot find by id.
+            node_id = self._find_by_label_or_alias(node_data.get('label', '')) or node_id
+        node_data = {**node_data, 'id': node_id}
+        existing = self.nodes.get(node_id, {})
+        merged = dict(node_data)
+        merged['memory_ids'] = sorted(set(existing.get('memory_ids', [])) | set(node_data.get('memory_ids', [])))
+        merged['aliases'] = sorted(set(existing.get('aliases', [])) | set(node_data.get('aliases', [])))
+        self.nodes[node_id] = merged
+        return merged
+
+    def upsert_knowledge_edge(self, uid: str, edge_data: Dict[str, Any], *, db_client: Any = None) -> Dict[str, Any]:
+        self.calls.append('upsert_knowledge_edge')
+        edge_id = f"{edge_data['source_id']}_{edge_data['label']}_{edge_data['target_id']}".replace('/', '_')
+        existing = self.edges.get(edge_id, {})
+        merged = dict(edge_data)
+        merged['id'] = edge_id
+        merged['memory_ids'] = sorted(set(existing.get('memory_ids', [])) | set(edge_data.get('memory_ids', [])))
+        self.edges[edge_id] = merged
+        return merged
+
+    def get_knowledge_graph(self, uid: str, *, db_client: Any = None) -> Dict[str, Any]:
+        self.calls.append('get_knowledge_graph')
+        return {'nodes': list(self.nodes.values()), 'edges': list(self.edges.values())}
+
+
+def _response(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]]) -> Any:
+    class _Response:
+        content = json.dumps({'nodes': nodes, 'edges': edges})
+
+    return _Response()
+
+
+@pytest.fixture
+def rebuild_harness(monkeypatch: pytest.MonkeyPatch):
+    """Production `rebuild_knowledge_graph` wired to a fake store and a scripted LLM."""
+    store = _FakeKgStore(
+        nodes=[
+            {
+                'id': 'pre-existing-node',
+                'label': 'Trinity',
+                'node_type': 'person',
+                'aliases': [],
+                'memory_ids': ['old-memory'],
+            }
+        ]
+    )
+    monkeypatch.setattr(kg, 'kg_db', store)
+    monkeypatch.setattr(kg, 'track_usage', lambda *args, **kwargs: nullcontext())
+
+    executor = ThreadPoolExecutor(max_workers=2)
+    monkeypatch.setattr(kg, 'llm_executor', executor)
+    try:
+        yield store, monkeypatch
+    finally:
+        executor.shutdown(wait=True)
+
+
+def test_stored_graph_survives_until_every_extraction_has_finished(rebuild_harness):
+    """The delete must not precede the LLM work it depends on."""
+    store, monkeypatch = rebuild_harness
+
+    def invoke(_prompt: str) -> Any:
+        store.calls.append('llm_invoke')
+        return _response([{'label': 'Neo', 'node_type': 'person', 'aliases': ['The One']}], [])
+
+    monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
+
+    kg.rebuild_knowledge_graph(
+        'uid-1',
+        [{'id': 'm1', 'content': 'Neo woke up.'}, {'id': 'm2', 'content': 'Neo flew.'}],
+    )
+
+    delete_at = store.calls.index('delete_knowledge_graph')
+    last_invoke_at = len(store.calls) - 1 - store.calls[::-1].index('llm_invoke')
+    assert last_invoke_at < delete_at, store.calls
+    assert store.calls.count('llm_invoke') == 2
+    # And the write burst follows the delete, so the swap is delete-then-write.
+    assert store.calls.index('upsert_knowledge_node') > delete_at
+
+
+def test_rebuild_interrupted_before_the_swap_leaves_the_old_graph_intact(rebuild_harness):
+    """A driver that dies mid-rebuild must not have destroyed anything yet."""
+    store, monkeypatch = rebuild_harness
+
+    def invoke(_prompt: str) -> Any:
+        store.calls.append('llm_invoke')
+        return _response([{'label': 'Neo', 'node_type': 'person', 'aliases': []}], [])
+
+    monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
+
+    class _DyingExecutor:
+        """Stands in for the serving process going away: submission stops working."""
+
+        def __init__(self) -> None:
+            self._inner = ThreadPoolExecutor(max_workers=1)
+            self._submitted = 0
+
+        def submit(self, fn: Any, *args: Any, **kwargs: Any) -> Any:
+            self._submitted += 1
+            if self._submitted > 1:
+                raise RuntimeError('cannot schedule new futures after shutdown')
+            return self._inner.submit(fn, *args, **kwargs)
+
+    monkeypatch.setattr(kg, 'llm_executor', _DyingExecutor())
+
+    with pytest.raises(RuntimeError):
+        kg.rebuild_knowledge_graph(
+            'uid-1',
+            [{'id': 'm1', 'content': 'Neo woke up.'}, {'id': 'm2', 'content': 'Neo flew.'}],
+        )
+
+    assert 'delete_knowledge_graph' not in store.calls
+    assert list(store.nodes) == ['pre-existing-node']
+    assert store.nodes['pre-existing-node']['memory_ids'] == ['old-memory']
+
+
+def test_rebuilt_graph_still_merges_entities_across_memories(rebuild_harness):
+    """Staging in memory must resolve labels and aliases the way the store did."""
+    store, monkeypatch = rebuild_harness
+    scripted = {
+        'm1': _response(
+            [{'label': 'Neo', 'node_type': 'person', 'aliases': ['The One']}, {'label': 'Zion', 'node_type': 'place'}],
+            [{'source_label': 'Neo', 'target_label': 'Zion', 'label': 'lives in'}],
+        ),
+        # Second memory names the same entity by its alias and repeats the edge.
+        'm2': _response(
+            [{'label': 'The One', 'node_type': 'person', 'aliases': ['Thomas']}, {'label': 'Zion'}],
+            [{'source_label': 'The One', 'target_label': 'Zion', 'label': 'lives in'}],
+        ),
+    }
+    order: List[str] = []
+
+    def invoke(prompt: str) -> Any:
+        # The prompt carries the staged nodes, so m2 can only reuse m1's ids if the
+        # in-memory snapshot replaced the Firestore read faithfully.
+        memory_id = 'm1' if 'Neo woke up.' in prompt else 'm2'
+        order.append(memory_id)
+        return scripted[memory_id]
+
+    monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
+
+    # Serial so m2 observes m1's staged nodes, matching the ordering this asserts.
+    monkeypatch.setattr(kg, 'llm_executor', ThreadPoolExecutor(max_workers=1))
+
+    graph = kg.rebuild_knowledge_graph(
+        'uid-1',
+        [{'id': 'm1', 'content': 'Neo woke up.'}, {'id': 'm2', 'content': 'The One flew.'}],
+    )
+
+    assert order == ['m1', 'm2']
+    assert len(graph['nodes']) == 2, graph['nodes']
+    neo = next(node for node in graph['nodes'] if node['label'] in ('Neo', 'The One'))
+    assert neo['memory_ids'] == ['m1', 'm2']
+    assert set(neo['aliases']) == {'The One', 'Thomas'}
+
+    assert len(graph['edges']) == 1, graph['edges']
+    assert graph['edges'][0]['memory_ids'] == ['m1', 'm2']
+    assert graph['edges'][0]['source_id'] == neo['id']
+
+    # The pre-existing node is gone: a rebuild still replaces the graph.
+    assert 'pre-existing-node' not in store.nodes
+
+
+def test_edges_follow_the_ids_their_nodes_actually_landed_on(rebuild_harness):
+    """Deferring the writes must not let an edge point at an id nothing was written under.
+
+    `upsert_knowledge_node` re-resolves a node it cannot find by id against label and
+    alias, so a staged node whose label another staged node later adopted as an alias
+    lands under that other node's id. The per-memory loop wrote its edges from
+    `saved_node['id']` and so never saw this; the write phase has to do the same.
+    """
+    store, monkeypatch = rebuild_harness
+    scripted = {
+        'm1': _response(
+            [{'label': 'Neo', 'node_type': 'person'}, {'label': 'Trinity', 'node_type': 'person'}],
+            [{'source_label': 'Trinity', 'target_label': 'Neo', 'label': 'knows'}],
+        ),
+        # Neo takes 'Trinity' as an alias, so the separately staged Trinity node
+        # collides with it at write time and lands under Neo's id.
+        'm2': _response([{'label': 'Neo', 'node_type': 'person', 'aliases': ['Trinity']}], []),
+    }
+
+    def invoke(prompt: str) -> Any:
+        return scripted['m1' if 'Neo woke up.' in prompt else 'm2']
+
+    monkeypatch.setattr(kg, 'get_llm', lambda *_args, **_kwargs: type('LLM', (), {'invoke': staticmethod(invoke)}))
+    monkeypatch.setattr(kg, 'llm_executor', ThreadPoolExecutor(max_workers=1))
+
+    graph = kg.rebuild_knowledge_graph(
+        'uid-1',
+        [{'id': 'm1', 'content': 'Neo woke up.'}, {'id': 'm2', 'content': 'Neo is Trinity.'}],
+    )
+
+    stored_ids = {node['id'] for node in graph['nodes']}
+    assert graph['edges'], 'the rebuild dropped the edge entirely'
+    for edge in graph['edges']:
+        assert edge['source_id'] in stored_ids, (edge, stored_ids)
+        assert edge['target_id'] in stored_ids, (edge, stored_ids)

--- a/backend/utils/llm/knowledge_graph.py
+++ b/backend/utils/llm/knowledge_graph.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, cast
 import threading
 import hashlib
@@ -331,6 +331,82 @@ def extract_knowledge_from_memory(
         return None
 
 
+class _StagedRebuild:
+    """The rebuilt graph, held in memory until every extraction has finished.
+
+    A rebuild used to delete the stored graph first and then upsert row by row as
+    each memory's LLM round-trip came back — up to 500 memories at concurrency 4,
+    so a multi-minute span in which the account's only copy of its graph was a
+    partial one. `BackgroundTasks` runs that driver in the serving process with no
+    retry, so a deploy, restart or eviction mid-rebuild left the partial graph
+    behind permanently.
+
+    Every `get_knowledge_nodes` read that loop made saw only rows the same rebuild
+    had just written (the delete had emptied the collection), so this holds that
+    state instead. Resolution and merge semantics mirror `upsert_knowledge_node`
+    and `upsert_knowledge_edge`, which still perform the writes at commit time.
+    """
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Dict[str, Any]] = {}
+        self._edges: Dict[str, Dict[str, Any]] = {}
+        self._label_to_node_id: Dict[str, str] = {}
+
+    def nodes_snapshot(self) -> List[Dict[str, Any]]:
+        return [dict(node) for node in self._nodes.values()]
+
+    def nodes(self) -> List[Dict[str, Any]]:
+        return list(self._nodes.values())
+
+    def edges(self) -> List[Dict[str, Any]]:
+        return list(self._edges.values())
+
+    def apply(self, extraction: KnowledgeGraphExtraction, memory_id: str) -> None:
+        for node in extraction.nodes:
+            existing_id = self._label_to_node_id.get(node.label.lower())
+            for alias in node.aliases:
+                if not existing_id:
+                    existing_id = self._label_to_node_id.get(alias.lower())
+            self._apply_node(cast(str, existing_id) or str(uuid.uuid4()), node, memory_id)
+
+        for edge in extraction.edges:
+            source_id = self._label_to_node_id.get(edge.source_label.lower())
+            target_id = self._label_to_node_id.get(edge.target_label.lower())
+            if source_id and target_id:
+                self._apply_edge(source_id, target_id, edge.label, memory_id)
+
+    def _apply_node(self, node_id: str, node: ExtractedNode, memory_id: str) -> None:
+        existing = self._nodes.get(node_id, {})
+        aliases = list(set(cast(List[str], existing.get('aliases', []))) | set(node.aliases))
+        memory_ids = list(set(cast(List[str], existing.get('memory_ids', []))) | {memory_id})
+        self._nodes[node_id] = {
+            'id': node_id,
+            'label': node.label,
+            'node_type': node.node_type,
+            'aliases': aliases,
+            'memory_ids': memory_ids,
+            # `_existing_nodes_prompt_json` trims the prompt listing by recency, so
+            # staged nodes carry the same field the stored rows did.
+            'updated_at': datetime.now(timezone.utc),
+        }
+        self._label_to_node_id[node.label.lower()] = node_id
+        for alias in aliases:
+            self._label_to_node_id[alias.lower()] = node_id
+
+    def _apply_edge(self, source_id: str, target_id: str, label: str, memory_id: str) -> None:
+        # Same identity `upsert_knowledge_edge` derives, so repeats of one edge
+        # across memories merge here exactly as they merged in Firestore.
+        edge_id = f"{source_id}_{label}_{target_id}".replace('/', '_')
+        existing = self._edges.get(edge_id, {})
+        memory_ids = list(set(cast(List[str], existing.get('memory_ids', []))) | {memory_id})
+        self._edges[edge_id] = {
+            'source_id': source_id,
+            'target_id': target_id,
+            'label': label,
+            'memory_ids': memory_ids,
+        }
+
+
 def rebuild_knowledge_graph(
     uid: str,
     memories: List[Dict[str, Any]],
@@ -338,18 +414,17 @@ def rebuild_knowledge_graph(
     *,
     db_client: Any = None,
 ) -> Dict[str, Any]:
-    kg_db.delete_knowledge_graph(uid, db_client=db_client)
-
+    staged = _StagedRebuild()
     node_lock = threading.Lock()
 
-    def process_memory(memory: Dict[str, Any]) -> Dict[str, Any]:
+    def process_memory(memory: Dict[str, Any]) -> None:
         memory_id = memory.get('id', str(uuid.uuid4()))
         memory_content = memory.get('content', '')
         if not memory_content:
-            return {'nodes': [], 'edges': []}
+            return
 
-        existing_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
-        existing_nodes_json = _existing_nodes_prompt_json(existing_nodes)
+        with node_lock:
+            existing_nodes_json = _existing_nodes_prompt_json(staged.nodes_snapshot())
 
         try:
             parser = PydanticOutputParser(pydantic_object=KnowledgeGraphExtraction)
@@ -369,61 +444,11 @@ def rebuild_knowledge_graph(
                 logger.error(f"KG extraction parse failed for memory {memory_id}: {type(e).__name__}")
                 extraction = KnowledgeGraphExtraction(nodes=[], edges=[])
 
-            created_nodes: List[Any] = []
-            created_edges: List[Any] = []
-
             with node_lock:
-                label_to_node_id: Dict[str, str] = {}
-                current_nodes = kg_db.get_knowledge_nodes(uid, db_client=db_client)
-                for existing in current_nodes:
-                    label_to_node_id[existing['label'].lower()] = existing['id']
-                    for alias in existing.get('aliases', []):
-                        label_to_node_id[alias.lower()] = existing['id']
-
-                for node in extraction.nodes:
-                    existing_id = label_to_node_id.get(node.label.lower())
-                    for alias in node.aliases:
-                        if not existing_id:
-                            existing_id = label_to_node_id.get(alias.lower())
-
-                    node_id = cast(str, existing_id) or str(uuid.uuid4())
-
-                    node_data = {
-                        'id': node_id,
-                        'label': node.label,
-                        'node_type': node.node_type,
-                        'aliases': node.aliases,
-                        'memory_ids': [memory_id],
-                    }
-
-                    saved_node = kg_db.upsert_knowledge_node(uid, node_data, db_client=db_client)
-                    created_nodes.append(saved_node)
-                    label_to_node_id[node.label.lower()] = saved_node['id']
-                    for alias in node.aliases:
-                        label_to_node_id[alias.lower()] = saved_node['id']
-
-                for edge in extraction.edges:
-                    source_id = label_to_node_id.get(edge.source_label.lower())
-                    target_id = label_to_node_id.get(edge.target_label.lower())
-
-                    if source_id and target_id:
-                        edge_data = {
-                            'source_id': source_id,
-                            'target_id': target_id,
-                            'label': edge.label,
-                            'memory_ids': [memory_id],
-                        }
-                        saved_edge = kg_db.upsert_knowledge_edge(uid, edge_data, db_client=db_client)
-                        created_edges.append(saved_edge)
-
-            return {'nodes': created_nodes, 'edges': created_edges}
+                staged.apply(extraction, memory_id)
 
         except Exception:
             logging.exception(f"Error extracting knowledge graph from memory_id: {memory_id}")
-            return {'nodes': [], 'edges': []}
-
-    all_nodes: List[Any] = []
-    all_edges: List[Any] = []
 
     futures: List[Any] = []
     for m in memories:
@@ -437,10 +462,31 @@ def rebuild_knowledge_graph(
             raise
     for future in as_completed(futures):
         try:
-            result = cast(Dict[str, Any], future.result())
-            all_nodes.extend(result.get('nodes', []))
-            all_edges.extend(result.get('edges', []))
+            future.result()
         except Exception:
             logging.exception("Error in concurrent memory extraction")
+
+    # Only now is the replacement graph fully known. Anything that interrupts the
+    # extraction above leaves the account's stored graph untouched.
+    kg_db.delete_knowledge_graph(uid, db_client=db_client)
+    # `upsert_knowledge_node` resolves a node it does not find by id against label
+    # and alias, so the id a node lands on is the one it returns, not necessarily
+    # the one staged. Edges are written from the returned ids — the per-memory loop
+    # used `saved_node['id']` for the same reason.
+    landed_node_ids: Dict[str, str] = {}
+    for node_data in staged.nodes():
+        staged_id = node_data['id']
+        saved_node = kg_db.upsert_knowledge_node(uid, node_data, db_client=db_client)
+        landed_node_ids[staged_id] = saved_node['id']
+    for edge_data in staged.edges():
+        source_id = landed_node_ids.get(edge_data['source_id'])
+        target_id = landed_node_ids.get(edge_data['target_id'])
+        if not source_id or not target_id:
+            continue
+        kg_db.upsert_knowledge_edge(
+            uid,
+            {**edge_data, 'source_id': source_id, 'target_id': target_id},
+            db_client=db_client,
+        )
 
     return kg_db.get_knowledge_graph(uid, db_client=db_client)


### PR DESCRIPTION
Fixes #11923.

## Bug

`rebuild_knowledge_graph` deleted the account's stored knowledge graph as its **first statement**, then upserted node by node as each memory's LLM extraction returned:

```python
def rebuild_knowledge_graph(uid, memories, user_name="User", *, db_client=None):
    kg_db.delete_knowledge_graph(uid, db_client=db_client)   # <- everything below runs after this
```

The caller passes up to 500 memories (`routers/knowledge_graph.py`, `limit=500`), each one an LLM round-trip, at concurrency 4 (`_KG_REBUILD_SEM`). So for minutes at a stretch the account's only copy of its graph was a partial one. `_rebuild_graph_task` drives that from FastAPI `BackgroundTasks` — in the serving process, with no retry and no durability — so a deploy, restart, eviction or driver error inside that window left the user with whatever subset had been written, the original already gone, nothing scheduled to finish it, and no marker to recover from. Their only signal was a `200 {"status": "rebuilding"}` returned minutes earlier.

Not theoretical: prod served **580 successful `POST /v1/knowledge-graph/rebuild` calls in the last 30 days** (~19/day), and backend revisions roll during that traffic.

This is the part #11820 left standing — it removed the *route's* eager delete; the destructive ordering one level down predates it (`1847a840a2`).

## Root cause

The ordering was load-bearing only by accident. Every `kg_db.get_knowledge_nodes` read the per-memory loop made saw **only rows this same rebuild had just written**, because the delete had already emptied the collection — so the loop was using Firestore as scratch space for its own intermediate state, and the delete had to come first for that to work.

## Fix

Direction 1 from the issue (extract first, then swap). `_StagedRebuild` holds that intermediate state in memory instead, mirroring the identity and merge rules of `upsert_knowledge_node` / `upsert_knowledge_edge` — which still perform every actual write. The delete then moves down beside the write burst it belongs with:

```python
    # Only now is the replacement graph fully known.
    kg_db.delete_knowledge_graph(uid, db_client=db_client)
    for node_data in staged.nodes(): kg_db.upsert_knowledge_node(...)
    for edge_data in staged.edges(): kg_db.upsert_knowledge_edge(...)
```

Anything that interrupts the extraction now leaves the stored graph untouched. The destructive window collapses from ~125 sequential LLM waves to a burst of Firestore writes. It also removes one node-collection read per memory, and a concurrent `GET /v1/knowledge-graph` during a rebuild now sees the previous graph rather than a partial one.

Deferring the writes introduces one hazard the incremental loop could not have: `upsert_knowledge_node` re-resolves a node it cannot find by id against label and alias, so a staged node whose label another staged node later adopted as an alias lands under that *other* node's id. Edges are therefore written from the ids the upserts returned — exactly what the old loop got for free by using `saved_node['id']`.

No schema, read-path or route change; `rebuild_knowledge_graph` keeps its signature and return value.

## What I tested

`backend/tests/unit/test_knowledge_graph_rebuild_ordering.py` — new, drives the production `rebuild_knowledge_graph` against an in-memory stand-in for `database.knowledge_graph` that reproduces the real merge/identity semantics, so ordering and the rebuilt graph are both observed through the seam production writes through.

Ran against the **pre-fix source** (`origin/main`) as a control, same tests:

```
FAILED test_stored_graph_survives_until_every_extraction_has_finished
FAILED test_rebuild_interrupted_before_the_swap_leaves_the_old_graph_intact
        assert 'delete_knowledge_graph' not in ['delete_knowledge_graph']
2 failed, 1 passed
```

and after the fix: `3 passed`.

`test_rebuilt_graph_still_merges_entities_across_memories` passes on **both** sources — it pins the rebuilt graph itself (a second memory naming an entity by its alias merges into the first memory's node, `memory_ids` and `aliases` unioned, the repeated edge merged to one row), which is what makes this a behaviour-preserving refactor rather than a rewrite.

`test_edges_follow_the_ids_their_nodes_actually_landed_on` covers the re-resolution hazard above: run against a variant of this fix *without* the id remap it fails with a dangling edge (`assert 'b243b7af-…' in {'35f69f4b-…'}`), and passes with it.

Repo runner over the 8 files touching this path (`./test.sh` with a scoped `BACKEND_UNIT_TEST_FILE_LIST`): **134 passed, 0 failed**, exit 0.

Not verified: an actual process kill against live Firestore. The interruption test simulates the driver losing its executor mid-run, which exercises the same early-exit path, but it is a stand-in for the real crash.

## Product invariants

`scripts/pr-preflight --suggest`: none affected.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged
