### PR TITLE
Rebase of #7977: date-range filter for conversation search (#4457)

### DIFF
--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -688,6 +688,8 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
   int? page,
   int? limit,
   bool includeDiscarded = true,
+  DateTime? startDate,
+  DateTime? endDate,
   String? speakerId,
 }) async {
   Logger.debug(Env.apiBaseUrl);
@@ -700,6 +702,8 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
       'page': page ?? 1,
       'per_page': limit ?? 10,
       'include_discarded': includeDiscarded,
+      if (startDate != null) 'start_date': startDate.toIso8601String(),
+      if (endDate != null) 'end_date': endDate.toIso8601String(),
       if (speakerId != null) 'speaker_id': speakerId,
     }),
   );

--- a/app/lib/pages/conversations/widgets/search_widget.dart
+++ b/app/lib/pages/conversations/widgets/search_widget.dart
@@ -154,27 +154,31 @@ class _SearchWidgetState extends State<SearchWidget> {
           // Calendar button - same height as search bar (48px)
           Consumer<ConversationProvider>(
             builder: (context, convoProvider, _) {
+              final hasSearchQuery = convoProvider.previousQuery.isNotEmpty;
+              final hasActiveFilter = hasSearchQuery
+                  ? convoProvider.searchStartDate != null
+                  : convoProvider.selectedStartDate != null;
               return Container(
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: convoProvider.selectedStartDate != null
-                      ? Colors.deepPurple.withValues(alpha: 0.5)
-                      : const Color(0xFF1F1F25),
+                  color: hasActiveFilter ? Colors.deepPurple.withValues(alpha: 0.5) : const Color(0xFF1F1F25),
                   borderRadius: BorderRadius.circular(24),
                 ),
                 child: IconButton(
                   padding: EdgeInsets.zero,
                   icon: FaIcon(
-                    convoProvider.selectedStartDate != null
-                        ? FontAwesomeIcons.calendarDay
-                        : FontAwesomeIcons.calendarDays,
+                    hasActiveFilter ? FontAwesomeIcons.calendarDay : FontAwesomeIcons.calendarDays,
                     size: 18,
-                    color: convoProvider.selectedStartDate != null ? Colors.white : Colors.white70,
+                    color: hasActiveFilter ? Colors.white : Colors.white70,
                   ),
                   onPressed: () async {
                     HapticFeedback.mediumImpact();
-                    await showConversationDateRangePicker(context);
+                    if (hasSearchQuery) {
+                      await showConversationSearchDateRangePicker(context);
+                    } else {
+                      await showConversationDateRangePicker(context);
+                    }
                   },
                 ),
               );

--- a/app/lib/pages/conversations/widgets/search_widget.dart
+++ b/app/lib/pages/conversations/widgets/search_widget.dart
@@ -155,9 +155,8 @@ class _SearchWidgetState extends State<SearchWidget> {
           Consumer<ConversationProvider>(
             builder: (context, convoProvider, _) {
               final hasSearchQuery = convoProvider.previousQuery.isNotEmpty;
-              final hasActiveFilter = hasSearchQuery
-                  ? convoProvider.searchStartDate != null
-                  : convoProvider.selectedStartDate != null;
+              final hasActiveFilter =
+                  hasSearchQuery ? convoProvider.searchStartDate != null : convoProvider.selectedStartDate != null;
               return Container(
                 width: 48,
                 height: 48,

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -21,6 +21,8 @@ typedef ConversationSearchFetcher = Future<(List<ServerConversation>, int, int)>
   int? page,
   int? limit,
   required bool includeDiscarded,
+  DateTime? startDate,
+  DateTime? endDate,
   String? speakerId,
 });
 typedef ConversationDetailsFetcher = Future<ServerConversation?> Function(String conversationId);
@@ -53,6 +55,9 @@ class ConversationProvider extends ChangeNotifier {
   DateTime? selectedEndDate;
   String? selectedFolderId;
   String? selectedSpeakerId;
+
+  DateTime? searchStartDate;
+  DateTime? searchEndDate;
 
   String previousQuery = '';
   int totalSearchPages = 1;
@@ -181,6 +186,8 @@ class ConversationProvider extends ChangeNotifier {
     selectedEndDate = null;
     selectedFolderId = null;
     selectedSpeakerId = null;
+    searchStartDate = null;
+    searchEndDate = null;
     previousQuery = '';
     totalSearchPages = 1;
     currentSearchPage = 1;
@@ -229,6 +236,8 @@ class ConversationProvider extends ChangeNotifier {
     var (convos, current, total) = await _conversationSearchFetcher(
       query,
       includeDiscarded: showDiscardedConversations,
+      startDate: searchStartDate,
+      endDate: searchEndDate,
       speakerId: selectedSpeakerId,
     );
     if (generation != _sessionGeneration || !_isSignedIn()) return;
@@ -263,6 +272,8 @@ class ConversationProvider extends ChangeNotifier {
       previousQuery,
       page: currentSearchPage + 1,
       includeDiscarded: showDiscardedConversations,
+      startDate: searchStartDate,
+      endDate: searchEndDate,
       speakerId: selectedSpeakerId,
     );
     if (generation != _sessionGeneration || !_isSignedIn()) return;
@@ -806,6 +817,25 @@ class ConversationProvider extends ChangeNotifier {
 
       return true;
     }).toList();
+  }
+
+  /// Set search date range (start and end). Null = no limit on that side.
+  ///
+  /// Dates are normalized to day boundaries so the selected final calendar day
+  /// is included: [start] is set to the start of its day (00:00:00) and [end]
+  /// is set to the end of its day (23:59:59.999), matching how the server
+  /// interprets the ISO-8601 bounds.
+  void setSearchDateRange(DateTime? start, DateTime? end) {
+    searchStartDate = start != null ? DateTime(start.year, start.month, start.day) : null;
+    searchEndDate = end != null ? DateTime(end.year, end.month, end.day, 23, 59, 59, 999) : null;
+    notifyListeners();
+  }
+
+  /// Clear the search date range filter
+  void clearSearchDateRange() {
+    searchStartDate = null;
+    searchEndDate = null;
+    notifyListeners();
   }
 
   /// Filter conversations by a date range (inclusive of both start and end day)

--- a/app/lib/widgets/calendar_date_picker_sheet.dart
+++ b/app/lib/widgets/calendar_date_picker_sheet.dart
@@ -145,3 +145,111 @@ Future<void> showConversationDateRangePicker(BuildContext context) async {
     },
   );
 }
+
+/// Date-range picker for conversation *search* (#4457 / #7977).
+///
+/// Sibling of [showConversationDateRangePicker]: that sheet filters the
+/// in-memory list via [ConversationProvider.selectedStartDate], while this
+/// one sets [ConversationProvider.searchStartDate] / [searchEndDate] and
+/// re-runs the active search. Apply is a no-op when there is no search query
+/// so an empty search bar cannot show a misleading active-filter state.
+Future<void> showConversationSearchDateRangePicker(BuildContext context) async {
+  final provider = Provider.of<ConversationProvider>(context, listen: false);
+  final hasExistingFilter = provider.searchStartDate != null;
+  DateTime? startDate = provider.searchStartDate;
+  DateTime? endDate = provider.searchEndDate;
+  List<DateTime?> range = [startDate, endDate];
+
+  await showCupertinoModalPopup<void>(
+    context: context,
+    builder: (BuildContext context) {
+      return Container(
+        height: 420,
+        padding: const EdgeInsets.only(top: 6.0),
+        margin: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        color: const Color(0xFF1F1F25),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                decoration: const BoxDecoration(
+                  color: Color(0xFF1F1F25),
+                  border: Border(bottom: BorderSide(color: Color(0xFF35343B), width: 0.5)),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: () async {
+                        if (hasExistingFilter) {
+                          Navigator.of(context).pop();
+                          provider.clearSearchDateRange();
+                          if (provider.previousQuery.isNotEmpty) {
+                            await provider.searchConversations(provider.previousQuery);
+                          }
+                          PlatformManager.instance.analytics.calendarFilterCleared();
+                        } else {
+                          Navigator.of(context).pop();
+                        }
+                      },
+                      child: Text(
+                        hasExistingFilter ? context.l10n.removeFilter : context.l10n.cancel,
+                        style: const TextStyle(color: Colors.white, fontSize: 16),
+                      ),
+                    ),
+                    const Spacer(),
+                    CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: () async {
+                        final start = range.isNotEmpty ? range[0] : startDate;
+                        if (start == null) {
+                          Navigator.of(context).pop();
+                          return;
+                        }
+                        final end = range.length > 1 ? range[1] : endDate;
+                        Navigator.of(context).pop();
+                        if (provider.previousQuery.isNotEmpty) {
+                          provider.setSearchDateRange(start, end);
+                          await provider.searchConversations(provider.previousQuery);
+                          PlatformManager.instance.analytics.calendarFilterApplied(start, end ?? start);
+                        }
+                      },
+                      child: Text(
+                        context.l10n.done,
+                        style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Material(
+                  color: ResponsiveHelper.backgroundSecondary,
+                  child: CalendarDatePicker2(
+                    config: getDefaultCalendarConfig(
+                      firstDate: DateTime(2020),
+                      lastDate: DateTime.now(),
+                      currentDate: DateTime.now(),
+                      calendarType: CalendarDatePicker2Type.range,
+                    ),
+                    value: range,
+                    onValueChanged: (dates) {
+                      range = dates;
+                      if (dates.isNotEmpty) {
+                        startDate = dates[0];
+                        endDate = dates.length > 1 ? dates[1] : null;
+                      }
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/app/test/providers/conversation_provider_auth_retry_test.dart
+++ b/app/test/providers/conversation_provider_auth_retry_test.dart
@@ -106,7 +106,8 @@ void main() {
   test('clearUserData invalidates an in-flight search result', () async {
     final response = Completer<(List<ServerConversation>, int, int)>();
     final provider = ConversationProvider(
-      conversationSearchFetcher: (query, {page, limit, required includeDiscarded, speakerId}) => response.future,
+      conversationSearchFetcher: (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) =>
+          response.future,
       isSignedIn: () => true,
     );
     addTearDown(provider.dispose);
@@ -123,7 +124,8 @@ void main() {
   test('clearUserData invalidates an in-flight search pagination result', () async {
     final response = Completer<(List<ServerConversation>, int, int)>();
     final provider = ConversationProvider(
-      conversationSearchFetcher: (query, {page, limit, required includeDiscarded, speakerId}) => response.future,
+      conversationSearchFetcher: (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) =>
+          response.future,
       isSignedIn: () => true,
     );
     addTearDown(provider.dispose);

--- a/app/test/providers/conversation_provider_date_range_test.dart
+++ b/app/test/providers/conversation_provider_date_range_test.dart
@@ -96,13 +96,13 @@ void main() {
       DateTime? capturedEnd;
       String? capturedQuery;
       final provider = makeProvider(
-        conversationSearchFetcher:
-            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
-              capturedQuery = query;
-              capturedStart = startDate;
-              capturedEnd = endDate;
-              return (<ServerConversation>[], 1, 1);
-            },
+        conversationSearchFetcher: (query,
+            {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+          capturedQuery = query;
+          capturedStart = startDate;
+          capturedEnd = endDate;
+          return (<ServerConversation>[], 1, 1);
+        },
       );
 
       provider.setSearchDateRange(DateTime(2026, 6, 1, 9), DateTime(2026, 6, 30, 17));
@@ -117,12 +117,12 @@ void main() {
       DateTime? capturedStart;
       DateTime? capturedEnd;
       final provider = makeProvider(
-        conversationSearchFetcher:
-            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
-              capturedStart = startDate;
-              capturedEnd = endDate;
-              return (<ServerConversation>[], page ?? 1, 2);
-            },
+        conversationSearchFetcher: (query,
+            {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+          capturedStart = startDate;
+          capturedEnd = endDate;
+          return (<ServerConversation>[], page ?? 1, 2);
+        },
       );
 
       provider.setSearchDateRange(DateTime(2026, 6, 1), DateTime(2026, 6, 2));

--- a/app/test/providers/conversation_provider_date_range_test.dart
+++ b/app/test/providers/conversation_provider_date_range_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+/// Regression tests for the search date-range boundary normalization in
+/// ConversationProvider.setSearchDateRange (#4457 / rebase of #7977).
+///
+/// The date range picker only carries calendar-day granularity, so the end of
+/// the selected final day must be included when the range is sent to the API:
+/// startDate is floored to 00:00:00.000 and endDate is ceilinged to
+/// 23:59:59.999 of the same day. Null on either side means "no limit".
+void main() {
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  ConversationProvider makeProvider({ConversationSearchFetcher? conversationSearchFetcher}) {
+    final provider = ConversationProvider(
+      conversationListFetcher: () async => (items: <ServerConversation>[], ok: true),
+      conversationSearchFetcher: conversationSearchFetcher,
+      isSignedIn: () => true,
+    );
+    addTearDown(provider.dispose);
+    return provider;
+  }
+
+  group('ConversationProvider.setSearchDateRange day-boundary normalization', () {
+    test('endDate is set to the last millisecond of its day', () {
+      final provider = makeProvider();
+      final midday = DateTime(2026, 6, 15, 13, 30, 45);
+
+      provider.setSearchDateRange(midday, midday);
+
+      expect(provider.searchStartDate, DateTime(2026, 6, 15, 0, 0, 0, 0));
+      expect(provider.searchEndDate, DateTime(2026, 6, 15, 23, 59, 59, 999));
+    });
+
+    test('a multi-day range includes the full final day', () {
+      final provider = makeProvider();
+      final start = DateTime(2026, 6, 1, 9, 0);
+      final end = DateTime(2026, 6, 30, 17, 0);
+
+      provider.setSearchDateRange(start, end);
+
+      expect(provider.searchStartDate, DateTime(2026, 6, 1));
+      expect(provider.searchEndDate, DateTime(2026, 6, 30, 23, 59, 59, 999));
+    });
+
+    test('null start leaves the lower bound open', () {
+      final provider = makeProvider();
+      provider.setSearchDateRange(null, DateTime(2026, 6, 15, 6, 0));
+
+      expect(provider.searchStartDate, isNull);
+      expect(provider.searchEndDate, DateTime(2026, 6, 15, 23, 59, 59, 999));
+    });
+
+    test('null end leaves the upper bound open', () {
+      final provider = makeProvider();
+      provider.setSearchDateRange(DateTime(2026, 6, 15, 6, 0), null);
+
+      expect(provider.searchStartDate, DateTime(2026, 6, 15));
+      expect(provider.searchEndDate, isNull);
+    });
+
+    test('clearSearchDateRange resets both bounds', () {
+      final provider = makeProvider();
+      provider.setSearchDateRange(DateTime(2026, 6, 1), DateTime(2026, 6, 30));
+      expect(provider.searchStartDate, isNotNull);
+      expect(provider.searchEndDate, isNotNull);
+
+      provider.clearSearchDateRange();
+
+      expect(provider.searchStartDate, isNull);
+      expect(provider.searchEndDate, isNull);
+    });
+
+    test('clearUserData resets search date bounds', () {
+      final provider = makeProvider();
+      provider.setSearchDateRange(DateTime(2026, 6, 1), DateTime(2026, 6, 30));
+
+      provider.clearUserData();
+
+      expect(provider.searchStartDate, isNull);
+      expect(provider.searchEndDate, isNull);
+    });
+  });
+
+  group('ConversationProvider.searchConversations date range forwarding', () {
+    test('searchConversations passes normalized startDate and endDate to the fetcher', () async {
+      DateTime? capturedStart;
+      DateTime? capturedEnd;
+      String? capturedQuery;
+      final provider = makeProvider(
+        conversationSearchFetcher:
+            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+              capturedQuery = query;
+              capturedStart = startDate;
+              capturedEnd = endDate;
+              return (<ServerConversation>[], 1, 1);
+            },
+      );
+
+      provider.setSearchDateRange(DateTime(2026, 6, 1, 9), DateTime(2026, 6, 30, 17));
+      await provider.searchConversations('weekly recap');
+
+      expect(capturedQuery, 'weekly recap');
+      expect(capturedStart, DateTime(2026, 6, 1));
+      expect(capturedEnd, DateTime(2026, 6, 30, 23, 59, 59, 999));
+    });
+
+    test('searchMoreConversations keeps the same date bounds', () async {
+      DateTime? capturedStart;
+      DateTime? capturedEnd;
+      final provider = makeProvider(
+        conversationSearchFetcher:
+            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+              capturedStart = startDate;
+              capturedEnd = endDate;
+              return (<ServerConversation>[], page ?? 1, 2);
+            },
+      );
+
+      provider.setSearchDateRange(DateTime(2026, 6, 1), DateTime(2026, 6, 2));
+      await provider.searchConversations('hello');
+      await provider.searchMoreConversations();
+
+      expect(capturedStart, DateTime(2026, 6, 1));
+      expect(capturedEnd, DateTime(2026, 6, 2, 23, 59, 59, 999));
+    });
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

This is a **rebase of #7977** (`feat/4457-date-range-search` from `Syed-Moiz-Ali/omi`) onto current `main`. GitHub's update-branch on #7977 failed with a merge conflict. `maintainer_can_modify` is true, but this token cannot push the rebased `main` onto that fork (GitHub App `workflows` permission). Same feature, no extras — original #7977 can be closed once this lands.

Conversation search can be limited to a date range (#4457):

- API client: optional `startDate`/`endDate` on `searchConversationsServer`, sent as ISO-8601 `start_date`/`end_date`
- Provider: `searchStartDate`/`searchEndDate`, `setSearchDateRange()` / `clearSearchDateRange()`, day-boundary normalization, passed through search + pagination
- Search-bar calendar: `CalendarDatePicker2Type.range` when a search query is active; the existing list date-range picker is unchanged when the query is empty

Backend `SearchRequest` already accepts `start_date`/`end_date` — no backend change.

Original work by @Syed-Moiz-Ali (with follow-up review fixes already on #7977).

Closes #4457

## Product invariants affected

none

## How it was verified

- `scripts/pr-preflight --suggest` → no locked invariants; no `fix:` declaration required
- Local pre-push manifest checks passed (12 checks)
- Flutter 3.44.5 + `bash test.sh` on the date-range / search-auth provider files: **19 tests passed**

```
flutter test \
  test/providers/conversation_provider_date_range_test.dart \
  test/providers/conversation_provider_auth_retry_test.dart \
  test/providers/conversation_date_range_filter_test.dart
# 00:01 +19: All tests passed!
```

Could not exercise the on-device search-bar calendar UI here (Linux VM, no device).

## Tests

- `app/test/providers/conversation_provider_date_range_test.dart` — day-boundary normalization, one-sided bounds, `clearSearchDateRange` / `clearUserData`, and `searchConversations` / `searchMoreConversations` forwarding `startDate`/`endDate` to the fetcher
- `conversation_provider_auth_retry_test.dart` updated for the new `ConversationSearchFetcher` signature

## Failure class (fixes)

Failure-Class: none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5682214b-6b7a-49f8-8634-52ef39391417?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5682214b-6b7a-49f8-8634-52ef39391417&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

