### PR TITLE
fix(import): rebase of #8075 — Limitless imports idempotent

### DIFF
--- a/.github/failure-classes/FC-import-unstable-identity.json
+++ b/.github/failure-classes/FC-import-unstable-identity.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-import-unstable-identity",
+  "violated_contract": "An imported conversation must have a deterministic identity derived from the source record so a re-import cannot insert a duplicate or overwrite user edits. Random document IDs plus last-writer-wins upsert violate first-import-wins.",
+  "canonical_prevention": "Key Limitless lifelogs with document_id_from_seed(limitless:uid:start-time) and persist through the lifecycle owner's create-if-absent (Firestore document.create). Skip when the document already exists.",
+  "canonical_prevention_artifact": [
+    "backend/utils/imports/limitless.py",
+    "backend/utils/conversations/lifecycle.py",
+    "backend/tests/unit/test_limitless_import_idempotency.py"
+  ],
+  "evidence_prs": [8075],
+  "scope_hints": [
+    "backend/utils/imports/**",
+    "backend/utils/conversations/lifecycle.py"
+  ],
+  "status": "open"
+}

--- a/app/lib/backend/schema/gen/imports_integrations_wire.g.dart
+++ b/app/lib/backend/schema/gen/imports_integrations_wire.g.dart
@@ -4,6 +4,7 @@
 
 class GeneratedImportJobResponse {
   final int? conversationsCreated;
+  final int? conversationsSkipped;
   final String? createdAt;
   final String? error;
   final String jobId;
@@ -13,6 +14,7 @@ class GeneratedImportJobResponse {
 
   const GeneratedImportJobResponse({
     this.conversationsCreated,
+    this.conversationsSkipped,
     this.createdAt,
     this.error,
     required this.jobId,
@@ -24,6 +26,7 @@ class GeneratedImportJobResponse {
   factory GeneratedImportJobResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedImportJobResponse(
       conversationsCreated: _readFieldValue<int>(_readField(json, const ["conversations_created"]), "conversations_created", _readInt, requiredField: false, nullable: true),
+      conversationsSkipped: _readFieldValue<int>(_readField(json, const ["conversations_skipped"]), "conversations_skipped", _readInt, requiredField: false, nullable: true),
       createdAt: _readFieldValue<String>(_readField(json, const ["created_at"]), "created_at", _readString, requiredField: false, nullable: true),
       error: _readFieldValue<String>(_readField(json, const ["error"]), "error", _readString, requiredField: false, nullable: true),
       jobId: _required(_readFieldValue<String>(_readField(json, const ["job_id"]), "job_id", _readString, requiredField: true, nullable: false), "job_id"),
@@ -36,6 +39,7 @@ class GeneratedImportJobResponse {
   Map<String, dynamic> toJson() {
     return {
       'conversations_created': conversationsCreated,
+      'conversations_skipped': conversationsSkipped,
       'created_at': createdAt,
       'error': error,
       'job_id': jobId,

--- a/backend/models/import_job.py
+++ b/backend/models/import_job.py
@@ -25,6 +25,7 @@ class ImportJob(BaseModel):
     total_files: int = Field(default=0, description="Total number of files to process")
     processed_files: int = Field(default=0, description="Number of files processed so far")
     conversations_created: int = Field(default=0, description="Number of conversations created")
+    conversations_skipped: int = Field(default=0, description="Number of lifelogs skipped as already imported")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     started_at: Optional[datetime] = Field(default=None, description="When processing started")
     completed_at: Optional[datetime] = Field(default=None, description="When processing completed")
@@ -47,5 +48,6 @@ class ImportJobResponse(BaseModel):
     total_files: Optional[int] = None
     processed_files: Optional[int] = None
     conversations_created: Optional[int] = None
+    conversations_skipped: Optional[int] = None
     created_at: Optional[str] = None
     error: Optional[str] = None

--- a/backend/routers/imports.py
+++ b/backend/routers/imports.py
@@ -123,6 +123,7 @@ def get_import_jobs(
                     total_files=job.get('total_files'),
                     processed_files=job.get('processed_files'),
                     conversations_created=job.get('conversations_created'),
+                    conversations_skipped=job.get('conversations_skipped'),
                     created_at=job.get('created_at'),
                     error=job.get('error'),
                 )
@@ -172,6 +173,7 @@ def get_import_job_status(
         total_files=job.get('total_files'),
         processed_files=job.get('processed_files'),
         conversations_created=job.get('conversations_created'),
+        conversations_skipped=job.get('conversations_skipped'),
         created_at=job.get('created_at'),
         error=job.get('error'),
     )
@@ -195,6 +197,7 @@ def cancel_import_job(job_id: str, uid: str = Depends(auth.get_current_user_uid)
         total_files=job.get('total_files'),
         processed_files=job.get('processed_files'),
         conversations_created=job.get('conversations_created'),
+        conversations_skipped=job.get('conversations_skipped'),
         created_at=job.get('created_at'),
         error='Cancelled by user',
     )

--- a/backend/tests/unit/test_conversation_lifecycle_contract.py
+++ b/backend/tests/unit/test_conversation_lifecycle_contract.py
@@ -292,7 +292,7 @@ def test_completed_conversation_creation_is_explicit_and_idempotent(lifecycle_st
 
 
 def test_import_persists_through_the_lifecycle_owner(lifecycle_store):
-    lifecycle_service.persist_imported_conversation(
+    created = lifecycle_service.persist_imported_conversation(
         'uid',
         {
             'id': 'imported',
@@ -303,8 +303,23 @@ def test_import_persists_through_the_lifecycle_owner(lifecycle_store):
         },
     )
 
+    assert created is True
     assert list(lifecycle_store.documents) == [('users', 'uid', 'conversations', 'imported')]
     assert lifecycle_store.conversation('uid', 'imported')['status'] == ConversationStatus.completed
+    assert (
+        lifecycle_service.persist_imported_conversation(
+            'uid',
+            {
+                'id': 'imported',
+                'status': ConversationStatus.completed,
+                'discarded': False,
+                'title': 'later export title',
+                'data_protection_level': 'standard',
+            },
+        )
+        is False
+    )
+    assert lifecycle_store.conversation('uid', 'imported')['title'] == 'imported title'
 
 
 def test_merge_rejects_processing_conversations():

--- a/backend/tests/unit/test_limitless_import_idempotency.py
+++ b/backend/tests/unit/test_limitless_import_idempotency.py
@@ -1,0 +1,219 @@
+"""Tests for Limitless import idempotency (deterministic conversation IDs).
+
+Re-importing the same Limitless export must not create duplicate conversations,
+and must not clobber edits a user made to a previously-imported conversation.
+This is achieved by deriving each conversation's Firestore document ID
+deterministically from (uid, lifelog start-time) and skipping lifelogs that are
+already stored ("first import wins").
+"""
+
+import io
+import uuid as uuid_lib
+from zipfile import ZipFile
+from unittest.mock import MagicMock
+
+import pytest
+
+from database.document_ids import document_id_from_seed
+from utils.imports import limitless
+
+UID = "user-abc"
+FN_A = "2025-10-08_07h00m25s_Morning-standup.md"
+FN_B = "2025-10-09_09h15m00s_Design-review.md"
+
+
+class _FakeConversationStore:
+    """In-memory stand-in for Firestore's atomic create-if-absent (document.create())."""
+
+    def __init__(self):
+        self.docs = {}
+        self.fail_ids = set()
+
+    def reset(self):
+        self.docs = {}
+        self.fail_ids = set()
+
+    def persist_imported_conversation(self, uid, data):
+        del uid
+        cid = data["id"]
+        if cid in self.fail_ids:
+            raise RuntimeError("simulated firestore error")
+        if cid in self.docs:
+            return False
+        self.docs[cid] = data
+        return True
+
+
+@pytest.fixture
+def store(monkeypatch):
+    fake = _FakeConversationStore()
+    monkeypatch.setattr(
+        limitless.lifecycle_service,
+        "persist_imported_conversation",
+        fake.persist_imported_conversation,
+    )
+    monkeypatch.setattr(limitless.import_jobs_db, "create_import_job", MagicMock())
+    monkeypatch.setattr(limitless.import_jobs_db, "update_import_job", MagicMock())
+    monkeypatch.setattr(limitless.import_jobs_db, "get_import_job", MagicMock(return_value={'status': 'processing'}))
+    monkeypatch.setattr(limitless, "send_notification", MagicMock())
+    return fake
+
+
+def _lifelog_md(first_line_text: str = "Hello team, let's begin.") -> str:
+    return (
+        "# Morning Standup\n\n"
+        "## Summary\n\n"
+        "### Key point\n\n"
+        f"> [1](#startMs=1000&endMs=5000): {first_line_text}\n"
+        "> [2](#startMs=5000&endMs=9000): Sounds good to me.\n"
+    )
+
+
+def _zip_bytes(files: dict) -> bytes:
+    buf = io.BytesIO()
+    with ZipFile(buf, "w") as zf:
+        for path, content in files.items():
+            zf.writestr(path, content)
+    return buf.getvalue()
+
+
+def _run_import(tmp_path, zip_data: bytes, uid: str = UID, job_id: str = "job-1"):
+    zip_path = tmp_path / "export.zip"
+    zip_path.write_bytes(zip_data)
+    limitless.process_limitless_import(job_id, uid, str(zip_path))
+
+
+def test_conversation_id_is_deterministic_and_timestamp_keyed():
+    id1 = limitless.conversation_id_for_lifelog(UID, FN_A)
+    id2 = limitless.conversation_id_for_lifelog(UID, FN_A)
+
+    assert id1 == id2, "same (uid, filename) must yield the same ID"
+    uuid_lib.UUID(id1)
+
+    retitled = "2025-10-08_07h00m25s_Completely-different-title.md"
+    assert limitless.conversation_id_for_lifelog(UID, retitled) == id1
+
+    assert limitless.conversation_id_for_lifelog(UID, FN_B) != id1
+    assert limitless.conversation_id_for_lifelog("user-xyz", FN_A) != id1
+
+    started_at, _slug = limitless.parse_lifelog_filename(FN_A)
+    assert started_at is not None
+    assert id1 == document_id_from_seed(f"{limitless.LIMITLESS_IMPORT_ID_NAMESPACE}:{UID}:{started_at.isoformat()}")
+
+
+def test_unparseable_filename_falls_back_to_full_path():
+    a = limitless.conversation_id_for_lifelog(UID, "no-timestamp.md")
+    b = limitless.conversation_id_for_lifelog(UID, "no-timestamp.md")
+    c = limitless.conversation_id_for_lifelog(UID, "other-no-timestamp.md")
+    assert a == b and a != c
+    d = limitless.conversation_id_for_lifelog(UID, "a/lifelogs/note.md")
+    e = limitless.conversation_id_for_lifelog(UID, "b/lifelogs/note.md")
+    assert d != e
+
+
+def test_reimport_same_export_creates_no_duplicates(tmp_path, store):
+    zip_data = _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md(), f"lifelogs/{FN_B}": _lifelog_md("Design review.")})
+
+    _run_import(tmp_path, zip_data)
+    after_first = dict(store.docs)
+    _run_import(tmp_path, zip_data)
+
+    assert len(after_first) == 2, "both lifelogs imported on first run"
+    assert set(store.docs) == set(after_first), "re-import must not add or change document IDs"
+
+
+def test_reimport_preserves_user_edits(tmp_path, store):
+    zip_data = _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()})
+
+    _run_import(tmp_path, zip_data)
+    (conv_id,) = list(store.docs)
+    store.docs[conv_id]["structured"]["title"] = "My edited title"
+
+    _run_import(tmp_path, zip_data)
+
+    assert len(store.docs) == 1, "no duplicate created"
+    assert store.docs[conv_id]["structured"]["title"] == "My edited title", "edit must survive re-import"
+
+
+def test_distinct_lifelogs_get_distinct_ids(tmp_path, store):
+    zip_data = _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md(), f"lifelogs/{FN_B}": _lifelog_md("Design review.")})
+
+    _run_import(tmp_path, zip_data)
+
+    assert len(store.docs) == 2, "two different lifelogs must map to two different IDs"
+
+
+def test_retitled_lifelog_is_deduped_across_imports(tmp_path, store):
+    original = "2025-10-08_07h00m25s_Morning-standup.md"
+    retitled = "2025-10-08_07h00m25s_Daily-sync.md"
+
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{original}": _lifelog_md()}))
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{retitled}": _lifelog_md()}))
+
+    assert len(store.docs) == 1, "re-titled re-export of the same lifelog must dedupe"
+
+
+def test_duplicate_basename_in_archive_does_not_overwrite(tmp_path, store):
+    zip_data = _zip_bytes(
+        {
+            f"a/lifelogs/{FN_A}": _lifelog_md("FIRST occurrence content."),
+            f"b/lifelogs/{FN_A}": _lifelog_md("SECOND occurrence content."),
+        }
+    )
+
+    _run_import(tmp_path, zip_data)
+
+    assert len(store.docs) == 1, "same-identity entries collapse to one conversation"
+    (conv_id,) = list(store.docs)
+    assert store.docs[conv_id]["transcript_segments"][0]["text"] == "FIRST occurrence content."
+
+
+def test_nested_unparseable_basenames_do_not_collide(tmp_path, store):
+    zip_data = _zip_bytes(
+        {
+            "a/lifelogs/note.md": _lifelog_md("Folder A content."),
+            "b/lifelogs/note.md": _lifelog_md("Folder B content."),
+        }
+    )
+
+    _run_import(tmp_path, zip_data)
+
+    assert len(store.docs) == 2, "same basename in different folders must not be deduped when unparseable"
+
+
+def test_persisted_id_is_deterministic_not_random(tmp_path, store):
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}))
+
+    assert list(store.docs) == [limitless.conversation_id_for_lifelog(UID, FN_A)]
+
+
+def test_different_users_do_not_collide(tmp_path, store):
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}), uid="user-a", job_id="job-a")
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}), uid="user-b", job_id="job-b")
+
+    assert len(store.docs) == 2, "same export imported by two users must not share conversation IDs"
+
+
+def test_create_error_is_isolated_per_file(tmp_path, store):
+    store.fail_ids.add(limitless.conversation_id_for_lifelog(UID, FN_A))
+
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md(), f"lifelogs/{FN_B}": _lifelog_md("ok")}))
+
+    assert list(store.docs) == [limitless.conversation_id_for_lifelog(UID, FN_B)]
+
+
+def test_retry_after_partial_failure_creates_only_missing(tmp_path, store):
+    store.fail_ids.add(limitless.conversation_id_for_lifelog(UID, FN_A))
+    zip_data = _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md(), f"lifelogs/{FN_B}": _lifelog_md("ok")})
+
+    _run_import(tmp_path, zip_data)
+    assert list(store.docs) == [limitless.conversation_id_for_lifelog(UID, FN_B)]
+
+    store.fail_ids.clear()
+    _run_import(tmp_path, zip_data)
+
+    assert set(store.docs) == {
+        limitless.conversation_id_for_lifelog(UID, FN_A),
+        limitless.conversation_id_for_lifelog(UID, FN_B),
+    }
+    assert store.docs[limitless.conversation_id_for_lifelog(UID, FN_B)]["transcript_segments"][0]["text"] == "ok"

--- a/backend/utils/conversations/lifecycle.py
+++ b/backend/utils/conversations/lifecycle.py
@@ -134,10 +134,14 @@ def persist_processed_conversation(uid: str, conversation_data: dict[str, Any]) 
     return conversations_db.persist_processing_result_with_lifecycle(uid, conversation_data)
 
 
-def persist_imported_conversation(uid: str, conversation_data: dict[str, Any]) -> None:
-    """Persist an externally completed immutable import through the lifecycle owner."""
+def persist_imported_conversation(uid: str, conversation_data: dict[str, Any]) -> bool:
+    """Persist an externally completed immutable import through the lifecycle owner.
+
+    Create-if-absent: returns True when the conversation was created, False when it
+    already existed. Re-imports must not overwrite user edits (first import wins).
+    """
     _require_status(conversation_data, ConversationStatus.completed)
-    conversations_db.upsert_conversation_with_lifecycle(uid, conversation_data)
+    return conversations_db.create_conversation_if_absent_with_lifecycle(uid, conversation_data)
 
 
 def transition(

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Tuple, Optional
 from zipfile import ZipFile
 
 import database.import_jobs as import_jobs_db
-import database.conversations as conversations_db
+from database.document_ids import document_id_from_seed
 from models.conversation import AppResult, Conversation
 from models.conversation_enums import CategoryEnum, ConversationSource, ConversationStatus
 from models.structured import Structured
@@ -199,6 +199,35 @@ def _create_overview_from_transcript(segments: List[TranscriptSegment], max_char
     return overview if overview else "Imported from Limitless"
 
 
+# Namespace prefix for deterministic Limitless conversation IDs. NEVER CHANGE this
+# string: it is baked into the ID of every already-imported conversation, so a new
+# value would orphan them and re-create duplicates on the next import.
+LIMITLESS_IMPORT_ID_NAMESPACE = "limitless"
+
+
+def conversation_id_for_lifelog(uid: str, lifelog_path: str) -> str:
+    """Deterministic conversation ID for a Limitless lifelog file.
+
+    Keyed on (uid, stable lifelog identity) via the shared ``document_id_from_seed``
+    primitive, so re-importing the same export resolves to the same ID and the
+    importer can skip lifelogs it has already stored (idempotent import).
+
+    The identity is the lifelog's start timestamp parsed from the filename
+    (e.g. ``2025-10-08_07h00m25s_Title-slug.md`` -> ``2025-10-08T07:00:25+00:00``).
+    The mutable title slug is deliberately excluded so that if Limitless
+    regenerates a lifelog's title between exports, the re-import still maps to the
+    same conversation instead of creating a near-duplicate. A single pendant cannot
+    start two lifelogs in the same second, so the timestamp alone identifies a
+    lifelog. If the filename carries no parseable timestamp, the lifelog's full path
+    within the export is used as the fallback identity — not just its basename — so
+    distinct files that share a basename in different folders don't collide (and get
+    one of them silently skipped).
+    """
+    started_at, _title_slug = parse_lifelog_filename(Path(lifelog_path).name)
+    identity = started_at.isoformat() if started_at else lifelog_path
+    return document_id_from_seed(f"{LIMITLESS_IMPORT_ID_NAMESPACE}:{uid}:{identity}")
+
+
 def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code: str = 'en') -> None:
     """
     Background worker to process a Limitless ZIP export using LIGHT IMPORT mode.
@@ -267,6 +296,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
 
             processed_files = 0
             conversations_created = 0
+            conversations_skipped = 0
             errors: List[str] = []
 
             for lifelog_path in lifelog_files:
@@ -282,6 +312,8 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         processed_files += 1
                         import_jobs_db.update_import_job(job_id, {'processed_files': processed_files})
                         continue
+
+                    conversation_id = conversation_id_for_lifelog(uid, lifelog_path)
 
                     # Calculate finished_at from last segment
                     if segments and started_at:
@@ -312,9 +344,9 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         events=[],
                     )
 
-                    # Create conversation object directly
+                    # Create conversation object directly (no AI processing).
                     conversation = Conversation(
-                        id=str(uuid.uuid4()),
+                        id=conversation_id,
                         created_at=started_at,  # Use started_at as created_at for proper ordering
                         started_at=started_at,
                         finished_at=finished_at,
@@ -327,9 +359,15 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         discarded=False,
                     )
 
-                    # Save directly to database (skip all AI processing)
-                    lifecycle_service.persist_imported_conversation(uid, conversation.model_dump())
-                    conversations_created += 1
+                    # Create-if-absent so re-importing the same export skips lifelogs already
+                    # stored instead of overwriting them. This is atomic (Firestore create()),
+                    # so it never duplicates and never clobbers edits a user may have made to a
+                    # previously-imported conversation ("first import wins").
+                    if lifecycle_service.persist_imported_conversation(uid, conversation.model_dump()):
+                        conversations_created += 1
+                    else:
+                        conversations_skipped += 1
+                        logger.info(f"[Limitless Import] Skipped already-imported lifelog: {filename}")
 
                 except Exception as e:
                     error_msg = f"Error processing {lifelog_path}: {str(e)}"
@@ -345,15 +383,23 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         {
                             'processed_files': processed_files,
                             'conversations_created': conversations_created,
+                            'conversations_skipped': conversations_skipped,
                         },
                     )
+
+            logger.info(
+                f"[Limitless Import] Done: {conversations_created} created, "
+                f"{conversations_skipped} skipped (already imported), {len(errors)} errors"
+            )
 
             # Mark as completed
             final_status = ImportJobStatus.completed.value
             error_msg = None
 
             if errors:
-                if conversations_created == 0:
+                # Only a hard failure if nothing was created and nothing was skipped
+                # (a re-import that skips everything is a success, not a failure).
+                if conversations_created == 0 and conversations_skipped == 0:
                     final_status = ImportJobStatus.failed.value
                     error_msg = f"All files failed to process. First error: {errors[0]}"
                 else:
@@ -373,19 +419,30 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     'status': final_status,
                     'completed_at': datetime.now(timezone.utc).isoformat(),
                     'error': error_msg,
+                    'conversations_created': conversations_created,
+                    'conversations_skipped': conversations_skipped,
                 },
             )
 
             # Send push notification
             if final_status == ImportJobStatus.completed.value:
+                complete_body = f"Successfully imported {conversations_created} conversations from your Limitless data."
+                if conversations_skipped:
+                    complete_body = (
+                        f"Imported {conversations_created} new conversations "
+                        f"({conversations_skipped} already imported) from your Limitless data."
+                    )
+                if errors:
+                    complete_body += f" {len(errors)} file(s) could not be processed."
                 send_notification(
                     user_id=uid,
                     title="Limitless Import Complete! 🎉",
-                    body=f"Successfully imported {conversations_created} conversations from your Limitless data.",
+                    body=complete_body,
                     data={
                         'type': 'import_complete',
                         'job_id': job_id,
                         'conversations_created': str(conversations_created),
+                        'conversations_skipped': str(conversations_skipped),
                     },
                 )
             else:

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2129,6 +2129,7 @@ export interface HasSpeechProfileResponse {
 
 export interface ImportJobResponse {
   conversations_created?: number | null;
+  conversations_skipped?: number | null;
   created_at?: string | null;
   error?: string | null;
   job_id: string;

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -13153,6 +13153,17 @@
             ],
             "title": "Conversations Created"
           },
+          "conversations_skipped": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversations Skipped"
+          },
           "created_at": {
             "anyOf": [
               {

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2129,6 +2129,7 @@ export interface HasSpeechProfileResponse {
 
 export interface ImportJobResponse {
   conversations_created?: number | null;
+  conversations_skipped?: number | null;
   created_at?: string | null;
   error?: string | null;
   job_id: string;

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2129,6 +2129,7 @@ export interface HasSpeechProfileResponse {
 
 export interface ImportJobResponse {
   conversations_created?: number | null;
+  conversations_skipped?: number | null;
   created_at?: string | null;
   error?: string | null;
   job_id: string;

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2129,6 +2129,7 @@ export interface HasSpeechProfileResponse {
 
 export interface ImportJobResponse {
   conversations_created?: number | null;
+  conversations_skipped?: number | null;
   created_at?: string | null;
   error?: string | null;
   job_id: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Rebase of #8075 (`alanshurafa/omi` `claude/kind-kapitsa-e81c75`) onto current `main`. GitHub update-branch failed, and a maintainer force-push to the fork was rejected (`GitHub App` cannot update workflow files that landed on `main` since the fork tip). This PR is the same Limitless import idempotency fix on BasedHardware/omi, adapted to today's lifecycle owner.

Re-uploading a Limitless export no longer creates a new random-ID conversation for every lifelog. Each conversation ID is `document_id_from_seed("limitless:{uid}:{start-time}")`, and persist is atomic create-if-absent. First import wins; user edits are not overwritten.

## Product invariants affected

none

## How it was verified

Focused backend unit tests via the pre-push selector:

- `backend/tests/unit/test_limitless_import_idempotency.py` — **12 passed**
- `backend/tests/unit/test_conversation_lifecycle_contract.py` — **16 passed** (includes import persist first-wins)

App-client OpenAPI `--check` accepted `docs/api-reference/app-client-openapi.json` after adding optional `conversations_skipped`. Regenerated first-party clients: `backend/scripts/generate_dart_models.py --group imports_integrations` and `backend/scripts/generate_ts_openapi_types.py`.

Local `scripts/pre-push` against `origin/main` passed. I did not run a live Limitless ZIP against a real Firestore; the worker path was exercised through `process_limitless_import` with an in-memory create-if-absent store.

## Tests

`backend/tests/unit/test_limitless_import_idempotency.py` — deterministic IDs, re-import skip, edit preservation, retitled lifelog, cross-user namespace, per-file create failure, retry after partial failure creates only missing docs.

## Failure class (fixes)

Failure-Class: new

## Rebase notes

- #8075 added `conversations_db.create_conversation_if_absent`. Current `main` already owns that primitive as `create_conversation_if_absent_with_lifecycle` and requires writes through `utils.conversations.lifecycle`. This rebase makes `persist_imported_conversation` create-if-absent (it already documented imports as immutable) instead of adding a parallel helper.
- `conversations_skipped` is added to `ImportJob` / `ImportJobResponse` and both list/detail (and cancel) endpoints, preserving main's malformed-job list handling.
- New unit tests do not mutate `sys.modules` at import time (current isolation ratchet).
- `backend/test.sh` is selector-driven; the new `tests/unit/` file is auto-discovered (no hand-maintained pytest line).

Do not merge until a maintainer reviews. #8075 remains open as the original fork PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c42f0c4f-64c2-4e33-a312-da92fd7d94cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c42f0c4f-64c2-4e33-a312-da92fd7d94cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

