### PR TITLE
fix: address open Codex review on #11927 and #11928

### DIFF
--- a/.github/failure-classes/FC-import-unstable-identity.json
+++ b/.github/failure-classes/FC-import-unstable-identity.json
@@ -8,7 +8,7 @@
     "backend/utils/conversations/lifecycle.py",
     "backend/tests/unit/test_limitless_import_idempotency.py"
   ],
-  "evidence_prs": [8075],
+  "evidence_prs": [11928],
   "scope_hints": [
     "backend/utils/imports/**",
     "backend/utils/conversations/lifecycle.py"

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -564,8 +564,8 @@ int? _parseRetryAfterSeconds(http.Response response) {
 /// Everything else remains a generic backend-capacity limit.
 SyncRateLimitKind syncRateLimitKindForResponse(http.Response response) =>
     response.headers['x-omi-rate-limit-reason']?.trim().toLowerCase() == 'fair_use'
-    ? SyncRateLimitKind.fairUse
-    : SyncRateLimitKind.backendCapacity;
+        ? SyncRateLimitKind.fairUse
+        : SyncRateLimitKind.backendCapacity;
 
 /// Upload-only: POST files and return as soon as the server acknowledges
 /// (HTTP 202 with a job_id, or the 200 fast-path with a finished result).

--- a/app/lib/backend/http/api/conversations.dart
+++ b/app/lib/backend/http/api/conversations.dart
@@ -564,8 +564,8 @@ int? _parseRetryAfterSeconds(http.Response response) {
 /// Everything else remains a generic backend-capacity limit.
 SyncRateLimitKind syncRateLimitKindForResponse(http.Response response) =>
     response.headers['x-omi-rate-limit-reason']?.trim().toLowerCase() == 'fair_use'
-        ? SyncRateLimitKind.fairUse
-        : SyncRateLimitKind.backendCapacity;
+    ? SyncRateLimitKind.fairUse
+    : SyncRateLimitKind.backendCapacity;
 
 /// Upload-only: POST files and return as soon as the server acknowledges
 /// (HTTP 202 with a job_id, or the 200 fast-path with a finished result).
@@ -683,6 +683,13 @@ Future<SyncJobFetch> fetchSyncJobStatus(String jobId) async {
   }
 }
 
+/// Serialize a local calendar-day bound for conversation search.
+///
+/// Local [DateTime] values have no offset in [DateTime.toIso8601String], and
+/// `search_conversations_endpoint` parses naive datetimes in the server TZ.
+/// Convert to UTC first, matching the conversation-list date filter.
+String serializeConversationSearchDateBound(DateTime date) => date.toUtc().toIso8601String();
+
 Future<(List<ServerConversation>, int, int)> searchConversationsServer(
   String query, {
   int? page,
@@ -702,8 +709,8 @@ Future<(List<ServerConversation>, int, int)> searchConversationsServer(
       'page': page ?? 1,
       'per_page': limit ?? 10,
       'include_discarded': includeDiscarded,
-      if (startDate != null) 'start_date': startDate.toIso8601String(),
-      if (endDate != null) 'end_date': endDate.toIso8601String(),
+      if (startDate != null) 'start_date': serializeConversationSearchDateBound(startDate),
+      if (endDate != null) 'end_date': serializeConversationSearchDateBound(endDate),
       if (speakerId != null) 'speaker_id': speakerId,
     }),
   );

--- a/app/lib/backend/http/api/imports.dart
+++ b/app/lib/backend/http/api/imports.dart
@@ -36,6 +36,7 @@ class ImportJobResponse {
   final int? totalFiles;
   final int? processedFiles;
   final int? conversationsCreated;
+  final int? conversationsSkipped;
   final DateTime? createdAt;
   final String? error;
 
@@ -45,6 +46,7 @@ class ImportJobResponse {
     this.totalFiles,
     this.processedFiles,
     this.conversationsCreated,
+    this.conversationsSkipped,
     this.createdAt,
     this.error,
   });
@@ -60,6 +62,7 @@ class ImportJobResponse {
       totalFiles: generated.totalFiles,
       processedFiles: generated.processedFiles,
       conversationsCreated: generated.conversationsCreated,
+      conversationsSkipped: generated.conversationsSkipped,
       createdAt: generated.createdAt == null ? null : DateTime.tryParse(generated.createdAt!),
       error: generated.error,
     );
@@ -85,6 +88,7 @@ class ImportJobResponse {
       totalFiles: totalFiles,
       processedFiles: processedFiles,
       conversationsCreated: conversationsCreated,
+      conversationsSkipped: conversationsSkipped,
       createdAt: createdAt?.toUtc().toIso8601String(),
       error: error,
     );

--- a/app/lib/pages/conversations/widgets/search_widget.dart
+++ b/app/lib/pages/conversations/widgets/search_widget.dart
@@ -155,9 +155,8 @@ class _SearchWidgetState extends State<SearchWidget> {
           Consumer<ConversationProvider>(
             builder: (context, convoProvider, _) {
               final hasSearchQuery = searchController.text.isNotEmpty;
-              final hasActiveFilter = hasSearchQuery
-                  ? convoProvider.searchStartDate != null
-                  : convoProvider.selectedStartDate != null;
+              final hasActiveFilter =
+                  hasSearchQuery ? convoProvider.searchStartDate != null : convoProvider.selectedStartDate != null;
               return Container(
                 width: 48,
                 height: 48,

--- a/app/lib/pages/conversations/widgets/search_widget.dart
+++ b/app/lib/pages/conversations/widgets/search_widget.dart
@@ -154,9 +154,10 @@ class _SearchWidgetState extends State<SearchWidget> {
           // Calendar button - same height as search bar (48px)
           Consumer<ConversationProvider>(
             builder: (context, convoProvider, _) {
-              final hasSearchQuery = convoProvider.previousQuery.isNotEmpty;
-              final hasActiveFilter =
-                  hasSearchQuery ? convoProvider.searchStartDate != null : convoProvider.selectedStartDate != null;
+              final hasSearchQuery = searchController.text.isNotEmpty;
+              final hasActiveFilter = hasSearchQuery
+                  ? convoProvider.searchStartDate != null
+                  : convoProvider.selectedStartDate != null;
               return Container(
                 width: 48,
                 height: 48,

--- a/app/lib/pages/settings/import_history_page.dart
+++ b/app/lib/pages/settings/import_history_page.dart
@@ -41,6 +41,20 @@ String formatImportJobTimestamp(AppLocalizations l10n, DateTime createdAt, {Date
   return '${local.day}/${local.month}/${local.year} at $time';
 }
 
+class ImportJobCountChip {
+  final int count;
+  final bool skipped;
+
+  const ImportJobCountChip({required this.count, required this.skipped});
+}
+
+List<ImportJobCountChip> importJobCountChips({int? created, int? skipped}) {
+  return [
+    if ((created ?? 0) > 0) ImportJobCountChip(count: created!, skipped: false),
+    if ((skipped ?? 0) > 0) ImportJobCountChip(count: skipped!, skipped: true),
+  ];
+}
+
 class ImportHistoryPage extends StatefulWidget {
   const ImportHistoryPage({super.key});
 
@@ -515,24 +529,37 @@ class _ImportHistoryPageState extends State<ImportHistoryPage> {
                   ],
                 ),
               ),
-              // Conversations count badge (extreme right)
-              if (job.conversationsCreated != null && job.conversationsCreated! > 0)
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: Colors.green.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        context.l10n.nConversations(job.conversationsCreated!),
-                        style: TextStyle(color: Colors.green.shade400, fontSize: 12, fontWeight: FontWeight.w500),
-                      ),
-                      const SizedBox(width: 4),
-                      Icon(Icons.check_circle, color: Colors.green.shade400, size: 14),
-                    ],
+              for (final chip in importJobCountChips(
+                created: job.conversationsCreated,
+                skipped: job.conversationsSkipped,
+              ))
+                Padding(
+                  padding: EdgeInsets.only(left: chip.skipped && (job.conversationsCreated ?? 0) > 0 ? 6 : 0),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: chip.skipped ? Colors.white.withValues(alpha: 0.12) : Colors.green.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          context.l10n.nConversations(chip.count),
+                          style: TextStyle(
+                            color: chip.skipped ? Colors.white70 : Colors.green.shade400,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        Icon(
+                          chip.skipped ? Icons.history : Icons.check_circle,
+                          color: chip.skipped ? Colors.white70 : Colors.green.shade400,
+                          size: 14,
+                        ),
+                      ],
+                    ),
                   ),
                 ),
             ],

--- a/app/lib/widgets/calendar_date_picker_sheet.dart
+++ b/app/lib/widgets/calendar_date_picker_sheet.dart
@@ -9,14 +9,15 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 
-typedef CalendarYearBuilder = Widget Function({
-  required int year,
-  TextStyle? textStyle,
-  BoxDecoration? decoration,
-  bool? isSelected,
-  bool? isDisabled,
-  bool? isCurrentYear,
-});
+typedef CalendarYearBuilder =
+    Widget Function({
+      required int year,
+      TextStyle? textStyle,
+      BoxDecoration? decoration,
+      bool? isSelected,
+      bool? isDisabled,
+      bool? isCurrentYear,
+    });
 
 CalendarDatePicker2Config getDefaultCalendarConfig({
   DateTime? firstDate,
@@ -146,6 +147,10 @@ Future<void> showConversationDateRangePicker(BuildContext context) async {
   );
 }
 
+/// Inclusive end of a calendar range. A single selected day has no second
+/// date, so fall back to [start] instead of leaving the upper bound open.
+DateTime closedCalendarRangeEnd(DateTime start, DateTime? end) => end ?? start;
+
 /// Date-range picker for conversation *search* (#4457 / #7977).
 ///
 /// Sibling of [showConversationDateRangePicker]: that sheet filters the
@@ -209,12 +214,12 @@ Future<void> showConversationSearchDateRangePicker(BuildContext context) async {
                           Navigator.of(context).pop();
                           return;
                         }
-                        final end = range.length > 1 ? range[1] : endDate;
+                        final end = closedCalendarRangeEnd(start, range.length > 1 ? range[1] : null);
                         Navigator.of(context).pop();
                         if (provider.previousQuery.isNotEmpty) {
                           provider.setSearchDateRange(start, end);
                           await provider.searchConversations(provider.previousQuery);
-                          PlatformManager.instance.analytics.calendarFilterApplied(start, end ?? start);
+                          PlatformManager.instance.analytics.calendarFilterApplied(start, end);
                         }
                       },
                       child: Text(

--- a/app/lib/widgets/calendar_date_picker_sheet.dart
+++ b/app/lib/widgets/calendar_date_picker_sheet.dart
@@ -9,15 +9,14 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 
-typedef CalendarYearBuilder =
-    Widget Function({
-      required int year,
-      TextStyle? textStyle,
-      BoxDecoration? decoration,
-      bool? isSelected,
-      bool? isDisabled,
-      bool? isCurrentYear,
-    });
+typedef CalendarYearBuilder = Widget Function({
+  required int year,
+  TextStyle? textStyle,
+  BoxDecoration? decoration,
+  bool? isSelected,
+  bool? isDisabled,
+  bool? isCurrentYear,
+});
 
 CalendarDatePicker2Config getDefaultCalendarConfig({
   DateTime? firstDate,

--- a/app/lib/widgets/calendar_date_picker_sheet.dart
+++ b/app/lib/widgets/calendar_date_picker_sheet.dart
@@ -187,6 +187,7 @@ Future<void> showConversationSearchDateRangePicker(BuildContext context) async {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     CupertinoButton(
+                      key: const Key('search_date_range_cancel'),
                       padding: EdgeInsets.zero,
                       onPressed: () async {
                         if (hasExistingFilter) {
@@ -207,6 +208,7 @@ Future<void> showConversationSearchDateRangePicker(BuildContext context) async {
                     ),
                     const Spacer(),
                     CupertinoButton(
+                      key: const Key('search_date_range_done'),
                       padding: EdgeInsets.zero,
                       onPressed: () async {
                         final start = range.isNotEmpty ? range[0] : startDate;

--- a/app/test/providers/conversation_provider_date_range_test.dart
+++ b/app/test/providers/conversation_provider_date_range_test.dart
@@ -5,6 +5,7 @@ import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/widgets/calendar_date_picker_sheet.dart';
 
 /// Regression tests for the search date-range boundary normalization in
 /// ConversationProvider.setSearchDateRange (#4457 / rebase of #7977).
@@ -66,6 +67,19 @@ void main() {
 
       expect(provider.searchStartDate, DateTime(2026, 6, 15));
       expect(provider.searchEndDate, isNull);
+    });
+
+    test('a single selected day falls back to a closed range ending on start', () {
+      final start = DateTime(2026, 6, 15, 9);
+      expect(closedCalendarRangeEnd(start, null), start);
+      expect(closedCalendarRangeEnd(start, DateTime(2026, 6, 20, 17)), DateTime(2026, 6, 20, 17));
+
+      final provider = makeProvider();
+      final end = closedCalendarRangeEnd(start, null);
+      provider.setSearchDateRange(start, end);
+
+      expect(provider.searchStartDate, DateTime(2026, 6, 15));
+      expect(provider.searchEndDate, DateTime(2026, 6, 15, 23, 59, 59, 999));
     });
 
     test('clearSearchDateRange resets both bounds', () {

--- a/app/test/providers/conversation_provider_date_range_test.dart
+++ b/app/test/providers/conversation_provider_date_range_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/providers/conversation_provider.dart';
@@ -96,13 +97,13 @@ void main() {
       DateTime? capturedEnd;
       String? capturedQuery;
       final provider = makeProvider(
-        conversationSearchFetcher: (query,
-            {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
-          capturedQuery = query;
-          capturedStart = startDate;
-          capturedEnd = endDate;
-          return (<ServerConversation>[], 1, 1);
-        },
+        conversationSearchFetcher:
+            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+              capturedQuery = query;
+              capturedStart = startDate;
+              capturedEnd = endDate;
+              return (<ServerConversation>[], 1, 1);
+            },
       );
 
       provider.setSearchDateRange(DateTime(2026, 6, 1, 9), DateTime(2026, 6, 30, 17));
@@ -113,16 +114,31 @@ void main() {
       expect(capturedEnd, DateTime(2026, 6, 30, 23, 59, 59, 999));
     });
 
+    test('search date bounds serialize as UTC with an explicit offset', () {
+      final localStart = DateTime(2026, 6, 15);
+      final localEnd = DateTime(2026, 6, 15, 23, 59, 59, 999);
+
+      final startIso = serializeConversationSearchDateBound(localStart);
+      final endIso = serializeConversationSearchDateBound(localEnd);
+
+      expect(localStart.isUtc, isFalse);
+      expect(localStart.toIso8601String().contains('Z'), isFalse);
+      expect(startIso.endsWith('Z'), isTrue);
+      expect(endIso.endsWith('Z'), isTrue);
+      expect(DateTime.parse(startIso), localStart.toUtc());
+      expect(DateTime.parse(endIso), localEnd.toUtc());
+    });
+
     test('searchMoreConversations keeps the same date bounds', () async {
       DateTime? capturedStart;
       DateTime? capturedEnd;
       final provider = makeProvider(
-        conversationSearchFetcher: (query,
-            {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
-          capturedStart = startDate;
-          capturedEnd = endDate;
-          return (<ServerConversation>[], page ?? 1, 2);
-        },
+        conversationSearchFetcher:
+            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+              capturedStart = startDate;
+              capturedEnd = endDate;
+              return (<ServerConversation>[], page ?? 1, 2);
+            },
       );
 
       provider.setSearchDateRange(DateTime(2026, 6, 1), DateTime(2026, 6, 2));

--- a/app/test/providers/conversation_provider_date_range_test.dart
+++ b/app/test/providers/conversation_provider_date_range_test.dart
@@ -111,13 +111,13 @@ void main() {
       DateTime? capturedEnd;
       String? capturedQuery;
       final provider = makeProvider(
-        conversationSearchFetcher:
-            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
-              capturedQuery = query;
-              capturedStart = startDate;
-              capturedEnd = endDate;
-              return (<ServerConversation>[], 1, 1);
-            },
+        conversationSearchFetcher: (query,
+            {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+          capturedQuery = query;
+          capturedStart = startDate;
+          capturedEnd = endDate;
+          return (<ServerConversation>[], 1, 1);
+        },
       );
 
       provider.setSearchDateRange(DateTime(2026, 6, 1, 9), DateTime(2026, 6, 30, 17));
@@ -147,12 +147,12 @@ void main() {
       DateTime? capturedStart;
       DateTime? capturedEnd;
       final provider = makeProvider(
-        conversationSearchFetcher:
-            (query, {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
-              capturedStart = startDate;
-              capturedEnd = endDate;
-              return (<ServerConversation>[], page ?? 1, 2);
-            },
+        conversationSearchFetcher: (query,
+            {page, limit, required includeDiscarded, startDate, endDate, speakerId}) async {
+          capturedStart = startDate;
+          capturedEnd = endDate;
+          return (<ServerConversation>[], page ?? 1, 2);
+        },
       );
 
       provider.setSearchDateRange(DateTime(2026, 6, 1), DateTime(2026, 6, 2));

--- a/app/test/unit/import_job_timestamp_test.dart
+++ b/app/test/unit/import_job_timestamp_test.dart
@@ -76,16 +76,41 @@ void main() {
       'created_at': DateTime(2026, 8, 1, 21, 0).toUtc().toIso8601String(),
     });
 
-    await tester.pumpWidget(MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: Builder(
-        builder: (context) =>
-            Text(formatImportJobTimestamp(context.l10n, job.createdAt!, now: DateTime(2026, 8, 1, 22))),
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) =>
+              Text(formatImportJobTimestamp(context.l10n, job.createdAt!, now: DateTime(2026, 8, 1, 22))),
+        ),
       ),
-    ));
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Today at 21:00'), findsOneWidget);
+  });
+
+  test('fromGenerated keeps conversations_skipped from the wire model', () {
+    final job = ImportJobResponse.fromJson({
+      'job_id': 'job-1',
+      'status': 'completed',
+      'conversations_created': 0,
+      'conversations_skipped': 4,
+    });
+
+    expect(job.conversationsCreated, 0);
+    expect(job.conversationsSkipped, 4);
+    expect(job.toGenerated().conversationsSkipped, 4);
+  });
+
+  test('import history shows a skipped-only job instead of hiding the count', () {
+    expect(importJobCountChips(created: 0, skipped: 4).single.skipped, isTrue);
+    expect(importJobCountChips(created: 0, skipped: 4).single.count, 4);
+    expect(importJobCountChips(created: 2, skipped: 3).map((chip) => (chip.count, chip.skipped)).toList(), [
+      (2, false),
+      (3, true),
+    ]);
+    expect(importJobCountChips(created: 0, skipped: 0), isEmpty);
   });
 }

--- a/backend/tests/unit/test_limitless_import_idempotency.py
+++ b/backend/tests/unit/test_limitless_import_idempotency.py
@@ -28,25 +28,28 @@ class _FakeConversationStore:
 
     def __init__(self):
         self.docs = {}
+        self.owners = {}
         self.fail_ids = set()
 
     def reset(self):
         self.docs = {}
+        self.owners = {}
         self.fail_ids = set()
 
     def persist_imported_conversation(self, uid, data):
-        del uid
         cid = data["id"]
         if cid in self.fail_ids:
             raise RuntimeError("simulated firestore error")
         if cid in self.docs:
             return False
         self.docs[cid] = data
+        self.owners[cid] = uid
         return True
 
     def find_legacy_limitless_conversation_id(self, uid, started_at):
-        del uid
         for cid, data in self.docs.items():
+            if self.owners.get(cid) != uid:
+                continue
             if data.get("source") in ("limitless",) and data.get("started_at") == started_at:
                 return cid
         return None
@@ -269,6 +272,7 @@ def test_reimport_skips_legacy_uuid_row_with_same_started_at(tmp_path, store):
         "source": "limitless",
         "structured": {"title": "legacy import"},
     }
+    store.owners[legacy_id] = UID
 
     _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}))
 
@@ -279,11 +283,13 @@ def test_reimport_skips_legacy_uuid_row_with_same_started_at(tmp_path, store):
 
 
 def test_legacy_row_with_different_started_at_does_not_block_import(tmp_path, store):
-    store.docs[str(uuid_lib.uuid4())] = {
-        "id": "other-legacy",
+    other_id = str(uuid_lib.uuid4())
+    store.docs[other_id] = {
+        "id": other_id,
         "started_at": datetime(2000, 1, 1, tzinfo=timezone.utc),
         "source": "limitless",
     }
+    store.owners[other_id] = UID
 
     _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}))
 

--- a/backend/tests/unit/test_limitless_import_idempotency.py
+++ b/backend/tests/unit/test_limitless_import_idempotency.py
@@ -122,6 +122,17 @@ def test_reimport_same_export_creates_no_duplicates(tmp_path, store):
     assert set(store.docs) == set(after_first), "re-import must not add or change document IDs"
 
 
+def test_skipped_lifelog_log_does_not_include_title_slug(tmp_path, store, caplog):
+    zip_data = _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()})
+    _run_import(tmp_path, zip_data)
+    with caplog.at_level("INFO"):
+        _run_import(tmp_path, zip_data)
+
+    skip_logs = [rec.message for rec in caplog.records if "Skipped already-imported" in rec.message]
+    assert skip_logs, "re-import should log that the lifelog was skipped"
+    assert all("Morning-standup" not in message and FN_A not in message for message in skip_logs)
+
+
 def test_reimport_preserves_user_edits(tmp_path, store):
     zip_data = _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()})
 

--- a/backend/tests/unit/test_limitless_import_idempotency.py
+++ b/backend/tests/unit/test_limitless_import_idempotency.py
@@ -9,6 +9,7 @@ already stored ("first import wins").
 
 import io
 import uuid as uuid_lib
+from datetime import datetime, timezone
 from zipfile import ZipFile
 from unittest.mock import MagicMock
 
@@ -59,13 +60,13 @@ def store(monkeypatch):
     return fake
 
 
-def _lifelog_md(first_line_text: str = "Hello team, let's begin.") -> str:
+def _lifelog_md(first_line_text: str = "Hello team, let's begin.", start_ms: int = 1000) -> str:
     return (
         "# Morning Standup\n\n"
         "## Summary\n\n"
         "### Key point\n\n"
-        f"> [1](#startMs=1000&endMs=5000): {first_line_text}\n"
-        "> [2](#startMs=5000&endMs=9000): Sounds good to me.\n"
+        f"> [1](#startMs={start_ms}&endMs={start_ms + 4000}): {first_line_text}\n"
+        f"> [2](#startMs={start_ms + 4000}&endMs={start_ms + 8000}): Sounds good to me.\n"
     )
 
 
@@ -109,6 +110,19 @@ def test_unparseable_filename_falls_back_to_full_path():
     d = limitless.conversation_id_for_lifelog(UID, "a/lifelogs/note.md")
     e = limitless.conversation_id_for_lifelog(UID, "b/lifelogs/note.md")
     assert d != e
+
+
+def test_unparseable_filename_uses_recovered_startms_before_path():
+    started_at = datetime.fromtimestamp(1.0, tz=timezone.utc)
+    wrapped = limitless.conversation_id_for_lifelog(UID, "export/lifelogs/note.md", started_at=started_at)
+    nested = limitless.conversation_id_for_lifelog(UID, "lifelogs/note.md", started_at=started_at)
+    path_only = limitless.conversation_id_for_lifelog(UID, "lifelogs/note.md")
+
+    assert wrapped == nested
+    assert wrapped != path_only
+    assert wrapped == document_id_from_seed(
+        f"{limitless.LIMITLESS_IMPORT_ID_NAMESPACE}:{UID}:{started_at.isoformat()}"
+    )
 
 
 def test_reimport_same_export_creates_no_duplicates(tmp_path, store):
@@ -182,14 +196,21 @@ def test_duplicate_basename_in_archive_does_not_overwrite(tmp_path, store):
 def test_nested_unparseable_basenames_do_not_collide(tmp_path, store):
     zip_data = _zip_bytes(
         {
-            "a/lifelogs/note.md": _lifelog_md("Folder A content."),
-            "b/lifelogs/note.md": _lifelog_md("Folder B content."),
+            "a/lifelogs/note.md": _lifelog_md("Folder A content.", start_ms=1000),
+            "b/lifelogs/note.md": _lifelog_md("Folder B content.", start_ms=2000),
         }
     )
 
     _run_import(tmp_path, zip_data)
 
-    assert len(store.docs) == 2, "same basename in different folders must not be deduped when unparseable"
+    assert len(store.docs) == 2, "same basename in different folders must not be deduped when startMs differs"
+
+
+def test_wrapper_prefixed_unparseable_lifelogs_share_recovered_startms(tmp_path, store):
+    _run_import(tmp_path, _zip_bytes({"lifelogs/note.md": _lifelog_md()}), job_id="job-1")
+    _run_import(tmp_path, _zip_bytes({"export/lifelogs/note.md": _lifelog_md()}), job_id="job-2")
+
+    assert len(store.docs) == 1, "same recovered startMs must dedupe across ZIP wrapper prefixes"
 
 
 def test_persisted_id_is_deterministic_not_random(tmp_path, store):

--- a/backend/tests/unit/test_limitless_import_idempotency.py
+++ b/backend/tests/unit/test_limitless_import_idempotency.py
@@ -135,9 +135,7 @@ def test_unparseable_filename_uses_recovered_startms_before_path():
 
     assert wrapped == nested
     assert wrapped != path_only
-    assert wrapped == document_id_from_seed(
-        f"{limitless.LIMITLESS_IMPORT_ID_NAMESPACE}:{UID}:{started_at.isoformat()}"
-    )
+    assert wrapped == document_id_from_seed(f"{limitless.LIMITLESS_IMPORT_ID_NAMESPACE}:{UID}:{started_at.isoformat()}")
 
 
 def test_reimport_same_export_creates_no_duplicates(tmp_path, store):

--- a/backend/tests/unit/test_limitless_import_idempotency.py
+++ b/backend/tests/unit/test_limitless_import_idempotency.py
@@ -44,6 +44,13 @@ class _FakeConversationStore:
         self.docs[cid] = data
         return True
 
+    def find_legacy_limitless_conversation_id(self, uid, started_at):
+        del uid
+        for cid, data in self.docs.items():
+            if data.get("source") in ("limitless",) and data.get("started_at") == started_at:
+                return cid
+        return None
+
 
 @pytest.fixture
 def store(monkeypatch):
@@ -52,6 +59,11 @@ def store(monkeypatch):
         limitless.lifecycle_service,
         "persist_imported_conversation",
         fake.persist_imported_conversation,
+    )
+    monkeypatch.setattr(
+        limitless,
+        "find_legacy_limitless_conversation_id",
+        fake.find_legacy_limitless_conversation_id,
     )
     monkeypatch.setattr(limitless.import_jobs_db, "create_import_job", MagicMock())
     monkeypatch.setattr(limitless.import_jobs_db, "update_import_job", MagicMock())
@@ -224,6 +236,59 @@ def test_different_users_do_not_collide(tmp_path, store):
     _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}), uid="user-b", job_id="job-b")
 
     assert len(store.docs) == 2, "same export imported by two users must not share conversation IDs"
+
+
+def test_find_legacy_limitless_matches_source_and_started_at(monkeypatch):
+    started_at = datetime(2025, 10, 8, 7, 0, 25, tzinfo=timezone.utc)
+    captured = {}
+
+    def fake_get_conversations(uid, **kwargs):
+        captured.update(kwargs)
+        captured["uid"] = uid
+        return [
+            {"id": "omi-row", "source": "omi", "started_at": started_at},
+            {"id": "legacy-uuid", "source": "limitless", "started_at": started_at},
+        ]
+
+    monkeypatch.setattr(limitless.conversations_db, "get_conversations", fake_get_conversations)
+
+    assert limitless.find_legacy_limitless_conversation_id(UID, started_at) == "legacy-uuid"
+    assert captured["uid"] == UID
+    assert captured["date_field"] == "started_at"
+    assert captured["start_date"] == started_at
+    assert captured["end_date"] == started_at
+    assert captured["include_discarded"] is True
+
+
+def test_reimport_skips_legacy_uuid_row_with_same_started_at(tmp_path, store):
+    started_at, _slug = limitless.parse_lifelog_filename(FN_A)
+    legacy_id = str(uuid_lib.uuid4())
+    store.docs[legacy_id] = {
+        "id": legacy_id,
+        "started_at": started_at,
+        "source": "limitless",
+        "structured": {"title": "legacy import"},
+    }
+
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}))
+
+    deterministic_id = limitless.conversation_id_for_lifelog(UID, FN_A)
+    assert list(store.docs) == [legacy_id]
+    assert deterministic_id not in store.docs
+    assert store.docs[legacy_id]["structured"]["title"] == "legacy import"
+
+
+def test_legacy_row_with_different_started_at_does_not_block_import(tmp_path, store):
+    store.docs[str(uuid_lib.uuid4())] = {
+        "id": "other-legacy",
+        "started_at": datetime(2000, 1, 1, tzinfo=timezone.utc),
+        "source": "limitless",
+    }
+
+    _run_import(tmp_path, _zip_bytes({f"lifelogs/{FN_A}": _lifelog_md()}))
+
+    assert limitless.conversation_id_for_lifelog(UID, FN_A) in store.docs
+    assert len(store.docs) == 2
 
 
 def test_create_error_is_isolated_per_file(tmp_path, store):

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -205,7 +205,7 @@ def _create_overview_from_transcript(segments: List[TranscriptSegment], max_char
 LIMITLESS_IMPORT_ID_NAMESPACE = "limitless"
 
 
-def conversation_id_for_lifelog(uid: str, lifelog_path: str) -> str:
+def conversation_id_for_lifelog(uid: str, lifelog_path: str, *, started_at: Optional[datetime] = None) -> str:
     """Deterministic conversation ID for a Limitless lifelog file.
 
     Keyed on (uid, stable lifelog identity) via the shared ``document_id_from_seed``
@@ -218,13 +218,14 @@ def conversation_id_for_lifelog(uid: str, lifelog_path: str) -> str:
     regenerates a lifelog's title between exports, the re-import still maps to the
     same conversation instead of creating a near-duplicate. A single pendant cannot
     start two lifelogs in the same second, so the timestamp alone identifies a
-    lifelog. If the filename carries no parseable timestamp, the lifelog's full path
-    within the export is used as the fallback identity — not just its basename — so
-    distinct files that share a basename in different folders don't collide (and get
-    one of them silently skipped).
+    lifelog. If the filename carries no parseable timestamp, a recovered
+    ``started_at`` from the lifelog body (``startMs``) is used before falling
+    back to the archive path, so the same record packaged as
+    ``export/lifelogs/note.md`` vs ``lifelogs/note.md`` does not duplicate.
     """
-    started_at, _title_slug = parse_lifelog_filename(Path(lifelog_path).name)
-    identity = started_at.isoformat() if started_at else lifelog_path
+    filename_started_at, _title_slug = parse_lifelog_filename(Path(lifelog_path).name)
+    identity_dt = filename_started_at or started_at
+    identity = identity_dt.isoformat() if identity_dt else lifelog_path
     return document_id_from_seed(f"{LIMITLESS_IMPORT_ID_NAMESPACE}:{uid}:{identity}")
 
 
@@ -313,7 +314,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         import_jobs_db.update_import_job(job_id, {'processed_files': processed_files})
                         continue
 
-                    conversation_id = conversation_id_for_lifelog(uid, lifelog_path)
+                    conversation_id = conversation_id_for_lifelog(uid, lifelog_path, started_at=started_at)
 
                     # Calculate finished_at from last segment
                     if segments and started_at:

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple, Optional
 from zipfile import ZipFile
 
+import database.conversations as conversations_db
 import database.import_jobs as import_jobs_db
 from database.document_ids import document_id_from_seed
 from models.conversation import AppResult, Conversation
@@ -229,6 +230,26 @@ def conversation_id_for_lifelog(uid: str, lifelog_path: str, *, started_at: Opti
     return document_id_from_seed(f"{LIMITLESS_IMPORT_ID_NAMESPACE}:{uid}:{identity}")
 
 
+def find_legacy_limitless_conversation_id(uid: str, started_at: datetime) -> Optional[str]:
+    """Return a pre-deterministic Limitless conversation id at this started_at.
+
+    Imports from before deterministic IDs used random UUIDs. A re-upload after
+    the upgrade must skip those rows instead of inserting a second document.
+    """
+    rows = conversations_db.get_conversations(
+        uid,
+        limit=20,
+        include_discarded=True,
+        start_date=started_at,
+        end_date=started_at,
+        date_field='started_at',
+    )
+    for row in rows:
+        if row.get('source') in (ConversationSource.limitless, ConversationSource.limitless.value):
+            return row.get('id')
+    return None
+
+
 def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code: str = 'en') -> None:
     """
     Background worker to process a Limitless ZIP export using LIGHT IMPORT mode.
@@ -323,6 +344,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     else:
                         finished_at = started_at or datetime.now(timezone.utc)
 
+                    source_started_at = started_at
                     if not started_at:
                         started_at = datetime.now(timezone.utc)
 
@@ -364,7 +386,16 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                     # stored instead of overwriting them. This is atomic (Firestore create()),
                     # so it never duplicates and never clobbers edits a user may have made to a
                     # previously-imported conversation ("first import wins").
-                    if lifecycle_service.persist_imported_conversation(uid, conversation.model_dump()):
+                    # Before create, skip when a legacy random-UUID Limitless row already
+                    # exists at this started_at so the first post-upgrade re-import does
+                    # not insert a deterministic duplicate.
+                    legacy_id = (
+                        find_legacy_limitless_conversation_id(uid, source_started_at) if source_started_at else None
+                    )
+                    if legacy_id and legacy_id != conversation_id:
+                        conversations_skipped += 1
+                        logger.info("[Limitless Import] Skipped already-imported lifelog")
+                    elif lifecycle_service.persist_imported_conversation(uid, conversation.model_dump()):
                         conversations_created += 1
                     else:
                         conversations_skipped += 1

--- a/backend/utils/imports/limitless.py
+++ b/backend/utils/imports/limitless.py
@@ -367,7 +367,7 @@ def process_limitless_import(job_id: str, uid: str, zip_path: str, language_code
                         conversations_created += 1
                     else:
                         conversations_skipped += 1
-                        logger.info(f"[Limitless Import] Skipped already-imported lifelog: {filename}")
+                        logger.info("[Limitless Import] Skipped already-imported lifelog")
 
                 except Exception as e:
                     error_msg = f"Error processing {lifelog_path}: {str(e)}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed and why

Follow-up for the still-open Codex review threads on just-merged #11927 (search date range) and #11928 (Limitless import idempotency). Each thread is a separate commit. Do not merge this PR from this agent run.

Codex threads addressed:

- https://github.com/BasedHardware/omi/pull/11927#discussion_r3821234004
- https://github.com/BasedHardware/omi/pull/11927#discussion_r3821234020
- https://github.com/BasedHardware/omi/pull/11927#discussion_r3821234034
- https://github.com/BasedHardware/omi/pull/11927#discussion_r3821234050
- https://github.com/BasedHardware/omi/pull/11928#discussion_r3821277761
- https://github.com/BasedHardware/omi/pull/11928#discussion_r3821277765
- https://github.com/BasedHardware/omi/pull/11928#discussion_r3821277773
- https://github.com/BasedHardware/omi/pull/11928#discussion_r3821277782
- https://github.com/BasedHardware/omi/pull/11928#discussion_r3821277793

## Product invariants affected

none

## How it was verified

Backend (this VM):

```
cd backend && source .venv/bin/activate
ENCRYPTION_SECRET=… OPENAI_API_KEY=…
.venv/bin/python -m pytest tests/unit/test_limitless_import_idempotency.py -q --tb=short
```

Result: **18 passed**.

`scripts/pr-preflight --pr-body-file /tmp/pr-body.md` passed 26 checks.

Formatting (same as CI Formatting job, Flutter 3.44.5 + black 26.5.1):

```
cd app && flutter pub get
dart format --line-length 120 --set-exit-if-changed --output=none <changed dart>
black --check --line-length 120 --skip-string-normalization <changed python>
```

Both now exit 0.

Flutter unit tests were not run here. This Cloud VM has no Flutter SDK for `flutter test`. I did not exercise the live search picker or import-history UI on a device.

## Tests

- `app/test/providers/conversation_provider_date_range_test.dart` — UTC serialization and single-day closed-range fallback
- `app/test/unit/import_job_timestamp_test.dart` — `conversations_skipped` adapter + history chips
- `backend/tests/unit/test_limitless_import_idempotency.py` — skip-log PII, recovered `startMs` identity, legacy UUID `started_at` skip

## Failure class (fixes)

Failure-Class: none

This PR mixes search fixes (`none`) with import-identity commits that declare `FC-import-unstable-identity` in their commit bodies. The registry `evidence_prs` update (#8075 → merged #11928) is included here as requested; the instance-fix protocol would otherwise require a separate registry-only PR for that field.

## Commits

1. `fix(search): serialize date-range bounds as UTC`
2. `fix(search): treat a single selected day as a closed range`
3. `fix(search): route the search calendar from live query text`
4. `test(search): add keys on the search date-range picker actions`
5. `fix(import): stop logging Limitless title slugs on skip`
6. `fix(import): key unparseable lifelogs by recovered startMs`
7. `fix(ci): cite merged #11928 in FC-import-unstable-identity`
8. `fix(app): surface conversations_skipped on import jobs`
9. `fix(import): skip re-import when a legacy Limitless row matches started_at`
10. `test(import): keep legacy started_at skip scoped per uid`
11. `style: match Flutter 3.44.5 and black 26.5.1 formatting`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45d1d936-bd40-4dd6-9727-73839e9902d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45d1d936-bd40-4dd6-9727-73839e9902d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

