### PR TITLE
fix(backend): keep models/chat.py out of the database import graph (#11925)

### DIFF
--- a/.github/failure-classes/FC-model-import-reaches-persistence-client.json
+++ b/.github/failure-classes/FC-model-import-reaches-persistence-client.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-model-import-reaches-persistence-client",
+  "violated_contract": "A pure data/model module must stay import-pure: importing it must not reach the persistence layer. models/ is imported by nearly every backend module and by unit suites that load it under stubs, so a module-scope `from database.* import ...` drags the Firestore client and its proto descriptors into every one of those import graphs and turns unrelated suites red.",
+  "canonical_prevention": "Keep the record lookup in the layer that already owns the database import and inject it into the model as a callable (Message.get_messages_as_string(..., app_name_resolver=...)). Guard it by importing the model in a clean interpreter and asserting no `database.*` or `google.cloud.firestore*` module was loaded, so any future model-layer import that reaches persistence fails, not just this symbol.",
+  "canonical_prevention_artifact": [
+    "backend/models/chat.py",
+    "backend/utils/llm/chat.py",
+    "backend/tests/unit/test_models_chat_import_purity.py"
+  ],
+  "evidence_prs": [11913],
+  "scope_hints": [
+    "backend/models/**"
+  ],
+  "status": "open"
+}

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -1,11 +1,14 @@
 import json
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
 
-from database.apps import get_app_by_id_db
+# App display names are resolved by an injected callable, never by importing the database
+# layer here: models/ must stay import-pure so a Pydantic module cannot drag the Firestore
+# client into every import graph that touches a chat message.
+AppNameResolver = Callable[[str], Optional[str]]
 
 
 class MessageSender(str, Enum):
@@ -147,14 +150,14 @@ class Message(BaseModel):
         *,
         use_plugin_name_if_available: bool,
         app_name_by_id: Dict[str, Optional[str]],
+        app_name_resolver: Optional[AppNameResolver],
     ) -> str:
         if message.sender == 'human':
             return 'User'
-        if use_plugin_name_if_available and message.app_id and message.app_id.strip():
+        if use_plugin_name_if_available and app_name_resolver and message.app_id and message.app_id.strip():
             app_id = message.app_id.strip()
             if app_id not in app_name_by_id:
-                app = get_app_by_id_db(app_id)
-                name = app.get('name') if app else None
+                name = app_name_resolver(app_id)
                 app_name_by_id[app_id] = name.strip() if isinstance(name, str) and name.strip() else None
             resolved_name = app_name_by_id[app_id]
             if resolved_name:
@@ -167,6 +170,7 @@ class Message(BaseModel):
         use_user_name_if_available: bool = False,
         use_plugin_name_if_available: bool = False,
         include_file_info: bool = False,
+        app_name_resolver: Optional[AppNameResolver] = None,
     ) -> str:
         sorted_messages = sorted(messages, key=lambda m: m.created_at)
         app_name_by_id: Dict[str, Optional[str]] = {}
@@ -177,6 +181,7 @@ class Message(BaseModel):
                 message,
                 use_plugin_name_if_available=use_plugin_name_if_available,
                 app_name_by_id=app_name_by_id,
+                app_name_resolver=app_name_resolver,
             )
             msg_text = f"({message.created_at.strftime('%d %b %Y at %H:%M UTC')}) {sender_name}: {message.text}"
 
@@ -195,6 +200,7 @@ class Message(BaseModel):
         use_user_name_if_available: bool = False,
         use_plugin_name_if_available: bool = False,
         include_file_info: bool = False,
+        app_name_resolver: Optional[AppNameResolver] = None,
     ) -> str:
         sorted_messages = sorted(messages, key=lambda m: m.created_at)
         app_name_by_id: Dict[str, Optional[str]] = {}
@@ -222,7 +228,7 @@ class Message(BaseModel):
 
             msg = f"""<message>
 <created_at>{message.created_at.strftime('%d %b %Y at %H:%M UTC')}</created_at>
-<sender>{Message._resolve_sender_name(message, use_plugin_name_if_available=use_plugin_name_if_available, app_name_by_id=app_name_by_id)}</sender>
+<sender>{Message._resolve_sender_name(message, use_plugin_name_if_available=use_plugin_name_if_available, app_name_by_id=app_name_by_id, app_name_resolver=app_name_resolver)}</sender>
 <content>{message.text}</content>
 {file_section}
 </message>"""

--- a/backend/tests/unit/test_message_formatting.py
+++ b/backend/tests/unit/test_message_formatting.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 from models.chat import Message, MessageSender, MessageType
 
@@ -17,8 +17,8 @@ def _ai_message(*, app_id='some-app-id', text='hello'):
 
 def test_get_messages_as_string_sender_uses_app_display_name():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
-        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+    lookup = MagicMock(return_value='Friendly Bot')
+    result = Message.get_messages_as_string([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
     assert 'Friendly Bot: hello' in result
     assert 'some-app-id' not in result
@@ -27,8 +27,8 @@ def test_get_messages_as_string_sender_uses_app_display_name():
 
 def test_get_messages_as_xml_sender_uses_app_display_name():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
-        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+    lookup = MagicMock(return_value='Friendly Bot')
+    result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
     assert '<sender>Friendly Bot</sender>' in result
     lookup.assert_called_once_with('some-app-id')
@@ -37,8 +37,8 @@ def test_get_messages_as_xml_sender_uses_app_display_name():
 def test_get_messages_as_string_defaults_to_ai_sender_for_app_id():
     m = _ai_message()
 
-    with patch('models.chat.get_app_by_id_db') as lookup:
-        result = Message.get_messages_as_string([m])
+    lookup = MagicMock()
+    result = Message.get_messages_as_string([m], app_name_resolver=lookup)
 
     assert 'AI: hello' in result
     lookup.assert_not_called()
@@ -47,8 +47,8 @@ def test_get_messages_as_string_defaults_to_ai_sender_for_app_id():
 def test_get_messages_as_xml_defaults_to_ai_sender_for_app_id():
     m = _ai_message()
 
-    with patch('models.chat.get_app_by_id_db') as lookup:
-        result = Message.get_messages_as_xml([m])
+    lookup = MagicMock()
+    result = Message.get_messages_as_xml([m], app_name_resolver=lookup)
 
     assert '<sender>AI</sender>' in result
     lookup.assert_not_called()
@@ -62,8 +62,8 @@ def test_get_messages_as_string_blank_app_id_falls_back_to_ai_sender():
     for app_id in _blank_app_id_variants():
         m = _ai_message(app_id=app_id)
 
-        with patch('models.chat.get_app_by_id_db') as lookup:
-            result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+        lookup = MagicMock()
+        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
         assert 'AI: hello' in result, f'blank app_id={app_id!r} must not emit an empty sender'
         lookup.assert_not_called()
@@ -73,8 +73,8 @@ def test_get_messages_as_xml_blank_app_id_falls_back_to_ai_sender():
     for app_id in _blank_app_id_variants():
         m = _ai_message(app_id=app_id)
 
-        with patch('models.chat.get_app_by_id_db') as lookup:
-            result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+        lookup = MagicMock()
+        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
         assert '<sender>AI</sender>' in result, f'blank app_id={app_id!r} must not emit an empty sender'
         lookup.assert_not_called()
@@ -82,8 +82,8 @@ def test_get_messages_as_xml_blank_app_id_falls_back_to_ai_sender():
 
 def test_get_messages_as_string_missing_app_falls_back_to_ai_sender():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value=None) as lookup:
-        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+    lookup = MagicMock(return_value=None)
+    result = Message.get_messages_as_string([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
     assert 'AI: hello' in result
     lookup.assert_called_once_with('some-app-id')
@@ -91,8 +91,8 @@ def test_get_messages_as_string_missing_app_falls_back_to_ai_sender():
 
 def test_get_messages_as_xml_missing_app_falls_back_to_ai_sender():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value=None) as lookup:
-        result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
+    lookup = MagicMock(return_value=None)
+    result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
     assert '<sender>AI</sender>' in result
     lookup.assert_called_once_with('some-app-id')
@@ -100,8 +100,8 @@ def test_get_messages_as_xml_missing_app_falls_back_to_ai_sender():
 
 def test_get_messages_as_string_blank_app_name_falls_back_to_ai_sender():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': '  '}):
-        result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
+    lookup = MagicMock(return_value='  ')
+    result = Message.get_messages_as_string([m], use_plugin_name_if_available=True, app_name_resolver=lookup)
 
     assert 'AI: hello' in result
 
@@ -118,8 +118,8 @@ def test_sender_name_lookup_is_cached_per_app_id():
             app_id='shared-app',
         ),
     ]
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'shared-app', 'name': 'Shared'}) as lookup:
-        result = Message.get_messages_as_string(messages, use_plugin_name_if_available=True)
+    lookup = MagicMock(return_value='Shared')
+    result = Message.get_messages_as_string(messages, use_plugin_name_if_available=True, app_name_resolver=lookup)
 
     assert result.count('Shared:') == 2
     lookup.assert_called_once_with('shared-app')

--- a/backend/tests/unit/test_models_chat_import_purity.py
+++ b/backend/tests/unit/test_models_chat_import_purity.py
@@ -1,0 +1,54 @@
+"""models/chat.py must not drag the database layer into its import graph.
+
+#11913 added `from database.apps import get_app_by_id_db` at module scope in
+`models/chat.py`. Every suite that loads the real chat model then transitively
+imported `google.cloud.firestore_v1`, which turned `Backend Unit Tests` red on
+main (#11925): 67 tests died on `duplicate file name
+google/cloud/firestore_v1/types/document.proto` once the descriptor pool had
+already been populated by another module in the same process.
+
+The guard runs the import in a clean interpreter and inspects the real
+`sys.modules` it produced, so it fails on any future model-layer import that
+reaches persistence — not just this one symbol.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+_PROBE = """
+import sys
+
+import models.chat  # noqa: F401
+
+leaked = sorted(
+    name
+    for name in sys.modules
+    if name == 'database' or name.startswith('database.') or name.startswith('google.cloud.firestore')
+)
+print('\\n'.join(leaked))
+"""
+
+
+def _import_models_chat_in_a_clean_interpreter() -> str:
+    result = subprocess.run(
+        [sys.executable, '-c', _PROBE],
+        cwd=BACKEND_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, f'importing models.chat failed:\n{result.stderr}'
+    return result.stdout.strip()
+
+
+def test_importing_models_chat_does_not_import_the_database_layer():
+    leaked = _import_models_chat_in_a_clean_interpreter()
+
+    assert leaked == '', (
+        'models/chat.py must stay import-pure: importing it pulled in '
+        f'{leaked.splitlines()}. Inject a resolver (see Message.get_messages_as_string\'s '
+        'app_name_resolver) instead of importing database.* at module scope.'
+    )

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, ValidationError
 import database.users as users_db
 import database.notifications as notification_db
 import database.goals as goals_db
+import database.apps as apps_db
 from database.redis_db import add_filter_category_item
 from database.auth import get_user_name
 from models.app import App
@@ -34,6 +35,15 @@ logger = logging.getLogger(__name__)
 def _content_str(response: Any) -> str:
     """Extract string content from an LLM response (langchain content is typed as a union)."""
     return cast(str, response.content)
+
+
+def resolve_app_display_name(app_id: str) -> Optional[str]:
+    """App-record -> display name. Lives here, not in models/chat.py: this layer already owns
+    the database import, so the model stays free of it. Bound as a module (like users_db /
+    goals_db above) rather than `from database.apps import ...`, so suites that stub
+    database.apps can still import this module."""
+    app = apps_db.get_app_by_id_db(app_id)
+    return app.get('name') if app else None
 
 
 def normalize_filter(value: str) -> str:
@@ -267,7 +277,10 @@ def chunk_extraction(
 
 def _get_answer_simple_message_prompt(uid: str, messages: List[Message], app: Optional[App] = None) -> str:
     conversation_history = Message.get_messages_as_string(
-        messages, use_user_name_if_available=True, use_plugin_name_if_available=True
+        messages,
+        use_user_name_if_available=True,
+        use_plugin_name_if_available=True,
+        app_name_resolver=resolve_app_display_name,
     )
     user_name, memories_str = get_prompt_memories(uid)
 
@@ -307,7 +320,10 @@ def answer_simple_message_stream(
 
 def _get_answer_omi_question_prompt(messages: List[Message], context: str) -> str:
     conversation_history = Message.get_messages_as_string(
-        messages, use_user_name_if_available=True, use_plugin_name_if_available=True
+        messages,
+        use_user_name_if_available=True,
+        use_plugin_name_if_available=True,
+        app_name_resolver=resolve_app_display_name,
     )
 
     return f"""


### PR DESCRIPTION
Fixes #11925.

## Bug

`Backend Unit Tests` has been red on `main` since **1822dc3397** (#11913, 2026-08-20 10:05Z) — every push since has failed, and it blocks the required check on every open PR. 67 tests fail across `test_chat_generate_reply_stateless.py`, `test_chat_quota_counting_router.py`, `test_chat_stream_error_fallback.py`, `test_desktop_message_quota_router.py`, `test_atomicity_lifecycle_regressions.py` and others.

## Root cause

#11913 added a **module-scope** import to `backend/models/chat.py`:

```python
from database.apps import get_app_by_id_db
```

`models/chat.py` is a pure Pydantic module that the chat and desktop-message suites load for real (`_chat_router_test_harness.wire_common_stubs` → `load_real_module('models.chat', ...)`) *before* they install their `database.*` stubs. That import therefore loads the real `database/apps.py`, which imports `google.cloud.firestore_v1` into a descriptor pool another module in the same process already populated:

```
E   TypeError: Couldn't build proto file into descriptor pool:
    duplicate file name google/cloud/firestore_v1/types/document.proto
```

The function itself is fine (`database/apps.py:40`); the defect is that a model module owns a database lookup at all. `backend-import-purity` passed because the import is legal in a full environment — it only detonates under the suites' stubs.

## Fix

Move the lookup to the layer that already owns the database import, and inject it:

- `models/chat.py` — drops the `database.apps` import. `get_messages_as_string` / `get_messages_as_xml` take an optional `app_name_resolver: Callable[[str], Optional[str]]`; `_resolve_sender_name` calls it and keeps the existing per-`app_id` cache and blank-name/missing-app fallbacks unchanged.
- `utils/llm/chat.py` — already imports `database.*` at module scope. Adds `resolve_app_display_name` and passes it at both call sites that use `use_plugin_name_if_available=True`, so #11913's user-visible behaviour (AI sender rendered as the app's display name) is preserved exactly. It binds the module (`import database.apps as apps_db`, matching `users_db` / `goals_db` two lines above) rather than `from database.apps import ...`: `test_prompt_cache_integration.py` and `test_chat_agent_provider_retry.py` stub `database.apps` and load this module for real, and the `from`-form breaks under those stubs the same way the original did. That is the same trap noted in `test_prompt_cache_integration.py:291` for `database.auth`.

No other caller passes `use_plugin_name_if_available=True`, so every other call site is byte-identical.

## Verification

Local, Python 3.11, `backend/`:

- **Reproduced first:** the five named suites at `11306b54c5` → `35 failed, 10 passed`.
- **After the fix:** the same five suites → `45 passed`.
- **New guard** `tests/unit/test_models_chat_import_purity.py` imports `models.chat` in a clean interpreter and asserts no `database.*` / `google.cloud.firestore*` module was loaded. Pre-fix **control**: re-adding the module-scope import makes it fail with the leaked `database._client`, `database.apps`, … list. Post-fix: passes.
- `tests/unit/test_message_formatting.py` — 10 tests, all pass; rewritten only to patch the new injected seam instead of `models.chat.get_app_by_id_db`, with the same assertions and expected values as #11913 shipped.
- **The feature still works end-to-end.** Ran the real production prompt builder in a live interpreter with only `database.apps` faked, and the rendered history carries the app name, not `AI`:

  ```
  >>> resolve_app_display_name('known')  -> 'Friendly Bot'
  >>> resolve_app_display_name('nope')   -> None
  >>> _get_answer_omi_question_prompt([ai_message(app_id='known')], 'ctx')
  ...
  Conversation History:
  (20 Aug 2026 at 12:30 UTC) Friendly Bot: hello
  ```
- `tests/unit/test_prompt_cache_integration.py` + `tests/unit/test_chat_agent_provider_retry.py` — 84 tests, all pass (these caught the `from`-import form of the resolver wiring during development).
- Full backend unit suite (`bash test.sh`, the CI source of truth, all 883 selected files — `models/chat.py` forces the full selection): see the CI result on this PR.
- `black --line-length 120 --skip-string-normalization` clean on all changed files.

Failure-Class: new

Registers `FC-model-import-reaches-persistence-client` in `.github/failure-classes/` — a model module whose import graph reaches the persistence layer. The guard artifact is the import-purity test above, which catches the whole class rather than this one symbol.

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

