### PR TITLE
fix(backend): keep models/chat.py importable without the database layer

### DIFF
--- a/.github/failure-classes/FC-model-module-imports-persistence-at-module-scope.json
+++ b/.github/failure-classes/FC-model-module-imports-persistence-at-module-scope.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "id": "FC-model-module-imports-persistence-at-module-scope",
+  "violated_contract": "A model module must stay importable without its persistence layer. Binding a database helper at module scope in backend/models/** makes every importer of the model — including test collection, which reaches these modules long before any route runs — load the real client package transitively. Suites that install a partial stub for that database module then fail at import rather than at the call they stubbed, and the retry re-imports the real client into an already-populated protobuf descriptor pool, so the error surfaced names a duplicate proto file and not the missing symbol. The defect is the placement of the import, not the helper: a module-scope binding also re-exports the helper as an attribute of the model module, which invites tests to patch it there and couples the seam to the layering violation that created it.",
+  "canonical_prevention": "Import a persistence helper inside the function that calls it, so the model module's import graph stays free of the database layer, and patch the helper in tests at the module that defines it rather than at the model module that borrowed it. Prove it with a test file that exercises the resolving behaviour through the defining module's seam, and check the guard by running the affected suite file-isolated — a partial stub only fails when its file is the one that first imports the client, so a multi-file run can pass while the isolated lane CI uses still fails.",
+  "canonical_prevention_artifact": [
+    "backend/models/chat.py",
+    "backend/tests/unit/test_message_formatting.py"
+  ],
+  "evidence_prs": [
+    11913,
+    11932
+  ],
+  "scope_hints": [
+    "backend/models/**"
+  ],
+  "status": "open"
+}

--- a/backend/models/chat.py
+++ b/backend/models/chat.py
@@ -5,8 +5,6 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
 
-from database.apps import get_app_by_id_db
-
 
 class MessageSender(str, Enum):
     ai = 'ai'
@@ -153,6 +151,10 @@ class Message(BaseModel):
         if use_plugin_name_if_available and message.app_id and message.app_id.strip():
             app_id = message.app_id.strip()
             if app_id not in app_name_by_id:
+                # Imported lazily: this models module must stay importable without the
+                # database layer, which module-scope import of it would drag in.
+                from database.apps import get_app_by_id_db
+
                 app = get_app_by_id_db(app_id)
                 name = app.get('name') if app else None
                 app_name_by_id[app_id] = name.strip() if isinstance(name, str) and name.strip() else None

--- a/backend/tests/unit/test_message_formatting.py
+++ b/backend/tests/unit/test_message_formatting.py
@@ -17,7 +17,7 @@ def _ai_message(*, app_id='some-app-id', text='hello'):
 
 def test_get_messages_as_string_sender_uses_app_display_name():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
+    with patch('database.apps.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
         result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
 
     assert 'Friendly Bot: hello' in result
@@ -27,7 +27,7 @@ def test_get_messages_as_string_sender_uses_app_display_name():
 
 def test_get_messages_as_xml_sender_uses_app_display_name():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
+    with patch('database.apps.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': 'Friendly Bot'}) as lookup:
         result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
 
     assert '<sender>Friendly Bot</sender>' in result
@@ -37,7 +37,7 @@ def test_get_messages_as_xml_sender_uses_app_display_name():
 def test_get_messages_as_string_defaults_to_ai_sender_for_app_id():
     m = _ai_message()
 
-    with patch('models.chat.get_app_by_id_db') as lookup:
+    with patch('database.apps.get_app_by_id_db') as lookup:
         result = Message.get_messages_as_string([m])
 
     assert 'AI: hello' in result
@@ -47,7 +47,7 @@ def test_get_messages_as_string_defaults_to_ai_sender_for_app_id():
 def test_get_messages_as_xml_defaults_to_ai_sender_for_app_id():
     m = _ai_message()
 
-    with patch('models.chat.get_app_by_id_db') as lookup:
+    with patch('database.apps.get_app_by_id_db') as lookup:
         result = Message.get_messages_as_xml([m])
 
     assert '<sender>AI</sender>' in result
@@ -62,7 +62,7 @@ def test_get_messages_as_string_blank_app_id_falls_back_to_ai_sender():
     for app_id in _blank_app_id_variants():
         m = _ai_message(app_id=app_id)
 
-        with patch('models.chat.get_app_by_id_db') as lookup:
+        with patch('database.apps.get_app_by_id_db') as lookup:
             result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
 
         assert 'AI: hello' in result, f'blank app_id={app_id!r} must not emit an empty sender'
@@ -73,7 +73,7 @@ def test_get_messages_as_xml_blank_app_id_falls_back_to_ai_sender():
     for app_id in _blank_app_id_variants():
         m = _ai_message(app_id=app_id)
 
-        with patch('models.chat.get_app_by_id_db') as lookup:
+        with patch('database.apps.get_app_by_id_db') as lookup:
             result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
 
         assert '<sender>AI</sender>' in result, f'blank app_id={app_id!r} must not emit an empty sender'
@@ -82,7 +82,7 @@ def test_get_messages_as_xml_blank_app_id_falls_back_to_ai_sender():
 
 def test_get_messages_as_string_missing_app_falls_back_to_ai_sender():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value=None) as lookup:
+    with patch('database.apps.get_app_by_id_db', return_value=None) as lookup:
         result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
 
     assert 'AI: hello' in result
@@ -91,7 +91,7 @@ def test_get_messages_as_string_missing_app_falls_back_to_ai_sender():
 
 def test_get_messages_as_xml_missing_app_falls_back_to_ai_sender():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value=None) as lookup:
+    with patch('database.apps.get_app_by_id_db', return_value=None) as lookup:
         result = Message.get_messages_as_xml([m], use_plugin_name_if_available=True)
 
     assert '<sender>AI</sender>' in result
@@ -100,7 +100,7 @@ def test_get_messages_as_xml_missing_app_falls_back_to_ai_sender():
 
 def test_get_messages_as_string_blank_app_name_falls_back_to_ai_sender():
     m = _ai_message()
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': '  '}):
+    with patch('database.apps.get_app_by_id_db', return_value={'id': 'some-app-id', 'name': '  '}):
         result = Message.get_messages_as_string([m], use_plugin_name_if_available=True)
 
     assert 'AI: hello' in result
@@ -118,7 +118,7 @@ def test_sender_name_lookup_is_cached_per_app_id():
             app_id='shared-app',
         ),
     ]
-    with patch('models.chat.get_app_by_id_db', return_value={'id': 'shared-app', 'name': 'Shared'}) as lookup:
+    with patch('database.apps.get_app_by_id_db', return_value={'id': 'shared-app', 'name': 'Shared'}) as lookup:
         result = Message.get_messages_as_string(messages, use_plugin_name_if_available=True)
 
     assert result.count('Shared:') == 2


### PR DESCRIPTION
Fixes #11925.

`Backend Unit Tests` has been red on `main` since **1822dc3397** (#11913), which blocks every open
PR's required check.

## Cause

#11913 added a module-scope import to `backend/models/chat.py`:

```python
from database.apps import get_app_by_id_db
```

`models/chat.py` is imported at collection time by the chat and desktop-message suites, whose shared
harness installs a stub `database.apps` carrying only `record_app_usage`
(`backend/tests/unit/_chat_router_test_harness.py`). The import raises `ImportError`, and the retry
that follows re-imports the real firestore package into an already-populated descriptor pool, which
is the error most of the failures actually print:

```
TypeError: Couldn't build proto file into descriptor pool:
duplicate file name google/cloud/firestore_v1/types/document.proto
```

The function itself is fine. The defect is where the import lives: a Pydantic models module should
not pull the database layer in at import time.

## The fix

Import the resolver at its single call site. The ten tests that patched
`models.chat.get_app_by_id_db` — an attribute that existed only because of the module-scope import —
now patch `database.apps.get_app_by_id_db`, where the symbol actually lives. They still exercise
#11913's behaviour: app-name resolution, the per-`app_id` cache, and the fallbacks for a missing app
and a blank name.

**Widening the harness stub instead does not work.** It only helps once another file has already
imported firestore into the process, so it passes a multi-file `pytest` invocation and still fails
under the file-isolated runner CI uses. Measured on `test_chat_stream_error_fallback.py` run alone,
as CI isolates it:

| tree | result |
|---|---|
| `03ec0c898e` (last green) | 11 passed |
| `5f37b17848` (`main`) | 10 failed, 1 passed |
| `main` + widened stub | 10 failed, 1 passed |
| `main` + this change | **11 passed** |

## Verification

Run at `5f37b17848`.

`backend/test.sh` — 881 files, file-isolated exactly as CI runs them:

```
before:  20 failing files
after:    2 failing files
```

Both survivors are `tests/unit/test_rendered_deployment_contract.py` and
`tests/unit/test_verify_pusher_config_references.py`. They fail identically at the last green commit
`03ec0c898e`, on `assert helm is not None, "helm must be installed for the rendered deployment
contract"` — a missing local binary, unrelated to this change.

Isolation guards:

```
scripts/check_module_stub_pollution.py     Checked 930 backend test file(s); 0 violation(s).
scripts/scan_import_time_side_effects.py   Checked 812 backend production file(s); 0 violation(s).
```

`scripts/pr-preflight --suggest --base upstream/main` reports **no product invariants affected**.

Exercised through the backend unit suite only. I have not run the chat UI against a live backend,
so the user-facing render of a bot sender name is covered by `test_message_formatting.py` rather
than by my having seen it in the app.

## Notes

`scan_import_time_side_effects.py` does not catch this class today: the import is legal at import
time in a full environment and only fails under the test stubs. Worth a follow-up on whether that
guard should also reject `models/**` importing `database/**` at module scope — happy to file it if
you'd like, but I did not want to widen this PR while `main` is red.

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

