### PR TITLE
fix(macOS): keep legacy Home visible when toggled

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -122,7 +122,10 @@ struct ChatFirstShell: View {
     {
       PageGlassLane(
         selectedIndex: ChatFirstPageGlassLanePolicy.pageGlassLaneIndex(for: navigation.route),
-        memoryDestinationRawValue: memoryDestinationRawValue
+        memoryDestinationRawValue: memoryDestinationRawValue,
+        homeOwnsItsPanels: HomeDesignPresentation.queryShellOwnsItsPanels(
+          useLegacyHomeDesign: true,
+          forceModernPresentation: true)
       ) {
         routeDestination
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -100,6 +100,8 @@ struct DesktopHomeView: View {
     selectedIndex == SidebarNavItem.settings.rawValue
   }
 
+  private var homeOwnsItsPanels: Bool { !useLegacyHomeDesign }
+
   private var shouldShowAuthEntryShell: Bool {
     authState.isRestoringAuth || authState.sessionPhase == .recoveryRequired || !authState.isSignedIn
       || !hasCompletedOnboardingAtAuthorityRead
@@ -529,13 +531,10 @@ struct DesktopHomeView: View {
     }
   }
 
-  /// Pins the hugged glass: not smaller than the destinations, not wider than the
-  /// readable lane plus its page margins. Height stays display-limited.
+  /// Pins the shell between the destination minimum and the visible display frame.
   private static func pinShellWindowSizeLimits(_ window: NSWindow, resizeFrame: Bool = true) {
     let minimumContentSize = DesktopWindowLayoutPolicy.minimumContentSize
-    let maximumContentSize = NSSize(
-      width: DesktopWindowLayoutPolicy.maximumContentWidth,
-      height: 10_000)
+    let maximumContentSize = DesktopWindowLayoutPolicy.maximumContentSize(for: window)
     window.contentMinSize = minimumContentSize
     window.minSize = window.frameRect(forContentRect: NSRect(origin: .zero, size: minimumContentSize)).size
     window.contentMaxSize = maximumContentSize
@@ -1388,7 +1387,7 @@ struct DesktopHomeView: View {
       PageGlassLane(
         selectedIndex: selectedIndex,
         memoryDestinationRawValue: memoryDestinationRawValue,
-        usesLegacyHomeDesign: useLegacyHomeDesign
+        homeOwnsItsPanels: homeOwnsItsPanels
       ) {
         HStack(spacing: 0) {
           if isInSettings && !showsPrimarySidebar { settingsSidebar }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -1386,7 +1386,9 @@ struct DesktopHomeView: View {
       // One panel per destination — see `PageGlassLane`. Settings' own section list rides inside it
       // so the page is one object rather than a panel with its nav stranded on the wallpaper.
       PageGlassLane(
-        selectedIndex: selectedIndex, memoryDestinationRawValue: memoryDestinationRawValue
+        selectedIndex: selectedIndex,
+        memoryDestinationRawValue: memoryDestinationRawValue,
+        usesLegacyHomeDesign: useLegacyHomeDesign
       ) {
         HStack(spacing: 0) {
           if isInSettings && !showsPrimarySidebar { settingsSidebar }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopShellPresentationPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopShellPresentationPolicy.swift
@@ -15,6 +15,32 @@ enum DesktopShellPresentationPolicy {
   }
 }
 
+enum HomeDesignPresentation: Equatable {
+  case queryShell
+  case redesignedHub
+  case oldestLegacy
+
+  static func resolve(
+    useLegacyHomeDesign: Bool,
+    useOldestHomeDesign: Bool,
+    forceModernPresentation: Bool
+  ) -> Self {
+    guard !forceModernPresentation, useLegacyHomeDesign else { return .queryShell }
+    return useOldestHomeDesign ? .oldestLegacy : .redesignedHub
+  }
+
+  static func queryShellOwnsItsPanels(
+    useLegacyHomeDesign: Bool,
+    forceModernPresentation: Bool
+  ) -> Bool {
+    resolve(
+      useLegacyHomeDesign: useLegacyHomeDesign,
+      useOldestHomeDesign: false,
+      forceModernPresentation: forceModernPresentation
+    ) == .queryShell
+  }
+}
+
 @MainActor
 enum FloatingPrimaryTextInputRouting {
   private(set) static var routesToMainApp = false

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -212,9 +212,9 @@ enum TopNavigationLayoutMetrics {
   /// `PageGlassLaneLayout.laneWidth` both delegate here, so the bar and whatever is under it cannot
   /// drift apart.
   ///
-  /// The lane fills the window. The 900 pt readable cap is a window-max
-  /// (`DesktopWindowLayoutPolicy.maximumContentWidth`), not an internal inset: capping here
-  /// inside a larger window is what drew the invisible click border around the glass.
+  /// The lane fills the window. The 900 pt readable cap belongs to content inside the lane, not to
+  /// the window itself: capping here inside a larger window is what drew the invisible click border
+  /// around the glass.
   static func contentLaneWidth(for availableWidth: CGFloat) -> CGFloat {
     max(0, availableWidth - (DesktopWindowLayoutPolicy.windowInset * 2))
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopWindowLayoutPolicy.swift
@@ -13,11 +13,11 @@ enum DesktopWindowLayoutPolicy {
   /// gutter. Chat's own `pageMargin` is interior layout and is not this inset.
   static let windowInset: CGFloat = 0
 
-  /// Readable lane plus `windowInset` on each side.
-  ///
-  /// Extra width beyond this is empty wallpaper that still belongs to the window
-  /// until AppKit clamps the frame. Height stays display-limited: a taller panel
-  /// is still hugged glass, not a gutter.
-  static let maximumContentWidth =
-    ChatComposerLayout.contentLaneMaxWidth + windowInset * 2
+  @MainActor
+  static func maximumContentSize(for window: NSWindow) -> NSSize {
+    guard let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame else {
+      return NSSize(width: 10_000, height: 10_000)
+    }
+    return window.contentRect(forFrameRect: visibleFrame).size
+  }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
@@ -6,11 +6,12 @@
 //  wallpaper. That is the whole point — panels sit *on* the desktop rather than on a full-bleed slab
 //  of glass the window painted for them.
 //
-//  Home and Rewind were already built that way: each is a set of glass objects with real air between
-//  them (`QueryShellHome`, `RewindSearchLayout`). **Every other destination was drawn assuming the
-//  window's ground was underneath it**, so without one they render type and controls straight onto the
-//  wallpaper. This file is where they get a surface, and it is one surface for all of them: a page that
-//  invents its own panel is the drift `InkGlass` exists to stop.
+//  QueryShell Home and Rewind were already built that way: each is a set of glass objects with real air
+//  between them (`QueryShellHome`, `RewindSearchLayout`). The two older Home surfaces are the exception:
+//  `DashboardPage` is laned when it mounts either one, so without this file they render straight onto
+//  the wallpaper. **Every other destination was drawn assuming the window's ground was underneath it**,
+//  so this file is where they get a surface, and it is one surface for all of them: a page that invents
+//  its own panel is the drift `InkGlass` exists to stop.
 //
 //  ## One tall panel, not a header plus a body
 //
@@ -50,15 +51,16 @@ enum PageGlassLanePolicy {
   ///
   /// It takes the raw index rather than a `SidebarNavItem` because the router's `switch` sends every
   /// unrecognised index to Home through its `default:` branch. Resolving an unknown index to anything
-  /// else here would wrap Home in a second panel on exactly the routes nobody tests.
+  /// else here would wrap Home in a second panel on exactly the routes nobody tests. The router passes
+  /// the already-resolved Home surface decision instead of making this lane read a settings key.
   static func ownsItsPanels(
     selectedIndex: Int,
     memoryDestinationRawValue: Int? = nil,
-    usesLegacyHomeDesign: Bool = false
+    homeOwnsItsPanels: Bool
   ) -> Bool {
     switch SidebarNavItem(rawValue: selectedIndex) ?? .dashboard {
     case .dashboard:
-      return !usesLegacyHomeDesign
+      return homeOwnsItsPanels
     case .rewind:
       return true
     case .conversations:
@@ -112,21 +114,23 @@ enum PageGlassLaneLayout {
 ///
 /// It wraps the router's whole page switch rather than each page in turn, so there is exactly one
 /// place that decides what a destination's surface is. A page inside it paints no background of its
-/// own (`glassContent()`); the panel is the ground.
+/// own (`glassContent()`); the panel is the ground. Home and Rewind are handed their own-glass answer
+/// by the router, while the older `DashboardPage` surfaces are handed `false` and use this panel.
 struct PageGlassLane<Content: View>: View {
   /// The route being rendered, used only to ask `PageGlassLanePolicy` whether it already has glass.
   let selectedIndex: Int
   /// The hub page being rendered when `selectedIndex` is the Memory hub's rail index. Nil for every
   /// other destination, whose glass does not depend on a sub-page.
   var memoryDestinationRawValue: Int? = nil
-  var usesLegacyHomeDesign: Bool = false
+  /// Whether the Home surface selected by the router owns its own glass.
+  let homeOwnsItsPanels: Bool
   @ViewBuilder var content: () -> Content
 
   var body: some View {
     if PageGlassLanePolicy.ownsItsPanels(
       selectedIndex: selectedIndex,
       memoryDestinationRawValue: memoryDestinationRawValue,
-      usesLegacyHomeDesign: usesLegacyHomeDesign)
+      homeOwnsItsPanels: homeOwnsItsPanels)
     {
       // Handed the whole content area, so a modal dim mounted inside it has to take the lane rather
       // than the surface it was given — see `ShellModalScrim`. Published here rather than chosen at

--- a/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
@@ -51,9 +51,15 @@ enum PageGlassLanePolicy {
   /// It takes the raw index rather than a `SidebarNavItem` because the router's `switch` sends every
   /// unrecognised index to Home through its `default:` branch. Resolving an unknown index to anything
   /// else here would wrap Home in a second panel on exactly the routes nobody tests.
-  static func ownsItsPanels(selectedIndex: Int, memoryDestinationRawValue: Int? = nil) -> Bool {
+  static func ownsItsPanels(
+    selectedIndex: Int,
+    memoryDestinationRawValue: Int? = nil,
+    usesLegacyHomeDesign: Bool = false
+  ) -> Bool {
     switch SidebarNavItem(rawValue: selectedIndex) ?? .dashboard {
-    case .dashboard, .rewind:
+    case .dashboard:
+      return !usesLegacyHomeDesign
+    case .rewind:
       return true
     case .conversations:
       // **Only this index is the Memory hub.** It is one rail slot wearing four different pages, and
@@ -113,11 +119,14 @@ struct PageGlassLane<Content: View>: View {
   /// The hub page being rendered when `selectedIndex` is the Memory hub's rail index. Nil for every
   /// other destination, whose glass does not depend on a sub-page.
   var memoryDestinationRawValue: Int? = nil
+  var usesLegacyHomeDesign: Bool = false
   @ViewBuilder var content: () -> Content
 
   var body: some View {
     if PageGlassLanePolicy.ownsItsPanels(
-      selectedIndex: selectedIndex, memoryDestinationRawValue: memoryDestinationRawValue)
+      selectedIndex: selectedIndex,
+      memoryDestinationRawValue: memoryDestinationRawValue,
+      usesLegacyHomeDesign: usesLegacyHomeDesign)
     {
       // Handed the whole content area, so a modal dim mounted inside it has to take the lane rather
       // than the surface it was given — see `ShellModalScrim`. Published here rather than chosen at

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -256,6 +256,7 @@ struct DashboardPage: View {
   @AppStorage(AssistantSettings.audioRecordingModeDefaultsKey) private var audioRecordingModeRaw =
     AssistantSettings.AudioRecordingMode.onlyMeetings.rawValue
   @AppStorage("useLegacyHomeDesign") private var useLegacyHomeDesign = false
+  @AppStorage("useOldestHomeDesign") private var useOldestHomeDesign = false
   @State private var homeMode: HomeStageMode = .hub
   @State private var didReportChatFirstTranscriptPage = false
   @FocusState private var homeAskFieldFocused: Bool
@@ -379,14 +380,15 @@ struct DashboardPage: View {
 
   private var homeSurface: some View {
     Group {
-      if useLegacyHomeDesign && !routesChatToPrimaryShell {
+      if useLegacyHomeDesign && useOldestHomeDesign && !routesChatToPrimaryShell {
         legacyHome
       } else {
         redesignedHome
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(useLegacyHomeDesign ? Color.clear : HomePalette.paper)
+    // `PageGlassLane.panel` supplies the ground for older Home surfaces; keep this clear to match it.
+    .background(Color.clear)
   }
 
   private func applyHomeSheets<Content: View>(to content: Content) -> some View {
@@ -456,7 +458,7 @@ struct DashboardPage: View {
       .overlay {
         if isLoadingCitation {
           ZStack {
-            // Home fills the content area, so this dim was window-wide too — the sweep missed it.
+            // The lane publishes the modal bounds for this legacy Home surface.
             ShellModalScrim()
             VStack(spacing: OmiSpacing.md) {
               ProgressView()
@@ -1442,9 +1444,7 @@ struct DashboardPage: View {
   ) -> some View {
     ZStack {
       if isShowingAppsPopup {
-        // Home owns its panels, so this page is handed the whole content area — a full-bleed dim
-        // here reaches the window's edges, and the window is transparent. `ShellModalScrim` reads
-        // that from `PageGlassLane` and puts the dim on the lane Home's own panels take.
+        // `PageGlassLane` supplies legacy Home ground and bounds this scrim; do not re-derive the preference.
         ShellModalScrim(onTap: dismissAppsPopup)
           .transition(.opacity)
           .zIndex(2)

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
@@ -897,6 +897,33 @@ extension SettingsContentView {
         }
       }
 
+      if useLegacyHomeDesign {
+        settingsCard(settingId: "advanced.preferences.oldesthome") {
+          HStack(spacing: OmiSpacing.lg) {
+            Image(systemName: "rectangle.stack")
+              .scaledFont(size: OmiType.subheading)
+              .foregroundColor(Ink.secondary)
+              .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+              Text("Use oldest Home theme")
+                .scaledFont(size: OmiType.subheading, weight: .semibold)
+                .foregroundColor(Ink.primary)
+
+              Text("Show the original widgets-and-chat Home")
+                .scaledFont(size: OmiType.body)
+                .foregroundColor(Ink.secondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $useOldestHomeDesign)
+              .toggleStyle(OmiToggleStyle())
+              .labelsHidden()
+          }
+        }
+      }
+
       settingsCard(settingId: "advanced.preferences.speaknotifications") {
         HStack(spacing: OmiSpacing.lg) {
           Image(systemName: "speaker.wave.2")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -362,6 +362,7 @@ struct SettingsContentView: View {
   @AppStorage("multiChatEnabled") var multiChatEnabled = false
   @AppStorage("conversationsCompactView") var conversationsCompactView = true
   @AppStorage("useLegacyHomeDesign") var useLegacyHomeDesign = false
+  @AppStorage("useOldestHomeDesign") var useOldestHomeDesign = false
   @AppStorage("speakNotificationsAloud") var speakNotificationsAloud = false
   @AppStorage(DefaultsKey.integrationNudgesEnabled.rawValue) var integrationNudgesEnabled = true
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryShellHome.swift
@@ -98,7 +98,9 @@ struct QueryShellHome: View {
   @State private var caretClaims = 0
 
   private var usesLegacyPresentation: Bool {
-    useLegacyHomeDesign && !forceModernPresentation
+    !HomeDesignPresentation.queryShellOwnsItsPanels(
+      useLegacyHomeDesign: useLegacyHomeDesign,
+      forceModernPresentation: forceModernPresentation)
   }
 
   var body: some View {

--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -54,7 +54,7 @@ enum ShellSummonPlacement {
   /// It stays above `DesktopWindowLayoutPolicy.minimumContentSize`, which is the floor the
   /// destinations lay out to.
   static let defaultSize = NSSize(
-    width: DesktopWindowLayoutPolicy.maximumContentWidth, height: 700)
+    width: ChatComposerLayout.contentLaneMaxWidth, height: 700)
 
   /// Where the shell lands on a given display.
   ///
@@ -123,7 +123,7 @@ enum ShellSummonPlacement {
   static func fitted(
     _ size: NSSize,
     in visibleFrame: NSRect,
-    maxWidth: CGFloat = DesktopWindowLayoutPolicy.maximumContentWidth
+    maxWidth: CGFloat = ChatComposerLayout.contentLaneMaxWidth
   ) -> NSSize {
     NSSize(
       width: min(size.width, visibleFrame.width, maxWidth),

--- a/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-
 @testable import Omi_Computer
 
 /// Unit tests for `ServerConversation.displayState` / `displayTitle` /
@@ -9,159 +8,159 @@ import XCTest
 /// label instead of a flat "Untitled".
 final class ConversationDisplayStateTests: XCTestCase {
 
-  // MARK: - Builders
+    // MARK: - Builders
 
-  /// Builds a minimally-populated `ServerConversation` with overridable knobs.
-  /// Keeps the tests focused on the fields that drive displayState.
-  private func makeConversation(
-    title: String = "",
-    status: ConversationStatus = .completed,
-    isLocked: Bool = false,
-    segments: [TranscriptSegment] = []
-  ) -> ServerConversation {
-    ServerConversation(
-      id: "id",
-      createdAt: Date(),
-      updatedAt: nil,
-      startedAt: nil,
-      finishedAt: nil,
-      structured: Structured(
-        title: title,
-        overview: "",
-        emoji: "",
-        category: "",
-        actionItems: [],
-        events: []
-      ),
-      transcriptSegments: segments,
-      transcriptSegmentsIncluded: !segments.isEmpty,
-      geolocation: nil,
-      photos: [],
-      appsResults: [],
-      source: nil,
-      language: nil,
-      status: status,
-      discarded: false,
-      deleted: false,
-      isLocked: isLocked,
-      starred: false,
-      folderId: nil,
-      inputDeviceName: nil
-    )
-  }
-
-  private func segment(_ text: String) -> TranscriptSegment {
-    TranscriptSegment(
-      id: UUID().uuidString,
-      text: text,
-      speaker: "SPEAKER_00",
-      isUser: false,
-      personId: nil,
-      start: 0,
-      end: 1
-    )
-  }
-
-  // MARK: - Titled
-
-  func test_completedWithTitle_returnsTitledState() {
-    let conv = makeConversation(title: "Morning standup")
-    if case .titled(let t) = conv.displayState {
-      XCTAssertEqual(t, "Morning standup")
-    } else {
-      XCTFail("Expected .titled, got \(conv.displayState)")
+    /// Builds a minimally-populated `ServerConversation` with overridable knobs.
+    /// Keeps the tests focused on the fields that drive displayState.
+    private func makeConversation(
+        title: String = "",
+        status: ConversationStatus = .completed,
+        isLocked: Bool = false,
+        segments: [TranscriptSegment] = []
+    ) -> ServerConversation {
+        ServerConversation(
+            id: "id",
+            createdAt: Date(),
+            updatedAt: nil,
+            startedAt: nil,
+            finishedAt: nil,
+            structured: Structured(
+                title: title,
+                overview: "",
+                emoji: "",
+                category: "",
+                actionItems: [],
+                events: []
+            ),
+            transcriptSegments: segments,
+            transcriptSegmentsIncluded: !segments.isEmpty,
+            geolocation: nil,
+            photos: [],
+            appsResults: [],
+            source: nil,
+            language: nil,
+            status: status,
+            discarded: false,
+            deleted: false,
+            isLocked: isLocked,
+            starred: false,
+            folderId: nil,
+            inputDeviceName: nil
+        )
     }
-    XCTAssertEqual(conv.displayTitle, "Morning standup")
-    XCTAssertFalse(conv.canReprocess)
-  }
 
-  // MARK: - Locked
+    private func segment(_ text: String) -> TranscriptSegment {
+        TranscriptSegment(
+            id: UUID().uuidString,
+            text: text,
+            speaker: "SPEAKER_00",
+            isUser: false,
+            personId: nil,
+            start: 0,
+            end: 1
+        )
+    }
 
-  func test_lockedTakesPrecedence_overEverythingElse() {
-    // Locked + has title + completed — locked still wins so the user
-    // gets an honest signal that their content is gated.
-    let conv = makeConversation(
-      title: "Was titled before lock",
-      status: .completed,
-      isLocked: true,
-      segments: [segment("plenty of words to look recoverable normally")]
-    )
-    XCTAssertEqual(conv.displayState, .locked)
-    XCTAssertEqual(conv.displayTitle, "Locked")
-    XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
-  }
+    // MARK: - Titled
 
-  // MARK: - Processing
+    func test_completedWithTitle_returnsTitledState() {
+        let conv = makeConversation(title: "Morning standup")
+        if case .titled(let t) = conv.displayState {
+            XCTAssertEqual(t, "Morning standup")
+        } else {
+            XCTFail("Expected .titled, got \(conv.displayState)")
+        }
+        XCTAssertEqual(conv.displayTitle, "Morning standup")
+        XCTAssertFalse(conv.canReprocess)
+    }
 
-  func test_inProgressStatus_returnsProcessing() {
-    let conv = makeConversation(status: .inProgress)
-    XCTAssertEqual(conv.displayState, .processing)
-    XCTAssertEqual(conv.displayTitle, "Processing…")
-    XCTAssertFalse(conv.canReprocess)
-  }
+    // MARK: - Locked
 
-  func test_processingStatus_returnsProcessing() {
-    let conv = makeConversation(status: .processing)
-    XCTAssertEqual(conv.displayState, .processing)
-  }
+    func test_lockedTakesPrecedence_overEverythingElse() {
+        // Locked + has title + completed — locked still wins so the user
+        // gets an honest signal that their content is gated.
+        let conv = makeConversation(
+            title: "Was titled before lock",
+            status: .completed,
+            isLocked: true,
+            segments: [segment("plenty of words to look recoverable normally")]
+        )
+        XCTAssertEqual(conv.displayState, .locked)
+        XCTAssertEqual(conv.displayTitle, "Locked")
+        XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
+    }
 
-  func test_mergingStatus_returnsProcessing() {
-    let conv = makeConversation(status: .merging)
-    XCTAssertEqual(conv.displayState, .processing)
-  }
+    // MARK: - Processing
 
-  // MARK: - Failed
+    func test_inProgressStatus_returnsProcessing() {
+        let conv = makeConversation(status: .inProgress)
+        XCTAssertEqual(conv.displayState, .processing)
+        XCTAssertEqual(conv.displayTitle, "Processing…")
+        XCTAssertFalse(conv.canReprocess)
+    }
 
-  func test_failedStatus_returnsFailed_andCanReprocess() {
-    let conv = makeConversation(status: .failed)
-    XCTAssertEqual(conv.displayState, .failed)
-    XCTAssertEqual(conv.displayTitle, "Failed to process")
-    XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
-  }
+    func test_processingStatus_returnsProcessing() {
+        let conv = makeConversation(status: .processing)
+        XCTAssertEqual(conv.displayState, .processing)
+    }
 
-  // MARK: - Recoverable vs empty
+    func test_mergingStatus_returnsProcessing() {
+        let conv = makeConversation(status: .merging)
+        XCTAssertEqual(conv.displayState, .processing)
+    }
 
-  func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
-    // 5+ words in a single segment satisfies the "real content" heuristic.
-    let conv = makeConversation(
-      status: .completed,
-      segments: [segment("hello this is a longer transcript please title me")]
-    )
-    XCTAssertEqual(conv.displayState, .untitledRecoverable)
-    XCTAssertEqual(conv.displayTitle, "Untitled")
-    XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
-  }
+    // MARK: - Failed
 
-  func test_completedNoTitle_withShortTranscript_returnsEmpty() {
-    // ≤ 4 words across the only segment — treat as ambient/accidental
-    // capture. No reprocess CTA (would burn LLM tokens on noise).
-    let conv = makeConversation(
-      status: .completed,
-      segments: [segment("hello there")]
-    )
-    XCTAssertEqual(conv.displayState, .untitledEmpty)
-    XCTAssertEqual(conv.displayTitle, "Untitled")
-    XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
-  }
+    func test_failedStatus_returnsFailed_andCanReprocess() {
+        let conv = makeConversation(status: .failed)
+        XCTAssertEqual(conv.displayState, .failed)
+        XCTAssertEqual(conv.displayTitle, "Failed to process")
+        XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
+    }
 
-  func test_completedNoTitle_withNoTranscript_returnsEmpty() {
-    let conv = makeConversation(status: .completed, segments: [])
-    XCTAssertEqual(conv.displayState, .untitledEmpty)
-    XCTAssertFalse(conv.canReprocess)
-  }
+    // MARK: - Recoverable vs empty
 
-  func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
-    // Even if the first segment is tiny, a later substantial segment
-    // promotes the conversation to recoverable.
-    let conv = makeConversation(
-      status: .completed,
-      segments: [
-        segment("um"),
-        segment("ok"),
-        segment("this is the substantive part of the conversation"),
-      ]
-    )
-    XCTAssertEqual(conv.displayState, .untitledRecoverable)
-    XCTAssertTrue(conv.canReprocess)
-  }
+    func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
+        // 5+ words in a single segment satisfies the "real content" heuristic.
+        let conv = makeConversation(
+            status: .completed,
+            segments: [segment("hello this is a longer transcript please title me")]
+        )
+        XCTAssertEqual(conv.displayState, .untitledRecoverable)
+        XCTAssertEqual(conv.displayTitle, "Untitled")
+        XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
+    }
+
+    func test_completedNoTitle_withShortTranscript_returnsEmpty() {
+        // ≤ 4 words across the only segment — treat as ambient/accidental
+        // capture. No reprocess CTA (would burn LLM tokens on noise).
+        let conv = makeConversation(
+            status: .completed,
+            segments: [segment("hello there")]
+        )
+        XCTAssertEqual(conv.displayState, .untitledEmpty)
+        XCTAssertEqual(conv.displayTitle, "Untitled")
+        XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
+    }
+
+    func test_completedNoTitle_withNoTranscript_returnsEmpty() {
+        let conv = makeConversation(status: .completed, segments: [])
+        XCTAssertEqual(conv.displayState, .untitledEmpty)
+        XCTAssertFalse(conv.canReprocess)
+    }
+
+    func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
+        // Even if the first segment is tiny, a later substantial segment
+        // promotes the conversation to recoverable.
+        let conv = makeConversation(
+            status: .completed,
+            segments: [
+                segment("um"),
+                segment("ok"),
+                segment("this is the substantive part of the conversation"),
+            ]
+        )
+        XCTAssertEqual(conv.displayState, .untitledRecoverable)
+        XCTAssertTrue(conv.canReprocess)
+    }
 }

--- a/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Omi_Computer
 
 /// Unit tests for `ServerConversation.displayState` / `displayTitle` /
@@ -8,159 +9,159 @@ import XCTest
 /// label instead of a flat "Untitled".
 final class ConversationDisplayStateTests: XCTestCase {
 
-    // MARK: - Builders
+  // MARK: - Builders
 
-    /// Builds a minimally-populated `ServerConversation` with overridable knobs.
-    /// Keeps the tests focused on the fields that drive displayState.
-    private func makeConversation(
-        title: String = "",
-        status: ConversationStatus = .completed,
-        isLocked: Bool = false,
-        segments: [TranscriptSegment] = []
-    ) -> ServerConversation {
-        ServerConversation(
-            id: "id",
-            createdAt: Date(),
-            updatedAt: nil,
-            startedAt: nil,
-            finishedAt: nil,
-            structured: Structured(
-                title: title,
-                overview: "",
-                emoji: "",
-                category: "",
-                actionItems: [],
-                events: []
-            ),
-            transcriptSegments: segments,
-            transcriptSegmentsIncluded: !segments.isEmpty,
-            geolocation: nil,
-            photos: [],
-            appsResults: [],
-            source: nil,
-            language: nil,
-            status: status,
-            discarded: false,
-            deleted: false,
-            isLocked: isLocked,
-            starred: false,
-            folderId: nil,
-            inputDeviceName: nil
-        )
+  /// Builds a minimally-populated `ServerConversation` with overridable knobs.
+  /// Keeps the tests focused on the fields that drive displayState.
+  private func makeConversation(
+    title: String = "",
+    status: ConversationStatus = .completed,
+    isLocked: Bool = false,
+    segments: [TranscriptSegment] = []
+  ) -> ServerConversation {
+    ServerConversation(
+      id: "id",
+      createdAt: Date(),
+      updatedAt: nil,
+      startedAt: nil,
+      finishedAt: nil,
+      structured: Structured(
+        title: title,
+        overview: "",
+        emoji: "",
+        category: "",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: segments,
+      transcriptSegmentsIncluded: !segments.isEmpty,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: nil,
+      language: nil,
+      status: status,
+      discarded: false,
+      deleted: false,
+      isLocked: isLocked,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil
+    )
+  }
+
+  private func segment(_ text: String) -> TranscriptSegment {
+    TranscriptSegment(
+      id: UUID().uuidString,
+      text: text,
+      speaker: "SPEAKER_00",
+      isUser: false,
+      personId: nil,
+      start: 0,
+      end: 1
+    )
+  }
+
+  // MARK: - Titled
+
+  func test_completedWithTitle_returnsTitledState() {
+    let conv = makeConversation(title: "Morning standup")
+    if case .titled(let t) = conv.displayState {
+      XCTAssertEqual(t, "Morning standup")
+    } else {
+      XCTFail("Expected .titled, got \(conv.displayState)")
     }
+    XCTAssertEqual(conv.displayTitle, "Morning standup")
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    private func segment(_ text: String) -> TranscriptSegment {
-        TranscriptSegment(
-            id: UUID().uuidString,
-            text: text,
-            speaker: "SPEAKER_00",
-            isUser: false,
-            personId: nil,
-            start: 0,
-            end: 1
-        )
-    }
+  // MARK: - Locked
 
-    // MARK: - Titled
+  func test_lockedTakesPrecedence_overEverythingElse() {
+    // Locked + has title + completed — locked still wins so the user
+    // gets an honest signal that their content is gated.
+    let conv = makeConversation(
+      title: "Was titled before lock",
+      status: .completed,
+      isLocked: true,
+      segments: [segment("plenty of words to look recoverable normally")]
+    )
+    XCTAssertEqual(conv.displayState, .locked)
+    XCTAssertEqual(conv.displayTitle, "Locked")
+    XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
+  }
 
-    func test_completedWithTitle_returnsTitledState() {
-        let conv = makeConversation(title: "Morning standup")
-        if case .titled(let t) = conv.displayState {
-            XCTAssertEqual(t, "Morning standup")
-        } else {
-            XCTFail("Expected .titled, got \(conv.displayState)")
-        }
-        XCTAssertEqual(conv.displayTitle, "Morning standup")
-        XCTAssertFalse(conv.canReprocess)
-    }
+  // MARK: - Processing
 
-    // MARK: - Locked
+  func test_inProgressStatus_returnsProcessing() {
+    let conv = makeConversation(status: .inProgress)
+    XCTAssertEqual(conv.displayState, .processing)
+    XCTAssertEqual(conv.displayTitle, "Processing…")
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    func test_lockedTakesPrecedence_overEverythingElse() {
-        // Locked + has title + completed — locked still wins so the user
-        // gets an honest signal that their content is gated.
-        let conv = makeConversation(
-            title: "Was titled before lock",
-            status: .completed,
-            isLocked: true,
-            segments: [segment("plenty of words to look recoverable normally")]
-        )
-        XCTAssertEqual(conv.displayState, .locked)
-        XCTAssertEqual(conv.displayTitle, "Locked")
-        XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
-    }
+  func test_processingStatus_returnsProcessing() {
+    let conv = makeConversation(status: .processing)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
 
-    // MARK: - Processing
+  func test_mergingStatus_returnsProcessing() {
+    let conv = makeConversation(status: .merging)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
 
-    func test_inProgressStatus_returnsProcessing() {
-        let conv = makeConversation(status: .inProgress)
-        XCTAssertEqual(conv.displayState, .processing)
-        XCTAssertEqual(conv.displayTitle, "Processing…")
-        XCTAssertFalse(conv.canReprocess)
-    }
+  // MARK: - Failed
 
-    func test_processingStatus_returnsProcessing() {
-        let conv = makeConversation(status: .processing)
-        XCTAssertEqual(conv.displayState, .processing)
-    }
+  func test_failedStatus_returnsFailed_andCanReprocess() {
+    let conv = makeConversation(status: .failed)
+    XCTAssertEqual(conv.displayState, .failed)
+    XCTAssertEqual(conv.displayTitle, "Failed to process")
+    XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
+  }
 
-    func test_mergingStatus_returnsProcessing() {
-        let conv = makeConversation(status: .merging)
-        XCTAssertEqual(conv.displayState, .processing)
-    }
+  // MARK: - Recoverable vs empty
 
-    // MARK: - Failed
+  func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
+    // 5+ words in a single segment satisfies the "real content" heuristic.
+    let conv = makeConversation(
+      status: .completed,
+      segments: [segment("hello this is a longer transcript please title me")]
+    )
+    XCTAssertEqual(conv.displayState, .untitledRecoverable)
+    XCTAssertEqual(conv.displayTitle, "Untitled")
+    XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
+  }
 
-    func test_failedStatus_returnsFailed_andCanReprocess() {
-        let conv = makeConversation(status: .failed)
-        XCTAssertEqual(conv.displayState, .failed)
-        XCTAssertEqual(conv.displayTitle, "Failed to process")
-        XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
-    }
+  func test_completedNoTitle_withShortTranscript_returnsEmpty() {
+    // ≤ 4 words across the only segment — treat as ambient/accidental
+    // capture. No reprocess CTA (would burn LLM tokens on noise).
+    let conv = makeConversation(
+      status: .completed,
+      segments: [segment("hello there")]
+    )
+    XCTAssertEqual(conv.displayState, .untitledEmpty)
+    XCTAssertEqual(conv.displayTitle, "Untitled")
+    XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
+  }
 
-    // MARK: - Recoverable vs empty
+  func test_completedNoTitle_withNoTranscript_returnsEmpty() {
+    let conv = makeConversation(status: .completed, segments: [])
+    XCTAssertEqual(conv.displayState, .untitledEmpty)
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
-        // 5+ words in a single segment satisfies the "real content" heuristic.
-        let conv = makeConversation(
-            status: .completed,
-            segments: [segment("hello this is a longer transcript please title me")]
-        )
-        XCTAssertEqual(conv.displayState, .untitledRecoverable)
-        XCTAssertEqual(conv.displayTitle, "Untitled")
-        XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
-    }
-
-    func test_completedNoTitle_withShortTranscript_returnsEmpty() {
-        // ≤ 4 words across the only segment — treat as ambient/accidental
-        // capture. No reprocess CTA (would burn LLM tokens on noise).
-        let conv = makeConversation(
-            status: .completed,
-            segments: [segment("hello there")]
-        )
-        XCTAssertEqual(conv.displayState, .untitledEmpty)
-        XCTAssertEqual(conv.displayTitle, "Untitled")
-        XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
-    }
-
-    func test_completedNoTitle_withNoTranscript_returnsEmpty() {
-        let conv = makeConversation(status: .completed, segments: [])
-        XCTAssertEqual(conv.displayState, .untitledEmpty)
-        XCTAssertFalse(conv.canReprocess)
-    }
-
-    func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
-        // Even if the first segment is tiny, a later substantial segment
-        // promotes the conversation to recoverable.
-        let conv = makeConversation(
-            status: .completed,
-            segments: [
-                segment("um"),
-                segment("ok"),
-                segment("this is the substantive part of the conversation"),
-            ]
-        )
-        XCTAssertEqual(conv.displayState, .untitledRecoverable)
-        XCTAssertTrue(conv.canReprocess)
-    }
+  func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
+    // Even if the first segment is tiny, a later substantial segment
+    // promotes the conversation to recoverable.
+    let conv = makeConversation(
+      status: .completed,
+      segments: [
+        segment("um"),
+        segment("ok"),
+        segment("this is the substantive part of the conversation"),
+      ]
+    )
+    XCTAssertEqual(conv.displayState, .untitledRecoverable)
+    XCTAssertTrue(conv.canReprocess)
+  }
 }

--- a/desktop/macos/Desktop/Tests/DesktopWindowLayoutPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopWindowLayoutPolicyTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @testable import Omi_Computer
 
+@MainActor
 final class DesktopWindowLayoutPolicyTests: XCTestCase {
   func testMainWindowMinimumFitsA1024PointWideDisplay() {
     XCTAssertLessThanOrEqual(
@@ -11,5 +12,24 @@ final class DesktopWindowLayoutPolicyTests: XCTestCase {
       "The responsive main window must fit common compact desktop displays."
     )
     XCTAssertEqual(DesktopWindowLayoutPolicy.minimumContentSize.height, 680)
+  }
+
+  func testMaximumContentSizeUsesTheVisibleDisplayInsteadOfTheContentLane() throws {
+    guard let screen = NSScreen.main else { throw XCTSkip("No display is available") }
+    guard screen.visibleFrame.width > ChatComposerLayout.contentLaneMaxWidth else {
+      throw XCTSkip("The test display is not wider than the content lane")
+    }
+
+    let window = NSWindow(
+      contentRect: screen.visibleFrame,
+      styleMask: .borderless,
+      backing: .buffered,
+      defer: true)
+    let maximum = DesktopWindowLayoutPolicy.maximumContentSize(for: window)
+
+    let expected = window.contentRect(forFrameRect: screen.visibleFrame).size
+    XCTAssertEqual(maximum.width, expected.width, accuracy: 0.01)
+    XCTAssertEqual(maximum.height, expected.height, accuracy: 0.01)
+    XCTAssertGreaterThan(maximum.width, ChatComposerLayout.contentLaneMaxWidth)
   }
 }

--- a/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
+++ b/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
@@ -78,6 +78,42 @@ final class PageGlassLaneTests: XCTestCase {
       PageGlassLanePolicy.ownsItsPanels(selectedIndex: SidebarNavItem.conversations.rawValue))
   }
 
+  func testTogglingLegacyHomeDesignGivesDashboardTheSharedPanelGround() throws {
+    XCTAssertTrue(
+      PageGlassLanePolicy.ownsItsPanels(
+        selectedIndex: SidebarNavItem.dashboard.rawValue,
+        usesLegacyHomeDesign: false))
+    XCTAssertFalse(
+      PageGlassLanePolicy.ownsItsPanels(
+        selectedIndex: SidebarNavItem.dashboard.rawValue,
+        usesLegacyHomeDesign: true))
+    XCTAssertFalse(
+      PageGlassLanePolicy.ownsItsPanels(
+        selectedIndex: 2,
+        usesLegacyHomeDesign: true))
+
+    let size = CGSize(width: 1_400, height: 800)
+    let recorder = PageGlassLaneFrameRecorder()
+    let host = NSHostingView(
+      rootView: PageGlassLane(
+        selectedIndex: SidebarNavItem.dashboard.rawValue,
+        usesLegacyHomeDesign: true
+      ) {
+        PageGlassLaneProbe(recorder: recorder) { Color.clear }
+      }
+      .frame(width: size.width, height: size.height)
+    )
+    host.frame = NSRect(origin: .zero, size: size)
+    host.layoutSubtreeIfNeeded()
+
+    let placed = try XCTUnwrap(recorder.frame)
+    XCTAssertEqual(placed.width, PageGlassLaneLayout.laneWidth(for: size.width), accuracy: 0.5)
+    XCTAssertEqual(
+      placed.height,
+      size.height - PageGlassLaneLayout.topGap - PageGlassLaneLayout.bottomGap,
+      accuracy: 0.5)
+  }
+
   /// The router sends every unrecognised index to Home through its `default:` branch. An index the
   /// nav enum does not carry must therefore resolve to Home here too, or those routes wrap Home's
   /// two panels inside a third one.

--- a/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
+++ b/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
@@ -23,18 +23,29 @@ final class PageGlassLaneTests: XCTestCase {
 
   // MARK: - Which destinations already have glass
 
-  /// Home and Rewind build their own panels. Wrapping them again does not stack two materials — a
+  /// QueryShell Home and Rewind build their own panels when the router says they do. Wrapping them
+  /// again does not stack two materials — a
   /// nested `.behindWindow` surface takes a *second* copy of the desktop and doubles the scrim — so a
   /// double-wrapped page reads visibly muddier than the pages around it.
   func testHomeAndRewindKeepTheirOwnPanelsAndEveryOtherDestinationIsGivenOne() {
-    XCTAssertTrue(
-      PageGlassLanePolicy.ownsItsPanels(selectedIndex: SidebarNavItem.dashboard.rawValue))
-    XCTAssertTrue(PageGlassLanePolicy.ownsItsPanels(selectedIndex: SidebarNavItem.rewind.rawValue))
+    for homeOwnsItsPanels in [false, true] {
+      XCTAssertEqual(
+        PageGlassLanePolicy.ownsItsPanels(
+          selectedIndex: SidebarNavItem.dashboard.rawValue,
+          homeOwnsItsPanels: homeOwnsItsPanels),
+        homeOwnsItsPanels)
+      XCTAssertTrue(
+        PageGlassLanePolicy.ownsItsPanels(
+          selectedIndex: SidebarNavItem.rewind.rawValue,
+          homeOwnsItsPanels: homeOwnsItsPanels))
 
-    for item in SidebarNavItem.allCases where item != .dashboard && item != .rewind {
-      XCTAssertFalse(
-        PageGlassLanePolicy.ownsItsPanels(selectedIndex: item.rawValue),
-        "\(item.title) has no glass of its own and must be given the lane's")
+      for item in SidebarNavItem.allCases where item != .dashboard && item != .rewind {
+        XCTAssertFalse(
+          PageGlassLanePolicy.ownsItsPanels(
+            selectedIndex: item.rawValue,
+            homeOwnsItsPanels: homeOwnsItsPanels),
+          "\(item.title) has no glass of its own and must be given the lane's")
+      }
     }
   }
 
@@ -50,79 +61,48 @@ final class PageGlassLaneTests: XCTestCase {
     XCTAssertTrue(
       PageGlassLanePolicy.ownsItsPanels(
         selectedIndex: hubIndex,
-        memoryDestinationRawValue: MemoryHubDestination.activity.rawValue),
+        memoryDestinationRawValue: MemoryHubDestination.activity.rawValue,
+        homeOwnsItsPanels: true),
       "Activity builds Home's own two panels and must not be wrapped in a third")
 
     for destination in MemoryHubDestination.allCases where destination != .activity {
       XCTAssertFalse(
         PageGlassLanePolicy.ownsItsPanels(
-          selectedIndex: hubIndex, memoryDestinationRawValue: destination.rawValue),
+          selectedIndex: hubIndex,
+          memoryDestinationRawValue: destination.rawValue,
+          homeOwnsItsPanels: true),
         "\(destination.title) paints no ground of its own and must be given the lane's")
     }
 
-    // **The standalone Memories page is not the hub.** `SidebarNavItem.memories` renders
-    // `MemoriesPage` directly in this shell, and nothing resets the persisted hub destination on
-    // the way there — so answering this question off that value stripped a page that paints no
-    // ground of its own and drew its rows onto the user's wallpaper.
     for destination in MemoryHubDestination.allCases {
       XCTAssertFalse(
         PageGlassLanePolicy.ownsItsPanels(
           selectedIndex: SidebarNavItem.memories.rawValue,
-          memoryDestinationRawValue: destination.rawValue),
+          memoryDestinationRawValue: destination.rawValue,
+          homeOwnsItsPanels: true),
         "the standalone Memories page must keep the lane whatever the hub last showed")
     }
 
-    // A caller that does not know which hub page is mounted keeps the wrap: the list pages are the
-    // majority and an unwrapped list page has no ground at all.
-    XCTAssertFalse(
-      PageGlassLanePolicy.ownsItsPanels(selectedIndex: SidebarNavItem.conversations.rawValue))
-  }
-
-  func testTogglingLegacyHomeDesignGivesDashboardTheSharedPanelGround() throws {
-    XCTAssertTrue(
-      PageGlassLanePolicy.ownsItsPanels(
-        selectedIndex: SidebarNavItem.dashboard.rawValue,
-        usesLegacyHomeDesign: false))
     XCTAssertFalse(
       PageGlassLanePolicy.ownsItsPanels(
-        selectedIndex: SidebarNavItem.dashboard.rawValue,
-        usesLegacyHomeDesign: true))
-    XCTAssertFalse(
-      PageGlassLanePolicy.ownsItsPanels(
-        selectedIndex: 2,
-        usesLegacyHomeDesign: true))
-
-    let size = CGSize(width: 1_400, height: 800)
-    let recorder = PageGlassLaneFrameRecorder()
-    let host = NSHostingView(
-      rootView: PageGlassLane(
-        selectedIndex: SidebarNavItem.dashboard.rawValue,
-        usesLegacyHomeDesign: true
-      ) {
-        PageGlassLaneProbe(recorder: recorder) { Color.clear }
-      }
-      .frame(width: size.width, height: size.height)
-    )
-    host.frame = NSRect(origin: .zero, size: size)
-    host.layoutSubtreeIfNeeded()
-
-    let placed = try XCTUnwrap(recorder.frame)
-    XCTAssertEqual(placed.width, PageGlassLaneLayout.laneWidth(for: size.width), accuracy: 0.5)
-    XCTAssertEqual(
-      placed.height,
-      size.height - PageGlassLaneLayout.topGap - PageGlassLaneLayout.bottomGap,
-      accuracy: 0.5)
+        selectedIndex: SidebarNavItem.conversations.rawValue,
+        homeOwnsItsPanels: true))
   }
 
   /// The router sends every unrecognised index to Home through its `default:` branch. An index the
   /// nav enum does not carry must therefore resolve to Home here too, or those routes wrap Home's
   /// two panels inside a third one.
   func testAnUnrecognisedIndexFollowsTheRouterBackToHome() {
-    for unknown in [2, 11, 13, -1, Int.max] {
-      XCTAssertNil(SidebarNavItem(rawValue: unknown), "fixture \(unknown) must not be a real route")
-      XCTAssertTrue(
-        PageGlassLanePolicy.ownsItsPanels(selectedIndex: unknown),
-        "an unknown index renders Home, which already owns its panels")
+    for homeOwnsItsPanels in [false, true] {
+      for unknown in [2, 11, 13, -1, Int.max] {
+        XCTAssertNil(SidebarNavItem(rawValue: unknown), "fixture \(unknown) must not be a real route")
+        XCTAssertEqual(
+          PageGlassLanePolicy.ownsItsPanels(
+            selectedIndex: unknown,
+            homeOwnsItsPanels: homeOwnsItsPanels),
+          homeOwnsItsPanels,
+          "an unknown index renders Home, which must use the router's Home surface decision")
+      }
     }
   }
 
@@ -159,29 +139,36 @@ final class PageGlassLaneTests: XCTestCase {
 
   /// The claim worth holding is geometric, so it is asserted against a real mounted view rather
   /// than against the constants twice: a destination without its own glass is placed in the lane,
-  /// centred, and inset from both ends by the gap.
-  func testAWrappedDestinationIsPlacedInTheLaneWithTheGapAboveAndBelowIt() {
+  /// centred, and inset from both ends by the gap. The legacy Home branch is the same geometry with
+  /// the route's Home surface answer flipped.
+  func testAWrappedDestinationIsPlacedInTheLaneWithTheGapAboveAndBelowIt() throws {
     let size = CGSize(width: 1_400, height: 800)
-    let recorder = PageGlassLaneFrameRecorder()
-    let host = NSHostingView(
-      rootView: PageGlassLane(selectedIndex: SidebarNavItem.tasks.rawValue) {
-        PageGlassLaneProbe(recorder: recorder) { Color.clear }
-      }
-      .frame(width: size.width, height: size.height)
-    )
-    host.frame = NSRect(origin: .zero, size: size)
-    host.layoutSubtreeIfNeeded()
+    for (index, homeOwnsItsPanels) in [
+      (SidebarNavItem.tasks.rawValue, true),
+      (SidebarNavItem.dashboard.rawValue, false),
+    ] {
+      let recorder = PageGlassLaneFrameRecorder()
+      let host = NSHostingView(
+        rootView: PageGlassLane(
+          selectedIndex: index,
+          homeOwnsItsPanels: homeOwnsItsPanels
+        ) {
+          PageGlassLaneProbe(recorder: recorder) { Color.clear }
+        }
+        .frame(width: size.width, height: size.height)
+      )
+      host.frame = NSRect(origin: .zero, size: size)
+      host.layoutSubtreeIfNeeded()
 
-    guard let placed = recorder.frame else {
-      return XCTFail("expected the wrapped destination to be placed")
+      let placed = try XCTUnwrap(recorder.frame)
+      let lane = PageGlassLaneLayout.laneWidth(for: size.width)
+      XCTAssertEqual(placed.width, lane, accuracy: 0.5)
+      XCTAssertEqual(
+        placed.height,
+        size.height - PageGlassLaneLayout.topGap - PageGlassLaneLayout.bottomGap,
+        accuracy: 0.5,
+        "one tall panel: the page fills the window and scrolls inside itself")
     }
-    let lane = PageGlassLaneLayout.laneWidth(for: size.width)
-    XCTAssertEqual(placed.width, lane, accuracy: 0.5)
-    XCTAssertEqual(
-      placed.height,
-      size.height - PageGlassLaneLayout.topGap - PageGlassLaneLayout.bottomGap,
-      accuracy: 0.5,
-      "one tall panel: the page fills the window and scrolls inside itself")
   }
 
   /// The lane fills the window horizontally. Vertical air between the top bar and the page remains
@@ -197,7 +184,10 @@ final class PageGlassLaneTests: XCTestCase {
     for size in sizes {
       let recorder = PageGlassLaneFrameRecorder()
       let host = NSHostingView(
-        rootView: PageGlassLane(selectedIndex: SidebarNavItem.tasks.rawValue) {
+        rootView: PageGlassLane(
+          selectedIndex: SidebarNavItem.tasks.rawValue,
+          homeOwnsItsPanels: true
+        ) {
           PageGlassLaneProbe(recorder: recorder) { Color.clear }
         }
         .frame(width: size.width, height: size.height)
@@ -228,7 +218,10 @@ final class PageGlassLaneTests: XCTestCase {
     let size = CGSize(width: 1_400, height: 800)
     let recorder = PageGlassLaneFrameRecorder()
     let host = NSHostingView(
-      rootView: PageGlassLane(selectedIndex: SidebarNavItem.dashboard.rawValue) {
+      rootView: PageGlassLane(
+        selectedIndex: SidebarNavItem.dashboard.rawValue,
+        homeOwnsItsPanels: true
+      ) {
         PageGlassLaneProbe(recorder: recorder) { Color.clear }
       }
       .frame(width: size.width, height: size.height)
@@ -324,12 +317,18 @@ final class ShellModalScrimTests: XCTestCase {
   /// Read out of a real environment through a real layout pass, from inside `PageGlassLane`'s own
   /// content closure, which is exactly where every modal in the app is mounted.
   func testTheSurfaceTellsTheDimWhichSurfaceItIs() {
-    for item in SidebarNavItem.allCases {
-      let expected: ShellModalScrimBounds =
-        PageGlassLanePolicy.ownsItsPanels(selectedIndex: item.rawValue) ? .contentArea : .ownSurface
-      XCTAssertEqual(
-        Self.boundsPublished(toDestination: item.rawValue), expected,
-        "\(item.title) hands its modals the wrong surface")
+    for homeOwnsItsPanels in [false, true] {
+      for item in SidebarNavItem.allCases {
+        let expected: ShellModalScrimBounds =
+          PageGlassLanePolicy.ownsItsPanels(
+            selectedIndex: item.rawValue,
+            homeOwnsItsPanels: homeOwnsItsPanels) ? .contentArea : .ownSurface
+        XCTAssertEqual(
+          Self.boundsPublished(
+            toDestination: item.rawValue,
+            homeOwnsItsPanels: homeOwnsItsPanels), expected,
+          "\(item.title) hands its modals the wrong surface")
+      }
     }
   }
 
@@ -448,10 +447,16 @@ final class ShellModalScrimTests: XCTestCase {
 
   /// Mounts a probe exactly where a page's modals are mounted and reads back the surface it was told
   /// it is on.
-  private static func boundsPublished(toDestination index: Int) -> ShellModalScrimBounds? {
+  private static func boundsPublished(
+    toDestination index: Int,
+    homeOwnsItsPanels: Bool
+  ) -> ShellModalScrimBounds? {
     let recorder = ShellModalScrimBoundsRecorder()
     let host = NSHostingView(
-      rootView: PageGlassLane(selectedIndex: index) {
+      rootView: PageGlassLane(
+        selectedIndex: index,
+        homeOwnsItsPanels: homeOwnsItsPanels
+      ) {
         ShellModalScrimBoundsProbe(recorder: recorder)
       }
       .frame(width: 1_400, height: 800))

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -8,6 +8,33 @@ import XCTest
 @MainActor
 final class QueryShellTests: XCTestCase {
 
+  func testHomeDesignSwitchReachesAllThreeHomePresentations() {
+    XCTAssertEqual(
+      HomeDesignPresentation.resolve(
+        useLegacyHomeDesign: false,
+        useOldestHomeDesign: false,
+        forceModernPresentation: false),
+      .queryShell)
+    XCTAssertEqual(
+      HomeDesignPresentation.resolve(
+        useLegacyHomeDesign: true,
+        useOldestHomeDesign: false,
+        forceModernPresentation: false),
+      .redesignedHub)
+    XCTAssertEqual(
+      HomeDesignPresentation.resolve(
+        useLegacyHomeDesign: true,
+        useOldestHomeDesign: true,
+        forceModernPresentation: false),
+      .oldestLegacy)
+    XCTAssertEqual(
+      HomeDesignPresentation.resolve(
+        useLegacyHomeDesign: true,
+        useOldestHomeDesign: true,
+        forceModernPresentation: true),
+      .queryShell)
+  }
+
   // MARK: - The one key
 
   /// **`⏎` sends. There is nothing else for it to mean.**

--- a/desktop/macos/Desktop/Tests/ShellSummonTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellSummonTests.swift
@@ -116,7 +116,7 @@ final class ShellSummonTests: XCTestCase {
   /// clear the floor every destination lays out to, or the shell arrives already clipping content.
   func testTheDefaultPanelIsSmallerThanAWindowButStillFitsTheDestinations() {
     XCTAssertEqual(
-      ShellSummonPlacement.defaultSize.width, DesktopWindowLayoutPolicy.maximumContentWidth,
+      ShellSummonPlacement.defaultSize.width, ChatComposerLayout.contentLaneMaxWidth,
       "a summoned panel is the hugged glass, not a sheet that stretches with the display")
     XCTAssertLessThan(
       ShellSummonPlacement.defaultSize.width, 1200,
@@ -132,7 +132,7 @@ final class ShellSummonTests: XCTestCase {
   func testARememberedFrameComesBackUntouched() {
     let placed = NSRect(
       x: 1700, y: 100,
-      width: DesktopWindowLayoutPolicy.maximumContentWidth, height: 820)
+      width: ChatComposerLayout.contentLaneMaxWidth, height: 820)
 
     let frame = ShellSummonPlacement.frame(remembered: placed, visibleFrame: studio)
 
@@ -146,7 +146,7 @@ final class ShellSummonTests: XCTestCase {
 
     let frame = ShellSummonPlacement.frame(remembered: placed, visibleFrame: studio)
 
-    XCTAssertEqual(frame.width, DesktopWindowLayoutPolicy.maximumContentWidth)
+    XCTAssertEqual(frame.width, ChatComposerLayout.contentLaneMaxWidth)
     XCTAssertEqual(frame.height, 820)
     XCTAssertEqual(frame.origin, placed.origin)
   }
@@ -165,7 +165,7 @@ final class ShellSummonTests: XCTestCase {
       shrunk.contains(frame),
       "a restored frame outside the display is a shell whose query field cannot be reached")
     XCTAssertEqual(
-      frame.width, DesktopWindowLayoutPolicy.maximumContentWidth,
+      frame.width, ChatComposerLayout.contentLaneMaxWidth,
       "the remembered 1200 pt width is the invisible border; hug it even though 1440 would fit")
     XCTAssertEqual(frame.height, 820)
   }
@@ -178,7 +178,7 @@ final class ShellSummonTests: XCTestCase {
     let frame = ShellSummonPlacement.frame(remembered: placed, visibleFrame: laptop)
 
     XCTAssertTrue(laptop.contains(frame))
-    XCTAssertEqual(frame.width, DesktopWindowLayoutPolicy.maximumContentWidth)
+    XCTAssertEqual(frame.width, ChatComposerLayout.contentLaneMaxWidth)
     XCTAssertEqual(frame.height, laptop.height)
   }
 

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -486,10 +486,10 @@ final class TopNavigationBarLayoutTests: XCTestCase {
   }
 
   func testNavigationLaneMatchesFullChatWidthAndPageInsets() {
-    // The 900 pt readable cap lives on the window, not inside the lane. The glass fills
-    // the window horizontally — including a hypothetical 1400 pt host that bypassed the max.
+    // The 900 pt readable cap belongs to content inside the lane. The glass fills the window
+    // horizontally — including a hypothetical 1400 pt host.
     XCTAssertEqual(
-      TopNavigationLayoutMetrics.contentLaneWidth(for: DesktopWindowLayoutPolicy.maximumContentWidth),
+      TopNavigationLayoutMetrics.contentLaneWidth(for: ChatComposerLayout.contentLaneMaxWidth),
       ChatComposerLayout.contentLaneMaxWidth)
     XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 1_400), 1_400)
     XCTAssertEqual(TopNavigationLayoutMetrics.contentLaneWidth(for: 800), 800)

--- a/desktop/macos/changelog/unreleased/20260820-legacy-home-window-ground.json
+++ b/desktop/macos/changelog/unreleased/20260820-legacy-home-window-ground.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the old Home design becoming transparent when enabled"
+}


### PR DESCRIPTION
## Root cause

`ShellWindowChrome` intentionally leaves the top-level window clear and non-opaque. The modern query-shell Home owns its own glass, but when `useLegacyHomeDesign` selected `DashboardPage`, `PageGlassLanePolicy` still classified the dashboard as self-contained. The legacy dashboard therefore received no panel ground and exposed the transparent shell.

## Fix

Make `PageGlassLanePolicy` receive the resolved Home surface ownership decision from `DesktopHomeView`. The modern query-shell Home and Rewind keep their existing self-owned panel behavior; the redesigned and oldest legacy Home surfaces mount through the shared `PageGlassLane`, which supplies the visible panel ground. The Home switcher now reaches all three presentations, and the window maximum follows the visible display while the content lane remains 900pt. Tests cover both ownership polarities, the unknown-index route, all three presentations, and the display-sized maximum.

## Product invariants affected

- INV-CHAT-1
- INV-NAV-1

## Verification

- `xcrun swift build -c debug --package-path Desktop` — passed.
- `xcrun swift test --package-path Desktop --filter PageGlassLaneTests` — 8 passed.
- `xcrun swift test --package-path Desktop --filter QueryShellTests` — 38 passed.
- `xcrun swift test --package-path Desktop --filter DesktopWindowLayoutPolicyTests` — 2 passed.
- `xcrun swift test --package-path Desktop --filter ShellSummonTests` — 26 passed.
- `xcrun swift test --package-path Desktop --filter TopNavigationBarLayoutTests` — 18 passed.
- `xcrun swift test --package-path Desktop --filter ConversationDisplayStateTests` — 10 passed.
- Strict Swift-format lint passed for the functional patch.
- Named bundle `com.omi.omi-legacy-home` was built, installed, launched, and exercised through the automation bridge with a synthetic local Auth/Firestore profile. Screenshots cover QueryShell Home, redesigned hub, oldest Home, and visible-frame fill.

Failure-Class: FC-transparent-top-level-window-occlusion

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1636 -> 1637 | Rebase onto current main kept Memory-hub destination glass ownership on the same PageGlassLane call; one extra argument is cheaper than splitting the router.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-window glass ownership and AppKit min/max sizing, so a wrong flag or max-size can make Home transparent or let the window fill the display. No auth or data-path changes.
> 
> **Overview**
> Stops the older Home designs from rendering onto the wallpaper. `PageGlassLane` now takes a router-supplied `homeOwnsItsPanels` flag, so QueryShell Home and Rewind keep their own glass while redesigned and oldest Home get the shared panel.
> 
> Adds a nested **Use oldest Home theme** setting under legacy Home, resolved through `HomeDesignPresentation` (query shell / redesigned hub / oldest widgets-and-chat). Older Home backgrounds stay clear so the lane is the ground.
> 
> The shell’s **max size follows the visible display** instead of the 900pt readable lane. Summoned windows still hug `ChatComposerLayout.contentLaneMaxWidth`. Tests cover both ownership polarities, all three presentations, and display-sized maxima.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63fd3a59016d51aeec1eb84663fc62961291e439. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

