### PR TITLE
style(desktop): format ConversationDisplayStateTests with pinned swift-format

### DIFF
--- a/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Omi_Computer
 
 /// Unit tests for `ServerConversation.displayState` / `displayTitle` /
@@ -8,159 +9,159 @@ import XCTest
 /// label instead of a flat "Untitled".
 final class ConversationDisplayStateTests: XCTestCase {
 
-    // MARK: - Builders
+  // MARK: - Builders
 
-    /// Builds a minimally-populated `ServerConversation` with overridable knobs.
-    /// Keeps the tests focused on the fields that drive displayState.
-    private func makeConversation(
-        title: String = "",
-        status: ConversationStatus = .completed,
-        isLocked: Bool = false,
-        segments: [TranscriptSegment] = []
-    ) -> ServerConversation {
-        ServerConversation(
-            id: "id",
-            createdAt: Date(),
-            updatedAt: nil,
-            startedAt: nil,
-            finishedAt: nil,
-            structured: Structured(
-                title: title,
-                overview: "",
-                emoji: "",
-                category: "",
-                actionItems: [],
-                events: []
-            ),
-            transcriptSegments: segments,
-            transcriptSegmentsIncluded: !segments.isEmpty,
-            geolocation: nil,
-            photos: [],
-            appsResults: [],
-            source: nil,
-            language: nil,
-            status: status,
-            discarded: false,
-            deleted: false,
-            isLocked: isLocked,
-            starred: false,
-            folderId: nil,
-            inputDeviceName: nil
-        )
+  /// Builds a minimally-populated `ServerConversation` with overridable knobs.
+  /// Keeps the tests focused on the fields that drive displayState.
+  private func makeConversation(
+    title: String = "",
+    status: ConversationStatus = .completed,
+    isLocked: Bool = false,
+    segments: [TranscriptSegment] = []
+  ) -> ServerConversation {
+    ServerConversation(
+      id: "id",
+      createdAt: Date(),
+      updatedAt: nil,
+      startedAt: nil,
+      finishedAt: nil,
+      structured: Structured(
+        title: title,
+        overview: "",
+        emoji: "",
+        category: "",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: segments,
+      transcriptSegmentsIncluded: !segments.isEmpty,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: nil,
+      language: nil,
+      status: status,
+      discarded: false,
+      deleted: false,
+      isLocked: isLocked,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil
+    )
+  }
+
+  private func segment(_ text: String) -> TranscriptSegment {
+    TranscriptSegment(
+      id: UUID().uuidString,
+      text: text,
+      speaker: "SPEAKER_00",
+      isUser: false,
+      personId: nil,
+      start: 0,
+      end: 1
+    )
+  }
+
+  // MARK: - Titled
+
+  func test_completedWithTitle_returnsTitledState() {
+    let conv = makeConversation(title: "Morning standup")
+    if case .titled(let t) = conv.displayState {
+      XCTAssertEqual(t, "Morning standup")
+    } else {
+      XCTFail("Expected .titled, got \(conv.displayState)")
     }
+    XCTAssertEqual(conv.displayTitle, "Morning standup")
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    private func segment(_ text: String) -> TranscriptSegment {
-        TranscriptSegment(
-            id: UUID().uuidString,
-            text: text,
-            speaker: "SPEAKER_00",
-            isUser: false,
-            personId: nil,
-            start: 0,
-            end: 1
-        )
-    }
+  // MARK: - Locked
 
-    // MARK: - Titled
+  func test_lockedTakesPrecedence_overEverythingElse() {
+    // Locked + has title + completed — locked still wins so the user
+    // gets an honest signal that their content is gated.
+    let conv = makeConversation(
+      title: "Was titled before lock",
+      status: .completed,
+      isLocked: true,
+      segments: [segment("plenty of words to look recoverable normally")]
+    )
+    XCTAssertEqual(conv.displayState, .locked)
+    XCTAssertEqual(conv.displayTitle, "Locked")
+    XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
+  }
 
-    func test_completedWithTitle_returnsTitledState() {
-        let conv = makeConversation(title: "Morning standup")
-        if case .titled(let t) = conv.displayState {
-            XCTAssertEqual(t, "Morning standup")
-        } else {
-            XCTFail("Expected .titled, got \(conv.displayState)")
-        }
-        XCTAssertEqual(conv.displayTitle, "Morning standup")
-        XCTAssertFalse(conv.canReprocess)
-    }
+  // MARK: - Processing
 
-    // MARK: - Locked
+  func test_inProgressStatus_returnsProcessing() {
+    let conv = makeConversation(status: .inProgress)
+    XCTAssertEqual(conv.displayState, .processing)
+    XCTAssertEqual(conv.displayTitle, "Processing…")
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    func test_lockedTakesPrecedence_overEverythingElse() {
-        // Locked + has title + completed — locked still wins so the user
-        // gets an honest signal that their content is gated.
-        let conv = makeConversation(
-            title: "Was titled before lock",
-            status: .completed,
-            isLocked: true,
-            segments: [segment("plenty of words to look recoverable normally")]
-        )
-        XCTAssertEqual(conv.displayState, .locked)
-        XCTAssertEqual(conv.displayTitle, "Locked")
-        XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
-    }
+  func test_processingStatus_returnsProcessing() {
+    let conv = makeConversation(status: .processing)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
 
-    // MARK: - Processing
+  func test_mergingStatus_returnsProcessing() {
+    let conv = makeConversation(status: .merging)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
 
-    func test_inProgressStatus_returnsProcessing() {
-        let conv = makeConversation(status: .inProgress)
-        XCTAssertEqual(conv.displayState, .processing)
-        XCTAssertEqual(conv.displayTitle, "Processing…")
-        XCTAssertFalse(conv.canReprocess)
-    }
+  // MARK: - Failed
 
-    func test_processingStatus_returnsProcessing() {
-        let conv = makeConversation(status: .processing)
-        XCTAssertEqual(conv.displayState, .processing)
-    }
+  func test_failedStatus_returnsFailed_andCanReprocess() {
+    let conv = makeConversation(status: .failed)
+    XCTAssertEqual(conv.displayState, .failed)
+    XCTAssertEqual(conv.displayTitle, "Failed to process")
+    XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
+  }
 
-    func test_mergingStatus_returnsProcessing() {
-        let conv = makeConversation(status: .merging)
-        XCTAssertEqual(conv.displayState, .processing)
-    }
+  // MARK: - Recoverable vs empty
 
-    // MARK: - Failed
+  func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
+    // 5+ words in a single segment satisfies the "real content" heuristic.
+    let conv = makeConversation(
+      status: .completed,
+      segments: [segment("hello this is a longer transcript please title me")]
+    )
+    XCTAssertEqual(conv.displayState, .untitledRecoverable)
+    XCTAssertEqual(conv.displayTitle, "Untitled")
+    XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
+  }
 
-    func test_failedStatus_returnsFailed_andCanReprocess() {
-        let conv = makeConversation(status: .failed)
-        XCTAssertEqual(conv.displayState, .failed)
-        XCTAssertEqual(conv.displayTitle, "Failed to process")
-        XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
-    }
+  func test_completedNoTitle_withShortTranscript_returnsEmpty() {
+    // ≤ 4 words across the only segment — treat as ambient/accidental
+    // capture. No reprocess CTA (would burn LLM tokens on noise).
+    let conv = makeConversation(
+      status: .completed,
+      segments: [segment("hello there")]
+    )
+    XCTAssertEqual(conv.displayState, .untitledEmpty)
+    XCTAssertEqual(conv.displayTitle, "Untitled")
+    XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
+  }
 
-    // MARK: - Recoverable vs empty
+  func test_completedNoTitle_withNoTranscript_returnsEmpty() {
+    let conv = makeConversation(status: .completed, segments: [])
+    XCTAssertEqual(conv.displayState, .untitledEmpty)
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
-        // 5+ words in a single segment satisfies the "real content" heuristic.
-        let conv = makeConversation(
-            status: .completed,
-            segments: [segment("hello this is a longer transcript please title me")]
-        )
-        XCTAssertEqual(conv.displayState, .untitledRecoverable)
-        XCTAssertEqual(conv.displayTitle, "Untitled")
-        XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
-    }
-
-    func test_completedNoTitle_withShortTranscript_returnsEmpty() {
-        // ≤ 4 words across the only segment — treat as ambient/accidental
-        // capture. No reprocess CTA (would burn LLM tokens on noise).
-        let conv = makeConversation(
-            status: .completed,
-            segments: [segment("hello there")]
-        )
-        XCTAssertEqual(conv.displayState, .untitledEmpty)
-        XCTAssertEqual(conv.displayTitle, "Untitled")
-        XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
-    }
-
-    func test_completedNoTitle_withNoTranscript_returnsEmpty() {
-        let conv = makeConversation(status: .completed, segments: [])
-        XCTAssertEqual(conv.displayState, .untitledEmpty)
-        XCTAssertFalse(conv.canReprocess)
-    }
-
-    func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
-        // Even if the first segment is tiny, a later substantial segment
-        // promotes the conversation to recoverable.
-        let conv = makeConversation(
-            status: .completed,
-            segments: [
-                segment("um"),
-                segment("ok"),
-                segment("this is the substantive part of the conversation"),
-            ]
-        )
-        XCTAssertEqual(conv.displayState, .untitledRecoverable)
-        XCTAssertTrue(conv.canReprocess)
-    }
+  func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
+    // Even if the first segment is tiny, a later substantial segment
+    // promotes the conversation to recoverable.
+    let conv = makeConversation(
+      status: .completed,
+      segments: [
+        segment("um"),
+        segment("ok"),
+        segment("this is the substantive part of the conversation"),
+      ]
+    )
+    XCTAssertEqual(conv.displayState, .untitledRecoverable)
+    XCTAssertTrue(conv.canReprocess)
+  }
 }


### PR DESCRIPTION
## Summary

`desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift` is on `main` indented inconsistently with pinned swift-format 602.0.0:

```
$ desktop/macos/scripts/swift-format-wrapper.sh lint \
    desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
...:11:1: error: [Indentation] unindent by 2 spaces
...:13:1: error: [Indentation] unindent by 2 spaces
```

## Why it matters

`scripts/pre-push` lints the **whole tree**, not the diff. So this one file fails the push gate for every branch cut from current `main`, on a file the pusher never touched.

Found while pushing an unrelated three-file change. Confirmed it is not branch-specific by cutting a fresh branch from `origin/main`, applying only that unrelated change, and watching the gate fail on this file alone:

```
FORMAT DRIFT: desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
```

CI's lint is diff-scoped and so does not catch it, which is why it reached `main`.

## The change

Whitespace only — `git diff --ignore-all-space` reports no changed lines. Ran the pinned wrapper's own formatter; nothing hand-edited.

## Verification

```
swift-format-wrapper.sh lint <file>                -> clean (was failing)
swift test --filter ConversationDisplayStateTests  -> 10 passed
git diff --ignore-all-space                        -> no non-whitespace changes
```

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

