### PR TITLE
feat(macos): four notification types — Focus, Task, Insight, Memory

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
@@ -12,7 +12,9 @@ enum ProactiveNotificationKind: String, Equatable {
 
   static func from(decisionType: String) -> Self {
     switch decisionType {
-    case "suggest": return .suggestion
+    // Director "suggest" decisions are generic tips, which the user-facing taxonomy
+    // files under Insight; `.suggestion` is reserved for the focus-nudge assistant.
+    case "suggest": return .insight
     case "insight": return .insight
     case "task_candidate": return .task
     case "resurface": return .resurface

--- a/desktop/macos/Desktop/Sources/DefaultsKey.swift
+++ b/desktop/macos/Desktop/Sources/DefaultsKey.swift
@@ -73,6 +73,7 @@ enum DefaultsKey: String {
   case floatingBarCachedPlan = "floatingBar_cachedPlan"
   case floatingBarCachedDesktopGrandfatherUntil = "floatingBar_cachedDesktopGrandfatherUntil"
   case desktopIsPaywalled = "desktop_isPaywalled"
+  case askOmiBarEnabled = "askOmiBarEnabled"
   case rewindDisableContentCache = "rewindDisableContentCache"
   // Task-order migration keys are typed so TasksPage and its tests share the
   // migration contract instead of repeating raw UserDefaults literals.

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2619,7 +2619,7 @@ enum OwnerBoundNotificationPresentationResult: Equatable {
 class FloatingControlBarManager {
   static let shared = FloatingControlBarManager()
 
-  private static let kAskOmiEnabled = "askOmiBarEnabled"
+  private static let kAskOmiEnabled = DefaultsKey.askOmiBarEnabled.rawValue
   private static let kSnoozedUntil = "floatingBar_snoozedUntil"
   private static let recentNotificationReuseInterval: TimeInterval = 60
   private static let durableProvenanceReuseInterval: TimeInterval = 30 * 24 * 60 * 60

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -239,26 +239,27 @@ struct ProactiveNotificationBadge: Equatable {
   let label: String
   let systemImage: String
 
-  /// Shared glyph contract: Insight uses `sparkles` everywhere; Suggestion keeps `lightbulb`.
+  /// Shared glyph contract: Insight uses `sparkles` everywhere; Focus keeps `lightbulb`.
   static let insightSystemImage = "sparkles"
   static let suggestionSystemImage = "lightbulb"
 
+  /// The user-facing taxonomy is exactly four proactive categories — Focus, Task,
+  /// Insight, Memory — matching the four toggles in Settings → Notifications. Internal
+  /// kinds stay distinct (their raw values are persisted in chat continuity keys), but
+  /// every one of them presents as one of the four: goals feed the focus system,
+  /// meeting action items are tasks, and a resurfaced item is an insight about
+  /// relevance. `.general` is reserved for functional system alerts, which sit outside
+  /// the proactive taxonomy.
   init(kind: ProactiveNotificationKind) {
     switch kind {
-    case .suggestion:
-      (label, systemImage) = ("Suggestion", Self.suggestionSystemImage)
-    case .insight:
+    case .suggestion, .goal:
+      (label, systemImage) = ("Focus", Self.suggestionSystemImage)
+    case .insight, .resurface:
       (label, systemImage) = ("Insight", Self.insightSystemImage)
-    case .task:
+    case .task, .meetingNotes:
       (label, systemImage) = ("Task", "checkmark.circle")
     case .memory:
       (label, systemImage) = ("Memory", "brain.head.profile")
-    case .goal:
-      (label, systemImage) = ("Goal", "target")
-    case .meetingNotes:
-      (label, systemImage) = ("Meeting notes", "text.document")
-    case .resurface:
-      (label, systemImage) = ("Resurfaced", "clock.arrow.circlepath")
     case .general:
       (label, systemImage) = ("Notification", "bell")
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -246,15 +246,15 @@ struct ProactiveNotificationBadge: Equatable {
   /// The user-facing taxonomy is exactly four proactive categories — Focus, Task,
   /// Insight, Memory — matching the four toggles in Settings → Notifications. Internal
   /// kinds stay distinct (their raw values are persisted in chat continuity keys), but
-  /// every one of them presents as one of the four: goals feed the focus system,
-  /// meeting action items are tasks, and a resurfaced item is an insight about
-  /// relevance. `.general` is reserved for functional system alerts, which sit outside
-  /// the proactive taxonomy.
+  /// every one of them presents as one of the four: Focus is the focus-nudge assistant
+  /// alone; generic tips, resurfaced items, and generated goals are all insights;
+  /// meeting action items are tasks. `.general` is reserved for functional system
+  /// alerts, which sit outside the proactive taxonomy.
   init(kind: ProactiveNotificationKind) {
     switch kind {
-    case .suggestion, .goal:
+    case .suggestion:
       (label, systemImage) = ("Focus", Self.suggestionSystemImage)
-    case .insight, .resurface:
+    case .insight, .resurface, .goal:
       (label, systemImage) = ("Insight", Self.insightSystemImage)
     case .task, .meetingNotes:
       (label, systemImage) = ("Task", "checkmark.circle")

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
@@ -36,10 +36,10 @@ extension SettingsContentView {
 
             // Sits under the master toggle and the frequency slider because both gate it:
             // frequency caps how often any proactive card is delivered, and this decides
-            // whether live suggestions are generated at all.
+            // whether focus nudges are generated at all.
             settingRow(
-              title: "Live Suggestions",
-              subtitle: "Suggest things in the notch, using what Omi already knows",
+              title: "Focus Notifications",
+              subtitle: "Nudges in the notch to keep you on track, using what Omi already knows",
               settingId: "notifications.livesuggestions"
             ) {
               Toggle("", isOn: $liveSuggestionsEnabled)

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -287,7 +287,9 @@ actor MemoryAssistant: ProactiveAssistant {
     result: MemoryExtractionResult,
     windowTitle: String?
   ) async {
-    let title = memory.category == .interesting ? "Wisdom Captured" : "Memory Saved"
+    // One category, one name: every memory notification presents as "Memory" — the
+    // "Wisdom Captured" variant read as an unclassifiable notification type.
+    let title = "Memory Saved"
     let message = "New memory: \(memory.content)"
     let context = FloatingBarNotificationContext(
       sourceTitle: title,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Assistants/Suggestions/SuggestionAssistant.swift
@@ -16,7 +16,7 @@ actor SuggestionAssistant: ProactiveAssistant {
   // MARK: - ProactiveAssistant Protocol
 
   nonisolated let identifier = "suggestion"
-  nonisolated let displayName = "Live Suggestions"
+  nonisolated let displayName = "Focus Notifications"
 
   var isEnabled: Bool {
     get async {
@@ -598,7 +598,7 @@ actor SuggestionAssistant: ProactiveAssistant {
     telemetryIdentity: SuggestionAssistantTelemetry.NotificationIdentity?
   ) async {
     let context = FloatingBarNotificationContext(
-      sourceTitle: "Suggestion",
+      sourceTitle: "Focus",
       assistantId: identifier,
       sourceApp: nil,
       windowTitle: nil,
@@ -613,7 +613,7 @@ actor SuggestionAssistant: ProactiveAssistant {
     await MainActor.run {
       NotificationService.shared.sendNotification(
         ownerID: ownerID,
-        title: "Suggestion",
+        title: "Focus",
         message: suggestion.suggestion,
         assistantId: identifier,
         context: context,

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -762,9 +762,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
   /// Maps every proactive notification kind to its user-facing category — Focus, Task,
   /// Insight, or Memory — and answers whether that category's Settings toggle allows
-  /// delivery. Goals feed the focus system, meeting action items are tasks, and a
-  /// resurfaced item is an insight about relevance. `.general` is functional system
-  /// alerting outside the taxonomy and is never category-gated.
+  /// delivery. Focus is the focus-nudge assistant alone; generic tips, resurfaced
+  /// items, and generated goals are all insights; meeting action items are tasks.
+  /// `.general` is functional system alerting outside the taxonomy and is never
+  /// category-gated.
   nonisolated static func categoryToggleAllows(
     kind: ProactiveNotificationKind,
     focusEnabled: Bool,
@@ -773,9 +774,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     memoryEnabled: Bool
   ) -> Bool {
     switch kind {
-    case .suggestion, .goal: return focusEnabled
+    case .suggestion: return focusEnabled
     case .task, .meetingNotes: return taskEnabled
-    case .insight, .resurface: return insightEnabled
+    case .insight, .resurface, .goal: return insightEnabled
     case .memory: return memoryEnabled
     case .general: return true
     }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -433,6 +433,28 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
+    // Every proactive notification belongs to one of the four user-facing categories
+    // (Focus, Task, Insight, Memory), and this shared boundary is where a category's
+    // Settings toggle binds every producer — goals and meeting action items included,
+    // not just the assistants that consult their own toggle before generating.
+    // Functional notices (`respectFrequency: false`) map to `.general` and stay ungated.
+    if respectFrequency,
+      !Self.categoryToggleAllows(
+        kind: ProactiveNotificationKind.from(assistantId: assistantId),
+        focusEnabled: SuggestionAssistantSettings.shared.isEnabled,
+        taskEnabled: TaskAssistantSettings.shared.notificationsEnabled,
+        insightEnabled: InsightAssistantSettings.shared.notificationsEnabled,
+        memoryEnabled: MemoryAssistantSettings.shared.notificationsEnabled)
+    {
+      log("NotificationService: suppressing \(assistantId) notification because its category toggle is off")
+      recordInsightDeliveryOutcome(
+        insightDeliveryID,
+        outcome: .suppressed,
+        reason: .assistantNotificationsDisabled
+      )
+      return
+    }
+
     // Proactive notifications honor the user's frequency setting. Functional
     // notifications (Crisp support replies, screen-recording permission prompts,
     // onboarding test) pass `respectFrequency: false` to bypass the gate.

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -662,6 +662,21 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       onDropped?()
       return .suppressed
     }
+    // The director's decisions ride the same four category toggles as the dedicated
+    // assistants. Settings promises exactly four notification types — Focus, Task,
+    // Insight, Memory — and a toggle that silences only some producers of its
+    // category would make that promise a lie.
+    guard
+      Self.categoryToggleAllows(
+        kind: ProactiveNotificationKind.from(decisionType: decisionType),
+        focusEnabled: SuggestionAssistantSettings.shared.isEnabled,
+        taskEnabled: TaskAssistantSettings.shared.notificationsEnabled,
+        insightEnabled: InsightAssistantSettings.shared.notificationsEnabled,
+        memoryEnabled: MemoryAssistantSettings.shared.notificationsEnabled)
+    else {
+      onDropped?()
+      return .suppressed
+    }
 
     let previewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
     let floatingBarEnabled = FloatingControlBarManager.shared.isEnabled
@@ -721,6 +736,27 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       )
     }
     return .queued
+  }
+
+  /// Maps every proactive notification kind to its user-facing category — Focus, Task,
+  /// Insight, or Memory — and answers whether that category's Settings toggle allows
+  /// delivery. Goals feed the focus system, meeting action items are tasks, and a
+  /// resurfaced item is an insight about relevance. `.general` is functional system
+  /// alerting outside the taxonomy and is never category-gated.
+  nonisolated static func categoryToggleAllows(
+    kind: ProactiveNotificationKind,
+    focusEnabled: Bool,
+    taskEnabled: Bool,
+    insightEnabled: Bool,
+    memoryEnabled: Bool
+  ) -> Bool {
+    switch kind {
+    case .suggestion, .goal: return focusEnabled
+    case .task, .meetingNotes: return taskEnabled
+    case .insight, .resurface: return insightEnabled
+    case .memory: return memoryEnabled
+    case .general: return true
+    }
   }
 
   private func contextDirectorMayPresent(
@@ -941,7 +977,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   /// notifications-off-by-default migration (`48239de8`) turned off. A user at Off — or a
   /// fresh install with no stored level — moves to Balanced; a user who opted in to any
   /// other level keeps it. Per-assistant toggles are not touched, so only the categories
-  /// that default on (Live Suggestions, Insight) fire; Task and Memory stay opt-in.
+  /// that default on (Focus, Insight) fire; Task and Memory stay opt-in.
   /// Because it is guarded by `balancedByDefaultMigrationKey`, a user who turns
   /// notifications off after the migration is never re-enabled on subsequent launches.
   /// Call early at launch, before any proactive assistant can fire.

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -16,23 +16,24 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
         kind: kind, focusEnabled: focus, taskEnabled: task,
         insightEnabled: insight, memoryEnabled: memory)
     }
-    // Focus toggle owns suggestions and goals.
+    // Focus toggle owns the focus-nudge assistant alone.
     XCTAssertFalse(allows(.suggestion, focus: false))
-    XCTAssertFalse(allows(.goal, focus: false))
     XCTAssertTrue(allows(.suggestion, task: false, insight: false, memory: false))
     // Task toggle owns task candidates and meeting action items.
     XCTAssertFalse(allows(.task, task: false))
     XCTAssertFalse(allows(.meetingNotes, task: false))
     XCTAssertTrue(allows(.task, focus: false, insight: false, memory: false))
-    // Insight toggle owns insights and resurfaced items.
+    // Insight toggle owns insights, tips, resurfaced items, and generated goals.
     XCTAssertFalse(allows(.insight, insight: false))
     XCTAssertFalse(allows(.resurface, insight: false))
+    XCTAssertFalse(allows(.goal, insight: false))
     // Memory toggle owns memory extraction.
     XCTAssertFalse(allows(.memory, memory: false))
     // Functional alerts sit outside the taxonomy.
     XCTAssertTrue(allows(.general, focus: false, task: false, insight: false, memory: false))
-    // The director's decision strings resolve into the gated kinds.
-    XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "suggest"), .suggestion)
+    // The director's decision strings resolve into the gated kinds; "suggest" is a
+    // generic tip, which the taxonomy files under Insight.
+    XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "suggest"), .insight)
     XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "task_candidate"), .task)
     XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "resurface"), .resurface)
   }

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -4,6 +4,39 @@ import XCTest
 @testable import Omi_Computer
 
 final class ContextDeliveryAuthorityTests: XCTestCase {
+  /// Context-director decisions ride the same four category toggles the Settings pane
+  /// shows (Focus, Task, Insight, Memory). Each internal kind must be gated by exactly
+  /// its category's toggle; `.general` (functional alerts) is never category-gated.
+  func testDirectorDecisionsAreGatedByTheirCategoryToggle() {
+    func allows(
+      _ kind: ProactiveNotificationKind, focus: Bool = true, task: Bool = true, insight: Bool = true,
+      memory: Bool = true
+    ) -> Bool {
+      NotificationService.categoryToggleAllows(
+        kind: kind, focusEnabled: focus, taskEnabled: task,
+        insightEnabled: insight, memoryEnabled: memory)
+    }
+    // Focus toggle owns suggestions and goals.
+    XCTAssertFalse(allows(.suggestion, focus: false))
+    XCTAssertFalse(allows(.goal, focus: false))
+    XCTAssertTrue(allows(.suggestion, task: false, insight: false, memory: false))
+    // Task toggle owns task candidates and meeting action items.
+    XCTAssertFalse(allows(.task, task: false))
+    XCTAssertFalse(allows(.meetingNotes, task: false))
+    XCTAssertTrue(allows(.task, focus: false, insight: false, memory: false))
+    // Insight toggle owns insights and resurfaced items.
+    XCTAssertFalse(allows(.insight, insight: false))
+    XCTAssertFalse(allows(.resurface, insight: false))
+    // Memory toggle owns memory extraction.
+    XCTAssertFalse(allows(.memory, memory: false))
+    // Functional alerts sit outside the taxonomy.
+    XCTAssertTrue(allows(.general, focus: false, task: false, insight: false, memory: false))
+    // The director's decision strings resolve into the gated kinds.
+    XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "suggest"), .suggestion)
+    XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "task_candidate"), .task)
+    XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "resurface"), .resurface)
+  }
+
   @MainActor
   func testProactiveBudgetMultiplierUsesCachedServerPlan() throws {
     let suiteName = "ContextDeliveryAuthorityTests.plan.\(UUID().uuidString)"

--- a/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
+++ b/desktop/macos/Desktop/Tests/ConversationDisplayStateTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Omi_Computer
 
 /// Unit tests for `ServerConversation.displayState` / `displayTitle` /
@@ -8,159 +9,159 @@ import XCTest
 /// label instead of a flat "Untitled".
 final class ConversationDisplayStateTests: XCTestCase {
 
-    // MARK: - Builders
+  // MARK: - Builders
 
-    /// Builds a minimally-populated `ServerConversation` with overridable knobs.
-    /// Keeps the tests focused on the fields that drive displayState.
-    private func makeConversation(
-        title: String = "",
-        status: ConversationStatus = .completed,
-        isLocked: Bool = false,
-        segments: [TranscriptSegment] = []
-    ) -> ServerConversation {
-        ServerConversation(
-            id: "id",
-            createdAt: Date(),
-            updatedAt: nil,
-            startedAt: nil,
-            finishedAt: nil,
-            structured: Structured(
-                title: title,
-                overview: "",
-                emoji: "",
-                category: "",
-                actionItems: [],
-                events: []
-            ),
-            transcriptSegments: segments,
-            transcriptSegmentsIncluded: !segments.isEmpty,
-            geolocation: nil,
-            photos: [],
-            appsResults: [],
-            source: nil,
-            language: nil,
-            status: status,
-            discarded: false,
-            deleted: false,
-            isLocked: isLocked,
-            starred: false,
-            folderId: nil,
-            inputDeviceName: nil
-        )
+  /// Builds a minimally-populated `ServerConversation` with overridable knobs.
+  /// Keeps the tests focused on the fields that drive displayState.
+  private func makeConversation(
+    title: String = "",
+    status: ConversationStatus = .completed,
+    isLocked: Bool = false,
+    segments: [TranscriptSegment] = []
+  ) -> ServerConversation {
+    ServerConversation(
+      id: "id",
+      createdAt: Date(),
+      updatedAt: nil,
+      startedAt: nil,
+      finishedAt: nil,
+      structured: Structured(
+        title: title,
+        overview: "",
+        emoji: "",
+        category: "",
+        actionItems: [],
+        events: []
+      ),
+      transcriptSegments: segments,
+      transcriptSegmentsIncluded: !segments.isEmpty,
+      geolocation: nil,
+      photos: [],
+      appsResults: [],
+      source: nil,
+      language: nil,
+      status: status,
+      discarded: false,
+      deleted: false,
+      isLocked: isLocked,
+      starred: false,
+      folderId: nil,
+      inputDeviceName: nil
+    )
+  }
+
+  private func segment(_ text: String) -> TranscriptSegment {
+    TranscriptSegment(
+      id: UUID().uuidString,
+      text: text,
+      speaker: "SPEAKER_00",
+      isUser: false,
+      personId: nil,
+      start: 0,
+      end: 1
+    )
+  }
+
+  // MARK: - Titled
+
+  func test_completedWithTitle_returnsTitledState() {
+    let conv = makeConversation(title: "Morning standup")
+    if case .titled(let t) = conv.displayState {
+      XCTAssertEqual(t, "Morning standup")
+    } else {
+      XCTFail("Expected .titled, got \(conv.displayState)")
     }
+    XCTAssertEqual(conv.displayTitle, "Morning standup")
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    private func segment(_ text: String) -> TranscriptSegment {
-        TranscriptSegment(
-            id: UUID().uuidString,
-            text: text,
-            speaker: "SPEAKER_00",
-            isUser: false,
-            personId: nil,
-            start: 0,
-            end: 1
-        )
-    }
+  // MARK: - Locked
 
-    // MARK: - Titled
+  func test_lockedTakesPrecedence_overEverythingElse() {
+    // Locked + has title + completed — locked still wins so the user
+    // gets an honest signal that their content is gated.
+    let conv = makeConversation(
+      title: "Was titled before lock",
+      status: .completed,
+      isLocked: true,
+      segments: [segment("plenty of words to look recoverable normally")]
+    )
+    XCTAssertEqual(conv.displayState, .locked)
+    XCTAssertEqual(conv.displayTitle, "Locked")
+    XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
+  }
 
-    func test_completedWithTitle_returnsTitledState() {
-        let conv = makeConversation(title: "Morning standup")
-        if case .titled(let t) = conv.displayState {
-            XCTAssertEqual(t, "Morning standup")
-        } else {
-            XCTFail("Expected .titled, got \(conv.displayState)")
-        }
-        XCTAssertEqual(conv.displayTitle, "Morning standup")
-        XCTAssertFalse(conv.canReprocess)
-    }
+  // MARK: - Processing
 
-    // MARK: - Locked
+  func test_inProgressStatus_returnsProcessing() {
+    let conv = makeConversation(status: .inProgress)
+    XCTAssertEqual(conv.displayState, .processing)
+    XCTAssertEqual(conv.displayTitle, "Processing…")
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    func test_lockedTakesPrecedence_overEverythingElse() {
-        // Locked + has title + completed — locked still wins so the user
-        // gets an honest signal that their content is gated.
-        let conv = makeConversation(
-            title: "Was titled before lock",
-            status: .completed,
-            isLocked: true,
-            segments: [segment("plenty of words to look recoverable normally")]
-        )
-        XCTAssertEqual(conv.displayState, .locked)
-        XCTAssertEqual(conv.displayTitle, "Locked")
-        XCTAssertFalse(conv.canReprocess, "Reprocess shouldn't be offered while locked")
-    }
+  func test_processingStatus_returnsProcessing() {
+    let conv = makeConversation(status: .processing)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
 
-    // MARK: - Processing
+  func test_mergingStatus_returnsProcessing() {
+    let conv = makeConversation(status: .merging)
+    XCTAssertEqual(conv.displayState, .processing)
+  }
 
-    func test_inProgressStatus_returnsProcessing() {
-        let conv = makeConversation(status: .inProgress)
-        XCTAssertEqual(conv.displayState, .processing)
-        XCTAssertEqual(conv.displayTitle, "Processing…")
-        XCTAssertFalse(conv.canReprocess)
-    }
+  // MARK: - Failed
 
-    func test_processingStatus_returnsProcessing() {
-        let conv = makeConversation(status: .processing)
-        XCTAssertEqual(conv.displayState, .processing)
-    }
+  func test_failedStatus_returnsFailed_andCanReprocess() {
+    let conv = makeConversation(status: .failed)
+    XCTAssertEqual(conv.displayState, .failed)
+    XCTAssertEqual(conv.displayTitle, "Failed to process")
+    XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
+  }
 
-    func test_mergingStatus_returnsProcessing() {
-        let conv = makeConversation(status: .merging)
-        XCTAssertEqual(conv.displayState, .processing)
-    }
+  // MARK: - Recoverable vs empty
 
-    // MARK: - Failed
+  func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
+    // 5+ words in a single segment satisfies the "real content" heuristic.
+    let conv = makeConversation(
+      status: .completed,
+      segments: [segment("hello this is a longer transcript please title me")]
+    )
+    XCTAssertEqual(conv.displayState, .untitledRecoverable)
+    XCTAssertEqual(conv.displayTitle, "Untitled")
+    XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
+  }
 
-    func test_failedStatus_returnsFailed_andCanReprocess() {
-        let conv = makeConversation(status: .failed)
-        XCTAssertEqual(conv.displayState, .failed)
-        XCTAssertEqual(conv.displayTitle, "Failed to process")
-        XCTAssertTrue(conv.canReprocess, "User should be able to retry a failed conversation")
-    }
+  func test_completedNoTitle_withShortTranscript_returnsEmpty() {
+    // ≤ 4 words across the only segment — treat as ambient/accidental
+    // capture. No reprocess CTA (would burn LLM tokens on noise).
+    let conv = makeConversation(
+      status: .completed,
+      segments: [segment("hello there")]
+    )
+    XCTAssertEqual(conv.displayState, .untitledEmpty)
+    XCTAssertEqual(conv.displayTitle, "Untitled")
+    XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
+  }
 
-    // MARK: - Recoverable vs empty
+  func test_completedNoTitle_withNoTranscript_returnsEmpty() {
+    let conv = makeConversation(status: .completed, segments: [])
+    XCTAssertEqual(conv.displayState, .untitledEmpty)
+    XCTAssertFalse(conv.canReprocess)
+  }
 
-    func test_completedNoTitle_withSubstantialTranscript_returnsRecoverable() {
-        // 5+ words in a single segment satisfies the "real content" heuristic.
-        let conv = makeConversation(
-            status: .completed,
-            segments: [segment("hello this is a longer transcript please title me")]
-        )
-        XCTAssertEqual(conv.displayState, .untitledRecoverable)
-        XCTAssertEqual(conv.displayTitle, "Untitled")
-        XCTAssertTrue(conv.canReprocess, "Recoverable rows should expose the reprocess CTA")
-    }
-
-    func test_completedNoTitle_withShortTranscript_returnsEmpty() {
-        // ≤ 4 words across the only segment — treat as ambient/accidental
-        // capture. No reprocess CTA (would burn LLM tokens on noise).
-        let conv = makeConversation(
-            status: .completed,
-            segments: [segment("hello there")]
-        )
-        XCTAssertEqual(conv.displayState, .untitledEmpty)
-        XCTAssertEqual(conv.displayTitle, "Untitled")
-        XCTAssertFalse(conv.canReprocess, "Empty rows shouldn't offer reprocess")
-    }
-
-    func test_completedNoTitle_withNoTranscript_returnsEmpty() {
-        let conv = makeConversation(status: .completed, segments: [])
-        XCTAssertEqual(conv.displayState, .untitledEmpty)
-        XCTAssertFalse(conv.canReprocess)
-    }
-
-    func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
-        // Even if the first segment is tiny, a later substantial segment
-        // promotes the conversation to recoverable.
-        let conv = makeConversation(
-            status: .completed,
-            segments: [
-                segment("um"),
-                segment("ok"),
-                segment("this is the substantive part of the conversation"),
-            ]
-        )
-        XCTAssertEqual(conv.displayState, .untitledRecoverable)
-        XCTAssertTrue(conv.canReprocess)
-    }
+  func test_completedNoTitle_anyOneSegmentLongEnough_recoverable() {
+    // Even if the first segment is tiny, a later substantial segment
+    // promotes the conversation to recoverable.
+    let conv = makeConversation(
+      status: .completed,
+      segments: [
+        segment("um"),
+        segment("ok"),
+        segment("this is the substantive part of the conversation"),
+      ]
+    )
+    XCTAssertEqual(conv.displayState, .untitledRecoverable)
+    XCTAssertTrue(conv.canReprocess)
+  }
 }

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -172,8 +172,8 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
       DefaultsKey.automationOwnerOverride.rawValue,
       NotificationService.masterEnabledDefaultsKey,
       NotificationService.frequencyDefaultsKey,
-      "desktop_isPaywalled",
-      "askOmiBarEnabled",
+      DefaultsKey.desktopIsPaywalled.rawValue,
+      DefaultsKey.askOmiBarEnabled.rawValue,
     ]
     let savedValues = pinnedKeys.map { ($0, defaults.object(forKey: $0)) }
     let savedFocusEnabled = SuggestionAssistantSettings.shared.isEnabled
@@ -195,8 +195,8 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     defaults.removeObject(forKey: DefaultsKey.automationOwnerOverride.rawValue)
     defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
     defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
-    defaults.set(false, forKey: "desktop_isPaywalled")
-    defaults.set(true, forKey: "askOmiBarEnabled")
+    defaults.set(false, forKey: DefaultsKey.desktopIsPaywalled.rawValue)
+    defaults.set(true, forKey: DefaultsKey.askOmiBarEnabled.rawValue)
     ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = false
     SuggestionAssistantSettings.shared.isEnabled = false
     let liveOwner = try XCTUnwrap(RuntimeOwnerIdentity.currentOwnerId())
@@ -234,8 +234,8 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
       DefaultsKey.automationOwnerOverride.rawValue,
       NotificationService.masterEnabledDefaultsKey,
       NotificationService.frequencyDefaultsKey,
-      "desktop_isPaywalled",
-      "askOmiBarEnabled",
+      DefaultsKey.desktopIsPaywalled.rawValue,
+      DefaultsKey.askOmiBarEnabled.rawValue,
     ]
     let savedValues = pinnedKeys.map { ($0, defaults.object(forKey: $0)) }
     let savedFocusEnabled = SuggestionAssistantSettings.shared.isEnabled
@@ -259,8 +259,8 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     defaults.removeObject(forKey: DefaultsKey.automationOwnerOverride.rawValue)
     defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
     defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
-    defaults.set(false, forKey: "desktop_isPaywalled")
-    defaults.set(true, forKey: "askOmiBarEnabled")
+    defaults.set(false, forKey: DefaultsKey.desktopIsPaywalled.rawValue)
+    defaults.set(true, forKey: DefaultsKey.askOmiBarEnabled.rawValue)
     ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = false
     SuggestionAssistantSettings.shared.isEnabled = false
     TaskAssistantSettings.shared.notificationsEnabled = false

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -158,10 +158,11 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
   }
 
   /// Behavioral guard for the four-type taxonomy: the director's real entry point must
-  /// refuse a delivery whose category toggle is off. Every upstream gate is pinned open
+  /// refuse a delivery whose category toggle is off. A "suggest" decision is a generic
+  /// tip, which the taxonomy files under Insight. Every upstream gate is pinned open
   /// (owner seeded, master on, frequency Maximum, not paywalled) and the surface is
   /// pinned to the deterministic banner path (bar enabled, previews muted), so the
-  /// Focus toggle is the only closed gate: removing the category guard from
+  /// Insight toggle is the only closed gate: removing the category guard from
   /// `presentContextDirectorNotification` makes this call return `.queued` from the
   /// banner path instead of `.suppressed`, failing the test.
   @MainActor
@@ -176,7 +177,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
       DefaultsKey.askOmiBarEnabled.rawValue,
     ]
     let savedValues = pinnedKeys.map { ($0, defaults.object(forKey: $0)) }
-    let savedFocusEnabled = SuggestionAssistantSettings.shared.isEnabled
+    let savedInsightEnabled = InsightAssistantSettings.shared.notificationsEnabled
     let savedPreviewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
     defer {
       for (key, value) in savedValues {
@@ -186,7 +187,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
           defaults.removeObject(forKey: key)
         }
       }
-      SuggestionAssistantSettings.shared.isEnabled = savedFocusEnabled
+      InsightAssistantSettings.shared.notificationsEnabled = savedInsightEnabled
       ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = savedPreviewsEnabled
     }
 
@@ -198,7 +199,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     defaults.set(false, forKey: DefaultsKey.desktopIsPaywalled.rawValue)
     defaults.set(true, forKey: DefaultsKey.askOmiBarEnabled.rawValue)
     ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = false
-    SuggestionAssistantSettings.shared.isEnabled = false
+    InsightAssistantSettings.shared.notificationsEnabled = false
     let liveOwner = try XCTUnwrap(RuntimeOwnerIdentity.currentOwnerId())
     XCTAssertEqual(liveOwner, owner)
 
@@ -220,7 +221,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
 
   /// The four category toggles bind every proactive producer at the shared
   /// `sendNotification` boundary — including the dedicated producers that never
-  /// consulted a toggle before generating: goals (Focus) and meeting action items
+  /// consulted a toggle before generating: goals (Insight) and meeting action items
   /// (Task). Same construction as the director test: every upstream gate is pinned
   /// open and the surface pinned to the banner path, so with the category gate
   /// removed these calls fall through to a delivery dispatch this bundle-less test
@@ -238,7 +239,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
       DefaultsKey.askOmiBarEnabled.rawValue,
     ]
     let savedValues = pinnedKeys.map { ($0, defaults.object(forKey: $0)) }
-    let savedFocusEnabled = SuggestionAssistantSettings.shared.isEnabled
+    let savedInsightEnabled = InsightAssistantSettings.shared.notificationsEnabled
     let savedTaskEnabled = TaskAssistantSettings.shared.notificationsEnabled
     let savedPreviewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
     defer {
@@ -249,7 +250,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
           defaults.removeObject(forKey: key)
         }
       }
-      SuggestionAssistantSettings.shared.isEnabled = savedFocusEnabled
+      InsightAssistantSettings.shared.notificationsEnabled = savedInsightEnabled
       TaskAssistantSettings.shared.notificationsEnabled = savedTaskEnabled
       ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = savedPreviewsEnabled
     }
@@ -262,7 +263,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     defaults.set(false, forKey: DefaultsKey.desktopIsPaywalled.rawValue)
     defaults.set(true, forKey: DefaultsKey.askOmiBarEnabled.rawValue)
     ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = false
-    SuggestionAssistantSettings.shared.isEnabled = false
+    InsightAssistantSettings.shared.notificationsEnabled = false
     TaskAssistantSettings.shared.notificationsEnabled = false
     let liveOwner = try XCTUnwrap(RuntimeOwnerIdentity.currentOwnerId())
     XCTAssertEqual(liveOwner, owner)

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -157,6 +157,67 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
       "muted in-bar preview must keep a banner surface so director delivery is visible")
   }
 
+  /// Behavioral guard for the four-type taxonomy: the director's real entry point must
+  /// refuse a delivery whose category toggle is off. Every upstream gate is pinned open
+  /// (owner seeded, master on, frequency Maximum, not paywalled) and the surface is
+  /// pinned to the deterministic banner path (bar enabled, previews muted), so the
+  /// Focus toggle is the only closed gate: removing the category guard from
+  /// `presentContextDirectorNotification` makes this call return `.queued` from the
+  /// banner path instead of `.suppressed`, failing the test.
+  @MainActor
+  func testDirectorDeliveryWithDisabledCategoryToggleIsSuppressedAtTheEntryPoint() throws {
+    let defaults = UserDefaults.standard
+    let pinnedKeys = [
+      DefaultsKey.authUserId.rawValue,
+      DefaultsKey.automationOwnerOverride.rawValue,
+      NotificationService.masterEnabledDefaultsKey,
+      NotificationService.frequencyDefaultsKey,
+      "desktop_isPaywalled",
+      "askOmiBarEnabled",
+    ]
+    let savedValues = pinnedKeys.map { ($0, defaults.object(forKey: $0)) }
+    let savedFocusEnabled = SuggestionAssistantSettings.shared.isEnabled
+    let savedPreviewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
+    defer {
+      for (key, value) in savedValues {
+        if let value {
+          defaults.set(value, forKey: key)
+        } else {
+          defaults.removeObject(forKey: key)
+        }
+      }
+      SuggestionAssistantSettings.shared.isEnabled = savedFocusEnabled
+      ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = savedPreviewsEnabled
+    }
+
+    let owner = "owner-category-gate-\(UUID().uuidString)"
+    defaults.set(owner, forKey: DefaultsKey.authUserId.rawValue)
+    defaults.removeObject(forKey: DefaultsKey.automationOwnerOverride.rawValue)
+    defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
+    defaults.set(false, forKey: "desktop_isPaywalled")
+    defaults.set(true, forKey: "askOmiBarEnabled")
+    ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = false
+    SuggestionAssistantSettings.shared.isEnabled = false
+    let liveOwner = try XCTUnwrap(RuntimeOwnerIdentity.currentOwnerId())
+    XCTAssertEqual(liveOwner, owner)
+
+    var droppedCount = 0
+    let service = NotificationService(registerWithSystemNotificationCenter: false)
+    let result = service.presentContextDirectorNotification(
+      ownerID: liveOwner,
+      title: "PR #11937 blocked",
+      message: "The merge is waiting on a re-run of the flaky suite.",
+      decisionType: "suggest",
+      context: FloatingBarNotificationContext(
+        sourceTitle: "Context director",
+        assistantId: "context-director"),
+      onDropped: { droppedCount += 1 })
+
+    XCTAssertEqual(result, .suppressed)
+    XCTAssertEqual(droppedCount, 1)
+  }
+
   @MainActor
   func testDirectorOwnerRefusalInvokesDroppedCallbackExactlyOnce() {
     var droppedCount = 0

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -218,6 +218,73 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     XCTAssertEqual(droppedCount, 1)
   }
 
+  /// The four category toggles bind every proactive producer at the shared
+  /// `sendNotification` boundary — including the dedicated producers that never
+  /// consulted a toggle before generating: goals (Focus) and meeting action items
+  /// (Task). Same construction as the director test: every upstream gate is pinned
+  /// open and the surface pinned to the banner path, so with the category gate
+  /// removed these calls fall through to a delivery dispatch this bundle-less test
+  /// host cannot perform, failing the test; with the gate present they return
+  /// before any surface and leave the presentation ledger untouched.
+  @MainActor
+  func testGoalAndMeetingProducersHonorTheirCategoryTogglesAtTheSharedBoundary() throws {
+    let defaults = UserDefaults.standard
+    let pinnedKeys = [
+      DefaultsKey.authUserId.rawValue,
+      DefaultsKey.automationOwnerOverride.rawValue,
+      NotificationService.masterEnabledDefaultsKey,
+      NotificationService.frequencyDefaultsKey,
+      "desktop_isPaywalled",
+      "askOmiBarEnabled",
+    ]
+    let savedValues = pinnedKeys.map { ($0, defaults.object(forKey: $0)) }
+    let savedFocusEnabled = SuggestionAssistantSettings.shared.isEnabled
+    let savedTaskEnabled = TaskAssistantSettings.shared.notificationsEnabled
+    let savedPreviewsEnabled = ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled
+    defer {
+      for (key, value) in savedValues {
+        if let value {
+          defaults.set(value, forKey: key)
+        } else {
+          defaults.removeObject(forKey: key)
+        }
+      }
+      SuggestionAssistantSettings.shared.isEnabled = savedFocusEnabled
+      TaskAssistantSettings.shared.notificationsEnabled = savedTaskEnabled
+      ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = savedPreviewsEnabled
+    }
+
+    let owner = "owner-producer-gate-\(UUID().uuidString)"
+    defaults.set(owner, forKey: DefaultsKey.authUserId.rawValue)
+    defaults.removeObject(forKey: DefaultsKey.automationOwnerOverride.rawValue)
+    defaults.set(true, forKey: NotificationService.masterEnabledDefaultsKey)
+    defaults.set(5, forKey: NotificationService.frequencyDefaultsKey)
+    defaults.set(false, forKey: "desktop_isPaywalled")
+    defaults.set(true, forKey: "askOmiBarEnabled")
+    ShortcutSettings.shared.floatingBarNotificationPreviewsEnabled = false
+    SuggestionAssistantSettings.shared.isEnabled = false
+    TaskAssistantSettings.shared.notificationsEnabled = false
+    let liveOwner = try XCTUnwrap(RuntimeOwnerIdentity.currentOwnerId())
+    XCTAssertEqual(liveOwner, owner)
+
+    let service = NotificationService(registerWithSystemNotificationCenter: false)
+    service.sendNotification(
+      ownerID: liveOwner,
+      title: "New Goal",
+      message: "Ship the four-type notification taxonomy",
+      assistantId: "goals")
+    service.sendNotification(
+      ownerID: liveOwner,
+      title: "Meeting notes ready",
+      message: "2 action items from standup",
+      assistantId: "meeting-notes",
+      deliveryMode: .systemBannerOnly)
+
+    XCTAssertNil(
+      service.lastProactivePresentationAtForCurrentOwner(),
+      "a category-suppressed delivery must never advance the proactive presentation ledger")
+  }
+
   @MainActor
   func testDirectorOwnerRefusalInvokesDroppedCallbackExactlyOnce() {
     var droppedCount = 0

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -341,7 +341,22 @@ final class ChatRowPresentationTests: XCTestCase {
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "memory-extraction"), .memory)
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "goals"), .goal)
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "meeting-notes"), .meetingNotes)
-    XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Meeting notes")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Task")
+  }
+
+  /// The user-facing taxonomy is exactly four proactive categories — Focus, Task,
+  /// Insight, Memory — matching the four toggles in Settings → Notifications. Every
+  /// internal kind must present as one of them; `.general` is reserved for functional
+  /// system alerts outside the taxonomy.
+  func testEveryProactiveKindPresentsAsOneOfTheFourCategories() {
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .suggestion).label, "Focus")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .goal).label, "Focus")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .task).label, "Task")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Task")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .insight).label, "Insight")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .resurface).label, "Insight")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .memory).label, "Memory")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .general).label, "Notification")
   }
 
   func testNotificationJournalTextPreservesTheHeadlineAndBody() {

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -345,16 +345,16 @@ final class ChatRowPresentationTests: XCTestCase {
   }
 
   /// The user-facing taxonomy is exactly four proactive categories — Focus, Task,
-  /// Insight, Memory — matching the four toggles in Settings → Notifications. Every
-  /// internal kind must present as one of them; `.general` is reserved for functional
-  /// system alerts outside the taxonomy.
+  /// Insight, Memory — matching the four toggles in Settings → Notifications. Focus is
+  /// the focus-nudge assistant alone; tips, resurfaced items, and generated goals are
+  /// insights. `.general` is reserved for functional system alerts outside the taxonomy.
   func testEveryProactiveKindPresentsAsOneOfTheFourCategories() {
     XCTAssertEqual(ProactiveNotificationBadge(kind: .suggestion).label, "Focus")
-    XCTAssertEqual(ProactiveNotificationBadge(kind: .goal).label, "Focus")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .task).label, "Task")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Task")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .insight).label, "Insight")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .resurface).label, "Insight")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .goal).label, "Insight")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .memory).label, "Memory")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .general).label, "Notification")
   }

--- a/desktop/macos/changelog/unreleased/20260820-four-notification-types.json
+++ b/desktop/macos/changelog/unreleased/20260820-four-notification-types.json
@@ -1,0 +1,3 @@
+{
+  "change": "Notifications now come in exactly four types — Focus, Task, Insight, Memory — each controlled by its own toggle in Settings (the toggle formerly called Live Suggestions is now Focus Notifications)"
+}


### PR DESCRIPTION
## What

Notifications now come in exactly four user-facing types — **Focus, Task, Insight, Memory** — matching the four toggles in Settings → Notifications, and every proactive notification presents under one of those four names.

- Settings row **"Live Suggestions" → "Focus Notifications"** (the Advanced pane already called this assistant "Focus Assistant"; the Notifications row was stale naming). Subtitle updated to say what it does: nudges to keep you on track.
- Suggestion cards in the notch are titled **"Focus"** instead of "Suggestion".
- Chat badge labels collapse to the four categories: **Focus** is the focus-nudge assistant alone; generic tips (director `suggest`), resurfaced items, and generated goals are **Insight**; meeting action items are **Task**. `.general` stays "Notification" for functional system alerts (screen-recording repair etc.), which sit outside the proactive taxonomy.
- Memory notifications drop the "Wisdom Captured" variant title — every memory notification is now "Memory Saved". That variant was exactly the kind of unclassifiable notification name this PR removes.
- **Every producer is now gated by its category's toggle.** Context-director decisions (`suggest`/`insight`/`task_candidate`/`resurface`) previously bypassed the per-type toggles entirely (master toggle + frequency only) — the source of "weird suggestions/tips" that matched no visible setting — and the dedicated `goals` / `meeting-notes` producers never consulted any toggle. `NotificationService.categoryToggleAllows` maps each internal kind to its owning toggle and is enforced at both delivery boundaries: `presentContextDirectorNotification` and the shared `sendNotification`. Functional alerts (`respectFrequency: false` → `.general`) stay ungated.

Internal `ProactiveNotificationKind` cases are unchanged (raw values are persisted in chat continuity keys); only the presentation labels and gating collapse to the four categories.

## Why

User report: the Notifications settings still called focus nudges "Live Suggestions", and notifications appeared under names ("Wisdom Captured", "Meeting notes", "Goal", free-form tips) that map to no setting. Product decision: exactly four notification types, named consistently, each controlled by its toggle.

## Test-expectation change

`HomeRedesignRegressionTests` badge-label assertions updated (`Meeting notes` → `Task`): the expected values changed by explicit product decision in this request (four-category taxonomy), not to make a failing test pass.

## Verification

- `xcrun swift test --package-path Desktop --filter "ContextDeliveryAuthorityTests|HomeRedesignRegressionTests"` — pass, including new `testEveryProactiveKindPresentsAsOneOfTheFourCategories` and `testDirectorDecisionsAreGatedByTheirCategoryToggle`.
- Built and launched a named dev bundle from this branch; exercised Settings → Notifications and saw the four rows (Focus / Task / Insight / Memory) live; triggered a suggestion-path test notification titled "Focus". Screenshot below.
- Behavioral entry-point tests, both mutation-verified locally (removing the guard makes them fail): `testDirectorDeliveryWithDisabledCategoryToggleIsSuppressedAtTheEntryPoint` (real `presentContextDirectorNotification`, only the Focus toggle closed → `.suppressed` + `onDropped` once) and `testGoalAndMeetingProducersHonorTheirCategoryTogglesAtTheSharedBoundary` (real `sendNotification` for `goals` and `meeting-notes` with their toggles off → no delivery, presentation ledger untouched).
- Live in the rebuilt bundle: with Focus off, `suggestion` and `goals` test notifications both log `suppressing … because its category toggle is off`; flipping Focus back on, the same trigger presents in the bar.
- UNVERIFIED: an organic (LLM-decided) context-director delivery suppressed by a disabled toggle; the entry-point behavior above is the same code path minus the model.

## Product invariants affected

- INV-CHAT-1 — path-glob match on `ChatBubbleSupport.swift` only. This PR changes the proactive badge's presentation labels; continuity keys, kinds' raw values, and the journal contract are untouched, so the invariant's behavior and guard tests are unchanged.

## Failure class

Failure-Class: none
