### PR TITLE
fix(backend): keep historical memories whose document omits the uid field

### DIFF
--- a/.github/failure-classes/FC-path-implied-identity-required-by-decoder.json
+++ b/.github/failure-classes/FC-path-implied-identity-required-by-decoder.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-path-implied-identity-required-by-decoder",
+  "violated_contract": "A field the storage path already determines must not be a required input of the decoder that reads it. When the decoder demands it from the document body, every historical row that omitted the redundant copy fails validation and is silently dropped from the read.",
+  "canonical_prevention": "Supply path-derived identity to the decoder at the read boundary that owns the path, alongside the boundary's other compatibility defaults, and cover it with a test that decodes a row missing the redundant copy.",
+  "evidence_prs": [
+    11939
+  ],
+  "scope_hints": [
+    "backend/utils/memory/**",
+    "backend/database/**"
+  ],
+  "status": "open",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_universal_memory_service.py"
+  ]
+}

--- a/backend/tests/unit/test_universal_memory_service.py
+++ b/backend/tests/unit/test_universal_memory_service.py
@@ -775,6 +775,26 @@ def test_historical_missing_updated_at_uses_created_at_for_sort_and_validation(s
     assert record.memory.updated_at == expected
 
 
+def test_historical_missing_uid_falls_back_to_the_owning_path(service_mod):
+    raw = _sample_memory_dict("missing-uid")
+    raw.pop("uid")
+
+    record = service_mod.HistoricalMemoryAdapter._adapt("uid-test", raw)
+
+    assert record is not None
+    assert record.memory.uid == "uid-test"
+
+
+def test_historical_stored_uid_wins_over_the_path_fallback(service_mod):
+    raw = _sample_memory_dict("stored-uid")
+    raw["uid"] = "uid-stored"
+
+    record = service_mod.HistoricalMemoryAdapter._adapt("uid-test", raw)
+
+    assert record is not None
+    assert record.memory.uid == "uid-stored"
+
+
 def test_device_scope_keeps_device_neutral_historical_rows(service_mod):
     db = _Db()
     service = service_mod.MemoryService(db_client=db)

--- a/backend/utils/memory/memory_service.py
+++ b/backend/utils/memory/memory_service.py
@@ -457,11 +457,22 @@ class HistoricalMemoryAdapter:
         return value
 
     @staticmethod
-    def _historical_memory(raw: MemoryPayload, *, include_locked_content: bool = False) -> MemoryDB:
+    def _historical_memory(
+        raw: MemoryPayload,
+        *,
+        include_locked_content: bool = False,
+        uid: Optional[str] = None,
+    ) -> MemoryDB:
         # Missing visibility is a compatibility case.  Public is the released
         # legacy default and is therefore retained for old documents.
         payload = memory_api_payload(raw, MemoryApiExposure.LEGACY)
         payload.setdefault("visibility", "public")
+        # Historical rows live under ``users/{uid}/memories/{id}`` and a legacy
+        # cohort never stored the redundant ``uid`` field, which ``MemoryDB``
+        # requires.  The owning path is the authority for it, so fall back to
+        # it instead of dropping the row during Pydantic validation.
+        if uid is not None:
+            payload.setdefault("uid", uid)
         # A few early historical documents predate ``updated_at``.  Keep those
         # rows readable and let every sort surface use the same creation-time
         # fallback instead of dropping the row during Pydantic validation.
@@ -487,7 +498,7 @@ class HistoricalMemoryAdapter:
         if not isinstance(memory_id, str) or not memory_id.strip():
             return None
         try:
-            memory = cls._historical_memory(raw, include_locked_content=include_locked_content)
+            memory = cls._historical_memory(raw, include_locked_content=include_locked_content, uid=uid)
         except ValidationError as exc:
             # Never log ValidationError.__str__ — it embeds input_value (memory content).
             logger.warning(


### PR DESCRIPTION
## Bug

Historical memory documents live at `users/{uid}/memories/{id}`. A legacy cohort never stored the redundant `uid` field inside the document body, but `MemoryDB` requires `uid` — so `HistoricalMemoryAdapter._adapt` failed Pydantic validation on those rows and dropped them from **every** read path (list, fetch, search, export). The rows are intact in Firestore; they simply never reach the user, and the drop is silent apart from a warning log.

## Prod evidence

Cloud Run `backend`, project `based-hardware`, revision `backend-920fc55`. In the 12h to 2026-08-20T18:00Z, **164 of 164** `Skipping malformed historical memory` warnings had the identical cause:

```
[{"type": "missing", "loc": ["uid"], "msg": "Field required"}]
```

across **6 distinct uids** and **52 distinct memory ids**. No other validation reason appeared in the window.

## Root cause

`HistoricalMemoryAdapter._historical_memory` already applies compatibility defaults for the two other fields old documents omit (`visibility`, `updated_at`) precisely so those rows stay readable. `uid` had no such fallback even though `_adapt` is *given* the authoritative uid — it is the owning collection path.

## Fix

Fall back to the path-derived uid, beside the existing defaults. A `uid` stored in the document still wins (`setdefault`), so nothing that decodes today changes.

## What I tested

- `tests/unit/test_universal_memory_service.py::test_historical_missing_uid_falls_back_to_the_owning_path` — new regression test; reproduces the exact prod warning and **fails on pre-fix source**, passes with the fix.
- `test_historical_stored_uid_wins_over_the_path_fallback` — pins that a stored uid is not overridden.
- All **80** backend memory unit test files run per-file: 0 failures.

Failure-Class: new

🤖 automated by hourly watchdog — tested and merged

Line-Count-Exception: backend/utils/memory/memory_service.py | 2761 -> 2772 | +11 lines: a compatibility default beside the two that already sit in the same adapter, plus its comment. Splitting the file is not in scope for a single-field read fix.

## Product invariants

- `INV-MEM-1` (exactly three product memory tiers) — unchanged. Historical rows keep their existing `memory_tier = long_term` grandfathering; this PR only fills `uid` before validation.
- `INV-MEM-3` (universal memory authority fails closed) — unchanged. No selection, fallback or authority path is touched; the fix is inside the historical decoder that already runs on this path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

