### PR TITLE
fix(desktop): project embedding into the compacted-winner CTE

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindDatabase+Embeddings.swift
@@ -67,7 +67,7 @@ extension RewindDatabase {
         db,
         sql: """
           WITH ranked AS (
-            SELECT id, ocrText, appName, windowTitle,
+            SELECT id, ocrText, appName, windowTitle, embedding,
                    ROW_NUMBER() OVER (
                      PARTITION BY appName, COALESCE(windowTitle, ''),
                                   CAST(strftime('%s', timestamp) AS INTEGER) / 300

--- a/desktop/macos/changelog/unreleased/20260820-compacted-embedding-backfill-query.json
+++ b/desktop/macos/changelog/unreleased/20260820-compacted-embedding-backfill-query.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the screenshot embedding backfill failing to find the entries it needed to re-index"
+}


### PR DESCRIPTION
## Problem

`getCompactedScreenshotsMissingEmbeddings` ranks compaction winners in a CTE that selects
`id, ocrText, appName, windowTitle`, then filters the outer query on `embedding IS NULL` — a column
the CTE never projects. SQLite answers `no such column: embedding`, so the query throws for every
caller and the compacted-embedding backfill it drives cannot run.

`ScreenshotEmbeddingBackfillRecoveryTests.testCompletedZeroProgressBackfillRearmsWhenCompactedWinnerIsMissing`
already covers this and has been failing on `main` since the query landed in 715a865e3d, which
blocks every desktop PR.

## Fix

Project `embedding` into the CTE so the outer filter has the column it reads.

## Verification

Controlled experiment in a worktree cut from `origin/main` whose only diff was this one line:

- fix reverted (pristine main code) → `Executed 1 test, with 1 failure`
- fix restored → `Executed 1 test, with 0 failures`

Reproduced independently in a second worktree before the fix existed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

