### PR TITLE
fix(macos): restore sizing guard after Chat-first navigation

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -484,11 +484,20 @@ struct DesktopHomeView: View {
 
   private func enforceMainWindowMinimumSize() {
     DispatchQueue.main.async {
-      // Appearance belongs to `WindowGlass.wear(_:as:)`; stamping one here unpinned the glass.
-      for window in NSApp.windows where window.title.lowercased().hasPrefix("omi") {
-        Self.pinShellWindowSizeLimits(window)
-        Self.disableMinSizeComputation(in: window)
-      }
+      Self.reassertMainWindowSizing(in: NSApp.windows)
+    }
+  }
+
+  /// Restores the AppKit-owned size contract after SwiftUI rebuilds a destination host.
+  ///
+  /// Chat-first navigation changes `ChatFirstShellNavigation.route`, not the legacy sidebar index.
+  /// Both paths must call this after a route change or the replacement hosting view resumes automatic
+  /// `minSize()` computation and every published state change traverses the full destination tree.
+  static func reassertMainWindowSizing(in windows: [NSWindow]) {
+    // Appearance belongs to `WindowGlass.wear(_:as:)`; stamping one here unpinned the glass.
+    for window in windows where window.title.lowercased().hasPrefix("omi") {
+      pinShellWindowSizeLimits(window)
+      disableMinSizeComputation(in: window)
     }
   }
 
@@ -1248,6 +1257,9 @@ struct DesktopHomeView: View {
         updateStoreActivity(for: newValue)
       }
       .onChange(of: chatFirstNavigation.route) { _, _ in
+        // Chat-first does not mutate `selectedIndex`, so the legacy navigation observer above cannot
+        // restore the NSHostingView sizing guard for this replacement destination.
+        enforceMainWindowMinimumSize()
         updateStoreActivityForCurrentShell()
         reportAutomationState()
       }

--- a/desktop/macos/Desktop/Tests/DesktopHomeWindowSizingTests.swift
+++ b/desktop/macos/Desktop/Tests/DesktopHomeWindowSizingTests.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import Omi_Computer
+
+final class DesktopHomeWindowSizingTests: XCTestCase {
+  @MainActor
+  func testReassertionDisablesAutomaticHostingSizeComputation() {
+    let host = NSHostingView(
+      rootView: Text("Settings").frame(minWidth: 900, minHeight: 600)
+    )
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+      styleMask: [.titled, .resizable],
+      backing: .buffered,
+      defer: false
+    )
+    window.title = "omi sizing regression"
+    window.contentView = host
+
+    XCTAssertNotEqual(host.sizingOptions, [])
+
+    DesktopHomeView.reassertMainWindowSizing(in: [window])
+
+    XCTAssertEqual(host.sizingOptions, [])
+    XCTAssertEqual(window.contentMinSize, DesktopWindowLayoutPolicy.minimumContentSize)
+    XCTAssertEqual(window.contentMaxSize.width, DesktopWindowLayoutPolicy.maximumContentWidth)
+  }
+
+  func testChatFirstRouteChangeReassertsWindowSizing() throws {
+    let testsURL = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    let sourceURL =
+      testsURL
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/MainWindow/DesktopHomeView.swift")
+    // omi-test-quality: source-inspection -- static contract: private SwiftUI route wiring has no runtime accessor; the AppKit effect is exercised above with a real NSWindow and NSHostingView.
+    let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+    let routeObserver = try XCTUnwrap(
+      source.range(of: ".onChange(of: chatFirstNavigation.route)"),
+      "Chat-first route changes need an explicit sizing reassertion hook"
+    )
+    let suffix = source[routeObserver.lowerBound...]
+    let observerEnd = suffix.range(of: "\n      }")?.upperBound ?? suffix.endIndex
+    XCTAssertTrue(
+      suffix[..<observerEnd].contains("enforceMainWindowMinimumSize()"),
+      "Chat-first navigation must restore the hosting-size guard just like legacy navigation"
+    )
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260820-chat-first-hidden-window-cpu.json
+++ b/desktop/macos/changelog/unreleased/20260820-chat-first-hidden-window-cpu.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed high CPU use after navigating through the Chat-first macOS interface or closing its window"
+}


### PR DESCRIPTION
## What changed and why

Reapply the AppKit-owned main-window sizing contract whenever `ChatFirstShellNavigation.route` changes. Chat-first navigation does not mutate the legacy `selectedIndex`, so a replacement hosting view could resume automatic `minSize()` / `sizeThatFits()` traversal and keep a hidden window consuming CPU.

## Product invariants affected

none

## How it was verified

- Reproduced on Omi 0.12.187: with the Settings window closed and capture idle, Omi used about 30–49% CPU; a 10-second process sample repeatedly entered `NSWindow.layoutIfNeeded`, `NSHostingView.layout`, and `NSHostingView.minSize`.
- `swift test --scratch-path /tmp/omi-ui-loop-build --filter DesktopHomeWindowSizingTests` — 2 tests passed, 0 failures.
- `python3 scripts/check_desktop_test_quality.py` — passed at the repository baseline.
- `./scripts/swift-format-wrapper.sh lint Desktop/Sources/MainWindow/DesktopHomeView.swift Desktop/Tests/DesktopHomeWindowSizingTests.swift` — passed with pinned swift-format 602.0.0.
- `git diff --check` — passed.
- Built, installed, and launched the isolated `/Applications/omi-ui-loop.app` bundle; production Omi was not modified or restarted.
- Limitation: the isolated bundle had no signed-in Omi Dev session, so the signed-in Chat-first route could not be exercised live without copying production credentials. The route hook is covered by a static wiring regression, and its AppKit effect is covered behaviorally using a real `NSWindow` and `NSHostingView`.

## Tests

`DesktopHomeWindowSizingTests` mounts a real hosting view in a real window and verifies that sizing reassertion clears automatic hosting size computation and restores the AppKit min/max policy. A companion regression pins the Chat-first route observer to that reassertion hook.

## Failure class (fixes)

Failure-Class: none

No existing registry class matches this missed Chat-first route reassertion. `FC-selection-overlay-layout-loop` covers transient selection-overlay state rebuilding selectable chat content and uses a different prevention primitive.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

