### PR TITLE
fix(desktop): stop a long PTT question from expiring its own screenshot

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+PushToTalk.swift
@@ -466,6 +466,8 @@ extension RealtimeHubController {
   /// pixels are captured only by the kernel-authorized screenshot tool; voice
   /// commits themselves never attach an ambient frame.
   func prepareAcceptedCommit(preservingContextPreparation: Bool = false) {
+    // PTT-up: the utterance is over, so the screen-evidence budget starts now.
+    screenEvidenceSpeechEndedAt = Date()
     let candidates = AssistantSettings.shared.voiceBaseLanguages
     if !preservingContextPreparation {
       turnPreparationTask?.cancel()

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController+ScreenEvidence.swift
@@ -58,6 +58,7 @@ extension RealtimeHubController {
     }
     // PTT-down capture is inert. A normal turn must never wait for a provider input
     // transcript; only a reducer-admitted screenshot request may seal provider output.
+    screenEvidenceSpeechEndedAt = nil
     screenGroundingState = .inactive
     screenFailurePresented = false
   }
@@ -135,7 +136,8 @@ extension RealtimeHubController {
       activeResponseID: voiceResponseID,
       currentTurnEpoch: realtimeToolTurnEpoch,
       enqueuedTurnEpoch: turnEpoch,
-      callID: callID)
+      callID: callID,
+      speechEndedAt: screenEvidenceSpeechEndedAt)
     switch receiptDecision {
     case .accepted(let receipt):
       screenGroundingState = .awaitingReport(receipt)

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift
@@ -78,6 +78,10 @@ final class RealtimeHubController: NSObject, RealtimeHubSessionDelegate {
   var sessionVoiceContextFreshnessIdentity = ""
   /// A PTT current-screen answer is grounded in exactly one pre-overlay, turn-scoped image.
   /// It is never ambient context and is released on terminal/cancel paths.
+  /// When the user stopped speaking for the current PTT turn. The screen-evidence freshness
+  /// budget runs from here rather than from capture, so a long question does not expire the
+  /// image before the model can ask for it.
+  var screenEvidenceSpeechEndedAt: Date?
   var screenEvidence: RealtimeScreenEvidence?
   var screenEvidenceReadiness: RealtimeScreenEvidenceReadiness?
   var screenGroundingState: RealtimeScreenGroundingState = .inactive

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeScreenEvidence.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeScreenEvidence.swift
@@ -118,13 +118,40 @@ struct RealtimeScreenEvidenceAttachment {
 enum RealtimeScreenEvidenceFreshnessPolicy {
   static let maximumAge: TimeInterval = 5
 
-  static func isFresh(_ descriptor: RealtimeScreenEvidenceDescriptor, now: Date) -> Bool {
-    let age = now.timeIntervalSince(descriptor.capturedAt)
+  /// The instant the budget starts counting from.
+  ///
+  /// The image is frozen at PTT-down, but the model cannot ask for it until the user stops
+  /// speaking — so measuring from capture spent the whole budget on the user's own sentence and
+  /// made screen grounding fail for any question longer than `maximumAge`. A held PTT key is not
+  /// screen drift: Omi's overlay is up and the user is talking, not switching applications.
+  /// The budget therefore covers provider latency after the utterance ends, which is the interval
+  /// during which the screen can actually change behind the frozen pixels.
+  static func referenceInstant(
+    _ descriptor: RealtimeScreenEvidenceDescriptor,
+    speechEndedAt: Date?
+  ) -> Date {
+    guard let speechEndedAt, speechEndedAt > descriptor.capturedAt else { return descriptor.capturedAt }
+    return speechEndedAt
+  }
+
+  static func isFresh(
+    _ descriptor: RealtimeScreenEvidenceDescriptor,
+    now: Date,
+    speechEndedAt: Date? = nil
+  ) -> Bool {
+    let age = now.timeIntervalSince(referenceInstant(descriptor, speechEndedAt: speechEndedAt))
     return age >= 0 && age < maximumAge
   }
 
-  static func remainingLifetime(_ descriptor: RealtimeScreenEvidenceDescriptor, now: Date) -> TimeInterval {
-    max(0, descriptor.capturedAt.addingTimeInterval(maximumAge).timeIntervalSince(now))
+  static func remainingLifetime(
+    _ descriptor: RealtimeScreenEvidenceDescriptor,
+    now: Date,
+    speechEndedAt: Date? = nil
+  ) -> TimeInterval {
+    max(
+      0,
+      referenceInstant(descriptor, speechEndedAt: speechEndedAt)
+        .addingTimeInterval(maximumAge).timeIntervalSince(now))
   }
 }
 
@@ -385,6 +412,7 @@ enum RealtimeScreenGroundingPolicy {
     currentTurnEpoch: Int,
     enqueuedTurnEpoch: Int,
     callID: String,
+    speechEndedAt: Date? = nil,
     now: Date = Date()
   ) -> RealtimeScreenTransportEnqueueDecision {
     guard enqueuedTurnEpoch == currentTurnEpoch,
@@ -397,7 +425,10 @@ enum RealtimeScreenGroundingPolicy {
         currentTurnEpoch: currentTurnEpoch,
         callID: callID)
     else { return .notAdmitted }
-    guard RealtimeScreenEvidenceFreshnessPolicy.isFresh(attachment.descriptor, now: now) else {
+    guard
+      RealtimeScreenEvidenceFreshnessPolicy.isFresh(
+        attachment.descriptor, now: now, speechEndedAt: speechEndedAt)
+    else {
       return .evidenceExpired(attachment.descriptor)
     }
     return .accepted(RealtimeScreenObservationReceipt(request: request, descriptor: attachment.descriptor))

--- a/desktop/macos/Desktop/Tests/RealtimeScreenEvidenceTests.swift
+++ b/desktop/macos/Desktop/Tests/RealtimeScreenEvidenceTests.swift
@@ -425,4 +425,54 @@ final class RealtimeScreenEvidenceTests: XCTestCase {
         activeTurnID: replacementTurn,
         invocationIsCurrent: false))
   }
+  // MARK: - The user's own speech must not expire the evidence
+
+  /// Reproduces the reported failure: a 6-second PTT question lost screen grounding while a
+  /// 4.5-second one kept it. The image is frozen at PTT-down, but the model cannot request it
+  /// until the user stops talking, so counting the utterance against a 5s budget made every
+  /// longer question ungrounded ("I couldn't verify the current screen").
+  func testALongSpokenQuestionDoesNotExpireThePTTScreenshot() {
+    let captured = evidence()
+    // PTT-down at t=1000, the user speaks for 6s, the model asks 0.5s after release.
+    let speechEndedAt = Date(timeIntervalSince1970: 1_006)
+    let modelAskedAt = Date(timeIntervalSince1970: 1_006.5)
+
+    XCTAssertFalse(
+      RealtimeScreenEvidenceFreshnessPolicy.isFresh(captured, now: modelAskedAt),
+      "precondition: measured from capture, a 6s question is already expired")
+    XCTAssertTrue(
+      RealtimeScreenEvidenceFreshnessPolicy.isFresh(
+        captured, now: modelAskedAt, speechEndedAt: speechEndedAt),
+      "the user's own speaking time must not consume the image's lifetime")
+  }
+
+  /// The budget still bounds real screen drift: time after the utterance ends is exactly the
+  /// window in which the user can switch apps behind the frozen pixels.
+  func testEvidenceStillExpiresWhenTheProviderIsSlowAfterTheUtterance() {
+    let captured = evidence()
+    let speechEndedAt = Date(timeIntervalSince1970: 1_006)
+
+    XCTAssertFalse(
+      RealtimeScreenEvidenceFreshnessPolicy.isFresh(
+        captured,
+        now: speechEndedAt.addingTimeInterval(RealtimeScreenEvidenceFreshnessPolicy.maximumAge + 0.1),
+        speechEndedAt: speechEndedAt))
+  }
+
+  /// A short question is unchanged: speech that ends before the capture instant (or a turn with
+  /// no recorded release) keeps the original capture-anchored budget.
+  func testShortQuestionAndMissingSpeechEndKeepCaptureAnchoredBudget() {
+    let captured = evidence()
+    let askedAt = Date(timeIntervalSince1970: 1_004.5)
+
+    XCTAssertTrue(RealtimeScreenEvidenceFreshnessPolicy.isFresh(captured, now: askedAt))
+    XCTAssertEqual(
+      RealtimeScreenEvidenceFreshnessPolicy.referenceInstant(captured, speechEndedAt: nil),
+      captured.capturedAt)
+    XCTAssertEqual(
+      RealtimeScreenEvidenceFreshnessPolicy.referenceInstant(
+        captured, speechEndedAt: Date(timeIntervalSince1970: 999)),
+      captured.capturedAt,
+      "a release stamp older than the capture must never shorten the budget")
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260820-ptt-screen-evidence-speech-window.json
+++ b/desktop/macos/changelog/unreleased/20260820-ptt-screen-evidence-speech-window.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed longer push-to-talk questions losing the screenshot Omi answers from, so it can still see your screen"
+}


### PR DESCRIPTION
## Problem

Screen evidence for a PTT turn is frozen at PTT-down and is valid for 5 seconds
(`RealtimeScreenEvidenceFreshnessPolicy.maximumAge`). The model cannot request that image until the
user stops speaking, so the budget runs during the utterance: any PTT question longer than about
five seconds loses screen grounding and falls back to "I couldn't verify the current screen."

Observed on Beta, same session, same user:

- 4.5s question — image enqueued 4.74s after capture, `report_accepted`
- 6.0s question (`floating_bar_ptt_started` 19:34:07 → `ptt_ended` 19:34:13) — rejected,
  `evidence_unavailable`, and the user got the canned failure line

An earlier turn failed the same way with `report_rejected_evidence_expired`. It reads as flaky, but
it is deterministic in the length of the question.

## Fix

Freshness is measured from the end of the utterance rather than from capture. That interval — after
the user stops talking — is the one in which the screen can actually change behind the frozen
pixels; a held PTT key is not screen drift, since Omi's overlay is up and the user is talking rather
than switching applications. A slow provider after the utterance still expires the evidence.


## Product invariants

- **INV-CHAT-1** — the diff touches floating-bar voice paths. Chat behaviour is unchanged: only the
  instant the screen-evidence freshness budget is measured from moved.
- **INV-VOICE-1** — the PTT turn lifecycle is untouched. Evidence is still captured once at PTT-down,
  still transmitted only through the screenshot tool, and an expired image still fails closed; the
  change is which instant starts its 5s budget.

## Verification

`swift test --filter RealtimeScreenEvidenceTests` → **26 pass**, including a regression that
reproduces both observed turns: it asserts the 6s question is already expired under the old
capture-anchored budget before asserting it survives under the new one, so the guard cannot rot into
a tautology. Short questions and a missing release stamp keep the original capture-anchored budget.

UNVERIFIED end-to-end: exercising this needs a real spoken 6-second question, which is the user's
own voice and hardware. The policy change is covered by test, not by a live PTT turn.

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/RealtimeHubController.swift | 1536 -> 1540 | the speech-end timestamp the freshness budget is measured from, plus the comment recording why capture time is the wrong anchor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

