### PR TITLE
feat(admin): release-cadence panels — latest release per platform + two-line release chart

### DIFF
--- a/web/admin/app/api/omi/stats/releases/route.ts
+++ b/web/admin/app/api/omi/stats/releases/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+import { posthogResults } from "@/lib/posthog";
+
+export const dynamic = "force-dynamic";
+
+const GITHUB_REPO = "BasedHardware/omi";
+const MACOS_TAG_SUFFIX = "-macos";
+const IOS_BUNDLE_ID = "com.friend-app-with-wearable.ios12";
+// TestFlight builds reach PostHog weeks before the App Store release; a
+// version counts as publicly released on the first day it has this many
+// distinct iOS users (public rollouts jump to thousands/day, betas stay low).
+const IOS_PUBLIC_DAILY_USERS = 200;
+
+type PlatformRelease = {
+  version: string | null;
+  date: string | null; // YYYY-MM-DD
+  daysSince: number | null;
+  display: string;
+};
+
+let cache: { data: any; days: number; timestamp: number } | null = null;
+const CACHE_TTL = 15 * 60 * 1000;
+
+function nycToday(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}
+
+function nycDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-CA", { timeZone: "America/New_York" });
+}
+
+function daysBetween(fromYmd: string, toYmd: string): number {
+  return Math.round(
+    (Date.parse(toYmd + "T00:00:00Z") - Date.parse(fromYmd + "T00:00:00Z")) / 86_400_000,
+  );
+}
+
+function shortDate(ymd: string): string {
+  return new Date(ymd + "T12:00:00Z").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function buildRelease(version: string | null, date: string | null): PlatformRelease {
+  if (!version || !date) {
+    return { version, date, daysSince: null, display: "no releases found" };
+  }
+  const daysSince = daysBetween(date, nycToday());
+  const ago = daysSince <= 0 ? "today" : daysSince === 1 ? "1d ago" : `${daysSince}d ago`;
+  return { version, date, daysSince, display: `${version} · ${shortDate(date)} (${ago})` };
+}
+
+async function fetchMacosReleases(days: number): Promise<{ dates: string[]; latest: PlatformRelease }> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const dates: string[] = [];
+  let latest: { version: string; date: string } | null = null;
+  const cutoff = Date.now() - days * 86_400_000;
+
+  for (let page = 1; page <= 3; page++) {
+    const res = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100&page=${page}`,
+      { headers, cache: "no-store" },
+    );
+    if (!res.ok) {
+      throw new Error(`GitHub releases fetch failed: ${res.status}`);
+    }
+    const releases: any[] = await res.json();
+    if (releases.length === 0) break;
+
+    let sawOlderThanWindow = false;
+    for (const release of releases) {
+      const tag: string = release.tag_name ?? "";
+      if (!tag.endsWith(MACOS_TAG_SUFFIX)) continue;
+      const createdAt: string = release.created_at ?? release.published_at;
+      if (!createdAt) continue;
+      if (!latest) {
+        const version = tag.replace(/^v/, "").replace(/\+.*$/, "").replace(MACOS_TAG_SUFFIX, "");
+        latest = { version, date: nycDate(createdAt) };
+      }
+      if (Date.parse(createdAt) < cutoff) {
+        sawOlderThanWindow = true;
+        continue;
+      }
+      dates.push(nycDate(createdAt));
+    }
+    if (sawOlderThanWindow) break;
+  }
+
+  return {
+    dates,
+    latest: buildRelease(latest?.version ?? null, latest?.date ?? null),
+  };
+}
+
+async function fetchIosReleases(days: number): Promise<{ dates: string[]; latest: PlatformRelease }> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const projectId = process.env.POSTHOG_PROJECT_ID;
+  const host = process.env.POSTHOG_HOST || "https://us.posthog.com";
+
+  // Latest release: the App Store itself (exact version + release date).
+  let latest: PlatformRelease;
+  try {
+    const res = await fetch(`https://itunes.apple.com/lookup?bundleId=${IOS_BUNDLE_ID}`, {
+      cache: "no-store",
+    });
+    const body = await res.json();
+    const app = body?.results?.[0];
+    latest = buildRelease(
+      app?.version ?? null,
+      app?.currentVersionReleaseDate ? nycDate(app.currentVersionReleaseDate) : null,
+    );
+  } catch {
+    latest = buildRelease(null, null);
+  }
+
+  // Release timeline: first day each version clears the public-rollout bar.
+  let dates: string[] = [];
+  if (apiKey && projectId) {
+    const rows = (await posthogResults(
+      host,
+      projectId,
+      apiKey,
+      `
+        SELECT v, min(d) AS release_day
+        FROM (
+          SELECT properties.$app_version AS v, toDate(timestamp) AS d,
+                 uniq(distinct_id) AS u
+          FROM events
+          WHERE event = 'Memory Created'
+            AND properties.$os_name = 'iOS'
+            AND timestamp >= now() - INTERVAL ${days + 14} DAY
+          GROUP BY v, d
+          HAVING u >= ${IOS_PUBLIC_DAILY_USERS}
+        )
+        GROUP BY v
+        ORDER BY release_day
+      `,
+    )) as [string, string][];
+    const cutoff = nycDate(new Date(Date.now() - days * 86_400_000).toISOString());
+    dates = rows.map(([, day]) => String(day).slice(0, 10)).filter((d) => d >= cutoff);
+  }
+
+  return { dates, latest };
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const days = Math.min(
+      parseInt(request.nextUrl.searchParams.get("days") || "30", 10),
+      90,
+    );
+
+    if (cache && cache.days === days && Date.now() - cache.timestamp < CACHE_TTL) {
+      return NextResponse.json(cache.data);
+    }
+
+    const [macos, ios] = await Promise.all([
+      fetchMacosReleases(days),
+      fetchIosReleases(days),
+    ]);
+
+    const perDay = new Map<string, { macos: number; ios: number }>();
+    const today = nycToday();
+    for (let i = days - 1; i >= 0; i--) {
+      const d = nycDate(new Date(Date.now() - i * 86_400_000).toISOString());
+      if (d <= today) perDay.set(d, { macos: 0, ios: 0 });
+    }
+    for (const d of macos.dates) {
+      const bucket = perDay.get(d);
+      if (bucket) bucket.macos += 1;
+    }
+    for (const d of ios.dates) {
+      const bucket = perDay.get(d);
+      if (bucket) bucket.ios += 1;
+    }
+
+    const data = {
+      days,
+      latest: { macos: macos.latest, ios: ios.latest },
+      daily: Array.from(perDay.entries()).map(([date, counts]) => ({ date, ...counts })),
+    };
+    cache = { data, days, timestamp: Date.now() };
+    return NextResponse.json(data);
+  } catch (error: any) {
+    console.error("Releases stats error:", error);
+    return NextResponse.json(
+      { error: error.message || "Failed to fetch release stats" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -247,6 +247,117 @@ def user_growth_series(panel, scope: str, field: str, series_name: str) -> None:
     panel["timeFrom"] = "30d"
 
 
+
+RELEASES_PATH = "/api/omi/stats/releases?days=30"
+RELEASES_CHART_TITLE = "Releases / day — macOS vs iOS"
+
+
+def releases_chart_panel(panel_id: int) -> dict:
+    """All-board timeline: one chart, two series — release cadence per
+    platform. A multi-day flat zero on either line is the alarm."""
+    return {
+        "id": panel_id,
+        "type": "timeseries",
+        "title": RELEASES_CHART_TITLE,
+        "description": "macOS: GitHub releases tagged -macos (candidates included). "
+                       "iOS: first day a version clears 200 daily App Store users "
+                       "(TestFlight noise excluded); latest verified against the "
+                       "App Store lookup API.",
+        "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "omi-admin-api"},
+        "gridPos": {"x": 0, "y": 14, "w": 24, "h": 6},
+        "timeFrom": "30d",
+        "fieldConfig": {
+            "defaults": {
+                "unit": "short",
+                "min": 0,
+                "color": {"mode": "palette-classic"},
+                "custom": {
+                    "drawStyle": "bars", "lineWidth": 1, "fillOpacity": 70,
+                    "showPoints": "always", "pointSize": 5, "barAlignment": 0,
+                    "stacking": {"mode": "none", "group": "A"},
+                    "axisPlacement": "auto", "gradientMode": "none",
+                    "spanNulls": False,
+                },
+            },
+            "overrides": [
+                {"matcher": {"id": "byName", "options": "macOS releases"},
+                 "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "#3b82f6"}}]},
+                {"matcher": {"id": "byName", "options": "iOS releases"},
+                 "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "#22c55e"}}]},
+            ],
+        },
+        "options": {
+            "legend": {"displayMode": "list", "placement": "bottom", "showLegend": True},
+            "tooltip": {"mode": "multi", "sort": "none"},
+        },
+        "targets": [{
+            "refId": "A",
+            "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "omi-admin-api"},
+            "type": "json", "source": "url", "parser": "backend", "format": "timeseries",
+            "url": f"{PROXY}{RELEASES_PATH}",
+            "url_options": {"method": "GET", "data": ""},
+            "root_selector": "daily",
+            "columns": [
+                {"selector": "date", "text": "time", "type": "timestamp",
+                 "timestampFormat": "2006-01-02"},
+                {"selector": "macos", "text": "macOS releases", "type": "number"},
+                {"selector": "ios", "text": "iOS releases", "type": "number"},
+            ],
+        }],
+    }
+
+
+def latest_release_stat(panel_id: int, scope: str) -> dict:
+    """Platform-board tile: latest release version + date, with days-since
+    colored green (fresh) → red (3+ days stale)."""
+    key = "macos" if scope == "macos" else "ios"
+    label = "macOS" if scope == "macos" else "Mobile"
+    return {
+        "id": panel_id,
+        "type": "stat",
+        "title": f"Latest {label} release",
+        "description": ("GitHub releases tagged -macos" if scope == "macos"
+                        else "App Store lookup (exact store release)"),
+        "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "omi-admin-api"},
+        "gridPos": {"x": 0, "y": 8, "w": 4, "h": 4},
+        "fieldConfig": {
+            "defaults": {
+                "unit": "short",
+                "thresholds": {"mode": "absolute", "steps": [
+                    {"color": "#22c55e", "value": None},
+                    {"color": "#f59e0b", "value": 2},
+                    {"color": "#ef4444", "value": 3},
+                ]},
+            },
+            "overrides": [{
+                "matcher": {"id": "byName", "options": "days ago"},
+                "properties": [{"id": "unit", "value": "d"}],
+            }],
+        },
+        "options": {
+            "reduceOptions": {"values": False, "calcs": ["lastNotNull"], "fields": ""},
+            "orientation": "horizontal",
+            "textMode": "value_and_name",
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "text": {"valueSize": 20, "titleSize": 11},
+        },
+        "targets": [{
+            "refId": "A",
+            "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "omi-admin-api"},
+            "type": "json", "source": "url", "parser": "backend", "format": "table",
+            "url": f"{PROXY}{RELEASES_PATH}",
+            "url_options": {"method": "GET", "data": ""},
+            "root_selector": f"latest.{key}",
+            "columns": [
+                {"selector": "display", "text": "release", "type": "string"},
+                {"selector": "daysSince", "text": "days ago", "type": "number"},
+            ],
+        }],
+    }
+
+
 def set_share_tile_description(dash, platform_label: str) -> None:
     """The share-rate proxy is platform-scoped per board; keep its description
     honest about which population the denominator counts."""
@@ -325,6 +436,10 @@ def build_platform_board(base, scope: str) -> dict:
     retarget_var(dash, "d_cum", path=viral_scoped, root="userGrowth", fields="users")
 
     set_share_tile_description(dash, label)
+    drop_panels(dash, {RELEASES_CHART_TITLE})
+    share_idx = next(i for i, p in enumerate(dash["panels"])
+                     if base_title(p).startswith("Share rate"))
+    dash["panels"].insert(share_idx + 1, latest_release_stat(990, scope))
 
     series_label = "Desktop" if scope == "macos" else "Mobile"
     for title, new_title, series in [
@@ -397,6 +512,8 @@ def build_platform_board(base, scope: str) -> dict:
 
 def main() -> None:
     base = json.loads(BASE_PATH.read_text(encoding="utf-8"))
+    if not any(base_title(p) == RELEASES_CHART_TITLE for p in base["panels"]):
+        base["panels"].append(releases_chart_panel(991))
     apply_tzdates(base)
     set_share_tile_description(base, "all platforms")
     apply_platform(base, "all")

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -567,6 +567,107 @@
       "type": "stat"
     },
     {
+      "id": 990,
+      "type": "stat",
+      "title": "Latest macOS release",
+      "description": "GitHub releases tagged -macos",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 4,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#22c55e",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 2
+              },
+              {
+                "color": "#ef4444",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "days ago"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "d"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {
+          "valueSize": 20,
+          "titleSize": 11
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "table",
+          "url": "http://127.0.0.1:8899/api/omi/stats/releases?days=30",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "latest.macos",
+          "columns": [
+            {
+              "selector": "display",
+              "text": "release",
+              "type": "string"
+            },
+            {
+              "selector": "daysSince",
+              "text": "days ago",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
@@ -613,7 +714,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 4,
         "y": 6,
         "w": 8,
         "h": 8
@@ -712,7 +813,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 12,
         "y": 6,
         "w": 8,
         "h": 8
@@ -787,8 +888,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 16,
-        "y": 6,
+        "x": 0,
+        "y": 14,
         "w": 8,
         "h": 8
       },
@@ -868,7 +969,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 14,
         "w": 3,
         "h": 4
@@ -942,7 +1043,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 3,
+        "x": 11,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1016,7 +1117,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 6,
+        "x": 14,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1090,7 +1191,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 9,
+        "x": 17,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1166,7 +1267,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 12,
+        "x": 20,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1241,8 +1342,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 15,
-        "y": 14,
+        "x": 0,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1317,8 +1418,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 18,
-        "y": 14,
+        "x": 3,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1392,8 +1493,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 21,
-        "y": 14,
+        "x": 6,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1467,8 +1568,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
-        "y": 18,
+        "x": 9,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1542,8 +1643,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 3,
-        "y": 18,
+        "x": 12,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1622,8 +1723,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 6,
-        "y": 18,
+        "x": 15,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1717,8 +1818,8 @@
         ]
       },
       "gridPos": {
-        "x": 9,
-        "y": 18,
+        "x": 0,
+        "y": 26,
         "w": 8,
         "h": 8
       },
@@ -1816,7 +1917,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 26,
         "w": 8,
         "h": 8
@@ -1961,7 +2062,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 26,
         "w": 8,
         "h": 8
@@ -2132,8 +2233,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 26,
+        "x": 0,
+        "y": 34,
         "w": 8,
         "h": 8
       },
@@ -2298,7 +2399,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 34,
         "w": 8,
         "h": 8
@@ -2383,7 +2484,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 34,
         "w": 8,
         "h": 8
@@ -2526,8 +2627,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 34,
+        "x": 0,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -2645,7 +2746,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 42,
         "w": 8,
         "h": 8
@@ -2806,7 +2907,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 42,
         "w": 8,
         "h": 8
@@ -2916,8 +3017,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 42,
+        "x": 0,
+        "y": 50,
         "w": 8,
         "h": 8
       },
@@ -2984,7 +3085,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 50,
         "w": 8,
         "h": 8
@@ -3065,7 +3166,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 50,
         "w": 8,
         "h": 8
@@ -3192,8 +3293,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 50,
+        "x": 0,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -3306,7 +3407,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 58,
         "w": 8,
         "h": 8
@@ -3420,7 +3521,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 58,
         "w": 8,
         "h": 8
@@ -3534,8 +3635,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 58,
+        "x": 0,
+        "y": 66,
         "w": 8,
         "h": 8
       },
@@ -3648,7 +3749,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 66,
         "w": 8,
         "h": 8

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -567,6 +567,107 @@
       "type": "stat"
     },
     {
+      "id": 990,
+      "type": "stat",
+      "title": "Latest Mobile release",
+      "description": "App Store lookup (exact store release)",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 4,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#22c55e",
+                "value": null
+              },
+              {
+                "color": "#f59e0b",
+                "value": 2
+              },
+              {
+                "color": "#ef4444",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "days ago"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "d"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "horizontal",
+        "textMode": "value_and_name",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {
+          "valueSize": 20,
+          "titleSize": 11
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "table",
+          "url": "http://127.0.0.1:8899/api/omi/stats/releases?days=30",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "latest.ios",
+          "columns": [
+            {
+              "selector": "display",
+              "text": "release",
+              "type": "string"
+            },
+            {
+              "selector": "daysSince",
+              "text": "days ago",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "omi-admin-api"
@@ -613,7 +714,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 4,
         "y": 6,
         "w": 8,
         "h": 8
@@ -712,7 +813,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 12,
         "y": 6,
         "w": 8,
         "h": 8
@@ -787,8 +888,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 16,
-        "y": 6,
+        "x": 0,
+        "y": 14,
         "w": 8,
         "h": 8
       },
@@ -868,7 +969,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 14,
         "w": 3,
         "h": 4
@@ -942,7 +1043,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 3,
+        "x": 11,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1016,7 +1117,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 6,
+        "x": 14,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1090,7 +1191,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 9,
+        "x": 17,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1166,7 +1267,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 12,
+        "x": 20,
         "y": 14,
         "w": 3,
         "h": 4
@@ -1241,8 +1342,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 15,
-        "y": 14,
+        "x": 0,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1317,8 +1418,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 18,
-        "y": 14,
+        "x": 3,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1392,8 +1493,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 21,
-        "y": 14,
+        "x": 6,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1467,8 +1568,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
-        "y": 18,
+        "x": 9,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1521,8 +1622,8 @@
       "type": "text",
       "title": "Crash-free rate (today)",
       "gridPos": {
-        "x": 3,
-        "y": 18,
+        "x": 12,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1558,8 +1659,8 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 6,
-        "y": 18,
+        "x": 15,
+        "y": 22,
         "w": 3,
         "h": 4
       },
@@ -1653,8 +1754,8 @@
         ]
       },
       "gridPos": {
-        "x": 9,
-        "y": 18,
+        "x": 0,
+        "y": 26,
         "w": 8,
         "h": 8
       },
@@ -1752,7 +1853,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 26,
         "w": 8,
         "h": 8
@@ -1897,7 +1998,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 26,
         "w": 8,
         "h": 8
@@ -2068,8 +2169,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 26,
+        "x": 0,
+        "y": 34,
         "w": 8,
         "h": 8
       },
@@ -2234,7 +2335,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 34,
         "w": 8,
         "h": 8
@@ -2320,7 +2421,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 34,
         "w": 8,
         "h": 8
@@ -2380,8 +2481,8 @@
       "type": "text",
       "title": "Floating bar sessions per user",
       "gridPos": {
-        "x": 16,
-        "y": 34,
+        "x": 0,
+        "y": 42,
         "w": 8,
         "h": 8
       },
@@ -2397,7 +2498,7 @@
       "type": "text",
       "title": "Floating bar queries",
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 42,
         "w": 8,
         "h": 8
@@ -2414,7 +2515,7 @@
       "type": "text",
       "title": "Floating bar notification CTR",
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 42,
         "w": 8,
         "h": 8
@@ -2431,8 +2532,8 @@
       "type": "text",
       "title": "Crash-free rate",
       "gridPos": {
-        "x": 16,
-        "y": 42,
+        "x": 0,
+        "y": 50,
         "w": 8,
         "h": 8
       },
@@ -2458,7 +2559,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 50,
         "w": 8,
         "h": 8
@@ -2539,7 +2640,7 @@
         "overrides": []
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 50,
         "w": 8,
         "h": 8
@@ -2666,8 +2767,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 50,
+        "x": 0,
+        "y": 58,
         "w": 8,
         "h": 8
       },
@@ -2780,7 +2881,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 58,
         "w": 8,
         "h": 8
@@ -2894,7 +2995,7 @@
         ]
       },
       "gridPos": {
-        "x": 8,
+        "x": 16,
         "y": 58,
         "w": 8,
         "h": 8
@@ -3008,8 +3109,8 @@
         ]
       },
       "gridPos": {
-        "x": 16,
-        "y": 58,
+        "x": 0,
+        "y": 66,
         "w": 8,
         "h": 8
       },
@@ -3122,7 +3223,7 @@
         ]
       },
       "gridPos": {
-        "x": 0,
+        "x": 8,
         "y": 66,
         "w": 8,
         "h": 8

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -5276,6 +5276,127 @@
       ],
       "title": "Infra cost by service \u2014 last 30 days",
       "type": "table"
+    },
+    {
+      "id": 991,
+      "type": "timeseries",
+      "title": "Releases / day \u2014 macOS vs iOS",
+      "description": "macOS: GitHub releases tagged -macos (candidates included). iOS: first day a version clears 200 daily App Store users (TestFlight noise excluded); latest verified against the App Store lookup API.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "omi-admin-api"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 24,
+        "h": 6
+      },
+      "timeFrom": "30d",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 70,
+            "showPoints": "always",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "gradientMode": "none",
+            "spanNulls": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "macOS releases"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#3b82f6"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iOS releases"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "#22c55e"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "omi-admin-api"
+          },
+          "type": "json",
+          "source": "url",
+          "parser": "backend",
+          "format": "timeseries",
+          "url": "http://127.0.0.1:8899/api/omi/stats/releases?days=30&_tzdates=date",
+          "url_options": {
+            "method": "GET",
+            "data": ""
+          },
+          "root_selector": "daily",
+          "columns": [
+            {
+              "selector": "date",
+              "text": "time",
+              "type": "timestamp",
+              "timestampFormat": "2006-01-02T15:04:05Z07:00"
+            },
+            {
+              "selector": "macos",
+              "text": "macOS releases",
+              "type": "number"
+            },
+            {
+              "selector": "ios",
+              "text": "iOS releases",
+              "type": "number"
+            }
+          ]
+        }
+      ]
     }
   ],
   "refresh": "1h",

--- a/web/admin/grafana/test_build_dashboards.py
+++ b/web/admin/grafana/test_build_dashboards.py
@@ -251,6 +251,28 @@ class AccountLevelLeakTests(unittest.TestCase):
                         "All board must keep the account-level panels")
 
 
+class ReleasePanelTests(unittest.TestCase):
+    def test_all_board_has_the_two_line_release_chart(self) -> None:
+        panel = next(p for p in load("omi-tv")["panels"]
+                     if build_dashboards.base_title(p) == build_dashboards.RELEASES_CHART_TITLE)
+        target = panel["targets"][0]
+        self.assertIn("/api/omi/stats/releases", target["url"])
+        self.assertIn("_tzdates=date", target["url"])
+        names = [c["text"] for c in target["columns"]]
+        self.assertEqual(names, ["time", "macOS releases", "iOS releases"])
+
+    def test_platform_boards_show_their_latest_release_stat(self) -> None:
+        for uid, root, absent in [("omi-tv-macos", "latest.macos", "latest.ios"),
+                                  ("omi-tv-mobile", "latest.ios", "latest.macos")]:
+            dash = load(uid)
+            titles = [build_dashboards.base_title(p) for p in dash["panels"]]
+            self.assertNotIn(build_dashboards.RELEASES_CHART_TITLE, titles, uid)
+            stat = next(p for p in dash["panels"]
+                        if build_dashboards.base_title(p).startswith("Latest"))
+            self.assertEqual(stat["targets"][0]["root_selector"], root, uid)
+            self.assertNotEqual(stat["targets"][0]["root_selector"], absent, uid)
+
+
 class ShareTileDescriptionTests(unittest.TestCase):
     def test_share_tile_description_names_its_board_scope(self) -> None:
         for uid, label in [("omi-tv", "all platforms"), ("omi-tv-macos", "macOS"),


### PR DESCRIPTION
## Summary
Release-cadence visibility (a 3-day macOS release gap went unnoticed):
- New `/api/omi/stats/releases?days=N`: macOS releases from GitHub (`-macos` tags, exact dates), iOS latest from the App Store lookup API, iOS timeline from the first day a version clears 200 daily users in PostHog (TestFlight builds appear weeks early at low volume; the crossing date matches the App Store date exactly — 1.0.548 → Aug 19).
- All board: one chart, two series — macOS and iOS releases per day (a multi-day flat zero is the alarm).
- macOS / Mobile boards: "Latest release" stat — version · date · days-ago, colored green ≤1d / amber 2d / red ≥3d.

## Verification
Local next dev + proxy: route returns macOS `0.12.188 · Aug 17 (3d ago)` (matches `gh release list` exactly, and shows the reported gap: 5 releases/day on Aug 16–17, zero since) and iOS `1.0.548 · Aug 19 (1d ago)` (matches the App Store). Builder tests 20/20 (incl. new release-panel contract: chart on All only, per-platform roots on the stats), deploy-scope 16/16, tsc clean. Live board verification on prod after deploy (local Grafana visual pass was flaky against the dev server; data + board JSON verified via API).

## Product invariants affected
none

## Failure class
No fix: commits.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

