### PR TITLE
test(backend): derive test-isolation stub membership instead of hand-listing it

### DIFF
--- a/.github/failure-classes/FC-hand-listed-test-isolation-membership.json
+++ b/.github/failure-classes/FC-hand-listed-test-isolation-membership.json
@@ -5,14 +5,19 @@
   "canonical_prevention": "Derive the isolation cluster from the source signal (here: a test file's use of RuntimeOwnerAuthorityTestFixture, which transitions the process-global owner authority through the standard UserDefaults domain) and union it with any explicit list, so omission is not an opt-out. Prove the derivation in the runner's hermetic self-test with an adopter suite that is deliberately absent from the explicit list.",
   "canonical_prevention_artifact": [
     "desktop/macos/scripts/swift-test-suites.sh",
-    "desktop/macos/tests/test-swift-test-suites.sh"
+    "desktop/macos/tests/test-swift-test-suites.sh",
+    "backend/testing/import_isolation.py",
+    "backend/tests/unit/test_import_isolation.py"
   ],
   "evidence_prs": [
-    9597
+    9597,
+    11888
   ],
   "scope_hints": [
     "desktop/macos/scripts/swift-test-suites.sh",
-    "desktop/macos/tests/**"
+    "desktop/macos/tests/**",
+    "backend/testing/import_isolation.py",
+    "backend/tests/**"
   ],
   "status": "open"
 }

--- a/backend/testing/import_isolation.py
+++ b/backend/testing/import_isolation.py
@@ -33,8 +33,9 @@ from __future__ import annotations
 
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from types import ModuleType
-from typing import Iterator
+from typing import Iterable, Iterator
 from unittest.mock import MagicMock
 
 
@@ -258,4 +259,131 @@ def fake_firestore_transactional(func):
     return wrapper
 
 
-__all__ = ["AutoMockModule", "stub_modules", "load_module_fresh", "fake_firestore_transactional"]
+def _dotted_parts(package: str) -> list[str]:
+    """Split a dotted package name, rejecting path-escape and non-identifier segments."""
+
+    parts = package.split(".")
+    if not parts or any(not part.isidentifier() for part in parts):
+        raise LookupError(f"package_submodule_stubs: {package!r} is not a dotted package name")
+    return parts
+
+
+def _package_directory(package: str) -> Path:
+    """Resolve a dotted package to its directory on disk, ignoring ``sys.modules``.
+
+    Deliberately does NOT use ``importlib.util.find_spec``: inside a ``stub_modules``
+    block the package may already be a stub whose ``__spec__`` is ``None``, so spec
+    lookup would report the fake instead of the real tree. This file lives at
+    ``backend/testing/import_isolation.py``, so ``parent.parent`` is the backend root
+    and joining the dotted name is the honest source — independent of cwd and of
+    whatever is currently in ``sys.modules``.
+    """
+
+    backend_root = Path(__file__).resolve().parent.parent
+    return backend_root.joinpath(*_dotted_parts(package))
+
+
+def _skip_directory_entry(name: str) -> bool:
+    """Skip hidden and dunder entries; keep ``_``-prefixed modules.
+
+    A router can ``from pkg._private import X``. Treating an underscore as an opt-out
+    would recreate the hand-list failure for those modules. ``__init__.py`` and
+    ``__pycache__`` still drop out because they start with ``__``.
+    """
+
+    return name.startswith(".") or name.startswith("__")
+
+
+def _enumerate_submodules(package: str, directory: Path) -> dict[str, bool]:
+    """Map dotted child names to ``is_package``, walking nested packages.
+
+    Sub-packages are included so a later ``from pkg.child.leaf import X`` can resolve
+    against stubs in ``sys.modules``. They must present as packages (empty ``__path__``)
+    *and* have their children stubbed: empty ``__path__`` prevents the import system
+    from loading the real nested module off disk.
+    """
+
+    found: dict[str, bool] = {}
+    for entry in sorted(directory.iterdir(), key=lambda path: path.name):
+        if _skip_directory_entry(entry.name):
+            continue
+        if entry.is_dir():
+            child = f"{package}.{entry.name}"
+            nested = _enumerate_submodules(child, entry)
+            if nested or (entry / "__init__.py").is_file():
+                found[child] = True
+                found.update(nested)
+        elif entry.is_file() and entry.suffix == ".py":
+            found[f"{package}.{entry.stem}"] = False
+    return found
+
+
+def package_submodule_stubs(
+    package: str,
+    *,
+    extra: Iterable[str] = (),
+    include_package: bool = True,
+    directory: Path | None = None,
+) -> dict[str, ModuleType]:
+    """Derive a stub set from a package's real submodules instead of hand-listing them.
+
+    WHY this exists: a hand-maintained list of module names drifts silently. The next
+    module added to the package is absent from the list, and every suite that stubs
+    that package fails at *collection* with ``ModuleNotFoundError`` — which reads as a
+    product bug rather than a stale fixture, and which the module's author discovers in
+    CI rather than the fixture's owner discovering it locally. This is
+    ``FC-hand-listed-test-isolation-membership`` in the backend.
+
+    The membership is derived from the source signal — what actually sits in the
+    package directory — and then unioned with ``extra``, so naming something
+    explicitly is still allowed but omitting it is not an opt-out.
+
+    Submodules are enumerated from disk and never imported, so no package side effect
+    runs. Sub-packages are stubbed with an empty ``__path__`` so they present as
+    packages and can themselves parent further stubs, without the import system
+    searching the real tree.
+
+    ``directory`` overrides the on-disk location (tests); the dotted ``package`` is
+    still the stub identity. The default resolves under the backend root without
+    consulting ``sys.modules``.
+
+    Example::
+
+        fakes = package_submodule_stubs("utils.conversations")
+        with stub_modules(fakes):
+            from routers.conversations import router
+    """
+
+    _dotted_parts(package)
+    package_dir = directory if directory is not None else _package_directory(package)
+    if not package_dir.is_dir():
+        raise LookupError(f"package_submodule_stubs: {package!r} is not a package directory ({package_dir})")
+
+    stubs: dict[str, ModuleType] = {}
+
+    def _stub(name: str, *, is_package: bool) -> ModuleType:
+        module = AutoMockModule(name)
+        if is_package:
+            module.__path__ = []  # type: ignore[attr-defined]
+        return module
+
+    if include_package:
+        stubs[package] = _stub(package, is_package=True)
+
+    for name, is_package in _enumerate_submodules(package, package_dir).items():
+        stubs[name] = _stub(name, is_package=is_package)
+
+    for name in extra:
+        if name not in stubs:
+            stubs[name] = _stub(name, is_package=False)
+
+    return stubs
+
+
+__all__ = [
+    "AutoMockModule",
+    "stub_modules",
+    "load_module_fresh",
+    "fake_firestore_transactional",
+    "package_submodule_stubs",
+]

--- a/backend/tests/unit/test_conversation_events_bounds.py
+++ b/backend/tests/unit/test_conversation_events_bounds.py
@@ -33,7 +33,12 @@ import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
-from testing.import_isolation import AutoMockModule, load_module_fresh, stub_modules
+from testing.import_isolation import (
+    AutoMockModule,
+    load_module_fresh,
+    package_submodule_stubs,
+    stub_modules,
+)
 
 _BACKEND = Path(__file__).resolve().parents[2]
 
@@ -142,7 +147,6 @@ def router():
         "database.webhook_health": _pkg("database.webhook_health"),
         "database.mem_db": _pkg("database.mem_db"),
         "utils.apps": _pkg("utils.apps"),
-        "utils.conversations.merge_conversations": _pkg("utils.conversations.merge_conversations"),
         "database.users": _pkg("database.users"),
         "database.vector_db": _pkg("database.vector_db"),
         # firebase
@@ -160,16 +164,9 @@ def router():
         "utils.other": _pkg("utils.other"),
         "utils.other.endpoints": endpoints,
         "utils.other.storage": _pkg("utils.other.storage"),
-        "utils.conversations": _pkg("utils.conversations"),
-        "utils.conversations.factory": _pkg("utils.conversations.factory"),
-        "utils.conversations.render": _pkg("utils.conversations.render"),
-        "utils.conversations.process_conversation": _pkg("utils.conversations.process_conversation"),
-        "utils.conversations.meeting_receipt": _pkg("utils.conversations.meeting_receipt"),
-        "utils.conversations.search": _pkg("utils.conversations.search"),
-        "utils.conversations.calendar_linking": _pkg("utils.conversations.calendar_linking"),
-        "utils.conversations.calendar_utils": _pkg("utils.conversations.calendar_utils"),
-        "utils.conversations.location": _pkg("utils.conversations.location"),
-        "utils.conversations.analytics": _pkg("utils.conversations.analytics"),
+        # utils.conversations.* is DERIVED, not listed: a new module in that package
+        # must not break this suite at collection. See package_submodule_stubs.
+        **package_submodule_stubs("utils.conversations"),
         "utils.llm": _pkg("utils.llm"),
         "utils.llm.conversation_processing": _pkg("utils.llm.conversation_processing"),
         "utils.speaker_identification": _pkg("utils.speaker_identification"),

--- a/backend/tests/unit/test_conversation_search_date_validation.py
+++ b/backend/tests/unit/test_conversation_search_date_validation.py
@@ -35,6 +35,8 @@ class _AutoMockModule(ModuleType):
         return mock
 
 
+from testing.import_isolation import package_submodule_stubs
+
 _stubs = [
     'ulid',
     'pinecone',
@@ -56,15 +58,10 @@ _stubs = [
     'utils.request_validation',
     'utils.other.endpoints',
     'utils.other.storage',
-    'utils.conversations.factory',
-    'utils.conversations.analytics',
-    'utils.conversations.render',
-    'utils.conversations.process_conversation',
-    'utils.conversations.meeting_receipt',
-    'utils.conversations.search',
-    'utils.conversations.calendar_linking',
-    'utils.conversations.calendar_utils',
-    'utils.conversations.location',
+    # Names only: this file's _AutoMockModule/_register_module wrap them. Parents
+    # (including utils.conversations) are created by _register_module, so the
+    # package itself is omitted here. See package_submodule_stubs.
+    *sorted(package_submodule_stubs('utils.conversations', include_package=False)),
     'utils.executors',
     'utils.product_telemetry',
     'utils.llm.conversation_processing',

--- a/backend/tests/unit/test_import_isolation.py
+++ b/backend/tests/unit/test_import_isolation.py
@@ -6,7 +6,12 @@ from types import ModuleType
 
 import pytest
 
-from testing.import_isolation import load_module_fresh, stub_modules
+from testing.import_isolation import (
+    AutoMockModule,
+    load_module_fresh,
+    package_submodule_stubs,
+    stub_modules,
+)
 
 
 def test_stub_modules_restores_child_attribute_when_child_is_stubbed_before_parent(monkeypatch):
@@ -61,3 +66,110 @@ def test_atom_keyword_index_import_does_not_require_typesense_submodules(
     atom_keyword_index_with_top_level_typesense_only,
 ):
     assert callable(atom_keyword_index_with_top_level_typesense_only.is_indexable_long_term_atom)
+
+
+def _write_pkg(root: Path, relative: str, content: str = "") -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_package_submodule_stubs_covers_a_module_absent_from_extra(tmp_path: Path):
+    """The derivation must cover a module that extra does not name.
+
+    FC-hand-listed-test-isolation-membership: proving the helper against a name that
+    extra already includes would prove nothing. A synthetic on-disk adopter that is
+    deliberately absent from extra is the omission a hand-maintained list cannot
+    survive, and it cannot go vacuous as other test files start mentioning modules.
+    """
+
+    pkg = tmp_path / "pkg"
+    _write_pkg(pkg, "listed.py")
+    _write_pkg(pkg, "unlisted_adopter.py")
+
+    stubs = package_submodule_stubs(
+        "synthetic.pkg",
+        extra=["synthetic.pkg.listed"],
+        directory=pkg,
+    )
+
+    assert "synthetic.pkg.unlisted_adopter" in stubs
+    assert "synthetic.pkg.listed" in stubs
+
+
+def test_package_submodule_stubs_includes_private_and_nested_modules(tmp_path: Path):
+    pkg = tmp_path / "pkg"
+    _write_pkg(pkg, "_private.py")
+    _write_pkg(pkg, "visible.py")
+    _write_pkg(pkg, "nested/__init__.py")
+    _write_pkg(pkg, "nested/leaf.py")
+    _write_pkg(pkg, "__init__.py")
+    (pkg / ".hidden.py").write_text("", encoding="utf-8")
+    (pkg / "notes.md").write_text("", encoding="utf-8")
+
+    stubs = package_submodule_stubs("synthetic.pkg", directory=pkg)
+
+    assert "synthetic.pkg._private" in stubs
+    assert "synthetic.pkg.visible" in stubs
+    assert "synthetic.pkg.nested" in stubs
+    assert "synthetic.pkg.nested.leaf" in stubs
+    assert hasattr(stubs["synthetic.pkg.nested"], "__path__")
+    assert not hasattr(stubs["synthetic.pkg.visible"], "__path__")
+    assert "synthetic.pkg.__init__" not in stubs
+    assert "synthetic.pkg.notes" not in stubs
+    assert not any(".hidden" in name for name in stubs)
+    assert "synthetic.pkg.__pycache__" not in stubs
+
+
+def test_package_submodule_stubs_unions_extra_without_letting_omission_opt_out():
+    stubs = package_submodule_stubs("utils.conversations", extra=["utils.conversations.not_on_disk"])
+
+    assert "utils.conversations" in stubs
+    assert hasattr(stubs["utils.conversations"], "__path__")
+    assert "utils.conversations.process_conversation" in stubs
+    assert "utils.conversations.not_on_disk" in stubs
+
+
+def test_package_submodule_stubs_covers_every_conversations_module_on_disk():
+    """Independent glob of the incident package; extra cannot replace disk membership."""
+
+    package_dir = Path(__file__).resolve().parents[2] / "utils" / "conversations"
+    on_disk = {
+        f"utils.conversations.{path.stem}" for path in package_dir.glob("*.py") if not path.name.startswith("__")
+    }
+    assert on_disk, "utils.conversations must still contain modules"
+    assert "utils.conversations.meeting_receipt" in on_disk
+
+    stubs = package_submodule_stubs("utils.conversations", extra=["utils.conversations.not_on_disk"])
+    missing = sorted(on_disk - set(stubs))
+    assert missing == []
+    assert "utils.conversations.not_on_disk" in stubs
+
+
+def test_package_submodule_stubs_resolves_from_disk_even_when_package_is_already_stubbed():
+    """Spec lookup would report the fake; the filesystem is the honest source."""
+
+    with stub_modules({"utils.conversations": AutoMockModule("utils.conversations")}):
+        stubs = package_submodule_stubs("utils.conversations")
+
+    assert "utils.conversations.process_conversation" in stubs
+
+
+def test_package_submodule_stubs_rejects_a_non_package():
+    with pytest.raises(LookupError):
+        package_submodule_stubs("utils.conversations.process_conversation")
+
+
+def test_package_submodule_stubs_rejects_a_path_escape_name():
+    with pytest.raises(LookupError):
+        package_submodule_stubs("..")
+
+
+def test_package_submodule_stubs_can_omit_the_package_key(tmp_path: Path):
+    """Legacy name-list adopters only need child names; parents are synthesized."""
+
+    pkg = tmp_path / "pkg"
+    _write_pkg(pkg, "child.py")
+    stubs = package_submodule_stubs("synthetic.pkg", include_package=False, directory=pkg)
+    assert "synthetic.pkg" not in stubs
+    assert list(stubs) == ["synthetic.pkg.child"]


### PR DESCRIPTION
## The drift

33 backend test files stub `utils.conversations.*` using hand-maintained lists of module names. That package holds 25 submodules; each file names only the few it happens to need.

[#11888](https://github.com/BasedHardware/omi/pull/11888) added `utils/conversations/meeting_receipt.py` and imported it from `routers/conversations.py`. Two of those suites failed in CI at **collection**:

```
ModuleNotFoundError: No module named 'utils.conversations.meeting_receipt'
```

That reads as a product bug rather than a stale fixture, and the module's author hits it in CI rather than the fixture's owner hitting it locally.

`FC-hand-listed-test-isolation-membership` already describes this exactly, and prescribes the cure: derive membership from the source signal, union it with the explicit list so omission is not an opt-out, and prove the derivation with an adopter deliberately absent from that list. Its `canonical_prevention_artifact` named only the Swift runner — the backend carried the same class with no guard. This adds one, and updates the class record to name it.

## The guard

`package_submodule_stubs(package, *, extra=(), include_package=True)` enumerates a package's real submodules from disk — never importing them, so no package side effect runs — and unions `extra`.

It resolves the directory relative to the backend root rather than through `importlib.util.find_spec`, because inside a `stub_modules` block the package is already a stub whose `__spec__` is `None`, so spec lookup would report the fake.

Three properties matter, and each has a test:

- **Private modules are included.** A router can `from pkg._private import X`; skipping `_`-prefixed names would reproduce the same omission bug.
- **Enumeration recurses.** A stubbed sub-package carries an empty `__path__`, which would otherwise block `from pkg.child.leaf import X` from resolving against the real tree.
- **A package is detected by containing modules, not by `__init__.py`.** `utils/conversations/` is a namespace package with no `__init__.py`; requiring that file would miss the very package in the incident.

## Verification

Added a module to `utils/conversations/`, imported it from the router with a dotted import, and ran the two suites:

| | result |
| --- | --- |
| before (hand-listed fixtures) | **10 errors** — `ModuleNotFoundError` |
| after (derived) | **10 passed** |

Repeated for a `_`-prefixed module and a nested sub-package leaf: both covered.

The import **form** matters and is worth knowing for anyone testing this: `from pkg import new` resolves through the stubbed parent's `__getattr__` and does *not* reproduce the failure. Only a dotted `from pkg.new import X` does.

43 tests pass across the three touched suites.

## Scope

Two suites adopt the helper — the two that actually broke. The remaining ~31 hand-listed suites are untouched; migrating them is a mechanical sweep with real regression risk and belongs in its own change. No production code is modified.

Failure-Class: FC-hand-listed-test-isolation-membership


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

