### PR TITLE
fix(desktop): stop the Add Memory Save button painting white on white

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1695,6 +1695,22 @@ class MemoriesViewModel: ObservableObject {
     guard !didRegisterAutomationActions else { return }
     didRegisterAutomationActions = true
     let registry = DesktopAutomationActionRegistry.shared
+    // The Add Memory sheet's Save button is only reachable by clicking, and cursor
+    // synthesis is barred, so its filled and empty states were unverifiable outside
+    // production. This presents the real sheet with the real draft text.
+    registry.register(
+      name: "memories_open_add_sheet",
+      summary: "Present the Add Memory sheet, optionally pre-filled with draft text",
+      params: ["text"]
+    ) { [weak self] params in
+      guard let self else { return ["error": "memories view model deallocated"] }
+      self.newMemoryText = params["text"] ?? ""
+      self.showingAddMemory = true
+      return [
+        "presented": "true",
+        "draft_is_empty": self.newMemoryText.isEmpty ? "true" : "false",
+      ]
+    }
     registry.register(
       name: "memories_search",
       summary: "Set memories search query and return filtered result count",

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryEditorSheets.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/MemoryEditorSheets.swift
@@ -64,7 +64,10 @@ struct AddMemorySheet: View {
             .padding(.horizontal, OmiSpacing.xl)
             .padding(.vertical, OmiSpacing.sm)
             .background(
-              viewModel.newMemoryText.isEmpty ? Ink.rowFillHover : Ink.surface
+              // Ink.surface is this label's own colour, so filling with it painted white on
+              // white and the button read as blank the moment the field had text. The edit
+              // sheet's identical button already fills with Ink.primary.
+              viewModel.newMemoryText.isEmpty ? Ink.rowFillHover : Ink.primary
             )
             .cornerRadius(OmiChrome.elementRadius)
             .overlay(

--- a/desktop/macos/changelog/unreleased/20260820-add-memory-save-button.json
+++ b/desktop/macos/changelog/unreleased/20260820-add-memory-save-button.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the Save button turning blank in the Add Memory dialog as soon as you typed"
+}


### PR DESCRIPTION
## Problem

In the Add Memory sheet the Save button goes blank the moment the field has text — a white rectangle
with no visible label.

`AddMemorySheet` fills the button with `Ink.surface` while its label is *also* `Ink.surface`, so a
non-empty draft paints white text on a white background. The empty state was never affected
(`Ink.secondary` on `Ink.rowFillHover`), which is why the button only breaks once you start typing.

`EditMemorySheet`'s identical button already fills with `Ink.primary`. The two sheets are the same
form twice, and one of the copies had the wrong fill.

## Fix

Fill with `Ink.primary`, matching the edit sheet.

Also adds `memories_open_add_sheet` to the non-production automation bridge. The sheet was reachable
only by clicking, and cursor synthesis is barred here, so neither state of this button was
verifiable outside production — which is how a blank primary button shipped.

## Product invariants

- INV-UI-1 — no purple introduced; the fill is the existing neutral `Ink.primary` already used by
  the edit sheet's Save button.

## Verification

Built and ran the `omi-savebtn` bundle, opened the real sheet through the bridge, and captured both
states:

- draft `fdgdfgdfg` → **"Save" renders white on the dark fill** (the reported case)
- empty draft → dimmed, disabled, unchanged from before

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift | 3468 -> 3484 | memories_open_add_sheet, the bridge seam that makes the Add Memory sheet's button states verifiable without synthesising cursor input


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

