### PR TITLE
fix(backend): window the chat-first materialization health scan

### DIFF
--- a/.github/failure-classes/FC-recurring-check-scans-unbounded-history.json
+++ b/.github/failure-classes/FC-recurring-check-scans-unbounded-history.json
@@ -7,7 +7,7 @@
     "backend/tests/unit/test_chat_first_materialization_drop_rate.py"
   ],
   "evidence_prs": [
-    11945
+    11949
   ],
   "scope_hints": [
     "backend/utils/task_intelligence/**",

--- a/.github/failure-classes/FC-recurring-check-scans-unbounded-history.json
+++ b/.github/failure-classes/FC-recurring-check-scans-unbounded-history.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "id": "FC-recurring-check-scans-unbounded-history",
+  "violated_contract": "A recurring health check that aggregates over a collection nothing ever deletes must window its scan to a recent period, not just bound the stale end with an age threshold. An upper age bound alone still leaves the query unbounded on the near side: read cost grows in lockstep with the collection's all-time size, and once a single record is ever counted bad, an all-time aggregate has no path back to healthy -- the same missing lower bound produces both failures at once.",
+  "canonical_prevention": "Add an explicit lower-bound filter (or equivalent recency cutoff) sized to the check's own cadence, so the query answers 'how does the current period look' instead of 'how does all of history look,' and give a deliberate, separate operator-invoked path (a CLI flag or script mode) for anyone who genuinely needs the unwindowed, all-time answer.",
+  "canonical_prevention_artifact": [
+    "backend/tests/unit/test_chat_first_materialization_drop_rate.py"
+  ],
+  "evidence_prs": [
+    11945
+  ],
+  "scope_hints": [
+    "backend/utils/task_intelligence/**",
+    "backend/database/chat_first_intents.py"
+  ],
+  "status": "open"
+}

--- a/backend/scripts/chat_first_materialization_drop_rate.py
+++ b/backend/scripts/chat_first_materialization_drop_rate.py
@@ -43,9 +43,22 @@ which a live client would have consumed it:
 Drop rate is ``dropped / (dropped + delivered)``. Intents still in flight are
 excluded from the denominator: their outcome is not yet decided.
 
+Windowing
+---------
+By default this reads every intent ever written -- unlike the weekly
+scheduled check (``run_scheduled_check`` in the health module this wraps),
+which windows itself to the last ``HEALTH_CHECK_WINDOW_DAYS`` so a single
+drop cannot latch its verdict unhealthy forever and so its read cost does not
+grow with the collection's all-time size. This script has neither problem: it
+is operator-invoked, not a permanent signal, and "what is our all-time drop
+rate" is exactly the question it exists to answer. Pass ``--window-days`` to
+scope a run to a recent period instead, e.g. to reproduce what the scheduled
+check just alarmed on.
+
 Usage:
     python scripts/chat_first_materialization_drop_rate.py --uid <uid>
     python scripts/chat_first_materialization_drop_rate.py --limit 5000
+    python scripts/chat_first_materialization_drop_rate.py --window-days 14
     python scripts/chat_first_materialization_drop_rate.py --json
 """
 
@@ -53,7 +66,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import List
 
@@ -79,6 +92,14 @@ def main(argv: List[str] | None = None) -> int:
         default=DEFAULT_STALE_AFTER_HOURS,
         help=f'Age past which an unacknowledged intent counts as dropped (default {DEFAULT_STALE_AFTER_HOURS}).',
     )
+    parser.add_argument(
+        '--window-days',
+        type=int,
+        help=(
+            'Only read intents created in the last N days (default: unwindowed, all-time). '
+            'Pass the same value the scheduled check uses (HEALTH_CHECK_WINDOW_DAYS) to reproduce its scan.'
+        ),
+    )
     parser.add_argument('--json', action='store_true', help='Emit the report as JSON.')
     parser.add_argument(
         '--fail-over-rate',
@@ -87,7 +108,9 @@ def main(argv: List[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    report = collect(args.uid, args.limit, args.stale_after_hours, datetime.now(timezone.utc))
+    now = datetime.now(timezone.utc)
+    min_created_at = now - timedelta(days=args.window_days) if args.window_days is not None else None
+    report = collect(args.uid, args.limit, args.stale_after_hours, now, min_created_at)
     print(json_report(report) if args.json else render(report))
 
     rate = report['drop_rate']

--- a/backend/tests/unit/test_chat_first_materialization_drop_rate.py
+++ b/backend/tests/unit/test_chat_first_materialization_drop_rate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -114,6 +115,7 @@ def test_scheduled_check_alarms_on_any_decided_drop(caplog: pytest.LogCaptureFix
         _limit: int | None,
         stale_after_hours: int,
         now: datetime,
+        _min_created_at: datetime | None,
     ) -> report.MaterializationHealthReport:
         return report.summarize(
             [_intent(created_at=now - timedelta(hours=72))],
@@ -136,6 +138,7 @@ def test_scheduled_check_routes_a_healthy_zero_drop_verdict(caplog: pytest.LogCa
         _limit: int | None,
         stale_after_hours: int,
         now: datetime,
+        _min_created_at: datetime | None,
     ) -> report.MaterializationHealthReport:
         return report.summarize(
             [_intent(delivery_state='delivered', delivered_at=now, materialization_receipt_id='r-1')],
@@ -158,6 +161,7 @@ def test_scheduled_check_alarms_when_the_monitor_cannot_read(caplog: pytest.LogC
         _limit: int | None,
         _stale_after_hours: int,
         _now: datetime,
+        _min_created_at: datetime | None,
     ) -> report.MaterializationHealthReport:
         raise RuntimeError('credential detail must not reach the log')
 
@@ -167,3 +171,168 @@ def test_scheduled_check_alarms_when_the_monitor_cannot_read(caplog: pytest.LogC
     assert status == 'monitor_error'
     assert 'review=true status=monitor_error error_class=RuntimeError' in caplog.text
     assert 'credential detail' not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Windowing: HEALTH_CHECK_WINDOW_DAYS bounds both the read and the verdict.
+#
+# These use a small Firestore stand-in rather than mocking `collect` itself,
+# so the assertions exercise the real `_documents` -> `summarize` pipeline,
+# including the `where(created_at >=```) filter `_documents` builds. The fake
+# reproduces the one Firestore behaviour the design leans on: a document is
+# excluded from a field filter's results whenever that field is missing or
+# the wrong type, regardless of when the document was written.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSnapshot:
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def to_dict(self) -> dict[str, Any]:
+        return self._data
+
+
+class _FakeCollectionGroupQuery:
+    def __init__(self, documents: list[dict[str, Any]]):
+        self._documents = documents
+        self._min_created_at: datetime | None = None
+        self._limit: int | None = None
+
+    def where(self, *, filter: Any) -> '_FakeCollectionGroupQuery':
+        assert filter.field_path == 'created_at'
+        assert filter.op_string == '>='
+        self._min_created_at = filter.value
+        return self
+
+    def limit(self, count: int) -> '_FakeCollectionGroupQuery':
+        self._limit = count
+        return self
+
+    def stream(self) -> Any:
+        matched = [document for document in self._documents if self._matches(document)]
+        if self._limit is not None:
+            matched = matched[: self._limit]
+        return iter(_FakeSnapshot(document) for document in matched)
+
+    def _matches(self, document: dict[str, Any]) -> bool:
+        if self._min_created_at is None:
+            return True
+        value = document.get('created_at')
+        if not isinstance(value, datetime):
+            # Firestore drops documents that lack (or mistype) a filtered field.
+            return False
+        normalized = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return normalized >= self._min_created_at
+
+
+class _FakeFirestoreClient:
+    def __init__(self, documents: list[dict[str, Any]]):
+        self._documents = documents
+
+    def collection_group(self, name: str) -> _FakeCollectionGroupQuery:
+        assert name == report.INTENTS_COLLECTION
+        return _FakeCollectionGroupQuery(self._documents)
+
+
+def test_windowed_collect_excludes_a_drop_older_than_the_window():
+    window_start = NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS)
+    old_drop = _intent(created_at=NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS + 5))
+    fresh_drop = _intent(created_at=NOW - timedelta(days=3))
+    client = _FakeFirestoreClient([old_drop, fresh_drop])
+
+    result = report.collect(None, None, 48, NOW, window_start, firestore_client=client)
+
+    assert result['dropped'] == 1
+    assert result['window_start'] == window_start.isoformat()
+
+
+def test_unwindowed_collect_still_counts_an_old_drop():
+    old_drop = _intent(created_at=NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS + 5))
+    client = _FakeFirestoreClient([old_drop])
+
+    result = report.collect(None, None, 48, NOW, None, firestore_client=client)
+
+    assert result['dropped'] == 1
+    assert result['window_start'] is None
+
+
+def test_scheduled_check_computes_the_window_from_its_own_run_time():
+    """`run_scheduled_check` must derive the window bound itself, not rely on a collector default."""
+    captured: dict[str, Any] = {}
+
+    def spy_collector(
+        _uid: str | None,
+        _limit: int | None,
+        _stale_after_hours: int,
+        now: datetime,
+        min_created_at: datetime | None,
+    ) -> report.MaterializationHealthReport:
+        captured['now'] = now
+        captured['min_created_at'] = min_created_at
+        return report.summarize([], scope='all_accounts', stale_after_hours=48, now=now)
+
+    report.run_scheduled_check(SCHEDULED_NOW, collector=spy_collector)
+
+    assert captured['min_created_at'] == captured['now'] - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS)
+
+
+def test_scheduled_check_still_alarms_on_a_drop_inside_the_window(caplog: pytest.LogCaptureFixture):
+    still_windowed = SCHEDULED_NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS - 1)
+    client = _FakeFirestoreClient([_intent(created_at=still_windowed)])
+    collector = functools.partial(report.collect, firestore_client=client)
+
+    with caplog.at_level(logging.ERROR, logger=report.__name__):
+        status = report.run_scheduled_check(SCHEDULED_NOW, collector=collector)
+
+    assert status == 'unhealthy'
+    assert 'window_days=14' in caplog.text
+
+
+def test_scheduled_check_clears_once_the_same_drop_rolls_past_the_window(caplog: pytest.LogCaptureFixture):
+    """The latch bug: an all-time scan never recovers once one intent has ever been dropped.
+
+    The same document that alarms the run above must stop alarming once its
+    `created_at` falls outside the window, with no change to the intent itself
+    -- only time passing. That is what lets a resolved problem return to
+    'healthy' instead of staying red forever.
+    """
+    now_outside_window = SCHEDULED_NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS + 1)
+    client = _FakeFirestoreClient([_intent(created_at=now_outside_window)])
+    collector = functools.partial(report.collect, firestore_client=client)
+
+    with caplog.at_level(logging.INFO, logger=report.__name__):
+        status = report.run_scheduled_check(SCHEDULED_NOW, collector=collector)
+
+    assert status == 'healthy'
+    assert 'chat_first_materialization_health review=true alarm=false status=healthy' in caplog.text
+
+
+def test_windowed_scan_cannot_see_an_undated_document_no_matter_how_recent():
+    """Documented trade-off: a filter on `created_at` excludes documents missing it outright."""
+    window_start = NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS)
+    fresh_but_undated = _intent(created_at=None)
+    client = _FakeFirestoreClient([fresh_but_undated])
+
+    windowed = report.collect(None, None, 48, NOW, window_start, firestore_client=client)
+    unwindowed = report.collect(None, None, 48, NOW, None, firestore_client=client)
+
+    assert windowed['undated'] == 0
+    assert unwindowed['undated'] == 1
+
+
+def test_render_reports_all_time_when_unwindowed():
+    summary = _summarize([_intent(delivery_state='delivered')])
+    assert 'window               all-time' in report.render(summary)
+
+
+def test_render_reports_the_window_start_when_windowed():
+    window_start = NOW - timedelta(days=report.HEALTH_CHECK_WINDOW_DAYS)
+    summary = report.summarize(
+        [_intent(delivery_state='delivered')],
+        scope='all_accounts',
+        stale_after_hours=48,
+        now=NOW,
+        window_start=window_start,
+    )
+    assert f'window               since {window_start.isoformat()}' in report.render(summary)

--- a/backend/utils/task_intelligence/chat_first_materialization_health.py
+++ b/backend/utils/task_intelligence/chat_first_materialization_health.py
@@ -8,12 +8,25 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Literal, TypedDict, cast
 
+from google.cloud.firestore_v1 import FieldFilter
+
 from database._client import get_firestore_client
 from database.chat_first_intents import INTENTS_COLLECTION
 
 DEFAULT_STALE_AFTER_HOURS = 48
 SCHEDULED_WEEKDAY_UTC = 0  # Monday
 SCHEDULED_HOUR_UTC = 14
+# The scheduled check runs weekly; a 14-day window is two report cycles. That
+# gives every intent that goes stale at least one full cycle in which a run is
+# guaranteed to see it (a 7-day window flush against a 7-day cadence would clip
+# documents at the boundary under any clock skew), plus a second cycle so a
+# genuinely-resolved problem is confirmed clear rather than blinking healthy
+# for exactly one week before the same class of drop reappears. It is also
+# comfortably longer than DEFAULT_STALE_AFTER_HOURS (48h): every intent inside
+# the window has already had its full staleness period to be decided, so
+# windowing never truncates an intent's chance to mature from in-flight to
+# dropped.
+HEALTH_CHECK_WINDOW_DAYS = 14
 HEALTH_LOG_MARKER = 'chat_first_materialization_health'
 DELIVERED = 'delivered'
 
@@ -23,6 +36,7 @@ logger = logging.getLogger(__name__)
 class MaterializationHealthReport(TypedDict):
     scope: str
     stale_after_hours: int
+    window_start: str | None
     delivered: int
     dropped: int
     in_flight: int
@@ -35,22 +49,52 @@ class MaterializationHealthReport(TypedDict):
 
 
 MaterializationHealthStatus = Literal['not_due', 'healthy', 'unhealthy', 'monitor_error']
-MaterializationHealthCollector = Callable[[str | None, int | None, int, datetime], MaterializationHealthReport]
+MaterializationHealthCollector = Callable[
+    [str | None, int | None, int, datetime, datetime | None], MaterializationHealthReport
+]
 
 
 def _documents(
     uid: str | None,
     limit: int | None,
+    min_created_at: datetime | None,
     *,
     firestore_client: Any = None,
 ) -> Iterator[Dict[str, Any]]:
-    """Stream intent documents without requiring a composite Firestore index."""
+    """Stream intent documents without requiring a composite Firestore index.
+
+    ``min_created_at``, when given, adds one ``created_at >=`` inequality
+    filter. A lone filter on a single field needs no explicit index -- it is
+    served by Firestore's automatic per-field index -- so this stays index-free
+    exactly like ``llm_usage.get_global_top_features``'s
+    ``collection_group("llm_usage").where("date", ">=", cutoff_id)``, the
+    existing precedent for a single-field range filter on a collection-group
+    query in this codebase. A *composite* (multi-field or field+order) shape
+    would need a registered index (see database/firestore_index_registry.py);
+    this query never grows past one filter, so it never needs one.
+
+    The filter also bounds the read itself: unfiltered, this was scanning
+    every intent ever written, with cost climbing in lockstep with the
+    collection's all-time size regardless of how much of it was recent.
+
+    Trade-off: Firestore excludes a document from a field filter's results
+    when that document is missing the field or holds a value of a different
+    type, independent of when the document was written. So a windowed scan
+    can never see a document with a missing or malformed ``created_at`` --
+    not "only an old one," but none, ever, no matter how fresh. That is an
+    acceptable gap here because ``ProactiveIntent.created_at`` is a required
+    field (models/chat_first.py), so a document missing it already bypassed
+    the normal write path; auditing for that class of corruption is what the
+    CLI's unwindowed run (``min_created_at=None``) is for.
+    """
 
     client = firestore_client or get_firestore_client()
     if uid:
         query: Any = client.collection('users').document(uid).collection(INTENTS_COLLECTION)
     else:
         query = client.collection_group(INTENTS_COLLECTION)
+    if min_created_at is not None:
+        query = query.where(filter=FieldFilter('created_at', '>=', min_created_at))
     if limit is not None:
         query = query.limit(limit)
     for snapshot in query.stream():
@@ -85,8 +129,16 @@ def summarize(
     scope: str,
     stale_after_hours: int,
     now: datetime,
+    window_start: datetime | None = None,
 ) -> MaterializationHealthReport:
-    """Bucket intent documents into delivered, dropped, in-flight, and malformed."""
+    """Bucket intent documents into delivered, dropped, in-flight, and malformed.
+
+    ``window_start`` is recorded on the report only -- it does not filter
+    ``documents`` here. The caller (``collect``) is responsible for having
+    already bounded the scan; this function just describes what period the
+    counts below cover, so a windowed and an all-time report never look alike
+    by accident.
+    """
 
     cutoff = now - timedelta(hours=stale_after_hours)
     delivered = 0
@@ -119,6 +171,7 @@ def summarize(
     return {
         'scope': scope,
         'stale_after_hours': stale_after_hours,
+        'window_start': window_start.isoformat() if window_start is not None else None,
         'delivered': delivered,
         'dropped': dropped,
         'in_flight': in_flight,
@@ -136,21 +189,26 @@ def collect(
     limit: int | None,
     stale_after_hours: int,
     now: datetime,
+    min_created_at: datetime | None = None,
     *,
     firestore_client: Any = None,
 ) -> MaterializationHealthReport:
     return summarize(
-        _documents(uid, limit, firestore_client=firestore_client),
+        _documents(uid, limit, min_created_at, firestore_client=firestore_client),
         scope=uid or 'all_accounts',
         stale_after_hours=stale_after_hours,
         now=now,
+        window_start=min_created_at,
     )
 
 
 def render(report: MaterializationHealthReport) -> str:
     rate = report['drop_rate']
+    window_start = report['window_start']
+    window_desc = 'all-time' if window_start is None else f'since {window_start}'
     lines = [
         f"scope                {report['scope']}",
+        f"window               {window_desc}",
         f"stale after          {report['stale_after_hours']}h",
         f"delivered            {report['delivered']}",
         f"dropped              {report['dropped']}",
@@ -187,6 +245,20 @@ def run_scheduled_check(
     must not let a clean result drift into "never." The log intentionally carries
     aggregate counts only; source labels and block payloads stay in the explicit
     operator CLI output.
+
+    The scan is windowed to the last HEALTH_CHECK_WINDOW_DAYS: an all-time scan
+    both grows its own read cost forever and, because nothing ever deletes an
+    intent document, latches this verdict unhealthy permanently after the first
+    drop -- there would be no way back to healthy even after the underlying
+    cause is fixed. Windowing bounds the read to recent volume and lets the
+    verdict describe the current period, so it can clear again once a drop
+    ages out of the window. It also makes ``drop_rate`` a rolling-window figure
+    instead of an all-time one that a burst of drops can no longer move once a
+    year of delivered intents has accumulated behind it. One known gap from
+    windowing: a document with a missing or malformed ``created_at`` is
+    invisible to this filtered scan regardless of how recently it was written
+    (see ``_documents``); that class of corruption is not what this check is
+    for and remains reachable through the CLI's unwindowed run.
     """
 
     checked_at = now or datetime.now(timezone.utc)
@@ -195,8 +267,9 @@ def run_scheduled_check(
     )
     if not is_scheduled_time(normalized):
         return 'not_due'
+    window_start = normalized - timedelta(days=HEALTH_CHECK_WINDOW_DAYS)
     try:
-        report = collector(None, None, DEFAULT_STALE_AFTER_HOURS, normalized)
+        report = collector(None, None, DEFAULT_STALE_AFTER_HOURS, normalized, window_start)
     except Exception as error:
         logger.error(
             '%s review=true status=monitor_error error_class=%s',
@@ -210,11 +283,12 @@ def run_scheduled_check(
     rate = report['drop_rate']
     log = logger.error if alarm else logger.info
     log(
-        '%s review=true alarm=%s status=%s stale_after_hours=%d delivered=%d dropped=%d '
+        '%s review=true alarm=%s status=%s window_days=%d stale_after_hours=%d delivered=%d dropped=%d '
         'in_flight=%d undated=%d decided=%d drop_rate=%s conversation_link_dropped=%d',
         HEALTH_LOG_MARKER,
         str(alarm).lower(),
         status,
+        HEALTH_CHECK_WINDOW_DAYS,
         report['stale_after_hours'],
         report['delivered'],
         report['dropped'],


### PR DESCRIPTION
## Summary

`backend/utils/task_intelligence/chat_first_materialization_health.py` (landed in #11873)
had an upper age bound on individual intents (`stale_after_hours`, 48h) but no lower bound
on the scan itself. Two consequences, one root cause:

1. **The weekly alarm latched permanently.** `dropped` counted *all-time* dropped intents
   and nothing in `backend/database/chat_first_intents.py` ever deletes an intent (verified —
   no `delete` call anywhere in that file). The first time a single card was ever dropped,
   every later weekly verdict was `unhealthy` forever, with no path back to `healthy`. That
   defeats the check's own stated purpose (see its docstring): forcing the deferred
   server-materialization decision, which a permanently-red signal gets muted instead of
   acted on.
2. **The scan grew without bound.** `run_scheduled_check` called the collector with
   `limit=None` over an unfiltered `collection_group` scan of an ever-growing collection.
   Weekly read cost rose linearly with the collection's all-time size forever.

## What changed

Added a lower bound: the scheduled check now windows its Firestore read to the last
`HEALTH_CHECK_WINDOW_DAYS` (14 days — two weekly report cycles) via a single
`created_at >=` inequality filter on the `collection_group` query. `summarize()`/`collect()`
gained an optional `min_created_at` parameter and the report now carries a `window_start`
field so a windowed and an all-time report are never confused.

**Index question.** A single-field filter on a `collection_group` query needs no explicit
index — this repo already ships exactly that shape unindexed and unregistered:
`backend/database/llm_usage.py`'s `db.collection_group("llm_usage").where("date", ">=", cutoff_id)`.
The repo's own `firestore_query_coverage.py` ratchet only tracks queries with 2+ chained
`where`/`order_by` calls (`len(state.components) < 2` is skipped entirely), which is exactly
why that `llm_usage` query never appears in the registry or the coverage report. I confirmed
this class of change trips neither the coverage ratchet nor the index-registry composite
requirement by running `python3 backend/scripts/firestore_query_coverage.py --check-ratchet`
before and after (exit 0, `chat_first_materialization_health` never appears in the report).
I rejected registering a composite index (unnecessary — this never becomes a multi-field or
ordered query) and rejected Python-side-only filtering (doesn't reduce Firestore read cost,
which is bug #2).

**Window length.** 14 days = 2× the weekly cadence. A 7-day window against a 7-day cadence
clips a document right at the boundary under any clock skew; 14 days guarantees every intent
that goes stale is seen by at least one weekly run, and a second cycle so a genuinely-fixed
problem is confirmed clear rather than blinking healthy for exactly one week. It's also
comfortably larger than `DEFAULT_STALE_AFTER_HOURS` (48h) — that value is unchanged and still
means what it meant before (when an *individual* intent flips from in-flight to decided); the
window is an unrelated, larger bound on which intents are read at all.

**Side effect, deliberately kept.** Because `drop_rate` is derived from whatever document set
it's given, windowing the scan also turns `drop_rate` into a rolling-window figure instead of
an all-time one that a burst of drops could no longer move once a year of delivered intents
had accumulated — the "also worth considering" note in the task. No separate mechanism needed.

**CLI.** `backend/scripts/chat_first_materialization_drop_rate.py` keeps its default
unwindowed, all-time behavior — "what is our all-time drop rate" is a legitimate,
operator-invoked question the scheduled alarm shouldn't have to answer, and it isn't a
permanent signal so it doesn't inherit either bug. Added an opt-in `--window-days` flag to
let an operator reproduce the scheduled check's own scan for comparison.

**Traded away.** Firestore excludes a document from a field-filter's results when that
document is missing the field or holds a mismatched type, independent of how recently it was
written. So the windowed scheduled check can no longer detect a document with a missing or
malformed `created_at` — not "only an old one," none, ever, regardless of window length. I
judged this acceptable because `ProactiveIntent.created_at` is a required field
(`models/chat_first.py`), so an undated document is already outside the normal write path; the
CLI's unwindowed default remains the way to audit for that class of corruption. This is called
out in `_documents`' and `run_scheduled_check`'s docstrings and covered by
`test_windowed_scan_cannot_see_an_undated_document_no_matter_how_recent`.

The check still routes a `healthy` verdict weekly (unchanged) — the docstring's own
"silence must not let a clean result drift into 'never'" requirement is untouched.

## Tests

Added to `backend/tests/unit/test_chat_first_materialization_drop_rate.py`, including a small
Firestore stand-in that reproduces the missing-field-exclusion behavior so the tests exercise
the real `_documents` → `summarize` pipeline, not a mocked `collect`:

- a drop older than the window is excluded (`test_windowed_collect_excludes_a_drop_older_than_the_window`)
- an unwindowed run still counts an old drop (`test_unwindowed_collect_still_counts_an_old_drop`)
- `run_scheduled_check` derives its own window bound from its own run time (`test_scheduled_check_computes_the_window_from_its_own_run_time`)
- the *same* dropped intent alarms while inside the window and clears once it ages out — the
  latch-bug regression test (`test_scheduled_check_still_alarms_on_a_drop_inside_the_window`,
  `test_scheduled_check_clears_once_the_same_drop_rolls_past_the_window`)
- the documented undated-detection trade-off (`test_windowed_scan_cannot_see_an_undated_document_no_matter_how_recent`)
- `render()` shows `all-time` vs. `since <timestamp>` correctly

All existing tests in that file were updated for the new `min_created_at` collector parameter
and continue to pass unchanged in behavior.

## Failure-Class

`backend/utils/task_intelligence/chat_first_materialization_health.py` and its known
candidates (`FC-hardcoded-absolute-date-bound`, `FC-unbounded-user-collection-in-prompt`,
`FC-deadline-bounded-query-without-covering-index`, `FC-day-bucket-key-recomputed`,
`FC-unbounded-module-cache`) don't match: this isn't an LLM-prompt bound, an interactive
deadline query, a day-bucket key, or a module cache — it's a recurring background health
check whose missing lower bound produces both an unbounded read *and* a latched alarm at
once. Recorded as a new class,
`.github/failure-classes/FC-recurring-check-scans-unbounded-history.json`.

Failure-Class: new

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

