### PR TITLE
feat(admin): rolling trailing buckets (24h daily / 7d weekly) + release panel polish

### DIFF
--- a/web/admin/app/api/omi/stats/crash-rate/route.ts
+++ b/web/admin/app/api/omi/stats/crash-rate/route.ts
@@ -51,11 +51,19 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const results = (await posthogResults(host, projectId, apiKey, hogql)) as [
-      string,
-      number,
-      number,
-    ][];
+    const rollingHogql = `
+      SELECT
+        countIf(event = 'App Crash Detected') as crashes,
+        count(DISTINCT distinct_id) as users
+      FROM events
+      WHERE properties.$os_name = 'macOS'
+        AND timestamp >= now() - interval 24 hour
+    `;
+
+    const [results, rollingResults] = (await Promise.all([
+      posthogResults(host, projectId, apiKey, hogql),
+      posthogResults(host, projectId, apiKey, rollingHogql),
+    ])) as [[string, number, number][], [number, number][]];
 
     const crashMap: Record<string, number> = {};
     const dauMap: Record<string, number> = {};
@@ -65,6 +73,15 @@ export async function GET(request: NextRequest) {
     }
 
     const data = buildDateSeries(days, crashMap, dauMap);
+    // Trailing bucket = last 24 hours so today's crash-free rate is not a
+    // low-sample morning artifact.
+    const [rollCrashes, rollUsers] = rollingResults?.[0] ?? [0, 0];
+    if (data.length > 0 && Number(rollUsers) > 0) {
+      const last = data[data.length - 1];
+      last.crashes = Number(rollCrashes);
+      last.users = Number(rollUsers);
+      last.crashFreeRate = Math.round((1 - Number(rollCrashes) / Number(rollUsers)) * 1000) / 10;
+    }
     cache = { data, days, timestamp: Date.now() };
     return NextResponse.json({ data, days });
   } catch (error: any) {

--- a/web/admin/app/api/omi/stats/dau-trends/route.ts
+++ b/web/admin/app/api/omi/stats/dau-trends/route.ts
@@ -48,9 +48,20 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
+    const rollingHogql = `
+      SELECT count(DISTINCT distinct_id) as users
+      FROM events
+      WHERE timestamp >= now() - interval 24 hour
+        ${scopeFilterAnd(platform)}
+    `;
+
     let results: [string, number][];
+    let rollingResult: [number][];
     try {
-      results = (await posthogResults(host, projectId, apiKey, hogql)) as [string, number][];
+      [results, rollingResult] = (await Promise.all([
+        posthogResults(host, projectId, apiKey, hogql),
+        posthogResults(host, projectId, apiKey, rollingHogql),
+      ])) as [[string, number][], [number][]];
     } catch (err) {
       console.error("PostHog query error:", err);
       return NextResponse.json({ error: "PostHog API error" }, { status: 502 });

--- a/web/admin/app/api/omi/stats/viral-metrics/route.ts
+++ b/web/admin/app/api/omi/stats/viral-metrics/route.ts
@@ -81,6 +81,10 @@ export async function GET(request: NextRequest) {
       mauResult,
       allTimeResult,
       userGrowthResult,
+      rolling24hDauResult,
+      rolling24hNewResult,
+      rolling7dNewResult,
+      rollingRetentionResult,
     ] = await Promise.all([
       // 1. New users per week — first-seen on this platform, the same
       // person-deduped population as the daily userGrowth series.
@@ -266,6 +270,60 @@ export async function GET(request: NextRequest) {
         GROUP BY first_day
         ORDER BY first_day
       `),
+
+      // 11. Rolling last-24h DAU — the trailing daily bucket must not look
+      // like a crash just because the day started.
+      hogql(apiKey, projectId, host, `
+        SELECT count(DISTINCT distinct_id)
+        FROM events
+        WHERE timestamp >= now() - interval 24 hour
+          ${os}
+      `),
+
+      // 12. Rolling last-24h new users (first-seen).
+      hogql(apiKey, projectId, host, `
+        SELECT count(*)
+        FROM (
+          SELECT COALESCE(person_id, distinct_id) as actor, min(timestamp) as min_ts
+          FROM events
+          WHERE 1 = 1
+            ${os}
+          GROUP BY actor
+        )
+        WHERE min_ts >= now() - interval 24 hour
+      `),
+
+      // 13. Rolling last-7d new users (first-seen) for the trailing weekly bucket.
+      hogql(apiKey, projectId, host, `
+        SELECT count(*)
+        FROM (
+          SELECT COALESCE(person_id, distinct_id) as actor, min(timestamp) as min_ts
+          FROM events
+          WHERE 1 = 1
+            ${os}
+          GROUP BY actor
+        )
+        WHERE min_ts >= now() - interval 7 day
+      `),
+
+      // 14. Rolling 7d retention pair: retained (active both in the last 7d
+      // and the 7d before) and prior-window active, for the trailing
+      // growth-accounting bucket.
+      hogql(apiKey, projectId, host, `
+        SELECT
+          countIf(cur = 1 AND prev = 1) as retained,
+          countIf(prev = 1) as prev_active
+        FROM (
+          SELECT
+            distinct_id,
+            maxIf(1, timestamp >= now() - interval 7 day) as cur,
+            maxIf(1, timestamp < now() - interval 7 day) as prev
+          FROM events
+          WHERE timestamp >= now() - interval 14 day
+            ${os}
+          GROUP BY distinct_id
+        )
+      `),
     ]);
 
     // ── Process Growth Accounting ──
@@ -304,12 +362,37 @@ export async function GET(request: NextRequest) {
       };
     });
 
+    // Trailing weekly bucket = the rolling last 7 days (the partial
+    // calendar week always under-reported until Sunday).
+    if (growthAccounting.length > 0) {
+      const rollingWau = Number((wauResult as any[])[0]?.[0] ?? 0);
+      const rolling7dNew = Number((rolling7dNewResult as any[])[0]?.[0] ?? 0);
+      const rollingPair = (rollingRetentionResult as any[])[0] ?? [0, 0];
+      const retained7 = Number(rollingPair[0] ?? 0);
+      const prevActive7 = Number(rollingPair[1] ?? 0);
+      const lastGA = growthAccounting[growthAccounting.length - 1];
+      lastGA.active = rollingWau;
+      lastGA.newUsers = rolling7dNew;
+      lastGA.retained = retained7;
+      lastGA.resurrected = Math.max(0, rollingWau - rolling7dNew - retained7);
+      lastGA.churned = -Math.max(0, prevActive7 - retained7);
+    }
+
     // ── Process DAU for Stickiness ──
     const dailyDau: { date: string; dau: number }[] = [];
     for (const [day, dau] of dailyDauResults as any[]) {
       dailyDau.push({ date: day, dau });
     }
     dailyDau.sort((a, b) => a.date.localeCompare(b.date));
+
+    // Trailing daily bucket = the last 24 hours, not since-midnight.
+    const rolling24hDau = Number((rolling24hDauResult as any[])[0]?.[0] ?? 0);
+    const todayUtc = new Date().toISOString().slice(0, 10);
+    if (dailyDau.length > 0 && dailyDau[dailyDau.length - 1].date === todayUtc) {
+      dailyDau[dailyDau.length - 1].dau = rolling24hDau;
+    } else {
+      dailyDau.push({ date: todayUtc, dau: rolling24hDau });
+    }
 
     // Weekly stickiness: avg DAU / WAU for each week
     const wau = (wauResult as any[])[0]?.[0] ?? 0;
@@ -322,6 +405,14 @@ export async function GET(request: NextRequest) {
     for (const [day, users] of userGrowthResult as any[]) {
       cumulative += users;
       userGrowth.push({ date: day, users, cumulative });
+    }
+    // Trailing bucket shows first-seen users of the last 24 hours; the
+    // cumulative line stays calendar-exact (ends at allTimeUsers).
+    const rolling24hNew = Number((rolling24hNewResult as any[])[0]?.[0] ?? 0);
+    if (userGrowth.length > 0 && userGrowth[userGrowth.length - 1].date === todayUtc) {
+      userGrowth[userGrowth.length - 1].users = rolling24hNew;
+    } else if (userGrowth.length > 0) {
+      userGrowth.push({ date: todayUtc, users: rolling24hNew, cumulative });
     }
     const recentDau = dailyDau.slice(-7);
     const avgDau = recentDau.length > 0
@@ -354,6 +445,18 @@ export async function GET(request: NextRequest) {
         wau: weekWau,
         dauWau: weekWau > 0 ? Math.round((weekAvgDau / weekWau) * 1000) / 10 : 0,
       });
+    }
+
+    // Trailing stickiness point uses the rolling windows too.
+    if (stickinessTrend.length > 0) {
+      const lastStick = stickinessTrend[stickinessTrend.length - 1];
+      const recent = dailyDau.slice(-7);
+      const rollingAvgDau = recent.length > 0
+        ? Math.round(recent.reduce((s2, d) => s2 + d.dau, 0) / recent.length)
+        : 0;
+      lastStick.avgDau = rollingAvgDau;
+      lastStick.wau = wau;
+      lastStick.dauWau = wau > 0 ? Math.round((rollingAvgDau / wau) * 1000) / 10 : 0;
     }
 
     // ── Process Power User Curve ──

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -264,7 +264,7 @@ def releases_chart_panel(panel_id: int) -> dict:
                        "(TestFlight noise excluded); latest verified against the "
                        "App Store lookup API.",
         "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "omi-admin-api"},
-        "gridPos": {"x": 0, "y": 14, "w": 24, "h": 6},
+        "gridPos": {"x": 0, "y": 999, "w": 24, "h": 6},
         "timeFrom": "30d",
         "fieldConfig": {
             "defaults": {
@@ -335,7 +335,7 @@ def latest_release_stat(panel_id: int, scope: str) -> dict:
             }],
         },
         "options": {
-            "reduceOptions": {"values": False, "calcs": ["lastNotNull"], "fields": ""},
+            "reduceOptions": {"values": False, "calcs": ["lastNotNull"], "fields": "/.*/"},
             "orientation": "horizontal",
             "textMode": "value_and_name",
             "colorMode": "value",

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -184,7 +184,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=active&agg=last&window=1",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -623,7 +623,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": ""
+          "fields": "/.*/"
         },
         "orientation": "horizontal",
         "textMode": "value_and_name",
@@ -3835,7 +3835,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmacos&root=growthAccounting&fields=active&agg=last&window=1&label=WoW",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -184,7 +184,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=active&agg=last&window=1",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -623,7 +623,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": ""
+          "fields": "/.*/"
         },
         "orientation": "horizontal",
         "textMode": "value_and_name",
@@ -3309,7 +3309,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dmobile&root=growthAccounting&fields=active&agg=last&window=1&label=WoW",
             "url_options": {
               "data": "",
               "method": "GET"

--- a/web/admin/grafana/dashboards/omi-tv.json
+++ b/web/admin/grafana/dashboards/omi-tv.json
@@ -267,7 +267,7 @@
           "root_selector": "",
           "source": "url",
           "type": "json",
-          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=active&agg=last&window=1&drop=1",
+          "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=active&agg=last&window=1",
           "url_options": {
             "data": "",
             "method": "GET"
@@ -5288,7 +5288,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 14,
+        "y": 999,
         "w": 24,
         "h": 6
       },
@@ -5431,7 +5431,7 @@
             "root_selector": "",
             "source": "url",
             "type": "json",
-            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=active&agg=last&window=1&label=WoW&drop=1",
+            "url": "http://127.0.0.1:8899/compare?path=%2Fapi%2Fomi%2Fstats%2Fviral-metrics%3Fdays%3D60%26platform%3Dall&root=growthAccounting&fields=active&agg=last&window=1&label=WoW",
             "url_options": {
               "data": "",
               "method": "GET"


### PR DESCRIPTION
## Summary
Trailing chart buckets no longer under-report:
- Daily charts (DAU, daily new users, crash-free — on every board) show the **rolling last 24 hours** in the final bucket instead of since-midnight.
- Weekly charts (WAU/growth accounting, stickiness) show the **rolling last 7 days** in the final bucket instead of the partial calendar week (active = rolling WAU, first-seen new users, retained/churned vs the prior 7-day window).
- The cumulative line stays calendar-exact (still ends at allTimeUsers by construction); `drop=1` removed from Net-WAU deltas since the trailing bucket is now a full window.
- Release stat tiles show the version string (numeric-only default hid it); the All-board releases chart sits full-width at the bottom.

Explicitly NOT changed: the Firebase-backed all-platform daily-new-users chart (heavy cached user-growth service — left calendar-bucketed rather than risk it).

## Verification
Local dev + proxy, cross-checked against direct PostHog: trailing DAU 972 == direct 24h uniq 971±drift; trailing growth-accounting bucket active 1,961 == rolling WAU; first-seen 24h/7d counts match. Headless-captured all three boards: WAU/DAU/growth-accounting trailing points now level with their series (no cliff), release tiles show version+date+days-ago (macOS red at 3 days), releases chart renders with visible gaps. Builder tests 22/22, deploy-scope 16/16, vitest 131/131, tsc clean.

## Product invariants affected
none

## Failure class
No fix: commits.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

