### PR TITLE
feat(macos): Integration Suggestions becomes the fifth notification type

### DIFF
--- a/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
+++ b/desktop/macos/Desktop/Sources/Chat/ChatContinuityInvariants.swift
@@ -9,6 +9,7 @@ enum ProactiveNotificationKind: String, Equatable {
   case goal
   case meetingNotes = "meeting_notes"
   case resurface
+  case integration
 
   static func from(decisionType: String) -> Self {
     switch decisionType {
@@ -30,6 +31,7 @@ enum ProactiveNotificationKind: String, Equatable {
     case "memory-extraction": return .memory
     case "goals": return .goal
     case "meeting-notes": return .meetingNotes
+    case "integration_connect": return .integration
     default: return .general
     }
   }

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ChatBubbleSupport.swift
@@ -243,13 +243,14 @@ struct ProactiveNotificationBadge: Equatable {
   static let insightSystemImage = "sparkles"
   static let suggestionSystemImage = "lightbulb"
 
-  /// The user-facing taxonomy is exactly four proactive categories — Focus, Task,
-  /// Insight, Memory — matching the four toggles in Settings → Notifications. Internal
-  /// kinds stay distinct (their raw values are persisted in chat continuity keys), but
-  /// every one of them presents as one of the four: Focus is the focus-nudge assistant
-  /// alone; generic tips, resurfaced items, and generated goals are all insights;
-  /// meeting action items are tasks. `.general` is reserved for functional system
-  /// alerts, which sit outside the proactive taxonomy.
+  /// The user-facing taxonomy is exactly five proactive categories — Focus, Task,
+  /// Insight, Memory, Integration — matching the five toggles in Settings →
+  /// Notifications. Internal kinds stay distinct (their raw values are persisted in
+  /// chat continuity keys), but every one of them presents as one of the five: Focus
+  /// is the focus-nudge assistant alone; generic tips, resurfaced items, and generated
+  /// goals are all insights; meeting action items are tasks; connect-an-app offers are
+  /// integrations. `.general` is reserved for functional system alerts, which sit
+  /// outside the proactive taxonomy.
   init(kind: ProactiveNotificationKind) {
     switch kind {
     case .suggestion:
@@ -260,6 +261,8 @@ struct ProactiveNotificationBadge: Equatable {
       (label, systemImage) = ("Task", "checkmark.circle")
     case .memory:
       (label, systemImage) = ("Memory", "brain.head.profile")
+    case .integration:
+      (label, systemImage) = ("Integration", "sparkles.rectangle.stack")
     case .general:
       (label, systemImage) = ("Notification", "bell")
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+Assistants.swift
@@ -995,6 +995,33 @@ extension SettingsContentView {
       settingsCard(settingId: "advanced.troubleshooting.rescanfiles") {
         RescanFilesRow(showConfirmation: $showRescanFilesAlert)
       }
+
+      // Reset Integration Suggestions
+      settingsCard(settingId: "advanced.troubleshooting.resetintegrationsuggestions") {
+        HStack(spacing: OmiSpacing.lg) {
+          Image(systemName: "sparkles.rectangle.stack")
+            .scaledFont(size: OmiType.subheading)
+            .foregroundColor(Ink.secondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: OmiSpacing.xxs) {
+            Text("Reset Integration Suggestions")
+              .scaledFont(size: OmiType.subheading, weight: .semibold)
+              .foregroundColor(Ink.primary)
+
+            Text("Clears every integration's suggestion history, including ones you hid, so Omi can offer them again")
+              .scaledFont(size: OmiType.body)
+              .foregroundColor(Ink.secondary)
+          }
+
+          Spacer()
+
+          Button("Reset") {
+            IntegrationNudgeStore.shared.resetAll()
+          }
+          .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
+        }
+      }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
@@ -121,22 +121,6 @@ extension SettingsContentView {
                 .toggleStyle(OmiToggleStyle())
                 .labelsHidden()
             }
-
-            if integrationNudgesEnabled {
-              GlassSeparator()
-
-              settingRow(
-                title: "Reset all suggestion history",
-                subtitle:
-                  "Clears every integration's suggestion history, including ones you hid, so Omi can offer them again",
-                settingId: "notifications.integrationsuggestions.reset"
-              ) {
-                Button("Reset") {
-                  IntegrationNudgeStore.shared.resetAll()
-                }
-                .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
-              }
-            }
           }
         }
       }

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/Settings/Sections/SettingsContentView+NotificationsPrivacy.swift
@@ -103,36 +103,24 @@ extension SettingsContentView {
                       memory: MemorySettingsResponse(notificationsEnabled: newValue)))
                 }
             }
-          }
-        }
-      }
 
-      // Integration suggestions sit inside the master gate because the feature
-      // genuinely depends on it: `IntegrationNudgeCoordinator.isEnabledNow`
-      // requires notifications to be on, so showing this switched ON beside a
-      // disabled master toggle would promise a feature that cannot run.
-      if notificationsEnabled {
-        // Integration suggestions
-        settingsCard(settingId: "notifications.integrationsuggestions") {
-          VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-            HStack {
-              settingsCardHeader(icon: "sparkles.rectangle.stack", title: "Integration Suggestions")
+            GlassSeparator()
 
-              Spacer()
-
-              // `@AppStorage` already persists to the key the coordinator reads;
-              // a second writer on one key only invites drift.
+            // The fifth notification type. It lives inside the master gate for the
+            // same reason as the other four: `IntegrationNudgeCoordinator.isEnabledNow`
+            // requires notifications to be on, so showing this switched ON beside a
+            // disabled master toggle would promise a feature that cannot run.
+            // `@AppStorage` already persists to the key the coordinator reads;
+            // a second writer on one key only invites drift.
+            settingRow(
+              title: "Integration Notifications",
+              subtitle: "Occasionally offer to connect an app Omi can use — Gmail, Notion, ChatGPT",
+              settingId: "notifications.integrationsuggestions"
+            ) {
               Toggle("", isOn: $integrationNudgesEnabled)
                 .toggleStyle(OmiToggleStyle())
                 .labelsHidden()
             }
-
-            Text(
-              "When you open an app Omi can connect to — Gmail, Notion, ChatGPT — occasionally offer the "
-                + "connection, with what it would do for you. At most a few times per integration."
-            )
-            .scaledFont(size: OmiType.body)
-            .foregroundColor(Ink.secondary)
 
             if integrationNudgesEnabled {
               GlassSeparator()

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -126,17 +126,17 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["memory", "facts", "notify memory"], section: .notifications, icon: "bell",
       settingId: "notifications.memory"),
     SettingsSearchItem(
-      name: "Integration Suggestions",
-      subtitle: "Offer to connect an app when you open one Omi works with",
+      name: "Integration Notifications",
+      subtitle: "Occasionally offer to connect an app Omi can use — Gmail, Notion, ChatGPT",
       keywords: ["integration", "suggestions", "connect", "gmail", "notion", "nudge"],
       section: .notifications, icon: "bell",
       settingId: "notifications.integrationsuggestions"),
     SettingsSearchItem(
-      name: "Reset all suggestion history",
+      name: "Reset Integration Suggestions",
       subtitle: "Clear every integration's suggestion history so Omi can offer them again",
       keywords: ["reset", "integration", "suggestions", "history", "again"],
-      section: .notifications, icon: "bell",
-      settingId: "notifications.integrationsuggestions.reset"),
+      section: .advanced, icon: "wrench.and.screwdriver",
+      settingId: "advanced.troubleshooting.resetintegrationsuggestions"),
     SettingsSearchItem(
       name: "Daily Summary",
       subtitle: "Receive a daily summary of your conversations and activities",

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -444,7 +444,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         focusEnabled: SuggestionAssistantSettings.shared.isEnabled,
         taskEnabled: TaskAssistantSettings.shared.notificationsEnabled,
         insightEnabled: InsightAssistantSettings.shared.notificationsEnabled,
-        memoryEnabled: MemoryAssistantSettings.shared.notificationsEnabled)
+        memoryEnabled: MemoryAssistantSettings.shared.notificationsEnabled,
+        integrationEnabled: IntegrationNudgeCoordinator.isFeatureEnabled)
     {
       log("NotificationService: suppressing \(assistantId) notification because its category toggle is off")
       recordInsightDeliveryOutcome(
@@ -694,7 +695,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         focusEnabled: SuggestionAssistantSettings.shared.isEnabled,
         taskEnabled: TaskAssistantSettings.shared.notificationsEnabled,
         insightEnabled: InsightAssistantSettings.shared.notificationsEnabled,
-        memoryEnabled: MemoryAssistantSettings.shared.notificationsEnabled)
+        memoryEnabled: MemoryAssistantSettings.shared.notificationsEnabled,
+        integrationEnabled: IntegrationNudgeCoordinator.isFeatureEnabled)
     else {
       onDropped?()
       return .suppressed
@@ -761,23 +763,25 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
   }
 
   /// Maps every proactive notification kind to its user-facing category — Focus, Task,
-  /// Insight, or Memory — and answers whether that category's Settings toggle allows
-  /// delivery. Focus is the focus-nudge assistant alone; generic tips, resurfaced
-  /// items, and generated goals are all insights; meeting action items are tasks.
-  /// `.general` is functional system alerting outside the taxonomy and is never
-  /// category-gated.
+  /// Insight, Memory, or Integration — and answers whether that category's Settings
+  /// toggle allows delivery. Focus is the focus-nudge assistant alone; generic tips,
+  /// resurfaced items, and generated goals are all insights; meeting action items are
+  /// tasks; connect-an-app offers are integrations. `.general` is functional system
+  /// alerting outside the taxonomy and is never category-gated.
   nonisolated static func categoryToggleAllows(
     kind: ProactiveNotificationKind,
     focusEnabled: Bool,
     taskEnabled: Bool,
     insightEnabled: Bool,
-    memoryEnabled: Bool
+    memoryEnabled: Bool,
+    integrationEnabled: Bool
   ) -> Bool {
     switch kind {
     case .suggestion: return focusEnabled
     case .task, .meetingNotes: return taskEnabled
     case .insight, .resurface, .goal: return insightEnabled
     case .memory: return memoryEnabled
+    case .integration: return integrationEnabled
     case .general: return true
     }
   }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -433,8 +433,8 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       return
     }
 
-    // Every proactive notification belongs to one of the four user-facing categories
-    // (Focus, Task, Insight, Memory), and this shared boundary is where a category's
+    // Every proactive notification belongs to one of the five user-facing categories
+    // (Focus, Task, Insight, Memory, Integration), and this shared boundary is where a category's
     // Settings toggle binds every producer — goals and meeting action items included,
     // not just the assistants that consult their own toggle before generating.
     // Functional notices (`respectFrequency: false`) map to `.general` and stay ungated.
@@ -685,10 +685,10 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
       onDropped?()
       return .suppressed
     }
-    // The director's decisions ride the same four category toggles as the dedicated
-    // assistants. Settings promises exactly four notification types — Focus, Task,
-    // Insight, Memory — and a toggle that silences only some producers of its
-    // category would make that promise a lie.
+    // The director's decisions ride the same category toggles as the dedicated
+    // assistants. Settings promises exactly five notification types — Focus, Task,
+    // Insight, Memory, Integration — and a toggle that silences only some producers
+    // of its category would make that promise a lie.
     guard
       Self.categoryToggleAllows(
         kind: ProactiveNotificationKind.from(decisionType: decisionType),

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -4,9 +4,10 @@ import XCTest
 @testable import Omi_Computer
 
 final class ContextDeliveryAuthorityTests: XCTestCase {
-  /// Context-director decisions ride the same four category toggles the Settings pane
-  /// shows (Focus, Task, Insight, Memory). Each internal kind must be gated by exactly
-  /// its category's toggle; `.general` (functional alerts) is never category-gated.
+  /// Context-director decisions ride the same five category toggles the Settings pane
+  /// shows (Focus, Task, Insight, Memory, Integration). Each internal kind must be
+  /// gated by exactly its category's toggle; `.general` (functional alerts) is never
+  /// category-gated.
   func testDirectorDecisionsAreGatedByTheirCategoryToggle() {
     func allows(
       _ kind: ProactiveNotificationKind, focus: Bool = true, task: Bool = true, insight: Bool = true,

--- a/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
+++ b/desktop/macos/Desktop/Tests/ContextDeliveryAuthorityTests.swift
@@ -10,11 +10,11 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
   func testDirectorDecisionsAreGatedByTheirCategoryToggle() {
     func allows(
       _ kind: ProactiveNotificationKind, focus: Bool = true, task: Bool = true, insight: Bool = true,
-      memory: Bool = true
+      memory: Bool = true, integration: Bool = true
     ) -> Bool {
       NotificationService.categoryToggleAllows(
         kind: kind, focusEnabled: focus, taskEnabled: task,
-        insightEnabled: insight, memoryEnabled: memory)
+        insightEnabled: insight, memoryEnabled: memory, integrationEnabled: integration)
     }
     // Focus toggle owns the focus-nudge assistant alone.
     XCTAssertFalse(allows(.suggestion, focus: false))
@@ -29,8 +29,12 @@ final class ContextDeliveryAuthorityTests: XCTestCase {
     XCTAssertFalse(allows(.goal, insight: false))
     // Memory toggle owns memory extraction.
     XCTAssertFalse(allows(.memory, memory: false))
+    // Integration toggle owns connect-an-app offers.
+    XCTAssertFalse(allows(.integration, integration: false))
+    XCTAssertTrue(allows(.integration, focus: false, task: false, insight: false, memory: false))
     // Functional alerts sit outside the taxonomy.
-    XCTAssertTrue(allows(.general, focus: false, task: false, insight: false, memory: false))
+    XCTAssertTrue(
+      allows(.general, focus: false, task: false, insight: false, memory: false, integration: false))
     // The director's decision strings resolve into the gated kinds; "suggest" is a
     // generic tip, which the taxonomy files under Insight.
     XCTAssertEqual(ProactiveNotificationKind.from(decisionType: "suggest"), .insight)

--- a/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
+++ b/desktop/macos/Desktop/Tests/FloatingBarNotificationPreviewPolicyTests.swift
@@ -157,7 +157,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
       "muted in-bar preview must keep a banner surface so director delivery is visible")
   }
 
-  /// Behavioral guard for the four-type taxonomy: the director's real entry point must
+  /// Behavioral guard for the category taxonomy: the director's real entry point must
   /// refuse a delivery whose category toggle is off. A "suggest" decision is a generic
   /// tip, which the taxonomy files under Insight. Every upstream gate is pinned open
   /// (owner seeded, master on, frequency Maximum, not paywalled) and the surface is
@@ -219,7 +219,7 @@ final class FloatingBarNotificationPreviewPolicyTests: XCTestCase {
     XCTAssertEqual(droppedCount, 1)
   }
 
-  /// The four category toggles bind every proactive producer at the shared
+  /// The category toggles bind every proactive producer at the shared
   /// `sendNotification` boundary — including the dedicated producers that never
   /// consulted a toggle before generating: goals (Insight) and meeting action items
   /// (Task). Same construction as the director test: every upstream gate is pinned

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -345,10 +345,11 @@ final class ChatRowPresentationTests: XCTestCase {
     XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Task")
   }
 
-  /// The user-facing taxonomy is exactly four proactive categories — Focus, Task,
-  /// Insight, Memory — matching the four toggles in Settings → Notifications. Focus is
-  /// the focus-nudge assistant alone; tips, resurfaced items, and generated goals are
-  /// insights. `.general` is reserved for functional system alerts outside the taxonomy.
+  /// The user-facing taxonomy is exactly five proactive categories — Focus, Task,
+  /// Insight, Memory, Integration — matching the five toggles in Settings →
+  /// Notifications. Focus is the focus-nudge assistant alone; tips, resurfaced items,
+  /// and generated goals are insights; connect-an-app offers are integrations.
+  /// `.general` is reserved for functional system alerts outside the taxonomy.
   func testEveryProactiveKindPresentsAsOneOfTheFourCategories() {
     XCTAssertEqual(ProactiveNotificationBadge(kind: .suggestion).label, "Focus")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .task).label, "Task")

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -350,7 +350,7 @@ final class ChatRowPresentationTests: XCTestCase {
   /// Notifications. Focus is the focus-nudge assistant alone; tips, resurfaced items,
   /// and generated goals are insights; connect-an-app offers are integrations.
   /// `.general` is reserved for functional system alerts outside the taxonomy.
-  func testEveryProactiveKindPresentsAsOneOfTheFourCategories() {
+  func testEveryProactiveKindPresentsAsOneOfTheFiveCategories() {
     XCTAssertEqual(ProactiveNotificationBadge(kind: .suggestion).label, "Focus")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .task).label, "Task")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Task")

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -341,6 +341,7 @@ final class ChatRowPresentationTests: XCTestCase {
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "memory-extraction"), .memory)
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "goals"), .goal)
     XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "meeting-notes"), .meetingNotes)
+    XCTAssertEqual(ProactiveNotificationKind.from(assistantId: "integration_connect"), .integration)
     XCTAssertEqual(ProactiveNotificationBadge(kind: .meetingNotes).label, "Task")
   }
 
@@ -356,6 +357,7 @@ final class ChatRowPresentationTests: XCTestCase {
     XCTAssertEqual(ProactiveNotificationBadge(kind: .resurface).label, "Insight")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .goal).label, "Insight")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .memory).label, "Memory")
+    XCTAssertEqual(ProactiveNotificationBadge(kind: .integration).label, "Integration")
     XCTAssertEqual(ProactiveNotificationBadge(kind: .general).label, "Notification")
   }
 

--- a/desktop/macos/changelog/unreleased/20260820-integration-fifth-type.json
+++ b/desktop/macos/changelog/unreleased/20260820-integration-fifth-type.json
@@ -1,0 +1,3 @@
+{
+  "change": "Integration Suggestions is now the fifth notification type — a row beside Focus, Task, Insight, and Memory in Settings, with its own Integration chat badge"
+}


### PR DESCRIPTION
## What

Integration Suggestions becomes the **fifth notification type**, joining Focus, Task, Insight, and Memory (#11937).

- The separate "Integration Suggestions" card in Settings → Notifications folds into the Notifications card as a fifth row, **"Integration Notifications"**, styled like the other four. The row keeps the same `integrationNudgesEnabled` key the coordinator reads, and sits inside the master gate for the same reason the old card did (`IntegrationNudgeCoordinator.isEnabledNow` requires notifications on).
- "Reset all suggestion history" moves to Advanced → Troubleshooting as a **Reset Integration Suggestions** card, beside Report Issue and Rescan Files. The settings search index follows both moves.
- `ProactiveNotificationKind` gains `.integration` (assistantId `integration_connect`), with an **Integration** chat badge (`sparkles.rectangle.stack`).
- `NotificationService.categoryToggleAllows` gains `integrationEnabled` (read from `IntegrationNudgeCoordinator.isFeatureEnabled`) at both delivery boundaries, so the shared gate covers the fifth category too. Functional `.general` alerts stay ungated. The nudge coordinator's own `isEnabledNow` check remains the primary gate for organic nudges; the shared gate is the same defense-in-depth the other four categories get.

## Verification

- Suites pass: `FloatingBarNotificationPreviewPolicyTests`, `ContextDeliveryAuthorityTests` (integration case added to the toggle-ownership test), `HomeRedesignRegressionTests` (badge + assistantId-mapping assertions extended).
- Live in a rebuilt named bundle (real account, prod backend): the Notifications card shows the five rows and the old card is gone; Advanced → Troubleshooting shows the Reset Integration Suggestions card (screenshots); with the Integration toggle ON an `integration_connect` test notification presents in the bar; with it OFF the same trigger logs `suppressing integration_connect notification because its category toggle is off`.
- UNVERIFIED: clicking the relocated Reset button (no automation-bridge action for it); it invokes the same `IntegrationNudgeStore.shared.resetAll()` the old row called, unchanged.
- UNVERIFIED: an organic integration nudge (needs opening a matching app with unspent nudge budget); its delivery path shares the same gates exercised above plus the coordinator's own toggle check, which predates this PR.

## Product invariants affected

- INV-CHAT-1 — path-glob match on `ChatBubbleSupport.swift` / `ChatContinuityInvariants.swift`. Adds a new kind case and badge label only; continuity-key format, existing raw values, and the journal contract are unchanged (a key with the new `integration:` segment decodes on this build, and older builds' kind-less keys still fall back to `.general`).

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

