### PR TITLE
fix(admin): release tile renders version and date on one line

### DIFF
--- a/web/admin/app/api/omi/stats/releases/route.ts
+++ b/web/admin/app/api/omi/stats/releases/route.ts
@@ -48,8 +48,9 @@ function buildRelease(version: string | null, date: string | null): PlatformRele
     return { version, date, daysSince: null, display: "no releases found" };
   }
   const daysSince = daysBetween(date, nycToday());
-  const ago = daysSince <= 0 ? "today" : daysSince === 1 ? "1d ago" : `${daysSince}d ago`;
-  return { version, date, daysSince, display: `${version} · ${shortDate(date)} (${ago})` };
+  // Age lives in the separate color-thresholded `daysSince` field; keeping it
+  // out of the display string stops the stat tile from wrapping.
+  return { version, date, daysSince, display: `${version} · ${shortDate(date)}` };
 }
 
 async function fetchMacosReleases(days: number): Promise<{ dates: string[]; latest: PlatformRelease }> {

--- a/web/admin/grafana/build_dashboards.py
+++ b/web/admin/grafana/build_dashboards.py
@@ -341,7 +341,7 @@ def latest_release_stat(panel_id: int, scope: str) -> dict:
             "colorMode": "value",
             "graphMode": "none",
             "justifyMode": "auto",
-            "text": {"valueSize": 20, "titleSize": 11},
+            "text": {"valueSize": 16, "titleSize": 11},
         },
         "targets": [{
             "refId": "A",

--- a/web/admin/grafana/dashboards/omi-tv-macos.json
+++ b/web/admin/grafana/dashboards/omi-tv-macos.json
@@ -631,7 +631,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "text": {
-          "valueSize": 20,
+          "valueSize": 16,
           "titleSize": 11
         }
       },

--- a/web/admin/grafana/dashboards/omi-tv-mobile.json
+++ b/web/admin/grafana/dashboards/omi-tv-mobile.json
@@ -631,7 +631,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "text": {
-          "valueSize": 20,
+          "valueSize": 16,
           "titleSize": 11
         }
       },


### PR DESCRIPTION
## Summary
The latest-release stat wrapped and clipped ('...(3d ago)' against the tile edge). Age already lives in the color-thresholded `daysSince` field, so the display string drops the redundant suffix and the stat font goes 20→16.

## Verification
Local dev + Grafana headless capture: both tiles render on one clean line — macOS `3 days` (red) + `0.12.188 · Aug 17`, Mobile `1 day` + `1.0.548 · Aug 19`. Builder tests 22/22, tsc clean.

## Product invariants affected
none

## Failure class
Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

