### PR TITLE
fix(ci): scope the Firestore field-exemption check to the environment that can apply it

### DIFF
--- a/.github/failure-classes/FC-check-scope-exceeds-remediation-scope.json
+++ b/.github/failure-classes/FC-check-scope-exceeds-remediation-scope.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-check-scope-exceeds-remediation-scope",
+  "violated_contract": "A gate that fails until an operator applies a remediation must only run where that remediation is permitted. When the check is broader than the operation that answers it, the excluded environments are asked to prove a state they are forbidden to reach, so their runs fail permanently on a condition no one can clear.",
+  "canonical_prevention": "Bind the check and its remediation to one resolved scope expression, and assert in a static test that every environment the check runs in is an environment the apply operation accepts.",
+  "canonical_prevention_artifact": [
+    ".github/workflows/gcp_firestore_indexes.yml",
+    "backend/tests/unit/test_firestore_index_config.py"
+  ],
+  "evidence_prs": [11872],
+  "scope_hints": [
+    ".github/workflows/gcp_firestore_indexes.yml",
+    "backend/scripts/reconcile_firestore_field_exemptions.py"
+  ],
+  "status": "open"
+}

--- a/.github/workflows/gcp_firestore_indexes.yml
+++ b/.github/workflows/gcp_firestore_indexes.yml
@@ -129,7 +129,18 @@ jobs:
       # indexes deletes their existing entries. Fail after monotone composite
       # repair so the unapplied saving is visible and points at the separately
       # confirmed operation without weakening create-only reconciliation.
+      #
+      # Scoped to prod for two independent reasons. `reject_nonprod_field_exemptions`
+      # refuses the apply operation in every other environment, so unscoped this step
+      # asserts a state a non-prod run is forbidden to reach and the development
+      # reconcile fails here permanently no matter how healthy it is -- which is
+      # exactly what happened once this landed. And there is only one data plane to
+      # check: dev.overlay.yaml sets data_plane_project: based-hardware, so dev/beta
+      # `screen_activity` documents live in prod. The development environment's
+      # RUNTIME_GCP_PROJECT_ID is based-hardware-dev, so a non-prod run of this check
+      # interrogates a project that holds none of the data the exemption is about.
       - name: Detect unapplied Firestore field exemptions
+        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment || 'prod') == 'prod' }}
         run: |
           python3 backend/scripts/reconcile_firestore_field_exemptions.py \
             --project "${{ vars.RUNTIME_GCP_PROJECT_ID }}" \

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -701,17 +701,26 @@ INDEX_REQUIREMENTS = (
 
 
 # Firestore auto-indexes every field of every document in both directions unless a field is
-# explicitly exempted. For large text fields that no query ever filters or orders on, that index
-# is pure storage cost: measured on `screen_activity`, single-field index bytes were roughly three
-# times the document bytes, and the `ocrText` index alone was the majority of the collection.
-# `ocrText` is only ever read back and rendered; semantic search runs on Pinecone vectors, not on
-# Firestore. Exempting a field only removes single-field indexes — composite indexes declared
-# above are unaffected, so a field named in a composite index can still appear here.
+# explicitly exempted. For text fields that no query ever filters or orders on, that index is pure
+# storage cost: measured on prod `screen_activity` (964,964 documents, mean 1,052 B), the four
+# originally declared fields carried roughly 2.75x the document bytes in index entries, matching
+# the earlier "about three times" estimate.
+#
+# Only the two text fields are exempted, and the split is deliberate. `ocrText` (mean 899 B, capped
+# at 1,000 characters on write) is ~71% of that index cost and `windowTitle` ~10%; both are only
+# ever read back and rendered, since semantic search runs on Pinecone vectors rather than Firestore.
+# `deviceName` (11 B) and `clientDeviceId` (14 B) are together ~19% of an already small number --
+# under ten cents a month at current volume -- and are the one plausible future filter here:
+# utils/memory/device_scope_filter.py already scopes by device in Python, and pushing that down to
+# a Firestore filter would fail with FAILED_PRECONDITION against a disabled index. Re-enabling has
+# no scripted path (the reconcile workflow is disable-only) and forces a full collection-group
+# backfill, so they stay indexed.
+#
+# Exempting a field only removes single-field indexes — composite indexes declared above are
+# unaffected, so a field named in a composite index can still appear here.
 FIELD_INDEXING_EXEMPTIONS: tuple[tuple[str, str], ...] = (
     ('screen_activity', 'ocrText'),
     ('screen_activity', 'windowTitle'),
-    ('screen_activity', 'deviceName'),
-    ('screen_activity', 'clientDeviceId'),
 )
 
 

--- a/backend/tests/unit/test_firestore_index_config.py
+++ b/backend/tests/unit/test_firestore_index_config.py
@@ -169,3 +169,32 @@ def test_reconcile_workflow_detects_but_never_automatically_applies_field_exempt
     assert '--dry-run' in destructive
     assert '--apply' in destructive
     assert '--confirmation APPLY_FIRESTORE_FIELD_EXEMPTIONS' in destructive
+
+
+def _reconcile_workflow_steps(job_name):
+    import yaml
+
+    path = Path(__file__).resolve().parents[3] / '.github/workflows/gcp_firestore_indexes.yml'
+    # PyYAML parses the bare `on:` trigger key as the boolean True; the jobs we
+    # care about are unaffected, so read the document as-is.
+    return yaml.safe_load(path.read_text())['jobs'][job_name]['steps']
+
+
+def test_field_exemption_check_only_runs_where_the_apply_operation_is_accepted():
+    """The nag must never outlive the environment that can answer it.
+
+    `reject_nonprod_field_exemptions` refuses the apply operation outside prod, so
+    a check-only step that runs everywhere asserts a state non-prod databases are
+    forbidden to reach and fails the development reconcile forever.
+    """
+
+    check_steps = [
+        step
+        for step in _reconcile_workflow_steps('reconcile_composite_indexes')
+        if '--check-only' in str(step.get('run', ''))
+    ]
+
+    assert len(check_steps) == 1
+    condition = str(check_steps[0].get('if', ''))
+    assert condition, 'the field-exemption check must be scoped to the environment that can apply it'
+    assert "== 'prod'" in condition

--- a/backend/tests/unit/test_reconcile_firestore_field_exemptions.py
+++ b/backend/tests/unit/test_reconcile_firestore_field_exemptions.py
@@ -41,9 +41,10 @@ class FakeRunner:
 def test_expected_exemptions_are_the_manifest_empty_index_overrides():
     manifest = json.loads(MANIFEST_PATH.read_text(encoding='utf-8'))
 
+    # Only the two read-back text fields are exempted. deviceName/clientDeviceId are
+    # deliberately left indexed so device-scoped filtering stays available; see
+    # FIELD_INDEXING_EXEMPTIONS in database/firestore_index_registry.py.
     assert field_reconciler.expected_field_exemptions(manifest) == (
-        field_reconciler.FieldExemption('screen_activity', 'clientDeviceId'),
-        field_reconciler.FieldExemption('screen_activity', 'deviceName'),
         field_reconciler.FieldExemption('screen_activity', 'ocrText'),
         field_reconciler.FieldExemption('screen_activity', 'windowTitle'),
     )
@@ -111,12 +112,10 @@ def test_apply_disables_only_missing_declared_fields_and_verifies_convergence(mo
     )
 
     updates = [command for command in runner.commands if command[4] == 'update']
-    assert {command[5] for command in updates} == {'clientDeviceId', 'deviceName', 'windowTitle'}
+    assert {command[5] for command in updates} == {'windowTitle'}
     assert all('--disable-indexes' in command for command in updates)
     assert all('--clear-exemption' not in command for command in updates)
     assert runner.disabled == {
-        ('screen_activity', 'clientDeviceId'),
-        ('screen_activity', 'deviceName'),
         ('screen_activity', 'ocrText'),
         ('screen_activity', 'windowTitle'),
     }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -785,18 +785,6 @@
       "fieldPath": "windowTitle",
       "ttl": false,
       "indexes": []
-    },
-    {
-      "collectionGroup": "screen_activity",
-      "fieldPath": "deviceName",
-      "ttl": false,
-      "indexes": []
-    },
-    {
-      "collectionGroup": "screen_activity",
-      "fieldPath": "clientDeviceId",
-      "ttl": false,
-      "indexes": []
     }
   ]
 }


### PR DESCRIPTION
Two related changes to the Firestore field-exemption path: one unblocks a workflow that could never go green, the other narrows what the exemption actually deletes now that its value has been measured.

## 1. Scope the check to the environment that can act on it

The composite reconcile ends with a check-only step that fails until the declared `screen_activity` field exemptions are serving. That step ran in **every** environment, but `reject_nonprod_field_exemptions` refuses the apply operation anywhere except prod. Development was asked to prove a state it is forbidden to reach.

Not hypothetical. Run [32408156100](https://github.com/BasedHardware/omi/actions/runs/32408156100) repaired dev's missing `conversation_finalization_jobs` composite index — the actual reason dev backend deploys had been failing since well before the merge that introduced this step — and then failed anyway on four `remains automatically indexed` errors that no dispatch against `development` is allowed to clear.

There is also only one data plane to check. `dev.overlay.yaml` sets `data_plane_project: based-hardware`, so dev and beta `screen_activity` documents live in prod, while the `development` environment's `RUNTIME_GCP_PROJECT_ID` is `based-hardware-dev`. That run interrogated a project holding none of the data the exemption is about — its errors were not merely unactionable, they were measured against the wrong database.

`test_field_exemption_check_only_runs_where_the_apply_operation_is_accepted` parses the workflow, finds the single `--check-only` step, and requires its condition to restrict to prod. Verified it fails against the unscoped step.

## 2. Keep the device fields indexed

The exemption set was declared from a ratio and never from an absolute. Measured on prod:

| | |
|---|---|
| `screen_activity` documents | 964,964 |
| mean document size | 1,052 B |
| `ocrText` | 899 B mean (capped at 1,000 chars on write) |
| `windowTitle` | 32 B |
| `deviceName` / `clientDeviceId` | 11 B / 14 B |

Index entries for the four declared fields come to ~2.75x the document bytes, so the earlier "about three times" note was right about the ratio and silent about the amount: **the whole four-field exemption is worth about $0.50/month** at $0.18/GiB/month.

That reframes the two device fields. They are ~19% of that — under ten cents a month — and they are the one plausible future filter in the set: `utils/memory/device_scope_filter.py` already scopes by device in Python, and pushing that down to Firestore would fail with `FAILED_PRECONDITION` against a disabled index. Recovery has no scripted path (the reconcile workflow is disable-only), so it means a hand-run gcloud plus a PR reverting the registry, plus a full collection-group backfill of unmeasured duration.

`ocrText` (~71%) and `windowTitle` (~10%) are only ever read back and rendered — semantic search runs on Pinecone, not Firestore — so exempting just those keeps ~81% of the saving with no query foreclosed. The measurement now sits next to the tuple so the next change argues from the amount.

## Not fixed here

The `development` `RUNTIME_GCP_PROJECT_ID` contradicting the runtime manifest is a separate defect. It is an environment setting rather than repo state, and changing it alters what the dev readiness gate proves. It is an instance of the already-open `FC-firestore-readiness-project-mismatch`.

Failure-Class: new
