### PR TITLE
fix(admin): iOS release timeline buckets by New York calendar day

### DIFF
--- a/web/admin/app/api/omi/stats/releases/route.ts
+++ b/web/admin/app/api/omi/stats/releases/route.ts
@@ -133,7 +133,8 @@ async function fetchIosReleases(days: number): Promise<{ dates: string[]; latest
       `
         SELECT v, min(d) AS release_day
         FROM (
-          SELECT properties.$app_version AS v, toDate(timestamp) AS d,
+          SELECT properties.$app_version AS v,
+                 toDate(toTimeZone(timestamp, 'America/New_York')) AS d,
                  uniq(distinct_id) AS u
           FROM events
           WHERE event = 'Memory Created'

--- a/web/admin/lib/__tests__/platform-scope-routes.test.ts
+++ b/web/admin/lib/__tests__/platform-scope-routes.test.ts
@@ -101,3 +101,26 @@ describe("dau-trends response cache", () => {
     expect(captured[captured.length - 1]).toContain(MOBILE_FILTER);
   });
 });
+
+describe("releases route", () => {
+  it("buckets the iOS release timeline by New York calendar day", async () => {
+    // GitHub + iTunes calls are irrelevant here; the assertion is that the
+    // PostHog rollout-crossing query follows the boards' NYC-day contract
+    // (UTC toDate would push evening releases onto the next day).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => [] }) as any),
+    );
+    try {
+      const queries = await capture(
+        () => import("@/app/api/omi/stats/releases/route"),
+        "/api/omi/stats/releases?days=30",
+      );
+      const ios = queries.find((q) => q.includes("$app_version"));
+      expect(ios).toBeTruthy();
+      expect(ios).toContain("toTimeZone(timestamp, 'America/New_York')");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
The iOS rollout-crossing query grouped days with UTC `toDate(timestamp)` while every board renders NYC days — an evening release landed on the next calendar day. Now buckets via `toTimeZone(timestamp, 'America/New_York')`.

## Verification
Behavioral regression in the platform-scope route harness (executes the route, asserts the captured HogQL contains the NYC conversion): vitest 18/18, tsc clean. This commit raced past #11953's merge and carries only the timezone change.

## Product invariants affected
none

## Failure class
Failure-Class: none

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

