### PR TITLE
feat(desktop): Rewind shows and follows the newest captured frame

### DIFF
--- a/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Core/RewindStorage.swift
@@ -161,6 +161,55 @@ actor RewindStorage {
     return relativePath
   }
 
+  // MARK: - Live Frames
+
+  /// Frames in the active (unfinalized) video chunk cannot be decoded yet, so ingest also writes
+  /// each JPEG here and the timeline falls back to it until the chunk finalizes. Lives in its own
+  /// subdirectory so pruning can never touch legacy per-frame history under the day directories.
+  private static let liveFramesDirectoryName = "live"
+  /// Comfortably above the 60s chunk duration plus finalization time.
+  private static let liveFrameMaxAge: TimeInterval = 10 * 60
+  private var lastLiveFramePruneAt: Date = .distantPast
+
+  /// Save a JPEG for a frame whose video chunk has not finalized yet; returns the relative path.
+  func saveLiveScreenshot(jpegData: Data, timestamp: Date) async throws -> String {
+    guard let screenshotsDirectory = screenshotsDirectory else {
+      throw RewindError.storageError("Storage not initialized")
+    }
+    let liveDirectory = screenshotsDirectory.appendingPathComponent(
+      Self.liveFramesDirectoryName, isDirectory: true)
+    try fileManager.createDirectory(at: liveDirectory, withIntermediateDirectories: true)
+
+    let filename = "frame_\(Int64(timestamp.timeIntervalSince1970 * 1000)).jpg"
+    let relativePath = "\(Self.liveFramesDirectoryName)/\(filename)"
+    try jpegData.write(to: screenshotsDirectory.appendingPathComponent(relativePath))
+
+    pruneLiveScreenshotsIfDue()
+    return relativePath
+  }
+
+  /// Delete live JPEGs old enough that their chunk has long since finalized (video storage wins
+  /// once available, so these files are only read while the frame's chunk is active or corrupted).
+  private func pruneLiveScreenshotsIfDue(now: Date = Date()) {
+    guard now.timeIntervalSince(lastLiveFramePruneAt) >= 60 else { return }
+    lastLiveFramePruneAt = now
+    guard let screenshotsDirectory = screenshotsDirectory else { return }
+    let liveDirectory = screenshotsDirectory.appendingPathComponent(
+      Self.liveFramesDirectoryName, isDirectory: true)
+    guard
+      let files = try? fileManager.contentsOfDirectory(
+        at: liveDirectory, includingPropertiesForKeys: [.contentModificationDateKey])
+    else { return }
+    for file in files {
+      let modified =
+        (try? file.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+        ?? .distantPast
+      if now.timeIntervalSince(modified) > Self.liveFrameMaxAge {
+        try? fileManager.removeItem(at: file)
+      }
+    }
+  }
+
   // MARK: - Load Screenshot
 
   /// Load image data from a relative path
@@ -547,8 +596,14 @@ actor RewindStorage {
       let videoPath = screenshot.videoChunkPath,
       let frameOffset = screenshot.frameOffset
     {
-      let frame = try await videoFrame(videoPath: videoPath, frameOffset: frameOffset)
-      return NSImage(cgImage: frame.cgImage, size: frame.pixelSize)
+      do {
+        let frame = try await videoFrame(videoPath: videoPath, frameOffset: frameOffset)
+        return NSImage(cgImage: frame.cgImage, size: frame.pixelSize)
+      } catch {
+        // Frame's chunk is still active (or unreadable) — fall back to the live JPEG if we have one.
+        guard let imagePath = screenshot.imagePath, !imagePath.isEmpty else { throw error }
+        return try await loadScreenshotImage(relativePath: imagePath)
+      }
     }
 
     let data = try await loadScreenshotData(for: screenshot)
@@ -594,15 +649,21 @@ actor RewindStorage {
       let videoPath = screenshot.videoChunkPath,
       let offset = screenshot.frameOffset
     {
-      // Load frame and convert to JPEG data
-      let image = try await loadVideoFrame(videoPath: videoPath, frameOffset: offset)
-      guard let tiffData = image.tiffRepresentation,
-        let bitmap = NSBitmapImageRep(data: tiffData),
-        let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 1.0])
-      else {
-        throw RewindError.invalidImage
+      do {
+        // Load frame and convert to JPEG data
+        let image = try await loadVideoFrame(videoPath: videoPath, frameOffset: offset)
+        guard let tiffData = image.tiffRepresentation,
+          let bitmap = NSBitmapImageRep(data: tiffData),
+          let jpegData = bitmap.representation(using: .jpeg, properties: [.compressionFactor: 1.0])
+        else {
+          throw RewindError.invalidImage
+        }
+        return jpegData
+      } catch {
+        // Frame's chunk is still active (or unreadable) — fall back to the live JPEG if we have one.
+        guard let imagePath = screenshot.imagePath, !imagePath.isEmpty else { throw error }
+        return try await loadScreenshot(relativePath: imagePath)
       }
-      return jpegData
     } else if let imagePath = screenshot.imagePath, !imagePath.isEmpty {
       return try await loadScreenshot(relativePath: imagePath)
     } else {

--- a/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/Services/RewindIndexer.swift
@@ -296,12 +296,18 @@ actor RewindIndexer {
         }
       }
 
+      // Persist the JPEG we already have so the timeline can show this frame before its
+      // video chunk finalizes (video storage wins once the chunk is readable).
+      let livePath =
+        (try? await RewindStorage.shared.saveLiveScreenshot(
+          jpegData: frame.jpegData, timestamp: frame.captureTime)) ?? ""
+
       // Create database record with video reference and OCR results
       let screenshot = Screenshot(
         timestamp: frame.captureTime,
         appName: frame.appName,
         windowTitle: frame.windowTitle,
-        imagePath: "",
+        imagePath: livePath,
         videoChunkPath: encodedFrame.videoChunkPath,
         frameOffset: encodedFrame.frameOffset,
         ocrText: ocrText,
@@ -338,6 +344,22 @@ actor RewindIndexer {
       logError("RewindIndexer: Failed to process frame", error: error)
       await RewindDatabase.shared.reportQueryError(error)
     }
+  }
+
+  /// JPEG-encode a frame and stash it as a live preview for the still-unfinalized video chunk.
+  /// Returns "" when encoding or storage is unavailable — the frame then stays hidden until its
+  /// chunk finalizes, exactly as before live previews existed.
+  private static func saveLiveJPEG(cgImage: CGImage, timestamp: Date) async -> String {
+    let data = NSMutableData()
+    guard
+      let destination = CGImageDestinationCreateWithData(data as CFMutableData, "public.jpeg" as CFString, 1, nil)
+    else { return "" }
+    CGImageDestinationAddImage(
+      destination, cgImage, [kCGImageDestinationLossyCompressionQuality: 0.8] as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else { return "" }
+    return
+      (try? await RewindStorage.shared.saveLiveScreenshot(jpegData: data as Data, timestamp: timestamp))
+      ?? ""
   }
 
   /// Process a frame directly from a CGImage (macOS 14+ path, avoids JPEG decode round-trip)
@@ -398,11 +420,15 @@ actor RewindIndexer {
         }
       }
 
+      // Persist a JPEG so the timeline can show this frame before its video chunk finalizes
+      // (video storage wins once the chunk is readable).
+      let livePath = await Self.saveLiveJPEG(cgImage: cgImage, timestamp: captureTime)
+
       let screenshot = Screenshot(
         timestamp: captureTime,
         appName: appName,
         windowTitle: windowTitle,
-        imagePath: "",
+        imagePath: livePath,
         videoChunkPath: encodedFrame.videoChunkPath,
         frameOffset: encodedFrame.frameOffset,
         ocrText: ocrText,

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindPage.swift
@@ -224,9 +224,9 @@ struct RewindPage: View {
           let currentId = oldScreenshots[currentIndex].id,
           let newIndex = newScreenshots.firstIndex(where: { $0.id == currentId })
         {
-          // Same screenshot found in new array - adjust index
-          currentIndex = newIndex
-          // No need to reload frame - it's the same screenshot
+          currentIndex = RewindTimelineNavigation.sameFrameIndex(
+            old: oldScreenshots.count, new: newScreenshots.count, current: currentIndex, found: newIndex)
+          if currentIndex != newIndex { scheduleLoadCurrentFrame() }
         } else if !newScreenshots.isEmpty {
           // A viewport query may replace every sampled row. Stay near the same visible moment instead
           // of snapping to the newest capture in all of history.

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindTrackModel.swift
@@ -21,6 +21,16 @@ enum RewindTimelineNavigation {
     return max(0, min(index, screenshots.count - 1))
   }
 
+  /// Player index when the loaded array changes but the viewed frame still exists at `found`.
+  /// Parked on the newest frame while new captures append (frame kept its position and the array
+  /// only grew) follows to the new newest; any other change (scrubbed-back position,
+  /// sampled-window replacement) preserves the user's position. A result different from `found`
+  /// means the player moved and the caller must load that frame.
+  static func sameFrameIndex(old: Int, new: Int, current: Int, found: Int) -> Int {
+    if current == old - 1, found == current, new > old { return new - 1 }
+    return found
+  }
+
   /// The capture nearest an absolute moment in an ascending viewport sample.
   static func nearestIndex(to instant: Double, screenshots: [Screenshot]) -> Int? {
     guard !screenshots.isEmpty else { return nil }
@@ -130,8 +140,19 @@ enum RewindTrackWindow {
     return range.lowerBound...max(range.upperBound, instant + 30)
   }
 
-  static func shouldRefreshLiveFrames(visibleRange: ClosedRange<Double>?, now: Date) -> Bool {
-    visibleRange?.contains(now.timeIntervalSince1970) == true
+  static func shouldRefreshLiveFrames(
+    visibleRange: ClosedRange<Double>?, newestLoadedTimestamp: Double?, now: Date,
+    isPlayerParkedOnNewestFrame: Bool = false
+  ) -> Bool {
+    // The player sitting on the newest loaded frame is the live edge regardless of where the
+    // track viewport is panned — the viewer wants the next capture, so keep refreshing.
+    if isPlayerParkedOnNewestFrame { return true }
+    guard let visibleRange else { return false }
+    if visibleRange.contains(now.timeIntervalSince1970) { return true }
+    // A viewport parked at the live edge always trails the clock (its end is the newest loaded
+    // frame). Keep refreshing there; only a viewport panned back into older history stops.
+    guard let newestLoadedTimestamp else { return false }
+    return visibleRange.upperBound >= newestLoadedTimestamp
   }
 }
 

--- a/desktop/macos/Desktop/Sources/Rewind/UI/RewindViewModel.swift
+++ b/desktop/macos/Desktop/Sources/Rewind/UI/RewindViewModel.swift
@@ -204,8 +204,15 @@ class RewindViewModel: ObservableObject {
     guard !isTranscriptExpanded else { return }
 
     // A today label can remain selected while the continuous viewport is panned into older history.
-    // Only append live frames when the actual visible window contains now.
-    guard RewindTrackWindow.shouldRefreshLiveFrames(visibleRange: visibleTimelineRange, now: Date()) else { return }
+    // Only append live frames when the visible window contains now or is parked at the live edge.
+    guard
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: visibleTimelineRange,
+        newestLoadedTimestamp: screenshots.last?.timestamp.timeIntervalSince1970,
+        now: Date(),
+        isPlayerParkedOnNewestFrame: selectedScreenshot?.id != nil
+          && selectedScreenshot?.id == screenshots.last?.id)
+    else { return }
 
     // Silent refresh: append newly finalized frames without rescanning the retained history.
     await silentlyRefreshNewestFrames()
@@ -568,11 +575,11 @@ class RewindViewModel: ObservableObject {
       )
       guard ownerSnapshot.isCurrent() else { return }
 
-      // Filter out frames from the active (unfinalized) video chunk — they can't be displayed yet
+      // Frames from the active (unfinalized) video chunk are only displayable via their live JPEG
       let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
       guard ownerSnapshot.isCurrent() else { return }
       if let activeChunk = activeChunk {
-        results = results.filter { $0.videoChunkPath != activeChunk }
+        results = results.filter { $0.videoChunkPath != activeChunk || !($0.imagePath ?? "").isEmpty }
       }
 
       // Apply app filter if set
@@ -617,8 +624,22 @@ class RewindViewModel: ObservableObject {
       }
       guard !additions.isEmpty else { return }
       guard ownerSnapshot.isCurrent() else { return }
+      // Follow the live edge: only when the user is parked on the newest frame does the
+      // selection advance with new captures; a scrubbed-back position stays put.
+      let wasParkedOnNewestFrame = selectedScreenshot?.id != nil && selectedScreenshot?.id == newest.id
       screenshots.append(contentsOf: additions)
       historyRange = RewindTrackWindow.extending(historyRange, toInclude: additions[additions.count - 1].timestamp)
+      if wasParkedOnNewestFrame {
+        // Not selectScreenshot(_:) — that emits a per-frame analytics view event; this is
+        // passive following, not a user navigation.
+        selectedScreenshot = additions[additions.count - 1]
+      }
+      // A viewport parked at the live edge follows the frames it accepts; otherwise the newest
+      // loaded frame moves past the viewport's end and the next refresh tick gates itself off.
+      if let visible = visibleTimelineRange, visible.upperBound >= newest.timestamp.timeIntervalSince1970 {
+        visibleTimelineRange = RewindTrackWindow.extending(
+          visible, toInclude: additions[additions.count - 1].timestamp)
+      }
 
       let today = calendar.startOfDay(for: additions[additions.count - 1].timestamp)
       if !capturedDays.contains(where: { calendar.isDate($0, inSameDayAs: today) }) {
@@ -633,7 +654,7 @@ class RewindViewModel: ObservableObject {
   where S.Element == Screenshot {
     var results = Array(source)
     if let activeChunk = await VideoChunkEncoder.shared.currentChunkPath {
-      results.removeAll { $0.videoChunkPath == activeChunk }
+      results.removeAll { $0.videoChunkPath == activeChunk && ($0.imagePath ?? "").isEmpty }
     }
     if let app = selectedApp {
       results.removeAll { $0.appName != app }

--- a/desktop/macos/Desktop/Tests/RewindTrackTests.swift
+++ b/desktop/macos/Desktop/Tests/RewindTrackTests.swift
@@ -213,10 +213,46 @@ final class RewindTrackTests: XCTestCase {
     XCTAssertFalse(RewindTimelinePresentation.showsTimeline(screenshotCount: 0, historyRange: nil))
   }
 
-  func testLiveRefreshRequiresAViewportContainingNow() {
+  func testLiveRefreshRequiresAViewportContainingNowOrParkedAtTheLiveEdge() {
     let now = Date(timeIntervalSince1970: 1_000)
-    XCTAssertTrue(RewindTrackWindow.shouldRefreshLiveFrames(visibleRange: 900...1_100, now: now))
-    XCTAssertFalse(RewindTrackWindow.shouldRefreshLiveFrames(visibleRange: 100...200, now: now))
+    XCTAssertTrue(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: 900...1_100, newestLoadedTimestamp: nil, now: now))
+    XCTAssertFalse(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: 100...200, newestLoadedTimestamp: nil, now: now))
+    // Parked at the live edge: the viewport ends at the newest loaded frame, which trails now.
+    XCTAssertTrue(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: 800...950, newestLoadedTimestamp: 950, now: now))
+    // Panned into older history: the newest loaded frame lies beyond the viewport's end.
+    XCTAssertFalse(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: 100...200, newestLoadedTimestamp: 950, now: now))
+    XCTAssertFalse(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: nil, newestLoadedTimestamp: 950, now: now))
+    // The player sitting on the newest loaded frame is the live edge even when the track
+    // viewport is panned into older history (e.g. a restored viewport from a prior session).
+    XCTAssertTrue(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: 100...200, newestLoadedTimestamp: 950, now: now,
+        isPlayerParkedOnNewestFrame: true))
+    XCTAssertTrue(
+      RewindTrackWindow.shouldRefreshLiveFrames(
+        visibleRange: nil, newestLoadedTimestamp: nil, now: now,
+        isPlayerParkedOnNewestFrame: true))
+  }
+
+  func testPlayerFollowsAppendsOnlyWhenParkedOnTheNewestFrame() {
+    // Parked on the newest frame and the array grew → follow to the new newest.
+    XCTAssertEqual(RewindTimelineNavigation.sameFrameIndex(old: 10, new: 12, current: 9, found: 9), 11)
+    // Scrubbed back → keep the viewed frame even though the array grew.
+    XCTAssertEqual(RewindTimelineNavigation.sameFrameIndex(old: 10, new: 12, current: 5, found: 5), 5)
+    // Sampled-window replacement moved the viewed frame → track it, no live-edge jump.
+    XCTAssertEqual(RewindTimelineNavigation.sameFrameIndex(old: 10, new: 12, current: 9, found: 4), 4)
+    // Same-size reload with the frame still last → stay put.
+    XCTAssertEqual(RewindTimelineNavigation.sameFrameIndex(old: 10, new: 10, current: 9, found: 9), 9)
   }
 
   func testNewCaptureExtendsTheRetainedHistoryUpperBound() {

--- a/desktop/macos/changelog/unreleased/20260820-rewind-live-frames.json
+++ b/desktop/macos/changelog/unreleased/20260820-rewind-live-frames.json
@@ -1,0 +1,3 @@
+{
+  "change": "Rewind now shows the latest screenshot within seconds of capture instead of trailing 1–2 minutes, and the player follows new captures live while parked on the newest frame"
+}


### PR DESCRIPTION
Rewind's newest visible frame trailed the clock by 1–2 minutes: frames are stored in 60-second H.265 video chunks, and a frame cannot be decoded until its chunk finalizes, so the UI filtered out everything in the active chunk. On top of that, the 3s live refresh gated itself off whenever the visible window stopped containing "now" (which the live edge always does), and the player kept its position when new frames appended, so the timeline froze behind the user.

## Changes

- **Live JPEG previews** (`RewindStorage`, `RewindIndexer`): ingest also writes each frame's JPEG to `Screenshots/live/` (already in memory on the CapturedFrame path; encoded once on the CGImage path) and records it in the row's `imagePath`. Video storage still wins once the chunk is readable; live files are pruned after 10 minutes (~28 MB rolling window measured live).
- **Timeline shows the active chunk** (`RewindViewModel`, `RewindStorage`): active-chunk frames with a live JPEG are no longer filtered out; the frame/thumbnail loaders fall back to the JPEG when the video frame is unavailable.
- **Live-edge refresh + follow** (`RewindTrackWindow.shouldRefreshLiveFrames`, `RewindViewModel`, `RewindPage`, `RewindTimelineNavigation.sameFrameIndex`): the player parked on the newest loaded frame counts as live regardless of where the track viewport is panned (a restored viewport used to silently kill the refresh); appends extend a viewport parked at the live edge; and the player follows newly appended captures when parked on the newest frame, while scrubbed-back positions stay put.

## Verification

Exercised on a named bundle (`omi-richmond`) against the real capture pipeline, at the exact merge SHA after rebase:

- Fresh open of Rewind showed the newest captured frame **7 s old** (16:14:17 clock, frame 16:14:10, 163/163) vs 1–2 min stale before.
- 3.5-minute parked soak: the player followed the live edge continuously (150 → 163 frames) instead of freezing; scrubbed-back position stays put (exercised via restored-viewport case).
- Post-rebase re-run: fresh open at 16:42, 2-minute park at 16:44 showed newest existing frame at 210/210.
- Live-JPEG store bounded at 54 files / 28 MB after an hour of capture (10-min prune window observed working).
- `RewindTrackTests`: 24 tests, 0 failures. `make preflight`: 21/21 PASS.

## Product invariants affected

none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

