### PR TITLE
fix: expose promoted macOS Beta artifacts immediately

### DIFF
--- a/.github/failure-classes/FC-promoted-artifact-hidden-by-stale-dependency-cache.json
+++ b/.github/failure-classes/FC-promoted-artifact-hidden-by-stale-dependency-cache.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-promoted-artifact-hidden-by-stale-dependency-cache",
+  "violated_contract": "A successful release-pointer promotion must become readable immediately through every public projection. Invalidating only the pointer cache while leaving a cached pre-publication artifact listing can return success from promotion yet keep the promoted release absent from the update feed until cache expiry.",
+  "canonical_prevention": "After the authoritative promotion commits, the promotion boundary invalidates both its channel pointer cache and every cached dependency used to resolve that channel's artifacts; idempotent retries repair the same cache set, and route tests assert both invalidations.",
+  "canonical_prevention_artifact": [
+    "backend/routers/updates.py",
+    "backend/tests/unit/test_desktop_updates.py"
+  ],
+  "evidence_prs": [11951],
+  "scope_hints": [
+    "backend/routers/updates.py",
+    "backend/utils/desktop_update_resolver.py"
+  ],
+  "status": "open"
+}

--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -1251,7 +1251,9 @@ async def promote_beta_candidate(
         logger.info("beta_candidate_promotion tag=%s result=conflict", request.tag)
         raise HTTPException(status_code=409, detail="Beta candidate promotion conflict") from None
     # A prior successful commit can lose its cache deletion. Every committed
-    # receipt, including an idempotent retry, repairs only this Beta projection.
+    # receipt, including an idempotent retry, repairs the Beta pointer and the
+    # raw GitHub release projection used to resolve Omi.Beta.zip.
+    await run_blocking(db_executor, delete_generic_cache, "github_releases_desktop")
     await run_blocking(db_executor, delete_generic_cache, live_cache_key("macos", "beta"))
     logger.info(
         "beta_candidate_promotion tag=%s result=%s", request.tag, "idempotent" if receipt["idempotent"] else "promoted"

--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -1,7 +1,7 @@
 """Tests for desktop update system (appcast XML, channel filtering, download endpoint)."""
 
 import xml.etree.ElementTree as ET
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -1377,7 +1377,10 @@ class TestDesktopUpdateAdminEndpoints:
             "idempotent": False,
         }
         admit.assert_called_once_with(manifest, control_generation=7)
-        invalidate.assert_called_once_with("desktop_update_pointer:macos:beta")
+        assert invalidate.call_args_list == [
+            call("github_releases_desktop"),
+            call("desktop_update_pointer:macos:beta"),
+        ]
 
     @pytest.mark.asyncio
     async def test_signed_beta_candidate_rejection_writes_nothing_and_never_invalidates_stable(self):
@@ -1406,7 +1409,7 @@ class TestDesktopUpdateAdminEndpoints:
         invalidate.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_signed_beta_candidate_idempotent_receipt_repairs_only_the_beta_cache_after_the_transaction(self):
+    async def test_signed_beta_candidate_idempotent_receipt_repairs_release_and_beta_caches_after_transaction(self):
         manifest = {"release_id": "v0.12.93+12093-macos"}
         receipt = {"manifest": manifest, "pointer": {"generation": 7}, "idempotent": True}
         with (
@@ -1424,7 +1427,10 @@ class TestDesktopUpdateAdminEndpoints:
                 )
 
         assert response.status_code == 200
-        invalidate.assert_called_once_with("desktop_update_pointer:macos:beta")
+        assert invalidate.call_args_list == [
+            call("github_releases_desktop"),
+            call("desktop_update_pointer:macos:beta"),
+        ]
 
     @pytest.mark.asyncio
     async def test_registers_immutable_manifest(self):


### PR DESCRIPTION
## Summary

- invalidate the raw GitHub release cache after every committed Beta promotion
- keep the existing pointer-cache invalidation
- cover both first promotion and idempotent retry receipts

## Failure class

Failure-Class: new

The live `v0.12.189` promotion advanced the Beta pointer to generation 47, but the appcast remained empty because its Beta-identity asset resolver read a pre-publication `github_releases_desktop` cache entry. Clearing that cache immediately exposed `Omi.Beta.zip`.

## Verification

- 12 `TestDesktopUpdateAdminEndpoints` tests passed
- async blocker scan found zero selected findings
- production cache clear made the Beta appcast return build `12189` and `Omi.Beta.zip` on three consecutive requests
- `git diff --check`

## Product invariants affected

- INV-BETA-1


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

