### PR TITLE
fix(macos): stop notification chat rows saying everything twice

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge+Notifications.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge+Notifications.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Notification-facing automation actions, grouped out of the main registry file.
+extension DesktopAutomationActionRegistry {
+  func registerNotificationActions() {
+    register(
+      name: "settings_notifications_snapshot",
+      summary: "Return notification settings and local permission state"
+    ) { _ in
+      async let settingsTask = APIClient.shared.getNotificationSettings()
+      let settings = try await settingsTask
+      let appState = await MainActor.run { AppState.current }
+      let hasPermission = appState?.hasNotificationPermission ?? false
+      let bannersDisabled = appState?.isNotificationBannerDisabled ?? false
+      return [
+        "schema": "enabled,frequency,frequency_label,has_permission,banners_disabled",
+        "enabled": settings.enabled ? "true" : "false",
+        "frequency": "\(settings.frequency)",
+        "frequency_label": settings.frequencyDescription,
+        "has_permission": hasPermission ? "true" : "false",
+        "banners_disabled": bannersDisabled ? "true" : "false",
+      ]
+    }
+
+    register(
+      name: "set_notification_settings",
+      summary: "Update notification settings via the real API",
+      params: ["enabled", "frequency"]
+    ) { params in
+      let enabled = params["enabled"].map { boolParam($0, default: true) }
+      let frequency = params["frequency"].flatMap { Int($0) }
+      let response = try await APIClient.shared.updateNotificationSettings(
+        enabled: enabled,
+        frequency: frequency
+      )
+      UserDefaults.standard.set(
+        response.enabled,
+        forKey: NotificationService.masterEnabledDefaultsKey)
+      UserDefaults.standard.set(
+        response.frequency,
+        forKey: NotificationService.frequencyDefaultsKey)
+      return [
+        "saved": "true",
+        "enabled": response.enabled ? "true" : "false",
+        "frequency": "\(response.frequency)",
+      ]
+    }
+
+    // The distributed com.omi.test.notification channel is machine-global: every
+    // running Omi bundle — the user's production install included — receives it,
+    // delivers it, and journals it into the real account's chat (#11943). This is
+    // the bundle-scoped alternative: it reaches only the bundle whose port and
+    // token the caller holds, through the same production sendNotification path.
+    register(
+      name: "send_test_notification",
+      summary: "Deliver a proactive test notification through the real sendNotification path (this bundle only)",
+      params: ["title", "message", "assistant_id"]
+    ) { params in
+      let title = params["title"] ?? "Insight"
+      let message = params["message"] ?? "Test notification from Omi"
+      let assistantId = params["assistant_id"] ?? "insight"
+      let posted = await MainActor.run { () -> Bool in
+        guard let ownerID = RuntimeOwnerIdentity.currentOwnerId() else { return false }
+        NotificationService.shared.sendNotification(
+          ownerID: ownerID,
+          title: title,
+          message: message,
+          assistantId: assistantId
+        )
+        return true
+      }
+      return ["posted": posted ? "true" : "false"]
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3446,75 +3446,7 @@ final class DesktopAutomationActionRegistry {
       ]
     }
 
-    register(
-      name: "settings_notifications_snapshot",
-      summary: "Return notification settings and local permission state"
-    ) { _ in
-      async let settingsTask = APIClient.shared.getNotificationSettings()
-      let settings = try await settingsTask
-      let appState = await MainActor.run { AppState.current }
-      let hasPermission = appState?.hasNotificationPermission ?? false
-      let bannersDisabled = appState?.isNotificationBannerDisabled ?? false
-      return [
-        "schema": "enabled,frequency,frequency_label,has_permission,banners_disabled",
-        "enabled": settings.enabled ? "true" : "false",
-        "frequency": "\(settings.frequency)",
-        "frequency_label": settings.frequencyDescription,
-        "has_permission": hasPermission ? "true" : "false",
-        "banners_disabled": bannersDisabled ? "true" : "false",
-      ]
-    }
-
-    register(
-      name: "set_notification_settings",
-      summary: "Update notification settings via the real API",
-      params: ["enabled", "frequency"]
-    ) { params in
-      let enabled = params["enabled"].map { boolParam($0, default: true) }
-      let frequency = params["frequency"].flatMap { Int($0) }
-      let response = try await APIClient.shared.updateNotificationSettings(
-        enabled: enabled,
-        frequency: frequency
-      )
-      UserDefaults.standard.set(
-        response.enabled,
-        forKey: NotificationService.masterEnabledDefaultsKey)
-      UserDefaults.standard.set(
-        response.frequency,
-        forKey: NotificationService.frequencyDefaultsKey)
-      return [
-        "saved": "true",
-        "enabled": response.enabled ? "true" : "false",
-        "frequency": "\(response.frequency)",
-      ]
-    }
-
-    // The distributed com.omi.test.notification channel is machine-global: every
-    // running Omi bundle — the user's production install included — receives it,
-    // delivers it, and journals it into the real account's chat (#11943). This is
-    // the bundle-scoped alternative: it reaches only the bundle whose port and
-    // token the caller holds, through the same production sendNotification path.
-    register(
-      name: "send_test_notification",
-      summary: "Deliver a proactive test notification through the real sendNotification path (this bundle only)",
-      params: ["title", "message", "assistant_id"]
-    ) { params in
-      let title = params["title"] ?? "Insight"
-      let message = params["message"] ?? "Test notification from Omi"
-      let assistantId = params["assistant_id"] ?? "insight"
-      let posted = await MainActor.run { () -> Bool in
-        guard let ownerID = RuntimeOwnerIdentity.currentOwnerId() else { return false }
-        NotificationService.shared.sendNotification(
-          ownerID: ownerID,
-          title: title,
-          message: message,
-          assistantId: assistantId
-        )
-        return true
-      }
-      return ["posted": posted ? "true" : "false"]
-    }
-
+    registerNotificationActions()
     register(
       name: "rewind_settings_snapshot",
       summary: "Return Rewind settings retention and excluded-app counts"
@@ -3861,7 +3793,7 @@ final class DesktopAutomationActionRegistry {
 }
 
 /// Coerce a string param ("true"/"1"/"yes") into a Bool, falling back when absent.
-private func boolParam(_ raw: String?, default fallback: Bool) -> Bool {
+func boolParam(_ raw: String?, default fallback: Bool) -> Bool {
   guard let raw = raw?.trimmingCharacters(in: .whitespaces).lowercased(), !raw.isEmpty else {
     return fallback
   }

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -3489,6 +3489,32 @@ final class DesktopAutomationActionRegistry {
       ]
     }
 
+    // The distributed com.omi.test.notification channel is machine-global: every
+    // running Omi bundle — the user's production install included — receives it,
+    // delivers it, and journals it into the real account's chat (#11943). This is
+    // the bundle-scoped alternative: it reaches only the bundle whose port and
+    // token the caller holds, through the same production sendNotification path.
+    register(
+      name: "send_test_notification",
+      summary: "Deliver a proactive test notification through the real sendNotification path (this bundle only)",
+      params: ["title", "message", "assistant_id"]
+    ) { params in
+      let title = params["title"] ?? "Insight"
+      let message = params["message"] ?? "Test notification from Omi"
+      let assistantId = params["assistant_id"] ?? "insight"
+      let posted = await MainActor.run { () -> Bool in
+        guard let ownerID = RuntimeOwnerIdentity.currentOwnerId() else { return false }
+        NotificationService.shared.sendNotification(
+          ownerID: ownerID,
+          title: title,
+          message: message,
+          assistantId: assistantId
+        )
+        return true
+      }
+      return ["posted": posted ? "true" : "false"]
+    }
+
     register(
       name: "rewind_settings_snapshot",
       summary: "Return Rewind settings retention and excluded-app counts"

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Copy policy for the one chat row a proactive notification journals into.
+extension FloatingControlBarManager {
+  /// The director's copy contract (5a076e10b3) makes the title AND the message both
+  /// name the same specific referent — measured as the only shape that keeps each
+  /// field useful on its own surface. Journaled together into one chat row, that
+  /// contract reads as saying everything twice ("Latest Omi desktop app download
+  /// link" / "The latest Omi desktop app download link is …"), so the headline is
+  /// kept only when it adds words the body does not already carry.
+  nonisolated static func notificationJournalText(title: String, body: String) -> String {
+    let headline = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
+    if headline.isEmpty { return detail }
+    if detail.isEmpty || detail == headline { return headline }
+    if bodyRestatesTitle(title: headline, body: detail) { return detail }
+    return "\(headline)\n\(detail)"
+  }
+
+  /// Whether every content-bearing token of the title already appears in the body,
+  /// compared case-insensitively with punctuation (smart quotes, dashes, commas)
+  /// stripped — so a body that quotes, inflects, or reorders the title still counts
+  /// as restating it. A title contributing even one new token keeps its own line.
+  nonisolated static func bodyRestatesTitle(title: String, body: String) -> Bool {
+    let titleTokens = copyTokens(title)
+    guard !titleTokens.isEmpty else { return true }
+    let bodyTokens = Set(copyTokens(body))
+    return titleTokens.allSatisfy(bodyTokens.contains)
+  }
+
+  private nonisolated static func copyTokens(_ text: String) -> [String] {
+    text.lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
+  }
+}

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4264,38 +4264,6 @@ class FloatingControlBarManager {
     }
   }
 
-  /// The director's copy contract (5a076e10b3) makes the title AND the message both
-  /// name the same specific referent — measured as the only shape that keeps each
-  /// field useful on its own surface. Journaled together into one chat row, that
-  /// contract reads as saying everything twice ("Latest Omi desktop app download
-  /// link" / "The latest Omi desktop app download link is …"), so the headline is
-  /// kept only when it adds words the body does not already carry.
-  nonisolated static func notificationJournalText(title: String, body: String) -> String {
-    let headline = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    let detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
-    if headline.isEmpty { return detail }
-    if detail.isEmpty || detail == headline { return headline }
-    if bodyRestatesTitle(title: headline, body: detail) { return detail }
-    return "\(headline)\n\(detail)"
-  }
-
-  /// Whether every content-bearing token of the title already appears in the body,
-  /// compared case-insensitively with punctuation (smart quotes, dashes, commas)
-  /// stripped — so a body that quotes, inflects, or reorders the title still counts
-  /// as restating it. A title contributing even one new token keeps its own line.
-  nonisolated static func bodyRestatesTitle(title: String, body: String) -> Bool {
-    let titleTokens = copyTokens(title)
-    guard !titleTokens.isEmpty else { return true }
-    let bodyTokens = Set(copyTokens(body))
-    return titleTokens.allSatisfy(bodyTokens.contains)
-  }
-
-  private nonisolated static func copyTokens(_ text: String) -> [String] {
-    text.lowercased()
-      .components(separatedBy: CharacterSet.alphanumerics.inverted)
-      .filter { !$0.isEmpty }
-  }
-
   func mainChatSurfaceReference() -> AgentSurfaceReference {
     historyChatProvider?.mainChatSurfaceReference()
       ?? .mainChat(chatId: "default")

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -4264,12 +4264,36 @@ class FloatingControlBarManager {
     }
   }
 
+  /// The director's copy contract (5a076e10b3) makes the title AND the message both
+  /// name the same specific referent — measured as the only shape that keeps each
+  /// field useful on its own surface. Journaled together into one chat row, that
+  /// contract reads as saying everything twice ("Latest Omi desktop app download
+  /// link" / "The latest Omi desktop app download link is …"), so the headline is
+  /// kept only when it adds words the body does not already carry.
   nonisolated static func notificationJournalText(title: String, body: String) -> String {
     let headline = title.trimmingCharacters(in: .whitespacesAndNewlines)
     let detail = body.trimmingCharacters(in: .whitespacesAndNewlines)
     if headline.isEmpty { return detail }
     if detail.isEmpty || detail == headline { return headline }
+    if bodyRestatesTitle(title: headline, body: detail) { return detail }
     return "\(headline)\n\(detail)"
+  }
+
+  /// Whether every content-bearing token of the title already appears in the body,
+  /// compared case-insensitively with punctuation (smart quotes, dashes, commas)
+  /// stripped — so a body that quotes, inflects, or reorders the title still counts
+  /// as restating it. A title contributing even one new token keeps its own line.
+  nonisolated static func bodyRestatesTitle(title: String, body: String) -> Bool {
+    let titleTokens = copyTokens(title)
+    guard !titleTokens.isEmpty else { return true }
+    let bodyTokens = Set(copyTokens(body))
+    return titleTokens.allSatisfy(bodyTokens.contains)
+  }
+
+  private nonisolated static func copyTokens(_ text: String) -> [String] {
+    text.lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
   }
 
   func mainChatSurfaceReference() -> AgentSurfaceReference {

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -370,6 +370,38 @@ final class ChatRowPresentationTests: XCTestCase {
       "Meeting notes ready")
   }
 
+  /// The director's copy contract makes the title and the message both name the same
+  /// referent; journaled together into one chat row that read as saying everything
+  /// twice (observed live on beta after 5a076e10b3). A headline whose every token the
+  /// body already carries — quoted, inflected, or reordered — is dropped from the row.
+  func testJournalDropsAHeadlineTheBodyAlreadyRestates() {
+    // Body quotes the title verbatim (smart quotes stripped by tokenization).
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Instruct David Editor to write extra script for main Omi demo video",
+        body:
+          "\u{201C}Instruct David Editor to write extra script for main Omi demo video\u{201D} is due August 21."),
+      "\u{201C}Instruct David Editor to write extra script for main Omi demo video\u{201D} is due August 21.")
+    // Body restates the title with different casing and inflection.
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Latest Omi desktop app download link",
+        body: "The latest Omi desktop app download link is omi.me/desktop."),
+      "The latest Omi desktop app download link is omi.me/desktop.")
+    // Body reorders the title's tokens ("fix on main" -> "fix is live on main").
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "The Omi macOS click-away deadzone fix on main",
+        body: "The Omi macOS click-away deadzone fix is live on main; verify it when you can."),
+      "The Omi macOS click-away deadzone fix is live on main; verify it when you can.")
+    // A headline contributing even one new token keeps its own line.
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Ship the quarterly report",
+        body: "You promised it by 5pm — draft the summary now."),
+      "Ship the quarterly report\nYou promised it by 5pm — draft the summary now.")
+  }
+
   func testAnOrdinaryReplyAndAUserTurnAreNotPushes() {
     XCTAssertEqual(ChatRowPresentation.of(message("Sounds good.", sender: .ai)), .assistantReply)
     XCTAssertEqual(ChatRowPresentation.of(message("hey", sender: .user)), .userTurn)

--- a/desktop/macos/changelog/unreleased/20260820-notification-text-dedup.json
+++ b/desktop/macos/changelog/unreleased/20260820-notification-text-dedup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Notification chat rows no longer repeat their content twice when the message already restates the headline"
+}

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -7,6 +7,7 @@ covers:
   - desktop/macos/Desktop/Sources/Chat/AgentCompletionVoiceDelivery.swift
   - desktop/macos/Desktop/Sources/Chat/ChatDraftStore.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+  - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
   - desktop/macos/Desktop/Sources/MainWindow/ClickThroughView.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AskAIInputView.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift

--- a/desktop/macos/e2e/flows/harness-smoke.yaml
+++ b/desktop/macos/e2e/flows/harness-smoke.yaml
@@ -5,6 +5,7 @@ description: Cursor-free smoke flow for the Omi desktop experience harness.
 app: non-prod
 covers:
   - desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+  - desktop/macos/Desktop/Sources/DesktopAutomationBridge+Notifications.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopAutomationWindowPresentation.swift
   - desktop/macos/Desktop/Sources/BrowserAutomationTarget.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+Environment.swift


### PR DESCRIPTION
## What

Notification chat rows on beta say their content twice — a title line plus a body that restates it:

> Latest Omi desktop app download link
> The latest Omi desktop app download link is omi.me/desktop.

Root cause: 5a076e10b3 deliberately makes the director name the same specific referent in **both** `title` and `message` (measured as the right contract for each field's own surface), and the chat journal renders `title\nbody` — so the contract reads as duplication in one chat row.

Fix (presentation-side; the measured prompt/schema are untouched): `notificationJournalText` drops the headline when the body already carries **every one of its tokens** (case-insensitive, punctuation stripped, order-free). A quoted, inflected, or reordered restatement collapses to the body; a headline contributing any new word keeps its own line. The notch card is unchanged — its bold-headline + dimmer-body hierarchy is a different surface.

Also adds a bundle-scoped `send_test_notification` automation-bridge action: the machine-global `com.omi.test.notification` distributed channel is received by every running Omi bundle including the user's production install, which delivers and journals test notifications into the real account's chat (#11943). The bridge action reaches only the bundle whose port and token the caller holds, through the same production `sendNotification` path (all gates apply; `respectFrequency` stays true).

## Verification

- `testJournalDropsAHeadlineTheBodyAlreadyRestates` covers the three duplicated shapes from the live report (verbatim quote, inflection/casing, token reorder) plus the keep-both case; the pre-existing `testNotificationJournalTextPreservesTheHeadlineAndBody` still passes unchanged.
- Live in a named dev bundle via the new bridge action: a restating notification journals as a single line; a non-restating one keeps headline + body (screenshot).
- Blast radius of the bug: every beta user on builds containing 5a076e10b3 (all context-director notifications).

## Product invariants affected

- INV-CHAT-1 — path-glob match on `FloatingControlBarWindow.swift`. The change is the journaled row's text content only; continuity keys, journal admission, and the mutation-ownership contract are untouched.

## Failure class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

