### PR TITLE
fix(backend): cap GET /v1/action-items at 12/min per uid

### DIFF
--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -352,7 +352,7 @@ def get_action_items(
     end_date: Optional[datetime] = Query(None, description="Filter by creation end date (inclusive)"),
     due_start_date: Optional[datetime] = Query(None, description="Filter by due start date (inclusive)"),
     due_end_date: Optional[datetime] = Query(None, description="Filter by due end date (inclusive)"),
-    uid: str = Depends(auth.get_current_user_uid),
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "action_items:list")),
 ):
     """Get action items for the current user."""
     if start_date is not None and end_date is not None and _ensure_aware(start_date) > _ensure_aware(end_date):

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -130,6 +130,11 @@ class TestRatePolicies(unittest.TestCase):
             max_req, _ = RATE_POLICIES[name]
             self.assertGreaterEqual(max_req, 100, f"{name} should allow bursts")
 
+    def test_action_items_list_caps_tight_loops(self):
+        """First-party listing must be below a Windows poll storm and above hydrate."""
+        max_req, window = RATE_POLICIES["action_items:list"]
+        self.assertEqual((max_req, window), (12, 60))
+
 
 class TestBoostFactor(unittest.TestCase):
     """Test boost factor applies correctly."""

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -67,6 +67,11 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # Action items — lightweight Firestore writes from MCP clients (no LLM), but
     # an agent can loop, so cap creation per hour. Complete/update/delete operate
     # on existing tasks and ride the shared mcp:sse / per-request auth limits.
+    # First-party GET /v1/action-items. Old Windows main-process listing
+    # stormed this route (~120 qps fleet) with no platform/version header.
+    # 12/min/uid covers Mac/Flutter hydrate plus a few pagination pages and
+    # stops a tight loop. Enforced in Depends() before Firestore.
+    "action_items:list": (12, 60),
     "action_items:write": (120, 3600),
     # Memories — single LLM call each
     "memories:create": (60, 3600),


### PR DESCRIPTION
## Summary

Cap first-party `GET /v1/action-items` at **12 requests / 60s / uid** via existing `with_rate_limit` (Redis, multi-instance). Rejects in `Depends()` **before** Firestore.

Old Windows main-process `taskSyncEngine` listed this route in a tight loop (~120 qps fleet) with only `Authorization` — no `X-App-Platform` / `X-App-Version`, so a version gate cannot see it. A global 429 would also hit Mac/mobile.

12/min is above Mac/Flutter hydrate + a few pagination pages; a tight loop dies after 12 calls.

Does **not** force clients to update. `/ids` census is unchanged.

## Failure-Class

Failure-Class: none

## Root Cause

Windows main-process listing storm on `GET /v1/action-items` with no client version header. Instrumented `action_items_list` was ~1k/day because Cloud Run backend is not scraped.

## How to Verify

1. Unit: `test_action_items_list_caps_tight_loops` and existing router-policy scan.
2. After deploy: 429 with `Retry-After` on the 13th listing GET in a minute for one uid; Firestore read ops on this route should fall.

## Test Plan

- [x] Policy tuple test
- [ ] Existing `test_rate_limiting` router scan (CI)
- [ ] Prod: listing 429s for a hot uid; Mac/Flutter hydrate still works

## Risk Assessment

Medium — legitimate rapid pagination >12/min gets 429 for the rest of the window. First-party limiter **fail-opens** if Redis is down. `/ids` and writes are not capped by this policy.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

