### PR TITLE
perf(backend-sync): restore backfill-lane routing behind a default-off flag

### DIFF
--- a/backend/tests/unit/test_sync_cloud_tasks.py
+++ b/backend/tests/unit/test_sync_cloud_tasks.py
@@ -695,18 +695,77 @@ class TestVerifyCloudTasksOidc:
                 cloud_tasks.enqueue_sync_job({'job_id': 'j'})
 
     def test_backfill_lane_still_uses_the_main_queue(self):
-        # An offline recording can never carry server capture proof, so every
-        # offline upload classifies as backfill. Routing that lane to the
-        # bounded historical-recovery worker sent the whole offline workload
-        # through a few dispatch slots, and Cloud Tasks backed the surplus off
-        # for hours. The lane label stays on the payload for metering.
+        # Flag-off is the #10400 contract: every offline upload classifies as
+        # backfill, and routing that lane to the bounded recovery worker used
+        # to strand recordings for hours. Default-off keeps that behaviour.
         cloud_tasks = _load_cloud_tasks()
         env = {
+            'SYNC_BACKFILL_ROUTING_ENABLED': 'false',
             'SYNC_TASKS_QUEUE': 'sync-jobs',
             'SYNC_TASKS_HANDLER_URL': 'https://backend-sync.example.com/v2/sync-jobs/run',
             'SYNC_BACKFILL_TASKS_QUEUE': 'sync-backfill',
             'SYNC_BACKFILL_TASKS_HANDLER_URL': 'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
             'SYNC_BACKFILL_TASKS_OIDC_AUDIENCE': 'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+        }
+        with patch.dict(os.environ, env), patch.object(cloud_tasks, '_enqueue_named_task') as enqueue:
+            cloud_tasks.enqueue_sync_job({'job_id': 'job-1', 'lane': 'backfill'})
+
+        enqueue.assert_called_once_with(
+            'sync-jobs',
+            'https://backend-sync.example.com/v2/sync-jobs/run',
+            'job-1',
+            {'job_id': 'job-1', 'lane': 'backfill'},
+        )
+
+    def test_backfill_lane_uses_backfill_queue_when_routing_enabled(self):
+        cloud_tasks = _load_cloud_tasks()
+        env = {
+            'SYNC_BACKFILL_ROUTING_ENABLED': 'true',
+            'SYNC_TASKS_QUEUE': 'sync-jobs',
+            'SYNC_TASKS_HANDLER_URL': 'https://backend-sync.example.com/v2/sync-jobs/run',
+            'SYNC_BACKFILL_TASKS_QUEUE': 'sync-backfill',
+            'SYNC_BACKFILL_TASKS_HANDLER_URL': 'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+            'SYNC_BACKFILL_TASKS_OIDC_AUDIENCE': 'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+        }
+        with patch.dict(os.environ, env), patch.object(cloud_tasks, '_enqueue_named_task') as enqueue:
+            cloud_tasks.enqueue_sync_job({'job_id': 'job-1', 'lane': 'backfill'})
+
+        enqueue.assert_called_once_with(
+            'sync-backfill',
+            'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+            'job-1',
+            {'job_id': 'job-1', 'lane': 'backfill'},
+            audience='https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+        )
+
+    def test_fresh_lane_uses_main_queue_when_backfill_routing_enabled(self):
+        cloud_tasks = _load_cloud_tasks()
+        env = {
+            'SYNC_BACKFILL_ROUTING_ENABLED': 'true',
+            'SYNC_TASKS_QUEUE': 'sync-jobs',
+            'SYNC_TASKS_HANDLER_URL': 'https://backend-sync.example.com/v2/sync-jobs/run',
+            'SYNC_BACKFILL_TASKS_QUEUE': 'sync-backfill',
+            'SYNC_BACKFILL_TASKS_HANDLER_URL': 'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+            'SYNC_BACKFILL_TASKS_OIDC_AUDIENCE': 'https://backend-sync-backfill.example.com/v2/sync-jobs/run',
+        }
+        with patch.dict(os.environ, env), patch.object(cloud_tasks, '_enqueue_named_task') as enqueue:
+            cloud_tasks.enqueue_sync_job({'job_id': 'job-1', 'lane': 'fresh'})
+
+        enqueue.assert_called_once_with(
+            'sync-jobs',
+            'https://backend-sync.example.com/v2/sync-jobs/run',
+            'job-1',
+            {'job_id': 'job-1', 'lane': 'fresh'},
+        )
+
+    def test_backfill_routing_falls_back_to_main_queue_when_env_missing(self):
+        cloud_tasks = _load_cloud_tasks()
+        env = {
+            'SYNC_BACKFILL_ROUTING_ENABLED': 'true',
+            'SYNC_TASKS_QUEUE': 'sync-jobs',
+            'SYNC_TASKS_HANDLER_URL': 'https://backend-sync.example.com/v2/sync-jobs/run',
+            'SYNC_BACKFILL_TASKS_QUEUE': '',
+            'SYNC_BACKFILL_TASKS_HANDLER_URL': '',
         }
         with patch.dict(os.environ, env), patch.object(cloud_tasks, '_enqueue_named_task') as enqueue:
             cloud_tasks.enqueue_sync_job({'job_id': 'job-1', 'lane': 'backfill'})

--- a/backend/utils/cloud_tasks.py
+++ b/backend/utils/cloud_tasks.py
@@ -81,6 +81,10 @@ def is_cloud_tasks_dispatch_enabled() -> bool:
     return os.getenv('SYNC_DISPATCH_MODE', 'inline') == 'cloud_tasks'
 
 
+def is_sync_backfill_routing_enabled() -> bool:
+    return os.getenv('SYNC_BACKFILL_ROUTING_ENABLED', 'false').lower() == 'true'
+
+
 def is_audio_merge_dispatch_enabled() -> bool:
     return os.getenv('AUDIO_MERGE_DISPATCH_MODE', 'inline') == 'cloud_tasks'
 
@@ -189,15 +193,32 @@ def enqueue_sync_job(payload: Dict[str, Any]) -> None:
     of times, then retain staged retry material if acknowledgement remains
     uncertain; they never fall back inline after submitting this task.
 
-    Every sync job goes to the main queue. Offline recordings can never carry
-    server capture proof — the server was not in the loop when they were
-    captured — so they all classify as backfill, which sent the entire offline
-    workload to a lane provisioned for occasional historical recovery. That
-    lane's worker admitted only a few jobs at once, so Cloud Tasks retried the
-    surplus with exponential backoff until recordings sat unprocessed for many
-    hours. The lane label is still carried on the payload for metering and
-    reporting; it no longer selects the queue.
+    Queue selection stays on the main queue unless SYNC_BACKFILL_ROUTING_ENABLED
+    is true, the payload lane is backfill, and both SYNC_BACKFILL_TASKS_QUEUE
+    and SYNC_BACKFILL_TASKS_HANDLER_URL are set. Missing backfill env falls
+    back to the main queue so a job is never dropped.
+
+    The two-lane split was collapsed in #10400 after a customer incident: every
+    offline upload classifies as backfill (no server capture proof), and the
+    backfill worker then admitted only a few jobs at once, so Cloud Tasks
+    retried the surplus with exponential backoff until recordings sat
+    unprocessed for many hours. Restoring the split is gated default-off
+    because the backfill worker is now maxScale 30 / concurrency 1
+    (request-based) rather than the ~4-dispatch lane that caused the incident.
+    The lane label is always carried on the payload for metering and reporting.
     """
+    if payload.get('lane') == 'backfill' and is_sync_backfill_routing_enabled():
+        queue = os.getenv('SYNC_BACKFILL_TASKS_QUEUE', '').strip()
+        handler_url = os.getenv('SYNC_BACKFILL_TASKS_HANDLER_URL', '').strip()
+        if queue and handler_url:
+            _enqueue_named_task(
+                queue,
+                handler_url,
+                str(payload['job_id']),
+                payload,
+                audience=os.getenv('SYNC_BACKFILL_TASKS_OIDC_AUDIENCE') or handler_url,
+            )
+            return
     _enqueue_named_task(os.getenv('SYNC_TASKS_QUEUE', ''), _handler_url(), str(payload['job_id']), payload)
 
 


### PR DESCRIPTION
## Summary

Always-on `backend-sync` (Cloud Run, minScale 5) is running at **16–22 instances** and costing **~$63.5/day net** because `enqueue_sync_job` sends every sync job to the main queue. 95% of lane tokens are `lane=backfill`. The already-provisioned `backend-sync-backfill` worker took **0 HTTP requests in 6 hours** and costs $2.30/day sitting idle.

Live config, verified 2026-08-20:
- always-on `backend-sync`: `SYNC_TASKS_QUEUE=sync-jobs`, minScale 5, max 25, cpu-throttling=false, concurrency 20
- `backend-sync-backfill`: `SYNC_BACKFILL_TASKS_QUEUE=sync-backfill`, `SYNC_BACKFILL_ENABLED=true`, minScale 1, **max 30**, request-based, **concurrency 1**
- Occupancy on always-on: `/v2/sync-jobs/run` (STT) 17,268 s/h = ~61%; audio-merge 10,660 s/h; admission 481 s/h

Modelled saving: always-on 18 → ~7 instances (−$38/day), request-based backfill picks up ~4.8 concurrent STT jobs (+$17/day) ⇒ **net ~$15–25/day**.

This PR restores lane-based queue selection in `enqueue_sync_job`: `lane=backfill` goes to `SYNC_BACKFILL_TASKS_QUEUE` + the backfill handler URL; everything else keeps the main queue. Audio-merge routing, minScale, and deploy YAML are out of scope.

## Why this is not a naive revert of #10400

The two-lane split was collapsed in #10400 **deliberately, to fix a real customer incident**. Offline recordings can never carry server capture proof, so they all classify as `lane=backfill`. That sent the entire offline workload to a lane provisioned for occasional historical recovery. The backfill worker **admitted only a few jobs at once** (~4-dispatch), so Cloud Tasks retried the surplus with exponential backoff until recordings sat unprocessed for many hours.

A naive restore of that routing would re-open that incident. It is safe to restore **now** because the backfill worker's admission capacity changed: it is **maxScale 30, concurrency 1, request-based** — i.e. 30 concurrent jobs, versus the ~4-dispatch lane that caused the incident.

## Flag

`SYNC_BACKFILL_ROUTING_ENABLED` (default `false`). With the flag off, behaviour is byte-identical to today: every job still goes to the main queue. With the flag on, `lane=backfill` is routed to the backfill queue/handler (including the backfill OIDC audience). If the backfill queue or handler env vars are unset or empty, the job falls back to the main queue and is never dropped.

## Rollout

1. **Ship dark.** Merge with `SYNC_BACKFILL_ROUTING_ENABLED` unset/false. No traffic moves.
2. **Enable.** Set `SYNC_BACKFILL_ROUTING_ENABLED=true` on the enqueueing service once the 30-wide backfill worker is confirmed live.
3. **Watch.** Confirm `backend-sync-backfill` starts taking `/v2/sync-jobs/run` traffic and always-on `instance_count` falls. Flip the flag off immediately if recordings stall or always-on occupancy does not move.

## Rollback bar

If `backend-sync` + `backend-sync-backfill` combined net over 7 closed UTC days is >= $56/day, the routing change saved nothing and the flag goes back off.
Independently: if always-on `instance_count` ALIGN_MEAN over 48 matched hours stays >= 16, STT did not leave the lane.

## Tests

`cd backend && python -m pytest tests/unit/test_sync_cloud_tasks.py` → 90 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

