### PR TITLE
perf(desktop-chat): cache the stable Anthropic prompt prefix

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -248,6 +248,12 @@ _MANAGED_STRUCTURED_ALIASES = {
     CHAT_STRUCTURED_AUTO_LANE_ID,
 }
 _MAX_TOKENS = 16_384
+# Top-level automatic prompt caching. Anthropic places this breakpoint on the last
+# cacheable block (tools → system → messages). TTL=1h: the default became 5m on
+# 2026-03-06, which is shorter than typical gaps between desktop-chat turns.
+# The ~14k-token tools+system prefix only hits if those bytes stay identical
+# across requests from the same client; volatile content belongs in the user turn.
+_PROMPT_CACHE_CONTROL = {'type': 'ephemeral', 'ttl': '1h'}
 
 
 def _managed_lane_id(body: Mapping[str, object]) -> str:
@@ -645,6 +651,7 @@ def _request(
         result['tools'] = ([_WEB_SEARCH_TOOL] if inject_web_search else []) + client_tools
     if choice is not None and result.get('tools'):
         result['tool_choice'] = choice
+    result['cache_control'] = dict(_PROMPT_CACHE_CONTROL)
     return model, result
 
 

--- a/backend/tests/unit/test_desktop_chat.py
+++ b/backend/tests/unit/test_desktop_chat.py
@@ -1864,3 +1864,134 @@ async def test_authorization_lookup_failure_is_not_reported_as_an_explicit_denia
     )
     assert 'tools' not in payload
     assert [fallback['reason'] for fallback in fallbacks] == ['authorization_unavailable']
+
+
+def _count_cache_control(value):
+    """Count cache_control keys in a payload. Nested markers would split or
+    duplicate the automatic breakpoint and silently miss the shared prefix."""
+    count = 0
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key == 'cache_control':
+                count += 1
+            count += _count_cache_control(nested)
+    elif isinstance(value, list):
+        for item in value:
+            count += _count_cache_control(item)
+    return count
+
+
+def _stable_prefix(payload):
+    """Byte-stable tools+system prefix. User turns sit after the automatic
+    breakpoint's shared prefix and must not appear here."""
+    return json.dumps(
+        {'system': payload.get('system'), 'tools': payload.get('tools')},
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+
+
+_STABLE_DESKTOP_SYSTEM = (
+    'You are Omi, a desktop assistant.\n'
+    '<sql_schema>\nCREATE TABLE memories (id TEXT, content TEXT);\n</sql_schema>\n'
+    '<memories>\n1. User prefers vim.\n2. User is in Ho Chi Minh City.\n</memories>'
+)
+_STABLE_DESKTOP_TOOLS = [
+    {'type': 'function', 'function': {'name': 'search_memories', 'parameters': {'type': 'object'}}},
+    {'type': 'function', 'function': {'name': 'execute_sql', 'parameters': {'type': 'object'}}},
+]
+
+
+def test_request_attaches_one_top_level_cache_control_breakpoint():
+    """Anthropic's direct API caches only at an explicit breakpoint. One
+    top-level automatic marker covers tools + system + the growing transcript;
+    a nested copy would consume a second slot and is not this change."""
+    _, payload = _authorized_request(
+        {
+            'model': 'omi-sonnet',
+            'messages': [
+                {'role': 'system', 'content': _STABLE_DESKTOP_SYSTEM},
+                {'role': 'user', 'content': 'hello'},
+            ],
+            'tools': _STABLE_DESKTOP_TOOLS,
+        }
+    )
+    assert payload['cache_control'] == desktop_chat._PROMPT_CACHE_CONTROL
+    assert payload['cache_control'] == {'type': 'ephemeral', 'ttl': '1h'}
+    assert _count_cache_control(payload) == 1
+    assert 'cache_control' not in json.dumps(payload.get('system'))
+    assert 'cache_control' not in json.dumps(payload.get('tools'))
+    assert 'cache_control' not in json.dumps(payload.get('messages'))
+
+
+def test_request_cache_prefix_is_byte_stable_across_volatile_user_turns():
+    """Cache hits require the tools+system prefix to be byte-identical across
+    turns from the same client. Timestamps and the current user turn live in
+    messages, after that prefix, so they cannot silently invalidate it."""
+    tools = _STABLE_DESKTOP_TOOLS
+    system = _STABLE_DESKTOP_SYSTEM
+    _, first = _authorized_request(
+        {
+            'model': 'omi-sonnet',
+            'messages': [
+                {'role': 'system', 'content': system},
+                {'role': 'user', 'content': 'Current time: 2024-01-19 14:23:45.123456\nWhat did I work on?'},
+            ],
+            'tools': tools,
+        }
+    )
+    _, second = _authorized_request(
+        {
+            'model': 'omi-sonnet',
+            'messages': [
+                {'role': 'system', 'content': system},
+                {'role': 'user', 'content': 'Current time: 2024-01-19 14:23:45.123456\nWhat did I work on?'},
+                {'role': 'assistant', 'content': 'You were on the desktop chat route.'},
+                {'role': 'user', 'content': 'Current time: 2024-06-01 09:00:00.654321\nSummarize that.'},
+            ],
+            'tools': tools,
+        }
+    )
+    assert _stable_prefix(first) == _stable_prefix(second)
+    assert first['system'] == second['system'] == system
+    assert first['tools'] == second['tools']
+    assert first['cache_control'] == second['cache_control'] == desktop_chat._PROMPT_CACHE_CONTROL
+    assert _count_cache_control(first) == _count_cache_control(second) == 1
+    assert first['messages'] != second['messages']
+    assert '2024-01-19 14:23:45.123456' not in _stable_prefix(first)
+    assert '2024-06-01 09:00:00.654321' not in _stable_prefix(second)
+
+
+def test_request_web_search_injection_keeps_a_constant_cached_prefix():
+    """Server-side web search appends a constant routing instruction and tool.
+    Two successive public-web turns from the same client must still share a
+    byte-identical prefix; only the user turn may change."""
+    _, first = _authorized_request(
+        {
+            'model': 'omi-sonnet',
+            'messages': [
+                {'role': 'system', 'content': _STABLE_DESKTOP_SYSTEM},
+                {'role': 'user', 'content': 'Search the web for the weather in New York. asked at 2024-01-19 14:23:45'},
+            ],
+            'tools': _STABLE_DESKTOP_TOOLS,
+            'omi_web_search': True,
+        }
+    )
+    _, second = _authorized_request(
+        {
+            'model': 'omi-sonnet',
+            'messages': [
+                {'role': 'system', 'content': _STABLE_DESKTOP_SYSTEM},
+                {'role': 'user', 'content': 'Search the web for the weather in London. asked at 2024-06-01 09:00:00'},
+            ],
+            'tools': _STABLE_DESKTOP_TOOLS,
+            'omi_web_search': True,
+        }
+    )
+    assert _stable_prefix(first) == _stable_prefix(second)
+    assert first['cache_control'] == second['cache_control'] == desktop_chat._PROMPT_CACHE_CONTROL
+    assert _count_cache_control(first) == 1
+    assert first['system'] == _STABLE_DESKTOP_SYSTEM + '\n\n' + desktop_chat._PUBLIC_WEB_ROUTING_INSTRUCTION
+    assert [tool['name'] for tool in first['tools']] == ['web_search', 'search_memories', 'execute_sql']
+    assert '2024-01-19' not in _stable_prefix(first)
+    assert '2024-06-01' not in _stable_prefix(second)


### PR DESCRIPTION
## Summary

- `POST /v2/chat/completions` never sent `cache_control`, so the ~14k-token base context (tool schemas ~7,343 tok, desktop-chat template ~1,863, SQL schema block, ~50 memories) was re-billed as **fresh input at $3.00/MTok on every round of every desktop chat turn**. Cache reads bill at $0.30/MTok — a 90% cut on the repeated prefix.
- Traffic: `/v2/chat/completions` on `desktop-backend` served 6,134 / 5,393 / 6,621 requests on 08-17/18/19. Of 08-19's 6,621, **2,776 (42%) are 200s** that reach the LLM (the rest are 405/402/401 and never spend). ~541 distinct callers/day. Estimated saving **$20–80/day**.
- This saving lands on the **Anthropic-direct invoice and will NOT show up in the GCP billing export**. `_record_usage` already records `cache_read_input_tokens` per uid (uniformly 0 today); that is the post-ship instrument. No env flag: prompt caching is semantics-preserving and rollback is a plain revert.

`_request()` now attaches one top-level automatic `cache_control` breakpoint (`{"type": "ephemeral", "ttl": "1h"}`). Anthropic places that marker on the last cacheable block (tools → system → messages), which covers the stable tools+system prefix. TTL is 1h because Anthropic's default became 5m on 2026-03-06, shorter than typical desktop-chat gaps.

### Stable prefix

Cache hits require the tools+system prefix to be **byte-identical** across turns from the same client. `_request()` does not inject timestamps, per-turn user state, or nondeterministic ordering into that prefix; volatile content stays in the user turn. If the prefix is not byte-stable, cache hits silently miss: it saves $0 and breaks nothing, which is why the tests assert prefix identity rather than waiting for production. BYOK is unchanged (still returns before our spend).

> "Anthropic caches implicitly, this is unnecessary" — false for the direct API. Caching requires an explicit `cache_control` breakpoint; `cache_read_input_tokens` is 0 without one (confirmed against Anthropic docs 2026-08-20).

### Rollback

> If `cache_read_input_tokens` share of total input tokens on this route (per the existing `llm_usage_db` buckets) is < 30% over a 7-day window, or successful-turn count drops > 5%, the change is not supported as costed and should be reverted.

## Test plan

- [x] `/Users/dazheng/workspace/omi-upstream/backend/.venv/bin/python -m pytest tests/unit/test_desktop_chat.py -q --tb=short` from this worktree's `backend/` — **73 passed**
- [ ] Dogfood a multi-turn desktop chat on `omi-sonnet` and confirm `cache_read_input_tokens` is non-zero in `llm_usage_db` after the second turn
- [ ] After ship, watch `cache_read_input_tokens` / total input on this route for 7 days against the rollback bar above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

