### PR TITLE
feat: add desktop referral links

### DIFF
--- a/backend/database/referrals.py
+++ b/backend/database/referrals.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+from google.cloud import firestore
+
+from database._client import get_customer_firestore_client, run_transactional
+from utils.referrals import referral_claim_patch
+
+
+def claim_referral_trial(
+    referred_uid: str,
+    referrer_uid: str,
+    *,
+    is_new_user: bool,
+    firestore_client: Any | None = None,
+) -> bool:
+    """Atomically grant the referred account its one-time 30-day Omi Pro entitlement."""
+    client = firestore_client or get_customer_firestore_client()
+    user_ref = client.collection('users').document(referred_uid)
+
+    @firestore.transactional
+    def apply(transaction: Any) -> bool:
+        snapshot = user_ref.get(transaction=transaction)
+        patch = referral_claim_patch(
+            referred_uid=referred_uid,
+            referrer_uid=referrer_uid,
+            is_new_user=is_new_user,
+            user_data=snapshot.to_dict() if snapshot.exists else None,
+        )
+        if patch is None:
+            return False
+        transaction.set(user_ref, patch, merge=True)
+        return True
+
+    return bool(run_transactional(client, apply))

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,6 +78,7 @@ from routers import (
     desktop_proxy,
     desktop_realtime,
     desktop_screen_crisp,
+    referrals,
     desktop_tts_updates,
     scores,
     stt,
@@ -171,6 +172,7 @@ app.include_router(notifications.router)
 app.include_router(integration.router)
 app.include_router(agents.router)
 app.include_router(users.router)
+app.include_router(referrals.router)
 app.include_router(conversation_finalization.router)
 app.include_router(trends.router)
 

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -43,6 +43,29 @@ routes:
     policy: *desktop_migration_policy
   - route_type: http
     method: GET
+    path: /r/{code}
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - public
+        placement: none
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: oauth
+      visibility: public_undocumented
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: GET
     path: /health
     policy: *desktop_migration_policy
   - route_type: http
@@ -100,6 +123,30 @@ routes:
   - route_type: http
     method: GET
     path: /v1/screen-activity/summary
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: validated_when_headers_present
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: GET
+    path: /v1/users/me/referral
     policy:
       review_status: reviewed
       auth:

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -15,11 +15,14 @@ from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 import pathlib
 import firebase_admin.auth
+from database.referrals import claim_referral_trial
 from database.redis_db import set_auth_session, get_auth_session, set_auth_code, get_auth_code, delete_auth_code
-from utils.executors import critical_executor, run_blocking
+from utils.executors import critical_executor, db_executor, run_blocking
 from utils.http_client import get_auth_client
 from utils.log_sanitizer import sanitize
 from utils.metrics import AUTH_FLOW_DURATION_SECONDS, AUTH_FLOW_EVENTS
+from utils.observability.fallback import record_fallback
+from utils.referrals import REFERRAL_COOKIE_NAME, ReferralCodeError, referrer_uid_from_code
 import logging
 
 logger = logging.getLogger(__name__)
@@ -203,8 +206,20 @@ def _auth_code_data_from_session(oauth_credentials: str, redirect_uri: str, sess
             'provider': session_data.get('provider'),
             'auth_flow_id': session_data.get('auth_flow_id'),
             'created_at': session_data.get('created_at'),
+            'referral_code': session_data.get('referral_code'),
         }
     )
+
+
+def _valid_referral_code_from_request(request: Request) -> Optional[str]:
+    code = request.cookies.get(REFERRAL_COOKIE_NAME)
+    if not code:
+        return None
+    try:
+        referrer_uid_from_code(code)
+    except ReferralCodeError:
+        return None
+    return code
 
 
 def _auth_flow_id_from_state(state: Optional[str]) -> str:
@@ -357,6 +372,7 @@ async def auth_authorize(
         'code_challenge_method': normalized_code_challenge_method,
         'auth_flow_id': auth_flow_id,
         'created_at': time.time(),
+        'referral_code': _valid_referral_code_from_request(request),
     }
 
     # Store in Redis with 5-minute expiration
@@ -618,6 +634,7 @@ async def auth_token(
         code_data = json.loads(raw_code_data)
 
         # Support both new format (with redirect_uri binding) and legacy format
+        referral_code: Optional[str] = None
         if 'credentials' in code_data:
             # New format: auth code bound to redirect_uri — fail closed if redirect_uri missing
             stored_redirect_uri = code_data.get('redirect_uri')
@@ -677,6 +694,7 @@ async def auth_token(
                 duration_seconds=(time.time() - created_at) if isinstance(created_at, (int, float)) else None,
             )
             oauth_credentials_json = code_data['credentials']
+            referral_code = code_data.get('referral_code')
             oauth_credentials = (
                 json.loads(oauth_credentials_json)
                 if isinstance(oauth_credentials_json, str)
@@ -710,7 +728,13 @@ async def auth_token(
                     auth_flow_id=auth_flow_id,
                     redirect_scheme=redirect_scheme,
                 )
-                custom_token = await _generate_custom_token(provider, id_token, access_token, display_name=full_name)
+                custom_token = await _generate_custom_token(
+                    provider,
+                    id_token,
+                    access_token,
+                    display_name=full_name,
+                    referral_code=referral_code,
+                )
                 response["custom_token"] = custom_token
                 _log_auth_event(
                     provider=provider,
@@ -1027,7 +1051,11 @@ async def _exchange_apple_code_for_oauth_credentials(code: str, session_data: Di
 
 
 async def _generate_custom_token(
-    provider: str, id_token: str, access_token: Optional[str] = None, display_name: Optional[str] = None
+    provider: str,
+    id_token: str,
+    access_token: Optional[str] = None,
+    display_name: Optional[str] = None,
+    referral_code: Optional[str] = None,
 ) -> str:
     """
     Generate Firebase custom token by signing in with OAuth credentials
@@ -1077,6 +1105,27 @@ async def _generate_custom_token(
             raise Exception("No Firebase UID returned from sign-in")
 
         logger.info(f"Firebase sign-in successful for {provider}, UID: {firebase_uid}")
+
+        if referral_code and result.get('isNewUser') is True:
+            try:
+                referrer_uid = referrer_uid_from_code(referral_code)
+                await run_blocking(
+                    db_executor,
+                    claim_referral_trial,
+                    firebase_uid,
+                    referrer_uid,
+                    is_new_user=True,
+                )
+            except Exception as error:
+                logger.error("Referral entitlement grant failed (non-fatal): %s", sanitize(str(error)))
+                record_fallback(
+                    component='other',
+                    from_mode='referral_entitlement',
+                    to_mode='authenticated_without_referral_entitlement',
+                    reason='other',
+                    outcome='degraded',
+                    log=logger,
+                )
 
         # Apple's id_token has no name and Firebase can't auto-populate it (unlike
         # Google), so persist the first-auth name onto the Firebase user. Only set

--- a/backend/routers/referrals.py
+++ b/backend/routers/referrals.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from utils.other import endpoints as auth
+from utils.referrals import (
+    REFERRAL_COOKIE_MAX_AGE_SECONDS,
+    REFERRAL_COOKIE_NAME,
+    REFERRAL_DOWNLOAD_URL,
+    ReferralCodeError,
+    referral_link,
+    referrer_uid_from_code,
+)
+
+router = APIRouter(tags=['referrals'])
+
+
+class ReferralLinkResponse(BaseModel):
+    referral_url: str
+
+
+@router.get('/v1/users/me/referral', response_model=ReferralLinkResponse)
+def get_referral_link(request: Request, uid: str = Depends(auth.get_current_user_uid)) -> ReferralLinkResponse:
+    return ReferralLinkResponse(referral_url=referral_link(uid, public_base_url=str(request.base_url)))
+
+
+@router.get('/r/{code}', response_class=RedirectResponse)
+def capture_referral(code: str) -> RedirectResponse:
+    try:
+        referrer_uid_from_code(code)
+    except ReferralCodeError as error:
+        raise HTTPException(status_code=404, detail='Referral link not found') from error
+
+    response = RedirectResponse(REFERRAL_DOWNLOAD_URL, status_code=302)
+    response.set_cookie(
+        REFERRAL_COOKIE_NAME,
+        code,
+        max_age=REFERRAL_COOKIE_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=True,
+        samesite='lax',
+        path='/',
+    )
+    return response

--- a/backend/tests/unit/test_referrals.py
+++ b/backend/tests/unit/test_referrals.py
@@ -1,0 +1,189 @@
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Iterator
+
+import pytest
+from starlette.requests import Request
+
+from routers import auth
+from testing.import_isolation import load_module_fresh, stub_modules
+from utils.referrals import (
+    REFERRAL_COOKIE_NAME,
+    ReferralCodeError,
+    create_referral_code,
+    referral_claim_patch,
+    referrer_uid_from_code,
+)
+
+TEST_SECRET = b'referral-test-secret-that-is-at-least-32-bytes'
+REFERRALS_ROUTER_PATH = Path(__file__).resolve().parents[2] / 'routers' / 'referrals.py'
+
+
+@contextmanager
+def _loaded_referrals_router() -> Iterator[ModuleType]:
+    endpoints = ModuleType('utils.other.endpoints')
+    endpoints.get_current_user_uid = lambda: 'test-user'
+    with stub_modules({'utils.other.endpoints': endpoints}):
+        yield load_module_fresh('routers.referrals', str(REFERRALS_ROUTER_PATH))
+
+
+def test_referral_code_round_trips_and_rejects_tampering():
+    code = create_referral_code('referrer-123', secret=TEST_SECRET)
+
+    assert referrer_uid_from_code(code, secret=TEST_SECRET) == 'referrer-123'
+
+    with pytest.raises(ReferralCodeError, match='invalid_referral_signature'):
+        referrer_uid_from_code(f'{code[:-1]}x', secret=TEST_SECRET)
+
+
+def test_referral_claim_grants_exactly_30_days_of_desktop_pro():
+    now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+
+    patch = referral_claim_patch(
+        referred_uid='new-user',
+        referrer_uid='referrer',
+        is_new_user=True,
+        user_data={'subscription': {'plan': 'basic', 'status': 'active'}},
+        now=now,
+    )
+
+    assert patch is not None
+    assert patch['subscription']['plan'] == 'architect'
+    assert patch['subscription']['status'] == 'active'
+    assert patch['subscription']['cancel_at_period_end'] is True
+    assert patch['subscription']['current_period_end'] - patch['subscription']['current_period_start'] == 30 * 86400
+    assert patch['referral']['referrer_uid'] == 'referrer'
+
+
+@pytest.mark.parametrize(
+    ('referred_uid', 'referrer_uid', 'is_new_user', 'user_data'),
+    [
+        ('same-user', 'same-user', True, {}),
+        ('existing-user', 'referrer', False, {}),
+        ('paid-user', 'referrer', True, {'subscription': {'plan': 'operator'}}),
+        ('claimed-user', 'referrer', True, {'referral': {'program': 'desktop_pro_month_v1'}}),
+    ],
+)
+def test_referral_claim_never_self_refers_rewards_existing_users_or_overwrites_paid_accounts(
+    referred_uid, referrer_uid, is_new_user, user_data
+):
+    assert (
+        referral_claim_patch(
+            referred_uid=referred_uid,
+            referrer_uid=referrer_uid,
+            is_new_user=is_new_user,
+            user_data=user_data,
+        )
+        is None
+    )
+
+
+def test_referral_link_captures_secure_cookie_and_opens_existing_desktop_download(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    code = create_referral_code('referrer-123')
+
+    with _loaded_referrals_router() as referrals:
+        response = referrals.capture_referral(code)
+
+    assert response.status_code == 302
+    assert response.headers['location'] == 'https://macos.omi.me'
+    cookie = response.headers['set-cookie']
+    assert f'{REFERRAL_COOKIE_NAME}={code}' in cookie
+    assert 'HttpOnly' in cookie
+    assert 'Secure' in cookie
+    assert 'SameSite=lax' in cookie
+
+
+def test_authenticated_referrer_receives_a_stable_unique_link(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    request = Request(
+        {
+            'type': 'http',
+            'scheme': 'https',
+            'server': ('api.omiapi.com', 443),
+            'path': '/',
+            'headers': [(b'host', b'api.omiapi.com')],
+        }
+    )
+
+    with _loaded_referrals_router() as referrals:
+        first = referrals.get_referral_link(request, 'referrer-123').referral_url
+        second = referrals.get_referral_link(request, 'referrer-123').referral_url
+        other = referrals.get_referral_link(request, 'another-user').referral_url
+
+    assert first == second
+    assert first != other
+    assert first.startswith('https://api.omiapi.com/r/ref1.')
+
+
+@pytest.mark.asyncio
+async def test_new_user_auth_redeems_captured_referral(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    monkeypatch.setenv('FIREBASE_API_KEY', 'test-key')
+    referral_code = create_referral_code('referrer-123')
+    claims = []
+
+    class Response:
+        status_code = 200
+        text = ''
+
+        @staticmethod
+        def json():
+            return {'localId': 'new-user', 'isNewUser': True}
+
+    class Client:
+        @staticmethod
+        async def post(*_args, **_kwargs):
+            return Response()
+
+    def claim(referred_uid, referrer_uid, *, is_new_user):
+        claims.append((referred_uid, referrer_uid, is_new_user))
+        return True
+
+    async def run_inline(_executor, function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(auth, 'get_auth_client', lambda: Client())
+    monkeypatch.setattr(auth, 'claim_referral_trial', claim)
+    monkeypatch.setattr(auth, 'run_blocking', run_inline)
+    monkeypatch.setattr(auth.firebase_admin.auth, 'create_custom_token', lambda _uid: b'custom-token', raising=False)
+
+    token = await auth._generate_custom_token('google', 'provider-token', referral_code=referral_code)
+
+    assert token == 'custom-token'
+    assert claims == [('new-user', 'referrer-123', True)]
+
+
+@pytest.mark.asyncio
+async def test_existing_user_auth_does_not_redeem_referral(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    monkeypatch.setenv('FIREBASE_API_KEY', 'test-key')
+    referral_code = create_referral_code('referrer-123')
+    claims = []
+
+    class Response:
+        status_code = 200
+        text = ''
+
+        @staticmethod
+        def json():
+            return {'localId': 'existing-user', 'isNewUser': False}
+
+    class Client:
+        @staticmethod
+        async def post(*_args, **_kwargs):
+            return Response()
+
+    async def run_inline(_executor, function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(auth, 'get_auth_client', lambda: Client())
+    monkeypatch.setattr(auth, 'claim_referral_trial', lambda *args, **kwargs: claims.append((args, kwargs)))
+    monkeypatch.setattr(auth, 'run_blocking', run_inline)
+    monkeypatch.setattr(auth.firebase_admin.auth, 'create_custom_token', lambda _uid: b'custom-token', raising=False)
+
+    await auth._generate_custom_token('google', 'provider-token', referral_code=referral_code)
+
+    assert claims == []

--- a/backend/utils/referrals.py
+++ b/backend/utils/referrals.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from models.users import PlanType
+
+REFERRAL_COOKIE_NAME = 'omi_desktop_referral'
+REFERRAL_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+REFERRAL_TRIAL_DAYS = 30
+REFERRAL_DOWNLOAD_URL = 'https://macos.omi.me'
+
+_CODE_PREFIX = 'ref1'
+_UID_PATTERN = re.compile(r'^[A-Za-z0-9:_-]{1,128}$')
+_PAID_PLAN_VALUES = {
+    PlanType.unlimited.value,
+    PlanType.architect.value,
+    PlanType.operator.value,
+    PlanType.plus.value,
+    PlanType.unlimited_v2.value,
+    'pro',
+}
+
+
+class ReferralCodeError(ValueError):
+    pass
+
+
+def _secret(secret: Optional[bytes] = None) -> bytes:
+    if secret is not None:
+        return secret
+    value = os.getenv('ENCRYPTION_SECRET', '')
+    if len(value) < 32:
+        raise ReferralCodeError('missing_referral_signing_secret')
+    return value.encode('utf-8')
+
+
+def _encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode('ascii').rstrip('=')
+
+
+def _decode(value: str) -> bytes:
+    try:
+        return base64.urlsafe_b64decode(value + ('=' * (-len(value) % 4)))
+    except (ValueError, TypeError) as error:
+        raise ReferralCodeError('malformed_referral_code') from error
+
+
+def create_referral_code(uid: str, *, secret: Optional[bytes] = None) -> str:
+    if not _UID_PATTERN.fullmatch(uid):
+        raise ReferralCodeError('invalid_referrer_uid')
+    payload = _encode(uid.encode('utf-8'))
+    signed_value = f'{_CODE_PREFIX}.{payload}'
+    signature = _encode(
+        hmac.new(_secret(secret), f'omi-desktop-referral:{signed_value}'.encode('ascii'), hashlib.sha256).digest()
+    )
+    return f'{signed_value}.{signature}'
+
+
+def referrer_uid_from_code(code: str, *, secret: Optional[bytes] = None) -> str:
+    parts = code.split('.') if code else []
+    if len(parts) != 3 or parts[0] != _CODE_PREFIX:
+        raise ReferralCodeError('malformed_referral_code')
+    signed_value = f'{parts[0]}.{parts[1]}'
+    expected_signature = _encode(
+        hmac.new(_secret(secret), f'omi-desktop-referral:{signed_value}'.encode('ascii'), hashlib.sha256).digest()
+    )
+    if not hmac.compare_digest(expected_signature, parts[2]):
+        raise ReferralCodeError('invalid_referral_signature')
+    try:
+        uid = _decode(parts[1]).decode('utf-8')
+    except UnicodeDecodeError as error:
+        raise ReferralCodeError('malformed_referrer_uid') from error
+    if not _UID_PATTERN.fullmatch(uid):
+        raise ReferralCodeError('invalid_referrer_uid')
+    return uid
+
+
+def referral_link(uid: str, *, secret: Optional[bytes] = None, public_base_url: Optional[str] = None) -> str:
+    base_url = (public_base_url or 'https://api.omi.me').rstrip('/')
+    return f'{base_url}/r/{create_referral_code(uid, secret=secret)}'
+
+
+def referral_claim_patch(
+    *,
+    referred_uid: str,
+    referrer_uid: str,
+    is_new_user: bool,
+    user_data: Optional[dict[str, Any]],
+    now: Optional[datetime] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the one-time referral entitlement, or None when the account is ineligible."""
+    if not is_new_user or referred_uid == referrer_uid:
+        return None
+
+    existing = user_data or {}
+    if existing.get('referral'):
+        return None
+
+    subscription = existing.get('subscription')
+    if isinstance(subscription, dict) and subscription.get('plan') in _PAID_PLAN_VALUES:
+        return None
+
+    started_at = now or datetime.now(timezone.utc)
+    if started_at.tzinfo is None:
+        started_at = started_at.replace(tzinfo=timezone.utc)
+    started_epoch = int(started_at.timestamp())
+    ends_epoch = int((started_at + timedelta(days=REFERRAL_TRIAL_DAYS)).timestamp())
+    return {
+        'subscription': {
+            'plan': PlanType.architect.value,
+            'status': 'active',
+            'current_period_start': started_epoch,
+            'current_period_end': ends_epoch,
+            'cancel_at_period_end': True,
+        },
+        'referral': {
+            'program': 'desktop_pro_month_v1',
+            'referrer_uid': referrer_uid,
+            'claimed_at': started_epoch,
+            'trial_ends_at': ends_epoch,
+        },
+    }

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -12683,6 +12683,30 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func getReferralLinkV1UsersMeReferralGet(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/me/referral"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func getUserSubscriptionEndpointV1UsersMeSubscriptionGet(client: OmiApiClient, xAppPlatform: String? = nil, xAppVersion: String? = nil, authorization: String? = nil, xDeviceIdHash: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/users/me/subscription"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -15045,5 +15069,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 402 Swift client methods generated.
+  // Total: 403 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// The constant floating top bar.
 ///
 /// **It carries the destinations flat, and nothing opens.** On the left, one pill per destination:
-/// `Home`, `Library`, `Tasks`, `Rewind`, `Apps`. On the right, three wordless controls:
+/// `Home`, `Library`, `Tasks`, `Rewind`, `Apps`, then the referral action. On the right, three wordless controls:
 /// microphone, screen capture, settings.
 ///
 /// The bar used to spell out `Home · Memory · Tasks · Apps` beside `Listening` and `Capture`, and both
@@ -47,6 +47,7 @@ struct DesktopTopBar: View {
   /// last resigned front (see DesktopHomeView).
   let sinceDate: Date
   let onRewind: () -> Void
+  @State private var showingReferral = false
 
   private var newConversations: Int {
     appState.conversations.filter { $0.createdAt > sinceDate && $0.deleted != true }.count
@@ -70,8 +71,11 @@ struct DesktopTopBar: View {
         Spacer(minLength: 0)
         TopNavigationBarLayout(
           expandedNavigation: {
-            TopNavigationDestinationRow(
-              selectedIndex: selectedIndex, badges: badges, onSelect: navigate)
+            HStack(spacing: TopNavigationPillMetrics.itemSpacing) {
+              TopNavigationDestinationRow(
+                selectedIndex: selectedIndex, badges: badges, onSelect: navigate)
+              ReferralTopBarButton { showingReferral = true }
+            }
           },
           compactNavigation: { compactNavigationMenu },
           persistentControls: {
@@ -103,6 +107,9 @@ struct DesktopTopBar: View {
     // belongs to the shared top-bar component so every shell and exported preview paints it above the
     // destination sibling rather than relying on each call site to remember (INV-NAV-1).
     .zIndex(1)
+    .sheet(isPresented: $showingReferral) {
+      ReferralSheetView()
+    }
   }
 
   /// The complete primary navigation remains available when the full row of pills will not fit beside
@@ -116,6 +123,12 @@ struct DesktopTopBar: View {
         } label: {
           Label(item.title, systemImage: item.icon)
         }
+      }
+      Divider()
+      Button {
+        showingReferral = true
+      } label: {
+        Label("Refer", systemImage: "gift")
       }
     } label: {
       Label("Navigate", systemImage: "sidebar.left")
@@ -201,11 +214,11 @@ enum TopNavigationLayoutMetrics {
   /// three objects on the lane are lit by the same light.
   static var barShadow: InkGlassShadow { .ambient }
 
-  /// What the trailing cluster costs the row: the two capture icons, the gap, and the gear.
+  /// What the trailing cluster costs the row: the two capture icons.
   ///
   /// Stated here so the layout test can ask "does the flat row of destinations fit beside the controls
   /// at the narrowest window" without hosting the capture stack and its permissions.
-  static let persistentControlsWidth: CGFloat = 32 * 2 + 2
+  static let persistentControlsWidth: CGFloat = 32 * 2 + OmiSpacing.sm
   static let settingsControlWidth: CGFloat = 32
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -404,6 +404,7 @@ struct SettingsContentView: View {
     case floatingBar = "Floating Bar"
     case shortcuts = "Shortcuts"
     case advanced = "Advanced"
+    case referral = "Refer a Friend"
     case about = "About"
     /// The established page that had no door. It was only ever written by the sidebar the glass
     /// shell stopped rendering, so `PermissionsPage` kept working with nothing on screen that
@@ -645,6 +646,8 @@ struct SettingsContentView: View {
           shortcutsSection
         case .advanced:
           advancedSection
+        case .referral:
+          referralSection
         case .about:
           aboutSection
         case .permissions:

--- a/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
@@ -1,0 +1,186 @@
+import AppKit
+import OmiTheme
+import SwiftUI
+
+@MainActor
+final class ReferralViewModel: ObservableObject {
+  enum State: Equatable {
+    case idle
+    case loading
+    case loaded(String)
+    case failed
+  }
+
+  @Published private(set) var state: State = .idle
+  private let loadLink: () async throws -> ReferralLinkResponse
+
+  init() {
+    self.loadLink = {
+      try await APIClient.shared.getReferralLink()
+    }
+  }
+
+  init(loadLink: @escaping () async throws -> ReferralLinkResponse) {
+    self.loadLink = loadLink
+  }
+
+  func load() async {
+    guard state == .idle || state == .failed else { return }
+    state = .loading
+    do {
+      state = .loaded(try await loadLink().referralURL)
+    } catch {
+      state = .failed
+    }
+  }
+}
+
+struct ReferralProgramView: View {
+  @StateObject private var viewModel: ReferralViewModel
+  @State private var copied = false
+
+  init() {
+    _viewModel = StateObject(wrappedValue: ReferralViewModel())
+  }
+
+  init(viewModel: ReferralViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  var body: some View {
+    VStack(spacing: OmiSpacing.xl) {
+      Image(systemName: "gift")
+        .scaledFont(size: 28, weight: .semibold)
+        .foregroundColor(Ink.primary)
+        .frame(width: 52, height: 52)
+        .background(Circle().fill(Ink.wash))
+        .accessibilityHidden(true)
+
+      VStack(spacing: OmiSpacing.sm) {
+        Text("Give a friend one free month of Omi Pro")
+          .scaledFont(size: OmiType.title, weight: .semibold)
+          .foregroundColor(Ink.primary)
+          .multilineTextAlignment(.center)
+
+        Text("Share your unique link. When a friend joins Omi, they'll get one month of Omi Pro free.")
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.secondary)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
+      referralControl
+    }
+    .frame(maxWidth: .infinity)
+    .task { await viewModel.load() }
+  }
+
+  @ViewBuilder
+  private var referralControl: some View {
+    switch viewModel.state {
+    case .idle, .loading:
+      ProgressView("Getting your link…")
+        .controlSize(.small)
+        .foregroundColor(Ink.secondary)
+        .frame(minHeight: 44)
+    case .loaded(let link):
+      HStack(spacing: OmiSpacing.sm) {
+        Text(link)
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.secondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, OmiSpacing.md)
+          .frame(height: 38)
+          .settingsGlassWell(radius: SettingsGlassMetrics.controlRadius)
+          .accessibilityIdentifier("referral-link")
+
+        Button {
+          copy(link)
+        } label: {
+          Label(copied ? "Copied" : "Copy link", systemImage: copied ? "checkmark" : "doc.on.doc")
+        }
+        .buttonStyle(OmiButtonStyle(.primary, size: .compact))
+        .accessibilityIdentifier("copy-referral-link")
+      }
+    case .failed:
+      VStack(spacing: OmiSpacing.sm) {
+        Text("We couldn't get your referral link.")
+          .scaledFont(size: OmiType.body)
+          .foregroundColor(Ink.secondary)
+        Button("Try again") {
+          Task { await viewModel.load() }
+        }
+        .buttonStyle(OmiButtonStyle(.secondary, size: .compact))
+        .accessibilityIdentifier("retry-referral-link")
+      }
+      .frame(minHeight: 44)
+    }
+  }
+
+  private func copy(_ link: String) {
+    NSPasteboard.general.clearContents()
+    NSPasteboard.general.setString(link, forType: .string)
+    copied = true
+    Task {
+      try? await Task.sleep(for: .seconds(2))
+      copied = false
+    }
+  }
+}
+
+struct ReferralSheetView: View {
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(alignment: .trailing, spacing: 0) {
+      Button {
+        dismiss()
+      } label: {
+        Image(systemName: "xmark")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .foregroundColor(Ink.secondary)
+          .frame(width: 28, height: 28)
+          .background(Circle().fill(Ink.wash))
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Close")
+
+      ReferralProgramView()
+        .padding(.horizontal, OmiSpacing.xxl)
+        .padding(.bottom, OmiSpacing.xxl)
+    }
+    .padding(OmiSpacing.lg)
+    .frame(width: 540, height: 340)
+    .background(Ink.surface)
+  }
+}
+
+struct ReferralTopBarButton: View {
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      TopNavigationPill(
+        icon: "gift",
+        title: "Refer",
+        badgeCount: 0,
+        isSelected: false
+      )
+    }
+    .buttonStyle(.plain)
+    .help("Refer a friend")
+    .accessibilityIdentifier("top-navigation-refer")
+  }
+}
+
+extension SettingsContentView {
+  var referralSection: some View {
+    settingsCard(settingId: "referral.link") {
+      ReferralProgramView()
+        .padding(.vertical, OmiSpacing.xl)
+    }
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -193,6 +193,12 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["upgrade", "buy", "pricing", "checkout", "architect", "operator", "unlimited"], section: .planUsage,
       icon: "creditcard", settingId: "planusage.purchase"),
 
+    // Referral
+    SettingsSearchItem(
+      name: "Refer a Friend", subtitle: "Share one free month of Omi Pro",
+      keywords: ["refer", "referral", "friend", "gift", "free month", "share link"],
+      section: .referral, icon: "gift", settingId: "referral.link"),
+
     // About
     SettingsSearchItem(
       name: "Software Updates", subtitle: "Check for and manage app updates",
@@ -391,6 +397,7 @@ enum SettingsSidebarRoutes {
     .permissions,
     .shortcuts,
     .advanced,
+    .referral,
     .about,
   ]
 }
@@ -597,6 +604,7 @@ struct SettingsSidebarItem: View {
     case .floatingBar: return "sparkles"
     case .shortcuts: return "keyboard"
     case .advanced: return "chart.bar"
+    case .referral: return "gift"
     case .about: return "info.circle"
     case .permissions: return PermissionNavSymbol.outline
     }

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -305,7 +305,7 @@ enum TopNavigationPillMetrics {
 /// One destination. **It hugs its own label** rather than taking a width from a table keyed by rail
 /// index: five pills whose widths were guessed one at a time is how a row that fitted in a mockup
 /// stops fitting once a badge appears on two of them.
-private struct TopNavigationPill: View {
+struct TopNavigationPill: View {
   let icon: String
   let title: String
   let badgeCount: Int

--- a/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Referrals.swift
+++ b/desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Referrals.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct ReferralLinkResponse: Decodable, Equatable {
+  let referralURL: String
+
+  enum CodingKeys: String, CodingKey {
+    case referralURL = "referral_url"
+  }
+}
+
+extension APIClient {
+  func getReferralLink() async throws -> ReferralLinkResponse {
+    try await get(
+      "v1/users/me/referral",
+      customBaseURL: DesktopBackendEnvironment.authBaseURL()
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/APIClientRoutingTests.swift
@@ -610,6 +610,7 @@ final class APIClientRoutingTests: XCTestCase {
   override func tearDown() {
     unsetenv("OMI_PYTHON_API_URL")
     unsetenv("OMI_DESKTOP_API_URL")
+    unsetenv("OMI_AUTH_API_URL")
     URLCapture.reset()
     super.tearDown()
   }
@@ -810,6 +811,16 @@ final class APIClientRoutingTests: XCTestCase {
       URLCapture.capturedRequests, host: "python-test", port: 9001,
       pathContains: "v1/users/me/subscription", method: "GET",
       label: "getUserSubscription")
+  }
+
+  func testGetReferralLinkRoutesToAuthAuthority() async {
+    setenv("OMI_AUTH_API_URL", "http://auth-test:9003", 1)
+    let client = await makeTestClient()
+    _ = try? await client.getReferralLink() as ReferralLinkResponse
+    assertRoutes(
+      URLCapture.capturedRequests, host: "auth-test", port: 9003,
+      pathContains: "v1/users/me/referral", method: "GET",
+      label: "getReferralLink")
   }
 
   // MARK: - Routing behavior: Rust-routed endpoints (customBaseURL: rustBackendURL)

--- a/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
+++ b/desktop/macos/Desktop/Tests/AutomationSettingsSectionTests.swift
@@ -20,6 +20,7 @@ final class AutomationSettingsSectionTests: XCTestCase {
     XCTAssertEqual(Section.automationMatch("rewind"), .rewind)
     XCTAssertEqual(Section.automationMatch("general"), .general)
     XCTAssertEqual(Section.automationMatch("advanced"), .advanced)
+    XCTAssertEqual(Section.automationMatch("refer-a-friend"), .referral)
     XCTAssertEqual(Section.automationMatch("shortcuts"), .shortcuts)
     XCTAssertEqual(Section.automationMatch("about"), .about)
   }

--- a/desktop/macos/Desktop/Tests/ReferralViewModelTests.swift
+++ b/desktop/macos/Desktop/Tests/ReferralViewModelTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class ReferralViewModelTests: XCTestCase {
+  func testLoadPublishesReferralLink() async {
+    let model = ReferralViewModel {
+      ReferralLinkResponse(referralURL: "https://api.omi.me/r/ref1.example.signature")
+    }
+
+    await model.load()
+
+    XCTAssertEqual(model.state, .loaded("https://api.omi.me/r/ref1.example.signature"))
+  }
+
+  func testFailedLoadCanRetry() async {
+    var attempts = 0
+    let model = ReferralViewModel {
+      attempts += 1
+      if attempts == 1 { throw ReferralTestError.unavailable }
+      return ReferralLinkResponse(referralURL: "https://api.omi.me/r/ref1.retry.signature")
+    }
+
+    await model.load()
+    XCTAssertEqual(model.state, .failed)
+
+    await model.load()
+    XCTAssertEqual(model.state, .loaded("https://api.omi.me/r/ref1.retry.signature"))
+    XCTAssertEqual(attempts, 2)
+  }
+
+  func testReferralResponseDecodesBackendWireKey() throws {
+    let response = try JSONDecoder().decode(
+      ReferralLinkResponse.self,
+      from: Data(#"{"referral_url":"https://api.omi.me/r/ref1.example.signature"}"#.utf8)
+    )
+
+    XCTAssertEqual(response.referralURL, "https://api.omi.me/r/ref1.example.signature")
+  }
+}
+
+private enum ReferralTestError: Error {
+  case unavailable
+}

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -236,6 +236,17 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     )
   }
 
+  func testReferAFriendSitsImmediatelyAfterAdvancedInSettings() {
+    guard
+      let advanced = SettingsSidebarRoutes.visibleSections.firstIndex(of: .advanced),
+      let referral = SettingsSidebarRoutes.visibleSections.firstIndex(of: .referral)
+    else {
+      return XCTFail("Advanced and Refer a Friend must both be visible Settings rows")
+    }
+
+    XCTAssertEqual(referral, advanced + 1)
+  }
+
   /// A destination whose `reach` points at a page the bar does not have a pill for is exactly the
   /// stranding INV-NAV-1 forbids, so the checker has to *see* it rather than pass vacuously.
   func testTheReachabilityCheckerCatchesADestinationWhosePillWasRemoved() {
@@ -353,11 +364,14 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       rootView: TopNavigationBarLayout(
         expandedNavigation: {
           TopNavigationLayoutProbe(recorder: recorder, slot: .expanded) {
-            TopNavigationDestinationRow(
-              selectedIndex: SidebarNavItem.dashboard.rawValue,
-              badges: TopNavigationDestinationBadges(library: 99, tasks: 99),
-              onSelect: { _ in }
-            )
+            HStack(spacing: TopNavigationPillMetrics.itemSpacing) {
+              TopNavigationDestinationRow(
+                selectedIndex: SidebarNavItem.dashboard.rawValue,
+                badges: TopNavigationDestinationBadges(library: 99, tasks: 99),
+                onSelect: { _ in }
+              )
+              ReferralTopBarButton {}
+            }
           }
         },
         compactNavigation: {
@@ -396,7 +410,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     // horizontal padding on both sides plus the fixed icon column, and the gaps are `itemSpacing`.
     // Real pills are wider than that — they carry a word, and two carry a badge — so this is a strict
     // lower bound that still fails the moment a pill stops being rendered.
-    let pills = CGFloat(TopNavigationRoutes.primaryItems.count)
+    let pills = CGFloat(TopNavigationRoutes.primaryItems.count + 1)
     let minimumPillWidth =
       TopNavigationPillMetrics.horizontalPadding * 2 + TopNavigationPillMetrics.iconWidth
     let floor = pills * minimumPillWidth + (pills - 1) * TopNavigationPillMetrics.itemSpacing

--- a/desktop/macos/changelog/unreleased/20260820-refer-a-friend.json
+++ b/desktop/macos/changelog/unreleased/20260820-refer-a-friend.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added Refer a Friend links that give eligible new Desktop users one free month of Omi Pro"
+}

--- a/desktop/macos/e2e/CORE_E2E.md
+++ b/desktop/macos/e2e/CORE_E2E.md
@@ -122,7 +122,7 @@ Local T2 and fault suites remain available as engineering QA tools. They do not 
 | `subagent-row-benchmark` | v1 | typed bridge | 3 | Perf |
 | `apps` | v2 | manual `do:` | manual | Marketplace walker journey |
 | `audio-recording` | v2 | manual `do:` | manual | Needs mic permission |
-| `refer-external` | v2 | manual `do:` | manual | Profile menu → affiliate URL |
+| `refer-external` | v2 | manual `do:` | manual | Top bar + Settings → unique referral link |
 | `delete-account` | v2 | manual `do:` | manual | Confirmation sheet only; never confirm |
 | `logout` | v2 | manual bridge | manual | `sign_out` bridge action; local Auth emulator only |
 | `onboarding-smoke` | v2 | manual `do:` + bridge | manual | `reset_onboarding`; Wave 7 fix — manual until 2× local green |
@@ -146,7 +146,7 @@ Local T2 and fault suites remain available as engineering QA tools. They do not 
 | Plan / usage | T2 | bridge | read subscription | ✅ `plan-usage.yaml` |
 | Apps catalog | T2 + Live P2 | bridge + manual | catalog snapshot + walker | ✅ `apps-marketplace.yaml` / ⚠️ `apps.yaml` |
 | Connector import | T2 + Live P2 | bridge + manual | API probe + sheet UI | ✅ `connector-import.yaml` / ⚠️ `connector-import-progress.yaml` |
-| Refer external | Live P2 | manual | opens browser | ⚠️ `refer-external.yaml` |
+| Referrals | Live P2 | manual | copies unique link | ⚠️ `refer-external.yaml` |
 | Delete account | Live P2 | manual | confirm sheet only | ⚠️ `delete-account.yaml` |
 | Logout | Live P2 | manual bridge | `sign_out` action | ⚠️ `logout.yaml` (local emulator; stays manual — destructive to session) |
 | Onboarding reset | Live P2 | manual + bridge | reset + restart | ⚠️ `onboarding-smoke.yaml` (fix landed; manual gate) |

--- a/desktop/macos/e2e/SKILL.md
+++ b/desktop/macos/e2e/SKILL.md
@@ -533,7 +533,7 @@ Reference flows in `desktop/macos/e2e/flows/*.yaml` describe the app's key user 
 | `flows/language.yaml` | Settings → Transcription language config | 5 | Language mode toggle, voice assistant languages |
 | `flows/screen-recording-permission.yaml` | Rewind permission flow | 7 | Grant Permission button, Capture status |
 | `flows/audio-recording.yaml` | Audio capture, mic source, transcription | 7 | Start/Stop Recording, BT/mic selection |
-| `flows/refer-external.yaml` | Refer a Friend | 3 | Profile → affiliate URL |
+| `flows/refer-external.yaml` | Refer a Friend | 3 | Top bar + Settings → copy unique link |
 | `flows/recording-finalization.yaml` | Recording lifecycle | 7 | Transcription storage, conversation detail |
 
 When you modify a Swift file, check if any flow's `covers:` includes it. That flow describes the user journey your change affects.

--- a/desktop/macos/e2e/feature-vector.md
+++ b/desktop/macos/e2e/feature-vector.md
@@ -69,7 +69,7 @@ Prioritized feature map to guide desktop E2E coverage. Uses the same two-dimensi
 | 25 | Plan / usage (billing) | — | 5 | 2 | 1 | ✅ flow: `plan-usage.yaml` (subscription snapshot) |
 | 26 | Apps / integrations catalog | retrieval-action (3) | 6 | 2 | 2 | ✅ flow: `apps-marketplace.yaml` + ⚠️ manual: `apps.yaml` |
 | 27 | Connector import (progress persistence) | retrieval-action (3) | 6 | 3 | 2 | ✅ flow: `connector-import.yaml` + ⚠️ manual: `connector-import-progress.yaml` |
-| 28 | Refer a Friend (external affiliate URL) | retrieval-action (3) | 6 | 0 | 2 | ⚠️ manual: `refer-external.yaml` (profile menu → browser) |
+| 28 | Refer a Friend (one month of Omi Pro) | retrieval-action (3) | 6 | 0 | 2 | ⚠️ manual: `refer-external.yaml` (top bar + Settings → copy link) |
 | 29 | Delete account (confirmation only) | — | 5 | 0 | 2 | ⚠️ manual: `delete-account.yaml` (never confirms) |
 | 30 | Logout (local auth / emulator) | — | 5 | 1 | 2 | ⚠️ manual: `logout.yaml` (`sign_out` bridge; not prod OAuth) |
 | 31 | Onboarding (first launch / reset) | — | 5 | 1 | 1 | ⚠️ manual: `onboarding-smoke.yaml` — reset fix landed; keep manual until 2× local green |
@@ -98,7 +98,7 @@ Agent-local flows with `tier: manual` — **not** qualification-tier (T2). Run i
 
 | Flow | Why manual | Destructive? |
 |------|------------|--------------|
-| `refer-external.yaml` | Opens `https://affiliate.omi.me` in the default browser | No |
+| `refer-external.yaml` | Copies the unique Omi Pro referral link from the top bar and Settings | No |
 | `delete-account.yaml` | Exercises confirmation sheet only; **never** taps Delete Permanently | Yes (gated) |
 | `logout.yaml` | Sign out via Settings; requires **local Auth emulator** (`make desktop-run-local`), not prod OAuth | No |
 | `onboarding-smoke.yaml` | `reset_onboarding` restarts app; Wave 7 fix landed — manual until 2× local green | Yes (local reset) |
@@ -136,7 +136,7 @@ Do **not** promote destructive flows (`delete-account`, `onboarding-smoke`) to t
 | settings-basic | 9/9 | PASS | flow-walker.beastoin.workers.dev/runs/RoTW8GeljN.html |
 | rewind | 4/4 | PASS | flow-walker.beastoin.workers.dev/runs/1HE5OsPOOy.html |
 | apps | 6/6 | PASS | flow-walker.beastoin.workers.dev/runs/VDGw-wbHqa.html |
-| refer-external | — | — | superseded old `refer.yaml` (profile menu, not sidebar page) |
+| refer-external | — | — | top-bar sheet plus Settings page |
 | screen-recording-permission | 7/7 | PASS | flow-walker.beastoin.workers.dev/runs/3WoXUG6xkT.html |
 | audio-recording | 7/7 | PASS | flow-walker.beastoin.workers.dev/runs/UdkzB-dYG_.html |
 

--- a/desktop/macos/e2e/flows/refer-external.yaml
+++ b/desktop/macos/e2e/flows/refer-external.yaml
@@ -1,31 +1,41 @@
 version: 2
-name: refer-external
+name: referrals
 tier: manual
-description: Refer a Friend — profile menu opens external affiliate URL (Live P2; not qualification tier)
+description: Refer a Friend — top bar and Settings share the same unique Omi Pro referral link
 app: com.omi.computer-macos
 covers:
-  - desktop/macos/Desktop/Sources/MainWindow/SidebarView.swift
-  - desktop/macos/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
+  - desktop/macos/Desktop/Sources/Services/APIClient/APIClient+Referrals.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+  - desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
 preconditions:
   - auth_ready
 
 steps:
   - id: S1
-    name: Open profile menu
-    do: "On the Dashboard, click the profile avatar/button at the bottom of the sidebar to open the profile popover menu. Verify menu items include Refer a Friend (when eligible), Discord, and Settings."
+    name: Open referral sheet from the top bar
+    do: "Click the gift icon and Refer label immediately left of the microphone control. Verify the referral sheet explains the one free month of Omi Pro and shows the unique link with Copy link."
     expect:
-      interactive_count: { min: 3 }
+      interactive_count: { min: 2 }
+      text_visible:
+        - Give a friend one free month of Omi Pro
+        - Copy link
 
   - id: S2
-    name: Open affiliate URL
-    do: "Click 'Refer a Friend' in the profile menu. Verify the default browser opens https://affiliate.omi.me (external tab). Note the browser window or URL bar; return focus to Omi."
+    name: Copy the unique link repeatedly
+    do: "Click Copy link, close and reopen the sheet, then repeat twice more. Verify every invocation shows the same link and changes the button to Copied without opening a browser."
     expect:
-      interactive_count: { min: 1 }
+      interactive_count: { min: 2 }
+      text_visible:
+        - Copied
 
   - id: S3
-    name: Return to Dashboard
-    do: "Confirm Omi is still on the Dashboard with the conversations list visible."
+    name: Open the Settings entry
+    do: "Open Settings and click Refer a Friend directly below Advanced. Verify it renders the same one-month offer, unique link, and Copy link control."
     expect:
-      interactive_count: { min: 5 }
+      interactive_count: { min: 2 }
       text_visible:
-        - Dashboard
+        - Refer a Friend
+        - Give a friend one free month of Omi Pro
+        - Copy link

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2927,6 +2927,10 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralLinkResponse {
+  referral_url: string;
+}
+
 export interface ReorderFoldersRequest {
   folder_ids: Array<string>;
 }
@@ -4527,6 +4531,7 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
   "ResponseMessage": ResponseMessage;
@@ -7863,6 +7868,16 @@ export interface OmiApiPaths {
       operationId: "get_user_paywall_status_v1_users_me_paywall_get";
       responses: {
         "200": PaywallStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral": {
+    get: {
+      operationId: "get_referral_link_v1_users_me_referral_get";
+      responses: {
+        "200": ReferralLinkResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -14900,6 +14915,25 @@ export async function get_user_paywall_status_v1_users_me_paywall_get(query: { p
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_referral_link_v1_users_me_referral_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ReferralLinkResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16695,4 +16729,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 402 client methods generated.
+// Total: 403 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -17816,6 +17816,19 @@
         "title": "RecordLlmUsageBucketRequest",
         "type": "object"
       },
+      "ReferralLinkResponse": {
+        "properties": {
+          "referral_url": {
+            "title": "Referral Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "referral_url"
+        ],
+        "title": "ReferralLinkResponse",
+        "type": "object"
+      },
       "ReorderFoldersRequest": {
         "description": "Request model for reordering folders.",
         "properties": {
@@ -52306,6 +52319,83 @@
         "summary": "Get User Paywall Status",
         "tags": [
           "users"
+        ]
+      }
+    },
+    "/v1/users/me/referral": {
+      "get": {
+        "operationId": "get_referral_link_v1_users_me_referral_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferralLinkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Referral Link",
+        "tags": [
+          "referrals"
         ]
       }
     },

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2927,6 +2927,10 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralLinkResponse {
+  referral_url: string;
+}
+
 export interface ReorderFoldersRequest {
   folder_ids: Array<string>;
 }
@@ -4527,6 +4531,7 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
   "ResponseMessage": ResponseMessage;
@@ -7863,6 +7868,16 @@ export interface OmiApiPaths {
       operationId: "get_user_paywall_status_v1_users_me_paywall_get";
       responses: {
         "200": PaywallStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral": {
+    get: {
+      operationId: "get_referral_link_v1_users_me_referral_get";
+      responses: {
+        "200": ReferralLinkResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -14900,6 +14915,25 @@ export async function get_user_paywall_status_v1_users_me_paywall_get(query: { p
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_referral_link_v1_users_me_referral_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ReferralLinkResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16695,4 +16729,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 402 client methods generated.
+// Total: 403 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2927,6 +2927,10 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralLinkResponse {
+  referral_url: string;
+}
+
 export interface ReorderFoldersRequest {
   folder_ids: Array<string>;
 }
@@ -4527,6 +4531,7 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
   "ResponseMessage": ResponseMessage;
@@ -7863,6 +7868,16 @@ export interface OmiApiPaths {
       operationId: "get_user_paywall_status_v1_users_me_paywall_get";
       responses: {
         "200": PaywallStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral": {
+    get: {
+      operationId: "get_referral_link_v1_users_me_referral_get";
+      responses: {
+        "200": ReferralLinkResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -14900,6 +14915,25 @@ export async function get_user_paywall_status_v1_users_me_paywall_get(query: { p
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_referral_link_v1_users_me_referral_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ReferralLinkResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16695,4 +16729,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 402 client methods generated.
+// Total: 403 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2927,6 +2927,10 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralLinkResponse {
+  referral_url: string;
+}
+
 export interface ReorderFoldersRequest {
   folder_ids: Array<string>;
 }
@@ -4527,6 +4531,7 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
   "ResponseMessage": ResponseMessage;
@@ -7863,6 +7868,16 @@ export interface OmiApiPaths {
       operationId: "get_user_paywall_status_v1_users_me_paywall_get";
       responses: {
         "200": PaywallStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral": {
+    get: {
+      operationId: "get_referral_link_v1_users_me_referral_get";
+      responses: {
+        "200": ReferralLinkResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -14900,6 +14915,25 @@ export async function get_user_paywall_status_v1_users_me_paywall_get(query: { p
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function get_referral_link_v1_users_me_referral_get(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<ReferralLinkResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16695,4 +16729,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 402 client methods generated.
+// Total: 403 client methods generated.


### PR DESCRIPTION
## Summary

- add a gift + Refer action to the Desktop navigation and Refer a Friend to Settings
- generate deterministic signed referral links that preserve attribution through the download and OAuth flow
- grant eligible new accounts exactly 30 days of the Desktop Omi Pro (`architect`) plan without overwriting paid or previously claimed accounts

## Verification

- `make preflight` — 34 selected checks passed
- `xcrun swift test -c debug --package-path Desktop --filter TopNavigationBarLayoutTests` — 17 passed
- focused Desktop referral/API/settings tests — 29 passed
- focused backend auth/referral tests — 74 passed
- named app `/Applications/omi-referrals.app`: corrected Refer pill visually inspected; opened and dismissed three consecutive times; Settings route and Copy link exercised
- real production Firestore transaction using an isolated throwaway UID: first grant succeeded, entitlement was exactly 30 days, a duplicate claim was rejected, and the test document was deleted

## Notes

- referral redemption is fail-open for authentication: an entitlement write failure is recorded through shared fallback telemetry without blocking sign-in
- the public capture route stores only the signed code in a secure HttpOnly SameSite cookie and redirects to the existing Desktop download URL


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

