### PR TITLE
fix: force referral links to public HTTPS origin

### DIFF
--- a/backend/routers/referrals.py
+++ b/backend/routers/referrals.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
@@ -20,8 +20,8 @@ class ReferralLinkResponse(BaseModel):
 
 
 @router.get('/v1/users/me/referral', response_model=ReferralLinkResponse)
-def get_referral_link(request: Request, uid: str = Depends(auth.get_current_user_uid)) -> ReferralLinkResponse:
-    return ReferralLinkResponse(referral_url=referral_link(uid, public_base_url=str(request.base_url)))
+def get_referral_link(uid: str = Depends(auth.get_current_user_uid)) -> ReferralLinkResponse:
+    return ReferralLinkResponse(referral_url=referral_link(uid))
 
 
 @router.get('/r/{code}', response_class=RedirectResponse)

--- a/backend/tests/unit/test_referrals.py
+++ b/backend/tests/unit/test_referrals.py
@@ -5,7 +5,6 @@ from types import ModuleType
 from typing import Iterator
 
 import pytest
-from starlette.requests import Request
 
 from routers import auth
 from testing.import_isolation import load_module_fresh, stub_modules
@@ -96,26 +95,17 @@ def test_referral_link_captures_secure_cookie_and_opens_existing_desktop_downloa
     assert 'SameSite=lax' in cookie
 
 
-def test_authenticated_referrer_receives_a_stable_unique_link(monkeypatch):
+def test_authenticated_referrer_receives_a_stable_unique_https_link(monkeypatch):
     monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
-    request = Request(
-        {
-            'type': 'http',
-            'scheme': 'https',
-            'server': ('api.omiapi.com', 443),
-            'path': '/',
-            'headers': [(b'host', b'api.omiapi.com')],
-        }
-    )
 
     with _loaded_referrals_router() as referrals:
-        first = referrals.get_referral_link(request, 'referrer-123').referral_url
-        second = referrals.get_referral_link(request, 'referrer-123').referral_url
-        other = referrals.get_referral_link(request, 'another-user').referral_url
+        first = referrals.get_referral_link('referrer-123').referral_url
+        second = referrals.get_referral_link('referrer-123').referral_url
+        other = referrals.get_referral_link('another-user').referral_url
 
     assert first == second
     assert first != other
-    assert first.startswith('https://api.omiapi.com/r/ref1.')
+    assert first.startswith('https://api.omi.me/r/ref1.')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- always mint referral links on the public `https://api.omi.me` authority
- prevent an internal load-balancer `http` scheme from leaking into user-facing links

## Testing

- `cd backend && ENCRYPTION_SECRET='referral-test-secret-that-is-at-least-32-bytes' OPENAI_API_KEY=test .venv/bin/python -m pytest -q tests/unit/test_referrals.py` (10 passed)
- `backend/.venv/bin/python backend/scripts/export_openapi.py --surface app-client --check docs/api-reference/app-client-openapi.json`
- live production failure reproduced before fix: authenticated endpoint returned `http://api.omi.me/r/...`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

