### PR TITLE
fix(chat): stop forwarding unsupported client params to the LLM gateway

### DIFF
--- a/backend/routers/desktop_chat.py
+++ b/backend/routers/desktop_chat.py
@@ -4,12 +4,14 @@ import asyncio
 import base64
 import json
 import re
+import sys
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from types import SimpleNamespace
 from typing import Any, Literal, cast
 from uuid import uuid4
 
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.routing import APIRoute
@@ -553,6 +555,87 @@ def _gateway_user_content(content: object) -> object:
     return blocks or ''
 
 
+# Top-level request keys the gateway will accept. The gateway validates the
+# forwarded body against a strict allowlist and rejects the whole request with
+# HTTP 400 on the first unknown key, so anything the desktop client sends that
+# is not listed here must be dropped rather than passed through.
+#
+# This is not a style preference. Forwarding the client body verbatim took every
+# managed desktop chat turn down for ~19 hours: the local pi-mono agent runs the
+# OpenAI JS SDK, which sets `store` on every request (and `reasoning_effort`
+# whenever a thinking level is set). Neither is in the gateway's allowlist, so
+# each turn 400ed before a lane was ever resolved, and `_stream` reported that as
+# an in-band `502 Upstream provider error` inside an HTTP 200 — invisible to
+# status-code monitoring.
+#
+# `test_gateway_forwardable_params_stay_within_the_gateway_allowlist` pins this
+# set against the gateway's own validator so the two cannot drift apart again.
+_GATEWAY_FORWARDABLE_PARAMS = frozenset(
+    {
+        'frequency_penalty',
+        'logit_bias',
+        'logprobs',
+        'max_completion_tokens',
+        'max_tokens',
+        'metadata',
+        'n',
+        'presence_penalty',
+        'prompt_cache_key',
+        'prompt_cache_options',
+        'response_format',
+        'seed',
+        'service_tier',
+        'stop',
+        'stream',
+        'stream_options',
+        'temperature',
+        'tool_choice',
+        'tools',
+        'top_logprobs',
+        'top_p',
+        'user',
+    }
+)
+
+
+def _log_gateway_rejection(response: httpx.Response, *, lane_id: str, request_id: str) -> None:
+    """Record why the gateway refused a request.
+
+    A 4xx from the gateway carries a typed body naming the offending field
+    (`{"error": {"message": ..., "param": ...}}`), and both call sites used to
+    discard it and report a bare `502 Upstream provider error`. That left the
+    real reason recorded nowhere: during the 2026-08-20 outage the rejected
+    parameter appeared in no log line in either GCP project, so a one-request
+    diagnosis took hours of log archaeology instead.
+
+    Client-supplied content is never logged — only the gateway's own error
+    message and param, which are gateway-authored and carry no user data.
+    """
+    status_code = response.status_code
+    message = ''
+    param = ''
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+    if isinstance(payload, Mapping):
+        error = payload.get('error')
+        if isinstance(error, Mapping):
+            message = str(error.get('message') or '')[:200]
+            param = str(error.get('param') or '')[:100]
+    event = {
+        'event': 'desktop_chat_gateway_refused',
+        'message': 'desktop_chat_gateway_refused',
+        'lane_id': lane_id,
+        'status_code': status_code,
+        'param': param or 'unknown',
+        'reason': message or 'unavailable',
+        'request_id': request_id,
+        'severity': 'WARNING',
+    }
+    sys.stdout.write(json.dumps(event, separators=(',', ':'), sort_keys=True) + '\n')
+
+
 def _gateway_body(body: Mapping[str, object], lane_id: str = CHAT_AGENT_AUTO_LANE_ID) -> dict[str, object]:
     messages = body.get('messages')
     if not isinstance(messages, list):
@@ -568,7 +651,7 @@ def _gateway_body(body: Mapping[str, object], lane_id: str = CHAT_AGENT_AUTO_LAN
         elif 'content' not in updated or updated.get('content') is None:
             updated['content'] = ''
         translated.append(updated)
-    gateway_body = {key: value for key, value in body.items() if key != 'omi_web_search'}
+    gateway_body = {key: value for key, value in body.items() if key in _GATEWAY_FORWARDABLE_PARAMS}
     result = {**gateway_body, 'model': lane_id, 'messages': translated}
     if lane_id == WEB_SEARCH_AUTO_LANE_ID:
         # The Perplexity web-search lane has tools: false. Public-web turns
@@ -1281,6 +1364,7 @@ async def _stream_gateway(
                     transport_failure = is_gateway_transport_failure(status_error)
                     if transport_failure:
                         gateway_circuit.record_transport_failure()
+                    _log_gateway_rejection(response, lane_id=lane_id, request_id=request_id)
                     observe_gateway_first_byte(
                         feature=_gateway_feature_for_lane(lane_id),
                         started_at=started_at,

--- a/backend/tests/unit/test_desktop_chat.py
+++ b/backend/tests/unit/test_desktop_chat.py
@@ -2204,3 +2204,56 @@ def test_request_web_search_injection_keeps_a_constant_cached_prefix():
     assert [tool['name'] for tool in first['tools']] == ['web_search', 'search_memories', 'execute_sql']
     assert '2024-01-19' not in _stable_prefix(first)
     assert '2024-06-01' not in _stable_prefix(second)
+
+
+def test_gateway_forwardable_params_stay_within_the_gateway_allowlist():
+    """The router must never forward a key the gateway will reject.
+
+    The gateway validates the forwarded body against a strict allowlist and
+    fails the whole request with HTTP 400 on the first unknown top-level key.
+    Forwarding the client body verbatim therefore took managed desktop chat
+    down for ~19 hours. Pin the router's projection against the gateway's own
+    constants so the two cannot drift apart again.
+    """
+    from llm_gateway.gateway.validator import (
+        CONTROL_PARAMS,
+        FORWARDED_CHAT_COMPLETION_PARAMS,
+        GATEWAY_LOCAL_PARAMS,
+    )
+
+    accepted = CONTROL_PARAMS | GATEWAY_LOCAL_PARAMS | FORWARDED_CHAT_COMPLETION_PARAMS
+    unsupported = desktop_chat._GATEWAY_FORWARDABLE_PARAMS - accepted
+
+    assert not unsupported, f'router forwards keys the gateway rejects: {sorted(unsupported)}'
+
+
+def test_gateway_body_drops_client_params_the_gateway_would_reject():
+    """A real pi-mono turn must survive gateway validation.
+
+    The OpenAI JS SDK the local agent runs sets `store` on every request, and
+    `reasoning_effort` whenever a thinking level is configured. Neither is in
+    the gateway allowlist, and forwarding either one 400s the turn before a
+    lane is resolved.
+    """
+    body = {
+        'model': 'omi-sonnet',
+        'messages': [{'role': 'user', 'content': 'hello'}],
+        'store': False,
+        'reasoning_effort': 'low',
+        'parallel_tool_calls': True,
+        'temperature': 0.5,
+        'stream': True,
+        'omi_web_search': True,
+    }
+
+    result = desktop_chat._gateway_body(body)
+
+    assert 'store' not in result
+    assert 'reasoning_effort' not in result
+    assert 'parallel_tool_calls' not in result
+    assert 'omi_web_search' not in result
+    # Supported params still reach the gateway.
+    assert result['temperature'] == 0.5
+    assert result['stream'] is True
+    assert result['model'] == desktop_chat.CHAT_AGENT_AUTO_LANE_ID
+    assert result['messages'][0]['role'] == 'user'

--- a/desktop/macos/Desktop/Sources/Chat/AgentErrorClassifier.swift
+++ b/desktop/macos/Desktop/Sources/Chat/AgentErrorClassifier.swift
@@ -23,6 +23,7 @@ enum AgentErrorCode: String, CaseIterable, Sendable {
   case credentialLeakSuspected = "credential_leak_suspected"
   case planLimitReached = "plan_limit_reached"
   case agentModeUnavailable = "agent_mode_unavailable"
+  case upstreamProviderFailed = "upstream_provider_failed"
   case userInterrupted = "user_interrupted"
   case unknown
 }
@@ -109,6 +110,27 @@ enum AgentErrorClassifier {
         code: .runtimeInstallIncomplete,
         userMessage: runtimeInstallIncompleteMessage,
         retryable: false)
+    }
+
+    // Omi's own desktop chat backend reports every upstream failure as the
+    // fixed string "Upstream provider error" with code 502, delivered as an SSE
+    // error frame inside an HTTP 200 body. The corpus had no rule for it, so it
+    // fell through to `unknown` and the transcript showed the generic "Omi
+    // couldn't answer this one" — which is what users saw for ~19 hours during
+    // the 2026-08-20 gateway-parameter outage, with nothing on screen
+    // indicating the failure was ours rather than their message.
+    //
+    // Retryable: the backend emits this for transient gateway conditions
+    // (circuit open, transport failure, upstream timeout) as well as hard
+    // rejections, and it does not distinguish them on the wire. Resending is
+    // worth one attempt.
+    if lower.contains("upstream provider error") {
+      return ClassifiedAgentError(
+        code: .upstreamProviderFailed,
+        userMessage:
+          "Omi's AI service didn't respond. This is on our side, not your message. "
+          + "Try again in a moment.",
+        retryable: true)
     }
 
     // The Omi-account proxy answers an exhausted billing lane with a bare 402

--- a/desktop/macos/Desktop/Tests/AgentErrorClassifierTests.swift
+++ b/desktop/macos/Desktop/Tests/AgentErrorClassifierTests.swift
@@ -251,6 +251,10 @@ final class AgentErrorClassifierTests: XCTestCase {
       ("403 \"byok_validation_failed\"", true, false),
       ("Connection error.", true, true),
       ("HTTP 402 status code (no body)", true, false),
+      // The desktop chat backend's own upstream-failure string. Unclassified,
+      // it renders as the generic "Omi couldn't answer this one", which is what
+      // the 2026-08-20 gateway-parameter outage showed users for ~19 hours.
+      ("Upstream provider error", true, true),
     ]
     for (raw, mustNotBeUnknown, expectedRetryable) in corpus {
       let c = AgentErrorClassifier.classify(raw)
@@ -259,5 +263,18 @@ final class AgentErrorClassifierTests: XCTestCase {
       }
       XCTAssertEqual(c.retryable, expectedRetryable, "retryability wrong for: \(raw)")
     }
+  }
+
+  func testUpstreamProviderErrorIsClassifiedRatherThanGeneric() {
+    let classified = AgentErrorClassifier.classify("Upstream provider error")
+
+    XCTAssertEqual(classified.code, .upstreamProviderFailed)
+    XCTAssertTrue(classified.retryable)
+    // The notice must show this rule's sentence, not the unclassified fallback.
+    let notice = ChatTurnFailureNotice.forFailure(
+      errorDescription: "Upstream provider error", presentsUserError: true)
+    XCTAssertNotNil(notice)
+    XCTAssertNotEqual(notice?.text, ChatTurnFailureNotice.unclassifiedText)
+    XCTAssertEqual(notice?.text, classified.userMessage)
   }
 }

--- a/desktop/macos/changelog/unreleased/20260821-chat-upstream-error-message.json
+++ b/desktop/macos/changelog/unreleased/20260821-chat-upstream-error-message.json
@@ -1,0 +1,3 @@
+{
+  "change": "Chat tells you when a failure is ours. When Omi's AI service did not respond, the transcript used to say \"Omi couldn't answer this one. Try sending it again\" — which reads as though your message was the problem, so people retried into a failure that could not succeed. It now says the AI service didn't respond and that it is on our side, not your message"
+}


### PR DESCRIPTION
> **Incident fix.** Managed desktop chat was down for ~19 hours (2026-08-20 04:53Z → 00:23Z).
> Prod and dev are currently mitigated with the documented kill switch
> (`OMI_LLM_CHAT_AGENT_ROUTE=direct`), which routes chat back to direct Anthropic.
> **Merging and deploying this is what allows the kill switch to be removed** and managed
> routing — and the Anthropic saving — to be restored.

## What broke

[#11886](https://github.com/BasedHardware/omi/pull/11886) turned on gateway routing for
`desktop-backend` (`OMI_LLM_CHAT_AGENT_ROUTE=gateway`, live from revision `ec46dbc51542` at
2026-08-20T04:51Z). From the first request after that revision took traffic, **every chat turn
routed through the macOS local pi-mono agent failed**.

Measured blast radius over the full window (2026-08-20T04:53Z → 2026-08-21T00:23Z), on
`/v2/chat/completions`:

| Client | Requests | Distinct IPs | Outcome |
|---|---|---:|---|
| macOS pi-mono agent (`OpenAI/JS 6.26.0`) | 174 | 64 | **100% failed** — 156 × exactly 323 B, 11 × 401, 7 × 402; zero real responses |
| Windows desktop app (Electron, `omi-windows/1.0.0`) | 4,820 | 372 | healthy — 1,447 real answers |
| macOS/iOS native (`Omi/… CFNetwork`) | 7 | 5 | healthy |

The Windows client hits the same endpoint and was unaffected, because its request stack does
not send `store` / `reasoning_effort`. The two populations separate cleanly: pi-mono failures
are uniformly **323 bytes** (a fixed error frame), while the Electron short responses vary in
size (545–553 B) with real latency.

`_gateway_body` forwarded the client's entire request body, stripping only `omi_web_search`:

```python
gateway_body = {key: value for key, value in body.items() if key != 'omi_web_search'}
```

The gateway validates the forwarded body against a strict allowlist and rejects the whole
request with HTTP 400 on the first unknown top-level key
(`llm_gateway/gateway/validator.py:185-190`). Desktop chat is executed by the local pi-mono
agent, which runs the OpenAI JS SDK; that SDK sets **`store` on every request**, and
**`reasoning_effort`** whenever a thinking level is configured. Neither is in the allowlist.

Reproduced directly against the live prod gateway:

```
{"model":"omi:auto:chat-agent","messages":[...],"store":false}
  → 400 {"error":{"message":"unsupported chat completion parameter: store","param":"store"}}
{"model":"omi:auto:chat-agent","messages":[...],"reasoning_effort":"low"}     → 400
{"model":"omi:auto:chat-agent","messages":[...],"parallel_tool_calls":false}  → 400
```

The rejection happens during route resolution, before a lane is selected — which is why the
`omi:auto:chat-agent` lane shows **zero** terminal events in gateway logs for the whole
outage, and why probing the lane directly returned a healthy 200.

## Why nobody noticed for 19 hours

Three failures of observability compounded, and this PR fixes all three.

**1. The failure was reported as success.** `/v2/chat/completions` is SSE, so the HTTP 200 and
headers are already flushed before the gateway call runs. A gateway 4xx became an in-band
`{'error': {'code': 502, 'message': 'Upstream provider error'}}` frame inside a **200**.
Cloud Run access logs showed an unbroken 200 rate; the only tell was response size — 323 bytes
in ~90ms, where a real answer is 5–11 KB over 15–20s. Post-deploy verification that counted
status codes therefore reported the service healthy while it was failing 100% of agent turns.

**2. The reason was recorded nowhere.** The gateway's 400 body names the offending key in
`error.param`, and both call sites discarded it. The string
`unsupported chat completion parameter` appears in **zero** log entries across both GCP
projects for the entire outage.

Combined with the affected path being ~3% of chat volume (~9 requests/hour), this is why the
outage went unreported: nothing status-based could fire, nothing was logged, and the failure
was worded so users concluded their own message was at fault and retried instead of reporting.

**3. The user-facing message blamed the message, not us.**
`AgentErrorClassifier` had no rule for `Upstream provider error`, so it returned `.unknown`
and `ChatTurnFailureNotice` substituted its generic fallback: *"Omi couldn't answer this one.
Try sending it again."* Users retried in a loop against a deterministic failure.

## The fix

**`_gateway_body` projects onto an allowlist** instead of forwarding the client body. Unknown
client keys are dropped rather than passed into a validator that hard-rejects them.

**`desktop_chat_gateway_refused` telemetry** records `status_code`, `param` and the gateway's
`reason` on any gateway 4xx/5xx, as a structured stdout event matching the existing
`desktop_gemini_proxy_terminal` idiom. Only gateway-authored strings are logged — never client
content. This turns the diagnosis that took hours into a single log query.

**An `upstreamProviderFailed` classifier rule** so the backend's own failure string says the
failure is ours: *"Omi's AI service didn't respond. This is on our side, not your message."*
Retryable, since the backend emits this for transient conditions (circuit open, transport
failure, timeout) as well as hard rejections and does not distinguish them on the wire. The
rule is ordered before the 402 rule so neither shadows the other.

## Product invariants affected

- INV-CHAT-1

`AgentErrorClassifier.swift` gains an error code and a rule; no transcript store, continuity
ring, session identity, or context assembly changes. The backend change removes keys from an
outbound request body and adds a log line; routing, taint, authorization and entitlement gates
are untouched.

## How it was verified

- `pytest tests/unit/test_desktop_chat.py` → **78 passed**.
- **Mutation-tested.** Restoring the old verbatim forwarding fails
  `test_gateway_body_drops_client_params_the_gateway_would_reject` with exactly the outage
  payload (`store`, `reasoning_effort`, `parallel_tool_calls` present); restoring the fix
  passes. The guard is load-bearing, not decorative.
- Live reproduction of all three rejected parameters against the prod gateway (above).
- Kill switch verified serving in prod and dev: real completions (7065 B / 13.8s, 1378 B /
  3.7s) with no 323-byte failures.

**Not verified:** the Swift changes are compile-untested locally; CI's Swift jobs are the gate.
No end-to-end pi-mono turn has yet been driven through the fixed backend — that requires a
deploy.

## Tests

| Test | Pins |
|---|---|
| `test_gateway_forwardable_params_stay_within_the_gateway_allowlist` | The router's allowlist is a **subset of the gateway's own** `CONTROL_PARAMS ∪ GATEWAY_LOCAL_PARAMS ∪ FORWARDED_CHAT_COMPLETION_PARAMS`. Imports the gateway constants, so tightening the gateway fails CI instead of production. |
| `test_gateway_body_drops_client_params_the_gateway_would_reject` | A realistic pi-mono body: `store`, `reasoning_effort`, `parallel_tool_calls` dropped; `temperature`, `stream`, `model`, `messages` preserved. |
| `testUpstreamProviderErrorIsClassifiedRatherThanGeneric` | The string resolves to `.upstreamProviderFailed` **and** that the notice is not `unclassifiedText`. |
| `AgentErrorClassifierTests` corpus | Adds `("Upstream provider error", true, true)`. |

The subset test is the one that matters: the defect was a contract between two components with
nothing asserting they agreed.

## Follow-ups not in this PR

- **The 200-on-failure shape is the deeper defect.** An SSE stream that has already committed a
  200 cannot retract it, but the turn could carry a typed terminal error the client
  distinguishes from a truncated stream. Worth designing separately.
- No deploy gate exercises a real chat turn's *content*. `desktop_backend_candidate_probe.py`
  checks status codes, which is exactly what missed this. A probe asserting a non-trivial
  response body would have caught it at deploy time.
- The desktop Gemini proxy is 429ing ~15% of calls at `phase=metering` (chronic since ~08-17,
  unrelated to this outage) — separate ticket.

## Failure class (fixes)

Failure-Class: none

The registered classes did not fit: this is a contract mismatch between a caller's pass-through
body and a callee's strict allowlist, made invisible by an error path that reports failure as
HTTP 200. I would rather declare `none` than misapply an existing class.

## Line-count exceptions

Line-Count-Exception: backend/routers/desktop_chat.py | 1550 -> 1634 | The growth is the fix and its rationale, not new behaviour: an explicit `_GATEWAY_FORWARDABLE_PARAMS` allowlist (the projection that replaces verbatim body forwarding), a `_log_gateway_rejection` helper that records the gateway's `status_code`/`param`/`reason` so an upstream refusal is never again invisible, and the comments recording why forwarding the client body verbatim caused a 19-hour outage. Splitting the router is a larger refactor that would obscure an incident fix under review.

