### PR TITLE
fix(ci): accept workflow_dispatch in the CI-impact predictor

### DIFF
--- a/.github/scripts/test_pre_push_ci_prediction.py
+++ b/.github/scripts/test_pre_push_ci_prediction.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -12,12 +13,62 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from pre_push_ci_prediction import (  # noqa: E402
+    ACCEPTED_EVENTS,
     DESKTOP_FLOW_LINT_INPUTS,
     DESKTOP_RELEASE_PATHSPECS,
     github_outputs,
     resolve_impact,
     select_checks,
 )
+
+WORKFLOWS_DIR = REPO_ROOT / ".github/workflows"
+# Both call sites forward `${{ github.event_name }}` verbatim, so a workflow reaching
+# either one can hand this script any trigger it declares. The direct pattern is
+# anchored on the script name rather than on `--event` alone: other workflows forward
+# `github.event_name` to unrelated scripts with their own `--event` flag, and matching
+# those would fail this test for a script it does not govern.
+_PREDICTOR_INVOCATION = "pre_push_ci_prediction.py"
+_EVENT_NAME_FORWARD = re.compile(r"--event\s+\"\$\{\{\s*github\.event_name\s*\}\}\"")
+_USES_DETECT_CHANGES = re.compile(r"uses:\s*\./\.github/actions/detect-changes")
+# A shell invocation continues across backslash-newlines; the flag always lands within
+# a few lines of the script name.
+_INVOCATION_TAIL_LINES = 12
+
+
+def _forwards_event_name_to_the_predictor(text: str) -> bool:
+    """True if some `pre_push_ci_prediction.py` call passes `${{ github.event_name }}`."""
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if _PREDICTOR_INVOCATION not in line:
+            continue
+        tail = "\n".join(lines[index : index + _INVOCATION_TAIL_LINES])
+        if _EVENT_NAME_FORWARD.search(tail):
+            return True
+    return False
+
+
+def _declared_triggers(workflow_text: str) -> list[str]:
+    """Trigger names from a workflow's top-level `on:` block, both YAML spellings."""
+    block = re.search(r"^on:[ \t]*(.*)\n((?:(?:[ \t].*)?\n)*?)(?=^\S)", workflow_text, re.MULTILINE)
+    if not block:
+        return []
+    inline = block.group(1).strip()
+    if inline.startswith("["):
+        return [name.strip().strip("'\"") for name in inline.strip("[]").split(",") if name.strip()]
+    if inline:
+        return [inline.strip("'\"")]
+    return re.findall(r"^  ([A-Za-z_]+):", block.group(2), re.MULTILINE)
+
+
+def _workflows_reaching_the_predictor() -> dict[str, list[str]]:
+    """-> {workflow filename: declared triggers} for every caller of this script."""
+    reaching = {}
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        if _forwards_event_name_to_the_predictor(text) or _USES_DETECT_CHANGES.search(text):
+            reaching[path.name] = _declared_triggers(text)
+    return reaching
+
 
 _PLANNER_SPEC = importlib.util.spec_from_file_location(
     "plan_desktop_release_pre_push_contract",
@@ -240,6 +291,35 @@ class PrePushCiPredictionTests(unittest.TestCase):
 
     def test_unrelated_windows_changes_do_not_select_kgworker_closure_test(self) -> None:
         self.assertEqual(self.select(["desktop/windows/src/renderer/src/pages/Tasks.tsx"]), [])
+
+    def test_every_declared_workflow_trigger_is_an_accepted_event(self) -> None:
+        """A trigger this script rejects kills change detection before it writes an output.
+
+        `--event` is validated by argparse, so an unlisted value exits 2 and the calling
+        step fails outright — no outputs, every dependent job skipped. `desktop-swift-ci.yml`
+        declared `workflow_dispatch` while the choices were push/pull_request only, so its
+        documented recovery hatch failed on every manual run. Deriving the requirement from
+        the workflows' own `on:` blocks makes the next added trigger fail here instead.
+        """
+        reaching = _workflows_reaching_the_predictor()
+        self.assertIn("desktop-swift-ci.yml", reaching, "predictor call sites moved; update the discovery patterns")
+        for workflow, triggers in reaching.items():
+            self.assertTrue(triggers, f"{workflow}: no triggers parsed out of its `on:` block")
+            for trigger in triggers:
+                with self.subTest(workflow=workflow, trigger=trigger):
+                    self.assertIn(trigger, ACCEPTED_EVENTS, f"{workflow} declares {trigger}, which --event rejects")
+
+    def test_accepted_events_keep_the_local_hook_value(self) -> None:
+        """`scripts/pre-push` relies on the default; dropping it would break the hook."""
+        self.assertIn("local", ACCEPTED_EVENTS)
+
+    def test_event_does_not_change_the_resolved_plan(self) -> None:
+        """Widening `--event` is safe precisely because no routing decision reads it."""
+        paths = ["desktop/macos/Desktop/Package.swift", "backend/database/users.py", "app/lib/main.dart"]
+        baseline = self.plan(paths, event="push").ordered()
+        for event in ACCEPTED_EVENTS:
+            with self.subTest(event=event):
+                self.assertEqual(self.plan(paths, event=event).ordered(), baseline)
 
 
 if __name__ == "__main__":

--- a/scripts/pre_push_ci_prediction.py
+++ b/scripts/pre_push_ci_prediction.py
@@ -66,6 +66,27 @@ WINDOWS_KGWORKER_NATIVE_CLOSURE_INPUTS = {
     "desktop/windows/pnpm-lock.yaml",
 }
 
+# Every value a caller may pass to `--event`. "local" is the pre-push hook; the rest
+# are GitHub event names, and each one is a trigger some workflow that reaches this
+# script actually declares.
+#
+# This is a hard-failure surface, not a hint: argparse rejects an unlisted value and
+# exits 2, so the calling step dies before it writes a single detect-changes output and
+# every job gated on those outputs is skipped. `desktop-swift-ci.yml` declares
+# `workflow_dispatch` and forwards `${{ github.event_name }}` straight through, so every
+# manual run of it failed at "Detect changed paths" — including the recovery hatch that
+# workflow's own `on:` comment documents as the only way to re-mint exact-SHA release
+# evidence for a commit already on main.
+# `test_every_declared_workflow_trigger_is_an_accepted_event` derives the required set
+# from the workflows' own `on:` blocks, so adding a trigger without adding it here fails
+# that test instead of failing the first manual run.
+ACCEPTED_EVENTS = (
+    "local",
+    "pull_request",
+    "push",
+    "workflow_dispatch",
+)
+
 ROUTING_INPUTS = {
     ".github/checks-manifest.yaml",
     ".github/scripts/run_checks.py",
@@ -409,7 +430,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--changed-files", type=Path, required=True)
     parser.add_argument("--base", help="Optional Git revision used to detect deleted inputs and marker removals.")
-    parser.add_argument("--event", choices=("local", "pull_request", "push"), default="local")
+    parser.add_argument("--event", choices=ACCEPTED_EVENTS, default="local")
     parser.add_argument("--github-output", type=Path, help="Append established detect-changes outputs to this file.")
     parser.add_argument("--output", choices=("lines", "json"), default="lines")
     args = parser.parse_args()


### PR DESCRIPTION
## What

`scripts/pre_push_ci_prediction.py` rejected `--event workflow_dispatch`, so every manual run of `desktop-swift-ci.yml` failed at **Detect changed paths** before writing a single output.

```
pre_push_ci_prediction.py: error: argument --event: invalid choice:
'workflow_dispatch' (choose from 'local', 'pull_request', 'push')
##[error]Process completed with exit code 2.
```

## Why it matters

`desktop-swift-ci.yml` declares `workflow_dispatch` deliberately, and its own `on:` comment explains why:

> Recovery hatch. `plan-desktop-release.py` requires this workflow's checks on the exact source SHA, so any interruption — the workflow being disabled, a run cancelled by concurrency, an infrastructure blip — leaves that SHA permanently unreleasable: push events do not replay, and neither a force-push nor a PR close/reopen produces a run for a commit already on main. Manual dispatch is the only way to re-mint the evidence without an unrelated commit.

The step forwards `${{ github.event_name }}` straight into the predictor, so the hatch failed on **every** manual run. The `changes` job is `needs:` for all three downstream jobs, so they were all skipped — the run ends red having verified nothing.

## The fix

`--event` choices now come from an `ACCEPTED_EVENTS` constant that includes `workflow_dispatch`.

This is behaviour-neutral by construction: `event` is threaded into `resolve_impact` but **no routing decision reads it**, so widening the accepted set cannot change any plan. Unknown values are still rejected, so the typo guard is intact.

## The regression test

`test_every_declared_workflow_trigger_is_an_accepted_event` derives the requirement from the workflows' own `on:` blocks rather than restating a list, so the next trigger added to any predictor caller fails this test instead of failing the first manual run.

Discovery is anchored on the script name, not on `--event` alone. An earlier draft matched `--event "${{ github.event_name }}"` anywhere and flagged `mobile_internal_build.yml`, which forwards `github.event_name` to `dispatch_mobile_internal_builds.py` — a different script with its own `--event` flag. That would have failed this test for a script it does not govern. The current form governs exactly the six workflows that reach the predictor directly or through `./.github/actions/detect-changes`.

Two smaller guards come with it: `local` must stay in the set (`scripts/pre-push` relies on the default), and the resolved plan must be identical across every accepted event — which is what makes the widening safe rather than merely convenient.

## Verification

- The previously failing invocation now exits 0; `--event bogus_event` still exits 2 naming the four valid choices.
- `pre-push-ci-prediction-tests` 25/25, `desktop-swift-ci-contract` 26/26, `desktop-manifest-routes` 4/4, `run_checks` 47/47.
- `python3 .github/scripts/run_checks.py --lane ci --changed-files <diff>` — all 14 selected manifest checks pass.
- **Non-vacuity, by mutation.** Removing only `"workflow_dispatch"` from `ACCEPTED_EVENTS` turns the new test red naming `desktop-swift-ci.yml`. Breaking the discovery patterns trips the explicit "predictor call sites moved" guard rather than silently passing on an empty set. Making `_declared_triggers` return `[]` trips the empty-triggers guard. Making `resolve_impact` branch on `event` turns the invariance test red. All four restored and re-run green.

## Not done

The observed failure is `desktop-swift-ci.yml` only. The other five predictor callers declare just `push` and `pull_request` today; they are covered by the test going forward but were never broken.

Failure-Class: FC-workflow-script-input-contract


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

