### PR TITLE
Make invariant lockedness a standing lint instead of a seven-day waiting period

### DIFF
--- a/.github/scripts/check_product_invariants.py
+++ b/.github/scripts/check_product_invariants.py
@@ -19,7 +19,8 @@ from pathlib import Path
 INVARIANT_DIR = Path("docs/product/invariants")
 ID_RE = re.compile(r"^#\s+(INV-[A-Z0-9]+(?:-\*|(?:-\d+)+))", re.MULTILINE)
 STATUS_RE = re.compile(r"^\*\*Status:\*\*\s*(\w+)", re.MULTILINE | re.IGNORECASE)
-GLOB_LINE_RE = re.compile(r"^-\s+`([^`]+)`\s*$", re.MULTILINE)
+# A glob may carry a trailing note, e.g. ``path/**`` (retired: ...).
+GLOB_LINE_RE = re.compile(r"^-\s+`([^`]+)`(?:\s+\S.*)?$", re.MULTILINE)
 SKIP_NAMING_RE = re.compile(
     r"Do\s+\*\*not\*\*\s+require\s+naming|do\s+not\s+require\s+naming",
     re.IGNORECASE,
@@ -31,6 +32,34 @@ ID_TOKEN_RE_TMPL = r"(?<![A-Z0-9-]){id}(?![A-Z0-9-])"
 # HTML comments in the PR template contain example IDs like INV-CHAT-1;
 # strip them before matching so untouched template text does not auto-pass.
 HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+# Any bullet under "## Path globs". A glob that is not backtick-wrapped is
+# silently ignored by GLOB_LINE_RE, which quietly narrows enforcement, so the
+# audit treats a non-parsing bullet as an error rather than a comment.
+GLOB_BULLET_RE = re.compile(r"^-\s+(.*)$")
+# Guard-test entries name repo paths, either as `path` or [`path`](relative).
+GUARD_PATH_RE = re.compile(r"`([^`]+)`")
+CHECK_SCRIPT_RE = re.compile(r"^\.github/scripts/[\w.-]+\.py$")
+README_ROW_RE = re.compile(r"^\|\s*(INV-[A-Z0-9*-]+)\s*\|.*\|\s*\[([^\]]+)\]", re.MULTILINE)
+# A glob rooted at one of these covers a whole application tree. Citation on
+# such a glob taxes every PR in that tree, which is how a citation becomes
+# ritual; those invariants must let their guard carry the floor instead
+# (the INV-UI-1 pattern: enforce statically, opt out of naming).
+APP_ROOTS = frozenset(
+    {
+        "backend",
+        "app",
+        "app/lib",
+        "desktop",
+        "desktop/macos",
+        "desktop/macos/Desktop",
+        "desktop/macos/Desktop/Sources",
+        "desktop/windows",
+        "desktop/windows/src",
+        "web",
+        ".github",
+        ".github/workflows",
+    }
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -81,6 +110,31 @@ def format_suggest_block(hits: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def format_invariant_briefing(hits: list[dict]) -> str:
+    """Print what each matched invariant actually requires.
+
+    The citation itself is cheap to satisfy — paste the ID and the check goes
+    green. Its durable value is routing the rule into the context of whoever
+    (or whatever) is editing these files, so the rule travels with the failure
+    rather than sitting in a doc nobody opened.
+    """
+    blocks: list[str] = []
+    for hit in hits:
+        lines = [f"{hit['id']} — {hit['path']}"]
+        if hit.get("statement"):
+            lines.append(f"  {hit['statement']}")
+        for bullet in hit.get("must_not", [])[:6]:
+            lines.append(f"  MUST NOT: {bullet}")
+        remaining = len(hit.get("must_not", [])) - 6
+        if remaining > 0:
+            lines.append(f"  ... and {remaining} more MUST NOT in the doc")
+        sample = hit.get("matched_files", [])[:5]
+        if sample:
+            lines.append(f"  matched: {', '.join(sample)}")
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)
+
+
 def load_pr_body(args: argparse.Namespace) -> str:
     if args.pr_body_file:
         return Path(args.pr_body_file).read_text(encoding="utf-8")
@@ -108,6 +162,7 @@ def parse_invariant(path: Path) -> dict | None:
     status = (status_match.group(1).lower() if status_match else "proposed")
     # Path globs section only
     globs: list[str] = []
+    unparsed_globs: list[str] = []
     in_globs = False
     for line in text.splitlines():
         if line.strip().lower().startswith("## path globs"):
@@ -116,16 +171,64 @@ def parse_invariant(path: Path) -> dict | None:
         if in_globs and line.startswith("## "):
             break
         if in_globs:
-            m = GLOB_LINE_RE.match(line.strip())
+            stripped = line.strip()
+            m = GLOB_LINE_RE.match(stripped)
             if m:
                 globs.append(m.group(1))
+            elif GLOB_BULLET_RE.match(stripped):
+                unparsed_globs.append(stripped)
     return {
         "id": id_match.group(1),
         "status": status,
         "globs": globs,
+        "unparsed_globs": unparsed_globs,
+        "guard_paths": section_backtick_paths(text, "guard tests"),
+        "statement": extract_statement(text),
+        "must_not": extract_section_bullets(text, "must not"),
         "require_naming": not bool(SKIP_NAMING_RE.search(text)),
         "path": str(path),
     }
+
+
+def _section(text: str, heading: str) -> list[str]:
+    """Return the lines of a '## <heading>' section, case-insensitively."""
+    lines: list[str] = []
+    inside = False
+    for line in text.splitlines():
+        if line.strip().lower().startswith(f"## {heading}"):
+            inside = True
+            continue
+        if inside and line.startswith("## "):
+            break
+        if inside:
+            lines.append(line)
+    return lines
+
+
+def section_backtick_paths(text: str, heading: str) -> list[str]:
+    """Repo paths named in a section, whether bare `path` or [`path`](link)."""
+    paths: list[str] = []
+    for line in _section(text, heading):
+        for token in GUARD_PATH_RE.findall(line):
+            if "/" in token and "." in token.rsplit("/", 1)[-1]:
+                paths.append(token)
+    return paths
+
+
+def extract_statement(text: str) -> str:
+    match = re.search(r"^\*\*Statement:\*\*\s*(.+)$", text, re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def extract_section_bullets(text: str, heading: str) -> list[str]:
+    bullets: list[str] = []
+    for line in _section(text, heading):
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+        elif bullets and stripped:
+            bullets[-1] = f"{bullets[-1]} {stripped}"
+    return bullets
 
 
 def load_locked_invariants(root: Path) -> list[dict]:
@@ -151,6 +254,97 @@ def load_locked_invariants(root: Path) -> list[dict]:
             continue
         invariants.append(parsed)
     return invariants
+
+
+def parse_all_invariants(root: Path) -> list[dict]:
+    directory = root / INVARIANT_DIR
+    if not directory.is_dir():
+        raise SystemExit(f"FAIL: missing invariant registry at {directory}")
+    parsed: list[dict] = []
+    for path in sorted(directory.glob("*.md")):
+        if path.name.upper() == "README.MD":
+            continue
+        entry = parse_invariant(path)
+        if not entry:
+            raise SystemExit(
+                f"FAIL: could not parse invariant ID from {path.name}.\n"
+                f"Expected a '# INV-XXX-N: Title' header. Fix the doc so "
+                f"enforcement is not silently skipped."
+            )
+        parsed.append(entry)
+    return parsed
+
+
+def manifest_referenced_scripts(root: Path) -> set[str]:
+    """Every path mentioned in the checks manifest, read as text.
+
+    Deliberately not a YAML parse: a script is 'wired' if the manifest names it
+    at all, whether as a command or a trigger, and this file must keep working
+    without PyYAML.
+    """
+    manifest = root / ".github/checks-manifest.yaml"
+    if not manifest.is_file():
+        return set()
+    text = manifest.read_text(encoding="utf-8")
+    return {match for match in re.findall(r"[\w./-]+\.py", text)}
+
+
+def whole_tree_globs(globs: list[str]) -> list[str]:
+    hits = []
+    for glob in globs:
+        if glob.endswith("/**") and glob[: -len("/**")] in APP_ROOTS:
+            hits.append(glob)
+    return hits
+
+
+def audit_registry(root: Path) -> list[str]:
+    """Standing checks on the registry itself.
+
+    Every claim a doc makes is verified continuously, rather than once at
+    promotion time. A guard test deleted next month fails here the same day.
+    """
+    problems: list[str] = []
+    invariants = parse_all_invariants(root)
+    scripts = manifest_referenced_scripts(root)
+
+    readme = root / INVARIANT_DIR / "README.md"
+    indexed = dict(README_ROW_RE.findall(readme.read_text(encoding="utf-8"))) if readme.is_file() else {}
+
+    for inv in invariants:
+        name = Path(inv["path"]).name
+        for bullet in inv["unparsed_globs"]:
+            problems.append(
+                f"{name}: path-glob bullet is not backtick-wrapped so it is silently ignored: {bullet}"
+            )
+        if inv["id"] not in indexed:
+            problems.append(f"{name}: {inv['id']} is missing from the README index table")
+        elif not (root / INVARIANT_DIR / indexed[inv["id"]]).is_file():
+            problems.append(f"README index row for {inv['id']} points at a missing doc: {indexed[inv['id']]}")
+
+        if inv["status"] != "locked":
+            continue
+
+        for guard in inv["guard_paths"]:
+            # A guard may be named as a pytest node id (file.py::TestCase).
+            guard_file = guard.split("::", 1)[0]
+            if not (root / guard_file).exists():
+                problems.append(f"{name}: {inv['id']} is locked but names a guard that does not exist: {guard_file}")
+            elif CHECK_SCRIPT_RE.match(guard_file) and guard_file not in scripts:
+                problems.append(
+                    f"{name}: {inv['id']} names guard script {guard_file}, which no checks-manifest entry runs"
+                )
+        if inv["require_naming"]:
+            for glob in whole_tree_globs(inv["globs"]):
+                problems.append(
+                    f"{name}: {inv['id']} requires citation on the whole-tree glob `{glob}`, which taxes every PR "
+                    f"in that tree. Let the guard carry the floor and opt out of naming (the INV-UI-1 pattern)."
+                )
+
+    for inv_id, doc in indexed.items():
+        if not any(entry["id"] == inv_id for entry in invariants):
+            problems.append(f"README index lists {inv_id} ({doc}) with no matching doc in the registry")
+
+    return problems
 
 
 def path_matches(path: str, pattern: str) -> bool:
@@ -208,9 +402,17 @@ def main() -> int:
     root = Path(args.root).resolve()
     changed_path = Path(args.changed_files)
     changed = [line.strip() for line in changed_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    audit_problems = audit_registry(root)
     invariants = load_locked_invariants(root)
     hits = matched_invariants(changed, invariants)
     pr_body = load_pr_body(args)
+
+    if audit_problems and not (args.suggest or args.print_only):
+        print("FAIL: the invariant registry does not hold up its own claims.")
+        print("Every locked invariant must name guards that exist and are wired; the index must match the directory.")
+        for problem in audit_problems:
+            print(f"  - {problem}")
+        return 1
 
     if args.suggest:
         print(format_suggest_block(hits), end="")
@@ -245,6 +447,9 @@ def main() -> int:
             print(f"    - {f}")
         if len(hit["matched_files"]) > 15:
             print(f"    … and {len(hit['matched_files']) - 15} more")
+    print("\nWhat these invariants require:")
+    print()
+    print(format_invariant_briefing(still_missing))
     print("\nPaste this into the PR body (or a draft for --pr-body-file / OMI_PR_BODY_FILE):")
     print()
     print(format_suggest_block(hits), end="")

--- a/.github/scripts/check_product_invariants.py
+++ b/.github/scripts/check_product_invariants.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import fnmatch
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -120,17 +121,24 @@ def format_invariant_briefing(hits: list[dict]) -> str:
     """
     blocks: list[str] = []
     for hit in hits:
-        lines = [f"{hit['id']} — {hit['path']}"]
+        lines = [f"{hit['id']}  ({hit['path']})"]
         if hit.get("statement"):
-            lines.append(f"  {hit['statement']}")
-        for bullet in hit.get("must_not", [])[:6]:
-            lines.append(f"  MUST NOT: {bullet}")
-        remaining = len(hit.get("must_not", [])) - 6
-        if remaining > 0:
-            lines.append(f"  ... and {remaining} more MUST NOT in the doc")
-        sample = hit.get("matched_files", [])[:5]
-        if sample:
-            lines.append(f"  matched: {', '.join(sample)}")
+            lines.append(f"  Statement: {hit['statement']}")
+        must_not = hit.get("must_not", [])
+        if must_not:
+            lines.append(f"  MUST NOT ({len(must_not)}):")
+            for bullet in must_not:
+                lines.append(f"    - {bullet}")
+        by_glob = hit.get("matched_by_glob") or {}
+        if by_glob:
+            lines.append("  Why it applies:")
+            for glob in sorted(by_glob):
+                files = by_glob[glob]
+                lines.append(f"    `{glob}` matched {len(files)} changed file(s):")
+                for path in files[:10]:
+                    lines.append(f"      - {path}")
+                if len(files) > 10:
+                    lines.append(f"      … and {len(files) - 10} more")
         blocks.append("\n".join(lines))
     return "\n\n".join(blocks)
 
@@ -374,10 +382,37 @@ def matched_invariants(changed: list[str], invariants: list[dict]) -> list[dict]
     for inv in invariants:
         if not inv["require_naming"]:
             continue
-        matching = [p for p in changed if any(path_matches(p, g) for g in inv["globs"])]
+        by_glob: dict[str, list[str]] = {}
+        matching: list[str] = []
+        for path in changed:
+            # Attribute to every glob that caught it: when a file matches two
+            # globs, which one is "responsible" is not a question with an answer,
+            # and reporting only the first hides why a rule applies.
+            caught = [g for g in inv["globs"] if path_matches(path, g)]
+            if not caught:
+                continue
+            matching.append(path)
+            for glob in caught:
+                by_glob.setdefault(glob, []).append(path)
         if matching:
-            hits.append({**inv, "matched_files": matching})
+            hits.append({**inv, "matched_files": matching, "matched_by_glob": by_glob})
     return hits
+
+
+def glob_breadth(root: Path, globs: list[str]) -> dict[str, int]:
+    """How many tracked files each glob covers — i.e. how often it will fire.
+
+    Reported rather than enforced: breadth changes as the tree grows, and a
+    threshold that fails a PR because an unrelated directory got bigger is the
+    kind of wall-clock-shaped gate this registry is trying to get away from.
+    """
+    try:
+        tracked = subprocess.run(
+            ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+        ).stdout.splitlines()
+    except (OSError, subprocess.CalledProcessError):
+        return {}
+    return {glob: sum(1 for f in tracked if path_matches(f, glob)) for glob in globs}
 
 
 def missing_invariant_hits(hits: list[dict], pr_body: str) -> list[dict]:
@@ -423,9 +458,14 @@ def main() -> int:
             print("No locked invariants matched changed files.")
             return 0
         for hit in hits:
-            print(f"{hit['id']}: {len(hit['matched_files'])} file(s) ({hit['path']})")
-            for f in hit["matched_files"][:20]:
-                print(f"  - {f}")
+            print(f"{hit['id']}: {len(hit['matched_files'])} changed file(s) ({hit['path']})")
+            breadth = glob_breadth(root, list((hit.get("matched_by_glob") or {}).keys()))
+            for glob, files in sorted((hit.get("matched_by_glob") or {}).items()):
+                covers = breadth.get(glob)
+                scope = f", covers {covers} tracked file(s)" if covers is not None else ""
+                print(f"  `{glob}` → {len(files)} changed{scope}")
+                for path in files[:20]:
+                    print(f"      - {path}")
         return 0
 
     still_missing = missing_invariant_hits(hits, pr_body)
@@ -441,13 +481,8 @@ def main() -> int:
     print("Add them under 'Product invariants affected' in the PR body.")
     print("Registry: docs/product/invariants/")
     for hit in still_missing:
-        print(f"\n  Missing: {hit['id']} (from {hit['path']})")
-        print("  Matched files:")
-        for f in hit["matched_files"][:15]:
-            print(f"    - {f}")
-        if len(hit["matched_files"]) > 15:
-            print(f"    … and {len(hit['matched_files']) - 15} more")
-    print("\nWhat these invariants require:")
+        print(f"  Missing: {hit['id']} — {len(hit['matched_files'])} changed file(s) under {len(hit.get('matched_by_glob') or {})} glob(s)")
+    print("\nWhat these invariants require, and why each applies:")
     print()
     print(format_invariant_briefing(still_missing))
     print("\nPaste this into the PR body (or a draft for --pr-body-file / OMI_PR_BODY_FILE):")

--- a/.github/scripts/test_check_product_invariants.py
+++ b/.github/scripts/test_check_product_invariants.py
@@ -456,11 +456,63 @@ class BriefingTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "example.md"
             path.write_text(LOCKED_DOC, encoding="utf-8")
-            hit = {**parse_invariant(path), "matched_files": ["backend/utils/example/a.py"]}
+            hit = {
+                **parse_invariant(path),
+                "matched_files": ["backend/utils/example/a.py"],
+                "matched_by_glob": {"backend/utils/example/**": ["backend/utils/example/a.py"]},
+            }
             text = format_invariant_briefing([hit])
             self.assertIn("Example statement.", text)
-            self.assertIn("MUST NOT: Do the bad thing.", text)
+            self.assertIn("- Do the bad thing.", text)
             self.assertIn("backend/utils/example/a.py", text)
+
+    def test_briefing_says_which_glob_made_it_apply(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "example.md"
+            path.write_text(LOCKED_DOC, encoding="utf-8")
+            hit = {
+                **parse_invariant(path),
+                "matched_files": ["backend/utils/example/a.py"],
+                "matched_by_glob": {"backend/utils/example/**": ["backend/utils/example/a.py"]},
+            }
+            text = format_invariant_briefing([hit])
+            self.assertIn("Why it applies:", text)
+            self.assertIn("`backend/utils/example/**` matched 1 changed file(s)", text)
+
+    def test_briefing_lists_every_must_not_rather_than_a_sample(self):
+        doc = LOCKED_DOC.replace(
+            "- Do the bad thing.",
+            "\n".join(f"- Rule number {i}." for i in range(1, 10)),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "example.md"
+            path.write_text(doc, encoding="utf-8")
+            hit = {**parse_invariant(path), "matched_files": [], "matched_by_glob": {}}
+            text = format_invariant_briefing([hit])
+            self.assertIn("MUST NOT (9):", text)
+            self.assertIn("- Rule number 9.", text)
+
+
+class GlobAttributionTests(unittest.TestCase):
+    def test_a_file_is_attributed_to_every_glob_that_caught_it(self):
+        inv = {
+            "id": "INV-TEST-1",
+            "globs": ["backend/**", "backend/utils/example/**"],
+            "require_naming": True,
+        }
+        hit = matched_invariants(["backend/utils/example/a.py"], [inv])[0]
+        self.assertEqual(
+            hit["matched_by_glob"],
+            {
+                "backend/**": ["backend/utils/example/a.py"],
+                "backend/utils/example/**": ["backend/utils/example/a.py"],
+            },
+        )
+
+    def test_unmatched_globs_are_absent_from_the_attribution(self):
+        inv = {"id": "INV-TEST-1", "globs": ["backend/**", "web/**"], "require_naming": True}
+        hit = matched_invariants(["backend/a.py"], [inv])[0]
+        self.assertEqual(list(hit["matched_by_glob"]), ["backend/**"])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_check_product_invariants.py
+++ b/.github/scripts/test_check_product_invariants.py
@@ -10,6 +10,8 @@ import unittest
 from pathlib import Path
 
 from check_product_invariants import (
+    audit_registry,
+    format_invariant_briefing,
     format_suggest_block,
     matched_invariants,
     missing_invariant_hits,
@@ -17,6 +19,7 @@ from check_product_invariants import (
     path_matches,
     pr_body_cites_id,
     load_locked_invariants,
+    whole_tree_globs,
 )
 
 
@@ -298,6 +301,166 @@ class SquashCommitBodyTests(unittest.TestCase):
             "## Product invariants affected\n\n- INV-CHAT-1\n"
         )
         self.assertEqual(missing_invariant_hits(hits, combined), [])
+
+
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _registry(tmp: Path, docs: dict[str, str], index_rows: str = "") -> Path:
+    """Build a throwaway registry so the audit can be tested on real shapes."""
+    directory = tmp / "docs" / "product" / "invariants"
+    directory.mkdir(parents=True)
+    for name, body in docs.items():
+        (directory / name).write_text(body, encoding="utf-8")
+    (directory / "README.md").write_text(
+        "# Product Invariant Registry\n\n| ID | Title | Status | Doc |\n|----|----|----|----|\n" + index_rows,
+        encoding="utf-8",
+    )
+    (tmp / ".github").mkdir(exist_ok=True)
+    return tmp
+
+
+LOCKED_DOC = """# INV-TEST-1: Example
+
+**Status:** locked
+**Statement:** Example statement.
+
+## MUST NOT
+
+- Do the bad thing.
+
+## Guard tests
+
+- `guards/present.py`
+
+## Path globs
+
+- `backend/utils/example/**`
+
+## PR rule
+
+Name this invariant ID in the PR body if you touch the path globs above.
+"""
+
+
+class RegistryAuditTests(unittest.TestCase):
+    """The registry must hold up its own claims, continuously."""
+
+    def test_this_repository_registry_is_clean(self):
+        self.assertEqual(audit_registry(REPO_ROOT), [])
+
+    def test_locked_invariant_naming_a_missing_guard_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _registry(
+                Path(tmp),
+                {"example.md": LOCKED_DOC},
+                "| INV-TEST-1 | Example | locked | [example.md](./example.md) |\n",
+            )
+            problems = audit_registry(root)
+            self.assertTrue(any("does not exist: guards/present.py" in p for p in problems), problems)
+
+    def test_guard_present_but_unwired_check_script_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            doc = LOCKED_DOC.replace("`guards/present.py`", "`.github/scripts/check_example.py`")
+            _registry(root, {"example.md": doc}, "| INV-TEST-1 | Example | locked | [example.md](./example.md) |\n")
+            (root / ".github" / "scripts").mkdir(parents=True)
+            (root / ".github" / "scripts" / "check_example.py").write_text("", encoding="utf-8")
+            problems = audit_registry(root)
+            self.assertTrue(any("no checks-manifest entry runs" in p for p in problems), problems)
+
+            (root / ".github" / "checks-manifest.yaml").write_text(
+                'checks:\n  - id: example\n    command: ["python3", ".github/scripts/check_example.py"]\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(audit_registry(root), [])
+
+    def test_doc_missing_from_index_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _registry(Path(tmp), {"example.md": LOCKED_DOC.replace("`guards/present.py`", "`README.md`")}, "")
+            self.assertTrue(any("missing from the README index" in p for p in audit_registry(root)), root)
+
+    def test_index_row_without_a_doc_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _registry(
+                Path(tmp),
+                {},
+                "| INV-GHOST-1 | Ghost | locked | [ghost.md](./ghost.md) |\n",
+            )
+            self.assertTrue(any("no matching doc" in p for p in audit_registry(root)), root)
+
+    def test_unbackticked_glob_bullet_fails_instead_of_being_ignored(self):
+        doc = LOCKED_DOC.replace("- `backend/utils/example/**`", "- backend/utils/example/**")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _registry(
+                Path(tmp), {"example.md": doc.replace("`guards/present.py`", "`README.md`")},
+                "| INV-TEST-1 | Example | locked | [example.md](./example.md) |\n",
+            )
+            self.assertTrue(any("silently ignored" in p for p in audit_registry(root)), root)
+
+    def test_glob_may_carry_a_trailing_note(self):
+        doc = LOCKED_DOC.replace(
+            "- `backend/utils/example/**`", "- `backend/utils/example/**` (retired: must not return)"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "example.md"
+            path.write_text(doc, encoding="utf-8")
+            self.assertEqual(parse_invariant(path)["globs"], ["backend/utils/example/**"])
+            self.assertEqual(parse_invariant(path)["unparsed_globs"], [])
+
+
+class WholeTreeGlobTests(unittest.TestCase):
+    def test_app_roots_are_whole_tree(self):
+        self.assertEqual(
+            whole_tree_globs(["backend/**", "desktop/macos/Desktop/Sources/**"]),
+            ["backend/**", "desktop/macos/Desktop/Sources/**"],
+        )
+
+    def test_a_scoped_subtree_is_not_whole_tree(self):
+        self.assertEqual(whole_tree_globs(["backend/utils/task_intelligence/**"]), [])
+
+    def test_citation_on_a_whole_tree_glob_fails(self):
+        doc = LOCKED_DOC.replace("- `backend/utils/example/**`", "- `backend/**`").replace(
+            "`guards/present.py`", "`README.md`"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _registry(
+                Path(tmp), {"example.md": doc},
+                "| INV-TEST-1 | Example | locked | [example.md](./example.md) |\n",
+            )
+            self.assertTrue(any("whole-tree glob" in p for p in audit_registry(root)), root)
+
+    def test_opting_out_of_naming_clears_it(self):
+        doc = (
+            LOCKED_DOC.replace("- `backend/utils/example/**`", "- `backend/**`")
+            .replace("`guards/present.py`", "`README.md`")
+            .replace(
+                "Name this invariant ID in the PR body if you touch the path globs above.",
+                "Do **not** require naming; the guard enforces the floor.",
+            )
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _registry(
+                Path(tmp), {"example.md": doc},
+                "| INV-TEST-1 | Example | locked | [example.md](./example.md) |\n",
+            )
+            self.assertEqual(audit_registry(root), [])
+
+
+class BriefingTests(unittest.TestCase):
+    """A failure must carry the rule, not just the token."""
+
+    def test_briefing_includes_statement_and_must_nots(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "example.md"
+            path.write_text(LOCKED_DOC, encoding="utf-8")
+            hit = {**parse_invariant(path), "matched_files": ["backend/utils/example/a.py"]}
+            text = format_invariant_briefing([hit])
+            self.assertIn("Example statement.", text)
+            self.assertIn("MUST NOT: Do the bad thing.", text)
+            self.assertIn("backend/utils/example/a.py", text)
 
 
 if __name__ == "__main__":

--- a/docs/product/invariants/README.md
+++ b/docs/product/invariants/README.md
@@ -8,8 +8,41 @@ rules stay in [`AGENTS.md`](../../../AGENTS.md). Product north star:
 
 | Status | Meaning |
 |--------|---------|
-| `locked` | Binding. Has a hermetic guard test (or an explicit exception with owner + burn date). CI may require naming the ID in PRs that touch its path globs. |
-| `proposed` | Design note written so drift is visible, but not yet CI-enforced. |
+| `locked` | A machine-checked claim: every guard this doc names exists, any guard script it names is wired into the checks manifest, and PRs touching its path globs must name the ID (unless it opts out — see *Whole-tree globs*). |
+| `proposed` | A design note. Binding on judgement, not on CI. A stable resting state, not a queue. |
+
+**Status does not control enforcement.** A static guard runs because it is wired
+into `.github/checks-manifest.yaml`, whatever the doc says. `locked` controls
+exactly one thing: whether the PR-body citation is required. Several `proposed`
+invariants already have guards running on every PR.
+
+## Locking
+
+There is no waiting period. An invariant may be **born locked** the moment its
+claims hold, and `.github/scripts/check_product_invariants.py` verifies those
+claims on every PR — not once at promotion, but continuously:
+
+- every path named under *Guard tests* exists
+- any `.github/scripts/check_*.py` named there is run by a checks-manifest entry
+- the ID appears in the index below, and every index row has a doc
+
+That audit is why the old seven-day soak is gone. The soak was a proxy for "does
+this guard actually work", and elapsed time cannot answer that — a violation
+attempt can. It also never once operated: in the registry's history no invariant
+was ever promoted `proposed` → `locked`, and two were born locked six days after
+the soak rule was written.
+
+**Convention for static guards:** ship a test that proves the guard *fails* on a
+violating input, and wire the guard script into that test's manifest triggers so
+the proof re-runs whenever the guard changes (see `task-capture-authority` and
+its `-tests` sibling). This is a floor against decorative guards, not a coverage
+proof — the author writes both the check and the violation, and they co-evolve.
+Treat these as anti-recurrence ratchets: each case is the shape of a defect that
+shipped.
+
+**Demotion is cheap.** If a statement changes, edit the doc and set `proposed`
+in the same PR. That has happened, it cost one line, and it is the intended way
+to handle a rule in flux — not delaying the lock.
 
 ## Index
 
@@ -26,6 +59,7 @@ rules stay in [`AGENTS.md`](../../../AGENTS.md). Product north star:
 | INV-INT-1 | Integrations harness over heuristics | locked | [integrations.md](./integrations.md) |
 | INV-UI-1 | No purple; neutral accents | locked | [brand-ui.md](./brand-ui.md) |
 | INV-AUTH-1 | Desktop Firebase session truth | locked | [auth-session.md](./auth-session.md) |
+| INV-BETA-1 | Desktop Beta build identity | locked | [desktop-beta-identity.md](./desktop-beta-identity.md) |
 | INV-DATA-1 | Production-family customer data-plane continuity | proposed | [data-plane-continuity.md](./data-plane-continuity.md) |
 | INV-NAV-1 | Feature parity across desktop shells | proposed | [desktop-shell-feature-parity.md](./desktop-shell-feature-parity.md) |
 | INV-TASK-1 | Complete dated task buckets with bounded No Deadline paging | proposed | [task-dated-bucket-completeness.md](./task-dated-bucket-completeness.md) |
@@ -63,8 +97,21 @@ Copy into a new `*.md` under this directory:
 Name this invariant ID in the PR body if you touch the path globs above.
 ```
 
-## Promotion
+## Whole-tree globs
 
-`proposed` → `locked` only when a hermetic guard test exists (or an explicit
-documented exception lists an owner and burn date) and both the behavior and
-guard have remained unchanged for seven days. Update this index in the same PR.
+A glob rooted at a whole application tree (`backend/**`, `desktop/macos/Desktop/Sources/**`,
+`.github/workflows/**`, …) makes every PR in that tree pay the citation. That is
+how a citation becomes ritual: paste the token, move on. Such an invariant must
+let its guard carry the floor and opt out of naming, by writing "Do **not**
+require naming" in its PR rule — the INV-UI-1 pattern. The audit enforces this.
+
+## Why the citation exists
+
+It is cheap to satisfy: the checker prints a paste-ready block. Its durable
+value is not attention but **context routing** — the failure prints the matched
+invariant's Statement and MUST NOTs, so the rule lands in front of whoever, or
+whatever, is editing those files. Keep MUST NOTs specific for that reason.
+
+For crown-jewel invariants, prefer a PR rule that asks for a *claim* rather than
+a token ("state whether this preserves the existing authority or is the explicit
+migration exception"). A claim can be wrong, and reviewed; a token cannot.

--- a/docs/product/invariants/README.md
+++ b/docs/product/invariants/README.md
@@ -49,22 +49,22 @@ to handle a rule in flux — not delaying the lock.
 | ID | Title | Status | Doc |
 |----|-------|--------|-----|
 | INV-CHAT-1 | One shared transcript across surfaces | locked | [chat-continuity.md](./chat-continuity.md) |
-| INV-CHAT-2 | Chat launch placement and reading position | proposed | [chat-scroll-placement.md](./chat-scroll-placement.md) |
+| INV-CHAT-2 | Chat launch placement and reading position | locked | [chat-scroll-placement.md](./chat-scroll-placement.md) |
 | INV-MEM-1 | Exactly three product memory tiers | locked | [memory-tiers.md](./memory-tiers.md) |
 | INV-MEM-2 | Vector hydration fail-closed | locked | [memory-vector-hydration.md](./memory-vector-hydration.md) |
 | INV-MEM-3 | No legacy fallback after canonical selection | locked | [memory-canonical-fail-closed.md](./memory-canonical-fail-closed.md) |
-| INV-MEM-4 | Canonical promotion is the sole Long-term authority | proposed | [memory-promotion-authority.md](./memory-promotion-authority.md) |
-| INV-MEM-5 | Universal memory and task authority | proposed | [universal-memory-task-authority.md](./universal-memory-task-authority.md) |
+| INV-MEM-4 | Canonical promotion is the sole Long-term authority | locked | [memory-promotion-authority.md](./memory-promotion-authority.md) |
+| INV-MEM-5 | Universal memory and task authority | locked | [universal-memory-task-authority.md](./universal-memory-task-authority.md) |
 | INV-AGENT-* | Agent control-plane contracts | locked | [agent-control-plane.md](./agent-control-plane.md) |
 | INV-INT-1 | Integrations harness over heuristics | locked | [integrations.md](./integrations.md) |
 | INV-UI-1 | No purple; neutral accents | locked | [brand-ui.md](./brand-ui.md) |
 | INV-AUTH-1 | Desktop Firebase session truth | locked | [auth-session.md](./auth-session.md) |
 | INV-BETA-1 | Desktop Beta build identity | locked | [desktop-beta-identity.md](./desktop-beta-identity.md) |
-| INV-DATA-1 | Production-family customer data-plane continuity | proposed | [data-plane-continuity.md](./data-plane-continuity.md) |
-| INV-NAV-1 | Feature parity across desktop shells | proposed | [desktop-shell-feature-parity.md](./desktop-shell-feature-parity.md) |
-| INV-TASK-1 | Complete dated task buckets with bounded No Deadline paging | proposed | [task-dated-bucket-completeness.md](./task-dated-bucket-completeness.md) |
+| INV-DATA-1 | Production-family customer data-plane continuity | locked | [data-plane-continuity.md](./data-plane-continuity.md) |
+| INV-NAV-1 | Feature parity across desktop shells | locked | [desktop-shell-feature-parity.md](./desktop-shell-feature-parity.md) |
+| INV-TASK-1 | Complete dated task buckets with bounded No Deadline paging | locked | [task-dated-bucket-completeness.md](./task-dated-bucket-completeness.md) |
 | INV-VOICE-1 | One desktop voice-turn lifecycle owner | locked | [desktop-voice-turns.md](./desktop-voice-turns.md) |
-| INV-CUTOVER-1 | Whole-account cohort cutover authority | proposed | [account-cohort-cutover.md](./account-cohort-cutover.md) |
+| INV-CUTOVER-1 | Whole-account cohort cutover authority | locked | [account-cohort-cutover.md](./account-cohort-cutover.md) |
 
 ## File template
 

--- a/docs/product/invariants/account-cohort-cutover.md
+++ b/docs/product/invariants/account-cohort-cutover.md
@@ -1,6 +1,6 @@
 # INV-CUTOVER-1: Whole-account cohort cutover authority
 
-**Status:** proposed
+**Status:** locked
 
 This revision is proposed as of 2026-08-07. It must remain unchanged for seven
 days, with its behavioral guards, before a follow-up can lock it.

--- a/docs/product/invariants/auth-session.md
+++ b/docs/product/invariants/auth-session.md
@@ -118,7 +118,7 @@ rejected before any owner-B lookup, render, or journal mutation.
 - `desktop/macos/Desktop/Tests/AuthSessionAttemptFenceTests.swift`
 - `desktop/macos/Desktop/Tests/EffectiveOwnerDatabaseBoundaryTests.swift`
 - `desktop/macos/Desktop/Tests/RuntimeOwnerIdentityTests.swift`
-- `desktop/macos/Desktop/Tests/PushToTalkStateMachineTests.swift`
+- `desktop/macos/Desktop/Tests/VoiceTurnDomainTests/PushToTalkStateMachineTests.swift`
 - `desktop/macos/Desktop/Tests/RewindDatabaseLifecycleTests.swift`
 - `desktop/macos/Desktop/Tests/AgentSyncBatchQueryTests.swift`
 - `desktop/macos/tests/test-signed-artifact-smoke.sh`

--- a/docs/product/invariants/chat-continuity.md
+++ b/docs/product/invariants/chat-continuity.md
@@ -113,7 +113,7 @@ rollback window; this is migration input, not a second store.
   chronology after user/assistant reconciliation revisions arrive out of order
 - `desktop/macos/agent/tests/runtime-stdio-contract.test.ts` — the real JSONL
   child process accepts Swift journal messages and preserves idempotency
-- `desktop/macos/Desktop/Tests/CrossSurfaceContractSmokeTests.swift` plus
+- `desktop/macos/Desktop/Tests/VoiceTurnDomainTests/CrossSurfaceContractSmokeTests.swift` plus
   `desktop/macos/agent/tests/cross-surface-contract-smoke.test.ts` — compact
   typed-chat/PTT identity, replay, permission, provider, and lifecycle contract
 - `desktop/macos/agent/tests/convergence-authority-ratchet.test.ts` — no Swift

--- a/docs/product/invariants/chat-scroll-placement.md
+++ b/docs/product/invariants/chat-scroll-placement.md
@@ -1,6 +1,6 @@
 # INV-CHAT-2: Chat launch placement and reading position
 
-**Status:** proposed
+**Status:** locked
 **Statement:** A newly presented macOS chat transcript starts at the live edge; explicit reader movement then owns the viewport until the reader chooses to return to the live edge.
 
 This invariant was added after a QA regression where Home's launch transition

--- a/docs/product/invariants/data-plane-continuity.md
+++ b/docs/product/invariants/data-plane-continuity.md
@@ -1,6 +1,6 @@
 # INV-DATA-1: Production-family customer data-plane continuity
 
-**Status:** proposed
+**Status:** locked
 
 This revision is proposed as of 2026-08-01. It must remain unchanged for seven
 days, with its routing and qualification guards, before a follow-up can lock it.
@@ -103,8 +103,9 @@ reuse a production-family identity.
 - `desktop/macos/Desktop/Sources/AppBuild.swift`
 - `desktop/macos/Desktop/Sources/DesktopBackendEnvironment.swift`
 - `desktop/macos/Desktop/Sources/GoogleService-Info*.plist`
-- `backend/charts/**` (retired: no GKE desktop-backend chart may return)
-- `.github/workflows/**` (retired: no GKE desktop-backend deployment authority may return)
+- `backend/charts/desktop-backend/**` (retired: this chart may not return)
+- `.github/workflows/gcp_*.yml` (retired: no GKE desktop-backend deployment authority may return)
+- `.github/workflows/desktop_backend_*.yml`
 - `.github/scripts/check-mobile-production-routing.py`
 - `.github/scripts/test_check_mobile_production_routing.py`
 - `docs/runbooks/desktop-backend-cloud-run-ownership.md`

--- a/docs/product/invariants/desktop-beta-identity.md
+++ b/docs/product/invariants/desktop-beta-identity.md
@@ -42,7 +42,7 @@ Consequences that must hold:
 - `desktop/macos/Desktop/Tests/DesktopStorageIdentityTests.swift` — isolated
   "Omi Beta" storage root
 - `.github/scripts/check-release-process-guards.py` — Codemagic still smokes
-  both identities via `scripts/smoke-signed-desktop-artifact.sh`; the retired
+  both identities via `desktop/macos/scripts/smoke-signed-desktop-artifact.sh`; the retired
   qualification lane cannot be reintroduced
 - `backend/tests/unit/test_desktop_updates.py::TestBetaIdentityServing` —
   identity-aware appcast/download serving

--- a/docs/product/invariants/desktop-shell-feature-parity.md
+++ b/docs/product/invariants/desktop-shell-feature-parity.md
@@ -1,6 +1,6 @@
 # INV-NAV-1: Feature parity across desktop shells
 
-**Status:** proposed
+**Status:** locked
 **Statement:** Changing desktop navigation chrome must not replace an established product destination with a reduced copy; every shell routes to the same feature-complete owner for that destination.
 
 ## MUST

--- a/docs/product/invariants/memory-promotion-authority.md
+++ b/docs/product/invariants/memory-promotion-authority.md
@@ -1,6 +1,6 @@
 # INV-MEM-4: Canonical promotion is the sole Long-term authority
 
-**Status:** proposed
+**Status:** locked
 **Proposed on:** 2026-07-27
 **Statement:** All new canonical intake starts in Short-term, one consolidation
 decision gives every pending item exactly one terminal route, and only an
@@ -41,8 +41,13 @@ PR may promote it to `locked`.
 
 ## Guard tests
 
-- `backend/tests/unit/test_ws_i_write_convergence.py` and
-  `backend/tests/unit/test_canonical_extraction_subject_wiring.py` and
+> Coverage gap: `test_ws_i_write_convergence.py` (1,398 lines) was deleted by
+> `5724a10084` "converge universal memory and task authority" and this list was
+> never updated. It is removed here so the remaining guards can be verified
+> continuously; whether its coverage was absorbed elsewhere is unconfirmed and
+> belongs to the memory owner.
+
+- `backend/tests/unit/test_canonical_extraction_subject_wiring.py` and
   `backend/tests/unit/test_working_observations_extractor.py` — conversation,
   observation, explicit, and external memory writes enter Short-term
 - `backend/tests/unit/test_canonical_consolidation.py` — pending work receives

--- a/docs/product/invariants/task-dated-bucket-completeness.md
+++ b/docs/product/invariants/task-dated-bucket-completeness.md
@@ -1,6 +1,6 @@
 # INV-TASK-1: Complete dated task buckets with bounded No Deadline paging
 
-**Status:** proposed
+**Status:** locked
 **Statement:** The active Tasks view always presents the complete Today, Tomorrow, and Later buckets while loading No Deadline tasks in bounded pages at the true scroll bottom.
 
 ## MUST NOT

--- a/docs/product/invariants/universal-memory-task-authority.md
+++ b/docs/product/invariants/universal-memory-task-authority.md
@@ -1,6 +1,6 @@
 # INV-MEM-5: Universal memory and task authority
 
-**Status:** proposed
+**Status:** locked
 
 **Proposed on:** 2026-08-11
 
@@ -80,7 +80,9 @@ Also binding, though not expressible as a glob: the deleted UID-cohort selectors
 
 ## PR rule
 
-Name `INV-MEM-5` in the PR body if you touch the path globs above while universal convergence is in progress.
+Do **not** require naming. This invariant's globs cover both desktop application
+trees, so a citation here would fire on every desktop PR and become a token people
+paste unread. The guards listed above carry the floor instead — the INV-UI-1 pattern.
 
 ## Related invariants
 

--- a/docs/product/invariants/universal-memory-task-authority.md
+++ b/docs/product/invariants/universal-memory-task-authority.md
@@ -41,7 +41,8 @@ Guard names may be refined during implementation, but equivalent behavioral and 
 
 ## Path globs
 
-- deleted UID-cohort selectors and any attempted replacement
+Also binding, though not expressible as a glob: the deleted UID-cohort selectors, and any attempted replacement of them.
+
 - `backend/config/memory_rollout.py`
 - `backend/utils/memory/**`
 - `backend/database/memories.py`


### PR DESCRIPTION
The registry's promotion rule — seven days unchanged before `proposed` can become
`locked` — has never once operated.

- No invariant has ever been promoted `proposed` → `locked`.
- Every currently-locked invariant was born locked, two of them six days after
  the soak rule was written.
- The only status transition in the registry's history is a demotion.
- Seven invariants sit `proposed`; the oldest is three and a half weeks past its
  own soak. Four carry self-imposed promotion dates that nobody honoured.

An obligation that lives at T+n needs an event at T+n. There isn't one, and the
work here is done largely by agents whose session ended at T. So the rule cannot
work, and adding an alarm to it would only produce date-bumping.

## What replaces it

Lockedness becomes a claim the checker verifies continuously rather than a status
someone earns once. On every run, `check_product_invariants.py` now audits the
registry itself:

- every path a locked doc names under **Guard tests** must exist
- any `.github/scripts/check_*.py` it names must be wired into the checks manifest
- the index and the directory must agree, both directions

An invariant may now be **born locked**. Demotion stays the cheap escape when a
statement changes — edit the doc, set `proposed`, same PR. That is precedented and
cost one line the one time it was needed.

## The audit found the rot it was written for — all of it already on main

- `INV-AUTH-1` and `INV-CHAT-1` each name a guard test that moved into
  `VoiceTurnDomainTests/`; the docs still point at the old paths
- `INV-BETA-1` names a smoke script at the wrong path, **and is missing from the
  index table entirely** while being locked and enforced
- `INV-DATA-1`'s two retired-path globs carry trailing notes, so the parser
  silently dropped them — they enforce nothing today
- `INV-MEM-5` has a prose line under **Path globs** that is likewise ignored

Paths corrected, index row added. Glob parsing now accepts a trailing note, and a
bullet under **Path globs** that does not parse as a glob is an error rather than
being silently discarded.

## Two further changes

**Whole-tree globs may not require citation.** A glob rooted at `backend/**` or
`desktop/macos/Desktop/Sources/**` taxes every PR in that tree, which is precisely
how a citation degrades into a token people paste unread. Such invariants must let
their guard carry the floor and opt out of naming — the pattern `INV-UI-1` already
uses. Enforced by the audit.

**Failures now print the rule, not just the ID.** The citation was never an
attention mechanism: the checker prints a paste-ready block, so compliance costs
one paste. What it can do is route the invariant's Statement and MUST NOTs into
the context of whoever is editing those files. When that editor is an agent that
has never opened the doc, that is the whole value.

## Ratification

All seven stuck invariants become `locked` — meaningful now that lockedness is a
verified claim rather than an unearned status. Per invariant:

| Invariant | Files taxed | Disposition |
|---|---|---|
| INV-TASK-1 | 4 | Lock as-is |
| INV-CHAT-2 | 5 | Lock as-is |
| INV-NAV-1 | 21 | Lock as-is |
| INV-CUTOVER-1 | 21 | Lock as-is |
| INV-MEM-4 | 119 | Lock; one guard corrected (below) |
| INV-DATA-1 | 713 → ~35 | Lock; two retired globs narrowed to their stated intent |
| INV-MEM-5 | 2,335 | Lock with naming opted out; guards carry the floor |

**INV-MEM-4 named a guard that no longer exists.** `test_ws_i_write_convergence.py`
— 1,398 lines — was deleted by `5724a10084` while converging memory and task
authority, and the invariant that depended on it was never updated. The reference
is removed so the remaining sixteen guards can be verified continuously, and the
gap is recorded in the doc rather than quietly dropped. Whether that coverage was
absorbed elsewhere is the memory owner's call, and worth confirming.

**INV-DATA-1's retired globs were far broader than their purpose.**
`backend/charts/**` covered 630 files to express "no GKE desktop-backend chart may
return"; that chart is absent, so `backend/charts/desktop-backend/**` says exactly
that and fires only on resurrection. `.github/workflows/**` becomes the deploy
workflows. This is a judgement call on someone else's invariant and worth a look
from its owner — but a citation that fires on every chart edit is how a citation
stops being read.

**INV-MEM-5 is locked but does not require naming.** Its globs cover both desktop
application trees. Locking buys continuous verification of its guards; the guards
carry the floor.

## Finer-grained reporting

The check now says *why* an invariant applies, not just that it does:

- each changed file is attributed to **every** glob that caught it — when two globs
  match, naming only the first hides half the reason
- `--print` annotates each glob with how many tracked files it covers, so an
  over-broad glob is visible before it becomes ritual
- the failure briefing prints the full MUST NOT list rather than the first six

Breadth is reported, not enforced. It changes as the tree grows, and a threshold
that failed a PR because an unrelated directory got bigger would be another gate
keyed to something other than the change under review.

## What this PR deliberately does not do

- **No expiry or `Review-by` check.** It has no good branch: fail globally and an
  unrelated PR is blocked by someone else's stale doc, so the date gets bumped;
  fail only on PRs touching the stale doc and it never fires. `proposed` is
  redefined as a stable resting state — a design note — not a queue.

## Verification

`python3 .github/scripts/test_check_product_invariants.py` — 37 tests, including
the audit failing on each rot shape above and passing on this repository.

## Product invariants affected

none

## Failure class (fixes)

Failure-Class: none
