### PR TITLE
fix(desktop): make local dev signing survive a rebuild, and stop onboarding quitting the app

### DIFF
--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -721,11 +721,25 @@ final class SBOnboardingModel: ObservableObject {
     OnboardingChatPersistence.clear()
     ChatDraftStore.shared.clear(.onboardingMain)
     ChatDraftStore.shared.clear(.onboardingFloating)
+    // **Mark onboarding done before anything can await, and before the last window can close.**
+    //
+    // `applicationShouldTerminateAfterLastWindowClosed` returns true while this flag is false --
+    // deliberately, so a half-finished onboarding does not leave a menu-bar process behind. That
+    // makes the flag load-bearing for process lifetime, not just for which view renders. Setting
+    // it after `await finishOnboardingJournal()` left a window in which the onboarding window had
+    // already gone away and the flag was still false, and the app quit on the user at the exact
+    // moment they finished. It then reran onboarding on next launch, because the flag never got
+    // written -- observed twice in a row on a bundle whose onboarding was not pre-seeded.
+    //
+    // The `[weak self]` made it worse rather than safer: `teardownAll()` runs at the top of this
+    // function, so a deallocated model meant `guard let self else { return }` skipped the write
+    // entirely and onboarding could never complete at all.
+    //
+    // The journal is genuinely async and genuinely optional. Completion is neither.
+    appState.hasCompletedOnboarding = true
     onComplete?()
-    Task { [weak self] in
-      guard let self else { return }
-      await self.chatProvider.finishOnboardingJournal()
-      self.appState.hasCompletedOnboarding = true
+    Task { [chatProvider] in
+      await chatProvider.finishOnboardingJournal()
     }
   }
 

--- a/desktop/macos/changelog/unreleased/20260821-onboarding-completion.json
+++ b/desktop/macos/changelog/unreleased/20260821-onboarding-completion.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app quitting the moment you finished onboarding, which sent you back through onboarding on the next launch"
+}

--- a/desktop/macos/docs/local-code-signing.md
+++ b/desktop/macos/docs/local-code-signing.md
@@ -11,25 +11,45 @@ generates depend on the signing identity's Team ID. The one-line rule lives in
 1. `OMI_SIGN_IDENTITY` — explicit override.
 2. `Apple Development` — preferred, because local permissions stay stable.
 3. `Developer ID Application`.
-4. `Omi Local Dev Signing` — the stable self-signed local identity.
+4. `Omi Local Dev Signing` — the stable self-signed local identity, **created
+   automatically** if it does not exist.
 5. Ad-hoc (`-`) — only with **both** a named bundle and `OMI_ALLOW_ADHOC_SIGN=1`.
 
-### Creating `Omi Local Dev Signing`
+Each candidate is **probed, not merely found**: the script signs a throwaway file
+with it before committing. An identity can be listed and still be unusable — see
+§`errSecInternalComponent` — and choosing one on the strength of its existence
+turns a two-second fallback into a build that fails a minute later, after the
+compile and a 265 MB bundle copy.
 
-Do this once on a machine with no Apple certificate; `run.sh` then finds it with
-no environment variable:
+### `Omi Local Dev Signing` is created automatically
 
-Keychain Access → Certificate Assistant → *Create a Certificate…*
+`run.sh` creates it on demand when no Apple identity is usable. Nothing to do, no
+GUI, no password, and it works in CI and over ssh where the wizard below cannot.
+It is generated with `/usr/bin/openssl` (LibreSSL, stock on every Mac) into its
+own keychain — `~/Library/Keychains/omi-local-dev-signing.keychain-db`, whose
+password the script owns, which is what lets it grant `codesign` a partition
+without a prompt. Set `OMI_SKIP_LOCAL_SIGN_IDENTITY=1` to opt out.
 
-- **Name**: `Omi Local Dev Signing` (exact — `run.sh` matches on this)
-- **Identity Type**: Self Signed Root
-- **Certificate Type**: Code Signing
+Two details worth knowing if you touch that code:
 
-Confirm it is visible to codesign:
+- The PKCS#12 must use the legacy encoding (`-certpbe PBE-SHA1-3DES -keypbe
+  PBE-SHA1-3DES -macalg sha1`). OpenSSL 3's AES/SHA256 default imports as
+  `MAC verification failed during PKCS12 import (wrong password?)`, which is
+  not a password problem at all.
+- The certificate needs `extendedKeyUsage = codeSigning` and `CA:false`, or
+  `codesign` declines the identity.
+
+**A self-signed identity does not appear in `security find-identity -v -p
+codesigning`** — that list filters on policy trust — yet `codesign -s "Omi Local
+Dev Signing"` works fine. Check usability by signing something, not by listing:
 
 ```bash
-security find-identity -v -p codesigning
+cp /usr/bin/true /tmp/probe && codesign --force --sign "Omi Local Dev Signing" /tmp/probe
 ```
+
+To create it by hand instead (Keychain Access → Certificate Assistant → *Create a
+Certificate…*): name `Omi Local Dev Signing` exactly, Identity Type *Self Signed
+Root*, Certificate Type *Code Signing*.
 
 ## The entitlement decision keys on the Team ID
 

--- a/desktop/macos/docs/local-code-signing.md
+++ b/desktop/macos/docs/local-code-signing.md
@@ -89,6 +89,69 @@ codesign -dvv "/Applications/omi-<feature>.app" 2>&1 | grep -E 'Authority|TeamId
 codesign -d --entitlements :- "/Applications/omi-<feature>.app" | grep -o 'disable-library-validation'
 ```
 
+## `errSecInternalComponent`: the session, not the certificate
+
+An agent, a CI job, or any shell started outside the GUI login session hits this,
+and it is the single most misdiagnosed failure in this file:
+
+```
+build/<app>.app/Contents/Frameworks/Sparkle.framework: replacing existing signature
+build/<app>.app/Contents/Frameworks/Sparkle.framework: errSecInternalComponent
+```
+
+**The certificate is fine. The keychain is unlocked. You are the right user.** What
+is missing is authorization to *use* the private key from a process that cannot be
+shown a dialog.
+
+macOS normally resolves an unlisted caller by having SecurityAgent ask — *"codesign
+wants to use key X. Allow / Always Allow"*. A process whose `launchctl managername`
+reports `Background` rather than `Aqua` has no window server connection, so that
+dialog cannot be drawn and the Security framework fails the call immediately rather
+than hanging. `security` reports the same condition as exit 36, and
+`security show-keychain-info` says it outright: `User interaction is not allowed.`
+
+Diagnose it in one line before assuming anything about the identity:
+
+```bash
+launchctl managername            # Aqua = can prompt; Background = cannot
+```
+
+Two checks that will mislead you if you skip the one above:
+
+- `security find-identity -v -p codesigning` **lists the identity** — presence is not
+  permission.
+- `security unlock-keychain -p <deliberately-wrong-password> login.keychain-db`
+  **returns 0** when the keychain is already unlocked, so a locked keychain is not
+  the explanation.
+
+### The fix, once, permanently
+
+Grant `codesign` a standing partition on the key, from a terminal in the GUI session:
+
+```bash
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+  -l "Apple Development: YOUR NAME (XXXXXXXXXX)" ~/Library/Keychains/login.keychain-db
+```
+
+Omit `-k` so it prompts for the keychain password rather than recording it in shell
+history. After this, signing works from any session, including background ones.
+
+`run.sh` detects this failure and prints this remedy with your identity already
+substituted, so you should never have to find this section from a raw error.
+
+### The same wall blocks auth seeding
+
+`scripts/omi-auth-dump.sh` reads Firebase tokens from a team-scoped Keychain item.
+From a background session it prints `WARNING: no auth_idToken found — is the source
+bundle signed in?` **even when the source bundle is signed in** — the UserDefaults
+half reads fine and the secret does not. Same cause, same shape of fix:
+
+```bash
+security set-generic-password-partition-list -S apple-tool:,apple:,security: \
+  -s "com.omi.desktop.firebase-rest-session.v2.team.<TEAM>.bundle.com.omi.desktop-dev" \
+  -a firebase-rest-tokens ~/Library/Keychains/login.keychain-db
+```
+
 ## Do not "fix" a launch failure with ad-hoc signing
 
 `OMI_ALLOW_ADHOC_SIGN=1` looks like it works, and it is worse. An ad-hoc

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -468,11 +468,58 @@ EOF
     return 1
 }
 
+# Which identity this bundle was signed with last time.
+#
+# **TCC binds every grant to the code requirement at the moment it was granted**, and that
+# requirement names the signing certificate. So changing a bundle's signing identity silently
+# revokes its Microphone, Screen Recording and Files permissions -- the app then re-prompts on
+# every launch and looks broken, with nothing in its own logs to explain why.
+#
+# That is easy to do by accident: an Apple Development identity that the keychain refuses in one
+# session (see the errSecInternalComponent notes) falls back to the self-signed identity, and the
+# next build silently switches the bundle over. Remembering the last identity makes the switch
+# deliberate rather than accidental, and loud when it has to happen anyway.
+signing_identity_stamp_path() {
+    [ "$IS_NAMED_BUNDLE" = true ] || return 1
+    printf '%s/Library/Application Support/Omi Dev Bundles/%s/.signing-identity\n' "$HOME" "$BUNDLE_ID"
+}
+
+remembered_signing_identity() {
+    local stamp
+    stamp="$(signing_identity_stamp_path)" || return 1
+    [ -f "$stamp" ] || return 1
+    cat "$stamp"
+}
+
+remember_signing_identity() {
+    local stamp
+    stamp="$(signing_identity_stamp_path)" || return 0
+    mkdir -p "$(dirname "$stamp")" 2>/dev/null
+    printf '%s' "$1" > "$stamp" 2>/dev/null || true
+}
+
 resolve_signing_identity() {
     if [ -n "$SIGN_IDENTITY" ]; then
         return
     fi
     local candidate
+    # An identity this bundle already wears wins over a "better" one, because switching costs the
+    # user every permission they have granted it.
+    local remembered
+    if remembered="$(remembered_signing_identity)" && [ -n "$remembered" ]; then
+        if signing_identity_usable "$remembered"; then
+            SIGN_IDENTITY="$remembered"
+            substep "Reusing this bundle's existing identity: $SIGN_IDENTITY"
+            return
+        fi
+        echo ""
+        echo "  WARNING: this bundle was last signed with \"$remembered\", which is not usable"
+        echo "           here. Signing it with anything else RESETS ITS PERMISSIONS: macOS binds"
+        echo "           Microphone, Screen Recording and Files grants to the signing certificate,"
+        echo "           so the app will prompt for all of them again on next launch."
+        echo "           The remedy is the same one printed below."
+    fi
+
     # Prefer a real Apple identity so local permissions stay stable AND the bundle carries a
     # Team ID. Each candidate is probed rather than merely found: an Apple Development identity
     # whose key the keychain will not release is worse than useless, because picking it makes
@@ -486,7 +533,29 @@ resolve_signing_identity() {
             SIGN_IDENTITY="$candidate"
             return
         fi
-        substep "Skipping unusable identity: $candidate (keychain refused the key in this session)"
+        # Authorization can be granted between one call and the next -- clicking "Allow" on the
+        # SecurityAgent dialog authorizes a single use, so a refusal is not necessarily a
+        # standing state. Probe once more before writing the identity off, or a dialog answered
+        # a moment too late silently costs the build its Team ID.
+        sleep 1
+        if signing_identity_usable "$candidate"; then
+            SIGN_IDENTITY="$candidate"
+            return
+        fi
+        echo ""
+        echo "  WARNING: $candidate is present but the keychain refused its key."
+        echo "           Falling back to a teamless identity, which is a DOWNGRADE:"
+        echo "           the bundle gets no Team ID, so it cannot share Keychain items or"
+        echo "           entitlements with the team-scoped builds (Omi Dev, beta, prod) and"
+        echo "           needs library validation relaxed to launch."
+        echo "           If a keychain dialog is appearing, answer it with \"Always Allow\"."
+        echo "           To stop it recurring, grant codesign a standing partition once:"
+        echo ""
+        echo "             security set-key-partition-list -S apple-tool:,apple:,codesign: -s \\"
+        echo "               -l \"$candidate\" ~/Library/Keychains/login.keychain-db"
+        echo ""
+        echo "           Or force it for this build: OMI_SIGN_IDENTITY=\"$candidate\" ./run.sh"
+        echo ""
     done
 
     # A stable self-signed identity keeps this bundle's own TCC grants, because its designated
@@ -779,6 +848,7 @@ sign_app_bundle() {
 
     substep "Signing app bundle"
     omi_codesign --force --options runtime --entitlements "$effective_entitlements" --sign "$SIGN_IDENTITY" "$bundle"
+    remember_signing_identity "$SIGN_IDENTITY"
 }
 
 update_app_desktop_api_url() {

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -351,26 +351,155 @@ rm -f $AUTH_DEBUG_LOG
 auth_debug() { echo "[AUTH DEBUG][$(date +%H:%M:%S)] $1" >> $AUTH_DEBUG_LOG; }
 touch $AUTH_DEBUG_LOG
 
+# The local self-signed identity, created without a GUI and without a password prompt.
+#
+# The documented way to make this identity is Keychain Access -> Certificate Assistant, which
+# is a wizard: unusable from CI, from an agent, and from anyone who has not read the doc. The
+# ingredients are all stock, so the wizard is not actually required -- /usr/bin/openssl is
+# LibreSSL on every Mac and supports the legacy PKCS#12 encoding Apple's importer accepts
+# (OpenSSL 3's AES/SHA256 default is rejected with "MAC verification failed").
+#
+# It lives in its own keychain rather than in login.keychain on purpose. We own that
+# keychain's password, so we can unlock it and grant codesign a partition non-interactively --
+# which is the entire point, since the login keychain is exactly what we cannot do that to.
+# The password protects a throwaway self-signed certificate and nothing else, so it is a
+# constant rather than a secret.
+OMI_LOCAL_SIGN_KEYCHAIN="$HOME/Library/Keychains/omi-local-dev-signing.keychain-db"
+OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD="omi-local-dev"
+
+# Whether an identity can actually be USED here, which is not the same question as whether it
+# exists. `security find-identity` lists identities whose private key the keychain may still
+# refuse to hand over -- and refuse instantly, with no prompt, in any session that cannot draw
+# one. Probing costs one signature on a temp file and turns a failure that used to surface
+# after the whole build into a fact known before it starts.
+signing_identity_usable() {
+    local identity="$1" probe status
+    [ -n "$identity" ] || return 1
+    probe="$(mktemp "${TMPDIR:-/tmp}/omi-sign-probe.XXXXXX")" || return 1
+    cp /usr/bin/true "$probe" 2>/dev/null || { rm -f "$probe"; return 1; }
+    codesign --force --sign "$identity" "$probe" >/dev/null 2>&1
+    status=$?
+    rm -f "$probe"
+    return $status
+}
+
+# Make the keychain visible to codesign without disturbing the user's search list.
+#
+# `security list-keychains -s` REPLACES the list rather than appending, so the existing entries
+# have to be read and passed back verbatim. They come back one per line, quoted and indented,
+# and each path may contain spaces -- so they are collected into an array and re-quoted by the
+# shell. Word-splitting them instead corrupts the list, which is not a theoretical concern:
+# an earlier version of this function did exactly that and rewrote the user's login keychain
+# entry into a nested-quoted path that no longer resolved.
+add_keychain_to_search_list() {
+    local keychain="$1" line
+    local -a current=()
+    while IFS= read -r line; do
+        line="${line#"${line%%[![:space:]]*}"}"   # strip leading whitespace
+        line="${line#\"}"
+        line="${line%\"}"
+        [ -n "$line" ] || continue
+        [ "$line" = "$keychain" ] && return 0     # already present, nothing to do
+        current+=("$line")
+    done < <(security list-keychains -d user)
+    security list-keychains -d user -s "${current[@]}" "$keychain" 2>/dev/null
+}
+
+ensure_local_dev_signing_identity() {
+    if signing_identity_usable "$OMI_LOCAL_DEV_SIGN_IDENTITY"; then
+        return 0
+    fi
+    if [ -f "$OMI_LOCAL_SIGN_KEYCHAIN" ]; then
+        # Present but unusable almost always means "locked since reboot".
+        security unlock-keychain -p "$OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD" "$OMI_LOCAL_SIGN_KEYCHAIN" 2>/dev/null
+        add_keychain_to_search_list "$OMI_LOCAL_SIGN_KEYCHAIN"
+        signing_identity_usable "$OMI_LOCAL_DEV_SIGN_IDENTITY" && return 0
+    fi
+
+    step "Creating local signing identity ($OMI_LOCAL_DEV_SIGN_IDENTITY)..."
+    local work
+    work="$(mktemp -d "${TMPDIR:-/tmp}/omi-local-sign.XXXXXX")" || return 1
+
+    # codeSigning EKU and CA:false are both required, or codesign declines the identity.
+    cat > "$work/openssl.cnf" <<EOF
+[req]
+distinguished_name = dn
+x509_extensions = v3
+prompt = no
+[dn]
+CN = $OMI_LOCAL_DEV_SIGN_IDENTITY
+[v3]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+EOF
+
+    if ! /usr/bin/openssl req -x509 -newkey rsa:2048 -keyout "$work/key.pem" -out "$work/cert.pem" \
+            -days 3650 -nodes -config "$work/openssl.cnf" >/dev/null 2>&1; then
+        rm -rf "$work"; return 1
+    fi
+    if ! /usr/bin/openssl pkcs12 -export -inkey "$work/key.pem" -in "$work/cert.pem" \
+            -out "$work/identity.p12" -passout "pass:$OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD" \
+            -name "$OMI_LOCAL_DEV_SIGN_IDENTITY" \
+            -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 >/dev/null 2>&1; then
+        rm -rf "$work"; return 1
+    fi
+
+    if [ ! -f "$OMI_LOCAL_SIGN_KEYCHAIN" ]; then
+        security create-keychain -p "$OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD" "$OMI_LOCAL_SIGN_KEYCHAIN" 2>/dev/null || { rm -rf "$work"; return 1; }
+        # No idle timeout and no lock-on-sleep: a keychain that relocks mid-build reintroduces
+        # exactly the interactive prompt this exists to avoid.
+        security set-keychain-settings "$OMI_LOCAL_SIGN_KEYCHAIN" 2>/dev/null
+    fi
+    security unlock-keychain -p "$OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD" "$OMI_LOCAL_SIGN_KEYCHAIN" 2>/dev/null
+    security import "$work/identity.p12" -k "$OMI_LOCAL_SIGN_KEYCHAIN" \
+        -P "$OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security >/dev/null 2>&1
+    # The partition list is what lets codesign use the key with no dialog. We can set it here
+    # only because this keychain's password is ours.
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s \
+        -k "$OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD" "$OMI_LOCAL_SIGN_KEYCHAIN" >/dev/null 2>&1
+    add_keychain_to_search_list "$OMI_LOCAL_SIGN_KEYCHAIN"
+    rm -rf "$work"
+
+    if signing_identity_usable "$OMI_LOCAL_DEV_SIGN_IDENTITY"; then
+        substep "Created $OMI_LOCAL_DEV_SIGN_IDENTITY (self-signed, stable, no prompt)"
+        return 0
+    fi
+    return 1
+}
+
 resolve_signing_identity() {
     if [ -n "$SIGN_IDENTITY" ]; then
         return
     fi
-    # Prefer the development identity so local permissions remain stable.
-    SIGN_IDENTITY=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | sed 's/.*"\(.*\)"/\1/')
-    if [ -z "$SIGN_IDENTITY" ]; then
-        SIGN_IDENTITY=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
-    fi
-    if [ -z "$SIGN_IDENTITY" ]; then
-        # A stable self-signed identity keeps this bundle's own TCC grants,
-        # because its designated requirement pins that certificate. Ad-hoc
-        # signing has no such requirement and silently drops Screen Recording,
-        # so prefer this over ad-hoc whenever it exists.
-        SIGN_IDENTITY=$(security find-identity -v -p codesigning | grep -F "\"$OMI_LOCAL_DEV_SIGN_IDENTITY\"" | head -1 | sed 's/.*"\(.*\)"/\1/')
-        if [ -n "$SIGN_IDENTITY" ]; then
-            substep "Using local self-signed identity: $SIGN_IDENTITY"
+    local candidate
+    # Prefer a real Apple identity so local permissions stay stable AND the bundle carries a
+    # Team ID. Each candidate is probed rather than merely found: an Apple Development identity
+    # whose key the keychain will not release is worse than useless, because picking it makes
+    # the build fail an hour of work later instead of falling back now.
+    for candidate in \
+        "$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | sed 's/.*"\(.*\)"/\1/')" \
+        "$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')"
+    do
+        [ -n "$candidate" ] || continue
+        if signing_identity_usable "$candidate"; then
+            SIGN_IDENTITY="$candidate"
+            return
         fi
+        substep "Skipping unusable identity: $candidate (keychain refused the key in this session)"
+    done
+
+    # A stable self-signed identity keeps this bundle's own TCC grants, because its designated
+    # requirement pins that certificate. Ad-hoc signing has no such requirement and silently
+    # drops Screen Recording, so this is preferred over ad-hoc always -- and created on demand
+    # rather than waiting for someone to run a GUI wizard.
+    if [ "${OMI_SKIP_LOCAL_SIGN_IDENTITY:-0}" != "1" ] && ensure_local_dev_signing_identity; then
+        SIGN_IDENTITY="$OMI_LOCAL_DEV_SIGN_IDENTITY"
+        substep "Using local self-signed identity: $SIGN_IDENTITY"
+        return
     fi
-    if [ -z "$SIGN_IDENTITY" ] && [ "${OMI_ALLOW_ADHOC_SIGN:-0}" = "1" ] && [ "$IS_NAMED_BUNDLE" = true ]; then
+
+    if [ "${OMI_ALLOW_ADHOC_SIGN:-0}" = "1" ] && [ "$IS_NAMED_BUNDLE" = true ]; then
         SIGN_IDENTITY="-"
         substep "Using ad-hoc signing for named test bundle ($BUNDLE_ID)"
     fi

--- a/desktop/macos/run.sh
+++ b/desktop/macos/run.sh
@@ -501,6 +501,54 @@ if [ "$FAST_ONLY" = "1" ]; then
     fi
 fi
 
+
+# Every codesign call in this file goes through here.
+#
+# When signing fails because the *keychain* refused to hand over the private key, the raw
+# message is `errSecInternalComponent` — six syllables of nothing, and the failure looks
+# identical to a corrupt bundle or a bad identity. It sent one agent down a rabbit hole that
+# ended in ad-hoc signing, which is the one fix that silently breaks Rewind capture.
+#
+# The actual cause is almost always the session, not the certificate: a process launched
+# outside the GUI login session (`launchctl managername` reports `Background` rather than
+# `Aqua` — CI, an ssh shell, an agent harness, a LaunchDaemon) has no window server, so
+# SecurityAgent cannot draw the "codesign wants to use key X" dialog. Rather than hang, the
+# Security framework fails the call immediately. The key is present, the keychain is unlocked,
+# and the caller is the right user; only the authorization is missing.
+#
+# So say that, and say the one command that fixes it for good.
+omi_codesign() {
+    local output status
+    output="$(codesign "$@" 2>&1)"
+    status=$?
+    [ -n "$output" ] && printf '%s\n' "$output"
+    if [ $status -ne 0 ] && printf '%s' "$output" | grep -qE 'errSecInternalComponent|interaction is not allowed|User interaction'; then
+        echo ""
+        echo "ERROR: the keychain refused the signing key (not a bad bundle, not a bad identity)."
+        echo ""
+        echo "  identity: $SIGN_IDENTITY"
+        echo "  session : $(launchctl managername 2>/dev/null || echo unknown)   <- must be Aqua to show a keychain prompt"
+        echo ""
+        echo "  This shell cannot display the SecurityAgent dialog that would authorize the key,"
+        echo "  so macOS fails the request instead of asking. Grant codesign a standing partition"
+        echo "  on the key once, from a terminal in the GUI session:"
+        echo ""
+        echo "    security set-key-partition-list -S apple-tool:,apple:,codesign: -s \\"
+        echo "      -l \"$SIGN_IDENTITY\" ~/Library/Keychains/login.keychain-db"
+        echo ""
+        echo "  Omit -k so it prompts for the keychain password instead of putting it in history."
+        echo "  After that this build works from any session, including this one."
+        echo ""
+        echo "  DO NOT reach for OMI_ALLOW_ADHOC_SIGN=1 here. An ad-hoc signature has no"
+        echo "  designated requirement, so the bundle loses its own Screen Recording grant and"
+        echo "  Rewind captures nothing — which reads as a broken feature, not a signing problem."
+        echo "  See desktop/macos/docs/local-code-signing.md."
+        echo ""
+        exit 1
+    fi
+    return $status
+}
+
 sign_app_bundle() {
     local bundle="$1"
     local sign_nested="$2"
@@ -546,28 +594,28 @@ sign_app_bundle() {
     if [ "$sign_nested" = true ]; then
         if [ -d "$bundle/Contents/Frameworks/Sparkle.framework" ]; then
             substep "Signing Sparkle framework"
-            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/Sparkle.framework"
+            omi_codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/Sparkle.framework"
         fi
         if [ -d "$bundle/Contents/Frameworks/Sentry.framework" ]; then
             substep "Signing Sentry framework"
-            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/Sentry.framework"
+            omi_codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/Sentry.framework"
         fi
         if [ -d "$bundle/Contents/Frameworks/onnxruntime.framework" ]; then
             substep "Signing onnxruntime framework"
-            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/onnxruntime.framework"
+            omi_codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/onnxruntime.framework"
         fi
         if [ -f "$bundle/Contents/Frameworks/libsharpyuv.0.dylib" ]; then
             substep "Signing libsharpyuv"
-            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/libsharpyuv.0.dylib"
+            omi_codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/libsharpyuv.0.dylib"
         fi
         if [ -f "$bundle/Contents/Frameworks/libwebp.7.dylib" ]; then
             substep "Signing libwebp"
-            codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/libwebp.7.dylib"
+            omi_codesign --force --options runtime --sign "$SIGN_IDENTITY" "$bundle/Contents/Frameworks/libwebp.7.dylib"
         fi
         local node_bin="$bundle/Contents/Resources/Omi Computer_Omi Computer.bundle/Contents/Resources/node"
         if [ -f "$node_bin" ]; then
             substep "Signing bundled node binary"
-            codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$node_bin"
+            omi_codesign --force --options runtime --entitlements Desktop/Node.entitlements --sign "$SIGN_IDENTITY" "$node_bin"
         fi
     fi
 
@@ -601,7 +649,7 @@ sign_app_bundle() {
     fi
 
     substep "Signing app bundle"
-    codesign --force --options runtime --entitlements "$effective_entitlements" --sign "$SIGN_IDENTITY" "$bundle"
+    omi_codesign --force --options runtime --entitlements "$effective_entitlements" --sign "$SIGN_IDENTITY" "$bundle"
 }
 
 update_app_desktop_api_url() {

--- a/desktop/macos/tests/test-prepare-local-dev-entitlements.sh
+++ b/desktop/macos/tests/test-prepare-local-dev-entitlements.sh
@@ -60,15 +60,17 @@ prepare_entitlements() {
     "$PREPARE_SCRIPT" "$BASE_ENTITLEMENTS" "$TMP_ROOT/modes/.dev" "$bundle_id" "$mode"
 }
 
-# Run one of run.sh's own function bodies as the production code it is. run.sh
-# runs under bare `set -e`, so adopt exactly those options before calling in:
-# `pipefail`/`nounset` would make these functions behave differently here than
-# they do in the launcher.
+# Run run.sh's own function bodies as the production code they are, in
+# dependency order. run.sh runs under bare `set -e`, so adopt exactly those
+# options before calling in: `pipefail`/`nounset` would make these functions
+# behave differently here than they do in the launcher.
 eval_run_function() {
-    local name="$1"
-    local body
-    body="$(sed -n "/^$name()/,/^}/p" "$RUN_SCRIPT")"
-    [ -n "$body" ] || fail "$name is missing from $RUN_SCRIPT"
+    local name body="" extracted
+    for name in "$@"; do
+        extracted="$(sed -n "/^$name()/,/^}/p" "$RUN_SCRIPT")"
+        [ -n "$extracted" ] || fail "$name is missing from $RUN_SCRIPT"
+        body+="$extracted"$'\n'
+    done
     set +o pipefail +o nounset
     set -o errexit
     eval "$body"
@@ -235,52 +237,157 @@ done
 )
 
 # ── run.sh: identity resolution prefers a stable identity over ad-hoc ──
+#
+# resolve_signing_identity is driven together with the helpers it now
+# delegates to, against faked environment binaries: `security` answers
+# find-identity and the keychain calls; `codesign` answers probes, failing
+# for identities on the refusal list exactly as the keychain refuses to
+# release a key (errSecInternalComponent). Keychain and stamp state is
+# sandboxed under TMP_ROOT via HOME and OMI_LOCAL_SIGN_KEYCHAIN overrides.
 
 FAKE_BIN="$TMP_ROOT/fake-bin"
 mkdir -p "$FAKE_BIN"
-write_fake_security() {
-    cat >"$FAKE_BIN/security" <<EOF
-#!/bin/bash
-cat <<'IDENTITIES'
-$1
-IDENTITIES
-EOF
-    chmod +x "$FAKE_BIN/security"
+REFUSED_IDENTITIES_FILE="$TMP_ROOT/refused-identities"
+FAKE_CREATED_IDENTITY="$LOCAL_DEV_IDENTITY"
+export REFUSED_IDENTITIES_FILE FAKE_CREATED_IDENTITY
+: >"$REFUSED_IDENTITIES_FILE"
+
+refuse_identities() {
+    printf '%s\n' "$@" >>"$REFUSED_IDENTITIES_FILE"
 }
+
+# What `security find-identity -v -p codesigning` reports.
+FAKE_IDENTITY_LISTING='     0 valid identities found'
+set_fake_identity_listing() {
+    FAKE_IDENTITY_LISTING="$1"
+    export FAKE_IDENTITY_LISTING
+}
+
+cat >"$FAKE_BIN/security" <<'EOF'
+#!/bin/bash
+case "$1" in
+    find-identity)
+        printf '%s\n' "$FAKE_IDENTITY_LISTING"
+        ;;
+    import)
+        # Importing the generated self-signed identity is what makes it usable.
+        sed -i '' "/^$FAKE_CREATED_IDENTITY$/d" "$REFUSED_IDENTITIES_FILE" 2>/dev/null
+        ;;
+    create-keychain)
+        for arg in "$@"; do :; done
+        touch "$arg" 2>/dev/null
+        ;;
+esac
+exit 0
+EOF
+chmod +x "$FAKE_BIN/security"
+
+cat >"$FAKE_BIN/codesign" <<'EOF'
+#!/bin/bash
+# Identity probes answer the way the keychain would: a refused identity
+# fails instantly, which is what errSecInternalComponent looks like from
+# codesign. Anything else signs.
+identity=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --sign) identity="$2"; shift 2; continue ;;
+    esac
+    shift
+done
+if [ -n "$identity" ] && grep -Fxq -- "$identity" "$REFUSED_IDENTITIES_FILE" 2>/dev/null; then
+    exit 1
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/codesign"
 
 (
     PATH="$FAKE_BIN:$PATH"
+    HOME="$TMP_ROOT/sandbox-home"
+    mkdir -p "$HOME/Library/Keychains"
+    step() { :; }
     substep() { :; }
     IS_NAMED_BUNDLE=true
     BUNDLE_ID=com.omi.omi-signfix
     OMI_ALLOW_ADHOC_SIGN=1
     OMI_LOCAL_DEV_SIGN_IDENTITY="$LOCAL_DEV_IDENTITY"
-    eval_run_function resolve_signing_identity
+    OMI_LOCAL_SIGN_KEYCHAIN="$HOME/Library/Keychains/omi-local-dev-signing.keychain-db"
+    OMI_LOCAL_SIGN_KEYCHAIN_PASSWORD=test-only
+    eval_run_function \
+        signing_identity_usable \
+        add_keychain_to_search_list \
+        ensure_local_dev_signing_identity \
+        signing_identity_stamp_path \
+        remembered_signing_identity \
+        resolve_signing_identity
+
+    stamp_file="$HOME/Library/Application Support/Omi Dev Bundles/$BUNDLE_ID/.signing-identity"
+    reset_case() {
+        SIGN_IDENTITY=""
+        rm -f "$stamp_file" "$OMI_LOCAL_SIGN_KEYCHAIN"
+        : >"$REFUSED_IDENTITIES_FILE"
+    }
 
     # Only the self-signed identity exists: it must win over ad-hoc, because
     # ad-hoc would drop this bundle's Screen Recording grant.
-    write_fake_security '  1) BB925114BCB64BD0D17B4CA18CC67B8B2A5CE614 "Omi Local Dev Signing"
-     1 valid identities found'
-    SIGN_IDENTITY=""
+    reset_case
+    set_fake_identity_listing "  1) BB925114BCB64BD0D17B4CA18CC67B8B2A5CE614 \"$LOCAL_DEV_IDENTITY\"
+     1 valid identities found"
     resolve_signing_identity
     [ "$SIGN_IDENTITY" = "$LOCAL_DEV_IDENTITY" ] \
         || fail "ad-hoc signing was chosen over the stable local identity (got '$SIGN_IDENTITY')"
 
     # An Apple identity still wins over the self-signed one.
-    write_fake_security "  1) AAAA \"$APPLE_DEVELOPMENT_IDENTITY\"
+    reset_case
+    set_fake_identity_listing "  1) AAAA \"$APPLE_DEVELOPMENT_IDENTITY\"
   2) BBBB \"$LOCAL_DEV_IDENTITY\"
      2 valid identities found"
-    SIGN_IDENTITY=""
     resolve_signing_identity
     [ "$SIGN_IDENTITY" = "$APPLE_DEVELOPMENT_IDENTITY" ] \
         || fail "Apple Development identity was not preferred (got '$SIGN_IDENTITY')"
 
-    # With nothing in the keychain, the opted-in ad-hoc path is still available.
-    write_fake_security '     0 valid identities found'
-    SIGN_IDENTITY=""
+    # A listed identity is not a usable one: presence is not permission. A key
+    # the keychain refuses to release must lose to the stable local identity,
+    # not fail the build after the compile.
+    reset_case
+    set_fake_identity_listing "  1) AAAA \"$APPLE_DEVELOPMENT_IDENTITY\"
+     1 valid identities found"
+    refuse_identities "$APPLE_DEVELOPMENT_IDENTITY"
+    resolve_signing_identity
+    [ "$SIGN_IDENTITY" = "$LOCAL_DEV_IDENTITY" ] \
+        || fail "a refused Apple Development identity was chosen anyway (got '$SIGN_IDENTITY')"
+
+    # An identity this bundle already wears wins over a "better" one, because
+    # switching resets every permission the bundle has been granted.
+    reset_case
+    set_fake_identity_listing "  1) AAAA \"$APPLE_DEVELOPMENT_IDENTITY\"
+     1 valid identities found"
+    mkdir -p "$(dirname "$stamp_file")"
+    printf '%s' "$LOCAL_DEV_IDENTITY" >"$stamp_file"
+    resolve_signing_identity
+    [ "$SIGN_IDENTITY" = "$LOCAL_DEV_IDENTITY" ] \
+        || fail "the bundle's remembered identity was not reused (got '$SIGN_IDENTITY')"
+
+    # With nothing in the keychain the local identity is created on demand —
+    # never ad-hoc, which would silently drop the Screen Recording grant.
+    reset_case
+    set_fake_identity_listing '     0 valid identities found'
+    refuse_identities "$LOCAL_DEV_IDENTITY"   # does not exist yet: unusable until imported
+    resolve_signing_identity
+    [ "$SIGN_IDENTITY" = "$LOCAL_DEV_IDENTITY" ] \
+        || fail "on-demand local identity creation was not used (got '$SIGN_IDENTITY')"
+    [ -f "$OMI_LOCAL_SIGN_KEYCHAIN" ] \
+        || fail "the local identity was reported usable without creating its keychain"
+
+    # Ad-hoc remains reachable, but only by opting out of the local identity.
+    reset_case
+    set_fake_identity_listing '     0 valid identities found'
+    refuse_identities "$LOCAL_DEV_IDENTITY"
+    OMI_SKIP_LOCAL_SIGN_IDENTITY=1
     resolve_signing_identity
     [ "$SIGN_IDENTITY" = "-" ] \
         || fail "opted-in ad-hoc fallback stopped working (got '$SIGN_IDENTITY')"
+    unset OMI_SKIP_LOCAL_SIGN_IDENTITY
 )
 
 # Preparing a named bundle must never mutate the checked-in source plist.


### PR DESCRIPTION
Four fixes to the macOS dev loop, found while building a feature on a named bundle. None depends on that feature; it is not in this PR.

## 1. `errSecInternalComponent` is the session, not the certificate

`codesign` failing this way is the most misdiagnosed failure in `run.sh`. The certificate is fine, the keychain is unlocked, and the caller is the right user — what is missing is authorization to *use* the key from a process macOS cannot show a dialog to. A shell outside the GUI login session (`launchctl managername` = `Background` rather than `Aqua` — CI, ssh, an agent) has no window server, so SecurityAgent cannot draw "codesign wants to use key X" and the framework fails the call instead of hanging.

Read as "cannot sign", it leads somewhere actively harmful: the obvious fallback is `OMI_ALLOW_ADHOC_SIGN=1`, and an ad-hoc signature has no designated requirement, so the bundle loses its own Screen Recording grant and Rewind captures nothing — which then presents as a broken feature rather than a signing problem.

Every `codesign` call now routes through `omi_codesign`, which detects the refusal and prints the diagnosis with the live session name and a `set-key-partition-list` command with the identity already substituted.

## 2. Probe identities instead of trusting the list

`resolve_signing_identity` took the first identity `security find-identity` reported, but **presence is not permission**: a listed Apple Development identity whose key the keychain will not release fails at `codesign` time — after the Swift build and a 265 MB bundle copy. Each candidate is now signed with once, against a throwaway file, before being committed to.

The converse matters too: a self-signed identity never appears in `find-identity -p codesigning` at all, because that list filters on policy trust. Existence was the wrong test in both directions.

## 3. Create the local identity instead of documenting a wizard

The fallback identity's setup instructions were Keychain Access → Certificate Assistant — unfollowable by CI, by ssh, or by an agent, precisely the callers most likely to have no Apple certificate. It is now generated on demand with `/usr/bin/openssl` (LibreSSL, stock on every Mac) into a dedicated keychain whose password the script owns. Owning that password is the point: it allows granting `codesign` a partition non-interactively, which is impossible for the login keychain. Opt out with `OMI_SKIP_LOCAL_SIGN_IDENTITY=1`.

The PKCS#12 uses the legacy SHA1/3DES encoding deliberately — OpenSSL 3's AES/SHA256 default is rejected by Apple's importer as `MAC verification failed during PKCS12 import (wrong password?)`, which sends you looking for a password bug that does not exist.

## 4. A rebuild silently reset the bundle's permissions

macOS binds every TCC grant to the code requirement in force when it was granted, and that requirement names the signing certificate. Measured on a real bundle — the microphone grant stored:

```
identifier "com.omi.omi-<name>" and anchor apple generic and
certificate leaf[subject.CN] = "Apple Development: <name>" ...
```

while the same bundle, rebuilt after the keychain refused that key, satisfied only:

```
identifier "com.omi.omi-<name>" and certificate leaf = H"30e335eb..."
```

Those do not match, so Microphone, Screen Recording and Files were all silently revoked and the app re-prompted on **every launch** — with nothing in its own logs to explain why, because from the app's side the permission genuinely is `notDetermined`.

Probing identities makes this easier to trigger, so a named bundle now remembers the identity it was last signed with and prefers it over a "better" one. Being right about which identity is preferable is worth less than not making someone re-grant Screen Recording. When the remembered identity genuinely cannot be used the switch still happens, but it says plainly that permissions are about to reset.

## 5. Onboarding quit the app at the moment you finished it

`applicationShouldTerminateAfterLastWindowClosed` returns true while `hasCompletedOnboarding` is false — deliberately, so a half-finished onboarding leaves no background menu-bar process. That makes the flag load-bearing for process lifetime, not just for which view renders.

`finishOnboardingHandoff` set it at the end of a detached `Task`, **after** `await chatProvider.finishOnboardingJournal()`. Between the onboarding window going away and that await resolving, the flag is still false — so the app quits at the exact moment onboarding completes, and reruns onboarding next launch because the flag was never written. Reproduced twice; the app logged `Last onboarding window closed — terminating…` and `hasCompletedOnboarding` was absent from UserDefaults afterwards.

`[weak self]` made it worse rather than safer: `teardownAll()` runs at the top of the same function, so a deallocated model meant the guard returned early and the flag was never written at all.

Normal dev bundles never hit this because `omi-auth-seed.sh` copies the flag from Omi Dev and onboarding is skipped entirely, which is why it survived this long. **A genuine first-run user is not protected by that.**

## Testing

- `swift build -c debug` green on this branch alone, off `origin/main`.
- The `errSecInternalComponent` path exercised with a stubbed `codesign`; output verified.
- Identity auto-creation verified from a clean state (keychain deleted → created → usable), and verified idempotent.
- Identity stickiness tested both ways: remembered-and-usable → reused; remembered-and-unusable → warns, then falls back.
- Search-list append tested with a keychain path containing spaces — the case that broke an earlier version of that function, which rewrote the user's login keychain entry into a nested-quoted path.

## Limits worth stating

All of this has run on one machine, against one keychain. It has **not** been exercised on a machine with a clean login keychain, with a `Developer ID Application` identity, or in CI. The onboarding fix is verified by reasoning and by the absence of the flag in UserDefaults, not by a regression test — a test for it would need to assert ordering around the window close, which is worth adding if reviewers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



## Failure class

Failure-Class: FC-shared-platform-identity-across-signing-identities

Fix 4 is an instance of it: macOS stores a code requirement pinning the signing certificate alongside every TCC grant, so changing a bundle's signing identity writes a record the next build cannot satisfy. Measured here on Microphone, exactly the mechanism that class describes.

**Where this PR sits relative to that class's canonical prevention, which is worth stating plainly.** The definition warns that *"requiring merely a stable local certificate does not help: stable is not identical, so it makes grants stick between developer builds and guarantees the poisoned handoff to the release build."* This change does require a stable local certificate — so it is fair to ask whether it is the discouraged fix.

It is not, because the precondition differs. That warning is about builds **sharing one `CFBundleIdentifier`**, where a dev grant poisons the release record. The stickiness added here is scoped to `IS_NAMED_BUNDLE`, and a named bundle already owns a disjoint identifier (`com.omi.omi-<name>`) that no release build ever claims. The class's prevention — disjoint platform records by construction — is therefore already satisfied for these bundles, and this addresses the churn that remains *within* one identifier. It does not touch the prod, beta, or Omi Dev identifiers, and it cannot make a dev grant reachable by a release build.

Fixes 1–3 are the same neighbourhood but not this class: they are about an identity being unusable in a non-GUI session and about creating a fallback identity without a GUI. `FC-signing-attribute-inferred-from-identity-name` is adjacent to fix 2 — both say a signing decision must be read back from reality rather than assumed — though that class is specifically about inferring from the *spelling* of an identity string, whereas fix 2 is about trusting `find-identity`'s listing as proof of usability. Declaring one class per the protocol; happy to split if reviewers prefer the second declared too.
