### PR TITLE
fix(desktop): register the relocated notification bridge actions with flow lint

### DIFF
--- a/desktop/macos/scripts/desktop_flow_contract.py
+++ b/desktop/macos/scripts/desktop_flow_contract.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 # validation route.
 ACTION_SOURCE_RELATIVE_PATHS = (
     "Desktop/Sources/DesktopAutomationBridge.swift",
+    "Desktop/Sources/DesktopAutomationBridge+Notifications.swift",
     "Desktop/Sources/FloatingControlBar/RealtimeHubController.swift",
     "Desktop/Sources/Rewind/Core/RewindArtifactGauntlet.swift",
     "Desktop/Sources/DesktopAutomationOpenOmiShortcutQA.swift",


### PR DESCRIPTION
## Summary

`desktop-flow-lint` currently fails on `main`. Two bridge actions were relocated to a new file without adding that file to the contract list the lint reads, so both became invisible and the flow that references them fails.

## Cause

`d5596a6` ("refactor(macos): relocate journal copy + notification bridge actions to satisfy line-count ratchet") moved `settings_notifications_snapshot` and `set_notification_settings` out of `DesktopAutomationBridge.swift` into `DesktopAutomationBridge+Notifications.swift`, but left `ACTION_SOURCE_RELATIVE_PATHS` in `desktop/macos/scripts/desktop_flow_contract.py` unchanged.

The lint reads registered actions only from that list. `notifications-settings.yaml` still references both actions, so on current `main`:

```
notifications-settings.yaml: unknown bridge action 'settings_notifications_snapshot'
notifications-settings.yaml: unknown bridge action 'set_notification_settings'
desktop-flow-lint: 2 error(s)
```

This is main-wide rather than branch-specific: every desktop PR that merges current main inherits a red `desktop-core-e2e-t0`. It went unnoticed because main's own **Desktop Backend Contracts** runs are sitting at `action_required` rather than executing, so nothing re-ran the lint after the relocation.

## Fix

One line: add the relocated file to `ACTION_SOURCE_RELATIVE_PATHS`.

That file's own comment states the intent this restores — *"Keep the flow lint reader and CI impact resolver on this single list so an added bridge action cannot skip its flow validation route."* A relocated action is an added action as far as that list is concerned.

## Verification

- Pristine `origin/main` (`41afef9b`) reproduces both errors — this is not introduced by any branch.
- With this line: `desktop-flow-lint OK (72 flows, 162 registered actions)`, up from 161.
- **Guard proven live**: removing the line again reproduces the same 2 errors, so the fix is doing the work rather than the failure having moved.
- `desktop/macos/tests/test-e2e-flow-coverage.sh` — passed.
- `.github/scripts/test_pre_push_ci_prediction.py` — 22 passed (the other consumer of this contract).

## Honest gaps

No new test. The lint itself is the guard, it already runs in the `desktop-core-e2e-t0` lane, and it fails correctly when the entry is absent — a test asserting the list contains a specific string would be a static tripwire restating the data, not behavioural coverage.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

