### PR TITLE
fix(desktop): stop a permission prompt quitting the app during onboarding

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
@@ -317,6 +317,30 @@ enum ShellSummon {
     summon()
   }
 
+  /// Whether the shell is currently ordered out to make room for macOS permission UI.
+  ///
+  /// The window being gone is not the user closing it, and `applicationShouldTerminateAfterLastWindowClosed`
+  /// cannot tell the difference on its own.
+  static var isSuspendedForPermissionPrompt: Bool { permissionSuspendedFrame != nil }
+
+  /// Whether losing the last window should end the process.
+  ///
+  /// Pure so the decision is provable without AppKit: the delegate hook it serves runs inside a
+  /// live `NSApplication` during a system permission prompt, which no hermetic test can stand up.
+  ///
+  /// Before onboarding completes there is no menu-bar residency to fall back on, so a closed last
+  /// window really does mean "quit". A permission prompt is the one case where the window is gone
+  /// because *we* took it away — `suspendForPermissionPrompt` orders it out so macOS can present
+  /// the dialog — and quitting there kills the app at the instant the user is granting the
+  /// permission onboarding just asked for. Every one of the eight callers reaches this path.
+  nonisolated static func shouldTerminateAfterLastWindowClosed(
+    hasCompletedOnboarding: Bool,
+    isSuspendedForPermissionPrompt: Bool
+  ) -> Bool {
+    guard !isSuspendedForPermissionPrompt else { return false }
+    return !hasCompletedOnboarding
+  }
+
   /// Temporarily remove the main Omi surface before handing control to macOS permission UI.
   ///
   /// This does not deactivate the application: callers may be about to trigger an in-process

--- a/desktop/macos/Desktop/Sources/OmiApp.swift
+++ b/desktop/macos/Desktop/Sources/OmiApp.swift
@@ -1278,8 +1278,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, @unchecked S
   }
 
   func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-    let shouldTerminate = !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-    if shouldTerminate {
+    let isSuspendedForPermissionPrompt = ShellSummon.isSuspendedForPermissionPrompt
+    let shouldTerminate = ShellSummon.shouldTerminateAfterLastWindowClosed(
+      hasCompletedOnboarding: UserDefaults.standard.bool(forKey: DefaultsKey.hasCompletedOnboarding.rawValue),
+      isSuspendedForPermissionPrompt: isSuspendedForPermissionPrompt)
+    if isSuspendedForPermissionPrompt {
+      log("AppDelegate: Last window closed for a permission prompt — staying alive to receive the answer")
+    } else if shouldTerminate {
       log(
         "AppDelegate: Last onboarding window closed — terminating instead of keeping a background menu bar process"
       )

--- a/desktop/macos/Desktop/Tests/ShellSummonTests.swift
+++ b/desktop/macos/Desktop/Tests/ShellSummonTests.swift
@@ -398,4 +398,36 @@ final class ShellSummonTests: XCTestCase {
 
     XCTAssertTrue(shellDismissed)
   }
+
+  /// A fresh install could not finish onboarding: granting the microphone quit the app.
+  ///
+  /// `requestMicrophonePermission` calls `suspendForPermissionPrompt`, which orders the only
+  /// window out so macOS can present the dialog. AppKit reports that as the last window closing,
+  /// and the handler returned `!hasCompletedOnboarding` — true during onboarding — so the process
+  /// ended before the prompt could be answered and before the completion handler restored the
+  /// shell. No crash report, because nothing crashed.
+  func testPermissionPromptDoesNotEndOnboarding() {
+    XCTAssertFalse(
+      ShellSummon.shouldTerminateAfterLastWindowClosed(
+        hasCompletedOnboarding: false, isSuspendedForPermissionPrompt: true),
+      "quitting here ends onboarding at the moment the user is granting the permission it asked for")
+  }
+
+  /// The behaviour the guard must not weaken: before onboarding completes there is no menu-bar
+  /// residency to fall back on, so a window the user actually closed still means quit.
+  func testClosingTheLastOnboardingWindowStillQuits() {
+    XCTAssertTrue(
+      ShellSummon.shouldTerminateAfterLastWindowClosed(
+        hasCompletedOnboarding: false, isSuspendedForPermissionPrompt: false))
+  }
+
+  /// After onboarding the app is a menu-bar resident, so losing the last window is never a quit —
+  /// with or without a prompt in flight.
+  func testOnboardedAppSurvivesLosingItsLastWindow() {
+    for suspended in [true, false] {
+      XCTAssertFalse(
+        ShellSummon.shouldTerminateAfterLastWindowClosed(
+          hasCompletedOnboarding: true, isSuspendedForPermissionPrompt: suspended))
+    }
+  }
 }

--- a/desktop/macos/changelog/unreleased/20260820-onboarding-permission-quit.json
+++ b/desktop/macos/changelog/unreleased/20260820-onboarding-permission-quit.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed the app quitting during onboarding when you granted microphone or screen recording permission"
+}


### PR DESCRIPTION
## Summary

A fresh install could not finish onboarding. Granting the microphone ended the process — with no crash report, because nothing crashed. The app quit itself.

## Root cause

`requestMicrophonePermission` calls `ShellSummon.suspendForPermissionPrompt()`, which orders the shell out so macOS can present the TCC dialog. That leaves the app with no windows, AppKit fires `applicationShouldTerminateAfterLastWindowClosed`, and the handler returned `!hasCompletedOnboarding` — true during onboarding — so the app terminated at the instant the user was granting the permission onboarding had just asked for.

`restoreAfterPermissionPrompt()` in the request's completion handler never ran, because the process was already gone.

The log stopped mid-flow, identically, every time:

```
Requesting microphone permission, current status: 0
AppDelegate: Last onboarding window closed — terminating instead of keeping a background menu bar process
ResourceMonitor: [app_terminating]
```

No signal, no `.ips` report, nothing in the system log — which is why it reads as a crash and isn't one.

## Why the fix is at the boundary

Eight call sites across five files suspend the shell for a permission prompt — `ScreenCaptureService` (2), `ChatToolExecutor` (3), `AppState+Permissions`, `AppState+SystemActions` (2). Every one reaches this handler, so a guard per call site would be seven more chances to miss one. One guard where the decision is made covers all of them.

The decision is now a pure function. The delegate hook it serves only runs inside a live `NSApplication` during a system permission prompt, which no hermetic test can stand up; the policy can be proven without AppKit.

**Behaviour outside a prompt is unchanged.** A window the user actually closed before onboarding completes still quits, because there is no menu-bar residency to fall back on yet. That case has its own test so the guard can't quietly widen.

## Verification

```
swift test --filter ShellSummonTests   -> 29 passed (26 existing + 3 new)
swift build                            -> clean
```

**Guard proven by removing it.** With the `isSuspendedForPermissionPrompt` check deleted, `testPermissionPromptDoesNotEndOnboarding` fails as intended — a guard that has never failed isn't a guard.

**Exercised end to end** on a fresh named bundle with no existing TCC grant, which is the state that reproduces the bug:

```
09:45:54.377  Requesting microphone permission, current status: 0
09:45:54.407  Last window closed for a permission prompt — staying alive to receive the answer
09:45:56.252  Microphone permission request completed, granted: true
09:45:56.253  Microphone permission granted
```

Before the fix, the log ended at the first of those lines. The guard fired again for the later prompts in the same session, so the other suspend callers are covered by the same boundary.

**Full desktop suite: 4 failures, all pre-existing.** Re-ran each with this diff stashed; they reproduce identically on main:

- `DesktopAutomationSecondaryActionTests.testSecondarySnapshotActionsAreRegistered`
- `FloatingBarNotificationPreviewPolicyTests.testDirectorDeliveryWithDisabledCategoryToggleIsSuppressedAtTheEntryPoint`
- `PermissionsPagePresentationTests.testSettingsListOrderPlacesPermissionsWithAccessSettings`
- `RewindCaptureExclusionGenerationTests.testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase`

This change adds no new failures.

## Product invariants affected

- INV-AUTH-1

Cited because `OmiApp.swift` is a path the invariant governs. Nothing here touches session
ownership: the change is confined to `applicationShouldTerminateAfterLastWindowClosed`, which
decides whether losing the last window ends the process. It reads no auth state and reaches no
credential path — the only inputs are the onboarding-complete flag and whether the shell was
ordered out for a permission prompt. `AuthSessionCoordinator` remains the sole owner of session
death; this change means the process is still alive to hear the permission answer.

## Failure class (fixes)

Failure-Class: none

Line-Count-Exception: desktop/macos/Desktop/Sources/OmiApp.swift | 1620 -> 1625 | The terminate handler now consults the shared policy and logs the permission-prompt case distinctly from the user-closed-window case, so the two reasons for losing the last window are separable in a log.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

