### PR TITLE
feat(observability): catch post-200 stream failures

### DIFF
--- a/backend/desktop_backend.py
+++ b/backend/desktop_backend.py
@@ -15,6 +15,7 @@ from routers import (
     desktop_core,
     desktop_deprecated,
     desktop_proxy,
+    metrics,
     desktop_proactivity,
     desktop_realtime,
     desktop_screen_crisp,
@@ -94,6 +95,7 @@ def _build_app() -> FastAPI:
     app.include_router(desktop_screen_crisp.router)
     app.include_router(desktop_tts_updates.router)
     app.include_router(desktop_deprecated.router)
+    app.include_router(metrics.router)
     return app
 
 

--- a/backend/docs/runbooks/real-traffic-journeys.md
+++ b/backend/docs/runbooks/real-traffic-journeys.md
@@ -30,6 +30,57 @@ or `cancelled`; its terminal `phase` is exactly `transcript_delivery`,
 `unknown`. There are no user, conversation, request, error-text, revision,
 image, provider-model, or content labels.
 
+## Client-segmented journey foundation
+
+The existing `omi_journey_*` family above is intentionally unchanged. It is a
+closed, alert-backed contract with historical `stale` semantics. New semantic
+journeys use a separate family so adding client segmentation does not silently
+rewrite that contract:
+
+| Metric | Labels | Meaning |
+| --- | --- | --- |
+| `omi_client_journey_accepted_total` | `journey`, `client_kind` | A semantic journey was accepted. |
+| `omi_client_journey_terminal_total` | `journey`, `client_kind`, `outcome` | Its one-shot coarse terminal result. |
+| `omi_client_journey_issues_total` | `journey`, `client_kind`, `issue_class` | One bounded detail for a failed, degraded, or unknown terminal. |
+| `omi_client_journey_duration_seconds` | `journey`, `outcome` | Acceptance-to-terminal duration. |
+
+`outcome` is `success`, `failure`, `degraded`, `cancelled`, or the coercion
+sentinel `unknown`. `degraded` means the request completed but did not deliver
+the requested primary product result. `canned_fallback` and `quota_capped` stay
+separate `issue_class` values; they must not be inferred from the coarse
+outcome. Failure/degradation detail is a separate counter, and `client_kind` is
+omitted from the histogram, to avoid multiplying every histogram bucket.
+
+`client_kind` prefers the bounded `X-App-Platform` value, then recognizes only
+known User-Agent families. Headerless CFNetwork and Electron clients resolve to
+macOS and Windows respectively; headerless Dart resolves to
+`dart_mobile_unknown_os`. Both pi-mono extensions currently send the same
+`OpenAI/JS 6.26.0` User-Agent, so both resolve to `pi_mono_unknown_os`. The
+server cannot separate them until the clients send `X-App-Platform`; it must not
+guess an operating system.
+
+The family is zero-initialized but has no per-journey call sites or alerts yet.
+A zero is meaningful only with the owning scrape job/revision selected; an
+unrelated healthy exporter also exposes the bounded zero children. Its closed
+cartesian product is capped at 3,915 Prometheus series per process with the
+pinned client's `_created` series enabled: 180 accepted, 900 terminal, 1,980
+issue, and 855 histogram series.
+
+Streaming callers must pass their source through
+`ClientJourneyAttempt.observe_stream` and provide both semantic predicates. A
+`[DONE]` frame is only a success candidate; `failure_when` must recognize every
+in-band error frame and assign its bounded `failure_class`. A detected error
+terminalizes immediately and cannot be overwritten by a later `[DONE]` or clean
+stream exhaustion. This is what detects failures emitted after HTTP 200 headers
+have already been committed.
+
+Acceptance and terminal counters are event rates, not an in-flight gauge.
+Never subtract them to infer backlog across processes or restarts. A journey
+accepted in one process and completed in another must persist its acceptance
+time for duration, export both sides to the same telemetry backend, and use a
+durable lifecycle projection/queue gauge for outstanding work. Capture
+finalization's `listen_finalization_durable_jobs` is the existing pattern.
+
 ## Boundary semantics
 
 - `chat_response` is accepted after `/v2/messages` has persisted the human

--- a/backend/tests/unit/test_client_journey_foundation.py
+++ b/backend/tests/unit/test_client_journey_foundation.py
@@ -349,3 +349,59 @@ def test_never_iterated_stream_is_cancelled_when_abandoned(monkeypatch):
     gc.collect()
 
     assert attempt.outcome == 'cancelled'
+
+
+def test_recorders_are_fail_open_and_still_report_their_own_breakage(monkeypatch, caplog):
+    """A broken recorder must not break the request, and must not be silent.
+
+    A recorder that quietly stops writing is indistinguishable from a healthy
+    path with nothing to report. That is the exact failure this metric family
+    exists to expose, so it must not be reproduced inside the family itself.
+    """
+    _install_client_journey_metrics(monkeypatch)
+    monkeypatch.setattr(journeys, '_last_recorder_warning_at', 0.0)
+    for name in (
+        'OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL',
+        'OMI_CLIENT_JOURNEY_TERMINAL_TOTAL',
+        'OMI_CLIENT_JOURNEY_DURATION_SECONDS',
+        'OMI_CLIENT_JOURNEY_ISSUES_TOTAL',
+    ):
+        broken = MagicMock()
+        broken.labels.side_effect = RuntimeError('metric backend is down')
+        monkeypatch.setattr(journeys, name, broken)
+
+    with caplog.at_level('WARNING'):
+        journeys.record_client_journey_accepted('desktop_chat', 'desktop_macos')
+        journeys.record_client_journey_terminal(
+            'desktop_chat', 'desktop_macos', 'failure', 1.0, issue_class='provider_error'
+        )
+
+    assert 'client_journey_metric_record_failed' in caplog.text
+
+
+def test_a_failing_recorder_never_reaches_the_user_stream(monkeypatch):
+    _install_client_journey_metrics(monkeypatch)
+    broken = MagicMock()
+    broken.labels.side_effect = RuntimeError('metric backend is down')
+    monkeypatch.setattr(journeys, 'OMI_CLIENT_JOURNEY_TERMINAL_TOTAL', broken)
+    monkeypatch.setattr(journeys, 'OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL', broken)
+
+    attempt = journeys.ClientJourneyAttempt('desktop_chat', 'desktop_macos')
+
+    async def source():
+        yield b'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'
+        yield _DESKTOP_CHAT_DONE_FRAME
+
+    async def drain():
+        return [
+            item
+            async for item in attempt.observe_stream(
+                source(),
+                success_when=lambda item: b'data: [DONE]' in item,
+                failure_when=lambda item: b'"error"' in item,
+            )
+        ]
+
+    delivered = asyncio.run(drain())
+
+    assert len(delivered) == 2

--- a/backend/tests/unit/test_client_journey_foundation.py
+++ b/backend/tests/unit/test_client_journey_foundation.py
@@ -1,0 +1,351 @@
+import asyncio
+import gc
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.requests import ClientDisconnect
+
+from utils import metrics
+from utils.journey_metrics_contract import (
+    CLIENT_JOURNEY_ISSUE_CLASSES,
+    CLIENT_JOURNEY_OUTCOMES,
+    CLIENT_JOURNEYS,
+    CLIENT_KINDS,
+    _bounded,
+    bounded_client_journey,
+    bounded_client_journey_issue_class,
+    bounded_client_journey_outcome,
+    bounded_client_kind,
+    resolve_client_kind,
+    resolve_client_kind_from_headers,
+)
+from utils.observability import journeys
+
+
+def _install_client_journey_metrics(monkeypatch):
+    accepted = MagicMock()
+    terminal = MagicMock()
+    issues = MagicMock()
+    duration = MagicMock()
+    for metric in (accepted, terminal, issues, duration):
+        metric.labels.return_value = MagicMock()
+    monkeypatch.setattr(journeys, 'OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL', accepted)
+    monkeypatch.setattr(journeys, 'OMI_CLIENT_JOURNEY_TERMINAL_TOTAL', terminal)
+    monkeypatch.setattr(journeys, 'OMI_CLIENT_JOURNEY_ISSUES_TOTAL', issues)
+    monkeypatch.setattr(journeys, 'OMI_CLIENT_JOURNEY_DURATION_SECONDS', duration)
+    return accepted, terminal, issues, duration
+
+
+def _sample_label_sets(metric, sample_name):
+    return {
+        tuple(sorted(sample.labels.items()))
+        for family in metric.collect()
+        for sample in family.samples
+        if sample.name == sample_name
+    }
+
+
+def test_label_coercion_collapses_unbounded_values_to_unknown():
+    raw = 'USER PROVIDED ' + ('x' * 10_000)
+
+    assert len(_bounded(raw)) == 128
+    assert bounded_client_journey(raw) == 'unknown'
+    assert bounded_client_journey_outcome(raw) == 'unknown'
+    assert bounded_client_journey_issue_class(raw) == 'unknown'
+    assert bounded_client_kind(raw) == 'unknown'
+
+
+@pytest.mark.parametrize(
+    ('platform', 'expected'),
+    [
+        ('android', 'mobile_android'),
+        ('ios', 'mobile_ios'),
+        ('macos', 'desktop_macos'),
+        ('windows', 'desktop_windows'),
+        ('linux', 'desktop_linux'),
+        ('web', 'web'),
+    ],
+)
+def test_client_kind_prefers_known_platform_header(platform, expected):
+    assert resolve_client_kind(x_app_platform=platform, user_agent='OpenAI/JS 6.26.0') == expected
+
+
+def test_client_kind_maps_known_headerless_populations_without_inventing_pi_mono_os():
+    assert (
+        resolve_client_kind(
+            x_app_platform=None,
+            user_agent='Omi/1.0 CFNetwork/1568.200.51 Darwin/24.1.0',
+        )
+        == 'desktop_macos'
+    )
+    assert (
+        resolve_client_kind(
+            x_app_platform=None,
+            user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/128 Electron/32.0.0',
+        )
+        == 'desktop_windows'
+    )
+    assert resolve_client_kind(x_app_platform=None, user_agent='Dart/3.8 (dart:io)') == 'dart_mobile_unknown_os'
+
+    pi_mono_user_agent = 'OpenAI/JS 6.26.0'
+    for platform, platform_kind in (('macos', 'desktop_macos'), ('windows', 'desktop_windows')):
+        assert resolve_client_kind(x_app_platform=platform, user_agent=pi_mono_user_agent) == platform_kind
+        assert resolve_client_kind(x_app_platform=None, user_agent=pi_mono_user_agent) == 'pi_mono_unknown_os'
+
+
+def test_client_kind_unknown_header_does_not_fall_through_to_user_agent():
+    assert (
+        resolve_client_kind_from_headers({'X-App-Platform': 'new-unbounded-client', 'User-Agent': 'OpenAI/JS 6.26.0'})
+        == 'unknown'
+    )
+
+
+def test_client_kind_non_string_header_collapses_to_unknown():
+    assert resolve_client_kind(x_app_platform=object(), user_agent='OpenAI/JS 6.26.0') == 'unknown'
+
+
+def test_client_journey_metrics_zero_initialize_the_complete_bounded_contract():
+    accepted = _sample_label_sets(metrics.OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL, 'omi_client_journey_accepted_total')
+    terminal = _sample_label_sets(metrics.OMI_CLIENT_JOURNEY_TERMINAL_TOTAL, 'omi_client_journey_terminal_total')
+    issues = _sample_label_sets(metrics.OMI_CLIENT_JOURNEY_ISSUES_TOTAL, 'omi_client_journey_issues_total')
+    duration = _sample_label_sets(
+        metrics.OMI_CLIENT_JOURNEY_DURATION_SECONDS, 'omi_client_journey_duration_seconds_count'
+    )
+
+    assert len(accepted) == len(CLIENT_JOURNEYS) * len(CLIENT_KINDS)
+    assert len(terminal) == len(CLIENT_JOURNEYS) * len(CLIENT_KINDS) * len(CLIENT_JOURNEY_OUTCOMES)
+    assert len(issues) == len(CLIENT_JOURNEYS) * len(CLIENT_KINDS) * len(CLIENT_JOURNEY_ISSUE_CLASSES)
+    assert len(duration) == len(CLIENT_JOURNEYS) * len(CLIENT_JOURNEY_OUTCOMES)
+    assert (
+        ('client_kind', 'pi_mono_unknown_os'),
+        ('journey', 'desktop_chat'),
+    ) in accepted
+    assert (
+        ('client_kind', 'desktop_macos'),
+        ('journey', 'desktop_chat'),
+        ('outcome', 'degraded'),
+    ) in terminal
+
+
+def test_streaming_attempt_records_failure_when_stream_breaks_after_success_candidate(monkeypatch):
+    _accepted, terminal, issues, duration = _install_client_journey_metrics(monkeypatch)
+    clock_values = iter((10.0, 12.0))
+    attempt = journeys.ClientJourneyAttempt(
+        'desktop_chat',
+        'desktop_macos',
+        clock=lambda: next(clock_values),
+    )
+
+    async def broken_stream():
+        yield 'terminal-content-frame'
+        raise RuntimeError('stream failed after headers')
+
+    async def consume():
+        async for _item in attempt.observe_stream(
+            broken_stream(),
+            success_when=lambda item: item == 'terminal-content-frame',
+            failure_when=lambda _item: False,
+            failure_class='provider_error',
+        ):
+            pass
+
+    with pytest.raises(RuntimeError, match='after headers'):
+        asyncio.run(consume())
+
+    assert attempt.outcome == 'failure'
+    terminal.labels.assert_called_once_with(
+        journey='desktop_chat',
+        client_kind='desktop_macos',
+        outcome='failure',
+    )
+    issues.labels.assert_called_once_with(
+        journey='desktop_chat',
+        client_kind='desktop_macos',
+        issue_class='provider_error',
+    )
+    duration.labels.assert_called_once_with(journey='desktop_chat', outcome='failure')
+
+
+def test_streaming_attempt_records_success_only_after_clean_exhaustion(monkeypatch):
+    _accepted, terminal, issues, _duration = _install_client_journey_metrics(monkeypatch)
+    clock_values = iter((20.0, 21.0))
+    attempt = journeys.ClientJourneyAttempt(
+        'desktop_chat',
+        'desktop_windows',
+        clock=lambda: next(clock_values),
+    )
+
+    async def complete_stream():
+        yield 'terminal-content-frame'
+
+    async def consume():
+        async for _item in attempt.observe_stream(
+            complete_stream(),
+            success_when=lambda item: item == 'terminal-content-frame',
+            failure_when=lambda _item: False,
+        ):
+            pass
+
+    asyncio.run(consume())
+
+    assert attempt.outcome == 'success'
+    terminal.labels.assert_called_once_with(
+        journey='desktop_chat',
+        client_kind='desktop_windows',
+        outcome='success',
+    )
+    issues.labels.assert_not_called()
+
+
+_DESKTOP_CHAT_ERROR_FRAME = (
+    b'data: {"error":{"message":"Upstream provider error","type":"server_error","code":502}}\n\n'
+)
+_DESKTOP_CHAT_DONE_FRAME = b'data: [DONE]\n\n'
+
+
+def test_streaming_attempt_error_frame_wins_over_later_done(monkeypatch):
+    _accepted, terminal, issues, _duration = _install_client_journey_metrics(monkeypatch)
+    clock_values = iter((30.0, 31.0))
+    attempt = journeys.ClientJourneyAttempt(
+        'desktop_chat',
+        'pi_mono_unknown_os',
+        clock=lambda: next(clock_values),
+    )
+
+    async def incident_stream():
+        # Literal desktop_chat gateway-rejection frames, including _sse's compact JSON.
+        yield _DESKTOP_CHAT_ERROR_FRAME
+        yield _DESKTOP_CHAT_DONE_FRAME
+
+    async def consume():
+        return [
+            item
+            async for item in attempt.observe_stream(
+                incident_stream(),
+                success_when=lambda item: b'data: [DONE]' in item,
+                failure_when=lambda item: b'"error":' in item,
+                failure_class='upstream_rejected',
+            )
+        ]
+
+    assert asyncio.run(consume()) == [_DESKTOP_CHAT_ERROR_FRAME, _DESKTOP_CHAT_DONE_FRAME]
+    assert attempt.outcome == 'failure'
+    assert attempt.issue_class == 'upstream_rejected'
+    terminal.labels.assert_called_once_with(
+        journey='desktop_chat',
+        client_kind='pi_mono_unknown_os',
+        outcome='failure',
+    )
+    issues.labels.assert_called_once_with(
+        journey='desktop_chat',
+        client_kind='pi_mono_unknown_os',
+        issue_class='upstream_rejected',
+    )
+
+
+@pytest.mark.parametrize(
+    ('frames', 'expected_issue'),
+    [
+        ([], 'empty_answer'),
+        ([_DESKTOP_CHAT_ERROR_FRAME], 'upstream_rejected'),
+    ],
+)
+def test_streaming_attempt_empty_and_error_only_streams_fail(monkeypatch, frames, expected_issue):
+    _install_client_journey_metrics(monkeypatch)
+    attempt = journeys.ClientJourneyAttempt('desktop_chat', 'desktop_macos')
+
+    async def source():
+        for frame in frames:
+            yield frame
+
+    async def consume():
+        async for _item in attempt.observe_stream(
+            source(),
+            success_when=lambda item: b'data: [DONE]' in item,
+            failure_when=lambda item: b'"error":' in item,
+            failure_class='upstream_rejected',
+        ):
+            pass
+
+    asyncio.run(consume())
+
+    assert attempt.outcome == 'failure'
+    assert attempt.issue_class == expected_issue
+
+
+def test_context_exit_defers_to_attached_stream(monkeypatch):
+    _install_client_journey_metrics(monkeypatch)
+    attempt = journeys.ClientJourneyAttempt('desktop_chat', 'desktop_windows')
+
+    async def complete_stream():
+        yield _DESKTOP_CHAT_DONE_FRAME
+
+    with attempt:
+        observed = attempt.observe_stream(
+            complete_stream(),
+            success_when=lambda item: b'data: [DONE]' in item,
+            failure_when=lambda _item: False,
+        )
+
+    assert attempt.outcome is None
+
+    async def consume():
+        async for _item in observed:
+            pass
+
+    asyncio.run(consume())
+    assert attempt.outcome == 'success'
+
+
+def test_context_exit_without_terminal_fails(monkeypatch):
+    _install_client_journey_metrics(monkeypatch)
+    attempt = journeys.ClientJourneyAttempt('desktop_chat', 'desktop_windows')
+
+    with attempt:
+        pass
+
+    assert attempt.outcome == 'failure'
+    assert attempt.issue_class == 'incomplete_attempt'
+
+
+@pytest.mark.parametrize('disconnect', [asyncio.CancelledError(), ClientDisconnect(), OSError('client disconnected')])
+def test_streaming_attempt_disconnects_are_cancelled(monkeypatch, disconnect):
+    _install_client_journey_metrics(monkeypatch)
+    attempt = journeys.ClientJourneyAttempt('desktop_chat', 'desktop_macos')
+
+    async def disconnected_stream():
+        if False:
+            yield b''
+        raise disconnect
+
+    async def consume():
+        async for _item in attempt.observe_stream(
+            disconnected_stream(),
+            success_when=lambda item: b'data: [DONE]' in item,
+            failure_when=lambda _item: False,
+        ):
+            pass
+
+    with pytest.raises(type(disconnect)):
+        asyncio.run(consume())
+
+    assert attempt.outcome == 'cancelled'
+    assert attempt.issue_class is None
+
+
+def test_never_iterated_stream_is_cancelled_when_abandoned(monkeypatch):
+    _install_client_journey_metrics(monkeypatch)
+    attempt = journeys.ClientJourneyAttempt('desktop_chat', 'desktop_macos')
+
+    async def source():
+        yield _DESKTOP_CHAT_DONE_FRAME
+
+    observed = attempt.observe_stream(
+        source(),
+        success_when=lambda item: b'data: [DONE]' in item,
+        failure_when=lambda _item: False,
+    )
+    del observed
+    gc.collect()
+
+    assert attempt.outcome == 'cancelled'

--- a/backend/tests/unit/test_desktop_backend_cors.py
+++ b/backend/tests/unit/test_desktop_backend_cors.py
@@ -146,3 +146,20 @@ def test_module_level_app_loads_environment_before_building_cors(monkeypatch):
 
     assert response.status_code == 200
     assert response.headers['access-control-allow-origin'] == 'https://app.example'
+
+
+def test_desktop_backend_mounts_authenticated_metrics(monkeypatch):
+    monkeypatch.setenv('METRICS_SECRET', 'test-metrics-secret')
+    client = _test_client(monkeypatch, desktop_backend._build_app())
+
+    with client:
+        unauthorized = client.get('/metrics')
+        response = client.get(
+            '/metrics',
+            headers={'Authorization': 'Bearer test-metrics-secret'},
+        )
+
+    assert unauthorized.status_code == 401
+    assert response.status_code == 200
+    assert response.headers['content-type'].startswith('text/plain')
+    assert 'omi_client_journey_accepted_total' in response.text

--- a/backend/utils/journey_metrics_contract.py
+++ b/backend/utils/journey_metrics_contract.py
@@ -13,7 +13,7 @@ unattributable population into misleading telemetry. Once those clients send
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Literal, cast
+from typing import Literal
 
 ClientJourneyName = Literal[
     'desktop_chat',
@@ -125,28 +125,22 @@ def _bounded(value: object | None, *, max_length: int = 128) -> str:
 
 def bounded_client_journey(value: object | None) -> ClientJourneyName:
     normalized = _bounded(value)
-    return cast(ClientJourneyName, normalized if normalized in _CLIENT_JOURNEY_SET else 'unknown')
+    return normalized if normalized in _CLIENT_JOURNEY_SET else 'unknown'
 
 
 def bounded_client_journey_outcome(value: object | None) -> ClientJourneyOutcome:
     normalized = _bounded(value)
-    return cast(
-        ClientJourneyOutcome,
-        normalized if normalized in _CLIENT_JOURNEY_OUTCOME_SET else 'unknown',
-    )
+    return normalized if normalized in _CLIENT_JOURNEY_OUTCOME_SET else 'unknown'
 
 
 def bounded_client_journey_issue_class(value: object | None) -> ClientJourneyIssueClass:
     normalized = _bounded(value)
-    return cast(
-        ClientJourneyIssueClass,
-        normalized if normalized in _CLIENT_JOURNEY_ISSUE_CLASS_SET else 'unknown',
-    )
+    return normalized if normalized in _CLIENT_JOURNEY_ISSUE_CLASS_SET else 'unknown'
 
 
 def bounded_client_kind(value: object | None) -> ClientKind:
     normalized = _bounded(value)
-    return cast(ClientKind, normalized if normalized in _CLIENT_KIND_SET else 'unknown')
+    return normalized if normalized in _CLIENT_KIND_SET else 'unknown'
 
 
 def resolve_client_kind(*, x_app_platform: object | None, user_agent: object | None) -> ClientKind:

--- a/backend/utils/journey_metrics_contract.py
+++ b/backend/utils/journey_metrics_contract.py
@@ -1,0 +1,186 @@
+"""Bounded label contract for client-segmented product journey metrics.
+
+``X-App-Platform`` is authoritative when present. User-Agent matching is only
+a compatibility fallback for clients that have not adopted that header.
+
+The macOS and Windows pi-mono extensions currently send the identical
+``OpenAI/JS 6.26.0`` User-Agent without a platform header. They are deliberately
+reported as ``pi_mono_unknown_os``; inferring an operating system would turn an
+unattributable population into misleading telemetry. Once those clients send
+``X-App-Platform``, the header resolves them to the corresponding desktop kind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal, cast
+
+ClientJourneyName = Literal[
+    'desktop_chat',
+    'mobile_chat',
+    'live_transcription',
+    'conversation_finalization',
+    'memory_retrieval',
+    'desktop_proactivity',
+    'app_webhook_delivery',
+    'realtime_voice',
+    'unknown',
+]
+ClientJourneyOutcome = Literal['success', 'failure', 'degraded', 'cancelled', 'unknown']
+ClientJourneyIssueClass = Literal[
+    'upstream_rejected',
+    'upstream_timeout',
+    'provider_error',
+    'empty_answer',
+    'invalid_response',
+    'dependency_unavailable',
+    'quota_capped',
+    'canned_fallback',
+    'incomplete_attempt',
+    'incomplete_stream',
+    'unknown',
+]
+ClientKind = Literal[
+    'mobile_android',
+    'mobile_ios',
+    'desktop_macos',
+    'desktop_windows',
+    'desktop_linux',
+    'desktop_unknown_os',
+    'web',
+    'dart_mobile_unknown_os',
+    'pi_mono_unknown_os',
+    'unknown',
+]
+
+CLIENT_JOURNEYS: tuple[ClientJourneyName, ...] = (
+    'desktop_chat',
+    'mobile_chat',
+    'live_transcription',
+    'conversation_finalization',
+    'memory_retrieval',
+    'desktop_proactivity',
+    'app_webhook_delivery',
+    'realtime_voice',
+    'unknown',
+)
+CLIENT_JOURNEY_OUTCOMES: tuple[ClientJourneyOutcome, ...] = (
+    'success',
+    'failure',
+    'degraded',
+    'cancelled',
+    'unknown',
+)
+CLIENT_JOURNEY_ISSUE_CLASSES: tuple[ClientJourneyIssueClass, ...] = (
+    'upstream_rejected',
+    'upstream_timeout',
+    'provider_error',
+    'empty_answer',
+    'invalid_response',
+    'dependency_unavailable',
+    'quota_capped',
+    'canned_fallback',
+    'incomplete_attempt',
+    'incomplete_stream',
+    'unknown',
+)
+CLIENT_KINDS: tuple[ClientKind, ...] = (
+    'mobile_android',
+    'mobile_ios',
+    'desktop_macos',
+    'desktop_windows',
+    'desktop_linux',
+    'desktop_unknown_os',
+    'web',
+    'dart_mobile_unknown_os',
+    'pi_mono_unknown_os',
+    'unknown',
+)
+
+_CLIENT_JOURNEY_SET = frozenset(CLIENT_JOURNEYS)
+_CLIENT_JOURNEY_OUTCOME_SET = frozenset(CLIENT_JOURNEY_OUTCOMES)
+_CLIENT_JOURNEY_ISSUE_CLASS_SET = frozenset(CLIENT_JOURNEY_ISSUE_CLASSES)
+_CLIENT_KIND_SET = frozenset(CLIENT_KINDS)
+_PLATFORM_CLIENT_KIND: dict[str, ClientKind] = {
+    'android': 'mobile_android',
+    'ios': 'mobile_ios',
+    'macos': 'desktop_macos',
+    'windows': 'desktop_windows',
+    'linux': 'desktop_linux',
+    'desktop': 'desktop_unknown_os',
+    'mobile': 'dart_mobile_unknown_os',
+    'web': 'web',
+}
+
+
+def _bounded(value: object | None, *, max_length: int = 128) -> str:
+    """Normalize and truncate a possible label value before allowlist lookup."""
+
+    raw_value = getattr(value, 'value', value)
+    if raw_value is None:
+        return 'unknown'
+    normalized = str(raw_value).strip().lower().replace(' ', '_').replace('-', '_')
+    return normalized[:max_length] if normalized else 'unknown'
+
+
+def bounded_client_journey(value: object | None) -> ClientJourneyName:
+    normalized = _bounded(value)
+    return cast(ClientJourneyName, normalized if normalized in _CLIENT_JOURNEY_SET else 'unknown')
+
+
+def bounded_client_journey_outcome(value: object | None) -> ClientJourneyOutcome:
+    normalized = _bounded(value)
+    return cast(
+        ClientJourneyOutcome,
+        normalized if normalized in _CLIENT_JOURNEY_OUTCOME_SET else 'unknown',
+    )
+
+
+def bounded_client_journey_issue_class(value: object | None) -> ClientJourneyIssueClass:
+    normalized = _bounded(value)
+    return cast(
+        ClientJourneyIssueClass,
+        normalized if normalized in _CLIENT_JOURNEY_ISSUE_CLASS_SET else 'unknown',
+    )
+
+
+def bounded_client_kind(value: object | None) -> ClientKind:
+    normalized = _bounded(value)
+    return cast(ClientKind, normalized if normalized in _CLIENT_KIND_SET else 'unknown')
+
+
+def resolve_client_kind(*, x_app_platform: object | None, user_agent: object | None) -> ClientKind:
+    """Resolve a closed client population, preferring the explicit platform.
+
+    An unrecognized non-empty platform remains ``unknown`` instead of falling
+    through to a potentially contradictory User-Agent. Header values of the
+    wrong type also collapse to ``unknown`` instead of raising or falling back.
+    """
+
+    if x_app_platform is not None and not isinstance(x_app_platform, str):
+        return 'unknown'
+    if isinstance(x_app_platform, str) and x_app_platform.strip():
+        return _PLATFORM_CLIENT_KIND.get(_bounded(x_app_platform), 'unknown')
+    if user_agent is not None and not isinstance(user_agent, str):
+        return 'unknown'
+
+    normalized_user_agent = _bounded(user_agent, max_length=256)
+    if 'openai/js' in normalized_user_agent:
+        return 'pi_mono_unknown_os'
+    if 'cfnetwork/' in normalized_user_agent or 'darwin/' in normalized_user_agent:
+        return 'desktop_macos'
+    if 'electron/' in normalized_user_agent and 'windows' in normalized_user_agent:
+        return 'desktop_windows'
+    if normalized_user_agent.startswith('dart/') or 'dart:io' in normalized_user_agent:
+        return 'dart_mobile_unknown_os'
+    return 'unknown'
+
+
+def resolve_client_kind_from_headers(headers: Mapping[str, str]) -> ClientKind:
+    """Resolve client kind from a case-insensitive HTTP header mapping."""
+
+    normalized_headers = {key.lower(): value for key, value in headers.items()}
+    return resolve_client_kind(
+        x_app_platform=normalized_headers.get('x-app-platform'),
+        user_agent=normalized_headers.get('user-agent'),
+    )

--- a/backend/utils/metrics.py
+++ b/backend/utils/metrics.py
@@ -1,6 +1,13 @@
 from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST
 from fastapi import Response
 
+from utils.journey_metrics_contract import (
+    CLIENT_JOURNEY_ISSUE_CLASSES,
+    CLIENT_JOURNEY_OUTCOMES,
+    CLIENT_JOURNEYS,
+    CLIENT_KINDS,
+)
+
 BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS = Gauge(
     'backend_listen_active_ws_connections',
     'Number of currently active WebSocket connections in backend-listen',
@@ -77,6 +84,54 @@ for _journey in ('chat_response', 'pusher_session', 'capture_finalization'):
         OMI_JOURNEY_LATENCY_SECONDS.labels(journey=_journey, outcome=_outcome)
 for _outcome in ('requeued', 'enqueue_failed'):
     OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL.labels(outcome=_outcome)
+
+OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL = Counter(
+    'omi_client_journey_accepted_total',
+    'Accepted client-segmented product journeys by bounded journey and client kind',
+    ['journey', 'client_kind'],
+)
+
+OMI_CLIENT_JOURNEY_TERMINAL_TOTAL = Counter(
+    'omi_client_journey_terminal_total',
+    'Terminal client-segmented product journey outcomes by bounded labels',
+    ['journey', 'client_kind', 'outcome'],
+)
+
+OMI_CLIENT_JOURNEY_ISSUES_TOTAL = Counter(
+    'omi_client_journey_issues_total',
+    'Bounded issue detail for failed or degraded client-segmented product journeys',
+    ['journey', 'client_kind', 'issue_class'],
+)
+
+OMI_CLIENT_JOURNEY_DURATION_SECONDS = Histogram(
+    'omi_client_journey_duration_seconds',
+    'Elapsed time from acceptance to terminal client-segmented journey outcome',
+    ['journey', 'outcome'],
+    buckets=(0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 900, 3600, 21600, 86400),
+)
+
+# This is a separate, versioned contract from the legacy omi_journey_* family
+# above. Keep client_kind off the histogram: its 16 bucket series per child
+# would multiply the most expensive metric without helping outcome segmentation.
+# Initialize the complete bounded product so healthy-but-idle exporters expose
+# zeros instead of making an idle process indistinguishable from a missing one.
+for _journey in CLIENT_JOURNEYS:
+    for _client_kind in CLIENT_KINDS:
+        OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL.labels(journey=_journey, client_kind=_client_kind)
+        for _outcome in CLIENT_JOURNEY_OUTCOMES:
+            OMI_CLIENT_JOURNEY_TERMINAL_TOTAL.labels(
+                journey=_journey,
+                client_kind=_client_kind,
+                outcome=_outcome,
+            )
+        for _issue_class in CLIENT_JOURNEY_ISSUE_CLASSES:
+            OMI_CLIENT_JOURNEY_ISSUES_TOTAL.labels(
+                journey=_journey,
+                client_kind=_client_kind,
+                issue_class=_issue_class,
+            )
+    for _outcome in CLIENT_JOURNEY_OUTCOMES:
+        OMI_CLIENT_JOURNEY_DURATION_SECONDS.labels(journey=_journey, outcome=_outcome)
 
 LISTEN_FINALIZATION_OLDEST_NONTERMINAL_AGE_SECONDS = Gauge(
     'listen_finalization_oldest_nonterminal_age_seconds',

--- a/backend/utils/observability/journeys.py
+++ b/backend/utils/observability/journeys.py
@@ -109,19 +109,19 @@ class _ObservedClientJourneyStream(AsyncIterator[_StreamItem]):
 
     async def aclose(self) -> None:
         if self._iterator is None:
-            self._attempt._abandon_stream()
+            self._attempt.abandon_stream()
             return
         close = getattr(self._iterator, 'aclose', None)
         if close is not None:
             await close()
         if not self._attempt.finished:
-            self._attempt._abandon_stream()
+            self._attempt.abandon_stream()
 
     def __del__(self) -> None:
         attempt = getattr(self, '_attempt', None)
         if attempt is not None and not attempt.finished:
             try:
-                attempt._abandon_stream()
+                attempt.abandon_stream()
             except Exception:
                 # Object finalizers may run during interpreter shutdown.
                 pass
@@ -252,7 +252,9 @@ class ClientJourneyAttempt:
     def cancel(self) -> None:
         self.finish('cancelled')
 
-    def _abandon_stream(self) -> None:
+    def abandon_stream(self) -> None:
+        """Terminalize an attached stream that was not exhausted."""
+
         self._stream_active = False
         self._stream_attached = False
         self.cancel()
@@ -290,7 +292,7 @@ class ClientJourneyAttempt:
                             success_observed = True
                     yield item
             except (asyncio.CancelledError, GeneratorExit, ClientDisconnect, OSError):
-                self._abandon_stream()
+                self.abandon_stream()
                 raise
             except BaseException:
                 self._stream_active = False

--- a/backend/utils/observability/journeys.py
+++ b/backend/utils/observability/journeys.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import threading
 from collections.abc import AsyncIterable, AsyncIterator, Callable
 from datetime import datetime, timezone
 from time import monotonic
@@ -127,13 +129,46 @@ class _ObservedClientJourneyStream(AsyncIterator[_StreamItem]):
                 pass
 
 
+logger = logging.getLogger(__name__)
+
+_RECORDER_WARNING_INTERVAL_SECONDS = 60.0
+_recorder_warning_lock = threading.Lock()
+_last_recorder_warning_at = 0.0
+
+
+def _record_fail_open(what: str, record: Callable[[], None]) -> None:
+    """Run a metric write that must never propagate into a product request.
+
+    Observability is not allowed to break the thing it observes. It is equally
+    not allowed to fail silently: a recorder that quietly stops writing is
+    indistinguishable from a healthy path with nothing to report, which is the
+    failure mode this whole metric family exists to make visible. Failures are
+    swallowed for the caller and logged at a bounded rate for the operator.
+    """
+
+    global _last_recorder_warning_at
+    try:
+        record()
+    except Exception:
+        now = monotonic()
+        with _recorder_warning_lock:
+            due = now - _last_recorder_warning_at >= _RECORDER_WARNING_INTERVAL_SECONDS
+            if due:
+                _last_recorder_warning_at = now
+        if due:
+            logger.warning('client_journey_metric_record_failed what=%s', what, exc_info=True)
+
+
 def record_client_journey_accepted(journey: object, client_kind: object) -> None:
     """Record a bounded acceptance event without creating labels from raw input."""
 
-    OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL.labels(
-        journey=bounded_client_journey(journey),
-        client_kind=bounded_client_kind(client_kind),
-    ).inc()
+    _record_fail_open(
+        'accepted',
+        lambda: OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL.labels(
+            journey=bounded_client_journey(journey),
+            client_kind=bounded_client_kind(client_kind),
+        ).inc(),
+    )
 
 
 def record_client_journey_terminal(
@@ -151,24 +186,27 @@ def record_client_journey_terminal(
     not queue state and must never be subtracted to infer in-flight work.
     """
 
-    journey_label = bounded_client_journey(journey)
-    client_kind_label = bounded_client_kind(client_kind)
-    outcome_label = bounded_client_journey_outcome(outcome)
-    OMI_CLIENT_JOURNEY_TERMINAL_TOTAL.labels(
-        journey=journey_label,
-        client_kind=client_kind_label,
-        outcome=outcome_label,
-    ).inc()
-    OMI_CLIENT_JOURNEY_DURATION_SECONDS.labels(
-        journey=journey_label,
-        outcome=outcome_label,
-    ).observe(max(0.0, elapsed_seconds))
-    if outcome_label in {'failure', 'degraded', 'unknown'}:
-        OMI_CLIENT_JOURNEY_ISSUES_TOTAL.labels(
+    def _record() -> None:
+        journey_label = bounded_client_journey(journey)
+        client_kind_label = bounded_client_kind(client_kind)
+        outcome_label = bounded_client_journey_outcome(outcome)
+        OMI_CLIENT_JOURNEY_TERMINAL_TOTAL.labels(
             journey=journey_label,
             client_kind=client_kind_label,
-            issue_class=bounded_client_journey_issue_class(issue_class),
+            outcome=outcome_label,
         ).inc()
+        OMI_CLIENT_JOURNEY_DURATION_SECONDS.labels(
+            journey=journey_label,
+            outcome=outcome_label,
+        ).observe(max(0.0, elapsed_seconds))
+        if outcome_label in {'failure', 'degraded', 'unknown'}:
+            OMI_CLIENT_JOURNEY_ISSUES_TOTAL.labels(
+                journey=journey_label,
+                client_kind=client_kind_label,
+                issue_class=bounded_client_journey_issue_class(issue_class),
+            ).inc()
+
+    _record_fail_open('terminal', _record)
 
 
 class ClientJourneyAttempt:

--- a/backend/utils/observability/journeys.py
+++ b/backend/utils/observability/journeys.py
@@ -2,15 +2,33 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator, Callable
 from datetime import datetime, timezone
 from time import monotonic
-from typing import Literal, cast
+from typing import Literal, TypeVar, cast
+
+from starlette.requests import ClientDisconnect
 
 from utils.metrics import (
     OMI_CAPTURE_FINALIZATION_RECONCILIATIONS_TOTAL,
+    OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL,
+    OMI_CLIENT_JOURNEY_DURATION_SECONDS,
+    OMI_CLIENT_JOURNEY_ISSUES_TOTAL,
+    OMI_CLIENT_JOURNEY_TERMINAL_TOTAL,
     OMI_JOURNEY_ACCEPTED_TOTAL,
     OMI_JOURNEY_LATENCY_SECONDS,
     OMI_JOURNEY_TERMINAL_TOTAL,
+)
+from utils.journey_metrics_contract import (
+    ClientJourneyIssueClass,
+    ClientJourneyName,
+    ClientJourneyOutcome,
+    ClientKind,
+    bounded_client_journey,
+    bounded_client_journey_issue_class,
+    bounded_client_journey_outcome,
+    bounded_client_kind,
 )
 
 JourneyName = Literal['chat_response', 'pusher_session', 'capture_finalization']
@@ -64,6 +82,236 @@ class JourneyAttempt:
             return
         self._finished = True
         record_journey_terminal(self.journey, outcome, monotonic() - self.started_at)
+
+
+_StreamItem = TypeVar('_StreamItem')
+
+
+class _ObservedClientJourneyStream(AsyncIterator[_StreamItem]):
+    """Lazily start an observed stream and close abandoned attempts."""
+
+    def __init__(
+        self,
+        attempt: 'ClientJourneyAttempt',
+        iterator_factory: Callable[[], AsyncIterator[_StreamItem]],
+    ) -> None:
+        self._attempt = attempt
+        self._iterator_factory = iterator_factory
+        self._iterator: AsyncIterator[_StreamItem] | None = None
+
+    def __aiter__(self) -> '_ObservedClientJourneyStream[_StreamItem]':
+        return self
+
+    async def __anext__(self) -> _StreamItem:
+        if self._iterator is None:
+            self._iterator = self._iterator_factory()
+        return await self._iterator.__anext__()
+
+    async def aclose(self) -> None:
+        if self._iterator is None:
+            self._attempt._abandon_stream()
+            return
+        close = getattr(self._iterator, 'aclose', None)
+        if close is not None:
+            await close()
+        if not self._attempt.finished:
+            self._attempt._abandon_stream()
+
+    def __del__(self) -> None:
+        attempt = getattr(self, '_attempt', None)
+        if attempt is not None and not attempt.finished:
+            try:
+                attempt._abandon_stream()
+            except Exception:
+                # Object finalizers may run during interpreter shutdown.
+                pass
+
+
+def record_client_journey_accepted(journey: object, client_kind: object) -> None:
+    """Record a bounded acceptance event without creating labels from raw input."""
+
+    OMI_CLIENT_JOURNEY_ACCEPTED_TOTAL.labels(
+        journey=bounded_client_journey(journey),
+        client_kind=bounded_client_kind(client_kind),
+    ).inc()
+
+
+def record_client_journey_terminal(
+    journey: object,
+    client_kind: object,
+    outcome: object,
+    elapsed_seconds: float,
+    *,
+    issue_class: object | None = None,
+) -> None:
+    """Record one bounded terminal event plus duration and optional issue detail.
+
+    This function is also the cross-process API: a durable worker can pass an
+    elapsed duration derived from persisted acceptance time. These counters are
+    not queue state and must never be subtracted to infer in-flight work.
+    """
+
+    journey_label = bounded_client_journey(journey)
+    client_kind_label = bounded_client_kind(client_kind)
+    outcome_label = bounded_client_journey_outcome(outcome)
+    OMI_CLIENT_JOURNEY_TERMINAL_TOTAL.labels(
+        journey=journey_label,
+        client_kind=client_kind_label,
+        outcome=outcome_label,
+    ).inc()
+    OMI_CLIENT_JOURNEY_DURATION_SECONDS.labels(
+        journey=journey_label,
+        outcome=outcome_label,
+    ).observe(max(0.0, elapsed_seconds))
+    if outcome_label in {'failure', 'degraded', 'unknown'}:
+        OMI_CLIENT_JOURNEY_ISSUES_TOTAL.labels(
+            journey=journey_label,
+            client_kind=client_kind_label,
+            issue_class=bounded_client_journey_issue_class(issue_class),
+        ).inc()
+
+
+class ClientJourneyAttempt:
+    """Fail-closed client journey attempt with streaming-aware completion.
+
+    A normal context exit without an explicit terminal is a failure. Attaching
+    a stream transfers terminal ownership to the returned iterator so a
+    ``StreamingResponse`` can consume it after the context has exited.
+    """
+
+    def __init__(
+        self,
+        journey: ClientJourneyName,
+        client_kind: ClientKind,
+        *,
+        clock: Callable[[], float] = monotonic,
+    ) -> None:
+        self.journey = bounded_client_journey(journey)
+        self.client_kind = bounded_client_kind(client_kind)
+        self._clock = clock
+        self.started_at = clock()
+        self._outcome: ClientJourneyOutcome | None = None
+        self._issue_class: ClientJourneyIssueClass | None = None
+        self._stream_active = False
+        self._stream_attached = False
+        self._stream_success_requested = False
+        record_client_journey_accepted(self.journey, self.client_kind)
+
+    @property
+    def finished(self) -> bool:
+        return self._outcome is not None
+
+    @property
+    def outcome(self) -> ClientJourneyOutcome | None:
+        return self._outcome
+
+    @property
+    def issue_class(self) -> ClientJourneyIssueClass | None:
+        return self._issue_class
+
+    def __enter__(self) -> 'ClientJourneyAttempt':
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, _exc: BaseException | None, _tb: object) -> bool:
+        if not self.finished and exc_type is not None:
+            self.fail('unknown')
+        elif not self.finished and not self._stream_attached:
+            self.fail('incomplete_attempt')
+        return False
+
+    def finish(self, outcome: object, *, issue_class: object | None = None) -> None:
+        outcome_label = bounded_client_journey_outcome(outcome)
+        if outcome_label == 'success' and self._stream_attached:
+            self._stream_success_requested = True
+            return
+        if self.finished:
+            return
+        self._outcome = outcome_label
+        self._issue_class = (
+            bounded_client_journey_issue_class(issue_class)
+            if outcome_label in {'failure', 'degraded', 'unknown'}
+            else None
+        )
+        record_client_journey_terminal(
+            self.journey,
+            self.client_kind,
+            outcome_label,
+            self._clock() - self.started_at,
+            issue_class=self._issue_class,
+        )
+
+    def succeed(self) -> None:
+        self.finish('success')
+
+    def fail(self, issue_class: object = 'unknown') -> None:
+        self.finish('failure', issue_class=issue_class)
+
+    def degrade(self, issue_class: object) -> None:
+        self.finish('degraded', issue_class=issue_class)
+
+    def cancel(self) -> None:
+        self.finish('cancelled')
+
+    def _abandon_stream(self) -> None:
+        self._stream_active = False
+        self._stream_attached = False
+        self.cancel()
+
+    def observe_stream(
+        self,
+        source: AsyncIterable[_StreamItem],
+        *,
+        success_when: Callable[[_StreamItem], bool],
+        failure_when: Callable[[_StreamItem], bool],
+        failure_class: object = 'provider_error',
+        missing_success_class: object = 'empty_answer',
+    ) -> AsyncIterator[_StreamItem]:
+        """Yield a stream and terminalize only after its semantic contract is known.
+
+        ``failure_when`` terminalizes immediately, so an in-band error frame
+        wins over a later success marker. Seeing a success item is necessary but
+        not sufficient: clean exhaustion is also required, so a later source
+        exception cannot leave a success.
+        """
+
+        if self._stream_attached:
+            raise RuntimeError('a stream is already attached to this journey attempt')
+        self._stream_attached = True
+
+        async def observed() -> AsyncIterator[_StreamItem]:
+            success_observed = False
+            self._stream_active = True
+            try:
+                async for item in source:
+                    if not self.finished:
+                        if failure_when(item):
+                            self.fail(failure_class)
+                        elif success_when(item):
+                            success_observed = True
+                    yield item
+            except (asyncio.CancelledError, GeneratorExit, ClientDisconnect, OSError):
+                self._abandon_stream()
+                raise
+            except BaseException:
+                self._stream_active = False
+                self._stream_attached = False
+                self.fail(failure_class)
+                raise
+            else:
+                self._stream_active = False
+                self._stream_attached = False
+                if not self.finished:
+                    if success_observed or self._stream_success_requested:
+                        self.succeed()
+                    else:
+                        self.fail(missing_success_class)
+            finally:
+                self._stream_active = False
+                self._stream_attached = False
+                if not self.finished:
+                    self.fail('incomplete_stream')
+
+        return _ObservedClientJourneyStream(self, observed)
 
 
 def record_capture_finalization_terminal(outcome: JourneyOutcome, accepted_at: datetime | None) -> None:


### PR DESCRIPTION
## Summary

- Add the bounded `omi_client_journey_*` family for accepted attempts, one-shot terminal outcomes, bounded issue classes, and duration.
- Keep the live, alert-backed `omi_journey_*` family unchanged while adding client segmentation and authenticated `/metrics` exposure to `desktop-backend`.
- Make stream classification fail closed after headers are committed: callers must provide both `success_when` and `failure_when`, and an in-band error frame terminalizes immediately so a later `[DONE]` cannot overwrite it.

The next inventory layer contains 50 semantic capabilities, including 35 that can fail after a committed 2xx response. That inventory folds onto this bounded foundation rather than minting capability labels here.

## Post-headers failure class

This catches the incident shape status-code monitoring cannot see: `/v2/chat/completions` commits HTTP 200/SSE headers, yields `data: {"error": {"code": 502, ...}}`, then yields `data: [DONE]` and exhausts normally. The regression test feeds the literal compact `desktop_chat` frames and requires `outcome="failure"` with `issue_class="upstream_rejected"`.

`ClientJourneyAttempt.observe_stream` now requires an explicit failure predicate. A detected failure is terminal before the frame is handed on, so later content, `[DONE]`, clean exhaustion, cancellation, or another exception cannot turn it into success.

## Cardinality budget

All label values are coerced through closed vocabularies: 9 journeys, 10 client kinds, 5 outcomes, and 11 issue classes. `client_kind` is deliberately omitted from the histogram. With the pinned `prometheus-client==0.21.1` actually emitting `_created` samples in this process, zero-initialization exports at most **3,915 series per process**: 180 accepted, 900 terminal, 1,980 issue, and 855 histogram series. There are no uid, session, request, content, error-text, model, or revision labels.

## Grok review

Addressed the blocking classification defect and the requested mutation gaps:

- added first-class `failure_when` precedence and the literal 502-error-then-`[DONE]` regression;
- attach stream ownership when `observe_stream` is called, allowing `StreamingResponse` consumption after `with` exits;
- cancel abandoned, never-iterated, `CancelledError`, `GeneratorExit`, `ClientDisconnect`, and `OSError` streams;
- cover normal `__exit__`, attached-stream `__exit__`, empty streams, error-only streams, disconnects, and abandonment;
- replace the tautological pi-mono assertion with two platform populations that become intentionally fused only when the authoritative platform header is absent;
- collapse non-string platform headers to `unknown` before string operations;
- document the required error-frame/`[DONE]` observer contract.

One review calculation was incorrect in this checkout: 2,340 assumes Prometheus `_created` samples are disabled, but direct collection with the pinned 0.21.1 environment produced 3,915 samples. The documented budget uses the measured value. The review's separate observation that deployed `desktop-backend` does not yet receive `METRICS_SECRET` is correct; this foundation adds no production scrape target or journey call sites, so deployment secret/scrape wiring remains with that follow-up rather than broadening this contract PR.

## Product invariants affected

none

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_client_journey_foundation.py backend/tests/unit/test_desktop_backend_cors.py backend/tests/unit/test_journey_observability.py -q --tb=short` — **37 passed in 1.95s**.
- `backend/.venv/bin/pyright backend/utils/journey_metrics_contract.py backend/utils/observability/journeys.py` — **0 errors**.
- `make preflight` — passed all selected checks.
- Direct collection under `prometheus-client==0.21.1` — **3,915** bounded series.

No deployed Cloud Run revision was exercised; this PR establishes the metric and observer contract but intentionally adds no production journey call site or scrape target.

## Failure class

## Added after review: recorders fail open without going silent

Two stacked call-site branches independently reached for the same guard — instrumentation must
never break the request it observes — with different structure, and would have conflicted over it.
It is consolidated here instead, with one change in meaning: both branches used a bare
`except Exception: pass`.

A recorder that quietly stops writing is indistinguishable from a healthy path with nothing to
report. That is precisely the failure mode this metric family exists to expose, so it must not be
reproduced inside the family itself. `_record_fail_open` swallows the exception for the caller and
logs it at a bounded rate for the operator, following the pattern already used by
`llm_gateway/gateway/metrics.py`.

Verified by mutation: making the helper re-raise fails both new tests — one asserting the
operator-visible warning, one proving a broken recorder still delivers every frame to the user.

Failure-Class: none

No registered product failure class describes an additive telemetry contract for post-header in-band failures; the regression is the reusable guard surface for the incident shape.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

