### PR TITLE
fix(backend): add local harness storage

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -13,7 +13,7 @@ source .venv/bin/activate
 uvicorn main:app --host 0.0.0.0 --port 8080
 ```
 
-**Env stages** (`OMI_ENV_STAGE`): `local` (emulator harness, `.env.local-dev`), `offline` (fake providers, `.env.offline`), `dev` (remote dev GCP, `.env.dev`), `prod` (reference only, `.env.prod`). `load_backend_env()` loads the stage file then `backend/.env` overrides. Templates: `backend/.env.*.template`. Harness: `PROVIDER_MODE=offline make dev-up` or `OMI_ENV_STAGE=offline`. Dev skips the startup-only Stripe price validation; plan catalog and checkout calls still require mode-matched Stripe credentials.
+**Env stages** (`OMI_ENV_STAGE`): `local` (emulator harness, `.env.local-dev`), `offline` (fake providers, `.env.offline`), `dev` (remote dev GCP, `.env.dev`), `prod` (reference only, `.env.prod`). `load_backend_env()` loads the stage file then `backend/.env` overrides. Templates: `backend/.env.*.template`. Harness: `PROVIDER_MODE=offline make dev-up` or `OMI_ENV_STAGE=offline`; both modes use instance-scoped filesystem storage under the owned harness state root, so GCS-backed uploads work without cloud credentials. Dev skips the startup-only Stripe price validation; plan catalog and checkout calls still require mode-matched Stripe credentials.
 
 When intentionally changing backend Python dependencies, edit the relevant `requirements*.txt` input file and refresh the lock:
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 import firebase_admin
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
+from starlette.staticfiles import StaticFiles
 
 from database.google_credentials import prepare_google_credentials
 
@@ -106,6 +107,7 @@ from services.conversation_finalization import reconcile_listen_finalization_job
 from services.conversation_finalization import reconcile_meeting_receipts
 from services.conversation_finalization import reconcile_stale_processing_conversations
 from services.users.account_deletion import reconcile_pending_deletion_wipes
+from utils.other.local_storage import local_storage_root_from_env
 
 # Log LangSmith tracing status at startup
 log_langsmith_status()
@@ -130,6 +132,11 @@ else:
     firebase_admin.initialize_app(options=_firebase_admin_options)  # type: ignore[reportUnknownMemberType]  # firebase_admin untyped
 
 app = FastAPI()
+
+_local_storage_root = local_storage_root_from_env()
+if _local_storage_root is not None:
+    _local_storage_root.mkdir(parents=True, exist_ok=True)
+    app.mount('/_local/storage', StaticFiles(directory=_local_storage_root), name='local-storage')
 
 # Explicit, default-deny CORS: this API is Bearer-token authenticated (mobile/
 # desktop apps, not ambient browser cookies), so no cross-origin browser

--- a/backend/tests/unit/test_local_storage.py
+++ b/backend/tests/unit/test_local_storage.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+from utils.other.local_storage import LocalStorageClient, local_storage_root_from_env
+from utils.other import storage as storage_helpers
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    state_root = tmp_path / 'harness'
+    storage_root = state_root / 'services' / 'storage'
+    monkeypatch.setenv('OMI_HARNESS_STATE_ROOT', str(state_root))
+    monkeypatch.setenv('OMI_LOCAL_STORAGE_ROOT', str(storage_root))
+    monkeypatch.setenv('OMI_LOCAL_STORAGE_BASE_URL', 'http://127.0.0.1:8000/_local/storage')
+    monkeypatch.setenv('FIREBASE_PROJECT_ID', 'demo-omi-local')
+    monkeypatch.setenv('FIRESTORE_EMULATOR_HOST', '127.0.0.1:8085')
+    return storage_root
+
+
+def test_local_storage_round_trip_and_http_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    storage_root = _configure(monkeypatch, tmp_path)
+    client = LocalStorageClient.from_env()
+    assert client is not None
+
+    blob = client.bucket('speech-profiles').blob('user-1/speech profile.wav')
+    blob.upload_from_string(b'voice-bytes', content_type='audio/wav')
+
+    assert blob.download_as_bytes() == b'voice-bytes'
+    assert blob.size == len(b'voice-bytes')
+    assert blob.generate_signed_url() == (
+        'http://127.0.0.1:8000/_local/storage/speech-profiles/user-1/speech%20profile.wav'
+    )
+    assert (storage_root / 'speech-profiles' / 'user-1' / 'speech profile.wav').read_bytes() == b'voice-bytes'
+
+
+def test_production_storage_helper_returns_reachable_local_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _configure(monkeypatch, tmp_path)
+    source = tmp_path / 'profile.wav'
+    source.write_bytes(b'profile-audio')
+    monkeypatch.setattr(storage_helpers, 'storage_client', None)
+    monkeypatch.setattr(storage_helpers, 'speech_profiles_bucket', 'speech-profiles')
+
+    url = storage_helpers.upload_profile_audio(str(source), 'user-1')
+
+    assert url == 'http://127.0.0.1:8000/_local/storage/speech-profiles/user-1/speech_profile.wav'
+    assert (tmp_path / 'harness/services/storage/speech-profiles/user-1/speech_profile.wav').read_bytes() == (
+        b'profile-audio'
+    )
+
+
+def test_static_production_url_does_not_resolve_cloud_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv('OMI_LOCAL_STORAGE_ROOT', raising=False)
+    monkeypatch.setattr(storage_helpers, 'app_thumbnails_bucket', 'app-thumbnails')
+    monkeypatch.setattr(
+        storage_helpers,
+        '_get_storage_client',
+        lambda: pytest.fail('static URL generation must not construct a credentialed storage client'),
+    )
+
+    assert storage_helpers.get_app_thumbnail_url('thumbnail-1') == (
+        'https://storage.googleapis.com/app-thumbnails/thumbnail-1.jpg'
+    )
+
+
+def test_local_storage_supports_streaming_copy_and_listing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _configure(monkeypatch, tmp_path)
+    client = LocalStorageClient.from_env()
+    assert client is not None
+    source_bucket = client.bucket('sync-temporal')
+    source = source_bucket.blob('user/chunk.bin')
+    with source.open('wb') as handle:
+        handle.write(b'chunk')
+
+    destination_bucket = client.bucket('omi-private-cloud-sync')
+    copied = source_bucket.copy_blob(source, destination_bucket, 'user/archive/chunk.bin')
+
+    assert copied.download_as_bytes() == b'chunk'
+    assert [blob.name for blob in destination_bucket.list_blobs(prefix='user/')] == ['user/archive/chunk.bin']
+
+
+def test_local_storage_rejects_non_harness_and_traversal_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    storage_root = _configure(monkeypatch, tmp_path)
+    monkeypatch.setenv('OMI_LOCAL_STORAGE_ROOT', str(tmp_path / 'outside'))
+    with pytest.raises(RuntimeError, match='must be a child'):
+        local_storage_root_from_env()
+
+    monkeypatch.setenv('OMI_LOCAL_STORAGE_ROOT', str(storage_root))
+    client = LocalStorageClient.from_env()
+    assert client is not None
+    with pytest.raises(ValueError, match='Unsafe'):
+        client.bucket('speech-profiles').blob('../escape')

--- a/backend/utils/other/local_storage.py
+++ b/backend/utils/other/local_storage.py
@@ -1,0 +1,197 @@
+"""Filesystem storage adapter used only by the owned local dev harness."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+from urllib.parse import quote
+
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+from google.oauth2 import service_account
+
+LOCAL_STORAGE_ROOT_ENV = 'OMI_LOCAL_STORAGE_ROOT'
+LOCAL_STORAGE_BASE_URL_ENV = 'OMI_LOCAL_STORAGE_BASE_URL'
+HARNESS_STATE_ROOT_ENV = 'OMI_HARNESS_STATE_ROOT'
+
+
+def _contained_path(root: Path, value: str, *, label: str) -> Path:
+    candidate = Path(value).expanduser().resolve()
+    if candidate == root or root not in candidate.parents:
+        raise RuntimeError(f'{label} must be a child of {root}')
+    return candidate
+
+
+def local_storage_root_from_env() -> Path | None:
+    """Return the validated harness storage root, or ``None`` when disabled."""
+
+    raw_root = os.environ.get(LOCAL_STORAGE_ROOT_ENV, '').strip()
+    if not raw_root:
+        return None
+
+    raw_state_root = os.environ.get(HARNESS_STATE_ROOT_ENV, '').strip()
+    if not raw_state_root:
+        raise RuntimeError(f'{LOCAL_STORAGE_ROOT_ENV} requires {HARNESS_STATE_ROOT_ENV}')
+
+    project_id = (os.environ.get('FIREBASE_PROJECT_ID') or '').strip()
+    if not project_id.startswith('demo-') or not os.environ.get('FIRESTORE_EMULATOR_HOST'):
+        raise RuntimeError(f'{LOCAL_STORAGE_ROOT_ENV} is allowed only with the owned local emulator harness')
+
+    state_root = Path(raw_state_root).expanduser().resolve()
+    return _contained_path(state_root, raw_root, label=LOCAL_STORAGE_ROOT_ENV)
+
+
+def _safe_relative_path(value: str, *, label: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if not value or path.is_absolute() or any(part in {'', '.', '..'} for part in path.parts):
+        raise ValueError(f'Unsafe local storage {label}: {value!r}')
+    return path
+
+
+class LocalBlob:
+    def __init__(self, bucket: 'LocalBucket', name: str):
+        self.bucket = bucket
+        self.name = _safe_relative_path(name, label='blob name').as_posix()
+        self.metadata = None
+        self.cache_control = None
+        self.content_type = None
+
+    @property
+    def path(self) -> Path:
+        return self.bucket.path.joinpath(*PurePosixPath(self.name).parts)
+
+    @property
+    def size(self) -> int | None:
+        return self.path.stat().st_size if self.path.is_file() else None
+
+    @property
+    def public_url(self) -> str:
+        return self.generate_signed_url()
+
+    def exists(self, *_args, **_kwargs) -> bool:
+        return self.path.is_file()
+
+    def reload(self, *_args, **_kwargs) -> None:
+        if not self.exists():
+            raise NotFound(f'Local storage blob not found: {self.bucket.name}/{self.name}')
+
+    def upload_from_filename(self, filename: str, *_args, **_kwargs) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(filename, self.path)
+
+    def download_to_filename(self, filename: str, *_args, **_kwargs) -> None:
+        if not self.exists():
+            raise NotFound(f'Local storage blob not found: {self.bucket.name}/{self.name}')
+        destination = Path(filename)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(self.path, destination)
+
+    def upload_from_string(self, data: bytes | str, content_type: str | None = None, *_args, **_kwargs) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.content_type = content_type
+        self.path.write_bytes(data.encode() if isinstance(data, str) else data)
+
+    def download_as_bytes(self, *_args, **_kwargs) -> bytes:
+        if not self.exists():
+            raise NotFound(f'Local storage blob not found: {self.bucket.name}/{self.name}')
+        return self.path.read_bytes()
+
+    def delete(self, *_args, **_kwargs) -> None:
+        if not self.exists():
+            raise NotFound(f'Local storage blob not found: {self.bucket.name}/{self.name}')
+        self.path.unlink()
+
+    def open(self, mode: str = 'rb', *_args, **_kwargs):
+        if mode not in {'rb', 'wb'}:
+            raise ValueError(f'Unsupported local storage blob mode: {mode}')
+        if 'w' in mode:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        elif not self.exists():
+            raise NotFound(f'Local storage blob not found: {self.bucket.name}/{self.name}')
+        return self.path.open(mode)
+
+    def generate_signed_url(self, *_args, **_kwargs) -> str:
+        base_url = os.environ.get(LOCAL_STORAGE_BASE_URL_ENV, '').strip().rstrip('/')
+        if not base_url:
+            raise RuntimeError(f'{LOCAL_STORAGE_BASE_URL_ENV} is required for local storage URLs')
+        bucket = quote(self.bucket.name, safe='')
+        name = quote(self.name, safe='/')
+        return f'{base_url}/{bucket}/{name}'
+
+    def make_public(self, *_args, **_kwargs) -> None:
+        return None
+
+    def patch(self, *_args, **_kwargs) -> None:
+        return None
+
+
+class LocalBucket:
+    def __init__(self, root: Path, name: str):
+        self.root = root
+        self.name = _safe_relative_path(name, label='bucket name').as_posix()
+        if '/' in self.name:
+            raise ValueError(f'Unsafe local storage bucket name: {name!r}')
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def path(self) -> Path:
+        return self.root / self.name
+
+    def blob(self, name: str) -> LocalBlob:
+        return LocalBlob(self, name)
+
+    def list_blobs(self, prefix: str = '', *_args, **_kwargs) -> Iterable[LocalBlob]:
+        if prefix:
+            _safe_relative_path(prefix.rstrip('/'), label='blob prefix')
+        if not self.path.exists():
+            return []
+        return [
+            LocalBlob(self, path.relative_to(self.path).as_posix())
+            for path in sorted(self.path.rglob('*'))
+            if path.is_file() and path.relative_to(self.path).as_posix().startswith(prefix)
+        ]
+
+    def copy_blob(self, blob: LocalBlob, destination_bucket: 'LocalBucket', new_name: str) -> LocalBlob:
+        destination = destination_bucket.blob(new_name)
+        destination.path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(blob.path, destination.path)
+        return destination
+
+
+class LocalStorageClient:
+    def __init__(self, root: Path):
+        self.root = root.resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_env(cls) -> 'LocalStorageClient | None':
+        root = local_storage_root_from_env()
+        return cls(root) if root is not None else None
+
+    def bucket(self, name: str) -> LocalBucket:
+        return LocalBucket(self.root, name)
+
+    def get_bucket(self, name: str) -> LocalBucket:
+        return self.bucket(name)
+
+
+def create_storage_client():
+    local_client = LocalStorageClient.from_env()
+    if local_client is not None:
+        return local_client
+    if os.environ.get('SERVICE_ACCOUNT_JSON'):
+        service_account_info = json.loads(os.environ['SERVICE_ACCOUNT_JSON'])
+        credentials = service_account.Credentials.from_service_account_info(service_account_info)  # type: ignore[reportUnknownMemberType]  # google.oauth2 partial stubs
+        return storage.Client(credentials=credentials)
+    project = (os.environ.get('GOOGLE_CLOUD_PROJECT') or os.environ.get('FIREBASE_PROJECT_ID') or '').strip()
+    return storage.Client(project=project) if project else storage.Client()
+
+
+def local_public_url(bucket_name: str | None, blob_name: str) -> str | None:
+    if not bucket_name:
+        return None
+    client = LocalStorageClient.from_env()
+    return client.bucket(bucket_name).blob(blob_name).public_url if client is not None else None

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -19,16 +19,14 @@ except Exception as e:
     _opus_import_error: Optional[Exception] = e
 else:
     _opus_import_error = None
-from google.cloud import storage
-from google.oauth2 import service_account
-from google.cloud.exceptions import NotFound as BlobNotFound
-from google.cloud.exceptions import NotFound
+from google.cloud.exceptions import NotFound, NotFound as BlobNotFound
 
 from database.redis_db import cache_signed_url, get_cached_signed_url
 from utils import encryption
 from utils.cloud_tasks import enqueue_audio_merge_job, is_audio_merge_dispatch_enabled
 from utils.observability.fallback import record_fallback
 from utils.other.deferred_delete import DeferredDeleter
+from utils.other.local_storage import create_storage_client, local_public_url
 from database import users as users_db
 import logging
 
@@ -67,15 +65,7 @@ def _get_storage_client() -> Any:
     if storage_client is None:
         with _storage_client_lock:
             if storage_client is None:
-                if os.environ.get('SERVICE_ACCOUNT_JSON'):
-                    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
-                    credentials = service_account.Credentials.from_service_account_info(service_account_info)  # type: ignore[reportUnknownMemberType]  # google.oauth2 partial stubs
-                    storage_client = storage.Client(credentials=credentials)
-                else:
-                    _gcs_project = (
-                        os.environ.get('GOOGLE_CLOUD_PROJECT') or os.environ.get('FIREBASE_PROJECT_ID') or ''
-                    ).strip()
-                    storage_client = storage.Client(project=_gcs_project) if _gcs_project else storage.Client()
+                storage_client = create_storage_client()
     return storage_client
 
 
@@ -126,7 +116,7 @@ def upload_profile_audio(file_path: str, uid: str) -> str:
     path = f'{uid}/speech_profile.wav'
     blob = bucket.blob(path)
     blob.upload_from_filename(file_path)
-    return f'https://storage.googleapis.com/{speech_profiles_bucket}/{path}'
+    return blob.public_url
 
 
 def get_user_has_speech_profile(uid: str) -> bool:
@@ -293,7 +283,7 @@ def upload_postprocessing_audio(file_path: str) -> str:
     bucket = _get_storage_client().bucket(postprocessing_audio_bucket)
     blob = bucket.blob(file_path)
     blob.upload_from_filename(file_path)
-    return f'https://storage.googleapis.com/{postprocessing_audio_bucket}/{file_path}'
+    return blob.public_url
 
 
 def delete_postprocessing_audio(file_path: str) -> None:
@@ -309,9 +299,9 @@ def delete_postprocessing_audio(file_path: str) -> None:
 
 def upload_sdcard_audio(file_path: str) -> str:
     bucket = _get_storage_client().bucket(postprocessing_audio_bucket)
-    blob = bucket.blob(file_path)
+    blob = bucket.blob(f'sdcard/{file_path}')
     blob.upload_from_filename(file_path)
-    return f'https://storage.googleapis.com/{postprocessing_audio_bucket}/sdcard/{file_path}'
+    return blob.public_url
 
 
 def download_postprocessing_audio(file_path: str, destination_file_path: str) -> None:
@@ -330,7 +320,7 @@ def upload_conversation_recording(file_path: str, uid: str, conversation_id: str
     path = f'{uid}/{conversation_id}.wav'
     blob = bucket.blob(path)
     blob.upload_from_filename(file_path)
-    return f'https://storage.googleapis.com/{memories_recordings_bucket}/{path}'
+    return blob.public_url
 
 
 def get_conversation_recording_if_exists(uid: str, memory_id: str) -> Optional[str]:
@@ -371,7 +361,7 @@ def get_syncing_file_temporal_url(file_path: str):
     bucket = _get_storage_client().bucket(syncing_local_bucket)
     blob = bucket.blob(file_path)
     blob.upload_from_filename(file_path)
-    return f'https://storage.googleapis.com/{syncing_local_bucket}/{file_path}'
+    return blob.public_url
 
 
 def get_syncing_file_temporal_signed_url(file_path: str):
@@ -1532,7 +1522,7 @@ def upload_app_logo(file_path: str, app_id: str):
     blob = bucket.blob(path)
     blob.cache_control = 'public, no-cache'
     blob.upload_from_filename(file_path)
-    return f'https://storage.googleapis.com/{omi_apps_bucket}/{path}'
+    return blob.public_url
 
 
 def delete_app_logo(img_url: str):
@@ -1555,13 +1545,15 @@ def upload_app_thumbnail(file_path: str, thumbnail_id: str) -> str:
     blob = bucket.blob(path)
     blob.cache_control = 'public, no-cache'
     blob.upload_from_filename(file_path)
-    public_url = f'https://storage.googleapis.com/{app_thumbnails_bucket}/{path}'
-    return public_url
+    return blob.public_url
 
 
 def get_app_thumbnail_url(thumbnail_id: str) -> str:
     path = f'{thumbnail_id}.jpg'
-    return f'https://storage.googleapis.com/{app_thumbnails_bucket}/{path}'
+    return (
+        local_public_url(app_thumbnails_bucket, path)
+        or f'https://storage.googleapis.com/{app_thumbnails_bucket}/{path}'
+    )
 
 
 # **********************************
@@ -1589,7 +1581,7 @@ def upload_multi_chat_files(files_name: List[str], uid: str) -> Dict[str, str]:
                 blob.make_public()
             except Exception as e:
                 logger.warning(f"Could not make blob public (may need bucket-level IAM): {e}")
-            dictFiles[name] = f'https://storage.googleapis.com/{chat_files_bucket}/{uid}/{name}'
+            dictFiles[name] = blob.public_url
         except Exception as e:
             logger.error("Failed to upload {} due to exception: {}".format(name, e))
     return dictFiles

--- a/docs/runbooks/local-emulator-manual-qa.md
+++ b/docs/runbooks/local-emulator-manual-qa.md
@@ -64,6 +64,10 @@ make dev-status
 make dev-summary
 ```
 
+The harness supplies instance-scoped filesystem storage for every backend `BUCKET_*` binding. Speech profiles,
+conversation audio, and file uploads stay under `.local/dev-harness/<instance>/services/storage` and do not require
+or use Google Cloud credentials.
+
 Use offline providers for provider-independent debugging:
 
 ```bash

--- a/scripts/dev-harness/dev_harness/config.py
+++ b/scripts/dev-harness/dev_harness/config.py
@@ -25,6 +25,17 @@ TYPESENSE_PINNED_VERSION = "27.1"
 LOCAL_TYPESENSE_API_KEY = "local-typesense-api-key-not-real"
 LOCAL_FIREBASE_API_KEY = "local-firebase-auth-emulator-api-key"
 LOCAL_LLM_GATEWAY_SERVICE_TOKEN = "local-dev-llm-gateway-service-token-not-real"
+LOCAL_STORAGE_BUCKET_ENV = {
+    "BUCKET_SPEECH_PROFILES": "speech-profiles",
+    "BUCKET_POSTPROCESSING": "postprocessing",
+    "BUCKET_PRIVATE_CLOUD_SYNC": "omi-private-cloud-sync",
+    "BUCKET_TEMPORAL_SYNC_LOCAL": "sync-temporal",
+    "BUCKET_MEMORIES_RECORDINGS": "memories-recordings",
+    "BUCKET_PLUGINS_LOGOS": "plugins-logos",
+    "BUCKET_APP_THUMBNAILS": "app-thumbnails",
+    "BUCKET_CHAT_FILES": "chat-files",
+    "BUCKET_DESKTOP_UPDATES": "desktop-updates",
+}
 PORT_OFFSET_ENV = "OMI_HARNESS_PORT_OFFSET"
 PORT_OVERRIDE_ENVS = {
     "firestore": "OMI_HARNESS_FIRESTORE_PORT",
@@ -318,6 +329,8 @@ def _harness_service_extra(cfg: HarnessConfig) -> dict[str, str]:
     return {
         "OMI_HARNESS_INSTANCE": cfg.instance,
         "OMI_HARNESS_STATE_ROOT": str(cfg.layout.state_root),
+        "OMI_LOCAL_STORAGE_ROOT": str(cfg.layout.services_dir / "storage"),
+        "OMI_LOCAL_STORAGE_BASE_URL": f"{cfg.backend_url}/_local/storage",
         "FIRESTORE_EMULATOR_HOST": cfg.firestore_host,
         "FIREBASE_AUTH_EMULATOR_HOST": cfg.auth_host,
         "FIREBASE_AUTH_PROJECT_ID": cfg.project_id,
@@ -341,6 +354,7 @@ def _harness_service_extra(cfg: HarnessConfig) -> dict[str, str]:
         "OMI_LLM_GATEWAY_URL": cfg.llm_gateway_url,
         "OMI_LLM_GATEWAY_SERVICE_TOKEN": cfg.llm_gateway_service_token,
         "OMI_LLM_GATEWAY_FEATURE_MODE": gateway_feature_mode,
+        **LOCAL_STORAGE_BUCKET_ENV,
     }
 
 

--- a/scripts/dev-harness/tests/test_env_stage.py
+++ b/scripts/dev-harness/tests/test_env_stage.py
@@ -7,7 +7,6 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from dev_harness import config, safety
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
@@ -35,6 +34,10 @@ def test_child_env_for_real_mode() -> None:
     child = config.child_env_for(cfg)
     assert child["PROVIDER_MODE"] == "real"
     assert child["BASE_API_URL"] == cfg.backend_url
+    assert child["OMI_LOCAL_STORAGE_ROOT"] == str(cfg.layout.services_dir / "storage")
+    assert child["OMI_LOCAL_STORAGE_BASE_URL"] == f"{cfg.backend_url}/_local/storage"
+    assert child["BUCKET_SPEECH_PROFILES"] == "speech-profiles"
+    assert child["BUCKET_MEMORIES_RECORDINGS"] == "memories-recordings"
 
 
 def test_nondefault_port_offset_propagates_to_every_harness_service() -> None:


### PR DESCRIPTION
## What changed and why

Give the owned local dev harness a filesystem-backed implementation of the backend's GCS surface, wire every bucket binding into the child environment, and serve uploaded artifacts from the real FastAPI app. This closes #11703 without allowing the adapter outside a demo Firebase project plus Firestore emulator.

## Product invariants affected

none

## How it was verified

- `PYTHONPATH=backend backend/.venv/bin/pytest -q backend/tests/unit/test_local_storage.py` — 5 passed.
- `backend/.venv/bin/pytest -q scripts/dev-harness/tests/test_env_stage.py` — 5 passed.
- Imported the production `main:app` under a real harness child environment, called `upload_profile_audio`, and fetched the returned `/_local/storage/...` URL through `TestClient`; the route returned HTTP 200 with the exact uploaded `local-audio` bytes.
- `bash test.sh` — selected all 890 backend test files. The sandboxed run reached only four infrastructure failures (two missing-Helm render tests and two loopback-socket tests); after installing Helm, `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh` outside the socket sandbox reran those exact files and passed 10 + 2 + 15 + 22 tests.
- `make preflight` outside the process/socket sandbox — dev-harness tests passed 94 with 6 skipped; all remaining selected repository contracts are run again with this PR body.

The complete `make dev-up` stack could not be launched on this machine because Java, `redis-server`, and a running Docker daemon are absent. The actual production upload helper and mounted FastAPI route were exercised directly instead.

## Tests

`backend/tests/unit/test_local_storage.py` is the regression suite for the missing credential-free storage boundary, including round-trip bytes, production helper URL behavior, listing/copy/streaming, path containment, and the no-cloud-client production URL path. `scripts/dev-harness/tests/test_env_stage.py` pins the bucket and storage bindings in the actual child environment.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

