### PR TITLE
fix(desktop): gate CLI test-notification observers to local dev builds

### DIFF
--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -1173,8 +1173,18 @@ public class ProactiveAssistantsPlugin: NSObject {
 
   // MARK: - CLI Test Triggers
 
-  /// Listen for distributed notifications from CLI to trigger test runs
+  /// Listen for distributed notifications from CLI to trigger test runs.
+  ///
+  /// Local development bundles only. `DistributedNotificationCenter` is a machine-wide bus with
+  /// no sender authentication, so a registered observer lets any local process deliver an
+  /// arbitrary proactive notification — floating-bar card, optional system banner — and journal
+  /// it into the signed-in user's real backend chat. `allowsLocalAutomation` (not the broader
+  /// `isNonProduction`) is the correct gate: external preview bundles ship to users outside the
+  /// team and share the non-production namespace, so they must ignore CLI triggers exactly as
+  /// the shipped apps do. Same predicate `DesktopAutomationBridge` uses for its debug surface.
   private func setupTestNotificationListeners() {
+    guard AppBuild.allowsLocalAutomation else { return }
+
     // Distributed notifications may arrive on the posting thread, so entering a selector on this
     // MainActor-isolated plugin can trap before a Task-based actor hop executes.
     let observers = [

--- a/desktop/macos/Desktop/Tests/ProactiveTestTriggerGateTests.swift
+++ b/desktop/macos/Desktop/Tests/ProactiveTestTriggerGateTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+@testable import Omi_Computer
+
+/// Guards issue #11943: the CLI test-notification observers
+/// (`com.omi.test.notification` / `com.omi.test.insight`) were registered
+/// unconditionally, so any local process could post a distributed notification and
+/// have a shipped build deliver an arbitrary proactive notification and journal it
+/// into the signed-in user's real backend chat.
+final class ProactiveTestTriggerGateTests: XCTestCase {
+  private func configuration(_ bundleIdentifier: String) -> AppBuild.Configuration {
+    AppBuild.configuration(bundleIdentifier: bundleIdentifier, infoDictionary: [:])
+  }
+
+  func testShippedBundlesDoNotAllowCLITestTriggers() {
+    // Both shipped identities. #11943 was observed on Omi Beta specifically: it received
+    // every trigger aimed at a dev bundle and journaled 13 test notifications into a real
+    // account, so beta must be asserted alongside stable rather than assumed to follow.
+    for bundleIdentifier in AppBuild.productionFamilyBundleIdentifiers {
+      XCTAssertFalse(
+        configuration(bundleIdentifier).allowsLocalAutomation,
+        "\(bundleIdentifier) must ignore CLI test triggers")
+    }
+  }
+
+  func testExternalPreviewBundlesDoNotAllowCLITestTriggers() {
+    // Preview builds ship outside the team and are non-production, so the broader
+    // `isNonProduction` predicate would have left this hole open.
+    let preview = configuration("com.omi.preview.p8b1f42a9")
+    XCTAssertTrue(preview.isNonProduction, "preview shares the non-production namespace")
+    XCTAssertFalse(preview.allowsLocalAutomation, "but must still ignore CLI test triggers")
+  }
+
+  func testLocalDevelopmentBundlesStillAllowCLITestTriggers() {
+    // The gate must not break the workflow it exists to serve — `omi-*` named bundles are
+    // how the notification delivery contract is exercised against a real running app.
+    XCTAssertTrue(configuration(AppBuild.desktopDevBundleIdentifier).allowsLocalAutomation)
+    XCTAssertTrue(configuration("com.omi.omi-fix-rewind").allowsLocalAutomation)
+  }
+
+  /// Returns nil when the source is correctly gated, or a failure reason when it is not.
+  private func ungatedRegistrationReason(in source: String) -> String? {
+    guard let range = source.range(of: "private func setupTestNotificationListeners() {") else {
+      return "setupTestNotificationListeners was renamed — re-point this guard"
+    }
+    let body = source[range.upperBound...]
+    guard let registration = body.range(of: "DistributedNotificationCenter") else {
+      return "observer registration moved out of setupTestNotificationListeners"
+    }
+    guard
+      body[..<registration.lowerBound].contains("guard AppBuild.allowsLocalAutomation else")
+    else {
+      return "observers registered without the AppBuild.allowsLocalAutomation gate"
+    }
+    return nil
+  }
+
+  /// Proves the static contract below actually discriminates. Without this, a scan that silently
+  /// stopped matching would read as PASS forever — the failure mode that makes source-inspection
+  /// guards untrustworthy. Fixtures are used so the real guard is never removed to test it.
+  func testGateDetectorRejectsUngatedSource() {
+    let ungated = """
+      private func setupTestNotificationListeners() {
+        let observers = [ProactiveTestNotificationObserver(name: name) { _ in }]
+        for observer in observers { observer.register(in: DistributedNotificationCenter.default()) }
+      }
+      """
+    XCTAssertEqual(
+      ungatedRegistrationReason(in: ungated),
+      "observers registered without the AppBuild.allowsLocalAutomation gate")
+
+    let gated = """
+      private func setupTestNotificationListeners() {
+        guard AppBuild.allowsLocalAutomation else { return }
+        let observers = [ProactiveTestNotificationObserver(name: name) { _ in }]
+        for observer in observers { observer.register(in: DistributedNotificationCenter.default()) }
+      }
+      """
+    XCTAssertNil(ungatedRegistrationReason(in: gated))
+  }
+
+  /// The defect was an absent guard in a private method on a MainActor plugin that cannot be
+  /// instantiated headlessly, and AppBuild reads Bundle.main, so no behavioral seam observes the
+  /// registration decision. The predicate tests above carry the behavioral half; this pins the
+  /// guard's presence, and testGateDetectorRejectsUngatedSource proves the scan discriminates.
+  func testRegistrationSiteKeepsTheGate() throws {
+    let sourcesRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources", isDirectory: true)
+    // omi-test-quality: source-inspection -- static contract: pins the AppBuild.allowsLocalAutomation guard at an unobservable private registration site (issue #11943)
+    let plugin = try String(
+      contentsOf: sourcesRoot.appendingPathComponent(
+        "ProactiveAssistants/ProactiveAssistantsPlugin.swift"),
+      encoding: .utf8)
+
+    XCTAssertNil(
+      ungatedRegistrationReason(in: plugin),
+      "CLI test observers must stay gated behind AppBuild.allowsLocalAutomation (issue #11943)")
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260821-gate-cli-test-triggers.json
+++ b/desktop/macos/changelog/unreleased/20260821-gate-cli-test-triggers.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed released builds accepting local CLI test triggers, which let any process on your Mac deliver a fake Omi notification and save it to your chat"
+}


### PR DESCRIPTION
## Summary

`ProactiveAssistantsPlugin.setupTestNotificationListeners()` registered the `com.omi.test.notification` and `com.omi.test.insight` `DistributedNotificationCenter` observers unconditionally, so shipped `Omi.app` and `Omi Beta.app` accepted them too.

`DistributedNotificationCenter` is a machine-wide bus with no sender authentication. Any local process could therefore deliver an arbitrary proactive notification — floating-bar card, optionally a system banner via `deliverSystemBanner=true` — and have it journaled into the signed-in user's real backend chat as an Omi message. That is how #11943 was found: a dev-bundle test run drove the running production Omi Beta and wrote 13 test notifications into a real account.

Fixes #11943.

## Why `allowsLocalAutomation`, not `isNonProduction`

The issue suggested `AppBuild.isNonProduction`. `allowsLocalAutomation` is the correct predicate: external preview bundles (`com.omi.preview.*`) ship to users outside the team and *are* non-production, so `isNonProduction` would have left them injectable. `allowsLocalAutomation` is also the predicate `DesktopAutomationBridge` already uses for its debug surface, so the CLI trigger surface now matches the automation surface it belongs to.

The guard sits inside `setupTestNotificationListeners()` rather than at the call site, so any future caller inherits it.

## Verification

Observer registration, counted from each bundle's own log at plugin init:

| Bundle identity | Code | Registered |
|---|---|---|
| `com.omi.computer-macos` (real shipped Omi.app) | unpatched | **2** ← the defect |
| `com.omi.preview.p11943` (external preview) | unpatched | **2** |
| `com.omi.preview.p11943` (external preview) | patched | **0** |
| `com.omi.omi-11943-dev` (local development) | patched | **2** ← CLI still works |

End-to-end delivery against the patched preview build, with a real trigger posted from a separate process. An independent observer process on the same bus witnessed the notification, so "the app logged no receipt" cannot be an unnoticed post failure:

```
witness process            -> received com.omi.test.insight (count=1)
patched app receipt count  -> 0
patched app plugin init    -> 1
```

The patched run still logs `ProactiveAssistantsPlugin initialized`, so the same code path is reached and the guard — not an unrelated early exit — is what suppresses registration.

Reaching a preview identity locally required a temporary uncommitted edit to `scripts/app-config.sh`, which otherwise forces every local bundle to an `omi-` development id. That edit is reverted and is not in this diff.

### Tests

- `desktop/macos/scripts/swift-test-suites.sh` — 660 suites in isolation. `ChatTranscriptGestureHarnessTests` failed only under 4-worker parallel load on a timing threshold (154.0 pt drift against a 120.0 pt bound); it passes alone (`dev-feedback.py --once swift 'ChatTranscriptGestureHarnessTests'` → 17 tests, 0 failures) and touches no code in this diff.
- `dev-feedback.py --once swift 'ProactiveTestTriggerGateTests'` → 5 tests, 0 failures.
- `python3 desktop/macos/scripts/check_desktop_test_quality.py` → at baseline (54 source-reading files / 147 sites).

The three predicate tests carry the behavioral half — production family, external preview, and local development identities. `testRegistrationSiteKeepsTheGate` is a labelled source-inspection static contract: the defect was an absent guard in a private method on a `MainActor` plugin that cannot be instantiated headlessly, and `AppBuild` reads `Bundle.main`, so no behavioral seam observes the registration decision. `testGateDetectorRejectsUngatedSource` proves that scan still discriminates, using fixtures rather than removing the real guard to test it.

Line-Count-Exception: desktop/macos/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift | 1798 -> 1808 | +1 guard line and a comment recording why this is `allowsLocalAutomation` rather than `isNonProduction`, and why an unauthenticated machine-wide bus makes the distinction load-bearing; splitting a 1798-line plugin is out of scope for a security fix

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

