### PR TITLE
fix(backend): retain exhausted webhooks for replay

### DIFF
--- a/backend/database/webhook_health.py
+++ b/backend/database/webhook_health.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import threading
 import time
@@ -428,3 +429,36 @@ def record_dev_webhook_success(uid: str, wtype: object):
         r.expire(key, _HEALTH_TTL)
     except Exception as e:
         logger.warning(f'record_dev_webhook_success redis error uid={uid} type={wtype}: {e}')
+
+
+_DLQ_TTL = 7 * 86400
+_DLQ_MAX = 100
+
+
+def enqueue_dev_webhook_dlq(
+    *,
+    webhook_name: str,
+    webhook_url: str,
+    status_code: int,
+    error: str,
+    idempotency_key: Optional[str] = None,
+    uid: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Store a failed developer webhook for manual replay after retries are exhausted (#5488)."""
+    try:
+        key = f'dev_webhook_dlq:{uid or "unknown"}'
+        entry = {
+            'webhook_name': webhook_name,
+            'webhook_url': webhook_url[:500],
+            'status_code': status_code,
+            'error': (error or '')[:500],
+            'idempotency_key': idempotency_key,
+            'payload': payload,
+            'failed_at': datetime.now(timezone.utc).isoformat(),
+        }
+        r.lpush(key, json.dumps(entry, separators=(',', ':')))
+        r.ltrim(key, 0, _DLQ_MAX - 1)
+        r.expire(key, _DLQ_TTL)
+    except Exception as e:
+        logger.warning(f'enqueue_dev_webhook_dlq failed name={webhook_name}: {e}')

--- a/backend/tests/unit/test_webhook_auto_disable.py
+++ b/backend/tests/unit/test_webhook_auto_disable.py
@@ -8,6 +8,7 @@ Verifies:
 - Circuit breaker + health tracking in chat tool endpoints
 """
 
+import json
 import os
 from types import ModuleType
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -297,6 +298,69 @@ class TestDevWebhookAutoDisable:
         idempotency_keys = [call.kwargs["headers"]["Idempotency-Key"] for call in mock_client.post.await_args_list]
         assert len(set(idempotency_keys)) == 1
         assert idempotency_keys[0]
+
+    @pytest.mark.asyncio
+    async def test_post_dev_webhook_enqueues_exhausted_delivery_without_blocking_event_loop(self):
+        from utils.webhooks import _post_dev_webhook, db_executor, enqueue_dev_webhook_dlq
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=MagicMock(status_code=503))
+        mock_sem = AsyncMock()
+        mock_sem.__aenter__ = AsyncMock()
+        mock_sem.__aexit__ = AsyncMock()
+
+        with (
+            patch("utils.webhooks.get_webhook_client", return_value=mock_client),
+            patch("utils.webhooks.get_webhook_semaphore", return_value=mock_sem),
+            patch("utils.webhooks.run_blocking", new_callable=AsyncMock) as mock_run_blocking,
+        ):
+            response = await _post_dev_webhook(
+                "test_webhook",
+                "https://example.com/webhook",
+                retry_delays=(),
+                idempotency_key="event-123",
+                dlq_uid="uid-1",
+                json={"hello": "world"},
+            )
+
+        assert response.status_code == 503
+        mock_run_blocking.assert_awaited_once_with(
+            db_executor,
+            enqueue_dev_webhook_dlq,
+            webhook_name="test_webhook",
+            webhook_url="https://example.com/webhook",
+            status_code=503,
+            error="HTTP 503",
+            idempotency_key="event-123",
+            uid="uid-1",
+            payload={"hello": "world"},
+        )
+
+    def test_enqueue_dev_webhook_dlq_caps_entries_and_sets_ttl(self, monkeypatch):
+        from database import webhook_health
+
+        mock_redis = MagicMock()
+        monkeypatch.setattr(webhook_health, "r", mock_redis)
+
+        webhook_health.enqueue_dev_webhook_dlq(
+            webhook_name="memory_created_webhook",
+            webhook_url="https://example.com/webhook",
+            status_code=502,
+            error="HTTP 502",
+            idempotency_key="event-123",
+            uid="uid-1",
+            payload={"conversation_id": "conversation-1"},
+        )
+
+        key, raw_entry = mock_redis.lpush.call_args.args
+        entry = json.loads(raw_entry)
+        assert key == "dev_webhook_dlq:uid-1"
+        assert entry["webhook_name"] == "memory_created_webhook"
+        assert entry["idempotency_key"] == "event-123"
+        assert entry["status_code"] == 502
+        assert entry["payload"] == {"conversation_id": "conversation-1"}
+        mock_redis.ltrim.assert_called_once_with(key, 0, webhook_health._DLQ_MAX - 1)
+        mock_redis.expire.assert_called_once_with(key, webhook_health._DLQ_TTL)
 
     @pytest.mark.asyncio
     async def test_dev_webhook_disabled_on_threshold(self):

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -14,7 +14,12 @@ from database.redis_db import (
     enable_user_webhook_db,
     set_user_webhook_db,
 )
-from database.webhook_health import record_dev_webhook_failure, record_dev_webhook_success, _DEV_FAILURE_THRESHOLD
+from database.webhook_health import (
+    record_dev_webhook_failure,
+    record_dev_webhook_success,
+    enqueue_dev_webhook_dlq,
+    _DEV_FAILURE_THRESHOLD,
+)
 from models.conversation import Conversation
 from models.users import WebhookType, webhook_url_from_setting
 import database.notifications as notification_db
@@ -117,6 +122,7 @@ async def _post_dev_webhook(
     *,
     retry_delays: Optional[tuple[float, ...]] = None,
     idempotency_key: Optional[str] = None,
+    dlq_uid: Optional[str] = None,
     **request_kwargs,
 ):
     if retry_delays is None:
@@ -163,11 +169,33 @@ async def _post_dev_webhook(
         logger.error(
             f'{webhook_name}: delivery failed status={last_response.status_code} attempts={attempts} url={webhook_url}'
         )
+        await run_blocking(
+            db_executor,
+            enqueue_dev_webhook_dlq,
+            webhook_name=webhook_name,
+            webhook_url=webhook_url,
+            status_code=last_response.status_code,
+            error=f'HTTP {last_response.status_code}',
+            idempotency_key=headers.get('Idempotency-Key'),
+            uid=dlq_uid,
+            payload=request_kwargs.get('json'),
+        )
         return last_response
 
     if last_exception is None:
         raise RuntimeError(f'{webhook_name}: delivery failed without a response or exception')
     logger.error(f'{webhook_name}: delivery failed error={type(last_exception).__name__} attempts={attempts}')
+    await run_blocking(
+        db_executor,
+        enqueue_dev_webhook_dlq,
+        webhook_name=webhook_name,
+        webhook_url=webhook_url,
+        status_code=0,
+        error=type(last_exception).__name__,
+        idempotency_key=headers.get('Idempotency-Key'),
+        uid=dlq_uid,
+        payload=request_kwargs.get('json'),
+    )
     raise last_exception
 
 
@@ -217,6 +245,7 @@ async def conversation_created_webhook(uid, memory: Conversation):
                 webhook_url,
                 json=payload,
                 headers={'Content-Type': 'application/json'},
+                dlq_uid=uid,
             )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
@@ -272,6 +301,7 @@ async def day_summary_webhook(uid, summary: str, summary_json: Optional[dict] = 
                     'created_at': datetime.now(timezone.utc).isoformat(),
                 },
                 headers={'Content-Type': 'application/json'},
+                dlq_uid=uid,
             )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
@@ -317,6 +347,7 @@ async def realtime_transcript_webhook(uid, segments: List[dict]):
                 webhook_url,
                 json={'segments': segments, 'session_id': uid},
                 headers={'Content-Type': 'application/json'},
+                dlq_uid=uid,
             )
             if response.status_code >= 200 and response.status_code < 300:
                 cb.record_success()
@@ -407,6 +438,7 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
                     webhook_url,
                     content=chunk,
                     headers={'Content-Type': 'application/octet-stream'},
+                    dlq_uid=uid,
                 )
                 if not (200 <= response.status_code < 300):
                     cb.record_failure()


### PR DESCRIPTION
## Summary

- retain exhausted developer webhook deliveries in a per-user Redis dead-letter queue
- preserve the idempotency key, destination metadata, failure details, and JSON event payload needed for manual replay
- cap each queue at 100 entries with a seven-day TTL and offload Redis mutation from the async request path

Closes #5488

## Verification

- `backend/.venv/bin/pytest -q backend/tests/unit/test_webhook_auto_disable.py` (121 passed)
- `OMI_PR_BODY_FILE=/tmp/omi-pr-body-5488.md make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-body-5488.md`

## Product invariants

None.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

