### PR TITLE
Serve referral links from omi.me

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -88,7 +88,7 @@ envFrom:
 
 env:
   - name: REFERRAL_PUBLIC_BASE_URL
-    value: "https://api.omi.me"
+    value: "https://omi.me"
   - name: ACCOUNT_DELETION_DISPATCH_MODE
     value: "cloud_tasks"
   - name: ACCOUNT_DELETION_TASKS_QUEUE

--- a/backend/deploy/runtime_env.yaml
+++ b/backend/deploy/runtime_env.yaml
@@ -1171,7 +1171,7 @@ environments:
               name: prod-omi-backend-config
               key: MCP_RESOURCE_URL
           REFERRAL_PUBLIC_BASE_URL:
-            value: https://api.omi.me
+            value: https://omi.me
             category: service_discovery
           ACCOUNT_DELETION_DISPATCH_MODE:
             value: cloud_tasks

--- a/backend/deploy/runtime_env/prod.overlay.yaml
+++ b/backend/deploy/runtime_env/prod.overlay.yaml
@@ -9,7 +9,7 @@ overlay:
     backend-listen:
       env:
         REFERRAL_PUBLIC_BASE_URL:
-          value: https://api.omi.me
+          value: https://omi.me
           category: service_discovery
         ACCOUNT_DELETION_DISPATCH_MODE:
           value: cloud_tasks

--- a/backend/tests/unit/test_referrals.py
+++ b/backend/tests/unit/test_referrals.py
@@ -107,7 +107,7 @@ def test_authenticated_referrer_receives_a_stable_unique_https_link(monkeypatch)
 
     assert first == second
     assert first != other
-    assert first.startswith('https://api.omi.me/r/ref1.')
+    assert first.startswith('https://omi.me/r/ref1.')
 
 
 def test_authenticated_referrer_uses_configured_dev_public_origin(monkeypatch):

--- a/backend/utils/referrals.py
+++ b/backend/utils/referrals.py
@@ -82,7 +82,7 @@ def referrer_uid_from_code(code: str, *, secret: Optional[bytes] = None) -> str:
 
 
 def referral_link(uid: str, *, secret: Optional[bytes] = None, public_base_url: Optional[str] = None) -> str:
-    base_url = (public_base_url or os.getenv('REFERRAL_PUBLIC_BASE_URL') or 'https://api.omi.me').rstrip('/')
+    base_url = (public_base_url or os.getenv('REFERRAL_PUBLIC_BASE_URL') or 'https://omi.me').rstrip('/')
     return f'{base_url}/r/{create_referral_code(uid, secret=secret)}'
 
 


### PR DESCRIPTION
## Summary

- emit production referral links as `https://omi.me/r/<code>`
- retain the configured dev origin so dev signatures stay on `api.omiapi.com`
- update the generated deployment manifest and production Helm value

## Product invariants affected

- INV-MEM-4 (path-only match through the shared generated runtime environment manifest; referral behavior does not alter memory promotion)

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_referrals.py backend/tests/unit/test_backend_runtime_env_validator.py -q` — 97 passed
- `backend/scripts/pre-deploy-check.sh` with the pinned backend Python — 198 passed and runtime/deploy contracts passed
- Shopify unpublished-theme test — a signed `omi.me/r/<code>` reached the macOS download page and set the referral cookie on three fresh browser runs
- Shopify live-theme test — the same signed URL reached the macOS download page and set the referral cookie on three fresh browser runs; invalid codes returned `Referral link not found`; ordinary store paths remained on Shopify


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/11999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

