### PR TITLE
feat(backend): add button event webhook dispatch

### DIFF
--- a/app/lib/backend/schema/gen/users_wire.g.dart
+++ b/app/lib/backend/schema/gen/users_wire.g.dart
@@ -28,12 +28,14 @@ class GeneratedUserStatusResponse {
 
 class GeneratedUserWebhooksStatusResponse {
   final bool audioBytes;
+  final bool buttonEvent;
   final bool daySummary;
   final bool memoryCreated;
   final bool realtimeTranscript;
 
   const GeneratedUserWebhooksStatusResponse({
     required this.audioBytes,
+    this.buttonEvent = false,
     required this.daySummary,
     required this.memoryCreated,
     required this.realtimeTranscript,
@@ -42,6 +44,7 @@ class GeneratedUserWebhooksStatusResponse {
   factory GeneratedUserWebhooksStatusResponse.fromJson(Map<String, dynamic> json) {
     return GeneratedUserWebhooksStatusResponse(
       audioBytes: _required(_readFieldValue<bool>(_readField(json, const ["audio_bytes"]), "audio_bytes", _readBool, requiredField: true, nullable: false), "audio_bytes"),
+      buttonEvent: _required(_readFieldValue<bool>(_readField(json, const ["button_event"]), "button_event", _readBool, requiredField: false, nullable: false, defaultValue: false), "button_event"),
       daySummary: _required(_readFieldValue<bool>(_readField(json, const ["day_summary"]), "day_summary", _readBool, requiredField: true, nullable: false), "day_summary"),
       memoryCreated: _required(_readFieldValue<bool>(_readField(json, const ["memory_created"]), "memory_created", _readBool, requiredField: true, nullable: false), "memory_created"),
       realtimeTranscript: _required(_readFieldValue<bool>(_readField(json, const ["realtime_transcript"]), "realtime_transcript", _readBool, requiredField: true, nullable: false), "realtime_transcript"),
@@ -51,6 +54,7 @@ class GeneratedUserWebhooksStatusResponse {
   Map<String, dynamic> toJson() {
     return {
       'audio_bytes': audioBytes,
+      'button_event': buttonEvent,
       'day_summary': daySummary,
       'memory_created': memoryCreated,
       'realtime_transcript': realtimeTranscript,

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -11,6 +11,7 @@ class WebhookType(str, Enum):
     realtime_transcript = 'realtime_transcript'
     memory_created = ('memory_created',)
     day_summary = 'day_summary'
+    button_event = 'button_event'
 
 
 def webhook_url_from_setting(wtype: WebhookType | str, value: Optional[str]) -> str:

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -81,6 +81,30 @@ routes:
     path: /v1/config/api-keys
     policy: *desktop_migration_policy
   - route_type: http
+    method: POST
+    path: /v1/users/developer/button-event
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: GET
     path: /v1/crisp/unread
     policy: *desktop_migration_policy

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import uuid
-from typing import List, Dict, Any, Union, Optional
+from typing import List, Dict, Any, Literal, Union, Optional
 import hashlib
 import os
 import asyncio
@@ -10,7 +10,7 @@ import asyncio
 import pytz
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 from database import (
     conversations as conversations_db,
@@ -124,7 +124,7 @@ from utils.other.storage import (
     delete_user_person_speech_samples,
     delete_user_person_speech_sample,
 )
-from utils.webhooks import webhook_first_time_setup
+from utils.webhooks import button_event_webhook, webhook_first_time_setup
 from utils.byok import has_byok_keys, invalidate_byok_state_cache, peppered_fingerprint
 import logging
 
@@ -182,6 +182,7 @@ class UserWebhooksStatusResponse(BaseModel):
     memory_created: bool
     realtime_transcript: bool
     day_summary: bool
+    button_event: bool = False
 
 
 class UserWebhookUrlResponse(BaseModel):
@@ -511,6 +512,28 @@ def enable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get
     return {'status': 'ok'}
 
 
+class ButtonEventRequest(BaseModel):
+    button_event: Literal['single_tap', 'double_tap', 'long_tap']
+    device_id: str = Field(min_length=1, max_length=128)
+    event_id: uuid.UUID = Field(description='Stable id for the physical gesture across retries')
+    timestamp: AwareDatetime
+    session_id: Optional[str] = Field(default=None, min_length=1, max_length=128)
+
+
+@router.post('/v1/users/developer/button-event', tags=['v1'], response_model=UserStatusResponse)
+async def post_developer_button_event(body: ButtonEventRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """App → backend forward of an opt-in hardware button gesture (#11719)."""
+    await button_event_webhook(
+        uid,
+        button_event=body.button_event,
+        device_id=body.device_id,
+        event_id=str(body.event_id),
+        timestamp=body.timestamp.isoformat(),
+        session_id=body.session_id,
+    )
+    return {'status': 'ok'}
+
+
 @router.get('/v1/users/developer/webhooks/status', tags=['v1'], response_model=UserWebhooksStatusResponse)
 def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
     # This only happens the first time because the user_webhook_status_db function will return None for existing users
@@ -526,11 +549,15 @@ def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
     day_summary = user_webhook_status_db(uid, WebhookType.day_summary)
     if day_summary is None:
         day_summary = webhook_first_time_setup(uid, WebhookType.day_summary)
+    button_event = user_webhook_status_db(uid, WebhookType.button_event)
+    if button_event is None:
+        button_event = webhook_first_time_setup(uid, WebhookType.button_event)
     return {
         'audio_bytes': audio_bytes,
         'memory_created': memory_created,
         'realtime_transcript': realtime_transcript,
         'day_summary': day_summary,
+        'button_event': button_event,
     }
 
 

--- a/backend/tests/unit/test_button_event_webhook.py
+++ b/backend/tests/unit/test_button_event_webhook.py
@@ -1,0 +1,115 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from routers.users import ButtonEventRequest, post_developer_button_event
+
+
+@pytest.mark.asyncio
+async def test_button_event_route_forwards_validated_contract():
+    body = ButtonEventRequest.model_validate(
+        {
+            'button_event': 'double_tap',
+            'device_id': 'omi-1',
+            'event_id': 'a02765ac-c962-4118-bfcc-a06c0d7750d9',
+            'timestamp': '2026-08-21T04:15:00Z',
+            'session_id': 'session-1',
+        }
+    )
+
+    with patch('routers.users.button_event_webhook', new_callable=AsyncMock) as mock_webhook:
+        response = await post_developer_button_event(body, uid='uid-1')
+
+    assert response == {'status': 'ok'}
+    mock_webhook.assert_awaited_once_with(
+        'uid-1',
+        button_event='double_tap',
+        device_id='omi-1',
+        event_id='a02765ac-c962-4118-bfcc-a06c0d7750d9',
+        timestamp='2026-08-21T04:15:00+00:00',
+        session_id='session-1',
+    )
+
+
+def test_button_event_contract_rejects_naive_timestamp():
+    with pytest.raises(ValidationError):
+        ButtonEventRequest.model_validate(
+            {
+                'button_event': 'single_tap',
+                'device_id': 'omi-1',
+                'event_id': 'a02765ac-c962-4118-bfcc-a06c0d7750d9',
+                'timestamp': '2026-08-21T04:15:00',
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_button_events_keep_stable_id_and_serialize_per_device(monkeypatch):
+    from utils import webhooks
+
+    monkeypatch.setattr(webhooks, 'user_webhook_status_db', MagicMock(return_value=True))
+    monkeypatch.setattr(webhooks, 'get_user_webhook_db', MagicMock(return_value='https://example.com/hook'))
+    monkeypatch.setattr(webhooks, 'record_dev_webhook_success', MagicMock())
+    circuit_breaker = MagicMock()
+    circuit_breaker.allow_request.return_value = True
+    monkeypatch.setattr(webhooks, 'get_webhook_circuit_breaker', MagicMock(return_value=circuit_breaker))
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    delivered: list[str] = []
+
+    async def post_webhook(_name, _url, *, json, idempotency_key, **_kwargs):
+        delivered.append(idempotency_key)
+        if idempotency_key == 'event-1':
+            first_started.set()
+            await release_first.wait()
+        return MagicMock(status_code=200)
+
+    monkeypatch.setattr(webhooks, '_post_dev_webhook', post_webhook)
+
+    first = asyncio.create_task(
+        webhooks.button_event_webhook(
+            'uid-1',
+            button_event='single_tap',
+            device_id='omi-1',
+            event_id='event-1',
+            timestamp='2026-08-21T04:15:00Z',
+        )
+    )
+    await first_started.wait()
+    second = asyncio.create_task(
+        webhooks.button_event_webhook(
+            'uid-1',
+            button_event='double_tap',
+            device_id='omi-1',
+            event_id='event-2',
+            timestamp='2026-08-21T04:15:01Z',
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert delivered == ['event-1']
+    release_first.set()
+    await asyncio.gather(first, second)
+    assert delivered == ['event-1', 'event-2']
+
+
+@pytest.mark.asyncio
+async def test_button_event_is_noop_when_not_configured(monkeypatch):
+    from utils import webhooks
+
+    monkeypatch.setattr(webhooks, 'user_webhook_status_db', MagicMock(return_value=False))
+    post_webhook = AsyncMock()
+    monkeypatch.setattr(webhooks, '_post_dev_webhook', post_webhook)
+
+    await webhooks.button_event_webhook(
+        'uid-1',
+        button_event='long_tap',
+        device_id='omi-1',
+        event_id='event-1',
+        timestamp='2026-08-21T04:15:00Z',
+    )
+
+    post_webhook.assert_not_awaited()

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Iterable, List, Optional
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from weakref import WeakValueDictionary
 
 from database.redis_db import (
     get_user_webhook_db,
@@ -48,6 +49,8 @@ _SAMPLE_RATE_RE = re.compile(r'^[1-9]\d{2,5}$')
 
 _audio_bytes_send_locks: dict[str, asyncio.Lock] = {}
 _audio_bytes_send_locks_guard = asyncio.Lock()
+_button_event_send_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
+_button_event_send_locks_guard = asyncio.Lock()
 
 
 async def _get_audio_bytes_send_lock(uid: str) -> asyncio.Lock:
@@ -56,6 +59,16 @@ async def _get_audio_bytes_send_lock(uid: str) -> asyncio.Lock:
         if lock is None:
             lock = asyncio.Lock()
             _audio_bytes_send_locks[uid] = lock
+        return lock
+
+
+async def _get_button_event_send_lock(uid: str, device_id: str) -> asyncio.Lock:
+    key = f'{uid}:{device_id}'
+    async with _button_event_send_locks_guard:
+        lock = _button_event_send_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _button_event_send_locks[key] = lock
         return lock
 
 
@@ -429,6 +442,87 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             )
             await _handle_dev_webhook_disable(uid, WebhookType.audio_bytes, should_disable)
             logger.error(f"Error sending audio bytes to developer webhook: {e}")
+
+
+async def button_event_webhook(
+    uid: str,
+    *,
+    button_event: str,
+    device_id: str,
+    event_id: str,
+    timestamp: str,
+    session_id: Optional[str] = None,
+) -> None:
+    """Forward an opt-in hardware button gesture to the developer webhook (#11719)."""
+    lock = await _get_button_event_send_lock(uid, device_id)
+    async with lock:
+        await _button_event_webhook_serialized(
+            uid,
+            button_event=button_event,
+            device_id=device_id,
+            event_id=event_id,
+            timestamp=timestamp,
+            session_id=session_id,
+        )
+
+
+async def _button_event_webhook_serialized(
+    uid: str,
+    *,
+    button_event: str,
+    device_id: str,
+    event_id: str,
+    timestamp: str,
+    session_id: Optional[str] = None,
+) -> None:
+    toggled = await run_blocking(db_executor, user_webhook_status_db, uid, WebhookType.button_event)
+    if not toggled:
+        return
+    webhook_url = await run_blocking(db_executor, get_user_webhook_db, uid, WebhookType.button_event)
+    if not webhook_url:
+        return
+    webhook_url = _append_query_params(webhook_url, {'uid': uid})
+    cb = get_webhook_circuit_breaker(webhook_url)
+    if not cb.allow_request():
+        logger.info(f'button_event_webhook: circuit breaker open for {webhook_url[:80]}')
+        return
+    payload = {
+        'event_type': 'button_event',
+        'button_event': button_event,
+        'device_id': device_id,
+        'event_id': event_id,
+        'timestamp': timestamp,
+        'session_id': session_id,
+    }
+    try:
+        response = await _post_dev_webhook(
+            'button_event_webhook',
+            webhook_url,
+            json=payload,
+            headers={'Content-Type': 'application/json'},
+            idempotency_key=event_id,
+        )
+        if 200 <= response.status_code < 300:
+            cb.record_success()
+            await run_blocking(db_executor, record_dev_webhook_success, uid, WebhookType.button_event)
+        else:
+            cb.record_failure()
+            should_disable = await run_blocking(
+                db_executor,
+                record_dev_webhook_failure,
+                uid,
+                WebhookType.button_event,
+                response.status_code,
+                f'HTTP {response.status_code}',
+            )
+            await _handle_dev_webhook_disable(uid, WebhookType.button_event, should_disable)
+    except Exception as e:
+        cb.record_failure()
+        should_disable = await run_blocking(
+            db_executor, record_dev_webhook_failure, uid, WebhookType.button_event, 0, type(e).__name__
+        )
+        await _handle_dev_webhook_disable(uid, WebhookType.button_event, should_disable)
+        logger.error(f'Error sending button_event developer webhook: {e}')
 
 
 def webhook_first_time_setup(uid: str, wType: WebhookType) -> bool:

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -12195,6 +12195,32 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func postDeveloperButtonEventV1UsersDeveloperButtonEventPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/developer/button-event"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func getUserWebhookEndpointV1UsersDeveloperWebhookWtypeGet(client: OmiApiClient, wtype: String, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/users/developer/webhook/\(wtype)"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -15069,5 +15095,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 403 Swift client methods generated.
+  // Total: 404 Swift client methods generated.
 }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -769,6 +769,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarEventLink {
   attendee_emails?: Array<string>;
   attendees?: Array<string>;
@@ -3958,6 +3966,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -3992,7 +4001,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4232,6 +4241,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
   "CalendarOnboardingResetResponse": CalendarOnboardingResetResponse;
@@ -7685,6 +7695,16 @@ export interface OmiApiPaths {
   "/v1/users/delete-account": {
     delete: {
       operationId: "delete_account_v1_users_delete_account_delete";
+      responses: {
+        "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
       responses: {
         "200": UserStatusResponse;
         "401": void;
@@ -14531,6 +14551,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -16729,4 +16770,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 404 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -4897,6 +4897,57 @@
         "title": "BulkMoveConversationsResponse",
         "type": "object"
       },
+      "ButtonEventRequest": {
+        "properties": {
+          "button_event": {
+            "enum": [
+              "single_tap",
+              "double_tap",
+              "long_tap"
+            ],
+            "title": "Button Event",
+            "type": "string"
+          },
+          "device_id": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Device Id",
+            "type": "string"
+          },
+          "event_id": {
+            "description": "Stable id for the physical gesture across retries",
+            "format": "uuid",
+            "title": "Event Id",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          }
+        },
+        "required": [
+          "button_event",
+          "device_id",
+          "event_id",
+          "timestamp"
+        ],
+        "title": "ButtonEventRequest",
+        "type": "object"
+      },
       "CalendarEventLink": {
         "description": "Links a conversation to a Google Calendar event.",
         "properties": {
@@ -24183,6 +24234,11 @@
             "title": "Audio Bytes",
             "type": "boolean"
           },
+          "button_event": {
+            "default": false,
+            "title": "Button Event",
+            "type": "boolean"
+          },
           "day_summary": {
             "title": "Day Summary",
             "type": "boolean"
@@ -24359,7 +24415,8 @@
           "audio_bytes_websocket",
           "realtime_transcript",
           "memory_created",
-          "day_summary"
+          "day_summary",
+          "button_event"
         ],
         "title": "WebhookType",
         "type": "string"
@@ -50696,6 +50753,94 @@
           }
         ],
         "summary": "Delete Account",
+        "tags": [
+          "v1"
+        ]
+      }
+    },
+    "/v1/users/developer/button-event": {
+      "post": {
+        "description": "App → backend forward of an opt-in hardware button gesture (#11719).",
+        "operationId": "post_developer_button_event_v1_users_developer_button_event_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ButtonEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Post Developer Button Event",
         "tags": [
           "v1"
         ]

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -769,6 +769,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarEventLink {
   attendee_emails?: Array<string>;
   attendees?: Array<string>;
@@ -3958,6 +3966,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -3992,7 +4001,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4232,6 +4241,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
   "CalendarOnboardingResetResponse": CalendarOnboardingResetResponse;
@@ -7685,6 +7695,16 @@ export interface OmiApiPaths {
   "/v1/users/delete-account": {
     delete: {
       operationId: "delete_account_v1_users_delete_account_delete";
+      responses: {
+        "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
       responses: {
         "200": UserStatusResponse;
         "401": void;
@@ -14531,6 +14551,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -16729,4 +16770,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 404 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -769,6 +769,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarEventLink {
   attendee_emails?: Array<string>;
   attendees?: Array<string>;
@@ -3958,6 +3966,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -3992,7 +4001,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4232,6 +4241,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
   "CalendarOnboardingResetResponse": CalendarOnboardingResetResponse;
@@ -7685,6 +7695,16 @@ export interface OmiApiPaths {
   "/v1/users/delete-account": {
     delete: {
       operationId: "delete_account_v1_users_delete_account_delete";
+      responses: {
+        "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
       responses: {
         "200": UserStatusResponse;
         "401": void;
@@ -14531,6 +14551,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -16729,4 +16770,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 404 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -769,6 +769,14 @@ export interface BulkMoveConversationsResponse {
   status: string;
 }
 
+export interface ButtonEventRequest {
+  button_event: "single_tap" | "double_tap" | "long_tap";
+  device_id: string;
+  event_id: string;
+  session_id?: string | null;
+  timestamp: string;
+}
+
 export interface CalendarEventLink {
   attendee_emails?: Array<string>;
   attendees?: Array<string>;
@@ -3958,6 +3966,7 @@ export interface UserWebhookUrlResponse {
 
 export interface UserWebhooksStatusResponse {
   audio_bytes: boolean;
+  button_event?: boolean;
   day_summary: boolean;
   memory_created: boolean;
   realtime_transcript: boolean;
@@ -3992,7 +4001,7 @@ export interface WebSearchAssistantSettings {
   enabled?: boolean | null;
 }
 
-export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary";
+export type WebhookType = "audio_bytes" | "audio_bytes_websocket" | "realtime_transcript" | "memory_created" | "day_summary" | "button_event";
 
 export interface WhatMattersNowProjection {
   evaluation_id: string;
@@ -4232,6 +4241,7 @@ export interface OmiApiSchemas {
   "BulkAssignSegmentsRequest": BulkAssignSegmentsRequest;
   "BulkMoveConversationsRequest": BulkMoveConversationsRequest;
   "BulkMoveConversationsResponse": BulkMoveConversationsResponse;
+  "ButtonEventRequest": ButtonEventRequest;
   "CalendarEventLink": CalendarEventLink;
   "CalendarMeetingContext": CalendarMeetingContext;
   "CalendarOnboardingResetResponse": CalendarOnboardingResetResponse;
@@ -7685,6 +7695,16 @@ export interface OmiApiPaths {
   "/v1/users/delete-account": {
     delete: {
       operationId: "delete_account_v1_users_delete_account_delete";
+      responses: {
+        "200": UserStatusResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/developer/button-event": {
+    post: {
+      operationId: "post_developer_button_event_v1_users_developer_button_event_post";
       responses: {
         "200": UserStatusResponse;
         "401": void;
@@ -14531,6 +14551,27 @@ export async function delete_account_v1_users_delete_account_delete(header: { au
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function post_developer_button_event_v1_users_developer_button_event_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ButtonEventRequest, init?: OmiApiClientInit): Promise<UserStatusResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/developer/button-event`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_webhook_endpoint_v1_users_developer_webhook__wtype__get(path: { wtype: WebhookType }, header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, init?: OmiApiClientInit): Promise<UserWebhookUrlResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/developer/webhook/${path.wtype}`;
@@ -16729,4 +16770,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 404 client methods generated.


### PR DESCRIPTION
## Summary

- add an authenticated app-to-backend endpoint for physical Omi button gestures
- expose opt-in `button_event` webhook settings and forward the documented event payload with the physical gesture ID as the delivery idempotency key
- serialize deliveries per user/device while keeping the lock registry weakly held, so gesture order is preserved without an unbounded module cache
- validate gesture kind, UUID event identity, device/session lengths, and timezone-aware timestamps at the public boundary
- regenerate the released app-client OpenAPI contract plus Dart, Swift, and TypeScript DTOs

Closes #11719

## Verification

- `backend/.venv/bin/pytest -q backend/tests/unit/test_button_event_webhook.py backend/tests/unit/test_webhook_auto_disable.py` (123 passed)
- app-client, public, and integration-public OpenAPI contract checks passed
- Dart, Swift, and TypeScript OpenAPI generator checks passed
- `cd web/app && bun run check` (54 files, 305 tests passed after one unrelated timing-sensitive retry)
- `xcrun swift build -c debug --package-path Desktop` was attempted twice; dependency artifact downloads timed out before compilation, so the generated Swift client is generator-verified but not locally compiled
- `OMI_PR_BODY_FILE=/tmp/omi-pr-body-11719.md make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-body-11719.md`

## Product invariants

None.

Line-Count-Exception: backend/routers/users.py | 2177 -> 2204 | existing developer-webhook routes and their shared response models are owned here; moving this one endpoint would split one API surface across routers


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

