### PR TITLE
docs(helm): explain pusher connection target

### DIFF
--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -397,6 +397,9 @@ autoscaling:
       selectPolicy: Max
   # targetCPUUtilizationPercentage: 60
   # targetMemoryUtilizationPercentage: 60
+  # Intentionally higher than backend-listen (22): pusher's WebSocket
+  # handling profile sustains 30 concurrent connections per pod, while
+  # backend-listen does not. Keep the two values independently tuned (#6752).
   activeConnectionsPerPod: 30
 
 podDisruptionBudget:


### PR DESCRIPTION
## Summary

- document that the production pusher target of 30 active WebSocket connections per pod is intentional
- explain why it remains independent from backend-listen's lower target of 22
- keep the deployed autoscaling value unchanged

Closes #6752

## Verification

- `helm template pusher backend/charts/pusher -f backend/charts/pusher/prod_omi_pusher_values.yaml --set image.tag=test`
- `OMI_PR_BODY_FILE=/tmp/omi-pr-body-6752.md make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-body-6752.md`

## Product invariants

None.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

