### PR TITLE
fix(app): stop OnDeviceWhisperProvider discarding the configured language

### DIFF
--- a/app/lib/services/sockets/on_device_whisper_provider.dart
+++ b/app/lib/services/sockets/on_device_whisper_provider.dart
@@ -59,6 +59,19 @@ class OnDeviceWhisperProvider implements ISttProvider {
     }
   }
 
+  @visibleForTesting
+  TranscribeRequest buildTranscribeRequest(String audioPath, {String? language}) {
+    final effectiveLanguage = language ?? this.language;
+    return TranscribeRequest(
+      audio: audioPath,
+      // Empty string lets whisper.cpp auto-detect; used for the 'multi' setting.
+      language: effectiveLanguage == 'multi' ? '' : effectiveLanguage,
+      isTranslate: false,
+      isNoTimestamps: true,
+      splitOnWord: false,
+    );
+  }
+
   @override
   Future<SttTranscriptionResult?> transcribe(
     Uint8List audioData, {
@@ -76,13 +89,7 @@ class OnDeviceWhisperProvider implements ISttProvider {
       await tempFile.writeAsBytes(audioData);
 
       try {
-        final req = TranscribeRequest(
-          audio: tempFile.path,
-          language: (language == 'multi' ? '' : language) ?? '',
-          isTranslate: false,
-          isNoTimestamps: true,
-          splitOnWord: false,
-        );
+        final req = buildTranscribeRequest(tempFile.path, language: language);
 
         final res = await _whisper!.transcribe(transcribeRequest: req);
 

--- a/app/test/services/sockets/on_device_whisper_provider_test.dart
+++ b/app/test/services/sockets/on_device_whisper_provider_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:omi/services/sockets/on_device_whisper_provider.dart';
+
+void main() {
+  group('OnDeviceWhisperProvider.buildTranscribeRequest', () {
+    // Regression: transcribe()'s optional `language` parameter shadowed the
+    // provider's `language` field, so the configured language was silently
+    // dropped and whisper always ran with '' (auto-detect).
+    test('falls back to the provider language when no per-call language is given', () {
+      final provider = OnDeviceWhisperProvider(modelPath: '/models/ggml-tiny.bin', language: 'ru');
+
+      final req = provider.buildTranscribeRequest('/tmp/audio.wav');
+
+      expect(req.language, 'ru');
+      expect(req.audio, '/tmp/audio.wav');
+    });
+
+    test('per-call language overrides the provider language', () {
+      final provider = OnDeviceWhisperProvider(modelPath: '/models/ggml-tiny.bin', language: 'ru');
+
+      final req = provider.buildTranscribeRequest('/tmp/audio.wav', language: 'de');
+
+      expect(req.language, 'de');
+    });
+
+    test("maps 'multi' to an empty string so whisper auto-detects", () {
+      final provider = OnDeviceWhisperProvider(modelPath: '/models/ggml-tiny.bin', language: 'multi');
+
+      final req = provider.buildTranscribeRequest('/tmp/audio.wav');
+
+      expect(req.language, '');
+    });
+  });
+}


### PR DESCRIPTION
## What changed and why

`OnDeviceWhisperProvider.transcribe` declared an optional named parameter `String? language`
that shadowed the provider's own `language` field. The only caller,
`PurePollingSocket._flushBuffer`, never passes it (`ISttProvider` has no such parameter), so
`(language == 'multi' ? '' : language) ?? ''` always resolved to `''` — whisper.cpp always ran
in auto-detect mode, silently dropping the language the user picked in transcription settings.
The sibling `OnDeviceAppleProvider` already resolves `language ?? this.language` correctly;
this provider didn't.

## Product invariants affected

none

## How it was verified

- `flutter test test/services/sockets/on_device_whisper_provider_test.dart` — 3/3 passed
  (provider-language fallback incl. `'ru'`, per-call override, `'multi'` → `''`).
- `bash app/test.sh` (full suite, Flutter 3.47.1) — 1393 passed, 0 failed.
- `bash app/scripts/analyze_ratchet.sh` — passed, no new lint occurrences (`avoid_print` and
  `sort_child_properties_last` baselines actually improved, unrelated to this change).

## Tests

Bug fix — regression test added: `test/services/sockets/on_device_whisper_provider_test.dart`
now covers the language fallback that was previously silently dropped (configured-language
fallback, per-call override, `'multi'` → `''` for whisper auto-detect).

## Failure class (fixes)

Failure-Class: none

## Scoped cleanups (optional)

Extracted request construction into `buildTranscribeRequest()` (marked `@visibleForTesting`)
so the regression test can assert the exact value handed to `TranscribeRequest` without
touching whisper's FFI layer. No unrelated cleanup bundled in.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

