### PR TITLE
fix(backend): emit Limitless creation webhook

### DIFF
--- a/backend/tests/unit/test_sync_v2.py
+++ b/backend/tests/unit/test_sync_v2.py
@@ -1607,6 +1607,28 @@ class TestAsyncCoordinatorBehavioral:
             'uid', 'current-conversation', {'audio_files': [{'path': 'current.opus'}]}
         )
 
+    def test_limitless_discard_recovery_emits_one_creation_webhook(self, fenced_worker_module):
+        """A pendant conversation becomes webhook-visible when merged speech revives it."""
+        _module, stubs = fenced_worker_module
+        pipeline = stubs['pipeline']
+        limitless_source = pipeline.ConversationSource.limitless
+        original = types.SimpleNamespace(source=limitless_source, discarded=True)
+        recovered = types.SimpleNamespace(source=limitless_source, discarded=False)
+
+        pipeline.conversations_db.get_conversation = MagicMock(return_value={'id': 'limitless-conversation'})
+        pipeline.deserialize_conversation = MagicMock(return_value=original)
+        pipeline.process_conversation = MagicMock(return_value=recovered)
+        pipeline._run_conversation_created_webhook = MagicMock()
+        pipeline.submit_with_context = MagicMock(side_effect=lambda _executor, fn, *args: fn(*args))
+
+        pipeline._reprocess_conversation_after_update('uid-1', 'limitless-conversation', 'en')
+
+        pipeline._run_conversation_created_webhook.assert_called_once_with('uid-1', recovered)
+
+        original.discarded = False
+        pipeline._reprocess_conversation_after_update('uid-1', 'limitless-conversation', 'en')
+        pipeline._run_conversation_created_webhook.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_durable_completion_offloads_epoch_and_terminal_metric(self, fenced_worker_module):
         """Redis-backed fencing and telemetry never run on the async coordinator loop."""

--- a/backend/utils/sync/pipeline.py
+++ b/backend/utils/sync/pipeline.py
@@ -64,14 +64,22 @@ from database.sync_ledger import (
     release_sync_content_claim_after_job_retired,
     release_sync_content_claim,
 )
-from models.conversation import CreateConversation
+from models.conversation import Conversation, CreateConversation
 from models.conversation_enums import ConversationSource
 from models.transcript_segment import TranscriptSegment
 from utils.analytics import record_usage
 from utils.byok import get_byok_keys, set_byok_keys, set_byok_uid
 from utils.conversations.factory import deserialize_conversation
 from utils.conversations.process_conversation import process_conversation
-from utils.executors import db_executor, run_blocking, start_background_task, storage_executor, sync_executor
+from utils.executors import (
+    db_executor,
+    postprocess_executor,
+    run_blocking,
+    start_background_task,
+    storage_executor,
+    submit_with_context,
+    sync_executor,
+)
 from utils.fair_use import (
     FAIR_USE_ENABLED,
     FAIR_USE_RESTRICT_DAILY_DG_MS,
@@ -761,6 +769,13 @@ def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None):
         del aseg
 
 
+def _run_conversation_created_webhook(uid: str, conversation: Conversation) -> None:
+    """Load the webhook surface only in the post-processing worker that uses it."""
+    from utils.webhooks import conversation_created_webhook
+
+    asyncio.run(conversation_created_webhook(uid, conversation))
+
+
 def _reprocess_conversation_after_update(uid: str, conversation_id: str, language: str):
     """
     Reprocess a conversation after new segments have been added.
@@ -776,7 +791,8 @@ def _reprocess_conversation_after_update(uid: str, conversation_id: str, languag
     # Convert to Conversation object
     conversation = deserialize_conversation(conversation_data)
 
-    process_conversation(
+    was_discarded = conversation.discarded
+    processed_conversation = process_conversation(
         uid=uid,
         language_code=language or 'en',
         conversation=conversation,
@@ -784,6 +800,15 @@ def _reprocess_conversation_after_update(uid: str, conversation_id: str, languag
         is_reprocess=True,
         persistence_observer=_require_current_conversation_persistence,
     )
+
+    # Limitless uploads commonly begin as a short discarded fragment and only
+    # become a real conversation after later WAL segments are merged. The
+    # initial discarded pass is not a useful creation event, while the generic
+    # reprocess path deliberately suppresses webhooks. Emit exactly at the
+    # discarded -> visible transition so pendant conversations reach developer
+    # integrations without duplicating events on ordinary later reprocessing.
+    if conversation.source == ConversationSource.limitless and was_discarded and not processed_conversation.discarded:
+        submit_with_context(postprocess_executor, _run_conversation_created_webhook, uid, processed_conversation)
 
     logger.info(f'Successfully reprocessed conversation {conversation_id}')
 

--- a/docs/doc/developer/apps/Integrations.mdx
+++ b/docs/doc/developer/apps/Integrations.mdx
@@ -52,6 +52,12 @@ flowchart LR
 
 These apps are activated when Omi creates a new memory, allowing you to process or store the data externally.
 
+<Note>
+  This trigger also covers conversations uploaded from a Limitless Pendant. If an
+  initial short fragment is discarded, Omi sends the event once later uploaded
+  speech makes the conversation visible.
+</Note>
+
 <AccordionGroup>
   <Accordion title="How It Works" icon="gear">
     1. User completes a conversation
@@ -148,6 +154,12 @@ Check out the [Notion CRM Example](https://github.com/BasedHardware/Omi/blob/mai
 
 Process conversation transcripts as they occur, enabling real-time analysis and actions.
 
+<Note>
+  This trigger requires an active live-listen session. Historical or
+  store-and-forward uploads, including Limitless Pendant WAL uploads, do not
+  replay transcript segments through the real-time webhook.
+</Note>
+
 <AccordionGroup>
   <Accordion title="How It Works" icon="gear">
     1. User starts speaking
@@ -231,6 +243,11 @@ Real-time processors require careful design to avoid performance issues.
 ## Real-Time Audio Bytes
 
 Stream raw audio bytes from Omi directly to your endpoint for custom audio processing.
+
+<Note>
+  Audio-byte delivery requires an active live-listen session. Historical or
+  store-and-forward uploads do not replay their audio through this webhook.
+</Note>
 
 <AccordionGroup>
   <Accordion title="How It Works" icon="gear">


### PR DESCRIPTION
## Summary

- send the conversation-created developer webhook when a Limitless sync upload revives an initially discarded fragment into a visible conversation
- emit only on the `discarded -> visible` transition, avoiding duplicate events during ordinary later reprocessing
- run delivery on the bounded post-processing executor so sync completion is not held open by a developer endpoint
- document that transcript and raw-audio webhooks require a live-listen session and are not replayed for store-and-forward uploads

Closes #11365

## Verification

- `backend/.venv/bin/pytest -q backend/tests/unit/test_sync_v2.py backend/tests/unit/test_webhook_auto_disable.py` (288 passed)
- `BACKEND_UNIT_TEST_FILE_LIST=/tmp/omi-backend-unit-failures.txt bash test.sh` (158 sync isolation/Cloud Tasks tests passed)
- `black --check --line-length 120 --skip-string-normalization backend/utils/sync/pipeline.py backend/tests/unit/test_sync_v2.py`
- `OMI_PR_BODY_FILE=/tmp/omi-pr-body-11365.md make preflight`
- `scripts/pr-preflight --pr-body-file /tmp/omi-pr-body-11365.md`

## Product invariants

None.

Failure-Class: none

Line-Count-Exception: backend/utils/sync/pipeline.py | 2499 -> 2524 | the sync merge owner must observe the Limitless discarded-to-visible transition at the point where reprocessing returns its persisted conversation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

