### PR TITLE
docs(backend): expose self-hosted Firebase auth project

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -84,6 +84,12 @@ RAPID_API_KEY=
 # Firebase OAuth
 FIREBASE_API_KEY=
 FIREBASE_AUTH_DOMAIN=
+# Project whose Firebase ID tokens this backend accepts. This is intentionally
+# separate from FIREBASE_PROJECT_ID so a self-hosted data project can verify
+# tokens minted for the Firebase project used by the client app. Stock Omi
+# mobile builds use based-hardware-dev; custom builds use their own project ID.
+FIREBASE_AUTH_PROJECT_ID=
+# Google Cloud/Firebase data project used by this backend's own services.
 FIREBASE_PROJECT_ID=
 
 # Encrypts conversations, memories, and chat messages. Required; set a unique

--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -330,6 +330,9 @@ OAuth is required for user authentication. You need to configure both Google and
 
     Firebase ID tokens are verified with the issuer's public signing keys, so
     `FIREBASE_AUTH_PROJECT_ID` does not require Omi service-account credentials.
+    When it is unset, Firebase Admin uses its default project selection instead;
+    set the auth project explicitly when it differs from your data-project setup,
+    or stock mobile-build tokens will be rejected.
     Do not enable `LOCAL_DEVELOPMENT` on an internet-accessible deployment: that
     mode intentionally bypasses authentication for local harnesses.
   </Step>
@@ -500,6 +503,12 @@ Complete reference for all `.env` variables:
     | `APPLE_KEY_ID` | Apple private key ID |
     | `APPLE_PRIVATE_KEY` | Apple .p8 file contents (with BEGIN/END lines) |
     | `BASE_API_URL` | Your backend URL (e.g., Ngrok URL) |
+  </Tab>
+  <Tab title="Firebase projects" icon="fire">
+    | Variable | Description |
+    |----------|-------------|
+    | `FIREBASE_AUTH_PROJECT_ID` | Firebase project whose ID-token audience the backend accepts; set this explicitly when it differs from the data project. |
+    | `FIREBASE_PROJECT_ID` | Google Cloud/Firebase project used for the backend's Firestore and other data services. |
   </Tab>
   <Tab title="Storage" icon="database">
     | Variable | Description |

--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -316,6 +316,22 @@ OAuth is required for user authentication. You need to configure both Google and
     ```
 
     Edit `.env` and fill in your API keys (see [Environment Variables](#environment-variables) below).
+
+    For a self-hosted backend used by an existing Omi mobile build, set the
+    Firebase token audience separately from your data project:
+
+    ```dotenv
+    # Stock development/community Omi mobile builds mint tokens for this project.
+    FIREBASE_AUTH_PROJECT_ID=based-hardware-dev
+
+    # Your own Google Cloud/Firebase project for Firestore and other backend data.
+    FIREBASE_PROJECT_ID=your-self-hosted-project
+    ```
+
+    Firebase ID tokens are verified with the issuer's public signing keys, so
+    `FIREBASE_AUTH_PROJECT_ID` does not require Omi service-account credentials.
+    Do not enable `LOCAL_DEVELOPMENT` on an internet-accessible deployment: that
+    mode intentionally bypasses authentication for local harnesses.
   </Step>
 </Steps>
 


### PR DESCRIPTION
## Summary

- expose `FIREBASE_AUTH_PROJECT_ID` in the backend environment template
- document credential-free Firebase ID-token verification for self-hosted backends
- keep the authentication audience separate from the operator's data project
- warn operators not to use the unauthenticated local-development bypass on public deployments

Fixes #6636

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_env_loader.py -q` (15 passed)
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

