### PR TITLE
fix(backend): bound critical executor backlog

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -8,7 +8,7 @@ from firebase_admin import auth
 import database.mcp_api_key as mcp_api_key_db
 import database.dev_api_key as dev_api_key_db
 from utils.api_key_families import DEV_FAMILY, MCP_FAMILY, wrong_key_family_detail
-from utils.executors import critical_executor, db_executor, run_blocking
+from utils.executors import ExecutorSaturatedError, critical_executor, db_executor, run_blocking
 from utils.log_sanitizer import sanitize
 from utils.observability.api_keys import record_api_key_repairs
 from utils.memory.product_authorization import ProductAuthorizationContext
@@ -61,6 +61,12 @@ async def get_current_user_id(
     try:
         id_token = credentials.credentials
         decoded_token = await run_blocking(critical_executor, auth.verify_id_token, id_token)
+    except ExecutorSaturatedError as error:
+        raise HTTPException(
+            status_code=503,
+            detail='Authentication temporarily unavailable. Try again shortly.',
+            headers={'Retry-After': '1'},
+        ) from error
     except Exception as e:
         logger.error(f"Error verifying Firebase ID token: {e}")
         raise HTTPException(status_code=401, detail="Invalid authentication credentials")

--- a/backend/routers/omni_relay.py
+++ b/backend/routers/omni_relay.py
@@ -14,9 +14,9 @@ from utils.byok import (
     set_byok_keys,
     validate_byok_websocket,
 )
-from utils.executors import critical_executor, db_executor, run_blocking
+from utils.executors import db_executor, run_blocking
 from utils.llm.gateway_client import raise_if_gateway_feature_mode_blocks_direct_model_surface
-from utils.other.endpoints import _verify_ws_auth  # type: ignore[reportPrivateUsage]  # shared WS auth helper, intentionally reused cross-module
+from utils.other.endpoints import run_critical_ws, verify_ws_auth
 import database.users as users_db
 from models.users import PlanType
 from utils.subscription import get_chat_quota_snapshot, is_trial_paywalled
@@ -85,7 +85,7 @@ async def omni_relay(websocket: WebSocket):
         f"provider={websocket.query_params.get('provider')}"
     )
     try:
-        uid = await run_blocking(critical_executor, _verify_ws_auth, cast(str, authz))
+        uid = await run_critical_ws(verify_ws_auth, cast(str, authz))
     except WebSocketException as e:
         logger.warning(f"omni relay auth rejected: code={e.code} reason={e.reason}")
         await websocket.close(code=e.code, reason=e.reason or "unauthorized")
@@ -95,7 +95,7 @@ async def omni_relay(websocket: WebSocket):
     byok = extract_byok_from_websocket(websocket)
     if byok:
         set_byok_keys(byok)
-        byok_err = await run_blocking(critical_executor, validate_byok_websocket, uid)
+        byok_err = await run_critical_ws(validate_byok_websocket, uid)
         if byok_err:
             logger.warning(f"omni relay BYOK invalid uid={uid}: {byok_err}")
             await websocket.close(code=4003, reason=byok_err)

--- a/backend/tests/unit/test_dependency_async_boundaries.py
+++ b/backend/tests/unit/test_dependency_async_boundaries.py
@@ -435,3 +435,16 @@ def test_authentication_and_scope_failures_preserve_public_http_semantics() -> N
             asyncio.run(dependencies.get_auth_with_goals_write(no_scope))
         assert scope_exc.value.status_code == 403
         assert dependencies.Scopes.GOALS_WRITE in scope_exc.value.detail
+
+
+def test_firebase_verification_saturation_is_retryable_503() -> None:
+    with _loaded_dependencies() as (dependencies, _firebase_auth, _mcp_db, _dev_db):
+        dependencies.run_blocking = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            dependencies.ExecutorSaturatedError('critical executor is saturated')
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(dependencies.get_current_user_id(SimpleNamespace(credentials='firebase-token')))
+
+        assert exc.value.status_code == 503
+        assert exc.value.headers == {'Retry-After': '1'}

--- a/backend/tests/unit/test_executor_backpressure.py
+++ b/backend/tests/unit/test_executor_backpressure.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from utils.executors import ExecutorSaturatedError, MonitoredThreadPoolExecutor
+
+
+def test_bounded_executor_rejects_work_after_worker_and_queue_fill() -> None:
+    release = threading.Event()
+    started = threading.Event()
+
+    def blocked() -> None:
+        started.set()
+        release.wait(timeout=5)
+
+    executor = MonitoredThreadPoolExecutor(name='test', max_workers=1, max_queue_size=2)
+    try:
+        futures = [executor.submit(blocked) for _ in range(3)]
+        assert started.wait(timeout=1)
+
+        with pytest.raises(ExecutorSaturatedError, match='test executor is saturated'):
+            executor.submit(lambda: None)
+
+        release.set()
+        for future in futures:
+            future.result(timeout=2)
+    finally:
+        release.set()
+        executor.shutdown(wait=True, cancel_futures=True)
+
+
+def test_bounded_executor_reopens_capacity_after_completion() -> None:
+    executor = MonitoredThreadPoolExecutor(name='test', max_workers=1, max_queue_size=0)
+    try:
+        assert executor.submit(lambda: 41).result(timeout=1) == 41
+        assert executor.submit(lambda: 42).result(timeout=1) == 42
+    finally:
+        executor.shutdown(wait=True, cancel_futures=True)

--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -390,6 +390,16 @@ class TestWithRateLimitWrapper(unittest.TestCase):
             asyncio.run(dep_func(uid="user123"))
         self.assertEqual(ctx.exception.status_code, 429)
 
+    def test_with_rate_limit_dependency_maps_executor_saturation_to_503(self):
+        dep_func = self.ep.with_rate_limit(lambda: "uid", "chat:send_message")
+
+        with patch.object(self.ep, 'run_blocking', side_effect=self.ep.ExecutorSaturatedError('saturated')):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(dep_func(uid="user123"))
+
+        self.assertEqual(ctx.exception.status_code, 503)
+        self.assertEqual(ctx.exception.headers, {'Retry-After': '1'})
+
     @patch('utils.other.endpoints._enforce_rate_limit')
     def test_with_rate_limit_context_uses_app_key_identity(self, mock_enforce):
         dep_func = self.ep.with_rate_limit_context(lambda: "unused", "dev:conversations_read")

--- a/backend/tests/unit/test_ws_auth_handshake.py
+++ b/backend/tests/unit/test_ws_auth_handshake.py
@@ -166,6 +166,19 @@ class TestWebSocketAuthListen(WebSocketAuthTestCase):
                 self.fail("Expected WebSocket to be closed by server")
         self.assertEqual(ctx.exception.code, 1008)
 
+    def test_critical_executor_saturation_sends_close_1013(self):
+        """Overloaded auth capacity tells clients to retry, rather than misreporting bad credentials."""
+        endpoints = sys.modules['utils.other.endpoints']
+        with patch.object(
+            endpoints,
+            'run_blocking',
+            side_effect=endpoints.ExecutorSaturatedError('critical executor is saturated'),
+        ):
+            with self.assertRaises(WebSocketDisconnect) as ctx:
+                with self.client.websocket_connect("/ws-listen", headers={"Authorization": "Bearer valid_token"}):
+                    self.fail("Expected overload close frame")
+        self.assertEqual(ctx.exception.code, 1013)
+
     @patch('utils.other.endpoints.verify_token', side_effect=InvalidIdTokenError('bad token'))
     def test_invalid_token_sends_close_1008(self, mock_verify):
         """Invalid token -> WebSocketDisconnect with code 1008."""

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -35,21 +35,42 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
-class MonitoredThreadPoolExecutor(ThreadPoolExecutor):
-    """ThreadPoolExecutor with active-task tracking for observability."""
+class ExecutorSaturatedError(RuntimeError):
+    """Raised when a bounded executor has no worker or queue capacity left."""
 
-    def __init__(self, name: str, **kwargs: Any):
+
+class MonitoredThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor with active-task tracking and optional backpressure."""
+
+    def __init__(self, name: str, *, max_queue_size: int | None = None, **kwargs: Any):
         super().__init__(**kwargs)
         self.name = name
         self._active_count = 0
         self._active_lock = threading.Lock()
+        self.max_queue_size = max_queue_size
+        max_workers = self._max_workers
+        self._submission_slots = (
+            threading.BoundedSemaphore(max_workers + max_queue_size) if max_queue_size is not None else None
+        )
 
     @property
     def active_count(self) -> int:
         return self._active_count
 
     def submit(self, fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> Future[T]:
-        future = super().submit(self._tracked, fn, *args, **kwargs)
+        slots = self._submission_slots
+        if slots is not None and not slots.acquire(blocking=False):
+            raise ExecutorSaturatedError(
+                f'{self.name} executor is saturated ({self._max_workers} workers, {self.max_queue_size} queued)'
+            )
+        try:
+            future = super().submit(self._tracked, fn, *args, **kwargs)
+        except BaseException:
+            if slots is not None:
+                slots.release()
+            raise
+        if slots is not None:
+            future.add_done_callback(lambda _future: slots.release())
         return future
 
     def _tracked(self, fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
@@ -62,7 +83,12 @@ class MonitoredThreadPoolExecutor(ThreadPoolExecutor):
                 self._active_count -= 1
 
 
-critical_executor = MonitoredThreadPoolExecutor(name="critical", max_workers=8, thread_name_prefix="critical")
+# Authentication and rate-limit work gates every request. Bound the outstanding
+# work so a slow identity provider cannot turn a burst into an unbounded memory
+# queue (#6753); callers receive an explicit saturation failure instead.
+critical_executor = MonitoredThreadPoolExecutor(
+    name="critical", max_workers=8, max_queue_size=64, thread_name_prefix="critical"
+)
 db_executor = MonitoredThreadPoolExecutor(name="db", max_workers=24, thread_name_prefix="db")
 llm_executor = MonitoredThreadPoolExecutor(name="llm", max_workers=6, thread_name_prefix="llm")
 stripe_executor = MonitoredThreadPoolExecutor(name="stripe", max_workers=4, thread_name_prefix="stripe")
@@ -113,6 +139,7 @@ def get_executor_metrics() -> List[Dict[str, Any]]:
                 'max_workers': max_w,
                 'active_count': active,
                 'queue_depth': queue_depth,
+                'queue_capacity': executor.max_queue_size,
                 'utilization_pct': utilization,
             }
         )

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -60,6 +60,12 @@ class MonitoredThreadPoolExecutor(ThreadPoolExecutor):
     def submit(self, fn: Callable[..., T], /, *args: Any, **kwargs: Any) -> Future[T]:
         slots = self._submission_slots
         if slots is not None and not slots.acquire(blocking=False):
+            logger.warning(
+                'executor_saturated executor=%s workers=%s queue_capacity=%s',
+                self.name,
+                self._max_workers,
+                self.max_queue_size,
+            )
             raise ExecutorSaturatedError(
                 f'{self.name} executor is saturated ({self._max_workers} workers, {self.max_queue_size} queued)'
             )

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -24,7 +24,7 @@ from utils.account_cutover.access import (
 from utils.api_key_families import FIREBASE_FAMILY, wrong_key_family_detail
 from utils.client_device import resolve_client_device
 from utils.byok import extract_byok_from_websocket, set_byok_keys, validate_byok_request, validate_byok_websocket
-from utils.executors import critical_executor, db_executor, run_blocking
+from utils.executors import ExecutorSaturatedError, critical_executor, db_executor, run_blocking
 from utils.rate_limit_config import RATE_POLICIES, RATE_LIMIT_SHADOW, get_effective_limit
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,23 @@ WS_AUTH_CODE_TOKEN_REFRESH = 4001
 WS_AUTH_CODE_RELOGIN_REQUIRED = 4004
 WS_AUTH_CODE_ACCOUNT_DELETION = 4005
 WS_AUTH_CODE_ACCOUNT_CUTOVER = 4006
+
+
+def _executor_saturated_http_exception(error: ExecutorSaturatedError) -> HTTPException:
+    """Return the retryable HTTP response for bounded critical-work overload."""
+    return HTTPException(
+        status_code=503,
+        detail='Service temporarily unavailable. Try again shortly.',
+        headers={'Retry-After': '1'},
+    )
+
+
+async def run_critical_ws(fn: Callable[..., Any], *args: Any) -> Any:
+    """Run critical WebSocket work and turn overload into a retryable close frame."""
+    try:
+        return await run_blocking(critical_executor, fn, *args)
+    except ExecutorSaturatedError as error:
+        raise WebSocketException(code=1013, reason='Service temporarily unavailable; retry shortly.') from error
 
 
 def get_user_deletion_wipe_status(uid: str) -> str | None:
@@ -308,6 +325,11 @@ def _verify_ws_auth(authorization: str) -> str:
         raise WebSocketException(code=1008, reason="Auth error")
 
 
+def verify_ws_auth(authorization: str) -> str:
+    """Public WebSocket-auth boundary for routers that share this policy."""
+    return _verify_ws_auth(authorization)
+
+
 def _get_ws_auth_close(error: Exception) -> 'tuple[int, str]':
     if isinstance(error, RevokedIdTokenError):
         return WS_AUTH_CODE_RELOGIN_REQUIRED, "Token revoked; re-login required"
@@ -345,7 +367,7 @@ async def get_current_user_uid_ws_listen(
     the mutation in the handler's context; the blocking Firebase and
     Firestore calls are offloaded via ``run_blocking``.
     """
-    uid = await run_blocking(critical_executor, _verify_ws_auth, authorization)
+    uid = await run_critical_ws(_verify_ws_auth, authorization)
     await run_blocking(db_executor, enforce_account_deletion_ws_access, uid)
     if cutover_enforcement_enabled() and websocket is not None:  # pyright: ignore[reportUnnecessaryComparison]
         await run_blocking(
@@ -361,7 +383,7 @@ async def get_current_user_uid_ws_listen(
         byok_keys = extract_byok_from_websocket(websocket)
         if byok_keys:
             set_byok_keys(byok_keys)
-        error = await run_blocking(critical_executor, validate_byok_websocket, uid)
+        error = await run_critical_ws(validate_byok_websocket, uid)
         if error:
             raise WebSocketException(code=4003, reason=error)
 
@@ -445,7 +467,7 @@ async def get_current_user_uid_from_ws_message(
     Pass ``websocket`` so account-cutover enforcement can fence product surfaces
     such as ``/v4/web/listen`` the same way header-auth listen does.
     """
-    uid = await run_blocking(critical_executor, _verify_user_uid_from_ws_message, message)
+    uid = await run_critical_ws(_verify_user_uid_from_ws_message, message)
     await run_blocking(db_executor, enforce_account_deletion_ws_access, uid)
     if cutover_enforcement_enabled() and websocket is not None:
         await run_blocking(
@@ -597,7 +619,10 @@ def with_rate_limit(auth_dependency: Callable[..., Any], policy_name: str) -> Ca
         raise ValueError(f"Unknown rate limit policy: {policy_name}")
 
     async def dependency(uid: str = Depends(auth_dependency)) -> str:
-        await run_blocking(critical_executor, _enforce_rate_limit, uid, policy_name)
+        try:
+            await run_blocking(critical_executor, _enforce_rate_limit, uid, policy_name)
+        except ExecutorSaturatedError as error:
+            raise _executor_saturated_http_exception(error) from error
         return uid
 
     return dependency
@@ -620,7 +645,10 @@ def with_rate_limit_context(auth_context_dependency: Callable[..., Any], policy_
 
     async def dependency(auth_context: Any = Depends(auth_context_dependency)) -> Any:
         key = rate_limit_key_for_context(auth_context)
-        await run_blocking(critical_executor, _enforce_rate_limit, key, policy_name, fail_closed=True)
+        try:
+            await run_blocking(critical_executor, _enforce_rate_limit, key, policy_name, fail_closed=True)
+        except ExecutorSaturatedError as error:
+            raise _executor_saturated_http_exception(error) from error
         return auth_context
 
     return dependency


### PR DESCRIPTION
## Summary

- bound the latency-sensitive critical executor to 64 queued tasks beyond its 8 workers
- reject excess submissions with a typed `ExecutorSaturatedError` instead of growing an unbounded process queue
- expose queue capacity alongside depth in executor health metrics
- add behavioral coverage for saturation and capacity recovery

Fixes #6753

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_executor_backpressure.py backend/tests/unit/test_async_http_infrastructure.py -q` (52 passed)
- `backend/.venv/bin/pyright backend/utils/executors.py` (0 errors)
- `make preflight`

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

