### PR TITLE
feat(backend): expose daily recaps in developer API

### DIFF
--- a/backend/models/daily_summary.py
+++ b/backend/models/daily_summary.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DailySummaryActionItem(BaseModel):
+    description: Optional[str] = None
+    priority: Optional[str] = None
+    source_conversation_id: Optional[str] = None
+    completed: Optional[bool] = None
+
+
+class DailySummaryTopicHighlight(BaseModel):
+    topic: Optional[str] = None
+    emoji: Optional[str] = None
+    summary: Optional[str] = None
+    conversation_ids: Optional[List[str]] = None
+
+
+class DailySummaryUnresolvedQuestion(BaseModel):
+    question: Optional[str] = None
+    conversation_id: Optional[str] = None
+
+
+class DailySummaryDecisionMade(BaseModel):
+    decision: Optional[str] = None
+    conversation_id: Optional[str] = None
+
+
+class DailySummaryKnowledgeNugget(BaseModel):
+    insight: Optional[str] = None
+    conversation_id: Optional[str] = None
+
+
+class DailySummaryDayStats(BaseModel):
+    total_conversations: Optional[int] = None
+    total_duration_minutes: Optional[int] = None
+    action_items_count: Optional[int] = None
+
+
+class DailySummaryLocationPin(BaseModel):
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    address: Optional[str] = None
+    conversation_id: Optional[str] = None
+    time: Optional[str] = None
+
+
+class DailySummaryResponse(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    id: Optional[str] = None
+    date: Optional[str] = None
+    created_at: Optional[datetime] = None
+    headline: Optional[str] = None
+    overview: Optional[str] = None
+    day_emoji: Optional[str] = None
+    stats: Optional[DailySummaryDayStats] = None
+    highlights: Optional[List[DailySummaryTopicHighlight]] = None
+    action_items: Optional[List[DailySummaryActionItem]] = None
+    unresolved_questions: Optional[List[DailySummaryUnresolvedQuestion]] = None
+    decisions_made: Optional[List[DailySummaryDecisionMade]] = None
+    knowledge_nuggets: Optional[List[DailySummaryKnowledgeNugget]] = None
+    locations: Optional[List[DailySummaryLocationPin]] = None
+
+
+class DailySummariesResponse(BaseModel):
+    summaries: List[DailySummaryResponse] = Field(default_factory=list)

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -8,6 +8,54 @@ service: backend-main
 routes:
   - route_type: http
     method: GET
+    path: /v1/dev/user/daily-summaries
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - developer_api_key
+        placement: dependency
+        scopes:
+          - conversations:read
+      byok: not_applicable
+      rate_limit:
+        policy_name: dev:conversations_read
+        key_subject: api_key
+        enforcement: fail_closed
+        placement: dependency
+      timeout_class: default_method
+      surface: developer_api
+      visibility: public_documented
+      data_domain: conversations
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: GET
+    path: /v1/dev/user/daily-summaries/{summary_id}
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - developer_api_key
+        placement: dependency
+        scopes:
+          - conversations:read
+      byok: not_applicable
+      rate_limit:
+        policy_name: dev:conversation_detail_read
+        key_subject: api_key
+        enforcement: fail_closed
+        placement: dependency
+      timeout_class: default_method
+      surface: developer_api
+      visibility: public_documented
+      data_domain: conversations
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
+    method: GET
     path: /
     policy: &desktop_migration_policy
       review_status: legacy_unreviewed

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -12,10 +12,12 @@ import database.conversations as conversations_db
 import database.action_items as action_items_db
 import database.goals as goals_db
 import database.users as users_db
+import database.daily_summaries as daily_summaries_db
 from database._client import db
 
 from models.folder import Folder
 from models.goal import GoalHistoryEntryResponse, GoalMetric
+from models.daily_summary import DailySummariesResponse, DailySummaryResponse
 from utils.client_device import resolve_client_device_from_request
 from utils.goals_response import normalize_goal_history_entry
 from models.memories import MemoryCategory, Memory, MemoryDB
@@ -1179,6 +1181,83 @@ class DeveloperFolder(BaseModel):
     is_default: bool = False
     is_system: bool = False
     conversation_count: int = 0
+
+
+@router.get(
+    "/v1/dev/user/daily-summaries",
+    response_model=DailySummariesResponse,
+    tags=["Daily Summaries"],
+    operation_id="listDailySummaries",
+)
+def get_developer_daily_summaries(
+    limit: int = Query(30, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    start_date: Optional[str] = Query(default=None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
+    end_date: Optional[str] = Query(default=None, pattern=r'^\d{4}-\d{2}-\d{2}$'),
+    auth: ApiKeyAuth = Depends(get_auth_with_conversations_read),
+    request: Request = None,
+):
+    """List the authenticated user's stored daily recaps.
+
+    Daily summaries are derived from conversations, so this read uses the same
+    `conversations:read` scope and aggregate read budget as conversation lists.
+    """
+    status = 500
+    returned_count = 0
+    try:
+        summaries = daily_summaries_db.get_daily_summaries(
+            auth.uid,
+            limit=limit,
+            offset=offset,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        returned_count = len(summaries)
+        status = 200
+        return {'summaries': summaries}
+    finally:
+        _audit_developer_read(
+            request=request,
+            auth=auth,
+            operation='list_daily_summaries',
+            status=status,
+            limit=limit,
+            offset=offset,
+            returned_count=returned_count,
+        )
+
+
+@router.get(
+    "/v1/dev/user/daily-summaries/{summary_id}",
+    response_model=DailySummaryResponse,
+    tags=["Daily Summaries"],
+    operation_id="getDailySummary",
+)
+def get_developer_daily_summary(
+    summary_id: str,
+    auth: ApiKeyAuth = Depends(get_auth_with_conversation_detail_read),
+    request: Request = None,
+):
+    """Get one stored daily recap by ID."""
+    status = 500
+    returned_count = 0
+    try:
+        summary = daily_summaries_db.get_daily_summary(auth.uid, summary_id)
+        if not summary:
+            status = 404
+            raise HTTPException(status_code=404, detail='Daily summary not found')
+        status = 200
+        returned_count = 1
+        return summary
+    finally:
+        _audit_developer_read(
+            request=request,
+            auth=auth,
+            operation='get_daily_summary',
+            status=status,
+            returned_count=returned_count,
+            resource_id=summary_id,
+        )
 
 
 @router.get("/v1/dev/user/folders", response_model=List[DeveloperFolder], tags=["Folders"], operation_id="listFolders")

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -117,6 +117,7 @@ from utils.llm.followup import followup_question_prompt
 from utils.notifications import send_notification, send_training_data_submitted_notification
 from utils.llm.external_integrations import generate_comprehensive_daily_summary
 from models.notification_message import NotificationMessage
+from models.daily_summary import DailySummariesResponse, DailySummaryResponse
 from utils.other import endpoints as auth
 from utils.other.storage import (
     delete_all_conversation_recordings,
@@ -239,71 +240,6 @@ def _location_context_consent_response(consent) -> LocationContextConsentRespons
 class DailySummaryTestResponse(UserStatusResponse):
     summary_id: str
     conversations_count: int
-
-
-class DailySummaryActionItem(BaseModel):
-    description: Optional[str] = None
-    priority: Optional[str] = None
-    source_conversation_id: Optional[str] = None
-    completed: Optional[bool] = None
-
-
-class DailySummaryTopicHighlight(BaseModel):
-    topic: Optional[str] = None
-    emoji: Optional[str] = None
-    summary: Optional[str] = None
-    conversation_ids: Optional[List[str]] = None
-
-
-class DailySummaryUnresolvedQuestion(BaseModel):
-    question: Optional[str] = None
-    conversation_id: Optional[str] = None
-
-
-class DailySummaryDecisionMade(BaseModel):
-    decision: Optional[str] = None
-    conversation_id: Optional[str] = None
-
-
-class DailySummaryKnowledgeNugget(BaseModel):
-    insight: Optional[str] = None
-    conversation_id: Optional[str] = None
-
-
-class DailySummaryDayStats(BaseModel):
-    total_conversations: Optional[int] = None
-    total_duration_minutes: Optional[int] = None
-    action_items_count: Optional[int] = None
-
-
-class DailySummaryLocationPin(BaseModel):
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-    address: Optional[str] = None
-    conversation_id: Optional[str] = None
-    time: Optional[str] = None
-
-
-class DailySummaryResponse(BaseModel):
-    model_config = ConfigDict(extra='allow')
-
-    id: Optional[str] = None
-    date: Optional[str] = None
-    created_at: Optional[datetime] = None
-    headline: Optional[str] = None
-    overview: Optional[str] = None
-    day_emoji: Optional[str] = None
-    stats: Optional[DailySummaryDayStats] = None
-    highlights: Optional[List[DailySummaryTopicHighlight]] = None
-    action_items: Optional[List[DailySummaryActionItem]] = None
-    unresolved_questions: Optional[List[DailySummaryUnresolvedQuestion]] = None
-    decisions_made: Optional[List[DailySummaryDecisionMade]] = None
-    knowledge_nuggets: Optional[List[DailySummaryKnowledgeNugget]] = None
-    locations: Optional[List[DailySummaryLocationPin]] = None
-
-
-class DailySummariesResponse(BaseModel):
-    summaries: List[DailySummaryResponse] = Field(default_factory=list)
 
 
 @router.get('/v1/users/profile', tags=['v1'], response_model=UserProfileResponse)

--- a/backend/tests/unit/test_dev_api_folder_filters.py
+++ b/backend/tests/unit/test_dev_api_folder_filters.py
@@ -105,11 +105,23 @@ _mock_populate_speaker_names = MagicMock()
 # ---- Prepare controllable mocks for database modules ----
 
 import database.conversations as conversations_db
+import database.daily_summaries as daily_summaries_db
 import database.folders as folders_db
-from dependencies import ApiKeyAuth, get_api_key_auth, get_auth_with_conversations_read, get_uid_with_conversations_read
+from dependencies import (
+    ApiKeyAuth,
+    get_api_key_auth,
+    get_auth_with_conversation_detail_read,
+    get_auth_with_conversations_read,
+    get_uid_with_conversations_read,
+)
 
 _mock_get_conversations = MagicMock(return_value=[])
 conversations_db.get_conversations = _mock_get_conversations
+
+_mock_get_daily_summaries = MagicMock(return_value=[])
+_mock_get_daily_summary = MagicMock(return_value=None)
+daily_summaries_db.get_daily_summaries = _mock_get_daily_summaries
+daily_summaries_db.get_daily_summary = _mock_get_daily_summary
 
 _mock_get_folders = MagicMock(return_value=[])
 _mock_initialize_system_folders = MagicMock(return_value=[])
@@ -377,6 +389,7 @@ def _build_test_app():
     app.include_router(developer_router)
     app.dependency_overrides[get_uid_with_conversations_read] = lambda: 'uid1'
     app.dependency_overrides[get_auth_with_conversations_read] = _read_auth
+    app.dependency_overrides[get_auth_with_conversation_detail_read] = _read_auth
     return app, TestClient(app)
 
 
@@ -418,6 +431,10 @@ class TestDevApiHttpLayer:
         _mock_get_conversations.return_value = []
         _mock_get_folders.reset_mock()
         _mock_get_folders.return_value = [_make_folder('f1', 'Work')]
+        _mock_get_daily_summaries.reset_mock()
+        _mock_get_daily_summaries.return_value = []
+        _mock_get_daily_summary.reset_mock()
+        _mock_get_daily_summary.return_value = None
         _mock_initialize_system_folders.reset_mock()
         _mock_populate_folder_names.reset_mock()
         _mock_populate_speaker_names.reset_mock()
@@ -508,6 +525,46 @@ class TestDevApiHttpLayer:
         assert len(body) == 1
         assert body[0]['id'] == 'f1'
         assert body[0]['name'] == 'Work'
+
+    def test_daily_summary_list_exposes_date_filters_and_pagination(self):
+        _mock_get_daily_summaries.return_value = [
+            {'id': 'recap-1', 'date': '2026-08-20', 'headline': 'A productive day'}
+        ]
+        _, client = _build_test_app()
+
+        response = client.get(
+            '/v1/dev/user/daily-summaries?limit=10&offset=2&start_date=2026-08-01&end_date=2026-08-20'
+        )
+
+        assert response.status_code == 200
+        assert response.json()['summaries'][0]['id'] == 'recap-1'
+        _mock_get_daily_summaries.assert_called_once_with(
+            'uid1', limit=10, offset=2, start_date='2026-08-01', end_date='2026-08-20'
+        )
+
+    def test_daily_summary_detail_returns_404_for_unknown_id(self):
+        _, client = _build_test_app()
+
+        response = client.get('/v1/dev/user/daily-summaries/missing')
+
+        assert response.status_code == 404
+        assert response.json() == {'detail': 'Daily summary not found'}
+        _mock_get_daily_summary.assert_called_once_with('uid1', 'missing')
+
+    def test_daily_summaries_require_conversations_read_scope(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from routers.developer import router as developer_router
+
+        app = FastAPI()
+        app.include_router(developer_router)
+        app.dependency_overrides[get_api_key_auth] = lambda: ApiKeyAuth(
+            uid='uid1', scopes=['memories:read'], app_id='test-app', key_id='test-key'
+        )
+
+        response = TestClient(app, raise_server_exceptions=False).get('/v1/dev/user/daily-summaries')
+
+        assert response.status_code == 403
 
 
 class TestDevApiMemoriesHttpLayer:

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -8290,6 +8290,60 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func listDailySummaries(client: OmiApiClient, limit: Int? = nil, offset: Int? = nil, startDate: String? = nil, endDate: String? = nil) async throws -> OmiAnyCodable {
+    let _path = "/v1/dev/user/daily-summaries"
+    guard var components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    var queryItems: [URLQueryItem] = []
+    if let limit {
+      queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
+    }
+    if let offset {
+      queryItems.append(URLQueryItem(name: "offset", value: String(offset)))
+    }
+    if let startDate {
+      queryItems.append(URLQueryItem(name: "start_date", value: String(startDate)))
+    }
+    if let endDate {
+      queryItems.append(URLQueryItem(name: "end_date", value: String(endDate)))
+    }
+    if !queryItems.isEmpty { components.queryItems = queryItems }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
+  public static func getDailySummary(client: OmiApiClient, summaryId: String) async throws -> OmiAnyCodable {
+    let _path = "/v1/dev/user/daily-summaries/\(summaryId)"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "GET"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func listFolders(client: OmiApiClient) async throws -> [OmiAnyCodable] {
     let _path = "/v1/dev/user/folders"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -15069,5 +15123,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 403 Swift client methods generated.
+  // Total: 405 Swift client methods generated.
 }

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -6128,6 +6128,27 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/dev/user/daily-summaries": {
+    get: {
+      operationId: "listDailySummaries";
+      responses: {
+        "200": DailySummariesResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/dev/user/daily-summaries/{summary_id}": {
+    get: {
+      operationId: "getDailySummary";
+      responses: {
+        "200": DailySummaryResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/dev/user/folders": {
     get: {
       operationId: "listFolders";
@@ -11568,6 +11589,39 @@ export async function deleteConversation(path: { conversation_id: string }, init
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function listDailySummaries(query: { limit?: number, offset?: number, start_date?: string | null, end_date?: string | null }, init?: OmiApiClientInit): Promise<DailySummariesResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function getDailySummary(path: { summary_id: string }, init?: OmiApiClientInit): Promise<DailySummaryResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries/${path.summary_id}`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function listFolders(init?: OmiApiClientInit): Promise<Array<DeveloperFolder>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/dev/user/folders`;
@@ -16729,4 +16783,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 405 client methods generated.

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -37864,6 +37864,159 @@
         ]
       }
     },
+    "/v1/dev/user/daily-summaries": {
+      "get": {
+        "description": "List the authenticated user's stored daily recaps.\n\nDaily summaries are derived from conversations, so this read uses the same\n`conversations:read` scope and aggregate read budget as conversation lists.",
+        "operationId": "listDailySummaries",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailySummariesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Developer Daily Summaries",
+        "tags": [
+          "Daily Summaries"
+        ]
+      }
+    },
+    "/v1/dev/user/daily-summaries/{summary_id}": {
+      "get": {
+        "description": "Get one stored daily recap by ID.",
+        "operationId": "getDailySummary",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "summary_id",
+            "required": true,
+            "schema": {
+              "title": "Summary Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailySummaryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Get Developer Daily Summary",
+        "tags": [
+          "Daily Summaries"
+        ]
+      }
+    },
     "/v1/dev/user/folders": {
       "get": {
         "description": "Get all folders for the authenticated user.\n\nThis endpoint is strictly read-only and returns an empty list if the user has no folders.\nUnlike the internal `/v1/folders` endpoint, it does NOT call `initialize_system_folders`,\nbecause doing so under a `conversations:read` scope would silently write to Firestore\n(violating the read-only contract) and opens a TOCTOU window where concurrent first\nrequests can race past the outer empty-check and create duplicate system folders.\n\nSystem folders (Work, Personal, Social) are still initialized lazily through other paths:\n- The mobile app calls the internal `GET /v1/folders` whenever the conversations screen\n  is rendered (`app/lib/pages/conversations/conversations_page.dart`), which triggers\n  `initialize_system_folders` on first access.\n- The conversation post-processing pipeline calls `initialize_system_folders` whenever\n  a new conversation is created (`backend/utils/conversations/process_conversation.py`).\n\nIn practice, any user who can issue a Developer API key has already gone through one of\nthose paths, so the empty-list case here only affects users who have never opened the\nconversations tab nor created a single conversation.",

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -712,6 +712,474 @@
         "title": "CreateMemoryRequest",
         "type": "object"
       },
+      "DailySummariesResponse": {
+        "properties": {
+          "summaries": {
+            "items": {
+              "$ref": "#/components/schemas/DailySummaryResponse"
+            },
+            "title": "Summaries",
+            "type": "array"
+          }
+        },
+        "title": "DailySummariesResponse",
+        "type": "object"
+      },
+      "DailySummaryActionItem": {
+        "properties": {
+          "completed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          },
+          "source_conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Conversation Id"
+          }
+        },
+        "title": "DailySummaryActionItem",
+        "type": "object"
+      },
+      "DailySummaryDayStats": {
+        "properties": {
+          "action_items_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Items Count"
+          },
+          "total_conversations": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Conversations"
+          },
+          "total_duration_minutes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Duration Minutes"
+          }
+        },
+        "title": "DailySummaryDayStats",
+        "type": "object"
+      },
+      "DailySummaryDecisionMade": {
+        "properties": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "decision": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decision"
+          }
+        },
+        "title": "DailySummaryDecisionMade",
+        "type": "object"
+      },
+      "DailySummaryKnowledgeNugget": {
+        "properties": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "insight": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Insight"
+          }
+        },
+        "title": "DailySummaryKnowledgeNugget",
+        "type": "object"
+      },
+      "DailySummaryLocationPin": {
+        "properties": {
+          "address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Address"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "latitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latitude"
+          },
+          "longitude": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Longitude"
+          },
+          "time": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time"
+          }
+        },
+        "title": "DailySummaryLocationPin",
+        "type": "object"
+      },
+      "DailySummaryResponse": {
+        "additionalProperties": true,
+        "properties": {
+          "action_items": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DailySummaryActionItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Items"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "day_emoji": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Day Emoji"
+          },
+          "decisions_made": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DailySummaryDecisionMade"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Decisions Made"
+          },
+          "headline": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Headline"
+          },
+          "highlights": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DailySummaryTopicHighlight"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Highlights"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "knowledge_nuggets": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DailySummaryKnowledgeNugget"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Knowledge Nuggets"
+          },
+          "locations": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DailySummaryLocationPin"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Locations"
+          },
+          "overview": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Overview"
+          },
+          "stats": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DailySummaryDayStats"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "unresolved_questions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DailySummaryUnresolvedQuestion"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unresolved Questions"
+          }
+        },
+        "title": "DailySummaryResponse",
+        "type": "object"
+      },
+      "DailySummaryTopicHighlight": {
+        "properties": {
+          "conversation_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Ids"
+          },
+          "emoji": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Emoji"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "topic": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Topic"
+          }
+        },
+        "title": "DailySummaryTopicHighlight",
+        "type": "object"
+      },
+      "DailySummaryUnresolvedQuestion": {
+        "properties": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "question": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Question"
+          }
+        },
+        "title": "DailySummaryUnresolvedQuestion",
+        "type": "object"
+      },
       "DevApiKey": {
         "properties": {
           "created_at": {
@@ -3219,6 +3687,165 @@
         "summary": "Update Conversation Endpoint",
         "tags": [
           "Conversations"
+        ]
+      }
+    },
+    "/v1/dev/user/daily-summaries": {
+      "get": {
+        "description": "List the authenticated user's stored daily recaps.\n\nDaily summaries are derived from conversations, so this read uses the same\n`conversations:read` scope and aggregate read budget as conversation lists.",
+        "operationId": "listDailySummaries",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 30,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Start Date"
+            }
+          },
+          {
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "End Date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailySummariesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Developer Daily Summaries",
+        "tags": [
+          "Daily Summaries"
+        ]
+      }
+    },
+    "/v1/dev/user/daily-summaries/{summary_id}": {
+      "get": {
+        "description": "Get one stored daily recap by ID.",
+        "operationId": "getDailySummary",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "summary_id",
+            "required": true,
+            "schema": {
+              "title": "Summary Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailySummaryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error403"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error404"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "developerApiKey": []
+          }
+        ],
+        "summary": "Get Developer Daily Summary",
+        "tags": [
+          "Daily Summaries"
         ]
       }
     },

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -6128,6 +6128,27 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/dev/user/daily-summaries": {
+    get: {
+      operationId: "listDailySummaries";
+      responses: {
+        "200": DailySummariesResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/dev/user/daily-summaries/{summary_id}": {
+    get: {
+      operationId: "getDailySummary";
+      responses: {
+        "200": DailySummaryResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/dev/user/folders": {
     get: {
       operationId: "listFolders";
@@ -11568,6 +11589,39 @@ export async function deleteConversation(path: { conversation_id: string }, init
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function listDailySummaries(query: { limit?: number, offset?: number, start_date?: string | null, end_date?: string | null }, init?: OmiApiClientInit): Promise<DailySummariesResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function getDailySummary(path: { summary_id: string }, init?: OmiApiClientInit): Promise<DailySummaryResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries/${path.summary_id}`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function listFolders(init?: OmiApiClientInit): Promise<Array<DeveloperFolder>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/dev/user/folders`;
@@ -16729,4 +16783,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 405 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -6128,6 +6128,27 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/dev/user/daily-summaries": {
+    get: {
+      operationId: "listDailySummaries";
+      responses: {
+        "200": DailySummariesResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/dev/user/daily-summaries/{summary_id}": {
+    get: {
+      operationId: "getDailySummary";
+      responses: {
+        "200": DailySummaryResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/dev/user/folders": {
     get: {
       operationId: "listFolders";
@@ -11568,6 +11589,39 @@ export async function deleteConversation(path: { conversation_id: string }, init
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function listDailySummaries(query: { limit?: number, offset?: number, start_date?: string | null, end_date?: string | null }, init?: OmiApiClientInit): Promise<DailySummariesResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function getDailySummary(path: { summary_id: string }, init?: OmiApiClientInit): Promise<DailySummaryResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries/${path.summary_id}`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function listFolders(init?: OmiApiClientInit): Promise<Array<DeveloperFolder>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/dev/user/folders`;
@@ -16729,4 +16783,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 405 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -6128,6 +6128,27 @@ export interface OmiApiPaths {
       };
     };
   };
+  "/v1/dev/user/daily-summaries": {
+    get: {
+      operationId: "listDailySummaries";
+      responses: {
+        "200": DailySummariesResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/dev/user/daily-summaries/{summary_id}": {
+    get: {
+      operationId: "getDailySummary";
+      responses: {
+        "200": DailySummaryResponse;
+        "401": void;
+        "404": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
   "/v1/dev/user/folders": {
     get: {
       operationId: "listFolders";
@@ -11568,6 +11589,39 @@ export async function deleteConversation(path: { conversation_id: string }, init
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function listDailySummaries(query: { limit?: number, offset?: number, start_date?: string | null, end_date?: string | null }, init?: OmiApiClientInit): Promise<DailySummariesResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries`;
+  const _params = query ? Object.entries(query)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&') : '';
+  const _search = _params ? `?${_params}` : "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
+export async function getDailySummary(path: { summary_id: string }, init?: OmiApiClientInit): Promise<DailySummaryResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/dev/user/daily-summaries/${path.summary_id}`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "GET",
+    headers: {
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function listFolders(init?: OmiApiClientInit): Promise<Array<DeveloperFolder>> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/dev/user/folders`;
@@ -16729,4 +16783,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 403 client methods generated.
+// Total: 405 client methods generated.


### PR DESCRIPTION
## Summary

- add Developer API endpoints to list stored daily recaps and fetch one by ID
- enforce the existing `conversations:read` scope and aggregate conversation-read budgets
- support bounded pagination and optional ISO-date filters
- share the daily-summary response models between user and Developer APIs
- regenerate the public OpenAPI contract and cover success, 403, and 404 paths

Fixes #4720

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_dev_api_folder_filters.py -q` (22 passed)
- public and integration-public OpenAPI checks (up to date)
- `make preflight`
- `xcrun swift build -c debug --package-path Desktop` resolved the pinned FluidAudio revision on retry, then stalled while downloading third-party binary artifacts; the bounded push used the documented `PRE_PUSH_SKIP_DESKTOP_SWIFT=1` hatch after generated Swift format and SwiftLint checks passed in `make preflight`

Failure-Class: none

Line-Count-Exception: backend/routers/developer.py | 2126 -> 2205 | the two daily-summary read routes belong on the existing Developer API router and splitting only this resource would create a second router owner


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

