### PR TITLE
fix(ci): centralize bounded Redis installation

### DIFF
--- a/.github/actions/install-redis-server/action.yml
+++ b/.github/actions/install-redis-server/action.yml
@@ -1,0 +1,11 @@
+name: Install Redis server
+description: Install the Redis binary for hermetic backend gauntlets with bounded apt networking
+
+runs:
+  using: composite
+  steps:
+    - name: Install Redis server with bounded apt retries
+      shell: bash
+      run: |
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server

--- a/.github/failure-classes/FC-unbounded-workflow-network-install.json
+++ b/.github/failure-classes/FC-unbounded-workflow-network-install.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "id": "FC-unbounded-workflow-network-install",
+  "status": "open",
+  "violated_contract": "A blocking CI job must not let a package-manager network operation inherit only the job-wide timeout. Package managers such as apt can remain connected to a stalled mirror without making progress, turning a transient dependency fetch into an opaque job cancellation that consumes the entire acceptance-gate budget.",
+  "canonical_prevention": "Put repository-owned retry and per-request network timeouts around update and install in one shared action, retain a short step-level timeout at every caller, and statically reject direct unbounded installs on the guarded workflow.",
+  "canonical_prevention_artifact": [
+    ".github/actions/install-redis-server/action.yml",
+    "backend/tests/unit/test_listen_pusher_stack_ci_wiring.py"
+  ],
+  "scope_hints": [
+    ".github/workflows/**",
+    ".github/actions/**"
+  ],
+  "evidence_prs": [11872]
+}

--- a/.github/workflows/backend-hermetic-e2e.yml
+++ b/.github/workflows/backend-hermetic-e2e.yml
@@ -163,21 +163,8 @@ jobs:
           java-version: '21'
 
       - name: Install Redis server
-        # The harness spawns its own `redis-server` binary per test on an
-        # ephemeral port (see backend/testing/*/run.py), so this needs the
-        # actual package installed, not a `services:` container.
-        #
-        # apt against the default Azure-mirror apt source on hosted runners
-        # can silently stall (connects but never completes the transfer)
-        # instead of failing, which previously let this step hang until the
-        # job's 20-minute timeout killed it with an opaque "operation was
-        # canceled". Bound each apt network attempt and retry a few times so
-        # a stalled mirror fails over quickly, and cap the step itself as a
-        # backstop.
         timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server
+        uses: ./.github/actions/install-redis-server
 
       - name: Run listen to pusher stack gauntlet
         run: npm run test:listen-pusher-stack:emulator -- --state-dir "$RUNNER_TEMP/listen-pusher-stack"
@@ -250,21 +237,8 @@ jobs:
           java-version: '21'
 
       - name: Install Redis server
-        # The harness spawns its own `redis-server` binary per test on an
-        # ephemeral port (see backend/testing/*/run.py), so this needs the
-        # actual package installed, not a `services:` container.
-        #
-        # apt against the default Azure-mirror apt source on hosted runners
-        # can silently stall (connects but never completes the transfer)
-        # instead of failing, which previously let this step hang until the
-        # job's 20-minute timeout killed it with an opaque "operation was
-        # canceled". Bound each apt network attempt and retry a few times so
-        # a stalled mirror fails over quickly, and cap the step itself as a
-        # backstop.
         timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server
+        uses: ./.github/actions/install-redis-server
 
       - name: Run Sync Cloud Tasks stack gauntlet
         run: npm run test:sync-cloud-tasks-stack:emulator
@@ -314,21 +288,8 @@ jobs:
           java-version: '21'
 
       - name: Install Redis server
-        # The harness spawns its own `redis-server` binary per test on an
-        # ephemeral port (see backend/testing/*/run.py), so this needs the
-        # actual package installed, not a `services:` container.
-        #
-        # apt against the default Azure-mirror apt source on hosted runners
-        # can silently stall (connects but never completes the transfer)
-        # instead of failing, which previously let this step hang until the
-        # job's 20-minute timeout killed it with an opaque "operation was
-        # canceled". Bound each apt network attempt and retry a few times so
-        # a stalled mirror fails over quickly, and cap the step itself as a
-        # backstop.
         timeout-minutes: 5
-        run: |
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 update
-          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 install --yes redis-server
+        uses: ./.github/actions/install-redis-server
 
       - name: Run Phase 0A replay harness feasibility experiment
         env:

--- a/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
+++ b/backend/tests/unit/test_listen_pusher_stack_ci_wiring.py
@@ -35,8 +35,7 @@ def test_listen_pusher_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -> N
     assert 'for attempt in 1 2 3' in job
     assert 'uses: actions/setup-java@v5' in job
     assert "java-version: '21'" in job
-    assert f'{_BOUNDED_APT_GET} update' in job
-    assert f'{_BOUNDED_APT_GET} install --yes redis-server' in job
+    assert 'uses: ./.github/actions/install-redis-server' in job
     assert 'timeout-minutes: 5' in job
     assert 'npm run test:listen-pusher-stack:emulator -- --state-dir "$RUNNER_TEMP/listen-pusher-stack"' in job
     assert 'name: Show listen gauntlet process diagnostics on failure' in job
@@ -139,7 +138,10 @@ def test_hermetic_e2e_tokenizer_warmup_is_cached_and_bounded() -> None:
 
 def test_hermetic_gauntlet_redis_apt_installs_are_bounded() -> None:
     workflow = (_REPO_ROOT / '.github' / 'workflows' / 'backend-hermetic-e2e.yml').read_text(encoding='utf-8')
+    action = (_REPO_ROOT / '.github' / 'actions' / 'install-redis-server' / 'action.yml').read_text(encoding='utf-8')
 
-    assert workflow.count(f'{_BOUNDED_APT_GET} update') == 3
-    assert workflow.count(f'{_BOUNDED_APT_GET} install --yes redis-server') == 3
+    assert workflow.count('uses: ./.github/actions/install-redis-server') == 3
+    assert workflow.count('timeout-minutes: 5') == 3
+    assert f'{_BOUNDED_APT_GET} update' in action
+    assert f'{_BOUNDED_APT_GET} install --yes redis-server' in action
     assert 'sudo apt-get install --yes redis-server' not in workflow

--- a/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
+++ b/backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py
@@ -12,10 +12,6 @@ from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Keep in lockstep with test_listen_pusher_stack_ci_wiring._BOUNDED_APT_GET:
-# unbounded apt-get is the hang that previously burned this job's timeout.
-_BOUNDED_APT_GET = 'sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10'
-
 
 def test_sync_cloud_tasks_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -> None:
     workflow = (_REPO_ROOT / '.github' / 'workflows' / 'backend-hermetic-e2e.yml').read_text(encoding='utf-8')
@@ -40,8 +36,7 @@ def test_sync_cloud_tasks_stack_gauntlet_has_a_deterministic_hermetic_ci_job() -
     assert 'npm ci --ignore-scripts' in job
     assert 'uses: actions/setup-java@v5' in job
     assert "java-version: '21'" in job
-    assert f'{_BOUNDED_APT_GET} update' in job
-    assert f'{_BOUNDED_APT_GET} install --yes redis-server' in job
+    assert 'uses: ./.github/actions/install-redis-server' in job
     assert 'timeout-minutes: 5' in job
     assert 'npm run test:sync-cloud-tasks-stack:emulator' in job
 


### PR DESCRIPTION
## Summary

- move the hermetic backend gauntlets' Redis installation into one repository-owned composite action
- keep apt update and install behind retry and network-timeout options
- retain a five-minute step ceiling in every consuming job
- update the static CI contract so duplicated or unbounded Redis installs cannot return

Fixes #11848

## Verification

- `backend/.venv/bin/python -m pytest backend/tests/unit/test_listen_pusher_stack_ci_wiring.py backend/tests/unit/test_sync_cloud_tasks_stack_ci_wiring.py -q` (5 passed)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -shellcheck '' .github/workflows/backend-hermetic-e2e.yml`
- `make preflight` (29 checks passed)

Failure-Class: new


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

