### PR TITLE
feat(backend): support MCP dynamic client registration

### DIFF
--- a/backend/database/mcp_oauth.py
+++ b/backend/database/mcp_oauth.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypedDict, cast
 import re
+import ipaddress
 from urllib.parse import unquote, urlsplit
 
 from google.cloud import firestore
@@ -48,6 +49,8 @@ AUTH_CODE_TTL_SECONDS = int(os.getenv("MCP_OAUTH_AUTH_CODE_TTL_SECONDS", "600"))
 REFRESH_TOKEN_TTL_DAYS = int(os.getenv("MCP_OAUTH_REFRESH_TOKEN_TTL_DAYS", "365"))
 PKCE_ALLOWED_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
 SUPPORTED_TOKEN_AUTH_METHODS = ["client_secret_post", "none"]
+DYNAMIC_CLIENT_REDIRECT_URI_LIMIT = 10
+DYNAMIC_CLIENT_REDIRECT_URI_MAX_LENGTH = 2048
 PUBLIC_CHATGPT_CLIENT_IDS = {"omi-chatgpt-prod", "omi-chatgpt-dev"}
 PRODUCTION_CROSS_PLANE_CLIENT_IDS = {"omi-chatgpt-prod", "omi-claude-prod"}
 CHATGPT_CONNECTOR_REDIRECT_URI_PREFIX = "https://chatgpt.com/connector/oauth/"
@@ -329,6 +332,70 @@ def get_client(client_id: str) -> Optional[Dict[str, Any]]:
         else:
             client = _builtin_public_chatgpt_client(client_id)
     return _finalize_client(client)
+
+
+def validate_dynamic_redirect_uris(redirect_uris: object) -> List[str]:
+    """Validate exact redirect URIs for a dynamically registered public client."""
+    if not isinstance(redirect_uris, list) or not redirect_uris:
+        raise ValueError("redirect_uris must be a non-empty array")
+    if len(redirect_uris) > DYNAMIC_CLIENT_REDIRECT_URI_LIMIT:
+        raise ValueError(f"redirect_uris supports at most {DYNAMIC_CLIENT_REDIRECT_URI_LIMIT} entries")
+
+    validated: List[str] = []
+    for value in cast(List[Any], redirect_uris):
+        if not isinstance(value, str) or not value or value != value.strip():
+            raise ValueError("redirect_uris must contain non-empty URI strings")
+        if len(value) > DYNAMIC_CLIENT_REDIRECT_URI_MAX_LENGTH:
+            raise ValueError("redirect_uri is too long")
+        try:
+            parts = urlsplit(value)
+            _ = parts.port
+        except ValueError as exc:
+            raise ValueError("redirect_uri is invalid") from exc
+        if not parts.hostname or parts.username or parts.password or parts.fragment:
+            raise ValueError("redirect_uri must be an absolute URI without credentials or a fragment")
+        if parts.scheme == "https":
+            pass
+        elif parts.scheme == "http":
+            is_loopback = parts.hostname == "localhost"
+            if not is_loopback:
+                try:
+                    is_loopback = ipaddress.ip_address(parts.hostname).is_loopback
+                except ValueError:
+                    is_loopback = False
+            if not is_loopback:
+                raise ValueError("http redirect_uri must use localhost or a loopback IP address")
+        else:
+            raise ValueError("redirect_uri must use https or loopback http")
+        if value not in validated:
+            validated.append(value)
+    return validated
+
+
+def register_dynamic_public_client(client_name: Optional[str], redirect_uris: object) -> Dict[str, Any]:
+    """Persist an RFC 7591 public PKCE client using exact redirect matching."""
+    validated_redirect_uris = validate_dynamic_redirect_uris(redirect_uris)
+    resolved_name = (client_name or "MCP client").strip()
+    if not resolved_name or len(resolved_name) > 100:
+        raise ValueError("client_name must be between 1 and 100 characters")
+
+    client_id = f"omi-dcr-{secrets.token_urlsafe(24)}"
+    now = _now()
+    client: Dict[str, Any] = {
+        "id": client_id,
+        "name": resolved_name,
+        "registration_mode": "dynamic_public_pkce",
+        "allowed_redirect_uris": validated_redirect_uris,
+        "allowed_redirect_uri_prefixes": [],
+        "allowed_resources": [MCP_RESOURCE_URL],
+        "allowed_scopes": SUPPORTED_SCOPES,
+        "token_endpoint_auth_method": "none",
+        "client_secret_hash": "",
+        "created_at": now,
+        "disabled_at": None,
+    }
+    db.collection("mcp_oauth_clients").document(client_id).set(client)
+    return client
 
 
 def verify_client_secret(client: Dict[str, Any], client_secret: Optional[str]) -> bool:

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -69,6 +69,29 @@ routes:
     path: /health
     policy: *desktop_migration_policy
   - route_type: http
+    method: POST
+    path: /api/oauth/register
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - public
+        placement: none
+        scopes: []
+      byok: not_applicable
+      rate_limit:
+        policy_name: mcp:client_registration
+        key_subject: ip
+        enforcement: fail_closed
+        placement: inline
+      timeout_class: default_method
+      surface: oauth
+      visibility: public_documented
+      data_domain: auth
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: GET
     path: /ready
     policy: *desktop_migration_policy

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -16,14 +16,14 @@ from datetime import datetime
 from typing import Optional, Any, Dict, List, Tuple, NoReturn, cast
 from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import firebase_admin.auth
 from google.api_core.exceptions import FailedPrecondition
 from fastapi import APIRouter, HTTPException, Header, Request, Response, Form
 from fastapi.responses import StreamingResponse, JSONResponse, HTMLResponse
 from fastapi.templating import Jinja2Templates
-from utils.other.endpoints import check_rate_limit_inline
+from utils.other.endpoints import check_rate_limit_inline, check_rate_limit_inline_fail_closed
 from utils.executors import critical_executor, db_executor, run_blocking
 
 import database.conversations as conversations_db
@@ -99,6 +99,7 @@ MCP_RESOURCE_URL = mcp_oauth_db.MCP_RESOURCE_URL
 MCP_AUTHORIZATION_SERVER_URL = os.getenv("MCP_AUTHORIZATION_SERVER_URL", "https://api.omi.me")
 MCP_AUTHORIZATION_ENDPOINT = f"{MCP_AUTHORIZATION_SERVER_URL}/authorize"
 MCP_TOKEN_ENDPOINT = f"{MCP_AUTHORIZATION_SERVER_URL}/token"
+MCP_REGISTRATION_ENDPOINT = f"{MCP_AUTHORIZATION_SERVER_URL}/api/oauth/register"
 MCP_PROTECTED_RESOURCE_METADATA_URL = f"{MCP_AUTHORIZATION_SERVER_URL}/.well-known/oauth-protected-resource/v1/mcp/sse"
 OPENAI_APPS_CHALLENGE_TOKEN = "ZsVB_wpc4R35_tHloCZCokY6H2fBkKyBJrz-4MtXjYE"
 
@@ -753,6 +754,7 @@ def oauth_authorization_server_metadata():
         "issuer": MCP_AUTHORIZATION_SERVER_URL,
         "authorization_endpoint": MCP_AUTHORIZATION_ENDPOINT,
         "token_endpoint": MCP_TOKEN_ENDPOINT,
+        "registration_endpoint": MCP_REGISTRATION_ENDPOINT,
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
@@ -1512,6 +1514,77 @@ class McpTokenResponse(BaseModel):
     token_type: str
     expires_in: int
     scope: str
+
+
+class McpClientRegistrationRequest(BaseModel):
+    redirect_uris: List[str] = Field(min_length=1, max_length=mcp_oauth_db.DYNAMIC_CLIENT_REDIRECT_URI_LIMIT)
+    client_name: Optional[str] = Field(default=None, max_length=100)
+    token_endpoint_auth_method: str = "none"
+    grant_types: List[str] = Field(default_factory=lambda: ["authorization_code"])
+    response_types: List[str] = Field(default_factory=lambda: ["code"])
+
+
+class McpClientRegistrationResponse(BaseModel):
+    client_id: str
+    client_id_issued_at: int
+    redirect_uris: List[str]
+    client_name: str
+    token_endpoint_auth_method: str
+    grant_types: List[str]
+    response_types: List[str]
+
+
+@router.post("/api/oauth/register", tags=["mcp"], response_model=McpClientRegistrationResponse, status_code=201)
+async def mcp_register_client(request: Request, registration: McpClientRegistrationRequest):
+    """Register an exact-redirect public PKCE client per RFC 7591."""
+    source = request.client.host if request.client else "unknown"
+    await run_blocking(
+        critical_executor,
+        check_rate_limit_inline_fail_closed,
+        source,
+        "mcp:client_registration",
+    )
+    if registration.token_endpoint_auth_method != "none":
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_client_metadata", "error_description": "Only public PKCE clients are supported"},
+        )
+    grant_types = set(registration.grant_types)
+    if "authorization_code" not in grant_types or not grant_types.issubset({"authorization_code", "refresh_token"}):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_client_metadata",
+                "error_description": "grant_types must include authorization_code and may include refresh_token",
+            },
+        )
+    if registration.response_types != ["code"]:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_client_metadata", "error_description": "response_types must be code"},
+        )
+    try:
+        client = await run_blocking(
+            db_executor,
+            mcp_oauth_db.register_dynamic_public_client,
+            registration.client_name,
+            registration.redirect_uris,
+        )
+    except ValueError as exc:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "invalid_redirect_uri", "error_description": str(exc)},
+        )
+    created_at = cast(datetime, client["created_at"])
+    return {
+        "client_id": client["id"],
+        "client_id_issued_at": int(created_at.timestamp()),
+        "redirect_uris": client["allowed_redirect_uris"],
+        "client_name": client["name"],
+        "token_endpoint_auth_method": "none",
+        "grant_types": registration.grant_types,
+        "response_types": ["code"],
+    }
 
 
 def _validate_authorize_request(

--- a/backend/tests/unit/test_mcp_data_endpoints.py
+++ b/backend/tests/unit/test_mcp_data_endpoints.py
@@ -8,12 +8,14 @@ stubbing pattern in test_mcp_search_memories.py.
 
 from datetime import datetime, timezone
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch, MagicMock
 import os
 import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 os.environ.setdefault('OPENAI_API_KEY', 'sk-test-not-real')
 os.environ.setdefault('ENCRYPTION_SECRET', 'omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv')
@@ -454,6 +456,65 @@ def test_authorize_redirect_builder_preserves_existing_query():
         'https://chatgpt.com/connector_platform_oauth_redirect?client=chatgpt', 'code-1', 's1'
     )
     assert redirect_uri == 'https://chatgpt.com/connector_platform_oauth_redirect?client=chatgpt&code=code-1&state=s1'
+
+
+def test_authorization_metadata_advertises_dynamic_registration():
+    metadata = sse.oauth_authorization_server_metadata()
+
+    assert metadata['registration_endpoint'] == f'{sse.MCP_AUTHORIZATION_SERVER_URL}/api/oauth/register'
+
+
+def test_dynamic_registration_returns_public_pkce_client_over_http():
+    created_at = datetime(2026, 8, 21, tzinfo=timezone.utc)
+    registered = {
+        'id': 'omi-dcr-test',
+        'name': 'Gemini Spark',
+        'allowed_redirect_uris': ['https://accounts.google.com/gemini-oauth-cb'],
+        'created_at': created_at,
+    }
+    app = FastAPI()
+    app.include_router(sse.router)
+
+    with (
+        patch.object(sse, 'run_blocking', new=AsyncMock(side_effect=[None, registered])) as run_blocking,
+        patch.object(sse.mcp_oauth_db, 'register_dynamic_public_client'),
+    ):
+        response = TestClient(app).post(
+            '/api/oauth/register',
+            json={
+                'redirect_uris': ['https://accounts.google.com/gemini-oauth-cb'],
+                'client_name': 'Gemini Spark',
+                'grant_types': ['authorization_code', 'refresh_token'],
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        'client_id': 'omi-dcr-test',
+        'client_id_issued_at': int(created_at.timestamp()),
+        'redirect_uris': ['https://accounts.google.com/gemini-oauth-cb'],
+        'client_name': 'Gemini Spark',
+        'token_endpoint_auth_method': 'none',
+        'grant_types': ['authorization_code', 'refresh_token'],
+        'response_types': ['code'],
+    }
+    assert run_blocking.await_args_list[0].args[2:] == ('testclient', 'mcp:client_registration')
+
+
+@pytest.mark.asyncio
+async def test_dynamic_registration_rejects_confidential_clients_before_write():
+    request = SimpleNamespace(client=SimpleNamespace(host='203.0.113.10'))
+    payload = sse.McpClientRegistrationRequest(
+        redirect_uris=['https://accounts.google.com/gemini-oauth-cb'],
+        token_endpoint_auth_method='client_secret_post',
+    )
+
+    with patch.object(sse, 'run_blocking', new=AsyncMock(return_value=None)) as run_blocking:
+        response = await sse.mcp_register_client(request, payload)
+
+    assert response.status_code == 400
+    assert json.loads(response.body)['error'] == 'invalid_client_metadata'
+    assert run_blocking.await_count == 1
 
 
 def test_authorize_request_accepts_chatgpt_public_client():

--- a/backend/tests/unit/test_mcp_oauth.py
+++ b/backend/tests/unit/test_mcp_oauth.py
@@ -520,6 +520,48 @@ def test_public_client_uses_pkce_without_shared_secret():
     )
 
 
+def test_dynamic_public_client_persists_exact_redirects_and_uses_pkce():
+    redirect_uri = 'https://accounts.google.com/gemini-oauth-cb'
+
+    registered = mcp_oauth.register_dynamic_public_client('Gemini Spark', [redirect_uri, redirect_uri])
+    loaded = mcp_oauth.get_client(registered['id'])
+
+    assert registered['id'].startswith('omi-dcr-')
+    assert loaded['registration_mode'] == 'dynamic_public_pkce'
+    assert loaded['allowed_redirect_uris'] == [redirect_uri]
+    assert mcp_oauth.verify_client_auth(loaded, None)
+    assert mcp_oauth.validate_redirect_uri(loaded, redirect_uri)
+    assert not mcp_oauth.validate_redirect_uri(loaded, 'https://attacker.example/callback')
+
+
+@pytest.mark.parametrize(
+    'redirect_uri',
+    [
+        'http://example.com/callback',
+        'https://user:password@example.com/callback',
+        'https://example.com/callback#fragment',
+        'custom-scheme://callback',
+    ],
+)
+def test_dynamic_public_client_rejects_unsafe_redirects(redirect_uri):
+    with pytest.raises(ValueError, match='redirect_uri'):
+        mcp_oauth.register_dynamic_public_client('Unsafe client', [redirect_uri])
+
+
+def test_dynamic_public_client_allows_native_loopback_redirect():
+    redirect_uri = 'http://127.0.0.1:49152/oauth/callback'
+    registered = mcp_oauth.register_dynamic_public_client('Native client', [redirect_uri])
+
+    assert mcp_oauth.validate_redirect_uri(registered, redirect_uri)
+
+
+def test_dynamic_public_client_allows_localhost_redirect():
+    redirect_uri = 'http://localhost:49152/oauth/callback'
+    registered = mcp_oauth.register_dynamic_public_client('Local client', [redirect_uri])
+
+    assert mcp_oauth.validate_redirect_uri(registered, redirect_uri)
+
+
 def test_delete_user_oauth_credentials_removes_unconsumed_authorization_codes():
     grant = mcp_oauth.create_or_update_grant(
         'deleted-user', 'omi-chatgpt-prod', mcp_oauth.MCP_RESOURCE_URL, ['memories.read']

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -639,6 +639,11 @@ def check_rate_limit_inline(key: str, policy_name: str) -> None:
     _enforce_rate_limit(key, policy_name)
 
 
+def check_rate_limit_inline_fail_closed(key: str, policy_name: str) -> None:
+    """Check a custom-auth or pre-auth route and reject when Redis is unavailable."""
+    _enforce_rate_limit(key, policy_name, fail_closed=True)
+
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -64,6 +64,10 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     # a reconnect storm into a 429 death-spiral, so this is sized for heavy multi-session
     # use rather than a single client. Tune via RATE_LIMIT_BOOST for events.
     "mcp:sse": (2000, 3600),
+    # RFC 7591 registration is public and writes one durable OAuth client.
+    # Bound it per source address so discovery remains automatic without
+    # allowing an unauthenticated caller to grow the client collection freely.
+    "mcp:client_registration": (120, 3600),
     # Action items — lightweight Firestore writes from MCP clients (no LLM), but
     # an agent can loop, so cap creation per hour. Complete/update/delete operate
     # on existing tasks and ride the shared mcp:sse / per-request auth limits.

--- a/docs/doc/developer/mcp/setup.mdx
+++ b/docs/doc/developer/mcp/setup.mdx
@@ -54,9 +54,17 @@ https://api.omi.me/.well-known/oauth-authorization-server
 ```
 
 OAuth uses browser sign-in, explicit consent, authorization code + PKCE, and refresh
-tokens. Omi currently provides registered public clients for its ChatGPT and Claude setup
-flows. A generic MCP client cannot invent a client ID; if it is not one of those supported
-flows, use an MCP key instead.
+tokens. Omi provides registered public clients for its ChatGPT and Claude setup flows and
+advertises RFC 7591 Dynamic Client Registration at:
+
+```text
+https://api.omi.me/api/oauth/register
+```
+
+MCP clients that support dynamic registration obtain a public PKCE client ID automatically.
+The registration endpoint accepts exact HTTPS redirect URIs and loopback HTTP redirects; it
+does not issue client secrets. Clients that support neither dynamic registration nor one of
+Omi's registered flows should use an MCP key instead.
 
 <Tabs>
   <Tab title="ChatGPT" icon="robot">
@@ -84,6 +92,15 @@ flows, use an MCP key instead.
     Click **Add**, then **Connect**, and approve Omi's OAuth consent screen. The Omi macOS
     app exposes the same flow under **Use omi memory anywhere → Claude / Claude Code →
     Claude (cloud)**.
+  </Tab>
+  <Tab title="Gemini Spark" icon="sparkles">
+    In Gemini, open **Settings & help → Connected Apps → Custom apps for Spark**, then use:
+
+    - **Name:** Omi Memory
+    - **Remote MCP server URL:** `https://api.omi.me/v1/mcp/sse`
+
+    Spark discovers Omi's OAuth metadata, registers its public PKCE client automatically,
+    and opens the Omi consent screen. You do not need to create or paste a client secret.
   </Tab>
 </Tabs>
 

--- a/docs/doc/developer/mcp/troubleshooting.mdx
+++ b/docs/doc/developer/mcp/troubleshooting.mdx
@@ -9,7 +9,8 @@ description: "Debug and fix common MCP connection issues"
 <AccordionGroup>
   <Accordion title="OAuth sign-in or consent does not open" icon="lock">
     - Confirm the remote server URL is exactly `https://api.omi.me/v1/mcp/sse`
-    - Use Omi's registered ChatGPT or Claude connection flow; arbitrary client IDs are not accepted
+    - Clients with RFC 7591 support should discover `https://api.omi.me/api/oauth/register` and obtain a public client ID automatically
+    - Clients without dynamic registration must use Omi's registered ChatGPT or Claude flow; arbitrary unregistered client IDs are rejected
     - For Claude, use client ID `omi-claude-prod` and leave the client secret blank
     - For ChatGPT's developer-mode fallback, use `omi-chatgpt-prod`, leave the secret blank, and set token auth method to `none`
     - If the client cannot complete OAuth, use the manual MCP-key fallback in the [Setup guide](/doc/developer/mcp/setup)


### PR DESCRIPTION
## Summary

- advertise an RFC 7591 registration endpoint in Omi's OAuth authorization-server metadata
- register durable public PKCE clients with exact redirect allowlists and no shared secret
- accept TLS redirects plus localhost/loopback HTTP redirects while rejecting credentials, fragments, and unsafe schemes
- fail closed behind a per-source registration budget before writing Firestore
- document automatic Gemini Spark setup and the manual-key fallback

Fixes #11263

## External contract

- [RFC 7591](https://datatracker.ietf.org/doc/rfc7591/) defines `redirect_uris`, public clients using `token_endpoint_auth_method: none`, and the dynamic-registration response metadata
- [MCP 2025-03-26 authorization](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) recommends RFC 7591 support and requires authorization-server metadata discovery

## Verification

- `backend/.venv/bin/python -m pytest tests/unit/test_mcp_oauth.py tests/unit/test_mcp_data_endpoints.py -q` from `backend/` (139 passed; includes the real FastAPI HTTP route)
- `backend/.venv/bin/python -m pytest tests/unit/test_rate_limiting.py -q` from `backend/` (73 passed, 1 skipped)
- public, integration-public, and app-client OpenAPI snapshots are up to date
- `make preflight` (25 checks passed)

Failure-Class: none

Line-Count-Exception: backend/routers/mcp_sse.py | 1880 -> 1953 | dynamic registration is part of the existing MCP OAuth authority and must share its metadata, authorization, and token contract


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

