### PR TITLE
fix(backend): mobile conversations never lose extracted tasks to Candidate review

### DIFF
--- a/backend/tests/unit/test_backend_candidate_capture.py
+++ b/backend/tests/unit/test_backend_candidate_capture.py
@@ -625,7 +625,7 @@ def test_rejected_policy_uses_no_drop_compatibility_writer_without_candidate(mon
     assert decisions == [('Send budget', 'conversation-1')]
 
 
-def test_read_mode_creates_pending_and_silently_accepts_commitment_without_notifications(monkeypatch):
+def test_conversation_capture_resolves_every_create_without_notifications(monkeypatch):
     _enable_canonical(monkeypatch)
     monkeypatch.setattr(
         conversation_capture.task_control_db,
@@ -678,8 +678,10 @@ def test_read_mode_creates_pending_and_silently_accepts_commitment_without_notif
     )
 
     assert len(records) == 2
-    assert accepted == ['candidate-1']
-    assert records[1].status == 'pending'
+    # Both creates resolve here: the direct_request item is policy-tier
+    # 'pending_candidate', and parking it would hide the task from every client
+    # except macOS.
+    assert accepted == ['candidate-1', 'candidate-2']
     assert emitted == [
         {
             'uid': 'user-1',
@@ -877,6 +879,11 @@ def test_repeated_descriptions_use_semantic_occurrences_without_order_dependent_
         return _record(proposal, len(keys))
 
     monkeypatch.setattr(conversation_capture.candidate_service, 'create_candidate', create)
+    monkeypatch.setattr(
+        conversation_capture.candidate_service,
+        'accept_candidate',
+        lambda uid, candidate_id, **kwargs: None,
+    )
 
     conversation_capture.process_before_legacy('user-1', 'conversation-1', [morning, evening])
     first_keys = list(keys)
@@ -885,3 +892,140 @@ def test_repeated_descriptions_use_semantic_occurrences_without_order_dependent_
 
     assert first_keys[0] != first_keys[1]
     assert keys == [first_keys[1], first_keys[0]]
+
+
+def _segment(segment_id, start, end):
+    return SimpleNamespace(id=segment_id, start=start, end=end)
+
+
+def test_capture_survives_negative_segment_offsets():
+    """Merged sync audio yields segment offsets below zero; evidence clamps to zero.
+
+    Before this, EvidenceRef(ge=0) raised inside the adapter and the raising call
+    sat first in _save_action_items, so the conversation produced no task at all.
+    """
+
+    action = _action(
+        'Comprar o presente da sogra',
+        capture_kind='explicit_command',
+        capture_owner='user',
+        concrete_deliverable=True,
+    )
+    action.source_segment_ids = ['segment-1', 'segment-2']
+    segments = [_segment('segment-1', -17.329691410064697, 5.790308589935304), _segment('segment-2', -1.8e-07, 2.15)]
+
+    decision = conversation_capture._capture_decision(action, 'conversation-1', segments)
+
+    assert decision.candidate is not None
+    evidence = decision.candidate.evidence_refs[0]
+    assert evidence.start_seconds == 0.0
+    assert evidence.end_seconds == 5.790308589935304
+    assert evidence.transcript_segment_ids == ['segment-1', 'segment-2']
+
+
+def test_pending_tier_create_is_accepted_so_the_task_is_visible(monkeypatch):
+    monkeypatch.setattr(
+        conversation_capture.task_control_db,
+        'get_task_workflow_control',
+        lambda uid: TaskWorkflowControl(workflow_mode='read', account_generation=3),
+    )
+    records = []
+    accepted = []
+
+    def create(uid, proposal, **kwargs):
+        record = _record(proposal, len(records) + 1)
+        records.append(record)
+        return record
+
+    monkeypatch.setattr(conversation_capture.candidate_service, 'create_candidate', create)
+    monkeypatch.setattr(
+        conversation_capture.candidate_service,
+        'accept_candidate',
+        lambda uid, candidate_id, **kwargs: accepted.append(candidate_id),
+    )
+    action = _action(
+        'Review the forecast',
+        capture_kind='direct_request',
+        capture_owner='user',
+        concrete_deliverable=True,
+    )
+
+    assert conversation_capture._capture_decision(action, 'conversation-1').policy.outcome == 'pending_candidate'
+    assert conversation_capture.process_before_legacy('user-1', 'conversation-1', [action]) is True
+    assert accepted == ['candidate-1']
+
+
+def test_task_mutation_still_waits_for_review(monkeypatch):
+    """Only creates resolve on capture; editing an existing task keeps its review gate."""
+
+    monkeypatch.setattr(
+        conversation_capture.task_control_db,
+        'get_task_workflow_control',
+        lambda uid: TaskWorkflowControl(workflow_mode='read', account_generation=3),
+    )
+    records = []
+    accepted = []
+    monkeypatch.setattr(
+        conversation_capture.candidate_service,
+        'create_candidate',
+        lambda uid, proposal, **kwargs: records.append(_record(proposal, len(records) + 1)) or records[-1],
+    )
+    monkeypatch.setattr(
+        conversation_capture.candidate_service,
+        'accept_candidate',
+        lambda uid, candidate_id, **kwargs: accepted.append(candidate_id),
+    )
+    action = _action(
+        'Send the revised budget',
+        capture_kind='direct_request',
+        capture_owner='user',
+        concrete_deliverable=True,
+        candidate_action='update',
+        target_task_id='task-budget',
+    )
+
+    assert conversation_capture.process_before_legacy('user-1', 'conversation-1', [action]) is True
+    assert len(records) == 1
+    assert accepted == []
+
+
+def test_capture_exception_falls_back_to_the_compatibility_writer(monkeypatch):
+    """A raising capture adapter must not swallow the conversation's tasks."""
+
+    def boom(uid, conversation):
+        raise ValueError('capture adapter exploded')
+
+    monkeypatch.setattr(process_conversation.conversation_capture, 'process_conversation_before_legacy', boom)
+    monkeypatch.setattr(process_conversation.action_items_db, 'get_action_items_by_conversation', lambda *args: [])
+    monkeypatch.setattr(process_conversation.action_items_db, 'delete_action_items_for_conversation', lambda *args: 0)
+    monkeypatch.setattr(process_conversation, 'upsert_action_item_vectors_batch', lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_conversation, 'delete_action_item_vectors_batch', lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_conversation, 'submit_with_context', lambda *args, **kwargs: None)
+    monkeypatch.setattr(process_conversation, 'emit_product_event', lambda **event: None)
+    fallbacks = []
+    monkeypatch.setattr(process_conversation, 'record_fallback', lambda **event: fallbacks.append(event))
+    writes = []
+
+    def write(uid, rows, **kwargs):
+        writes.append(rows)
+        return [f'task-{index + 1}' for index in range(len(rows))]
+
+    monkeypatch.setattr(process_conversation.action_items_db, 'create_action_items_batch', write)
+
+    conversation = _conversation(
+        _action('Send the budget', capture_kind='explicit_command', capture_owner='user', concrete_deliverable=True)
+    )
+    conversation.transcript_segments = []
+
+    process_conversation._save_action_items('user-1', conversation)
+
+    assert [row['description'] for rows in writes for row in rows] == ['Send the budget']
+    assert fallbacks == [
+        {
+            'component': 'other',
+            'from_mode': 'canonical_task_capture',
+            'to_mode': 'legacy_action_items',
+            'reason': 'other',
+            'outcome': 'degraded',
+        }
+    ]

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -1482,12 +1482,40 @@ def _save_action_items(uid: str, conversation: Conversation, people: Sequence[Pe
     if not conversation.structured:
         return
 
-    wake_word_gate = conversation_capture.prepare_wake_word_capture_gate(uid, conversation, people)
+    try:
+        wake_word_gate = conversation_capture.prepare_wake_word_capture_gate(uid, conversation, people)
+    except Exception:
+        logger.exception(f"wake-word capture gate failed for conversation {conversation.id}")
+        record_fallback(
+            component='other',
+            from_mode='wake_word_gate',
+            to_mode='ungated_capture',
+            reason='other',
+            outcome='degraded',
+        )
+        wake_word_gate = None
     if not conversation.structured.action_items:
         return
 
     is_locked = conversation.is_locked
-    if conversation_capture.process_conversation_before_legacy(uid, conversation, wake_word_gate):
+    try:
+        captured_canonically = conversation_capture.process_conversation_before_legacy(
+            uid, conversation, wake_word_gate
+        )
+    except Exception:
+        # Everything above the compatibility writer runs before any task row exists, so an
+        # exception here used to drop the conversation's tasks entirely: the writer below
+        # never ran and the executor discarded the traceback.
+        logger.exception(f"canonical task capture failed for conversation {conversation.id}")
+        record_fallback(
+            component='other',
+            from_mode='canonical_task_capture',
+            to_mode='legacy_action_items',
+            reason='other',
+            outcome='degraded',
+        )
+        captured_canonically = False
+    if captured_canonically:
         emit_product_event(
             uid=uid,
             event='Task Extracted',

--- a/backend/utils/executors.py
+++ b/backend/utils/executors.py
@@ -91,12 +91,27 @@ async def run_blocking(executor: ThreadPoolExecutor, fn: Callable[P, T], *args: 
     return await loop.run_in_executor(executor, call)
 
 
+def _log_background_failure(name: str, future: "Future[Any]") -> None:
+    if future.cancelled():
+        return
+    error = future.exception()
+    if error is not None:
+        logger.error("background task %s failed: %s", name, error, exc_info=error)
+
+
 def submit_with_context(
     executor: ThreadPoolExecutor, fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs
 ) -> Future[T]:
-    """Submit *fn* to *executor*, propagating the current contextvars (BYOK keys, etc.)."""
+    """Submit *fn* to *executor*, propagating the current contextvars (BYOK keys, etc.).
+
+    Callers overwhelmingly discard the Future, so a raised exception would otherwise
+    be retained on it and never surface. The done callback logs it instead; callers
+    that do read the Future keep their own handling.
+    """
     ctx = contextvars.copy_context()
-    return executor.submit(ctx.run, fn, *args, **kwargs)
+    future = executor.submit(ctx.run, fn, *args, **kwargs)
+    future.add_done_callback(functools.partial(_log_background_failure, getattr(fn, '__name__', repr(fn))))
+    return future
 
 
 def get_executor_metrics() -> List[Dict[str, Any]]:

--- a/backend/utils/task_intelligence/conversation_capture.py
+++ b/backend/utils/task_intelligence/conversation_capture.py
@@ -118,6 +118,20 @@ def prepare_wake_word_capture_gate(
     )
 
 
+def _evidence_seconds(value: Any) -> float | None:
+    """Clamp a segment offset to the non-negative range EvidenceRef accepts.
+
+    Segment offsets are relative to conversation start and audio-merge arithmetic
+    lands them marginally below zero (-1e-07 is common, whole seconds happen when a
+    synced file predates the conversation). Evidence offsets are absolute positions,
+    so the floor is zero rather than a validation error.
+    """
+
+    if not isinstance(value, (int, float)):
+        return None
+    return max(0.0, float(value))
+
+
 def _conversation_evidence_ref(
     action_item: Any,
     conversation_id: str,
@@ -130,8 +144,8 @@ def _conversation_evidence_ref(
         id=conversation_id,
         scope=EvidenceScope.canonical,
         transcript_segment_ids=[segment.id for segment in supporting_segments],
-        start_seconds=min((segment.start for segment in supporting_segments), default=None),
-        end_seconds=max((segment.end for segment in supporting_segments), default=None),
+        start_seconds=_evidence_seconds(min((segment.start for segment in supporting_segments), default=None)),
+        end_seconds=_evidence_seconds(max((segment.end for segment in supporting_segments), default=None)),
     )
 
 
@@ -172,6 +186,21 @@ def canonical_fields(
 
 def canonical_conversation_fields(action_item: Any, conversation: Any) -> dict[str, Any]:
     return canonical_fields(action_item, conversation.id, getattr(conversation, 'transcript_segments', ()) or ())
+
+
+_CAPTURE_ACCEPT_OUTCOMES = frozenset({'auto_accept_silent', 'create_direct', 'pending_candidate'})
+
+
+def _accepts_on_capture(decision: Any, proposal: Any) -> bool:
+    """Return whether a conversation capture resolves itself instead of waiting for review.
+
+    Conversation capture reaches every client, and only macOS reads the Candidate
+    review surface. A parked ``create`` therefore never becomes a task for mobile
+    users, so this surface accepts every proposed create and leaves only mutations
+    of existing tasks (update/complete) for explicit review.
+    """
+
+    return proposal.proposed_action == CandidateAction.create and decision.policy.outcome in _CAPTURE_ACCEPT_OUTCOMES
 
 
 def process_before_legacy(
@@ -218,7 +247,7 @@ def process_before_legacy(
             idempotency_key=_idempotency_key(conversation_id, semantic_key, occurrence),
             account_generation=control.account_generation,
         )
-        if decision.policy.outcome in {'auto_accept_silent', 'create_direct'}:
+        if _accepts_on_capture(decision, proposal):
             candidate_service.accept_candidate(
                 uid,
                 candidate.candidate_id,


### PR DESCRIPTION
## Problem

A user reported action items appearing inside conversations but never on the Tasks page. Their account (uid redacted) had 3 conversations from Aug 20 with 6 extracted action items, **0** rows in `action_items`, and **0** documents in `candidates` — the items existed only on the conversation documents.

Since `5724a10084` ("feat: converge universal memory and task authority", Aug 11) `capture_enabled()` returns `bool(uid)`, so every conversation's action items route through the Candidate lifecycle. That exposed two defects fleet-wide.

### 1. Negative segment offsets abort the whole save, silently

Segment offsets are relative to conversation start, and audio-merge arithmetic lands them below zero — `-1.8e-07` routinely, `-17.33s` when a synced file predates the conversation. `EvidenceRef` pins `start_seconds`/`end_seconds` to `ge=0`, so building evidence raised `ValidationError`.

That call is the *first* statement of `_save_action_items`, so the compatibility writer below it never ran either: the conversation produced no task at all. Nothing reads the `postprocess_executor` Future, so the traceback was discarded — no log line, no metric, no error.

Replaying the reporter's three conversations through the adapter reproduces it on every one:

```
ValidationError: 1 validation error for EvidenceRef
start_seconds  Input should be greater than or equal to 0 [input_value=-17.329691410064697]
  at conversation_capture.py:92 in _capture_decision
```

### 2. A `pending_candidate` create is invisible to every client except macOS

Items at policy tier `pending_candidate` (a `direct_request` or a lower-confidence `clear_commitment`) are written to `candidates/` and wait for review. A task row only exists once a Candidate is accepted. The only client that reads the Candidate review surface is the macOS app (`/v1/staged-tasks`, `/v1/candidates?surface=suggested`); the Flutter app only calls `GET /v1/action-items`. On mobile, "pending review" means "discarded, forever".

### Blast radius

Read-only audit of 44 recently active users over 3 days — 234 conversations with extracted action items (302 items):

| outcome | conversations | items |
|---|---|---|
| reached Tasks (compatibility writer) | 126 | 264 visible |
| reached Tasks (Candidate accepted) | 58 | |
| **wrote nothing (defect 1)** | **25** | **30 lost** |
| **pending-only (defect 2)** | **25** | **34 hidden** |

21% of conversations with action items produced tasks the user could never see.

## Change

- `_evidence_seconds` clamps evidence offsets to zero. Evidence offsets are absolute positions in the recording, so a marginally negative merge artifact is a floor, not a validation error.
- Conversation-surface `create` proposals resolve on capture instead of parking. Mutations of an existing task (`update`/`complete`) still require explicit review, so nothing silently edits or completes a task the user already has.
- `_save_action_items` falls back to the compatibility writer when the capture adapter raises, and records the fallback (`record_fallback`) instead of dropping the conversation's tasks.
- `prepare_wake_word_capture_gate` (#11980, landed while this was open) is fenced the same way. It runs an LLM adjudication ahead of the compatibility writer, so a provider error there drops the conversation's tasks by exactly the mechanism this PR exists to remove; on failure capture proceeds ungated, which is the no-wake-word-detected path. The call stays above the empty-extraction return so its `task_command_without_extraction` metric still fires.
- `submit_with_context` logs background-task exceptions. Callers overwhelmingly discard the Future; that is why this class of failure ran for ten days without a single log line.

## Product invariants

- `INV-MEM-4` — canonical promotion remains the sole Long-term authority. This change does not alter promotion or memory admission; it only decides whether a task Candidate waits for a review surface the client does not have.

## Verification

```
python -m pytest tests/unit/test_backend_candidate_capture.py -q   # rebased onto main
37 passed, 8 warnings in 2.25s
```

New regressions, all of which fail on `main`:

- `test_capture_survives_negative_segment_offsets` — the reporter's real offsets (`-17.329691410064697`, `-1.8e-07`) produce evidence clamped to `0.0` instead of raising.
- `test_pending_tier_create_is_accepted_so_the_task_is_visible` — asserts the tier is still `pending_candidate` and that capture accepts it anyway.
- `test_task_mutation_still_waits_for_review` — an `update` targeting an existing task creates a Candidate and is *not* accepted.
- `test_capture_exception_falls_back_to_the_compatibility_writer` — a raising adapter still writes the action item rows and emits the fallback event.

Two existing tests were updated, both harness-only:

- `test_conversation_capture_resolves_every_create_without_notifications` (renamed from `test_read_mode_creates_pending_and_silently_accepts_commitment_without_notifications`) asserts the new contract — this behavior change *is* the fix, justified by the production evidence above, not by a rewritten expectation.
- `test_repeated_descriptions_use_semantic_occurrences_without_order_dependent_candidate_keys` now stubs `accept_candidate`; it stubbed only `create_candidate` and reached real Firestore once creates began accepting. Its assertions are unchanged.

## Not in this PR

Recovery of already-affected accounts is forward-only here. Two backfills are needed and are prod writes, tracked separately: reprocessing conversations that wrote nothing, and accepting pending conversation-surface `create` Candidates for clients with no review surface.

Line-Count-Exception: backend/utils/conversations/process_conversation.py | 2375 -> 2403 | both fences must wrap their calls in place; moving the task writer out of its coordinator mid-incident would be a larger change than the fix

Failure-Class: FC-derived-state-gate-without-legacy-source-path
