### PR TITLE
fix(chat): hide desktop Chat-first chrome on mobile

### DIFF
--- a/app/lib/backend/schema/message.dart
+++ b/app/lib/backend/schema/message.dart
@@ -383,10 +383,50 @@ class ServerMessage {
     return value.whereType<Map>().map((item) => Map<String, dynamic>.from(item)).toList(growable: false);
   }
 
+  static const _desktopChatChromeTypes = {
+    'goalLink',
+    'goal_link',
+    'taskCard',
+    'task_card',
+    'questionCard',
+    'question_card',
+  };
+
+  /// Desktop Chat-first cards (goal/task/question) are interactive shell chrome.
+  /// Mobile has no renderer for them, so fallback dumps like
+  /// `Goal - … Task Task Task` should not appear in the phone timeline.
+  bool get hideFromMobileChat {
+    if (sender != MessageSender.ai) return false;
+    if (type != MessageType.text) return false;
+    if (files.isNotEmpty || memories.isNotEmpty) return false;
+    if (contentBlocks.isEmpty) return false;
+    if (!_blocksAreDesktopChatChromeOnly(contentBlocks)) return false;
+    final fallback = _structuredFallbackText(contentBlocks);
+    if (fallback.isEmpty) return false;
+    final body = text.trim();
+    return body.isEmpty || _normalizeWhitespace(body) == _normalizeWhitespace(fallback);
+  }
+
+  static List<ServerMessage> visibleOnMobile(Iterable<ServerMessage> messages) {
+    return messages.where((message) => !message.hideFromMobileChat).toList();
+  }
+
+  static bool _blocksAreDesktopChatChromeOnly(List<Map<String, dynamic>> blocks) {
+    return blocks.every((block) => _desktopChatChromeTypes.contains(block['type']));
+  }
+
+  static String _normalizeWhitespace(String value) {
+    return value.split(RegExp(r'\s+')).where((part) => part.isNotEmpty).join(' ');
+  }
+
+  static String _structuredFallbackText(List<Map<String, dynamic>> blocks) {
+    if (blocks.isEmpty) return '';
+    return blocks.map(_blockFallbackText).where((value) => value.isNotEmpty).join('\n');
+  }
+
   static String _textWithStructuredFallback(String text, List<Map<String, dynamic>> blocks) {
     if (text.trim().isNotEmpty || blocks.isEmpty) return text;
-    final fallbacks = blocks.map(_blockFallbackText).where((value) => value.isNotEmpty).toList(growable: false);
-    return fallbacks.join('\n');
+    return _structuredFallbackText(blocks);
   }
 
   static String _blockFallbackText(Map<String, dynamic> block) {

--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -362,7 +362,7 @@ class MessageProvider extends ChangeNotifier {
     }
     messages = await getMessagesFromServer(dropdownSelected: dropdownSelected);
     if (messages.isEmpty) {
-      messages = SharedPreferencesUtil().cachedMessages;
+      messages = ServerMessage.visibleOnMobile(SharedPreferencesUtil().cachedMessages);
     } else {
       SharedPreferencesUtil().cachedMessages = messages;
       setHasCachedMessages(true);
@@ -375,7 +375,7 @@ class MessageProvider extends ChangeNotifier {
   void setMessagesFromCache() {
     if (SharedPreferencesUtil().cachedMessages.isNotEmpty) {
       setHasCachedMessages(true);
-      messages = SharedPreferencesUtil().cachedMessages;
+      messages = ServerMessage.visibleOnMobile(SharedPreferencesUtil().cachedMessages);
       messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
     }
     notifyListeners();
@@ -393,7 +393,7 @@ class MessageProvider extends ChangeNotifier {
       firstTimeLoadingText = l10n?.msgLearningMemories ?? 'Learning from your memories...';
       notifyListeners();
     }
-    messages = mes;
+    messages = ServerMessage.visibleOnMobile(mes);
     messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
     setLoadingMessages(false);
     notifyListeners();
@@ -411,7 +411,7 @@ class MessageProvider extends ChangeNotifier {
   Future clearChat() async {
     setClearingChat(true);
     var mes = await clearChatServer(appId: appProvider?.selectedChatAppId);
-    messages = mes;
+    messages = ServerMessage.visibleOnMobile(mes);
     messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
     setClearingChat(false);
     notifyListeners();
@@ -450,6 +450,7 @@ class MessageProvider extends ChangeNotifier {
   }
 
   void addMessage(ServerMessage message) {
+    if (message.hideFromMobileChat) return;
     if (messages.firstWhereOrNull((m) => m.id == message.id) != null) {
       return;
     }

--- a/app/test/unit/server_message_content_blocks_test.dart
+++ b/app/test/unit/server_message_content_blocks_test.dart
@@ -2,7 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:omi/backend/schema/message.dart';
 
 void main() {
-  Map<String, dynamic> messageJson({required String text, Object? contentBlocks, String? metadata}) {
+  Map<String, dynamic> messageJson({
+    required String text,
+    Object? contentBlocks,
+    String? metadata,
+  }) {
     return {
       'id': 'message-1',
       'created_at': '2026-08-18T12:00:00Z',
@@ -14,19 +18,26 @@ void main() {
     };
   }
 
-  test('uses first-class conversation block fallback instead of a blank bubble', () {
-    final message = ServerMessage.fromJson(
-      messageJson(
-        text: '',
-        contentBlocks: [
-          {'type': 'conversationLink', 'conversationId': 'conversation-1', 'summary': 'Founders explore AI memory'},
-        ],
-      ),
-    );
+  test(
+    'uses first-class conversation block fallback instead of a blank bubble',
+    () {
+      final message = ServerMessage.fromJson(
+        messageJson(
+          text: '',
+          contentBlocks: [
+            {
+              'type': 'conversationLink',
+              'conversationId': 'conversation-1',
+              'summary': 'Founders explore AI memory',
+            },
+          ],
+        ),
+      );
 
-    expect(message.text, 'Meeting notes ready - Founders explore AI memory');
-    expect(message.contentBlocks.single['conversationId'], 'conversation-1');
-  });
+      expect(message.text, 'Meeting notes ready - Founders explore AI memory');
+      expect(message.contentBlocks.single['conversationId'], 'conversation-1');
+    },
+  );
 
   test('keeps legacy metadata blocks readable during wire migration', () {
     final message = ServerMessage.fromJson(
@@ -38,19 +49,132 @@ void main() {
     );
 
     expect(message.text, 'Meeting notes ready - Legacy weekly planning');
-    expect(message.contentBlocks.single['conversationId'], 'conversation-legacy');
+    expect(
+      message.contentBlocks.single['conversationId'],
+      'conversation-legacy',
+    );
   });
 
-  test('preserves canonical backend fallback text when the client knows the block', () {
+  test(
+    'preserves canonical backend fallback text when the client knows the block',
+    () {
+      final message = ServerMessage.fromJson(
+        messageJson(
+          text: 'Meeting notes ready - Canonical title',
+          contentBlocks: [
+            {
+              'type': 'conversationLink',
+              'summary': 'Different local rendering',
+            },
+          ],
+        ),
+      );
+
+      expect(message.text, 'Meeting notes ready - Canonical title');
+      expect(message.hideFromMobileChat, isFalse);
+    },
+  );
+
+  test(
+    'hides desktop goal and task chrome fallbacks from the mobile timeline',
+    () {
+      final message = ServerMessage.fromJson(
+        messageJson(
+          text: '',
+          contentBlocks: [
+            {
+              'type': 'goalLink',
+              'goalId': 'goal-1',
+              'summary': 'Make Omi Great Again',
+            },
+            {'type': 'taskCard', 'taskId': 'task-1'},
+            {'type': 'taskCard', 'taskId': 'task-2'},
+            {'type': 'taskCard', 'taskId': 'task-3'},
+          ],
+        ),
+      );
+
+      expect(message.text, 'Goal - Make Omi Great Again\nTask\nTask\nTask');
+      expect(message.hideFromMobileChat, isTrue);
+      expect(ServerMessage.visibleOnMobile([message]), isEmpty);
+    },
+  );
+
+  test('hides stored one-line goal/task fallback dumps', () {
     final message = ServerMessage.fromJson(
       messageJson(
-        text: 'Meeting notes ready - Canonical title',
+        text: 'Goal - Make Omi Great Again Task Task Task',
         contentBlocks: [
-          {'type': 'conversationLink', 'summary': 'Different local rendering'},
+          {'type': 'goalLink', 'summary': 'Make Omi Great Again'},
+          {'type': 'taskCard', 'taskId': 'task-1'},
+          {'type': 'taskCard', 'taskId': 'task-2'},
+          {'type': 'taskCard', 'taskId': 'task-3'},
         ],
       ),
     );
 
-    expect(message.text, 'Meeting notes ready - Canonical title');
+    expect(message.hideFromMobileChat, isTrue);
+  });
+
+  test('hides question cards that have no other content', () {
+    final message = ServerMessage.fromJson(
+      messageJson(
+        text: 'What should we focus on?',
+        contentBlocks: [
+          {
+            'type': 'questionCard',
+            'questionId': 'question-1',
+            'text': 'What should we focus on?',
+            'subject': {'kind': 'goal', 'id': 'goal-1'},
+            'options': [
+              {'optionId': 'a', 'label': 'Ship', 'preparedAnswer': 'Ship'},
+            ],
+          },
+        ],
+      ),
+    );
+
+    expect(message.hideFromMobileChat, isTrue);
+  });
+
+  test('keeps meeting-note cards and mixed useful blocks', () {
+    final meeting = ServerMessage.fromJson(
+      messageJson(
+        text: '',
+        contentBlocks: [
+          {
+            'type': 'conversationLink',
+            'conversationId': 'conversation-1',
+            'summary': 'Founders explore AI memory',
+          },
+        ],
+      ),
+    );
+    final mixed = ServerMessage.fromJson(
+      messageJson(
+        text: 'I started tracking this.',
+        contentBlocks: [
+          {'type': 'text', 'text': 'I started tracking this.'},
+          {'type': 'goalLink', 'summary': 'Make Omi Great Again'},
+        ],
+      ),
+    );
+    final prose = ServerMessage.fromJson(
+      messageJson(
+        text: 'Here is a real reply about the weather.',
+        contentBlocks: [
+          {'type': 'goalLink', 'summary': 'Make Omi Great Again'},
+        ],
+      ),
+    );
+
+    expect(meeting.hideFromMobileChat, isFalse);
+    expect(mixed.hideFromMobileChat, isFalse);
+    expect(prose.hideFromMobileChat, isFalse);
+    expect(ServerMessage.visibleOnMobile([meeting, mixed, prose]), [
+      meeting,
+      mixed,
+      prose,
+    ]);
   });
 }


### PR DESCRIPTION
## Bug Description

Desktop Chat-first goal/task/question cards sync into the shared transcript. On mobile they have no native renderer, so they show as fallback dumps like `Goal - Make Omi Great Again Task Task Task`.

## Root Cause

The desktop kernel persists structured `content_blocks` plus unaware-client fallback text. Flutter parses the blocks but only renders `message.text`, including the `Goal - …` / `Task` labels.

## Fix

Keep interactive Chat-first cards desktop-only. Mobile hides assistant turns that are **only** `goalLink` / `taskCard` / `questionCard` chrome (empty text or text equal to the structured fallback). Meeting-note cards, mixed useful blocks, and real prose stay visible.

## How to Verify

1. On desktop, create a Chat-first turn with a goal link and task cards.
2. Open the same chat on mobile: the `Goal - … Task Task Task` dump should not appear.
3. A "Meeting notes ready - …" conversation card still appears.
4. Normal text replies still appear.

## Test Plan

- [x] Added regression tests in `app/test/unit/server_message_content_blocks_test.dart`
- [x] `bash app/test.sh` — 1403 passed, 5 skipped
- [ ] Manual verification on a signed-in phone (not exercised in this session)

## Risk Assessment

Low — display filter only. Desktop rendering, backend storage, and useful structured fallbacks are unchanged.

## Failure-Class

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

