### PR TITLE
fix(backend): only propose a meeting-summary recipient we are sure of

### DIFF
--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -206,3 +206,55 @@ def test_quota_redis_outage_fails_open_and_records_fallback(monkeypatch):
     assert se.consume_daily_send_quota('uid-1', 1) is True
     assert len(events) == 1
     assert events[0]['to_mode'] == 'quota_bypassed'
+
+
+def test_unnamed_participant_is_not_proposed():
+    """A bare address is an unknown person: one click must not mail it."""
+    conversation = _conversation_with_calendar_context(
+        [
+            {'name': 'Nik', 'email': 'nik@basedhardware.com'},
+            {'name': '  ', 'email': 'unknown@acme.com'},
+            {'email': 'noname@acme.com'},
+        ]
+    )
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []
+
+
+def test_unresolved_owner_suppresses_the_whole_proposal(monkeypatch):
+    """#12017: without a known owner address the owner looks like a recipient."""
+    import utils.conversations.share_email as se
+    import utils.observability.fallback as fallback
+
+    events = []
+    monkeypatch.setattr(fallback, 'record_fallback', lambda **kw: events.append(kw))
+    monkeypatch.setattr(se, 'get_user_from_uid', lambda uid: {'uid': uid, 'email': None})
+
+    conversation = _conversation_with_calendar_context(
+        [
+            {'name': 'David Zhang', 'email': 'david@scalingforever.com'},
+            {'name': 'Sarah Chen', 'email': 'sarah@acme.com'},
+        ]
+    )
+    assert se.get_share_recipients('uid-1', conversation) == []
+    assert events and events[0]['to_mode'] == 'share_recipients_suppressed'
+
+
+def test_resolved_owner_still_proposes_the_other_participant(monkeypatch):
+    import utils.conversations.share_email as se
+
+    monkeypatch.setattr(se, 'get_user_from_uid', lambda uid: {'uid': uid, 'email': 'David@ScalingForever.com'})
+    conversation = _conversation_with_calendar_context(
+        [
+            {'name': 'David Zhang', 'email': 'david@scalingforever.com'},
+            {'name': 'Sarah Chen', 'email': 'sarah@acme.com'},
+        ]
+    )
+    assert se.get_share_recipients('uid-1', conversation) == [{'name': 'Sarah Chen', 'email': 'sarah@acme.com'}]
+
+
+def test_sender_name_falls_back_to_the_address_local_part():
+    import utils.conversations.share_email as se
+
+    assert se._sender_display_name({'display_name': 'David Zhang'}) == 'David Zhang'
+    assert se._sender_display_name({'display_name': None, 'email': 'david@scalingforever.com'}) == 'david'
+    assert se._sender_display_name({}) == 'Someone'

--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -258,3 +258,31 @@ def test_sender_name_falls_back_to_the_address_local_part():
     assert se._sender_display_name({'display_name': 'David Zhang'}) == 'David Zhang'
     assert se._sender_display_name({'display_name': None, 'email': 'david@scalingforever.com'}) == 'david'
     assert se._sender_display_name({}) == 'Someone'
+
+
+def test_google_attendee_without_display_name_is_not_proposed():
+    """extract_attendees stores a nameless attendee as name==email; that is not a captured name."""
+    conversation = {
+        'id': 'conv-1',
+        'calendar_event': {
+            'event_id': 'evt-3',
+            'title': 'Intro call',
+            # Shape produced by utils.conversations.calendar_utils.extract_attendees
+            # when the attendee has no displayName.
+            'attendees': ['jordan@acme.com', 'Sam Rivera'],
+            'attendee_emails': ['jordan@acme.com', 'sam@acme.com'],
+        },
+    }
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+        {'name': 'Sam Rivera', 'email': 'sam@acme.com'}
+    ]
+
+
+def test_local_part_stand_in_name_is_not_proposed():
+    conversation = _conversation_with_calendar_context(
+        [
+            {'name': 'Nik', 'email': 'nik@basedhardware.com'},
+            {'name': 'JORDAN', 'email': 'jordan@acme.com'},
+        ]
+    )
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -98,6 +98,20 @@ def _participants_from_conversation(conversation: Dict[str, Any]) -> List[Dict[s
     return participants
 
 
+def _is_captured_name(name: str, email: str) -> bool:
+    """Whether `name` is a real captured name rather than a stand-in address.
+
+    Google attendees without a `displayName` reach us as `name = email`
+    (`calendar_utils.extract_attendees`), so a non-empty name alone does not
+    prove we know who the person is.
+    """
+    if not name:
+        return False
+    normalized = name.strip().casefold()
+    local_part = email.split('@', 1)[0]
+    return normalized != email and normalized != local_part
+
+
 def extract_share_recipients(conversation: Dict[str, Any], owner_emails: List[str]) -> List[Dict[str, Optional[str]]]:
     """Detected share recipients: meeting participants minus the owner.
 
@@ -123,7 +137,7 @@ def extract_share_recipients(conversation: Dict[str, Any], owner_emails: List[st
             continue
         raw_name = participant.get('name')
         name = raw_name.strip() if isinstance(raw_name, str) else ''
-        if not name:
+        if not _is_captured_name(name, email):
             continue
         seen.add(email)
         recipients.append({'name': name, 'email': email})

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -3,9 +3,9 @@
 Recipient detection mirrors Granola's follow-up-email rule: recipients come
 from the calendar meeting context attached to the conversation (system
 calendar / Google Calendar / on-device meeting identity), never from guessing
-at transcript content. The proposal exists only when the meeting had at least
-one participant with an email other than the owner's and no more than
-MAX_MEETING_PARTICIPANTS people total.
+at transcript content. The proposal exists only when the owner's own address
+is known (so it can be excluded), at least one other participant has both a
+name and an email, and no more than MAX_MEETING_PARTICIPANTS people attended.
 
 Sending goes through Resend from Omi's verified domain with the owner's
 address as reply-to; the recipient list a client may send to is validated
@@ -101,9 +101,14 @@ def _participants_from_conversation(conversation: Dict[str, Any]) -> List[Dict[s
 def extract_share_recipients(conversation: Dict[str, Any], owner_emails: List[str]) -> List[Dict[str, Optional[str]]]:
     """Detected share recipients: meeting participants minus the owner.
 
+    Only participants whose name *and* address the calendar actually recorded
+    are proposed. A one-click send to a half-identified attendee is a mistake
+    the user cannot take back, so an unnamed address is treated as an unknown
+    person rather than a guess.
+
     Pure so it is unit-testable; returns [] whenever the proposal should not
-    exist (no calendar identity, owner-only meeting, or a meeting too large
-    for a blanket proposal).
+    exist (no calendar identity, owner-only meeting, no fully identified
+    participant, or a meeting too large for a blanket proposal).
     """
     participants = _participants_from_conversation(conversation)
     if len(participants) > MAX_MEETING_PARTICIPANTS:
@@ -116,19 +121,55 @@ def extract_share_recipients(conversation: Dict[str, Any], owner_emails: List[st
         email = _normalized_email(participant.get('email'))
         if not email or email in owner_set or email in seen:
             continue
+        raw_name = participant.get('name')
+        name = raw_name.strip() if isinstance(raw_name, str) else ''
+        if not name:
+            continue
         seen.add(email)
-        name = participant.get('name')
-        recipients.append({'name': name.strip() if isinstance(name, str) and name.strip() else None, 'email': email})
+        recipients.append({'name': name, 'email': email})
         if len(recipients) >= MAX_RECIPIENTS:
             break
     return recipients
 
 
 def get_share_recipients(uid: str, conversation: Dict[str, Any]) -> List[Dict[str, Optional[str]]]:
+    """Recipients to propose, or [] when the owner cannot be identified.
+
+    Owner exclusion is what keeps the proposal from offering to mail the notes
+    back to the person who just recorded them, so an unresolved owner address
+    disqualifies the whole proposal instead of degrading it: without a known
+    owner address every attendee — including the user — looks like a valid
+    recipient (issue #12017).
+    """
     owner = get_user_from_uid(uid) or {}
-    owner_email = owner.get('email')
-    owner_emails: List[str] = [owner_email] if isinstance(owner_email, str) and owner_email else []
+    owner_emails = normalized_recipient_emails([owner.get('email') or ''])
+    if not owner_emails:
+        from utils.observability.fallback import record_fallback
+
+        record_fallback(
+            component='other',
+            from_mode='share_recipients_proposed',
+            to_mode='share_recipients_suppressed',
+            reason='auth',
+            outcome='degraded',
+            log=logger,
+        )
+        return []
     return extract_share_recipients(conversation, owner_emails)
+
+
+def _sender_display_name(owner: Dict[str, Any]) -> str:
+    """Who the recipient sees the notes came from.
+
+    An account without a display name still has an address; showing its local
+    part beats an anonymous "Someone", which reads like spam to the recipient.
+    """
+    display_name = (owner.get('display_name') or '').strip()
+    if display_name:
+        return display_name
+    email = _normalized_email(owner.get('email'))
+    local_part = email.split('@', 1)[0].strip() if email else ''
+    return local_part or 'Someone'
 
 
 def build_summary_email(
@@ -259,7 +300,7 @@ def send_summary_email(
         raise ValueError('no valid recipients')
 
     owner = get_user_from_uid(uid) or {}
-    sender_name = (owner.get('display_name') or '').strip() or 'Someone'
+    sender_name = _sender_display_name(owner)
     structured = conversation.get('structured') or {}
     title = (structured.get('title') or '').strip()
     overview = (structured.get('overview') or '').strip()


### PR DESCRIPTION
## Summary

The post-meeting share card offered to email the meeting notes **back to the user**. On Beta v0.12.195 a teammate ended a real meeting and the card proposed sending the summary to himself; the email that went out also read "Someone via Omi".

Both symptoms have one cause: owner exclusion was built solely from the owner's resolved account email. When that lookup returns no email, `owner_emails` is empty, so the owner stays in the participant list as a valid recipient and `sender_name` falls through to the literal `'Someone'`.

Two rules now gate the proposal, so Send only appears when we are sure who it goes to:

1. **An unresolved owner address disqualifies the whole proposal** instead of degrading it. Without a known owner address every attendee — including the user — looks like a valid recipient, so returning nothing is the only safe answer. The suppression is observable via `record_fallback` (`share_recipients_proposed` → `share_recipients_suppressed`, reason `auth`).
2. **Only participants whose name *and* address the calendar recorded are proposed.** A bare address is an unknown person, and a one-click send cannot be taken back.

With no detected recipients the card keeps **Copy link** and **See summary** and simply renders no **Send** button — that branch already existed in `MeetingSummaryShareCard` (`if let firstRecipient = recipients.first`), so this is a backend-only change. The send endpoint validates requested recipients against the detected set, so an empty detection also makes any send request 400 rather than relaying.

Sender name now falls back to the address local part before `'Someone'`.

## Verification

- `backend/tests/unit/test_share_email.py` — 16 passed (4 new: unnamed participant not proposed, unresolved owner suppresses the proposal and records the fallback, resolved owner still proposes the other participant, sender-name fallback).
- `backend/tests/unit/test_share_email_routes.py` — 15 passed.
- Exercised `get_share_recipients` against the **real Firebase identities from the incident**:
  - the reporter's own meeting → proposes the other attendee (previously: himself), sender name resolves to his display name;
  - a meeting whose companion has an address but no name → proposes nobody;
  - an owner-only meeting → proposes nobody;
  - a uid whose identity lookup fails → proposes nobody, fallback event recorded.

Fixes #12017

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

