### PR TITLE
fix(desktop): function words never keep a redundant notification headline alive

### DIFF
--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarNotificationJournalCopy.swift
@@ -20,13 +20,26 @@ extension FloatingControlBarManager {
   /// Whether every content-bearing token of the title already appears in the body,
   /// compared case-insensitively with punctuation (smart quotes, dashes, commas)
   /// stripped — so a body that quotes, inflects, or reorders the title still counts
-  /// as restating it. A title contributing even one new token keeps its own line.
+  /// as restating it. Function words are ignored on both sides: live beta rows
+  /// ("Latest Omi desktop link for David at scalingforever.com" over a body that
+  /// says the same thing with "to" instead of "for"/"at") kept their redundant
+  /// headline because a preposition was the title's only "novel" token. A title
+  /// contributing even one new CONTENT token keeps its own line.
   nonisolated static func bodyRestatesTitle(title: String, body: String) -> Bool {
-    let titleTokens = copyTokens(title)
+    let titleTokens = copyTokens(title).filter { !Self.functionWords.contains($0) }
     guard !titleTokens.isEmpty else { return true }
     let bodyTokens = Set(copyTokens(body))
     return titleTokens.allSatisfy(bodyTokens.contains)
   }
+
+  /// English function words that carry no referent of their own. Deliberately
+  /// small: an over-broad list would let a title that genuinely adds meaning
+  /// ("draft FOR the board" vs a body about a different draft) be swallowed.
+  private nonisolated static let functionWords: Set<String> = [
+    "a", "an", "the", "for", "to", "at", "of", "in", "on", "with", "and", "or",
+    "is", "are", "was", "were", "be", "your", "you", "it", "its", "this", "that",
+    "from", "by", "about", "into", "as",
+  ]
 
   private nonisolated static func copyTokens(_ text: String) -> [String] {
     text.lowercased()

--- a/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
+++ b/desktop/macos/Desktop/Tests/HomeRedesignRegressionTests.swift
@@ -403,6 +403,32 @@ final class ChatRowPresentationTests: XCTestCase {
         title: "Ship the quarterly report",
         body: "You promised it by 5pm — draft the summary now."),
       "Ship the quarterly report\nYou promised it by 5pm — draft the summary now.")
+    // Live beta rows (Aug 21): the title's only novel tokens were prepositions
+    // ("for", "at") the body phrased differently — function words never keep a
+    // redundant headline alive.
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Latest Omi desktop link for David at scalingforever.com",
+        body:
+          "The latest Omi desktop app download link is omi.me/desktop. You can paste it into the message to david@scalingforever.com."
+      ),
+      "The latest Omi desktop app download link is omi.me/desktop. You can paste it into the message to david@scalingforever.com."
+    )
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Latest Omi desktop link for david@scalingforever.com",
+        body:
+          "The latest Omi desktop download link is omi.me/desktop, so you may not need to send the draft to david@scalingforever.com."
+      ),
+      "The latest Omi desktop download link is omi.me/desktop, so you may not need to send the draft to david@scalingforever.com."
+    )
+    // A title whose content genuinely differs from the body still keeps its line
+    // even when it shares function words.
+    XCTAssertEqual(
+      FloatingControlBarManager.notificationJournalText(
+        title: "Draft for the board meeting",
+        body: "You promised the revenue summary by 5pm."),
+      "Draft for the board meeting\nYou promised the revenue summary by 5pm.")
   }
 
   func testAnOrdinaryReplyAndAUserTurnAreNotPushes() {

--- a/desktop/macos/changelog/unreleased/20260821-notification-headline-dedup.json
+++ b/desktop/macos/changelog/unreleased/20260821-notification-headline-dedup.json
@@ -1,0 +1,3 @@
+{
+  "change": "Proactive insight cards in Chat no longer repeat their headline when the message already says the same thing"
+}


### PR DESCRIPTION
## What

Live beta chat rows still showed the redundant echo headline ("Latest Omi desktop link for David at scalingforever.com" stacked over a body that says the same thing). The existing `bodyRestatesTitle` dedup demanded EVERY title token appear in the body — and the failing titles' only "novel" tokens were prepositions the body phrased differently ("for"/"at" vs "to"). The containment test now ignores a small function-word set, so a headline earns its own line only by contributing a content token.

## Verification

- `ChatRowPresentationTests` green, including both live beta rows verbatim and a content-adding negative ("Draft for the board meeting" keeps its line).
- Real path: on the signed-in dev bundle (prod backend), `send_test_notification` with both live-row payloads journaled to chat WITHOUT the headline; the content-adding payload kept its headline — read back from `/v2/desktop/messages`.

## Product invariants affected

INV-CHAT-1 — the journaled notification row remains a real chat message; this change only trims a redundant headline from its text and never skips or duplicates the journal write (guard tests in ChatRowPresentationTests cover the row text; continuity-key journaling is untouched).

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

