### PR TITLE
fix(desktop): align Refer with capture controls

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -4,8 +4,8 @@ import SwiftUI
 /// The constant floating top bar.
 ///
 /// **It carries the destinations flat, and nothing opens.** On the left, one pill per destination:
-/// `Home`, `Library`, `Tasks`, `Rewind`, `Apps`, then the referral action. On the right, three wordless controls:
-/// microphone, screen capture, settings.
+/// `Home`, `Library`, `Tasks`, `Rewind`, `Apps`. On the right, the referral action sits immediately
+/// before the microphone, followed by screen capture and settings.
 ///
 /// The bar used to spell out `Home · Memory · Tasks · Apps` beside `Listening` and `Capture`, and both
 /// halves were wrong once Home became a search surface. A **`Memory` destination sitting next to a
@@ -71,18 +71,16 @@ struct DesktopTopBar: View {
         Spacer(minLength: 0)
         TopNavigationBarLayout(
           expandedNavigation: {
-            HStack(spacing: TopNavigationPillMetrics.itemSpacing) {
-              TopNavigationDestinationRow(
-                selectedIndex: selectedIndex, badges: badges, onSelect: navigate)
-              ReferralTopBarButton { showingReferral = true }
-            }
+            TopNavigationDestinationRow(
+              selectedIndex: selectedIndex, badges: badges, onSelect: navigate)
           },
           compactNavigation: { compactNavigationMenu },
           persistentControls: {
-            HStack(spacing: OmiSpacing.sm) {
-              DesktopUpdateStatusChip()
-              ShellStatusIcons(appState: appState)
-            }
+            TopNavigationTrailingControlsLayout(
+              updateStatus: { DesktopUpdateStatusChip() },
+              referral: { ReferralTopBarButton { showingReferral = true } },
+              statusControls: { ShellStatusIcons(appState: appState) }
+            )
           },
           settings: { settingsButton }
         )
@@ -123,12 +121,6 @@ struct DesktopTopBar: View {
         } label: {
           Label(item.title, systemImage: item.icon)
         }
-      }
-      Divider()
-      Button {
-        showingReferral = true
-      } label: {
-        Label("Refer", systemImage: "gift")
       }
     } label: {
       Label("Navigate", systemImage: "sidebar.left")
@@ -173,6 +165,32 @@ struct DesktopTopBar: View {
       return
     }
     OmiMotion.withGated(.easeOut(duration: 0.08)) { selectedIndex = index }
+  }
+}
+
+/// The right-side controls in their visual order. Keeping Refer in this cluster makes its placement
+/// independent of navigation width and keeps it directly beside the microphone at every window size.
+struct TopNavigationTrailingControlsLayout<UpdateStatus: View, Referral: View, StatusControls: View>: View {
+  let updateStatus: UpdateStatus
+  let referral: Referral
+  let statusControls: StatusControls
+
+  init(
+    @ViewBuilder updateStatus: () -> UpdateStatus,
+    @ViewBuilder referral: () -> Referral,
+    @ViewBuilder statusControls: () -> StatusControls
+  ) {
+    self.updateStatus = updateStatus()
+    self.referral = referral()
+    self.statusControls = statusControls()
+  }
+
+  var body: some View {
+    HStack(spacing: OmiSpacing.sm) {
+      updateStatus
+      referral
+      statusControls
+    }
   }
 }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
@@ -160,18 +160,41 @@ struct ReferralSheetView: View {
 
 struct ReferralTopBarButton: View {
   let action: () -> Void
+  @State private var isHovering = false
 
   var body: some View {
     Button(action: action) {
-      TopNavigationPill(
-        icon: "gift",
-        title: "Refer",
-        badgeCount: 0,
-        isSelected: false
-      )
+      HStack(spacing: OmiSpacing.xs) {
+        Image(systemName: "gift")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .frame(width: TopNavigationPillMetrics.iconWidth)
+        Text("Refer")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+          .lineLimit(1)
+          .fixedSize()
+      }
+      .foregroundStyle(Ink.primary)
+      .padding(.horizontal, TopNavigationPillMetrics.horizontalPadding)
+      .frame(height: TopNavigationPillMetrics.height)
+      .background {
+        Capsule(style: .continuous)
+          .fill(Ink.rowFillHover)
+          .overlay {
+            if isHovering {
+              Capsule(style: .continuous).fill(Ink.wash)
+            }
+          }
+      }
+      .overlay {
+        Capsule(style: .continuous).strokeBorder(Ink.hairline, lineWidth: 1)
+      }
+      .contentShape(Capsule(style: .continuous))
+      .fixedSize()
     }
     .buttonStyle(.plain)
+    .onHover { isHovering = $0 }
     .help("Refer a friend")
+    .accessibilityLabel("Refer a friend")
     .accessibilityIdentifier("top-navigation-refer")
   }
 }

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -146,7 +146,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     )
   }
 
-  /// The bar carries six flat pills and no menu. The claim worth holding is not the pill count —
+  /// The bar carries five flat destination pills and no destination menu. The claim worth holding is not the pill count —
   /// it is that **nothing was stranded when the menu was deleted** (INV-NAV-1). `reach` names the one
   /// mechanism responsible for each destination, so this fails the moment a pill is removed without
   /// the destination being moved somewhere that exists.
@@ -245,6 +245,45 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     }
 
     XCTAssertEqual(referral, advanced + 1)
+  }
+
+  func testReferControlIsPinnedImmediatelyBeforeTheMicrophoneControl() {
+    let recorder = TopNavigationLayoutRecorder()
+    let host = NSHostingView(
+      rootView: TopNavigationTrailingControlsLayout(
+        updateStatus: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .updateStatus) {
+            Color.clear.frame(width: 100, height: 32)
+          }
+        },
+        referral: {
+          TopNavigationLayoutProbe(recorder: recorder, slot: .referral) {
+            Color.clear.frame(width: 78, height: 30)
+          }
+        },
+        statusControls: {
+          HStack(spacing: 2) {
+            TopNavigationLayoutProbe(recorder: recorder, slot: .microphone) {
+              Color.clear.frame(width: 32, height: 32)
+            }
+            Color.clear.frame(width: 32, height: 32)
+          }
+        }
+      )
+    )
+    host.frame = NSRect(x: 0, y: 0, width: 280, height: 32)
+    host.layoutSubtreeIfNeeded()
+
+    guard
+      let updateStatus = recorder.frame(of: .updateStatus),
+      let referral = recorder.frame(of: .referral),
+      let microphone = recorder.frame(of: .microphone)
+    else {
+      return XCTFail("expected every trailing control to be laid out")
+    }
+
+    XCTAssertEqual(referral.minX, updateStatus.maxX + OmiSpacing.sm, accuracy: 0.5)
+    XCTAssertEqual(microphone.minX, referral.maxX + OmiSpacing.sm, accuracy: 0.5)
   }
 
   /// A destination whose `reach` points at a page the bar does not have a pill for is exactly the
@@ -364,14 +403,11 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       rootView: TopNavigationBarLayout(
         expandedNavigation: {
           TopNavigationLayoutProbe(recorder: recorder, slot: .expanded) {
-            HStack(spacing: TopNavigationPillMetrics.itemSpacing) {
-              TopNavigationDestinationRow(
-                selectedIndex: SidebarNavItem.dashboard.rawValue,
-                badges: TopNavigationDestinationBadges(library: 99, tasks: 99),
-                onSelect: { _ in }
-              )
-              ReferralTopBarButton {}
-            }
+            TopNavigationDestinationRow(
+              selectedIndex: SidebarNavItem.dashboard.rawValue,
+              badges: TopNavigationDestinationBadges(library: 99, tasks: 99),
+              onSelect: { _ in }
+            )
           }
         },
         compactNavigation: {
@@ -380,8 +416,11 @@ final class TopNavigationBarLayoutTests: XCTestCase {
           }
         },
         persistentControls: {
-          Color.clear.frame(
-            width: TopNavigationLayoutMetrics.persistentControlsWidth, height: 32)
+          HStack(spacing: OmiSpacing.sm) {
+            ReferralTopBarButton {}
+            Color.clear.frame(
+              width: TopNavigationLayoutMetrics.persistentControlsWidth, height: 32)
+          }
         },
         settings: {
           Color.clear.frame(width: TopNavigationLayoutMetrics.settingsControlWidth, height: 32)
@@ -410,7 +449,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     // horizontal padding on both sides plus the fixed icon column, and the gaps are `itemSpacing`.
     // Real pills are wider than that — they carry a word, and two carry a badge — so this is a strict
     // lower bound that still fails the moment a pill stops being rendered.
-    let pills = CGFloat(TopNavigationRoutes.primaryItems.count + 1)
+    let pills = CGFloat(TopNavigationRoutes.primaryItems.count)
     let minimumPillWidth =
       TopNavigationPillMetrics.horizontalPadding * 2 + TopNavigationPillMetrics.iconWidth
     let floor = pills * minimumPillWidth + (pills - 1) * TopNavigationPillMetrics.itemSpacing
@@ -508,6 +547,9 @@ private enum TopNavigationLayoutSlot: Hashable {
   case compact
   case persistentControls
   case settings
+  case updateStatus
+  case referral
+  case microphone
 }
 
 private final class TopNavigationLayoutRecorder: @unchecked Sendable {

--- a/desktop/macos/changelog/unreleased/20260821-align-refer-control.json
+++ b/desktop/macos/changelog/unreleased/20260821-align-refer-control.json
@@ -1,0 +1,3 @@
+{
+  "change": "Moved Refer beside the microphone and gave it a clearer neutral treatment"
+}


### PR DESCRIPTION
## Summary

- pin Refer in the right-side top-bar controls immediately before the microphone
- give Refer a neutral grey capsule treatment so it reads as a distinct referral action
- keep Refer visible at narrow widths instead of duplicating it inside the navigation menu

## Product invariants affected

- INV-NAV-1

## Failure class

Failure-Class: none

## Verification

- `./scripts/dev-feedback.py --once swift 'TopNavigationBarLayoutTests'` — 18 tests passed
- `./scripts/agent-logic-harness.sh --cross-surface-smoke` — passed
- built and launched `/Applications/omi-refer-right.app` (`com.omi.omi-refer-right`) against dev
- Accessibility snapshot measured Refer at x=824, width=78 and microphone at x=910, width=32: an 8 pt gap with Refer immediately before the microphone
- opened and closed the top-bar referral sheet three times, copied the link each time, and confirmed the same `https://omi.me` link hash on all three copies
- opened Settings → Refer a Friend and copied the link successfully
- real running-app screenshot: `.cross-review-verify.png`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

