### PR TITLE
feat(context-for-claude): measure the eight things the app could not answer

### DIFF
--- a/desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySurface.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Activity/ActivitySurface.swift
@@ -143,7 +143,15 @@ struct ActivitySurface: View {
             )
             .padding(.horizontal, ActivitySurfaceLayout.horizontalPadding)
             if showsChips {
-                ActivityKindChips(selection: kind, onSelect: { kind = $0 })
+                ActivityKindChips(
+                    selection: kind,
+                    onSelect: { picked in
+                        // Reported here rather than inside `ActivityKindChips`, so the render
+                        // harness building the row for a snapshot is not a person filtering.
+                        // Which chip is not sent: the vocabulary counts that the filter was used.
+                        ContextAnalytics.record(.controlUsed(.activityKindChip))
+                        kind = picked
+                    })
                     .padding(.horizontal, ActivitySurfaceLayout.horizontalPadding)
             }
             // Only when a column on screen is standing in for the account, and never for a reason

--- a/desktop/context-for-claude/Sources/ContextApp/ContextApp.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/ContextApp.swift
@@ -48,7 +48,7 @@ struct ContextApp: App {
                 // accident" the header above says there must not be. Replacing the group is what
                 // removes SwiftUI's own item rather than sitting a second one beside it.
                 CommandGroup(replacing: .appSettings) {
-                    Button("Settings…") { SettingsWindow.present() }
+                    Button("Settings…") { SettingsWindow.present(via: .shortcut) }
                         .keyboardShortcut(",", modifiers: .command)
                 }
 
@@ -299,7 +299,17 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
             // What each one does is `shortcutFired`; the toggle it acts on is built here, once, so
             // the mapping below never has to know how to find a window.
             GlobalShortcuts.shared.start { action in
-                Self.shortcutFired(action, on: SearchBarWindow.hotkeyToggle())
+                // The chord and a recorded key are the same press to this closure and two different
+                // routes to the person making it: one is the gesture the product teaches, the other
+                // is a shortcut they chose. `binding(for:)` is the only thing that can tell them
+                // apart, and it lives out here rather than inside the toggle so the window stays a
+                // parameter — see `shortcutFired`.
+                let via: AnalyticsEvent.OpenSource
+                switch GlobalShortcuts.shared.binding(for: action) {
+                case .gestureDefault: via = .gesture
+                case .recorded: via = .shortcut
+                }
+                Self.shortcutFired(action, on: SearchBarWindow.hotkeyToggle(via: via))
             }
 
             // …and "both rebindable" is only true because of this line. Settings' two recorders talk
@@ -375,7 +385,7 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
     /// rest of a reopen — un-minimising a window the user had put in the Dock is its half, and
     /// nothing here duplicates it.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
-        MainActor.assumeIsolated { Self.surfaceSomethingForTheUser() }
+        MainActor.assumeIsolated { Self.surfaceSomethingForTheUser(via: .reopen) }
         return true
     }
 
@@ -435,8 +445,12 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
     /// for that reason alone — a reset that opened `OnboardingWindow` itself would be a second opinion
     /// about what an un-onboarded install shows, and the first flow to earn a place in `landing` would
     /// find only one of the two updated.
+    ///
+    /// - Parameter via: how the app was asked for. `.launch` is the default because two of the three
+    ///   callers are one — a process starting, and a reset that puts the install back to a first run
+    ///   — and only the Dock icon is the other, which says so.
     @MainActor
-    static func surfaceSomethingForTheUser() {
+    static func surfaceSomethingForTheUser(via: AnalyticsEvent.OpenSource = .launch) {
         switch landing(
             onboarded: UserDefaults.standard.bool(forKey: onboardedKey),
             onboardingInProgress: OnboardingResume().step != nil,
@@ -451,7 +465,7 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
             // being stopped.
             Tutorial.start(resumingAt: beat)
         case .activity:
-            openActivities()
+            openActivities(via: via)
         }
     }
 
@@ -470,8 +484,8 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
     /// showed nothing for the second or two before the store opens would be exactly the inert gesture
     /// this panel exists to stop.
     @MainActor
-    private static func openActivities() {
-        SearchBarWindow.present()
+    private static func openActivities(via: AnalyticsEvent.OpenSource) {
+        SearchBarWindow.present(via: via)
     }
 
     /// The timeline, opened the one way it is ever opened.
@@ -485,8 +499,13 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
     /// to delete it: the menu bar's "Open Timeline" row is now the app's route to this window, and it
     /// had a hand-rolled copy of exactly the reconstruction the note above warns about. One owner,
     /// called from there.
+    ///
+    /// - Parameter via: which of this window's routes was taken — the menu bar's row, the search
+    ///   panel's Timeline pill, or the tutorial. It is threaded through rather than reported at the
+    ///   two call sites for the same reason the hand-offs are constructed here: a third route would
+    ///   otherwise arrive with the second one's label on it.
     @MainActor
-    static func openTimeline() {
+    static func openTimeline(via: AnalyticsEvent.OpenSource) {
         // The store opens lazily on the engine's own queue, so ask at open time rather than at
         // launch. Nil means it is not open yet: decline to put a timeline over nothing instead of
         // showing an empty one. That answer is worth keeping even though it makes a Dock click do
@@ -499,7 +518,8 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
 
         RewindWindow.present(
             store: store,
-            onOpenSettings: { SettingsWindow.present() },
+            via: via,
+            onOpenSettings: { SettingsWindow.present(via: .inAppPill) },
             // The "Search All" pill brings the main window forward with the timeline's query in it.
             // The tutorial's search beat rides on this the way the timeline beat rides on the
             // shortcut: the press falls straight through, the real window comes forward because the
@@ -508,7 +528,7 @@ final class ContextAppDelegate: NSObject, NSApplicationDelegate {
             // It used to `guard !Tutorial.searchPillWasPressed() else { return }` — the tutorial
             // consumed the click and drew its own imitation of the results, so the one beat that
             // teaches people to search was the one beat where searching did not open the search bar.
-            onSearch: { query in SearchBarWindow.present(prefill: query) })
+            onSearch: { query in SearchBarWindow.present(via: .inAppPill, prefill: query) })
     }
 
     /// **Whether a process being terminated right now has to bring itself back.**

--- a/desktop/context-for-claude/Sources/ContextApp/Engine.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Engine.swift
@@ -1520,6 +1520,8 @@ private final class EngineStore: @unchecked Sendable {
             {
                 if let previous = openSessionId {
                     try store.closeSession(previous, at: lastSegmentEndedAt ?? line.startedAt)
+                    // After the write and inside the `do`, so a close that threw is not counted.
+                    UsageClock.shared.noteConversation()
                     // A closed session is a finished conversation; the uploader turns it into a
                     // real one in the user's Omi account. Enqueued, not sent — it survives being
                     // signed out, offline, or rate limited.
@@ -1648,7 +1650,9 @@ private final class EngineStore: @unchecked Sendable {
     func closeOpenSession() {
         queue.sync {
             guard let store = self.store, let id = self.openSessionId else { return }
-            try? store.closeSession(id, at: self.lastSegmentEndedAt ?? ContextTime.now)
+            if (try? store.closeSession(id, at: self.lastSegmentEndedAt ?? ContextTime.now)) != nil {
+                UsageClock.shared.noteConversation()
+            }
             self.openSessionId = nil
             Task { @MainActor in ConversationUploader.shared.enqueue(sessionId: id) }
         }
@@ -1667,7 +1671,9 @@ private final class EngineStore: @unchecked Sendable {
             // in the query that produced the row, and to `startedAt` when it holds no lines at all,
             // which is the same fallback this loop used to spell out.
             let lastLineAt = session.startedAt + session.durationSeconds
-            try? store.closeSession(session.id, at: lastLineAt)
+            if (try? store.closeSession(session.id, at: lastLineAt)) != nil {
+                UsageClock.shared.noteConversation()
+            }
             // Sessions orphaned by a crash still belong in the account.
             let orphan = session.id
             Task { @MainActor in ConversationUploader.shared.enqueue(sessionId: orphan) }

--- a/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusItemController.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusItemController.swift
@@ -126,7 +126,7 @@ final class StatusItemController: NSObject {
         } else {
             // Only on the opening half. Counting the close too would double every visit and make
             // "how many people open the menu bar item" read as twice the truth.
-            ContextAnalytics.record(.surfaceOpened(.menuBar))
+            ContextAnalytics.record(.surfaceOpened(.menuBar, via: .statusItem))
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
             // An `.accessory` app's popover opens behind the active app's windows otherwise.
             NSApp.activate(ignoringOtherApps: true)

--- a/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/MenuBar/StatusView.swift
@@ -559,8 +559,14 @@ struct StatusView: View {
             // the engine was never paused. A control that cannot work is worse than no control.
             MenuCommand(title: engine.isPaused ? "Resume" : "Pause") {
                 if engine.isPaused {
+                    // Named for what the press *did*, read off the state before it. Two cases
+                    // rather than one `captureToggled` with a bool, because the question people
+                    // ask of this row is "how many installs pause capture and never come back",
+                    // and that is a comparison of two counts.
+                    ContextAnalytics.record(.controlUsed(.captureResume))
                     engine.resume()
                 } else {
+                    ContextAnalytics.record(.controlUsed(.capturePause))
                     engine.pause()
                 }
             }
@@ -587,7 +593,7 @@ struct StatusView: View {
             // ungranted user can reach the window at all, and a dead chord beside it suggests they
             // never needed the row.
             MenuCommand(title: "Open Activity", shortcut: activityShortcut) {
-                SearchBarWindow.present()
+                SearchBarWindow.present(via: .menuBarRow)
             }
 
             // **No shortcut, because the timeline has none.** ⌘ + ⌘ opens Activity now, and printing
@@ -599,10 +605,12 @@ struct StatusView: View {
             // rebuilt here — store guard, Settings hand-off, search hand-off — and a second
             // reconstruction of three arguments is how one of them quietly stops being passed.
             MenuCommand(title: "Open Timeline") {
-                ContextAppDelegate.openTimeline()
+                ContextAppDelegate.openTimeline(via: .menuBarRow)
             }
 
-            MenuCommand(title: "Settings…", shortcut: "⌘,") { SettingsWindow.present() }
+            MenuCommand(title: "Settings…", shortcut: "⌘,") {
+                SettingsWindow.present(via: .menuBarRow)
+            }
                 .keyboardShortcut(",")
 
             // **The only way back into the walkthrough once it has been left.**
@@ -613,6 +621,7 @@ struct StatusView: View {
             // once per install. Skipping was therefore permanent, and the app's own explanation of
             // itself was unreachable for the rest of its life on that Mac.
             MenuCommand(title: "Show Me Around") {
+                ContextAnalytics.record(.controlUsed(.showMeAround))
                 Tutorial.start(store: Engine.shared.contextStore)
             }
 
@@ -626,6 +635,11 @@ struct StatusView: View {
             // straight back — an app that cannot be quit, which is worse than one that needs
             // reopening.
             MenuCommand(title: "Quit", shortcut: "⌘Q") {
+                // Before `TerminationOrigin`, because the two lines below end this process
+                // synchronously — `NSApp.terminate` runs `applicationWillTerminate` on the way
+                // through — and an emit after them would be an emit by a process that is gone.
+                // The sink is drained on `willTerminate`, so a record made here still leaves.
+                ContextAnalytics.record(.controlUsed(.quit))
                 TerminationOrigin.userAskedToQuit()
                 NSApp.terminate(nil)
             }

--- a/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Onboarding/OnboardingView.swift
@@ -1145,8 +1145,15 @@ struct OnboardingView: View {
         // Every "continue" goes through here, so the funnel is measured at the one place the
         // ordering lives. Ordinal only: the step *names* are product copy that changes every
         // release, and a funnel keyed on copy resets every release.
+        //
+        // **The total is this run's itinerary, not `allCases`.** A signed-in install never sees the
+        // sign-in card, so its itinerary is shorter *and* its indices skip that card's raw value —
+        // reporting 7 for every run put a permanent step in the funnel that a whole population could
+        // not reach, which reads as a cliff rather than as a card they were never shown. Recomputed
+        // on every transition for the same reason `advance()` recomputes it: `.signIn` deletes
+        // itself from the itinerary by succeeding, mid-run.
         ContextAnalytics.recordOnboardingStep(
-            index: next.rawValue, of: OnboardingStep.allCases.count)
+            index: next.rawValue, of: OnboardingStep.itinerary(signedIn: auth.isSignedIn).count)
         withAnimation(stepAnimation) { step = next }
         beginStep()
     }

--- a/desktop/context-for-claude/Sources/ContextApp/Rewind/RewindView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Rewind/RewindView.swift
@@ -73,6 +73,7 @@ struct RewindView: View {
     /// index that does not exist.
     private var searchPill: some View {
         Button {
+            ContextAnalytics.record(.controlUsed(.searchAllPill))
             onSearch("")
         } label: {
             HStack(spacing: 6) {
@@ -288,6 +289,10 @@ struct RewindView: View {
     private func dayStepButton(forward: Bool) -> some View {
         let enabled = forward ? model.hasNextDay : model.hasPreviousDay
         return Button {
+            // One control, not two. Which direction somebody stepped is not a product question;
+            // whether anybody reaches past the loaded day at all is, and a case per direction would
+            // split that count in half for nothing.
+            ContextAnalytics.record(.controlUsed(.rewindDayStep))
             model.goToAdjacentDay(forward: forward)
         } label: {
             Image(systemName: forward ? "chevron.right.2" : "chevron.left.2")
@@ -418,7 +423,10 @@ struct RewindView: View {
             // literally. It stays pressable — pressing it is what runs the pass.
             enabled: model.liveTextIsAvailable,
             isOn: model.showsLiveText
-        ) { model.toggleLiveText() }
+        ) {
+            ContextAnalytics.record(.controlUsed(.rewindLiveText))
+            model.toggleLiveText()
+        }
     }
 
     private func circleButton(

--- a/desktop/context-for-claude/Sources/ContextApp/Rewind/RewindWindow.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Rewind/RewindWindow.swift
@@ -44,13 +44,37 @@ enum RewindWindow {
     private static var model: RewindModel?
     private static var liveRefreshTimer: Timer?
 
+    /// This window's current visit. See `DwellClock` for why the lifecycle is its own type.
+    ///
+    /// **The nil is what makes it correct, in both directions.** `dismiss()` only orders the window
+    /// out — `isReleasedWhenClosed = false`, so `current` survives — which means the *second* open is
+    /// the bring-forward branch and a stash written only on the building branch would never restart.
+    /// Written whenever nothing is stamped, so a raise of a window already up leaves the clock where
+    /// it is (the dwell is one visit, not one press) and a re-open after a close begins a new one.
+    /// Cleared on the way out, so a second `dismiss()` has nothing left to report.
+    private static var dwell = DwellClock()
+
+    /// Watches for the window closing itself, which is most of how it actually closes.
+    ///
+    /// **`dismiss()` is not the close path a user takes.** This window is `.titled` and `.closable`
+    /// on purpose — the X and ⌘W both work, and both call AppKit's own `close()`, which never
+    /// reaches `dismiss()`. Measuring dwell only there would miss the ordinary close *and* leave
+    /// `presentedAt` running: the next open takes the bring-forward branch, which deliberately does
+    /// not restart the clock, so the close after that would report one bucket spanning every minute
+    /// the window spent shut. A fabricated `hours` in the series is worse than no series.
+    private static var closeObserver: NSObjectProtocol?
+
     /// Opens the window, or brings the existing one forward with its state intact.
     ///
     /// - Parameters:
     ///   - store: the capture database. Injected rather than opened here so the app's single store
     ///     is reused; opening a second writer would be a second migration racing the first.
+    ///   - via: the route that asked for it. **The reason this parameter exists at all**: all four
+    ///     routes land on this one window, so a count without a source says the timeline was opened
+    ///     and nothing about what opened it.
     static func present(
         store: ContextStore,
+        via: AnalyticsEvent.OpenSource,
         onOpenSettings: @escaping () -> Void = {},
         onSearch: @escaping (String) -> Void = { _ in }
     ) {
@@ -72,6 +96,7 @@ enum RewindWindow {
             // longer *depends* on activation landing (see `RewindWindowFrame`), but nothing is served
             // by asking in the wrong order either.
             raise(window)
+            reportPresented(via: via)
             return
         }
 
@@ -101,6 +126,18 @@ enum RewindWindow {
         window.isMovableByWindowBackground = true
         window.minSize = minimumSize
         window.isReleasedWhenClosed = false
+        // Registered on the branch that builds the window, which runs once — `isReleasedWhenClosed`
+        // is false, so `current` outlives every close and this is never re-entered for it.
+        if closeObserver == nil {
+            closeObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.willCloseNotification, object: window, queue: .main
+            ) { _ in
+                // Delivered on `.main` by the queue above, so the isolation is real and asserted
+                // rather than hopped to: a `Task { @MainActor }` here would report the dwell after
+                // the window is already gone, and after any `present` that raced it.
+                MainActor.assumeIsolated { reportClosed() }
+            }
+        }
         window.title = RewindView.modeTitle
         // Deliberately not `.floating`: this window is worked *in*, and something always on top of
         // every other window is something to fight rather than something to read.
@@ -154,6 +191,19 @@ enum RewindWindow {
         current = window
         startLiveRefresh()
         raise(window)
+        reportPresented(via: via)
+    }
+
+    /// **The open, and the start of the dwell clock** — on both branches that really put a window on
+    /// screen, and on neither that returns without one.
+    ///
+    /// After the presentation rather than before it, which is the difference between reporting a
+    /// window and reporting an intention: the screen guard above declines on a Mac with no display,
+    /// and an emit ahead of it would have counted that as an open *and* left `presentedAt` running
+    /// against a window that never appeared — so the next `dismiss()` would report a dwell for it.
+    private static func reportPresented(via: AnalyticsEvent.OpenSource) {
+        ContextAnalytics.record(.surfaceOpened(.rewind, via: via))
+        dwell.presented()
     }
 
     /// Brings the timeline forward **and makes it the key window**, in the order that works.
@@ -210,11 +260,12 @@ enum RewindWindow {
     static func present(
         store: ContextStore,
         at instant: Double,
+        via: AnalyticsEvent.OpenSource,
         onOpenSettings: @escaping () -> Void = {},
         onSearch: @escaping (String) -> Void = { _ in }
     ) {
         // Present first, then aim. The other order would ask a model that does not exist yet.
-        present(store: store, onOpenSettings: onOpenSettings, onSearch: onSearch)
+        present(store: store, via: via, onOpenSettings: onOpenSettings, onSearch: onSearch)
         focus(instant)
     }
 
@@ -239,7 +290,20 @@ enum RewindWindow {
     /// app orders the timeline back in on its own, and the only routes back on screen are the ones a
     /// person takes on purpose — `present`, `focus`, the menu row, the chord.
     static func dismiss() {
+        reportClosed()
         current?.orderOut(nil)
+    }
+
+    /// **The dwell, reported once per visit however the window went away.**
+    ///
+    /// Both close paths funnel here — `dismiss()`, which orders out and fires no notification, and
+    /// the X / ⌘W, which close for real and fire one. Clearing the stash is what makes it once: a
+    /// close arriving down both paths, or a second dismissal racing the first, finds nothing left to
+    /// report. A window that was never up has no dwell either, and inventing a `seconds` for it
+    /// would put noise exactly where the honest answer is silence.
+    private static func reportClosed() {
+        guard let openFor = dwell.closed() else { return }
+        ContextAnalytics.record(.surfaceClosed(.rewind, openFor: openFor))
     }
 
     static var isVisible: Bool { current?.isVisible ?? false }

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarView.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarView.swift
@@ -414,12 +414,36 @@ struct SearchBarView: View {
     /// `claude` command, or a clipboard fallback that needs the user to paste. Dismissing on those
     /// would be the silent failure this whole path is supposed to be incapable of.
     private func askClaude(_ question: String) {
-        switch ClaudeRouter.handOff(question, to: SettingsStore.shared.claudeTarget) {
+        let target = SettingsStore.shared.claudeTarget
+        // Two events, deliberately, because they answer two questions: the control says a person
+        // pressed Return meaning "ask Claude", and the handoff says whether it got there. A single
+        // event could not separate "nobody uses this" from "it fails for everybody".
+        //
+        // **The question itself goes nowhere near either of them.** It is the one string in reach at
+        // this call site and the schema has nowhere to put it, which is the point of the schema.
+        ContextAnalytics.record(.controlUsed(.askClaude))
+        switch ClaudeRouter.handOff(question, to: target) {
         case .arrived:
+            ContextAnalytics.record(
+                .claudeHandoff(target: Self.analyticsTarget(target), delivered: true))
             handoffNote = nil
             onDismiss()
         case .note(let sentence):
+            // Not delivered, including the clipboard branch — that one reached Claude and filled
+            // nothing in, so the user still has to paste, which is not the question arriving.
+            ContextAnalytics.record(
+                .claudeHandoff(target: Self.analyticsTarget(target), delivered: false))
             handoffNote = sentence
+        }
+    }
+
+    /// The preference, in the analytics vocabulary. An exhaustive switch rather than a raw-value
+    /// bridge, so a third target added to `ClaudeRouter.Target` is a compile error here rather than
+    /// a silent absence from the series.
+    private static func analyticsTarget(_ target: ClaudeRouter.Target) -> AnalyticsEvent.ClaudeTarget {
+        switch target {
+        case .claudeApp: return .claudeApp
+        case .terminal: return .terminal
         }
     }
 

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchBarWindow.swift
@@ -48,10 +48,13 @@ final class SearchBarWindow {
 
     /// Opens the bar, or brings it forward and re-focuses the field if it is already up.
     ///
+    /// - Parameter via: the route that asked for it. Required rather than defaulted, because a
+    ///   default is exactly how a new call site ends up filed under whichever route was most
+    ///   convenient to leave in place — and the route *is* the question this event exists to answer.
     /// - Parameter prefill: a question to start from. This is the seam the timeline's "Search All"
     ///   pill plugs into — `RewindWindow.present(onSearch:)` hands its query straight through, so the
     ///   two surfaces share one bar rather than each growing their own.
-    static func present(prefill: String = "") {
+    static func present(via: AnalyticsEvent.OpenSource, prefill: String = "") {
         if let window = current {
             window.alphaValue = 1
             window.makeKeyAndOrderFront(nil)
@@ -67,6 +70,13 @@ final class SearchBarWindow {
             // Announced on this branch too. "The panel is up" is the fact observers care about, and a
             // second press of the pill on an already-open bar leaves them holding it either way.
             SearchPanelWatch.report(.opened)
+            // **Reported on this branch too, which it was not.** A press that brings an app already
+            // running to the front is the ordinary shape of using this product all day — the Dock
+            // icon, a second chord, the menu row while the panel sits behind Xcode — and an emit
+            // that only fired when a window had to be built counted first opens and called them
+            // opens. `via` is what tells the two apart afterwards, so nothing is lost by counting
+            // both here rather than by splitting the series.
+            ContextAnalytics.record(.surfaceOpened(.activity, via: via))
             return
         }
 
@@ -186,16 +196,20 @@ final class SearchBarWindow {
         // search beat — is being told a fact about the display, so it is announced after the display
         // has it and not before.
         SearchPanelWatch.report(.opened)
-        // **This branch and not the one above**, which is the difference between "the surface was
-        // opened" and "a key was pressed at a surface that was already up". Here rather than at the
-        // callers because there are five of them — the gesture, the bound shortcut, the menu bar,
-        // the timeline's "Search All" pill and the tutorial's own button — and a per-caller emit
-        // would have measured whichever ones somebody remembered.
+        // Here rather than at the callers because there are seven of them — launch, the Dock icon,
+        // the gesture, a bound shortcut, the menu bar's row, the timeline's "Search All" pill and
+        // the tutorial's own button — and a per-caller emit would have measured whichever ones
+        // somebody remembered. The route arrives as `via`, so one seam still answers "which of
+        // them".
         //
         // Not implied by `cfc_gesture_fired`: that counts the gesture, which also *closes* an open
-        // panel and fires from a Mac where the panel never appeared at all. This is the app's
-        // primary surface, and it was the only one in `Surface` with no emitter.
-        ContextAnalytics.record(.surfaceOpened(.search))
+        // panel and fires from a Mac where the panel never appeared at all.
+        //
+        // **`.activity` and not `.search`.** This window *is* the Activity panel — it opens on the
+        // spine, before anything has been typed — and reporting the surface a query produces would
+        // have made the two indistinguishable. `.search` is emitted where a query is actually
+        // committed; see `SearchResultsModel.searchEvents`.
+        ContextAnalytics.record(.surfaceOpened(.activity, via: via))
     }
 
     /// **Activating a result: open the timeline there, then get out of the way.**
@@ -237,11 +251,12 @@ final class SearchBarWindow {
         RewindWindow.present(
             store: store,
             at: instant,
+            via: .resultActivation,
             // The same two handlers the menu bar and the global shortcut hand it, because the window
             // this opens is the same window: one that could not reach Settings, or whose "Search All"
             // pill did nothing, would be a second-class timeline reachable only from here.
-            onOpenSettings: { SettingsWindow.present() },
-            onSearch: { query in SearchBarWindow.present(prefill: query) })
+            onOpenSettings: { SettingsWindow.present(via: .inAppPill) },
+            onSearch: { query in SearchBarWindow.present(via: .inAppPill, prefill: query) })
         // Announced before the panel goes, so an observer sees "a result was activated" followed by
         // "the panel closed" rather than the other way round — the close is a *consequence* of the
         // activation here, and an observer that saw it first would read the beat as abandoned.
@@ -261,8 +276,13 @@ final class SearchBarWindow {
     /// It dismisses for the same reason activating a result does: this panel floats, and a Spotlight
     /// that stays on top of the window it just opened is covering the thing it was asked for.
     private static func openTheTimeline() {
-        ContextAnalytics.record(.surfaceOpened(.activity))
-        ContextAppDelegate.openTimeline()
+        // The press, and only the press. **The surface this opens reports itself** — it used to be
+        // reported from here, as `.activity`, which is the wrong window under the wrong name: this
+        // opens `RewindWindow`, and the series named for the app's primary window was counting the
+        // demoted one through one of its four routes. The open is now `RewindWindow.present`'s to
+        // report, from the one seam every route goes through.
+        ContextAnalytics.record(.controlUsed(.timelinePill))
+        ContextAppDelegate.openTimeline(via: .inAppPill)
         dismiss()
     }
 
@@ -279,8 +299,11 @@ final class SearchBarWindow {
     /// too and closing on those would break both. So the routes that really mean "leave" have to say
     /// so explicitly, here, rather than being inferred from focus moving.
     private static func openSettings() {
-        ContextAnalytics.record(.surfaceOpened(.settings))
-        SettingsWindow.present()
+        // The gear was pressed; the window it opens says so itself, from `SettingsWindow.present`,
+        // because the menu bar's row and ⌘, open exactly the same window and an emit here could
+        // only ever have covered this one route.
+        ContextAnalytics.record(.controlUsed(.settingsGear))
+        SettingsWindow.present(via: .inAppPill)
         dismiss()
     }
 
@@ -422,12 +445,15 @@ final class SearchBarWindow {
     ///   `LiveShortcutBindings.init` resolves its registry inside). A caller overrides it only to assert
     ///   the three transitions, none of which a headless process can produce — a test cannot make a
     ///   window key.
+    /// - Parameter via: the route the press came in on. `.gesture` for the ⌘ + ⌘ default and
+    ///   `.shortcut` for a key the user recorded, decided by the caller that can read the binding.
     static func hotkeyToggle(
+        via: AnalyticsEvent.OpenSource = .gesture,
         presence: (() -> HotkeyToggle.Presence)? = nil
     ) -> HotkeyToggle {
         HotkeyToggle(
             presence: presence ?? { Self.presence },
-            show: { present() },
+            show: { present(via: via) },
             dismiss: { dismiss() })
     }
 

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchResultsModel.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchResultsModel.swift
@@ -246,7 +246,14 @@ final class SearchResultsModel: ObservableObject {
     ///   again" is a question, so it must not be de-duplicated away.
     func ask(_ text: String) {
         query = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Asked before the reload, because the reload is what closes over it: `reload()` returns
+        // early when the capture database is not open yet, leaving `totalCount` holding the
+        // *previous* question's answer. Reporting then would bucket one query's result count
+        // against another's — and a search that never ran is not a search. The emit used to live
+        // inside `reload()` past this same guard, so this keeps the behaviour it always had.
+        let storeWasOpen = store() != nil
         reload()
+        guard storeWasOpen else { return }
         report(Self.searchEvents(
             query: query, resultCount: totalCount, isFirstOfSession: !hasReportedTheSearchSurface))
     }

--- a/desktop/context-for-claude/Sources/ContextApp/Search/SearchResultsModel.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Search/SearchResultsModel.swift
@@ -190,6 +190,14 @@ final class SearchResultsModel: ObservableObject {
     /// instead, so the answer is always the store that exists *now*.
     private let store: () -> ContextStore?
 
+    /// Whether this panel session has already reported that results were shown.
+    ///
+    /// **An instance flag is the session**, and it is one because of how `SearchBarWindow` is built:
+    /// `dismiss()` drops `current` and the next `present()` rebuilds the window, its view, and this
+    /// model — so a new model *is* a new panel, and a panel merely brought forward keeps the one it
+    /// had. Nothing has to reset it, which is the reason it cannot drift out of step.
+    private var hasReportedTheSearchSurface = false
+
     init(store: @escaping () -> ContextStore?) {
         self.store = store
     }
@@ -239,6 +247,45 @@ final class SearchResultsModel: ObservableObject {
     func ask(_ text: String) {
         query = text.trimmingCharacters(in: .whitespacesAndNewlines)
         reload()
+        report(Self.searchEvents(
+            query: query, resultCount: totalCount, isFirstOfSession: !hasReportedTheSearchSurface))
+    }
+
+    /// **What a committed question reports** — nothing at all for an empty one.
+    ///
+    /// Pure, and separated from the emit, because the rule it states is the whole of a defect that
+    /// shipped: `cfc_search_ran` came from `reload()`, which runs on **every keystroke** (there is no
+    /// debounce), once per panel open with an *empty* query from `SearchBarView.onAppear`, and again
+    /// on every filter click. The series counted typing, opening and filtering, and called all three
+    /// searches. A question is a question when it is committed, and an empty field is not one.
+    ///
+    /// `.search` rides along on the first of them rather than on the panel opening, and that is the
+    /// distinction `Surface` now draws: `.activity` is the window going up, `.search` is results
+    /// being shown in it. Once per panel session, so it counts sessions that searched rather than
+    /// letters typed.
+    ///
+    /// `nonisolated` because it reads nothing but its arguments — which is the property that makes
+    /// it assertable at all, from a suite that has no panel and no main actor to run one on.
+    ///
+    /// - Parameter isFirstOfSession: whether results have already been reported for this panel.
+    nonisolated static func searchEvents(
+        query: String, resultCount: Int, isFirstOfSession: Bool
+    ) -> [AnalyticsEvent] {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        var events: [AnalyticsEvent] = []
+        // `.inAppPill`: the results body is only ever reached from a control inside the panel that
+        // is already open — the field itself, or a query another surface handed it.
+        if isFirstOfSession { events.append(.surfaceOpened(.search, via: .inAppPill)) }
+        // Bucketed, and never the query. Read after the answer settles so a zero-result search —
+        // the one worth knowing about — is counted as a search rather than as nothing happening.
+        events.append(.searchRan(resultCountBucket: AnalyticsEvent.CountBucket(resultCount)))
+        return events
+    }
+
+    private func report(_ events: [AnalyticsEvent]) {
+        guard !events.isEmpty else { return }
+        hasReportedTheSearchSurface = true
+        for event in events { ContextAnalytics.record(event) }
     }
 
     /// A new query. Cheap to call on every keystroke: identical text is a no-op.
@@ -435,11 +482,9 @@ final class SearchResultsModel: ObservableObject {
             // something is: "109 results" over a grid of four is a lie either way round. Unnarrowed,
             // it is both halves added up — the page is one answer, so its count has to be too.
             totalCount = narrowedBySource ? visibleScreens.count : seen.total + spoken.total
-            // Bucketed, and never the query itself. Recorded after the answer settles so a
-            // zero-result search — the one worth knowing about — is counted as a search rather
-            // than as nothing having happened.
-            ContextAnalytics.record(
-                .searchRan(resultCountBucket: AnalyticsEvent.CountBucket(totalCount)))
+            // **Nothing is reported from here**, and that is the fix rather than an omission: this
+            // runs on every keystroke, on every filter click, and once per panel open with an empty
+            // query. See `searchEvents`, which `ask(_:)` is the one caller of.
             // A selection the new answer no longer contains is a keyboard target that is not on
             // screen — Return would open a card the user cannot see. Kept when the moment survived
             // the re-read, because a chip that merely reorders the page should not cost somebody

--- a/desktop/context-for-claude/Sources/ContextApp/Settings/SettingsGeneralPane.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Settings/SettingsGeneralPane.swift
@@ -196,6 +196,9 @@ struct SettingsGeneralPane: View {
             titleVisibility: .visible
         ) {
             Button(Self.resetConfirmationAction) {
+                // On the confirmation, not on the row that opens it: the row is somebody reading
+                // what "reset" means, and this is the one that puts the install back to a first run.
+                ContextAnalytics.record(.controlUsed(.runSetupAgain))
                 Sound.effect(.click)
                 OnboardingReset.restart()
             }

--- a/desktop/context-for-claude/Sources/ContextApp/Settings/SettingsWindow.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Settings/SettingsWindow.swift
@@ -32,10 +32,12 @@ enum SettingsWindow {
     /// `ShortcutBindingsTests` pins the live provider's behaviour rather than the stand-in's.
     static var shortcutProvider: ShortcutBindingProvider = InMemoryShortcutBindings()
 
+    /// - Parameter via: the route that asked for it — the panel's gear, the menu bar's row, or ⌘,.
+    ///   Reported here rather than at those three, so a fourth cannot arrive uncounted.
     /// - Parameter pane: which pane to open on. A caller that has a reason to be specific — the
     ///   permissions row in the menu bar wanting Capture, a privacy prompt wanting Exclusions — should
     ///   say so rather than dropping the user on General to find it.
-    static func present(pane: SettingsPane = .general) {
+    static func present(via: AnalyticsEvent.OpenSource, pane: SettingsPane = .general) {
         if let window = current {
             // A re-open should reflect anything that changed outside the app — a login item removed in
             // System Settings, an exclusions file edited by hand.
@@ -43,6 +45,10 @@ enum SettingsWindow {
             selection?.pane = pane
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+            // A window brought forward is a visit to Settings; which branch it took is a fact about
+            // this process's history rather than about the user. Reported after the window is up, so
+            // the screen guard below — which declines rather than presenting — reports nothing.
+            ContextAnalytics.record(.surfaceOpened(.settings, via: via))
             return
         }
 
@@ -113,6 +119,7 @@ enum SettingsWindow {
         current = window
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        ContextAnalytics.record(.surfaceOpened(.settings, via: via))
     }
 
     static func dismiss() {

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/AnalyticsEvent.swift
@@ -71,8 +71,45 @@ enum AnalyticsEvent: Sendable {
     /// The ⌘ + ⌘ gesture fired. The product's one deliberate foreground interaction.
     case gestureFired
 
-    /// A surface the user opened by hand.
-    case surfaceOpened(Surface)
+    /// A surface the user opened by hand, and the route they took to it.
+    ///
+    /// **`via` is the half that was missing.** Every route below lands on the same window, so a
+    /// count without a source says a surface was opened and nothing about what opened it — and the
+    /// routes are the product decision: a chord nobody uses and a menu row everybody uses are the
+    /// same number here without it.
+    case surfaceOpened(Surface, via: OpenSource)
+
+    /// A surface the user closed, and how long it was up. **Bucketed, never a duration.**
+    ///
+    /// Dwell is the only question `surfaceOpened` structurally cannot answer: a timeline opened and
+    /// abandoned in four seconds and one read for half an hour are one event each. A raw interval
+    /// would be a per-person activity timestamp — how long somebody sat with their own recorded
+    /// screen, to the second — so the bucket is the disclosure boundary, not a rounding convenience.
+    case surfaceClosed(Surface, openFor: DurationBucket)
+
+    /// The user handed a question to Claude from the search bar. **Never the question.**
+    ///
+    /// The inverse of `tool_*` on `dailyActive`: those count Claude reaching in, this counts the
+    /// person reaching out, and until now nothing counted the second. It is a lower bound on "does
+    /// this person use Claude with our context" and always will be — somebody who opens Claude
+    /// directly is invisible to this app by construction, which is a fact about process boundaries
+    /// rather than a gap worth closing.
+    case claudeHandoff(target: ClaudeTarget, delivered: Bool)
+
+    /// A named control was used. One closed enum, not a per-button event.
+    ///
+    /// `surfaceOpened` measures four windows; this measures the decisions taken inside them. The
+    /// vocabulary is deliberately short — the controls that answer a product question, not the ~65
+    /// clickable things in the app, because a case per button is how a closed enum becomes a string
+    /// bag with extra steps.
+    case controlUsed(Control)
+
+    /// A tutorial beat was reached. Ordinal only, for the same reason as `onboardingStep`.
+    ///
+    /// Onboarding hands off to the tutorial and the tutorial is where the product is actually
+    /// taught — including the one beat gated on Claude genuinely calling a tool. The measured funnel
+    /// used to stop exactly where the interesting drop-off starts.
+    case tutorialStep(index: Int, of: Int, outcome: TutorialOutcome)
 
     /// A local search ran. Length buckets only, never the query.
     case searchRan(resultCountBucket: CountBucket)
@@ -156,9 +193,88 @@ enum AnalyticsEvent: Sendable {
     /// it" — the more dangerous of the two, because it looks like a finding.
     enum Surface: String, Sendable, CaseIterable {
         case menuBar
+        /// The Activity panel — the app's primary window, which `SearchBarWindow` presents.
         case activity
         case settings
+        /// The search bar, once a query is committed into it.
         case search
+        /// The timeline window.
+        ///
+        /// **It had no case, and `activity` was standing in for it.** `openTheTimeline()` reported
+        /// `.activity` while opening `RewindWindow`, so the series named for the primary window was
+        /// counting the demoted one, through one of its four routes. Anything read from `activity`
+        /// or `search` before this case existed is describing the other surface.
+        case rewind
+    }
+
+    /// How a surface was reached. Closed, and every case is a route that exists in the app today.
+    enum OpenSource: String, Sendable, CaseIterable {
+        /// Process launch surfaced it.
+        case launch
+        /// Already running, brought forward — Dock, `open -a`, Finder, or a second press.
+        case reopen
+        /// The ⌘ + ⌘ chord.
+        case gesture
+        /// The menu bar status item itself, which opens the popover.
+        case statusItem
+        /// A row in the menu bar popover.
+        case menuBarRow
+        /// A control inside another of our surfaces — the Timeline pill, the gear, "Search All".
+        case inAppPill
+        /// Activating a search or activity result.
+        case resultActivation
+        /// The tutorial drove it.
+        case tutorial
+        /// A bound keyboard shortcut other than the chord.
+        case shortcut
+    }
+
+    /// How long a surface was up. Buckets, never an interval — see `surfaceClosed`.
+    enum DurationBucket: String, Sendable, CaseIterable {
+        case seconds        // < 10s
+        case aMinute        // < 60s
+        case minutes        // < 10m
+        case tensOfMinutes  // < 60m
+        case hours          // 60m+
+
+        init(_ interval: TimeInterval) {
+            switch max(0, interval) {
+            case ..<10: self = .seconds
+            case ..<60: self = .aMinute
+            case ..<600: self = .minutes
+            case ..<3600: self = .tensOfMinutes
+            default: self = .hours
+            }
+        }
+    }
+
+    /// Where a handed-off question went. Mirrors `SettingsStore.claudeTarget`.
+    enum ClaudeTarget: String, Sendable, CaseIterable {
+        case claudeApp
+        case terminal
+    }
+
+    /// The controls worth counting. Short on purpose — see `controlUsed`.
+    enum Control: String, Sendable, CaseIterable {
+        case capturePause
+        case captureResume
+        case timelinePill
+        case settingsGear
+        case searchAllPill
+        case activityKindChip
+        case rewindDayStep
+        case rewindLiveText
+        case askClaude
+        case showMeAround
+        case runSetupAgain
+        case quit
+    }
+
+    /// How a tutorial beat ended.
+    enum TutorialOutcome: String, Sendable, CaseIterable {
+        case entered
+        case finished
+        case skipped
     }
 
     /// What the install first stored. **Two cases, because two things are stored**, and a case with
@@ -260,6 +376,10 @@ enum AnalyticsEvent: Sendable {
         case .captureStateChanged: return "cfc_capture_state"
         case .gestureFired: return "cfc_gesture_fired"
         case .surfaceOpened: return "cfc_surface_opened"
+        case .surfaceClosed: return "cfc_surface_closed"
+        case .claudeHandoff: return "cfc_claude_handoff"
+        case .controlUsed: return "cfc_control_used"
+        case .tutorialStep: return "cfc_tutorial_step"
         case .searchRan: return "cfc_search_ran"
         case .firstArtifact: return "cfc_first_artifact"
         case .updateOutcome: return "cfc_update_outcome"
@@ -292,8 +412,23 @@ enum AnalyticsEvent: Sendable {
         case let .captureStateChanged(source, live):
             return ["source": .string(source.rawValue), "live": .bool(live)]
 
-        case let .surfaceOpened(surface):
-            return ["surface": .string(surface.rawValue)]
+        case let .surfaceOpened(surface, via):
+            return ["surface": .string(surface.rawValue), "via": .string(via.rawValue)]
+
+        case let .surfaceClosed(surface, openFor):
+            return ["surface": .string(surface.rawValue), "open_for": .string(openFor.rawValue)]
+
+        case let .claudeHandoff(target, delivered):
+            return ["target": .string(target.rawValue), "delivered": .bool(delivered)]
+
+        case let .controlUsed(control):
+            return ["control": .string(control.rawValue)]
+
+        case let .tutorialStep(index, total, outcome):
+            return [
+                "step_index": .int(index), "step_total": .int(total),
+                "outcome": .string(outcome.rawValue),
+            ]
 
         case let .searchRan(bucket):
             return ["result_count": .string(bucket.rawValue)]
@@ -337,10 +472,20 @@ struct DailyRollup: Sendable, Equatable {
     /// always false in practice; it is here so that if the suppression is ever wrongly relaxed the
     /// evidence is in the payload rather than absent from it.
     var airgapped: Bool
+    /// Conversations this install durably closed today.
+    ///
+    /// **A count, because the minutes could not be one.** `firstArtifact` fires once per install
+    /// ever, and `captureMinutes` reads the same on the hundredth day as the first — so "how much
+    /// does this person actually produce in a day" had no answer at all. Counted at the one seam a
+    /// session closes through, so an open session and a failed insert are both excluded.
+    ///
+    /// Deliberately not the downloaded-memory cache: that is a copy of what the account already
+    /// holds, and counting it would report another device's work as this one's.
+    var conversations: Int
 
     static let empty = DailyRollup(
         toolCalls: [:], captureMinutes: 0, screenMinutes: 0, activeHours: 0,
-        signedIn: false, airgapped: false)
+        signedIn: false, airgapped: false, conversations: 0)
 
     /// Did anything actually happen? An install that ran all day and captured nothing is still a
     /// DAU, so this is not a send gate — it is a dimension, so "available" and "used" can be told
@@ -359,6 +504,7 @@ struct DailyRollup: Sendable, Equatable {
             "signed_in": .bool(signedIn),
             "airgapped": .bool(airgapped),
             "idle": .bool(isIdle),
+            "conversations": .int(conversations),
         ]
         // One property per tool, so "which tools does Claude actually reach for" is answerable
         // without a second event type. The names come from our own dispatch table and are sanitised

--- a/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Support/Analytics/ContextAnalytics.swift
@@ -45,6 +45,18 @@ enum ContextAnalytics {
     static func record(_ event: AnalyticsEvent) {
         guard isEnabled else { return }
 
+        // **`active_hours` had no production emitter and this is it.** `UsageClock.noteActivity` was
+        // called from nowhere, so the hour set was filled only as a side effect of capture
+        // transitions inside `mark()` — which measures "hours in which capture toggled", not the
+        // "distinct hours in which anything at all happened" the rollup documents. Every recorded
+        // event is something happening, so this is the honest denominator.
+        //
+        // Safe from any thread and safe under the one re-entrancy this function has: `noteActivity`
+        // takes `UsageClock`'s lock, inserts an `Int`, and releases it before returning — it calls
+        // nothing, so the airgap path's `record` → `recordSuppression` → `recordFallback` → `record`
+        // hop cannot arrive back here holding that lock.
+        UsageClock.shared.noteActivity()
+
         // Read live, never cached: the toggle takes effect on the next event, which is what lets
         // Airgap Mode promise "immediately" rather than "after relaunch".
         guard !NetworkEgress.isSuppressed(.analytics) else {
@@ -290,7 +302,8 @@ enum ContextAnalytics {
             screenMinutes: UsageClock.shared.minutes(for: .screen),
             activeHours: UsageClock.shared.activeHourCount,
             signedIn: OmiAuth.shared.isSignedIn,
-            airgapped: NetworkEgress.isAirgapped)
+            airgapped: NetworkEgress.isAirgapped,
+            conversations: UsageClock.shared.conversationCount)
 
         // An install with nothing at all to say on its first partial day is not a data point, it is
         // noise from a launch that happened at 23:58. Everything else reports, idle included — an
@@ -337,6 +350,43 @@ enum ContextAnalytics {
 
 /// How long capture actually ran today, and how much of the day it was spread across.
 ///
+/// **One visit to a surface, as a state machine** — the thing `cfc_surface_closed` reports.
+///
+/// A window's dwell looks like two lines of arithmetic and is not: it is an optional whose lifetime
+/// has to survive a window that closes by routes the app does not own. The timeline is `.titled` and
+/// `.closable`, so the X and ⌘W call AppKit's `close()` and never reach the app's own `dismiss()` —
+/// and a stash cleared on only one of those paths keeps running while the window is shut, so the
+/// *next* close reports a single bucket spanning every minute in between. A fabricated `hours` is
+/// worse than no measurement, because it is indistinguishable from a real one.
+///
+/// Extracted rather than left inline because that failure is invisible in a window test and obvious
+/// here: `testAVisitAfterACloseMeasuresOnlyTheSecondVisit` is the regression, and it fails against
+/// an implementation that forgets to clear.
+struct DwellClock {
+    private var presentedAt: Date?
+
+    /// Starts a visit, or leaves one already running alone.
+    ///
+    /// Idempotent on purpose: raising a window that is already up is the same visit, not a new one,
+    /// and restarting here would report a long read as a series of short ones.
+    mutating func presented(at now: Date = Date()) {
+        if presentedAt == nil { presentedAt = now }
+    }
+
+    /// Ends the visit and yields its bucket, or nil when there is no visit to end.
+    ///
+    /// Nil is the answer for a close with no matching open — a second close racing the first, or a
+    /// teardown of a window that never appeared — and the caller reports nothing rather than
+    /// inventing a `seconds`.
+    mutating func closed(at now: Date = Date()) -> AnalyticsEvent.DurationBucket? {
+        guard let presentedAt else { return nil }
+        self.presentedAt = nil
+        return AnalyticsEvent.DurationBucket(now.timeIntervalSince(presentedAt))
+    }
+
+    var isRunning: Bool { presentedAt != nil }
+}
+
 /// Wall-clock accumulation rather than a count of start/stop events: "started capture 40 times" and
 /// "captured for 40 minutes" are very different products, and only the second one says whether the
 /// app is doing its job.
@@ -363,6 +413,8 @@ final class UsageClock: @unchecked Sendable {
     /// runs while *any* of its sources is live and stops when the last one does.
     private var live: [Channel: Set<AnalyticsEvent.CaptureSource>] = [:]
     private var activeHours: Set<Int> = []
+    /// Conversations durably closed today. See `noteConversation`.
+    private var conversations = 0
 
     private static func channel(for source: AnalyticsEvent.CaptureSource) -> Channel {
         switch source {
@@ -389,6 +441,26 @@ final class UsageClock: @unchecked Sendable {
             }
         }
         noteHourLocked(now)
+    }
+
+    /// Records that a conversation was durably closed.
+    ///
+    /// **Counted at the close, because that is when a conversation exists.** A session is open while
+    /// somebody is still talking; the row that becomes a conversation in the account is written when
+    /// it closes, and `Engine` has three sites that close one — the rollover inside `append`, the
+    /// explicit close on pause and quit, and the sweep that closes what a crash left open. All three
+    /// count, and an insert that threw does not.
+    ///
+    /// Not the downloaded-memory cache: that is a copy of what the account already holds, and
+    /// counting it would report another device's work as this Mac's.
+    func noteConversation() {
+        lock.lock(); defer { lock.unlock() }
+        conversations += 1
+    }
+
+    var conversationCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return conversations
     }
 
     /// Records that something happened, for the active-hours spread. Cheap enough to call from any
@@ -422,6 +494,9 @@ final class UsageClock: @unchecked Sendable {
         lock.lock(); defer { lock.unlock() }
         seconds.removeAll()
         activeHours.removeAll()
+        // The same day boundary as the minutes, and it has to be: a count that survived the reset
+        // would report yesterday's conversations again today, and again the day after.
+        conversations = 0
         for channel in startedAt.keys { startedAt[channel] = now }
         noteHourLocked(now)
     }
@@ -435,6 +510,7 @@ final class UsageClock: @unchecked Sendable {
         startedAt.removeAll()
         live.removeAll()
         activeHours.removeAll()
+        conversations = 0
     }
     #endif
 }

--- a/desktop/context-for-claude/Sources/ContextApp/Tutorial/TutorialEnvironment.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Tutorial/TutorialEnvironment.swift
@@ -313,15 +313,16 @@ struct TutorialEnvironment {
             guard let store else { return }
             RewindWindow.present(
                 store: store,
-                onOpenSettings: { SettingsWindow.present() },
-                onSearch: { query in SearchBarWindow.present(prefill: query) })
+                via: .tutorial,
+                onOpenSettings: { SettingsWindow.present(via: .inAppPill) },
+                onSearch: { query in SearchBarWindow.present(via: .inAppPill, prefill: query) })
         }
         environment.dismissTimeline = { RewindWindow.dismiss() }
         environment.timelineIsVisible = { RewindWindow.isVisible }
         environment.watchSearchPanel = { happened in TutorialSearchPanelWatch.start(happened) }
         environment.stopWatchingSearchPanel = { TutorialSearchPanelWatch.stop() }
         environment.searchPanelIsVisible = { SearchBarWindow.isVisible }
-        environment.presentSearchPanel = { SearchBarWindow.present() }
+        environment.presentSearchPanel = { SearchBarWindow.present(via: .tutorial) }
         // The panel's own dismissal and not `orderOut`, because that is what announces `.closed` —
         // so a panel the tutorial takes away and one the user pressed Escape on leave every observer
         // in the same state.

--- a/desktop/context-for-claude/Sources/ContextApp/Tutorial/TutorialModel.swift
+++ b/desktop/context-for-claude/Sources/ContextApp/Tutorial/TutorialModel.swift
@@ -994,6 +994,43 @@ final class TutorialModel: ObservableObject {
 
     // MARK: - Transitions
 
+    /// **The tutorial funnel**, as an ordinal and an outcome.
+    ///
+    /// Onboarding hands off to the walkthrough and the walkthrough is where the product is actually
+    /// taught — including the one beat gated on Claude genuinely calling a tool — so the measured
+    /// funnel used to stop exactly where the interesting drop-off starts.
+    ///
+    /// Ordinal only, never the beat's name: the names are product copy, and a funnel keyed on copy
+    /// resets every release. `flow` is the order, and `flow.count` the denominator, so a beat added
+    /// or cut moves both together.
+    ///
+    /// The index is read off `flow` rather than off `plan`: this run's plan may have dropped
+    /// `screenAccess` for a Mac that already had the grant, and an index that shifted with it would
+    /// make two installs' step 4 mean different beats.
+    ///
+    /// **`abandon()` reports nothing, and that is the sharpest rule here.** It reaches `.skipped` by
+    /// the same transition `skip()` does, and it is *not* a person leaving: it is this process being
+    /// torn down under a live run — which `screenAccess` causes on purpose, by asking macOS for a
+    /// grant whose dialog offers "Quit & Reopen". Counting it would put a cliff at the one beat
+    /// nearly every install passes through, and the run it belongs to resumes in the next process.
+    /// `runWasConcluded` is already the app's word for "somebody ended this", so it is the word here.
+    private func recordBeat(entering next: TutorialStep, leaving previous: TutorialStep) {
+        let total = TutorialStep.flow.count
+        let outcome: AnalyticsEvent.TutorialOutcome
+        let beat: TutorialStep
+        switch next {
+        case .finished:
+            (outcome, beat) = (.finished, previous)
+        case .skipped:
+            guard runWasConcluded else { return }
+            (outcome, beat) = (.skipped, previous)
+        default:
+            (outcome, beat) = (.entered, next)
+        }
+        guard let index = TutorialStep.flow.firstIndex(of: beat) else { return }
+        ContextAnalytics.record(.tutorialStep(index: index, of: total, outcome: outcome))
+    }
+
     /// The next step in *this run's* plan, so a step dropped at `begin()` is never walked into.
     private func nextStep() -> TutorialStep {
         guard let index = plan.firstIndex(of: step) else { return step.next ?? .finished }
@@ -1002,6 +1039,10 @@ final class TutorialModel: ObservableObject {
     }
 
     private func enter(_ next: TutorialStep) {
+        // Before the assignment, because a terminal transition is reported against the beat it is
+        // *leaving* — "they got to the chord and stopped" is the whole of what a drop-off says, and
+        // `.finished`/`.skipped` are not on `flow` and have no ordinal of their own.
+        recordBeat(entering: next, leaving: step)
         step = next
         stepEnteredAt = environment.now()
         // Written before the beat does anything, and on the transition rather than on arrival: the

--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -115,6 +115,11 @@ final class AnalyticsEventTests: XCTestCase {
         allowed += AnalyticsEvent.PermissionState.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.CaptureSource.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.Surface.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.OpenSource.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.DurationBucket.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.ClaudeTarget.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.Control.allCases.map(\.rawValue)
+        allowed += AnalyticsEvent.TutorialOutcome.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.ArtifactKind.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.UpdateOutcome.allCases.map(\.rawValue)
         allowed += AnalyticsEvent.FallbackReason.allCases.map(\.rawValue)
@@ -138,7 +143,7 @@ final class AnalyticsEventTests: XCTestCase {
     func testTheDailyRollupExpandsToolCallsIntoOnePropertyEach() {
         let rollup = DailyRollup(
             toolCalls: ["recall": 7, "screen": 2], captureMinutes: 41, screenMinutes: 120,
-            activeHours: 6, signedIn: true, airgapped: false)
+            activeHours: 6, signedIn: true, airgapped: false, conversations: 3)
 
         XCTAssertEqual(rollup.properties["tool_recall"], .int(7))
         XCTAssertEqual(rollup.properties["tool_screen"], .int(2))
@@ -170,7 +175,11 @@ final class AnalyticsEventTests: XCTestCase {
             .firstLaunch, .appLaunched, .dailyActive(.empty), .permission(.microphone, .granted),
             .onboardingStep(index: 0, of: 1), .onboardingFinished(secondsElapsed: 0),
             .accountStateChanged(signedIn: false), .captureStateChanged(source: .screen, live: true),
-            .gestureFired, .surfaceOpened(.settings), .searchRan(resultCountBucket: .zero),
+            .gestureFired, .surfaceOpened(.settings, via: .menuBarRow),
+            .surfaceClosed(.rewind, openFor: .minutes),
+            .claudeHandoff(target: .claudeApp, delivered: true), .controlUsed(.askClaude),
+            .tutorialStep(index: 0, of: 11, outcome: .entered),
+            .searchRan(resultCountBucket: .zero),
             .firstArtifact(.conversation), .updateOutcome(.upToDate),
             .fallback(area: .capture, outcome: .degraded, reason: .offline),
         ]
@@ -256,6 +265,143 @@ final class UsageClockTests: XCTestCase {
             UsageClock.shared.noteActivity(at: calendar.date(from: components)!)
         }
         XCTAssertEqual(UsageClock.shared.activeHourCount, 3)
+    }
+
+    /// **The count the minutes could not be.** `capture_minutes` reads the same on an install's
+    /// hundredth day as on its first, and `cfc_first_artifact` fires once per install ever — so
+    /// "how much does this person actually produce in a day" had no answer at all.
+    func testConversationsAreCountedAndClearedOnTheDayBoundary() {
+        let clock = UsageClock.shared
+        XCTAssertEqual(clock.conversationCount, 0, "a fresh clock has closed nothing")
+
+        clock.noteConversation()
+        clock.noteConversation()
+        clock.noteConversation()
+        XCTAssertEqual(clock.conversationCount, 3)
+
+        // The same reset the minutes roll over on. A count that survived it would report yesterday's
+        // conversations again today, and again the day after.
+        clock.reset(at: Date(timeIntervalSince1970: 1_760_000_000))
+        XCTAssertEqual(clock.conversationCount, 0)
+    }
+}
+
+/// Dwell, as the buckets that are the disclosure boundary rather than a rounding convenience.
+final class DurationBucketTests: XCTestCase {
+
+    /// Every boundary, from both sides. A bucket whose edges are wrong reports a timeline read for
+    /// an hour as one abandoned in seconds, and nothing downstream can tell.
+    func testDurationBucketsSplitAtTheirDocumentedBoundaries() {
+        typealias Bucket = AnalyticsEvent.DurationBucket
+        XCTAssertEqual(Bucket(0), .seconds)
+        XCTAssertEqual(Bucket(9.999), .seconds)
+        XCTAssertEqual(Bucket(10), .aMinute)
+        XCTAssertEqual(Bucket(59.999), .aMinute)
+        XCTAssertEqual(Bucket(60), .minutes)
+        XCTAssertEqual(Bucket(599.999), .minutes)
+        XCTAssertEqual(Bucket(600), .tensOfMinutes)
+        XCTAssertEqual(Bucket(3599.999), .tensOfMinutes)
+        XCTAssertEqual(Bucket(3600), .hours)
+        XCTAssertEqual(Bucket(86_400), .hours)
+    }
+
+    /// A clock that ran backwards — a system clock corrected mid-visit — is a dwell of nothing, not
+    /// a negative one that would fall through every `..<` above.
+    func testANegativeIntervalIsTheShortestBucket() {
+        XCTAssertEqual(AnalyticsEvent.DurationBucket(-500), .seconds)
+    }
+}
+
+/// **The open/close state machine behind Rewind's dwell**, and the close path that does not go
+/// through the app.
+///
+/// The timeline is `.titled` and `.closable`: the X button and ⌘W call AppKit's own `close()` and
+/// never reach `RewindWindow.dismiss()`. The first version of this measurement stashed the open
+/// instant and cleared it only in `dismiss()`, which meant an ordinary close left the clock running
+/// — and because re-opening takes the bring-forward branch, which deliberately does not restart it,
+/// the *next* close reported one bucket covering every minute the window had spent shut.
+final class DwellClockTests: XCTestCase {
+
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    func testAClockThatWasNeverPresentedHasNothingToReport() {
+        var clock = DwellClock()
+        XCTAssertFalse(clock.isRunning)
+        XCTAssertNil(clock.closed(at: epoch), "a close with no open is silence, not a zero")
+    }
+
+    func testAVisitReportsItsBucketOnce() {
+        var clock = DwellClock()
+        clock.presented(at: epoch)
+        XCTAssertTrue(clock.isRunning)
+        XCTAssertEqual(clock.closed(at: epoch.addingTimeInterval(90)), .minutes)
+        XCTAssertFalse(clock.isRunning)
+        XCTAssertNil(
+            clock.closed(at: epoch.addingTimeInterval(120)),
+            "a second close — the notification arriving behind dismiss() — must report nothing")
+    }
+
+    func testRaisingAWindowThatIsAlreadyUpDoesNotRestartTheVisit() {
+        var clock = DwellClock()
+        clock.presented(at: epoch)
+        clock.presented(at: epoch.addingTimeInterval(1_800))
+        XCTAssertEqual(
+            clock.closed(at: epoch.addingTimeInterval(3_000)), .tensOfMinutes,
+            "one visit spanning 50 minutes, not a fresh 20-minute one")
+    }
+
+    /// The regression. Against an implementation that closes without clearing, the second visit
+    /// measures from the first open and reports `.hours`.
+    func testAVisitAfterACloseMeasuresOnlyTheSecondVisit() {
+        var clock = DwellClock()
+        clock.presented(at: epoch)
+        XCTAssertEqual(clock.closed(at: epoch.addingTimeInterval(30)), .aMinute)
+
+        // Two hours shut, then opened again for five seconds.
+        let reopened = epoch.addingTimeInterval(7_200)
+        clock.presented(at: reopened)
+        XCTAssertEqual(
+            clock.closed(at: reopened.addingTimeInterval(5)), .seconds,
+            "the time the window spent closed is not dwell")
+    }
+}
+
+
+/// What a committed question reports, and what typing one does not.
+final class SearchEventTests: XCTestCase {
+
+    /// **The defect this moved to fix.** `cfc_search_ran` came from `reload()`, which runs on every
+    /// keystroke, once per panel open with an empty query, and again on every filter click. An empty
+    /// field is not a question and must report nothing at all.
+    func testAnEmptyQueryReportsNothing() {
+        for query in ["", "   ", "\n\t "] {
+            XCTAssertTrue(
+                SearchResultsModel.searchEvents(
+                    query: query, resultCount: 0, isFirstOfSession: true).isEmpty,
+                "'\(query)' is the absence of a question, not a search for nothing")
+        }
+    }
+
+    /// A real question reports the search — including a zero-result one, which is the search most
+    /// worth knowing about.
+    func testACommittedQuestionReportsTheSearch() {
+        let names = SearchResultsModel.searchEvents(
+            query: "invoice", resultCount: 0, isFirstOfSession: false).map(\.name)
+        XCTAssertEqual(names, ["cfc_search_ran"])
+    }
+
+    /// `.search` is the results body being shown, once per panel session — not once per keystroke,
+    /// which is what an emit keyed on the read would have been.
+    func testTheSearchSurfaceIsReportedOnceForTheFirstQuestionOnly() {
+        let first = SearchResultsModel.searchEvents(
+            query: "invoice", resultCount: 12, isFirstOfSession: true)
+        XCTAssertEqual(first.map(\.name), ["cfc_surface_opened", "cfc_search_ran"])
+        XCTAssertEqual(first.first?.properties["surface"], .string("search"))
+        XCTAssertEqual(first.last?.properties["result_count"], .string("several"))
+
+        let second = SearchResultsModel.searchEvents(
+            query: "receipt", resultCount: 1, isFirstOfSession: false)
+        XCTAssertEqual(second.map(\.name), ["cfc_search_ran"])
     }
 }
 
@@ -513,13 +659,26 @@ final class SurfaceEmitterTripwireTests: XCTestCase {
         XCTAssertFalse(text.isEmpty, "read no app source at all, so nothing below was checked")
 
         for surface in AnalyticsEvent.Surface.allCases {
+            // **`, via:` is part of the pattern, and it is what keeps this a guard rather than a
+            // formality.** The emit now carries a route, so matching on the surface alone would be
+            // satisfied by the *enum declaration* and by any prose mentioning the case — and the
+            // trailing comma is the only thing that cannot appear in either.
             XCTAssertTrue(
-                text.contains(".surfaceOpened(.\(surface.rawValue))"),
+                text.contains(".surfaceOpened(.\(surface.rawValue), via:"),
                 """
                 No call site records \(surface.rawValue). Either give it one or take the case out — \
                 an empty series is read as an answer about users, not as a gap in the instrumentation.
                 """)
         }
+
+        // The other half of the same rule, for the case this change added: a surface whose *close*
+        // is measured has to have a call site closing it, or `open_for` is a dimension with no data
+        // behind it. Only `.rewind` is dwell-measured today, and this asserts that one rather than
+        // demanding a `surfaceClosed` for every surface — a panel that dismisses itself on a click
+        // outside it has no dwell worth the name.
+        XCTAssertTrue(
+            text.contains(".surfaceClosed(.rewind, openFor:"),
+            "nothing reports how long the timeline was up, so cfc_surface_closed has no emitter")
     }
 }
 
@@ -555,7 +714,7 @@ extension AnalyticsEvent {
             .appLaunched,
             .dailyActive(DailyRollup(
                 toolCalls: ["recall": 3], captureMinutes: 12, screenMinutes: 30,
-                activeHours: 4, signedIn: true, airgapped: false)),
+                activeHours: 4, signedIn: true, airgapped: false, conversations: 5)),
             .onboardingStep(index: 2, of: 5),
             .onboardingFinished(secondsElapsed: 94),
             .accountStateChanged(signedIn: true),
@@ -569,7 +728,22 @@ extension AnalyticsEvent {
             [AnalyticsEvent.captureStateChanged(source: source, live: true),
              AnalyticsEvent.captureStateChanged(source: source, live: false)]
         }
-        events += Surface.allCases.map { AnalyticsEvent.surfaceOpened($0) }
+        // Every surface against every route, because `via` is a payload value like any other and
+        // the privacy invariant is checked on values.
+        events += Surface.allCases.flatMap { surface in
+            OpenSource.allCases.map { AnalyticsEvent.surfaceOpened(surface, via: $0) }
+        }
+        events += Surface.allCases.flatMap { surface in
+            DurationBucket.allCases.map { AnalyticsEvent.surfaceClosed(surface, openFor: $0) }
+        }
+        events += ClaudeTarget.allCases.flatMap { target in
+            [AnalyticsEvent.claudeHandoff(target: target, delivered: true),
+             AnalyticsEvent.claudeHandoff(target: target, delivered: false)]
+        }
+        events += Control.allCases.map { AnalyticsEvent.controlUsed($0) }
+        events += TutorialOutcome.allCases.map {
+            AnalyticsEvent.tutorialStep(index: 3, of: 11, outcome: $0)
+        }
         events += ArtifactKind.allCases.map { AnalyticsEvent.firstArtifact($0) }
         events += UpdateOutcome.allCases.map { AnalyticsEvent.updateOutcome($0) }
         events += FallbackReason.allCases.map {
@@ -588,7 +762,8 @@ final class AnalyticsEventShapeTests: XCTestCase {
         let expected: Set<String> = [
             "cfc_first_launch", "cfc_app_launched", "cfc_daily_active", "cfc_permission",
             "cfc_onboarding_step", "cfc_onboarding_finished", "cfc_account_state",
-            "cfc_capture_state", "cfc_gesture_fired", "cfc_surface_opened", "cfc_search_ran",
+            "cfc_capture_state", "cfc_gesture_fired", "cfc_surface_opened", "cfc_surface_closed",
+            "cfc_claude_handoff", "cfc_control_used", "cfc_tutorial_step", "cfc_search_ran",
             "cfc_first_artifact", "cfc_update_outcome", "cfc_fallback",
         ]
         XCTAssertEqual(

--- a/desktop/context-for-claude/Tests/ContextAppTests/RewindTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/RewindTests.swift
@@ -818,7 +818,7 @@ final class RewindVisibilityTests: XCTestCase {
     /// asserted is where the window is, not what is in it.
     private func presentTheTimeline() throws {
         let store = try ContextStore(url: root.appendingPathComponent("context.db"))
-        RewindWindow.present(store: store)
+        RewindWindow.present(store: store, via: .menuBarRow)
     }
 
     /// The search surface being asked for, and going away again, leaves the timeline alone.

--- a/desktop/context-for-claude/Tests/ContextAppTests/TimelineKeyStatusTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/TimelineKeyStatusTests.swift
@@ -208,7 +208,7 @@ final class TimelineKeyStatusTests: XCTestCase {
     /// app builds, so nothing here may build one.
     private func presentTheTimeline() throws -> RewindWindowFrame {
         let store = try ContextStore(url: root.appendingPathComponent("context.db"))
-        RewindWindow.present(store: store)
+        RewindWindow.present(store: store, via: .menuBarRow)
         return try XCTUnwrap(
             NSApp.windows.compactMap { $0 as? RewindWindowFrame }.first { $0.isVisible },
             "the timeline never came up, so nothing here is measured")

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -42,11 +42,73 @@ enum; `AnalyticsEventTests.testNoEventCarriesFreeFormText` fails if a free strin
 | `cfc_account_state` | whether an Omi account is attached (never which) |
 | `cfc_capture_state` | mic / system audio / screen going live and stopping |
 | `cfc_gesture_fired` | ⌘ + ⌘ actually firing — inert without Accessibility |
-| `cfc_surface_opened` | which surfaces people open by hand |
+| `cfc_surface_opened` | which surfaces people open by hand, **and by which route** |
+| `cfc_surface_closed` | **how long the timeline is actually read**, bucketed |
+| `cfc_claude_handoff` | the user handing a question to Claude — the inverse of `tool_*` |
+| `cfc_control_used` | the twelve controls that answer a product question |
+| `cfc_tutorial_step` | the eleven-beat tutorial, where the product is actually taught |
 | `cfc_search_ran` | local search use, bucketed result counts only |
 | `cfc_first_artifact` | **activation** — the first time this install ever stored anything |
 | `cfc_update_outcome` | update health — a fleet that stops updating looks like a fleet nobody uses |
 | `cfc_fallback` | fail-open paths, mirroring `ContextTelemetry.recordFallback` |
+
+### `via` is why `cfc_surface_opened` is worth reading
+
+Four routes reach the search panel and four reach the timeline. Without a source they were one
+number, and the route is the product decision — a chord nobody uses and a menu row everybody uses
+were indistinguishable. It is emitted inside the three presenters rather than at each caller,
+because a per-caller emit measures whichever callers somebody remembered to touch. **The
+bring-forward branch emits too**, so summoning a panel that is already up is counted; before this it
+returned early and "brought to the front" was invisible.
+
+`Surface.rewind` exists as of this change. Before it, `openTheTimeline()` reported `.activity` while
+opening `RewindWindow` — so the series named for the primary window was counting the demoted one,
+through one of its four routes, and the primary window reported as `.search`. **Anything read from
+`activity` or `search` before 2026-08-21 describes the other surface.**
+
+### `cfc_surface_closed` is bucketed, and that is the disclosure boundary
+
+Dwell is the one question `cfc_surface_opened` structurally cannot answer: a timeline opened and
+abandoned in four seconds and one read for half an hour are one event each. A raw interval would be
+a per-person record of how long somebody sat with their own recorded screen, so the payload carries
+a `DurationBucket` and never a number of seconds.
+
+The state machine is `DwellClock`, extracted rather than left inline because its failure is
+invisible in a window test. **The timeline is `.titled` and `.closable`**, so the X and ⌘W call
+AppKit's own `close()` and never reach `dismiss()`. A stash cleared only in `dismiss()` keeps
+running while the window is shut, and because re-opening takes the bring-forward branch — which
+deliberately does not restart the clock, since raising a window that is already up is the same visit
+— the *next* close reports one bucket spanning every minute in between. Both paths funnel through
+one reporter, and `testAVisitAfterACloseMeasuresOnlyTheSecondVisit` fails against an implementation
+that forgets to clear.
+
+### `conversations` on the rollup, because the minutes could not be a count
+
+`cfc_first_artifact` fires once per install ever, and `capture_minutes` reads the same on the
+hundredth day as on the first — so "how much does this person actually produce in a day" had no
+answer. Counted at the three seams `Engine` closes a session through (the rollover inside `append`,
+the explicit close on pause and quit, and the sweep that closes what a crash left open), never for a
+close that threw, and cleared by `UsageClock.reset()` on the same day boundary as the minutes.
+
+Deliberately not the `account_rows` cache: that is a copy of what the account already holds, and
+counting it would report another device's work as this Mac's.
+
+### What `active_hours` used to measure
+
+`UsageClock.noteActivity` had **no production caller** — only its own definition and one test. The
+hour set was therefore filled only as a side effect of capture transitions inside `mark()`, which
+measures "hours in which capture toggled", not the "distinct hours in which anything at all
+happened" this document has always claimed. The documented reading — twelve active hours and twelve
+capture minutes is a person at a desk — was unreachable. `ContextAnalytics.record` now marks the
+hour for every event. **Any `active_hours` read before 2026-08-21 is a capture-transition count.**
+
+### What `cfc_search_ran` used to count
+
+Keystrokes. It was emitted from `SearchResultsModel.reload()`, which runs on every keystroke with no
+debounce, once per panel open with an empty query via `onAppear`, and once per filter click — so
+typing a seven-letter word reported seven searches, and a panel nobody typed into reported one. It
+now fires when a question is committed. **This is also why 82% of historical results bucket as
+`many` and none as `zero`: an empty query returns the newest captures.**
 
 ### `cfc_first_artifact` is the activation moment
 
@@ -64,6 +126,14 @@ the first. An install that captured all day and one that captured nothing were i
 process that cannot report anything (see below), and the local `account_rows` table is a copy of what
 the account already holds — first-storing a *downloaded* memory would fire this for an install that
 has captured nothing at all.
+
+### `step_total` describes the run, not the enum
+
+The emit used to pass all seven `OnboardingStep` cases, but a signed-in user's itinerary is six and
+their events skip the sign-in index — which put a permanent, real-looking cliff in the funnel that
+was a reinstall arriving already known rather than a person giving up. It now reports the length of
+the itinerary the run is actually on, so the value is 6 or 7 and the funnel is readable. Both
+values are reported, so cross-version comparison still works.
 
 ### `cfc_onboarding_finished` is once per install, across a relaunch
 


### PR DESCRIPTION
## What this is

Context for Claude's analytics answered *how many people use this* and almost nothing about *what they do with it*. Four coarse surfaces, one gesture, and a daily rollup of minutes. This adds the instruments that were missing and repairs three that were measuring something other than their name.

It came out of a live audit of the existing data, which is what surfaced the three repairs — every one of them was producing numbers that read as findings.

## New

| Event / field | The question it answers |
|---|---|
| `via:` on `cfc_surface_opened` | which of the four routes to each window people actually take — including **brought to the front while already running**, which the early-return branch never counted |
| `cfc_surface_closed` | how long the timeline is actually read, bucketed |
| `conversations` on `cfc_daily_active` | how much an install produces **per day** |
| `cfc_claude_handoff` | the user handing a question to Claude — every other signal counts Claude reaching in |
| `cfc_control_used` | twelve named controls; roughly 4 of ~65 meaningful ones were measured |
| `cfc_tutorial_step` | the eleven-beat tutorial, which reported nothing at all |

`Surface.rewind` exists now. `openTheTimeline()` reported `.activity` while opening `RewindWindow`, so the series named for the primary window was counting the demoted one through one of its four routes, and the primary window reported as `.search`. **Anything read from `activity` or `search` before this merges describes the other surface** — recorded in `docs/analytics.md`.

## Repaired

- **`active_hours` had no production emitter.** `UsageClock.noteActivity` was called from nowhere, so the hour set was filled only as a side effect of capture transitions — "hours in which capture toggled", not the "distinct hours in which anything happened" the rollup documents. The documented reading, *twelve active hours and twelve capture minutes is a person at a desk*, was unreachable.
- **`cfc_search_ran` counted keystrokes.** Emitted from `reload()` with no debounce, once per panel open with an empty query, and once per filter click — so a seven-letter word reported seven searches. This is also why 82% of historical results bucket as `many` and none as `zero`: an empty query returns the newest captures.
- **`cfc_onboarding_step` reported the wrong total.** `step_total` was all seven cases even when the run in progress was six, and those runs skip the sign-in index — a permanent cliff in the funnel that was a reinstall arriving already known, not a person giving up.

## The bug found while building it

The first version of the dwell measurement stashed the open instant and cleared it only in `dismiss()`. The timeline is `.titled` and `.closable`, so the X and ⌘W call AppKit's own `close()` and never reach `dismiss()` — leaving the clock running while the window was shut. Because re-opening takes the bring-forward branch, which deliberately does not restart it, the *next* close would have reported one bucket spanning every minute in between. A fabricated `hours` is worse than no measurement, because it is indistinguishable from a real one.

Both paths now funnel through one reporter, and the state machine is extracted as `DwellClock` because that failure is invisible in a window test and obvious in a unit test.

## Privacy contract — unchanged

Every associated value added here is a number, a bool, or another closed enum. No event carries a query, a window title, an app name, a URL, a path, or a tool argument. `testNoEventCarriesFreeFormText` covers the new cases. No `identify()`, and the distinct id is still the salted install hash that does not change on sign-in.

## Verification

- `swift build` — clean. The two remaining warnings (an unhandled `fluidaudio` resource, and a deprecated `onChange(of:perform:)` at `SearchBarView.swift:206`) are present unchanged on `upstream/main`.
- `swift test` — **1681 tests, 9 skipped, 0 failures.** Baseline on the merge-base was 1671.
- **The dwell regression test was verified by sabotage**: removing the clear in `DwellClock.closed` makes `testAVisitAfterACloseMeasuresOnlyTheSecondVisit` report `.hours` instead of `.seconds` — the exact defect it guards. Restored and re-run green.
- **Exercised as a real signed bundle**, launched with `CONTEXT_ANALYTICS_FORCE=1`: `cfc_daily_active` carried the new `conversations` field and `cfc_first_artifact` fired, confirming the schema serializes at runtime. The process was `SIGKILL`ed before the 60-second flush and the spool restored from a pristine snapshot, so **none of these test events reached PostHog**.
- `make preflight` — 12 checks passed.

**Not verified at runtime:** `via` on `cfc_surface_opened` and `cfc_surface_closed`. The dev build never surfaced its panel in a headless run and the ⌘+⌘ chord did not register against the dev bundle's own TCC identity, so those two rest on unit coverage plus the no-dead-case tripwire rather than an observed event. Worth watching in the first day of field data after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Failure-Class: none
