### PR TITLE
feat(referrals): add signup-first redemption

### DIFF
--- a/backend/database/referrals.py
+++ b/backend/database/referrals.py
@@ -15,7 +15,7 @@ def claim_referral_trial(
     is_new_user: bool,
     firestore_client: Any | None = None,
 ) -> bool:
-    """Atomically grant the referred account its one-time 30-day Omi Pro entitlement."""
+    """Atomically grant the referred account its one-time 30-day Operator entitlement."""
     client = firestore_client or get_customer_firestore_client()
     user_ref = client.collection('users').document(referred_uid)
 

--- a/backend/route_policy_manifest.yaml
+++ b/backend/route_policy_manifest.yaml
@@ -169,6 +169,30 @@ routes:
         state: active
       owner: backend
   - route_type: http
+    method: POST
+    path: /v1/users/me/referral/claim
+    policy:
+      review_status: reviewed
+      auth:
+        mechanisms:
+          - firebase_id_token
+          - admin_key_uid_prefix
+        placement: dependency
+        scopes: []
+      byok: validated_when_headers_present
+      rate_limit:
+        policy_name: none
+        key_subject: none
+        enforcement: none
+        placement: none
+      timeout_class: default_method
+      surface: first_party_app
+      visibility: first_party
+      data_domain: user_profile
+      deprecation:
+        state: active
+      owner: backend
+  - route_type: http
     method: GET
     path: /v3/speech-profile/status
     policy:

--- a/backend/routers/referrals.py
+++ b/backend/routers/referrals.py
@@ -1,14 +1,18 @@
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
+import firebase_admin.auth
 from pydantic import BaseModel
 
+from database.referrals import claim_referral_trial
 from utils.other import endpoints as auth
 from utils.referrals import (
     REFERRAL_COOKIE_MAX_AGE_SECONDS,
     REFERRAL_COOKIE_NAME,
-    REFERRAL_DOWNLOAD_URL,
+    REFERRAL_TRIAL_DAYS,
     ReferralCodeError,
+    is_new_referral_account,
     referral_link,
+    referral_signup_url,
     referrer_uid_from_code,
 )
 
@@ -17,6 +21,15 @@ router = APIRouter(tags=['referrals'])
 
 class ReferralLinkResponse(BaseModel):
     referral_url: str
+
+
+class ReferralClaimRequest(BaseModel):
+    code: str
+
+
+class ReferralClaimResponse(BaseModel):
+    claimed: bool
+    trial_days: int
 
 
 @router.get('/v1/users/me/referral', response_model=ReferralLinkResponse)
@@ -34,7 +47,7 @@ def capture_referral(code: str) -> RedirectResponse:
     except ReferralCodeError as error:
         raise HTTPException(status_code=404, detail='Referral link not found') from error
 
-    response = RedirectResponse(REFERRAL_DOWNLOAD_URL, status_code=302)
+    response = RedirectResponse(referral_signup_url(code), status_code=302)
     response.set_cookie(
         REFERRAL_COOKIE_NAME,
         code,
@@ -45,3 +58,23 @@ def capture_referral(code: str) -> RedirectResponse:
         path='/',
     )
     return response
+
+
+@router.post('/v1/users/me/referral/claim', response_model=ReferralClaimResponse)
+def claim_referral(
+    body: ReferralClaimRequest,
+    uid: str = Depends(auth.get_current_user_uid),
+) -> ReferralClaimResponse:
+    try:
+        referrer_uid = referrer_uid_from_code(body.code)
+    except ReferralCodeError as error:
+        raise HTTPException(status_code=404, detail='Referral link not found') from error
+
+    user = firebase_admin.auth.get_user(uid)
+    creation_timestamp = getattr(getattr(user, 'user_metadata', None), 'creation_timestamp', None)
+    claimed = claim_referral_trial(
+        uid,
+        referrer_uid,
+        is_new_user=is_new_referral_account(creation_timestamp),
+    )
+    return ReferralClaimResponse(claimed=claimed, trial_days=REFERRAL_TRIAL_DAYS)

--- a/backend/tests/unit/test_referrals.py
+++ b/backend/tests/unit/test_referrals.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from typing import Iterator
 
 import pytest
@@ -13,6 +13,7 @@ from utils.referrals import (
     REFERRAL_COOKIE_NAME,
     ReferralCodeError,
     create_referral_code,
+    is_new_referral_account,
     referral_claim_patch,
     referrer_uid_from_code,
 )
@@ -38,7 +39,7 @@ def test_referral_code_round_trips_and_rejects_tampering():
         referrer_uid_from_code(f'{code[:-1]}x', secret=TEST_SECRET)
 
 
-def test_referral_claim_grants_exactly_30_days_of_desktop_pro():
+def test_referral_claim_grants_exactly_30_days_of_operator():
     now = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
 
     patch = referral_claim_patch(
@@ -50,10 +51,11 @@ def test_referral_claim_grants_exactly_30_days_of_desktop_pro():
     )
 
     assert patch is not None
-    assert patch['subscription']['plan'] == 'architect'
+    assert patch['subscription']['plan'] == 'operator'
     assert patch['subscription']['status'] == 'active'
     assert patch['subscription']['cancel_at_period_end'] is True
     assert patch['subscription']['current_period_end'] - patch['subscription']['current_period_start'] == 30 * 86400
+    assert patch['referral']['program'] == 'desktop_operator_month_v1'
     assert patch['referral']['referrer_uid'] == 'referrer'
 
 
@@ -63,7 +65,7 @@ def test_referral_claim_grants_exactly_30_days_of_desktop_pro():
         ('same-user', 'same-user', True, {}),
         ('existing-user', 'referrer', False, {}),
         ('paid-user', 'referrer', True, {'subscription': {'plan': 'operator'}}),
-        ('claimed-user', 'referrer', True, {'referral': {'program': 'desktop_pro_month_v1'}}),
+        ('claimed-user', 'referrer', True, {'referral': {'program': 'desktop_operator_month_v1'}}),
     ],
 )
 def test_referral_claim_never_self_refers_rewards_existing_users_or_overwrites_paid_accounts(
@@ -80,20 +82,104 @@ def test_referral_claim_never_self_refers_rewards_existing_users_or_overwrites_p
     )
 
 
-def test_referral_link_captures_secure_cookie_and_opens_existing_desktop_download(monkeypatch):
+def test_referral_link_captures_secure_cookie_and_opens_signup_before_download(monkeypatch):
     monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    monkeypatch.setenv('REFERRAL_PUBLIC_BASE_URL', 'https://omi.me')
     code = create_referral_code('referrer-123')
 
     with _loaded_referrals_router() as referrals:
         response = referrals.capture_referral(code)
 
     assert response.status_code == 302
-    assert response.headers['location'] == 'https://macos.omi.me'
+    assert response.headers['location'] == f'https://app.omi.me/login?referral={code}&environment=prod'
     cookie = response.headers['set-cookie']
     assert f'{REFERRAL_COOKIE_NAME}={code}' in cookie
     assert 'HttpOnly' in cookie
     assert 'Secure' in cookie
     assert 'SameSite=lax' in cookie
+
+
+def test_dev_referral_opens_signup_against_the_dev_backend(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    monkeypatch.setenv('REFERRAL_PUBLIC_BASE_URL', 'https://api.omiapi.com')
+    code = create_referral_code('referrer-123')
+
+    with _loaded_referrals_router() as referrals:
+        response = referrals.capture_referral(code)
+
+    assert response.headers['location'] == f'https://app.omi.me/login?referral={code}&environment=dev'
+
+
+def test_referral_claim_grants_trial_only_to_a_fresh_authenticated_account(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    code = create_referral_code('referrer-123')
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    claims = []
+
+    with _loaded_referrals_router() as referrals:
+        monkeypatch.setattr(
+            referrals.firebase_admin.auth,
+            'get_user',
+            lambda _uid: SimpleNamespace(user_metadata=SimpleNamespace(creation_timestamp=now_ms)),
+        )
+        monkeypatch.setattr(
+            referrals,
+            'claim_referral_trial',
+            lambda referred_uid, referrer_uid, *, is_new_user: claims.append((referred_uid, referrer_uid, is_new_user))
+            or True,
+        )
+        response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), 'new-user')
+
+    assert response.claimed is True
+    assert response.trial_days == 30
+    assert claims == [('new-user', 'referrer-123', True)]
+
+
+def test_referral_claim_marks_an_existing_authenticated_account_ineligible(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+    code = create_referral_code('referrer-123')
+    old_ms = int(datetime(2025, 1, 1, tzinfo=timezone.utc).timestamp() * 1000)
+    claims = []
+
+    with _loaded_referrals_router() as referrals:
+        monkeypatch.setattr(
+            referrals.firebase_admin.auth,
+            'get_user',
+            lambda _uid: SimpleNamespace(user_metadata=SimpleNamespace(creation_timestamp=old_ms)),
+        )
+        monkeypatch.setattr(
+            referrals,
+            'claim_referral_trial',
+            lambda referred_uid, referrer_uid, *, is_new_user: claims.append((referred_uid, referrer_uid, is_new_user))
+            or False,
+        )
+        response = referrals.claim_referral(referrals.ReferralClaimRequest(code=code), 'existing-user')
+
+    assert response.claimed is False
+    assert claims == [('existing-user', 'referrer-123', False)]
+
+
+def test_referral_claim_rejects_an_invalid_code_before_loading_the_user(monkeypatch):
+    monkeypatch.setenv('ENCRYPTION_SECRET', TEST_SECRET.decode())
+
+    with _loaded_referrals_router() as referrals:
+        get_user = lambda _uid: pytest.fail('invalid referral must not load the user')
+        monkeypatch.setattr(referrals.firebase_admin.auth, 'get_user', get_user)
+
+        with pytest.raises(HTTPException) as error:
+            referrals.claim_referral(referrals.ReferralClaimRequest(code='invalid'), 'new-user')
+
+    assert error.value.status_code == 404
+    assert error.value.detail == 'Referral link not found'
+
+
+def test_referral_new_user_window_rejects_missing_future_and_old_timestamps():
+    now = datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)
+
+    assert is_new_referral_account(int(now.timestamp() * 1000), now=now) is True
+    assert is_new_referral_account(None, now=now) is False
+    assert is_new_referral_account(int((now.timestamp() + 1) * 1000), now=now) is False
+    assert is_new_referral_account(int((now.timestamp() - 901) * 1000), now=now) is False
 
 
 def test_authenticated_referrer_receives_a_stable_unique_https_link(monkeypatch):

--- a/backend/utils/referrals.py
+++ b/backend/utils/referrals.py
@@ -7,13 +7,15 @@ import os
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+from urllib.parse import urlencode, urlparse
 
 from models.users import PlanType
 
 REFERRAL_COOKIE_NAME = 'omi_desktop_referral'
 REFERRAL_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
 REFERRAL_TRIAL_DAYS = 30
-REFERRAL_DOWNLOAD_URL = 'https://macos.omi.me'
+REFERRAL_SIGNUP_URL = 'https://app.omi.me/login'
+REFERRAL_NEW_USER_WINDOW_SECONDS = 15 * 60
 
 _CODE_PREFIX = 'ref1'
 _UID_PATTERN = re.compile(r'^[A-Za-z0-9:_-]{1,128}$')
@@ -86,6 +88,30 @@ def referral_link(uid: str, *, secret: Optional[bytes] = None, public_base_url: 
     return f'{base_url}/r/{create_referral_code(uid, secret=secret)}'
 
 
+def referral_environment(public_base_url: Optional[str] = None) -> str:
+    base_url = public_base_url or os.getenv('REFERRAL_PUBLIC_BASE_URL') or 'https://omi.me'
+    return 'dev' if urlparse(base_url).hostname == 'api.omiapi.com' else 'prod'
+
+
+def referral_signup_url(code: str, *, public_base_url: Optional[str] = None) -> str:
+    query = urlencode({'referral': code, 'environment': referral_environment(public_base_url)})
+    return f'{REFERRAL_SIGNUP_URL}?{query}'
+
+
+def is_new_referral_account(
+    creation_timestamp_ms: Optional[int],
+    *,
+    now: Optional[datetime] = None,
+) -> bool:
+    if creation_timestamp_ms is None:
+        return False
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    age_seconds = current_time.timestamp() - (creation_timestamp_ms / 1000)
+    return 0 <= age_seconds <= REFERRAL_NEW_USER_WINDOW_SECONDS
+
+
 def referral_claim_patch(
     *,
     referred_uid: str,
@@ -113,14 +139,14 @@ def referral_claim_patch(
     ends_epoch = int((started_at + timedelta(days=REFERRAL_TRIAL_DAYS)).timestamp())
     return {
         'subscription': {
-            'plan': PlanType.architect.value,
+            'plan': PlanType.operator.value,
             'status': 'active',
             'current_period_start': started_epoch,
             'current_period_end': ends_epoch,
             'cancel_at_period_end': True,
         },
         'referral': {
-            'program': 'desktop_pro_month_v1',
+            'program': 'desktop_operator_month_v1',
             'referrer_uid': referrer_uid,
             'claimed_at': started_epoch,
             'trial_ends_at': ends_epoch,

--- a/desktop/macos/CHANGELOG.json
+++ b/desktop/macos/CHANGELOG.json
@@ -50,7 +50,7 @@
       "changes": [
         "Integration Suggestions is now the fifth notification type — a row beside Focus, Task, Insight, and Memory in Settings, with its own Integration chat badge",
         "Notification chat rows no longer repeat their content twice when the message already restates the headline",
-        "Added Refer a Friend links that give eligible new Desktop users one free month of Omi Pro"
+        "Added Refer a Friend links that give eligible new Desktop users one free month of Operator"
       ]
     },
     {

--- a/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
@@ -57,12 +57,12 @@ struct ReferralProgramView: View {
         .accessibilityHidden(true)
 
       VStack(spacing: OmiSpacing.sm) {
-        Text("Give a friend one free month of Omi Pro")
+        Text("Give a friend one free month of Operator")
           .scaledFont(size: OmiType.title, weight: .semibold)
           .foregroundColor(Ink.primary)
           .multilineTextAlignment(.center)
 
-        Text("Share your unique link. When a friend joins Omi, they'll get one month of Omi Pro free.")
+        Text("Share your unique link. When a friend joins Omi, they'll get one month of Operator free.")
           .scaledFont(size: OmiType.body)
           .foregroundColor(Ink.secondary)
           .multilineTextAlignment(.center)
@@ -178,12 +178,7 @@ struct ReferralTopBarButton: View {
       .frame(height: TopNavigationPillMetrics.height)
       .background {
         Capsule(style: .continuous)
-          .fill(Ink.rowFillHover)
-          .overlay {
-            if isHovering {
-              Capsule(style: .continuous).fill(Ink.wash)
-            }
-          }
+          .fill(isHovering ? Ink.wash : Color.clear)
       }
       .overlay {
         Capsule(style: .continuous).strokeBorder(Ink.hairline, lineWidth: 1)

--- a/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -195,7 +195,7 @@ struct SettingsSearchItem: Identifiable {
 
     // Referral
     SettingsSearchItem(
-      name: "Refer a Friend", subtitle: "Share one free month of Omi Pro",
+      name: "Refer a Friend", subtitle: "Share one free month of Operator",
       keywords: ["refer", "referral", "friend", "gift", "free month", "share link"],
       section: .referral, icon: "gift", settingId: "referral.link"),
 

--- a/desktop/macos/changelog/releases/0.12.192.json
+++ b/desktop/macos/changelog/releases/0.12.192.json
@@ -4,6 +4,6 @@
   "changes": [
     "Integration Suggestions is now the fifth notification type — a row beside Focus, Task, Insight, and Memory in Settings, with its own Integration chat badge",
     "Notification chat rows no longer repeat their content twice when the message already restates the headline",
-    "Added Refer a Friend links that give eligible new Desktop users one free month of Omi Pro"
+    "Added Refer a Friend links that give eligible new Desktop users one free month of Operator"
   ]
 }

--- a/desktop/macos/changelog/unreleased/20260821-refine-refer-control.json
+++ b/desktop/macos/changelog/unreleased/20260821-refine-refer-control.json
@@ -1,0 +1,3 @@
+{
+  "change": "Refined the Refer button with a clean outlined treatment"
+}

--- a/desktop/macos/e2e/feature-vector.md
+++ b/desktop/macos/e2e/feature-vector.md
@@ -69,7 +69,7 @@ Prioritized feature map to guide desktop E2E coverage. Uses the same two-dimensi
 | 25 | Plan / usage (billing) | — | 5 | 2 | 1 | ✅ flow: `plan-usage.yaml` (subscription snapshot) |
 | 26 | Apps / integrations catalog | retrieval-action (3) | 6 | 2 | 2 | ✅ flow: `apps-marketplace.yaml` + ⚠️ manual: `apps.yaml` |
 | 27 | Connector import (progress persistence) | retrieval-action (3) | 6 | 3 | 2 | ✅ flow: `connector-import.yaml` + ⚠️ manual: `connector-import-progress.yaml` |
-| 28 | Refer a Friend (one month of Omi Pro) | retrieval-action (3) | 6 | 0 | 2 | ⚠️ manual: `refer-external.yaml` (top bar + Settings → copy link) |
+| 28 | Refer a Friend (one month of Operator) | retrieval-action (3) | 6 | 0 | 2 | ⚠️ manual: `refer-external.yaml` (top bar + Settings → copy link) |
 | 29 | Delete account (confirmation only) | — | 5 | 0 | 2 | ⚠️ manual: `delete-account.yaml` (never confirms) |
 | 30 | Logout (local auth / emulator) | — | 5 | 1 | 2 | ⚠️ manual: `logout.yaml` (`sign_out` bridge; not prod OAuth) |
 | 31 | Onboarding (first launch / reset) | — | 5 | 1 | 1 | ⚠️ manual: `onboarding-smoke.yaml` — reset fix landed; keep manual until 2× local green |
@@ -98,7 +98,7 @@ Agent-local flows with `tier: manual` — **not** qualification-tier (T2). Run i
 
 | Flow | Why manual | Destructive? |
 |------|------------|--------------|
-| `refer-external.yaml` | Copies the unique Omi Pro referral link from the top bar and Settings | No |
+| `refer-external.yaml` | Copies the unique Operator referral link from the top bar and Settings | No |
 | `delete-account.yaml` | Exercises confirmation sheet only; **never** taps Delete Permanently | Yes (gated) |
 | `logout.yaml` | Sign out via Settings; requires **local Auth emulator** (`make desktop-run-local`), not prod OAuth | No |
 | `onboarding-smoke.yaml` | `reset_onboarding` restarts app; Wave 7 fix landed — manual until 2× local green | Yes (local reset) |

--- a/desktop/macos/e2e/flows/refer-external.yaml
+++ b/desktop/macos/e2e/flows/refer-external.yaml
@@ -1,7 +1,7 @@
 version: 2
 name: referrals
 tier: manual
-description: Refer a Friend — top bar and Settings share the same unique Omi Pro referral link
+description: Refer a Friend — top bar and Settings share the same unique Operator referral link
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -15,11 +15,11 @@ preconditions:
 steps:
   - id: S1
     name: Open referral sheet from the top bar
-    do: "Click the gift icon and Refer label immediately left of the microphone control. Verify the referral sheet explains the one free month of Omi Pro and shows the unique link with Copy link."
+    do: "Click the gift icon and Refer label immediately left of the microphone control. Verify the referral sheet explains the one free month of Operator and shows the unique link with Copy link."
     expect:
       interactive_count: { min: 2 }
       text_visible:
-        - Give a friend one free month of Omi Pro
+        - Give a friend one free month of Operator
         - Copy link
 
   - id: S2
@@ -37,5 +37,5 @@ steps:
       interactive_count: { min: 2 }
       text_visible:
         - Refer a Friend
-        - Give a friend one free month of Omi Pro
+        - Give a friend one free month of Operator
         - Copy link

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -17828,6 +17828,37 @@
         "title": "RecordLlmUsageBucketRequest",
         "type": "object"
       },
+      "ReferralClaimRequest": {
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code"
+        ],
+        "title": "ReferralClaimRequest",
+        "type": "object"
+      },
+      "ReferralClaimResponse": {
+        "properties": {
+          "claimed": {
+            "title": "Claimed",
+            "type": "boolean"
+          },
+          "trial_days": {
+            "title": "Trial Days",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "claimed",
+          "trial_days"
+        ],
+        "title": "ReferralClaimResponse",
+        "type": "object"
+      },
       "ReferralLinkResponse": {
         "properties": {
           "referral_url": {
@@ -52667,6 +52698,93 @@
           }
         ],
         "summary": "Get Referral Link",
+        "tags": [
+          "referrals"
+        ]
+      }
+    },
+    "/v1/users/me/referral/claim": {
+      "post": {
+        "operationId": "claim_referral_v1_users_me_referral_claim_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Platform",
+            "required": false,
+            "schema": {
+              "title": "X-App-Platform",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Device-Id-Hash",
+            "required": false,
+            "schema": {
+              "title": "X-Device-Id-Hash",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-App-Version",
+            "required": false,
+            "schema": {
+              "title": "X-App-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReferralClaimRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferralClaimResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "$ref": "#/components/responses/Error401"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "firebaseBearer": []
+          }
+        ],
+        "summary": "Claim Referral",
         "tags": [
           "referrals"
         ]

--- a/web/app/src/app/api/referrals/claim/__tests__/route.test.ts
+++ b/web/app/src/app/api/referrals/claim/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { POST, referralBackendOrigin } from '@/app/api/referrals/claim/route';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('referral claim proxy', () => {
+  it('allows only the fixed production and development referral backends', () => {
+    expect(referralBackendOrigin('prod')).toBe('https://api.omi.me');
+    expect(referralBackendOrigin('dev')).toBe('https://api.omiapi.com');
+    expect(referralBackendOrigin('https://attacker.example')).toBeNull();
+  });
+
+  it('forwards the authenticated claim to the selected backend', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ claimed: true, trial_days: 30 }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await POST(
+      new Request('https://app.omi.me/api/referrals/claim', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ code: 'ref1.test.code', environment: 'dev' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.omiapi.com/v1/users/me/referral/claim',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+        body: JSON.stringify({ code: 'ref1.test.code' }),
+      }),
+    );
+  });
+
+  it('rejects a caller-selected backend before forwarding credentials', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await POST(
+      new Request('https://app.omi.me/api/referrals/claim', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          code: 'ref1.test.code',
+          environment: 'https://attacker.example',
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/src/app/api/referrals/claim/route.ts
+++ b/web/app/src/app/api/referrals/claim/route.ts
@@ -1,0 +1,59 @@
+import { moonshineJson } from '@tschk/moonshine-next/server';
+
+const REFERRAL_BACKENDS = {
+  dev: 'https://api.omiapi.com',
+  prod: 'https://api.omi.me',
+} as const;
+
+type ReferralEnvironment = keyof typeof REFERRAL_BACKENDS;
+
+export function referralBackendOrigin(environment: string): string | null {
+  return environment in REFERRAL_BACKENDS
+    ? REFERRAL_BACKENDS[environment as ReferralEnvironment]
+    : null;
+}
+
+export async function POST(request: Request) {
+  const authorization = request.headers.get('Authorization');
+  if (!authorization) {
+    return moonshineJson({ error: 'Authorization header required' }, { status: 401 });
+  }
+
+  let body: { code?: unknown; environment?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return moonshineJson({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  if (typeof body.code !== 'string' || typeof body.environment !== 'string') {
+    return moonshineJson({ error: 'Invalid referral claim' }, { status: 400 });
+  }
+  const backendOrigin = referralBackendOrigin(body.environment);
+  if (!backendOrigin) {
+    return moonshineJson({ error: 'Invalid referral environment' }, { status: 400 });
+  }
+
+  try {
+    const response = await fetch(`${backendOrigin}/v1/users/me/referral/claim`, {
+      method: 'POST',
+      headers: {
+        Authorization: authorization,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ code: body.code }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const responseBody = await response.text();
+    return new Response(responseBody, {
+      status: response.status,
+      headers: {
+        'Content-Type':
+          response.headers.get('content-type') || 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch {
+    return moonshineJson({ error: 'Referral service unavailable' }, { status: 502 });
+  }
+}

--- a/web/app/src/app/login/LoginClient.tsx
+++ b/web/app/src/app/login/LoginClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from '@tschk/moonshine-next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from '@tschk/moonshine-next/navigation';
 import Image from '@tschk/moonshine-next/image';
 import Link from '@tschk/moonshine-next/link';
 import { motion } from 'framer-motion';
@@ -9,6 +9,11 @@ import { useAuth } from '@/components/auth/AuthProvider';
 import { cn } from '@/lib/utils';
 import { MixpanelManager } from '@/lib/analytics/mixpanel';
 import { isFirebaseAuthConfigured } from '@/lib/firebase';
+import {
+  claimReferralTrial,
+  navigateToDesktopDownload,
+  parseReferralEnvironment,
+} from '@/lib/referrals';
 
 export function getAuthErrorMessage(
   error: unknown,
@@ -47,8 +52,14 @@ const omiMarkDots = [
 export function LoginClient() {
   const { user, loading, signInWithGoogle, signInWithApple } = useAuth();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isSigningIn, setIsSigningIn] = useState<'google' | 'apple' | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [referralClaimFailure, setReferralClaimFailure] = useState<string | null>(null);
+  const referralClaimStarted = useRef(false);
+  const referralCode = searchParams.get('referral');
+  const referralEnvironment = parseReferralEnvironment(searchParams.get('environment'));
+  const isReferralFlow = Boolean(referralCode && referralEnvironment);
   const signInUnavailable = !isFirebaseAuthConfigured;
   const statusMessage =
     error ??
@@ -59,19 +70,45 @@ export function LoginClient() {
     MixpanelManager.pageView('Login');
   }, []);
 
-  // Redirect to home if already logged in
+  const finishReferral = useCallback(async () => {
+    if (!referralCode || !referralEnvironment || referralClaimStarted.current) {
+      return;
+    }
+    referralClaimStarted.current = true;
+    try {
+      const result = await claimReferralTrial(referralCode, referralEnvironment);
+      MixpanelManager.track('Referral Signup Completed', {
+        claimed: result.claimed,
+      });
+      if (!result.claimed) {
+        referralClaimStarted.current = false;
+        setReferralClaimFailure('This free month is only available to new accounts.');
+        return;
+      }
+      navigateToDesktopDownload();
+    } catch (claimError) {
+      referralClaimStarted.current = false;
+      setReferralClaimFailure('We could not apply this referral. Please try again.');
+      console.error(claimError);
+    }
+  }, [referralCode, referralEnvironment]);
+
   useEffect(() => {
     if (!loading && user) {
-      router.push('/home');
+      if (isReferralFlow) {
+        void finishReferral();
+      } else {
+        router.push('/home');
+      }
     }
-  }, [user, loading, router]);
+  }, [user, loading, router, isReferralFlow, finishReferral]);
 
   const handleGoogleSignIn = async () => {
     setIsSigningIn('google');
     setError(null);
     try {
       await signInWithGoogle();
-      router.push('/home');
+      if (!isReferralFlow) router.push('/home');
     } catch (err) {
       setError(getAuthErrorMessage(err, 'Google'));
       console.error(err);
@@ -85,7 +122,7 @@ export function LoginClient() {
     setError(null);
     try {
       await signInWithApple();
-      router.push('/home');
+      if (!isReferralFlow) router.push('/home');
     } catch (err) {
       setError(getAuthErrorMessage(err, 'Apple'));
       console.error(err);
@@ -95,10 +132,32 @@ export function LoginClient() {
   };
 
   // Show loading state while checking auth
-  if (loading) {
+  if (loading || (user && isReferralFlow && !referralClaimFailure)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-bg-primary">
-        <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+        <div className="flex flex-col items-center gap-3 text-sm text-text-tertiary">
+          <div className="w-8 h-8 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+          {isReferralFlow && <span>Activating your free month...</span>}
+        </div>
+      </div>
+    );
+  }
+
+  if (user && isReferralFlow && referralClaimFailure) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-black px-5 text-center">
+        <div className="max-w-sm">
+          <h1 className="text-2xl font-display font-semibold text-text-primary">
+            Referral unavailable
+          </h1>
+          <p className="mt-2 text-sm text-text-tertiary">{referralClaimFailure}</p>
+          <a
+            href="https://macos.omi.me"
+            className="mt-6 inline-flex h-12 items-center justify-center rounded-lg bg-white px-5 font-medium text-black hover:bg-gray-100"
+          >
+            Download Omi
+          </a>
+        </div>
       </div>
     );
   }
@@ -172,7 +231,7 @@ export function LoginClient() {
               transition={{ duration: 0.3, delay: 0.1 }}
               className="text-2xl font-display font-semibold text-text-primary mb-1"
             >
-              Omi
+              {isReferralFlow ? 'One free month of Operator' : 'Omi'}
             </motion.h1>
 
             {/* Tagline */}
@@ -182,7 +241,7 @@ export function LoginClient() {
               transition={{ duration: 0.3, delay: 0.3 }}
               className="text-text-tertiary text-sm mb-8"
             >
-              thought to action
+              {isReferralFlow ? 'Create your account to claim it' : 'thought to action'}
             </motion.p>
 
             {/*

--- a/web/app/src/app/login/__tests__/LoginClient.test.ts
+++ b/web/app/src/app/login/__tests__/LoginClient.test.ts
@@ -1,9 +1,18 @@
 import { createElement, type ReactNode } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let query = '';
+let authUser: { uid: string } | null = null;
+const referralHarness = vi.hoisted(() => ({
+  claim: vi.fn(),
+  navigate: vi.fn(),
+}));
 
 vi.mock('@tschk/moonshine-next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(query),
 }));
 
 vi.mock('@tschk/moonshine-next/image', () => ({
@@ -18,7 +27,7 @@ vi.mock('@tschk/moonshine-next/link', () => ({
 
 vi.mock('@/components/auth/AuthProvider', () => ({
   useAuth: () => ({
-    user: null,
+    user: authUser,
     loading: false,
     signInWithApple: vi.fn(),
     signInWithGoogle: vi.fn(),
@@ -29,13 +38,29 @@ vi.mock('@/lib/firebase', () => ({
   isFirebaseAuthConfigured: false,
 }));
 
+vi.mock('@/lib/referrals', () => ({
+  claimReferralTrial: referralHarness.claim,
+  navigateToDesktopDownload: referralHarness.navigate,
+  parseReferralEnvironment: (value: string | null) =>
+    value === 'dev' || value === 'prod' ? value : null,
+}));
+
 vi.mock('@/lib/analytics/mixpanel', () => ({
-  MixpanelManager: { pageView: vi.fn() },
+  MixpanelManager: { pageView: vi.fn(), track: vi.fn() },
 }));
 
 import { LoginClient } from '@/app/login/LoginClient';
 
 describe('LoginClient geometry', () => {
+  beforeEach(() => {
+    query = '';
+    authUser = null;
+    referralHarness.claim.mockReset();
+    referralHarness.navigate.mockReset();
+  });
+
+  afterEach(cleanup);
+
   it('renders fixed auth actions, an out-of-flow status lane, and desktop mark clearance', () => {
     const markup = renderToStaticMarkup(createElement(LoginClient));
 
@@ -46,5 +71,43 @@ describe('LoginClient geometry', () => {
       'aria-hidden="true" class="mb-16 hidden h-16 w-16 sm:block"',
     );
     expect(markup).not.toContain('min-h-[52px]');
+  });
+
+  it('shows the promised free month before a referred user signs up', () => {
+    query = 'referral=ref1.test.code&environment=prod';
+
+    const markup = renderToStaticMarkup(createElement(LoginClient));
+
+    expect(markup).toContain('One free month of Operator');
+    expect(markup).toContain('Create your account to claim it');
+    expect(markup).toContain('Continue with Apple');
+    expect(markup).toContain('Continue with Google');
+  });
+
+  it('claims once and downloads after authentication succeeds', async () => {
+    query = 'referral=ref1.test.code&environment=prod';
+    authUser = { uid: 'new-user' };
+    referralHarness.claim.mockResolvedValue({ claimed: true, trial_days: 30 });
+
+    const view = render(createElement(LoginClient));
+    view.rerender(createElement(LoginClient));
+
+    await waitFor(() => expect(referralHarness.claim).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(referralHarness.navigate).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not download for an ineligible existing account', async () => {
+    query = 'referral=ref1.test.code&environment=prod';
+    authUser = { uid: 'existing-user' };
+    referralHarness.claim.mockResolvedValue({ claimed: false, trial_days: 30 });
+
+    const view = render(createElement(LoginClient));
+
+    await waitFor(() =>
+      expect(
+        view.getByText('This free month is only available to new accounts.'),
+      ).toBeTruthy(),
+    );
+    expect(referralHarness.navigate).not.toHaveBeenCalled();
   });
 });

--- a/web/app/src/lib/referrals.test.ts
+++ b/web/app/src/lib/referrals.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getIdToken } = vi.hoisted(() => ({ getIdToken: vi.fn() }));
+
+vi.mock('@/lib/firebase', () => ({ getIdToken }));
+
+import { claimReferralTrial, parseReferralEnvironment } from '@/lib/referrals';
+
+describe('web referral handoff', () => {
+  beforeEach(() => {
+    getIdToken.mockReset();
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts only the backend environments emitted by referral capture', () => {
+    expect(parseReferralEnvironment('prod')).toBe('prod');
+    expect(parseReferralEnvironment('dev')).toBe('dev');
+    expect(parseReferralEnvironment('https://attacker.example')).toBeNull();
+    expect(parseReferralEnvironment(null)).toBeNull();
+  });
+
+  it('claims with the signed-in user token', async () => {
+    getIdToken.mockResolvedValue('test-token');
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ claimed: true, trial_days: 30 }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(claimReferralTrial('ref1.test.code', 'prod')).resolves.toEqual({
+      claimed: true,
+      trial_days: 30,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/referrals/claim',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      }),
+    );
+  });
+
+  it('fails closed without an authenticated user', async () => {
+    getIdToken.mockResolvedValue(null);
+    await expect(claimReferralTrial('ref1.test.code', 'prod')).rejects.toThrow(
+      'Not authenticated',
+    );
+  });
+});

--- a/web/app/src/lib/referrals.ts
+++ b/web/app/src/lib/referrals.ts
@@ -1,0 +1,39 @@
+import { getIdToken } from './firebase';
+
+export type ReferralEnvironment = 'dev' | 'prod';
+
+export interface ReferralClaimResult {
+  claimed: boolean;
+  trial_days: number;
+}
+
+export function navigateToDesktopDownload(): void {
+  window.location.assign('https://macos.omi.me');
+}
+
+export function parseReferralEnvironment(
+  value: string | null,
+): ReferralEnvironment | null {
+  return value === 'dev' || value === 'prod' ? value : null;
+}
+
+export async function claimReferralTrial(
+  code: string,
+  environment: ReferralEnvironment,
+): Promise<ReferralClaimResult> {
+  const token = await getIdToken();
+  if (!token) throw new Error('Not authenticated');
+
+  const response = await fetch('/api/referrals/claim', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ code, environment }),
+  });
+  if (!response.ok) {
+    throw new Error(`Referral claim failed: ${response.status}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary

- send valid referral links to Omi's account screen before downloading Desktop
- grant the 30-day Operator entitlement through an authenticated, one-time claim for newly created Firebase accounts
- preserve dev/prod code validation through a fixed, allowlisted web proxy
- keep the top-bar Refer control outlined with no persistent fill

## Product invariants affected

none

## Access-control review

`POST /v1/users/me/referral/claim` requires the existing Firebase bearer-token dependency. The server validates the signed referral code, derives the referred UID from that token, admits only accounts created in the last 15 minutes, and relies on the existing Firestore transaction to reject self-referrals, paid accounts, and repeat claims. The web proxy accepts only the fixed prod/dev API origins, so a query parameter cannot exfiltrate the bearer token.

## Verification

- `backend/.venv/bin/pytest backend/tests/unit/test_referrals.py -q` — 17 passed
- `cd web/app && bun run check` — 5 Moonshine smoke tests and 326 Vitest tests passed; TypeScript passed
- real Firebase registration and Firestore claim — Operator active for exactly 30 days; repeat claim returned false; invalid code returned 404; test user and row deleted
- real browser at `/login?referral=...&environment=prod` showed the referral promise plus Google and Apple account actions
- named `omi-referral-final` bundle — Refer remained immediately left of the microphone, opened the Operator sheet, and copied the identical link twice
- screenshot: `.cross-review-verify.png` (running Desktop top bar and referral sheet)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

