### PR TITLE
fix(desktop): detect a joined Google Meet tab in meetings-only capture

### DIFF
--- a/desktop/macos/Desktop/Sources/ConferencingApps.swift
+++ b/desktop/macos/Desktop/Sources/ConferencingApps.swift
@@ -174,10 +174,7 @@ enum ConferencingApps {
         browserApps.contains(owner),
         let title = window[kCGWindowName as String] as? String
       else { continue }
-      let lower = title.lowercased()
-      for keyword in browserCallKeywords where lower.contains(keyword.lowercased()) {
-        return true
-      }
+      if isBrowserCallTitle(title) { return true }
     }
     return false
   }

--- a/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingGatedSystemAudioTests.swift
@@ -32,6 +32,24 @@ import XCTest
       XCTAssertTrue(ConferencingApps.isCallWindow(ownerName: "WhatsApp", title: nil))
     }
 
+    /// A *joined* Google Meet tab is titled with the bare meeting code and contains none of
+    /// `browserCallKeywords`. `browserCallWindowPresent()` used to run the keyword loop inline
+    /// instead of calling `isBrowserCallTitle`, so the one title shape a live call actually
+    /// carries was the one it missed — on macOS 14.0-14.3 that is the only detection path, and
+    /// on 14.4+ it is the path a muted browser call falls back to.
+    func testJoinedMeetCodeTitleCountsAsABrowserCall() {
+      XCTAssertTrue(ConferencingApps.isBrowserCallTitle("Meet - amc-iajq-asx"))
+      XCTAssertTrue(ConferencingApps.isBrowserCallTitle("Meet – amc-iajq-asx"))  // en dash
+      XCTAssertFalse(ConferencingApps.isBrowserCallTitle("Meet - notacode"))
+      XCTAssertFalse(ConferencingApps.isBrowserCallTitle("Meeting notes - Acme"))
+
+      // The keyword shapes must keep matching: this replaced an inline keyword loop.
+      XCTAssertTrue(ConferencingApps.isBrowserCallTitle("Google Meet — Standup"))
+      XCTAssertTrue(ConferencingApps.isBrowserCallTitle("https://meet.google.com/abc-defg"))
+      XCTAssertTrue(ConferencingApps.isBrowserCallTitle("Teams - Microsoft Teams"))
+      XCTAssertFalse(ConferencingApps.isBrowserCallTitle("GitHub - omi"))
+    }
+
     func testBrowserRequiresCallKeywordInTitle() {
       XCTAssertTrue(
         ConferencingApps.isCallWindow(ownerName: "Google Chrome", title: "Google Meet — Standup"))

--- a/desktop/macos/changelog/unreleased/20260822-meet-code-title-detection.json
+++ b/desktop/macos/changelog/unreleased/20260822-meet-code-title-detection.json
@@ -1,0 +1,3 @@
+{
+  "change": "Fixed meetings-only listening missing Google Meet calls, where a joined tab is titled with just the meeting code"
+}


### PR DESCRIPTION
## Summary

`browserCallWindowPresent()` ran the `browserCallKeywords` loop inline instead of calling `isBrowserCallTitle`, so the one title shape a live Google Meet call actually carries was the one it missed.

A joined Meet tab is titled with the bare meeting code — `Meet - amc-iajq-asx` — which contains none of `Google Meet`, `meet.google.com`, or `Teams - Microsoft`. `isBrowserCallTitle` exists precisely for that case (its doc comment says so) and had **no production caller at all**; `browserCallTitlePattern` was only being used by `OnDeviceMeetingIdentityService` for identity extraction, not for detection.

This swaps the inline loop for the helper. `isBrowserCallTitle` is a strict superset — same keywords plus the bare-code pattern — so nothing that matched before stops matching.

## When this path is the one that decides

- **macOS 14.0–14.3**: there is no CoreAudio process-input API, so the window title is the *only* meeting-detection signal. A joined Meet was never detected at all.
- **macOS 14.4+, muted browser call**: `callAppIsUsingMicrophone()` goes false when the browser stops using the mic, and detection falls back to the title. With the bare code unmatched, the off-grace expires and capture stops mid-meeting — while system audio (everyone else speaking) is still what the user wants recorded.

**Caveat, stated plainly:** the "a browser drops mic input when muted" premise is taken from the existing comment on `callAppIsUsingMicrophone()` ([ConferencingApps.swift:147](https://github.com/BasedHardware/omi/blob/main/desktop/macos/Desktop/Sources/ConferencingApps.swift#L147)), not from my own measurement — verifying it needs a real two-party Meet call. I verified the title half physically. If that premise is wrong, this fix still corrects a real gap, it just matters mainly on older macOS.

## Verification

Run against a real bundle in `onlyMeetings` mode, **same bundle id for both builds** so Screen Recording grants were identical, with a Safari window titled `Meet - abc-defg-hij` and no browser holding mic input (forcing the title path):

| Build | Fixture window | `MeetingDetector: meeting STARTED` |
|---|---|---|
| unpatched | present | **0** ← the bug |
| patched | absent | **0** ← no false positive |
| patched | present | **1** |

The patched run with the fixture present then logged:

```
Transcription: System audio capture started (mode=onlyMeetings)
```

The middle row matters as much as the last: it shows the patched build isn't simply firing on everything.

### Tests

- `desktop/macos/scripts/dev-feedback.py --once swift 'ConferencingAppsTests'` → Executed 11 tests, 0 failures.

The new test pins both halves: the bare meeting code (hyphen and en dash) now matches, near-misses like `Meet - notacode` and `Meeting notes - Acme` do not, and every keyword shape that matched before still matches — since this replaced an inline keyword loop, that regression direction needed pinning too.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

