### PR TITLE
fix(desktop): keep onboarding account-scoped

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -379,6 +379,7 @@ struct DesktopHomeView: View {
     .preferredColorScheme(.light)  // Glass is pinned light — see `InkGlass`. Deliberate, not a bug.
     .tint(Ink.accent)
     .onAppear {
+      reconcileOnboardingCompletionOwner()
       log(
         "DesktopHomeView: View appeared - isSignedIn=\(authState.isSignedIn), hasCompletedOnboarding=\(appState.hasCompletedOnboarding)"
       )
@@ -428,6 +429,7 @@ struct DesktopHomeView: View {
       consumePendingMainChatRequestForChatFirstShell()
     }
     .onReceive(NotificationCenter.default.publisher(for: .runtimeOwnerDidChange)) { _ in
+      reconcileOnboardingCompletionOwner()
       chatFirstCapabilitySample.ownerDidChange(to: RuntimeOwnerIdentity.currentOwnerId())
       // The provider's owner-bound gate rejects the previous sample for this
       // owner; no replacement sample is persisted or inferred locally.
@@ -467,6 +469,18 @@ struct DesktopHomeView: View {
     .onReceive(NotificationCenter.default.publisher(for: .openMainChatRequested)) { _ in
       handleMainChatRequest()
     }
+  }
+
+  private func reconcileOnboardingCompletionOwner() {
+    guard
+      OnboardingFlow.reconcileCompletionOwner(
+        currentOwnerID: RuntimeOwnerIdentity.currentOwnerId()) == .resetForDifferentOwner
+    else { return }
+
+    onboardingStep = 0
+    onboardingFurthestStep = 0
+    onboardingJustCompleted = false
+    appState.hasCompletedOnboarding = false
   }
 
   private func handleMainChatRequest() {

--- a/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Referrals/ReferralProgramView.swift
@@ -38,35 +38,40 @@ final class ReferralViewModel: ObservableObject {
 struct ReferralProgramView: View {
   @StateObject private var viewModel: ReferralViewModel
   @State private var copied = false
+  private let showsIntroduction: Bool
 
-  init() {
+  init(showsIntroduction: Bool = true) {
+    self.showsIntroduction = showsIntroduction
     _viewModel = StateObject(wrappedValue: ReferralViewModel())
   }
 
-  init(viewModel: ReferralViewModel) {
+  init(viewModel: ReferralViewModel, showsIntroduction: Bool = true) {
+    self.showsIntroduction = showsIntroduction
     _viewModel = StateObject(wrappedValue: viewModel)
   }
 
   var body: some View {
     VStack(spacing: OmiSpacing.xl) {
-      Image(systemName: "gift")
-        .scaledFont(size: 28, weight: .semibold)
-        .foregroundColor(Ink.primary)
-        .frame(width: 52, height: 52)
-        .background(Circle().fill(Ink.wash))
-        .accessibilityHidden(true)
-
-      VStack(spacing: OmiSpacing.sm) {
-        Text("Give a friend one free month of Operator")
-          .scaledFont(size: OmiType.title, weight: .semibold)
+      if showsIntroduction {
+        Image(systemName: "gift")
+          .scaledFont(size: 28, weight: .semibold)
           .foregroundColor(Ink.primary)
-          .multilineTextAlignment(.center)
+          .frame(width: 52, height: 52)
+          .background(Circle().fill(Ink.wash))
+          .accessibilityHidden(true)
 
-        Text("Share your unique link. When a friend joins Omi, they'll get one month of Operator free.")
-          .scaledFont(size: OmiType.body)
-          .foregroundColor(Ink.secondary)
-          .multilineTextAlignment(.center)
-          .fixedSize(horizontal: false, vertical: true)
+        VStack(spacing: OmiSpacing.sm) {
+          Text("Give a friend one free month of Operator")
+            .scaledFont(size: OmiType.title, weight: .semibold)
+            .foregroundColor(Ink.primary)
+            .multilineTextAlignment(.center)
+
+          Text("Share your unique link. When a friend joins Omi, they'll get one month of Operator free.")
+            .scaledFont(size: OmiType.body)
+            .foregroundColor(Ink.secondary)
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+        }
       }
 
       referralControl

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingFlow.swift
@@ -2,6 +2,13 @@ import Foundation
 import VoiceTurnDomain
 
 enum OnboardingFlow {
+  enum CompletionOwnerReconciliation: Equatable {
+    case unchanged
+    case backfilled
+    case resetForDifferentOwner
+  }
+
+  static let completionOwnerKey = "onboardingCompletedOwnerId"
   static let steps = [
     "Name",
     "Language",
@@ -57,6 +64,30 @@ enum OnboardingFlow {
     if target <= furthestStep { return true }
     let frontier = max(0, furthestStep)
     return !(frontier..<target).contains { unskippableSteps.contains($0) }
+  }
+
+  @discardableResult
+  static func reconcileCompletionOwner(
+    currentOwnerID: String?, defaults: UserDefaults = .standard
+  ) -> CompletionOwnerReconciliation {
+    guard let currentOwnerID, !currentOwnerID.isEmpty,
+      defaults.bool(forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
+    else { return .unchanged }
+
+    guard let completedOwnerID = defaults.string(forKey: completionOwnerKey) else {
+      defaults.set(currentOwnerID, forKey: completionOwnerKey)
+      return .backfilled
+    }
+    guard completedOwnerID != currentOwnerID else { return .unchanged }
+
+    clearPersistedState(in: defaults)
+    defaults.removeObject(forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
+    return .resetForDifferentOwner
+  }
+
+  static func markCompleted(for ownerID: String?, defaults: UserDefaults = .standard) {
+    guard let ownerID, !ownerID.isEmpty else { return }
+    defaults.set(ownerID, forKey: completionOwnerKey)
   }
 
   /// What a bare arrow key does at `step`. Left/up go back one step; right/down
@@ -244,6 +275,7 @@ enum OnboardingFlow {
     "onboardingRole",
     "onboardingGoalDraft",
     "onboardingJustCompleted",
+    completionOwnerKey,
     "hasSeenRewindIntro",
     "hasTriggeredNotification",
     "hasTriggeredAutomation",

--- a/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/OnboardingView.swift
@@ -643,6 +643,7 @@ struct OnboardingView: View {
     // Restore the real chat projection before revealing the product UI.
     Task {
       await chatProvider.finishOnboardingJournal()
+      OnboardingFlow.markCompleted(for: RuntimeOwnerIdentity.currentOwnerId())
       appState.hasCompletedOnboarding = true
     }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingModel.swift
@@ -55,7 +55,7 @@ final class SBOnboardingModel: ObservableObject {
   enum Step: Int, CaseIterable {
     case promise, name, howHeard, language, role
     case mic, systemAudio, screen, files, accessibility, automation
-    case shortcutOpen, shortcutTalk, screenDemo, agents, context, capture
+    case shortcutOpen, shortcutTalk, screenDemo, agents, context, capture, referral
   }
 
   /// "How did you hear about Omi?" options (mirrors the legacy step).
@@ -328,7 +328,9 @@ final class SBOnboardingModel: ObservableObject {
       return "The more I can see, the more I can help. Connect anything you want me to know:"
     case .capture:
       return
-        "You're all set, \(name). One last thing: should I listen all the time, or only during your meetings?"
+        "You're all set, \(name). Should I listen all the time, or only during your meetings?"
+    case .referral:
+      return "Want to invite a friend? They'll get one free month of Operator."
     }
   }
 
@@ -689,6 +691,10 @@ final class SBOnboardingModel: ObservableObject {
 
   func capture(_ selection: CaptureSelection) {
     AssistantSettings.shared.audioRecordingMode = selection.audioRecordingMode
+    advance(userAnswer: nil, to: .referral)
+  }
+
+  func finishReferral() {
     complete()
   }
 
@@ -736,6 +742,7 @@ final class SBOnboardingModel: ObservableObject {
     // entirely and onboarding could never complete at all.
     //
     // The journal is genuinely async and genuinely optional. Completion is neither.
+    OnboardingFlow.markCompleted(for: RuntimeOwnerIdentity.currentOwnerId())
     appState.hasCompletedOnboarding = true
     onComplete?()
     Task { [chatProvider] in
@@ -747,6 +754,10 @@ final class SBOnboardingModel: ObservableObject {
   /// tab (with the personalized opener), without force-enabling capture or screen
   /// analysis the user chose to bypass. They can turn those on later.
   func skip() {
+    if step == .referral {
+      complete()
+      return
+    }
     finishOnboardingHandoff(clearOnboardingChatFlag: false)
   }
 

--- a/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
+++ b/desktop/macos/Desktop/Sources/Onboarding/SecondBrain/SBOnboardingView.swift
@@ -293,6 +293,7 @@ struct SBOnboardingView: View {
     case .agents: agentsWidget
     case .context: contextWidget
     case .capture: captureWidget
+    case .referral: referralWidget
     }
   }
 
@@ -926,6 +927,17 @@ struct SBOnboardingView: View {
       .buttonStyle(InkButtonStyle(kind: .secondary))
     }
     .frame(maxWidth: 340, alignment: .leading)
+  }
+
+  private var referralWidget: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      ReferralProgramView(showsIntroduction: false)
+
+      SBInkButton(title: "Take me to Omi", isDefaultAction: true) {
+        model.finishReferral()
+      }
+    }
+    .frame(maxWidth: 380, alignment: .leading)
   }
 }
 

--- a/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingFlowTests.swift
@@ -412,8 +412,11 @@ final class OnboardingFlowTests: XCTestCase {
     }
     XCTAssertEqual(
       secondBrainSource.components(separatedBy: "isDefaultAction: true").count - 1,
-      7,
+      8,
       "every visible second-brain proceed action must register Return")
+    XCTAssertTrue(
+      secondBrainSource.contains("SBInkButton(title: \"Take me to Omi\", isDefaultAction: true)"),
+      "the final referral action must accept Return")
     XCTAssertTrue(
       secondBrainSource.contains("Text(\"Continue →\")")
         && secondBrainSource.contains(".keyboardShortcut(.defaultAction)\n      } else {"),

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -41,12 +41,44 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
       "sbOnboardingResumeStep",
       "sbOnboardingShortcutsCompleted",
       "onboardingRole",
+      OnboardingFlow.completionOwnerKey,
     ]
     for key in required {
       XCTAssertTrue(
         OnboardingFlow.persistedStateKeys.contains(key),
         "\(key) is account-scoped and must be in the shared clearing list")
     }
+  }
+
+  func testCompletedOnboardingResetsWhenAuthenticatedOwnerChanges() throws {
+    let suiteName = "OnboardingCompletionOwnerTests-\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    defaults.set(true, forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
+    OnboardingFlow.markCompleted(for: "owner-a", defaults: defaults)
+    defaults.set(18, forKey: "onboardingStep")
+
+    XCTAssertEqual(
+      OnboardingFlow.reconcileCompletionOwner(currentOwnerID: "owner-b", defaults: defaults),
+      .resetForDifferentOwner)
+    XCTAssertFalse(defaults.bool(forKey: DefaultsKey.hasCompletedOnboarding.rawValue))
+    XCTAssertNil(defaults.object(forKey: "onboardingStep"))
+    XCTAssertNil(defaults.object(forKey: OnboardingFlow.completionOwnerKey))
+  }
+
+  func testExistingInstallBackfillsCompletionOwnerWithoutRestartingOnboarding() throws {
+    let suiteName = "OnboardingCompletionOwnerMigrationTests-\(UUID().uuidString)"
+    let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    defaults.set(true, forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
+
+    XCTAssertEqual(
+      OnboardingFlow.reconcileCompletionOwner(currentOwnerID: "owner-a", defaults: defaults),
+      .backfilled)
+    XCTAssertTrue(defaults.bool(forKey: DefaultsKey.hasCompletedOnboarding.rawValue))
+    XCTAssertEqual(defaults.string(forKey: OnboardingFlow.completionOwnerKey), "owner-a")
   }
 
   /// An earlier version of this fix was silently reverted when a merge

--- a/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
+++ b/desktop/macos/Desktop/Tests/SBPostOnboardingGuidanceWiringTests.swift
@@ -152,6 +152,25 @@ final class SBPostOnboardingGuidanceWiringTests: XCTestCase {
     XCTAssertTrue(PostOnboardingPromptSuggestions.shouldShowPopup)
   }
 
+  func testCaptureChoiceAdvancesToOptionalReferralBeforeCompletion() {
+    let model = makeConfiguredModel()
+    let previousMode = AssistantSettings.shared.audioRecordingMode
+    let previousCompletion = appState?.hasCompletedOnboarding ?? false
+    appState?.hasCompletedOnboarding = false
+    defer {
+      AssistantSettings.shared.audioRecordingMode = previousMode
+      appState?.hasCompletedOnboarding = previousCompletion
+    }
+
+    model.capture(SBOnboardingModel.defaultCaptureSelection)
+
+    XCTAssertEqual(model.step, .referral)
+    XCTAssertEqual(
+      UserDefaults.standard.integer(forKey: SBOnboardingModel.resumeStepKey),
+      SBOnboardingModel.Step.referral.rawValue)
+    XCTAssertFalse(try XCTUnwrap(appState).hasCompletedOnboarding)
+  }
+
   func testSkippedSetupStillProducesAnswerableGuidance() {
     let model = makeModel()
 

--- a/desktop/macos/changelog/unreleased/20260821-referral-onboarding.json
+++ b/desktop/macos/changelog/unreleased/20260821-referral-onboarding.json
@@ -1,0 +1,3 @@
+{
+  "change": "Added an optional referral link as the final onboarding step and kept onboarding completion scoped to each signed-in account"
+}

--- a/web/app/src/app/login/LoginClient.tsx
+++ b/web/app/src/app/login/LoginClient.tsx
@@ -229,7 +229,7 @@ export function LoginClient() {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3, delay: 0.1 }}
-              className="text-2xl font-display font-semibold text-text-primary mb-1"
+              className="mb-1 text-center font-display text-2xl font-semibold text-text-primary"
             >
               {isReferralFlow ? 'One free month of Operator' : 'Omi'}
             </motion.h1>

--- a/web/app/src/app/login/__tests__/LoginClient.test.ts
+++ b/web/app/src/app/login/__tests__/LoginClient.test.ts
@@ -80,6 +80,7 @@ describe('LoginClient geometry', () => {
 
     expect(markup).toContain('One free month of Operator');
     expect(markup).toContain('Create your account to claim it');
+    expect(markup).toContain('text-center font-display text-2xl');
     expect(markup).toContain('Continue with Apple');
     expect(markup).toContain('Continue with Google');
   });


### PR DESCRIPTION
## Summary

- add an optional referral-link prompt as the final Second Brain onboarding step
- scope local onboarding completion to the authenticated owner so a new account cannot inherit another account's completed state
- center the referral signup heading with its subtitle and sign-in actions

## Verification

- `bun run check` — 326/326 web tests passed with a clean typecheck
- `env -u OMI_FORCE_CONTEXT_BUCKETS ./test.sh` — full desktop component runner
- named bundle `com.omi.omi-referral-onboarding`: capture choice → Refer, Back → capture choice, capture choice → Refer, Copy twice, and Take me to Omi → main app
- both Copy actions returned the same `https://omi.me/r/...` link; Playwright followed that exact link to `app.omi.me/login` with the production referral handoff
- local 1000×750 referral signup render confirmed the heading, subtitle, and buttons are centered

## Product invariant

- INV-NAV-1 — no navigation destination or routing changed; `DesktopHomeView` only reconciles owner-scoped onboarding completion on appearance and owner change

Line-Count-Exception: desktop/macos/Desktop/Sources/MainWindow/DesktopHomeView.swift | 1620 -> 1634 | owner reconciliation must run at the shell's appearance and authenticated-owner-change lifecycle boundaries

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

