### PR TITLE
fix(desktop-windows): document pnpm instead of npm in README

### DIFF
--- a/desktop/windows/README.md
+++ b/desktop/windows/README.md
@@ -10,13 +10,13 @@ Omi for Windows — an Electron + React + TypeScript port of the Omi desktop app
 
 ```bash
 # 1. Install dependencies
-npm install
+pnpm install
 
 # 2. Create your local env file (required — the app won't start without it)
 cp .env.example .env
 
 # 3. Start the app
-npm run dev
+pnpm dev
 ```
 
 `.env` is gitignored. `.env.example` ships with Omi's **public** Firebase + PostHog
@@ -75,13 +75,13 @@ indexed folder. Adapter code lives in `src/main/codingAgent/`.
 
 ```bash
 # Windows
-npm run build:win
+pnpm build:win
 
 # macOS
-npm run build:mac
+pnpm build:mac
 
 # Linux
-npm run build:linux
+pnpm build:linux
 ```
 
 Vite inlines the `.env` values at build time, so a packaged installer needs no `.env` —


### PR DESCRIPTION
## Summary
- The Windows Electron app (`desktop/windows/`) is managed with pnpm (`pnpm-lock.yaml`, `pnpm-workspace.yaml`) and both CI workflows (`desktop-windows-ci.yml`, `desktop_windows_release.yml`) install exclusively with `pnpm install --frozen-lockfile`.
- The README's "Run from source" and "Build" sections still told contributors to use `npm install` / `npm run <script>`, which builds against a different resolved dependency tree than CI and generates a stray, untracked `package-lock.json`.
- Updated all 5 npm references to their pnpm equivalents, matching this repo's existing pnpm command style (`pnpm dev`, not `pnpm run dev`).

Fixes #12032

Failure-Class: none

## Test plan
- [x] Diffed against `.github/workflows/desktop-windows-ci.yml` and `desktop_windows_release.yml` to confirm pnpm is the actual install/build tool in CI.
- [x] Docs-only change — no code/behavior affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
