### PR TITLE
fix(desktop): use the typed DefaultsKey for onboardingStep in tests

### DIFF
--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -57,13 +57,13 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
 
     defaults.set(true, forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
     OnboardingFlow.markCompleted(for: "owner-a", defaults: defaults)
-    defaults.set(18, forKey: "onboardingStep")
+    defaults.set(18, forKey: DefaultsKey.onboardingStep.rawValue)
 
     XCTAssertEqual(
       OnboardingFlow.reconcileCompletionOwner(currentOwnerID: "owner-b", defaults: defaults),
       .resetForDifferentOwner)
     XCTAssertFalse(defaults.bool(forKey: DefaultsKey.hasCompletedOnboarding.rawValue))
-    XCTAssertNil(defaults.object(forKey: "onboardingStep"))
+    XCTAssertNil(defaults.object(forKey: DefaultsKey.onboardingStep.rawValue))
     XCTAssertNil(defaults.object(forKey: OnboardingFlow.completionOwnerKey))
   }
 


### PR DESCRIPTION
## Summary

`Desktop Swift Static & Test Contracts` is red on `main`, and every open desktop PR inherits the failure through its merge ref. The cause is two raw UserDefaults key strings in a test file:

```
OnboardingPersistenceClearingTests.swift:60:22: error: omi_inline_userdefaults_key Violation: Use DefaultsKey.swift for typed UserDefaults keys
OnboardingPersistenceClearingTests.swift:66:34: error: omi_inline_userdefaults_key Violation: Use DefaultsKey.swift for typed UserDefaults keys
```

The custom rule's regex is `(?<!removeValue\()forKey:\s*"`, and this file is not in `.swiftlint-baseline.json`, so both are new violations rather than baselined debt.

`DefaultsKey.onboardingStep` already exists with the raw value `"onboardingStep"`, so this is behavior-identical by construction — the same string reaches `UserDefaults` either way. The lines immediately around these two already used `DefaultsKey.hasCompletedOnboarding.rawValue`; these two were simply missed.

## Verification

- After the swap, the rule's regex no longer matches anywhere in the file (`grep -P '(?<!removeValue\()forKey:\s*"'` returns nothing).
- The file is absent from `.swiftlint-baseline.json` (grep count 0), confirming these were flagged as new rather than pre-existing.
- Diff is two lines, no behavior surface: `DefaultsKey.onboardingStep.rawValue == "onboardingStep"`.

Verified with the pinned linter itself, through the repo's own lane:

```
$ scripts/pr-preflight --pr-body-file /tmp/pr-defaultskey.md
PR preflight passed: 19 checks in 48.38s.
```

`desktop-swiftlint` is one of those 19. To confirm the check was actually exercising this file rather than skipping it, I restored the two raw strings and re-ran:

```
<== FAIL desktop-swiftlint (0.50s)
Manifest checks failed: desktop-swiftlint
```

Then restored the fix and it passes again.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

