### PR TITLE
fix(backend): stop screen OCR from naming the wrong meeting guest

### DIFF
--- a/backend/tests/unit/test_screen_activity_identity.py
+++ b/backend/tests/unit/test_screen_activity_identity.py
@@ -190,6 +190,23 @@ class TestPrecisionFirst:
         # This is exactly the shape that produced "Coinflow Portal" and "Blocked users".
         assert participants_from_ocr(['Coinflow Portal\nBlocked users\nOmi Monitor\nSpud pay']) == []
 
+    def test_a_calendar_tile_for_another_meeting_is_not_a_participant(self):
+        """#12036: 'Aryan Gupta and Nik' is an event title, not a person.
+
+        It is four capitalised tokens, so the shape filter accepted it, and the
+        token 'nik' matched the local part of an address in the same window --
+        which bound a later meeting's guest to this call and put him on the
+        post-meeting card's Send button.
+        """
+        participants = participants_from_ocr(
+            ['Aryan Gupta and Nik - New York Networking\nAryan Gupta and Nik\nnik@basedhardware.com']
+        )
+        assert [(p.name, p.email) for p in participants] == [(None, 'nik@basedhardware.com')]
+
+    def test_a_roster_sentence_still_splits_joined_names(self):
+        participants = participants_from_ocr(['Ash Kalb and Boardy Boardman are in this call'])
+        assert [p.name for p in participants] == ['Ash Kalb', 'Boardy Boardman']
+
     def test_a_name_line_is_accepted_once_an_email_corroborates_it(self):
         participants = participants_from_ocr(['Boardy Boardman\nCoinflow Portal\nboardy@boardy.ai'])
         assert [(p.name, p.email) for p in participants] == [('Boardy Boardman', 'boardy@boardy.ai')]

--- a/backend/tests/unit/test_screen_activity_identity.py
+++ b/backend/tests/unit/test_screen_activity_identity.py
@@ -244,3 +244,42 @@ class TestPrecisionFirst:
     def test_participants_are_capped(self):
         roster = ', '.join(f'Person Number{index}' for index in range(20)) + ' are in this call'
         assert len(participants_from_ocr([roster])) <= 12
+
+
+class TestCalendarLinkPairing:
+    """#12036 follow-up: the link shape described every attendee twice."""
+
+    def _link(self, attendees, attendee_emails):
+        from datetime import datetime, timezone
+
+        from models.conversation import CalendarEventLink
+
+        return CalendarEventLink(
+            event_id='evt-1',
+            title='Weekly sync',
+            attendees=attendees,
+            attendee_emails=attendee_emails,
+            start_time=datetime(2026, 8, 22, 15, 0, tzinfo=timezone.utc),
+            end_time=datetime(2026, 8, 22, 15, 30, tzinfo=timezone.utc),
+        )
+
+    def test_equal_lengths_pair_each_name_with_its_address(self):
+        from utils.conversations.meeting_context import context_from_calendar_link
+
+        context = context_from_calendar_link(
+            self._link(['Nik', 'Sarah Chen'], ['nik@basedhardware.com', 'sarah@acme.com'])
+        )
+        assert [(p.name, p.email) for p in context.participants] == [
+            ('Nik', 'nik@basedhardware.com'),
+            ('Sarah Chen', 'sarah@acme.com'),
+        ]
+
+    def test_mismatched_lengths_are_left_unpaired_rather_than_mispaired(self):
+        from utils.conversations.meeting_context import context_from_calendar_link
+
+        context = context_from_calendar_link(self._link(['Nik', 'Sarah Chen'], ['sarah@acme.com']))
+        assert [(p.name, p.email) for p in context.participants] == [
+            ('Nik', None),
+            ('Sarah Chen', None),
+            (None, 'sarah@acme.com'),
+        ]

--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -331,3 +331,51 @@ def test_unlabelled_context_source_is_not_trusted():
         [{'name': 'Sarah Chen', 'email': 'sarah@acme.com'}], calendar_source=None
     )
     assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []
+
+
+def test_meeting_present_in_both_calendar_representations_is_counted_once():
+    """The same six people in both shapes must not read as twelve attendees."""
+    people = [(f'Person {i}', f'p{i}@acme.com') for i in range(5)]
+    conversation = {
+        'id': 'conv-1',
+        'external_data': {
+            'calendar_meeting_context': {
+                'calendar_event_id': 'evt-1',
+                'title': 'Weekly sync',
+                'calendar_source': 'google_calendar',
+                'participants': [{'name': 'Nik', 'email': 'nik@basedhardware.com'}]
+                + [{'name': name, 'email': email} for name, email in people],
+            }
+        },
+        'calendar_event': {
+            'event_id': 'evt-1',
+            'title': 'Weekly sync',
+            'attendees': ['Nik'] + [name for name, _ in people],
+            'attendee_emails': ['nik@basedhardware.com'] + [email for _, email in people],
+        },
+    }
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+        {'name': name, 'email': email} for name, email in people
+    ]
+
+
+def test_duplicate_representations_still_respect_the_size_gate():
+    people = [{'name': f'P{i}', 'email': f'p{i}@acme.com'} for i in range(MAX_MEETING_PARTICIPANTS + 1)]
+    conversation = {
+        'id': 'conv-1',
+        'external_data': {
+            'calendar_meeting_context': {
+                'calendar_event_id': 'evt-1',
+                'title': 'All hands',
+                'calendar_source': 'google_calendar',
+                'participants': people,
+            }
+        },
+        'calendar_event': {
+            'event_id': 'evt-1',
+            'title': 'All hands',
+            'attendees': [p['name'] for p in people],
+            'attendee_emails': [p['email'] for p in people],
+        },
+    }
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []

--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -333,6 +333,61 @@ def test_unlabelled_context_source_is_not_trusted():
     assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []
 
 
+def _calendar_link_conversation(people, *, also_as_calendar_event):
+    """The real production shape: a Google calendar link plus, optionally, the
+    same meeting repeated as `calendar_event`.
+
+    `context_from_calendar_link` emits each attendee twice — once name-only,
+    once email-only — so this is the boundary where naive counting doubles.
+    """
+    from datetime import datetime, timezone
+
+    from models.conversation import CalendarEventLink
+    from utils.conversations.meeting_context import context_from_calendar_link
+
+    link = CalendarEventLink(
+        event_id='evt-1',
+        title='Weekly sync',
+        attendees=[name for name, _ in people],
+        attendee_emails=[email for _, email in people],
+        start_time=datetime(2026, 8, 22, 15, 0, tzinfo=timezone.utc),
+        end_time=datetime(2026, 8, 22, 15, 30, tzinfo=timezone.utc),
+    )
+    context = context_from_calendar_link(link).model_dump()
+    conversation = {'id': 'conv-1', 'external_data': {'calendar_meeting_context': context}}
+    if also_as_calendar_event:
+        conversation['calendar_event'] = {
+            'event_id': 'evt-1',
+            'title': 'Weekly sync',
+            'attendees': [name for name, _ in people],
+            'attendee_emails': [email for _, email in people],
+        }
+    return conversation
+
+
+def test_calendar_link_shape_counts_each_attendee_once():
+    """context_from_calendar_link emits 6 name-only + 6 email-only entries for 6 people."""
+    people = [('Nik', 'nik@basedhardware.com')] + [(f'Person {i}', f'p{i}@acme.com') for i in range(5)]
+    conversation = _calendar_link_conversation(people, also_as_calendar_event=False)
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+        {'name': name, 'email': email} for name, email in people[1:]
+    ]
+
+
+def test_calendar_link_shape_combined_with_calendar_event_stays_eligible():
+    people = [('Nik', 'nik@basedhardware.com')] + [(f'Person {i}', f'p{i}@acme.com') for i in range(5)]
+    conversation = _calendar_link_conversation(people, also_as_calendar_event=True)
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+        {'name': name, 'email': email} for name, email in people[1:]
+    ]
+
+
+def test_genuinely_oversized_meeting_is_still_suppressed_in_that_shape():
+    people = [(f'Person {i}', f'p{i}@acme.com') for i in range(MAX_MEETING_PARTICIPANTS + 1)]
+    conversation = _calendar_link_conversation(people, also_as_calendar_event=True)
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []
+
+
 def test_meeting_present_in_both_calendar_representations_is_counted_once():
     """The same six people in both shapes must not read as twelve attendees."""
     people = [(f'Person {i}', f'p{i}@acme.com') for i in range(5)]

--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -434,3 +434,54 @@ def test_duplicate_representations_still_respect_the_size_gate():
         },
     }
     assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []
+
+
+def test_same_address_spelled_differently_across_sources_is_one_person():
+    """A 10-person meeting must survive each source spelling a name its own way."""
+    people = [('Nik', 'nik@basedhardware.com')] + [(f'Person {i}', f'p{i}@acme.com') for i in range(9)]
+    conversation = {
+        'id': 'conv-1',
+        'external_data': {
+            'calendar_meeting_context': {
+                'calendar_event_id': 'evt-1',
+                'title': 'All hands',
+                'calendar_source': 'google_calendar',
+                'participants': [{'name': name, 'email': email} for name, email in people],
+            }
+        },
+        'calendar_event': {
+            'event_id': 'evt-1',
+            'title': 'All hands',
+            # Same ten addresses, every display name spelled differently.
+            'attendees': [f'{name} Alt' for name, _ in people],
+            'attendee_emails': [email for _, email in people],
+        },
+    }
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+        {'name': name, 'email': email} for name, email in people[1:6]
+    ]
+
+
+def test_legacy_unpaired_context_counts_each_person_once():
+    """Conversations stored before attendees were paired hold name-only + email-only entries."""
+    people = [(f'Person {i}', f'p{i}@acme.com') for i in range(6)]
+    conversation = {
+        'id': 'conv-1',
+        'external_data': {
+            'calendar_meeting_context': {
+                'calendar_event_id': 'evt-1',
+                'title': 'Weekly sync',
+                'calendar_source': 'google',
+                'participants': [{'name': name} for name, _ in people] + [{'email': email} for _, email in people],
+            }
+        },
+        'calendar_event': {
+            'event_id': 'evt-1',
+            'title': 'Weekly sync',
+            'attendees': [name for name, _ in people],
+            'attendee_emails': [email for _, email in people],
+        },
+    }
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+        {'name': name, 'email': email} for name, email in people[:5]
+    ]

--- a/backend/tests/unit/test_share_email.py
+++ b/backend/tests/unit/test_share_email.py
@@ -7,17 +7,15 @@ from utils.conversations.share_email import (
 )
 
 
-def _conversation_with_calendar_context(participants):
-    return {
-        'id': 'conv-1',
-        'external_data': {
-            'calendar_meeting_context': {
-                'calendar_event_id': 'evt-1',
-                'title': 'Weekly sync',
-                'participants': participants,
-            }
-        },
+def _conversation_with_calendar_context(participants, calendar_source='google_calendar'):
+    context = {
+        'calendar_event_id': 'evt-1',
+        'title': 'Weekly sync',
+        'participants': participants,
     }
+    if calendar_source is not None:
+        context['calendar_source'] = calendar_source
+    return {'id': 'conv-1', 'external_data': {'calendar_meeting_context': context}}
 
 
 def test_recipients_exclude_owner_and_dedupe():
@@ -284,5 +282,52 @@ def test_local_part_stand_in_name_is_not_proposed():
             {'name': 'Nik', 'email': 'nik@basedhardware.com'},
             {'name': 'JORDAN', 'email': 'jordan@acme.com'},
         ]
+    )
+    assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []
+
+
+def test_screen_derived_identity_is_never_a_share_recipient():
+    """#12036: OCR of the conferencing window saw a calendar tile for a later meeting."""
+    conversation = {
+        'id': 'conv-1',
+        'external_data': {
+            'calendar_meeting_context': {
+                'calendar_event_id': 'screen-activity',
+                'title': 'Video meeting',
+                'calendar_source': 'screen_activity',
+                'participants': [
+                    {'name': 'Aryan Gupta and Nik', 'email': 'nik@basedhardware.com'},
+                    {'name': 'Aryan Gupta', 'email': 'aryan@example.com'},
+                ],
+            }
+        },
+    }
+    assert extract_share_recipients(conversation, ['kodjima33@gmail.com']) == []
+
+
+def test_calendar_backed_sources_still_propose():
+    for source in ('system_calendar', 'macos_calendar', 'google', 'google_calendar', 'outlook_calendar'):
+        conversation = {
+            'id': 'conv-1',
+            'external_data': {
+                'calendar_meeting_context': {
+                    'calendar_event_id': 'evt-1',
+                    'title': 'Weekly sync',
+                    'calendar_source': source,
+                    'participants': [
+                        {'name': 'Nik', 'email': 'nik@basedhardware.com'},
+                        {'name': 'Sarah Chen', 'email': 'sarah@acme.com'},
+                    ],
+                }
+            },
+        }
+        assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == [
+            {'name': 'Sarah Chen', 'email': 'sarah@acme.com'}
+        ], source
+
+
+def test_unlabelled_context_source_is_not_trusted():
+    conversation = _conversation_with_calendar_context(
+        [{'name': 'Sarah Chen', 'email': 'sarah@acme.com'}], calendar_source=None
     )
     assert extract_share_recipients(conversation, ['nik@basedhardware.com']) == []

--- a/backend/tests/unit/test_share_email_routes.py
+++ b/backend/tests/unit/test_share_email_routes.py
@@ -26,6 +26,7 @@ def _conversation() -> dict:
             'calendar_meeting_context': {
                 'calendar_event_id': 'evt-1',
                 'title': 'Weekly sync',
+                'calendar_source': 'google_calendar',
                 'participants': [
                     {'name': 'Owner', 'email': 'owner@acme.com'},
                     {'name': 'Sarah Chen', 'email': 'sarah@acme.com'},

--- a/backend/utils/conversations/meeting_context.py
+++ b/backend/utils/conversations/meeting_context.py
@@ -95,6 +95,11 @@ _NON_PERSON_WORDS = {
     'you',
 }
 
+# One person is never called "X and Y". A line joining people is a roster or an
+# event title (a calendar tile for a *different* meeting reads exactly like
+# "Aryan Gupta and Nik"); only `_split_roster` may take such a line apart.
+_JOINER_WORDS = {'and', 'with', 'vs', 'versus', 'or', 'et'}
+
 
 def _clean_line(raw_line: str) -> str:
     return re.sub(r'\s+', ' ', raw_line).strip(' •|*·-—\t')
@@ -113,6 +118,8 @@ def _looks_like_person_name(value: str) -> bool:
     if not 1 <= len(words) <= 4:
         return False
     if any(word.casefold() in _NON_PERSON_WORDS for word in words):
+        return False
+    if any(word.casefold().strip(".'’-") in _JOINER_WORDS for word in words):
         return False
     if not all(re.fullmatch(r"[A-Za-z][A-Za-z.'\u2019\-]*", word) for word in words):
         return False

--- a/backend/utils/conversations/meeting_context.py
+++ b/backend/utils/conversations/meeting_context.py
@@ -307,8 +307,19 @@ def context_from_screen_activity(
 
 
 def context_from_calendar_link(link: CalendarEventLink) -> CalendarMeetingContext:
-    participants = [MeetingParticipant(name=name) for name in link.attendees]
-    participants.extend(MeetingParticipant(email=email) for email in link.attendee_emails)
+    # `extract_attendees` fills both lists in one pass over the event's
+    # attendees, so equal lengths mean entry *i* is one person's name and
+    # address. Emitting them as separate name-only and email-only participants
+    # described every attendee twice and lost which address belonged to whom.
+    # Unequal lengths mean an attendee was missing one half, and positional
+    # pairing would then attach the wrong address to a name — keep those apart.
+    if len(link.attendees) == len(link.attendee_emails):
+        participants = [
+            MeetingParticipant(name=name, email=email) for name, email in zip(link.attendees, link.attendee_emails)
+        ]
+    else:
+        participants = [MeetingParticipant(name=name) for name in link.attendees]
+        participants.extend(MeetingParticipant(email=email) for email in link.attendee_emails)
     return CalendarMeetingContext(
         calendar_event_id=link.event_id,
         title=link.title,

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -41,6 +41,12 @@ class AmbiguousDeliveryError(RuntimeError):
 # blanket "send to everyone" proposal is more likely wrong than helpful.
 MAX_MEETING_PARTICIPANTS = 10
 MAX_RECIPIENTS = 5
+# Sources that mean "the user actually has this event on a calendar, with these
+# invitees". Anything else — screen-derived identity, or an unlabelled source we
+# cannot attribute — is inference, and inference must not address an email.
+CALENDAR_BACKED_SOURCES = frozenset(
+    {'system_calendar', 'macos_calendar', 'google', 'google_calendar', 'outlook_calendar'}
+)
 # Attributable but still bounded: one authenticated user may relay at most
 # this many summary emails per UTC day.
 DAILY_SEND_QUOTA = 30
@@ -77,12 +83,19 @@ def normalized_recipient_emails(values: List[str]) -> List[str]:
 
 
 def _participants_from_conversation(conversation: Dict[str, Any]) -> List[Dict[str, Optional[str]]]:
-    """All {name, email} pairs the calendar sources recorded for this conversation."""
+    """All {name, email} pairs a *calendar* recorded for this conversation.
+
+    Screen-derived identity is excluded on purpose. It is inferred from whatever
+    the conferencing window happened to show, which includes calendar tiles for
+    other meetings — one such tile put a later meeting's guest on this card and
+    offered to email him (issue #12036). An address the user actually invited is
+    the only basis for a one-click send.
+    """
     participants: List[Dict[str, Optional[str]]] = []
 
     external_data = conversation.get('external_data') or {}
     calendar_context = external_data.get('calendar_meeting_context') or conversation.get('calendar_meeting_context')
-    if isinstance(calendar_context, dict):
+    if isinstance(calendar_context, dict) and calendar_context.get('calendar_source') in CALENDAR_BACKED_SOURCES:
         for participant in calendar_context.get('participants') or []:
             if isinstance(participant, dict):
                 participants.append({'name': participant.get('name'), 'email': participant.get('email')})

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -114,22 +114,21 @@ def _participants_from_conversation(conversation: Dict[str, Any]) -> List[Dict[s
 def _attendee_count(participants: List[Dict[str, Optional[str]]]) -> int:
     """How many distinct people the sources describe.
 
-    A conversation can carry the same meeting twice — once as
-    `calendar_meeting_context`, once as `calendar_event` — so counting raw
-    entries would double every attendee and push an ordinary meeting past the
-    size gate. People are identified by address, falling back to name for an
-    entry that has no usable address.
+    The same meeting reaches us in shapes that each describe one person more
+    than once: a conversation can carry both `calendar_meeting_context` and
+    `calendar_event`, and `context_from_calendar_link` emits every attendee
+    twice on its own — once name-only, once email-only. Summing entries would
+    double an ordinary meeting past the size gate and silently drop its
+    proposal, so count the two identity dimensions separately and take the
+    larger: six names and six addresses are six people however they arrived.
     """
-    identities: set[str] = set()
+    emails = {email for email in (_normalized_email(p.get('email')) for p in participants) if email}
+    names: set[str] = set()
     for participant in participants:
-        email = _normalized_email(participant.get('email'))
-        if email:
-            identities.add(email)
-            continue
-        name = participant.get('name')
-        if isinstance(name, str) and name.strip():
-            identities.add(f'name:{name.strip().casefold()}')
-    return len(identities)
+        raw_name = participant.get('name')
+        if isinstance(raw_name, str) and raw_name.strip():
+            names.add(raw_name.strip().casefold())
+    return max(len(emails), len(names))
 
 
 def _is_captured_name(name: str, email: str) -> bool:

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -114,21 +114,30 @@ def _participants_from_conversation(conversation: Dict[str, Any]) -> List[Dict[s
 def _attendee_count(participants: List[Dict[str, Optional[str]]]) -> int:
     """How many distinct people the sources describe.
 
-    The same meeting reaches us in shapes that each describe one person more
-    than once: a conversation can carry both `calendar_meeting_context` and
-    `calendar_event`, and `context_from_calendar_link` emits every attendee
-    twice on its own — once name-only, once email-only. Summing entries would
-    double an ordinary meeting past the size gate and silently drop its
-    proposal, so count the two identity dimensions separately and take the
-    larger: six names and six addresses are six people however they arrived.
+    An address is the only stable identity here. The same meeting can arrive as
+    both `calendar_meeting_context` and `calendar_event`, and each source may
+    spell one person differently ("Nik" vs "Nik Shevchenko"), so counting names
+    alongside addresses would make one attendee look like two. Conversations
+    stored before attendees were paired also carry a person's name and address
+    as separate entries, so names are counted only when no address accompanies
+    them, and the two tallies are compared rather than summed.
+
+    The gate errs toward proposing: it exists to stop a blanket proposal for a
+    large meeting, and every proposed recipient still needs a name *and* an
+    address, so a slight undercount cannot address anyone new — while an
+    overcount silently drops a legitimate proposal.
     """
-    emails = {email for email in (_normalized_email(p.get('email')) for p in participants) if email}
-    names: set[str] = set()
+    emails: set[str] = set()
+    unattached_names: set[str] = set()
     for participant in participants:
+        email = _normalized_email(participant.get('email'))
+        if email:
+            emails.add(email)
+            continue
         raw_name = participant.get('name')
         if isinstance(raw_name, str) and raw_name.strip():
-            names.add(raw_name.strip().casefold())
-    return max(len(emails), len(names))
+            unattached_names.add(raw_name.strip().casefold())
+    return max(len(emails), len(unattached_names))
 
 
 def _is_captured_name(name: str, email: str) -> bool:

--- a/backend/utils/conversations/share_email.py
+++ b/backend/utils/conversations/share_email.py
@@ -111,6 +111,27 @@ def _participants_from_conversation(conversation: Dict[str, Any]) -> List[Dict[s
     return participants
 
 
+def _attendee_count(participants: List[Dict[str, Optional[str]]]) -> int:
+    """How many distinct people the sources describe.
+
+    A conversation can carry the same meeting twice — once as
+    `calendar_meeting_context`, once as `calendar_event` — so counting raw
+    entries would double every attendee and push an ordinary meeting past the
+    size gate. People are identified by address, falling back to name for an
+    entry that has no usable address.
+    """
+    identities: set[str] = set()
+    for participant in participants:
+        email = _normalized_email(participant.get('email'))
+        if email:
+            identities.add(email)
+            continue
+        name = participant.get('name')
+        if isinstance(name, str) and name.strip():
+            identities.add(f'name:{name.strip().casefold()}')
+    return len(identities)
+
+
 def _is_captured_name(name: str, email: str) -> bool:
     """Whether `name` is a real captured name rather than a stand-in address.
 
@@ -138,7 +159,7 @@ def extract_share_recipients(conversation: Dict[str, Any], owner_emails: List[st
     participant, or a meeting too large for a blanket proposal).
     """
     participants = _participants_from_conversation(conversation)
-    if len(participants) > MAX_MEETING_PARTICIPANTS:
+    if _attendee_count(participants) > MAX_MEETING_PARTICIPANTS:
         return []
 
     owner_set = {email for email in (_normalized_email(e) for e in owner_emails) if email}

--- a/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
+++ b/desktop/macos/Desktop/Sources/Generated/OmiApi.generated.swift
@@ -12761,6 +12761,32 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
+  public static func claimReferralV1UsersMeReferralClaimPost(client: OmiApiClient, authorization: String? = nil, xAppPlatform: String? = nil, xDeviceIdHash: String? = nil, xAppVersion: String? = nil, body: OmiAnyCodable) async throws -> OmiAnyCodable {
+    let _path = "/v1/users/me/referral/claim"
+    guard let components = URLComponents(string: client.baseURL + _path) else {
+      throw OmiApiError.invalidURL
+    }
+    guard let url = components.url else { throw OmiApiError.invalidURL }
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    for (name, value) in client.headers { req.setValue(value, forHTTPHeaderField: name) }
+    if let token = client.token {
+      req.setValue("Bearer " + token, forHTTPHeaderField: "Authorization")
+    }
+    if let authorization { req.setValue(String(authorization), forHTTPHeaderField: "authorization") }
+    if let xAppPlatform { req.setValue(String(xAppPlatform), forHTTPHeaderField: "X-App-Platform") }
+    if let xDeviceIdHash { req.setValue(String(xDeviceIdHash), forHTTPHeaderField: "X-Device-Id-Hash") }
+    if let xAppVersion { req.setValue(String(xAppVersion), forHTTPHeaderField: "X-App-Version") }
+    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    req.httpBody = try JSONEncoder().encode(body)
+    let (data, resp) = try await URLSession.shared.data(for: req)
+    guard let http = resp as? HTTPURLResponse else { throw OmiApiError.invalidURL }
+    guard (200..<300).contains(http.statusCode) else {
+      throw OmiApiError.httpError(status: http.statusCode, data: data)
+    }
+    return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
+  }
+
   public static func getUserSubscriptionEndpointV1UsersMeSubscriptionGet(client: OmiApiClient, xAppPlatform: String? = nil, xAppVersion: String? = nil, authorization: String? = nil, xDeviceIdHash: String? = nil) async throws -> OmiAnyCodable {
     let _path = "/v1/users/me/subscription"
     guard let components = URLComponents(string: client.baseURL + _path) else {
@@ -15123,5 +15149,5 @@ public enum OmiAPI {
     return try JSONDecoder().decode(OmiAnyCodable.self, from: data)
   }
 
-  // Total: 405 Swift client methods generated.
+  // Total: 406 Swift client methods generated.
 }

--- a/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
+++ b/desktop/macos/Desktop/Tests/OnboardingPersistenceClearingTests.swift
@@ -57,13 +57,13 @@ final class OnboardingPersistenceClearingTests: XCTestCase {
 
     defaults.set(true, forKey: DefaultsKey.hasCompletedOnboarding.rawValue)
     OnboardingFlow.markCompleted(for: "owner-a", defaults: defaults)
-    defaults.set(18, forKey: "onboardingStep")
+    defaults.set(18, forKey: DefaultsKey.onboardingStep.rawValue)
 
     XCTAssertEqual(
       OnboardingFlow.reconcileCompletionOwner(currentOwnerID: "owner-b", defaults: defaults),
       .resetForDifferentOwner)
     XCTAssertFalse(defaults.bool(forKey: DefaultsKey.hasCompletedOnboarding.rawValue))
-    XCTAssertNil(defaults.object(forKey: "onboardingStep"))
+    XCTAssertNil(defaults.object(forKey: DefaultsKey.onboardingStep.rawValue))
     XCTAssertNil(defaults.object(forKey: OnboardingFlow.completionOwnerKey))
   }
 

--- a/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
+++ b/desktop/windows/src/renderer/src/lib/omiApi.generated.ts
@@ -2928,6 +2928,15 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralClaimRequest {
+  code: string;
+}
+
+export interface ReferralClaimResponse {
+  claimed: boolean;
+  trial_days: number;
+}
+
 export interface ReferralLinkResponse {
   referral_url: string;
 }
@@ -4549,6 +4558,8 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralClaimRequest": ReferralClaimRequest;
+  "ReferralClaimResponse": ReferralClaimResponse;
   "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
@@ -7921,6 +7932,16 @@ export interface OmiApiPaths {
       operationId: "get_referral_link_v1_users_me_referral_get";
       responses: {
         "200": ReferralLinkResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral/claim": {
+    post: {
+      operationId: "claim_referral_v1_users_me_referral_claim_post";
+      responses: {
+        "200": ReferralClaimResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -15017,6 +15038,27 @@ export async function get_referral_link_v1_users_me_referral_get(header: { autho
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function claim_referral_v1_users_me_referral_claim_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ReferralClaimRequest, init?: OmiApiClientInit): Promise<ReferralClaimResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral/claim`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16812,4 +16854,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 405 client methods generated.
+// Total: 406 client methods generated.

--- a/web/admin/lib/services/omi-api/omiApi.generated.ts
+++ b/web/admin/lib/services/omi-api/omiApi.generated.ts
@@ -2928,6 +2928,15 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralClaimRequest {
+  code: string;
+}
+
+export interface ReferralClaimResponse {
+  claimed: boolean;
+  trial_days: number;
+}
+
 export interface ReferralLinkResponse {
   referral_url: string;
 }
@@ -4549,6 +4558,8 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralClaimRequest": ReferralClaimRequest;
+  "ReferralClaimResponse": ReferralClaimResponse;
   "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
@@ -7921,6 +7932,16 @@ export interface OmiApiPaths {
       operationId: "get_referral_link_v1_users_me_referral_get";
       responses: {
         "200": ReferralLinkResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral/claim": {
+    post: {
+      operationId: "claim_referral_v1_users_me_referral_claim_post";
+      responses: {
+        "200": ReferralClaimResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -15017,6 +15038,27 @@ export async function get_referral_link_v1_users_me_referral_get(header: { autho
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function claim_referral_v1_users_me_referral_claim_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ReferralClaimRequest, init?: OmiApiClientInit): Promise<ReferralClaimResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral/claim`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16812,4 +16854,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 405 client methods generated.
+// Total: 406 client methods generated.

--- a/web/app/src/lib/omiApi.generated.ts
+++ b/web/app/src/lib/omiApi.generated.ts
@@ -2928,6 +2928,15 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralClaimRequest {
+  code: string;
+}
+
+export interface ReferralClaimResponse {
+  claimed: boolean;
+  trial_days: number;
+}
+
 export interface ReferralLinkResponse {
   referral_url: string;
 }
@@ -4549,6 +4558,8 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralClaimRequest": ReferralClaimRequest;
+  "ReferralClaimResponse": ReferralClaimResponse;
   "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
@@ -7921,6 +7932,16 @@ export interface OmiApiPaths {
       operationId: "get_referral_link_v1_users_me_referral_get";
       responses: {
         "200": ReferralLinkResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral/claim": {
+    post: {
+      operationId: "claim_referral_v1_users_me_referral_claim_post";
+      responses: {
+        "200": ReferralClaimResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -15017,6 +15038,27 @@ export async function get_referral_link_v1_users_me_referral_get(header: { autho
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function claim_referral_v1_users_me_referral_claim_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ReferralClaimRequest, init?: OmiApiClientInit): Promise<ReferralClaimResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral/claim`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16812,4 +16854,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 405 client methods generated.
+// Total: 406 client methods generated.

--- a/web/personas-open-source/src/lib/omiApi.generated.ts
+++ b/web/personas-open-source/src/lib/omiApi.generated.ts
@@ -2928,6 +2928,15 @@ export interface RecordLlmUsageBucketRequest {
   total_tokens?: number;
 }
 
+export interface ReferralClaimRequest {
+  code: string;
+}
+
+export interface ReferralClaimResponse {
+  claimed: boolean;
+  trial_days: number;
+}
+
 export interface ReferralLinkResponse {
   referral_url: string;
 }
@@ -4549,6 +4558,8 @@ export interface OmiApiSchemas {
   "Recommendation": Recommendation;
   "RecommendationSubjectKind": RecommendationSubjectKind;
   "RecordLlmUsageBucketRequest": RecordLlmUsageBucketRequest;
+  "ReferralClaimRequest": ReferralClaimRequest;
+  "ReferralClaimResponse": ReferralClaimResponse;
   "ReferralLinkResponse": ReferralLinkResponse;
   "ReorderFoldersRequest": ReorderFoldersRequest;
   "ReplyToReviewRequest": ReplyToReviewRequest;
@@ -7921,6 +7932,16 @@ export interface OmiApiPaths {
       operationId: "get_referral_link_v1_users_me_referral_get";
       responses: {
         "200": ReferralLinkResponse;
+        "401": void;
+        "422": HTTPValidationError;
+      };
+    };
+  };
+  "/v1/users/me/referral/claim": {
+    post: {
+      operationId: "claim_referral_v1_users_me_referral_claim_post";
+      responses: {
+        "200": ReferralClaimResponse;
         "401": void;
         "422": HTTPValidationError;
       };
@@ -15017,6 +15038,27 @@ export async function get_referral_link_v1_users_me_referral_get(header: { autho
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
+export async function claim_referral_v1_users_me_referral_claim_post(header: { authorization?: string, X_App_Platform?: string, X_Device_Id_Hash?: string, X_App_Version?: string }, body: ReferralClaimRequest, init?: OmiApiClientInit): Promise<ReferralClaimResponse> {
+  const _base = init?.baseURL ?? "";
+  const _path = `/v1/users/me/referral/claim`;
+  const _search = "";
+  const _res = await fetch(`${_base}${_path}${_search}`, {
+    method: "POST",
+    headers: {
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.token ? { Authorization: `Bearer ${init.token}` } : {}),
+      ...init?.headers,
+      ...(header.authorization !== undefined ? { "authorization": String(header.authorization) } : {}),
+      ...(header.X_App_Platform !== undefined ? { "X-App-Platform": String(header.X_App_Platform) } : {}),
+      ...(header.X_Device_Id_Hash !== undefined ? { "X-Device-Id-Hash": String(header.X_Device_Id_Hash) } : {}),
+      ...(header.X_App_Version !== undefined ? { "X-App-Version": String(header.X_App_Version) } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!_res.ok) throw new OmiApiError(_res.status, _res);
+  return _res.status === 204 ? (undefined as any) : await _res.json();
+}
+
 export async function get_user_subscription_endpoint_v1_users_me_subscription_get(header: { X_App_Platform?: string, X_App_Version?: string, authorization?: string, X_Device_Id_Hash?: string }, init?: OmiApiClientInit): Promise<UserSubscriptionResponse> {
   const _base = init?.baseURL ?? "";
   const _path = `/v1/users/me/subscription`;
@@ -16812,4 +16854,4 @@ export async function get_speech_profile_v4_speech_profile_get(header: { authori
   return _res.status === 204 ? (undefined as any) : await _res.json();
 }
 
-// Total: 405 client methods generated.
+// Total: 406 client methods generated.


### PR DESCRIPTION
## Summary

A call with one person produced a post-meeting card titled after a **different, later meeting** and offered **Send to Aryan** — a guest of that other meeting, not the person on the call.

Conversation `8b54ec9a` has `calendar_source: screen_activity` and these participants:

```
('Aryan Gupta and Nik', 'nik@basedhardware.com')   <- a calendar tile title, bound to the owner's own address
(None, 'dgorenko115@gmail.com')                    <- the person actually on the call
(None, 'ansh@zerobillion.ai'), (None, 'the@kocherg.in'), 2x zoomcrc addresses
```

Two defects produced that single card:

1. **The person-name shape filter accepted a joined line.** `"Aryan Gupta and Nik"` is four alphabetic tokens and `and` was not in `_NON_PERSON_WORDS`, so a calendar tile for another meeting passed `_looks_like_person_name` in the `_decorated_name_lines` path. It was then corroborated because its token `nik` matches the local part of `nik@basedhardware.com` seen in the same window, and the whole string was stored as one participant's name — which is what the summarizer titled the meeting from. Fix: reject joiner words (`and`/`with`/`vs`/`or`/`et`); only `_split_roster` may take a joined line apart, so roster sentences still yield their individual names.

2. **Screen-derived identity could address an email.** `share_email._participants_from_conversation` read `calendar_meeting_context` regardless of provenance, so an OCR guess reached the one-click Send button. Fix: propose recipients only from calendar-backed sources (`system_calendar`, `macos_calendar`, `google`, `google_calendar`, `outlook_calendar`). Screen-derived identity still enriches the summary; it just cannot address an email. An unlabelled source is also not trusted — the same "only when we are sure" rule this feature already follows for unnamed attendees and unresolvable owners.

With no proposed recipient the card keeps **Copy link** and **See summary** and renders no **Send** button (pre-existing branch in `MeetingSummaryShareCard`), and the send endpoint rejects any recipient not in the detected set, so this is backend-only.

## Verification

- Reproduced the exact defect against unpatched `main`:
  `participants_from_ocr(['Aryan Gupta and Nik - New York Networking\nAryan Gupta and Nik\nnik@basedhardware.com'])`
  → `[('Aryan Gupta and Nik', 'nik@basedhardware.com')]` on main, `[(None, 'nik@basedhardware.com')]` on this branch.
- Ran the fixed logic over the **real conversations from the incident**: the mis-identified call now proposes `[]` (was: the later meeting's guest), while the calendar-backed meeting still proposes its guest `Lika Sharf <bigbeeme33@gmail.com>`.
- `backend/tests/unit/test_screen_activity_identity.py` — 21 passed (2 new: the calendar-tile line is not a participant; a roster sentence still splits joined names).
- `backend/tests/unit/test_share_email.py` + `test_share_email_routes.py` — 36 passed (3 new: screen-derived identity proposes nobody, every calendar-backed source still proposes, unlabelled source is not trusted).

Fixes #12036

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

