### PR TITLE
fix(desktop): Windows README documents pnpm, not npm (#12032)

### DIFF
--- a/desktop/windows/README.md
+++ b/desktop/windows/README.md
@@ -10,13 +10,13 @@ Omi for Windows — an Electron + React + TypeScript port of the Omi desktop app
 
 ```bash
 # 1. Install dependencies
-npm install
+pnpm install
 
 # 2. Create your local env file (required — the app won't start without it)
 cp .env.example .env
 
 # 3. Start the app
-npm run dev
+pnpm run dev
 ```
 
 `.env` is gitignored. `.env.example` ships with Omi's **public** Firebase + PostHog
@@ -75,13 +75,13 @@ indexed folder. Adapter code lives in `src/main/codingAgent/`.
 
 ```bash
 # Windows
-npm run build:win
+pnpm run build:win
 
 # macOS
-npm run build:mac
+pnpm run build:mac
 
 # Linux
-npm run build:linux
+pnpm run build:linux
 ```
 
 Vite inlines the `.env` values at build time, so a packaged installer needs no `.env` —


### PR DESCRIPTION
## Summary
- `desktop/windows/README.md` told contributors to run `npm install` / `npm run dev` / `npm run build:*`, but the directory is pnpm-managed (`pnpm-lock.yaml`, `pnpm-workspace.yaml`) and both `desktop-windows-ci.yml` and `desktop_windows_release.yml` install with pnpm exclusively.
- Following the README verbatim resolves a different dependency tree than CI builds against, which is exactly what was reported in #12032.
- Updated the "Run from source" and "Build" sections to use `pnpm install` / `pnpm run dev` / `pnpm run build:win|mac|linux`.

## Test plan
- [x] Ran `pnpm install --frozen-lockfile` in `desktop/windows` — completes cleanly against the committed `pnpm-lock.yaml`, confirming `pnpm` (not `npm`) is the correct command.
- [x] Confirmed `dev`, `build:win`, `build:mac`, `build:linux` scripts exist in `package.json`.
- No stray `package-lock.json` is tracked in the repo (verified via `git log --all` and `find`), so there was nothing to remove from `desktop/windows/`.

Closes #12032.

Failure-Class: none

🤖 automated by hourly watchdog — tested and merged


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

