### PR TITLE
feat(desktop): Share button with an address you choose, and a note-taking notice when a meeting starts

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -1382,19 +1382,22 @@ def get_conversation_share_recipients(conversation_id: str, uid: str = Depends(a
 def send_conversation_share_email(
     conversation_id: str, request: SendShareEmailRequest, uid: str = Depends(auth.get_current_user_uid)
 ):
-    """One-click send of the meeting summary to detected participants.
+    """Send the meeting summary to the addresses the owner chose.
 
-    Recipients are validated against the calendar-detected set so this can
-    never relay to arbitrary addresses. Sending makes the conversation
-    link-visible first (same contract as copying the share link) so the
-    emailed link resolves.
+    The card lets the owner type a recipient, so the address is theirs to pick
+    rather than something we detected; detection only prefills the field. What
+    keeps this from being an open relay is unchanged: the sender must own the
+    conversation, the mail carries only that conversation's own summary and
+    share link with the owner as reply-to, the request schema caps how many
+    addresses one send may carry, and a per-owner daily quota bounds the total.
+    Sending
+    makes the conversation link-visible first (same contract as copying the
+    share link) so the emailed link resolves.
     """
     conversation = _get_valid_conversation_by_id(uid, conversation_id)
-    detected = {recipient['email'] for recipient in share_email.get_share_recipients(uid, conversation)}
     requested = share_email.normalized_recipient_emails(request.recipient_emails)
-    unknown = [email for email in requested if email not in detected]
-    if unknown:
-        raise HTTPException(status_code=400, detail='Recipients must be detected meeting participants')
+    if not requested:
+        raise HTTPException(status_code=400, detail='A valid recipient email is required')
 
     # Idempotency under concurrency: a Firestore transaction atomically claims
     # the not-yet-emailed recipients, so simultaneous duplicate requests can

--- a/backend/tests/unit/test_share_email_routes.py
+++ b/backend/tests/unit/test_share_email_routes.py
@@ -1,7 +1,7 @@
 """Route-level contract tests for the meeting-summary share endpoints.
 
 Drives the real mounted router with only the auth edge overridden, so the
-recipient-membership rejection and the publish→send→rollback ordering are
+owner-typed recipient bounds and the publish→send→rollback ordering are
 exercised through the same code paths the desktop client calls.
 """
 
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import pytest
 from fastapi import FastAPI
+
+from utils.conversations import share_email
 from fastapi.testclient import TestClient
 
 from routers import conversations as conversations_router
@@ -123,12 +125,40 @@ def test_share_recipients_excludes_owner():
     assert response.json() == {'recipients': [{'name': 'Sarah Chen', 'email': 'sarah@acme.com'}]}
 
 
-def test_share_email_rejects_foreign_recipient(_stub_data_layer):
+def test_share_email_sends_to_an_address_the_owner_typed(monkeypatch, _stub_data_layer):
+    """The Share control lets the owner type the recipient, so detection only prefills."""
+    monkeypatch.setattr(
+        conversations_router.share_email,
+        'send_summary_email',
+        lambda *, uid, conversation, recipient_emails: {'sent_to': recipient_emails},
+    )
     response = _client().post(
         f'/v1/conversations/{CONV_ID}/share-email',
-        json={'recipient_emails': ['attacker@evil.com']},
+        json={'recipient_emails': ['someone-not-on-the-invite@acme.com']},
+    )
+    assert response.status_code == 200
+    assert response.json() == {'sent_to': ['someone-not-on-the-invite@acme.com']}
+    assert _stub_data_layer['visibility'] == 'shared'
+
+
+def test_share_email_rejects_an_unusable_address(_stub_data_layer):
+    response = _client().post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['not-an-email']},
     )
     assert response.status_code == 400
+    assert _stub_data_layer['visibility'] == 'private'
+    assert _stub_data_layer['redis'] == set()
+
+
+def test_share_email_rejects_more_than_the_per_send_cap(_stub_data_layer):
+    """The request schema owns the cap, so an oversized send never reaches the handler."""
+    too_many = [f'p{index}@acme.com' for index in range(share_email.MAX_RECIPIENTS + 1)]
+    response = _client().post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': too_many},
+    )
+    assert response.status_code == 422
     assert _stub_data_layer['visibility'] == 'private'
     assert _stub_data_layer['redis'] == set()
 

--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -1007,6 +1007,11 @@ extension Notification.Name {
   static let desktopAutomationNavigateRequested = Notification.Name(
     "desktopAutomationNavigateRequested")
   /// Posted by the local desktop automation bridge to open a specific conversation detail.
+  /// Opens the meeting-summary card's Share address field. Posted by the
+  /// automation bridge so the field can be exercised without a cursor.
+  static let meetingSummaryShareBeginAddressing = Notification.Name(
+    "meetingSummaryShareBeginAddressing")
+
   static let desktopAutomationOpenConversationRequested = Notification.Name(
     "desktopAutomationOpenConversationRequested")
   static let desktopAutomationSetConversationsSearchRequested = Notification.Name(

--- a/desktop/macos/Desktop/Sources/AppState/AppState+MeetingBoundaries.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+MeetingBoundaries.swift
@@ -117,6 +117,10 @@ extension AppState {
       rotationSucceeded: rotationSucceeded)
     meetingBoundaryInProgress = false
 
+    if currentConversationRole == .meeting {
+      MeetingNoteTakingNotice.present()
+    }
+
     if let pending = pendingMeetingState {
       pendingMeetingState = nil
       await handleMeetingObservation(active: pending)

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1697,6 +1697,21 @@ final class DesktopAutomationActionRegistry {
       return ["posted": conversationID]
     }
 
+    // Presents the same "Omi is taking notes" notice the meeting boundary
+    // posts once a detected meeting has rotated into its recording session.
+    register(
+      name: "trigger_meeting_started_notice",
+      summary:
+        "Present the meeting-started note-taking notice (the card shown when a meeting is detected). Non-prod only.",
+      params: []
+    ) { _ in
+      guard AppBuild.isNonProduction else {
+        return ["error": "trigger_meeting_started_notice is disabled on production bundles"]
+      }
+      MeetingNoteTakingNotice.present()
+      return ["presented": "true"]
+    }
+
     // Cursor-free driver for the meeting summary share card: `state` reads the
     // presented card, `copy`/`send` run the same MeetingSummaryShareActions the
     // card's buttons call, `close` is the user dismissal path.
@@ -1731,18 +1746,30 @@ final class DesktopAutomationActionRegistry {
         let feedback = await MeetingSummaryShareActions.copyLink(conversationID: conversationID)
         return ["copied": feedback == .copied ? "true" : "false"]
       case "send":
+        // `email` mirrors what the owner types into the Share field; with no
+        // address supplied the detected suggestion is used, which is exactly
+        // what the field prefills with.
+        let typed = params["email"]?.trimmingCharacters(in: .whitespaces) ?? ""
+        let addresses = typed.isEmpty ? recipients.map(\.email) : [typed]
+        guard !addresses.isEmpty else {
+          return ["error": "no recipient: pass email=<address>"]
+        }
         do {
           let sent = try await MeetingSummaryShareActions.sendSummary(
-            conversationID: conversationID, recipients: recipients)
+            conversationID: conversationID, recipientEmails: addresses)
           return ["sent_to": sent.joined(separator: ",")]
         } catch {
           return ["error": "send failed: \(error.localizedDescription)"]
         }
+      case "share":
+        NotificationCenter.default.post(name: .meetingSummaryShareBeginAddressing, object: nil)
+        return ["addressing": "true"]
       case "close":
         mgr.dismissCurrentNotification()
         return ["closed": "true"]
       default:
-        throw DesktopAutomationActionError.invalidParams("action must be state, copy, send, or close")
+        throw DesktopAutomationActionError.invalidParams(
+          "action must be state, share, copy, send, or close")
       }
     }
 

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -2736,11 +2736,17 @@ private struct MeetingSummaryShareCard: View {
   }
 
   @State private var phase: Phase = .idle
+  @State private var isAddressing = false
+  @State private var recipientEmail: String = ""
+  @FocusState private var recipientFieldFocused: Bool
 
-  private var sendLabel: String {
-    guard let first = recipients.first else { return "" }
-    let extra = recipients.count - 1
-    return extra > 0 ? "Send to \(first.shortLabel) +\(extra)" : "Send to \(first.shortLabel)"
+  /// Shape-only: the address is the owner's to choose, so this rejects an
+  /// obvious typo without pretending to know the mailbox exists.
+  private var typedEmailIsSendable: Bool {
+    let value = recipientEmail.trimmingCharacters(in: .whitespaces)
+    guard !value.contains(" "), let at = value.firstIndex(of: "@"), at != value.startIndex else { return false }
+    let domain = value[value.index(after: at)...]
+    return !domain.isEmpty && domain.contains(".") && !domain.hasSuffix(".") && !domain.contains("@")
   }
 
   private var isBusy: Bool { phase == .copying || phase == .sending }
@@ -2824,66 +2830,135 @@ private struct MeetingSummaryShareCard: View {
       .padding(.vertical, OmiSpacing.md)
       .accessibilityLabel("Dismiss meeting summary notification")
     }
+    .onReceive(NotificationCenter.default.publisher(for: .meetingSummaryShareBeginAddressing)) { _ in
+      beginAddressing()
+    }
   }
 
   private var actionRow: some View {
-    HStack(spacing: 9) {
+    Group {
+      if isAddressing {
+        addressRow
+      } else {
+        HStack(spacing: 9) {
+          Button {
+            beginAddressing()
+          } label: {
+            HStack(spacing: 4) {
+              Image(systemName: "lock.fill")
+                .font(.system(size: 9, weight: .semibold))
+              Text("Share")
+            }
+            .scaledFont(size: 12, weight: .semibold)
+            .foregroundColor(.black)
+            .padding(.horizontal, 11).padding(.vertical, 4)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+          }
+          .buttonStyle(.plain)
+          .disabled(isBusy)
+          .help("Email these notes to someone")
+          .accessibilityIdentifier("meeting-summary-share-send")
+
+          Button {
+            copyLink()
+          } label: {
+            Group {
+              if phase == .copying {
+                ProgressView().controlSize(.mini)
+              } else {
+                Image(systemName: "link")
+                  .font(.system(size: 11, weight: .semibold))
+              }
+            }
+            .foregroundColor(.white)
+            .frame(width: 26, height: 21)
+            .background(Color.white.opacity(0.18))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+          }
+          .buttonStyle(.plain)
+          .disabled(isBusy)
+          .help("Copy the share link")
+          .accessibilityIdentifier("meeting-summary-share-copy")
+
+          // Text-style link, deliberately chrome-free beside the two controls.
+          Button {
+            FloatingControlBarManager.shared.dismissCurrentNotification()
+            MeetingSummaryShareActions.openSummary(conversationID: conversationID)
+          } label: {
+            Text("See summary")
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(.white.opacity(0.55))
+              .underline()
+          }
+          .buttonStyle(.plain)
+          .disabled(isBusy)
+          .accessibilityIdentifier("meeting-summary-share-open")
+        }
+      }
+    }
+    .padding(.top, 6)
+  }
+
+  /// The Share affordance in its open state: one address field and one send.
+  private var addressRow: some View {
+    HStack(spacing: 7) {
+      TextField("name@company.com", text: $recipientEmail)
+        .textFieldStyle(.plain)
+        .scaledFont(size: 12, weight: .medium)
+        .foregroundColor(.white)
+        .focused($recipientFieldFocused)
+        .onSubmit { sendSummary() }
+        .padding(.horizontal, 9).padding(.vertical, 4)
+        .background(Color.white.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .frame(maxWidth: 210)
+        .accessibilityIdentifier("meeting-summary-share-email-field")
+
       Button {
-        copyLink()
+        sendSummary()
       } label: {
         HStack(spacing: 4) {
-          if phase == .copying {
+          if phase == .sending {
             ProgressView().controlSize(.mini)
           }
-          Text("Copy link")
+          Text("Send")
         }
         .scaledFont(size: 12, weight: .semibold)
         .foregroundColor(.black)
         .padding(.horizontal, 11).padding(.vertical, 4)
-        .background(Color.white)
+        .background(Color.white.opacity(typedEmailIsSendable ? 1 : 0.35))
         .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
       }
       .buttonStyle(.plain)
-      .disabled(isBusy)
-      .accessibilityIdentifier("meeting-summary-share-copy")
+      .disabled(isBusy || !typedEmailIsSendable)
+      .accessibilityIdentifier("meeting-summary-share-email-send")
 
-      if let firstRecipient = recipients.first {
-        Button {
-          sendSummary()
-        } label: {
-          HStack(spacing: 4) {
-            if phase == .sending {
-              ProgressView().controlSize(.mini)
-            }
-            Text(sendLabel)
-          }
-          .scaledFont(size: 12, weight: .semibold)
-          .foregroundColor(.white)
-          .padding(.horizontal, 11).padding(.vertical, 4)
-          .background(Color.white.opacity(0.18))
-          .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .disabled(isBusy)
-        .help("Email the summary to \(firstRecipient.email)")
-        .accessibilityIdentifier("meeting-summary-share-send")
-      }
-
-      // Text-style link, deliberately chrome-free beside the two pills.
       Button {
-        FloatingControlBarManager.shared.dismissCurrentNotification()
-        MeetingSummaryShareActions.openSummary(conversationID: conversationID)
+        isAddressing = false
+        recipientFieldFocused = false
       } label: {
-        Text("See summary")
+        Text("Cancel")
           .scaledFont(size: 12, weight: .medium)
           .foregroundColor(.white.opacity(0.55))
-          .underline()
       }
       .buttonStyle(.plain)
       .disabled(isBusy)
-      .accessibilityIdentifier("meeting-summary-share-open")
+      .accessibilityIdentifier("meeting-summary-share-email-cancel")
     }
-    .padding(.top, 6)
+  }
+
+  /// Detection now only prefills the field: the owner still confirms or
+  /// replaces the address before anything is sent, which is what keeps a
+  /// mis-identified participant from being emailed by one click.
+  func beginAddressing() {
+    guard !isBusy else { return }
+    if recipientEmail.isEmpty, let suggested = recipients.first?.email {
+      recipientEmail = suggested
+    }
+    isAddressing = true
+    FloatingControlBarManager.shared.focusBarWindowForTextEntry()
+    recipientFieldFocused = true
   }
 
   private func copyLink() {
@@ -2900,15 +2975,18 @@ private struct MeetingSummaryShareCard: View {
   }
 
   private func sendSummary() {
-    guard !isBusy, !recipients.isEmpty else { return }
+    let address = recipientEmail.trimmingCharacters(in: .whitespaces)
+    guard !isBusy, typedEmailIsSendable else { return }
     phase = .sending
+    recipientFieldFocused = false
     Task { @MainActor in
       do {
         let sent = try await MeetingSummaryShareActions.sendSummary(
-          conversationID: conversationID, recipients: recipients)
-        let label = recipients.first?.shortLabel ?? "them"
+          conversationID: conversationID, recipientEmails: [address])
+        let label = ConversationShareRecipient(name: nil, email: address).shortLabel
         finish(confirmation: sent.count > 1 ? "Sent to \(label) +\(sent.count - 1)" : "Sent to \(label)")
       } catch {
+        isAddressing = true
         phase = .failed("Couldn't send — try again")
       }
     }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -3495,6 +3495,16 @@ class FloatingControlBarManager {
     return .queued
   }
 
+  /// Let a card own the keyboard. The bar is ordinarily a non-activating
+  /// panel, so a text field inside a notification would silently swallow every
+  /// keystroke; the Share card's address field needs the panel to be key while
+  /// the owner types, and only while they type.
+  func focusBarWindowForTextEntry() {
+    guard let window else { return }
+    NSApp.activate(ignoringOtherApps: true)
+    window.makeKeyAndOrderFront(nil)
+  }
+
   func dismissCurrentNotification() {
     dismissCurrentNotification(kind: .user)
   }

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/MeetingSummaryShareActions.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/MeetingSummaryShareActions.swift
@@ -39,12 +39,14 @@ enum MeetingSummaryShareActions {
     NotificationCenter.default.post(name: .desktopAutomationOpenConversationRequested, object: nil)
   }
 
+  /// Email these notes to the addresses the owner typed (detection only
+  /// prefilled the field, so the address is theirs, not ours).
   static func sendSummary(
-    conversationID: String, recipients: [ConversationShareRecipient]
+    conversationID: String, recipientEmails: [String]
   ) async throws -> [String] {
     try await APIClient.shared.sendConversationSummaryEmail(
       id: conversationID,
-      recipientEmails: recipients.map(\.email)
+      recipientEmails: recipientEmails
     )
   }
 }

--- a/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingNoteTakingNotice.swift
+++ b/desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingNoteTakingNotice.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The notch card shown once a detected meeting has actually started
+/// recording: a statement, not a prompt.
+///
+/// It is posted from the meeting boundary *after* the session rotated into the
+/// meeting role, so "taking notes" is true when the card says it rather than a
+/// prediction that a rotation might succeed. It carries no action — nothing is
+/// being asked of the owner — and it is not persistent, so it behaves like the
+/// other ambient proactive cards and clears itself.
+@MainActor
+enum MeetingNoteTakingNotice {
+  static let title = "Meeting detected"
+  static let message = "Omi is taking notes"
+
+  /// Overridable so a test can observe the decision without a notification
+  /// centre or a signed-in owner.
+  static var present: () -> Void = {
+    guard let snapshot = RuntimeOwnerIdentity.captureAuthorizationSnapshot() else { return }
+    NotificationService.shared.sendNotification(
+      ownerID: snapshot.ownerID,
+      title: title,
+      message: message,
+      assistantId: MeetingActionItemBannerPolicy.assistantID,
+      authorizationSnapshot: snapshot
+    )
+  }
+}

--- a/desktop/macos/Desktop/Tests/MeetingNoteTakingNoticeTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingNoteTakingNoticeTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class MeetingNoteTakingNoticeTests: XCTestCase {
+  override func tearDown() {
+    MeetingNoteTakingNotice.present = MeetingNoteTakingNoticeTests.originalPresenter
+    super.tearDown()
+  }
+
+  private static let originalPresenter = MeetingNoteTakingNotice.present
+
+  /// The card states what already happened rather than asking permission, so
+  /// its copy must stay a statement — a question here would re-introduce the
+  /// prompt the notice deliberately replaces.
+  func testNoticeCopyIsAStatementNotAPrompt() {
+    XCTAssertEqual(MeetingNoteTakingNotice.title, "Meeting detected")
+    XCTAssertEqual(MeetingNoteTakingNotice.message, "Omi is taking notes")
+    XCTAssertFalse(MeetingNoteTakingNotice.message.contains("?"))
+  }
+
+  /// The boundary presents through this seam, so a test can prove the call
+  /// happens without a notification centre or a signed-in owner.
+  func testPresenterSeamIsInvokable() {
+    var presented = 0
+    MeetingNoteTakingNotice.present = { presented += 1 }
+    MeetingNoteTakingNotice.present()
+    XCTAssertEqual(presented, 1)
+  }
+}

--- a/desktop/macos/changelog/unreleased/20260822-meeting-share-address.json
+++ b/desktop/macos/changelog/unreleased/20260822-meeting-share-address.json
@@ -1,0 +1,3 @@
+{
+  "change": "The meeting notes card now has a Share button that opens an address field — prefilled with the detected participant, but yours to change — plus a link button to copy, and Omi tells you it is taking notes when it detects a meeting"
+}

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -4,6 +4,7 @@ tier: 2
 description: Hermetic capture lifecycle via capture_test_transcript seam (no mic/STT)
 app: non-prod
 covers:
+  - desktop/macos/Desktop/Sources/ProactiveAssistants/Services/MeetingNoteTakingNotice.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+FinishedRecordingLifecycle.swift
   - desktop/macos/Desktop/Sources/AppState/AppState+Transcription.swift
   - desktop/macos/Desktop/Sources/Audio/PreferredMicrophoneReconnect.swift

--- a/docs/api-reference/app-client-openapi.json
+++ b/docs/api-reference/app-client-openapi.json
@@ -36356,7 +36356,7 @@
     },
     "/v1/conversations/{conversation_id}/share-email": {
       "post": {
-        "description": "One-click send of the meeting summary to detected participants.\n\nRecipients are validated against the calendar-detected set so this can\nnever relay to arbitrary addresses. Sending makes the conversation\nlink-visible first (same contract as copying the share link) so the\nemailed link resolves.",
+        "description": "Send the meeting summary to the addresses the owner chose.\n\nThe card lets the owner type a recipient, so the address is theirs to pick\nrather than something we detected; detection only prefills the field. What\nkeeps this from being an open relay is unchanged: the sender must own the\nconversation, the mail carries only that conversation's own summary and\nshare link with the owner as reply-to, the request schema caps how many\naddresses one send may carry, and a per-owner daily quota bounds the total.\nSending\nmakes the conversation link-visible first (same contract as copying the\nshare link) so the emailed link resolves.",
         "operationId": "send_conversation_share_email_v1_conversations__conversation_id__share_email_post",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

Two changes to the meeting-notes experience, both requested directly.

**1. Share replaces "Send to <guess>".** The card's pills were `Copy link` and a one-click `Send to <detected participant>`. That assumed we knew who the meeting was with — and when detection is wrong (see #12036), the mis-sent email cannot be recalled. The card now shows a **Share** button and a **link** button: Share opens a single address field, prefilled with the detected participant when we have one, so detection becomes a *suggestion the owner confirms or replaces*; the link button copies. `See summary` stays.

Because the owner now types the address, `POST /v1/conversations/{id}/share-email` no longer requires recipients to be detected participants. The bounds that actually prevent relay abuse are unchanged and still tested: the sender must own the conversation, the mail carries only that conversation's own summary and share link with the owner as reply-to, the request schema caps recipients per send, and the per-owner daily quota bounds the total.

`test_share_email_rejects_foreign_recipient` asserted the contract this change deliberately replaces, so it is gone; the guards that remain are asserted by three tests in its place (a typed non-detected address sends, an unusable address is rejected before any publish, an oversized list is rejected by the schema). The external source for the new expected behaviour is the product decision itself: "Share will basically open an option to put email and Copy link will copy link."

**2. Omi says when it starts taking notes.** A detected meeting began recording silently — the first signal was the summary card after it ended. The notch now shows `Meeting detected / Omi is taking notes` once the session has rotated into the meeting role. No buttons (nothing is being asked), not persistent, and posted *after* the rotation succeeds so it never claims note-taking that did not start. It inherits the existing Meeting Summary notification category; no new setting.

## Verification

Exercised in the running app — dev bundle `omi-share-btn` against a local backend on this branch (`omi-ctl health` → `pythonBackendURL: http://127.0.0.1:8412/`), driven cursor-free through the automation bridge. Screenshot: `.cross-review-verify.png` (three panels).

- Card renders **🔒 Share** + **🔗** + `See summary`.
- Share opens the address field prefilled with the detected participant, with Send/Cancel.
- Sending to an address that was **not** the detected participant delivered: Resend shows `to=[bigbeeme33@gmail.com]`, `from=Lika via Omi <notes@mail.omi.me>`, `delivered`.
- `trigger_meeting_started_notice` presents the note-taking card as shown.
- `backend/tests/unit/test_share_email_routes.py` + `test_share_email.py` — 45 passed. `swift build -c debug` — Build complete.

## Product invariants affected

- **INV-CHAT-1** — unchanged. The Share card still journals no Chat row; the durable Chat surface remains the conversation-link card the backend materializes, and the new note-taking notice carries no action and no Chat entry either.

Failure-Class: none

Line-Count-Exception: backend/routers/conversations.py | 1819 -> 1822 | the recipient contract lives in the share endpoint it governs; splitting the router mid-feature would be a larger unrelated migration
Line-Count-Exception: desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift | 4634 -> 4661 | two bridge actions for cursor-free QA of the Share field and the note-taking notice, following the file's established registry pattern
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift | 2927 -> 3005 | the Share address row belongs with the card it replaces the buttons on, beside the other notch card views it shares chrome with
Line-Count-Exception: desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift | 5299 -> 5309 | the key-window helper for text entry is in the notch panel's owner; extracting it is out of scope


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

