### PR TITLE
test(desktop): drive the share card's own Send from the automation bridge

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState.swift
+++ b/desktop/macos/Desktop/Sources/AppState.swift
@@ -1007,6 +1007,10 @@ extension Notification.Name {
   static let desktopAutomationNavigateRequested = Notification.Name(
     "desktopAutomationNavigateRequested")
   /// Posted by the local desktop automation bridge to open a specific conversation detail.
+  /// Submits the meeting-summary card's Share field with the address in the
+  /// notification object, driving the same handler the Send button calls.
+  static let meetingSummaryShareSubmit = Notification.Name("meetingSummaryShareSubmit")
+
   /// Opens the meeting-summary card's Share address field. Posted by the
   /// automation bridge so the field can be exercised without a cursor.
   static let meetingSummaryShareBeginAddressing = Notification.Name(

--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1749,18 +1749,16 @@ final class DesktopAutomationActionRegistry {
         // `email` mirrors what the owner types into the Share field; with no
         // address supplied the detected suggestion is used, which is exactly
         // what the field prefills with.
+        // Drive the card's own Send handler so its phase (sending → sent /
+        // failed) is exercised, not just the network call underneath it.
         let typed = params["email"]?.trimmingCharacters(in: .whitespaces) ?? ""
-        let addresses = typed.isEmpty ? recipients.map(\.email) : [typed]
-        guard !addresses.isEmpty else {
+        let address = typed.isEmpty ? (recipients.first?.email ?? "") : typed
+        guard !address.isEmpty else {
           return ["error": "no recipient: pass email=<address>"]
         }
-        do {
-          let sent = try await MeetingSummaryShareActions.sendSummary(
-            conversationID: conversationID, recipientEmails: addresses)
-          return ["sent_to": sent.joined(separator: ",")]
-        } catch {
-          return ["error": "send failed: \(error.localizedDescription)"]
-        }
+        NotificationCenter.default.post(
+          name: .meetingSummaryShareSubmit, object: address)
+        return ["submitted": address]
       case "share":
         NotificationCenter.default.post(name: .meetingSummaryShareBeginAddressing, object: nil)
         return ["addressing": "true"]

--- a/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/macos/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -2833,6 +2833,13 @@ private struct MeetingSummaryShareCard: View {
     .onReceive(NotificationCenter.default.publisher(for: .meetingSummaryShareBeginAddressing)) { _ in
       beginAddressing()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .meetingSummaryShareSubmit)) { note in
+      if let address = note.object as? String, !address.isEmpty {
+        recipientEmail = address
+      }
+      isAddressing = true
+      sendSummary()
+    }
   }
 
   private var actionRow: some View {


### PR DESCRIPTION
## Summary

Follow-up to #12043. The automation bridge's `meeting_summary_share action=send` called the network helper directly, so a scripted send proved the request reached the backend but never exercised the card's `sending → sent / failed` states — the part a person actually sees. It now posts the address to the card, which runs its own Send handler.

This is what let the Share flow be verified through the real UI path rather than around it.

## Verification

Exercised in the running app (dev bundle `omi-share-btn` against a backend on this branch):

- Success: card shows `✓ Sent to bigbeeme33`, and Resend confirms `to=[bigbeeme33@gmail.com]`, `from=Lika via Omi <notes@mail.omi.me>`, `last_event=delivered`. The address used was **not** the detected participant.
- Repeat: three identical sends to one fresh conversation each returned `{"sent_to":[…]}` and produced **exactly one** email — the Firestore `share_email_sent_to` ledger short-circuits attempts 2 and 3.
- Failure: with the backend stopped, the card shows `Couldn't send — try again` and keeps the typed address so it can be retried.
- Client guard: `nobody@invalid` leaves Send disabled with the card open to correct.

Screenshot: `.cross-review-verify.png` (five panels).

## Product invariants affected

- **INV-CHAT-1** — unchanged; the card still journals no Chat row.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

