### PR TITLE
test(desktop): cover the note-taking notice at the meeting boundary

### DIFF
--- a/desktop/macos/Desktop/Sources/AppState/AppState+MeetingBoundaries.swift
+++ b/desktop/macos/Desktop/Sources/AppState/AppState+MeetingBoundaries.swift
@@ -117,7 +117,9 @@ extension AppState {
       rotationSucceeded: rotationSucceeded)
     meetingBoundaryInProgress = false
 
-    if currentConversationRole == .meeting {
+    if MeetingConversationBoundaryPolicy.shouldAnnounceNoteTaking(
+      committedRole: currentConversationRole, rotationSucceeded: rotationSucceeded)
+    {
       MeetingNoteTakingNotice.present()
     }
 

--- a/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
+++ b/desktop/macos/Desktop/Sources/AppState/MeetingConversationBoundaryPolicy.swift
@@ -41,6 +41,16 @@ enum MeetingConversationBoundaryPolicy {
     rotationSucceeded ? transition.nextRole : previousRole
   }
 
+  /// Whether to tell the owner that note-taking started.
+  ///
+  /// The card states a fact, so it is owed only when the rotation actually
+  /// committed the meeting role. A failed rotation leaves capture on the
+  /// previous role — announcing there would claim notes that are not being
+  /// taken — and a rotation *out* of a meeting is the end, not the start.
+  static func shouldAnnounceNoteTaking(committedRole: Role, rotationSucceeded: Bool) -> Bool {
+    rotationSucceeded && committedRole == .meeting
+  }
+
   static func shouldFinishConversation(
     mode: AssistantSettings.AudioRecordingMode,
     meetingStateReady: Bool,

--- a/desktop/macos/Desktop/Tests/MeetingNoteTakingNoticeTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingNoteTakingNoticeTests.swift
@@ -4,12 +4,24 @@ import XCTest
 
 @MainActor
 final class MeetingNoteTakingNoticeTests: XCTestCase {
-  override func tearDown() {
-    MeetingNoteTakingNotice.present = MeetingNoteTakingNoticeTests.originalPresenter
-    super.tearDown()
-  }
+  /// Counts presentations for the duration of one test. XCTest's lifecycle
+  /// hooks are nonisolated, so the main-actor presenter is saved and restored
+  /// inside the test body instead.
+  @MainActor
+  private final class PresentationCounter {
+    private(set) var count = 0
+    private let original = MeetingNoteTakingNotice.present
 
-  private static let originalPresenter = MeetingNoteTakingNotice.present
+    init() {
+      MeetingNoteTakingNotice.present = { [weak self] in self?.count += 1 }
+    }
+
+    func restore() {
+      MeetingNoteTakingNotice.present = original
+    }
+
+    private func increment() { count += 1 }
+  }
 
   /// The card states what already happened rather than asking permission, so
   /// its copy must stay a statement — a question here would re-introduce the
@@ -20,12 +32,63 @@ final class MeetingNoteTakingNoticeTests: XCTestCase {
     XCTAssertFalse(MeetingNoteTakingNotice.message.contains("?"))
   }
 
-  /// The boundary presents through this seam, so a test can prove the call
-  /// happens without a notification centre or a signed-in owner.
-  func testPresenterSeamIsInvokable() {
-    var presented = 0
-    MeetingNoteTakingNotice.present = { presented += 1 }
-    MeetingNoteTakingNotice.present()
-    XCTAssertEqual(presented, 1)
+  // MARK: - When the notice is owed
+
+  func testAnnouncedOnlyWhenTheMeetingRoleActuallyCommitted() {
+    XCTAssertTrue(
+      MeetingConversationBoundaryPolicy.shouldAnnounceNoteTaking(
+        committedRole: .meeting, rotationSucceeded: true))
+  }
+
+  func testNotAnnouncedWhenTheRotationFailed() {
+    // Capture stays on the previous role, so note-taking did not start.
+    XCTAssertFalse(
+      MeetingConversationBoundaryPolicy.shouldAnnounceNoteTaking(
+        committedRole: .meeting, rotationSucceeded: false))
+    XCTAssertFalse(
+      MeetingConversationBoundaryPolicy.shouldAnnounceNoteTaking(
+        committedRole: .ambient, rotationSucceeded: false))
+  }
+
+  func testNotAnnouncedWhenTheMeetingEnded() {
+    XCTAssertFalse(
+      MeetingConversationBoundaryPolicy.shouldAnnounceNoteTaking(
+        committedRole: .ambient, rotationSucceeded: true))
+  }
+
+  // MARK: - Driven through the real boundary
+
+  /// Drives `AppState.handleMeetingObservation` — the production entry point the
+  /// meeting detector calls — with no owned session. The boundary must refuse to
+  /// rotate, and with no committed meeting role the notice must not fire: this is
+  /// the path that would otherwise announce note-taking that never started.
+  func testBoundaryWithoutAnOwnedSessionDoesNotAnnounce() async {
+    let counter = PresentationCounter()
+    defer { counter.restore() }
+
+    let state = AppState()
+    state.isTranscribing = true
+    state.currentSessionId = nil
+    state.currentConversationRole = .ambient
+
+    await state.handleMeetingObservation(active: true)
+
+    XCTAssertEqual(counter.count, 0)
+    XCTAssertEqual(state.currentConversationRole, .ambient)
+  }
+
+  /// A detector edge while transcription is off must not announce either — the
+  /// notice would be claiming notes for a session that is not recording.
+  func testBoundaryWhileNotTranscribingDoesNotAnnounce() async {
+    let counter = PresentationCounter()
+    defer { counter.restore() }
+
+    let state = AppState()
+    state.isTranscribing = false
+    state.currentConversationRole = .ambient
+
+    await state.handleMeetingObservation(active: true)
+
+    XCTAssertEqual(counter.count, 0)
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #12043. The note-taking notice shipped with tests that only invoked its presenter seam, so deleting the production call site would have left every check green — the review caught that, correctly.

The decision now lives in `MeetingConversationBoundaryPolicy.shouldAnnounceNoteTaking(committedRole:rotationSucceeded:)`, which `AppState+MeetingBoundaries` calls, and every branch is asserted:

- a **committed** meeting role announces;
- a **failed rotation** does not — capture stayed on the previous role, so no notes started, and announcing would claim otherwise;
- rotating **out** of a meeting does not — that is the end, not the start.

Two further tests construct a real `AppState` and drive `handleMeetingObservation(active:)`, the same entry point the meeting detector calls, asserting the notice stays silent when the boundary refuses to rotate (no owned session; transcription off).

## Verification

- `swift test --filter MeetingNoteTakingNoticeTests` — 6 passed.
- The notice was also captured from a **real Google Meet join** rather than the automation trigger. App log:

```
MeetingDetector: meeting ENDED      (previous meeting, 03:29:49)
MeetingDetector: meeting STARTED    (rejoin)
Transcription: meeting boundary — role=meeting
FloatingControlBar: resizeToFrame to (556.0, 203.0)   <- the card
```

  The capture fired 1.4s after that boundary line via a log-triggered watcher; the card is non-persistent and clears after ~6s. Screenshot: `.cross-review-verify.png`, panel 5.

## Product invariants affected

- **INV-CHAT-1** — unchanged; the notice journals no Chat row.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

