### PR TITLE
test(desktop): assert the note-taking notice in the flow that claims it

### DIFF
--- a/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/macos/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1697,6 +1697,26 @@ final class DesktopAutomationActionRegistry {
       return ["posted": conversationID]
     }
 
+    // Reads whatever notch card is on screen, so a flow can assert the card a
+    // person actually sees rather than trusting that a trigger fired.
+    register(
+      name: "notification_state",
+      summary: "Read the notch notification currently on screen (title, message, persistence).",
+      params: []
+    ) { _ in
+      guard let bar = FloatingControlBarManager.shared.barState,
+        let notification = bar.currentNotification
+      else {
+        return ["present": "false"]
+      }
+      return [
+        "present": "true",
+        "title": notification.title,
+        "message": notification.message,
+        "persistent": notification.isPersistent ? "true" : "false",
+      ]
+    }
+
     // Presents the same "Omi is taking notes" notice the meeting boundary
     // posts once a detected meeting has rotated into its recording session.
     register(

--- a/desktop/macos/e2e/flows/capture-lifecycle.yaml
+++ b/desktop/macos/e2e/flows/capture-lifecycle.yaml
@@ -183,6 +183,23 @@ steps:
       result.detail.is_transcribing: "false"
 
   - id: S11
+    name: A detected meeting announces that notes are being taken
+    bridge.action:
+      name: trigger_meeting_started_notice
+    expect:
+      result.detail.presented: "true"
+
+  - id: S12
+    name: The notch shows the note-taking statement, not a prompt
+    bridge.action:
+      name: notification_state
+    expect:
+      result.detail.present: "true"
+      result.detail.title: "Meeting detected"
+      result.detail.message: "Omi is taking notes"
+      result.detail.persistent: "false"
+
+  - id: S13
     name: Logs clean
     log.expect:
       absent:

--- a/desktop/macos/e2e/flows/floating-bar-functional.yaml
+++ b/desktop/macos/e2e/flows/floating-bar-functional.yaml
@@ -13,7 +13,6 @@ covers:
   - desktop/macos/Desktop/Sources/FloatingControlBar/AgentPill.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/CursorScreenTracker.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/DelayedActionScheduler.swift
-  - desktop/macos/Desktop/Sources/FloatingControlBar/MeetingSummaryShareActions.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarAdviceDelivery.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarLaunchPolicy.swift
   - desktop/macos/Desktop/Sources/FloatingControlBar/FloatingBarPresentation.swift


### PR DESCRIPTION
## Summary

Review follow-up to #12043 / #12047. Two `covers` entries claimed E2E coverage that no flow step asserted — the repo's own anti-pattern, and the review caught it.

- **`capture-lifecycle.yaml` now earns its entry.** `S11` presents the note-taking notice and expects `presented: "true"`; `S12` reads the notch through a new `notification_state` bridge action and expects `title: "Meeting detected"`, `message: "Omi is taking notes"`, `persistent: "false"`. The assertion is on the card a person sees, not on the trigger having fired.
- **`floating-bar-functional.yaml`'s entry is removed.** That flow is hermetic and has no conversation to present a share card for, so it cannot assert `MeetingSummaryShareActions.swift`. Deleting the claim is honest; that file's behavior is covered by unit tests and by manual send verification (Resend delivery, idempotent repeat, both failure paths).

`notification_state` reads `FloatingControlBarManager.shared.barState.currentNotification` — the same accessor the existing `meeting_summary_share` action uses.

## Verification

Both new steps were executed live against the running bundle (`com.omi.omi-share-btn`, bridge 47921):

```
trigger_meeting_started_notice -> {"presented": "true"}
notification_state             -> {"present": "true", "title": "Meeting detected",
                                   "message": "Omi is taking notes", "persistent": "false"}
```

Screenshot `.cross-review-verify.png` panel 6 is the card those steps assert; panel 5 is the same card produced by a real Google Meet join. `swift build -c debug` — Build complete.

## Product invariants affected

- **INV-CHAT-1** — unchanged; the notice journals no Chat row.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

