### PR TITLE
fix(desktop): capture the notice presenter inside init, not as a default

### DIFF
--- a/desktop/macos/Desktop/Tests/MeetingNoteTakingNoticeTests.swift
+++ b/desktop/macos/Desktop/Tests/MeetingNoteTakingNoticeTests.swift
@@ -10,9 +10,13 @@ final class MeetingNoteTakingNoticeTests: XCTestCase {
   @MainActor
   private final class PresentationCounter {
     private(set) var count = 0
-    private let original = MeetingNoteTakingNotice.present
+    // Captured in `init`, not as a default value: a stored property's default
+    // expression is nonisolated even when the type is @MainActor, so reading
+    // the main-actor presenter there fails under strict concurrency.
+    private let original: () -> Void
 
     init() {
+      original = MeetingNoteTakingNotice.present
       MeetingNoteTakingNotice.present = { [weak self] in self?.count += 1 }
     }
 


### PR DESCRIPTION
## Summary

`MeetingNoteTakingNoticeTests.PresentationCounter` captured the presenter as a stored-property default:

```swift
private let original = MeetingNoteTakingNotice.present
```

A stored property's default-value expression is **nonisolated** even when the type is `@MainActor`, so reading the main-actor `present` there fails strict concurrency and reddens `Desktop Swift CI` on `main`. Capturing it inside `init()` — which *is* main-actor isolated — fixes it.

Reported by a teammate whose PR was blocked behind red main; the diagnosis was theirs, the file is mine.

## Verification

- `swift build -c debug` — Build complete (clean).
- `swift test --filter MeetingNoteTakingNoticeTests` — 6 passed.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

