### PR TITLE
fix(backend): never report an in-flight share send as delivered

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -1518,11 +1518,14 @@ SHARE_EMAIL_CLAIM_TTL_SECONDS = 180
 def _in_flight_field(email: str) -> str:
     """Field path for one recipient's dispatch claim.
 
-    Dots inside the address would otherwise read as nesting, so they are
-    escaped for Firestore's field-path syntax.
+    An address contains characters (dots, `@`) that Firestore's field-path
+    syntax reads as structure, so the segment is quoted by the client's own
+    FieldPath rather than by hand — escaping only the dots still left `@`
+    unparseable and failed the write.
     """
-    escaped = email.replace('.', '\\.')
-    return f'share_email_in_flight.{escaped}'
+    from google.cloud.firestore_v1.field_path import FieldPath
+
+    return FieldPath('share_email_in_flight', email).to_api_repr()
 
 
 def reserve_share_email_recipients(

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -1509,15 +1509,41 @@ def update_conversation_segments(
 # ***********************************
 
 
-def reserve_share_email_recipients(uid: str, conversation_id: str, emails: list[str]) -> list[str]:
-    """Atomically claim not-yet-emailed recipients for this request.
+# A claim this old is treated as abandoned: the process that took it died
+# mid-dispatch, and holding the recipient hostage forever would make the send
+# unretryable. Comfortably longer than the provider request timeout.
+SHARE_EMAIL_CLAIM_TTL_SECONDS = 180
 
-    A Firestore transaction reads the sent ledger and writes the claimed
-    subset in one step, so two concurrent requests can never both claim the
-    same recipient. Returns the subset this caller owns dispatching.
+
+def _in_flight_field(email: str) -> str:
+    """Field path for one recipient's dispatch claim.
+
+    Dots inside the address would otherwise read as nesting, so they are
+    escaped for Firestore's field-path syntax.
     """
+    escaped = email.replace('.', '\\.')
+    return f'share_email_in_flight.{escaped}'
+
+
+def reserve_share_email_recipients(
+    uid: str, conversation_id: str, emails: list[str], *, now_epoch: float | None = None
+) -> tuple[list[str], list[str], list[str]]:
+    """Atomically decide who this request owns dispatching.
+
+    Returns ``(to_dispatch, already_sent, in_flight_elsewhere)``.
+
+    Two ledgers, deliberately distinct. ``share_email_sent_to`` means an email
+    definitively went out; ``share_email_in_flight`` means some request is
+    dispatching right now. Collapsing them lets a concurrent duplicate report
+    success for a send that is still in flight — and if that send then fails and
+    releases its claim, nobody sent anything while somebody was told otherwise.
+    A caller that finds a live claim it does not own is told so, not lied to.
+    """
+    import time as _time
+
     from google.cloud import firestore as gc_firestore
 
+    stamp = now_epoch if now_epoch is not None else _time.time()
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
 
@@ -1525,24 +1551,60 @@ def reserve_share_email_recipients(uid: str, conversation_id: str, emails: list[
     def _reserve(transaction):
         snapshot = conversation_ref.get(transaction=transaction)
         data = snapshot.to_dict() or {}
-        already = {e for e in (data.get('share_email_sent_to') or []) if isinstance(e, str)}
-        claimed = [e for e in emails if e not in already]
-        if claimed:
-            transaction.update(conversation_ref, {'share_email_sent_to': gc_firestore.ArrayUnion(claimed)})
-        return claimed
+        sent = {e for e in (data.get('share_email_sent_to') or []) if isinstance(e, str)}
+        raw_in_flight = data.get('share_email_in_flight')
+        in_flight = raw_in_flight if isinstance(raw_in_flight, dict) else {}
+
+        to_dispatch: list[str] = []
+        already_sent: list[str] = []
+        in_flight_elsewhere: list[str] = []
+        claims: dict[str, float] = {}
+        for email in emails:
+            if email in sent:
+                already_sent.append(email)
+                continue
+            claimed_at = in_flight.get(email)
+            fresh = isinstance(claimed_at, (int, float)) and (stamp - claimed_at) < SHARE_EMAIL_CLAIM_TTL_SECONDS
+            if fresh:
+                in_flight_elsewhere.append(email)
+                continue
+            to_dispatch.append(email)
+            claims[_in_flight_field(email)] = stamp
+
+        if claims:
+            transaction.update(conversation_ref, claims)
+        return to_dispatch, already_sent, in_flight_elsewhere
 
     return run_transactional(db, _reserve)
 
 
-def release_share_email_recipients(uid: str, conversation_id: str, emails: list[str]) -> None:
-    """Release a reservation after a definitive send failure so retries work."""
+def confirm_share_email_recipients(uid: str, conversation_id: str, emails: list[str]) -> None:
+    """Record a definitive send and drop its in-flight claim, in that order."""
     from google.cloud import firestore as gc_firestore
 
     if not emails:
         return
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
-    conversation_ref.update({'share_email_sent_to': gc_firestore.ArrayRemove(emails)})
+    update: dict[str, object] = {'share_email_sent_to': gc_firestore.ArrayUnion(emails)}
+    for email in emails:
+        update[_in_flight_field(email)] = gc_firestore.DELETE_FIELD
+    conversation_ref.update(update)
+
+
+def release_share_email_recipients(uid: str, conversation_id: str, emails: list[str]) -> None:
+    """Drop claims after a definitive failure so a retry can dispatch again.
+
+    Only the in-flight claim is dropped; nothing is removed from the sent
+    ledger, because a recipient only lands there once delivery was definitive.
+    """
+    from google.cloud import firestore as gc_firestore
+
+    if not emails:
+        return
+    user_ref = db.collection('users').document(uid)
+    conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
+    conversation_ref.update({_in_flight_field(email): gc_firestore.DELETE_FIELD for email in emails})
 
 
 def set_conversation_visibility(uid: str, conversation_id: str, visibility: str):

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -1401,11 +1401,20 @@ def send_conversation_share_email(
 
     # Idempotency under concurrency: a Firestore transaction atomically claims
     # the not-yet-emailed recipients, so simultaneous duplicate requests can
-    # never both dispatch to the same address; repeats return success without
-    # a duplicate email.
-    to_dispatch = conversations_db.reserve_share_email_recipients(uid, conversation_id, requested)
+    # never both dispatch to the same address. A repeat of an address that was
+    # definitively sent returns success without a duplicate email; an address
+    # some other request is dispatching *right now* is not reported as sent,
+    # because that dispatch may still fail and release its claim.
+    to_dispatch, already_sent, in_flight_elsewhere = conversations_db.reserve_share_email_recipients(
+        uid, conversation_id, requested
+    )
     if not to_dispatch:
-        return {'sent_to': requested}
+        if in_flight_elsewhere:
+            raise HTTPException(
+                status_code=409,
+                detail='That summary is already being sent to this recipient — check back in a moment',
+            )
+        return {'sent_to': already_sent}
 
     if not share_email.consume_daily_send_quota(uid, len(to_dispatch)):
         conversations_db.release_share_email_recipients(uid, conversation_id, to_dispatch)
@@ -1453,12 +1462,20 @@ def send_conversation_share_email(
         redis_db.remove_public_conversation(conversation_id)
 
     def _send():
-        # The reservation above is the durable ledger entry — nothing to write
-        # after the provider accepts, so no failure after a successful dispatch
-        # can trigger the visibility rollback (a delivered email keeps a live
-        # link).
+        # The claim taken above only says "dispatching"; the sent ledger is
+        # written once the provider accepted, and it is what makes a later
+        # repeat a no-op. Recording it is the last step, so no failure after a
+        # successful dispatch can trigger the visibility rollback (a delivered
+        # email keeps a live link).
         share_email.send_summary_email(uid=uid, conversation=conversation, recipient_emails=to_dispatch)
-        return {'sent_to': requested}
+        try:
+            conversations_db.confirm_share_email_recipients(uid, conversation_id, to_dispatch)
+        except Exception:
+            # Delivery already happened; a lost ledger write can only cost a
+            # duplicate on a later retry, which is strictly better than
+            # reporting a failure for mail the recipient holds.
+            logger.exception('share email: failed to record delivered recipients')
+        return {'sent_to': sorted(set(already_sent) | set(to_dispatch))}
 
     def _release_reservation_and_quota():
         try:
@@ -1470,8 +1487,16 @@ def send_conversation_share_email(
     try:
         return share_email.publish_then_send(publish=_publish, unpublish=_unpublish, send=_send)
     except share_email.AmbiguousDeliveryError as e:
-        # Delivery may have happened: reservation and quota stand (no duplicate
-        # on retry) and the link stays published.
+        # Delivery may have happened, so the claim is promoted to the sent
+        # ledger rather than left in flight or released: a retry must not risk
+        # a duplicate in the recipient's inbox, and a claim nobody ever
+        # resolves would block the address until its TTL expires. Quota stands
+        # and the link stays published. The caller still gets 504 — we do not
+        # know that it arrived, and only the ledger pretends otherwise.
+        try:
+            conversations_db.confirm_share_email_recipients(uid, conversation_id, to_dispatch)
+        except Exception:
+            logger.exception('share email: failed to record ambiguous dispatch')
         raise HTTPException(status_code=504, detail=str(e))
     except ValueError as e:
         _release_reservation_and_quota()

--- a/backend/tests/unit/test_share_email_routes.py
+++ b/backend/tests/unit/test_share_email_routes.py
@@ -89,16 +89,36 @@ def _stub_data_layer(monkeypatch):
     monkeypatch.setattr(conversations_router.conversations_db, 'set_conversation_visibility_if_unchanged', guarded_set)
     monkeypatch.setattr(conversations_router.share_email, 'consume_daily_send_quota', lambda uid, n: True)
 
+    # Two ledgers, same split the Firestore layer keeps: 'in_flight' is a
+    # dispatch claim, 'sent' is a delivery that happened.
+    state['in_flight'] = []
+
     def reserve(uid, cid, emails):
-        claimed = [e for e in emails if e not in state['sent']]
-        state['sent'].extend(claimed)
-        return claimed
+        to_dispatch, already_sent, in_flight_elsewhere = [], [], []
+        for email in emails:
+            if email in state['sent']:
+                already_sent.append(email)
+            elif email in state['in_flight']:
+                in_flight_elsewhere.append(email)
+            else:
+                to_dispatch.append(email)
+                state['in_flight'].append(email)
+        return to_dispatch, already_sent, in_flight_elsewhere
 
     monkeypatch.setattr(conversations_router.conversations_db, 'reserve_share_email_recipients', reserve)
+
+    def confirm(uid, cid, emails):
+        for email in emails:
+            if email in state['in_flight']:
+                state['in_flight'].remove(email)
+            if email not in state['sent']:
+                state['sent'].append(email)
+
+    monkeypatch.setattr(conversations_router.conversations_db, 'confirm_share_email_recipients', confirm)
     monkeypatch.setattr(
         conversations_router.conversations_db,
         'release_share_email_recipients',
-        lambda uid, cid, emails: [state['sent'].remove(e) for e in emails if e in state['sent']],
+        lambda uid, cid, emails: [state['in_flight'].remove(e) for e in emails if e in state['in_flight']],
     )
     monkeypatch.setattr(
         conversations_router.redis_db, 'store_conversation_to_uid', lambda cid, uid: state['redis'].add(cid)
@@ -421,3 +441,71 @@ def test_publish_contention_with_private_visibility_fails_without_sending(monkey
     assert dispatched == []
     assert refunds == [1]
     assert _stub_data_layer['sent'] == []
+
+
+def test_overlapping_request_is_not_told_a_dispatch_in_flight_was_sent(monkeypatch, _stub_data_layer):
+    """Request B overlaps A, then A fails definitively.
+
+    B must not be told the mail went out — A's claim was only a dispatch in
+    progress, and it released. Nothing was sent, and nothing claimed otherwise.
+    """
+    monkeypatch.setattr(
+        conversations_router.share_email,
+        'send_summary_email',
+        lambda **kw: (_ for _ in ()).throw(RuntimeError('provider rejected')),
+    )
+    client = _client()
+
+    # A claims the recipient and is mid-dispatch; B arrives while that claim is live.
+    _stub_data_layer['in_flight'].append('sarah@acme.com')
+    overlapping = client.post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['sarah@acme.com']},
+    )
+    assert overlapping.status_code == 409
+    assert 'sent_to' not in overlapping.json()
+
+    # A now fails definitively and releases its claim.
+    _stub_data_layer['in_flight'].remove('sarah@acme.com')
+    assert _stub_data_layer['sent'] == []
+
+    # The retry is the first real dispatch, and it is the only one.
+    sends = []
+    monkeypatch.setattr(
+        conversations_router.share_email,
+        'send_summary_email',
+        lambda *, uid, conversation, recipient_emails: sends.append(list(recipient_emails))
+        or {'sent_to': recipient_emails},
+    )
+    retry = client.post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['sarah@acme.com']},
+    )
+    assert retry.status_code == 200
+    assert retry.json() == {'sent_to': ['sarah@acme.com']}
+    assert sends == [['sarah@acme.com']]
+    assert _stub_data_layer['sent'] == ['sarah@acme.com']
+    assert _stub_data_layer['in_flight'] == []
+
+    # A later repeat is a no-op: the recipient is in the sent ledger now.
+    again = client.post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['sarah@acme.com']},
+    )
+    assert again.status_code == 200
+    assert sends == [['sarah@acme.com']]
+
+
+def test_failed_dispatch_leaves_nothing_in_the_sent_ledger(monkeypatch, _stub_data_layer):
+    monkeypatch.setattr(
+        conversations_router.share_email,
+        'send_summary_email',
+        lambda **kw: (_ for _ in ()).throw(RuntimeError('provider rejected')),
+    )
+    response = _client().post(
+        f'/v1/conversations/{CONV_ID}/share-email',
+        json={'recipient_emails': ['sarah@acme.com']},
+    )
+    assert response.status_code == 502
+    assert _stub_data_layer['sent'] == []
+    assert _stub_data_layer['in_flight'] == []


### PR DESCRIPTION
## Summary

The share-email recipient ledger conflated two different facts: *a request is dispatching* and *the mail went out*. Both lived in `share_email_sent_to`, which makes this sequence possible:

1. Request **A** claims `sarah@acme.com` and starts dispatching.
2. Request **B** arrives, sees the address in the ledger, and returns `200 {"sent_to": ["sarah@acme.com"]}`.
3. **A** fails definitively and *releases* the claim.

Nobody sent anything, and somebody was told it was sent.

The two states are now distinct:

- `share_email_in_flight` — a map of `email → claim timestamp`. Taken transactionally before dispatch.
- `share_email_sent_to` — definitive deliveries only. Written *after* the provider accepted, which is what makes a later repeat a genuine no-op.

Behaviour that follows:

- A request meeting a **live claim it does not own** gets **409**, never a false success.
- A **definitive failure** releases the claim, so a retry dispatches.
- **Ambiguous delivery** (read timeout — the provider may have accepted) *promotes* the claim to sent instead of releasing it: the mail may already be in the inbox and a retry must not risk a duplicate. The caller still gets 504, because we do not know it arrived.
- A claim older than `SHARE_EMAIL_CLAIM_TTL_SECONDS` (180s) is re-claimable, so a process dying mid-dispatch cannot strand a recipient forever.

## Verification

`backend/tests/unit/test_share_email_routes.py` + `test_share_email.py` — **47 passed**, including the reviewer's exact scenario:

- `test_overlapping_request_is_not_told_a_dispatch_in_flight_was_sent` — B overlaps A's live claim and is refused with 409 (no `sent_to` in the body); A then fails and releases; the retry is the **only** dispatch (`sends == [['sarah@acme.com']]`), lands in the sent ledger, and a further repeat sends nothing.
- `test_failed_dispatch_leaves_nothing_in_the_sent_ledger` — a definitive failure leaves both ledgers empty.

The route fixture now models the same two-ledger split, so these tests exercise the real handler logic rather than a stub that hides it.

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

