### PR TITLE
harden(app): keep native token + backup-safe secure storage

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
     <!-- Add android:stopWithTask option only when necessary. -->
     <application
         android:name=".MyApp"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"

--- a/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/batch/OmiBackgroundAudioStreamer.kt
@@ -303,7 +303,7 @@ class OmiBackgroundAudioStreamer(private val context: Context) {
     }
 
     private fun buildRequest(url: String): Request? {
-        val token = stringPref("authToken")
+        val token = stringPref("nativeAuthToken").ifEmpty { stringPref("authToken") }
         if (token.isEmpty()) {
             Log.w(TAG, "Cannot open background transcription socket without auth token")
             return null

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -31,6 +31,9 @@ class SharedPreferencesUtil {
   static const String _authTokenSecureKey = 'authToken';
   static const String _authTokenMigratedPrefsKey = 'authTokenSecureMigrated';
 
+  /// Plain prefs mirror for in-tree native readers (Android background socket).
+  static const String _nativeAuthTokenPrefsKey = 'nativeAuthToken';
+
   factory SharedPreferencesUtil() {
     return _instance;
   }
@@ -52,11 +55,17 @@ class SharedPreferencesUtil {
     } else {
       _secureStorage = const FlutterSecureStorage(
         aOptions: AndroidOptions(encryptedSharedPreferences: true),
+        iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
       );
       _testSecureFallback = null;
     }
     await migrateAuthTokenFromPrefs();
     _authTokenCache = await _readSecureAuthToken() ?? '';
+    // Codex P2: a failed secure write leaves the legacy prefs token; still use it.
+    if (_authTokenCache.isEmpty) {
+      _authTokenCache = _preferences?.getString('authToken') ?? '';
+    }
+    await _syncNativeAuthToken(_authTokenCache);
   }
 
   /// One-time move of `authToken` from SharedPreferences into secure storage.
@@ -111,9 +120,22 @@ class SharedPreferencesUtil {
     final fallback = _testSecureFallback;
     if (fallback != null) {
       fallback.remove(_authTokenSecureKey);
-      return;
+    } else {
+      await _secureStorage?.delete(key: _authTokenSecureKey);
     }
-    await _secureStorage?.delete(key: _authTokenSecureKey);
+    await _syncNativeAuthToken('');
+  }
+
+  /// Native Android still reads SharedPreferences. Mirror the live token there
+  /// under a dedicated key so background streaming survives the secure migration.
+  static Future<void> _syncNativeAuthToken(String value) async {
+    final prefs = _preferences;
+    if (prefs == null) return;
+    if (value.isEmpty) {
+      await prefs.remove(_nativeAuthTokenPrefsKey);
+    } else {
+      await prefs.setString(_nativeAuthTokenPrefsKey, value);
+    }
   }
 
   /// Picks up values written natively (the Dart cache doesn't see those otherwise).
@@ -771,6 +793,7 @@ class SharedPreferencesUtil {
       unawaited(_deleteSecureAuthToken());
     } else {
       unawaited(_writeSecureAuthToken(value));
+      unawaited(_syncNativeAuthToken(value));
     }
   }
 

--- a/app/test/unit/auth_token_secure_storage_migration_test.dart
+++ b/app/test/unit/auth_token_secure_storage_migration_test.dart
@@ -24,6 +24,7 @@ void main() {
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.containsKey('authToken'), isFalse);
     expect(prefs.getBool('authTokenSecureMigrated'), isTrue);
+    expect(prefs.getString('nativeAuthToken'), 'legacy-session-token');
     // Non-secret expiry stays in SharedPreferences.
     expect(SharedPreferencesUtil().tokenExpirationTime, 42);
     expect(SharedPreferencesUtil().uid, 'user-1');
@@ -64,6 +65,7 @@ void main() {
 
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.containsKey('authToken'), isFalse);
+    expect(prefs.getString('nativeAuthToken'), 'fresh-token');
 
     await SharedPreferencesUtil().clear();
     expect(SharedPreferencesUtil().authToken, isEmpty);


### PR DESCRIPTION
## Summary
Follow-up to #11917. That squash landed the Flutter secure-storage move before the Codex items were on the branch.

Ports from #11352 (now closed) plus the Codex review:

- Mirror `authToken` to `nativeAuthToken` in prefs so Android BLE/WS can still read a token after the Flutter key is gone from SharedPreferences.
- `OmiBackgroundAudioStreamer` reads `nativeAuthToken`, then falls back to `authToken`.
- `android:allowBackup="false"` so encrypted prefs cannot restore without the keystore key.
- iOS Keychain accessibility is `first_unlock` so a locked BLE restore can still get the token.
- If secure-store migration fails, keep the leftover prefs token instead of logging the user out.

## Test plan
- [ ] Fresh login: Flutter session works; Android background streamer can auth.
- [ ] Upgrade from a pre-#11917 install: token migrates; native path still has `nativeAuthToken`.
- [ ] iOS locked-device BLE restore after first unlock.
- [ ] Confirm no backend/token-format change (app-only).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session-token storage, Android backup, and iOS Keychain accessibility. Native still mirrors the token in SharedPreferences for background BLE/WS.
> 
> **Overview**
> Follow-up to the Flutter secure-storage migration so native Android can still auth background transcription after `authToken` leaves SharedPreferences.
> 
> Mirrors the live session into a dedicated `nativeAuthToken` prefs key on init, set, and delete. `OmiBackgroundAudioStreamer` reads that first, then falls back to `authToken`. If a secure write fails, init still uses a leftover prefs token instead of logging the user out.
> 
> Also sets `android:allowBackup="false"` so encrypted prefs cannot restore without the keystore key, and uses iOS Keychain `first_unlock` so a locked-device BLE restore can still read the token. Migration tests now assert the native mirror.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4934527002a7addbab9a0bcbb421b3869f4ba5c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->