### PR TITLE
fix(backend): expose with_rate_limit on the task-sharing endpoints stub

### DIFF
--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -123,6 +123,12 @@ utils_users_mod.get_user_display_name = MagicMock(return_value="TestUser")
 _stub_module("utils.other")
 _stub_module("utils.other.endpoints")
 sys.modules["utils.other.endpoints"].get_current_user_uid = MagicMock()
+# The action-items router wraps its list auth dependency at module level:
+#   Depends(auth.with_rate_limit(auth.get_current_user_uid, "action_items:list"))
+# so the stub has to expose it or importing the router raises AttributeError
+# during collection. Pass the dependency straight through: these tests assert
+# sharing behavior, and the real wrapper only adds a Redis rate-limit check.
+sys.modules["utils.other.endpoints"].with_rate_limit = lambda auth_dependency, policy_name: auth_dependency
 
 # The action-items router imports the list-read budget seam at module level
 # (#11831). Delegate the stubbed submodule to the real (stdlib-only) module so


### PR DESCRIPTION
## Summary

`tests/unit/test_task_sharing.py` fails at **collection** on `main`, which errors the whole `Backend unit suite` job:

```
ERROR tests/unit/test_task_sharing.py - AttributeError: module 'utils.other.endpoints' has no attribute 'with_rate_limit'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Because it is a collection error rather than a test failure, the job exits 1 before running, so every backend PR inherits a red `Backend unit suite` through its merge ref.

## Cause

The file stubs `utils.other.endpoints` with a single attribute:

```python
_stub_module("utils.other.endpoints")
sys.modules["utils.other.endpoints"].get_current_user_uid = MagicMock()
```

`routers/action_items.py:362` now resolves the rate-limit wrapper at **module level**, so it is evaluated at import:

```python
uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "action_items:list")),
```

Importing the router under that stub raises before any test runs. The stub predates the wrapper; nothing about the sharing behavior under test changed.

## The fix

One stub entry that passes the auth dependency straight through. The real `with_rate_limit` only wraps it with a Redis per-UID check — which these tests neither exercise nor have a Redis for, since `database.redis_db.r` is itself a `MagicMock` a few lines above in the same file.

## Verification

Both directions, on a pristine checkout of `main` (not on a feature branch):

```
before:  no tests collected, 1 error in 0.35s
after:   30 passed
```

`black --line-length 120 --skip-string-normalization --check` reports the file unchanged.

## Notes

I hit this because it reddens `Backend unit suite` on my own PR #11452, but the failure is not from that diff — `main`'s own run at `08-22T14:42` (`fix(backend): cap GET /v1/action-items at 12`) shows the identical error. This is the same shape as #12035 earlier today: a small test-side fix unblocking a lane for everyone, and I am equally happy for someone to land an equivalent fix directly instead of merging this.

## Product invariants affected

none

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

