### PR TITLE
test(context-for-claude): close the analytics privacy boundary the existing tests left open

### DIFF
--- a/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
+++ b/desktop/context-for-claude/Tests/ContextAppTests/AnalyticsTests.swift
@@ -93,10 +93,59 @@ final class AnalyticsPayloadTests: XCTestCase {
     /// captured rows and is joinable to their account, so an analytics id equal to it would make every
     /// "anonymous" event trivially re-identifiable by anyone holding both datasets.
     func testTheAnalyticsIDIsNotTheBackendDeviceHash() {
-        let installID = "6E7D2C61-0000-4000-8000-000000000000"
+        let installID = Self.pinnedInstallID
         XCTAssertNotEqual(AnalyticsIdentity.derive(from: installID), ClientDevice.hash(of: installID))
         XCTAssertFalse(AnalyticsIdentity.derive(from: installID).contains(ClientDevice.hash(of: installID)))
     }
+
+    /// The derivation, pinned to a literal rather than recomputed.
+    ///
+    /// The two tests above are both *relative*: they compare the derivation against itself and
+    /// against the device hash, so a change to the salt, the digest, the prefix or the truncation
+    /// satisfies all of them while re-anonymising every install on the planet and restarting every
+    /// retention curve. The property the identity actually needs is that it produces the **same
+    /// string it produced last release**, and only a literal can say that.
+    ///
+    /// If this fails, the answer is almost never to update the literal. Read the doc comment on
+    /// `AnalyticsIdentity.salt` first.
+    func testTheAnalyticsIDDerivationIsPinnedToItsShippedValue() {
+        XCTAssertEqual(
+            AnalyticsIdentity.derive(from: Self.pinnedInstallID), "cfc_436214da822c0b7e",
+            "changing this severs every install's history — see AnalyticsIdentity.salt")
+        XCTAssertEqual(
+            ClientDevice.hash(of: Self.pinnedInstallID), "667a8eea",
+            "the backend's eight-hex contract, pinned beside the analytics id it must stay apart from")
+    }
+
+    /// **The super-property set is closed, and the closure is the privacy boundary.**
+    ///
+    /// Keeping `distinct_id` salted apart from the backend's device hash only buys anonymity while
+    /// nothing *else* on the payload carries the join. A `device_hash` super-property — proposed to
+    /// make the PostHog series joinable to the Firestore install roster — is not a weaker version of
+    /// making the two ids equal; it is the same join, spelled as a property. `macos_<hash>` is the
+    /// key of `users/{uid}/screen_activity/{clientDeviceId}-{rowId}`, so it resolves to a uid and a
+    /// uid resolves to a person, and every property on every event here would become a named
+    /// person's record of when their microphone was on.
+    ///
+    /// Asserted as an exact key set rather than as a blocklist of forbidden names, because the
+    /// failure mode is somebody adding a *new* identifier, and a blocklist can only ever refuse the
+    /// ones already imagined. Adding a genuinely non-identifying super-property means editing this
+    /// literal and saying why in the commit — which is the review this boundary is owed.
+    func testTheSuperPropertySetIsClosed() {
+        let keys = Set(
+            AnalyticsPayload.superProperties(
+                version: "1.0.12", build: "1000012", macOSVersion: "Version 15.5.0"
+            ).keys)
+
+        XCTAssertEqual(
+            keys, ["app", "app_version", "app_build", "macos_version"],
+            "a new super-property is a new disclosure on every event this app has ever sent")
+    }
+
+    /// The install id both derivations are pinned against. Fixed rather than minted, and never read
+    /// from `UserDefaults`: `ClientDevice.deviceIdHash` would mint and store a real install id in the
+    /// test process's own defaults domain, which is a side effect a test has no business having.
+    private static let pinnedInstallID = "6E7D2C61-0000-4000-8000-000000000000"
 }
 
 /// The closed-vocabulary invariant, checked against the real event list.

--- a/desktop/context-for-claude/docs/analytics.md
+++ b/desktop/context-for-claude/docs/analytics.md
@@ -182,6 +182,22 @@ somebody's microphone was on.
 Changing `AnalyticsIdentity.salt` re-anonymises every install and restarts every retention curve.
 Don't.
 
+### Carrying the device hash as a super-property would be the same mistake in a different spelling
+
+The recurring proposal is to leave `distinct_id` alone and add `ClientDevice.deviceIdHash` as a
+super-property instead, so the PostHog series can be joined to the Firestore install roster. Adding
+it beside `distinct_id` is not weaker than making the two ids equal — it *is* the join, made
+explicit. `macos_<hash>` is the key of `users/{uid}/screen_activity/{clientDeviceId}-{rowId}`, so it
+resolves to a uid and a uid resolves to a person; every property on this page would then be a named
+person's record of when their microphone was on. And the usual argument for it — "the backend
+already receives that hash, so PostHog learns nothing new" — is about the wrong party: the backend
+receiving it is precisely what makes it a join key, and PostHog does **not** receive it today.
+
+The question it is reached for does not need it. `cfc_daily_active` is already one event per install
+per day carrying `tool_calls_total`, so a day-by-day activity grid is answerable from this project
+alone — including for the install that never signs in, which the Firestore roster cannot see at all.
+The MCP key's single `last_used_at` is the thing that undercounts; fix that where it is stored.
+
 ## The three refusals
 
 1. **Airgap Mode drops events, it does not defer them.** Every other `NetworkEgress.Client` queues
@@ -253,6 +269,41 @@ FROM events
 WHERE timestamp > now() - INTERVAL 1 DAY AND properties.app = 'context-for-claude'
 GROUP BY event ORDER BY n DESC
 ```
+
+## Bucketing days: two clocks, and neither of them is ambiguous
+
+An install shows up in two datasets stamped on two different clocks. Reading them as one clock is
+the error this note exists to prevent, and the naive-looking timestamps invite it.
+
+**`cfc_daily_active` is one event per install per *local* calendar day.**
+`ContextAnalytics.dayStamp` takes `.year/.month/.day` from `Calendar.current`, so the boundary is
+the machine's own midnight. That is the right boundary for the question the event answers — "was
+this person at their desk today" — and it means two installs in different zones roll over at
+different instants. Cohort on the day the install already declared, not on a UTC re-derivation of
+the event timestamp.
+
+**Screen-activity rows are UTC.** They land in Firestore looking timezone-less —
+`'2026-08-17 20:55:09.022'` — but that is an instant in UTC with the offset dropped, never a
+device-local wall clock. `ScreenActivityUploader.storageTimestamp` pins it:
+
+```swift
+formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+formatter.locale = Locale(identifier: "en_US_POSIX")
+formatter.timeZone = TimeZone(secondsFromGMT: 0)
+```
+
+The backend agrees by construction rather than by convention: `normalize_screen_activity_timestamp`
+in `backend/database/screen_activity.py` runs `parsed.astimezone(timezone.utc).replace(tzinfo=None)`
+on anything tz-aware before storing, and the Omi desktop app's `makeCanonicalTimestampFormatter`
+fixes the same zone. The offset is absent because the field is a **lexicographic sort key, not a
+date type** — the backend range-filters it by string comparison — and an offset would break the
+sort, which is the same defect in a different disguise as the RFC-3339 stamp that used to ship here.
+
+So the string is safe to bucket by UTC day directly, and comparable across users. What is *not*
+safe is assuming it agrees with the `cfc_daily_active` day for the same install: for anybody not on
+UTC, an evening capture belongs to one calendar day in Firestore and the other in PostHog.
+`ScreenActivityWireFormatTests` pins the exact emitted string, so a formatter that silently fell
+back to device-local fails there rather than in a query months later.
 
 ## Asking it questions
 


### PR DESCRIPTION
## What happened

I asked for a change that would have broken this app's anonymity promise, and the existing tests would not have caught it. This PR is the guard, not the change.

**The proposal:** add the backend device hash to the analytics payload as a super-property, so PostHog events could be joined to the Firestore install roster and per-day MCP usage could be attributed per install.

**Why it is wrong.** `ClientDevice.clientDeviceId` is `"macos_<deviceIdHash>"`, and that string is the Firestore document key at `users/{uid}/screen_activity/{clientDeviceId}-{rowId}`. So the hash resolves to a uid, and a uid resolves to a person. Shipping it as a super-property makes every property CFC sends — when the mic was on, capture and screen minutes, active hours, permission states — a named person's behavioural record for anyone holding both datasets.

`AnalyticsIdentity` already says so, and says it is deliberate:

> `ClientDevice` already mints a per-install UUID and hashes it into `X-Device-Id-Hash`. This one is derived from the same UUID under a **different salt**, and that separation is the point: the backend id keys the user's own captured rows and is joinable to their account, so reusing it here would make every anonymous analytics event trivially re-identifiable by anyone holding both datasets.

The premise I argued from — "PostHog already receives it" — is simply false. `AnalyticsPayload.superProperties` returns exactly `app`, `app_version`, `app_build`, `macos_version`.

## Why the existing tests allowed it

Two holes, both real:

1. **The identity tests were relative, not pinned.** `testTheAnalyticsIDIsStableAcrossCalls` compares the derivation to itself; `testTheAnalyticsIDIsNotTheBackendDeviceHash` compares it to the device hash. Changing the salt, digest, prefix or truncation keeps both green while silently re-anonymising every existing install and orphaning its history.
2. **The disclosure test only ever inspected `distinct_id`.** The join could walk in as a *property* with the whole suite green — which is exactly the shape of the change proposed here.

## The guards

- `testTheAnalyticsIDDerivationIsPinnedToItsShippedValue` — pins both derivations to literals (`cfc_436214da822c0b7e` / `667a8eea`) against a fixed install id, so a change to either derivation is a failing test rather than silent data loss.
- `testTheSuperPropertySetIsClosed` — asserts the **exact** super-property key set. A closed set, not a blocklist, so the next new identifier fails by default instead of needing to be predicted.

## Verification

- `swift test`: **1681 → 1683 tests, 9 skipped, 0 failures.**
- **Mutation-checked, independently re-run:** applying the proposed `device_hash` line makes the guard fail with
  `("["device_hash", "macos_version", "app", "app_build", "app_version"]") is not equal to ("["macos_version", "app_build", "app_version", "app"]") - a new super-property is a new disclosure on every event this app has ever sent`
  and it passes again on revert.

## Also: the timezone basis, settled and documented

Screen-activity rows carry naive strings like `2026-08-17 20:55:09.022`. They are **UTC**, by construction:

```swift
formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
formatter.locale = Locale(identifier: "en_US_POSIX")
formatter.timeZone = TimeZone(secondsFromGMT: 0)
```

The backend agrees — `normalize_screen_activity_timestamp` does `parsed.astimezone(timezone.utc).replace(tzinfo=None)`. The offset is absent because the field is a lexicographic sort key that the backend range-filters by string comparison, not a date type.

**The trap this documents:** `cfc_daily_active` buckets by the **local** calendar day (`ContextAnalytics.dayStamp` reads `Calendar.current`), while screen rows are UTC. For anyone not on UTC, an evening capture belongs to one day in Firestore and the other in PostHog. Both are correct for what they measure; neither is a re-derivation of the other, and analysis must not treat them as interchangeable.

No production behaviour changes in this PR.

## Product invariants affected

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

