### PR TITLE
feat(desktop): Activity's row is a View, and every page it opens can get back

### DIFF
--- a/app/lib/backend/schema/structured.dart
+++ b/app/lib/backend/schema/structured.dart
@@ -51,10 +51,20 @@ class Structured {
     final sections = json['sections'];
     if (sections is List) {
       for (final section in sections) {
-        if (section is Map<String, dynamic>) {
-          structured.sections.add(Section.fromJson(section));
-        } else if (section is Map) {
-          structured.sections.add(Section.fromJson(Map<String, dynamic>.from(section)));
+        final Map<String, dynamic>? sectionJson = section is Map<String, dynamic>
+            ? section
+            : section is Map
+                ? Map<String, dynamic>.from(section)
+                : null;
+        if (sectionJson == null) continue;
+        // Section.fromJson throws a FormatException on a missing or mistyped
+        // `heading` / `body_markdown`. Skip the bad entry the way the
+        // actionItems and events loops below do: one malformed section used to
+        // throw out of here and take the whole conversation decode with it.
+        try {
+          structured.sections.add(Section.fromJson(sectionJson));
+        } on FormatException {
+          continue;
         }
       }
     }

--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -405,13 +405,19 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
     notifyListeners();
   }
 
-  /// Returns the first app result from the conversation if available
-  /// This is typically the summary of the conversation
+  /// Returns the first app result that actually carries content, which is the
+  /// summary of the conversation. An app result with empty content is not a
+  /// summary: returning it suppressed the structured sections (they only render
+  /// when `appId == null`) while `AppResultDetailWidget` fell into its
+  /// "no summary" placeholder, so a conversation with a full sections summary
+  /// rendered as having none. Mirrors desktop's `ConversationSummarySelection`.
   AppResponse? getSummarizedApp() {
-    if (conversation.appResults.isNotEmpty) {
-      return conversation.appResults[0];
+    final appResult = conversation.appResults.firstWhereOrNull((r) => r.content.trim().isNotEmpty);
+    if (appResult != null) {
+      return appResult;
     }
-    // If no appResults but we have a structured overview or sections, create a fake AppResponse
+    // If no app result carries content but we have a structured overview or
+    // sections, create a fake AppResponse
     if (conversation.structured.overview.isNotEmpty || conversation.structured.sections.isNotEmpty) {
       return AppResponse(conversation.structured.overview, appId: null);
     }

--- a/app/test/backend/structured_sections_test.dart
+++ b/app/test/backend/structured_sections_test.dart
@@ -77,5 +77,37 @@ void main() {
 
       expect(Structured.fromJson(json).sections, isEmpty);
     });
+
+    test('a malformed section is skipped instead of failing the decode', () {
+      // Regression: Section.fromJson throws a FormatException on a missing or
+      // mistyped heading/body_markdown, and the sections loop let it escape
+      // Structured.fromJson — so one bad section took the whole conversation
+      // decode with it, while the neighbouring actionItems/events loops have
+      // always skipped bad entries.
+      final json = _structuredJson();
+      (json['sections'] as List).insert(1, {'heading': 'Missing body'});
+      (json['sections'] as List).add({'heading': 42, 'body_markdown': 'Wrong heading type'});
+
+      final structured = Structured.fromJson(json);
+
+      expect(structured.sections.map((s) => s.heading), ['Decisions', 'Risks']);
+      expect(structured.sections.first.bodyMarkdown, '- Ship the **beta** on Friday');
+    });
+
+    test('a conversation with one malformed section still decodes', () {
+      final conversation = ServerConversation(
+        id: 'conv-malformed-section',
+        createdAt: DateTime.utc(2026, 7, 1, 12, 0, 0),
+        structured: Structured.fromJson(_structuredJson()),
+      );
+      final json = jsonDecode(jsonEncode(conversation.toJson())) as Map<String, dynamic>;
+      (json['structured']['sections'] as List).insert(0, {'body_markdown': 'Heading is missing'});
+
+      final restored = ServerConversation.fromJson(json);
+
+      expect(restored.id, 'conv-malformed-section');
+      expect(restored.structured.title, 'Sprint sync');
+      expect(restored.structured.sections.map((s) => s.heading), ['Decisions', 'Risks']);
+    });
   });
 }

--- a/app/test/providers/conversation_detail_summary_selection_test.dart
+++ b/app/test/providers/conversation_detail_summary_selection_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/gen/conversation_wire.g.dart' as wire;
+import 'package:omi/backend/schema/structured.dart';
+import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
+import 'package:omi/providers/conversation_provider.dart';
+
+/// A conversation whose first-party summary lives entirely in `sections`, with
+/// whatever app results the case under test needs.
+ServerConversation _conversation({List<AppResponse> appResults = const []}) {
+  final structured = Structured('Sprint sync', 'Short compatibility paragraph.', emoji: '🧠');
+  structured.sections = [
+    const wire.GeneratedSection(heading: 'Decisions', bodyMarkdown: 'Ship the beta on Friday'),
+  ];
+  return ServerConversation(
+    id: 'conv-1',
+    createdAt: DateTime(2026, 7, 1, 9).toUtc(),
+    structured: structured,
+    appResults: appResults,
+  );
+}
+
+ConversationDetailProvider _providerFor(ServerConversation conversation) {
+  final provider = ConversationDetailProvider();
+  addTearDown(provider.dispose);
+  provider.selectedDate = conversationLocalDayKey(conversation.createdAt);
+  provider.setCachedConversation(conversation);
+  return provider;
+}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('an app result with empty content is not treated as the summary', () {
+    // Regression: getSummarizedApp() returned appResults[0] unconditionally.
+    // A result with empty content then carried a non-null appId, which
+    // suppressed the structured sections (AppResultDetailWidget only renders
+    // them when appId == null) while the empty content sent the widget into its
+    // "no summary available for this app" placeholder — a conversation with a
+    // full sections summary rendered as having no summary at all.
+    final conversation = _conversation(appResults: [AppResponse('   ', appId: 'app-1')]);
+
+    final summary = _providerFor(conversation).getSummarizedApp();
+
+    expect(summary, isNotNull);
+    expect(summary!.appId, isNull, reason: 'a null appId is what lets the structured sections render');
+    expect(summary.content, 'Short compatibility paragraph.');
+  });
+
+  test('the first app result that carries content is the summary', () {
+    final conversation = _conversation(appResults: [
+      AppResponse('', appId: 'empty-app'),
+      AppResponse('App summary', appId: 'app-2'),
+    ]);
+
+    final summary = _providerFor(conversation).getSummarizedApp();
+
+    expect(summary!.appId, 'app-2');
+    expect(summary.content, 'App summary');
+  });
+
+  test('sections alone still produce a first-party summary when no app ran', () {
+    final conversation = _conversation();
+
+    final summary = _providerFor(conversation).getSummarizedApp();
+
+    expect(summary!.appId, isNull);
+    expect(summary.content, 'Short compatibility paragraph.');
+  });
+}

--- a/app/test/widgets/conversation_summary_sections_test.dart
+++ b/app/test/widgets/conversation_summary_sections_test.dart
@@ -1,19 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/gen/conversation_wire.g.dart' as wire;
 import 'package:omi/backend/schema/structured.dart';
 import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/widgets.dart';
+import 'package:omi/providers/conversation_provider.dart';
 
-ServerConversation _conversationWithSections() {
+ServerConversation _conversationWithSections({List<AppResponse> appResults = const []}) {
   final structured = Structured('Sprint sync', 'Short compatibility paragraph.', emoji: '🧠');
   structured.sections = [
     const wire.GeneratedSection(heading: 'Decisions', bodyMarkdown: 'Ship the beta on Friday'),
     const wire.GeneratedSection(heading: 'Risks', bodyMarkdown: 'Backend migration is not started yet'),
   ];
-  return ServerConversation(id: 'conv-1', createdAt: DateTime.utc(2026, 7, 1), structured: structured);
+  return ServerConversation(
+    id: 'conv-1',
+    createdAt: DateTime(2026, 7, 1, 9).toUtc(),
+    structured: structured,
+    appResults: appResults,
+  );
 }
 
 Future<void> _pumpSummary(WidgetTester tester, ServerConversation conversation, AppResponse response) async {
@@ -80,6 +89,27 @@ void main() {
 
       expect(find.textContaining('App summary', findRichText: true), findsOneWidget);
       expect(find.textContaining('Decisions', findRichText: true), findsNothing);
+    });
+
+    testWidgets('an app result with empty content still renders the structured sections', (tester) async {
+      // End of the regression this pane actually showed: the provider handed
+      // over an empty-content app result, its non-null appId suppressed the
+      // sections, and the empty content selected the "no summary" placeholder.
+      SharedPreferences.setMockInitialValues({});
+      await SharedPreferencesUtil.init();
+
+      final conversation = _conversationWithSections(appResults: [AppResponse('', appId: 'app-1')]);
+
+      final provider = ConversationDetailProvider();
+      addTearDown(provider.dispose);
+      provider.selectedDate = conversationLocalDayKey(conversation.createdAt);
+      provider.setCachedConversation(conversation);
+
+      await _pumpSummary(tester, conversation, provider.getSummarizedApp()!);
+
+      expect(find.textContaining('Decisions', findRichText: true), findsOneWidget);
+      expect(find.textContaining('Ship the beta on Friday', findRichText: true), findsOneWidget);
+      expect(find.textContaining('No summary available for this app', findRichText: true), findsNothing);
     });
   });
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/CaptureArchivePage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/CaptureArchivePage.swift
@@ -156,7 +156,8 @@ struct CaptureArchivePage: View {
   @ViewBuilder
   private func summarySection(_ capture: ServerConversation) -> some View {
     let primary = ConversationSummarySelection.primarySummary(for: capture)
-    let sections = capture.structured.sections
+    // Same provenance rule as the full editor: an app summary replaces Omi's own, sections included.
+    let sections = primary.appId == nil ? capture.structured.sections : []
     if !primary.content.isEmpty || !sections.isEmpty {
       detailSection("Summary") {
         VStack(alignment: .leading, spacing: OmiSpacing.lg) {

--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -161,13 +161,22 @@ struct ChatFirstShell: View {
       // No switcher here either. Every hub page is reached from Activity's chip row, and the
       // `Activity` pill in the top bar is always one click away from this route, so the siblings
       // are two clicks out rather than stranded (INV-NAV-1, `ShellDestination.reach`).
-      ChatFirstConversationsHost(
-        navigation: navigation,
-        appState: appState,
-        chatProvider: viewModelContainer.chatProvider,
-        automationRuntime: automationRuntime,
-        explicitSelectionGeneration: conversationsSelectionGeneration
-      )
+      VStack(alignment: .leading, spacing: 0) {
+        HStack {
+          ActivityBackButton { selectHubDestination(.activity) }
+          Spacer(minLength: 0)
+        }
+        .padding(.top, 18)
+        .padding(.horizontal, 28)
+        .padding(.bottom, 6)
+        ChatFirstConversationsHost(
+          navigation: navigation,
+          appState: appState,
+          chatProvider: viewModelContainer.chatProvider,
+          automationRuntime: automationRuntime,
+          explicitSelectionGeneration: conversationsSelectionGeneration
+        )
+      }
       .accessibilityIdentifier("chat-first-route-conversations")
       .onAppear { navigation.markRouteVisible(.conversations) }
     case .tasks:
@@ -205,8 +214,7 @@ struct ChatFirstShell: View {
         // host as a record rather than as an id the host has to find again. `selectPrimary` — what
         // the spine used to call — is the tab-selection primitive and drops pending records by
         // design, which is why the click landed on the list.
-        onOpenConversationRecord: { navigation.open(conversation: $0) },
-        onOpenTasks: { navigation.selectPrimary(.tasks) }
+        onOpenConversationRecord: { navigation.open(conversation: $0) }
       )
       .accessibilityIdentifier("chat-first-route-memories")
       .onAppear { navigation.markRouteVisible(.memories) }
@@ -253,18 +261,17 @@ struct ChatFirstShell: View {
     Binding(
       get: { ChatFirstModernNavigationPolicy.topBarIndex(for: navigation.route) },
       set: { rawValue in
-        if rawValue == SidebarNavItem.conversations.rawValue {
-          // The pill says `Activity`, so it opens Activity — not whichever hub view happened to be
-          // persisted last. Routing through the same writer the hub's own switcher uses keeps one
-          // path responsible for moving both halves of the state.
-          selectHubDestination(.activity)
-          return
-        }
         guard let route = ChatFirstModernNavigationPolicy.route(forTopBarIndex: rawValue) else {
           return
         }
         switch route {
-        case .chat, .conversations, .tasks, .memories, .goals:
+        case .conversations:
+          // The hub's one pill says `Activity`, so it opens Activity — not whichever hub view
+          // happened to be persisted last, and not the Conversations route this index maps back
+          // from. Routing through the same writer the chip row uses keeps one path responsible for
+          // moving both halves of the state.
+          selectHubDestination(.activity)
+        case .chat, .tasks, .memories, .goals:
           navigation.selectPrimary(route)
         case .more(let page):
           navigation.selectMore(page)

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
@@ -1,0 +1,43 @@
+//
+//  ActivityBackButton.swift — the way back from a page Activity's chip row opened.
+//
+//  The chip row is a one-way door: pressing `Memories` leaves Activity, and the row goes with it,
+//  because the row lives on Activity's panel. The top-bar `Activity` pill does come back, but a pill
+//  in the window's chrome is a different gesture from the control that brought you here — you have
+//  to know the pill is the answer, and nothing on the page says so.
+//
+//  So the page you land on says it. One control, leading edge, naming where it goes rather than a
+//  bare chevron, matching the `‹ Back` affordance the conversation detail already uses.
+//
+//  Brand: `Ink` semantics only (INV-UI-1).
+//
+
+import OmiTheme
+import SwiftUI
+
+/// A back control that returns to the Activity spine.
+struct ActivityBackButton: View {
+  let action: () -> Void
+
+  @State private var isHovering = false
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 5) {
+        Image(systemName: "chevron.left")
+          .scaledFont(size: OmiType.micro, weight: .semibold)
+        Text("Activity")
+          .scaledFont(size: OmiType.caption, weight: .semibold)
+      }
+      .foregroundStyle(GlassShell.controlLabel(isProminent: isHovering))
+      .padding(.horizontal, 12)
+      .frame(height: QueryShellLayout.chipHeight + 2)
+      .glassChip(isActive: false)
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovering = $0 }
+    .help("Back to Activity")
+    .accessibilityLabel("Back to Activity")
+    .accessibilityIdentifier("activity-back-button")
+  }
+}

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationSummarySections.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ConversationSummarySections.swift
@@ -29,7 +29,10 @@ struct ConversationSummarySections: View {
   var body: some View {
     if !sections.isEmpty {
       VStack(alignment: .leading, spacing: OmiSpacing.lg) {
-        ForEach(sections) { section in
+        // Keyed by position, not by heading. These blocks are model-written, so two can share a
+        // heading — or have none at all, which this view explicitly allows below — and identical
+        // `ForEach` ids make SwiftUI drop or duplicate rows rather than render both.
+        ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
           VStack(alignment: .leading, spacing: OmiSpacing.xs) {
             if !section.heading.isEmpty {
               Text(section.heading)

--- a/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
@@ -4,22 +4,23 @@ import SwiftUI
 /// The constant floating top bar.
 ///
 /// **It carries the destinations flat, and nothing opens.** On the left, one pill per destination:
-/// `Home`, `Library`, `Tasks`, `Rewind`, `Apps`. On the right, the referral action sits immediately
+/// `Home`, `Activity`, `Tasks`, `Rewind`, `Apps`. On the right, the referral action sits immediately
 /// before the microphone, followed by screen capture and settings.
 ///
 /// The bar used to spell out `Home · Memory · Tasks · Apps` beside `Listening` and `Capture`, and both
 /// halves were wrong once Home became a search surface. A **`Memory` destination sitting next to a
 /// field that already returns memories is a contradiction** — the user reads it as two different
-/// memories — so the destinations that search absorbs are reached through `Library`, which is where
+/// memories — so the destinations that search absorbs are reached through `Activity`, which is where
 /// the whole corpus lives when you want to browse it rather than ask for it. The right-hand pills,
 /// meanwhile, were two labels permanently occupying the corner of a window whose point is the field in
 /// the middle of it; `ShellStatusIcons` carries the same state in a dot and the same sentence in a
 /// tooltip, at a third of the width.
 ///
-/// `Library` then briefly opened a **hover menu** of seven destinations, and that was the worse
-/// mistake: a control that opens because the pointer crossed it and closes because the pointer left on
-/// the way to the row you wanted. It is gone. Three of its seven entries were the Memory hub's own
-/// views and now live on the hub's page (`MemoryHubSwitcher`); the rest are the flat pills above. See
+/// That pill — then labelled `Library` — briefly opened a **hover menu** of seven destinations, and
+/// that was the worse mistake: a control that opens because the pointer crossed it and closes because
+/// the pointer left on the way to the row you wanted. It is gone. Three of its seven entries were the
+/// Memory hub's own views and now live as chips on the page this pill opens
+/// (`ActivityDestinationChip`); the rest are the flat pills above. See
 /// `TopNavigationDestinations.swift` for the full argument and `ShellDestination` for the
 /// reachability contract that keeps it honest.
 ///

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -4,14 +4,10 @@ import CoreGraphics
 enum MemoryHubDestination: Int, CaseIterable, Identifiable {
   static let storageKey = "memoryHubDestination"
 
-  /// The order the hub's own switcher reads in: the thing you captured, what Omi kept from it, then
-  /// the map over all of it. Declared here rather than inside the switcher view so it stays a plain
-  /// value a test can read without hopping to the main actor.
-  ///
-  /// `allCases` is *not* this order — its raw values are storage identity and start at `memories`,
-  /// which is where the persisted default lands, not where the row should start.
-  static let switcherOrder: [MemoryHubDestination] = [.activity, .conversations, .memories, .brainMap]
-
+  /// `allCases` is storage identity, not reading order: the raw values are persisted, so this list
+  /// starts at `memories` — where the stored default lands — rather than where the user's row
+  /// starts. The order the four pages are *presented* in belongs to the control that presents them,
+  /// `ActivityDestinationChip`.
   case memories
   case conversations
   case brainMap

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
@@ -44,9 +44,6 @@ struct MemoryHubPage: View {
   /// singleton below — correct for the modern shell, where this page mounts `ConversationsPageHost`
   /// itself and that host is guaranteed to be the one that consumes the request.
   var onOpenConversationRecord: ((ServerConversation) -> Void)? = nil
-  /// Tasks lives on the shell rail, so Activity's chip row reaches it through the host that owns
-  /// that index — the same shape as `onOpenRewind`.
-  var onOpenTasks: (() -> Void)? = nil
 
   private var destination: MemoryHubDestination {
     MemoryHubDestination(rawValue: destinationRawValue) ?? .memories
@@ -62,9 +59,6 @@ struct MemoryHubPage: View {
     )
   }
 
-  /// The hub wears its own switcher. It used to live in the top bar's `Library` hover menu, which
-  /// made the window's chrome responsible for one page's three views — and made Brain Map reachable
-  /// only by hovering. A page's tabs belong to the page (INV-NAV-1: same destinations, same owner).
   /// **The hub wears no switcher.** It used to carry one directly above Activity's own filter row —
   /// two chip rows a few points apart, sharing three of their words, doing different things. The
   /// row that survived is Activity's, and every chip in it navigates (`ActivityDestinationChip`),
@@ -72,6 +66,25 @@ struct MemoryHubPage: View {
   /// pressing `Activity` in the top bar comes back to that row (INV-NAV-1).
   var body: some View {
     hubContent
+  }
+
+  /// Puts the way back to Activity on the page itself.
+  ///
+  /// Activity's chip row is what opened this page, and the row stayed behind on Activity's panel.
+  /// The top-bar pill does return, but that is window chrome answering for a control the page
+  /// offered — the page has to carry its own way back (INV-NAV-1).
+  @ViewBuilder
+  private func backToActivity<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        ActivityBackButton { select(.activity) }
+        Spacer(minLength: 0)
+      }
+      .padding(.top, 18)
+      .padding(.horizontal, 28)
+      .padding(.bottom, 6)
+      content()
+    }
   }
 
   private func select(_ next: MemoryHubDestination) {
@@ -115,26 +128,31 @@ struct MemoryHubPage: View {
         },
         onOpenBrainMap: { select(.brainMap) },
         onOpenRewind: { onOpenRewind?() },
-        onOpenHubDestination: select,
-        onOpenTasks: { onOpenTasks?() }
+        onOpenHubDestination: select
       )
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     case .memories:
-      adaptiveContent(
-        MemoriesPage(viewModel: viewModelContainer.memoriesViewModel),
-        conversationID: viewModelContainer.memoriesViewModel.linkedConversation?.id
-      )
+      backToActivity {
+        adaptiveContent(
+          MemoriesPage(viewModel: viewModelContainer.memoriesViewModel),
+          conversationID: viewModelContainer.memoriesViewModel.linkedConversation?.id
+        )
+      }
     case .conversations:
-      ConversationsPageHost(appState: appState)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      backToActivity {
+        ConversationsPageHost(appState: appState)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
     case .brainMap:
-      brainMapDestination
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        // The lifecycle capability is established by the first authoritative
-        // memory response. Without this, opening straight into a persisted
-        // Brain Map destination would resolve the compatibility graph before
-        // the server capability was known purely because Memories was never visited.
-        .task { await memoriesViewModel.loadMemoriesIfNeeded() }
+      backToActivity {
+        brainMapDestination
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+      // The lifecycle capability is established by the first authoritative
+      // memory response. Without this, opening straight into a persisted
+      // Brain Map destination would resolve the compatibility graph before
+      // the server capability was known purely because Memories was never visited.
+      .task { await memoriesViewModel.loadMemoriesIfNeeded() }
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/PageGlassLane.swift
@@ -55,12 +55,18 @@ enum PageGlassLanePolicy {
     switch SidebarNavItem(rawValue: selectedIndex) ?? .dashboard {
     case .dashboard, .rewind:
       return true
-    case .conversations, .memories:
-      // The Memory hub is one rail index wearing four different pages, and only one of them builds
-      // its own glass. Activity is Home's column — a search bar and a results panel, each already
-      // an `inkGlassPanel` — so wrapping the hub wholesale nested those two inside a third and
-      // double-scrimmed both, which is exactly the muddier-than-its-neighbours failure this policy
-      // exists to prevent. The hub's list pages paint no ground and still need the lane.
+    case .conversations:
+      // **Only this index is the Memory hub.** It is one rail slot wearing four different pages, and
+      // only one of them builds its own glass: Activity is Home's column — a search bar and a
+      // results panel, each already an `inkGlassPanel` — so wrapping the hub wholesale nested those
+      // two inside a third and double-scrimmed both, the muddier-than-its-neighbours failure this
+      // policy exists to prevent. The hub's list pages paint no ground and still need the lane.
+      //
+      // `SidebarNavItem.memories` is deliberately NOT here. In this shell that index is the
+      // *standalone* `MemoriesPage`, not the hub, and it paints no ground of its own — answering
+      // for it off a persisted hub destination stripped its panel and drew its rows onto the
+      // wallpaper. The chat-first shell reaches the hub through `ChatFirstPageGlassLanePolicy`,
+      // which never constructs this view for Activity at all.
       return MemoryHubDestination(rawValue: memoryDestinationRawValue ?? -1) == .activity
     default:
       return false

--- a/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationDetailView.swift
@@ -602,8 +602,15 @@ struct ConversationDetailView: View {
 
     // The backend's headed summary blocks. `overview` is only a compatibility paragraph now, so
     // without these the pane shows a fraction of what was actually written.
-    ConversationSummarySections(sections: displayConversation.structured.sections)
-      .padding(.horizontal, OmiSpacing.lg)
+    //
+    // Shown only when Omi's own summary is the one on screen. `sections` belongs to the first-party
+    // structured summary, and a promoted app result already *replaces* that summary — rendering
+    // both stacks a second, unattributed Omi summary under the app's, which is also the one thing
+    // the Flutter client deliberately does not do.
+    if selection.appId == nil {
+      ConversationSummarySections(sections: displayConversation.structured.sections)
+        .padding(.horizontal, OmiSpacing.lg)
+    }
 
     // Metadata chips
     metadataSection

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
@@ -26,8 +26,6 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
   case conversations
   case memories
   case brainMap
-  case tasks
-  case rewind
 
   var id: String { rawValue }
 
@@ -37,25 +35,27 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
     case .conversations: return "Conversations"
     case .memories: return "Memories"
     case .brainMap: return "Brain Map"
-    case .tasks: return "Tasks"
-    case .rewind: return "Rewind"
     }
   }
 
-  /// The Memory hub page this chip opens, for the ones the hub owns. `Tasks` and `Rewind` are the
-  /// shell's own destinations and answer nil.
-  var hubDestination: MemoryHubDestination? {
+  /// The Memory hub page this chip opens. Every chip in this row is one of the hub's four pages:
+  /// `Tasks` and `Rewind` were here too and were removed, because each already has its own pill in
+  /// the bar directly above — a second control to the same place, two inches apart.
+  ///
+  /// **Not optional, and that is the reachability claim's teeth.** A chip that opens no hub page
+  /// would be a chip that reaches nothing while `reachableHubDestinations` quietly dropped it; the
+  /// type forbids adding one rather than leaving a test to notice.
+  var hubDestination: MemoryHubDestination {
     switch self {
     case .activity: return .activity
     case .conversations: return .conversations
     case .memories: return .memories
     case .brainMap: return .brainMap
-    case .tasks, .rewind: return nil
     }
   }
 
   /// Every hub page this row can reach. `ShellDestination.unreachable()` reads exactly this.
   static var reachableHubDestinations: [MemoryHubDestination] {
-    allCases.compactMap(\.hubDestination)
+    allCases.map(\.hubDestination)
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
@@ -19,8 +19,6 @@ struct ActivityHubTab: View {
   /// Opens one of the Memory hub's sibling pages. The chip row is the only door to them now that
   /// the hub's switcher is gone, so a host that cannot supply this would strand three pages.
   let onOpenHubDestination: (MemoryHubDestination) -> Void
-  /// Tasks is the shell's own destination, reached from the rail the host owns.
-  let onOpenTasks: () -> Void
 
   @ObservedObject private var tasksStore = TasksStore.shared
   @State private var filters = QueryShellFilters()
@@ -80,12 +78,7 @@ struct ActivityHubTab: View {
     case .activity:
       return
     case .conversations, .memories, .brainMap:
-      guard let destination = chip.hubDestination else { return }
-      onOpenHubDestination(destination)
-    case .tasks:
-      onOpenTasks()
-    case .rewind:
-      onOpenRewind()
+      onOpenHubDestination(chip.hubDestination)
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/QueryResultsPanel.swift
@@ -69,6 +69,10 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
   /// what it costs, so it is the only thing that can say what is left; the host measures the window
   /// and `QueryShellLayout.panelBodyHeight` does the arithmetic.
   let bodyHeight: CGFloat
+  /// What the chip row does on this surface. Home narrows its search results in place; Activity's
+  /// row is navigation — see `ActivityDestinationChip`.
+  var chipBehavior: QueryPanelChipBehavior = .filterKinds
+
   /// One slot in the header's leading cluster, next to `Filter ›` / `‹ Results`.
   ///
   /// **The chrome still learns nothing about the body.** It does not know that the thing beside the
@@ -76,17 +80,6 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
   /// it knows there is a control there and where controls on this panel sit. The alternative was to
   /// hand this file a `HomeChatMenu`, which would make a panel that draws counts and time windows
   /// start knowing what chat is.
-  /// What the chip row does on this surface. Home narrows its search results in place; Activity's
-  /// row is navigation — see `ActivityDestinationChip`.
-  var chipBehavior: ChipBehavior = .filterKinds
-
-  /// The two things a chip row can mean. Modelled so one surface cannot quietly become the other:
-  /// a row where some chips filter and some navigate teaches a rule and then breaks it.
-  enum ChipBehavior {
-    case filterKinds
-    case openDestinations(selected: ActivityDestinationChip, open: (ActivityDestinationChip) -> Void)
-  }
-
   @ViewBuilder var headerAccessory: () -> Accessory
   /// **The slot under the body, for the composer once a conversation is open.**
   ///
@@ -157,7 +150,7 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
       HStack(spacing: 6) {
         Image(systemName: "line.3.horizontal.decrease")
           .scaledFont(size: OmiType.caption, weight: .semibold)
-        Text(request.range == .all ? "Filter" : request.range.title)
+        Text(request.range == .all ? chipBehavior.disclosureLabel : request.range.title)
           .scaledFont(size: OmiType.caption, weight: .semibold)
         Image(systemName: "chevron.right")
           .scaledFont(size: OmiType.micro, weight: .semibold)
@@ -237,6 +230,25 @@ struct QueryResultsPanel<Content: View, Accessory: View, Footer: View>: View {
         }
       }
       Spacer(minLength: 0)
+    }
+  }
+}
+
+/// The two things a chip row can mean. Standalone rather than nested in the generic panel so the
+/// contract is assertable without naming three view types, and modelled as a value so one surface
+/// cannot quietly become the other: a row where some chips filter and some navigate teaches a rule
+/// and then breaks it.
+enum QueryPanelChipBehavior {
+  case filterKinds
+  case openDestinations(selected: ActivityDestinationChip, open: (ActivityDestinationChip) -> Void)
+
+  /// What the row's own header calls it. The word has to follow the behaviour: on Home the chips
+  /// narrow the results in place and `Filter` is the truth; on Activity they open pages, and a row
+  /// of destinations under the word `Filter` describes something the row does not do.
+  var disclosureLabel: String {
+    switch self {
+    case .filterKinds: return "Filter"
+    case .openDestinations: return "View"
     }
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -9,10 +9,12 @@
 //
 //  So the disclosure is gone and the seven destinations were re-sorted by what they actually are:
 //
-//  - **Three of them are one page.** Conversations, Memories and Brain Map are the Memory hub's own
-//    three views (`MemoryHubDestination`). The bar was carrying a page's internal tabs, which is why
-//    it needed a menu to hold them. They now live on that page, in its own switcher — see
-//    `MemoryHubSwitcher`. The bar keeps one pill, `Library`, that opens the hub.
+//  - **Three of them are one page.** Conversations, Memories and Brain Map are three of the Memory
+//    hub's four views (`MemoryHubDestination`). The bar was carrying a page's internal tabs, which is
+//    why it needed a menu to hold them. The bar keeps one pill, `Activity`, which opens the hub's
+//    fourth view — the chronological spine — and the other three are chips in that page's own
+//    navigating row (`ActivityDestinationChip`), with a `‹ Activity` control on each of them for the
+//    way back (`ActivityBackButton`).
 //  - **The rest are genuinely separate views**, so they are flat pills: `Tasks`, `Rewind`, `Apps`.
 //    Always visible, one click, no disclosure, no hover.
 //
@@ -138,7 +140,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
   var reach: Reach {
     switch self {
     /// `Activity` is what the hub's pill opens, so its door is the bar itself — the other three
-    /// hub views are reached from the hub's switcher once you are there.
+    /// hub views are reached from Activity's chip row once you are there.
     case .conversations, .memories, .brainMap: return .activityChipRow
     case .permissions: return .settingsSidebar
     case .home, .tasks, .rewind, .apps, .activity: return .topBar
@@ -147,8 +149,9 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
 
   /// Every destination whose `reach` is not actually wired up — empty, or INV-NAV-1 is broken.
   ///
-  /// A `topBar` destination must have a pill; a `memoryHubView` must be one of the hub's own views
-  /// *and* the hub itself must have a pill; a `settingsSidebar` destination must be a row the
+  /// A `topBar` destination must have a pill; an `activityChipRow` destination must be a hub view
+  /// Activity's row actually offers *and* the page that carries the row must itself have a pill; a
+  /// `settingsSidebar` destination must be a row the
   /// Settings list actually shows, that row must mount the whole page rather than a summary of it,
   /// *and* the bar must still carry the gear that opens Settings.
   static func unreachable(
@@ -180,7 +183,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
     }
   }
 
-  /// Whether the page currently on screen is one of the hub's, so the `Library` pill can read as
+  /// Whether the page currently on screen is one of the hub's, so the `Activity` pill can read as
   /// current while you are reading a conversation rather than claiming you are nowhere.
   static func isHubPage(selectedIndex: Int) -> Bool {
     selectedIndex == SidebarNavItem.conversations.rawValue
@@ -209,9 +212,9 @@ struct TopNavigationItem: Identifiable, Equatable {
 }
 
 enum TopNavigationRoutes {
-  /// **The whole navigation, flat.** `Library` is the Memory hub — the one destination that owns
-  /// more than one view, and it shows those views itself. The other four are single pages, so they
-  /// are single pills. Nothing here opens a menu.
+  /// **The whole navigation, flat.** `Activity` is the Memory hub — the one destination that owns
+  /// more than one view, and it offers the other three from a chip row on its own page. The other
+  /// four are single pages, so they are single pills. Nothing here opens a menu.
   static let primaryItems = [
     TopNavigationItem(
       index: SidebarNavItem.dashboard.rawValue, title: "Chat", icon: "bubble.left.and.text.bubble.right",
@@ -219,8 +222,8 @@ enum TopNavigationRoutes {
     // The hub's pill names the view it opens. It used to say `Memories` while opening whichever hub
     // view was last persisted, so the word on the bar and the page you landed on were only
     // sometimes the same thing. It opens `Activity` — the chronological spine over everything
-    // captured — and says so; Conversations, Memories and Brain Map stay one click away in the
-    // hub's own switcher, which is the mechanism `ShellDestination.reach` records for them.
+    // captured — and says so; Conversations, Memories and Brain Map stay one click away in that
+    // page's own chip row, which is the mechanism `ShellDestination.reach` records for them.
     // The glyph is deliberately not `clock.arrow.circlepath`: that is Rewind's, two pills away.
     TopNavigationItem(
       index: SidebarNavItem.conversations.rawValue, title: "Activity", icon: "square.stack",
@@ -253,9 +256,9 @@ enum TopNavigationRoutes {
 
 /// The `+N` counts the row carries, one per pill that owns them.
 ///
-/// Split rather than summed onto one pill: while `Tasks` lived inside the `Library` menu, a single
-/// badge on `Library` was the only honest place to put a task count. Now that `Tasks` is its own pill,
-/// a task counted on `Library` would send you to the wrong page.
+/// Split rather than summed onto one pill: while `Tasks` lived inside the retired `Library` menu, a
+/// single badge on that pill was the only honest place to put a task count. Now that `Tasks` is its
+/// own pill, a task counted on the hub's pill would send you to the wrong page.
 struct TopNavigationDestinationBadges: Equatable {
   var library: Int = 0
   var tasks: Int = 0

--- a/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
@@ -24,7 +24,7 @@ final class ChatFirstDestinationParityTests: XCTestCase {
   /// **The regression this policy actually shipped.** The memory route used to preserve `.brainMap`
   /// by name, so `.activity` — added later as a fourth hub view sharing that route — was rewritten
   /// to `.memories` by the route sync that runs right after the click. Pressing Activity landed on
-  /// Memories, from the pill and from the hub's own switcher alike. Every view whose route is the
+  /// Memories, from the pill and from Activity's own chip row alike. Every view whose route is the
   /// memory route must survive it, not just the two that were there when the policy was written.
   func testActivitySelectionSurvivesTheMemoryRouteTransition() {
     XCTAssertEqual(
@@ -41,15 +41,6 @@ final class ChatFirstDestinationParityTests: XCTestCase {
     }
   }
 
-  /// The hub's switcher replaced the top bar's hover menu, so it has to offer all three of the hub's
-  /// views — a switcher missing one is exactly the "reduced copy" INV-NAV-1 forbids.
-  func testTheMemoryHubSwitcherOffersEveryHubView() {
-    XCTAssertEqual(
-      Set(MemoryHubDestination.switcherOrder), Set(MemoryHubDestination.allCases),
-      "the hub's switcher must offer every hub view")
-    XCTAssertEqual(MemoryHubDestination.switcherOrder, [.activity, .conversations, .memories, .brainMap])
-  }
-
   /// Selecting a hub view in the chat-first shell has to move its typed route as well as the
   /// persisted destination. Conversations has its own route (it carries capture-archive focus);
   /// Memories and Brain Map are both the Memory route, which is where `MemoryHubPage` is mounted.
@@ -61,6 +52,34 @@ final class ChatFirstDestinationParityTests: XCTestCase {
     XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .memories), .memories)
     XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .brainMap), .memories)
     XCTAssertEqual(MemoryHubSelectionPolicy.chatFirstRoute(for: .activity), .memories)
+  }
+
+  /// **The chip row is the door, so its contents are a contract.**
+  ///
+  /// The hub's switcher was deleted and this row replaced it. `ShellDestination.Reach.activityChipRow`
+  /// claims the row reaches Conversations, Memories and Brain Map; that claim is only true while the
+  /// row actually offers every hub page. Tasks and Rewind were removed from the row deliberately —
+  /// each already has its own pill in the bar directly above it — and neither is a hub page, so
+  /// neither may come back here without the reachability model being revisited. That every chip
+  /// opens *some* hub page is held by the type — `hubDestination` is not optional — rather than by
+  /// an assertion here.
+  func testTheActivityChipRowOffersEveryHubPageAndNothingElse() {
+    XCTAssertEqual(
+      ActivityDestinationChip.allCases.map(\.title),
+      ["Activity", "Conversations", "Memories", "Brain Map"])
+
+    XCTAssertEqual(
+      Set(ActivityDestinationChip.reachableHubDestinations), Set(MemoryHubDestination.allCases),
+      "a hub page the chip row does not offer has no door")
+  }
+
+  /// The row's word for itself has to follow what the row does. Home's chips narrow results in
+  /// place and are a filter; Activity's open pages and are a view.
+  func testThePanelHeaderNamesWhatTheChipRowActuallyDoes() {
+    XCTAssertEqual(QueryPanelChipBehavior.filterKinds.disclosureLabel, "Filter")
+    XCTAssertEqual(
+      QueryPanelChipBehavior.openDestinations(selected: .activity, open: { _ in }).disclosureLabel,
+      "View")
   }
 
   /// Every flat pill the bar now shows must resolve to a chat-first route, both ways. `Focus` did

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -39,12 +39,9 @@ final class MemoryGraphRevisitTests: XCTestCase {
       MemoryHubDestination.allCases,
       [.memories, .conversations, .brainMap, .activity]
     )
-    // Storage identity and reading order are different lists, and only one of them may be reordered
-    // freely: `allCases` is pinned by the persisted raw values above.
-    XCTAssertEqual(
-      MemoryHubDestination.switcherOrder,
-      [.activity, .conversations, .memories, .brainMap]
-    )
+    // Storage identity, pinned: these raw values are persisted, so the enum may not be reordered.
+    // Reading order is a different list and lives with the control that presents it — see
+    // `ChatFirstDestinationParityTests.testTheActivityChipRowOffersEveryHubPageAndNothingElse`.
     XCTAssertEqual(MemoryHubDestination.activity.title, "Activity")
     XCTAssertEqual(MemoryHubDestination.memories.title, "Memories")
     XCTAssertEqual(MemoryHubDestination.conversations.title, "Conversations")
@@ -66,8 +63,9 @@ final class MemoryGraphRevisitTests: XCTestCase {
 
   /// The hover menu these three tests used to cover is gone, and so is
   /// `MemoryDropdownInteractionState` — its hover-generation machinery had no other caller. The
-  /// Memory hub's three destinations are now selected by the hub's own switcher; that contract is
-  /// held behaviorally by `MemoryHubSwitcherTests` and `TopNavigationBarLayoutTests`.
+  /// Memory hub's four destinations are now selected by Activity's chip row; that contract is held
+  /// by `ChatFirstDestinationParityTests.testTheActivityChipRowOffersEveryHubPageAndNothingElse`
+  /// and `TopNavigationBarLayoutTests`.
   func testTopNavigationUsesCompactPillSpacing() {
     XCTAssertEqual(TopNavigationPillMetrics.itemSpacing, 4)
     XCTAssertEqual(TopNavigationPillMetrics.horizontalPadding, 12)

--- a/desktop/macos/Desktop/Tests/MemoryHubSidebarRoutingTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryHubSidebarRoutingTests.swift
@@ -3,13 +3,13 @@ import XCTest
 @testable import Omi_Computer
 
 final class MemoryHubSidebarRoutingTests: XCTestCase {
-  /// The Activity spine — Home's former landing surface — is a hub destination, first in the
-  /// switcher row, and reachable like every other persisted hub view.
-  func testActivityIsAHubDestinationAndLeadsTheSwitcherRow() {
-    XCTAssertEqual(MemoryHubDestination.switcherOrder.first, .activity)
+  /// The Activity spine — Home's former landing surface — is a hub destination, the page the bar's
+  /// pill opens, and the chip that leads the row that reaches the rest.
+  func testActivityIsAHubDestinationAndLeadsTheChipRow() {
+    XCTAssertEqual(ActivityDestinationChip.allCases.first?.hubDestination, .activity)
     XCTAssertEqual(
-      Set(MemoryHubDestination.switcherOrder), Set(MemoryHubDestination.allCases),
-      "every destination is reachable from the switcher")
+      Set(ActivityDestinationChip.reachableHubDestinations), Set(MemoryHubDestination.allCases),
+      "every destination is reachable from Activity's chip row")
     XCTAssertEqual(
       MemoryHubDestination.destination(
         for: .conversations, requestedRawValue: MemoryHubDestination.activity.rawValue),

--- a/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
+++ b/desktop/macos/Desktop/Tests/PageGlassLaneTests.swift
@@ -46,19 +46,30 @@ final class PageGlassLaneTests: XCTestCase {
   /// than Chat and its two panels lost their separation. The hub's list pages paint no ground of
   /// their own and must keep the lane.
   func testOnlyTheActivityHubPageBringsItsOwnPanels() {
-    for hubIndex in [SidebarNavItem.conversations.rawValue, SidebarNavItem.memories.rawValue] {
-      XCTAssertTrue(
-        PageGlassLanePolicy.ownsItsPanels(
-          selectedIndex: hubIndex,
-          memoryDestinationRawValue: MemoryHubDestination.activity.rawValue),
-        "Activity builds Home's own two panels and must not be wrapped in a third")
+    let hubIndex = SidebarNavItem.conversations.rawValue
+    XCTAssertTrue(
+      PageGlassLanePolicy.ownsItsPanels(
+        selectedIndex: hubIndex,
+        memoryDestinationRawValue: MemoryHubDestination.activity.rawValue),
+      "Activity builds Home's own two panels and must not be wrapped in a third")
 
-      for destination in MemoryHubDestination.allCases where destination != .activity {
-        XCTAssertFalse(
-          PageGlassLanePolicy.ownsItsPanels(
-            selectedIndex: hubIndex, memoryDestinationRawValue: destination.rawValue),
-          "\(destination.title) paints no ground of its own and must be given the lane's")
-      }
+    for destination in MemoryHubDestination.allCases where destination != .activity {
+      XCTAssertFalse(
+        PageGlassLanePolicy.ownsItsPanels(
+          selectedIndex: hubIndex, memoryDestinationRawValue: destination.rawValue),
+        "\(destination.title) paints no ground of its own and must be given the lane's")
+    }
+
+    // **The standalone Memories page is not the hub.** `SidebarNavItem.memories` renders
+    // `MemoriesPage` directly in this shell, and nothing resets the persisted hub destination on
+    // the way there — so answering this question off that value stripped a page that paints no
+    // ground of its own and drew its rows onto the user's wallpaper.
+    for destination in MemoryHubDestination.allCases {
+      XCTAssertFalse(
+        PageGlassLanePolicy.ownsItsPanels(
+          selectedIndex: SidebarNavItem.memories.rawValue,
+          memoryDestinationRawValue: destination.rawValue),
+        "the standalone Memories page must keep the lane whatever the hub last showed")
     }
 
     // A caller that does not know which hub page is mounted keeps the wrap: the list pages are the

--- a/desktop/macos/Desktop/Tests/QueryShellTests.swift
+++ b/desktop/macos/Desktop/Tests/QueryShellTests.swift
@@ -490,8 +490,8 @@ final class QueryShellTests: XCTestCase {
     for route in QueryShellRoute.allCases {
       guard let hubView = route.memoryDestination else { continue }
       XCTAssertTrue(
-        MemoryHubDestination.switcherOrder.contains(hubView),
-        "\(route) selects a hub view the hub's own switcher does not show")
+        ActivityDestinationChip.reachableHubDestinations.contains(hubView),
+        "\(route) selects a hub view Activity's chip row has no chip for")
     }
   }
 

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -388,7 +388,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
       "without the gear there is no way into Settings, so the page behind it is stranded")
   }
 
-  func testLibraryPillReadsAsCurrentOnEveryHubView() {
+  func testTheActivityPillReadsAsCurrentOnEveryHubPage() {
     for destination in ShellDestination.allCases
     where destination.reach == .activityChipRow || destination == .activity {
       XCTAssertTrue(
@@ -399,9 +399,9 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     XCTAssertFalse(ShellDestination.isHubPage(selectedIndex: SidebarNavItem.apps.rawValue))
   }
 
-  /// The badge used to be one number on `Library` covering conversations, memories *and* tasks,
-  /// because Tasks lived inside the menu. Tasks has its own pill now, so a task counted on `Library`
-  /// would point at the wrong page.
+  /// The badge used to be one number on the hub's pill — then labelled `Library` — covering
+  /// conversations, memories *and* tasks, because Tasks lived inside the menu. Tasks has its own
+  /// pill now, so a task counted on the hub's pill would point at the wrong page.
   func testNewItemCountsAreCarriedByThePillThatOwnsThem() {
     let badges = TopNavigationDestinationBadges(library: 4, tasks: 7)
     XCTAssertEqual(badges.count(forNavItemIndex: SidebarNavItem.conversations.rawValue), 4)

--- a/desktop/macos/changelog/unreleased/20260822-activity-view-and-back.json
+++ b/desktop/macos/changelog/unreleased/20260822-activity-view-and-back.json
@@ -1,0 +1,3 @@
+{
+  "change": "Activity's row is now labelled View, carries only the pages it opens, and every page it opens — Conversations, Memories and Brain Map — has a back control to return to it."
+}

--- a/desktop/macos/e2e/flows/home-spine.yaml
+++ b/desktop/macos/e2e/flows/home-spine.yaml
@@ -76,7 +76,8 @@ steps:
     name: Starring a conversation writes through
     do: >-
       Hover a conversation row and click its star. The star fills immediately. Navigate to
-      Library → Conversations and confirm the same conversation is starred there.
+      Activity → Conversations (the Activity pill, then the Conversations chip in its row) and
+      confirm the same conversation is starred there.
 
   - id: S7
     name: Rows hand off to the page that owns them

--- a/desktop/macos/e2e/flows/home.yaml
+++ b/desktop/macos/e2e/flows/home.yaml
@@ -65,7 +65,7 @@ steps:
 
   - id: S4
     name: Reach the Brain Map from the panel's filter row
-    do: "In results mode, verify the panel header carries a 'Brain Map ›' control beside 'Filter ›' — in the header, not among the All / Conversations / Memories / Rewind chips, which only narrow the list in place. Click it and verify the app lands on the Library page with its Brain Map view selected (the hub's own switcher shows Brain Map as current). Press Escape to return Home."
+    do: "In results mode, verify the panel header carries a 'Brain Map ›' control beside 'Filter ›' — in the header, not among the All / Conversations / Memories / Rewind chips, which only narrow the list in place. Click it and verify the app lands on the hub's Brain Map page, and that the page carries the '‹ Activity' control (accessibility identifier activity-back-button) back to the spine. Press Escape to return Home."
     expect:
       text_visible:
         - Brain Map

--- a/desktop/macos/e2e/flows/memories.yaml
+++ b/desktop/macos/e2e/flows/memories.yaml
@@ -6,14 +6,15 @@ app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/OmiSupport/DesktopLocalProfile.swift
   - desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
-  # The hub page itself: it mounts the switcher S1/S3/S5/S6 press, branches to the three views, and
-  # resolves the Brain Map cohort S5 lands on. Extracted from `DesktopHomeView` — these steps walked
-  # it before it had its own file.
+  # The hub page itself: it branches to the four views S1/S2/S3/S5/S6 walk, carries the "‹ Activity"
+  # control back off three of them, and resolves the Brain Map cohort S5 lands on. Extracted from
+  # `DesktopHomeView` — these steps walked it before it had its own file.
   - desktop/macos/Desktop/Sources/MainWindow/MemoryHubPage.swift
-  # The Activity destination: the chronological spine that was Home's landing surface, first in the
-  # switcher row, with its own search bar and filter chips.
+  # The Activity destination: the chronological spine that was Home's landing surface and the page
+  # the bar's pill opens, with its own search bar and the chip row that reaches the other three.
   - desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityHubTab.swift
-  - desktop/macos/Desktop/Sources/MainWindow/Components/HubDestinationSwitcher.swift
+  - desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
   - desktop/macos/Desktop/Sources/MainWindow/Components/OmiSearchField.swift
   - desktop/macos/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
   # The Add/Edit forms, exercised by S2c. `memory-crud` writes straight to the view model, so these
@@ -43,20 +44,22 @@ preconditions:
 
 steps:
   - id: S1
-    name: Open the Memory hub and read its own switcher
-    # There is no `Memory` pill and no hover menu any more. The bar carries one `Library` pill, and
-    # the hub's three views are a switcher on the page itself — see `MemoryHubPage` /
-    # `MemoryHubSwitcher` and the note at the top of `TopNavigationDestinations`.
-    do: "Click the Library pill in the top bar (accessibility identifier top-navigation-1). Verify the hub page opens with its own switcher above the content, reading Conversations, Memories, Brain Map — on the page, not hanging off the bar, and with no hover needed to see them."
+    name: Open Activity and read its chip row
+    # There is no `Memory` pill, no hover menu and no hub switcher any more. The bar carries one
+    # `Activity` pill, and the hub's other three views are chips in Activity's own row — see
+    # `MemoryHubPage` / `ActivityDestinationChip` and the note at the top of
+    # `TopNavigationDestinations`.
+    do: "Click the Activity pill in the top bar (accessibility identifier top-navigation-1). Verify the Activity spine opens with one row of chips above the content, reading Activity, Conversations, Memories, Brain Map — on the page, not hanging off the bar, and with no hover needed to see them. Activity reads as the current chip, and there is no second look-alike chip row beneath it."
     expect:
       text_visible:
+        - Activity
         - Memories
         - Conversations
         - Brain Map
 
   - id: S2
     name: Select and verify Memories
-    do: "Choose Memories in the hub's switcher. Verify the full-width page shows the shared search field ('Search memories'), filter buttons ('This device', 'All'), Add button, and memory rows with timestamps."
+    do: "Choose Memories in Activity's chip row. Verify the full-width page shows the shared search field ('Search memories'), filter buttons ('This device', 'All'), Add button, and memory rows with timestamps."
     expect:
       interactive_count: { min: 4 }
 
@@ -79,7 +82,10 @@ steps:
 
   - id: S3
     name: Select Conversations
-    do: "Choose Conversations in the hub's switcher. Verify the full-width Conversations page loads with the shared search field, filters, and a list grouped by date."
+    # The chip row stayed behind on Activity, so getting from one sibling page to the next goes
+    # through the page's own "‹ Activity" control — that control is the only thing making these
+    # pages navigable from each other, so press it rather than the top-bar pill.
+    do: "Press the ‹ Activity control on the Memories page (accessibility identifier activity-back-button) and verify the spine and its chip row come back. Then choose Conversations in that row. Verify the full-width Conversations page loads with the shared search field, filters, and a list grouped by date."
     expect:
       text_visible:
         - Conversations
@@ -95,14 +101,14 @@ steps:
     # The hub resolves which of the two Brain Map surfaces this account gets, and must mount neither
     # until it knows: a one-frame appearance of the legacy graph latches the shared view model and
     # leaves the atlas permanently blank. Watch for the placeholder, not just the end state.
-    do: "Choose Brain Map in the hub's switcher. Verify that while the cohort is still resolving the page shows only a spinner (accessibility identifier brain_map_resolving_capability), and that exactly one surface then appears: an interactive node graph showing connected entities, or the canonical atlas."
+    do: "Press ‹ Activity on the Conversations page to return to the spine, then choose Brain Map in its chip row. Verify that while the cohort is still resolving the page shows only a spinner (accessibility identifier brain_map_resolving_capability), and that exactly one surface then appears: an interactive node graph showing connected entities, or the canonical atlas."
     expect:
       text_visible:
         - Brain Map
 
   - id: S6
     name: Return to Memories
-    do: "Choose Memories in the hub's switcher. Verify the memory list is visible with the shared search and filter controls."
+    do: "Press ‹ Activity on the Brain Map page to return to the spine, then choose Memories in its chip row. Verify the memory list is visible with the shared search and filter controls."
     expect:
       text_visible:
         - Memories

--- a/desktop/macos/e2e/flows/navigation.yaml
+++ b/desktop/macos/e2e/flows/navigation.yaml
@@ -1,7 +1,7 @@
 version: 2
 name: navigation
 tier: manual
-description: Top navigation bar smoke — the flat destination row (Home, Library, Tasks, Rewind, Apps), the Memory hub's own three-way switcher, the Settings gear and Rewind all reach their real pages with no menu and nothing opening on hover
+description: Top navigation bar smoke — the flat destination row (Home, Activity, Tasks, Rewind, Apps), Activity's navigating chip row into the hub's other three pages and the "‹ Activity" control back off each of them, the Settings gear and Rewind all reach their real pages with no menu and nothing opening on hover
 app: com.omi.computer-macos
 covers:
   - desktop/macos/Desktop/Sources/MainWindow/ShellClickThrough.swift
@@ -15,7 +15,7 @@ covers:
   - desktop/macos/Desktop/Sources/MainWindow/Pages/ConversationsDestinationView.swift
   - desktop/macos/Desktop/Sources/MainWindow/DesktopTopBar.swift
   - desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
-  - desktop/macos/Desktop/Sources/MainWindow/Components/HubDestinationSwitcher.swift
+  - desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
   - desktop/macos/Desktop/Sources/MainWindow/ShellWindowChrome.swift
   - desktop/macos/Desktop/Sources/MainWindow/ShellSummon.swift
   - desktop/macos/Desktop/Sources/MainWindow/ActiveDisplay.swift
@@ -29,34 +29,39 @@ preconditions:
 steps:
   - id: S1
     name: Verify Home tab loads
-    do: "Verify the app is on the search surface. The top bar shows the flat row of destinations — Home, Library, Tasks, Rewind, Apps — with nothing that opens a menu and no Omi mark duplicated out of the query bar; the right cluster is three wordless icons with state dots (microphone, screen capture, settings). Home content is a query bar above a separate results panel."
+    do: "Verify the app is on the search surface. The top bar shows the flat row of destinations — Home, Activity, Tasks, Rewind, Apps — with nothing that opens a menu and no Omi mark duplicated out of the query bar; the right cluster is three wordless icons with state dots (microphone, screen capture, settings). Home content is a query bar above a separate results panel."
     expect:
       interactive_count: { min: 8 }
       text_visible:
         - Home
-        - Library
+        - Activity
         - Tasks
         - Rewind
         - Apps
 
   - id: S2
-    name: Navigate to the Memory hub and move between its three views
+    name: Navigate to Activity and reach the hub's other three pages from its chip row
     do: >-
-      Click the Library button in the top nav bar (agent-swift find text 'Library' click).
-      Verify the Memory hub loads and that the hub's own switcher — Conversations,
-      Memories, Brain Map — is visible on the page itself, not in the top bar. Click
-      each of the three and confirm the page changes: the conversations list, the
-      memories list, then the Brain Map. No menu opens at any point, and nothing opens
-      on hover.
+      Click the Activity button in the top nav bar (agent-swift find text 'Activity' click).
+      Verify the Activity spine loads and that a single row of chips — Activity,
+      Conversations, Memories, Brain Map — sits on the page itself, not in the top bar,
+      with Activity shown as the current one. There is exactly one such row: no second
+      row of look-alike chips underneath it that narrows the list in place. Click each of
+      the other three in turn and confirm the page actually changes — the conversations
+      list, the memories list, then the Brain Map — and that each of those pages carries
+      a "‹ Activity" control on its leading edge (accessibility identifier
+      activity-back-button) that returns to the spine, with the chip row back with it. No
+      menu opens at any point, and nothing opens on hover.
     expect:
       text_visible:
+        - Activity
         - Memories
         - Conversations
         - Brain Map
 
   - id: S2a
     name: Return Home with Escape
-    do: "Press Escape while the Memory page is visible. Verify the app returns to Home and the top navigation bar remains visible."
+    do: "Press Escape while an Activity page is visible. Verify the app returns to Home and the top navigation bar remains visible."
     expect:
       text_visible:
         - Home
@@ -147,7 +152,7 @@ steps:
     expect:
       text_visible:
         - Home
-        - Library
+        - Activity
         - Tasks
         - Apps
 
@@ -167,6 +172,6 @@ steps:
     expect:
       text_visible:
         - Home
-        - Library
+        - Activity
         - Tasks
         - Apps


### PR DESCRIPTION
feat(desktop): Activity's row is a View, and every page it opens can get back

Follow-up to #12042, which shipped the Activity spine, its navigating chip row and
the summary sections. Three things that PR left wrong, plus the five defects an
independent review found in it.

**The row's header called itself `Filter`.** Its chips open pages; nothing about them
narrows a list. The word now follows the behaviour rather than the surface — Home's
search results still say `Filter`, because there the chips genuinely do filter in place,
and `QueryPanelChipBehavior` is what decides. It was hoisted out of the generic panel so
a test can assert the two cases without naming three view types.

**`Tasks` and `Rewind` were in the row.** Both already have their own pill in the bar
two inches above; a second control to the same place is not a shortcut. The row is now
exactly the hub's four pages, and a test pins that — it is the reachability mechanism,
so a page dropped from it must fail a test rather than quietly become unreachable.

**The row is a one-way door.** It lives on Activity's panel and does not travel, so
opening Conversations, Memories or Brain Map left no way back except knowing the top-bar
pill was the answer. Each of those pages, and the chat-first Conversations route that
mounts its own host, now carries a `‹ Activity` control that names where it goes.

Review findings fixed:

- **The standalone Memories page lost its glass.** #12042's `PageGlassLane` rule keyed
  panel-ownership on `.conversations` *and* `.memories`; only the first is the hub. In the
  modern shell `SidebarNavItem.memories` renders a standalone `MemoriesPage` that paints
  no ground, so pressing `Activity` and then reaching Memories by a route that does not
  reset the persisted destination drew its rows onto the wallpaper. The test added with it
  asserted the wrong claim for that index and locked it in; it now asserts the opposite.
- **`SummarySection.id` was the heading.** Model-written blocks repeat headings and may
  have none, and duplicate `ForEach` ids make SwiftUI drop or duplicate rows.
- **Desktop and mobile disagreed on provenance.** Flutter suppresses `sections` when a
  summarization app produced the summary; desktop rendered them anyway, stacking a second
  unattributed Omi summary under the app's. Desktop now matches.
- **Flutter: an empty-content app result hid the sections and reported "no summary."**
  `getSummarizedApp()` returned `appResults[0]` without checking it carried anything.
- **Flutter: one malformed section killed the whole conversation decode.** The sections
  loop threw where the `actionItems` and `events` loops beside it tolerate bad entries.

Also: `ActivityDestinationChip.hubDestination` is non-optional, so "every chip opens a hub
page" is a compiler guarantee; the orphaned `MemoryHubDestination.switcherOrder` is gone
with four tests that had become assertions about nothing; and four e2e flows plus several
doc comments stop describing the deleted switcher and the retired `Library` pill.

Verified: `scripts/swift-test-suites.sh` — 665 suites in isolation, 0 failures.
`app/test.sh` — 1421 passed, 5 skipped, 0 failures, each Flutter fix confirmed to fail
without it. `check-e2e-flow-coverage.py --strict` — exit 0. Clicked through a real signed
build for the `View` header, the four-chip row, and `‹ Activity` on Conversations and
Brain Map.

INV-NAV-1
INV-UI-1

Failure-Class: FC-mirrored-model-omits-new-member

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

## Known-red, not caused by this PR

`tests/test-desktop-core-harness-readiness-teardown.sh` fails on a pristine upstream/main
checkout with a clean tree — verified in a separate worktree at d6b9e35775. It shells out
to `make dev-up` and is state-dependent locally. Separately,
`RewindCaptureExclusionGenerationTests.testOwnerSnapshotStaysCurrentWhenAuthLeadsUnresolvedRewindDatabase`
fails at that same pristine baseline: it reads `auth_userId` out of the real machine's
`UserDefaults`, so it is non-hermetic and depends on who is signed in. It passes under the
per-suite isolation `test.sh` and CI use. Both predate this change and neither touches any
symbol in it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

