### PR TITLE
feat(desktop): rename the Activity destination to Brain

### DIFF
--- a/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/ChatFirst/ChatFirstShell.swift
@@ -266,7 +266,7 @@ struct ChatFirstShell: View {
         }
         switch route {
         case .conversations:
-          // The hub's one pill says `Activity`, so it opens Activity — not whichever hub view
+          // The hub's one pill says `Brain`, so it opens the Brain spine — not whichever hub view
           // happened to be persisted last, and not the Conversations route this index maps back
           // from. Routing through the same writer the chip row uses keeps one path responsible for
           // moving both halves of the state.

--- a/desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/Components/ActivityBackButton.swift
@@ -1,8 +1,8 @@
 //
-//  ActivityBackButton.swift — the way back from a page Activity's chip row opened.
+//  ActivityBackButton.swift — the way back from a page the Brain chip row opened.
 //
-//  The chip row is a one-way door: pressing `Memories` leaves Activity, and the row goes with it,
-//  because the row lives on Activity's panel. The top-bar `Activity` pill does come back, but a pill
+//  The chip row is a one-way door: pressing `Memories` leaves Brain, and the row goes with it,
+//  because the row lives on Brain's panel. The top-bar `Brain` pill does come back, but a pill
 //  in the window's chrome is a different gesture from the control that brought you here — you have
 //  to know the pill is the answer, and nothing on the page says so.
 //
@@ -15,7 +15,7 @@
 import OmiTheme
 import SwiftUI
 
-/// A back control that returns to the Activity spine.
+/// A back control that returns to the Brain spine.
 struct ActivityBackButton: View {
   let action: () -> Void
 
@@ -26,7 +26,7 @@ struct ActivityBackButton: View {
       HStack(spacing: 5) {
         Image(systemName: "chevron.left")
           .scaledFont(size: OmiType.micro, weight: .semibold)
-        Text("Activity")
+        Text("Brain")
           .scaledFont(size: OmiType.caption, weight: .semibold)
       }
       .foregroundStyle(GlassShell.controlLabel(isProminent: isHovering))
@@ -36,8 +36,8 @@ struct ActivityBackButton: View {
     }
     .buttonStyle(.plain)
     .onHover { isHovering = $0 }
-    .help("Back to Activity")
-    .accessibilityLabel("Back to Activity")
+    .help("Back to Brain")
+    .accessibilityLabel("Back to Brain")
     .accessibilityIdentifier("activity-back-button")
   }
 }

--- a/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/MemoryHubDestination.swift
@@ -27,7 +27,7 @@ enum MemoryHubDestination: Int, CaseIterable, Identifiable {
     case .memories: return "Memories"
     case .conversations: return "Conversations"
     case .brainMap: return "Brain Map"
-    case .activity: return "Activity"
+    case .activity: return "Brain"
     }
   }
 

--- a/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/QueryShell/ActivityDestinationChip.swift
@@ -31,7 +31,7 @@ enum ActivityDestinationChip: String, CaseIterable, Identifiable {
 
   var title: String {
     switch self {
-    case .activity: return "Activity"
+    case .activity: return "Brain"
     case .conversations: return "Conversations"
     case .memories: return "Memories"
     case .brainMap: return "Brain Map"

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -226,7 +226,7 @@ enum TopNavigationRoutes {
     // page's own chip row, which is the mechanism `ShellDestination.reach` records for them.
     // The glyph is deliberately not `clock.arrow.circlepath`: that is Rewind's, two pills away.
     TopNavigationItem(
-      index: SidebarNavItem.conversations.rawValue, title: "Brain", icon: "square.stack",
+      index: SidebarNavItem.conversations.rawValue, title: "Brain", icon: "brain",
       tooltip: "Brain — everything Omi captured, newest first"),
     TopNavigationItem(
       index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist",

--- a/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
+++ b/desktop/macos/Desktop/Sources/MainWindow/TopNavigationDestinations.swift
@@ -11,9 +11,9 @@
 //
 //  - **Three of them are one page.** Conversations, Memories and Brain Map are three of the Memory
 //    hub's four views (`MemoryHubDestination`). The bar was carrying a page's internal tabs, which is
-//    why it needed a menu to hold them. The bar keeps one pill, `Activity`, which opens the hub's
+//    why it needed a menu to hold them. The bar keeps one pill, `Brain`, which opens the hub's
 //    fourth view — the chronological spine — and the other three are chips in that page's own
-//    navigating row (`ActivityDestinationChip`), with a `‹ Activity` control on each of them for the
+//    navigating row (`ActivityDestinationChip`), with a `‹ Brain` control on each of them for the
 //    way back (`ActivityBackButton`).
 //  - **The rest are genuinely separate views**, so they are flat pills: `Tasks`, `Rewind`, `Apps`.
 //    Always visible, one click, no disclosure, no hover.
@@ -102,7 +102,7 @@ enum ShellDestination: Int, CaseIterable, Identifiable {
     case .rewind: return "Rewind"
     case .apps: return "Apps"
     case .permissions: return "Permissions"
-    case .activity: return "Activity"
+    case .activity: return "Brain"
     }
   }
 
@@ -221,13 +221,13 @@ enum TopNavigationRoutes {
       tooltip: "Chat — talk to Omi about everything you've seen and heard"),
     // The hub's pill names the view it opens. It used to say `Memories` while opening whichever hub
     // view was last persisted, so the word on the bar and the page you landed on were only
-    // sometimes the same thing. It opens `Activity` — the chronological spine over everything
+    // sometimes the same thing. It opens `Brain` — the chronological spine over everything
     // captured — and says so; Conversations, Memories and Brain Map stay one click away in that
     // page's own chip row, which is the mechanism `ShellDestination.reach` records for them.
     // The glyph is deliberately not `clock.arrow.circlepath`: that is Rewind's, two pills away.
     TopNavigationItem(
-      index: SidebarNavItem.conversations.rawValue, title: "Activity", icon: "square.stack",
-      tooltip: "Activity — everything Omi captured, newest first"),
+      index: SidebarNavItem.conversations.rawValue, title: "Brain", icon: "square.stack",
+      tooltip: "Brain — everything Omi captured, newest first"),
     TopNavigationItem(
       index: SidebarNavItem.tasks.rawValue, title: "Tasks", icon: "checklist",
       tooltip: "Tasks — everything Omi heard you commit to"),

--- a/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
+++ b/desktop/macos/Desktop/Tests/ChatFirstDestinationParityTests.swift
@@ -66,7 +66,7 @@ final class ChatFirstDestinationParityTests: XCTestCase {
   func testTheActivityChipRowOffersEveryHubPageAndNothingElse() {
     XCTAssertEqual(
       ActivityDestinationChip.allCases.map(\.title),
-      ["Activity", "Conversations", "Memories", "Brain Map"])
+      ["Brain", "Conversations", "Memories", "Brain Map"])
 
     XCTAssertEqual(
       Set(ActivityDestinationChip.reachableHubDestinations), Set(MemoryHubDestination.allCases),

--- a/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
+++ b/desktop/macos/Desktop/Tests/MemoryGraphRevisitTests.swift
@@ -42,7 +42,7 @@ final class MemoryGraphRevisitTests: XCTestCase {
     // Storage identity, pinned: these raw values are persisted, so the enum may not be reordered.
     // Reading order is a different list and lives with the control that presents it — see
     // `ChatFirstDestinationParityTests.testTheActivityChipRowOffersEveryHubPageAndNothingElse`.
-    XCTAssertEqual(MemoryHubDestination.activity.title, "Activity")
+    XCTAssertEqual(MemoryHubDestination.activity.title, "Brain")
     XCTAssertEqual(MemoryHubDestination.memories.title, "Memories")
     XCTAssertEqual(MemoryHubDestination.conversations.title, "Conversations")
     XCTAssertEqual(MemoryHubDestination.brainMap.title, "Brain Map")

--- a/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
+++ b/desktop/macos/Desktop/Tests/TopNavigationBarLayoutTests.swift
@@ -200,7 +200,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     let hubPill = TopNavigationRoutes.primaryItems.first {
       $0.index == SidebarNavItem.conversations.rawValue
     }
-    XCTAssertEqual(hubPill?.title, "Activity")
+    XCTAssertEqual(hubPill?.title, "Brain")
     XCTAssertNotEqual(
       hubPill?.icon, "clock.arrow.circlepath",
       "the hub pill must not wear Rewind's glyph two pills away from Rewind")
@@ -393,7 +393,7 @@ final class TopNavigationBarLayoutTests: XCTestCase {
     where destination.reach == .activityChipRow || destination == .activity {
       XCTAssertTrue(
         ShellDestination.isHubPage(selectedIndex: destination.navItem.rawValue),
-        "\(destination.title) must light the Activity pill")
+        "\(destination.title) must light the Brain pill")
     }
     XCTAssertFalse(ShellDestination.isHubPage(selectedIndex: SidebarNavItem.dashboard.rawValue))
     XCTAssertFalse(ShellDestination.isHubPage(selectedIndex: SidebarNavItem.apps.rawValue))

--- a/desktop/macos/changelog/unreleased/20260822-rename-activity-to-brain.json
+++ b/desktop/macos/changelog/unreleased/20260822-rename-activity-to-brain.json
@@ -1,0 +1,3 @@
+{
+  "change": "Renamed the Activity tab to Brain"
+}


### PR DESCRIPTION
## What

Renames the desktop main-menu destination `Activity` to `Brain`. The bar pill, the spine's own chip row and the Memory hub destination all carried the same word, so all three move together — a pill that says `Brain` opening a page whose current chip says `Activity` is exactly the bar/page mismatch the pill's note argues against.

Bar now reads: `Chat · Brain · Tasks · Rewind · Apps`.

## Product invariants

- **INV-NAV-1** — unchanged. Only the label moves: `ShellDestination.activity` keeps `reach == .topBar`, the chip row still reaches Conversations, Memories and Brain Map, and `ShellDestination.unreachable()` stays empty (asserted by the tests below).

## Verification

Built and ran the real app as a named bundle, then exercised the pill through the accessibility bridge (no compile-only claim):

```
OMI_APP_NAME=omi-brain-tab ./run.sh --yolo
agent-swift find identifier "top-navigation-1" press   # Brain
agent-swift find identifier "top-navigation-0" press   # Chat
agent-swift find identifier "top-navigation-1" press   # Brain again
omi-ctl action capture_main_window_png ...
```

- Captured main window after each press: the bar reads `Chat | Brain | Tasks | Rewind | Apps`, the `Brain` pill lights when the hub is on screen, and the spine's first chip reads `Brain` (`Brain | Conversations | Memories | Brain Map | Tasks | Rewind`).
- Repeat presses (2nd and 3rd) land on the same page with the same labels — no first-run-only behavior.

```
swift test --filter 'TopNavigationBarLayoutTests|MemoryGraphRevisitTests|ChatFirstDestinationParityTests'
→ Executed 32 tests, with 0 failures
```

The layout test that measures the real pills at the narrowest window still passes; `Brain` is narrower than `Activity`, so the flat row keeps its fit without the compact fallback.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

