### PR TITLE
perf(backend): cut Firestore read amplification on action items, exports, and photos

### DIFF
--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -9,6 +9,12 @@ from google.cloud.firestore_v1 import FieldFilter
 
 from database.firestore_transaction_retry import run_with_transaction_contention_retry
 from database.firestore_read_metrics import FirestoreReadFamily, FirestoreReadMode, record_firestore_read
+from database.firestore_index_registry import (
+    ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
+    ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
+    ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY,
+    ACTION_ITEMS_CREATED_RANGE_QUERY,
+)
 from ._client import db, get_firestore_client
 from utils.other.list_budget import ListReadBudget, ListReadBudgetExhausted
 
@@ -19,6 +25,7 @@ logger = logging.getLogger(__name__)
 action_items_collection = 'action_items'
 TASK_INTELLIGENCE_CONTROL_COLLECTION = 'task_intelligence_control'
 TASK_INTELLIGENCE_CONTROL_DOCUMENT = 'state'
+_ACTION_ITEM_SCAN_PAGE_SIZE = 500
 
 
 class TaskRelationshipConflictError(ValueError):
@@ -101,12 +108,28 @@ class BatchMutationResult:
         }
 
 
-def get_action_item_ids(uid: str) -> List[str]:
+def _iter_query_pages(query: Any, *, page_size: int = _ACTION_ITEM_SCAN_PAGE_SIZE) -> Iterable[Any]:
+    """Yield a complete query result through bounded snapshot-cursor pages."""
+    cursor = None
+    while True:
+        page_query = query.limit(page_size)
+        if cursor is not None:
+            page_query = page_query.start_after(cursor)
+        page = list(page_query.stream())
+        yield from page
+        if len(page) < page_size:
+            return
+        cursor = page[-1]
+
+
+def get_action_item_ids(uid: str, *, firestore_client: Any = None) -> List[str]:
     """Return all action item document IDs for a user (IDs-only projection, no field reads).
 
     Used for bulk operations like account deletion (e.g. to purge derived Pinecone vectors)."""
-    coll = db.collection('users').document(uid).collection(action_items_collection)
-    return [doc.id for doc in coll.select([]).stream()]
+    client = firestore_client or get_firestore_client()
+    coll = client.collection('users').document(uid).collection(action_items_collection)
+    query = coll.select([]).order_by('__name__')
+    return [doc.id for doc in _iter_query_pages(query)]
 
 
 def get_visible_action_item_ids(
@@ -135,10 +158,14 @@ def get_visible_action_item_ids(
     """
     client = firestore_client or get_firestore_client()
     coll = client.collection('users').document(uid).collection(action_items_collection)
-    query = coll.select(['completed', 'deleted']).where(filter=FieldFilter('completed', '==', completed))
+    query = ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY.build(
+        coll.select(['completed', 'deleted']),
+        {'completed': completed},
+        field_filter_factory=FieldFilter,
+    ).order_by('__name__')
     visible_ids: List[str] = []
     doc_count = 0
-    for doc in query.stream():
+    for doc in _iter_query_pages(query):
         doc_count += 1
         data = _typed_doc(doc)
         if data.get('deleted'):
@@ -146,7 +173,7 @@ def get_visible_action_item_ids(
         visible_ids.append(doc.id)
     record_firestore_read(
         FirestoreReadFamily.ACTION_ITEMS_VISIBLE_IDS,
-        FirestoreReadMode.UNBOUNDED,
+        FirestoreReadMode.BOUNDED,
         doc_count,
     )
     return visible_ids
@@ -750,9 +777,13 @@ def get_active_action_item_by_description(uid: str, description: str) -> Optiona
         return None
 
     user_ref = db.collection('users').document(uid)
-    query = user_ref.collection(action_items_collection).where(filter=FieldFilter('completed', '==', False))
+    query = ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY.build(
+        user_ref.collection(action_items_collection),
+        {'completed': False},
+        field_filter_factory=FieldFilter,
+    ).order_by('__name__')
 
-    for doc in query.stream():
+    for doc in _iter_query_pages(query):
         data: Dict[str, Any] = _typed_doc(doc)
         if data.get('deleted'):
             continue
@@ -1256,7 +1287,7 @@ def get_daily_score(uid: str, date: Optional[str] = None) -> Dict[str, Any]:
     return {'date': day.strftime('%Y-%m-%d'), 'score': score, 'completed_tasks': completed, 'total_tasks': total}
 
 
-def get_scores(uid: str, date: Optional[str] = None) -> Dict[str, Any]:
+def get_scores(uid: str, date: Optional[str] = None, *, firestore_client: Any = None) -> Dict[str, Any]:
     """Compute daily, weekly, and overall scores (matching Rust backend behavior).
 
     Takes a single date (or defaults to today) and returns:
@@ -1276,44 +1307,73 @@ def get_scores(uid: str, date: Optional[str] = None) -> Dict[str, Any]:
     # day-7 spanned 8 calendar days and over-counted the weekly totals.
     week_start = day - timedelta(days=6)
 
-    col = db.collection('users').document(uid).collection(action_items_collection)
+    client = firestore_client or get_firestore_client()
+    col = client.collection('users').document(uid).collection(action_items_collection)
 
     def _score(completed: int, total: int) -> float:
         return round((completed / total * 100) if total > 0 else 0, 1)
 
+    def _count(query: Any) -> int:
+        return int(query.count().get()[0][0].value)
+
+    # Count aggregation reads scale per 1,000 index entries instead of materializing
+    # every task document. Soft-deleted rows are rare and cannot be excluded with a
+    # Firestore equality predicate without also dropping legacy rows where ``deleted``
+    # is absent, so read only that small subset once and subtract it below.
+    deleted_items = [
+        _typed_doc(doc)
+        for doc in _iter_query_pages(col.where(filter=FieldFilter('deleted', '==', True)).order_by('__name__'))
+    ]
+
     # Daily: tasks due today
     daily_q = col.where(filter=FieldFilter('due_at', '>=', day_start)).where(filter=FieldFilter('due_at', '<', day_end))
-    daily_completed = daily_total = 0
-    for doc in daily_q.stream():
-        data: Dict[str, Any] = _typed_doc(doc)
-        if data.get('deleted'):
-            continue
-        daily_total += 1
-        if data.get('completed'):
-            daily_completed += 1
+    daily_total = _count(daily_q)
+    daily_completed = _count(
+        ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY.build(
+            col,
+            {'start': day_start, 'end': day_end, 'completed': True},
+            field_filter_factory=FieldFilter,
+        )
+    )
 
     # Weekly: tasks created in last 7 days (matches Rust backend which uses created_at)
-    weekly_q = col.where(filter=FieldFilter('created_at', '>=', week_start)).where(
-        filter=FieldFilter('created_at', '<', day_end)
+    weekly_q = ACTION_ITEMS_CREATED_RANGE_QUERY.build(
+        col,
+        {'start': week_start, 'end': day_end},
+        field_filter_factory=FieldFilter,
     )
-    weekly_completed = weekly_total = 0
-    for doc in weekly_q.stream():
-        data = _typed_doc(doc)
-        if data.get('deleted'):
-            continue
-        weekly_total += 1
-        if data.get('completed'):
-            weekly_completed += 1
+    weekly_total = _count(weekly_q)
+    weekly_completed = _count(
+        ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY.build(
+            col,
+            {'start': week_start, 'end': day_end, 'completed': True},
+            field_filter_factory=FieldFilter,
+        )
+    )
 
     # Overall: all non-deleted tasks
-    overall_completed = overall_total = 0
-    for doc in col.stream():
-        data = _typed_doc(doc)
-        if data.get('deleted'):
-            continue
-        overall_total += 1
-        if data.get('completed'):
-            overall_completed += 1
+    overall_total = _count(col)
+    overall_completed = _count(col.where(filter=FieldFilter('completed', '==', True)))
+
+    for data in deleted_items:
+        completed = data.get('completed') is True
+        due_at = data.get('due_at')
+        if isinstance(due_at, datetime) and day_start <= due_at < day_end:
+            daily_total -= 1
+            daily_completed -= int(completed)
+        created_at = data.get('created_at')
+        if isinstance(created_at, datetime) and week_start <= created_at < day_end:
+            weekly_total -= 1
+            weekly_completed -= int(completed)
+        overall_total -= 1
+        overall_completed -= int(completed)
+
+    daily_total = max(0, daily_total)
+    daily_completed = max(0, daily_completed)
+    weekly_total = max(0, weekly_total)
+    weekly_completed = max(0, weekly_completed)
+    overall_total = max(0, overall_total)
+    overall_completed = max(0, overall_completed)
 
     daily: Dict[str, Any] = {
         'score': _score(daily_completed, daily_total),

--- a/backend/database/chat.py
+++ b/backend/database/chat.py
@@ -174,7 +174,7 @@ def add_summary_message(text: str, uid: str) -> Message:
 
 @prepare_for_read(decrypt_func=_prepare_message_for_read)
 def get_app_messages(
-    uid: str, app_id: str, limit: int = 20, offset: int = 0, include_conversations: bool = False
+    uid: str, app_id: str, limit: int = 20, include_conversations: bool = False
 ) -> List[Dict[str, Any]]:
     user_ref = db.collection('users').document(uid)
     messages_ref = (
@@ -182,7 +182,6 @@ def get_app_messages(
         .where(filter=FieldFilter('plugin_id', '==', app_id))
         .order_by('created_at', direction=firestore.Query.DESCENDING)
         .limit(limit)
-        .offset(offset)
     )
     messages: List[Dict[str, Any]] = []
     conversations_id: set[str] = set()
@@ -461,19 +460,22 @@ def iter_all_messages(uid: str, batch_size: int = 1000) -> Iterator[Dict[str, An
     """Yield all chat messages for a user, decrypted, in batches. Used for streaming data export."""
     user_ref = db.collection('users').document(uid)
     msgs_ref = user_ref.collection('messages').order_by('created_at', direction=firestore.Query.DESCENDING)
-    offset = 0
+    cursor = None
     while True:
-        batch_ref = msgs_ref.limit(batch_size).offset(offset)
+        batch_ref = msgs_ref.limit(batch_size)
+        if cursor is not None:
+            batch_ref = batch_ref.start_after(cursor)
         batch: List[Dict[str, Any]] = []
-        for doc in batch_ref.stream():
+        snapshots = list(batch_ref.stream())
+        for doc in snapshots:
             msg: Dict[str, Any] = _typed_doc(doc)
             msg['id'] = doc.id
             msg = _prepare_message_for_read(msg, uid) or msg
             batch.append(msg)
         yield from batch
-        if len(batch) < batch_size:
+        if len(snapshots) < batch_size:
             break
-        offset += batch_size
+        cursor = snapshots[-1]
 
 
 def get_message(uid: str, message_id: str) -> tuple[Message, str] | None:

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -404,6 +404,7 @@ def upsert_conversation_with_lifecycle(uid: str, conversation_data: dict):
             transaction.set(conversation_ref, write_data, merge=True)
             return
 
+        write_data.setdefault('has_photos', False)
         transaction.set(conversation_ref, write_data)
 
     _write_processing_result(transaction)
@@ -494,6 +495,7 @@ def create_conversation_if_absent_with_lifecycle(uid: str, conversation_data: di
         del conversation_data['audio_base64_url']
     if 'photos' in conversation_data:
         del conversation_data['photos']
+    conversation_data.setdefault('has_photos', False)
 
     user_ref = db.collection('users').document(uid)
     conversation_ref = user_ref.collection(conversations_collection).document(conversation_data['id'])
@@ -748,18 +750,21 @@ def iter_all_conversations(uid: str, batch_size: int = 400, include_discarded: b
     if not include_discarded:
         conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
     conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
-    offset = 0
+    cursor = None
     while True:
-        batch_ref = conversations_ref.limit(batch_size).offset(offset)
+        batch_ref = conversations_ref.limit(batch_size)
+        if cursor is not None:
+            batch_ref = batch_ref.start_after(cursor)
         batch = []
-        for doc in batch_ref.stream():
+        snapshots = list(batch_ref.stream())
+        for doc in snapshots:
             conv = doc.to_dict()
             conv = _prepare_conversation_for_read(conv, uid) or conv
             batch.append(conv)
         yield from batch
-        if len(batch) < batch_size:
+        if len(snapshots) < batch_size:
             break
-        offset += batch_size
+        cursor = snapshots[-1]
 
 
 def update_conversation(uid: str, conversation_id: str, update_data: dict) -> bool:
@@ -1818,7 +1823,7 @@ def store_conversation_photos(
             data = photo.model_dump()
             data['id'] = photo_id
             transaction.set(photo_ref, _prepare_photo_for_write(data, uid, level))
-        transaction.update(conversation_ref, {'has_content': True})
+        transaction.update(conversation_ref, {'has_content': True, 'has_photos': True})
         return True
 
     return _store(transaction)

--- a/backend/database/firestore_index_registry.py
+++ b/backend/database/firestore_index_registry.py
@@ -193,6 +193,12 @@ INDEX_ONLY_REQUIREMENTS = (
         (_asc('completed'), _asc('due_at'), _asc('__name__')),
     ),
     FirestoreIndexRequirement(
+        'action_items_completed_created',
+        'action_items',
+        'COLLECTION',
+        (_asc('completed'), _asc('created_at'), _asc('__name__')),
+    ),
+    FirestoreIndexRequirement(
         'action_items_conversation_due',
         'action_items',
         'COLLECTION',
@@ -612,6 +618,49 @@ STALE_IN_PROGRESS_CONVERSATIONS_QUERY = FirestoreQuerySpec(
     ),
 )
 
+ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY = FirestoreQuerySpec(
+    identifier='action_items_completion_id_scan',
+    collection_group='action_items',
+    query_scope='COLLECTION',
+    filters=(FirestoreQueryFilter('completed', '==', 'completed'),),
+    index_fields=(_asc('completed'), _asc('__name__')),
+)
+
+ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY = FirestoreQuerySpec(
+    identifier='action_items_completed_due_range',
+    collection_group='action_items',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('due_at', '>=', 'start'),
+        FirestoreQueryFilter('due_at', '<', 'end'),
+        FirestoreQueryFilter('completed', '==', 'completed'),
+    ),
+    index_fields=(_asc('completed'), _asc('due_at'), _asc('__name__')),
+)
+
+ACTION_ITEMS_CREATED_RANGE_QUERY = FirestoreQuerySpec(
+    identifier='action_items_created_range',
+    collection_group='action_items',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('created_at', '>=', 'start'),
+        FirestoreQueryFilter('created_at', '<', 'end'),
+    ),
+    index_fields=(_asc('created_at'), _asc('__name__')),
+)
+
+ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY = FirestoreQuerySpec(
+    identifier='action_items_completed_created_range',
+    collection_group='action_items',
+    query_scope='COLLECTION',
+    filters=(
+        FirestoreQueryFilter('created_at', '>=', 'start'),
+        FirestoreQueryFilter('created_at', '<', 'end'),
+        FirestoreQueryFilter('completed', '==', 'completed'),
+    ),
+    index_fields=(_asc('completed'), _asc('created_at'), _asc('__name__')),
+)
+
 CHAT_FIRST_DEFERRALS_DUE_QUERY = FirestoreQuerySpec(
     identifier='chat_first_deferrals_due',
     collection_group='chat_first_deferrals',
@@ -696,6 +745,10 @@ HOURLY_USAGE_PLAN_ATTRIBUTION_QUERY = FirestoreQuerySpec(
 )
 
 QUERY_SPECS = (
+    ACTION_ITEMS_COMPLETION_ID_SCAN_QUERY,
+    ACTION_ITEMS_COMPLETED_DUE_RANGE_QUERY,
+    ACTION_ITEMS_CREATED_RANGE_QUERY,
+    ACTION_ITEMS_COMPLETED_CREATED_RANGE_QUERY,
     CANDIDATES_COMPATIBILITY_QUERY,
     DUE_MEMORY_OUTBOX_QUERY,
     EXPIRED_MEMORY_OUTBOX_LEASE_QUERY,

--- a/backend/database/helpers.py
+++ b/backend/database/helpers.py
@@ -279,6 +279,14 @@ def with_photos(photos_getter: Callable[..., Any]) -> Callable[[F], F]:
                 if data_dict.get('photos'):
                     return data_dict
 
+                # New conversation documents carry an authoritative marker maintained
+                # transactionally with photo writes. Avoid an empty subcollection query
+                # for the overwhelmingly common no-photo case. Legacy documents omit the
+                # marker and deliberately keep the lookup so their response cannot change.
+                if data_dict.get('has_photos') is False:
+                    data_dict['photos'] = []
+                    return data_dict
+
                 conversation_id = data_dict['id']
                 photos = photos_getter(uid=uid, conversation_id=conversation_id)
                 data_dict['photos'] = photos

--- a/backend/tests/unit/test_action_item_ids_endpoint.py
+++ b/backend/tests/unit/test_action_item_ids_endpoint.py
@@ -42,6 +42,10 @@ class _Query:
         self.docs = docs
         self.projected_fields = None
         self.applied_filters = []
+        self.page_limit = None
+        self.cursor = None
+        self.page_sizes = []
+        self.start_after_calls = []
 
     def select(self, fields):
         self.projected_fields = fields
@@ -49,6 +53,19 @@ class _Query:
 
     def where(self, filter):
         self.applied_filters.append((filter.field_path, filter.op_string, filter.value))
+        return self
+
+    def order_by(self, field):
+        assert field == '__name__'
+        return self
+
+    def limit(self, value):
+        self.page_limit = value
+        return self
+
+    def start_after(self, cursor):
+        self.cursor = cursor
+        self.start_after_calls.append(cursor.id)
         return self
 
     def stream(self):
@@ -64,7 +81,12 @@ class _Query:
                 and type(doc._data[field_path]) is type(value)
                 and doc._data[field_path] == value
             ]
-        return filtered
+        if self.cursor is not None:
+            cursor_index = next(index for index, doc in enumerate(filtered) if doc.id == self.cursor.id)
+            filtered = filtered[cursor_index + 1 :]
+        page = filtered[: self.page_limit]
+        self.page_sizes.append(len(page))
+        return page
 
 
 class _CollectionPath:
@@ -186,12 +208,46 @@ def test_visible_action_item_ids_records_firestore_read():
         ]
     )
 
-    before = FIRESTORE_READ_OPERATIONS.labels(family='action_items_visible_ids', mode='unbounded')._value.get()
+    before = FIRESTORE_READ_OPERATIONS.labels(family='action_items_visible_ids', mode='bounded')._value.get()
 
     action_items_db.get_visible_action_item_ids('user-9', completed=False, firestore_client=client)
 
-    after = FIRESTORE_READ_OPERATIONS.labels(family='action_items_visible_ids', mode='unbounded')._value.get()
+    after = FIRESTORE_READ_OPERATIONS.labels(family='action_items_visible_ids', mode='bounded')._value.get()
     assert after == before + 1
+
+
+def test_visible_action_item_ids_uses_bounded_cursor_pages():
+    client = _Firestore([_Doc(f'task-{index:04d}', {'completed': False}) for index in range(501)])
+
+    ids = action_items_db.get_visible_action_item_ids('user-9', completed=False, firestore_client=client)
+
+    assert len(ids) == 501
+    assert client.query.page_sizes == [500, 1]
+    assert client.query.start_after_calls == ['task-0499']
+
+
+def test_all_action_item_ids_uses_bounded_cursor_pages():
+    client = _Firestore([_Doc(f'task-{index:04d}', {}) for index in range(501)])
+
+    ids = action_items_db.get_action_item_ids('user-9', firestore_client=client)
+
+    assert len(ids) == 501
+    assert client.query.projected_fields == []
+    assert client.query.page_sizes == [500, 1]
+    assert client.query.start_after_calls == ['task-0499']
+
+
+def test_active_description_lookup_continues_after_first_bounded_page(monkeypatch):
+    docs = [_Doc(f'task-{index:04d}', {'completed': False, 'description': 'other'}) for index in range(500)]
+    docs.append(_Doc('task-0500', {'completed': False, 'description': 'Target'}))
+    client = _Firestore(docs)
+    monkeypatch.setattr(action_items_db, 'db', client)
+
+    result = action_items_db.get_active_action_item_by_description('user-9', 'target')
+
+    assert result['id'] == 'task-0500'
+    assert client.query.page_sizes == [500, 1]
+    assert client.query.start_after_calls == ['task-0499']
 
 
 def test_batch_delete_rejects_locked_items_before_any_delete(monkeypatch):

--- a/backend/tests/unit/test_conversation_revision_contract.py
+++ b/backend/tests/unit/test_conversation_revision_contract.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 import database.conversations as conversations_db
 from models.conversation import Conversation, ConversationMutationResponse
+from models.conversation_photo import ConversationPhoto
 from models.structured import Structured
 
 
@@ -69,6 +70,32 @@ class _Transaction:
 
     def update(self, ref, data):
         ref.update(data)
+
+
+class _PhotoRef:
+    def __init__(self):
+        self.set_calls = []
+
+    def set(self, data, **kwargs):
+        self.set_calls.append((data, kwargs))
+
+
+class _PhotoCollection:
+    def __init__(self):
+        self.refs = {}
+
+    def document(self, photo_id):
+        return self.refs.setdefault(photo_id, _PhotoRef())
+
+
+class _PhotoConversationRef(_ConversationRef):
+    def __init__(self, snapshot):
+        super().__init__(snapshot)
+        self.photos = _PhotoCollection()
+
+    def collection(self, name):
+        assert name == 'photos'
+        return self.photos
 
 
 def test_document_update_time_is_exposed_as_server_revision():
@@ -201,6 +228,7 @@ def test_first_processing_write_still_creates_complete_document(monkeypatch):
     assert options == {}
     assert 'updated_at' not in written
     assert written['structured']['title'] == 'Generated title'
+    assert written['has_photos'] is False
 
 
 def test_create_if_absent_never_persists_firestore_revision_metadata(monkeypatch):
@@ -220,6 +248,24 @@ def test_create_if_absent_never_persists_firestore_revision_metadata(monkeypatch
 
     assert len(ref.create_calls) == 1
     assert 'updated_at' not in ref.create_calls[0]
+    assert ref.create_calls[0]['has_photos'] is False
+
+
+def test_storing_photos_sets_authoritative_parent_marker(monkeypatch):
+    ref = _PhotoConversationRef(_Snapshot({'data_protection_level': 'standard'}))
+    client = _Firestore(ref)
+    monkeypatch.setattr(conversations_db.firestore, 'transactional', lambda function: function)
+
+    stored = conversations_db.store_conversation_photos(
+        'user-1',
+        'conversation-1',
+        [ConversationPhoto(id='photo-1', base64='encoded')],
+        firestore_client=client,
+    )
+
+    assert stored is True
+    assert ref.update_calls == [{'has_content': True, 'has_photos': True}]
+    assert ref.photos.refs['photo-1'].set_calls[0][0]['id'] == 'photo-1'
 
 
 def test_processing_transaction_reloads_user_fields_when_firestore_retries(monkeypatch):

--- a/backend/tests/unit/test_data_export_cursor_pagination.py
+++ b/backend/tests/unit/test_data_export_cursor_pagination.py
@@ -1,0 +1,86 @@
+from database import chat as chat_db
+from database import conversations as conversations_db
+
+
+class _Doc:
+    def __init__(self, doc_id):
+        self.id = doc_id
+
+    def to_dict(self):
+        return {'id': self.id}
+
+
+class _Query:
+    def __init__(self, docs, tracker, *, cursor=None, page_limit=None):
+        self.docs = docs
+        self.tracker = tracker
+        self.cursor = cursor
+        self.page_limit = page_limit
+
+    def where(self, **_kwargs):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, value):
+        self.tracker['limits'].append(value)
+        return _Query(self.docs, self.tracker, cursor=self.cursor, page_limit=value)
+
+    def start_after(self, cursor):
+        self.tracker['cursors'].append(cursor.id)
+        return _Query(self.docs, self.tracker, cursor=cursor, page_limit=self.page_limit)
+
+    def stream(self):
+        docs = self.docs
+        if self.cursor is not None:
+            cursor_index = next(index for index, doc in enumerate(docs) if doc.id == self.cursor.id)
+            docs = docs[cursor_index + 1 :]
+        page = docs[: self.page_limit]
+        self.tracker['page_sizes'].append(len(page))
+        return page
+
+
+class _Firestore:
+    def __init__(self, count):
+        self.tracker = {'limits': [], 'cursors': [], 'page_sizes': []}
+        self.query = _Query([_Doc(f'doc-{index}') for index in range(count)], self.tracker)
+
+    def collection(self, _name):
+        return self
+
+    def document(self, _doc_id):
+        return self
+
+    def order_by(self, *_args, **_kwargs):
+        return self.query
+
+
+def test_iter_all_conversations_uses_snapshot_cursor_pages(monkeypatch):
+    client = _Firestore(5)
+    monkeypatch.setattr(conversations_db, 'db', client)
+    monkeypatch.setattr(conversations_db, '_prepare_conversation_for_read', lambda data, _uid: data)
+
+    rows = list(conversations_db.iter_all_conversations('uid', batch_size=2))
+
+    assert [row['id'] for row in rows] == [f'doc-{index}' for index in range(5)]
+    assert client.tracker == {
+        'limits': [2, 2, 2],
+        'cursors': ['doc-1', 'doc-3'],
+        'page_sizes': [2, 2, 1],
+    }
+
+
+def test_iter_all_messages_uses_snapshot_cursor_pages(monkeypatch):
+    client = _Firestore(5)
+    monkeypatch.setattr(chat_db, 'db', client)
+    monkeypatch.setattr(chat_db, '_prepare_message_for_read', lambda data, _uid: data)
+
+    rows = list(chat_db.iter_all_messages('uid', batch_size=2))
+
+    assert [row['id'] for row in rows] == [f'doc-{index}' for index in range(5)]
+    assert client.tracker == {
+        'limits': [2, 2, 2],
+        'cursors': ['doc-1', 'doc-3'],
+        'page_sizes': [2, 2, 1],
+    }

--- a/backend/tests/unit/test_desktop_migration.py
+++ b/backend/tests/unit/test_desktop_migration.py
@@ -1601,212 +1601,172 @@ class TestDailyScoreWireCompat:
         assert result['score'] == 50
 
 
-class TestScoreComputation:
-    """Verify score computation logic."""
+class _ScoreDoc:
+    def __init__(self, doc_id, data):
+        self.id = doc_id
+        self._data = data
 
-    def _make_mock_doc(self, data):
-        doc = MagicMock()
-        doc.to_dict.return_value = data
-        doc.id = data.get('id', 'doc-1')
-        return doc
+    def to_dict(self):
+        return self._data
 
-    def test_weekly_uses_created_at_not_due_at(self):
-        """get_scores weekly query uses created_at field, not due_at."""
-        mock_col = MagicMock()
 
-        # Daily query (due_at) returns empty
-        daily_query = MagicMock()
-        daily_query.where.return_value = daily_query
-        daily_query.stream.return_value = []
+class _ScoreFilter:
+    def __init__(self, field_path, op_string, value):
+        self.field_path = field_path
+        self.op_string = op_string
+        self.value = value
 
-        # Weekly query (created_at) returns 1 completed task
-        weekly_query = MagicMock()
-        weekly_query.where.return_value = weekly_query
-        weekly_doc = self._make_mock_doc({'completed': True, 'created_at': datetime.now(timezone.utc)})
-        weekly_query.stream.return_value = [weekly_doc]
 
-        # Overall stream returns same
-        mock_col.stream.return_value = [weekly_doc]
+class _ScoreCount:
+    def __init__(self, value):
+        self.value = value
 
-        # Track which field filters are created
-        captured_filters = []
-        original_ff = action_items_db.FieldFilter
 
-        def tracking_filter(field, op, value):
-            captured_filters.append(field)
-            return original_ff(field, op, value)
+class _ScoreAggregation:
+    def __init__(self, query):
+        self.query = query
 
-        call_count = [0]
+    def get(self):
+        return [[_ScoreCount(len(self.query._matching_docs()))]]
 
-        def col_where(**kwargs):
-            call_count[0] += 1
-            if call_count[0] <= 1:
-                return daily_query
+
+class _ScoreQuery:
+    def __init__(self, docs, filters=(), tracker=None, cursor=None, page_limit=None):
+        self.docs = docs
+        self.filters = filters
+        self.tracker = tracker if tracker is not None else {'filters': [], 'streams': []}
+        self.cursor = cursor
+        self.page_limit = page_limit
+
+    def where(self, *, filter):
+        self.tracker['filters'].append((filter.field_path, filter.op_string, filter.value))
+        return _ScoreQuery(
+            self.docs,
+            self.filters + ((filter.field_path, filter.op_string, filter.value),),
+            self.tracker,
+            self.cursor,
+            self.page_limit,
+        )
+
+    def order_by(self, *_args, **_kwargs):
+        return self
+
+    def limit(self, value):
+        return _ScoreQuery(self.docs, self.filters, self.tracker, self.cursor, value)
+
+    def start_after(self, cursor):
+        return _ScoreQuery(self.docs, self.filters, self.tracker, cursor, self.page_limit)
+
+    def _matching_docs(self):
+        docs = self.docs
+        for field, op, value in self.filters:
+            if op == '==':
+                docs = [
+                    doc for doc in docs if type(doc._data.get(field)) is type(value) and doc._data.get(field) == value
+                ]
+            elif op == '>=':
+                docs = [doc for doc in docs if doc._data.get(field) is not None and doc._data[field] >= value]
+            elif op == '<':
+                docs = [doc for doc in docs if doc._data.get(field) is not None and doc._data[field] < value]
             else:
-                return weekly_query
+                raise AssertionError(f'unsupported fake filter: {op}')
+        if self.cursor is not None:
+            cursor_index = next(index for index, doc in enumerate(docs) if doc.id == self.cursor.id)
+            docs = docs[cursor_index + 1 :]
+        return docs[: self.page_limit]
 
-        mock_col.where = col_where
+    def count(self):
+        return _ScoreAggregation(self)
 
-        with (
-            patch.object(action_items_db, 'db') as patched_db,
-            patch.object(action_items_db, 'FieldFilter', side_effect=tracking_filter),
-        ):
-            patched_db.collection.return_value.document.return_value.collection.return_value = mock_col
-            result = action_items_db.get_scores('test-uid', date='2025-01-15')
+    def stream(self):
+        self.tracker['streams'].append(self.filters)
+        return self._matching_docs()
 
-        # Verify created_at was used in filter calls (for weekly query)
-        assert 'created_at' in captured_filters, f"Expected created_at in filters, got: {captured_filters}"
 
-    def test_weekly_window_spans_seven_days_ending_on_date(self):
-        """The weekly window is the 7 days ending on `date`, i.e. [date-6, date+1).
+class _ScoreFirestore:
+    def __init__(self, rows):
+        self.query = _ScoreQuery([_ScoreDoc(f'task-{index}', row) for index, row in enumerate(rows)])
 
-        Regression: it was [date-7, date+1) — 8 calendar days — which over-counted
-        every task created on the date-7 day, inconsistent with the docstring and
-        with the one-day daily window [date, date+1).
-        """
+    def collection(self, _name):
+        if _name == action_items_db.action_items_collection:
+            return self.query
+        return self
+
+    def document(self, _doc_id):
+        return self
+
+
+class TestScoreComputation:
+    """Verify score computation logic through aggregate-query semantics."""
+
+    @pytest.fixture(autouse=True)
+    def _use_evaluable_field_filters(self, monkeypatch):
+        monkeypatch.setattr(action_items_db, 'FieldFilter', _ScoreFilter)
+
+    def test_weekly_uses_created_at_and_seven_day_window(self):
         from datetime import timedelta
 
-        mock_col = MagicMock()
-        empty = MagicMock()
-        empty.where.return_value = empty
-        empty.stream.return_value = []
-        mock_col.where.return_value = empty
-        mock_col.stream.return_value = []
-
-        captured = []  # (field, op, value)
-        original_ff = action_items_db.FieldFilter
-
-        def tracking_filter(field, op, value):
-            captured.append((field, op, value))
-            return original_ff(field, op, value)
-
-        with (
-            patch.object(action_items_db, 'db') as patched_db,
-            patch.object(action_items_db, 'FieldFilter', side_effect=tracking_filter),
-        ):
-            patched_db.collection.return_value.document.return_value.collection.return_value = mock_col
-            action_items_db.get_scores('test-uid', date='2026-07-19')
+        client = _ScoreFirestore([])
+        action_items_db.get_scores('test-uid', date='2026-07-19', firestore_client=client)
 
         day = datetime(2026, 7, 19, tzinfo=timezone.utc)
-        created_at_lower = [v for (f, op, v) in captured if f == 'created_at' and op == '>=']
-        assert created_at_lower, f"no created_at >= filter captured: {captured}"
-        # 7 days ending on 2026-07-19 -> lower bound is 2026-07-13 (day-6), not 2026-07-12 (day-7).
-        assert created_at_lower[0] == day - timedelta(days=6), created_at_lower[0]
+        filters = client.query.tracker['filters']
+        created_at_lower = [value for field, op, value in filters if field == 'created_at' and op == '>=']
+        assert created_at_lower == [day - timedelta(days=6)] * 2
 
     def test_default_tab_daily_when_highest(self):
-        """default_tab is 'daily' when daily has tasks and highest score."""
-        mock_col = MagicMock()
+        day = datetime(2025, 1, 15, 12, tzinfo=timezone.utc)
+        client = _ScoreFirestore(
+            [
+                {'completed': True, 'due_at': day, 'created_at': day},
+                {'completed': True, 'due_at': day, 'created_at': day},
+            ]
+        )
 
-        # Daily: 2/2 completed = 100%
-        daily_docs = [
-            self._make_mock_doc({'completed': True}),
-            self._make_mock_doc({'completed': True}),
-        ]
-        daily_query = MagicMock()
-        daily_query.where.return_value = daily_query
-        daily_query.stream.return_value = daily_docs
-
-        # Weekly: 1/2 = 50%
-        weekly_docs = [
-            self._make_mock_doc({'completed': True}),
-            self._make_mock_doc({'completed': False}),
-        ]
-        weekly_query = MagicMock()
-        weekly_query.where.return_value = weekly_query
-        weekly_query.stream.return_value = weekly_docs
-
-        # Overall: same as weekly
-        mock_col.stream.return_value = weekly_docs
-
-        call_count = [0]
-
-        def col_where(**kwargs):
-            call_count[0] += 1
-            if call_count[0] <= 1:
-                return daily_query
-            else:
-                return weekly_query
-
-        mock_col.where = col_where
-
-        with patch.object(action_items_db, 'db') as patched_db:
-            patched_db.collection.return_value.document.return_value.collection.return_value = mock_col
-            result = action_items_db.get_scores('test-uid', date='2025-01-15')
+        result = action_items_db.get_scores('test-uid', date='2025-01-15', firestore_client=client)
 
         assert result['default_tab'] == 'daily'
 
     def test_default_tab_weekly_when_no_daily_tasks(self):
-        """default_tab is 'weekly' when daily has no tasks."""
-        mock_col = MagicMock()
+        day = datetime(2025, 1, 15, 12, tzinfo=timezone.utc)
+        client = _ScoreFirestore(
+            [
+                {'completed': True, 'created_at': day},
+                {'completed': False, 'created_at': day},
+            ]
+        )
 
-        # Daily: 0 tasks
-        daily_query = MagicMock()
-        daily_query.where.return_value = daily_query
-        daily_query.stream.return_value = []
-
-        # Weekly: 1/1 = 100%
-        weekly_doc = self._make_mock_doc({'completed': True})
-        weekly_query = MagicMock()
-        weekly_query.where.return_value = weekly_query
-        weekly_query.stream.return_value = [weekly_doc]
-
-        # Overall: 1/2 = 50%
-        overall_docs = [
-            self._make_mock_doc({'completed': True}),
-            self._make_mock_doc({'completed': False}),
-        ]
-        mock_col.stream.return_value = overall_docs
-
-        call_count = [0]
-
-        def col_where(**kwargs):
-            call_count[0] += 1
-            if call_count[0] <= 1:
-                return daily_query
-            else:
-                return weekly_query
-
-        mock_col.where = col_where
-
-        with patch.object(action_items_db, 'db') as patched_db:
-            patched_db.collection.return_value.document.return_value.collection.return_value = mock_col
-            result = action_items_db.get_scores('test-uid', date='2025-01-15')
+        result = action_items_db.get_scores('test-uid', date='2025-01-15', firestore_client=client)
 
         assert result['default_tab'] == 'weekly'
 
-    def test_default_tab_overall_when_lowest_weekly(self):
-        """default_tab is 'overall' when overall score exceeds weekly."""
-        mock_col = MagicMock()
+    def test_default_tab_overall_when_weekly_is_lower(self):
+        client = _ScoreFirestore(
+            [
+                {'completed': False, 'created_at': datetime(2025, 1, 15, 12, tzinfo=timezone.utc)},
+                {'completed': True, 'created_at': datetime(2024, 1, 1, tzinfo=timezone.utc)},
+            ]
+        )
 
-        # Daily: 0 tasks
-        daily_query = MagicMock()
-        daily_query.where.return_value = daily_query
-        daily_query.stream.return_value = []
-
-        # Weekly: 0/1 = 0%
-        weekly_query = MagicMock()
-        weekly_query.where.return_value = weekly_query
-        weekly_query.stream.return_value = [self._make_mock_doc({'completed': False})]
-
-        # Overall: 1/1 = 100%
-        mock_col.stream.return_value = [self._make_mock_doc({'completed': True})]
-
-        call_count = [0]
-
-        def col_where(**kwargs):
-            call_count[0] += 1
-            if call_count[0] <= 1:
-                return daily_query
-            else:
-                return weekly_query
-
-        mock_col.where = col_where
-
-        with patch.object(action_items_db, 'db') as patched_db:
-            patched_db.collection.return_value.document.return_value.collection.return_value = mock_col
-            result = action_items_db.get_scores('test-uid', date='2025-01-15')
+        result = action_items_db.get_scores('test-uid', date='2025-01-15', firestore_client=client)
 
         assert result['default_tab'] == 'overall'
+
+    def test_soft_deleted_tasks_are_subtracted_without_full_document_scans(self):
+        day = datetime(2025, 1, 15, 12, tzinfo=timezone.utc)
+        client = _ScoreFirestore(
+            [
+                {'completed': True, 'due_at': day, 'created_at': day},
+                {'completed': True, 'deleted': True, 'due_at': day, 'created_at': day},
+            ]
+        )
+
+        result = action_items_db.get_scores('test-uid', date='2025-01-15', firestore_client=client)
+
+        assert result['daily'] == {'score': 100.0, 'completed_tasks': 1, 'total_tasks': 1}
+        assert result['weekly'] == {'score': 100.0, 'completed_tasks': 1, 'total_tasks': 1}
+        assert result['overall'] == {'score': 100.0, 'completed_tasks': 1, 'total_tasks': 1}
+        assert client.query.tracker['streams'] == [(('deleted', '==', True),)]
 
 
 # ===========================================================================

--- a/backend/tests/unit/test_staged_tasks_dedup.py
+++ b/backend/tests/unit/test_staged_tasks_dedup.py
@@ -61,6 +61,9 @@ def _make_doc(doc_id, data):
 def _stub_action_items_query(monkeypatch, docs):
     """Stub db.collection(...).document(uid).collection(action_items).where(...).stream() to yield docs."""
     fake_query = MagicMock()
+    fake_query.order_by.return_value = fake_query
+    fake_query.limit.return_value = fake_query
+    fake_query.start_after.return_value = fake_query
     fake_query.stream.return_value = iter(docs)
 
     fake_subcol = MagicMock()

--- a/backend/tests/unit/test_with_photos_marker.py
+++ b/backend/tests/unit/test_with_photos_marker.py
@@ -1,0 +1,34 @@
+from database.helpers import with_photos
+
+
+def test_with_photos_skips_empty_subcollection_read_for_authoritative_false_marker():
+    calls = []
+
+    @with_photos(lambda **kwargs: calls.append(kwargs) or [{'id': 'unexpected'}])
+    def load(uid):
+        return {'id': 'conversation-1', 'has_photos': False}
+
+    assert load('user-1') == {'id': 'conversation-1', 'has_photos': False, 'photos': []}
+    assert calls == []
+
+
+def test_with_photos_preserves_legacy_lookup_when_marker_is_absent():
+    calls = []
+
+    @with_photos(lambda **kwargs: calls.append(kwargs) or [{'id': 'photo-1'}])
+    def load(uid):
+        return {'id': 'legacy-conversation'}
+
+    assert load('user-1')['photos'] == [{'id': 'photo-1'}]
+    assert calls == [{'uid': 'user-1', 'conversation_id': 'legacy-conversation'}]
+
+
+def test_with_photos_loads_when_marker_is_true():
+    calls = []
+
+    @with_photos(lambda **kwargs: calls.append(kwargs) or [{'id': 'photo-1'}])
+    def load(uid):
+        return {'id': 'conversation-1', 'has_photos': True}
+
+    assert load('user-1')['photos'] == [{'id': 'photo-1'}]
+    assert calls == [{'uid': 'user-1', 'conversation_id': 'conversation-1'}]

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -257,6 +257,24 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
+          "fieldPath": "completed",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "action_items",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
           "fieldPath": "conversation_id",
           "order": "ASCENDING"
         },


### PR DESCRIPTION
## What changed and why

Firestore bills per document read, and four backend read paths were reading far more documents than they returned. Firestore read spend is roughly $497/day; these are the paths a read audit implicated.

- **`action_items` unbounded scans.** `get_action_item_ids`, the desktop visible-ID census, and the description dedup lookup each streamed a whole collection. They now page with 500-document snapshot cursors, bounding every RPC.
- **`get_scores` full-collection read.** It read every action item to compute three counts. It now uses index-backed count aggregations and reads only soft-deleted rows in order to subtract them.
- **Quadratic export iterators.** `iter_all_conversations` and `iter_all_messages` advanced with `.offset()`. Firestore bills every skipped document, so a full export cost O(n²) reads in its own length. Both now advance with `start_after` cursors.
- **`@with_photos` N+1.** Every conversation read issued a photos subcollection query that almost always returned nothing. New conversations now carry a `has_photos` marker written transactionally with photo writes.

Also drops an unused `offset` parameter from `get_app_messages`, which only ever reads the first page.

## Product invariants affected

None locked. The behaviour-preservation risks are called out under Verification.

## How it was verified

Reviewed independently for product regressions before this PR was opened. Three specific risks were traced end to end:

**Photos cannot be lost.** `@with_photos` skips the subcollection query only when `has_photos` is exactly `False`. Conversations written before this change omit the field entirely and keep the lookup, so no historical conversation can change its response. Every production writer of the photos subcollection was enumerated and all three go through `store_conversation_photos`, which sets the marker true in the same transaction: live listen photos (`routers/listen/transcripts.py`), `process_conversation` CreateConversation, and merge. Desktop sync builds `CreateConversation` without photos; Limitless import writes no photos subcollection. The `setdefault` that stamps `false` sits only on create branches — existing documents take `merge=True` writes, and `Conversation` has no `has_photos` field, so a merge payload cannot overwrite a true marker.

**`get_scores` arithmetic is unchanged.** Compared against the previous Python loops case by case: zero rows, missing `deleted`, `deleted: False`, `deleted: True`, missing `completed`, the weekly window boundary, rounding, the default tab, and UTC day boundaries. One intentional narrowing: `completed == True` is now an equality filter rather than Python truthiness, so a legacy non-boolean `completed: 1` would no longer count. Writes normalize to bool and no non-boolean writes exist.

**Cursor pagination cannot skip or duplicate.** Firestore snapshot cursors include `__name__`, so equal `created_at` values are ordered deterministically. Termination keys off the raw snapshot count rather than the decrypted batch length, so a decrypt miss cannot end the scan early. Documents missing `created_at` are excluded by `order_by`, exactly as under the previous `.offset()` loops.

Test modules were run individually; running several of these modules in one pytest process fails on `main` too, from pre-existing collector and import-order collisions unrelated to this change.

## Tests

- `test_with_photos_marker.py` (new) — marker-present-false skips the lookup, marker-absent still looks up.
- `test_data_export_cursor_pagination.py` (new) — cursor paging across a page boundary.
- `test_desktop_migration.py` — `get_scores` weekly window and soft-deleted subtraction.
- `test_action_item_ids_endpoint.py` — 501 documents across two cursor pages.
- `test_conversation_revision_contract.py` — first-write create stamps `has_photos: false`; storing photos sets it true.
- `test_firestore_query_contract.py` — the new query shape's required composite is declared in the manifest.

## Failure class (fixes)

Failure-Class: none

## Deploy ordering

The weekly score aggregation needs a new composite index on `action_items` (`completed`, `created_at`, `__name__`), added to `firestore.indexes.json` and the registry. It does not exist in any live project yet. **The index must be serving before this code takes traffic.** Both backend deploy lanes run `reconcile_firestore_indexes.py --check-only` and fail closed if it is not, so the failure mode is a blocked deploy rather than a `FailedPrecondition` on `/v1/scores`.

## Line-count exceptions

Line-Count-Exception: backend/database/conversations.py | 1921 -> 1926 | five lines: two `has_photos` setdefaults on the create branches, one field on the photo-write transaction, and the `start_after` cursor in the export iterator. Splitting this file is unrelated to the change and would obscure a small, reviewable diff.

## Known leftovers, deliberately not in this PR

`services/users/data_export.py:_iter_paginated` still offset-paginates action items. Its offset is bounded by an existing 2000-item hard cap in `get_action_items`, so the read amplification is small — but that same cap silently truncates the `action_items` array in exports for users with more than 2000 live tasks. That is a pre-existing user-facing data-completeness bug whose fix changes export behaviour, so it belongs in its own change.

`migrations/004_migrate_action_items_to_collection.py` retains two `.offset()` calls. It is a one-time migration script, not a request path.

Thirteen `.offset()` call sites remain under `backend/database/`. Each backs a released page-number API parameter; removing them requires a versioned cursor contract on those endpoints.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

