### PR TITLE
test(backend): teach the task-sharing stub about with_rate_limit

### DIFF
--- a/backend/tests/unit/test_task_sharing.py
+++ b/backend/tests/unit/test_task_sharing.py
@@ -123,6 +123,14 @@ utils_users_mod.get_user_display_name = MagicMock(return_value="TestUser")
 _stub_module("utils.other")
 _stub_module("utils.other.endpoints")
 sys.modules["utils.other.endpoints"].get_current_user_uid = MagicMock()
+# The action-items router wraps its list dependency at module level
+# (`auth.with_rate_limit(auth.get_current_user_uid, ...)`, #11993). The stub must
+# expose it or importing the router raises AttributeError during collection.
+# Return the wrapped dependency unchanged: this suite asserts sharing behaviour,
+# not rate-limit policy, which has its own coverage.
+sys.modules["utils.other.endpoints"].with_rate_limit = MagicMock(
+    side_effect=lambda auth_dependency, policy_name: auth_dependency
+)
 
 # The action-items router imports the list-read budget seam at module level
 # (#11831). Delegate the stubbed submodule to the real (stdlib-only) module so


### PR DESCRIPTION
## What changed and why

`main` has been red since #11965 merged at 14:42 UTC today. Every PR branching off it fails the Backend unit suite.

#11965 wrapped the action-items list dependency at module scope:

```python
uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "action_items:list")),
```

`backend/tests/unit/test_task_sharing.py` stubs `utils.other.endpoints` with only `get_current_user_uid`, so importing `routers.action_items` raises `AttributeError: module 'utils.other.endpoints' has no attribute 'with_rate_limit'` during collection and the entire module errors out.

This adds `with_rate_limit` to the stub, returning the wrapped dependency unchanged. The suite asserts task-sharing behaviour, not rate-limit policy, and that policy has its own coverage in `test_rate_limiting.py` (updated by #11965). The same test already delegates `utils.other.list_budget` to the real module for exactly this class of module-scope import, added by #11831.

## Product invariants affected

None. Test-only change; no production code is touched.

## How it was verified

`backend/tests/unit/test_task_sharing.py` — 30 passed, against `origin/main` at `b16ad4508d`. Confirmed failing without the change at `b16ad4508d`, at `8ec49fa7c3`, and passing at `a5dc6a1092` (before #11965), which isolates the regression to that merge.

CI history confirms the same boundary: `backend-unit-tests.yml` on `main` is `success` at `b5ad95e26` and `failure` from `c622d3dfe` (#11965) onward.

## Tests

No new test. This restores an existing suite that a module-scope import change silently broke.

## Failure class (fixes)

Failure-Class: none


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/BasedHardware/omi/pull/12064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

